### PR TITLE
feat(editor): integrate safe PR 14 improvements

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -259,3 +259,93 @@ test("commits a pending component from a semantic canvas click", async ({
   await expect(page.getByTestId("hit-R1")).toBeVisible();
   await expect(page.getByTestId("component-input-plane")).toHaveCount(0);
 });
+
+test("quick-places a starter, records it as recent, and restores Library state", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const panel = page.getByTestId("shapes-library-panel");
+  const canvas = page.getByTestId("schematic-canvas");
+
+  await expect(panel).toHaveAttribute("data-open", "true");
+  await page.getByTestId("shapes-chip-resistor").click();
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error("Canvas is not measurable");
+  await page.mouse.move(box.x + 280, box.y + 220);
+  await expect(page.getByTestId("component-placement-preview")).toBeVisible();
+  await canvas.click({ position: { x: 280, y: 220 } });
+  await expect(page.getByTestId("hit-R1")).toBeVisible();
+  await expect(page.getByTestId("shapes-recent-resistor")).toBeVisible();
+
+  await page.keyboard.press("q");
+  await expect(page.getByLabel("Component value")).toHaveValue("");
+  await page.getByTestId("library-toggle").click();
+  await expect(panel).toHaveAttribute("data-open", "false");
+  await expect
+    .poll(() =>
+      page.evaluate(() => localStorage.getItem("icm.library-panel-open.v1")),
+    )
+    .toBe("false");
+
+  await page.reload();
+  await expect(page.getByTestId("shapes-library-panel")).toHaveAttribute(
+    "data-open",
+    "false",
+  );
+  await expect
+    .poll(() =>
+      page.evaluate(() => localStorage.getItem("icm.recent-components.v1")),
+    )
+    .toContain("resistor");
+});
+
+test("keeps a usable canvas while toggling Library at the narrow breakpoint", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 720, height: 720 });
+  await page.goto("/");
+
+  const canvas = page.getByTestId("schematic-canvas");
+  const openWidth = (await canvas.boundingBox())?.width ?? 0;
+  expect(openWidth).toBeGreaterThan(300);
+
+  await page.getByTestId("library-toggle").click();
+  await expect(page.getByTestId("shapes-library-panel")).toHaveAttribute(
+    "data-open",
+    "false",
+  );
+  const closedWidth = (await canvas.boundingBox())?.width ?? 0;
+  expect(closedWidth).toBeGreaterThan(openWidth);
+  expect(
+    await page.evaluate(() => ({
+      horizontal:
+        document.documentElement.scrollWidth >
+        document.documentElement.clientWidth,
+      vertical:
+        document.documentElement.scrollHeight >
+        document.documentElement.clientHeight,
+    })),
+  ).toEqual({ horizontal: false, vertical: false });
+});
+
+test("double-clicking a placed device opens Properties for editing", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.keyboard.press("i");
+  const dialog = page.getByRole("dialog", { name: "Insert Component" });
+  await dialog.getByLabel("Component search").fill("resistor");
+  await dialog.getByLabel("Component value").fill("4.7k");
+  await dialog.getByRole("button", { name: "Apply" }).click();
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.click({ position: { x: 280, y: 220 } });
+
+  await page.getByTestId("hit-R1").dblclick();
+  await expect(page.getByTestId("selection-shelf")).toHaveAttribute(
+    "aria-expanded",
+    "true",
+  );
+  const propertyValue = page.getByLabel("Component value");
+  await expect(propertyValue).toHaveValue("4.7k");
+  await expect(propertyValue).toBeFocused();
+});

