### PR TITLE
feat(editor): restructure chrome shell and library quick-place

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -128,8 +128,30 @@ test("keeps the workspace inside the viewport and exposes low-interference zoom 
 
   const canvasBefore = await page.getByTestId("schematic-canvas").boundingBox();
   await page.getByTestId("selection-shelf").click();
-  const canvasAfter = await page.getByTestId("schematic-canvas").boundingBox();
-  expect(canvasAfter?.width).toBe(canvasBefore?.width);
+  await expect(page.getByTestId("selection-shelf")).toHaveAttribute(
+    "aria-expanded",
+    "true",
+  );
+  // Properties is an in-flow right dock; opening it may reflow the canvas width
+  // but must not push the page into scroll overflow.
+  await expect
+    .poll(
+      async () =>
+        (await page.getByTestId("schematic-canvas").boundingBox())?.width ??
+        canvasBefore?.width ??
+        0,
+    )
+    .toBeLessThan(canvasBefore?.width ?? 0);
+  expect(
+    await page.evaluate(() => ({
+      horizontal:
+        document.documentElement.scrollWidth >
+        document.documentElement.clientWidth,
+      vertical:
+        document.documentElement.scrollHeight >
+        document.documentElement.clientHeight,
+    })),
+  ).toEqual({ horizontal: false, vertical: false });
 });
 
 test("keeps preview fixed while the compact catalog expands and collapses", async ({
@@ -258,4 +280,63 @@ test("commits a pending component from a semantic canvas click", async ({
 
   await expect(page.getByTestId("hit-R1")).toBeVisible();
   await expect(page.getByTestId("component-input-plane")).toHaveCount(0);
+});
+
+test("double-clicking a placed device opens Properties for editing", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.keyboard.press("i");
+  const dialog = page.getByRole("dialog", { name: "Insert Component" });
+  await dialog.getByLabel("Component search").fill("resistor");
+  await dialog.getByLabel("Component value").fill("4.7k");
+  await dialog.getByRole("button", { name: "Apply" }).click();
+
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.click({ position: { x: 360, y: 230 } });
+  await expect(page.getByTestId("hit-R1")).toBeVisible();
+  await expect(page.getByTestId("selection-shelf")).toHaveAttribute(
+    "aria-expanded",
+    "false",
+  );
+
+  await page.getByTestId("hit-R1").dblclick();
+  await expect(page.getByTestId("selection-shelf")).toHaveAttribute(
+    "aria-expanded",
+    "true",
+  );
+  const propertyValue = page.getByLabel("Component value");
+  await expect(propertyValue).toBeVisible();
+  await expect(propertyValue).toHaveValue("4.7k");
+  await expect(propertyValue).toBeFocused();
+});
+
+test("Library rail folds the sidebar; Insert and title open the catalog", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const panel = page.getByTestId("shapes-library-panel");
+  await expect(panel).toHaveAttribute("data-open", "true");
+
+  await page.getByTestId("library-toggle").click();
+  await expect(panel).toHaveAttribute("data-open", "false");
+  await page.getByTestId("library-toggle").click();
+  await expect(panel).toHaveAttribute("data-open", "true");
+
+  await page.getByTestId("shapes-insert").click();
+  await expect(
+    page.getByRole("dialog", { name: "Insert Component" }),
+  ).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(
+    page.getByRole("dialog", { name: "Insert Component" }),
+  ).toHaveCount(0);
+
+  await page
+    .getByRole("button", { name: /Library/ })
+    .filter({ hasText: "Quick place" })
+    .click();
+  await expect(
+    page.getByRole("dialog", { name: "Insert Component" }),
+  ).toBeVisible();
 });

--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -139,7 +139,7 @@ test("adds formatted drafting text and undo/redo restores it", async ({
     page.getByTestId("canvas-text-editor"),
   );
   await draftInput.fill("Vin");
-  await draftInput.press("Control+a");
+  await draftInput.press("ControlOrMeta+A");
   await page.getByRole("button", { name: "Subscript" }).click();
   await page.getByRole("button", { name: "Apply text changes" }).click();
 
@@ -465,7 +465,7 @@ test("drafting content and anchor survive save and reopen", async ({
     name: "Canvas text editor",
   });
   await draftInput.fill("Vref");
-  await draftInput.press("Control+a");
+  await draftInput.press("ControlOrMeta+A");
   await page.getByRole("button", { name: "Italic" }).click();
   await page.getByRole("button", { name: "Apply text changes" }).click();
   await expect(page.getByTestId("revision")).toHaveText("2");
@@ -600,7 +600,7 @@ test("R creates a selectable, styleable rectangle with four resize handles", asy
   await expect(page.getByTestId("revision")).toHaveText("3");
 
   const pointsBeforeResize = await rectangle.getAttribute("points");
-  await page.getByTestId("selection-shelf").click();
+  // Properties docks on the right; corner handles remain free without closing it.
   await dragLocator(page.getByTestId(/^draft-handle-corner-0-/), {
     x: -20,
     y: -10,
@@ -733,9 +733,11 @@ test("drawing Properties follows selection and closes with the dock", async ({
   await hit.click({ force: true });
   await page.keyboard.press("q");
   await expect(page.getByTestId("drafting-properties")).toBeVisible();
+  // Click blank canvas well inside the drawing area; the right Properties dock
+  // and left Shapes column shrink the canvas, so far-corner clicks can miss it.
   await page
     .getByTestId("schematic-canvas")
-    .click({ position: { x: 820, y: 520 } });
+    .click({ position: { x: 120, y: 480 } });
   await expect(page.getByTestId("drafting-properties")).toHaveCount(0);
 });
 

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -42,6 +42,13 @@ async function openSelectionShelf(page: Page): Promise<void> {
   }
 }
 
+async function closeSelectionShelf(page: Page): Promise<void> {
+  const shelf = page.getByTestId("selection-shelf");
+  if ((await shelf.getAttribute("aria-expanded")) === "true") {
+    await shelf.click();
+  }
+}
+
 async function clickRoute(
   page: Page,
   routeId: string,
@@ -1038,8 +1045,10 @@ test("edits instance, electrical Net, and free text with bounded label handles",
   const noteHandle = page.locator('[data-testid^="drafting-hit-note-"]');
   const beforeBox = await noteHandle.boundingBox();
   if (!beforeBox) throw new Error("Text handle is not measurable");
+  // Properties dock is in-flow on the right; close it and aim left of center.
+  await closeSelectionShelf(page);
   await noteHandle.dragTo(page.getByTestId("schematic-canvas"), {
-    targetPosition: { x: 700, y: 300 },
+    targetPosition: { x: 360, y: 300 },
   });
   const afterBox = await noteHandle.boundingBox();
   expect(afterBox?.x).not.toBe(beforeBox.x);
@@ -1115,26 +1124,28 @@ test("selects and moves multiple instances while viewport gestures stay transien
   await expect(
     page.getByTestId("selection-shelf").getByText("M1, M2", { exact: true }),
   ).toBeVisible();
+  await closeSelectionShelf(page);
 
   await page
     .getByTestId("hit-M1")
     .dragTo(page.getByTestId("schematic-canvas"), {
-      targetPosition: { x: 450, y: 330 },
+      targetPosition: { x: 360, y: 280 },
     });
   await expect(page.getByTestId("revision")).toHaveText("3");
 
   const canvas = page.getByTestId("schematic-canvas");
   const beforeViewBox = await canvas.getAttribute("viewBox");
-  await canvas.hover({ position: { x: 700, y: 350 } });
+  // Stay in the open canvas area (library + properties shrink usable width).
+  await canvas.hover({ position: { x: 320, y: 280 } });
   await page.mouse.wheel(0, -120);
   await expect(canvas).not.toHaveAttribute("viewBox", beforeViewBox!);
   await expect(page.getByTestId("revision")).toHaveText("3");
 
   const canvasBox = await canvas.boundingBox();
   if (!canvasBox) throw new Error("Canvas is not measurable");
-  await page.mouse.move(canvasBox.x + 700, canvasBox.y + 350);
+  await page.mouse.move(canvasBox.x + 320, canvasBox.y + 280);
   await page.mouse.down({ button: "middle" });
-  await page.mouse.move(canvasBox.x + 750, canvasBox.y + 390, { steps: 3 });
+  await page.mouse.move(canvasBox.x + 370, canvasBox.y + 320, { steps: 3 });
   await page.mouse.up({ button: "middle" });
   await expect(page.getByTestId("revision")).toHaveText("3");
 
@@ -1295,7 +1306,7 @@ test("uses automatic recovery and guards shortcuts while typing", async ({
   await expect(page.getByTestId("revision")).toHaveText("1");
 });
 
-test("keeps component insertion and inspection from resizing the canvas", async ({
+test("keeps component insertion from resizing the canvas until Properties opens", async ({
   page,
 }) => {
   await page.goto("/");
@@ -1318,9 +1329,20 @@ test("keeps component insertion and inspection from resizing the canvas", async 
   await expect(
     page.getByRole("complementary", { name: "Properties" }),
   ).toBeVisible();
+  // Placement leaves Properties collapsed, so canvas width stays stable until
+  // the dock is opened explicitly.
+  expect((await canvas.boundingBox())?.width).toBe(beforePlaceCanvas.width);
   await page.getByTestId("selection-shelf").click();
-  const afterCanvas = await canvas.boundingBox();
-  expect(afterCanvas?.width).toBe(beforePlaceCanvas.width);
+  await expect(page.getByTestId("selection-shelf")).toHaveAttribute(
+    "aria-expanded",
+    "true",
+  );
+  await expect
+    .poll(
+      async () =>
+        (await canvas.boundingBox())?.width ?? beforePlaceCanvas.width,
+    )
+    .toBeLessThan(beforePlaceCanvas.width);
 
   await expect(page.getByTestId("selection-shelf")).toContainText("M1");
 });
@@ -1463,9 +1485,7 @@ test("dismisses a command menu on outside click or Escape", async ({
   const fileMenu = await openMenu(page, "File");
   await expect(fileMenu).toHaveAttribute("open", "");
 
-  await page
-    .getByRole("heading", { name: "Interactive Circuit Maker" })
-    .click();
+  await page.getByRole("heading", { name: "Circuit Maker" }).click();
   await expect(fileMenu).not.toHaveAttribute("open", "");
 
   await openMenu(page, "File");
@@ -1473,16 +1493,21 @@ test("dismisses a command menu on outside click or Escape", async ({
   await expect(fileMenu).not.toHaveAttribute("open", "");
 });
 
-test("selecting an object does not change canvas width", async ({ page }) => {
+test("selecting an object does not open Properties or reflow the canvas", async ({
+  page,
+}) => {
   await page.goto("/");
   const canvas = page.getByTestId("schematic-canvas");
   const widthBefore = (await canvas.boundingBox())!.width;
 
-  // placeComponent selects the placed instance, which before E opened a right
-  // Properties column and shrank the canvas. With the inspector in the left
-  // dock, the canvas column count and width must stay constant.
+  // Placement selects the instance but leaves Properties collapsed. Canvas
+  // width must stay constant until the user explicitly opens the dock.
   await placeComponent(page, "resistor", { x: 280, y: 180 });
   await expect(page.getByTestId("hit-R1")).toBeVisible();
+  await expect(page.getByTestId("selection-shelf")).toHaveAttribute(
+    "aria-expanded",
+    "false",
+  );
 
   const widthAfter = (await canvas.boundingBox())!.width;
   expect(widthAfter).toBe(widthBefore);

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -151,7 +151,7 @@ describe("editor shell", () => {
     expect(markup).not.toContain("<summary>Analytics</summary>");
   });
 
-  it("keeps Selection as an explicit overlay without a permanent library", () => {
+  it("keeps Properties docked with shapes quick-place, not a searchable catalog", () => {
     const project = createEmptyProject("selection-shelf", "Selection Shelf");
     const markup = renderToStaticMarkup(<App project={project} />);
 
@@ -160,9 +160,19 @@ describe("editor shell", () => {
     );
     expect(markup).toContain('data-testid="selection-shelf"');
     expect(markup).toContain('aria-label="Properties"');
+    expect(markup).toContain('aria-label="Tool rail"');
+    expect(markup).toContain('aria-label="Shapes"');
+    expect(markup).toContain('data-testid="shapes-chip-resistor"');
+    expect(markup).toContain('data-testid="shapes-insert"');
+    expect(markup).toContain('data-testid="library-toggle"');
+    expect(markup).toContain('data-testid="shapes-library-panel"');
+    expect(markup).toContain('data-open="true"');
+    expect(markup).toContain(">Library</span>");
     expect(markup).toContain("Insert component (I)");
+    expect(markup).toContain('data-testid="canvas-empty-state"');
     expect(markup).not.toContain("Symbols &amp; Tools");
     expect(markup).not.toContain("Search components");
+    expect(markup).not.toContain("Browse all");
   });
 
   it("gives an implicit instance label its own selection surface", () => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -97,6 +97,7 @@ import {
   stepBoundedScale,
 } from "../interaction/editor-shortcuts";
 import { EditorHelpDialog } from "../components/editor-help-dialog";
+import { ShapesPanel } from "../features/editor-shell/shapes-panel";
 import { referencedDocumentId } from "../document/editor-session";
 import { useInteractionState } from "../interaction/interaction-state";
 import type { EditorTool } from "../interaction/interaction-state";
@@ -480,6 +481,7 @@ function isTypingTarget(target: EventTarget | null): boolean {
 export function App({ project: initialProject, visitStats }: AppProps) {
   const [status, setStatus] = useState("Ready");
   const [insertDialogOpen, setInsertDialogOpen] = useState(false);
+  const [libraryPanelOpen, setLibraryPanelOpen] = useState(true);
   const [selectionOpen, setSelectionOpen] = useState(false);
   const [componentPreviewPoint, setComponentPreviewPoint] =
     useState<Point | null>(null);
@@ -609,6 +611,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   const [copyPreviewPoint, setCopyPreviewPoint] = useState<Point | null>(null);
   const suppressInstanceClick = useRef(false);
   const projectInputRef = useRef<HTMLInputElement>(null);
+  const spiceInputRef = useRef<HTMLInputElement>(null);
   const selectionShelfRef = useRef<HTMLButtonElement>(null);
   const instanceValueInputRef = useRef<HTMLInputElement>(null);
   const netLabelPropertyInputRef = useRef<HTMLInputElement>(null);
@@ -1016,6 +1019,21 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       } else {
         selectionShelfRef.current?.focus();
       }
+    });
+  }
+
+  /** Select a placed instance and open Properties (double-click / inspect). */
+  function inspectInstance(instanceId: string): void {
+    setSelectedEndpoint(null);
+    updateInstanceSelection(instanceId, false);
+    setImportReviewOpen(false);
+    setSelectionOpen(true);
+    setStatus(`Properties for ${instanceId}`);
+    // Wait for selection + dock open so the primary field exists before focus.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        instanceValueInputRef.current?.focus();
+      });
     });
   }
 
@@ -4851,28 +4869,255 @@ export function App({ project: initialProject, visitStats }: AppProps) {
 
   return (
     <main className="app-shell">
-      <header className="app-header">
-        <div>
-          <h1>Interactive Circuit Maker</h1>
-          <p>
-            {project.name} /{" "}
-            <span data-testid="active-document-name">{document.name}</span>
-          </p>
+      <header className="app-chrome">
+        <div className="app-chrome-main">
+          <div className="app-brand">
+            <span className="app-brand-mark" aria-hidden="true" />
+            <div className="app-brand-copy">
+              <h1 title="Interactive Circuit Maker">Circuit Maker</h1>
+              <p title={`${project.name} / ${document.name}`}>
+                {project.name} /{" "}
+                <span data-testid="active-document-name">{document.name}</span>
+              </p>
+            </div>
+          </div>
+          <nav
+            className="app-command-surface"
+            aria-label="Editor commands"
+            onClick={(event) => {
+              const target = event.target;
+              if (
+                target instanceof Element &&
+                target.closest(".command-popover button")
+              ) {
+                dismissOpenCommandMenus();
+              }
+            }}
+          >
+            <div className="menubar-row">
+              <details className="command-menu" name="editor-command-menu">
+                <summary>File</summary>
+                <div className="command-popover">
+                  <button type="button" onClick={saveProjectFile}>
+                    Save Project
+                  </button>
+                  <label className="file-import">
+                    Open Project
+                    <input
+                      ref={projectInputRef}
+                      data-testid="project-file"
+                      type="file"
+                      accept=".json,.icproj.json,application/json"
+                      onChange={(event) =>
+                        void openProjectFile(
+                          event.currentTarget.files?.[0] ?? null,
+                        )
+                      }
+                    />
+                  </label>
+                  <label className="file-import">
+                    Import SPICE
+                    <input
+                      ref={spiceInputRef}
+                      data-testid="spice-files"
+                      type="file"
+                      accept=".spi,.cir,.sp,.inc,.lib"
+                      multiple
+                      onChange={(event) =>
+                        void importSpiceFiles(event.currentTarget.files)
+                      }
+                    />
+                  </label>
+                  <span className="command-group-label">Export</span>
+                  <button
+                    type="button"
+                    aria-label="Export SVG"
+                    onClick={exportSvg}
+                  >
+                    SVG
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Export PNG"
+                    onClick={() => void exportRaster("png")}
+                  >
+                    PNG
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Export PDF"
+                    onClick={() => void exportRaster("pdf")}
+                  >
+                    PDF
+                  </button>
+                  {recoveryCandidate ? (
+                    <>
+                      <button type="button" onClick={restoreRecovery}>
+                        Restore recovery
+                      </button>
+                      <button type="button" onClick={discardRecovery}>
+                        Discard recovery
+                      </button>
+                    </>
+                  ) : null}
+                </div>
+              </details>
+              <details className="command-menu" name="editor-command-menu">
+                <summary>Edit</summary>
+                <div className="command-popover">
+                  <button
+                    type="button"
+                    onClick={() => transact([{ kind: "undo" }])}
+                    disabled={!canUndo}
+                  >
+                    Undo
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => transact([{ kind: "redo" }])}
+                    disabled={!canRedo}
+                  >
+                    Redo
+                  </button>
+                  <button
+                    type="button"
+                    onClick={deleteSelection}
+                    disabled={
+                      !hasVisualSelection(visualSelection) && !selectedEndpoint
+                    }
+                  >
+                    Delete
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => rotateSelected()}
+                    disabled={selectedIds.length === 0}
+                  >
+                    <ToolIcon name="rotate" />
+                    Rotate
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => mirrorSelected("left-right")}
+                    disabled={selectedIds.length === 0}
+                  >
+                    Mirror left/right (Shift+R)
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => mirrorSelected("top-bottom")}
+                    disabled={selectedIds.length === 0}
+                  >
+                    Mirror top/bottom (Shift+V)
+                  </button>
+                  {selectedIds.length > 1 ? (
+                    <button type="button" onClick={alignSelectedInstances}>
+                      Align
+                    </button>
+                  ) : null}
+                </div>
+              </details>
+              <details className="command-menu" name="editor-command-menu">
+                <summary>Draw</summary>
+                <div className="command-popover">
+                  <button type="button" onClick={openInsertComponentDialog}>
+                    <ToolIcon name="insert" />
+                    Insert component (I)
+                  </button>
+                  <button
+                    type="button"
+                    aria-pressed={tool === "wire"}
+                    onClick={() => activateTool("wire")}
+                  >
+                    <ToolIcon name="wire" />
+                    Wire (W)
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Text"
+                    onClick={addPlainText}
+                  >
+                    <ToolIcon name="text" />
+                    Text (T)
+                  </button>
+                  <button
+                    type="button"
+                    aria-pressed={tool === "arrow"}
+                    onClick={() => activateTool("arrow")}
+                  >
+                    <ToolIcon name="arrow" />
+                    Arrow (A)
+                  </button>
+                  <button
+                    type="button"
+                    aria-pressed={tool === "construction-line"}
+                    onClick={() => activateTool("construction-line")}
+                  >
+                    <ToolIcon name="line" />
+                    Construction line (P)
+                  </button>
+                  <button
+                    type="button"
+                    aria-pressed={tool === "rectangle"}
+                    onClick={() => activateTool("rectangle")}
+                  >
+                    <ToolIcon name="rectangle" />
+                    Rectangle (R)
+                  </button>
+                </div>
+              </details>
+              <details className="command-menu" name="editor-command-menu">
+                <summary>More</summary>
+                <div className="command-popover">
+                  <span className="command-group-label">Guides</span>
+                  <button type="button" onClick={() => addGuide("vertical")}>
+                    Add vertical guide
+                  </button>
+                  <button type="button" onClick={() => addGuide("horizontal")}>
+                    Add horizontal guide
+                  </button>
+                  <button type="button" onClick={toggleGuidesVisible}>
+                    Show/hide guides
+                  </button>
+                  <button type="button" onClick={clearUnlockedGuides}>
+                    Clear unlocked guides
+                  </button>
+                  <button type="button" onClick={() => activateTool("guide")}>
+                    Guide tool (G)
+                  </button>
+                </div>
+              </details>
+              <button
+                type="button"
+                className="menubar-help"
+                ref={helpButtonRef}
+                aria-haspopup="dialog"
+                aria-expanded={helpOpen}
+                aria-controls="editor-help-dialog"
+                onClick={() => setHelpOpen(true)}
+              >
+                Help
+              </button>
+            </div>
+          </nav>
+          <a
+            className="analytics-link"
+            href="/analytics"
+            aria-label="Open visitor analytics"
+          >
+            {visitStats ? (
+              <>
+                <span>{visitStats.uv.toLocaleString()} visitors</span>
+                <span aria-hidden="true">·</span>
+                <span>{visitStats.pv.toLocaleString()} views</span>
+              </>
+            ) : (
+              "Analytics"
+            )}
+          </a>
         </div>
-        <nav
-          className="toolbar"
-          aria-label="Editor commands"
-          onClick={(event) => {
-            const target = event.target;
-            if (
-              target instanceof Element &&
-              target.closest(".command-popover button")
-            ) {
-              dismissOpenCommandMenus();
-            }
-          }}
-        >
-          {hasImportedHierarchy ? (
+        {hasImportedHierarchy ? (
+          <div className="toolbar-row" aria-label="Document hierarchy">
             <div
               className="document-nav"
               aria-label="Imported cell navigation"
@@ -4925,223 +5170,8 @@ export function App({ project: initialProject, visitStats }: AppProps) {
                 Enter Cell
               </button>
             </div>
-          ) : null}
-          <details className="command-menu" name="editor-command-menu">
-            <summary>Draw</summary>
-            <div className="command-popover">
-              <button type="button" onClick={openInsertComponentDialog}>
-                <ToolIcon name="insert" />
-                Insert component (I)
-              </button>
-              <button
-                type="button"
-                aria-pressed={tool === "wire"}
-                onClick={() => activateTool("wire")}
-              >
-                <ToolIcon name="wire" />
-                Wire (W)
-              </button>
-              <button type="button" aria-label="Text" onClick={addPlainText}>
-                <ToolIcon name="text" />
-                Text (T)
-              </button>
-              <button
-                type="button"
-                aria-pressed={tool === "arrow"}
-                onClick={() => activateTool("arrow")}
-              >
-                <ToolIcon name="arrow" />
-                Arrow (A)
-              </button>
-              <button
-                type="button"
-                aria-pressed={tool === "construction-line"}
-                onClick={() => activateTool("construction-line")}
-              >
-                <ToolIcon name="line" />
-                Construction line (P)
-              </button>
-              <button
-                type="button"
-                aria-pressed={tool === "rectangle"}
-                onClick={() => activateTool("rectangle")}
-              >
-                <ToolIcon name="rectangle" />
-                Rectangle (R)
-              </button>
-            </div>
-          </details>
-          <details className="command-menu" name="editor-command-menu">
-            <summary>File</summary>
-            <div className="command-popover">
-              <button type="button" onClick={saveProjectFile}>
-                Save Project
-              </button>
-              <label className="file-import">
-                Open Project
-                <input
-                  ref={projectInputRef}
-                  data-testid="project-file"
-                  type="file"
-                  accept=".json,.icproj.json,application/json"
-                  onChange={(event) =>
-                    void openProjectFile(event.currentTarget.files?.[0] ?? null)
-                  }
-                />
-              </label>
-              <label className="file-import">
-                Import SPICE
-                <input
-                  data-testid="spice-files"
-                  type="file"
-                  accept=".spi,.cir,.sp,.inc,.lib"
-                  multiple
-                  onChange={(event) =>
-                    void importSpiceFiles(event.currentTarget.files)
-                  }
-                />
-              </label>
-              <span className="command-group-label">Export</span>
-              <button type="button" aria-label="Export SVG" onClick={exportSvg}>
-                SVG
-              </button>
-              <button
-                type="button"
-                aria-label="Export PNG"
-                onClick={() => void exportRaster("png")}
-              >
-                PNG
-              </button>
-              <button
-                type="button"
-                aria-label="Export PDF"
-                onClick={() => void exportRaster("pdf")}
-              >
-                PDF
-              </button>
-              {recoveryCandidate ? (
-                <>
-                  <button type="button" onClick={restoreRecovery}>
-                    Restore recovery
-                  </button>
-                  <button type="button" onClick={discardRecovery}>
-                    Discard recovery
-                  </button>
-                </>
-              ) : null}
-            </div>
-          </details>
-          <details className="command-menu" name="editor-command-menu">
-            <summary>Edit</summary>
-            <div className="command-popover">
-              <button
-                type="button"
-                onClick={() => transact([{ kind: "undo" }])}
-                disabled={!canUndo}
-              >
-                Undo
-              </button>
-              <button
-                type="button"
-                onClick={() => transact([{ kind: "redo" }])}
-                disabled={!canRedo}
-              >
-                Redo
-              </button>
-              <button
-                type="button"
-                onClick={deleteSelection}
-                disabled={
-                  !hasVisualSelection(visualSelection) && !selectedEndpoint
-                }
-              >
-                Delete
-              </button>
-              <button
-                type="button"
-                onClick={() => rotateSelected()}
-                disabled={selectedIds.length === 0}
-              >
-                <ToolIcon name="rotate" />
-                Rotate
-              </button>
-              <button
-                type="button"
-                onClick={() => mirrorSelected("left-right")}
-                disabled={selectedIds.length === 0}
-              >
-                Mirror left/right (Shift+R)
-              </button>
-              <button
-                type="button"
-                onClick={() => mirrorSelected("top-bottom")}
-                disabled={selectedIds.length === 0}
-              >
-                Mirror top/bottom (Shift+V)
-              </button>
-              {selectedIds.length > 1 ? (
-                <button type="button" onClick={alignSelectedInstances}>
-                  Align
-                </button>
-              ) : null}
-            </div>
-          </details>
-          <details className="command-menu" name="editor-command-menu">
-            <summary>More</summary>
-            <div className="command-popover">
-              <span className="command-group-label">Guides</span>
-              <button type="button" onClick={() => addGuide("vertical")}>
-                Add vertical guide
-              </button>
-              <button type="button" onClick={() => addGuide("horizontal")}>
-                Add horizontal guide
-              </button>
-              <button type="button" onClick={toggleGuidesVisible}>
-                Show/hide guides
-              </button>
-              <button type="button" onClick={clearUnlockedGuides}>
-                Clear unlocked guides
-              </button>
-              <button type="button" onClick={() => activateTool("guide")}>
-                Guide tool (G)
-              </button>
-              <small>
-                I insert · C copy · R rotate · W wire · G guide · Home fit ·
-                wheel zoom · middle-drag pan · Enter finish
-              </small>
-            </div>
-          </details>
-          <button
-            type="button"
-            ref={helpButtonRef}
-            aria-haspopup="dialog"
-            aria-expanded={helpOpen}
-            aria-controls="editor-help-dialog"
-            onClick={() => setHelpOpen(true)}
-          >
-            Help
-          </button>
-        </nav>
-        <div className="editor-header-meta">
-          <p className="editor-status" data-testid="status" aria-live="polite">
-            {status}
-          </p>
-          <a
-            className="analytics-link"
-            href="/analytics"
-            aria-label="Open visitor analytics"
-          >
-            {visitStats ? (
-              <>
-                <span>{visitStats.uv.toLocaleString()} visitors</span>
-                <span aria-hidden="true">·</span>
-                <span>{visitStats.pv.toLocaleString()} views</span>
-              </>
-            ) : (
-              "Analytics"
-            )}
-          </a>
-        </div>
+          </div>
+        ) : null}
         <div data-testid="editor-test-telemetry" hidden>
           <output data-testid="selected-internal-route-count">
             {internalSelection.routeIds.length}
@@ -5184,1414 +5214,1510 @@ export function App({ project: initialProject, visitStats }: AppProps) {
         onApply={beginInsertedComponentPlacement}
         onCancel={cancelComponentInsert}
       />
-      <aside
-        className={selectionOpen ? "selection-dock open" : "selection-dock"}
-        aria-label="Properties"
-        role="complementary"
+      <div
+        className={
+          libraryPanelOpen ? "app-workspace" : "app-workspace library-collapsed"
+        }
       >
-        <section className="selection-shelf" aria-label="Selection">
+        <aside className="tool-rail" aria-label="Tool rail">
           <button
             type="button"
-            ref={selectionShelfRef}
-            className="selection-shelf-header"
-            data-testid="selection-shelf"
-            aria-expanded={selectionOpen}
-            onClick={() => {
-              setSelectionOpen((current) => !current);
-              if (selectionOpen) setImportReviewOpen(false);
-            }}
+            className="tool-rail-button"
+            title={
+              libraryPanelOpen
+                ? "Hide component library"
+                : "Show component library"
+            }
+            aria-pressed={libraryPanelOpen}
+            aria-controls="shapes-library-panel"
+            aria-expanded={libraryPanelOpen}
+            data-testid="library-toggle"
+            onClick={() => setLibraryPanelOpen((current) => !current)}
           >
-            <span className="selection-shelf-title">
-              <ToolIcon name="inspect" />
-              <span>Properties</span>
-            </span>
-            <span className="selection-shelf-summary">
-              {selectedIds.length > 0
-                ? selectedIds.join(", ")
-                : (selectedRouteId ??
-                  selectedAnnotationId ??
-                  selectedDraftingId ??
-                  "None")}
-              {hasInspectableSelection ? (
-                <span
-                  className="selection-shelf-indicator"
-                  aria-hidden="true"
-                />
-              ) : null}
-            </span>
+            <ToolIcon name="library" />
+            <span>Library</span>
           </button>
-          <div className="selection-panel" hidden={!selectionOpen}>
-            {!hasInspectableSelection ? (
-              <p className="inspect-empty">Select an object to inspect.</p>
-            ) : null}
-            {selectedIds.length > 1 ? (
-              <section className="selection-overview">
-                <span>Component group</span>
-                <h2>{selectedIds.length} components</h2>
-                <p>{selectedIds.join(", ")}</p>
-              </section>
-            ) : null}
-            {selectedInstance?.placement ? (
-              <section className="selection-overview">
-                <span>Component</span>
-                <h2>{selectedInstance.id}</h2>
-                <dl>
-                  <dt>Symbol</dt>
-                  <dd>{selectedInstance.symbolId}</dd>
-                </dl>
-              </section>
-            ) : null}
-            {selectedInstance ? (
-              <section
-                className="context-actions"
-                aria-label="Component properties"
-              >
-                <h2>Component properties</h2>
-                {componentParameters(selectedInstance.symbolId).map(
-                  (parameter, index) => (
-                    <label key={parameter.key} title={parameter.help}>
-                      <span className="property-parameter-name">
-                        {parameter.label}
-                        {parameter.unit ? ` / ${parameter.unit}` : ""}
-                        <em>({parameter.help})</em>
-                      </span>
-                      <input
-                        ref={index === 0 ? instanceValueInputRef : undefined}
-                        aria-label={`Component ${parameter.label.toLowerCase()}`}
-                        inputMode={parameter.inputMode}
-                        value={
-                          instancePropertyDraft.parameters[parameter.key] ?? ""
-                        }
-                        placeholder={parameter.placeholder}
-                        onChange={(event) => {
-                          const value = event.currentTarget.value;
-                          setInstancePropertyDraft((current) => ({
-                            ...current,
-                            parameters: {
-                              ...current.parameters,
-                              [parameter.key]: value,
-                            },
-                          }));
-                        }}
-                      />
-                    </label>
-                  ),
-                )}
-                {typeof selectedInstance.properties["spice.target"] ===
-                "string" ? (
-                  <p className="property-source-fact">
-                    Model: {selectedInstance.properties["spice.target"]}
-                  </p>
+          <button
+            type="button"
+            className="tool-rail-button"
+            aria-pressed={tool === "wire"}
+            title="Wire (W)"
+            onClick={() => activateTool("wire")}
+          >
+            <ToolIcon name="wire" />
+            <span>Wire</span>
+          </button>
+          <button
+            type="button"
+            className="tool-rail-button"
+            title="Text (T)"
+            aria-label="Text"
+            onClick={addPlainText}
+          >
+            <ToolIcon name="text" />
+            <span>Text</span>
+          </button>
+          <button
+            type="button"
+            className="tool-rail-button"
+            aria-pressed={tool === "arrow"}
+            title="Arrow (A)"
+            onClick={() => activateTool("arrow")}
+          >
+            <ToolIcon name="arrow" />
+            <span>Arrow</span>
+          </button>
+          <button
+            type="button"
+            className="tool-rail-button"
+            aria-pressed={tool === "construction-line"}
+            title="Construction line (P)"
+            onClick={() => activateTool("construction-line")}
+          >
+            <ToolIcon name="line" />
+            <span>Line</span>
+          </button>
+          <button
+            type="button"
+            className="tool-rail-button"
+            aria-pressed={tool === "rectangle"}
+            title="Rectangle"
+            onClick={() => activateTool("rectangle")}
+          >
+            <ToolIcon name="rectangle" />
+            <span>Rect</span>
+          </button>
+          <div className="tool-rail-divider" aria-hidden="true" />
+          <button
+            type="button"
+            className="tool-rail-button"
+            title="Guide tool (G)"
+            aria-pressed={tool === "guide"}
+            onClick={() => activateTool("guide")}
+          >
+            <ToolIcon name="guide" />
+            <span>Guide</span>
+          </button>
+        </aside>
+        <ShapesPanel
+          styleProfileId={document.presentation.styleProfileId}
+          recentSymbolIds={recentSymbolIds}
+          open={libraryPanelOpen}
+          onOpenInsert={openInsertComponentDialog}
+          onQuickPlace={beginInsertedComponentPlacement}
+        />
+        <aside
+          className={selectionOpen ? "selection-dock open" : "selection-dock"}
+          aria-label="Properties"
+          role="complementary"
+        >
+          <section className="selection-shelf" aria-label="Selection">
+            <button
+              type="button"
+              ref={selectionShelfRef}
+              className="selection-shelf-header"
+              data-testid="selection-shelf"
+              aria-expanded={selectionOpen}
+              onClick={() => {
+                setSelectionOpen((current) => !current);
+                if (selectionOpen) setImportReviewOpen(false);
+              }}
+            >
+              <span className="selection-shelf-title">
+                <ToolIcon name="inspect" />
+                <span>Properties</span>
+              </span>
+              <span className="selection-shelf-summary">
+                {selectedIds.length > 0
+                  ? selectedIds.join(", ")
+                  : (selectedRouteId ??
+                    selectedAnnotationId ??
+                    selectedDraftingId ??
+                    "None")}
+                {hasInspectableSelection ? (
+                  <span
+                    className="selection-shelf-indicator"
+                    aria-hidden="true"
+                  />
                 ) : null}
-                {selectedInstance.placement ? (
-                  <>
-                    <div
-                      className="component-geometry-row"
-                      aria-label="Component geometry"
-                    >
-                      <label>
-                        X
+              </span>
+            </button>
+            <div className="selection-panel" hidden={!selectionOpen}>
+              {!hasInspectableSelection ? (
+                <p className="inspect-empty">Select an object to inspect.</p>
+              ) : null}
+              {selectedIds.length > 1 ? (
+                <section className="selection-overview">
+                  <span>Component group</span>
+                  <h2>{selectedIds.length} components</h2>
+                  <p>{selectedIds.join(", ")}</p>
+                </section>
+              ) : null}
+              {selectedInstance?.placement ? (
+                <section className="selection-overview">
+                  <span>Component</span>
+                  <h2>{selectedInstance.id}</h2>
+                  <dl>
+                    <dt>Symbol</dt>
+                    <dd>{selectedInstance.symbolId}</dd>
+                  </dl>
+                </section>
+              ) : null}
+              {selectedInstance ? (
+                <section
+                  className="context-actions"
+                  aria-label="Component properties"
+                >
+                  <h2>Component properties</h2>
+                  {componentParameters(selectedInstance.symbolId).map(
+                    (parameter, index) => (
+                      <label key={parameter.key} title={parameter.help}>
+                        <span className="property-parameter-name">
+                          {parameter.label}
+                          {parameter.unit ? ` / ${parameter.unit}` : ""}
+                          <em>({parameter.help})</em>
+                        </span>
                         <input
-                          aria-label="Component X position"
-                          inputMode="decimal"
-                          value={instancePropertyDraft.x}
-                          onChange={(event) => {
-                            const x = event.currentTarget.value;
-                            setInstancePropertyDraft((current) => ({
-                              ...current,
-                              x,
-                            }));
-                          }}
-                        />
-                      </label>
-                      <label>
-                        Y
-                        <input
-                          aria-label="Component Y position"
-                          inputMode="decimal"
-                          value={instancePropertyDraft.y}
-                          onChange={(event) => {
-                            const y = event.currentTarget.value;
-                            setInstancePropertyDraft((current) => ({
-                              ...current,
-                              y,
-                            }));
-                          }}
-                        />
-                      </label>
-                      <label>
-                        Rotate
-                        <select
-                          aria-label="Component rotation"
-                          value={instancePropertyDraft.rotation}
-                          onChange={(event) => {
-                            const rotation = event.currentTarget.value as
-                              "0" | "90" | "180" | "270";
-                            setInstancePropertyDraft((current) => ({
-                              ...current,
-                              rotation,
-                            }));
-                          }}
-                        >
-                          <option value="0">0°</option>
-                          <option value="90">90°</option>
-                          <option value="180">180°</option>
-                          <option value="270">270°</option>
-                        </select>
-                      </label>
-                    </div>
-                    <div
-                      className="component-mirror-row"
-                      aria-label="Mirror component"
-                    >
-                      <button
-                        type="button"
-                        aria-label="Mirror component left to right, Shift+R"
-                        title="Mirror left/right (Shift+R)"
-                        onClick={() => mirrorSelected("left-right")}
-                      >
-                        ↔ Shift+R
-                      </button>
-                      <button
-                        type="button"
-                        aria-label="Mirror component top to bottom, Shift+V"
-                        title="Mirror top/bottom (Shift+V)"
-                        onClick={() => mirrorSelected("top-bottom")}
-                      >
-                        ↕ Shift+V
-                      </button>
-                    </div>
-                  </>
-                ) : null}
-                <button type="button" onClick={applyInstanceProperties}>
-                  Apply component properties
-                </button>
-                <button type="button" onClick={discardInstancePropertyDraft}>
-                  Cancel property edits
-                </button>
-              </section>
-            ) : null}
-            {selectedRoute ? (
-              <section className="selection-overview">
-                <span>Electrical route</span>
-                <h2>{selectedRoute.id}</h2>
-                <dl>
-                  <dt>Net</dt>
-                  <dd>
-                    {document.nets.find((net) => net.id === selectedRoute.netId)
-                      ?.name ?? selectedRoute.netId}
-                  </dd>
-                  <dt>Segment</dt>
-                  <dd>{(selectedRouteSegmentIndex ?? 0) + 1}</dd>
-                </dl>
-              </section>
-            ) : null}
-            {selectedAnnotation ? (
-              <section className="selection-overview">
-                <span>Annotation</span>
-                <h2>{selectedAnnotation.id}</h2>
-                <dl>
-                  <dt>Kind</dt>
-                  <dd>{selectedAnnotation.kind}</dd>
-                  <dt>Locked</dt>
-                  <dd>{selectedAnnotation.locked ? "Yes" : "No"}</dd>
-                </dl>
-              </section>
-            ) : null}
-            {selectedDrafting ? (
-              <section className="selection-overview">
-                <span>Drawing</span>
-                <h2>{selectedDrafting.id}</h2>
-                <dl>
-                  <dt>Kind</dt>
-                  <dd>{selectedDrafting.kind}</dd>
-                  <dt>Locked</dt>
-                  <dd>{selectedDrafting.locked ? "Yes" : "No"}</dd>
-                </dl>
-              </section>
-            ) : null}
-            {selectedDrafting
-              ? (() => {
-                  const geometry = resolveDraftingObjectGeometry(
-                    document,
-                    resolver,
-                    selectedDrafting,
-                  );
-                  if (
-                    geometry.kind !== "arrow" &&
-                    geometry.kind !== "construction-line" &&
-                    geometry.kind !== "rectangle"
-                  ) {
-                    return null;
-                  }
-                  const lineStyle =
-                    selectedDrafting.styleOverride?.lineStyle ??
-                    (selectedDrafting.kind === "construction-line" ||
-                    selectedDrafting.kind === "rectangle"
-                      ? selectedDrafting.lineStyle
-                      : "solid");
-                  const isRectangle = geometry.kind === "rectangle";
-                  const points = isRectangle
-                    ? geometry.corners
-                    : geometry.points;
-                  const curveControls = isRectangle
-                    ? points.slice(0, -1).map(() => null)
-                    : geometry.curveControls;
-                  const segmentIndex =
-                    draftingInspectorSegment?.objectId === selectedDrafting.id
-                      ? draftingInspectorSegment.index
-                      : Math.max(0, curveControls.findIndex(Boolean));
-                  const tangentAngle = isRectangle
-                    ? 0
-                    : quadraticTangentAngle(
-                        points[segmentIndex]!,
-                        curveControls[segmentIndex] ?? null,
-                        points[segmentIndex + 1]!,
-                      );
-                  const tangentInputKey = `${selectedDrafting.id}:${segmentIndex}`;
-                  const realizedAngleText = String(
-                    Math.round(tangentAngle * 10) / 10,
-                  );
-                  const tangentInputValue =
-                    draftingTangentInput?.key === tangentInputKey
-                      ? draftingTangentInput.value
-                      : realizedAngleText;
-                  const bearing = isRectangle
-                    ? geometry.rotation
-                    : normalizedBearing(points[0]!, points[1]!);
-                  const realizedBearingText = String(
-                    Math.round(bearing * 10) / 10,
-                  );
-                  const bearingInputValue =
-                    draftingBearingInput?.objectId === selectedDrafting.id
-                      ? draftingBearingInput.value
-                      : realizedBearingText;
-                  return (
-                    <section
-                      className="context-actions drawing-properties"
-                      aria-label="Drawing style"
-                      data-testid="drafting-properties"
-                    >
-                      <h2>Drawing style</h2>
-                      <label>
-                        Line style
-                        <select
-                          aria-label="Line style"
-                          value={lineStyle}
-                          disabled={selectedDrafting.locked}
-                          onChange={(event) =>
-                            setDraftingStyle({
-                              lineStyle: event.currentTarget.value as
-                                "solid" | "dashed" | "dotted",
-                            })
+                          ref={index === 0 ? instanceValueInputRef : undefined}
+                          aria-label={`Component ${parameter.label.toLowerCase()}`}
+                          inputMode={parameter.inputMode}
+                          value={
+                            instancePropertyDraft.parameters[parameter.key] ??
+                            ""
                           }
-                        >
-                          <option value="solid">Solid</option>
-                          <option value="dashed">Dashed</option>
-                          <option value="dotted">Dotted</option>
-                        </select>
-                      </label>
-                      <label>
-                        Stroke width
-                        <select
-                          aria-label="Stroke width"
-                          value={String(
-                            selectedDrafting.styleOverride?.strokeScale ?? 1,
-                          )}
-                          disabled={selectedDrafting.locked}
-                          onChange={(event) =>
-                            setDraftingStyle({
-                              strokeScale: Number(event.currentTarget.value) as
-                                0.75 | 1 | 1.5 | 2,
-                            })
-                          }
-                        >
-                          <option value="0.75">0.75×</option>
-                          <option value="1">1×</option>
-                          <option value="1.5">1.5×</option>
-                          <option value="2">2×</option>
-                        </select>
-                      </label>
-                      {selectedDrafting.kind === "construction-line" &&
-                      points.length > 2 ? (
-                        <label>
-                          Curve segment
-                          <select
-                            aria-label="Curve segment"
-                            value={String(segmentIndex)}
-                            disabled={selectedDrafting.locked}
-                            onChange={(event) => {
-                              setDraftingInspectorSegment({
-                                objectId: selectedDrafting.id,
-                                index: Number(event.currentTarget.value),
-                              });
-                              setDraftingTangentInput(null);
-                            }}
-                          >
-                            {points.slice(0, -1).map((_, index) => (
-                              <option key={index} value={index}>
-                                Segment {index + 1}
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                      ) : null}
-                      {!isRectangle ? (
-                        <label>
-                          Tangent angle (°)
-                          <input
-                            aria-label="Tangent angle"
-                            type="number"
-                            min="0"
-                            max="170"
-                            step="1"
-                            value={tangentInputValue}
-                            disabled={selectedDrafting.locked}
-                            placeholder={realizedAngleText}
-                            onFocus={() => {
-                              setDraftingTangentInput({
-                                key: tangentInputKey,
-                                value: "",
-                              });
-                            }}
-                            onChange={(event) => {
-                              const value = event.currentTarget.value;
-                              setDraftingTangentInput({
-                                key: tangentInputKey,
-                                value,
-                              });
-                              const angle = Number(value);
-                              if (value !== "" && Number.isFinite(angle)) {
-                                setDraftingTangentAngle(angle);
-                              }
-                            }}
-                            onBlur={() => setDraftingTangentInput(null)}
-                          />
-                        </label>
-                      ) : null}
-                      <label>
-                        Bearing (°)
-                        <input
-                          aria-label="Drawing bearing"
-                          type="number"
-                          min="0"
-                          max="359"
-                          step="1"
-                          value={bearingInputValue}
-                          disabled={selectedDrafting.locked}
-                          placeholder={realizedBearingText}
-                          onFocus={() =>
-                            setDraftingBearingInput({
-                              objectId: selectedDrafting.id,
-                              value: "",
-                            })
-                          }
+                          placeholder={parameter.placeholder}
                           onChange={(event) => {
                             const value = event.currentTarget.value;
-                            setDraftingBearingInput({
-                              objectId: selectedDrafting.id,
-                              value,
-                            });
-                            const bearing = Number(value);
-                            if (value !== "" && Number.isFinite(bearing)) {
-                              setDraftingBearing(bearing);
-                            }
+                            setInstancePropertyDraft((current) => ({
+                              ...current,
+                              parameters: {
+                                ...current.parameters,
+                                [parameter.key]: value,
+                              },
+                            }));
                           }}
-                          onBlur={() => setDraftingBearingInput(null)}
                         />
                       </label>
-                      {selectedDrafting.kind === "arrow" ? (
-                        <>
-                          <label>
-                            Arrow head
-                            <select
-                              aria-label="Arrow head"
-                              value={
-                                selectedDrafting.styleOverride?.arrowHead ??
-                                "filled"
-                              }
-                              disabled={selectedDrafting.locked}
-                              onChange={(event) =>
-                                setDraftingStyle({
-                                  arrowHead: event.currentTarget.value as
-                                    "none" | "filled" | "open",
-                                })
-                              }
-                            >
-                              <option value="none">No head</option>
-                              <option value="filled">Filled</option>
-                              <option value="open">Open</option>
-                            </select>
-                          </label>
-                          <label>
-                            Arrow head size
-                            <select
-                              aria-label="Arrow head size"
-                              value={String(
-                                selectedDrafting.styleOverride
-                                  ?.arrowHeadScale ?? 1,
-                              )}
-                              disabled={selectedDrafting.locked}
-                              onChange={(event) =>
-                                setDraftingStyle({
-                                  arrowHeadScale: Number(
-                                    event.currentTarget.value,
-                                  ) as 0.75 | 1 | 1.25 | 1.5,
-                                })
-                              }
-                            >
-                              <option value="0.75">0.75×</option>
-                              <option value="1">1×</option>
-                              <option value="1.25">1.25×</option>
-                              <option value="1.5">1.5×</option>
-                            </select>
-                          </label>
-                          <button
-                            type="button"
-                            disabled={selectedDrafting.locked}
-                            onClick={() => {
-                              const { from, to } = selectedDrafting;
-                              transact([
-                                {
-                                  kind: "upsert_drafting_object",
-                                  object: {
-                                    ...selectedDrafting,
-                                    from: to,
-                                    to: from,
-                                    waypoints: [
-                                      ...(selectedDrafting.waypoints ?? []),
-                                    ].reverse(),
-                                    curveControls: [
-                                      ...(selectedDrafting.curveControls ?? []),
-                                    ].reverse(),
-                                  },
-                                },
-                              ]);
+                    ),
+                  )}
+                  {typeof selectedInstance.properties["spice.target"] ===
+                  "string" ? (
+                    <p className="property-source-fact">
+                      Model: {selectedInstance.properties["spice.target"]}
+                    </p>
+                  ) : null}
+                  {selectedInstance.placement ? (
+                    <>
+                      <div
+                        className="component-geometry-row"
+                        aria-label="Component geometry"
+                      >
+                        <label>
+                          X
+                          <input
+                            aria-label="Component X position"
+                            inputMode="decimal"
+                            value={instancePropertyDraft.x}
+                            onChange={(event) => {
+                              const x = event.currentTarget.value;
+                              setInstancePropertyDraft((current) => ({
+                                ...current,
+                                x,
+                              }));
+                            }}
+                          />
+                        </label>
+                        <label>
+                          Y
+                          <input
+                            aria-label="Component Y position"
+                            inputMode="decimal"
+                            value={instancePropertyDraft.y}
+                            onChange={(event) => {
+                              const y = event.currentTarget.value;
+                              setInstancePropertyDraft((current) => ({
+                                ...current,
+                                y,
+                              }));
+                            }}
+                          />
+                        </label>
+                        <label>
+                          Rotate
+                          <select
+                            aria-label="Component rotation"
+                            value={instancePropertyDraft.rotation}
+                            onChange={(event) => {
+                              const rotation = event.currentTarget.value as
+                                "0" | "90" | "180" | "270";
+                              setInstancePropertyDraft((current) => ({
+                                ...current,
+                                rotation,
+                              }));
                             }}
                           >
-                            Reverse
-                          </button>
-                        </>
-                      ) : null}
-                      <button
-                        type="button"
-                        disabled={selectedDrafting.locked}
-                        onClick={() => rotateSelected()}
+                            <option value="0">0°</option>
+                            <option value="90">90°</option>
+                            <option value="180">180°</option>
+                            <option value="270">270°</option>
+                          </select>
+                        </label>
+                      </div>
+                      <div
+                        className="component-mirror-row"
+                        aria-label="Mirror component"
                       >
-                        <ToolIcon name="rotate" />
-                        Rotate
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => toggleDraftingLock(selectedDrafting)}
-                      >
-                        <ToolIcon name="lock" />
-                        {selectedDrafting.locked ? "Unlock" : "Lock"}
-                      </button>
-                    </section>
-                  );
-                })()
-              : null}
-            {unplaced.length > 0 ? <h3>Unplaced Instances</h3> : null}
-            {unplaced.map((instance) => (
-              <button
-                type="button"
-                draggable
-                data-testid={`unplaced-${instance.id}`}
-                key={instance.id}
-                onClick={() => {
-                  selectOnly("instance", [instance.id]);
-                  setStatus(`Selected ${instance.id}`);
-                }}
-                onDragStart={(event) => {
-                  event.dataTransfer.setData(
-                    "application/x-icm-instance",
-                    instance.id,
-                  );
-                  event.dataTransfer.effectAllowed = "move";
-                }}
-              >
-                {instance.id} · {instance.symbolId}
-              </button>
-            ))}
-            {unplacedPorts.length > 0 ? <h3>Unplaced Ports</h3> : null}
-            {unplacedPorts.map((port) => (
-              <button
-                type="button"
-                data-testid={`unplaced-port-${port.id}`}
-                key={port.id}
-                onClick={() => placePortAtViewCenter(port.id)}
-              >
-                Place {port.name}
-              </button>
-            ))}
-            {selectedInstance && selectedHiddenBulkNet ? (
-              <section
-                className="context-actions"
-                aria-label="Hidden MOS bulk warning"
-              >
-                <h2>Hidden bulk warning</h2>
-                <p>
-                  {selectedInstance.id}.B is electrically connected to{" "}
-                  {selectedHiddenBulkNet.name ?? selectedHiddenBulkNet.id}, but
-                  Razavi MOS stays in three-terminal display.
-                </p>
-              </section>
-            ) : null}
-            {selectedRouteId ? (
-              <section className="context-actions" aria-label="Route actions">
-                <h2>Route</h2>
-                <p>Segment {(selectedRouteSegmentIndex ?? 0) + 1} selected</p>
-                <label>
-                  Electrical Net label
-                  <input
-                    ref={netLabelPropertyInputRef}
-                    aria-label="Electrical Net label"
-                    value={netLabelDraft}
-                    onChange={(event) =>
-                      setNetLabelDraft(event.currentTarget.value)
+                        <button
+                          type="button"
+                          aria-label="Mirror component left to right, Shift+R"
+                          title="Mirror left/right (Shift+R)"
+                          onClick={() => mirrorSelected("left-right")}
+                        >
+                          ↔ Shift+R
+                        </button>
+                        <button
+                          type="button"
+                          aria-label="Mirror component top to bottom, Shift+V"
+                          title="Mirror top/bottom (Shift+V)"
+                          onClick={() => mirrorSelected("top-bottom")}
+                        >
+                          ↕ Shift+V
+                        </button>
+                      </div>
+                    </>
+                  ) : null}
+                  <button type="button" onClick={applyInstanceProperties}>
+                    Apply component properties
+                  </button>
+                  <button type="button" onClick={discardInstancePropertyDraft}>
+                    Cancel property edits
+                  </button>
+                </section>
+              ) : null}
+              {selectedRoute ? (
+                <section className="selection-overview">
+                  <span>Electrical route</span>
+                  <h2>{selectedRoute.id}</h2>
+                  <dl>
+                    <dt>Net</dt>
+                    <dd>
+                      {document.nets.find(
+                        (net) => net.id === selectedRoute.netId,
+                      )?.name ?? selectedRoute.netId}
+                    </dd>
+                    <dt>Segment</dt>
+                    <dd>{(selectedRouteSegmentIndex ?? 0) + 1}</dd>
+                  </dl>
+                </section>
+              ) : null}
+              {selectedAnnotation ? (
+                <section className="selection-overview">
+                  <span>Annotation</span>
+                  <h2>{selectedAnnotation.id}</h2>
+                  <dl>
+                    <dt>Kind</dt>
+                    <dd>{selectedAnnotation.kind}</dd>
+                    <dt>Locked</dt>
+                    <dd>{selectedAnnotation.locked ? "Yes" : "No"}</dd>
+                  </dl>
+                </section>
+              ) : null}
+              {selectedDrafting ? (
+                <section className="selection-overview">
+                  <span>Drawing</span>
+                  <h2>{selectedDrafting.id}</h2>
+                  <dl>
+                    <dt>Kind</dt>
+                    <dd>{selectedDrafting.kind}</dd>
+                    <dt>Locked</dt>
+                    <dd>{selectedDrafting.locked ? "Yes" : "No"}</dd>
+                  </dl>
+                </section>
+              ) : null}
+              {selectedDrafting
+                ? (() => {
+                    const geometry = resolveDraftingObjectGeometry(
+                      document,
+                      resolver,
+                      selectedDrafting,
+                    );
+                    if (
+                      geometry.kind !== "arrow" &&
+                      geometry.kind !== "construction-line" &&
+                      geometry.kind !== "rectangle"
+                    ) {
+                      return null;
                     }
-                  />
-                </label>
-                <button type="button" onClick={applyNetLabel}>
-                  Apply Net label
-                </button>
-                <button type="button" onClick={addCurrentArrow}>
-                  Add current arrow
-                </button>
-                <button type="button" onClick={deleteSelectedRouteConnection}>
-                  Delete wire
-                </button>
-              </section>
-            ) : null}
-            {selectedEndpoint &&
-            selectedEndpoint.endpoint.kind !== "junction" ? (
-              <section
-                className="context-actions"
-                aria-label="Endpoint actions"
-              >
-                <h2>Endpoint</h2>
+                    const lineStyle =
+                      selectedDrafting.styleOverride?.lineStyle ??
+                      (selectedDrafting.kind === "construction-line" ||
+                      selectedDrafting.kind === "rectangle"
+                        ? selectedDrafting.lineStyle
+                        : "solid");
+                    const isRectangle = geometry.kind === "rectangle";
+                    const points = isRectangle
+                      ? geometry.corners
+                      : geometry.points;
+                    const curveControls = isRectangle
+                      ? points.slice(0, -1).map(() => null)
+                      : geometry.curveControls;
+                    const segmentIndex =
+                      draftingInspectorSegment?.objectId === selectedDrafting.id
+                        ? draftingInspectorSegment.index
+                        : Math.max(0, curveControls.findIndex(Boolean));
+                    const tangentAngle = isRectangle
+                      ? 0
+                      : quadraticTangentAngle(
+                          points[segmentIndex]!,
+                          curveControls[segmentIndex] ?? null,
+                          points[segmentIndex + 1]!,
+                        );
+                    const tangentInputKey = `${selectedDrafting.id}:${segmentIndex}`;
+                    const realizedAngleText = String(
+                      Math.round(tangentAngle * 10) / 10,
+                    );
+                    const tangentInputValue =
+                      draftingTangentInput?.key === tangentInputKey
+                        ? draftingTangentInput.value
+                        : realizedAngleText;
+                    const bearing = isRectangle
+                      ? geometry.rotation
+                      : normalizedBearing(points[0]!, points[1]!);
+                    const realizedBearingText = String(
+                      Math.round(bearing * 10) / 10,
+                    );
+                    const bearingInputValue =
+                      draftingBearingInput?.objectId === selectedDrafting.id
+                        ? draftingBearingInput.value
+                        : realizedBearingText;
+                    return (
+                      <section
+                        className="context-actions drawing-properties"
+                        aria-label="Drawing style"
+                        data-testid="drafting-properties"
+                      >
+                        <h2>Drawing style</h2>
+                        <label>
+                          Line style
+                          <select
+                            aria-label="Line style"
+                            value={lineStyle}
+                            disabled={selectedDrafting.locked}
+                            onChange={(event) =>
+                              setDraftingStyle({
+                                lineStyle: event.currentTarget.value as
+                                  "solid" | "dashed" | "dotted",
+                              })
+                            }
+                          >
+                            <option value="solid">Solid</option>
+                            <option value="dashed">Dashed</option>
+                            <option value="dotted">Dotted</option>
+                          </select>
+                        </label>
+                        <label>
+                          Stroke width
+                          <select
+                            aria-label="Stroke width"
+                            value={String(
+                              selectedDrafting.styleOverride?.strokeScale ?? 1,
+                            )}
+                            disabled={selectedDrafting.locked}
+                            onChange={(event) =>
+                              setDraftingStyle({
+                                strokeScale: Number(
+                                  event.currentTarget.value,
+                                ) as 0.75 | 1 | 1.5 | 2,
+                              })
+                            }
+                          >
+                            <option value="0.75">0.75×</option>
+                            <option value="1">1×</option>
+                            <option value="1.5">1.5×</option>
+                            <option value="2">2×</option>
+                          </select>
+                        </label>
+                        {selectedDrafting.kind === "construction-line" &&
+                        points.length > 2 ? (
+                          <label>
+                            Curve segment
+                            <select
+                              aria-label="Curve segment"
+                              value={String(segmentIndex)}
+                              disabled={selectedDrafting.locked}
+                              onChange={(event) => {
+                                setDraftingInspectorSegment({
+                                  objectId: selectedDrafting.id,
+                                  index: Number(event.currentTarget.value),
+                                });
+                                setDraftingTangentInput(null);
+                              }}
+                            >
+                              {points.slice(0, -1).map((_, index) => (
+                                <option key={index} value={index}>
+                                  Segment {index + 1}
+                                </option>
+                              ))}
+                            </select>
+                          </label>
+                        ) : null}
+                        {!isRectangle ? (
+                          <label>
+                            Tangent angle (°)
+                            <input
+                              aria-label="Tangent angle"
+                              type="number"
+                              min="0"
+                              max="170"
+                              step="1"
+                              value={tangentInputValue}
+                              disabled={selectedDrafting.locked}
+                              placeholder={realizedAngleText}
+                              onFocus={() => {
+                                setDraftingTangentInput({
+                                  key: tangentInputKey,
+                                  value: "",
+                                });
+                              }}
+                              onChange={(event) => {
+                                const value = event.currentTarget.value;
+                                setDraftingTangentInput({
+                                  key: tangentInputKey,
+                                  value,
+                                });
+                                const angle = Number(value);
+                                if (value !== "" && Number.isFinite(angle)) {
+                                  setDraftingTangentAngle(angle);
+                                }
+                              }}
+                              onBlur={() => setDraftingTangentInput(null)}
+                            />
+                          </label>
+                        ) : null}
+                        <label>
+                          Bearing (°)
+                          <input
+                            aria-label="Drawing bearing"
+                            type="number"
+                            min="0"
+                            max="359"
+                            step="1"
+                            value={bearingInputValue}
+                            disabled={selectedDrafting.locked}
+                            placeholder={realizedBearingText}
+                            onFocus={() =>
+                              setDraftingBearingInput({
+                                objectId: selectedDrafting.id,
+                                value: "",
+                              })
+                            }
+                            onChange={(event) => {
+                              const value = event.currentTarget.value;
+                              setDraftingBearingInput({
+                                objectId: selectedDrafting.id,
+                                value,
+                              });
+                              const bearing = Number(value);
+                              if (value !== "" && Number.isFinite(bearing)) {
+                                setDraftingBearing(bearing);
+                              }
+                            }}
+                            onBlur={() => setDraftingBearingInput(null)}
+                          />
+                        </label>
+                        {selectedDrafting.kind === "arrow" ? (
+                          <>
+                            <label>
+                              Arrow head
+                              <select
+                                aria-label="Arrow head"
+                                value={
+                                  selectedDrafting.styleOverride?.arrowHead ??
+                                  "filled"
+                                }
+                                disabled={selectedDrafting.locked}
+                                onChange={(event) =>
+                                  setDraftingStyle({
+                                    arrowHead: event.currentTarget.value as
+                                      "none" | "filled" | "open",
+                                  })
+                                }
+                              >
+                                <option value="none">No head</option>
+                                <option value="filled">Filled</option>
+                                <option value="open">Open</option>
+                              </select>
+                            </label>
+                            <label>
+                              Arrow head size
+                              <select
+                                aria-label="Arrow head size"
+                                value={String(
+                                  selectedDrafting.styleOverride
+                                    ?.arrowHeadScale ?? 1,
+                                )}
+                                disabled={selectedDrafting.locked}
+                                onChange={(event) =>
+                                  setDraftingStyle({
+                                    arrowHeadScale: Number(
+                                      event.currentTarget.value,
+                                    ) as 0.75 | 1 | 1.25 | 1.5,
+                                  })
+                                }
+                              >
+                                <option value="0.75">0.75×</option>
+                                <option value="1">1×</option>
+                                <option value="1.25">1.25×</option>
+                                <option value="1.5">1.5×</option>
+                              </select>
+                            </label>
+                            <button
+                              type="button"
+                              disabled={selectedDrafting.locked}
+                              onClick={() => {
+                                const { from, to } = selectedDrafting;
+                                transact([
+                                  {
+                                    kind: "upsert_drafting_object",
+                                    object: {
+                                      ...selectedDrafting,
+                                      from: to,
+                                      to: from,
+                                      waypoints: [
+                                        ...(selectedDrafting.waypoints ?? []),
+                                      ].reverse(),
+                                      curveControls: [
+                                        ...(selectedDrafting.curveControls ??
+                                          []),
+                                      ].reverse(),
+                                    },
+                                  },
+                                ]);
+                              }}
+                            >
+                              Reverse
+                            </button>
+                          </>
+                        ) : null}
+                        <button
+                          type="button"
+                          disabled={selectedDrafting.locked}
+                          onClick={() => rotateSelected()}
+                        >
+                          <ToolIcon name="rotate" />
+                          Rotate
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => toggleDraftingLock(selectedDrafting)}
+                        >
+                          <ToolIcon name="lock" />
+                          {selectedDrafting.locked ? "Unlock" : "Lock"}
+                        </button>
+                      </section>
+                    );
+                  })()
+                : null}
+              {unplaced.length > 0 ? <h3>Unplaced Instances</h3> : null}
+              {unplaced.map((instance) => (
                 <button
                   type="button"
-                  onClick={() => disconnectSelectedEndpoint(false)}
+                  draggable
+                  data-testid={`unplaced-${instance.id}`}
+                  key={instance.id}
+                  onClick={() => {
+                    selectOnly("instance", [instance.id]);
+                    setStatus(`Selected ${instance.id}`);
+                  }}
+                  onDragStart={(event) => {
+                    event.dataTransfer.setData(
+                      "application/x-icm-instance",
+                      instance.id,
+                    );
+                    event.dataTransfer.effectAllowed = "move";
+                  }}
                 >
-                  Disconnect endpoint
+                  {instance.id} · {instance.symbolId}
                 </button>
+              ))}
+              {unplacedPorts.length > 0 ? <h3>Unplaced Ports</h3> : null}
+              {unplacedPorts.map((port) => (
                 <button
                   type="button"
-                  onClick={() => disconnectSelectedEndpoint(true)}
+                  data-testid={`unplaced-port-${port.id}`}
+                  key={port.id}
+                  onClick={() => placePortAtViewCenter(port.id)}
                 >
-                  Delete connection
+                  Place {port.name}
                 </button>
-                {selectedPortId ? (
+              ))}
+              {selectedInstance && selectedHiddenBulkNet ? (
+                <section
+                  className="context-actions"
+                  aria-label="Hidden MOS bulk warning"
+                >
+                  <h2>Hidden bulk warning</h2>
+                  <p>
+                    {selectedInstance.id}.B is electrically connected to{" "}
+                    {selectedHiddenBulkNet.name ?? selectedHiddenBulkNet.id},
+                    but Razavi MOS stays in three-terminal display.
+                  </p>
+                </section>
+              ) : null}
+              {selectedRouteId ? (
+                <section className="context-actions" aria-label="Route actions">
+                  <h2>Route</h2>
+                  <p>Segment {(selectedRouteSegmentIndex ?? 0) + 1} selected</p>
+                  <label>
+                    Electrical Net label
+                    <input
+                      ref={netLabelPropertyInputRef}
+                      aria-label="Electrical Net label"
+                      value={netLabelDraft}
+                      onChange={(event) =>
+                        setNetLabelDraft(event.currentTarget.value)
+                      }
+                    />
+                  </label>
+                  <button type="button" onClick={applyNetLabel}>
+                    Apply Net label
+                  </button>
+                  <button type="button" onClick={addCurrentArrow}>
+                    Add current arrow
+                  </button>
+                  <button type="button" onClick={deleteSelectedRouteConnection}>
+                    Delete wire
+                  </button>
+                </section>
+              ) : null}
+              {selectedEndpoint &&
+              selectedEndpoint.endpoint.kind !== "junction" ? (
+                <section
+                  className="context-actions"
+                  aria-label="Endpoint actions"
+                >
+                  <h2>Endpoint</h2>
                   <button
                     type="button"
-                    onClick={() => placePortAtViewCenter(selectedPortId)}
+                    onClick={() => disconnectSelectedEndpoint(false)}
                   >
-                    Move port to view center
+                    Disconnect endpoint
                   </button>
-                ) : null}
-              </section>
-            ) : null}
-            {selectedEndpoint?.endpoint.kind === "junction" ? (
-              <section
-                className="context-actions"
-                aria-label="Junction actions"
-              >
-                <h2>Junction</h2>
-                <button type="button" onClick={deleteSelectedJunction}>
-                  Delete junction and attached wires
+                  <button
+                    type="button"
+                    onClick={() => disconnectSelectedEndpoint(true)}
+                  >
+                    Delete connection
+                  </button>
+                  {selectedPortId ? (
+                    <button
+                      type="button"
+                      onClick={() => placePortAtViewCenter(selectedPortId)}
+                    >
+                      Move port to view center
+                    </button>
+                  ) : null}
+                </section>
+              ) : null}
+              {selectedEndpoint?.endpoint.kind === "junction" ? (
+                <section
+                  className="context-actions"
+                  aria-label="Junction actions"
+                >
+                  <h2>Junction</h2>
+                  <button type="button" onClick={deleteSelectedJunction}>
+                    Delete junction and attached wires
+                  </button>
+                </section>
+              ) : null}
+              {selectedAnnotation && isRoutedMarker(selectedAnnotation) ? (
+                <section
+                  className="context-actions"
+                  aria-label="Current arrow actions"
+                >
+                  <h2>Current arrow</h2>
+                  <button type="button" onClick={reverseSelectedCurrentArrow}>
+                    Reverse direction (X)
+                  </button>
+                  <small>Drag to slide along the wire or move its label.</small>
+                  <button type="button" onClick={deleteSelectedAnnotation}>
+                    Delete current arrow
+                  </button>
+                </section>
+              ) : null}
+              {importReviewOpen ? (
+                <section className="import-review" aria-label="Import Review">
+                  <h2>Import Review</h2>
+                  <SelectionInspectorDetails
+                    snapshot={{
+                      selected:
+                        selectedIds.length > 0
+                          ? selectedIds.join(", ")
+                          : (selectedRouteId ?? selectedAnnotationId ?? "None"),
+                      internalRouteCount: internalSelection.routeIds.length,
+                      revision: document.revision,
+                      sourceStatus: document.sourceStatus,
+                      documentCount: project.documents.length,
+                      activeDocumentId: document.id,
+                      activeInstanceCount: document.instances.length,
+                      projectInstanceCount,
+                      netCount: document.nets.length,
+                      tool,
+                      flightlineCount: flightlines.length,
+                      crossingCount: crossings.length,
+                      annotationCount: document.annotations.length,
+                      status,
+                    }}
+                    importDiagnostics={importDiagnostics}
+                    visualSummary={visualDiagnosticSummary}
+                    onSelectVisualDiagnostic={jumpToVisualDiagnostic}
+                  />
+                </section>
+              ) : null}
+            </div>
+          </section>
+        </aside>
+        <section className="canvas-panel">
+          {canvasIsEmpty &&
+          !pendingSymbolId &&
+          !insertDialogOpen &&
+          tool === "pointer" &&
+          !copyPlacement ? (
+            <div
+              className="canvas-empty-state"
+              data-testid="canvas-empty-state"
+            >
+              <p className="canvas-empty-kicker">New schematic</p>
+              <strong>Start from a shape or a file</strong>
+              <span>
+                Pick a starter on the left, open the full library, or import an
+                existing SPICE netlist.
+              </span>
+              <div className="canvas-empty-actions">
+                <button
+                  type="button"
+                  className="canvas-empty-primary"
+                  onClick={openInsertComponentDialog}
+                >
+                  Insert component
+                  <kbd>I</kbd>
                 </button>
-              </section>
-            ) : null}
-            {selectedAnnotation && isRoutedMarker(selectedAnnotation) ? (
-              <section
-                className="context-actions"
-                aria-label="Current arrow actions"
-              >
-                <h2>Current arrow</h2>
-                <button type="button" onClick={reverseSelectedCurrentArrow}>
-                  Reverse direction (X)
+                <button type="button" onClick={() => activateTool("wire")}>
+                  Draw wire
+                  <kbd>W</kbd>
                 </button>
-                <small>Drag to slide along the wire or move its label.</small>
-                <button type="button" onClick={deleteSelectedAnnotation}>
-                  Delete current arrow
+                <button
+                  type="button"
+                  onClick={() => spiceInputRef.current?.click()}
+                >
+                  Import SPICE
                 </button>
-              </section>
-            ) : null}
-            {importReviewOpen ? (
-              <section className="import-review" aria-label="Import Review">
-                <h2>Import Review</h2>
-                <SelectionInspectorDetails
-                  snapshot={{
-                    selected:
-                      selectedIds.length > 0
-                        ? selectedIds.join(", ")
-                        : (selectedRouteId ?? selectedAnnotationId ?? "None"),
-                    internalRouteCount: internalSelection.routeIds.length,
-                    revision: document.revision,
-                    sourceStatus: document.sourceStatus,
-                    documentCount: project.documents.length,
-                    activeDocumentId: document.id,
-                    activeInstanceCount: document.instances.length,
-                    projectInstanceCount,
-                    netCount: document.nets.length,
-                    tool,
-                    flightlineCount: flightlines.length,
-                    crossingCount: crossings.length,
-                    annotationCount: document.annotations.length,
-                    status,
-                  }}
-                  importDiagnostics={importDiagnostics}
-                  visualSummary={visualDiagnosticSummary}
-                  onSelectVisualDiagnostic={jumpToVisualDiagnostic}
-                />
-              </section>
-            ) : null}
-          </div>
-        </section>
-      </aside>
-      <section className="canvas-panel">
-        {canvasIsEmpty ? (
-          <div className="canvas-empty-state" data-testid="canvas-empty-state">
-            <strong>Start a schematic</strong>
-            <span>
-              Press <kbd>I</kbd> to insert a component or <kbd>W</kbd> to wire.
-            </span>
-          </div>
-        ) : null}
-        <svg
-          className={[
-            "schematic-canvas",
-            tool === "wire" ? "wire-mode" : "",
-            pendingSymbolId ? "component-mode" : "",
-            tool === "arrow" ||
-            tool === "construction-line" ||
-            tool === "rectangle"
-              ? "drawing-mode"
-              : "",
-            panPreview ? "pan-mode" : "",
-          ]
-            .filter(Boolean)
-            .join(" ")}
-          data-testid="schematic-canvas"
-          role="img"
-          aria-label="Schematic canvas"
-          viewBox={`${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}`}
-          onWheel={handleWheel}
-          onPointerDownCapture={(event) => {
-            const target = event.target as Element;
-            if (
-              selectedDrafting &&
-              (selectedDrafting.kind === "arrow" ||
-                selectedDrafting.kind === "construction-line" ||
-                selectedDrafting.kind === "rectangle") &&
-              !target.closest(
-                `[data-testid="drafting-hit-${selectedDrafting.id}"]`,
-              ) &&
-              !target.closest(
-                `[data-testid="drafting-handles-${selectedDrafting.id}"]`,
+              </div>
+            </div>
+          ) : null}
+          <svg
+            className={[
+              "schematic-canvas",
+              tool === "wire" ? "wire-mode" : "",
+              pendingSymbolId ? "component-mode" : "",
+              tool === "arrow" ||
+              tool === "construction-line" ||
+              tool === "rectangle"
+                ? "drawing-mode"
+                : "",
+              panPreview ? "pan-mode" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            data-testid="schematic-canvas"
+            role="img"
+            aria-label="Schematic canvas"
+            viewBox={`${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}`}
+            onWheel={handleWheel}
+            onPointerDownCapture={(event) => {
+              const target = event.target as Element;
+              if (
+                selectedDrafting &&
+                (selectedDrafting.kind === "arrow" ||
+                  selectedDrafting.kind === "construction-line" ||
+                  selectedDrafting.kind === "rectangle") &&
+                !target.closest(
+                  `[data-testid="drafting-hit-${selectedDrafting.id}"]`,
+                ) &&
+                !target.closest(
+                  `[data-testid="drafting-handles-${selectedDrafting.id}"]`,
+                )
+              ) {
+                replaceSelectionKind("drafting", []);
+              }
+              handleCanvasHitPointerDown(event);
+            }}
+            onPointerDown={beginCanvasGesture}
+            onPointerMove={continueCanvasGesture}
+            onPointerLeave={() => {
+              if (pendingSymbolId) setComponentPreviewPoint(null);
+              if (copyPlacement) setCopyPreviewPoint(null);
+            }}
+            onPointerUp={finishCanvasGesture}
+            onPointerCancel={finishCanvasGesture}
+            onClick={(event) => {
+              if (copyPlacement) {
+                const point = pointFromClient(
+                  event.clientX,
+                  event.clientY,
+                  event.currentTarget,
+                );
+                commitCopyPlacement({
+                  x: snapCoordinate(point.x, document.presentation.grid),
+                  y: snapCoordinate(point.y, document.presentation.grid),
+                });
+                return;
+              }
+              if (pendingSymbolId && pendingComponentPlacement) {
+                placeNewComponent(
+                  pendingSymbolId,
+                  pointFromClient(
+                    event.clientX,
+                    event.clientY,
+                    event.currentTarget,
+                  ),
+                  pendingComponentPlacement,
+                );
+                return;
+              }
+              const target = event.target as Element;
+              const onBackground =
+                target === event.currentTarget || target.tagName === "rect";
+              if (
+                (tool === "arrow" ||
+                  tool === "construction-line" ||
+                  tool === "rectangle") &&
+                event.detail === 1 &&
+                onBackground
+              ) {
+                handleDraftingCanvasClick(
+                  pointFromClient(
+                    event.clientX,
+                    event.clientY,
+                    event.currentTarget,
+                  ),
+                  event.altKey,
+                  event.shiftKey,
+                  logicalRadiusForPixels(
+                    event.currentTarget,
+                    SNAP_CAPTURE_RADIUS_PX,
+                  ),
+                );
+                return;
+              }
+              if (tool !== "wire" || event.detail !== 1) return;
+              applyWireCanvasPoint(
+                pointFromClient(
+                  event.clientX,
+                  event.clientY,
+                  event.currentTarget,
+                  false,
+                ),
+                event.currentTarget,
+                event.altKey,
+                false,
+              );
+            }}
+            onDoubleClick={(event) => {
+              const target = event.target as Element;
+              if (
+                tool === "arrow" ||
+                tool === "construction-line" ||
+                tool === "rectangle"
+              ) {
+                if (target !== event.currentTarget && target.tagName !== "rect")
+                  return;
+                finishDraftingCreate();
+                return;
+              }
+              if (
+                tool !== "wire" ||
+                (target !== event.currentTarget && target.tagName !== "rect")
               )
-            ) {
-              replaceSelectionKind("drafting", []);
-            }
-            handleCanvasHitPointerDown(event);
-          }}
-          onPointerDown={beginCanvasGesture}
-          onPointerMove={continueCanvasGesture}
-          onPointerLeave={() => {
-            if (pendingSymbolId) setComponentPreviewPoint(null);
-            if (copyPlacement) setCopyPreviewPoint(null);
-          }}
-          onPointerUp={finishCanvasGesture}
-          onPointerCancel={finishCanvasGesture}
-          onClick={(event) => {
-            if (copyPlacement) {
+                return;
               const point = pointFromClient(
                 event.clientX,
                 event.clientY,
                 event.currentTarget,
-              );
-              commitCopyPlacement({
-                x: snapCoordinate(point.x, document.presentation.grid),
-                y: snapCoordinate(point.y, document.presentation.grid),
-              });
-              return;
-            }
-            if (pendingSymbolId && pendingComponentPlacement) {
-              placeNewComponent(
-                pendingSymbolId,
-                pointFromClient(
-                  event.clientX,
-                  event.clientY,
-                  event.currentTarget,
-                ),
-                pendingComponentPlacement,
-              );
-              return;
-            }
-            const target = event.target as Element;
-            const onBackground =
-              target === event.currentTarget || target.tagName === "rect";
-            if (
-              (tool === "arrow" ||
-                tool === "construction-line" ||
-                tool === "rectangle") &&
-              event.detail === 1 &&
-              onBackground
-            ) {
-              handleDraftingCanvasClick(
-                pointFromClient(
-                  event.clientX,
-                  event.clientY,
-                  event.currentTarget,
-                ),
-                event.altKey,
-                event.shiftKey,
-                logicalRadiusForPixels(
-                  event.currentTarget,
-                  SNAP_CAPTURE_RADIUS_PX,
-                ),
-              );
-              return;
-            }
-            if (tool !== "wire" || event.detail !== 1) return;
-            applyWireCanvasPoint(
-              pointFromClient(
-                event.clientX,
-                event.clientY,
-                event.currentTarget,
                 false,
-              ),
-              event.currentTarget,
-              event.altKey,
-              false,
-            );
-          }}
-          onDoubleClick={(event) => {
-            const target = event.target as Element;
-            if (
-              tool === "arrow" ||
-              tool === "construction-line" ||
-              tool === "rectangle"
-            ) {
-              if (target !== event.currentTarget && target.tagName !== "rect")
+              );
+              const resolved = resolveWireCanvasSnap(
+                point,
+                event.currentTarget,
+                event.altKey,
+              );
+              if (
+                wireSource?.endpoint.kind === "junction" &&
+                wireSource.preludeEdits.some(
+                  (edit) => edit.kind === "add_junction" && edit.createNet,
+                ) &&
+                wireSource.point.x === resolved.point.x &&
+                wireSource.point.y === resolved.point.y
+              ) {
+                setStatus("Choose a different point to finish the wire");
                 return;
-              finishDraftingCreate();
-              return;
-            }
-            if (
-              tool !== "wire" ||
-              (target !== event.currentTarget && target.tagName !== "rect")
-            )
-              return;
-            const point = pointFromClient(
-              event.clientX,
-              event.clientY,
-              event.currentTarget,
-              false,
-            );
-            const resolved = resolveWireCanvasSnap(
-              point,
-              event.currentTarget,
-              event.altKey,
-            );
-            if (
-              wireSource?.endpoint.kind === "junction" &&
-              wireSource.preludeEdits.some(
-                (edit) => edit.kind === "add_junction" && edit.createNet,
-              ) &&
-              wireSource.point.x === resolved.point.x &&
-              wireSource.point.y === resolved.point.y
-            ) {
-              setStatus("Choose a different point to finish the wire");
-              return;
-            }
-            applyWireCanvasPoint(
-              point,
-              event.currentTarget,
-              event.altKey,
-              true,
-            );
-          }}
-          onContextMenu={(event) => {
-            event.preventDefault();
-            if (
-              tool === "arrow" ||
-              tool === "construction-line" ||
-              tool === "rectangle"
-            ) {
-              if (draftingSource !== null) {
-                clearDraftingCreate();
-                setStatus("Drawing cancelled");
               }
-              return;
-            }
-            if (wireSource) {
-              setWireSource(null);
-              setWirePreviewPoint(null);
-              setWireWaypoints([]);
-              setTool("pointer");
-              setStatus("Wire cancelled");
-            }
-          }}
-          onDragOver={(event) => event.preventDefault()}
-          onDrop={handleDrop}
-        >
-          <defs>
-            <pattern
-              id="grid"
-              width="10"
-              height="10"
-              patternUnits="userSpaceOnUse"
-            >
-              <circle cx="0" cy="0" r="0.7" fill="#d8d8d2" />
-            </pattern>
-          </defs>
-          <rect
-            x={viewBox.x}
-            y={viewBox.y}
-            width={viewBox.width}
-            height={viewBox.height}
-            fill="url(#grid)"
-          />
-          <g dangerouslySetInnerHTML={{ __html: scene.formalBody }} />
-          {copyPreviewScene ? (
-            <g
-              data-testid="copy-placement-preview"
-              className="copy-placement-preview"
-              dangerouslySetInnerHTML={{ __html: copyPreviewScene.formalBody }}
-            />
-          ) : null}
-          {tool === "wire" ? (
+              applyWireCanvasPoint(
+                point,
+                event.currentTarget,
+                event.altKey,
+                true,
+              );
+            }}
+            onContextMenu={(event) => {
+              event.preventDefault();
+              if (
+                tool === "arrow" ||
+                tool === "construction-line" ||
+                tool === "rectangle"
+              ) {
+                if (draftingSource !== null) {
+                  clearDraftingCreate();
+                  setStatus("Drawing cancelled");
+                }
+                return;
+              }
+              if (wireSource) {
+                setWireSource(null);
+                setWirePreviewPoint(null);
+                setWireWaypoints([]);
+                setTool("pointer");
+                setStatus("Wire cancelled");
+              }
+            }}
+            onDragOver={(event) => event.preventDefault()}
+            onDrop={handleDrop}
+          >
+            <defs>
+              <pattern
+                id="grid"
+                width="10"
+                height="10"
+                patternUnits="userSpaceOnUse"
+              >
+                <circle cx="0" cy="0" r="0.7" fill="#d8d8d2" />
+              </pattern>
+            </defs>
             <rect
-              data-testid="wire-input-plane"
-              className="wire-input-plane"
               x={viewBox.x}
               y={viewBox.y}
               width={viewBox.width}
               height={viewBox.height}
+              fill="url(#grid)"
             />
-          ) : null}
-          {pendingSymbolId || copyPlacement ? (
-            <rect
-              data-testid={
-                copyPlacement
-                  ? "copy-placement-input-plane"
-                  : "component-input-plane"
-              }
-              className="component-input-plane"
-              x={viewBox.x}
-              y={viewBox.y}
-              width={viewBox.width}
-              height={viewBox.height}
-            />
-          ) : null}
-          <g data-layer="editor-overlay">
-            {pendingSymbolId && componentPreviewPoint ? (
-              <ComponentPlacementPreview
-                styleProfileId={document.presentation.styleProfileId}
-                symbolId={pendingSymbolId}
-                position={componentPreviewPoint}
-                rotation={componentPlacementRotation}
+            <g dangerouslySetInnerHTML={{ __html: scene.formalBody }} />
+            {copyPreviewScene ? (
+              <g
+                data-testid="copy-placement-preview"
+                className="copy-placement-preview"
+                dangerouslySetInnerHTML={{
+                  __html: copyPreviewScene.formalBody,
+                }}
               />
             ) : null}
-            {netLabelEditorOpen && selectedRoute
-              ? (() => {
-                  const polyline = routePolyline(
-                    document,
-                    resolver,
-                    selectedRoute,
-                  );
-                  if (!polyline) return null;
+            {tool === "wire" ? (
+              <rect
+                data-testid="wire-input-plane"
+                className="wire-input-plane"
+                x={viewBox.x}
+                y={viewBox.y}
+                width={viewBox.width}
+                height={viewBox.height}
+              />
+            ) : null}
+            {pendingSymbolId || copyPlacement ? (
+              <rect
+                data-testid={
+                  copyPlacement
+                    ? "copy-placement-input-plane"
+                    : "component-input-plane"
+                }
+                className="component-input-plane"
+                x={viewBox.x}
+                y={viewBox.y}
+                width={viewBox.width}
+                height={viewBox.height}
+              />
+            ) : null}
+            <g data-layer="editor-overlay">
+              {pendingSymbolId && componentPreviewPoint ? (
+                <ComponentPlacementPreview
+                  styleProfileId={document.presentation.styleProfileId}
+                  symbolId={pendingSymbolId}
+                  position={componentPreviewPoint}
+                  rotation={componentPlacementRotation}
+                />
+              ) : null}
+              {netLabelEditorOpen && selectedRoute
+                ? (() => {
+                    const polyline = routePolyline(
+                      document,
+                      resolver,
+                      selectedRoute,
+                    );
+                    if (!polyline) return null;
+                    const segmentIndex = Math.min(
+                      selectedRouteSegmentIndex ?? 0,
+                      polyline.points.length - 2,
+                    );
+                    const from = polyline.points[segmentIndex]!;
+                    const to = polyline.points[segmentIndex + 1]!;
+                    const x = Math.round((from.x + to.x) / 2 - 58);
+                    const y = Math.round((from.y + to.y) / 2 - 34);
+                    return (
+                      <foreignObject
+                        data-testid="net-label-editor"
+                        x={x}
+                        y={y}
+                        width="116"
+                        height="32"
+                      >
+                        <form
+                          className="net-label-editor"
+                          onPointerDown={(event) => event.stopPropagation()}
+                          onSubmit={(event) => {
+                            event.preventDefault();
+                            commitNetLabelEditing();
+                          }}
+                        >
+                          <input
+                            ref={netLabelEditorInputRef}
+                            aria-label="Net Label"
+                            value={netLabelDraft}
+                            onChange={(event) =>
+                              setNetLabelDraft(event.currentTarget.value)
+                            }
+                            onKeyDown={(event) => {
+                              if (event.key === "Escape") {
+                                event.preventDefault();
+                                setNetLabelEditorOpen(false);
+                              }
+                            }}
+                          />
+                        </form>
+                      </foreignObject>
+                    );
+                  })()
+                : null}
+              {displayedFlightlines.map((flightline) => (
+                <g key={flightline.id}>
+                  <line
+                    data-testid="flightline-hit"
+                    className="flightline-hit"
+                    data-net-id={flightline.netId}
+                    x1={flightline.fromPoint.x}
+                    y1={flightline.fromPoint.y}
+                    x2={flightline.toPoint.x}
+                    y2={flightline.toPoint.y}
+                    onClick={(event) => handleFlightline(event, flightline)}
+                  />
+                  <line
+                    data-testid="flightline"
+                    className="flightline"
+                    data-net-id={flightline.netId}
+                    x1={flightline.fromPoint.x}
+                    y1={flightline.fromPoint.y}
+                    x2={flightline.toPoint.x}
+                    y2={flightline.toPoint.y}
+                  />
+                </g>
+              ))}
+              {wireDraftPoints.length >= 2 ? (
+                <polyline
+                  data-testid="wire-preview"
+                  className="wire-preview"
+                  points={serializePolylinePoints(wireDraftPoints)}
+                />
+              ) : null}
+              {(document.drafting?.guides ?? [])
+                .filter((guide) => guide.visible)
+                .map((guide) => (
+                  <g key={guide.id}>
+                    <line
+                      className="guide-hit"
+                      x1={
+                        guide.axis === "vertical" ? guide.coordinate : viewBox.x
+                      }
+                      y1={
+                        guide.axis === "horizontal"
+                          ? guide.coordinate
+                          : viewBox.y
+                      }
+                      x2={
+                        guide.axis === "vertical"
+                          ? guide.coordinate
+                          : viewBox.x + viewBox.width
+                      }
+                      y2={
+                        guide.axis === "horizontal"
+                          ? guide.coordinate
+                          : viewBox.y + viewBox.height
+                      }
+                      onPointerDown={(event) => {
+                        const visual = event.currentTarget
+                          .nextElementSibling as SVGLineElement | null;
+                        if (visual) beginGuideDrag(event, guide, visual);
+                      }}
+                      pointerEvents={tool === "wire" ? "none" : undefined}
+                      onDoubleClick={() => toggleGuideLock(guide.id)}
+                    />
+                    <line
+                      data-testid={`guide-${guide.id}`}
+                      className={guide.locked ? "guide guide-locked" : "guide"}
+                      x1={
+                        guide.axis === "vertical" ? guide.coordinate : viewBox.x
+                      }
+                      y1={
+                        guide.axis === "horizontal"
+                          ? guide.coordinate
+                          : viewBox.y
+                      }
+                      x2={
+                        guide.axis === "vertical"
+                          ? guide.coordinate
+                          : viewBox.x + viewBox.width
+                      }
+                      y2={
+                        guide.axis === "horizontal"
+                          ? guide.coordinate
+                          : viewBox.y + viewBox.height
+                      }
+                      pointerEvents="none"
+                      onKeyDown={(event) => {
+                        if (
+                          event.key === "Delete" ||
+                          event.key === "Backspace"
+                        ) {
+                          event.stopPropagation();
+                          deleteGuide(guide.id);
+                        }
+                      }}
+                      tabIndex={0}
+                    />
+                  </g>
+                ))}
+              <g ref={snapGuideLayerRef} data-layer="snap-guides" />
+              {routePolylines
+                .filter(({ route }) => route.id === selectedRouteId)
+                .map(({ route, polyline }) => {
                   const segmentIndex = Math.min(
                     selectedRouteSegmentIndex ?? 0,
                     polyline.points.length - 2,
                   );
                   const from = polyline.points[segmentIndex]!;
                   const to = polyline.points[segmentIndex + 1]!;
-                  const x = Math.round((from.x + to.x) / 2 - 58);
-                  const y = Math.round((from.y + to.y) / 2 - 34);
-                  return (
-                    <foreignObject
-                      data-testid="net-label-editor"
-                      x={x}
-                      y={y}
-                      width="116"
-                      height="32"
-                    >
-                      <form
-                        className="net-label-editor"
-                        onPointerDown={(event) => event.stopPropagation()}
-                        onSubmit={(event) => {
-                          event.preventDefault();
-                          commitNetLabelEditing();
-                        }}
-                      >
-                        <input
-                          ref={netLabelEditorInputRef}
-                          aria-label="Net Label"
-                          value={netLabelDraft}
-                          onChange={(event) =>
-                            setNetLabelDraft(event.currentTarget.value)
-                          }
-                          onKeyDown={(event) => {
-                            if (event.key === "Escape") {
-                              event.preventDefault();
-                              setNetLabelEditorOpen(false);
-                            }
-                          }}
-                        />
-                      </form>
-                    </foreignObject>
+                  const translatesWholeRoute =
+                    looseRouteAnchorIds(document, route) !== null;
+                  const routeCenter = centerOfBounds(
+                    polylineBounds(polyline.points),
                   );
-                })()
-              : null}
-            {displayedFlightlines.map((flightline) => (
-              <g key={flightline.id}>
-                <line
-                  data-testid="flightline-hit"
-                  className="flightline-hit"
-                  data-net-id={flightline.netId}
-                  x1={flightline.fromPoint.x}
-                  y1={flightline.fromPoint.y}
-                  x2={flightline.toPoint.x}
-                  y2={flightline.toPoint.y}
-                  onClick={(event) => handleFlightline(event, flightline)}
-                />
-                <line
-                  data-testid="flightline"
-                  className="flightline"
-                  data-net-id={flightline.netId}
-                  x1={flightline.fromPoint.x}
-                  y1={flightline.fromPoint.y}
-                  x2={flightline.toPoint.x}
-                  y2={flightline.toPoint.y}
-                />
-              </g>
-            ))}
-            {wireDraftPoints.length >= 2 ? (
-              <polyline
-                data-testid="wire-preview"
-                className="wire-preview"
-                points={serializePolylinePoints(wireDraftPoints)}
-              />
-            ) : null}
-            {(document.drafting?.guides ?? [])
-              .filter((guide) => guide.visible)
-              .map((guide) => (
-                <g key={guide.id}>
-                  <line
-                    className="guide-hit"
-                    x1={
-                      guide.axis === "vertical" ? guide.coordinate : viewBox.x
-                    }
-                    y1={
-                      guide.axis === "horizontal" ? guide.coordinate : viewBox.y
-                    }
-                    x2={
-                      guide.axis === "vertical"
-                        ? guide.coordinate
-                        : viewBox.x + viewBox.width
-                    }
-                    y2={
-                      guide.axis === "horizontal"
-                        ? guide.coordinate
-                        : viewBox.y + viewBox.height
-                    }
-                    onPointerDown={(event) => {
-                      const visual = event.currentTarget
-                        .nextElementSibling as SVGLineElement | null;
-                      if (visual) beginGuideDrag(event, guide, visual);
-                    }}
-                    pointerEvents={tool === "wire" ? "none" : undefined}
-                    onDoubleClick={() => toggleGuideLock(guide.id)}
-                  />
-                  <line
-                    data-testid={`guide-${guide.id}`}
-                    className={guide.locked ? "guide guide-locked" : "guide"}
-                    x1={
-                      guide.axis === "vertical" ? guide.coordinate : viewBox.x
-                    }
-                    y1={
-                      guide.axis === "horizontal" ? guide.coordinate : viewBox.y
-                    }
-                    x2={
-                      guide.axis === "vertical"
-                        ? guide.coordinate
-                        : viewBox.x + viewBox.width
-                    }
-                    y2={
-                      guide.axis === "horizontal"
-                        ? guide.coordinate
-                        : viewBox.y + viewBox.height
-                    }
-                    pointerEvents="none"
-                    onKeyDown={(event) => {
-                      if (event.key === "Delete" || event.key === "Backspace") {
+                  const preview =
+                    routeStretchPreview?.routeId === route.id
+                      ? routeStretchPreview.point
+                      : null;
+                  return (
+                    <circle
+                      key={`handle-${route.id}`}
+                      data-testid={`route-handle-${route.id}`}
+                      data-canvas-hit-kind="handle"
+                      data-canvas-hit-id={`route-handle-${route.id}`}
+                      className="route-handle"
+                      cx={
+                        translatesWholeRoute
+                          ? (preview?.x ?? routeCenter.x)
+                          : from.y === to.y
+                            ? (from.x + to.x) / 2
+                            : (preview?.x ?? (from.x + to.x) / 2)
+                      }
+                      cy={
+                        translatesWholeRoute
+                          ? (preview?.y ?? routeCenter.y)
+                          : from.x === to.x
+                            ? (from.y + to.y) / 2
+                            : (preview?.y ?? (from.y + to.y) / 2)
+                      }
+                      r="6"
+                      onPointerDown={(event) => {
+                        const primaryInstanceId = selectedIds.at(-1);
+                        if (
+                          primaryInstanceId &&
+                          compositeSelectionOwnsHit("route", route.id)
+                        ) {
+                          beginMove(event, primaryInstanceId);
+                          return;
+                        }
+                        beginRouteStretch(
+                          event,
+                          route.id,
+                          segmentIndex,
+                          translatesWholeRoute ? "translate" : "segment",
+                        );
+                      }}
+                      pointerEvents={tool === "wire" ? "none" : undefined}
+                    />
+                  );
+                })}
+              {document.instances
+                .filter((instance) => instance.placement !== null)
+                .map((instance) => {
+                  const hitBox = instanceHitBox(instance, resolver);
+                  if (!hitBox) return null;
+                  const childDocumentId = referencedDocumentId(
+                    project,
+                    instance,
+                  );
+                  return (
+                    <rect
+                      key={instance.id}
+                      data-testid={`hit-${instance.id}`}
+                      data-canvas-hit-kind="instance"
+                      data-canvas-hit-id={instance.id}
+                      data-drag-object-id={instance.id}
+                      {...hitBox}
+                      className={
+                        selectedIds.includes(instance.id)
+                          ? "hit-target selected"
+                          : "hit-target"
+                      }
+                      onClick={(event) => {
                         event.stopPropagation();
-                        deleteGuide(guide.id);
-                      }
-                    }}
-                    tabIndex={0}
-                  />
-                </g>
-              ))}
-            <g ref={snapGuideLayerRef} data-layer="snap-guides" />
-            {routePolylines
-              .filter(({ route }) => route.id === selectedRouteId)
-              .map(({ route, polyline }) => {
-                const segmentIndex = Math.min(
-                  selectedRouteSegmentIndex ?? 0,
-                  polyline.points.length - 2,
+                        if (suppressInstanceClick.current) {
+                          suppressInstanceClick.current = false;
+                          return;
+                        }
+                        selectInstance(
+                          instance.id,
+                          event.shiftKey || event.ctrlKey,
+                        );
+                      }}
+                      onDoubleClick={(event) => {
+                        event.stopPropagation();
+                        // Hierarchical cells still descend on double-click;
+                        // ordinary devices open the property editor (same as Q).
+                        if (childDocumentId) {
+                          enterHierarchy(instance.id);
+                          return;
+                        }
+                        inspectInstance(instance.id);
+                      }}
+                      onPointerDown={(event) => beginMove(event, instance.id)}
+                      pointerEvents={tool === "wire" ? "none" : undefined}
+                    />
+                  );
+                })}
+              {document.instances.map((instance) => {
+                if (
+                  document.annotations.some(
+                    (annotation) =>
+                      annotation.kind === "instance-label" &&
+                      annotation.attachedObjectId === instance.id,
+                  )
+                ) {
+                  return null;
+                }
+                const label = defaultInstanceLabel(
+                  document,
+                  instance,
+                  resolver,
+                  styleProfile,
                 );
-                const from = polyline.points[segmentIndex]!;
-                const to = polyline.points[segmentIndex + 1]!;
-                const translatesWholeRoute =
-                  looseRouteAnchorIds(document, route) !== null;
-                const routeCenter = centerOfBounds(
-                  polylineBounds(polyline.points),
-                );
-                const preview =
-                  routeStretchPreview?.routeId === route.id
-                    ? routeStretchPreview.point
-                    : null;
-                return (
-                  <circle
-                    key={`handle-${route.id}`}
-                    data-testid={`route-handle-${route.id}`}
-                    data-canvas-hit-kind="handle"
-                    data-canvas-hit-id={`route-handle-${route.id}`}
-                    className="route-handle"
-                    cx={
-                      translatesWholeRoute
-                        ? (preview?.x ?? routeCenter.x)
-                        : from.y === to.y
-                          ? (from.x + to.x) / 2
-                          : (preview?.x ?? (from.x + to.x) / 2)
-                    }
-                    cy={
-                      translatesWholeRoute
-                        ? (preview?.y ?? routeCenter.y)
-                        : from.x === to.x
-                          ? (from.y + to.y) / 2
-                          : (preview?.y ?? (from.y + to.y) / 2)
-                    }
-                    r="6"
-                    onPointerDown={(event) => {
-                      const primaryInstanceId = selectedIds.at(-1);
-                      if (
-                        primaryInstanceId &&
-                        compositeSelectionOwnsHit("route", route.id)
-                      ) {
-                        beginMove(event, primaryInstanceId);
-                        return;
-                      }
-                      beginRouteStretch(
-                        event,
-                        route.id,
-                        segmentIndex,
-                        translatesWholeRoute ? "translate" : "segment",
-                      );
-                    }}
-                    pointerEvents={tool === "wire" ? "none" : undefined}
-                  />
-                );
-              })}
-            {document.instances
-              .filter((instance) => instance.placement !== null)
-              .map((instance) => {
-                const hitBox = instanceHitBox(instance, resolver);
-                if (!hitBox) return null;
-                const childDocumentId = referencedDocumentId(project, instance);
+                if (!label) return null;
                 return (
                   <rect
-                    key={instance.id}
-                    data-testid={`hit-${instance.id}`}
-                    data-canvas-hit-kind="instance"
+                    key={`default-label-hit-${instance.id}`}
+                    data-testid={`default-label-hit-${instance.id}`}
+                    data-canvas-hit-kind="instance-label"
                     data-canvas-hit-id={instance.id}
                     data-drag-object-id={instance.id}
-                    {...hitBox}
-                    className={
-                      selectedIds.includes(instance.id)
-                        ? "hit-target selected"
-                        : "hit-target"
+                    className="annotation-hit"
+                    {...annotationHitBox(
+                      label,
+                      label.position,
+                      routePolylines,
+                      styleProfile,
+                    )}
+                    onClick={(event) => event.stopPropagation()}
+                    onPointerDown={(event) =>
+                      selectDefaultInstanceLabel(event, instance)
                     }
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      if (suppressInstanceClick.current) {
-                        suppressInstanceClick.current = false;
-                        return;
-                      }
-                      selectInstance(
-                        instance.id,
-                        event.shiftKey || event.ctrlKey,
-                      );
-                    }}
-                    onDoubleClick={
-                      childDocumentId
-                        ? (event) => {
-                            event.stopPropagation();
-                            enterHierarchy(instance.id);
-                          }
-                        : undefined
+                    onDoubleClick={(event) =>
+                      editDefaultInstanceLabel(event, instance)
                     }
-                    onPointerDown={(event) => beginMove(event, instance.id)}
                     pointerEvents={tool === "wire" ? "none" : undefined}
                   />
                 );
               })}
-            {document.instances.map((instance) => {
-              if (
-                document.annotations.some(
-                  (annotation) =>
-                    annotation.kind === "instance-label" &&
-                    annotation.attachedObjectId === instance.id,
-                )
-              ) {
-                return null;
-              }
-              const label = defaultInstanceLabel(
-                document,
-                instance,
-                resolver,
-                styleProfile,
-              );
-              if (!label) return null;
-              return (
-                <rect
-                  key={`default-label-hit-${instance.id}`}
-                  data-testid={`default-label-hit-${instance.id}`}
-                  data-canvas-hit-kind="instance-label"
-                  data-canvas-hit-id={instance.id}
-                  data-drag-object-id={instance.id}
-                  className="annotation-hit"
-                  {...annotationHitBox(
-                    label,
-                    label.position,
-                    routePolylines,
-                    styleProfile,
-                  )}
-                  onClick={(event) => event.stopPropagation()}
+              {routePolylines.map(({ route, polyline }) => (
+                <polyline
+                  key={route.id}
+                  data-testid={`route-hit-${route.id}`}
+                  data-canvas-hit-kind="route"
+                  data-canvas-hit-id={route.id}
+                  data-drag-object-id={route.id}
+                  className={
+                    selectedRouteId === route.id ||
+                    supplementalSelection.routeIds.includes(route.id) ||
+                    selectedInternalRouteIds.has(route.id)
+                      ? "route-hit selected"
+                      : "route-hit"
+                  }
+                  points={serializePolylinePoints(polyline.points)}
                   onPointerDown={(event) =>
-                    selectDefaultInstanceLabel(event, instance)
+                    handleRoutePointerDown(event, route.id)
                   }
-                  onDoubleClick={(event) =>
-                    editDefaultInstanceLabel(event, instance)
-                  }
-                  pointerEvents={tool === "wire" ? "none" : undefined}
+                  onClick={(event) => event.stopPropagation()}
                 />
-              );
-            })}
-            {routePolylines.map(({ route, polyline }) => (
-              <polyline
-                key={route.id}
-                data-testid={`route-hit-${route.id}`}
-                data-canvas-hit-kind="route"
-                data-canvas-hit-id={route.id}
-                data-drag-object-id={route.id}
-                className={
-                  selectedRouteId === route.id ||
-                  supplementalSelection.routeIds.includes(route.id) ||
-                  selectedInternalRouteIds.has(route.id)
-                    ? "route-hit selected"
-                    : "route-hit"
-                }
-                points={serializePolylinePoints(polyline.points)}
-                onPointerDown={(event) =>
-                  handleRoutePointerDown(event, route.id)
-                }
-                onClick={(event) => event.stopPropagation()}
-              />
-            ))}
-            {visibleEndpoints.map((candidate) => (
-              <circle
-                key={`${candidate.netId}:${endpointTestId(candidate.endpoint)}`}
-                data-testid={endpointTestId(candidate.endpoint)}
-                data-canvas-hit-kind={
-                  candidate.endpoint.kind === "junction"
-                    ? "junction"
-                    : undefined
-                }
-                data-canvas-hit-id={
-                  candidate.endpoint.kind === "junction"
-                    ? candidate.endpoint.junctionId
-                    : undefined
-                }
-                data-drag-object-id={
-                  candidate.endpoint.kind === "junction"
-                    ? candidate.endpoint.junctionId
-                    : undefined
-                }
-                className={
-                  tool === "wire" ||
-                  (candidate.endpoint.kind === "junction" &&
-                    supplementalSelection.junctionIds.includes(
-                      candidate.endpoint.junctionId,
-                    )) ||
-                  (selectedEndpoint?.endpoint.kind === "junction" &&
-                    candidate.endpoint.kind === "junction" &&
-                    selectedEndpoint.endpoint.junctionId ===
-                      candidate.endpoint.junctionId)
-                    ? "endpoint-hit active"
-                    : "endpoint-hit"
-                }
-                cx={candidate.point.x}
-                cy={candidate.point.y}
-                r={4}
-                onClick={(event) => event.stopPropagation()}
-                onContextMenu={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  selectEndpoint(candidate);
-                  setStatus(
-                    `Endpoint actions: ${endpointTestId(candidate.endpoint)}`,
-                  );
-                }}
-                onPointerDown={(event) => {
-                  if (
-                    tool === "pointer" &&
+              ))}
+              {visibleEndpoints.map((candidate) => (
+                <circle
+                  key={`${candidate.netId}:${endpointTestId(candidate.endpoint)}`}
+                  data-testid={endpointTestId(candidate.endpoint)}
+                  data-canvas-hit-kind={
                     candidate.endpoint.kind === "junction"
-                  ) {
+                      ? "junction"
+                      : undefined
+                  }
+                  data-canvas-hit-id={
+                    candidate.endpoint.kind === "junction"
+                      ? candidate.endpoint.junctionId
+                      : undefined
+                  }
+                  data-drag-object-id={
+                    candidate.endpoint.kind === "junction"
+                      ? candidate.endpoint.junctionId
+                      : undefined
+                  }
+                  className={
+                    tool === "wire" ||
+                    (candidate.endpoint.kind === "junction" &&
+                      supplementalSelection.junctionIds.includes(
+                        candidate.endpoint.junctionId,
+                      )) ||
+                    (selectedEndpoint?.endpoint.kind === "junction" &&
+                      candidate.endpoint.kind === "junction" &&
+                      selectedEndpoint.endpoint.junctionId ===
+                        candidate.endpoint.junctionId)
+                      ? "endpoint-hit active"
+                      : "endpoint-hit"
+                  }
+                  cx={candidate.point.x}
+                  cy={candidate.point.y}
+                  r={4}
+                  onClick={(event) => event.stopPropagation()}
+                  onContextMenu={(event) => {
+                    event.preventDefault();
                     event.stopPropagation();
                     selectEndpoint(candidate);
-                    setStatus(`Selected ${endpointTestId(candidate.endpoint)}`);
-                    return;
-                  }
-                  handleWireEndpoint(event, candidate);
-                }}
-              />
-            ))}
-            {document.annotations.map((annotation) => {
-              const anchor = annotationAnchor(annotation, routePolylines);
-              const hitBox = annotationHitBox(
-                annotation,
-                anchor,
-                routePolylines,
-                styleProfile,
-              );
-              const selected =
-                selectedAnnotationId === annotation.id ||
-                supplementalSelection.annotationIds.includes(annotation.id);
-              return (
-                <rect
-                  key={`annotation-hit-${annotation.id}`}
-                  data-testid={`annotation-hit-${annotation.id}`}
-                  data-canvas-hit-kind="annotation"
-                  data-canvas-hit-id={annotation.id}
-                  data-drag-object-id={annotation.id}
-                  className={
-                    selected
-                      ? "hit-target annotation-text-hit selected"
-                      : "hit-target annotation-text-hit"
-                  }
-                  {...hitBox}
-                  onClick={(event) => event.stopPropagation()}
-                  onPointerDown={(event) =>
-                    beginAnnotationDrag(event, annotation)
-                  }
-                  pointerEvents={tool === "wire" ? "none" : undefined}
-                  onDoubleClick={(event) => {
-                    event.stopPropagation();
-                    beginAnnotationTextEditing(annotation);
+                    setStatus(
+                      `Endpoint actions: ${endpointTestId(candidate.endpoint)}`,
+                    );
+                  }}
+                  onPointerDown={(event) => {
+                    if (
+                      tool === "pointer" &&
+                      candidate.endpoint.kind === "junction"
+                    ) {
+                      event.stopPropagation();
+                      selectEndpoint(candidate);
+                      setStatus(
+                        `Selected ${endpointTestId(candidate.endpoint)}`,
+                      );
+                      return;
+                    }
+                    handleWireEndpoint(event, candidate);
                   }}
                 />
-              );
-            })}
-            {(document.drafting?.objects ?? []).map((object) => {
-              // WP-R5/P1: every drafting object gets a selectable/deletable hit
-              // shape derived from the shared geometry. P1: use the object's
-              // actual shape (stroke polyline/line for lines and arrows) instead
-              // of a full bounding rect, so large leader/callout boxes do not
-              // block the canvas underneath.
-              const geometry = resolveDraftingObjectGeometry(
-                document,
-                resolver,
-                object,
-              );
-              const draggable = !object.locked && draftingDragOrigin(object);
-              const selected =
-                selectedDraftingId === object.id ||
-                supplementalSelection.draftingIds.includes(object.id)
-                  ? "annotation-hit selected"
-                  : "annotation-hit";
-              const textSelected =
-                selectedDraftingId === object.id ||
-                supplementalSelection.draftingIds.includes(object.id)
-                  ? "hit-target annotation-text-hit selected"
-                  : "hit-target annotation-text-hit";
-              const onDown = (event: ReactPointerEvent<SVGElement>): void => {
-                if (draggable) {
-                  beginDraftingDrag(event, object);
-                } else {
-                  event.stopPropagation();
-                  selectDraftingObject(object.id);
-                }
-              };
-              if (
-                object.kind === "construction-line" &&
-                geometry.kind === "construction-line"
-              ) {
-                const points = object.points
-                  .map((point) => `${point.x},${point.y}`)
-                  .join(" ");
-                const hasCurve = geometry.curveControls.some(Boolean);
-                const commonProps = {
-                  "data-testid": `drafting-hit-${object.id}`,
-                  "data-canvas-hit-kind": "drafting",
-                  "data-canvas-hit-id": object.id,
-                  "data-drag-object-id": object.id,
-                  className: selected,
-                  fill: "none",
-                  onPointerDown: onDown,
-                  onDoubleClick: (event: ReactMouseEvent<SVGElement>) => {
+              ))}
+              {document.annotations.map((annotation) => {
+                const anchor = annotationAnchor(annotation, routePolylines);
+                const hitBox = annotationHitBox(
+                  annotation,
+                  anchor,
+                  routePolylines,
+                  styleProfile,
+                );
+                const selected =
+                  selectedAnnotationId === annotation.id ||
+                  supplementalSelection.annotationIds.includes(annotation.id);
+                return (
+                  <rect
+                    key={`annotation-hit-${annotation.id}`}
+                    data-testid={`annotation-hit-${annotation.id}`}
+                    data-canvas-hit-kind="annotation"
+                    data-canvas-hit-id={annotation.id}
+                    data-drag-object-id={annotation.id}
+                    className={
+                      selected
+                        ? "hit-target annotation-text-hit selected"
+                        : "hit-target annotation-text-hit"
+                    }
+                    {...hitBox}
+                    onClick={(event) => event.stopPropagation()}
+                    onPointerDown={(event) =>
+                      beginAnnotationDrag(event, annotation)
+                    }
+                    pointerEvents={tool === "wire" ? "none" : undefined}
+                    onDoubleClick={(event) => {
+                      event.stopPropagation();
+                      beginAnnotationTextEditing(annotation);
+                    }}
+                  />
+                );
+              })}
+              {(document.drafting?.objects ?? []).map((object) => {
+                // WP-R5/P1: every drafting object gets a selectable/deletable hit
+                // shape derived from the shared geometry. P1: use the object's
+                // actual shape (stroke polyline/line for lines and arrows) instead
+                // of a full bounding rect, so large leader/callout boxes do not
+                // block the canvas underneath.
+                const geometry = resolveDraftingObjectGeometry(
+                  document,
+                  resolver,
+                  object,
+                );
+                const draggable = !object.locked && draftingDragOrigin(object);
+                const selected =
+                  selectedDraftingId === object.id ||
+                  supplementalSelection.draftingIds.includes(object.id)
+                    ? "annotation-hit selected"
+                    : "annotation-hit";
+                const textSelected =
+                  selectedDraftingId === object.id ||
+                  supplementalSelection.draftingIds.includes(object.id)
+                    ? "hit-target annotation-text-hit selected"
+                    : "hit-target annotation-text-hit";
+                const onDown = (event: ReactPointerEvent<SVGElement>): void => {
+                  if (draggable) {
+                    beginDraftingDrag(event, object);
+                  } else {
                     event.stopPropagation();
-                    insertConstructionVertex(
-                      object,
-                      pointFromClient(
-                        event.clientX,
-                        event.clientY,
-                        event.currentTarget.ownerSVGElement!,
-                      ),
-                    );
-                  },
-                  pointerEvents: tool === "wire" ? "none" : undefined,
+                    selectDraftingObject(object.id);
+                  }
                 };
-                return hasCurve ? (
-                  <path
-                    key={`drafting-hit-${object.id}`}
-                    {...commonProps}
-                    d={draftingPathData(
-                      geometry.points,
-                      geometry.curveControls,
-                    )}
-                  />
-                ) : (
-                  <polyline
-                    key={`drafting-hit-${object.id}`}
-                    {...commonProps}
-                    points={points}
-                  />
-                );
-              }
-              if (object.kind === "arrow" && geometry.kind === "arrow") {
-                return geometry.curveControls.some(Boolean) ? (
-                  <path
-                    key={`drafting-hit-${object.id}`}
-                    data-testid={`drafting-hit-${object.id}`}
-                    data-canvas-hit-kind="drafting"
-                    data-canvas-hit-id={object.id}
-                    data-drag-object-id={object.id}
-                    className={selected}
-                    d={draftingPathData(
-                      geometry.points,
-                      geometry.curveControls,
-                    )}
-                    fill="none"
-                    onPointerDown={onDown}
-                    onDoubleClick={(event) => {
+                if (
+                  object.kind === "construction-line" &&
+                  geometry.kind === "construction-line"
+                ) {
+                  const points = object.points
+                    .map((point) => `${point.x},${point.y}`)
+                    .join(" ");
+                  const hasCurve = geometry.curveControls.some(Boolean);
+                  const commonProps = {
+                    "data-testid": `drafting-hit-${object.id}`,
+                    "data-canvas-hit-kind": "drafting",
+                    "data-canvas-hit-id": object.id,
+                    "data-drag-object-id": object.id,
+                    className: selected,
+                    fill: "none",
+                    onPointerDown: onDown,
+                    onDoubleClick: (event: ReactMouseEvent<SVGElement>) => {
                       event.stopPropagation();
-                      insertArrowWaypoint(
+                      insertConstructionVertex(
                         object,
                         pointFromClient(
                           event.clientX,
@@ -6599,333 +6725,397 @@ export function App({ project: initialProject, visitStats }: AppProps) {
                           event.currentTarget.ownerSVGElement!,
                         ),
                       );
-                    }}
-                    pointerEvents={tool === "wire" ? "none" : undefined}
-                  />
-                ) : (
-                  <polyline
-                    key={`drafting-hit-${object.id}`}
-                    data-testid={`drafting-hit-${object.id}`}
-                    data-canvas-hit-kind="drafting"
-                    data-canvas-hit-id={object.id}
-                    data-drag-object-id={object.id}
-                    className={selected}
-                    points={geometry.points
-                      .map((point) => `${point.x},${point.y}`)
-                      .join(" ")}
-                    fill="none"
-                    onPointerDown={onDown}
-                    onDoubleClick={(event) => {
-                      event.stopPropagation();
-                      insertArrowWaypoint(
-                        object,
-                        pointFromClient(
-                          event.clientX,
-                          event.clientY,
-                          event.currentTarget.ownerSVGElement!,
-                        ),
-                      );
-                    }}
-                    pointerEvents={tool === "wire" ? "none" : undefined}
-                  />
-                );
-              }
-              if (
-                object.kind === "rectangle" &&
-                geometry.kind === "rectangle"
-              ) {
-                return (
-                  <polygon
-                    key={`drafting-hit-${object.id}`}
-                    data-testid={`drafting-hit-${object.id}`}
-                    data-canvas-hit-kind="drafting"
-                    data-canvas-hit-id={object.id}
-                    data-drag-object-id={object.id}
-                    className={`${selected} drafting-rectangle-hit`}
-                    points={serializePolylinePoints(geometry.corners)}
-                    fill="none"
-                    onPointerDown={onDown}
-                    pointerEvents={tool === "wire" ? "none" : undefined}
-                  />
-                );
-              }
-              if (object.kind === "leader" && geometry.kind === "leader") {
-                return (
-                  <line
-                    key={`drafting-hit-${object.id}`}
-                    data-testid={`drafting-hit-${object.id}`}
-                    data-canvas-hit-kind="drafting"
-                    data-canvas-hit-id={object.id}
-                    data-drag-object-id={object.id}
-                    className={selected}
-                    x1={geometry.anchor.x}
-                    y1={geometry.anchor.y}
-                    x2={geometry.target.x}
-                    y2={geometry.target.y}
-                    onPointerDown={onDown}
-                    pointerEvents={tool === "wire" ? "none" : undefined}
-                  />
-                );
-              }
-              if (object.kind === "callout" && geometry.kind === "callout") {
-                return (
-                  <g
-                    key={`drafting-hit-${object.id}`}
-                    data-testid={`drafting-hit-${object.id}`}
-                    data-canvas-hit-kind="drafting"
-                    data-canvas-hit-id={object.id}
-                    data-drag-object-id={object.id}
-                    onPointerDown={onDown}
-                    pointerEvents={tool === "wire" ? "none" : undefined}
-                  >
-                    <line
+                    },
+                    pointerEvents: tool === "wire" ? "none" : undefined,
+                  };
+                  return hasCurve ? (
+                    <path
+                      key={`drafting-hit-${object.id}`}
+                      {...commonProps}
+                      d={draftingPathData(
+                        geometry.points,
+                        geometry.curveControls,
+                      )}
+                    />
+                  ) : (
+                    <polyline
+                      key={`drafting-hit-${object.id}`}
+                      {...commonProps}
+                      points={points}
+                    />
+                  );
+                }
+                if (object.kind === "arrow" && geometry.kind === "arrow") {
+                  return geometry.curveControls.some(Boolean) ? (
+                    <path
+                      key={`drafting-hit-${object.id}`}
+                      data-testid={`drafting-hit-${object.id}`}
+                      data-canvas-hit-kind="drafting"
+                      data-canvas-hit-id={object.id}
+                      data-drag-object-id={object.id}
                       className={selected}
-                      x1={geometry.textPosition.x}
-                      y1={geometry.textPosition.y}
+                      d={draftingPathData(
+                        geometry.points,
+                        geometry.curveControls,
+                      )}
+                      fill="none"
+                      onPointerDown={onDown}
+                      onDoubleClick={(event) => {
+                        event.stopPropagation();
+                        insertArrowWaypoint(
+                          object,
+                          pointFromClient(
+                            event.clientX,
+                            event.clientY,
+                            event.currentTarget.ownerSVGElement!,
+                          ),
+                        );
+                      }}
+                      pointerEvents={tool === "wire" ? "none" : undefined}
+                    />
+                  ) : (
+                    <polyline
+                      key={`drafting-hit-${object.id}`}
+                      data-testid={`drafting-hit-${object.id}`}
+                      data-canvas-hit-kind="drafting"
+                      data-canvas-hit-id={object.id}
+                      data-drag-object-id={object.id}
+                      className={selected}
+                      points={geometry.points
+                        .map((point) => `${point.x},${point.y}`)
+                        .join(" ")}
+                      fill="none"
+                      onPointerDown={onDown}
+                      onDoubleClick={(event) => {
+                        event.stopPropagation();
+                        insertArrowWaypoint(
+                          object,
+                          pointFromClient(
+                            event.clientX,
+                            event.clientY,
+                            event.currentTarget.ownerSVGElement!,
+                          ),
+                        );
+                      }}
+                      pointerEvents={tool === "wire" ? "none" : undefined}
+                    />
+                  );
+                }
+                if (
+                  object.kind === "rectangle" &&
+                  geometry.kind === "rectangle"
+                ) {
+                  return (
+                    <polygon
+                      key={`drafting-hit-${object.id}`}
+                      data-testid={`drafting-hit-${object.id}`}
+                      data-canvas-hit-kind="drafting"
+                      data-canvas-hit-id={object.id}
+                      data-drag-object-id={object.id}
+                      className={`${selected} drafting-rectangle-hit`}
+                      points={serializePolylinePoints(geometry.corners)}
+                      fill="none"
+                      onPointerDown={onDown}
+                      pointerEvents={tool === "wire" ? "none" : undefined}
+                    />
+                  );
+                }
+                if (object.kind === "leader" && geometry.kind === "leader") {
+                  return (
+                    <line
+                      key={`drafting-hit-${object.id}`}
+                      data-testid={`drafting-hit-${object.id}`}
+                      data-canvas-hit-kind="drafting"
+                      data-canvas-hit-id={object.id}
+                      data-drag-object-id={object.id}
+                      className={selected}
+                      x1={geometry.anchor.x}
+                      y1={geometry.anchor.y}
                       x2={geometry.target.x}
                       y2={geometry.target.y}
+                      onPointerDown={onDown}
+                      pointerEvents={tool === "wire" ? "none" : undefined}
                     />
-                    <rect className={selected} {...geometry.textBounds} />
-                  </g>
+                  );
+                }
+                if (object.kind === "callout" && geometry.kind === "callout") {
+                  return (
+                    <g
+                      key={`drafting-hit-${object.id}`}
+                      data-testid={`drafting-hit-${object.id}`}
+                      data-canvas-hit-kind="drafting"
+                      data-canvas-hit-id={object.id}
+                      data-drag-object-id={object.id}
+                      onPointerDown={onDown}
+                      pointerEvents={tool === "wire" ? "none" : undefined}
+                    >
+                      <line
+                        className={selected}
+                        x1={geometry.textPosition.x}
+                        y1={geometry.textPosition.y}
+                        x2={geometry.target.x}
+                        y2={geometry.target.y}
+                      />
+                      <rect className={selected} {...geometry.textBounds} />
+                    </g>
+                  );
+                }
+                return (
+                  <rect
+                    key={`drafting-hit-${object.id}`}
+                    data-testid={`drafting-hit-${object.id}`}
+                    data-canvas-hit-kind="drafting"
+                    data-canvas-hit-id={object.id}
+                    data-drag-object-id={object.id}
+                    className={object.kind === "text" ? textSelected : selected}
+                    {...geometry.bounds}
+                    onPointerDown={onDown}
+                    onDoubleClick={(event) => {
+                      if (object.kind !== "text") return;
+                      event.stopPropagation();
+                      beginDraftingTextEditing(object);
+                    }}
+                  />
                 );
-              }
-              return (
+              })}
+              {selectedDraftingId
+                ? (() => {
+                    const object = document.drafting?.objects.find(
+                      (candidate) => candidate.id === selectedDraftingId,
+                    );
+                    if (!object || object.locked) return null;
+                    const geometry = resolveDraftingObjectGeometry(
+                      document,
+                      resolver,
+                      object,
+                    );
+                    if (object.kind === "arrow" && geometry.kind === "arrow") {
+                      return (
+                        <g
+                          data-testid={`drafting-handles-${object.id}`}
+                          data-canvas-hit-kind="handle"
+                          data-canvas-hit-id={`drafting-handles-${object.id}`}
+                        >
+                          <circle
+                            className="draft-handle"
+                            data-testid={`draft-handle-from-${object.id}`}
+                            cx={geometry.from.x}
+                            cy={geometry.from.y}
+                            r="5"
+                            onPointerDown={(event) =>
+                              beginDraftingHandleDrag(event, object, {
+                                kind: "from",
+                              })
+                            }
+                          />
+                          {geometry.points.slice(1, -1).map((point, index) => (
+                            <circle
+                              key={`draft-arrow-waypoint-${index}`}
+                              className="draft-handle"
+                              data-testid={`draft-handle-waypoint-${index}-${object.id}`}
+                              cx={point.x}
+                              cy={point.y}
+                              r="5"
+                              onPointerDown={(event) =>
+                                beginDraftingHandleDrag(event, object, {
+                                  kind: "waypoint",
+                                  index,
+                                })
+                              }
+                            />
+                          ))}
+                          {geometry.points.slice(0, -1).map((point, index) => {
+                            const next = geometry.points[index + 1]!;
+                            const midpoint = quadraticMidpoint(
+                              point,
+                              geometry.curveControls[index] ?? null,
+                              next,
+                            );
+                            return (
+                              <rect
+                                key={`draft-arrow-segment-${index}`}
+                                className="draft-handle draft-midpoint-handle"
+                                data-testid={`draft-handle-segment-${index}-${object.id}`}
+                                x={midpoint.x - 3}
+                                y={midpoint.y - 3}
+                                width="6"
+                                height="6"
+                                transform={`rotate(45 ${midpoint.x} ${midpoint.y})`}
+                                onPointerDown={(event) =>
+                                  beginDraftingHandleDrag(event, object, {
+                                    kind: "curve",
+                                    index,
+                                  })
+                                }
+                              />
+                            );
+                          })}
+                          <circle
+                            className="draft-handle"
+                            data-testid={`draft-handle-to-${object.id}`}
+                            cx={geometry.to.x}
+                            cy={geometry.to.y}
+                            r="5"
+                            onPointerDown={(event) =>
+                              beginDraftingHandleDrag(event, object, {
+                                kind: "to",
+                              })
+                            }
+                          />
+                        </g>
+                      );
+                    }
+                    if (
+                      object.kind === "construction-line" &&
+                      geometry.kind === "construction-line"
+                    ) {
+                      return (
+                        <g
+                          data-testid={`drafting-handles-${object.id}`}
+                          data-canvas-hit-kind="handle"
+                          data-canvas-hit-id={`drafting-handles-${object.id}`}
+                        >
+                          {geometry.vertices.map((vertex, index) => (
+                            <circle
+                              key={`draft-vx-${index}`}
+                              className="draft-handle"
+                              data-testid={`draft-handle-vx-${index}-${object.id}`}
+                              cx={vertex.x}
+                              cy={vertex.y}
+                              r="5"
+                              onPointerDown={(event) =>
+                                beginDraftingHandleDrag(event, object, {
+                                  kind: "vertex",
+                                  index,
+                                })
+                              }
+                              onDoubleClick={(event) => {
+                                event.stopPropagation();
+                                deleteConstructionVertex(object, index);
+                              }}
+                            />
+                          ))}
+                          {geometry.vertices
+                            .slice(0, -1)
+                            .map((vertex, index) => {
+                              const next = geometry.vertices[index + 1]!;
+                              const midpoint = quadraticMidpoint(
+                                vertex,
+                                geometry.curveControls[index] ?? null,
+                                next,
+                              );
+                              return (
+                                <rect
+                                  key={`draft-line-segment-${index}`}
+                                  className="draft-handle draft-midpoint-handle"
+                                  data-testid={`draft-handle-segment-${index}-${object.id}`}
+                                  x={midpoint.x - 3}
+                                  y={midpoint.y - 3}
+                                  width="6"
+                                  height="6"
+                                  transform={`rotate(45 ${midpoint.x} ${midpoint.y})`}
+                                  onPointerDown={(event) =>
+                                    beginDraftingHandleDrag(event, object, {
+                                      kind: "curve",
+                                      index,
+                                    })
+                                  }
+                                />
+                              );
+                            })}
+                        </g>
+                      );
+                    }
+                    if (
+                      object.kind === "rectangle" &&
+                      geometry.kind === "rectangle"
+                    ) {
+                      return (
+                        <g data-testid={`drafting-handles-${object.id}`}>
+                          {geometry.corners.map((corner, index) => (
+                            <rect
+                              key={`draft-rectangle-corner-${index}`}
+                              className="draft-handle"
+                              data-testid={`draft-handle-corner-${index}-${object.id}`}
+                              x={corner.x - 4}
+                              y={corner.y - 4}
+                              width="8"
+                              height="8"
+                              onPointerDown={(event) =>
+                                beginDraftingHandleDrag(event, object, {
+                                  kind: "rectangle-corner",
+                                  index,
+                                })
+                              }
+                            />
+                          ))}
+                        </g>
+                      );
+                    }
+                    return null;
+                  })()
+                : null}
+              {boxPreview ? (
                 <rect
-                  key={`drafting-hit-${object.id}`}
-                  data-testid={`drafting-hit-${object.id}`}
-                  data-canvas-hit-kind="drafting"
-                  data-canvas-hit-id={object.id}
-                  data-drag-object-id={object.id}
-                  className={object.kind === "text" ? textSelected : selected}
-                  {...geometry.bounds}
-                  onPointerDown={onDown}
-                  onDoubleClick={(event) => {
-                    if (object.kind !== "text") return;
-                    event.stopPropagation();
-                    beginDraftingTextEditing(object);
-                  }}
+                  data-testid="selection-box"
+                  className="selection-box"
+                  {...normalizedRect(boxPreview.start, boxPreview.end)}
                 />
-              );
-            })}
-            {selectedDraftingId
-              ? (() => {
-                  const object = document.drafting?.objects.find(
-                    (candidate) => candidate.id === selectedDraftingId,
-                  );
-                  if (!object || object.locked) return null;
-                  const geometry = resolveDraftingObjectGeometry(
-                    document,
-                    resolver,
-                    object,
-                  );
-                  if (object.kind === "arrow" && geometry.kind === "arrow") {
-                    return (
-                      <g
-                        data-testid={`drafting-handles-${object.id}`}
-                        data-canvas-hit-kind="handle"
-                        data-canvas-hit-id={`drafting-handles-${object.id}`}
-                      >
-                        <circle
-                          className="draft-handle"
-                          data-testid={`draft-handle-from-${object.id}`}
-                          cx={geometry.from.x}
-                          cy={geometry.from.y}
-                          r="5"
-                          onPointerDown={(event) =>
-                            beginDraftingHandleDrag(event, object, {
-                              kind: "from",
-                            })
-                          }
-                        />
-                        {geometry.points.slice(1, -1).map((point, index) => (
-                          <circle
-                            key={`draft-arrow-waypoint-${index}`}
-                            className="draft-handle"
-                            data-testid={`draft-handle-waypoint-${index}-${object.id}`}
-                            cx={point.x}
-                            cy={point.y}
-                            r="5"
-                            onPointerDown={(event) =>
-                              beginDraftingHandleDrag(event, object, {
-                                kind: "waypoint",
-                                index,
-                              })
-                            }
-                          />
-                        ))}
-                        {geometry.points.slice(0, -1).map((point, index) => {
-                          const next = geometry.points[index + 1]!;
-                          const midpoint = quadraticMidpoint(
-                            point,
-                            geometry.curveControls[index] ?? null,
-                            next,
-                          );
-                          return (
-                            <rect
-                              key={`draft-arrow-segment-${index}`}
-                              className="draft-handle draft-midpoint-handle"
-                              data-testid={`draft-handle-segment-${index}-${object.id}`}
-                              x={midpoint.x - 3}
-                              y={midpoint.y - 3}
-                              width="6"
-                              height="6"
-                              transform={`rotate(45 ${midpoint.x} ${midpoint.y})`}
-                              onPointerDown={(event) =>
-                                beginDraftingHandleDrag(event, object, {
-                                  kind: "curve",
-                                  index,
-                                })
-                              }
-                            />
-                          );
-                        })}
-                        <circle
-                          className="draft-handle"
-                          data-testid={`draft-handle-to-${object.id}`}
-                          cx={geometry.to.x}
-                          cy={geometry.to.y}
-                          r="5"
-                          onPointerDown={(event) =>
-                            beginDraftingHandleDrag(event, object, {
-                              kind: "to",
-                            })
-                          }
-                        />
-                      </g>
-                    );
-                  }
-                  if (
-                    object.kind === "construction-line" &&
-                    geometry.kind === "construction-line"
-                  ) {
-                    return (
-                      <g
-                        data-testid={`drafting-handles-${object.id}`}
-                        data-canvas-hit-kind="handle"
-                        data-canvas-hit-id={`drafting-handles-${object.id}`}
-                      >
-                        {geometry.vertices.map((vertex, index) => (
-                          <circle
-                            key={`draft-vx-${index}`}
-                            className="draft-handle"
-                            data-testid={`draft-handle-vx-${index}-${object.id}`}
-                            cx={vertex.x}
-                            cy={vertex.y}
-                            r="5"
-                            onPointerDown={(event) =>
-                              beginDraftingHandleDrag(event, object, {
-                                kind: "vertex",
-                                index,
-                              })
-                            }
-                            onDoubleClick={(event) => {
-                              event.stopPropagation();
-                              deleteConstructionVertex(object, index);
-                            }}
-                          />
-                        ))}
-                        {geometry.vertices.slice(0, -1).map((vertex, index) => {
-                          const next = geometry.vertices[index + 1]!;
-                          const midpoint = quadraticMidpoint(
-                            vertex,
-                            geometry.curveControls[index] ?? null,
-                            next,
-                          );
-                          return (
-                            <rect
-                              key={`draft-line-segment-${index}`}
-                              className="draft-handle draft-midpoint-handle"
-                              data-testid={`draft-handle-segment-${index}-${object.id}`}
-                              x={midpoint.x - 3}
-                              y={midpoint.y - 3}
-                              width="6"
-                              height="6"
-                              transform={`rotate(45 ${midpoint.x} ${midpoint.y})`}
-                              onPointerDown={(event) =>
-                                beginDraftingHandleDrag(event, object, {
-                                  kind: "curve",
-                                  index,
-                                })
-                              }
-                            />
-                          );
-                        })}
-                      </g>
-                    );
-                  }
-                  if (
-                    object.kind === "rectangle" &&
-                    geometry.kind === "rectangle"
-                  ) {
-                    return (
-                      <g data-testid={`drafting-handles-${object.id}`}>
-                        {geometry.corners.map((corner, index) => (
-                          <rect
-                            key={`draft-rectangle-corner-${index}`}
-                            className="draft-handle"
-                            data-testid={`draft-handle-corner-${index}-${object.id}`}
-                            x={corner.x - 4}
-                            y={corner.y - 4}
-                            width="8"
-                            height="8"
-                            onPointerDown={(event) =>
-                              beginDraftingHandleDrag(event, object, {
-                                kind: "rectangle-corner",
-                                index,
-                              })
-                            }
-                          />
-                        ))}
-                      </g>
-                    );
-                  }
-                  return null;
-                })()
-              : null}
-            {boxPreview ? (
-              <rect
-                data-testid="selection-box"
-                className="selection-box"
-                {...normalizedRect(boxPreview.start, boxPreview.end)}
-              />
-            ) : null}
-            {draftingSource && draftingHover ? (
-              <DraftingCreatePreview
-                tool={tool}
-                start={draftingSource}
-                waypoints={draftingWaypoints}
-                hover={draftingHover}
-                snap={draftingSnapPoint}
-                styleProfile={styleProfile}
-              />
-            ) : null}
-            {tool === "wire" && wirePreviewPoint ? (
-              <circle
-                className="snap-preview"
-                cx={wirePreviewPoint.x}
-                cy={wirePreviewPoint.y}
-                r="4"
-              />
-            ) : null}
-            {textEditing && textEditingBounds ? (
-              <CanvasTextEditorOverlay
-                session={textEditing}
-                bounds={textEditingBounds}
-                viewBox={viewBox}
-                disabled={textEditingLocked}
-                onUpdate={updateTextEditing}
-                onCommit={commitTextEditing}
-                onCancel={() => setTextEditing(null)}
-                onDelete={deleteTextEditing}
-                {...(editingAnnotation &&
-                isRoutedMarker(editingAnnotation) &&
-                effectiveRouteAttachment(editingAnnotation)
-                  ? { onReverseCurrentArrow: reverseSelectedCurrentArrow }
-                  : {})}
-              />
-            ) : null}
-          </g>
-        </svg>
+              ) : null}
+              {draftingSource && draftingHover ? (
+                <DraftingCreatePreview
+                  tool={tool}
+                  start={draftingSource}
+                  waypoints={draftingWaypoints}
+                  hover={draftingHover}
+                  snap={draftingSnapPoint}
+                  styleProfile={styleProfile}
+                />
+              ) : null}
+              {tool === "wire" && wirePreviewPoint ? (
+                <circle
+                  className="snap-preview"
+                  cx={wirePreviewPoint.x}
+                  cy={wirePreviewPoint.y}
+                  r="4"
+                />
+              ) : null}
+              {textEditing && textEditingBounds ? (
+                <CanvasTextEditorOverlay
+                  session={textEditing}
+                  bounds={textEditingBounds}
+                  viewBox={viewBox}
+                  disabled={textEditingLocked}
+                  onUpdate={updateTextEditing}
+                  onCommit={commitTextEditing}
+                  onCancel={() => setTextEditing(null)}
+                  onDelete={deleteTextEditing}
+                  {...(editingAnnotation &&
+                  isRoutedMarker(editingAnnotation) &&
+                  effectiveRouteAttachment(editingAnnotation)
+                    ? { onReverseCurrentArrow: reverseSelectedCurrentArrow }
+                    : {})}
+                />
+              ) : null}
+            </g>
+          </svg>
+        </section>
+      </div>
+      <footer className="app-statusbar">
+        <div className="statusbar-left">
+          <p className="editor-status" data-testid="status" aria-live="polite">
+            {status}
+          </p>
+          <span className="statusbar-tool" data-testid="statusbar-tool">
+            {pendingSymbolId
+              ? `Placing ${pendingSymbolId}`
+              : tool === "pointer"
+                ? "Select"
+                : tool === "construction-line"
+                  ? "Line"
+                  : tool.charAt(0).toUpperCase() + tool.slice(1)}
+          </span>
+        </div>
         <div className="canvas-controls" aria-label="Canvas zoom controls">
           <button
             type="button"
@@ -6953,7 +7143,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
             <ToolIcon name="fit" />
           </button>
         </div>
-      </section>
+      </footer>
     </main>
   );
 }

--- a/apps/editor/src/components/editor-help-dialog.tsx
+++ b/apps/editor/src/components/editor-help-dialog.tsx
@@ -65,19 +65,26 @@ export function EditorHelpDialog({
             </p>
             <h3>Place, select, and connect</h3>
             <p>
-              Select a symbol in the left library, or a drawing tool from
-              <strong>Draw</strong>, then click the canvas to place or draw.
-              Select objects to move them or reveal selection actions. Choose
-              Wire (or <kbd>W</kbd>), click a terminal to start, click to add
-              bends, then press <kbd>Enter</kbd> to finish. <kbd>Delete</kbd> or
+              Click a starter or recent chip in the left{" "}
+              <strong>Library</strong>
+              column for quick placement defaults, or press <kbd>I</kbd> / use{" "}
+              <strong>Insert</strong> at the bottom of that column for the full
+              library with parameters. Drawing tools live on the left tool rail
+              and in the
+              <strong>Draw</strong> menu. Select objects to move them; open
+              Properties with <kbd>Q</kbd> or by double-clicking a device.
+              Choose Wire (or <kbd>W</kbd>), click a terminal to start, click to
+              add bends, then press
+              <kbd>Enter</kbd> to finish. <kbd>Delete</kbd> or
               <kbd>Backspace</kbd> removes the selection, or removes the latest
               wire bend while drawing.
             </p>
             <h3>View and drawing tools</h3>
             <p>
               With the pointer over the canvas, use the mouse wheel to zoom and
-              middle-drag to pan; <kbd>F</kbd> fits the circuit in view. Draw
-              also contains Wire, Text, Arrow, Construction line, and Rectangle.
+              middle-drag to pan; <kbd>F</kbd> fits the circuit in view. The
+              left rail is the primary Draw home; the <strong>Draw</strong>
+              menu mirrors Wire, Text, Arrow, Construction line, and Rectangle.
               With no rotatable selection, <kbd>R</kbd> starts Rectangle; with a
               component or drawing selected it rotates clockwise.{" "}
               <kbd>Shift+R</kbd> mirrors left/right; <kbd>Shift+V</kbd> mirrors
@@ -89,6 +96,12 @@ export function EditorHelpDialog({
           </section>
           <section id="help-shortcuts" className="help-shortcuts">
             <h3>Keyboard shortcuts</h3>
+            <p className="help-quick-ref">
+              <strong>Quick reference:</strong> <kbd>I</kbd> insert ·{" "}
+              <kbd>C</kbd> copy · <kbd>R</kbd> rotate · <kbd>W</kbd> wire ·{" "}
+              <kbd>G</kbd> guide · <kbd>Home</kbd> fit · wheel zoom ·
+              middle-drag pan · <kbd>Enter</kbd> finish
+            </p>
             <dl>
               <div>
                 <dt>File and history</dt>

--- a/apps/editor/src/features/component-insert/insert-component-dialog.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.tsx
@@ -34,16 +34,19 @@ export interface ComponentInsertRequest {
 export function SymbolArtwork({
   symbol,
   className,
+  /** Fraction of max(viewBox width, height) added around the glyph. */
+  paddingRatio = 0.18,
 }: {
   symbol: SymbolDefinition;
   className: string;
+  paddingRatio?: number;
 }) {
   const variantId = defaultRazaviSymbolVariantId(symbol.id);
   const variant = symbol.variants.find(
     (candidate) => candidate.id === variantId,
   );
   const { x, y, width, height } = symbol.viewBox;
-  const padding = Math.max(width, height) * 0.18;
+  const padding = Math.max(width, height) * paddingRatio;
 
   return (
     <svg

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { STARTER_SYMBOL_IDS, quickPlaceRequest } from "./shapes-panel";
+
+describe("shapes quick-place", () => {
+  it("exposes starter chips with placement defaults", () => {
+    expect(STARTER_SYMBOL_IDS).toContain("resistor");
+    expect(STARTER_SYMBOL_IDS).toContain("nmos");
+
+    const request = quickPlaceRequest("razavi", "resistor");
+    expect(request).toMatchObject({
+      symbolId: "resistor",
+      symbolName: "Resistor",
+      initialRotation: 0,
+      showReference: true,
+      referenceText: null,
+    });
+    expect(request?.properties.value).toBe("10k");
+  });
+
+  it("returns null for unknown symbols", () => {
+    expect(quickPlaceRequest("razavi", "not-a-symbol")).toBeNull();
+  });
+});

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -1,0 +1,187 @@
+import {
+  SymbolArtwork,
+  type ComponentInsertRequest,
+} from "../component-insert/insert-component-dialog";
+import {
+  componentParameters,
+  initialComponentParameterValues,
+} from "../component-insert/component-parameters";
+import { findPaletteSymbol } from "../component-insert/symbol-catalog";
+
+/** Starter chips always offered in the left shapes column . */
+export const STARTER_SYMBOL_IDS = [
+  "resistor",
+  "capacitor",
+  "nmos",
+  "pmos",
+  "voltage-source",
+  "ground",
+  "vdd",
+  "opamp",
+] as const;
+
+export function quickPlaceRequest(
+  styleProfileId: string,
+  symbolId: string,
+): ComponentInsertRequest | null {
+  const symbol = findPaletteSymbol(styleProfileId, symbolId);
+  if (!symbol) return null;
+  const parameters = componentParameters(symbolId);
+  const properties =
+    parameters.length === 0
+      ? initialComponentParameterValues(symbolId)
+      : Object.fromEntries(
+          parameters.map((parameter) => [
+            parameter.key,
+            parameter.placeholder || "",
+          ]),
+        );
+  return {
+    symbolId: symbol.id,
+    symbolName: symbol.name,
+    properties,
+    initialRotation: 0,
+    showReference: true,
+    referenceText: null,
+  };
+}
+
+export interface ShapesPanelProps {
+  styleProfileId: string;
+  recentSymbolIds: readonly string[];
+  open: boolean;
+  onOpenInsert(): void;
+  onQuickPlace(request: ComponentInsertRequest): void;
+}
+
+export function ShapesPanel({
+  styleProfileId,
+  recentSymbolIds,
+  open,
+  onOpenInsert,
+  onQuickPlace,
+}: ShapesPanelProps) {
+  const starters = STARTER_SYMBOL_IDS.map((symbolId) =>
+    findPaletteSymbol(styleProfileId, symbolId),
+  ).filter((symbol): symbol is NonNullable<typeof symbol> => Boolean(symbol));
+
+  const recents = recentSymbolIds
+    .map((symbolId) => findPaletteSymbol(styleProfileId, symbolId))
+    .filter((symbol): symbol is NonNullable<typeof symbol> => Boolean(symbol))
+    .slice(0, 6);
+
+  function placeSymbol(symbolId: string): void {
+    const request = quickPlaceRequest(styleProfileId, symbolId);
+    if (request) onQuickPlace(request);
+  }
+
+  return (
+    <aside
+      id="shapes-library-panel"
+      className={open ? "shapes-panel" : "shapes-panel collapsed"}
+      aria-label="Shapes"
+      aria-hidden={!open}
+      inert={!open ? true : undefined}
+      data-testid="shapes-library-panel"
+      data-open={open ? "true" : "false"}
+    >
+      <header className="shapes-panel-header">
+        <button
+          type="button"
+          className="shapes-panel-title"
+          onClick={onOpenInsert}
+          title="Open insert dialog (I)"
+        >
+          <span className="shapes-kicker">Quick place</span>
+          <span className="shapes-panel-heading">Library</span>
+        </button>
+      </header>
+
+      <div className="shapes-panel-body">
+        <details
+          className="shapes-fold"
+          open
+          data-testid="shapes-fold-starters"
+        >
+          <summary className="shapes-fold-summary">
+            <span className="shapes-fold-label">Starters</span>
+            <span className="shapes-fold-count">{starters.length}</span>
+          </summary>
+          <div className="shapes-fold-body">
+            <div className="shapes-grid">
+              {starters.map((symbol) => (
+                <button
+                  key={symbol.id}
+                  type="button"
+                  className="shapes-chip"
+                  data-testid={`shapes-chip-${symbol.id}`}
+                  title={`Place ${symbol.name}`}
+                  onClick={() => placeSymbol(symbol.id)}
+                >
+                  <SymbolArtwork
+                    symbol={symbol}
+                    className="shapes-chip-art"
+                    paddingRatio={0.04}
+                  />
+                  <span>{symbol.name}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </details>
+
+        <details
+          className="shapes-fold"
+          open={recents.length > 0}
+          data-testid="shapes-fold-recent"
+        >
+          <summary className="shapes-fold-summary">
+            <span className="shapes-fold-label">Recent</span>
+            <span className="shapes-fold-count">{recents.length}</span>
+          </summary>
+          <div className="shapes-fold-body">
+            {recents.length > 0 ? (
+              <div className="shapes-grid">
+                {recents.map((symbol) => (
+                  <button
+                    key={`recent-${symbol.id}`}
+                    type="button"
+                    className="shapes-chip"
+                    data-testid={`shapes-recent-${symbol.id}`}
+                    title={`Place ${symbol.name}`}
+                    onClick={() => placeSymbol(symbol.id)}
+                  >
+                    <SymbolArtwork
+                      symbol={symbol}
+                      className="shapes-chip-art"
+                      paddingRatio={0.04}
+                    />
+                    <span>{symbol.name}</span>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <p className="shapes-hint">
+                Recent parts appear here after you place something. Use Insert
+                for the full catalog with parameters.
+              </p>
+            )}
+          </div>
+        </details>
+      </div>
+
+      <footer className="shapes-panel-footer">
+        <button
+          type="button"
+          className="shapes-insert"
+          data-testid="shapes-insert"
+          onClick={onOpenInsert}
+          title="Insert component with parameters (I)"
+        >
+          Insert
+          <kbd>I</kbd>
+        </button>
+      </footer>
+    </aside>
+  );
+}

--- a/apps/editor/src/features/editor-shell/tool-icon.tsx
+++ b/apps/editor/src/features/editor-shell/tool-icon.tsx
@@ -1,5 +1,6 @@
 export type ToolIconName =
   | "insert"
+  | "library"
   | "wire"
   | "text"
   | "arrow"
@@ -10,7 +11,11 @@ export type ToolIconName =
   | "zoom-in"
   | "zoom-out"
   | "fit"
-  | "inspect";
+  | "inspect"
+  | "undo"
+  | "redo"
+  | "delete"
+  | "guide";
 
 export function ToolIcon({ name }: { name: ToolIconName }) {
   const common = {
@@ -22,17 +27,20 @@ export function ToolIcon({ name }: { name: ToolIconName }) {
   };
 
   return (
-    <svg
-      className="tool-icon"
-      viewBox="0 0 20 20"
-      width="18"
-      height="18"
-      aria-hidden="true"
-    >
+    <svg className="tool-icon" viewBox="0 0 20 20" aria-hidden="true">
       {name === "insert" ? (
         <>
           <rect x="4" y="4" width="12" height="12" rx="1.5" {...common} />
           <path d="M10 7v6M7 10h6" {...common} />
+        </>
+      ) : null}
+      {name === "library" ? (
+        <>
+          {/* 2x2 tile grid = one clear library / catalog mark */}
+          <rect x="3" y="3.5" width="6" height="6" rx="1" {...common} />
+          <rect x="11" y="3.5" width="6" height="6" rx="1" {...common} />
+          <rect x="3" y="10.5" width="6" height="6" rx="1" {...common} />
+          <rect x="11" y="10.5" width="6" height="6" rx="1" {...common} />
         </>
       ) : null}
       {name === "wire" ? (
@@ -84,6 +92,28 @@ export function ToolIcon({ name }: { name: ToolIconName }) {
         <>
           <path d="M4 3h12v14H4z" {...common} />
           <path d="M7 7h6M7 10h6M7 13h4" {...common} />
+        </>
+      ) : null}
+      {name === "undo" ? (
+        <>
+          <path d="M4 9h8a4 4 0 1 1 0 8H8" {...common} />
+          <path d="M7 5L3 9l4 4" {...common} />
+        </>
+      ) : null}
+      {name === "redo" ? (
+        <>
+          <path d="M16 9H8a4 4 0 1 0 0 8h4" {...common} />
+          <path d="M13 5l4 4-4 4" {...common} />
+        </>
+      ) : null}
+      {name === "delete" ? (
+        <>
+          <path d="M4 6h12M8 6V4h4v2M7 6l.6 10h4.8L13 6" {...common} />
+        </>
+      ) : null}
+      {name === "guide" ? (
+        <>
+          <path d="M4 3v14M16 3v14M4 10h12" {...common} />
         </>
       ) : null}
     </svg>

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -1,43 +1,73 @@
 :root {
-  /* Editor chrome design tokens. These cover panels, controls, selection
-     state, diagnostics and editor-only SVG overlays ONLY. The white canvas
-     background (`.schematic-canvas`), the SVG grid-dot fill, and the injected
-     `scene.formalBody` are deliberately NOT tokenized so formal SVG/PNG/PDF
-     export output stays visually stable and decoupled from chrome restyling. */
-  --icm-chrome-bg: #f1f4f8;
+  /* Editor chrome design tokens only. Formal schematic SVG/export is not
+     tokenized so export appearance stays independent of chrome restyling.
+     Scale: 4px grid, three type sizes, one icon size. */
+  --icm-chrome-bg: #f7f6f3;
   --icm-surface: #ffffff;
-  --icm-surface-muted: #f8fafc;
-  --icm-surface-hover: #f1f5f9;
-  --icm-border: #e2e8f0;
-  --icm-border-strong: #cbd5e1;
-  --icm-border-hover: #94a3b8;
-  --icm-text: #172033;
-  --icm-text-muted: #64748b;
-  --icm-text-disabled: #a3afbf;
-  --icm-accent: #2563eb;
-  --icm-accent-rgb: 37 99 235;
-  --icm-accent-soft: rgb(37 99 235 / 8%);
-  --icm-accent-selection: rgb(37 99 235 / 13%);
-  --icm-accent-tint: #eff6ff;
-  --icm-error: #b42318;
+  --icm-surface-muted: #f1f1ef;
+  --icm-surface-hover: #ebebea;
+  --icm-border: #e9e9e7;
+  --icm-border-strong: #dfdfde;
+  --icm-border-hover: #cfcfcd;
+  --icm-text: #37352f;
+  --icm-text-muted: #787774;
+  --icm-text-disabled: #b4b4b0;
+  --icm-accent: #2383e2;
+  --icm-accent-rgb: 35 131 226;
+  --icm-accent-soft: rgb(35 131 226 / 10%);
+  --icm-accent-selection: rgb(35 131 226 / 14%);
+  --icm-accent-tint: #e7f3fc;
+  --icm-error: #eb5757;
   --icm-warning: #9a6700;
-  --icm-radius-sm: 0.375rem;
-  --icm-radius-md: 0.625rem;
-  --icm-radius-lg: 0.875rem;
-  --icm-shadow-sm: 0 1px 2px rgb(15 23 42 / 5%);
-  --icm-shadow-md: 0 10px 28px rgb(15 23 42 / 11%);
-  --icm-shadow-lg: 0 22px 60px rgb(15 23 42 / 18%);
+
+  /* Spacing: 4px base */
+  --icm-space-1: 4px;
+  --icm-space-2: 8px;
+  --icm-space-3: 12px;
+  --icm-space-4: 16px;
+  --icm-space-5: 20px;
+  --icm-space-6: 24px;
+
+  /* Type: three steps only */
+  --icm-font-xs: 11px; /* kickers, meta, rail captions */
+  --icm-font-sm: 12px; /* secondary UI, chips, status */
+  --icm-font-md: 13px; /* menus, buttons, body chrome */
+  --icm-font-lg: 14px; /* panel titles, brand */
+  --icm-line: 1.35;
+  --icm-line-tight: 1.2;
+
+  /* Controls */
+  --icm-icon: 16px;
+  --icm-control-h: 28px;
+  --icm-control-h-lg: 32px;
+  --icm-radius-sm: 6px;
+  --icm-radius-md: 8px;
+  --icm-radius-lg: 12px;
+  --icm-shadow-sm: 0 1px 2px rgb(15 15 15 / 4%);
+  --icm-shadow-md: 0 8px 24px rgb(15 15 15 / 8%);
+  --icm-shadow-lg: 0 18px 48px rgb(15 15 15 / 12%);
+
+  /* Layout columns */
+  --icm-rail-width: 56px;
+  --icm-shapes-width: 248px;
+  --icm-props-collapsed: 40px;
+  --icm-props-open: 280px;
+  --icm-menubar-h: 44px;
+  --icm-statusbar-h: 36px;
 
   color: var(--icm-text);
   background: var(--icm-chrome-bg);
   font-family:
-    Inter,
     ui-sans-serif,
-    system-ui,
     -apple-system,
     BlinkMacSystemFont,
     "Segoe UI",
+    Helvetica,
+    Arial,
     sans-serif;
+  font-size: var(--icm-font-md);
+  line-height: var(--icm-line);
+  -webkit-font-smoothing: antialiased;
 }
 
 * {
@@ -49,15 +79,23 @@ button {
   border-radius: var(--icm-radius-sm);
   color: var(--icm-text);
   background: var(--icm-surface);
-  box-shadow: var(--icm-shadow-sm);
+  box-shadow: none;
   cursor: pointer;
   font: inherit;
+  font-size: var(--icm-font-md);
+  line-height: var(--icm-line-tight);
   transition:
     border-color 120ms ease,
     background-color 120ms ease,
     box-shadow 120ms ease,
-    color 120ms ease,
-    transform 120ms ease;
+    color 120ms ease;
+}
+
+.tool-icon {
+  width: var(--icm-icon);
+  height: var(--icm-icon);
+  flex: 0 0 auto;
+  display: block;
 }
 
 .file-import {
@@ -67,7 +105,7 @@ button {
   background: var(--icm-surface);
   box-shadow: var(--icm-shadow-sm);
   cursor: pointer;
-  font-size: 0.8rem;
+  font-size: var(--icm-font-md);
 }
 
 .file-import:hover {
@@ -93,10 +131,6 @@ button {
 button:hover:not(:disabled) {
   border-color: var(--icm-border-hover);
   background: var(--icm-surface-hover);
-}
-
-button:active:not(:disabled) {
-  transform: translateY(1px);
 }
 
 button:focus-visible,
@@ -135,77 +169,115 @@ body {
 .app-shell {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr) auto;
   width: 100%;
   height: 100dvh;
   min-height: 0;
   overflow: hidden;
+  background: var(--icm-chrome-bg);
 }
 
-.app-header {
+.app-chrome {
   position: relative;
   z-index: 20;
-  display: grid;
-  grid-column: 1 / -1;
-  grid-template-columns: minmax(10rem, 1fr) auto minmax(10rem, 1fr);
-  align-items: center;
-  gap: 1rem;
-  min-height: 3.75rem;
-  padding: 0.6rem 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  min-height: var(--icm-menubar-h);
+  padding: 0;
   border-bottom: 1px solid var(--icm-border);
-  background: rgb(255 255 255 / 92%);
-  box-shadow: 0 1px 0 rgb(15 23 42 / 3%);
-  backdrop-filter: blur(12px);
+  background: var(--icm-surface);
+  overflow: visible;
 }
 
-.app-header h1,
-.app-header p {
-  margin: 0;
+.app-chrome-main {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--icm-space-3);
+  height: var(--icm-menubar-h);
+  min-height: var(--icm-menubar-h);
+  padding: 0 var(--icm-space-3);
 }
 
-.app-header h1 {
-  font-size: 0.95rem;
-  font-weight: 700;
-  letter-spacing: -0.015em;
-}
-
-.app-header p {
-  color: var(--icm-text-muted);
-  font-size: 0.76rem;
-}
-
-.editor-status {
-  box-sizing: border-box;
-  width: min(17rem, 100%);
-  max-width: 17rem;
-  justify-self: end;
+.app-brand {
+  display: flex;
+  align-items: center;
+  gap: var(--icm-space-2);
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: min(16rem, 36vw);
+  padding: 0;
   overflow: hidden;
-  padding: 0.25rem 0.5rem;
-  border: 1px solid transparent;
-  border-radius: 999px;
-  color: var(--icm-text-muted);
-  background: var(--icm-surface-muted);
-  font-size: 0.72rem;
-  font-weight: 500;
-  text-align: right;
+}
+
+.app-brand-mark {
+  width: 22px;
+  height: 22px;
+  flex: 0 0 auto;
+  border-radius: 6px;
+  background: linear-gradient(
+    145deg,
+    #2f3437 0%,
+    #37352f 55%,
+    #2383e2 55%,
+    #2383e2 100%
+  );
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 8%);
+}
+
+.app-brand-copy {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.app-brand-copy h1,
+.app-brand-copy p {
+  margin: 0;
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.editor-header-meta {
-  display: grid;
-  justify-items: end;
-  gap: 0.18rem;
-  min-width: 0;
+.app-brand-copy h1 {
+  font-size: var(--icm-font-lg);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: var(--icm-line-tight);
 }
 
+.app-brand-copy p {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  line-height: var(--icm-line-tight);
+}
+
+.app-command-surface {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0;
+  min-width: 0;
+  margin-right: auto;
+  overflow: visible;
+}
+
+/* Visitor analytics entry (compact, does not crowd menubar commands). */
 .analytics-link {
   display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
   gap: 0.3rem;
+  margin-left: auto;
   color: var(--icm-text-muted);
-  font-size: 0.66rem;
+  font-size: var(--icm-font-xs);
   font-variant-numeric: tabular-nums;
+  line-height: var(--icm-line-tight);
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .analytics-link:hover {
@@ -214,42 +286,115 @@ body {
   text-underline-offset: 0.15rem;
 }
 
-.toolbar {
+.menubar-row,
+.toolbar-row {
   display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 2px;
+  min-width: 0;
+}
+
+.menubar-row {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.toolbar-row {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: var(--icm-space-1);
+  width: 100%;
+  padding: var(--icm-space-1) var(--icm-space-3);
+  border-top: 1px solid var(--icm-border);
+  background: var(--icm-surface-muted);
+  white-space: nowrap;
+  overflow-x: auto;
+}
+
+.toolbar-group {
+  display: inline-flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.2rem;
-  padding: 0.22rem;
-  border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-md);
-  background: var(--icm-surface-muted);
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 70%);
+  gap: 2px;
+}
+
+.toolbar-divider {
+  width: 1px;
+  height: 18px;
+  margin: 0 var(--icm-space-2);
+  background: var(--icm-border-strong);
+}
+
+.toolbar-button,
+.tool-rail-button,
+.menubar-help,
+.command-menu summary {
+  min-height: var(--icm-control-h);
+  border: 1px solid transparent;
+  border-radius: var(--icm-radius-sm);
+  background: transparent;
+  box-shadow: none;
+  color: var(--icm-text);
+  font-size: var(--icm-font-md);
+  font-weight: 500;
+  line-height: var(--icm-line-tight);
+  white-space: nowrap;
+}
+
+.toolbar-button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--icm-space-1);
+  padding: 0 var(--icm-space-2);
+}
+
+.toolbar-button:hover:not(:disabled),
+.tool-rail-button:hover:not(:disabled),
+.menubar-help:hover:not(:disabled),
+.command-menu summary:hover {
+  border-color: transparent;
+  background: var(--icm-surface-hover);
+}
+
+.toolbar-button[aria-pressed="true"],
+.tool-rail-button[aria-pressed="true"],
+.command-menu[open] summary {
+  border-color: transparent;
+  color: var(--icm-accent);
+  background: var(--icm-accent-tint);
+  box-shadow: none;
+}
+
+.menubar-help {
+  height: var(--icm-control-h);
+  padding: 0 10px;
+  white-space: nowrap;
 }
 
 .document-nav {
   display: flex;
-  gap: 0.25rem;
-  padding-right: 0.35rem;
-  margin-right: 0.1rem;
-  border-right: 1px solid var(--icm-border-strong);
+  align-items: center;
+  gap: var(--icm-space-1);
+  min-width: 0;
+}
+
+.document-nav button {
+  height: var(--icm-control-h);
+  padding: 0 var(--icm-space-2);
+  white-space: nowrap;
 }
 
 .document-nav select {
-  max-width: 13rem;
-  padding: 0.3rem;
+  max-width: 12rem;
+  height: var(--icm-control-h);
+  padding: 0 var(--icm-space-2);
   border: 1px solid var(--icm-border-strong);
   border-radius: var(--icm-radius-sm);
   background: var(--icm-surface);
   font: inherit;
-  font-size: 0.8rem;
-}
-
-.toolbar button,
-.command-menu summary {
-  min-height: 1.95rem;
-  padding: 0.34rem 0.58rem;
-  font-size: 0.76rem;
-  font-weight: 550;
+  font-size: var(--icm-font-sm);
 }
 
 .command-menu {
@@ -257,26 +402,30 @@ body {
 }
 
 .command-menu summary {
-  border: 1px solid transparent;
-  border-radius: var(--icm-radius-sm);
-  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: var(--icm-control-h);
+  padding: 0 10px;
   cursor: pointer;
   list-style: none;
-  transition:
-    border-color 120ms ease,
-    background-color 120ms ease,
-    color 120ms ease;
+  white-space: nowrap;
 }
 
-.command-menu summary:hover {
-  border-color: var(--icm-border);
-  background: var(--icm-surface);
+.command-menu summary::after {
+  content: "";
+  width: 0;
+  height: 0;
+  border-left: 3.5px solid transparent;
+  border-right: 3.5px solid transparent;
+  border-top: 4px solid currentColor;
+  opacity: 0.45;
+  translate: 0 1px;
 }
 
-.command-menu[open] summary {
-  border-color: rgb(var(--icm-accent-rgb) / 20%);
-  color: var(--icm-accent);
-  background: var(--icm-accent-tint);
+.command-menu[open] summary::after {
+  opacity: 0.75;
+  rotate: 180deg;
 }
 
 .command-menu summary::-webkit-details-marker {
@@ -285,26 +434,645 @@ body {
 
 .command-popover {
   position: absolute;
-  z-index: 10;
-  top: calc(100% + 0.35rem);
-  right: 0;
+  z-index: 40;
+  top: calc(100% + 6px);
+  left: 0;
   display: grid;
-  min-width: 11rem;
-  gap: 0.2rem;
-  padding: 0.4rem;
+  min-width: 15rem;
+  gap: 2px;
+  padding: 6px;
   border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-md);
+  border-radius: 10px;
   background: var(--icm-surface);
-  box-shadow: var(--icm-shadow-md);
+  box-shadow:
+    0 0 0 1px rgb(15 15 15 / 3%),
+    0 12px 32px rgb(15 15 15 / 12%);
 }
 
 .command-popover button,
 .command-popover .file-import {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   width: 100%;
-  min-height: 2rem;
-  border-color: transparent;
+  min-height: 32px;
+  padding: 0 10px;
+  border: 1px solid transparent;
+  border-radius: 6px;
   box-shadow: none;
+  font-size: var(--icm-font-md);
+  font-weight: 500;
   text-align: left;
+  white-space: nowrap;
+}
+
+.command-popover button:hover:not(:disabled),
+.command-popover .file-import:hover {
+  border-color: transparent;
+  background: var(--icm-surface-hover);
+}
+
+.command-popover button:disabled {
+  opacity: 0.45;
+}
+
+.command-popover .tool-icon {
+  opacity: 0.85;
+}
+
+.command-popover small {
+  display: block;
+  margin: 4px 6px 2px;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  line-height: 1.4;
+  white-space: normal;
+}
+
+.file-import {
+  padding: 0 var(--icm-space-2);
+  border: 1px solid transparent;
+  border-radius: var(--icm-radius-sm);
+  background: transparent;
+  box-shadow: none;
+  cursor: pointer;
+  font-size: var(--icm-font-md);
+}
+
+.app-workspace {
+  display: grid;
+  grid-template-columns:
+    var(--icm-rail-width) var(--icm-shapes-width) minmax(0, 1fr)
+    auto;
+  grid-template-areas: "tools shapes canvas props";
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  transition: grid-template-columns 160ms ease;
+}
+
+.app-workspace.library-collapsed {
+  grid-template-columns: var(--icm-rail-width) 0 minmax(0, 1fr) auto;
+}
+
+.tool-rail {
+  grid-area: tools;
+  display: flex;
+  flex-direction: column;
+  gap: var(--icm-space-1);
+  min-height: 0;
+  padding: var(--icm-space-2) var(--icm-space-1);
+  border-right: 1px solid var(--icm-border);
+  background: var(--icm-surface);
+  overflow: auto;
+}
+
+.tool-rail-button {
+  display: grid;
+  justify-items: center;
+  align-content: center;
+  gap: 3px;
+  width: 100%;
+  min-height: 44px;
+  padding: var(--icm-space-1) 2px;
+  font-size: var(--icm-font-xs);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  line-height: 1.1;
+}
+
+.tool-rail-button span {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tool-rail-divider {
+  height: 1px;
+  margin: var(--icm-space-1) var(--icm-space-2);
+  background: var(--icm-border);
+}
+
+.shapes-panel {
+  grid-area: shapes;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  border-right: 1px solid var(--icm-border);
+  background: var(--icm-surface);
+  overflow: hidden;
+  transition:
+    opacity 160ms ease,
+    border-color 160ms ease;
+}
+
+.shapes-panel.collapsed {
+  opacity: 0;
+  border-right-color: transparent;
+  pointer-events: none;
+}
+
+.shapes-panel-title {
+  display: grid;
+  gap: 2px;
+  width: 100%;
+  padding: var(--icm-space-1);
+  border: 0;
+  border-radius: var(--icm-radius-sm);
+  background: transparent;
+  box-shadow: none;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.shapes-panel-title:hover {
+  background: var(--icm-surface-hover);
+}
+
+.shapes-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--icm-space-2);
+  padding: var(--icm-space-3) var(--icm-space-3) var(--icm-space-2);
+  border-bottom: 1px solid var(--icm-border);
+}
+
+.shapes-panel-header h2,
+.shapes-panel-header p,
+.shapes-panel-heading,
+.shapes-section h3 {
+  margin: 0;
+}
+
+.shapes-kicker {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  line-height: var(--icm-line-tight);
+}
+
+.shapes-panel-header h2,
+.shapes-panel-heading {
+  font-size: var(--icm-font-lg);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: var(--icm-line-tight);
+}
+
+.shapes-panel-footer {
+  display: grid;
+  gap: var(--icm-space-2);
+  padding: var(--icm-space-2) var(--icm-space-3) var(--icm-space-3);
+  border-top: 1px solid var(--icm-border);
+  background: var(--icm-surface);
+}
+
+.shapes-insert {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--icm-space-2);
+  width: 100%;
+  min-height: var(--icm-control-h-lg);
+  padding: 0 var(--icm-space-3);
+  border: 1px solid transparent;
+  border-radius: var(--icm-radius-sm);
+  color: #fff;
+  background: var(--icm-accent);
+  box-shadow: none;
+  font-size: var(--icm-font-md);
+  font-weight: 600;
+}
+
+.shapes-insert:hover:not(:disabled) {
+  border-color: transparent;
+  filter: brightness(0.97);
+  background: var(--icm-accent);
+}
+
+.shapes-insert kbd {
+  padding: 1px 5px;
+  border: 1px solid rgb(255 255 255 / 35%);
+  border-radius: 4px;
+  background: rgb(255 255 255 / 16%);
+  font: inherit;
+  font-size: var(--icm-font-xs);
+  font-weight: 600;
+}
+
+.shapes-panel-body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: var(--icm-space-3);
+  min-height: 0;
+  padding: var(--icm-space-3);
+  overflow: auto;
+  scrollbar-color: var(--icm-border-strong) transparent;
+  scrollbar-width: thin;
+}
+
+.shapes-section {
+  display: grid;
+  gap: var(--icm-space-2);
+}
+
+/* Stacking fold sections must stay in normal flow — no absolute/overlap. */
+.shapes-fold {
+  position: relative;
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  min-width: 0;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-md);
+  background: var(--icm-surface);
+  overflow: clip;
+}
+
+.shapes-fold-summary {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  column-gap: 8px;
+  flex: 0 0 auto;
+  min-height: 32px;
+  padding: 0 10px;
+  cursor: pointer;
+  list-style: none;
+  color: var(--icm-text);
+  font-size: var(--icm-font-xs);
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  user-select: none;
+  background: var(--icm-surface-muted);
+}
+
+.shapes-fold-summary::-webkit-details-marker {
+  display: none;
+}
+
+.shapes-fold-summary::before {
+  content: "";
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid currentColor;
+  opacity: 0.45;
+  transition: transform 120ms ease;
+}
+
+.shapes-fold[open] > .shapes-fold-summary::before {
+  transform: rotate(90deg);
+}
+
+.shapes-fold-summary:hover {
+  background: var(--icm-surface-hover);
+}
+
+.shapes-fold-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shapes-fold-count {
+  min-width: 1.25rem;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: rgb(15 15 15 / 6%);
+  color: var(--icm-text-muted);
+  font-size: 10px;
+  font-weight: 650;
+  line-height: 1.2;
+  text-align: center;
+}
+
+.shapes-fold-body {
+  position: relative;
+  display: block;
+  flex: 0 0 auto;
+  min-width: 0;
+  padding: var(--icm-space-2);
+  border-top: 1px solid var(--icm-border);
+  background: var(--icm-surface);
+}
+
+.shapes-fold:not([open]) > .shapes-fold-body {
+  display: none;
+}
+
+.shapes-section h3 {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  line-height: var(--icm-line-tight);
+}
+
+.shapes-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--icm-space-2);
+}
+
+.shapes-chip {
+  display: grid;
+  justify-items: center;
+  align-content: center;
+  gap: var(--icm-space-2);
+  min-height: 104px;
+  padding: var(--icm-space-3) var(--icm-space-2) var(--icm-space-2);
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-md);
+  background: var(--icm-surface-muted);
+  box-shadow: none;
+  color: var(--icm-text);
+  font-size: var(--icm-font-xs);
+  font-weight: 600;
+  line-height: var(--icm-line-tight);
+  text-align: center;
+}
+
+.shapes-chip:hover:not(:disabled) {
+  border-color: var(--icm-border-hover);
+  background: #fff;
+  box-shadow: var(--icm-shadow-sm);
+}
+
+.shapes-chip-art {
+  /* Keep the tile size; paddingRatio on SymbolArtwork crops empty margin. */
+  width: 64px;
+  height: 48px;
+  overflow: visible;
+  color: var(--icm-text);
+}
+
+.shapes-chip span {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shapes-hint {
+  margin: 0;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-sm);
+  line-height: var(--icm-line);
+}
+
+.shapes-hint kbd,
+.inspect-empty kbd {
+  padding: 1px 5px;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: 4px;
+  background: var(--icm-surface-muted);
+  font: inherit;
+  font-size: var(--icm-font-xs);
+}
+
+.statusbar-left {
+  display: flex;
+  align-items: center;
+  gap: var(--icm-space-2);
+  min-width: 0;
+}
+
+.statusbar-tool {
+  flex: 0 0 auto;
+  padding: 2px 8px;
+  border-radius: 999px;
+  color: var(--icm-text-muted);
+  background: var(--icm-surface-muted);
+  font-size: var(--icm-font-xs);
+  font-weight: 600;
+  line-height: var(--icm-line-tight);
+}
+
+.selection-dock {
+  grid-area: props;
+  z-index: 12;
+  display: flex;
+  flex-direction: column;
+  width: var(--icm-props-collapsed);
+  min-height: 0;
+  overflow: hidden;
+  border-left: 1px solid var(--icm-border);
+  background: var(--icm-surface);
+  transition: width 160ms ease;
+}
+
+.selection-dock.open {
+  width: min(var(--icm-props-open), 42vw);
+}
+
+.command-popover small {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  line-height: var(--icm-line);
+}
+
+.selection-panel h2 {
+  margin: 0 0 var(--icm-space-2);
+  font-size: var(--icm-font-md);
+  font-weight: 600;
+}
+
+.selection-shelf {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
+  background: var(--icm-surface);
+}
+
+.selection-shelf-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--icm-space-2);
+  width: 100%;
+  min-height: 40px;
+  padding: 0 var(--icm-space-3);
+  overflow: hidden;
+  border: 0;
+  border-bottom: 1px solid var(--icm-border);
+  border-radius: 0;
+  color: var(--icm-text);
+  background: var(--icm-surface);
+  box-shadow: none;
+  font-size: var(--icm-font-md);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.selection-shelf-title {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--icm-space-2);
+}
+
+.selection-dock:not(.open) .selection-shelf-header {
+  justify-content: center;
+  padding-inline: 0;
+  border-bottom: 0;
+}
+
+.selection-dock:not(.open) .selection-shelf-title > span,
+.selection-dock:not(.open) .selection-shelf-summary {
+  display: none;
+}
+
+.selection-shelf-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--icm-space-1);
+  max-width: 11rem;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.selection-shelf-indicator {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--icm-accent);
+  box-shadow: 0 0 0 3px var(--icm-accent-soft);
+}
+
+.selection-panel {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: var(--icm-space-3);
+  scrollbar-color: var(--icm-border-strong) transparent;
+  scrollbar-width: thin;
+}
+
+.selection-overview {
+  margin-bottom: var(--icm-space-3);
+  padding: var(--icm-space-3);
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-md);
+  background: var(--icm-surface-muted);
+}
+
+.selection-overview > span {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.selection-overview h2,
+.selection-overview p {
+  margin: 0;
+}
+
+.selection-overview h2 {
+  margin-top: 2px;
+  font-size: var(--icm-font-lg);
+  font-weight: 600;
+}
+
+.selection-overview p {
+  margin-top: var(--icm-space-1);
+  overflow-wrap: anywhere;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-sm);
+}
+
+.selection-overview dl {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--icm-space-1) var(--icm-space-2);
+  margin: var(--icm-space-2) 0 0;
+  font-size: var(--icm-font-sm);
+}
+
+.selection-overview dt {
+  color: var(--icm-text-muted);
+}
+
+.selection-overview dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+  text-align: right;
+}
+
+.inspect-empty {
+  margin: var(--icm-space-1) 0;
+  padding: var(--icm-space-3);
+  border: 1px dashed var(--icm-border-strong);
+  border-radius: var(--icm-radius-md);
+  color: var(--icm-text-muted);
+  background: var(--icm-surface-muted);
+  font-size: var(--icm-font-sm);
+  line-height: var(--icm-line);
+}
+
+.selection-panel > h3 {
+  margin: 0 0 var(--icm-space-2);
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-sm);
+  font-weight: 600;
+}
+
+.selection-panel > button {
+  display: block;
+  width: 100%;
+  margin-bottom: var(--icm-space-2);
+  min-height: var(--icm-control-h);
+  padding: 0 var(--icm-space-2);
+  border-color: var(--icm-border);
+  box-shadow: none;
+  font-size: var(--icm-font-md);
+  text-align: left;
+}
+
+.editor-status {
+  box-sizing: border-box;
+  min-width: 0;
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-sm);
+  font-weight: 500;
+  line-height: var(--icm-line-tight);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-statusbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--icm-space-3);
+  min-height: var(--icm-statusbar-h);
+  padding: 0 var(--icm-space-3);
+  border-top: 1px solid var(--icm-border);
+  background: var(--icm-surface);
 }
 
 .help-backdrop {
@@ -314,8 +1082,8 @@ body {
   display: grid;
   place-items: center;
   padding: 1.25rem;
-  background: rgb(15 23 42 / 42%);
-  backdrop-filter: blur(3px);
+  background: rgb(55 53 47 / 28%);
+  backdrop-filter: blur(4px);
 }
 
 .help-dialog {
@@ -351,7 +1119,7 @@ body {
 
 .help-kicker {
   color: var(--icm-text-muted);
-  font-size: 0.75rem;
+  font-size: var(--icm-font-sm);
   font-weight: 700;
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -359,7 +1127,7 @@ body {
 
 .help-dialog-header h2 {
   margin-top: 0.2rem;
-  font-size: 1.2rem;
+  font-size: 18px;
 }
 
 .help-dialog-content {
@@ -371,12 +1139,12 @@ body {
 
 .help-dialog-content h3 {
   margin-bottom: 0.25rem;
-  font-size: 0.95rem;
+  font-size: var(--icm-font-lg);
 }
 
 .help-dialog-content p {
   color: var(--icm-text-muted);
-  font-size: 0.88rem;
+  font-size: var(--icm-font-lg);
 }
 
 .help-dialog-content strong {
@@ -385,7 +1153,7 @@ body {
 
 .help-section-label {
   color: var(--icm-text-muted);
-  font-size: 0.72rem;
+  font-size: var(--icm-font-sm);
   font-weight: 700;
   letter-spacing: 0.07em;
   text-transform: uppercase;
@@ -403,7 +1171,7 @@ body {
   padding: 0.7rem 0;
   border-top: 1px solid var(--icm-border);
   border-bottom: 1px solid var(--icm-border);
-  font-size: 0.8rem;
+  font-size: var(--icm-font-md);
 }
 
 .help-index a {
@@ -417,7 +1185,27 @@ body {
   text-underline-offset: 0.18em;
 }
 
-.help-handbook,
+.help-handbook {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.help-quick-ref {
+  margin: 0 0 var(--icm-space-3);
+  padding: var(--icm-space-3);
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-md);
+  background: var(--icm-surface-muted);
+  color: var(--icm-text);
+  font-size: var(--icm-font-sm);
+  line-height: var(--icm-line);
+}
+
+.help-quick-ref strong {
+  color: var(--icm-text);
+  font-weight: 600;
+}
+
 .help-shortcuts {
   display: grid;
   gap: 0.7rem;
@@ -437,14 +1225,14 @@ body {
 
 .help-shortcuts dt {
   color: var(--icm-text);
-  font-size: 0.82rem;
+  font-size: var(--icm-font-md);
   font-weight: 700;
 }
 
 .help-shortcuts dd {
   margin: 0;
   color: var(--icm-text-muted);
-  font-size: 0.84rem;
+  font-size: var(--icm-font-md);
 }
 
 .help-dialog-content kbd {
@@ -465,196 +1253,12 @@ body {
   background: linear-gradient(135deg, var(--icm-surface-muted), #fff);
 }
 
-.selection-dock {
-  position: fixed;
-  z-index: 14;
-  top: 4.6rem;
-  left: 0.75rem;
-  width: 2.8rem;
-  max-height: calc(100dvh - 5.35rem);
-  overflow: hidden;
-  border: 1px solid var(--icm-border-strong);
-  border-radius: var(--icm-radius-md);
-  background: rgb(255 255 255 / 96%);
-  box-shadow: var(--icm-shadow-md);
-  transition: width 160ms ease;
-  backdrop-filter: blur(12px);
-}
-
-.selection-dock.open {
-  width: min(18rem, calc(100vw - 1.5rem));
-}
-
-.command-popover small {
-  color: var(--icm-text-muted);
-  font-size: 0.72rem;
-}
-
-.selection-panel h2 {
-  margin: 0 0 0.75rem;
-  font-size: 0.9rem;
-}
-
-.selection-shelf {
-  display: flex;
-  flex-direction: column;
-  max-height: calc(100dvh - 5.35rem);
-  overflow: hidden;
-  background: var(--icm-surface);
-}
-
-.selection-shelf-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.6rem;
-  width: 100%;
-  min-height: 2.55rem;
-  padding: 0 0.75rem;
-  overflow: hidden;
-  border: 0;
-  border-radius: 0;
-  color: var(--icm-text);
-  background: linear-gradient(180deg, #fff, var(--icm-surface-muted));
-  box-shadow: none;
-  font-size: 0.76rem;
-  font-weight: 700;
-  white-space: nowrap;
-}
-
-.selection-shelf-title {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-}
-
-.selection-dock:not(.open) .selection-shelf-header {
-  justify-content: center;
-  padding-inline: 0;
-}
-
-.selection-dock:not(.open) .selection-shelf-title > span,
-.selection-dock:not(.open) .selection-shelf-summary {
-  display: none;
-}
-
-.selection-shelf-summary {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  max-width: 11rem;
-  color: var(--icm-text-muted);
-  font-size: 0.7rem;
-  font-weight: 500;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.selection-shelf-indicator {
-  width: 0.4rem;
-  height: 0.4rem;
-  flex: 0 0 auto;
-  border-radius: 50%;
-  background: var(--icm-accent);
-  box-shadow: 0 0 0 3px var(--icm-accent-soft);
-}
-
-.selection-panel {
-  flex: 0 1 auto;
-  min-height: 0;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  max-height: calc(100dvh - 8rem);
-  padding: 0.75rem;
-  scrollbar-color: var(--icm-border-strong) transparent;
-  scrollbar-width: thin;
-}
-
-.selection-overview {
-  margin-bottom: 0.75rem;
-  padding: 0.75rem;
-  border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-md);
-  background: var(--icm-surface-muted);
-}
-
-.selection-overview > span {
-  color: var(--icm-accent);
-  font-size: 0.62rem;
-  font-weight: 750;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-}
-
-.selection-overview h2,
-.selection-overview p {
-  margin: 0;
-}
-
-.selection-overview h2 {
-  margin-top: 0.2rem;
-  font-size: 0.95rem;
-}
-
-.selection-overview p {
-  margin-top: 0.35rem;
-  overflow-wrap: anywhere;
-  color: var(--icm-text-muted);
-  font-size: 0.72rem;
-}
-
-.selection-overview dl {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.3rem 0.65rem;
-  margin: 0.65rem 0 0;
-  font-size: 0.7rem;
-}
-
-.selection-overview dt {
-  color: var(--icm-text-muted);
-}
-
-.selection-overview dd {
-  margin: 0;
-  overflow-wrap: anywhere;
-  text-align: right;
-}
-
-.inspect-empty {
-  margin: 0.25rem 0;
-  padding: 0.7rem;
-  border: 1px dashed var(--icm-border-strong);
-  border-radius: var(--icm-radius-md);
-  color: var(--icm-text-muted);
-  background: var(--icm-surface-muted);
-  font-size: 0.74rem;
-  line-height: 1.45;
-}
-
-.selection-panel > h3 {
-  margin: 0 0 0.55rem;
-  color: var(--icm-text-muted);
-  font-size: 0.78rem;
-}
-
-.selection-panel > button {
-  display: block;
-  width: 100%;
-  margin-bottom: 0.45rem;
-  padding: 0.55rem 0.6rem;
-  border-color: var(--icm-border);
-  box-shadow: none;
-  text-align: left;
-}
-
 .inspector {
   display: none;
   grid-template-columns: auto 1fr;
   gap: 0.35rem 0.6rem;
   margin-top: 1.5rem;
-  font-size: 0.78rem;
+  font-size: var(--icm-font-md);
 }
 
 .inspector dt {
@@ -671,11 +1275,11 @@ body {
   margin-top: 1rem;
   border-top: 1px solid var(--icm-border);
   padding-top: 0.75rem;
-  font-size: 0.75rem;
+  font-size: var(--icm-font-sm);
 }
 
 .diagnostics h2 {
-  font-size: 0.85rem;
+  font-size: var(--icm-font-md);
 }
 
 .diagnostics ul {
@@ -702,20 +1306,13 @@ body {
 }
 
 .canvas-panel {
-  grid-column: 1;
-  grid-row: 2;
+  grid-area: canvas;
   position: relative;
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  padding: 0.65rem;
-  background:
-    radial-gradient(
-      circle at 50% 0%,
-      rgb(255 255 255 / 68%),
-      transparent 36rem
-    ),
-    var(--icm-chrome-bg);
+  padding: 0;
+  background: #fafaf9;
 }
 
 .schematic-canvas {
@@ -723,12 +1320,10 @@ body {
   width: 100%;
   height: 100%;
   min-height: 0;
-  border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-sm);
+  border: 0;
+  border-radius: 0;
   background: #fff;
-  box-shadow:
-    0 1px 2px rgb(15 23 42 / 4%),
-    0 12px 32px rgb(15 23 42 / 8%);
+  box-shadow: none;
   touch-action: none;
 }
 
@@ -815,7 +1410,8 @@ body {
 
 .guide-hit {
   fill: none;
-  stroke: transparent;
+  /* Match route-hit: fully transparent strokes are not reliably targetable. */
+  stroke: rgb(0 0 0 / 0.4%);
   stroke-width: 14;
   cursor: move;
   pointer-events: stroke;
@@ -1013,7 +1609,7 @@ body {
   padding: 0.15rem 0.35rem;
   border: 0;
   background: transparent;
-  font-size: 0.74rem;
+  font-size: var(--icm-font-sm);
 }
 
 .rich-text-floating-toolbar button:hover:not(:disabled) {
@@ -1057,7 +1653,8 @@ body {
   stroke-width: 1;
   stroke-dasharray: 6 4;
   cursor: move;
-  pointer-events: stroke;
+  /* Visual only; `.guide-hit` owns pointer interaction. */
+  pointer-events: none;
   vector-effect: non-scaling-stroke;
 }
 
@@ -1076,13 +1673,12 @@ body {
 
 .command-group-label {
   display: block;
-  margin: 0.5rem 0 0.125rem;
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  margin: 8px 8px 4px;
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--icm-text-muted);
-  opacity: 1;
 }
 
 .annotation-drag-preview {
@@ -1110,13 +1706,13 @@ body {
   display: grid;
   gap: 0.25rem;
   color: var(--icm-text-muted);
-  font-size: 0.75rem;
+  font-size: var(--icm-font-sm);
 }
 
 .context-actions input,
 .context-actions select {
   min-width: 0;
-  min-height: 2.15rem;
+  min-height: var(--icm-control-h-lg);
   padding: 0.45rem 0.55rem;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
@@ -1133,7 +1729,7 @@ body {
 .property-parameter-name em {
   margin-left: 0.25rem;
   color: var(--icm-text-muted);
-  font-size: 0.66rem;
+  font-size: var(--icm-font-xs);
   font-style: normal;
   font-weight: 500;
 }
@@ -1164,14 +1760,14 @@ body {
 .component-mirror-row button {
   min-width: 0;
   padding: 0.3rem 0.45rem;
-  font-size: 0.7rem;
+  font-size: var(--icm-font-sm);
   white-space: nowrap;
 }
 
 .property-source-fact {
   margin: 0.5rem 0 0;
   color: var(--icm-text-muted);
-  font-size: 0.72rem;
+  font-size: var(--icm-font-sm);
 }
 
 .drawing-properties {
@@ -1189,17 +1785,6 @@ body {
   border-top: 1px solid var(--icm-border-strong);
 }
 
-.tool-icon {
-  display: block;
-  flex: 0 0 auto;
-}
-
-.command-popover button {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
 .insert-dialog-backdrop {
   position: fixed;
   z-index: 80;
@@ -1207,8 +1792,8 @@ body {
   display: grid;
   place-items: center;
   padding: 1.25rem;
-  background: rgb(15 23 42 / 24%);
-  backdrop-filter: blur(2px);
+  background: rgb(55 53 47 / 28%);
+  backdrop-filter: blur(4px);
 }
 
 .insert-component-dialog {
@@ -1243,7 +1828,7 @@ body {
 
 .insert-dialog-header p {
   color: var(--icm-text-muted);
-  font-size: 0.68rem;
+  font-size: var(--icm-font-xs);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -1251,7 +1836,7 @@ body {
 
 .insert-dialog-header h2 {
   margin-top: 0.15rem;
-  font-size: 1.15rem;
+  font-size: 16px;
 }
 
 .insert-dialog-header kbd,
@@ -1262,14 +1847,14 @@ body {
   background: var(--icm-surface-muted);
   box-shadow: 0 1px 0 var(--icm-border-strong);
   font: inherit;
-  font-size: 0.75rem;
+  font-size: var(--icm-font-sm);
 }
 
 .insert-search-field {
   display: grid;
   gap: 0.35rem;
   color: var(--icm-text-muted);
-  font-size: 0.72rem;
+  font-size: var(--icm-font-sm);
   font-weight: 650;
 }
 
@@ -1282,7 +1867,7 @@ body {
   color: var(--icm-text);
   background: var(--icm-surface-muted);
   font: inherit;
-  font-size: 0.9rem;
+  font-size: var(--icm-font-lg);
 }
 
 .insert-search-field input:focus {
@@ -1317,7 +1902,7 @@ body {
   padding: 0.55rem 0.75rem 0.35rem;
   color: var(--icm-text-muted);
   background: rgb(248 250 252 / 95%);
-  font-size: 0.64rem;
+  font-size: var(--icm-font-xs);
   letter-spacing: 0.075em;
   text-transform: uppercase;
   backdrop-filter: blur(8px);
@@ -1349,7 +1934,7 @@ body {
 
 .insert-option-group button span {
   overflow: hidden;
-  font-size: 0.8rem;
+  font-size: var(--icm-font-md);
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1357,14 +1942,14 @@ body {
 
 .insert-option-group button small {
   color: var(--icm-text-muted);
-  font-size: 0.66rem;
+  font-size: var(--icm-font-xs);
 }
 
 .insert-no-results {
   margin: 0;
   padding: 1.25rem;
   color: var(--icm-text-muted);
-  font-size: 0.8rem;
+  font-size: var(--icm-font-md);
   text-align: center;
 }
 
@@ -1390,18 +1975,18 @@ body {
 }
 
 .insert-component-preview h3 {
-  font-size: 1rem;
+  font-size: var(--icm-font-lg);
 }
 
 .insert-component-preview p,
 .insert-component-preview small {
   color: var(--icm-text-muted);
-  font-size: 0.72rem;
+  font-size: var(--icm-font-sm);
 }
 
 .insert-dialog-actions > small {
   color: var(--icm-text-muted);
-  font-size: 0.7rem;
+  font-size: var(--icm-font-sm);
 }
 
 .insert-dialog-actions > div {
@@ -1472,7 +2057,7 @@ body {
   padding: 0;
   border-color: var(--icm-border-strong);
   box-shadow: none;
-  font-size: 1rem;
+  font-size: var(--icm-font-lg);
 }
 
 .insert-component-options {
@@ -1492,7 +2077,7 @@ body {
 .insert-control-section h3 {
   margin: 0;
   color: var(--icm-text-muted);
-  font-size: 0.68rem;
+  font-size: var(--icm-font-xs);
   letter-spacing: 0.07em;
   text-transform: uppercase;
 }
@@ -1501,12 +2086,12 @@ body {
   display: grid;
   gap: 0.22rem;
   color: var(--icm-text-muted);
-  font-size: 0.72rem;
+  font-size: var(--icm-font-sm);
 }
 
 .insert-control-section input {
   min-width: 0;
-  min-height: 2.15rem;
+  min-height: var(--icm-control-h-lg);
   padding: 0.4rem 0.5rem;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
@@ -1517,7 +2102,7 @@ body {
 
 .insert-control-section small {
   color: var(--icm-text-muted);
-  font-size: 0.65rem;
+  font-size: var(--icm-font-xs);
 }
 
 .insert-placement-options {
@@ -1535,13 +2120,13 @@ body {
   display: grid;
   gap: 0.22rem;
   color: var(--icm-text-muted);
-  font-size: 0.72rem;
+  font-size: var(--icm-font-sm);
 }
 
 .insert-rotation-control select,
 .insert-label-control > input {
   min-width: 0;
-  min-height: 2.15rem;
+  min-height: var(--icm-control-h-lg);
   padding: 0.4rem 0.5rem;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
@@ -1560,7 +2145,7 @@ body {
 .insert-reference-toggle {
   display: flex !important;
   align-items: center;
-  min-height: 2.15rem;
+  min-height: var(--icm-control-h-lg);
   gap: 0.45rem;
   color: var(--icm-text) !important;
 }
@@ -1578,7 +2163,7 @@ body {
 .insert-parameter-name em {
   margin-left: 0.25rem;
   color: var(--icm-text-muted);
-  font-size: 0.66rem;
+  font-size: var(--icm-font-xs);
   font-style: normal;
   font-weight: 500;
 }
@@ -1631,101 +2216,182 @@ body {
   top: 50%;
   left: 50%;
   display: grid;
-  gap: 0.35rem;
-  padding: 0.75rem 1rem;
+  gap: var(--icm-space-2);
+  width: min(22rem, calc(100% - 2rem));
+  padding: var(--icm-space-4);
+  border: 1px solid var(--icm-border);
   color: var(--icm-text-muted);
-  background: rgb(255 255 255 / 76%);
-  border-radius: var(--icm-radius-md);
+  background: rgb(255 255 255 / 96%);
+  border-radius: var(--icm-radius-lg);
+  box-shadow: var(--icm-shadow-md);
   pointer-events: none;
-  text-align: center;
+  text-align: left;
   transform: translate(-50%, -50%);
-  backdrop-filter: blur(5px);
+  backdrop-filter: blur(8px);
+}
+
+.canvas-empty-kicker {
+  margin: 0;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  line-height: var(--icm-line-tight);
 }
 
 .canvas-empty-state strong {
   color: var(--icm-text);
-  font-size: 0.84rem;
+  font-size: var(--icm-font-lg);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: var(--icm-line-tight);
 }
 
 .canvas-empty-state span {
-  font-size: 0.72rem;
+  font-size: var(--icm-font-sm);
+  line-height: var(--icm-line);
+}
+
+.canvas-empty-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--icm-space-2);
+  margin-top: var(--icm-space-1);
+  pointer-events: auto;
+}
+
+.canvas-empty-actions button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--icm-space-2);
+  min-height: var(--icm-control-h-lg);
+  padding: 0 var(--icm-space-3);
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface);
+  box-shadow: none;
+  font-size: var(--icm-font-md);
+  font-weight: 600;
+}
+
+.canvas-empty-actions button:hover:not(:disabled) {
+  background: var(--icm-surface-hover);
+}
+
+.canvas-empty-primary {
+  border-color: transparent !important;
+  color: #fff !important;
+  background: var(--icm-accent) !important;
+}
+
+.canvas-empty-primary:hover:not(:disabled) {
+  filter: brightness(0.96);
+  background: var(--icm-accent) !important;
+}
+
+.canvas-empty-actions kbd {
+  padding: 0.05rem 0.28rem;
+  border: 1px solid rgb(255 255 255 / 35%);
+  border-radius: 0.25rem;
+  background: rgb(255 255 255 / 16%);
+  font: inherit;
+  font-size: 0.72em;
+}
+
+.canvas-empty-actions button:not(.canvas-empty-primary) kbd {
+  border-color: var(--icm-border-strong);
+  background: var(--icm-surface-muted);
+  color: var(--icm-text-muted);
 }
 
 .canvas-controls {
-  position: absolute;
-  z-index: 12;
-  right: 1.15rem;
-  bottom: 1.15rem;
   display: flex;
   align-items: center;
   overflow: hidden;
-  border: 1px solid var(--icm-border-strong);
-  border-radius: var(--icm-radius-md);
-  background: rgb(255 255 255 / 94%);
-  box-shadow: var(--icm-shadow-md);
-  backdrop-filter: blur(10px);
+  border: 1px solid var(--icm-border);
+  border-radius: 999px;
+  background: var(--icm-surface-muted);
 }
 
 .canvas-controls button {
   display: grid;
-  width: 2.15rem;
-  height: 2.15rem;
+  width: 28px;
+  height: 28px;
   place-items: center;
   padding: 0;
   border: 0;
   border-radius: 0;
   box-shadow: none;
+  background: transparent;
+}
+
+.canvas-controls button:hover:not(:disabled) {
+  background: var(--icm-surface-hover);
 }
 
 .canvas-controls output {
-  min-width: 3.4rem;
-  padding: 0 0.35rem;
+  min-width: 3rem;
+  padding: 0 var(--icm-space-1);
   color: var(--icm-text-muted);
-  font-size: 0.68rem;
+  font-size: var(--icm-font-xs);
   font-variant-numeric: tabular-nums;
+  line-height: var(--icm-line-tight);
   text-align: center;
 }
 
 @media (max-width: 1100px) {
-  .app-header {
-    gap: 0.65rem;
-    padding-inline: 0.75rem;
+  .app-brand-copy h1 {
+    font-size: var(--icm-font-md);
   }
 
-  .app-header h1 {
-    font-size: 0.88rem;
+  .toolbar-button span {
+    display: none;
   }
 
-  .app-header p,
-  .editor-status {
-    font-size: 0.68rem;
+  .toolbar-button {
+    min-width: 2rem;
+    justify-content: center;
+    padding-inline: 0.4rem;
   }
 
-  .toolbar button,
-  .command-menu summary {
-    padding-inline: 0.45rem;
+  .app-workspace {
+    grid-template-columns:
+      var(--icm-rail-width) min(220px, var(--icm-shapes-width))
+      minmax(0, 1fr) auto;
+  }
+
+  .app-brand {
+    min-width: 9rem;
   }
 }
 
 @media (max-width: 860px) {
-  .app-header {
-    display: flex;
-    align-items: flex-start;
-    flex-wrap: wrap;
+  .app-chrome-main {
+    column-gap: var(--icm-space-2);
+    padding: 0 var(--icm-space-2);
   }
 
-  .editor-status {
-    width: auto;
+  .app-workspace {
+    grid-template-columns: var(--icm-rail-width) minmax(0, 1fr);
+    grid-template-areas:
+      "tools canvas"
+      "shapes shapes"
+      "props props";
   }
 
-  .toolbar {
-    order: 3;
+  .shapes-panel {
+    max-height: 30dvh;
+    border-right: 0;
+    border-top: 1px solid var(--icm-border);
+  }
+
+  .selection-dock,
+  .selection-dock.open {
     width: 100%;
-  }
-
-  .selection-dock {
-    top: 6.7rem;
-    max-height: calc(100dvh - 7.45rem);
+    max-height: 36dvh;
+    border-left: 0;
+    border-top: 1px solid var(--icm-border);
   }
 
   .insert-component-dialog {

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -2,7 +2,7 @@
 
 Status: `accepted`
 
-Version: `1.6`
+Version: `1.13`
 
 Owning phase: `Phase 8`
 
@@ -42,32 +42,42 @@ Project and Document baseline.
 
 ## Command surface
 
-The production header exposes document/navigation and high-frequency document
-commands. Component placement uses one modeless master/detail insertion dialog;
-drawing tools live in the compact `Draw` menu rather than a permanent toolbar
-row or component sidebar:
+The production chrome uses a compact schematic-editor shell with calm surfaces:
+menubar, left tool rail, left Shapes quick-place column, canvas, right
+Properties panel, and bottom status bar. There is no permanent second toolbar
+row for Draw or Edit commands; those live in the left rail and menus.
+Keyboard shortcuts remain the fast path for Undo/Redo/Delete/Rotate. Full
+component setup still uses one modeless master/detail insertion dialog; the
+left Shapes column offers starter and recent chips only (not a permanent
+searchable catalog).
 
 ```text
-File | Edit | Draw | More
+File | Edit | Draw | More | Help
+[tool rail: Library/Wire/Text/…] [Library quick-place + Insert]  canvas  [Properties]
+status · active tool · zoom
 ```
 
 The exact visual treatment may use icons, labels, or responsive grouping, but
 the information architecture is normative:
 
-| Group | Commands                                                              |
-| ----- | --------------------------------------------------------------------- |
-| File  | Open, Save, Import, Export, and recent/example documents              |
-| Edit  | Undo, Redo, Delete, and contextual Align                              |
-| Draw  | Insert Component; Wire, Text, Arrow, Construction line, and Rectangle |
-| More  | Guides and shortcut reference; diagnostics remain in Import Review    |
+| Group      | Commands                                                                     |
+| ---------- | ---------------------------------------------------------------------------- |
+| File       | Open, Save, Import, Export, and recent/example documents                     |
+| Edit       | Undo, Redo, Delete, Rotate, Mirror, and contextual Align (menu home)         |
+| Draw       | Insert Component; Wire, Text, Arrow, Construction line, and Rectangle        |
+| More       | Guides and shortcut reference; diagnostics remain in Import Review           |
+| Tool rail  | Library toggles the left library panel; Wire, Text, Arrow, Line, Rect, Guide |
+| Library    | Starter/recent chips; title click or bottom Insert opens the full dialog     |
+| Properties | Contextual inspector docked on the right; closed by default                  |
 
 The following are not permanent production toolbar modes:
 
-- Select, Junction, Crossing, Stretch, Detach, Rotate, Mirror, Zoom, and Pan.
+- Select, Junction, Crossing, Stretch, Detach, Mirror, Zoom, and Pan as exclusive modes.
 - Save snapshot and Reopen snapshot; recovery is automatic infrastructure.
 - Phase/demo actions; examples belong in File/Open Example or development mode.
+- A permanent searchable full-catalog sidebar; `I` / library title / shapes Insert opens the dialog. Rail Library folds or expands the panel.
 
-`I` or `Draw > Insert component` opens one stable two-column dialog. Its left
+`I`, library title, shapes-panel **Insert**, or `Draw > Insert component` opens one stable two-column dialog. The rail **Library** control only shows or hides the panel. Its left
 setup column contains one compact searchable component picker, device-specific
 parameters, and one compact placement row for initial rotation plus an optional
 label/name; the
@@ -177,6 +187,7 @@ component or short Route drag.
 | `L`                        | Edit/create the selected Route's electrical Net Label.                             |
 | `P`                        | Enter Construction line mode.                                                      |
 | `Q`                        | Open Properties for the selected object and focus its primary editor.              |
+| Double-click (instance)    | Open Properties for a non-hierarchical device; enter cell for hierarchical cells.  |
 | `Escape`                   | Cancel the active gesture, then return to Pointer mode.                            |
 | `Delete` / `Backspace`     | Delete the selected object after applying the selection-specific semantic command. |
 | `U` / `Shift+U`            | Undo / redo one committed transaction.                                             |
@@ -262,10 +273,12 @@ operation.
 - Component selection is transient in the `I` insertion dialog. No permanent
   component library consumes canvas width or duplicates the Draw command
   surface.
-- Object properties live in a floating left `Properties` shelf. It is collapsed
-  by default; direct selection never opens it. `Q`, a direct click on the shelf,
-  and the explicit Import Review exception can expand it. It overlays rather
-  than resizes the canvas and scrolls internally when its details overflow.
+- Object properties live in the right `Properties` dock. It is collapsed by
+  default; a single click that only selects never opens it. `Q`, double-click on
+  a non-hierarchical instance, a direct click on the shelf header, and the
+  explicit Import Review exception expand it. Hierarchical instance double-click
+  still enters the child cell instead of opening Properties. The dock reflows
+  the workspace when open and scrolls internally when details overflow.
 - A component's identity card shows only its reference and symbol. Editable
   `X`, `Y`, and `Rotate` appear once in a compact Properties row; device
   parameters use the same inline symbol/unit/explanation notation as `I`.

--- a/plan/2026-08-12-chrome-type-scale-redesign/plan.md
+++ b/plan/2026-08-12-chrome-type-scale-redesign/plan.md
@@ -1,0 +1,12 @@
+---
+status: completed
+experience: none
+---
+
+# Chrome type/icon/gap scale redesign
+
+## Outcome
+
+Unified chrome tokens: 4px spacing grid, three type steps (11/12/13/14px),
+16px icons, fixed control heights, consistent rail/library/properties/status
+gaps. Formal schematic canvas unchanged. Focused e2e green.

--- a/plan/2026-08-12-dedupe-editor-tool-chrome/plan.md
+++ b/plan/2026-08-12-dedupe-editor-tool-chrome/plan.md
@@ -1,0 +1,31 @@
+---
+status: completed
+experience: none
+---
+
+# Deduplicate editor tool chrome
+
+## Goal
+
+Remove duplicated drawing tools from the top toolbar so each action has one
+primary chrome home: left rail for draw tools, top strip for edit actions,
+Shapes for quick-place, Draw menu for secondary/e2e access.
+
+## Work
+
+1. Removed Insert/Wire/Text/Arrow/Line/Rect from the top toolbar row.
+2. Kept hierarchy nav + Undo/Redo/Delete/Rotate on top.
+3. Left tool rail + Draw menu + Shapes quick-place unchanged as intentional
+   layered access (rail primary, menu secondary, shapes for components).
+4. Updated interaction contract to v1.9 and help copy.
+
+## Validation
+
+- App Vitest 11/11
+- Playwright e2e 73/73
+- Prettier + `git diff --check`
+
+## Outcome
+
+Drawing tools no longer appear twice in the main chrome. Top strip is edit-only;
+left rail is the primary Draw home.

--- a/plan/2026-08-12-double-click-opens-properties/plan.md
+++ b/plan/2026-08-12-double-click-opens-properties/plan.md
@@ -1,0 +1,15 @@
+---
+status: completed
+experience: none
+---
+
+# Double-click instance opens Properties
+
+## Goal
+
+Double-clicking a placed non-hierarchical device opens Properties.
+
+## Outcome
+
+`inspectInstance` on double-click for ordinary devices; hierarchical cells still
+enter on double-click. Contract v1.11 + e2e coverage. Q remains supported.

--- a/plan/2026-08-12-editor-chrome-polish/plan.md
+++ b/plan/2026-08-12-editor-chrome-polish/plan.md
@@ -1,0 +1,54 @@
+---
+status: completed
+experience: none
+---
+
+# Editor chrome polish pass
+
+## Goal
+
+Polish the redesigned editor shell for clearer first-run operation: quick-place shapes column, empty state and dialog surfaces, clearer
+Properties/status feedback. Keep formal schematic export styling and the full
+insert dialog as the complete catalog.
+
+## State and Ownership
+
+Prior chrome commit was local-only on `main` (ahead 1). This target continued on
+that line.
+
+Owned paths:
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/app/App.test.tsx`
+- `apps/editor/src/styles.css`
+- `apps/editor/src/features/editor-shell/*`
+- `apps/editor/src/components/editor-help-dialog.tsx`
+- `apps/editor/e2e/drafting.spec.ts`
+- `docs/specs/editor-interaction.md`
+- `plan/2026-08-12-editor-chrome-polish/plan.md`
+- `plan/log.md`
+
+## Work
+
+1. Added left Shapes quick-place panel (starters + recent + Browse all).
+2. Redesigned canvas empty state with actionable cards; hidden during placement.
+3. Polished insert/help backdrops, Properties empty copy, status tool readout.
+4. Updated interaction contract to v1.8 and focused tests.
+
+## Validation
+
+- `pnpm exec vitest run apps/editor/src/app/App.test.tsx apps/editor/src/features/editor-shell/shapes-panel.test.ts` — 13/13
+- `CI=1 ICM_E2E_ISOLATED=1 pnpm exec playwright test` — 73/73
+- Prettier + `git diff --check` on touched files
+
+## Commit Intent
+
+```text
+Polish editor chrome with shapes quick-place and empty-state actions
+```
+
+## Outcome
+
+Shapes quick-place, empty-state actions, status tool chip, and chrome surface
+polish landed. Full catalog remains the insert dialog. Unit and full editor e2e
+passed.

--- a/plan/2026-08-12-editor-chrome-shell/plan.md
+++ b/plan/2026-08-12-editor-chrome-shell/plan.md
@@ -1,0 +1,72 @@
+---
+status: completed
+experience: none
+---
+
+# layout + chrome redesign
+
+## Goal
+
+Redesign the editor shell so the layout is easier to scan and operate, using
+information architecture (menubar, tool strip, canvas, right format
+panel, status bar) and visual details (calm surfaces, soft borders,
+quiet hover states). Preserve existing editing contracts, testids, and File /
+Edit / Draw / More command names.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+Worktree was clean.
+
+Owned paths:
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/styles.css`
+- `apps/editor/src/features/editor-shell/tool-icon.tsx`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `apps/editor/e2e/manual-editor.spec.ts`
+- `apps/editor/e2e/drafting.spec.ts`
+- `apps/editor/src/app/App.test.tsx`
+- `docs/specs/editor-interaction.md`
+- `plan/2026-08-12-editor-chrome-editor-chrome/plan.md`
+- `plan/log.md`
+
+## Work
+
+1. Restructured shell into menubar, primary tool strip, left tool rail, canvas,
+   right Properties panel, and bottom status bar.
+2. Restyled chrome with tokens; formal schematic canvas export
+   styling remains untouched.
+3. Kept File / Edit / Draw / More menus and insert dialog; mirrored high-frequency
+   tools on the strip and rail.
+4. Updated interaction contract to v1.7 for the new chrome IA.
+5. Adjusted e2e for in-flow Properties reflow and macOS text-select shortcuts.
+6. Fixed guide hit-testing so visual guides no longer steal pointer events from
+   `.guide-hit`.
+
+## Validation
+
+- `pnpm exec vitest run apps/editor/src/app/App.test.tsx` — pass
+- `CI=1 ICM_E2E_ISOLATED=1 pnpm exec playwright test` — 73 passed
+- `pnpm exec prettier --check` on touched files — pass
+- `git diff --check` — pass
+
+## Commit Intent
+
+Commit as:
+
+```text
+Redesign editor chrome to layout with details
+```
+
+## Outcome
+
+Editor chrome now uses a shell (menubar + tool strip + left tool
+rail + right Properties + status bar) with calm surfaces. Insert
+remains dialog-based; formal schematic styling is unchanged. Focused unit and
+full editor e2e suites passed.

--- a/plan/2026-08-12-fold-edit-actions-into-menu/plan.md
+++ b/plan/2026-08-12-fold-edit-actions-into-menu/plan.md
@@ -1,0 +1,16 @@
+---
+status: completed
+experience: none
+---
+
+# Fold top edit actions into Edit menu
+
+## Goal
+
+Remove Undo/Redo/Delete/Rotate from the top strip; Edit menu is their chrome
+home. Shortcuts remain primary for speed.
+
+## Outcome
+
+Top edit strip removed. Hierarchy nav remains only when needed. Interaction
+contract updated to v1.10. Unit and full e2e passed.

--- a/plan/2026-08-12-library-fold-and-insert/plan.md
+++ b/plan/2026-08-12-library-fold-and-insert/plan.md
@@ -1,0 +1,11 @@
+---
+status: completed
+experience: none
+---
+
+# Library fold/expand + sidebar Insert entry
+
+## Outcome
+
+Rail Library toggles the left library panel. Library title and bottom Insert
+open the full insert dialog; starter/recent chips remain quick-place.

--- a/plan/2026-08-12-library-rail-insert-footer/plan.md
+++ b/plan/2026-08-12-library-rail-insert-footer/plan.md
@@ -1,0 +1,12 @@
+---
+status: completed
+experience: none
+---
+
+# Library rail + Insert footer on Shapes
+
+## Outcome
+
+Tool rail Insert renamed to Library. Shapes panel is titled Library with a
+sticky bottom Insert button (replacing Browse all). Full catalog dialog still
+opens via I / Library / Insert / Draw menu.

--- a/plan/log.md
+++ b/plan/log.md
@@ -15,6 +15,16 @@ Use concise entries:
 
 Keep reusable lessons in `docs/experience/`, not in this log.
 
+## 2026-08-12 - Editor chrome shell redesign
+
+- Target: restructure the editor shell for clearer operation (menubar, tool
+  rail, library panel, properties dock, status bar) and a consistent visual
+  scale without changing formal schematic export styling.
+- Changed areas: editor App shell, styles tokens, tool icons, library
+  quick-place panel, help dialog, interaction contract, e2e/unit coverage.
+- Validation: App/shapes unit tests and editor Playwright suites passed.
+- Commit status: committed as reorganized history from origin/main.
+
 ## 2026-08-12 - Bound transient canvas state and runtime caches
 
 - Target: remove stale Smart Snap guide remnants and bound audit-identified


### PR DESCRIPTION
## Summary
- Restructures the editor chrome into a left-aligned menubar, tool rail, collapsible library panel, right Properties dock, and status bar.
- Adds a foldable quick-place library (starters/recent) with bottom Insert and rail Library toggle.
- Opens component Properties on device double-click; keeps formal schematic export styling unchanged.
- Unifies chrome type/icon/spacing tokens and updates interaction contract, help, and tests.

## Commits
1. `feat(editor): add library quick-place panel module`
2. `feat(editor): restructure chrome shell and visual scale`
3. `test(editor): cover library chrome and properties double-click`
4. `docs(editor): record chrome shell contract and maintenance history`

## Test plan
- [x] `pnpm exec vitest run apps/editor/src/app/App.test.tsx apps/editor/src/features/editor-shell/shapes-panel.test.ts`
- [ ] `CI=1 ICM_E2E_ISOLATED=1 pnpm exec playwright test apps/editor/e2e/component-insert.spec.ts apps/editor/e2e/chrome-isolation.spec.ts apps/editor/e2e/manual-editor.spec.ts`
- [ ] Manual: library fold/expand, Insert dialog, double-click Properties, menubar left-align, Starters/Recent collapse