### PR TITLE
Fix Cloudflare deployment command

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "plan/**"
   workflow_dispatch:
 
 permissions:
@@ -31,9 +35,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @icm/editor... build
-      - id: deploy
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy
+      - run: pnpm dlx wrangler@4.120.1 deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/plan/2026-08-12-cloudflare-workflow-fix/plan.md
+++ b/plan/2026-08-12-cloudflare-workflow-fix/plan.md
@@ -1,0 +1,64 @@
+---
+status: active
+experience: none
+---
+
+# Cloudflare Workflow Fix
+
+## Goal
+
+Repair the first Cloudflare deployment after the Wrangler Action failed to
+install Wrangler in this pnpm workspace.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree was clean before creating `codex/cloudflare-workflow-fix`.
+
+- `.github/workflows/cloudflare.yml`
+- `plan/2026-08-12-cloudflare-deployment/plan.md`
+- `plan/2026-08-12-cloudflare-workflow-fix/plan.md`
+- `plan/log.md`
+
+The application and Cloudflare Worker configuration are read-only. The original
+deployment plan will be closed only after this automatic workflow succeeds on
+`main`.
+
+## Work
+
+1. Replace the failing Action wrapper with a direct ephemeral Wrangler CLI
+   invocation using the same repository secrets.
+2. Avoid redeploying for plan-only and documentation-only commits.
+3. Validate the workflow syntax and deployment command, pass remote CI, merge,
+   and verify the production URL.
+
+## Validation
+
+- `pnpm --filter @icm/editor... build`
+- `pnpm dlx wrangler deploy --dry-run`
+- GitHub Actions required checks
+- Cloudflare deployment workflow on `main`
+- HTTP request to `https://analog-canvas.tokenzhang.com`
+- `git diff --check`
+- `git status --short --branch`
+
+The preceding deployment PR passed the complete remote CI matrix; this repair
+only changes the deployment command wrapper, so the same remote gate is the
+mainline behavioral authority.
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(ci): invoke Wrangler directly
+```
+
+## Outcome
+
+To be recorded after production verification.


### PR DESCRIPTION
## Summary
- invoke the verified Wrangler CLI directly instead of the Action wrapper that cannot install into this pnpm workspace
- skip Cloudflare deployments for documentation-only commits

## Validation
- direct production deployment succeeded
- https://analog-canvas.tokenzhang.com returns the editor with HTTP 200
- Wrangler dry-run passed
- remote CI required before merge