### PR TITLE
Isolate Analog Arena analytics reset

### DIFF
--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -1758,6 +1758,20 @@ body.analytics-body {
   background: #10161f;
 }
 
+html:not(.light) {
+  color-scheme: dark;
+}
+
+html.light {
+  color-scheme: light;
+}
+
+html:has(body.analytics-body) {
+  tab-size: 4;
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: transparent;
+}
+
 html.light body.analytics-body {
   background: #ffffff;
 }
@@ -1850,6 +1864,17 @@ html.light .analytics-shell {
 .analytics-shell dl,
 .analytics-shell ul {
   margin-block: 0;
+}
+
+.analytics-shell .analytics-sub {
+  margin-top: 0.55rem;
+}
+
+.analytics-shell *,
+.analytics-shell *::before,
+.analytics-shell *::after {
+  border-style: solid;
+  border-width: 0;
 }
 
 .analytics-shell button {
@@ -2064,6 +2089,7 @@ html.light .analytics-shell {
 }
 
 .analytics-range-input {
+  appearance: auto;
   box-sizing: border-box;
   min-width: 9.5rem;
   padding: 0.35rem 0.55rem;
@@ -2075,6 +2101,8 @@ html.light .analytics-shell {
   font-family: var(--font-mono);
   font-size: 0.84rem;
   color-scheme: inherit;
+  -webkit-font-smoothing: antialiased;
+  height: 2.16796875rem;
 }
 
 html.light .analytics-range-input {
@@ -2092,6 +2120,7 @@ html.light .analytics-range-input {
 }
 
 .analytics-range-reset {
+  appearance: button;
   padding: 0.35rem 0.55rem;
   border: 1px solid var(--analytics-line);
   border-radius: var(--analytics-radius);

--- a/plan/2026-08-12-align-analytics-dashboard/plan.md
+++ b/plan/2026-08-12-align-analytics-dashboard/plan.md
@@ -71,6 +71,12 @@ adaptation, and editor body isolation changed. Added the matching theme preload
 and mono font, plus browser coverage for date controls, theme switching, and
 breakdown expansion.
 
+Post-deployment computed-style comparison found that the editor's global CSS
+still overrode Arena's reset for subtitle spacing, zero-width border style, and
+native date/button appearance. The target was reopened to isolate those reset
+differences inside `.analytics-shell`; the shared geometry now matches Arena's
+computed layout exactly in Chromium for the compared page sections and controls.
+
 Focused typecheck, editor build, and analytics Playwright passed. The canonical
 install and static/unit/release gates passed locally. Local E2E passed 72/74,
 with the two pre-existing drafting rich-text `span` assertions failing; all five

--- a/plan/log.md
+++ b/plan/log.md
@@ -20,13 +20,14 @@ Keep reusable lessons in `docs/experience/`, not in this log.
 - Target: make Analog Canvas analytics match the existing Analog Arena page
   without redesigning it.
 - Changed areas: analytics component and styles, theme preload, matching mono
-  font dependency, and focused browser regression coverage.
+  font dependency, Arena-compatible reset isolation, and focused browser
+  regression coverage.
 - Validation: frozen install, static/unit/release gates, focused analytics
   Playwright, and all five GitHub Actions PR checks passed. Local full E2E was
   72/74 with two pre-existing unrelated drafting rich-text assertions failing;
   both remote browser shards passed.
-- Commit status: implementation committed and PR checks green; close-out
-  documentation ready to commit before merge.
+- Commit status: initial implementation merged through PR #11; post-deployment
+  reset-alignment follow-up ready for review.
 
 ## 2026-08-12 - Bound transient canvas state and runtime caches
 


### PR DESCRIPTION
## Summary
- isolate the copied Analog Arena reset from the editor global stylesheet
- match subtitle spacing, zero-width border style, color scheme, and native date/button geometry
- preserve the copied dashboard design and behavior unchanged

## Validation
- compared computed geometry against the live Analog Arena dashboard in Chromium
- pnpm install --frozen-lockfile
- static, 475 unit tests, release contracts, editor build, and focused analytics Playwright passed
- local full E2E passed 72/74 with the same two known unrelated drafting rich-text span assertions; remote shards required before merge
