### PR TITLE
fix(pages): build editor workspace dependencies

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,10 @@ jobs:
           cache: pnpm
       - uses: actions/configure-pages@v5
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter @icm/editor build
+      # The editor imports workspace packages whose public entries are emitted
+      # into dist/. The trailing ellipsis selects that dependency closure and
+      # pnpm builds it in dependency order on a clean Actions runner.
+      - run: pnpm --filter @icm/editor... build
         env:
           ICM_PAGE_BASE_PATH: ${{ github.event.repository.name }}
       - uses: actions/upload-pages-artifact@v4

--- a/plan/2026-08-09-pages-dependency-build-fix/plan.md
+++ b/plan/2026-08-09-pages-dependency-build-fix/plan.md
@@ -1,0 +1,76 @@
+# Pages Dependency Build Fix
+
+## Goal
+
+Repair the GitHub Pages build so a clean GitHub Actions runner builds the
+editor's internal workspace dependencies before Vite bundles the editor.
+
+## Dirty-State Note
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/fix-pages-dependency-build
+```
+
+The worktree is clean. The failed Pages run `31311029301` proves the scoped
+editor build cannot resolve `@icm/edit-engine` on a fresh checkout because its
+dependency output has not yet been built.
+
+## Owned Files
+
+- `.github/workflows/pages.yml`
+- `plan/2026-08-09-pages-dependency-build-fix/**`
+- `plan/log.md`
+
+## Read-Only Files
+
+- `apps/editor/**`
+- all workspace package source and package manifests
+
+## Shared Dependencies
+
+- pnpm workspace dependency-closure filter syntax
+- Vite resolution of workspace packages' generated `dist` entries
+- GitHub Pages artifact deployment workflow
+
+## Expected Work
+
+1. Replace the editor-only build command with the editor dependency closure
+   build command.
+2. Verify the exact fresh-runner build sequence locally.
+3. Commit, push, merge the focused workflow repair, then rerun Pages.
+
+## Validation
+
+- `pnpm install --frozen-lockfile`
+- `ICM_PAGE_BASE_PATH=interactive-circuit-maker pnpm --filter @icm/editor... build`
+- `git diff --check`
+- `git status --short --branch`
+
+The workflow-only repair has one failure mode: dependency order on a clean
+checkout. The dependency-closure build command exercises precisely that
+contract without repeating unrelated suite work.
+
+## Experience Signal (for human review)
+
+None.
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(pages): build editor workspace dependencies
+```
+
+## Result and Validation (2026-08-09)
+
+- Changed the Pages build command to `pnpm --filter @icm/editor... build`.
+  It selects the editor and all local workspace dependencies, allowing pnpm to
+  build package `dist` entries before Vite resolves editor imports.
+- Passed: `pnpm install --frozen-lockfile` and
+  `ICM_PAGE_BASE_PATH=interactive-circuit-maker pnpm --filter @icm/editor...
+  build`. Model, symbols, derived, SPICE, edit-engine, render-svg, exporters,
+  and the editor built in dependency order.
+- Passed: `git diff --check`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -15,6 +15,18 @@ Use concise entries:
 
 Keep reusable lessons in `docs/experience/`, not in this log.
 
+## 2026-08-09 - Pages workspace dependency build repair
+
+- Target: repair Pages run `31311029301`, whose fresh runner could not resolve
+  `@icm/edit-engine` while building only the editor package.
+- Changed areas: Pages workflow now builds the editor dependency closure using
+  pnpm's trailing-ellipsis filter.
+- Validation: `pnpm install --frozen-lockfile` and the base-path Pages build
+  passed after model, symbols, derived, SPICE, edit-engine, render-svg,
+  exporters, and editor packages built in dependency order; `git diff --check`
+  passed.
+- Commit status: ready to commit, merge, and rerun Pages.
+
 ## 2026-08-09 - GitHub Pages release preparation
 
 - Target: publish the GUI-only, local-first editor as a static GitHub Pages


### PR DESCRIPTION
Build the editor workspace dependency closure before Vite bundles the Pages artifact. Fixes the clean-runner @icm/edit-engine resolution failure in run 31311029301. Validation: frozen pnpm install and base-path dependency-closure build passed.