--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -139,7 +139,7 @@ test("adds formatted drafting text and undo/redo restores it", async ({
     page.getByTestId("canvas-text-editor"),
   );
   await draftInput.fill("Vin");
-  await draftInput.press("Control+a");
+  await draftInput.press("ControlOrMeta+A");
   await page.getByRole("button", { name: "Subscript" }).click();
   await page.getByRole("button", { name: "Apply text changes" }).click();
 
@@ -465,7 +465,7 @@ test("drafting content and anchor survive save and reopen", async ({
     name: "Canvas text editor",
   });
   await draftInput.fill("Vref");
-  await draftInput.press("Control+a");
+  await draftInput.press("ControlOrMeta+A");
   await page.getByRole("button", { name: "Italic" }).click();
   await page.getByRole("button", { name: "Apply text changes" }).click();
   await expect(page.getByTestId("revision")).toHaveText("2");

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -151,7 +151,7 @@ describe("editor shell", () => {
     expect(markup).not.toContain("<summary>Analytics</summary>");
   });
 
-  it("keeps Selection as an explicit overlay without a permanent library", () => {
+  it("keeps Properties as an overlay and exposes the quick-place Library", () => {
     const project = createEmptyProject("selection-shelf", "Selection Shelf");
     const markup = renderToStaticMarkup(<App project={project} />);
 
@@ -161,8 +161,9 @@ describe("editor shell", () => {
     expect(markup).toContain('data-testid="selection-shelf"');
     expect(markup).toContain('aria-label="Properties"');
     expect(markup).toContain("Insert component (I)");
-    expect(markup).not.toContain("Symbols &amp; Tools");
-    expect(markup).not.toContain("Search components");
+    expect(markup).toContain('data-testid="shapes-library-panel"');
+    expect(markup).toContain('data-testid="library-toggle"');
+    expect(markup).toContain("Quick place");
   });
 
   it("gives an implicit instance label its own selection surface", () => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -101,6 +101,7 @@ import {
   effectiveComponentParameterValue,
 } from "../features/component-insert/component-parameters";
 import { ToolIcon } from "../features/editor-shell/tool-icon";
+import { ShapesPanel } from "../features/editor-shell/shapes-panel";
 import { useDocumentController } from "../document/document-controller";
 import {
   applyDraftingHandle,
@@ -200,6 +201,7 @@ import type { SnapGuideLine, SnapResult } from "../snap/engine";
 
 const DEFAULT_VIEWBOX: Rect = { x: 0, y: 0, width: 960, height: 640 };
 const RECENT_COMPONENTS_STORAGE_KEY = "icm.recent-components.v1";
+const LIBRARY_PANEL_STORAGE_KEY = "icm.library-panel-open.v1";
 const DRAG_START_DISTANCE_PX = 4;
 const SNAP_CAPTURE_RADIUS_PX = 7;
 
@@ -432,6 +434,14 @@ function isTypingTarget(target: EventTarget | null): boolean {
 export function App({ project: initialProject, visitStats }: AppProps) {
   const [status, setStatus] = useState("Ready");
   const [insertDialogOpen, setInsertDialogOpen] = useState(false);
+  const [libraryPanelOpen, setLibraryPanelOpen] = useState(() => {
+    if (typeof window === "undefined") return true;
+    try {
+      return window.localStorage.getItem(LIBRARY_PANEL_STORAGE_KEY) !== "false";
+    } catch {
+      return true;
+    }
+  });
   const [selectionOpen, setSelectionOpen] = useState(false);
   const [componentPreviewPoint, setComponentPreviewPoint] =
     useState<Point | null>(null);
@@ -1091,6 +1101,29 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       } else {
         selectionShelfRef.current?.focus();
       }
+    });
+  }
+
+  function inspectInstance(instanceId: string): void {
+    setSelectedEndpoint(null);
+    updateInstanceSelection(instanceId, false);
+    setImportReviewOpen(false);
+    setSelectionOpen(true);
+    setStatus(`Properties for ${instanceId}`);
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => instanceValueInputRef.current?.focus());
+    });
+  }
+
+  function toggleLibraryPanel(): void {
+    setLibraryPanelOpen((current) => {
+      const next = !current;
+      try {
+        window.localStorage.setItem(LIBRARY_PANEL_STORAGE_KEY, String(next));
+      } catch {
+        // The Library remains usable when storage is unavailable.
+      }
+      return next;
     });
   }
 
@@ -5164,7 +5197,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   }
 
   return (
-    <main className="app-shell">
+    <main className={libraryPanelOpen ? "app-shell library-open" : "app-shell"}>
       <header className="app-header">
         <div>
           <h1>Interactive Circuit Maker</h1>
@@ -5186,6 +5219,22 @@ export function App({ project: initialProject, visitStats }: AppProps) {
             }
           }}
         >
+          <button
+            type="button"
+            aria-controls="shapes-library-panel"
+            aria-expanded={libraryPanelOpen}
+            aria-pressed={libraryPanelOpen}
+            data-testid="library-toggle"
+            title={
+              libraryPanelOpen
+                ? "Hide component library"
+                : "Show component library"
+            }
+            onClick={toggleLibraryPanel}
+          >
+            <ToolIcon name="library" />
+            Library
+          </button>
           {hasImportedHierarchy ? (
             <div
               className="document-nav"
@@ -5514,6 +5563,13 @@ export function App({ project: initialProject, visitStats }: AppProps) {
         recentSymbolIds={recentSymbolIds}
         onApply={beginInsertedComponentPlacement}
         onCancel={cancelComponentInsert}
+      />
+      <ShapesPanel
+        styleProfileId={document.presentation.styleProfileId}
+        recentSymbolIds={recentSymbolIds}
+        open={libraryPanelOpen}
+        onOpenInsert={openInsertComponentDialog}
+        onQuickPlace={beginInsertedComponentPlacement}
       />
       <aside
         className={selectionOpen ? "selection-dock open" : "selection-dock"}
@@ -6777,14 +6833,14 @@ export function App({ project: initialProject, visitStats }: AppProps) {
                         event.shiftKey || event.ctrlKey,
                       );
                     }}
-                    onDoubleClick={
-                      childDocumentId
-                        ? (event) => {
-                            event.stopPropagation();
-                            enterHierarchy(instance.id);
-                          }
-                        : undefined
-                    }
+                    onDoubleClick={(event) => {
+                      event.stopPropagation();
+                      if (childDocumentId) {
+                        enterHierarchy(instance.id);
+                        return;
+                      }
+                      inspectInstance(instance.id);
+                    }}
                     onPointerDown={(event) => beginMove(event, instance.id)}
                     pointerEvents={tool === "wire" ? "none" : undefined}
                   />

--- a/apps/editor/src/features/component-insert/component-insert-request.ts
+++ b/apps/editor/src/features/component-insert/component-insert-request.ts
@@ -1,0 +1,8 @@
+export interface ComponentInsertRequest {
+  symbolId: string;
+  symbolName: string;
+  properties: Record<string, string>;
+  initialRotation: 0 | 90 | 180 | 270;
+  showReference: boolean;
+  referenceText: string | null;
+}

--- a/apps/editor/src/features/component-insert/insert-component-dialog.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.tsx
@@ -34,16 +34,19 @@ export interface ComponentInsertRequest {
 export function SymbolArtwork({
   symbol,
   className,
+  /** Fraction of max(viewBox width, height) added around the glyph. */
+  paddingRatio = 0.18,
 }: {
   symbol: SymbolDefinition;
   className: string;
+  paddingRatio?: number;
 }) {
   const variantId = defaultRazaviSymbolVariantId(symbol.id);
   const variant = symbol.variants.find(
     (candidate) => candidate.id === variantId,
   );
   const { x, y, width, height } = symbol.viewBox;
-  const padding = Math.max(width, height) * 0.18;
+  const padding = Math.max(width, height) * paddingRatio;
 
   return (
     <svg

--- a/apps/editor/src/features/component-insert/insert-component-dialog.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { renderSymbolDefinitionBody } from "@icm/render-svg";
-import type { SymbolDefinition } from "@icm/symbols";
 
 import { defaultRazaviSymbolVariantId } from "../../presentation/razavi-presentation";
 import {
@@ -13,6 +12,10 @@ import {
   findPaletteSymbol,
   flattenComponentCatalog,
 } from "./symbol-catalog";
+import type { ComponentInsertRequest } from "./component-insert-request";
+import { SymbolArtwork } from "./symbol-artwork";
+
+export type { ComponentInsertRequest } from "./component-insert-request";
 
 export interface InsertComponentDialogProps {
   open: boolean;
@@ -20,56 +23,6 @@ export interface InsertComponentDialogProps {
   recentSymbolIds: readonly string[];
   onApply(request: ComponentInsertRequest): void;
   onCancel(): void;
-}
-
-export interface ComponentInsertRequest {
-  symbolId: string;
-  symbolName: string;
-  properties: Record<string, string>;
-  initialRotation: 0 | 90 | 180 | 270;
-  showReference: boolean;
-  referenceText: string | null;
-}
-
-export function SymbolArtwork({
-  symbol,
-  className,
-  /** Fraction of max(viewBox width, height) added around the glyph. */
-  paddingRatio = 0.18,
-}: {
-  symbol: SymbolDefinition;
-  className: string;
-  paddingRatio?: number;
-}) {
-  const variantId = defaultRazaviSymbolVariantId(symbol.id);
-  const variant = symbol.variants.find(
-    (candidate) => candidate.id === variantId,
-  );
-  const { x, y, width, height } = symbol.viewBox;
-  const padding = Math.max(width, height) * paddingRatio;
-
-  return (
-    <svg
-      className={className}
-      viewBox={`${x - padding} ${y - padding} ${width + padding * 2} ${height + padding * 2}`}
-      aria-hidden="true"
-    >
-      <g
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1"
-        strokeLinecap="square"
-        strokeLinejoin="miter"
-        dangerouslySetInnerHTML={{
-          __html: renderSymbolDefinitionBody(
-            symbol,
-            variant?.hiddenPrimitiveParts,
-            variant?.additionalPrimitives,
-          ),
-        }}
-      />
-    </svg>
-  );
 }
 
 export function ComponentPlacementPreview({

--- a/apps/editor/src/features/component-insert/symbol-artwork.tsx
+++ b/apps/editor/src/features/component-insert/symbol-artwork.tsx
@@ -1,0 +1,45 @@
+import { renderSymbolDefinitionBody } from "@icm/render-svg";
+import type { SymbolDefinition } from "@icm/symbols";
+
+import { defaultRazaviSymbolVariantId } from "../../presentation/razavi-presentation";
+
+export function SymbolArtwork({
+  symbol,
+  className,
+  /** Fraction of max(viewBox width, height) added around the glyph. */
+  paddingRatio = 0.18,
+}: {
+  symbol: SymbolDefinition;
+  className: string;
+  paddingRatio?: number;
+}) {
+  const variantId = defaultRazaviSymbolVariantId(symbol.id);
+  const variant = symbol.variants.find(
+    (candidate) => candidate.id === variantId,
+  );
+  const { x, y, width, height } = symbol.viewBox;
+  const padding = Math.max(width, height) * paddingRatio;
+
+  return (
+    <svg
+      className={className}
+      viewBox={`${x - padding} ${y - padding} ${width + padding * 2} ${height + padding * 2}`}
+      aria-hidden="true"
+    >
+      <g
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+        strokeLinecap="square"
+        strokeLinejoin="miter"
+        dangerouslySetInnerHTML={{
+          __html: renderSymbolDefinitionBody(
+            symbol,
+            variant?.hiddenPrimitiveParts,
+            variant?.additionalPrimitives,
+          ),
+        }}
+      />
+    </svg>
+  );
+}

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { STARTER_SYMBOL_IDS, quickPlaceRequest } from "./shapes-panel";
+
+describe("shapes quick-place", () => {
+  it("exposes starter chips with placement defaults", () => {
+    expect(STARTER_SYMBOL_IDS).toContain("resistor");
+    expect(STARTER_SYMBOL_IDS).toContain("nmos");
+
+    const request = quickPlaceRequest("razavi", "resistor");
+    expect(request).toMatchObject({
+      symbolId: "resistor",
+      symbolName: "Resistor",
+      initialRotation: 0,
+      showReference: true,
+      referenceText: null,
+    });
+    expect(request?.properties.value).toBe("10k");
+  });
+
+  it("returns null for unknown symbols", () => {
+    expect(quickPlaceRequest("razavi", "not-a-symbol")).toBeNull();
+  });
+});

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { STARTER_SYMBOL_IDS, quickPlaceRequest } from "./shapes-panel";
 
 describe("shapes quick-place", () => {
-  it("exposes starter chips with placement defaults", () => {
+  it("exposes starter chips without persisting parameter placeholders", () => {
     expect(STARTER_SYMBOL_IDS).toContain("resistor");
     expect(STARTER_SYMBOL_IDS).toContain("nmos");
 
@@ -15,7 +15,7 @@ describe("shapes quick-place", () => {
       showReference: true,
       referenceText: null,
     });
-    expect(request?.properties.value).toBe("10k");
+    expect(request?.properties.value).toBe("");
   });
 
   it("returns null for unknown symbols", () => {

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -1,0 +1,187 @@
+import {
+  SymbolArtwork,
+  type ComponentInsertRequest,
+} from "../component-insert/insert-component-dialog";
+import {
+  componentParameters,
+  initialComponentParameterValues,
+} from "../component-insert/component-parameters";
+import { findPaletteSymbol } from "../component-insert/symbol-catalog";
+
+/** Starter chips always offered in the left shapes column . */
+export const STARTER_SYMBOL_IDS = [
+  "resistor",
+  "capacitor",
+  "nmos",
+  "pmos",
+  "voltage-source",
+  "ground",
+  "vdd",
+  "opamp",
+] as const;
+
+export function quickPlaceRequest(
+  styleProfileId: string,
+  symbolId: string,
+): ComponentInsertRequest | null {
+  const symbol = findPaletteSymbol(styleProfileId, symbolId);
+  if (!symbol) return null;
+  const parameters = componentParameters(symbolId);
+  const properties =
+    parameters.length === 0
+      ? initialComponentParameterValues(symbolId)
+      : Object.fromEntries(
+          parameters.map((parameter) => [
+            parameter.key,
+            parameter.placeholder || "",
+          ]),
+        );
+  return {
+    symbolId: symbol.id,
+    symbolName: symbol.name,
+    properties,
+    initialRotation: 0,
+    showReference: true,
+    referenceText: null,
+  };
+}
+
+export interface ShapesPanelProps {
+  styleProfileId: string;
+  recentSymbolIds: readonly string[];
+  open: boolean;
+  onOpenInsert(): void;
+  onQuickPlace(request: ComponentInsertRequest): void;
+}
+
+export function ShapesPanel({
+  styleProfileId,
+  recentSymbolIds,
+  open,
+  onOpenInsert,
+  onQuickPlace,
+}: ShapesPanelProps) {
+  const starters = STARTER_SYMBOL_IDS.map((symbolId) =>
+    findPaletteSymbol(styleProfileId, symbolId),
+  ).filter((symbol): symbol is NonNullable<typeof symbol> => Boolean(symbol));
+
+  const recents = recentSymbolIds
+    .map((symbolId) => findPaletteSymbol(styleProfileId, symbolId))
+    .filter((symbol): symbol is NonNullable<typeof symbol> => Boolean(symbol))
+    .slice(0, 6);
+
+  function placeSymbol(symbolId: string): void {
+    const request = quickPlaceRequest(styleProfileId, symbolId);
+    if (request) onQuickPlace(request);
+  }
+
+  return (
+    <aside
+      id="shapes-library-panel"
+      className={open ? "shapes-panel" : "shapes-panel collapsed"}
+      aria-label="Shapes"
+      aria-hidden={!open}
+      inert={!open ? true : undefined}
+      data-testid="shapes-library-panel"
+      data-open={open ? "true" : "false"}
+    >
+      <header className="shapes-panel-header">
+        <button
+          type="button"
+          className="shapes-panel-title"
+          onClick={onOpenInsert}
+          title="Open insert dialog (I)"
+        >
+          <span className="shapes-kicker">Quick place</span>
+          <span className="shapes-panel-heading">Library</span>
+        </button>
+      </header>
+
+      <div className="shapes-panel-body">
+        <details
+          className="shapes-fold"
+          open
+          data-testid="shapes-fold-starters"
+        >
+          <summary className="shapes-fold-summary">
+            <span className="shapes-fold-label">Starters</span>
+            <span className="shapes-fold-count">{starters.length}</span>
+          </summary>
+          <div className="shapes-fold-body">
+            <div className="shapes-grid">
+              {starters.map((symbol) => (
+                <button
+                  key={symbol.id}
+                  type="button"
+                  className="shapes-chip"
+                  data-testid={`shapes-chip-${symbol.id}`}
+                  title={`Place ${symbol.name}`}
+                  onClick={() => placeSymbol(symbol.id)}
+                >
+                  <SymbolArtwork
+                    symbol={symbol}
+                    className="shapes-chip-art"
+                    paddingRatio={0.04}
+                  />
+                  <span>{symbol.name}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </details>
+
+        <details
+          className="shapes-fold"
+          open={recents.length > 0}
+          data-testid="shapes-fold-recent"
+        >
+          <summary className="shapes-fold-summary">
+            <span className="shapes-fold-label">Recent</span>
+            <span className="shapes-fold-count">{recents.length}</span>
+          </summary>
+          <div className="shapes-fold-body">
+            {recents.length > 0 ? (
+              <div className="shapes-grid">
+                {recents.map((symbol) => (
+                  <button
+                    key={`recent-${symbol.id}`}
+                    type="button"
+                    className="shapes-chip"
+                    data-testid={`shapes-recent-${symbol.id}`}
+                    title={`Place ${symbol.name}`}
+                    onClick={() => placeSymbol(symbol.id)}
+                  >
+                    <SymbolArtwork
+                      symbol={symbol}
+                      className="shapes-chip-art"
+                      paddingRatio={0.04}
+                    />
+                    <span>{symbol.name}</span>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <p className="shapes-hint">
+                Recent parts appear here after you place something. Use Insert
+                for the full catalog with parameters.
+              </p>
+            )}
+          </div>
+        </details>
+      </div>
+
+      <footer className="shapes-panel-footer">
+        <button
+          type="button"
+          className="shapes-insert"
+          data-testid="shapes-insert"
+          onClick={onOpenInsert}
+          title="Insert component with parameters (I)"
+        >
+          Insert
+          <kbd>I</kbd>
+        </button>
+      </footer>
+    </aside>
+  );
+}

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -1,14 +1,9 @@
-import {
-  SymbolArtwork,
-  type ComponentInsertRequest,
-} from "../component-insert/insert-component-dialog";
-import {
-  componentParameters,
-  initialComponentParameterValues,
-} from "../component-insert/component-parameters";
+import type { ComponentInsertRequest } from "../component-insert/component-insert-request";
+import { SymbolArtwork } from "../component-insert/symbol-artwork";
+import { initialComponentParameterValues } from "../component-insert/component-parameters";
 import { findPaletteSymbol } from "../component-insert/symbol-catalog";
 
-/** Starter chips always offered in the left shapes column . */
+/** Starter chips always offered in the left shapes panel. */
 export const STARTER_SYMBOL_IDS = [
   "resistor",
   "capacitor",
@@ -26,20 +21,13 @@ export function quickPlaceRequest(
 ): ComponentInsertRequest | null {
   const symbol = findPaletteSymbol(styleProfileId, symbolId);
   if (!symbol) return null;
-  const parameters = componentParameters(symbolId);
-  const properties =
-    parameters.length === 0
-      ? initialComponentParameterValues(symbolId)
-      : Object.fromEntries(
-          parameters.map((parameter) => [
-            parameter.key,
-            parameter.placeholder || "",
-          ]),
-        );
   return {
     symbolId: symbol.id,
     symbolName: symbol.name,
-    properties,
+    // Quick-place follows the full Insert dialog's existing blank-value
+    // semantics. Placeholders remain hints rather than silently persisted
+    // electrical parameters.
+    properties: initialComponentParameterValues(symbolId),
     initialRotation: 0,
     showReference: true,
     referenceText: null,

--- a/apps/editor/src/features/editor-shell/tool-icon.tsx
+++ b/apps/editor/src/features/editor-shell/tool-icon.tsx
@@ -10,7 +10,8 @@ export type ToolIconName =
   | "zoom-in"
   | "zoom-out"
   | "fit"
-  | "inspect";
+  | "inspect"
+  | "library";
 
 export function ToolIcon({ name }: { name: ToolIconName }) {
   const common = {
@@ -84,6 +85,14 @@ export function ToolIcon({ name }: { name: ToolIconName }) {
         <>
           <path d="M4 3h12v14H4z" {...common} />
           <path d="M7 7h6M7 10h6M7 13h4" {...common} />
+        </>
+      ) : null}
+      {name === "library" ? (
+        <>
+          <path
+            d="M3.5 4.5h5v11h-5zM11.5 4.5h5v4h-5zM11.5 11.5h5v4h-5z"
+            {...common}
+          />
         </>
       ) : null}
     </svg>

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -147,6 +147,201 @@ body {
   overflow: hidden;
 }
 
+.app-shell.library-open {
+  grid-template-columns: 15.5rem minmax(0, 1fr);
+}
+
+.shapes-panel {
+  grid-column: 1;
+  grid-row: 2;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border-right: 1px solid var(--icm-border);
+  background: var(--icm-surface);
+}
+
+.shapes-panel.collapsed {
+  display: none;
+}
+
+.shapes-panel-header {
+  padding: 0.75rem;
+  border-bottom: 1px solid var(--icm-border);
+}
+
+.shapes-panel-title {
+  display: grid;
+  gap: 0.15rem;
+  width: 100%;
+  padding: 0.35rem;
+  border: 0;
+  box-shadow: none;
+  text-align: left;
+}
+
+.shapes-kicker {
+  color: var(--icm-text-muted);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.shapes-panel-heading {
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.shapes-panel-body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 0;
+  padding: 0.75rem;
+  overflow: auto;
+}
+
+.shapes-fold {
+  flex: 0 0 auto;
+  overflow: clip;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-md);
+  background: var(--icm-surface);
+}
+
+.shapes-fold-summary {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.45rem;
+  min-height: 2rem;
+  padding: 0 0.6rem;
+  color: var(--icm-text);
+  background: var(--icm-surface-muted);
+  cursor: pointer;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  list-style: none;
+  text-transform: uppercase;
+}
+
+.shapes-fold-summary::-webkit-details-marker {
+  display: none;
+}
+
+.shapes-fold-summary::before {
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid currentColor;
+  content: "";
+  opacity: 0.5;
+  transition: transform 120ms ease;
+}
+
+.shapes-fold[open] > .shapes-fold-summary::before {
+  transform: rotate(90deg);
+}
+
+.shapes-fold-count {
+  min-width: 1.25rem;
+  padding: 1px 6px;
+  border-radius: 999px;
+  color: var(--icm-text-muted);
+  background: var(--icm-surface-hover);
+  font-size: 0.62rem;
+  text-align: center;
+}
+
+.shapes-fold-body {
+  padding: 0.5rem;
+  border-top: 1px solid var(--icm-border);
+}
+
+.shapes-fold:not([open]) > .shapes-fold-body {
+  display: none;
+}
+
+.shapes-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.shapes-chip {
+  display: grid;
+  min-width: 0;
+  min-height: 6.25rem;
+  align-content: center;
+  justify-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.4rem;
+  border-color: var(--icm-border);
+  background: var(--icm-surface-muted);
+  box-shadow: none;
+  font-size: 0.68rem;
+  font-weight: 650;
+}
+
+.shapes-chip-art {
+  width: 4rem;
+  height: 3rem;
+  overflow: visible;
+}
+
+.shapes-chip span {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shapes-hint {
+  margin: 0;
+  color: var(--icm-text-muted);
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
+.shapes-panel-footer {
+  padding: 0.65rem 0.75rem 0.75rem;
+  border-top: 1px solid var(--icm-border);
+}
+
+.shapes-insert {
+  display: flex;
+  width: 100%;
+  min-height: 2rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  color: #fff;
+  border-color: var(--icm-accent);
+  background: var(--icm-accent);
+  font-weight: 650;
+}
+
+.shapes-insert:hover:not(:disabled) {
+  border-color: var(--icm-accent);
+  background: var(--icm-accent);
+  filter: brightness(0.96);
+}
+
+.shapes-insert kbd {
+  padding: 0.05rem 0.3rem;
+  border: 1px solid rgb(255 255 255 / 38%);
+  border-radius: 0.25rem;
+  background: rgb(255 255 255 / 14%);
+  font: inherit;
+  font-size: 0.65rem;
+}
+
 .app-header {
   position: relative;
   z-index: 20;
@@ -816,6 +1011,10 @@ body {
     var(--icm-chrome-bg);
 }
 
+.app-shell.library-open .canvas-panel {
+  grid-column: 2;
+}
+
 .schematic-canvas {
   display: block;
   width: 100%;
@@ -943,7 +1142,8 @@ body {
 
 .guide-hit {
   fill: none;
-  stroke: transparent;
+  /* A near-transparent stroke remains targetable across SVG engines. */
+  stroke: rgb(0 0 0 / 0.4%);
   stroke-width: 14;
   cursor: move;
   pointer-events: stroke;
@@ -1185,7 +1385,8 @@ body {
   stroke-width: 1;
   stroke-dasharray: 6 4;
   cursor: move;
-  pointer-events: stroke;
+  /* The wider `.guide-hit` overlay owns pointer interaction. */
+  pointer-events: none;
   vector-effect: non-scaling-stroke;
 }
 
@@ -1836,6 +2037,10 @@ body {
 }
 
 @media (max-width: 860px) {
+  .app-shell.library-open {
+    grid-template-columns: 12rem minmax(0, 1fr);
+  }
+
   .app-header {
     display: flex;
     align-items: flex-start;

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -2,7 +2,7 @@
 
 Status: `accepted`
 
-Version: `1.6`
+Version: `1.7`
 
 Owning phase: `Phase 8`
 
@@ -49,23 +49,24 @@ Project and Document baseline.
 ## Command surface
 
 The production header exposes document/navigation and high-frequency document
-commands. Component placement uses one modeless master/detail insertion dialog;
-drawing tools live in the compact `Draw` menu rather than a permanent toolbar
-row or component sidebar:
+commands. Component placement uses a compact quick-place Library for starter
+and recent devices plus the existing master/detail insertion dialog for the
+full catalog and parameters. Drawing tools remain in the `Draw` menu:
 
 ```text
-File | Edit | Draw | More
+Library | File | Edit | Draw | More
 ```
 
 The exact visual treatment may use icons, labels, or responsive grouping, but
 the information architecture is normative:
 
-| Group | Commands                                                              |
-| ----- | --------------------------------------------------------------------- |
-| File  | Open, Save, Import, Export, and recent/example documents              |
-| Edit  | Undo, Redo, Delete, and contextual Align                              |
-| Draw  | Insert Component; Wire, Text, Arrow, Construction line, and Rectangle |
-| More  | Guides and shortcut reference; diagnostics remain in Import Review    |
+| Group   | Commands                                                              |
+| ------- | --------------------------------------------------------------------- |
+| File    | Open, Save, Import, Export, and recent/example documents              |
+| Edit    | Undo, Redo, Delete, and contextual Align                              |
+| Draw    | Insert Component; Wire, Text, Arrow, Construction line, and Rectangle |
+| More    | Guides and shortcut reference; diagnostics remain in Import Review    |
+| Library | Toggle starter/recent quick-place chips; open the full Insert dialog  |
 
 The following are not permanent production toolbar modes:
 
@@ -73,7 +74,8 @@ The following are not permanent production toolbar modes:
 - Save snapshot and Reopen snapshot; recovery is automatic infrastructure.
 - Phase/demo actions; examples belong in File/Open Example or development mode.
 
-`I` or `Draw > Insert component` opens one stable two-column dialog. Its left
+`I`, `Draw > Insert component`, or the Library's Insert entry opens one stable
+two-column dialog. Its left
 setup column contains one compact searchable component picker, device-specific
 parameters, and one compact placement row for initial rotation plus an optional
 label/name; the
@@ -82,8 +84,10 @@ The right column always shows the currently selected symbol's full preview.
 Arrow keys move the current option, `Enter` or `Apply` starts single-shot
 placement, and `Escape` cancels. During placement the resolved symbol follows
 the pointer; `R` rotates it before the placement click. Recent symbols
-are promoted only inside their existing category. The dialog reuses the Symbol
-DSL renderer and owns no separate thumbnail assets.
+are promoted inside their existing category and in the Library's bounded Recent
+section. Quick-place starts with blank parameter values; displayed placeholders
+remain hints rather than persisted electrical values. The dialog and Library
+reuse the Symbol DSL renderer and own no separate thumbnail assets.
 
 The editor shell is viewport-contained: the document body never becomes the
 scroll owner, overlays and inspectors scroll internally, and the SVG canvas
@@ -265,13 +269,15 @@ operation.
   the inspected object must not change the canvas column count, width, or
   viewport. The app shell is a stable single canvas column; no selection state
   adds or removes a layout column.
-- Component selection is transient in the `I` insertion dialog. No permanent
-  component library consumes canvas width or duplicates the Draw command
-  surface.
+- The collapsible Library uses a bounded canvas column for starter/recent
+  quick-place chips. Its open state is remembered locally; the full searchable
+  catalog remains in the `I` insertion dialog.
 - Object properties live in a floating left `Properties` shelf. It is collapsed
-  by default; direct selection never opens it. `Q`, a direct click on the shelf,
-  and the explicit Import Review exception can expand it. It overlays rather
-  than resizes the canvas and scrolls internally when its details overflow.
+  by default; direct selection never opens it. `Q`, double-click on a
+  non-hierarchical instance, a direct click on the shelf, and the explicit
+  Import Review exception can expand it. Hierarchical instance double-click
+  still enters its child cell. The shelf overlays rather than resizes the canvas
+  and scrolls internally when its details overflow.
 - A component's identity card shows only its reference and symbol. Editable
   `X`, `Y`, and `Rotate` appear once in a compact Properties row; device
   parameters use the same inline symbol/unit/explanation notation as `I`.

--- a/plan/2026-08-12-merge-pr14-safe/plan.md
+++ b/plan/2026-08-12-merge-pr14-safe/plan.md
@@ -1,0 +1,88 @@
+---
+status: completed
+experience: none
+---
+
+# Merge Safe PR 14 Improvements
+
+## Goal
+
+Port the independently useful, reviewable parts of PR #14 onto the current
+post-PR-#15 mainline without adopting its whole editor-shell redesign.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree was clean. PR #15 is already merged into `main`; PR #14 now
+conflicts with it, so this target owns a manual forward-port rather than a
+merge of the stale application shell.
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/features/component-insert/insert-component-dialog.tsx`
+- `apps/editor/src/features/component-insert/component-insert-request.ts`
+- `apps/editor/src/features/component-insert/symbol-artwork.tsx`
+- `apps/editor/src/features/editor-shell/shapes-panel.tsx`
+- `apps/editor/src/features/editor-shell/shapes-panel.test.ts`
+- `apps/editor/src/features/editor-shell/tool-icon.tsx`
+- `apps/editor/src/styles.css`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `apps/editor/e2e/drafting.spec.ts`
+- `docs/specs/editor-interaction.md`
+- `plan/2026-08-12-merge-pr14-safe/plan.md`
+- `plan/log.md`
+
+Read-only shared dependencies include the post-#15 connectivity/routing paths
+and the existing Analytics component/CSS. The port must preserve both.
+
+## Work
+
+1. Port the Library starter/recent panel with empty parameter values, its
+   existing full-catalog entry, and persisted open state.
+2. Port configurable symbol-preview padding, ordinary-device double-click to
+   Properties, the Guide hit-target fix, and the platform-neutral text test.
+3. Add focused browser coverage for quick-place, recents, reload persistence,
+   and the narrow-screen Library layout.
+4. Update only the accepted interaction contract affected by the retained
+   behavior; exclude the rejected full shell, status bar, and Properties
+   reflow redesign.
+
+## Validation
+
+- Focused unit tests for ShapesPanel and App
+- Focused Playwright component insertion and drafting tests
+- `pnpm install --frozen-lockfile`
+- `pnpm ci:check`
+- `git diff --check`
+- `git status --short --branch`
+- Required GitHub Actions checks on the review branch
+
+The full canonical gate is required because the change affects editor canvas
+interaction and will be delivered to `main`.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): integrate safe library quick-place improvements
+```
+
+## Outcome
+
+Ported the useful PR #14 behavior onto the post-#15 mainline without its stale
+whole-shell rewrite. The result adds a persisted collapsible starter/recent
+Library, blank-value quick placement, ordinary-device double-click Properties,
+configurable symbol-preview padding, reliable Guide hit targets, and
+platform-neutral text-selection tests. It preserves the floating Properties
+overlay, the accepted connectivity/routing implementation, and the Analytics
+CSS byte-for-byte from `main`.
+
+Validation passed: focused unit tests (14), focused component/drafting browser
+tests (34), frozen install, and complete `pnpm ci:check` including 599 unit tests,
+release/performance/export/PWA/smoke gates, and 88 browser tests. `git diff
+--check` is clean.

--- a/plan/log.md
+++ b/plan/log.md
@@ -5472,3 +5472,17 @@ contracts (WP-R1)`.
   independent E2E cases timed out only in the initial 16-worker run, passed 3/3
   at one worker, and the complete suite passed 85/85 at eight workers.
 - Commit status: integration branch validated and ready to fast-forward main.
+
+## 2026-08-12 - Safe PR 14 improvements
+
+- Target: retain the useful PR #14 Library and direct-inspection behavior on
+  top of merged PR #15 without adopting the conflicting full shell redesign.
+- Changed areas: persisted starter/recent quick-place Library; shared insertion
+  request/artwork modules; device double-click Properties; Guide hit testing;
+  interaction contract; focused unit and browser regressions.
+- Validation: frozen install and complete `pnpm ci:check`: formatting,
+  references, typecheck, 599 unit tests, build/performance/export/PWA/
+  production/release gates, and 88 browser E2E tests all passed. Analytics CSS
+  from `body.analytics-body` onward remains byte-identical to `main`.
+- Commit status: ready to commit on `codex/merge-pr14-safe` as
+  `feat(editor): integrate safe library quick-place improvements`.


### PR DESCRIPTION
## Summary

- forward-port the useful PR #14 Library quick-place and direct Properties behavior onto post-#15 main
- preserve the existing floating Properties overlay, connectivity/routing implementation, and Analytics styling
- keep quick-place parameter values blank instead of persisting placeholders
- fix Guide hit testing and add cross-platform text-selection coverage
- add browser coverage for actual quick-place, Recent persistence, Library persistence, narrow viewport layout, and double-click Properties

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm ci:check`
  - 599 unit tests
  - release/performance/export/PWA/production/release smoke gates
  - 88 browser tests
- Analytics CSS from `body.analytics-body` onward is byte-identical to main

This intentionally does not close or merge #14; it integrates only the reviewed safe subset without the conflicting full shell redesign.