### PR TITLE
Record visitor analytics deployment

### DIFF
--- a/plan/2026-08-12-visitor-analytics/plan.md
+++ b/plan/2026-08-12-visitor-analytics/plan.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: completed
 experience: none
 ---
 
@@ -88,4 +88,11 @@ feat(web): add privacy-friendly visitor analytics
 
 ## Outcome
 
-To be recorded after production verification.
+Analog Canvas now records privacy-friendly first-party PV/UV, daily traffic,
+country, rounded location, acquisition source, and page breakdowns in its own
+SQLite-backed Durable Object. The editor header exposes compact totals and
+links to a noindex `/analytics` dashboard; the dashboard does not count itself.
+Pull request #8 passed all five remote CI jobs and merged as `4b9a09e`; the
+subsequent Cloudflare workflow succeeded. Live production checks recorded and
+read back all dimensions, while cross-site and DNT submissions returned 204
+without incrementing counts.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4630,3 +4630,17 @@ diff --check` passed. The full Playwright baseline completed 30/49, with the
 - Validation: direct production deploy, Wrangler dry-run, all five pull request
   CI jobs, successful `main` Cloudflare workflow, and live URL checks passed.
 - Commit status: merged through pull request #6 as `b7a4424`.
+
+## 2026-08-12 - Visitor Analytics
+
+- Target: add Analog Arena-style first-party visitor counts, origins, and
+  acquisition analytics to Analog Canvas.
+- Changed areas: Worker API, SQLite-backed Durable Object, bounded privacy
+  filters, custom-domain-only tracking, editor totals link, noindex dashboard,
+  world heatmap, tests, and Cloudflare migration/configuration.
+- Validation: 475 unit/integration tests, release contracts, focused analytics
+  browser test, remote five-job CI matrix, Wrangler dry-run, successful
+  Cloudflare deploy, live PV/UV/dimension reads, and cross-site/DNT rejection
+  passed.
+- Commit status: merged through pull request #8 as `4b9a09e`; production is
+  live at `https://analog-canvas.tokenzhang.com/analytics`.


### PR DESCRIPTION
Closes the visitor analytics target and records the successful CI, Cloudflare deployment, live metric reads, and privacy-gate verification. Documentation only.