### PR TITLE
Record completed Cloudflare deployment

### DIFF
--- a/plan/2026-08-12-cloudflare-deployment/plan.md
+++ b/plan/2026-08-12-cloudflare-deployment/plan.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: completed
 experience: none
 ---
 
@@ -72,4 +72,9 @@ ci: deploy editor to Cloudflare Workers
 
 ## Outcome
 
-To be recorded after deployment verification.
+The existing editor is deployed as the `interactive-circuit-maker` Worker at
+`https://analog-canvas.tokenzhang.com`, with SPA fallback and the Worker's
+`workers.dev` address retained. Cloudflare credentials are stored only as
+GitHub Actions secrets. Pull request #5 passed the required CI matrix and was
+merged; the initial Action-wrapper deployment exposed a pnpm-workspace issue
+that was repaired and verified by the follow-up workflow target.

--- a/plan/2026-08-12-cloudflare-workflow-fix/plan.md
+++ b/plan/2026-08-12-cloudflare-workflow-fix/plan.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: completed
 experience: none
 ---
 
@@ -61,4 +61,9 @@ fix(ci): invoke Wrangler directly
 
 ## Outcome
 
-To be recorded after production verification.
+Replaced the incompatible Action wrapper with a pinned direct Wrangler CLI
+invocation and excluded documentation-only changes from production deploys.
+Pull request #6 passed all five CI jobs, merged as `b7a4424`, and its subsequent
+`main` Cloudflare workflow completed successfully. The production root and SPA
+fallback both return HTTP 200, and the manifest identifies Interactive Circuit
+Maker as an installable standalone application.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4608,3 +4608,25 @@ diff --check` passed. The full Playwright baseline completed 30/49, with the
   Prettier check, and `git diff --check` passed.
 - Commit status: ready to commit on `main` as
   `docs(roadmap): plan connectivity and routing unification`.
+
+## 2026-08-12 - Cloudflare Deployment
+
+- Target: publish the existing editor at `analog-canvas.tokenzhang.com` and
+  automate subsequent production deployments from `main`.
+- Changed areas: Workers Static Assets configuration, SPA fallback, custom
+  domain binding, GitHub Actions deployment, and repository secrets.
+- Validation: frozen dependency install, production build, Wrangler dry-run,
+  pull request CI matrix, successful production deployment, HTTP 200 root/SPA
+  requests, and PWA manifest inspection.
+- Commit status: merged through pull request #5 as `99914d8`; production is
+  live and the Action-wrapper follow-up is recorded separately.
+
+## 2026-08-12 - Cloudflare Workflow Fix
+
+- Target: repair the first automatic deployment's Wrangler installation
+  failure in the pnpm workspace.
+- Changed areas: direct pinned Wrangler invocation and documentation-only path
+  exclusions.
+- Validation: direct production deploy, Wrangler dry-run, all five pull request
+  CI jobs, successful `main` Cloudflare workflow, and live URL checks passed.
+- Commit status: merged through pull request #6 as `b7a4424`.


### PR DESCRIPTION
Close the Cloudflare deployment plans and record successful production verification. Documentation only; the Cloudflare workflow ignores plan-only commits.