### PR TITLE
Match analytics dashboard to Analog Arena

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -1419,20 +1419,37 @@ test("keeps the production command surface compact and publishes PWA metadata", 
 test("shows first-party visitor analytics without tracking the dashboard itself", async ({
   page,
 }) => {
+  await page.addInitScript(() => localStorage.setItem("theme", "dark"));
   let dashboardTracked = false;
   await page.route("**/api/track", async (route) => {
     dashboardTracked = true;
     await route.fulfill({ status: 204 });
   });
   await page.route("**/api/analytics", async (route) => {
+    const countries = [
+      "CN",
+      "US",
+      "GB",
+      "DE",
+      "FR",
+      "JP",
+      "SG",
+      "CA",
+      "AU",
+      "IN",
+      "NZ",
+    ].map((code, index) => ({ code, pv: 12 - index, uv: 11 - index }));
     await route.fulfill({
       contentType: "application/json",
       body: JSON.stringify({
         generatedAt: "2026-08-12T00:00:00.000Z",
         totals: { pv: 12, uv: 7 },
         today: { date: "2026-08-12", pv: 3, uv: 2 },
-        days: [{ date: "2026-08-12", pv: 3, uv: 2 }],
-        countries: [{ code: "CN", pv: 8, uv: 5 }],
+        days: [
+          { date: "2026-05-15", pv: 1, uv: 1 },
+          { date: "2026-08-12", pv: 3, uv: 2 },
+        ],
+        countries,
         points: [{ lat: 40, lng: 116, count: 8 }],
         paths: [{ path: "/", pv: 12, uv: 7 }],
         sources: [{ source: "direct-or-unknown", pv: 12, uv: 7 }],
@@ -1447,12 +1464,36 @@ test("shows first-party visitor analytics without tracking the dashboard itself"
   });
 
   await page.goto("/analytics");
+  await expect(page.getByRole("heading", { name: "Analytics" })).toBeVisible();
+  await expect(page).toHaveTitle("Analytics — Analog Canvas");
   await expect(
-    page.getByRole("heading", { name: "Visitor analytics" }),
+    page.getByRole("link", { name: "Back to editor" }),
+  ).toHaveAttribute("href", "/");
+  await expect(page.getByRole("textbox", { name: "From" })).toHaveValue(
+    "2026-05-15",
+  );
+  await expect(
+    page.getByRole("textbox", { name: "To", exact: true }),
+  ).toHaveValue("2026-08-12");
+  await expect(
+    page.getByRole("button", { name: "Last 90 days" }),
   ).toBeVisible();
-  await expect(page.getByText("Countries and regions")).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "ISO 3166 Code" }),
+  ).toBeVisible();
   await expect(page.getByText("China")).toBeVisible();
-  await expect(page.getByText("No IP addresses")).toBeVisible();
+  await expect(page.getByText("New Zealand")).toHaveCount(0);
+  await page.getByRole("button", { name: "Show all 11" }).click();
+  await expect(page.getByText("New Zealand")).toBeVisible();
+
+  const themeSwitch = page.getByRole("button", {
+    name: "Switch to light theme",
+  });
+  await themeSwitch.click();
+  await expect(page.locator("html")).toHaveClass(/light/);
+  await expect(
+    page.getByRole("button", { name: "Switch to dark theme" }),
+  ).toBeVisible();
   expect(dashboardTracked).toBe(false);
 });
 

--- a/apps/editor/index.html
+++ b/apps/editor/index.html
@@ -7,6 +7,15 @@
     <link rel="manifest" href="%BASE_URL%manifest.webmanifest" />
     <link rel="icon" href="%BASE_URL%icon.svg" />
     <title>Interactive Circuit Maker</title>
+    <script>
+      if (
+        localStorage.theme === "light" ||
+        (!localStorage.theme &&
+          matchMedia("(prefers-color-scheme: light)").matches)
+      ) {
+        document.documentElement.classList.add("light");
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -8,6 +8,7 @@
     "dev": "vite"
   },
   "dependencies": {
+    "@fontsource-variable/google-sans-code": "^5.3.0",
     "@icm/derived": "workspace:*",
     "@icm/edit-engine": "workspace:*",
     "@icm/exporters": "workspace:*",

--- a/apps/editor/src/components/analytics-page.tsx
+++ b/apps/editor/src/components/analytics-page.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
-
+import { useEffect, useId, useMemo, useState, type ReactNode } from "react";
 import land from "../data/land-110m.json";
 import {
   landPathsForWorld,
@@ -8,25 +7,28 @@ import {
 } from "../lib/world-map";
 
 type DayRow = { date: string; pv: number; uv: number };
-type MetricRow = { pv: number; uv: number };
+type BreakdownRow = { pv?: number; uv?: number; count?: number };
+type BreakdownTotal = { pv: number; uv: number };
 type Summary = {
   generatedAt: string;
-  totals: MetricRow;
+  totals: { pv: number; uv: number };
   today: DayRow;
   days: DayRow[];
-  countries: ({ code: string } & MetricRow)[];
+  countries: ({ code: string } & BreakdownRow)[];
   points: { lat: number; lng: number; count: number }[];
-  paths: ({ path: string } & MetricRow)[];
-  sources: ({ source: string } & MetricRow)[];
+  paths: ({ path: string } & BreakdownRow)[];
+  sources: ({ source: string } & BreakdownRow)[];
   breakdownStartedAt: string;
   breakdownTotals: {
-    countries: MetricRow;
-    sources: MetricRow;
-    pages: MetricRow;
+    countries: BreakdownTotal;
+    sources: BreakdownTotal;
+    pages: BreakdownTotal;
   };
 };
 
-const MAP_W = 1800;
+const DEFAULT_RANGE_DAYS = 90;
+const DEFAULT_BREAKDOWN_ROWS = 10;
+const MAP_W = 3600;
 const MAP_H = Math.round(
   MAP_W *
     ((WORLD_BOUNDS.north - WORLD_BOUNDS.south) /
@@ -37,7 +39,7 @@ const LAND_PATHS = landPathsForWorld(
   MAP_W,
   MAP_H,
 );
-const number = new Intl.NumberFormat("en");
+const fmt = new Intl.NumberFormat("en");
 
 const SOURCE_LABELS: Record<string, string> = {
   "direct-or-unknown": "Direct / unknown",
@@ -69,9 +71,31 @@ const SOURCE_LABELS: Record<string, string> = {
   __other__: "Other sources",
 };
 
+function shiftUtcDay(iso: string, delta: number): string {
+  const date = new Date(`${iso}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() + delta);
+  return date.toISOString().slice(0, 10);
+}
+
+function dayCount(from: string, to: string): number {
+  const start = Date.parse(`${from}T00:00:00.000Z`);
+  const end = Date.parse(`${to}T00:00:00.000Z`);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return 0;
+  return Math.round((end - start) / 86_400_000) + 1;
+}
+
+function rowMetrics(row: BreakdownRow): BreakdownTotal {
+  return { pv: row.pv ?? row.count ?? 0, uv: row.uv ?? 0 };
+}
+
 export function AnalyticsPage() {
   const [summary, setSummary] = useState<Summary | null>(null);
   const [error, setError] = useState(false);
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+  const [theme, setTheme] = useState<"dark" | "light">(() =>
+    document.documentElement.classList.contains("light") ? "light" : "dark",
+  );
 
   useEffect(() => {
     const previousTitle = document.title;
@@ -95,29 +119,64 @@ export function AnalyticsPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    const key = new URLSearchParams(window.location.search).get("key");
-    const endpoint = key
+    const params = new URLSearchParams(window.location.search);
+    const key = params.get("key");
+    const url = key
       ? `/api/analytics?key=${encodeURIComponent(key)}`
       : "/api/analytics";
-    void fetch(endpoint, { signal: controller.signal, cache: "no-store" })
+    void fetch(url, {
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    })
       .then(async (response) => {
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         return response.json() as Promise<Summary>;
       })
-      .then(setSummary)
-      .catch((reason: unknown) => {
-        if (!(reason instanceof DOMException && reason.name === "AbortError")) {
-          setError(true);
+      .then((data) => {
+        setSummary(data);
+        if (data.days.length) {
+          const end = data.days[data.days.length - 1]!.date;
+          const earliest = data.days[0]!.date;
+          const start = shiftUtcDay(end, -(DEFAULT_RANGE_DAYS - 1));
+          setFrom(start < earliest ? earliest : start);
+          setTo(end);
         }
+      })
+      .catch((reason: unknown) => {
+        if (!(reason instanceof DOMException && reason.name === "AbortError"))
+          setError(true);
       });
     return () => controller.abort();
   }, []);
 
-  const visibleDays = useMemo(
-    () =>
-      summary?.days.filter((day) => day.pv > 0 || day.uv > 0).slice(-90) ?? [],
-    [summary],
-  );
+  const visibleDays = useMemo(() => {
+    if (!summary || !from || !to) return [];
+    const start = from < to ? from : to;
+    const end = from < to ? to : from;
+    return summary.days.filter((day) => day.date >= start && day.date <= end);
+  }, [from, summary, to]);
+
+  const rangeDays =
+    from && to ? dayCount(from < to ? from : to, from < to ? to : from) : 90;
+  const minDate = summary?.days[0]?.date;
+  const maxDate = summary?.days[summary.days.length - 1]?.date;
+
+  function resetRange() {
+    if (!summary?.days.length) return;
+    const end = summary.days[summary.days.length - 1]!.date;
+    const earliest = summary.days[0]!.date;
+    const start = shiftUtcDay(end, -(DEFAULT_RANGE_DAYS - 1));
+    setFrom(start < earliest ? earliest : start);
+    setTo(end);
+  }
+
+  function toggleTheme() {
+    const next = theme === "dark" ? "light" : "dark";
+    document.documentElement.classList.toggle("light", next === "light");
+    localStorage.setItem("theme", next);
+    setTheme(next);
+  }
+
   const generated = summary
     ? new Date(summary.generatedAt).toLocaleString("en", {
         dateStyle: "medium",
@@ -127,81 +186,198 @@ export function AnalyticsPage() {
 
   return (
     <div className="analytics-shell">
-      <header className="analytics-topbar">
-        <a href="/">← Back to editor</a>
-        <span>Analog Canvas</span>
-      </header>
-      <main className="analytics-page">
-        <header className="analytics-head">
-          <p className="analytics-kicker">First-party, privacy-friendly</p>
-          <h1>Visitor analytics</h1>
-          <p>
-            UTC days · updated{" "}
-            <time dateTime={summary?.generatedAt}>{generated}</time>
-          </p>
-        </header>
-
-        {error ? (
-          <p className="analytics-error">
-            Analytics are temporarily unavailable. If a dashboard key is
-            configured, append it as
-            <code>?key=…</code>.
-          </p>
-        ) : null}
-
-        <dl className="analytics-metrics" aria-label="Traffic totals">
-          <Metric label="Unique visitors" value={summary?.totals.uv} />
-          <Metric label="Page views" value={summary?.totals.pv} />
-          <Metric label="Visitors today" value={summary?.today.uv} />
-          <Metric label="Views today" value={summary?.today.pv} />
-        </dl>
-
-        <Section title="Daily traffic" aside="Last 90 active days">
-          <DailyChart days={visibleDays} />
-        </Section>
-
-        <Section title="Visitor origins" aside="≈1° request buckets">
-          <WorldHeatmap points={summary?.points ?? []} />
-        </Section>
-
-        <div className="analytics-columns">
-          <Section title="Countries and regions" aside="Top">
-            <BreakdownTable
-              heading="Region"
-              rows={summary?.countries ?? []}
-              total={summary?.breakdownTotals.countries ?? { pv: 0, uv: 0 }}
-              label={(row) => countryName(row.code)}
-              loading={!summary && !error}
-            />
-          </Section>
-          <Section title="Acquisition sources" aside="Top">
-            <BreakdownTable
-              heading="Source"
-              rows={summary?.sources ?? []}
-              total={summary?.breakdownTotals.sources ?? { pv: 0, uv: 0 }}
-              label={(row) => sourceName(row.source)}
-              loading={!summary && !error}
-            />
-          </Section>
-          <section className="analytics-section analytics-section-wide">
-            <SectionHead title="Pages" aside="Top" />
-            <BreakdownTable
-              heading="Path"
-              rows={summary?.paths ?? []}
-              total={summary?.breakdownTotals.pages ?? { pv: 0, uv: 0 }}
-              label={(row) =>
-                row.path === "__other__" ? "Other pages" : row.path
-              }
-              loading={!summary && !error}
-            />
-          </section>
+      <header className="analytics-top-bar" aria-label="Page controls">
+        <div className="analytics-top-bar-left">
+          <button
+            type="button"
+            className="analytics-theme-switch"
+            onClick={toggleTheme}
+            aria-label={
+              theme === "dark"
+                ? "Switch to light theme"
+                : "Switch to dark theme"
+            }
+            title={
+              theme === "dark"
+                ? "Switch to light theme"
+                : "Switch to dark theme"
+            }
+          >
+            {theme === "dark" ? <SunIcon /> : <MoonIcon />}
+          </button>
         </div>
+        <div className="analytics-top-bar-right">
+          <a className="analytics-home" href="/">
+            ← Back to editor
+          </a>
+        </div>
+      </header>
 
-        <p className="analytics-privacy">
-          No IP addresses, full referrer URLs, search terms, or canvas documents
-          are stored. Location comes from Cloudflare and is rounded to
-          approximately one degree. Do Not Track is honored.
-        </p>
+      <main className="analytics-page" id="content">
+        <div className="analytics-container">
+          <header className="analytics-head">
+            <h1>Analytics</h1>
+            <p className="analytics-sub">
+              First-party counts · UTC days · updated{" "}
+              <time dateTime={summary?.generatedAt}>{generated}</time>
+            </p>
+          </header>
+
+          {error && (
+            <p className="analytics-error">
+              Could not load analytics. If a dashboard key is set, append{" "}
+              <code>?key=…</code> to the URL.
+            </p>
+          )}
+
+          <dl className="analytics-metrics" aria-label="Totals">
+            <Metric label="Unique visitors" value={summary?.totals.uv} />
+            <Metric label="Page views" value={summary?.totals.pv} />
+            <Metric label="Visitors today" value={summary?.today.uv} />
+            <Metric label="Views today" value={summary?.today.pv} />
+          </dl>
+
+          <section
+            className="analytics-section"
+            aria-labelledby="analytics-chart-h"
+          >
+            <SectionHead
+              title="Daily traffic"
+              id="analytics-chart-h"
+              meta={
+                <>
+                  <ul className="analytics-legend" aria-hidden="true">
+                    <li>
+                      <span className="analytics-swatch analytics-swatch--pv" />
+                      Views
+                    </li>
+                    <li>
+                      <span className="analytics-swatch analytics-swatch--uv" />
+                      Visitors
+                    </li>
+                  </ul>
+                  <span className="analytics-aside" aria-hidden="true">
+                    {rangeDays === 1 ? "1 day" : `${rangeDays} days`}
+                  </span>
+                </>
+              }
+            />
+            <form
+              className="analytics-range"
+              onSubmit={(event) => event.preventDefault()}
+            >
+              <label className="analytics-range-field">
+                <span>From</span>
+                <input
+                  className="analytics-range-input"
+                  type="date"
+                  name="from"
+                  value={from}
+                  min={minDate}
+                  max={maxDate}
+                  onChange={(event) => setFrom(event.target.value)}
+                  required
+                />
+              </label>
+              <label className="analytics-range-field">
+                <span>To</span>
+                <input
+                  className="analytics-range-input"
+                  type="date"
+                  name="to"
+                  value={to}
+                  min={minDate}
+                  max={maxDate}
+                  onChange={(event) => setTo(event.target.value)}
+                  required
+                />
+              </label>
+              <button
+                type="button"
+                className="analytics-range-reset"
+                onClick={resetRange}
+              >
+                Last 90 days
+              </button>
+              <span className="analytics-range-hint">UTC</span>
+            </form>
+            <DailyChart days={visibleDays} />
+          </section>
+
+          <section
+            className="analytics-section"
+            aria-labelledby="analytics-map-h"
+          >
+            <SectionHead
+              title="Origins"
+              id="analytics-map-h"
+              aside="Map"
+              meta={<p className="analytics-note">≈1° request buckets</p>}
+            />
+            <WorldHeatmap points={summary?.points ?? []} />
+          </section>
+
+          <div className="analytics-cols">
+            <section
+              className="analytics-section"
+              aria-labelledby="analytics-countries-h"
+            >
+              <SectionHead
+                title="ISO 3166 Code"
+                id="analytics-countries-h"
+                aside="Top"
+              />
+              <BreakdownTable
+                heading="Region"
+                rows={summary?.countries ?? []}
+                total={summary?.breakdownTotals.countries ?? { pv: 0, uv: 0 }}
+                label={(row) =>
+                  countryName((row as Summary["countries"][number]).code)
+                }
+                loading={!summary && !error}
+                unavailable={error}
+              />
+            </section>
+            <section
+              className="analytics-section"
+              aria-labelledby="analytics-sources-h"
+            >
+              <SectionHead
+                title="Sources"
+                id="analytics-sources-h"
+                aside="Top"
+              />
+              <BreakdownTable
+                heading="Source"
+                rows={summary?.sources ?? []}
+                total={summary?.breakdownTotals.sources ?? { pv: 0, uv: 0 }}
+                label={(row) =>
+                  sourceName((row as Summary["sources"][number]).source)
+                }
+                loading={!summary && !error}
+                unavailable={error}
+              />
+            </section>
+            <section
+              className="analytics-section analytics-section--wide"
+              aria-labelledby="analytics-pages-h"
+            >
+              <SectionHead title="Pages" id="analytics-pages-h" aside="Top" />
+              <BreakdownTable
+                heading="Path"
+                rows={summary?.paths ?? []}
+                total={summary?.breakdownTotals.pages ?? { pv: 0, uv: 0 }}
+                label={(row) => {
+                  const path = (row as Summary["paths"][number]).path;
+                  return path === "__other__" ? "Other pages" : path;
+                }}
+                mono
+                loading={!summary && !error}
+                unavailable={error}
+              />
+            </section>
+          </div>
+        </div>
       </main>
     </div>
   );
@@ -217,33 +393,33 @@ function Metric({
   return (
     <div>
       <dt>{label}</dt>
-      <dd>{value == null ? "—" : number.format(value)}</dd>
+      <dd>{value == null ? "—" : fmt.format(value)}</dd>
     </div>
   );
 }
 
-function Section({
+function SectionHead({
   title,
+  id,
   aside,
-  children,
+  meta,
 }: {
   title: string;
-  aside: string;
-  children: ReactNode;
+  id: string;
+  aside?: string;
+  meta?: ReactNode;
 }) {
   return (
-    <section className="analytics-section">
-      <SectionHead title={title} aside={aside} />
-      {children}
-    </section>
-  );
-}
-
-function SectionHead({ title, aside }: { title: string; aside: string }) {
-  return (
     <div className="analytics-section-head">
-      <h2>{title}</h2>
-      <span>{aside}</span>
+      <h2 id={id}>{title}</h2>
+      <div className="analytics-section-head-meta">
+        {meta}
+        {aside && (
+          <span className="analytics-aside" aria-hidden="true">
+            {aside}
+          </span>
+        )}
+      </div>
     </div>
   );
 }
@@ -251,114 +427,164 @@ function SectionHead({ title, aside }: { title: string; aside: string }) {
 function DailyChart({ days }: { days: DayRow[] }) {
   const width = 900;
   const height = 220;
-  const bottom = 24;
+  const padTop = 16;
+  const padBottom = 22;
+  const padX = 2;
+  const plotHeight = height - padTop - padBottom;
+
   if (!days.length) {
     return (
-      <div className="analytics-empty">No traffic has been recorded yet.</div>
+      <svg
+        className="analytics-chart"
+        viewBox={`0 0 ${width} ${height}`}
+        role="img"
+        aria-label="Daily page views and unique visitors"
+      >
+        <text
+          className="analytics-chart-tick"
+          x={width / 2}
+          y={height / 2}
+          textAnchor="middle"
+        >
+          No days in this range
+        </text>
+      </svg>
     );
   }
+
   const max = Math.max(1, ...days.map((day) => day.pv));
-  const slot = width / days.length;
+  const slot = (width - padX * 2) / days.length;
+  const ticks =
+    days.length === 1
+      ? [{ index: 0, x: width / 2, anchor: "middle" as const }]
+      : days.length === 2
+        ? [
+            { index: 0, x: 0, anchor: "start" as const },
+            { index: 1, x: width, anchor: "end" as const },
+          ]
+        : [
+            { index: 0, x: 0, anchor: "start" as const },
+            {
+              index: Math.floor(days.length / 2),
+              x: width / 2,
+              anchor: "middle" as const,
+            },
+            { index: days.length - 1, x: width, anchor: "end" as const },
+          ];
+
   return (
     <svg
       className="analytics-chart"
       viewBox={`0 0 ${width} ${height}`}
       role="img"
-      aria-label="Daily page views and visitors"
+      aria-label="Daily page views and unique visitors"
     >
       {days.map((day, index) => {
-        const pvHeight = (day.pv / max) * (height - bottom - 18);
-        const uvHeight = (day.uv / max) * (height - bottom - 18);
-        const title = `${day.date}: ${number.format(day.pv)} views, ${number.format(day.uv)} visitors`;
+        const pvHeight = (day.pv / max) * plotHeight;
+        const uvHeight = (day.uv / max) * plotHeight;
+        const x = padX + index * slot;
+        const title = `${day.date}: ${fmt.format(day.pv)} views, ${fmt.format(day.uv)} visitors`;
         return (
           <g key={day.date}>
             <rect
-              className="analytics-bar-pv"
-              x={index * slot + slot * 0.15}
-              y={height - bottom - pvHeight}
-              width={slot * 0.7}
-              height={Math.max(pvHeight, day.pv ? 1 : 0)}
+              className="analytics-chart-bar-pv"
+              x={x + slot * 0.18}
+              y={height - padBottom - pvHeight}
+              width={slot * 0.64}
+              height={Math.max(pvHeight, day.pv > 0 ? 1.25 : 0)}
             >
               <title>{title}</title>
             </rect>
-            <rect
-              className="analytics-bar-uv"
-              x={index * slot + slot * 0.35}
-              y={height - bottom - uvHeight}
-              width={slot * 0.3}
-              height={Math.max(uvHeight, day.uv ? 1 : 0)}
-            >
-              <title>{title}</title>
-            </rect>
+            {day.uv > 0 && (
+              <rect
+                className="analytics-chart-bar-uv"
+                x={x + slot * 0.34}
+                y={height - padBottom - uvHeight}
+                width={slot * 0.32}
+                height={Math.max(uvHeight, 1.25)}
+              >
+                <title>{title}</title>
+              </rect>
+            )}
           </g>
         );
       })}
       <line
-        className="analytics-axis"
+        className="analytics-chart-axis"
         x1="0"
         x2={width}
-        y1={height - bottom}
-        y2={height - bottom}
+        y1={height - padBottom}
+        y2={height - padBottom}
       />
-      <text className="analytics-tick" x="0" y="12">
-        {number.format(max)}
+      <text className="analytics-chart-tick" x="0" y={padTop - 2}>
+        {fmt.format(max)}
       </text>
-      <text className="analytics-tick" x="0" y={height - 5}>
-        {days[0]!.date.slice(5)}
-      </text>
-      <text
-        className="analytics-tick"
-        x={width}
-        y={height - 5}
-        textAnchor="end"
-      >
-        {days.at(-1)!.date.slice(5)}
-      </text>
+      {ticks.map((tick) => (
+        <text
+          key={`${tick.index}-${tick.anchor}`}
+          className="analytics-chart-tick"
+          x={tick.x}
+          y={height - 4}
+          textAnchor={tick.anchor}
+        >
+          {days[tick.index]!.date.slice(5)}
+        </text>
+      ))}
     </svg>
   );
 }
 
 function WorldHeatmap({ points }: { points: Summary["points"] }) {
-  const max = Math.max(1, ...points.map((point) => point.count));
+  const maxCount = Math.max(1, ...points.map((point) => point.count));
   return (
     <div className="analytics-map-frame">
       <svg
-        className="analytics-map"
+        className="analytics-map-svg"
         viewBox={`0 0 ${MAP_W} ${MAP_H}`}
         role="img"
-        aria-label="World heatmap of visitor origins"
+        aria-label="World heatmap of request origins"
       >
         <defs>
-          <radialGradient id="canvas-heat">
-            <stop offset="0%" stopOpacity="0.9" />
-            <stop offset="60%" stopOpacity="0.3" />
+          <radialGradient id="analytics-heat-gradient">
+            <stop offset="0%" stopOpacity="0.85" />
+            <stop offset="55%" stopOpacity="0.35" />
             <stop offset="100%" stopOpacity="0" />
           </radialGradient>
         </defs>
-        <rect className="analytics-ocean" width={MAP_W} height={MAP_H} />
-        <g className="analytics-land">
+        <rect
+          className="analytics-map-ocean"
+          x="0"
+          y="0"
+          width={MAP_W}
+          height={MAP_H}
+        />
+        <g className="analytics-map-land" aria-hidden="true">
           {LAND_PATHS.map((path, index) => (
             <path d={path} key={index} />
           ))}
         </g>
-        <g>
+        <g className="analytics-map-heat">
           {points.map((point) => {
-            const x =
-              ((point.lng - WORLD_BOUNDS.west) /
-                (WORLD_BOUNDS.east - WORLD_BOUNDS.west)) *
-              MAP_W;
-            const y =
-              ((WORLD_BOUNDS.north - point.lat) /
-                (WORLD_BOUNDS.north - WORLD_BOUNDS.south)) *
-              MAP_H;
-            const radius = 10 + 34 * Math.sqrt(point.count / max);
-            const title = `${number.format(point.count)} views near ${point.lat}, ${point.lng}`;
+            const cx = (point.lng + 180) * 10;
+            const cy = (84 - point.lat) * 10;
+            const radius = 18 + 64 * Math.sqrt(point.count / maxCount);
+            const title = `${fmt.format(point.count)} views near ${point.lat}, ${point.lng}`;
             return (
               <g key={`${point.lat},${point.lng}`}>
-                <circle className="analytics-heat" cx={x} cy={y} r={radius}>
+                <circle
+                  className="analytics-heat-blob"
+                  cx={cx}
+                  cy={cy}
+                  r={radius}
+                >
                   <title>{title}</title>
                 </circle>
-                <circle className="analytics-heat-core" cx={x} cy={y} r={3}>
+                <circle
+                  className="analytics-heat-core"
+                  cx={cx}
+                  cy={cy}
+                  r={Math.max(2.8, radius * 0.09)}
+                >
                   <title>{title}</title>
                 </circle>
               </g>
@@ -370,56 +596,97 @@ function WorldHeatmap({ points }: { points: Summary["points"] }) {
   );
 }
 
-function BreakdownTable<T extends MetricRow>({
+function BreakdownTable<T extends BreakdownRow>({
   heading,
   rows,
   total,
   label,
+  mono = false,
   loading,
+  unavailable,
 }: {
   heading: string;
   rows: T[];
-  total: MetricRow;
+  total: BreakdownTotal;
   label: (row: T) => string;
+  mono?: boolean;
   loading: boolean;
+  unavailable: boolean;
 }) {
+  const [expanded, setExpanded] = useState(false);
+  const tableId = useId();
+  const canExpand = rows.length > DEFAULT_BREAKDOWN_ROWS;
+  const visibleRows = expanded ? rows : rows.slice(0, DEFAULT_BREAKDOWN_ROWS);
+
   return (
-    <div className="analytics-table-wrap">
-      <table className="analytics-table">
-        <thead>
-          <tr>
-            <th>{heading}</th>
-            <th>Visitors</th>
-            <th>Views</th>
-          </tr>
-        </thead>
-        <tbody>
-          {loading || rows.length === 0 ? (
+    <div className="analytics-breakdown">
+      <div className="analytics-table-scroll">
+        <table className="analytics-table" id={tableId}>
+          <thead>
             <tr>
-              <td colSpan={3} className="analytics-empty">
-                {loading ? "Loading…" : "No data yet."}
-              </td>
+              <th scope="col">{heading}</th>
+              <th scope="col" className="num">
+                Unique Visitors
+              </th>
+              <th scope="col" className="num">
+                Page Views
+              </th>
             </tr>
-          ) : (
-            rows.slice(0, 12).map((row, index) => (
-              <tr key={`${label(row)}-${index}`}>
-                <td>{label(row)}</td>
-                <MetricCell value={row.uv} total={total.uv} />
-                <MetricCell value={row.pv} total={total.pv} />
+          </thead>
+          <tbody>
+            {loading || unavailable || rows.length === 0 ? (
+              <tr>
+                <td colSpan={3} className="analytics-empty">
+                  {loading
+                    ? "Loading…"
+                    : unavailable
+                      ? "Unavailable."
+                      : "No data yet."}
+                </td>
               </tr>
-            ))
-          )}
-        </tbody>
-      </table>
+            ) : (
+              visibleRows.map((row, index) => {
+                const metric = rowMetrics(row);
+                return (
+                  <tr key={`${label(row)}-${index}`}>
+                    <td className={mono ? "mono" : undefined}>{label(row)}</td>
+                    <MetricCell value={metric.uv} total={total.uv} />
+                    <MetricCell value={metric.pv} total={total.pv} />
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+      {canExpand && (
+        <button
+          type="button"
+          className="analytics-table-toggle"
+          aria-controls={tableId}
+          aria-expanded={expanded}
+          onClick={() => setExpanded((value) => !value)}
+        >
+          <span>
+            {expanded
+              ? `Show top ${DEFAULT_BREAKDOWN_ROWS}`
+              : `Show all ${rows.length}`}
+          </span>
+          <ChevronIcon expanded={expanded} />
+        </button>
+      )}
     </div>
   );
 }
 
 function MetricCell({ value, total }: { value: number; total: number }) {
-  const share = total > 0 ? (value / total) * 100 : 0;
+  const percentage = total > 0 ? (value / total) * 100 : 0;
   return (
-    <td className="analytics-number">
-      {number.format(value)} <small>{share.toFixed(1)}%</small>
+    <td className="num analytics-metric">
+      <span>{fmt.format(value)}</span>
+      <span className="analytics-metric-distribution">
+        {percentage.toFixed(1)}%
+      </span>
     </td>
   );
 }
@@ -435,9 +702,59 @@ function countryName(code: string): string {
   }
 }
 
+function ChevronIcon({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={expanded ? "is-expanded" : undefined}
+    >
+      <path d="m7 10 5 5 5-5" />
+    </svg>
+  );
+}
+
 function sourceName(source: string): string {
   return (
     SOURCE_LABELS[source] ??
     (source.startsWith("ref:") ? source.slice(4) : source)
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 14.3A8.5 8.5 0 0 1 9.7 3a7 7 0 1 0 11.3 11.3Z" />
+    </svg>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+    </svg>
   );
 }

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -1,4 +1,9 @@
+@import "@fontsource-variable/google-sans-code/index.css";
+
 :root {
+  --font-mono:
+    "Google Sans Code Variable", "Google Sans Code", ui-monospace, "SF Mono",
+    monospace;
   /* Editor chrome design tokens. These cover panels, controls, selection
      state, diagnostics and editor-only SVG overlays ONLY. The white canvas
      background (`.schematic-canvas`), the SVG grid-dot fill, and the injected
@@ -1750,7 +1755,11 @@ body.analytics-body {
   min-width: 0;
   height: auto;
   overflow: auto;
-  background: #f4f7fb;
+  background: #10161f;
+}
+
+html.light body.analytics-body {
+  background: #ffffff;
 }
 
 body.analytics-body #root {
@@ -1762,281 +1771,586 @@ body.analytics-body #root {
   display: grid;
   min-height: 100vh;
   place-items: center;
-  color: #64748b;
-  background: #f4f7fb;
+  color: #aeb8ca;
+  background: #10161f;
   font-size: 0.85rem;
 }
 
-.analytics-shell {
-  min-height: 100vh;
-  color: #172033;
-  background:
-    radial-gradient(
-      circle at 10% -10%,
-      rgb(37 99 235 / 10%),
-      transparent 34rem
-    ),
-    #f4f7fb;
+html.light .analytics-loading {
+  color: #68738a;
+  background: #ffffff;
 }
 
-.analytics-topbar {
+/* Analytics (/analytics) mirrors tokenzhang.com's restrained academic page. */
+.analytics-shell {
+  --analytics-ink: #f4f7fc;
+  --analytics-ink-soft: #d5dce8;
+  --analytics-muted: #aeb8ca;
+  --analytics-accent: #a8c2ff;
+  --analytics-accent-soft: #243352;
+  --analytics-bg: #10161f;
+  --analytics-bg-band: #1a222f;
+  --analytics-line: #3a465a;
+  --analytics-line-strong: #556378;
+  --analytics-radius: 10px;
+  --analytics-container: 68rem;
+  --analytics-gutter: 1.25rem;
+  --analytics-topbar-height: 4.2rem;
+  min-height: 100dvh;
+  color: var(--analytics-ink);
+  background:
+    radial-gradient(
+      1100px 520px at 8% -8%,
+      rgb(110 145 210 / 0.07),
+      transparent 55%
+    ),
+    radial-gradient(
+      900px 480px at 92% 0%,
+      rgb(70 100 160 / 0.05),
+      transparent 50%
+    ),
+    radial-gradient(
+      700px 420px at 50% 110%,
+      rgb(40 70 120 / 0.04),
+      transparent 55%
+    ),
+    var(--analytics-bg);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro SC", system-ui,
+    "Segoe UI", Roboto, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei",
+    sans-serif;
+  font-size: 1rem;
+  line-height: 1.6;
+  transition:
+    color 0.28s ease,
+    background-color 0.28s ease;
+}
+
+html.light .analytics-shell {
+  --analytics-ink: #131c28;
+  --analytics-ink-soft: #3d4756;
+  --analytics-muted: #68738a;
+  --analytics-accent: #1d4fd7;
+  --analytics-accent-soft: #eef3fd;
+  --analytics-bg: #ffffff;
+  --analytics-bg-band: #f5f7fa;
+  --analytics-line: #e3e8ef;
+  --analytics-line-strong: #cbd3dd;
+  background: var(--analytics-bg);
+}
+
+.analytics-shell h1,
+.analytics-shell h2 {
+  margin: 0;
+  line-height: 1.25;
+  text-wrap: balance;
+}
+
+.analytics-shell p,
+.analytics-shell dl,
+.analytics-shell ul {
+  margin-block: 0;
+}
+
+.analytics-shell button {
+  box-shadow: none;
+}
+
+.analytics-shell :focus-visible {
+  outline: 2px solid var(--analytics-accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.analytics-top-bar {
+  position: fixed;
+  inset: 0 0 auto;
+  z-index: 60;
+  height: var(--analytics-topbar-height);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  min-height: 3.75rem;
-  padding: 0 1.25rem;
-  border-bottom: 1px solid #dbe3ef;
-  background: rgb(255 255 255 / 86%);
-  backdrop-filter: blur(12px);
+  padding-inline: 1rem;
+  pointer-events: none;
 }
 
-.analytics-topbar a {
-  color: #2563eb;
-  font-size: 0.82rem;
-  font-weight: 650;
-  text-decoration: none;
+.analytics-top-bar > * {
+  pointer-events: auto;
 }
 
-.analytics-topbar span {
-  color: #64748b;
-  font-size: 0.78rem;
-  font-weight: 650;
+.analytics-top-bar-left,
+.analytics-top-bar-right {
+  display: inline-flex;
+  align-items: center;
+}
+
+.analytics-theme-switch {
+  width: 2.7rem;
+  height: 2.7rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--analytics-ink);
+  cursor: pointer;
+  line-height: 1;
+  box-shadow: none;
+  transition:
+    color 0.15s ease,
+    transform 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.analytics-theme-switch:hover {
+  color: var(--analytics-ink-soft);
+  border-color: transparent;
+  background: transparent;
+  transform: scale(1.06);
+}
+
+.analytics-theme-switch:active {
+  transform: scale(0.96);
+}
+
+.analytics-theme-switch svg {
+  width: 22px;
+  height: 22px;
+  transition:
+    transform 0.35s ease,
+    opacity 0.2s ease;
+}
+
+.analytics-theme-switch:hover svg {
+  transform: rotate(24deg);
 }
 
 .analytics-page {
-  width: min(72rem, calc(100% - 2rem));
-  margin: 0 auto;
-  padding: 4rem 0 5rem;
+  min-height: 100dvh;
+  padding: calc(var(--analytics-topbar-height) + 0.5rem) 0 4rem;
 }
 
-.analytics-head h1,
-.analytics-head p,
-.analytics-section h2,
-.analytics-privacy {
-  margin: 0;
-}
-
-.analytics-kicker {
-  color: #2563eb;
-  font-size: 0.72rem;
-  font-weight: 750;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+.analytics-container {
+  box-sizing: border-box;
+  width: min(100% - (var(--analytics-gutter) * 2), var(--analytics-container));
+  max-width: 100%;
+  margin-inline: auto;
+  display: grid;
+  gap: 2.5rem;
+  overflow-wrap: break-word;
 }
 
 .analytics-head h1 {
-  margin-top: 0.35rem;
-  font-size: clamp(2.25rem, 5vw, 4rem);
-  letter-spacing: -0.055em;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
 }
 
-.analytics-head > p:last-child {
+.analytics-sub {
   margin-top: 0.55rem;
-  color: #64748b;
-  font-size: 0.86rem;
+  max-width: 40rem;
+  color: var(--analytics-muted);
+  font-size: 0.92rem;
+}
+
+.analytics-home {
+  color: var(--analytics-ink-soft);
+  font-size: 0.9rem;
+  text-decoration: none;
+  white-space: nowrap;
+  padding: 0.35rem 0.2rem;
+}
+
+.analytics-home:hover {
+  color: var(--analytics-ink);
 }
 
 .analytics-error {
-  margin: 1.25rem 0 0;
-  padding: 0.8rem 1rem;
-  border: 1px solid #fecaca;
-  border-radius: 0.6rem;
-  color: #991b1b;
-  background: #fff1f2;
+  margin: -1rem 0 0;
+  padding: 0.65rem 0;
+  border-top: 1px solid var(--analytics-line-strong);
+  border-bottom: 1px solid var(--analytics-line-strong);
+  color: var(--analytics-ink-soft);
+  font-size: 0.92rem;
+}
+
+.analytics-error code {
+  font-family: var(--font-mono);
+  font-size: 0.86em;
 }
 
 .analytics-metrics {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 1px;
-  margin: 2.5rem 0 0;
-  overflow: hidden;
-  border: 1px solid #dbe3ef;
-  border-radius: 0.9rem;
-  background: #dbe3ef;
-  box-shadow: 0 14px 40px rgb(15 23 42 / 6%);
+  gap: 1rem 1.5rem;
+  padding: 0.15rem 0 0.35rem;
+  border-top: 2px solid var(--analytics-ink);
+  border-bottom: 1px solid var(--analytics-line);
 }
 
 .analytics-metrics > div {
-  padding: 1.1rem 1.25rem;
-  background: rgb(255 255 255 / 92%);
+  display: grid;
+  gap: 0.35rem;
+  min-width: 0;
 }
 
 .analytics-metrics dt {
-  color: #64748b;
-  font-size: 0.72rem;
+  color: var(--analytics-muted);
+  font-size: 0.8rem;
 }
 
 .analytics-metrics dd {
-  margin: 0.4rem 0 0;
-  font-size: clamp(1.5rem, 3vw, 2.35rem);
-  font-weight: 760;
-  letter-spacing: -0.04em;
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: clamp(1.35rem, 2.4vw, 1.75rem);
+  font-weight: 650;
   font-variant-numeric: tabular-nums;
-}
-
-.analytics-section {
-  margin-top: 3rem;
+  line-height: 1.15;
+  color: var(--analytics-ink);
 }
 
 .analytics-section-head {
   display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 0.8rem;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.65rem 1rem;
+  border-bottom: 2px solid var(--analytics-ink);
+  padding-bottom: 0.7rem;
+  margin-bottom: 1.15rem;
 }
 
 .analytics-section-head h2 {
-  font-size: 1.05rem;
+  font-size: 1.6rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
 }
 
-.analytics-section-head span {
-  color: #64748b;
-  font-size: 0.72rem;
+.analytics-section-head-meta {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
 }
 
-.analytics-chart,
-.analytics-map {
-  display: block;
-  width: 100%;
-  height: auto;
+.analytics-aside {
+  font-size: 0.8rem;
+  color: var(--analytics-muted);
+  font-family: var(--font-mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.analytics-note {
+  margin: 0;
+  color: var(--analytics-muted);
+  font-size: 0.8rem;
+  font-family: var(--font-mono);
+}
+
+.analytics-range {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.65rem 1rem;
+  margin: -0.35rem 0 1rem;
+}
+
+.analytics-range-field {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.78rem;
+  color: var(--analytics-muted);
+}
+
+.analytics-range-input {
+  box-sizing: border-box;
+  min-width: 9.5rem;
+  padding: 0.35rem 0.55rem;
+  border: 1px solid var(--analytics-line);
+  border-radius: var(--analytics-radius);
+  background: var(--analytics-bg-band);
+  color: var(--analytics-ink);
+  font: inherit;
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  color-scheme: inherit;
+}
+
+html.light .analytics-range-input {
+  background: var(--analytics-bg);
+}
+
+.analytics-range-input:hover {
+  border-color: var(--analytics-line-strong);
+}
+
+.analytics-range-input:focus {
+  outline: none;
+  border-color: var(--analytics-accent);
+  box-shadow: 0 0 0 3px var(--analytics-accent-soft);
+}
+
+.analytics-range-reset {
+  padding: 0.35rem 0.55rem;
+  border: 1px solid var(--analytics-line);
+  border-radius: var(--analytics-radius);
+  background: transparent;
+  color: var(--analytics-ink-soft);
+  font: inherit;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.analytics-range-reset:hover {
+  border-color: var(--analytics-line-strong);
+  background: transparent;
+  color: var(--analytics-ink);
+}
+
+.analytics-range-reset:active {
+  transform: none;
+}
+
+.analytics-range-hint {
+  align-self: center;
+  margin-left: auto;
+  color: var(--analytics-muted);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.analytics-legend {
+  display: flex;
+  gap: 0.9rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--analytics-muted);
+  font-family: var(--font-mono);
+}
+
+.analytics-legend li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.analytics-swatch {
+  width: 0.55rem;
+  height: 0.55rem;
+  display: inline-block;
+  background: var(--analytics-accent);
+}
+
+.analytics-swatch--pv {
+  opacity: 0.3;
 }
 
 .analytics-chart {
-  min-height: 9rem;
-  padding: 0.8rem;
-  border: 1px solid #dbe3ef;
-  border-radius: 0.75rem;
-  background: #fff;
+  width: 100%;
+  height: auto;
+  display: block;
 }
 
-.analytics-bar-pv {
-  fill: #93c5fd;
+.analytics-chart-bar-pv {
+  fill: var(--analytics-accent);
+  opacity: 0.28;
 }
 
-.analytics-bar-uv {
-  fill: #2563eb;
+.analytics-chart-bar-uv {
+  fill: var(--analytics-accent);
 }
 
-.analytics-axis {
-  stroke: #94a3b8;
+.analytics-chart-axis {
+  stroke: var(--analytics-line-strong);
+  stroke-width: 1;
 }
 
-.analytics-tick {
-  fill: #64748b;
+.analytics-chart-tick {
+  fill: var(--analytics-muted);
+  font-family: var(--font-mono);
   font-size: 11px;
 }
 
 .analytics-map-frame {
   overflow: hidden;
-  border: 1px solid #dbe3ef;
-  border-radius: 0.75rem;
-  background: #dbeafe;
+  border: 1px solid var(--analytics-line);
 }
 
-.analytics-ocean {
-  fill: #dbeafe;
+.analytics-map-svg {
+  width: 100%;
+  height: auto;
+  display: block;
 }
 
-.analytics-land path {
-  fill: #f8fafc;
-  stroke: #cbd5e1;
-  stroke-width: 0.8;
+.analytics-map-ocean {
+  fill: #16202e;
 }
 
-#canvas-heat stop {
-  stop-color: #2563eb;
+.analytics-map-land path {
+  fill: #2a3547;
 }
 
-.analytics-heat {
-  fill: url(#canvas-heat);
+html.light .analytics-map-ocean {
+  fill: #b7c9de;
+}
+
+html.light .analytics-map-land path {
+  fill: #dde7f1;
+}
+
+#analytics-heat-gradient stop {
+  stop-color: var(--analytics-accent);
+}
+
+.analytics-heat-blob {
+  fill: url(#analytics-heat-gradient);
 }
 
 .analytics-heat-core {
-  fill: #1d4ed8;
+  fill: var(--analytics-accent);
+  opacity: 0.8;
 }
 
-.analytics-columns {
+.analytics-cols {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0 2rem;
+  gap: 2.5rem 3rem;
+  align-items: start;
 }
 
-.analytics-section-wide {
+.analytics-section--wide {
   grid-column: 1 / -1;
 }
 
-.analytics-table-wrap {
+.analytics-table-scroll {
   overflow-x: auto;
-  border: 1px solid #dbe3ef;
-  border-radius: 0.75rem;
-  background: #fff;
+}
+
+.analytics-breakdown {
+  display: grid;
 }
 
 .analytics-table {
   width: 100%;
-  min-width: 26rem;
+  min-width: 23rem;
   border-collapse: collapse;
-  font-size: 0.82rem;
+  font-size: 0.92rem;
 }
 
 .analytics-table th,
 .analytics-table td {
-  padding: 0.7rem 0.8rem;
-  border-bottom: 1px solid #e7edf5;
   text-align: left;
+  padding: 0.55rem 0.35rem;
+  border-bottom: 1px solid var(--analytics-line);
+  vertical-align: top;
 }
 
 .analytics-table th {
-  color: #64748b;
-  font-size: 0.7rem;
-  font-weight: 650;
+  font-size: 0.8rem;
+  color: var(--analytics-muted);
+  font-weight: 600;
+  letter-spacing: 0.04em;
 }
 
-.analytics-table th:not(:first-child),
-.analytics-number {
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
+.analytics-table td {
+  color: var(--analytics-ink-soft);
 }
 
-.analytics-number small {
-  margin-left: 0.25rem;
-  color: #94a3b8;
-}
-
-.analytics-table tbody tr:last-child td {
+.analytics-table tr:last-child td {
   border-bottom: 0;
 }
 
+.analytics-table .num {
+  text-align: right;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.analytics-table .mono {
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+}
+
+.analytics-metric {
+  white-space: nowrap;
+}
+
+.analytics-metric-distribution {
+  margin-left: 0.32rem;
+  color: var(--analytics-muted);
+  font-size: 0.72em;
+  font-weight: 500;
+}
+
 .analytics-empty {
-  min-height: 8rem;
-  padding: 3rem 1rem;
-  color: #64748b;
-  text-align: center;
+  color: var(--analytics-muted);
 }
 
-.analytics-privacy {
-  margin-top: 3.5rem;
-  padding-top: 1.25rem;
-  border-top: 1px solid #dbe3ef;
-  color: #64748b;
-  font-size: 0.78rem;
-  line-height: 1.65;
+.analytics-table-toggle {
+  justify-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.8rem;
+  padding: 0.35rem 0.55rem;
+  border: 0;
+  background: transparent;
+  color: var(--analytics-muted);
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: color 0.15s ease;
 }
 
-@media (max-width: 760px) {
-  .analytics-page {
-    padding-top: 2.5rem;
-  }
+.analytics-table-toggle:hover {
+  border-color: transparent;
+  background: transparent;
+  color: var(--analytics-ink);
+}
 
-  .analytics-metrics,
-  .analytics-columns {
+.analytics-table-toggle:active {
+  transform: none;
+}
+
+.analytics-table-toggle svg {
+  width: 1rem;
+  height: 1rem;
+  transition: transform 0.2s ease;
+}
+
+.analytics-table-toggle svg.is-expanded {
+  transform: rotate(180deg);
+}
+
+@media (max-width: 52rem) {
+  .analytics-metrics {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .analytics-columns > .analytics-section {
-    grid-column: 1 / -1;
+  .analytics-cols {
+    grid-template-columns: 1fr;
+    gap: 2.25rem;
+  }
+}
+
+@media (max-width: 28rem) {
+  .analytics-metrics {
+    grid-template-columns: 1fr 1fr;
+    gap: 0.85rem 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .analytics-theme-switch:hover {
+    transform: none;
+  }
+
+  .analytics-table-toggle svg {
+    transition: none;
   }
 }

--- a/plan/2026-08-12-align-analytics-dashboard/plan.md
+++ b/plan/2026-08-12-align-analytics-dashboard/plan.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: completed
 experience: none
 ---
 
@@ -65,4 +65,13 @@ fix(editor): match analytics dashboard to Analog Arena
 
 ## Outcome
 
-Pending.
+Ported the Analog Arena analytics dashboard component and styles to Analog
+Canvas, with only the document title, return-to-editor link, local module/export
+adaptation, and editor body isolation changed. Added the matching theme preload
+and mono font, plus browser coverage for date controls, theme switching, and
+breakdown expansion.
+
+Focused typecheck, editor build, and analytics Playwright passed. The canonical
+install and static/unit/release gates passed locally. Local E2E passed 72/74,
+with the two pre-existing drafting rich-text `span` assertions failing; all five
+GitHub Actions PR checks, including both browser shards, passed.

--- a/plan/2026-08-12-align-analytics-dashboard/plan.md
+++ b/plan/2026-08-12-align-analytics-dashboard/plan.md
@@ -1,0 +1,68 @@
+---
+status: active
+experience: none
+---
+
+# Align Analytics Dashboard with Analog Arena
+
+## Goal
+
+Make the Analog Canvas `/analytics` page match the existing Analog Arena analytics page exactly, except for the Analog Canvas document title and the link back to the editor.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree was clean. This target owns:
+
+- `apps/editor/src/components/analytics-page.tsx`
+- `apps/editor/src/styles.css`
+- `apps/editor/index.html`
+- `apps/editor/package.json`
+- `apps/editor/e2e/manual-editor.spec.ts`
+- `pnpm-lock.yaml`
+- `plan/2026-08-12-align-analytics-dashboard/plan.md`
+- `plan/log.md`
+
+Read-only references and shared dependencies:
+
+- `/Users/tokenzhang/Documents/analog-arena/site/src/components/AnalyticsPage.tsx`
+- `/Users/tokenzhang/Documents/analog-arena/site/src/index.css`
+- `apps/editor/src/lib/world-map.ts`
+- `apps/editor/src/data/land-110m.json`
+- `/api/analytics` response contract
+
+## Work
+
+1. Port the Analog Arena analytics component without redesigning it.
+2. Port the Analog Arena analytics styles without redesigning them.
+3. Adapt only the site title, editor return link, local module names, export shape, and analytics-page body isolation.
+4. Update the analytics route regression coverage for the copied controls and behavior.
+
+## Validation
+
+- Focused editor unit/type/build and analytics Playwright checks during development.
+- `pnpm install --frozen-lockfile`
+- `pnpm ci:check`
+- GitHub Actions required checks on the review branch.
+- Production verification at `https://analog-canvas.tokenzhang.com/analytics` after merge and deployment.
+- `git diff --check`
+- `git status --short --branch`
+
+The full mainline gate is required because this is a production UI change delivered to `main`.
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): match analytics dashboard to Analog Arena
+```
+
+## Outcome
+
+Pending.

--- a/plan/log.md
+++ b/plan/log.md
@@ -15,6 +15,19 @@ Use concise entries:
 
 Keep reusable lessons in `docs/experience/`, not in this log.
 
+## 2026-08-12 - Align Analytics Dashboard with Analog Arena
+
+- Target: make Analog Canvas analytics match the existing Analog Arena page
+  without redesigning it.
+- Changed areas: analytics component and styles, theme preload, matching mono
+  font dependency, and focused browser regression coverage.
+- Validation: frozen install, static/unit/release gates, focused analytics
+  Playwright, and all five GitHub Actions PR checks passed. Local full E2E was
+  72/74 with two pre-existing unrelated drafting rich-text assertions failing;
+  both remote browser shards passed.
+- Commit status: implementation committed and PR checks green; close-out
+  documentation ready to commit before merge.
+
 ## 2026-08-12 - Bound transient canvas state and runtime caches
 
 - Target: remove stale Smart Snap guide remnants and bound audit-identified

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
 
   apps/editor:
     dependencies:
+      "@fontsource-variable/google-sans-code":
+        specifier: ^5.3.0
+        version: 5.3.0
       "@icm/derived":
         specifier: workspace:*
         version: link:../../packages/derived
@@ -204,6 +207,12 @@ importers:
         version: 4.4.3
 
 packages:
+  "@fontsource-variable/google-sans-code@5.3.0":
+    resolution:
+      {
+        integrity: sha512-etsB8s2nyLqWlBrASPpT9LvPtxNxrLjrys4RZzW0mQnt8qYoNL7m1SLzCqY5Pp1g/6LWoVOI/6jPqiwO2l5xgA==,
+      }
+
   "@jridgewell/sourcemap-codec@1.5.5":
     resolution:
       {
@@ -1275,6 +1284,8 @@ packages:
       }
 
 snapshots:
+  "@fontsource-variable/google-sans-code@5.3.0": {}
+
   "@jridgewell/sourcemap-codec@1.5.5": {}
 
   "@oxc-project/types@0.143.0": {}


### PR DESCRIPTION
## Summary
- port the Analog Arena analytics page and styles without redesigning them
- retain only Analog Canvas title and return-to-editor adaptations
- add coverage for date range, theme toggle, and expandable breakdowns

## Validation
- pnpm install --frozen-lockfile
- typecheck, editor build, focused analytics Playwright passed
- pnpm ci:check: static, 475 unit tests, release checks passed; 72/74 browser tests passed, with the two known unrelated drafting rich-text span tests failing locally
