### PR TITLE
feat: unify Razavi MOS bulk semantics

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -434,8 +434,57 @@ test("normalizes a legacy VDD Net and completes its PMOS bulk", async ({
   });
 
   await expect(page.getByTestId("status")).toContainText(
-    "Normalized 1 power-Net rule(s), reconciled 0 visible power contact(s), and added 1 Razavi bulk connection(s)",
+    "Opened legacy-contact.icproj.json",
   );
+  await page.getByTestId("hit-M4").click();
+  await openSelectionShelf(page);
+  await expect(page.getByText(/M4\.B → VDD · product-fallback/u)).toBeVisible();
+});
+
+test("draws and deletes one Razavi bulk route through the normal Wire workflow", async ({
+  page,
+}) => {
+  const project = createEmptyProject("bulk-route", "Bulk route");
+  const document = project.documents[0]!;
+  document.instances.push({
+    id: "M1",
+    symbolId: "nmos",
+    symbolVariantId: "textbook-3terminal",
+    placement: {
+      position: { x: 200, y: 160 },
+      rotation: 0,
+      mirror: "none",
+    },
+    properties: {},
+  });
+  await page.goto("/");
+  await page.getByTestId("project-file").setInputFiles({
+    name: "bulk-route.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(project)),
+  });
+  await page.getByTestId("hit-M1").click();
+  await openSelectionShelf(page);
+  await expect(page.getByText(/M1\.B → 0 · product-fallback/u)).toBeVisible();
+  await page.getByRole("button", { name: "Draw bulk connection" }).click();
+  await expect(page.getByTestId("terminal-M1-B")).toBeVisible();
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.dblclick({ position: { x: 320, y: 160 } });
+
+  const route = page.locator(
+    '[data-layer="routes"] [data-route-presentation="bulk-dashed"]',
+  );
+  await expect(route).toHaveCount(1);
+  const routeId = await onlyRouteId(page);
+  // Select away from the MOS hit box; the route intentionally starts at an
+  // internal body anchor below the instance selection surface.
+  await clickRoute(page, routeId, 0.85);
+  await page.keyboard.press("Delete");
+  await expect(route).toHaveCount(0);
+
+  await page.getByTestId("hit-M1").click();
+  await openSelectionShelf(page);
+  await expect(page.getByText(/M1\.B → 0 · product-fallback/u)).toBeVisible();
 });
 
 test("uses a flightline as direct Wire guidance", async ({ page }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -33,6 +33,7 @@ import {
   resolveEndpointPoint,
   resolveDraftingObjectGeometry,
   resolveNetLabelBinding,
+  resolveMosBulkConnection,
   runErcChecks,
   routeAttachmentPlacement,
   traceHierarchyNet,
@@ -138,6 +139,7 @@ import {
 import type { TextEditingSession } from "../features/text-editing/text-editing";
 import {
   defaultRazaviSymbolVariantId,
+  materializeRazaviProjectBulkConnections,
   razaviHiddenBulkRisk,
   razaviManualBulkConnectionEdits,
   razaviMosPresentationEdits,
@@ -430,6 +432,12 @@ function isTypingTarget(target: EventTarget | null): boolean {
 }
 
 export function App({ project: initialProject, visitStats }: AppProps) {
+  const [preparedInitialProject] = useState(
+    () =>
+      materializeRazaviProjectBulkConnections(
+        initialProject ?? createEmptyProject("project-main", "New Circuit"),
+      ).project,
+  );
   const [status, setStatus] = useState("Ready");
   const [insertDialogOpen, setInsertDialogOpen] = useState(false);
   const [selectionOpen, setSelectionOpen] = useState(false);
@@ -467,10 +475,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     openDocument,
     replaceProject,
     transact: transactDocument,
-  } = useDocumentController(
-    initialProject ?? createEmptyProject("project-main", "New Circuit"),
-    stageRecovery,
-  );
+  } = useDocumentController(preparedInitialProject, stageRecovery);
   const [documentStack, setDocumentStack] = useState<HierarchyFrame[]>([]);
   const {
     selection: visualSelection,
@@ -536,6 +541,9 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     number | null
   >(null);
   const [selectedEndpoint, setSelectedEndpoint] = useState<WireSource | null>(
+    null,
+  );
+  const [bulkDrawInstanceId, setBulkDrawInstanceId] = useState<string | null>(
     null,
   );
   const [netLabelDraft, setNetLabelDraft] = useState("");
@@ -857,12 +865,17 @@ export function App({ project: initialProject, visitStats }: AppProps) {
             return {
               endpoint,
               netId: endpointNetId(document, endpoint),
-              point: transformPoint(
-                pin.at,
-                instance.placement!.position,
-                instance.placement!,
-              ),
+              point:
+                resolveEndpointPoint(document, resolver, endpoint) ??
+                transformPoint(
+                  pin.at,
+                  instance.placement!.position,
+                  instance.placement!,
+                ),
               preludeEdits: [],
+              ...(pin.name === "B"
+                ? { routePresentation: "bulk-dashed" as const }
+                : {}),
             };
           });
       }),
@@ -895,6 +908,48 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     ],
     [document, resolver],
   );
+  const visibleBulkEndpoints: WireSource[] = useMemo(
+    () =>
+      document.instances.flatMap((instance): WireSource[] => {
+        if (!instance.placement || bulkDrawInstanceId !== instance.id) {
+          return [];
+        }
+        const resolved = resolver.resolve(
+          instance.symbolId,
+          instance.symbolVariantId,
+        );
+        const anchor = resolved?.variant?.auxiliaryPins?.find(
+          (pin) => pin.name === "B",
+        );
+        if (!anchor) return [];
+        const endpoint: RouteEndpoint = {
+          kind: "terminal",
+          instanceId: instance.id,
+          pinName: "B",
+        };
+        return [
+          {
+            endpoint,
+            netId: endpointNetId(document, endpoint),
+            point: transformPoint(
+              anchor.at,
+              instance.placement.position,
+              instance.placement,
+            ),
+            preludeEdits: [],
+            routePresentation: "bulk-dashed",
+          },
+        ];
+      }),
+    [bulkDrawInstanceId, document, resolver],
+  );
+  const wiringEndpoints = useMemo(() => {
+    const byKey = new Map<string, WireSource>();
+    for (const endpoint of [...visibleEndpoints, ...visibleBulkEndpoints]) {
+      byKey.set(endpointKey(endpoint.endpoint), endpoint);
+    }
+    return [...byKey.values()];
+  }, [visibleBulkEndpoints, visibleEndpoints]);
   useEffect(() => {
     const normalizationEdits = powerNetNormalizations(document).length
       ? [{ kind: "normalize_power_nets" as const }]
@@ -904,16 +959,12 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       document.instances,
       visibleEndpoints,
     );
-    const bulkEdits = razaviManualBulkConnectionEdits(
-      document,
-      document.instances,
-    );
-    const edits = [...normalizationEdits, ...powerContactEdits, ...bulkEdits];
+    const edits = [...normalizationEdits, ...powerContactEdits];
     if (edits.length === 0) return;
     const result = transact(edits);
     if (result.ok) {
       setStatus(
-        `Normalized ${normalizationEdits.length} power-Net rule(s), reconciled ${powerContactEdits.length} visible power contact(s), and added ${bulkEdits.length} Razavi bulk connection(s)`,
+        `Normalized ${normalizationEdits.length} power-Net rule(s) and reconciled ${powerContactEdits.length} visible power contact(s)`,
       );
     }
   }, [document, resolver, visibleEndpoints]);
@@ -944,6 +995,9 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       : undefined;
   const selectedHiddenBulkNet = selectedInstance
     ? razaviHiddenBulkRisk(document, selectedInstance.id)
+    : undefined;
+  const selectedBulkResolution = selectedInstance
+    ? resolveMosBulkConnection(document, selectedInstance)
     : undefined;
   const editingDrafting =
     textEditingTarget?.owner === "drafting"
@@ -1101,6 +1155,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     setTextEditing(null);
     setSelectedEndpoint(null);
     cancelInteraction();
+    setBulkDrawInstanceId(null);
   }
 
   function selectEndpoint(candidate: WireSource): void {
@@ -1280,7 +1335,8 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     // revive after Save/Discard/Open/Import/Restore/demo-load swaps the project.
     // Callers that also remove the recovery key do so after this cancels.
     cancelRecovery();
-    const nextDocument = replaceProject(nextProject);
+    const prepared = materializeRazaviProjectBulkConnections(nextProject);
+    const nextDocument = replaceProject(prepared.project);
     documentViewBoxes.current = new Map();
     setDocumentStack([]);
     setViewBox(nextViewBox);
@@ -1473,12 +1529,18 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       netId: flightline.netId,
       point: flightline.fromPoint,
       preludeEdits: [],
+      ...(flightline.from.kind === "terminal" && flightline.from.pinName === "B"
+        ? { routePresentation: "bulk-dashed" }
+        : {}),
     };
     const to: WireSource = {
       endpoint: flightline.to,
       netId: flightline.netId,
       point: flightline.toPoint,
       preludeEdits: [],
+      ...(flightline.to.kind === "terminal" && flightline.to.pinName === "B"
+        ? { routePresentation: "bulk-dashed" }
+        : {}),
     };
     setTool("wire");
     if (wireSource) {
@@ -1508,14 +1570,96 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       wireWaypoints,
       suffix,
     );
-    const result = transact(proposal.edits);
+    const bulkEndpoint = [wireSource.endpoint, candidate.endpoint].find(
+      (endpoint) => endpoint.kind === "terminal" && endpoint.pinName === "B",
+    );
+    const defaultBoundInstance =
+      bulkEndpoint?.kind === "terminal"
+        ? document.instances.find(
+            (instance) => instance.id === bulkEndpoint.instanceId,
+          )
+        : undefined;
+    const edits = defaultBoundInstance?.mosBulkBinding
+      ? [
+          {
+            kind: "clear_mos_bulk_default" as const,
+            instanceId: defaultBoundInstance.id,
+          },
+          ...proposal.edits.map((edit) => {
+            if (edit.kind !== "connect_endpoints") return edit;
+            const target =
+              edit.from.kind === "terminal" && edit.from.pinName === "B"
+                ? edit.to
+                : edit.from;
+            return {
+              ...edit,
+              from: target,
+              to: {
+                kind: "terminal" as const,
+                instanceId: defaultBoundInstance.id,
+                pinName: "B",
+              },
+            };
+          }),
+        ]
+      : proposal.edits;
+    const result = transact(edits);
     if (result.ok) {
       setWireSource(null);
       setWirePreviewPoint(null);
       setWireWaypoints([]);
       setTool("pointer");
+      setBulkDrawInstanceId(null);
       setStatus(`Committed route at revision ${result.revision}`);
     }
+  }
+
+  function drawSelectedMosBulk(): void {
+    if (!selectedInstance?.placement) return;
+    const resolved = resolver.resolve(
+      selectedInstance.symbolId,
+      selectedInstance.symbolVariantId,
+    );
+    const anchor = resolved?.variant?.auxiliaryPins?.find(
+      (pin) => pin.name === "B",
+    );
+    if (!anchor) {
+      setStatus("Selected instance has no Razavi bulk anchor");
+      return;
+    }
+    const endpoint: RouteEndpoint = {
+      kind: "terminal",
+      instanceId: selectedInstance.id,
+      pinName: "B",
+    };
+    const source: WireSource = {
+      endpoint,
+      // A materialized default is cleared in the same commit before the new
+      // explicit route is connected. Treat it as unowned during planning so
+      // the planner cannot merge VSS/VDD with the chosen body-bias Net.
+      netId: selectedInstance.mosBulkBinding
+        ? null
+        : endpointNetId(document, endpoint),
+      point: transformPoint(
+        anchor.at,
+        selectedInstance.placement.position,
+        selectedInstance.placement,
+      ),
+      preludeEdits: document.noConnects.flatMap((noConnect) =>
+        noConnect.endpoint.kind === "terminal" &&
+        noConnect.endpoint.instanceId === selectedInstance.id &&
+        noConnect.endpoint.pinName === "B"
+          ? [{ kind: "remove_no_connect" as const, noConnectId: noConnect.id }]
+          : [],
+      ),
+      routePresentation: "bulk-dashed",
+    };
+    setBulkDrawInstanceId(selectedInstance.id);
+    setTool("wire");
+    setWireSource(source);
+    setWirePreviewPoint(source.point);
+    setWireWaypoints([]);
+    setStatus(`Drawing ${selectedInstance.id}.B bulk connection`);
   }
 
   function freeWireAnchor(
@@ -2880,10 +3024,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
           `Project uses unsupported non-Razavi symbols: ${unsupported.join(", ")}`,
         );
       }
-      const openedDocument = opened.documents.find(
-        (candidate) => candidate.id === opened.topDocumentId,
-      )!;
-      replaceActiveProject(opened);
+      const openedDocument = replaceActiveProject(opened);
       setImportDiagnostics([]);
       setImportReviewOpen(false);
       clearRecovery();
@@ -6056,17 +6197,29 @@ export function App({ project: initialProject, visitStats }: AppProps) {
                 Place {port.name}
               </button>
             ))}
-            {selectedInstance && selectedHiddenBulkNet ? (
+            {selectedInstance && selectedBulkResolution ? (
               <section
                 className="context-actions"
-                aria-label="Hidden MOS bulk warning"
+                aria-label="MOS bulk connection"
               >
-                <h2>Hidden bulk warning</h2>
+                <h2>Bulk</h2>
                 <p>
-                  {selectedInstance.id}.B is electrically connected to{" "}
-                  {selectedHiddenBulkNet.name ?? selectedHiddenBulkNet.id}, but
-                  Razavi MOS stays in three-terminal display.
+                  {selectedInstance.id}.B →{" "}
+                  {selectedBulkResolution.net
+                    ? (selectedBulkResolution.net.name ??
+                      selectedBulkResolution.net.id)
+                    : selectedBulkResolution.status === "product-fallback"
+                      ? selectedBulkResolution.fallbackName
+                      : "unresolved"}
+                  {" · "}
+                  {selectedBulkResolution.status}
                 </p>
+                {selectedHiddenBulkNet ? (
+                  <p>Explicit bulk is shown with a Razavi dashed route.</p>
+                ) : null}
+                <button type="button" onClick={drawSelectedMosBulk}>
+                  Draw bulk connection
+                </button>
               </section>
             ) : null}
             {selectedRouteId ? (
@@ -6427,6 +6580,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
               setWirePreviewPoint(null);
               setWireWaypoints([]);
               setTool("pointer");
+              setBulkDrawInstanceId(null);
               setStatus("Wire cancelled");
             }
           }}
@@ -6622,7 +6776,11 @@ export function App({ project: initialProject, visitStats }: AppProps) {
             {wireDraftPoints.length >= 2 ? (
               <polyline
                 data-testid="wire-preview"
-                className="wire-preview"
+                className={
+                  wireSource?.routePresentation === "bulk-dashed"
+                    ? "wire-preview bulk-route-preview"
+                    : "wire-preview"
+                }
                 points={serializePolylinePoints(wireDraftPoints)}
               />
             ) : null}
@@ -6853,7 +7011,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
                 onClick={(event) => event.stopPropagation()}
               />
             ))}
-            {visibleEndpoints.map((candidate) => (
+            {wiringEndpoints.map((candidate) => (
               <circle
                 key={`${candidate.netId}:${endpointTestId(candidate.endpoint)}`}
                 data-testid={endpointTestId(candidate.endpoint)}

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -251,6 +251,16 @@ export function proposePaste(
       instance: {
         ...structuredClone(instance),
         id: instanceIds.get(instance.id)!,
+        ...(instance.mosBulkBinding
+          ? {
+              mosBulkBinding: {
+                ...instance.mosBulkBinding,
+                netId:
+                  netIds.get(instance.mosBulkBinding.netId) ??
+                  instance.mosBulkBinding.netId,
+              },
+            }
+          : {}),
         placement: instance.placement
           ? {
               ...instance.placement,
@@ -329,6 +339,7 @@ export function proposePaste(
       to: mapEndpoint(route.to, instanceIds, junctionIds),
       waypoints: route.waypoints.map((point) => movePoint(point, offset)),
       segmentModes: [...route.segmentModes],
+      ...(route.presentation ? { presentation: route.presentation } : {}),
     })),
   );
   edits.push(

--- a/apps/editor/src/features/selection/delete-selection.ts
+++ b/apps/editor/src/features/selection/delete-selection.ts
@@ -91,6 +91,7 @@ export function proposeConnectedInstanceDeletion(
         to,
         waypoints: route.waypoints.map((point) => ({ ...point })),
         segmentModes: [...route.segmentModes],
+        ...(route.presentation ? { presentation: route.presentation } : {}),
       },
     ];
   });

--- a/apps/editor/src/features/wiring/wire-editing.test.ts
+++ b/apps/editor/src/features/wiring/wire-editing.test.ts
@@ -106,5 +106,15 @@ describe("wire editing proposals", () => {
         },
       ],
     });
+
+    expect(
+      createRouteWireAnchor(
+        { ...route, presentation: "bulk-dashed" },
+        { x: 23.2, y: 37.8 },
+        1,
+        10,
+        10,
+      ),
+    ).toMatchObject({ routePresentation: "bulk-dashed" });
   });
 });

--- a/apps/editor/src/presentation/razavi-presentation.test.ts
+++ b/apps/editor/src/presentation/razavi-presentation.test.ts
@@ -1,7 +1,10 @@
-import { createEmptyDocument } from "@icm/model";
+import { createEmptyDocument, createEmptyProject } from "@icm/model";
 import { describe, expect, it } from "vitest";
 
-import { razaviManualBulkConnectionEdits } from "./razavi-presentation";
+import {
+  materializeRazaviProjectBulkConnections,
+  razaviManualBulkConnectionEdits,
+} from "./razavi-presentation";
 
 function manualMos(id: string, symbolId: "nmos" | "pmos") {
   return {
@@ -14,7 +17,21 @@ function manualMos(id: string, symbolId: "nmos" | "pmos") {
 }
 
 describe("Razavi hidden bulk policy", () => {
-  it("connects a new manual MOS bulk only to its matching explicit global supply", () => {
+  it("materializes entry-boundary fallback without mutating the supplied Project", () => {
+    const project = createEmptyProject("project-entry", "Entry");
+    project.documents[0]!.instances.push(manualMos("M1", "nmos"));
+
+    const prepared = materializeRazaviProjectBulkConnections(project);
+
+    expect(prepared.instanceCount).toBe(1);
+    expect(project.documents[0]!.nets).toEqual([]);
+    expect(prepared.project.documents[0]!.nets[0]).toMatchObject({
+      id: "net-global-0",
+      terminals: [{ instanceId: "M1", pinName: "B" }],
+    });
+  });
+
+  it("delegates matching-supply materialization to the Edit Engine", () => {
     const document = createEmptyDocument("main", "Main");
     document.instances.push(manualMos("M4", "pmos"));
     document.nets.push({
@@ -29,9 +46,8 @@ describe("Razavi hidden bulk policy", () => {
       razaviManualBulkConnectionEdits(document, document.instances),
     ).toEqual([
       {
-        kind: "connect_endpoints",
-        from: { kind: "terminal", instanceId: "M4", pinName: "B" },
-        to: { kind: "terminal", instanceId: "VDD1", pinName: "P" },
+        kind: "reconcile_mos_bulk",
+        instanceIds: ["M4"],
       },
     ]);
   });
@@ -55,14 +71,13 @@ describe("Razavi hidden bulk policy", () => {
       razaviManualBulkConnectionEdits(document, document.instances),
     ).toEqual([
       {
-        kind: "connect_endpoints",
-        from: { kind: "terminal", instanceId: "M4", pinName: "B" },
-        to: { kind: "terminal", instanceId: "VDD3", pinName: "P" },
+        kind: "reconcile_mos_bulk",
+        instanceIds: ["M4"],
       },
     ]);
   });
 
-  it("never guesses a body short for imported or supply-less MOS", () => {
+  it("never guesses imported source data but applies the product fallback manually", () => {
     const document = createEmptyDocument("main", "Main");
     document.instances.push(
       {
@@ -85,6 +100,6 @@ describe("Razavi hidden bulk policy", () => {
 
     expect(
       razaviManualBulkConnectionEdits(document, document.instances),
-    ).toEqual([]);
+    ).toEqual([{ kind: "reconcile_mos_bulk", instanceIds: ["MnoSupply"] }]);
   });
 });

--- a/apps/editor/src/presentation/razavi-presentation.ts
+++ b/apps/editor/src/presentation/razavi-presentation.ts
@@ -1,161 +1,110 @@
-import type { SchematicEdit } from "@icm/edit-engine";
-import { powerDomainForNet } from "@icm/model";
-import type { RouteEndpoint, SchematicDocument } from "@icm/model";
+import { executeTransaction, type SchematicEdit } from "@icm/edit-engine";
+import { mosBulkShouldBeVisible, resolveMosBulkConnection } from "@icm/derived";
+import { replaceProjectDocument } from "../document/editor-session";
+import type { CircuitProject, SchematicDocument } from "@icm/model";
+import { builtInSymbols, createProjectSymbolResolver } from "@icm/symbols";
 
 const DEFAULT_SYMBOL_VARIANTS: Readonly<Record<string, string>> = {
   nmos: "textbook-3terminal",
   pmos: "textbook-3terminal",
 };
 
-const IMPLICIT_BULK_NET_NAMES = new Set([
-  "0",
-  "gnd",
-  "vss",
-  "vdd",
-  "vssa",
-  "vdda",
-  "vgnd",
-  "vpwr",
-]);
-
-const BULK_SUPPLY_BY_SYMBOL: Readonly<Record<string, "VDD" | "0">> = {
-  pmos: "VDD",
-  nmos: "0",
-};
-
-function normalizedSupplyName(value: string | undefined): string | undefined {
-  return value?.toLowerCase().replaceAll(/[^a-z0-9]/gu, "");
-}
-
-function endpointForNet(
-  net: SchematicDocument["nets"][number],
-): RouteEndpoint | undefined {
-  const terminal = net.terminals[0];
-  if (terminal) return { kind: "terminal", ...terminal };
-  const portId = net.ports[0];
-  return portId ? { kind: "port", portId } : undefined;
-}
-
-function endpointHasNoConnect(
-  document: SchematicDocument,
-  instanceId: string,
-  pinName: string,
-): boolean {
-  return document.noConnects.some(
-    (noConnect) =>
-      noConnect.endpoint.kind === "terminal" &&
-      noConnect.endpoint.instanceId === instanceId &&
-      noConnect.endpoint.pinName === pinName,
-  );
-}
-
-function endpointNet(
-  document: SchematicDocument,
-  instanceId: string,
-  pinName: string,
-): SchematicDocument["nets"][number] | undefined {
-  return document.nets.find((net) =>
-    net.terminals.some(
-      (terminal) =>
-        terminal.instanceId === instanceId && terminal.pinName === pinName,
-    ),
-  );
-}
-
-function matchingGlobalSupply(
-  document: SchematicDocument,
-  supplyName: "VDD" | "0",
-): SchematicDocument["nets"][number] | undefined {
-  const canonicalNames =
-    supplyName === "VDD"
-      ? new Set(["vdd", "vdda", "vddd", "vcc", "vpwr"])
-      : new Set(["0", "gnd", "vss", "vssa", "vssd", "vee", "vgnd"]);
-  return document.nets.find(
-    (net) =>
-      powerDomainForNet(document, net) ===
-        (supplyName === "VDD" ? "vdd" : "ground") ||
-      (net.scope === "global" &&
-        [net.name, net.id]
-          .map(normalizedSupplyName)
-          .some((name) => name !== undefined && canonicalNames.has(name))),
-  );
-}
-
-/**
- * Textbook MOS artwork can hide B, never erase it. New manually authored MOS
- * may join an already explicit matching global supply, but imported/source-bound
- * devices, NoConnect declarations, body-bias Nets, and missing supplies remain
- * untouched so the electrical model cannot be silently guessed.
- */
-export function razaviManualBulkConnectionEdits(
-  document: SchematicDocument,
-  instances: readonly SchematicDocument["instances"][number][],
-): SchematicEdit[] {
-  return instances.flatMap((instance) => {
-    const supplyName = BULK_SUPPLY_BY_SYMBOL[instance.symbolId];
-    if (
-      !supplyName ||
-      instance.sourceRef ||
-      instance.binding ||
-      endpointNet(document, instance.id, "B") ||
-      endpointHasNoConnect(document, instance.id, "B")
-    ) {
-      return [];
-    }
-    const supply = matchingGlobalSupply(document, supplyName);
-    const target = supply && endpointForNet(supply);
-    return target
-      ? [
-          {
-            kind: "connect_endpoints" as const,
-            from: {
-              kind: "terminal" as const,
-              instanceId: instance.id,
-              pinName: "B",
-            },
-            to: target,
-          },
-        ]
-      : [];
-  });
-}
-
-/**
- * Razavi is the sole current presentation family. Canonical MOS definitions
- * retain D/G/S/B electrically, while this variant controls the approved
- * visible three-terminal body and source arrow.
- */
 export function defaultRazaviSymbolVariantId(
   symbolId: string,
 ): string | undefined {
   return DEFAULT_SYMBOL_VARIANTS[symbolId];
 }
 
+/** Compatibility helper: explicit body-bias is information, never an error. */
 export function razaviHiddenBulkRisk(
   document: SchematicDocument,
   instanceId: string,
 ): SchematicDocument["nets"][number] | undefined {
-  const bulkNet = document.nets.find((net) =>
-    net.terminals.some(
-      (terminal) =>
-        terminal.instanceId === instanceId && terminal.pinName === "B",
-    ),
-  );
-  if (!bulkNet || powerDomainForNet(document, bulkNet) !== "none") {
-    return undefined;
-  }
+  const resolution = resolveMosBulkConnection(document, instanceId);
+  return resolution?.status === "explicit" &&
+    mosBulkShouldBeVisible(document, instanceId)
+    ? resolution.net
+    : undefined;
+}
 
-  const isImplicitSupply = [bulkNet.name, bulkNet.id]
-    .filter((name): name is string => Boolean(name))
-    .map((name) => name.toLowerCase().replaceAll(/[^a-z0-9]/gu, ""))
-    .some((name) => IMPLICIT_BULK_NET_NAMES.has(name));
-  return isImplicitSupply ? undefined : bulkNet;
+/** One Edit-Engine operation owns all manual MOS default/fallback materialization. */
+export function razaviManualBulkConnectionEdits(
+  document: SchematicDocument,
+  instances: readonly SchematicDocument["instances"][number][],
+): SchematicEdit[] {
+  const instanceIds = instances
+    .filter((instance) => {
+      const resolution = resolveMosBulkConnection(document, instance);
+      return Boolean(
+        resolution &&
+        !resolution.materialized &&
+        (resolution.status === "cell-default" ||
+          resolution.status === "product-fallback"),
+      );
+    })
+    .map((instance) => instance.id);
+  return instanceIds.length > 0
+    ? [{ kind: "reconcile_mos_bulk", instanceIds }]
+    : [];
 }
 
 /**
- * The B terminal stays in electrical/SPICE data; non-supply B connections are
- * surfaced as hidden-bulk risks instead of changing the visible artwork.
+ * Upgrade manual-authoring bulk defaults at a Project entry boundary. This is
+ * intentionally performed before the editor history/recovery graph is
+ * installed, so compatibility materialization is not presented as a human
+ * edit or stored as a spurious unsaved recovery.
  */
+export function materializeRazaviProjectBulkConnections(
+  project: CircuitProject,
+): { project: CircuitProject; instanceCount: number } {
+  let nextProject = structuredClone(project);
+  let instanceCount = 0;
+  for (const sourceDocument of [...nextProject.documents]) {
+    const edits = razaviManualBulkConnectionEdits(
+      sourceDocument,
+      sourceDocument.instances,
+    );
+    if (edits.length === 0) continue;
+    const affectedCount =
+      edits[0]?.kind === "reconcile_mos_bulk"
+        ? (edits[0].instanceIds?.length ?? sourceDocument.instances.length)
+        : 0;
+    const result = executeTransaction(
+      sourceDocument,
+      {
+        transactionId: `razavi-bulk-entry-${sourceDocument.id}`,
+        documentId: sourceDocument.id,
+        expectedRevision: sourceDocument.revision,
+        // This is a deterministic editor compatibility transform, not an
+        // Agent request. It executes before user history is installed.
+        actor: { kind: "human", id: "razavi-bulk-entry" },
+        edits,
+      },
+      {
+        symbolResolver: createProjectSymbolResolver(
+          nextProject,
+          builtInSymbols,
+        ),
+      },
+    );
+    if (!result.ok) {
+      throw new Error(
+        `Cannot materialize Razavi bulk defaults for ${sourceDocument.id}: ${result.error.message}`,
+      );
+    }
+    nextProject = replaceProjectDocument(nextProject, result.document);
+    instanceCount += affectedCount;
+  }
+  return { project: nextProject, instanceCount };
+}
+
+export function razaviBulkAnchorIsVisible(
+  document: SchematicDocument,
+  instanceId: string,
+): boolean {
+  return mosBulkShouldBeVisible(document, instanceId);
+}
+
 export function razaviMosPresentationEdits(
   document: SchematicDocument,
 ): SchematicEdit[] {

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -922,6 +922,11 @@ body {
   vector-effect: non-scaling-stroke;
 }
 
+.wire-preview.bulk-route-preview {
+  stroke: #000;
+  stroke-dasharray: 3 3;
+}
+
 /* Wire mode owns the canvas input surface. It sits above formal symbols/text
    but below endpoint and route targets, so labels never steal a wiring click. */
 .wire-input-plane {

--- a/docs/overall-product-plan.md
+++ b/docs/overall-product-plan.md
@@ -447,6 +447,13 @@ flowchart LR
 
 SPICE MOS 可能有 D/G/S/B 四个 electrical terminals，而教材式符号可以不显示独立 bulk lead。隐藏只改变视觉表达，不能删除 logical terminal。
 
+Razavi MOS 的最终约定是“四端电气、三端默认显示”。B 的唯一事实仍是
+`Net.terminals`；Cell 可用稳定 Net ID 配置 NMOS/PMOS bulk defaults，未配置时
+手工器件采用 NMOS→0、PMOS→VDD fallback。显式 body-bias、B=S 或 SPICE 第四
+节点永远优先且不会被 ERC 当成 floating。非默认显式 B 从器件内部辅助 pin
+引出，使用与 Wire 完全相同的 Route/Net/Edit Engine，只以 `bulk-dashed` 呈现；
+飞线仍是导入后未完成布线的派生 guidance，不成为第二套电气协议。
+
 ```typescript
 interface SymbolPin {
   name: string;

--- a/docs/specs/agent-api.md
+++ b/docs/specs/agent-api.md
@@ -90,12 +90,14 @@ target cell/subcircuit name when available, and resolved `targetDocumentId` or
   and complete `presentation`;
 - ports with direction, position, and owning `netId | null`;
 - instances with display/source name, symbol/variant, target/model description,
-  complete primitive properties and parameters, placement, bounds, and complete
-  resolved/connected pin inventory;
+  complete primitive properties and parameters, placement, bounds, complete
+  resolved/connected pin inventory, and effective MOS bulk status/Net when
+  applicable;
 - every pin's name, role/direction when resolvable, local/page position,
   visibility, and `netId | null`;
 - Nets with scope, complete terminal refs, port IDs, route IDs, and Junction IDs;
-- complete Route endpoints, waypoints, segment modes, and derived polyline;
+- complete Route endpoints, waypoints, segment modes, optional presentation
+  (`wire`/`bulk-dashed`), and derived polyline;
 - Junctions, annotations, layout groups, and constraints with all persisted
   fields and members;
 - drafting objects with canonical RichText AST, resolved anchor, bounds,
@@ -170,6 +172,11 @@ it never returns or accepts a whole writable Document.
 Capability edit kinds are the shared Edit Engine schemas. Phase 9 adds generic
 symbol/port edits only through that shared boundary; GUI and Agent must validate
 identically.
+
+MOS bulk authoring uses the same typed boundary: `set_mos_bulk_defaults`
+configures Cell-level stable Net IDs, `reconcile_mos_bulk` materializes the
+effective default/fallback, and an explicit dashed body connection is still a
+normal Route plus terminal/Net edits. There is no Agent-only bulk protocol.
 
 `patch_instance_properties` is the single typed property edit. It accepts an
 instance ID plus a primitive `set` record and/or an `unset` key list, rejects an

--- a/docs/specs/connectivity-and-routing.md
+++ b/docs/specs/connectivity-and-routing.md
@@ -74,12 +74,27 @@ Flightlines never request routing for implicit terminals. Hiding a terminal
 cannot remove or rewrite its logical terminal record, merge its Net with
 another Net, or imply a device-specific short such as MOS `B=S`.
 
+The Razavi MOS bulk is the context-gated exception: when canonical `B` has an
+explicit non-default Net, its variant auxiliary anchor participates in imported
+flightline guidance. Completing that guidance persists an ordinary Route with
+`presentation: "bulk-dashed"`.
+
 ## Orthogonal route geometry
 
 The rendered polyline is `[fromPoint, ...waypoints, toPoint]`. Every segment
 must be horizontal or vertical and non-zero. Normalization removes consecutive
 duplicates and collinear interior points while retaining endpoint identity.
 `segmentModes.length` is always `waypoints.length + 1` after normalization.
+`RouteBranch.presentation` is optional: omitted/`wire` is a normal conductor;
+`bulk-dashed` is the Razavi body appearance. Both share Net membership,
+snapping, selection, split, stretch, highlight, deletion, clipboard, undo,
+Agent snapshot, and formal export behavior.
+
+Deleting an ordinary Route cuts stored geometry while retaining its Net fact.
+Deleting any segment of one connected `bulk-dashed` chain removes that visual
+chain, disconnects the explicit B terminal, and reconciles the configured Cell
+default or product fallback atomically. This semantic exception is implemented
+in the common route-deletion planner rather than in individual GUI commands.
 
 Segment modes mean:
 

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -322,6 +322,25 @@ attached `instance-label`: an empty attached label deliberately suppresses the
 renderer-owned default reference, rather than introducing a hidden editor-only
 flag.
 
+Canonical NMOS/PMOS always retain D/G/S/B electrically and use the Razavi
+three-terminal variant by default. A new manual MOS resolves B in this order:
+explicit membership, the active Cell's stable `mosBulkDefaults` Net ID, then
+NMOS -> `0` / PMOS -> `VDD`. The Edit Engine materializes that result in
+`Net.terminals`; imported/source-bound MOS instances are never repaired by the
+fallback. Selection shows the effective B Net and origin. `Draw bulk
+connection` exposes the internal B anchor and starts the normal Wire workflow,
+rendered as a Razavi dashed route. Starting an override atomically clears the
+materialized default first, so the body-bias target cannot merge with VSS/VDD.
+Deleting that dashed route disconnects explicit B and reapplies the default in
+one transaction. `set_mos_bulk_defaults` updates the Cell-level stable Net IDs;
+`reconcile_mos_bulk` is the only operation that materializes those defaults or
+the product fallback onto B.
+
+Project creation/open/import prepares eligible manual MOS defaults before the
+editor history and recovery scheduler are installed. This compatibility
+materialization is therefore not exposed as a synthetic user edit or an
+unsaved-recovery candidate. Imported/source-bound MOS instances remain exempt.
+
 `C` captures selected instances and only Nets, Routes, Junctions, and attached
 annotations wholly internal to that selection. It shows a non-interactive,
 mouse-following formal ghost; its next canvas click creates fresh stable IDs and

--- a/docs/specs/symbol-dsl.md
+++ b/docs/specs/symbol-dsl.md
@@ -148,6 +148,12 @@ Symbol DSL 1.9 separates visual geometry precision from electrical grid
 precision. Primitive points may retain finite decimals decoded from VSS, while
 pin anchors and instance placement remain integer grid coordinates.
 
+Symbol DSL 1.10 adds variant `auxiliaryPins`. An auxiliary pin names an existing
+canonical electrical pin and supplies context-gated artwork coordinates; it
+does not create another terminal or connectivity protocol. Razavi MOS uses it
+to expose canonical `B` from the internal body region only while an explicit
+body connection is being authored or displayed.
+
 ## Deterministic validation
 
 - schema and generated JSON Schema inspection

--- a/fixtures/agent-api/agent-circuit-request.schema.json
+++ b/fixtures/agent-api/agent-circuit-request.schema.json
@@ -540,6 +540,28 @@
                         ],
                         "additionalProperties": false
                       },
+                      "mosBulkBinding": {
+                        "type": "object",
+                        "properties": {
+                          "origin": {
+                            "type": "string",
+                            "enum": [
+                              "cell-default",
+                              "product-fallback"
+                            ]
+                          },
+                          "netId": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 256
+                          }
+                        },
+                        "required": [
+                          "origin",
+                          "netId"
+                        ],
+                        "additionalProperties": false
+                      },
                       "placement": {
                         "anyOf": [
                           {
@@ -1203,6 +1225,13 @@
                         "trunk"
                       ]
                     }
+                  },
+                  "presentation": {
+                    "type": "string",
+                    "enum": [
+                      "wire",
+                      "bulk-dashed"
+                    ]
                   }
                 },
                 "required": [
@@ -1369,6 +1398,13 @@
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 1000
+                  },
+                  "presentation": {
+                    "type": "string",
+                    "enum": [
+                      "wire",
+                      "bulk-dashed"
+                    ]
                   }
                 },
                 "required": [
@@ -1789,6 +1825,83 @@
                 },
                 "required": [
                   "kind"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "const": "set_mos_bulk_defaults"
+                  },
+                  "nmosNetId": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 256
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "pmosNetId": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 256
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "const": "reconcile_mos_bulk"
+                  },
+                  "instanceIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 256
+                    }
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "const": "clear_mos_bulk_default"
+                  },
+                  "instanceId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 256
+                  }
+                },
+                "required": [
+                  "kind",
+                  "instanceId"
                 ],
                 "additionalProperties": false
               },

--- a/fixtures/agent-api/agent-circuit-response.schema.json
+++ b/fixtures/agent-api/agent-circuit-response.schema.json
@@ -1383,6 +1383,38 @@
                           "additionalProperties": false
                         }
                       },
+                      "mosBulk": {
+                        "type": "object",
+                        "properties": {
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "explicit",
+                              "cell-default",
+                              "product-fallback",
+                              "no-connect",
+                              "unresolved"
+                            ]
+                          },
+                          "netId": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 256
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "status",
+                          "netId"
+                        ],
+                        "additionalProperties": false
+                      },
                       "sourceRef": {
                         "type": "object",
                         "properties": {
@@ -1737,6 +1769,13 @@
                             "trunk"
                           ]
                         }
+                      },
+                      "presentation": {
+                        "type": "string",
+                        "enum": [
+                          "wire",
+                          "bulk-dashed"
+                        ]
                       },
                       "polyline": {
                         "anyOf": [

--- a/fixtures/agent-api/agent-circuit.openapi.json
+++ b/fixtures/agent-api/agent-circuit.openapi.json
@@ -561,6 +561,28 @@
                                       ],
                                       "additionalProperties": false
                                     },
+                                    "mosBulkBinding": {
+                                      "type": "object",
+                                      "properties": {
+                                        "origin": {
+                                          "type": "string",
+                                          "enum": [
+                                            "cell-default",
+                                            "product-fallback"
+                                          ]
+                                        },
+                                        "netId": {
+                                          "type": "string",
+                                          "minLength": 1,
+                                          "maxLength": 256
+                                        }
+                                      },
+                                      "required": [
+                                        "origin",
+                                        "netId"
+                                      ],
+                                      "additionalProperties": false
+                                    },
                                     "placement": {
                                       "anyOf": [
                                         {
@@ -1224,6 +1246,13 @@
                                       "trunk"
                                     ]
                                   }
+                                },
+                                "presentation": {
+                                  "type": "string",
+                                  "enum": [
+                                    "wire",
+                                    "bulk-dashed"
+                                  ]
                                 }
                               },
                               "required": [
@@ -1390,6 +1419,13 @@
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 1000
+                                },
+                                "presentation": {
+                                  "type": "string",
+                                  "enum": [
+                                    "wire",
+                                    "bulk-dashed"
+                                  ]
                                 }
                               },
                               "required": [
@@ -1810,6 +1846,83 @@
                               },
                               "required": [
                                 "kind"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "const": "set_mos_bulk_defaults"
+                                },
+                                "nmosNetId": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "minLength": 1,
+                                      "maxLength": 256
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "pmosNetId": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "minLength": 1,
+                                      "maxLength": 256
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "kind"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "const": "reconcile_mos_bulk"
+                                },
+                                "instanceIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 256
+                                  }
+                                }
+                              },
+                              "required": [
+                                "kind"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "const": "clear_mos_bulk_default"
+                                },
+                                "instanceId": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 256
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "instanceId"
                               ],
                               "additionalProperties": false
                             },
@@ -36422,6 +36535,38 @@
                                           "additionalProperties": false
                                         }
                                       },
+                                      "mosBulk": {
+                                        "type": "object",
+                                        "properties": {
+                                          "status": {
+                                            "type": "string",
+                                            "enum": [
+                                              "explicit",
+                                              "cell-default",
+                                              "product-fallback",
+                                              "no-connect",
+                                              "unresolved"
+                                            ]
+                                          },
+                                          "netId": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "maxLength": 256
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "status",
+                                          "netId"
+                                        ],
+                                        "additionalProperties": false
+                                      },
                                       "sourceRef": {
                                         "type": "object",
                                         "properties": {
@@ -36776,6 +36921,13 @@
                                             "trunk"
                                           ]
                                         }
+                                      },
+                                      "presentation": {
+                                        "type": "string",
+                                        "enum": [
+                                          "wire",
+                                          "bulk-dashed"
+                                        ]
                                       },
                                       "polyline": {
                                         "anyOf": [
@@ -65076,6 +65228,28 @@
                                       ],
                                       "additionalProperties": false
                                     },
+                                    "mosBulkBinding": {
+                                      "type": "object",
+                                      "properties": {
+                                        "origin": {
+                                          "type": "string",
+                                          "enum": [
+                                            "cell-default",
+                                            "product-fallback"
+                                          ]
+                                        },
+                                        "netId": {
+                                          "type": "string",
+                                          "minLength": 1,
+                                          "maxLength": 256
+                                        }
+                                      },
+                                      "required": [
+                                        "origin",
+                                        "netId"
+                                      ],
+                                      "additionalProperties": false
+                                    },
                                     "placement": {
                                       "anyOf": [
                                         {
@@ -65739,6 +65913,13 @@
                                       "trunk"
                                     ]
                                   }
+                                },
+                                "presentation": {
+                                  "type": "string",
+                                  "enum": [
+                                    "wire",
+                                    "bulk-dashed"
+                                  ]
                                 }
                               },
                               "required": [
@@ -65905,6 +66086,13 @@
                                   "type": "integer",
                                   "exclusiveMinimum": 0,
                                   "maximum": 1000
+                                },
+                                "presentation": {
+                                  "type": "string",
+                                  "enum": [
+                                    "wire",
+                                    "bulk-dashed"
+                                  ]
                                 }
                               },
                               "required": [
@@ -66325,6 +66513,83 @@
                               },
                               "required": [
                                 "kind"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "const": "set_mos_bulk_defaults"
+                                },
+                                "nmosNetId": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "minLength": 1,
+                                      "maxLength": 256
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "pmosNetId": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "minLength": 1,
+                                      "maxLength": 256
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "kind"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "const": "reconcile_mos_bulk"
+                                },
+                                "instanceIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 256
+                                  }
+                                }
+                              },
+                              "required": [
+                                "kind"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "const": "clear_mos_bulk_default"
+                                },
+                                "instanceId": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 256
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "instanceId"
                               ],
                               "additionalProperties": false
                             },
@@ -100937,6 +101202,38 @@
                                           "additionalProperties": false
                                         }
                                       },
+                                      "mosBulk": {
+                                        "type": "object",
+                                        "properties": {
+                                          "status": {
+                                            "type": "string",
+                                            "enum": [
+                                              "explicit",
+                                              "cell-default",
+                                              "product-fallback",
+                                              "no-connect",
+                                              "unresolved"
+                                            ]
+                                          },
+                                          "netId": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string",
+                                                "minLength": 1,
+                                                "maxLength": 256
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "status",
+                                          "netId"
+                                        ],
+                                        "additionalProperties": false
+                                      },
                                       "sourceRef": {
                                         "type": "object",
                                         "properties": {
@@ -101291,6 +101588,13 @@
                                             "trunk"
                                           ]
                                         }
+                                      },
+                                      "presentation": {
+                                        "type": "string",
+                                        "enum": [
+                                          "wire",
+                                          "bulk-dashed"
+                                        ]
                                       },
                                       "polyline": {
                                         "anyOf": [

--- a/packages/agent-adapter/src/schema.ts
+++ b/packages/agent-adapter/src/schema.ts
@@ -12,6 +12,7 @@ import {
   PresentationIntentSchema,
   RectSchema,
   RouteEndpointSchema,
+  RoutePresentationSchema,
   SegmentModeSchema,
   SourceSpanSchema,
   StableIdSchema,
@@ -225,6 +226,18 @@ export const AgentSnapshotInstanceSchema = z.strictObject({
   placement: PlacementSchema.nullable(),
   bounds: RectSchema.nullable(),
   pins: z.array(AgentSnapshotPinSchema),
+  mosBulk: z
+    .strictObject({
+      status: z.enum([
+        "explicit",
+        "cell-default",
+        "product-fallback",
+        "no-connect",
+        "unresolved",
+      ]),
+      netId: StableIdSchema.nullable(),
+    })
+    .optional(),
   sourceRef: SourceSpanSchema.optional(),
 });
 
@@ -250,6 +263,7 @@ export const AgentSnapshotRouteSchema = z.strictObject({
   to: RouteEndpointSchema,
   waypoints: z.array(PointSchema),
   segmentModes: z.array(SegmentModeSchema),
+  presentation: RoutePresentationSchema.optional(),
   polyline: z.array(PointSchema).min(2).nullable(),
 });
 

--- a/packages/agent-adapter/src/service.ts
+++ b/packages/agent-adapter/src/service.ts
@@ -75,6 +75,10 @@ export const AGENT_EDIT_KINDS = [
   "connect_endpoints",
   "merge_nets",
   "set_net_name",
+  "normalize_power_nets",
+  "set_mos_bulk_defaults",
+  "reconcile_mos_bulk",
+  "clear_mos_bulk_default",
   "disconnect_endpoint",
   "upsert_annotation",
   "remove_annotation",
@@ -476,6 +480,9 @@ function editCategory(
     case "merge_nets":
     case "set_net_name":
     case "normalize_power_nets":
+    case "set_mos_bulk_defaults":
+    case "reconcile_mos_bulk":
+    case "clear_mos_bulk_default":
     case "disconnect_endpoint":
     case "add_no_connect":
     case "remove_no_connect":

--- a/packages/agent-adapter/src/snapshot.ts
+++ b/packages/agent-adapter/src/snapshot.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import {
   diagnoseVisualQuality,
   electricalTopologyHash,
+  resolveMosBulkConnection,
   resolveDraftingObjectGeometry,
   resolveDocumentRoutingGeometry,
 } from "@icm/derived";
@@ -260,6 +261,7 @@ function documentSnapshot(
         ? target.slice("model:".length)
         : null;
       const sourceName = properties["spice.name"];
+      const mosBulk = resolveMosBulkConnection(document, instance);
       return {
         id: instance.id,
         name: typeof sourceName === "string" ? sourceName : instance.id,
@@ -295,6 +297,14 @@ function documentSnapshot(
                 : null,
             netId: terminalNetByKey.get(`${instance.id}\u0000${name}`) ?? null,
           })),
+        ...(mosBulk
+          ? {
+              mosBulk: {
+                status: mosBulk.status,
+                netId: mosBulk.net?.id ?? null,
+              },
+            }
+          : {}),
         ...(options.includeSourceSpans && instance.sourceRef
           ? { sourceRef: structuredClone(instance.sourceRef) }
           : {}),
@@ -313,6 +323,7 @@ function documentSnapshot(
         to: structuredClone(route.to),
         waypoints: structuredClone(route.waypoints),
         segmentModes: [...route.segmentModes],
+        ...(route.presentation ? { presentation: route.presentation } : {}),
         polyline: geometry ? [...geometry.centerline] : null,
       };
     });

--- a/packages/derived/src/diagnostics/erc.test.ts
+++ b/packages/derived/src/diagnostics/erc.test.ts
@@ -413,6 +413,12 @@ describe("ERC engine", () => {
         placement: null,
         properties: {},
       },
+      {
+        id: "M1",
+        symbolId: "nmos",
+        placement: null,
+        properties: {},
+      },
     ];
     project.documents[0]!.nets = [
       {
@@ -427,6 +433,13 @@ describe("ERC engine", () => {
         name: "0",
         scope: "global",
         terminals: [{ instanceId: "GND2", pinName: "0" }],
+        ports: [],
+      },
+      {
+        id: "net-global-0",
+        name: "0",
+        scope: "global",
+        terminals: [{ instanceId: "M1", pinName: "B" }],
         ports: [],
       },
     ];

--- a/packages/derived/src/diagnostics/erc.test.ts
+++ b/packages/derived/src/diagnostics/erc.test.ts
@@ -250,7 +250,7 @@ describe("ERC engine", () => {
     );
   });
 
-  it("reports unconnected and hidden non-safe bulk without hiding electrical intent", () => {
+  it("reports only unresolved imported bulk and accepts explicit body-bias", () => {
     const project = emptyProject();
     const document = project.documents[0]!;
     document.instances = [roleInstance("three-terminal")];
@@ -268,9 +268,9 @@ describe("ERC engine", () => {
       },
     ];
 
-    expect(roleRun(project).map((diagnostic) => diagnostic.code)).toEqual([
-      "ERC_FLOATING_BULK",
-    ]);
+    expect(roleRun(project)).toContainEqual(
+      expect.objectContaining({ code: "ERC_BULK_UNRESOLVED" }),
+    );
 
     document.nets.push({
       id: "net-body-bias",
@@ -280,21 +280,21 @@ describe("ERC engine", () => {
       ports: [],
     });
     document.revision += 1;
-    const hiddenBulk = roleRun(project).find(
-      (diagnostic) => diagnostic.code === "ERC_FLOATING_BULK",
-    );
-    expect(hiddenBulk).toMatchObject({
-      primary: { objectId: "M1:B" },
-      parameters: { hidden: true, netId: "net-body-bias" },
-    });
+    expect(roleRun(project)).toEqual([]);
 
-    document.nets[2] = {
-      ...document.nets[2]!,
-      id: "net-vss",
-      name: "VSS",
+    document.nets = document.nets.filter((net) => net.id !== "net-body-bias");
+    document.instances[0] = {
+      ...document.instances[0]!,
+      sourceRef: {
+        fileId: "source.sp",
+        start: { offset: 0, line: 1, column: 1 },
+        end: { offset: 1, line: 1, column: 2 },
+      },
     };
     document.revision += 1;
-    expect(roleRun(project)).toEqual([]);
+    expect(roleRun(project)).toContainEqual(
+      expect.objectContaining({ code: "ERC_BULK_UNRESOLVED" }),
+    );
   });
 
   it("reports a Net that shorts reviewed VDD and ground symbols", () => {

--- a/packages/derived/src/diagnostics/erc.test.ts
+++ b/packages/derived/src/diagnostics/erc.test.ts
@@ -398,6 +398,42 @@ describe("ERC engine", () => {
     expect(diagnostic!.severity).toBe("error");
   });
 
+  it("accepts repeated global ground-symbol Nets", () => {
+    const project = emptyProject();
+    project.documents[0]!.instances = [
+      {
+        id: "GND1",
+        symbolId: "ground",
+        placement: null,
+        properties: {},
+      },
+      {
+        id: "GND2",
+        symbolId: "ground",
+        placement: null,
+        properties: {},
+      },
+    ];
+    project.documents[0]!.nets = [
+      {
+        id: "net-ground-1",
+        name: "0",
+        scope: "global",
+        terminals: [{ instanceId: "GND1", pinName: "0" }],
+        ports: [],
+      },
+      {
+        id: "net-ground-2",
+        name: "0",
+        scope: "global",
+        terminals: [{ instanceId: "GND2", pinName: "0" }],
+        ports: [],
+      },
+    ];
+
+    expect(codes(project)).not.toContain("ERC_DUPLICATE_NET_NAME");
+  });
+
   it("defensively reports a NoConnect endpoint that is also on a Net", () => {
     // The schema invariant (WP-R7) rejects this at parse/Edit-Engine time; ERC
     // repeats the check defensively. Construct the invalid state via a cast.

--- a/packages/derived/src/diagnostics/erc.ts
+++ b/packages/derived/src/diagnostics/erc.ts
@@ -39,7 +39,18 @@ function isRepeatedGlobalPowerNet(
   nets: readonly CircuitProject["documents"][number]["nets"][number][],
 ): boolean {
   if (!nets.every((net) => net.scope === "global")) return false;
-  const domains = new Set(nets.map((net) => powerDomainForNet(document, net)));
+  const domains = new Set(
+    nets.map((net) => {
+      const symbolDomain = powerDomainForNet(document, net);
+      if (symbolDomain !== "none") return symbolDomain;
+      // MOS bulk fallback predates power-symbol Net normalization. Its stable
+      // IDs intentionally express the same two global supply domains even
+      // though the fallback Net has no marker terminal of its own.
+      if (net.id === "net-global-0" && net.name === "0") return "ground";
+      if (net.id === "net-global-vdd" && net.name === "VDD") return "vdd";
+      return "none";
+    }),
+  );
   return domains.size === 1 && (domains.has("vdd") || domains.has("ground"));
 }
 

--- a/packages/derived/src/diagnostics/erc.ts
+++ b/packages/derived/src/diagnostics/erc.ts
@@ -34,6 +34,15 @@ function noConnectKey(endpoint: {
     : `port:${endpoint.portId}`;
 }
 
+function isRepeatedGlobalPowerNet(
+  document: CircuitProject["documents"][number],
+  nets: readonly CircuitProject["documents"][number]["nets"][number][],
+): boolean {
+  if (!nets.every((net) => net.scope === "global")) return false;
+  const domains = new Set(nets.map((net) => powerDomainForNet(document, net)));
+  return domains.size === 1 && (domains.has("vdd") || domains.has("ground"));
+}
+
 function terminalLocator(
   documentId: string,
   instanceId: string,
@@ -297,18 +306,20 @@ export function runErcChecks(
     }
 
     // ERC_DUPLICATE_NET_NAME
-    const netsByName = new Map<string, string[]>();
+    const netsByName = new Map<string, typeof document.nets>();
     for (const net of document.nets) {
       if (!net.name) continue;
       const name = net.name.toLowerCase();
       const group = netsByName.get(name) ?? [];
-      group.push(net.id);
+      group.push(net);
       netsByName.set(name, group);
     }
-    for (const [name, ids] of netsByName) {
-      if (ids.length < 2) continue;
-      const [primaryId, ...restIds] = [...ids].sort((a, b) =>
-        a.localeCompare(b, "en"),
+    for (const [name, nets] of netsByName) {
+      if (nets.length < 2 || isRepeatedGlobalPowerNet(document, nets)) {
+        continue;
+      }
+      const [primary, ...rest] = [...nets].sort((a, b) =>
+        a.id.localeCompare(b.id, "en"),
       );
       diagnostics.push({
         id: `erc:dup-net:${document.id}:${name}`,
@@ -317,12 +328,12 @@ export function runErcChecks(
         severity: "error",
         confidence: "high",
         gateEligible: true,
-        message: `Net name "${name}" is shared by ${ids.length} nets in document ${document.id} without an explicit merge`,
-        primary: directObjectLocator(document.id, "net", primaryId!),
-        related: restIds.map((objectId) =>
-          directObjectLocator(document.id, "net", objectId),
+        message: `Net name "${name}" is shared by ${nets.length} nets in document ${document.id} without an explicit merge`,
+        primary: directObjectLocator(document.id, "net", primary!.id),
+        related: rest.map((net) =>
+          directObjectLocator(document.id, "net", net.id),
         ),
-        parameters: { name, count: ids.length },
+        parameters: { name, count: nets.length },
       });
     }
 

--- a/packages/derived/src/diagnostics/erc.ts
+++ b/packages/derived/src/diagnostics/erc.ts
@@ -3,6 +3,7 @@ import type { CircuitProject } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 
 import type { ProjectConnectivityIndex } from "../connectivity-index.js";
+import { resolveMosBulkConnection } from "../mos-bulk.js";
 import { directObjectLocator, type ObjectLocator } from "../object-locator.js";
 import type { Diagnostic, DiagnosticSeverity } from "./diagnostic.js";
 
@@ -44,23 +45,6 @@ function terminalLocator(
   };
 }
 
-const SAFE_BULK_NET_NAMES = new Set([
-  "0",
-  "gnd",
-  "vss",
-  "vssa",
-  "vssd",
-  "vee",
-  "vdd",
-  "vdda",
-  "vddd",
-  "vcc",
-]);
-
-function normalizedNetName(name: string): string {
-  return name.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
-}
-
 function endpointHasOnlyInternalMembership(
   document: CircuitProject["documents"][number],
   netId: string,
@@ -74,24 +58,6 @@ function endpointHasOnlyInternalMembership(
     net.terminals.length === 1 &&
     net.terminals[0]?.instanceId === instanceId &&
     net.terminals[0]?.pinName === pinName,
-  );
-}
-
-function isSafeBulkNet(
-  document: CircuitProject["documents"][number],
-  netId: string,
-  expectedDomain: "vdd" | "ground" | undefined,
-): boolean {
-  const net = document.nets.find((candidate) => candidate.id === netId);
-  if (!net) return false;
-  const symbolDomain = powerDomainForNet(document, net);
-  if (symbolDomain === "conflict") return false;
-  if (symbolDomain === "vdd" || symbolDomain === "ground") {
-    return expectedDomain === undefined || symbolDomain === expectedDomain;
-  }
-  return (
-    net.scope === "global" ||
-    SAFE_BULK_NET_NAMES.has(normalizedNetName(net.name ?? net.id))
   );
 }
 
@@ -438,41 +404,27 @@ export function runErcChecks(
         }
 
         if (role === "bulk") {
-          const isThreeTerminalHidden = hidden.has(pin.name);
-          const expectedDomain =
-            instance.symbolId === "pmos"
-              ? "vdd"
-              : instance.symbolId === "nmos"
-                ? "ground"
-                : undefined;
-          const unsafeHiddenNet =
-            isThreeTerminalHidden &&
-            netId &&
-            !isSafeBulkNet(document, netId, expectedDomain);
+          const resolution = resolveMosBulkConnection(document, instance);
           if (
             !explicitlyNoConnect &&
-            (!netId || unsafeHiddenNet) &&
+            !netId &&
+            (!resolution || resolution.status === "unresolved") &&
             pin.presentation.visibility !== "implicit"
           ) {
             diagnostics.push({
-              id: `erc:floating-bulk:${document.id}:${instance.id}:${pin.name}`,
+              id: `erc:bulk-unresolved:${document.id}:${instance.id}:${pin.name}`,
               domain: "erc",
-              code: "ERC_FLOATING_BULK",
+              code: "ERC_BULK_UNRESOLVED",
               severity: "warning",
               confidence: "high",
               gateEligible: false,
-              message: !netId
-                ? `Bulk ${instance.id}.${pin.name} is not connected and has no NoConnect`
-                : `Hidden bulk ${instance.id}.${pin.name} is connected to non-safe net ${netId}`,
+              message: `Bulk ${instance.id}.${pin.name} has no explicit, cell-default, or product-fallback connection`,
               primary: terminalLocator(document.id, instance.id, pin.name),
-              related: netId
-                ? [directObjectLocator(document.id, "net", netId)]
-                : [],
+              related: [],
               parameters: {
                 instanceId: instance.id,
                 pinName: pin.name,
-                hidden: isThreeTerminalHidden,
-                ...(netId ? { netId } : {}),
+                hidden: hidden.has(pin.name),
               },
             });
           }

--- a/packages/derived/src/endpoint.ts
+++ b/packages/derived/src/endpoint.ts
@@ -1,6 +1,7 @@
 import { transformPoint } from "@icm/model";
 import type { Net, Point, RouteEndpoint, SchematicDocument } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
+import { mosBulkShouldBeVisible } from "./mos-bulk.js";
 
 export function endpointKey(endpoint: RouteEndpoint): string {
   switch (endpoint.kind) {
@@ -42,7 +43,13 @@ export function isVisibleEndpoint(
     instance.symbolVariantId,
   );
   if (!resolved) return false;
-  if (resolved.variant?.hiddenPinNames.includes(endpoint.pinName)) return false;
+  if (resolved.variant?.hiddenPinNames.includes(endpoint.pinName)) {
+    return Boolean(
+      endpoint.pinName === "B" &&
+      resolved.variant.auxiliaryPins?.some((pin) => pin.name === "B") &&
+      mosBulkShouldBeVisible(document, instance),
+    );
+  }
   const pin = resolved.definition.pins.find(
     (candidate) => candidate.name === endpoint.pinName,
   );
@@ -75,10 +82,14 @@ export function resolveEndpointPoint(
         instance.symbolId,
         instance.symbolVariantId,
       );
-      const pin = symbol?.definition.pins.find(
+      const basePin = symbol?.definition.pins.find(
         (candidate) => candidate.name === endpoint.pinName,
       );
-      if (!pin) return null;
+      if (!basePin) return null;
+      const auxiliary = symbol?.variant?.auxiliaryPins?.find(
+        (candidate) => candidate.name === endpoint.pinName,
+      );
+      const pin = auxiliary ?? basePin;
       return transformPoint(
         pin.at,
         instance.placement.position,
@@ -99,10 +110,14 @@ export function resolveEndpointOutwardDirection(
   );
   if (!instance?.placement) return null;
   const symbol = resolver.resolve(instance.symbolId, instance.symbolVariantId);
-  const pin = symbol?.definition.pins.find(
+  const basePin = symbol?.definition.pins.find(
     (candidate) => candidate.name === endpoint.pinName,
   );
-  if (!pin) return null;
+  if (!basePin) return null;
+  const auxiliary = symbol?.variant?.auxiliaryPins?.find(
+    (candidate) => candidate.name === endpoint.pinName,
+  );
+  const pin = auxiliary ?? basePin;
   const localDirection = {
     north: { x: 0, y: -1 },
     east: { x: 1, y: 0 },

--- a/packages/derived/src/index.ts
+++ b/packages/derived/src/index.ts
@@ -9,6 +9,7 @@ export * from "./hierarchy-navigation.js";
 export * from "./instance-label-placement.js";
 export * from "./net-highlight.js";
 export * from "./net-label.js";
+export * from "./mos-bulk.js";
 export * from "./object-locator.js";
 export * from "./project-search.js";
 export * from "./routes.js";

--- a/packages/derived/src/mos-bulk.test.ts
+++ b/packages/derived/src/mos-bulk.test.ts
@@ -1,0 +1,107 @@
+import { createEmptyDocument } from "@icm/model";
+import { describe, expect, it } from "vitest";
+
+import {
+  mosBulkShouldBeVisible,
+  resolveMosBulkConnection,
+} from "./mos-bulk.js";
+
+function mos(id: string, symbolId: "nmos" | "pmos") {
+  return {
+    id,
+    symbolId,
+    symbolVariantId: "textbook-3terminal",
+    placement: null,
+    properties: {},
+  };
+}
+
+describe("MOS bulk resolution", () => {
+  it("prefers explicit membership over defaults and exposes body bias", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.instances.push(mos("M1", "nmos"));
+    document.nets.push(
+      {
+        id: "net-vss",
+        name: "VSS",
+        scope: "global",
+        terminals: [],
+        ports: [],
+      },
+      {
+        id: "net-body",
+        name: "VBODY",
+        scope: "local",
+        terminals: [{ instanceId: "M1", pinName: "B" }],
+        ports: [],
+      },
+    );
+    document.mosBulkDefaults = { nmosNetId: "net-vss" };
+
+    expect(resolveMosBulkConnection(document, "M1")).toMatchObject({
+      status: "explicit",
+      net: { id: "net-body" },
+    });
+    expect(mosBulkShouldBeVisible(document, "M1")).toBe(true);
+  });
+
+  it("uses the stable cell default before the named product fallback", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.instances.push(mos("M1", "nmos"));
+    document.nets.push(
+      {
+        id: "net-cell-substrate",
+        name: "SUBSTRATE",
+        scope: "local",
+        terminals: [],
+        ports: [],
+      },
+      {
+        id: "net-vss",
+        name: "VSS",
+        scope: "global",
+        terminals: [],
+        ports: [],
+      },
+    );
+    document.mosBulkDefaults = { nmosNetId: "net-cell-substrate" };
+
+    expect(resolveMosBulkConnection(document, "M1")).toMatchObject({
+      status: "cell-default",
+      net: { id: "net-cell-substrate" },
+      materialized: false,
+    });
+  });
+
+  it("keeps a materialized Cell default visually implicit", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.instances.push(mos("M1", "nmos"));
+    document.nets.push({
+      id: "net-cell-substrate",
+      name: "SUBSTRATE",
+      scope: "local",
+      terminals: [{ instanceId: "M1", pinName: "B" }],
+      ports: [],
+    });
+    document.mosBulkDefaults = { nmosNetId: "net-cell-substrate" };
+
+    expect(mosBulkShouldBeVisible(document, "M1")).toBe(false);
+  });
+
+  it("does not guess when imported fourth-node evidence is missing", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.instances.push({
+      ...mos("M1", "pmos"),
+      sourceRef: {
+        fileId: "source.sp",
+        start: { offset: 0, line: 1, column: 1 },
+        end: { offset: 1, line: 1, column: 2 },
+      },
+    });
+
+    expect(resolveMosBulkConnection(document, "M1")).toMatchObject({
+      status: "unresolved",
+      net: undefined,
+    });
+  });
+});

--- a/packages/derived/src/mos-bulk.ts
+++ b/packages/derived/src/mos-bulk.ts
@@ -1,0 +1,163 @@
+import { powerDomainForNet } from "@icm/model";
+import type { Instance, Net, SchematicDocument } from "@icm/model";
+
+export type MosBulkKind = "nmos" | "pmos";
+export type MosBulkResolution =
+  | {
+      status: "explicit" | "cell-default" | "product-fallback";
+      instance: Instance;
+      net: Net;
+      materialized: boolean;
+    }
+  | {
+      status: "product-fallback";
+      instance: Instance;
+      net: undefined;
+      materialized: false;
+      fallbackName: "0" | "VDD";
+    }
+  | {
+      status: "no-connect" | "unresolved";
+      instance: Instance;
+      net: undefined;
+      materialized: false;
+    };
+
+export function mosBulkKind(instance: Instance): MosBulkKind | undefined {
+  return instance.symbolId === "nmos" || instance.symbolId === "pmos"
+    ? instance.symbolId
+    : undefined;
+}
+
+function normalizedName(value: string | undefined): string | undefined {
+  return value?.toLowerCase().replaceAll(/[^a-z0-9]/gu, "");
+}
+
+function fallbackNet(
+  document: SchematicDocument,
+  kind: MosBulkKind,
+): Net | undefined {
+  const domain = kind === "nmos" ? "ground" : "vdd";
+  const names =
+    kind === "nmos"
+      ? new Set(["0", "gnd", "vss", "vssa", "vssd", "vgnd"])
+      : new Set(["vdd", "vdda", "vddd", "vcc", "vpwr"]);
+  return document.nets.find(
+    (net) =>
+      powerDomainForNet(document, net) === domain ||
+      [net.name, net.id]
+        .map(normalizedName)
+        .some((name) => name !== undefined && names.has(name)),
+  );
+}
+
+/**
+ * Single authority for MOS body intent. Net membership remains the electrical
+ * truth; this function only explains whether that truth was explicit or was
+ * materialized from a cell/product default.
+ */
+export function resolveMosBulkConnection(
+  document: SchematicDocument,
+  instanceOrId: Instance | string,
+): MosBulkResolution | undefined {
+  const instance =
+    typeof instanceOrId === "string"
+      ? document.instances.find((candidate) => candidate.id === instanceOrId)
+      : instanceOrId;
+  if (!instance || !mosBulkKind(instance)) return undefined;
+
+  const connectedNet = document.nets.find((net) =>
+    net.terminals.some(
+      (terminal) =>
+        terminal.instanceId === instance.id && terminal.pinName === "B",
+    ),
+  );
+  if (connectedNet) {
+    const origin = instance.mosBulkBinding;
+    return {
+      status: origin?.netId === connectedNet.id ? origin.origin : "explicit",
+      instance,
+      net: connectedNet,
+      materialized: true,
+    };
+  }
+
+  if (
+    document.noConnects.some(
+      (item) =>
+        item.endpoint.kind === "terminal" &&
+        item.endpoint.instanceId === instance.id &&
+        item.endpoint.pinName === "B",
+    )
+  ) {
+    return {
+      status: "no-connect",
+      instance,
+      net: undefined,
+      materialized: false,
+    };
+  }
+
+  // Imported/source-bound MOS instances must already carry the fourth SPICE
+  // node. Never repair missing source data by guessing a body connection.
+  if (instance.sourceRef || instance.binding) {
+    return {
+      status: "unresolved",
+      instance,
+      net: undefined,
+      materialized: false,
+    };
+  }
+
+  const kind = mosBulkKind(instance)!;
+  const configuredId =
+    kind === "nmos"
+      ? document.mosBulkDefaults?.nmosNetId
+      : document.mosBulkDefaults?.pmosNetId;
+  const configured = configuredId
+    ? document.nets.find((net) => net.id === configuredId)
+    : undefined;
+  if (configured) {
+    return {
+      status: "cell-default",
+      instance,
+      net: configured,
+      materialized: false,
+    };
+  }
+
+  const fallback = fallbackNet(document, kind);
+  return fallback
+    ? {
+        status: "product-fallback",
+        instance,
+        net: fallback,
+        materialized: false,
+      }
+    : {
+        status: "product-fallback",
+        instance,
+        net: undefined,
+        materialized: false,
+        fallbackName: kind === "nmos" ? "0" : "VDD",
+      };
+}
+
+export function mosBulkShouldBeVisible(
+  document: SchematicDocument,
+  instanceOrId: Instance | string,
+): boolean {
+  const resolution = resolveMosBulkConnection(document, instanceOrId);
+  if (resolution?.status !== "explicit") return false;
+  const kind = mosBulkKind(resolution.instance)!;
+  const configuredId =
+    kind === "nmos"
+      ? document.mosBulkDefaults?.nmosNetId
+      : document.mosBulkDefaults?.pmosNetId;
+  if (configuredId === resolution.net.id) return false;
+  const expectedDomain = kind === "nmos" ? "ground" : "vdd";
+  return (
+    powerDomainForNet(document, resolution.net) !== expectedDomain &&
+    fallbackNet(document, kind)?.id !== resolution.net.id
+  );
+}

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -4,7 +4,12 @@ import {
   proposeWireSegmentDrag,
   type SegmentMode,
 } from "@icm/derived";
-import type { Point, RouteEndpoint, SchematicDocument } from "@icm/model";
+import type {
+  Point,
+  RouteEndpoint,
+  RoutePresentation,
+  SchematicDocument,
+} from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 
 import type { SchematicEdit } from "./transaction.js";
@@ -23,6 +28,7 @@ export interface WireSource extends WireEndpointGeometry {
   endpoint: RouteEndpoint;
   netId: string | null;
   preludeEdits: SchematicEdit[];
+  routePresentation?: RoutePresentation;
 }
 
 export interface WireCommitProposal {
@@ -102,6 +108,7 @@ function routeEdits(
       to: route.to,
       waypoints: proposal.waypoints,
       segmentModes: proposal.segmentModes,
+      ...(route.presentation ? { presentation: route.presentation } : {}),
     };
   });
 }
@@ -207,15 +214,19 @@ export function proposeLooseRouteTranslation(
           y: point.y + delta.y,
         })),
         segmentModes: [...route.segmentModes],
+        ...(route.presentation ? { presentation: route.presentation } : {}),
       },
     ],
   };
 }
 
 /**
- * Collect the closure for deleting visual route geometry. It deliberately uses
- * `cut_connection`, which removes only stored Wire/Junction facts; it does not
- * remove Net membership or implicitly sever the electrical net.
+ * Collect the closure for deleting visual route geometry. Ordinary Wire
+ * deletion deliberately preserves Net membership. A `bulk-dashed` route is
+ * different: it is the visible representation of an explicit MOS B binding,
+ * so deleting the terminal-touching route also disconnects B and restores the
+ * configured/default bulk policy. Keeping that exception here makes button,
+ * keyboard, marquee, and Agent-facing deletion paths share one contract.
  */
 export function proposeVisualRouteDeletion(
   document: SchematicDocument,
@@ -227,6 +238,36 @@ export function proposeVisualRouteDeletion(
   let changed = true;
   while (changed) {
     changed = false;
+    const bulkJunctions = new Set(
+      document.routes
+        .filter(
+          (route) =>
+            routesToRemove.has(route.id) &&
+            route.presentation === "bulk-dashed",
+        )
+        .flatMap((route) => [route.from, route.to])
+        .filter(
+          (
+            endpoint,
+          ): endpoint is Extract<RouteEndpoint, { kind: "junction" }> =>
+            endpoint.kind === "junction",
+        )
+        .map((endpoint) => endpoint.junctionId),
+    );
+    for (const route of document.routes) {
+      if (
+        route.presentation === "bulk-dashed" &&
+        !routesToRemove.has(route.id) &&
+        [route.from, route.to].some(
+          (endpoint) =>
+            endpoint.kind === "junction" &&
+            bulkJunctions.has(endpoint.junctionId),
+        )
+      ) {
+        routesToRemove.add(route.id);
+        changed = true;
+      }
+    }
     for (const route of document.routes) {
       const touchesDeletedJunction =
         (route.from.kind === "junction" &&
@@ -273,6 +314,37 @@ export function proposeVisualRouteDeletion(
           (route.to.kind === "junction" && route.to.junctionId === junctionId),
       ),
   );
+  const disconnectedBulkInstances = [
+    ...new Set(
+      document.routes
+        .filter(
+          (route) =>
+            routesToRemove.has(route.id) &&
+            route.presentation === "bulk-dashed",
+        )
+        .flatMap((route) => [route.from, route.to])
+        .filter(
+          (
+            endpoint,
+          ): endpoint is Extract<RouteEndpoint, { kind: "terminal" }> =>
+            endpoint.kind === "terminal" && endpoint.pinName === "B",
+        )
+        .filter(
+          (endpoint) =>
+            !document.routes.some(
+              (route) =>
+                !routesToRemove.has(route.id) &&
+                [route.from, route.to].some(
+                  (candidate) =>
+                    candidate.kind === "terminal" &&
+                    candidate.instanceId === endpoint.instanceId &&
+                    candidate.pinName === "B",
+                ),
+            ),
+        )
+        .map((endpoint) => endpoint.instanceId),
+    ),
+  ].sort((a, b) => a.localeCompare(b, "en"));
   return {
     routeIds: sortedRouteIds,
     junctionIds: sortedJunctionIds,
@@ -285,6 +357,13 @@ export function proposeVisualRouteDeletion(
         kind: "remove_junction",
         junctionId,
       })),
+      ...disconnectedBulkInstances.flatMap((instanceId): SchematicEdit[] => [
+        {
+          kind: "disconnect_endpoint",
+          endpoint: { kind: "terminal", instanceId, pinName: "B" },
+        },
+        { kind: "reconcile_mos_bulk", instanceIds: [instanceId] },
+      ]),
     ],
   };
 }
@@ -356,6 +435,11 @@ export function proposeWireCommit(
   suffix: number,
 ): WireCommitProposal {
   const edits: SchematicEdit[] = [...from.preludeEdits, ...to.preludeEdits];
+  const presentation =
+    from.routePresentation === "bulk-dashed" ||
+    to.routePresentation === "bulk-dashed"
+      ? "bulk-dashed"
+      : undefined;
   let netId = from.netId ?? to.netId;
   if (from.netId && to.netId && from.netId !== to.netId) {
     netId = from.netId;
@@ -382,6 +466,7 @@ export function proposeWireCommit(
     to: to.endpoint,
     waypoints: routed.waypoints,
     segmentModes: routed.segmentModes,
+    ...(presentation ? { presentation } : {}),
   });
   return { routeId, netId, edits };
 }
@@ -426,6 +511,7 @@ export function createRouteWireAnchor(
     endpoint: { kind: "junction", junctionId },
     netId: route.netId,
     point: splitPoint,
+    ...(route.presentation ? { routePresentation: route.presentation } : {}),
     preludeEdits: [
       {
         kind: "add_junction",

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -15,6 +15,7 @@ import { executeTransaction } from "./transaction.js";
 import {
   proposeGroupMoveEdits,
   proposeLooseRouteTranslation,
+  proposeVisualRouteDeletion,
   proposeWireSegmentMove,
 } from "./routing-planner.js";
 
@@ -50,6 +51,91 @@ function transaction(documentId: string, revision: number, edits: unknown[]) {
 }
 
 describe("routing Edit Engine", () => {
+  it("centralizes bulk route deletion as disconnect plus fallback reconciliation", () => {
+    const document = documentFixture();
+    document.instances.push({
+      id: "MB",
+      symbolId: "nmos",
+      symbolVariantId: "textbook-3terminal",
+      placement: { position: { x: 600, y: 200 }, rotation: 0, mirror: "none" },
+      properties: {},
+    });
+    document.nets.push({
+      id: "net-body",
+      name: "VBODY",
+      scope: "local",
+      terminals: [{ instanceId: "MB", pinName: "B" }],
+      ports: [],
+    });
+    document.junctions.push({
+      id: "body-end",
+      netId: "net-body",
+      position: { x: 720, y: 200 },
+      role: "route-anchor",
+    });
+    document.routes.push({
+      id: "route-body",
+      netId: "net-body",
+      from: { kind: "terminal", instanceId: "MB", pinName: "B" },
+      to: { kind: "junction", junctionId: "body-end" },
+      waypoints: [],
+      segmentModes: ["manual"],
+      presentation: "bulk-dashed",
+    });
+    document.junctions.push({
+      id: "body-middle",
+      netId: "net-body",
+      position: { x: 680, y: 200 },
+      role: "route-anchor",
+    });
+    document.routes[document.routes.length - 1] = {
+      ...document.routes.at(-1)!,
+      id: "route-body-head",
+      to: { kind: "junction", junctionId: "body-middle" },
+    };
+    document.routes.push({
+      id: "route-body-tail",
+      netId: "net-body",
+      from: { kind: "junction", junctionId: "body-middle" },
+      to: { kind: "junction", junctionId: "body-end" },
+      waypoints: [],
+      segmentModes: ["manual"],
+      presentation: "bulk-dashed",
+    });
+
+    const proposal = proposeVisualRouteDeletion(
+      document,
+      ["route-body-tail"],
+      [],
+    );
+    expect(proposal.edits).toEqual([
+      { kind: "cut_connection", routeId: "route-body-head" },
+      { kind: "cut_connection", routeId: "route-body-tail" },
+      {
+        kind: "disconnect_endpoint",
+        endpoint: { kind: "terminal", instanceId: "MB", pinName: "B" },
+      },
+      { kind: "reconcile_mos_bulk", instanceIds: ["MB"] },
+    ]);
+    const result = executeTransaction(
+      document,
+      transaction(document.id, 0, proposal.edits),
+      context,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(
+      result.document.routes.some((route) => route.id.startsWith("route-body")),
+    ).toBe(false);
+    expect(
+      result.document.instances.find((instance) => instance.id === "MB")
+        ?.mosBulkBinding,
+    ).toEqual({
+      origin: "product-fallback",
+      netId: "net-global-0",
+    });
+  });
+
   it("plans a segment drag as transaction edits", () => {
     const document = documentFixture();
     const routed = executeTransaction(

--- a/packages/edit-engine/src/transaction.test.ts
+++ b/packages/edit-engine/src/transaction.test.ts
@@ -34,6 +34,102 @@ function transaction(expectedRevision = 0, dryRun = false) {
 }
 
 describe("Edit Transaction envelope", () => {
+  it("sets a Cell bulk default by stable Net id before reconciliation", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.instances.push({
+      id: "M1",
+      symbolId: "nmos",
+      placement: null,
+      properties: {},
+    });
+    document.nets.push({
+      id: "net-substrate",
+      name: "SUBSTRATE",
+      scope: "local",
+      terminals: [],
+      ports: [],
+    });
+    const result = executeTransaction(
+      document,
+      {
+        ...transaction(),
+        edits: [
+          { kind: "set_mos_bulk_defaults", nmosNetId: "net-substrate" },
+          { kind: "reconcile_mos_bulk", instanceIds: ["M1"] },
+        ],
+      },
+      { symbolResolver: resolver },
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.document.mosBulkDefaults).toEqual({
+      nmosNetId: "net-substrate",
+    });
+    expect(result.document.instances[0]?.mosBulkBinding).toEqual({
+      origin: "cell-default",
+      netId: "net-substrate",
+    });
+  });
+
+  it("materializes manual MOS fallback bulk and permits an explicit override", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.instances.push({
+      id: "M1",
+      symbolId: "nmos",
+      symbolVariantId: "textbook-3terminal",
+      placement: { position: { x: 0, y: 0 }, rotation: 0, mirror: "none" },
+      properties: {},
+    });
+    const reconciled = executeTransaction(
+      document,
+      {
+        ...transaction(),
+        edits: [{ kind: "reconcile_mos_bulk", instanceIds: ["M1"] }],
+      },
+      { symbolResolver: resolver },
+    );
+    expect(reconciled.ok).toBe(true);
+    if (!reconciled.ok) return;
+    expect(reconciled.document.instances[0]?.mosBulkBinding).toEqual({
+      origin: "product-fallback",
+      netId: "net-global-0",
+    });
+    expect(reconciled.document.nets[0]?.terminals).toContainEqual({
+      instanceId: "M1",
+      pinName: "B",
+    });
+
+    reconciled.document.nets.push({
+      id: "net-vbody",
+      name: "VBODY",
+      scope: "local",
+      terminals: [],
+      ports: [],
+    });
+    const overridden = executeTransaction(
+      reconciled.document,
+      {
+        ...transaction(reconciled.document.revision),
+        edits: [
+          { kind: "clear_mos_bulk_default", instanceId: "M1" },
+          {
+            kind: "connect_endpoints",
+            from: { kind: "terminal", instanceId: "M1", pinName: "B" },
+            to: { kind: "terminal", instanceId: "M1", pinName: "B" },
+            newNetId: "net-explicit-body",
+          },
+        ],
+      },
+      { symbolResolver: resolver },
+    );
+    expect(overridden.ok).toBe(true);
+    if (!overridden.ok) return;
+    expect(overridden.document.instances[0]?.mosBulkBinding).toBeUndefined();
+    expect(
+      overridden.document.nets.find((net) => net.id === "net-global-0")
+        ?.terminals,
+    ).not.toContainEqual({ instanceId: "M1", pinName: "B" });
+  });
   it("accepts Net-id Label bindings and rejects overloaded object ids", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.nets.push({

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -13,6 +13,7 @@ import {
   PlacementSchema,
   PointSchema,
   RouteEndpointSchema,
+  RoutePresentationSchema,
   RotationSchema,
   SegmentModeSchema,
   SchematicDocumentSchema,
@@ -42,6 +43,7 @@ import {
   placeUprightInstanceLabel,
   resolveEndpointOutwardDirection,
   resolveEndpointPoint,
+  resolveMosBulkConnection,
   resolveSchematicStyleProfile,
   routePolyline,
   visibleSymbolLocalBounds,
@@ -117,6 +119,7 @@ export const SetRoutePointsEditSchema = z.strictObject({
   to: RouteEndpointSchema,
   waypoints: z.array(PointSchema),
   segmentModes: z.array(SegmentModeSchema),
+  presentation: RoutePresentationSchema.optional(),
 });
 export const RouteOrthogonalEditSchema = z.strictObject({
   kind: z.literal("route_orthogonal"),
@@ -125,6 +128,7 @@ export const RouteOrthogonalEditSchema = z.strictObject({
   from: RouteEndpointSchema,
   to: RouteEndpointSchema,
   escapeLength: z.number().int().positive().max(1000).optional(),
+  presentation: RoutePresentationSchema.optional(),
 });
 export const AddJunctionEditSchema = z.strictObject({
   kind: z.literal("add_junction"),
@@ -179,6 +183,19 @@ export const SetNetNameEditSchema = z.strictObject({
 });
 export const NormalizePowerNetsEditSchema = z.strictObject({
   kind: z.literal("normalize_power_nets"),
+});
+export const SetMosBulkDefaultsEditSchema = z.strictObject({
+  kind: z.literal("set_mos_bulk_defaults"),
+  nmosNetId: StableIdSchema.nullable().optional(),
+  pmosNetId: StableIdSchema.nullable().optional(),
+});
+export const ReconcileMosBulkEditSchema = z.strictObject({
+  kind: z.literal("reconcile_mos_bulk"),
+  instanceIds: z.array(StableIdSchema).optional(),
+});
+export const ClearMosBulkDefaultEditSchema = z.strictObject({
+  kind: z.literal("clear_mos_bulk_default"),
+  instanceId: StableIdSchema,
 });
 export const DisconnectEndpointEditSchema = z.strictObject({
   kind: z.literal("disconnect_endpoint"),
@@ -287,6 +304,9 @@ export const SchematicEditSchema = z.discriminatedUnion("kind", [
   MergeNetsEditSchema,
   SetNetNameEditSchema,
   NormalizePowerNetsEditSchema,
+  SetMosBulkDefaultsEditSchema,
+  ReconcileMosBulkEditSchema,
+  ClearMosBulkDefaultEditSchema,
   DisconnectEndpointEditSchema,
   AddNoConnectEditSchema,
   RemoveNoConnectEditSchema,
@@ -661,6 +681,7 @@ function routeFromEdit(
     to: structuredClone(edit.to),
     waypoints: structuredClone(edit.waypoints),
     segmentModes: [...edit.segmentModes],
+    ...(edit.presentation ? { presentation: edit.presentation } : {}),
   };
 }
 
@@ -1215,6 +1236,7 @@ function splitRoute(
         to: junctionEndpoint,
         waypoints: firstNormalized.points.slice(1, -1),
         segmentModes: firstNormalized.segmentModes,
+        ...(route.presentation ? { presentation: route.presentation } : {}),
       },
       second: {
         id: secondRouteId,
@@ -1223,6 +1245,7 @@ function splitRoute(
         to: structuredClone(route.to),
         waypoints: secondNormalized.points.slice(1, -1),
         segmentModes: secondNormalized.segmentModes,
+        ...(route.presentation ? { presentation: route.presentation } : {}),
       },
     };
   }
@@ -1250,6 +1273,7 @@ function splitRoute(
       to: junctionEndpoint,
       waypoints: firstNormalized.points.slice(1, -1),
       segmentModes: firstNormalized.segmentModes,
+      ...(route.presentation ? { presentation: route.presentation } : {}),
     },
     second: {
       id: secondRouteId,
@@ -1258,6 +1282,7 @@ function splitRoute(
       to: structuredClone(route.to),
       waypoints: secondNormalized.points.slice(1, -1),
       segmentModes: secondNormalized.segmentModes,
+      ...(route.presentation ? { presentation: route.presentation } : {}),
     },
   };
 }
@@ -2231,6 +2256,9 @@ export function executeTransaction(
           );
         }
         const route = routeFromEdit(edit);
+        if (!route.presentation && existing?.presentation) {
+          route.presentation = existing.presentation;
+        }
         const routeError = validateRoute(draft, route, resolver);
         if (routeError) {
           return rejectAt("EDIT_PRECONDITION", routeError, [], [edit.routeId]);
@@ -2300,7 +2328,11 @@ export function executeTransaction(
           to: structuredClone(edit.to),
           waypoints: geometry.waypoints,
           segmentModes: geometry.segmentModes,
+          ...(edit.presentation ? { presentation: edit.presentation } : {}),
         };
+        if (!route.presentation && existing?.presentation) {
+          route.presentation = existing.presentation;
+        }
         const routeError = validateRoute(draft, route, resolver);
         if (routeError) {
           return rejectAt("EDIT_PRECONDITION", routeError);
@@ -2566,6 +2598,12 @@ export function executeTransaction(
             (candidate) => candidate.id !== net.id,
           );
           changedObjectIds.add(net.id);
+          if (draft.mosBulkDefaults?.nmosNetId === net.id) {
+            delete draft.mosBulkDefaults.nmosNetId;
+          }
+          if (draft.mosBulkDefaults?.pmosNetId === net.id) {
+            delete draft.mosBulkDefaults.pmosNetId;
+          }
           connectivityChanged = true;
           break;
         }
@@ -2594,6 +2632,20 @@ export function executeTransaction(
                 : deriveStableId("net-split", net.id, route.id, group[0]!);
             for (const key of group) netIdByEndpoint.set(key, groupNetId);
           });
+          for (const instance of draft.instances) {
+            if (instance.mosBulkBinding?.netId !== net.id) continue;
+            const bodyNetId = netIdByEndpoint.get(
+              endpointKey({
+                kind: "terminal",
+                instanceId: instance.id,
+                pinName: "B",
+              }),
+            );
+            if (bodyNetId && bodyNetId !== net.id) {
+              instance.mosBulkBinding.netId = bodyNetId;
+              changedObjectIds.add(instance.id);
+            }
+          }
           const originalTerminals = [...net.terminals];
           const originalPorts = [...net.ports];
           const terminalsFor = (groupNetId: string) =>
@@ -2727,6 +2779,18 @@ export function executeTransaction(
             `Net merge target/source does not exist: ${edit.targetNetId}, ${edit.sourceNetId}`,
           );
         }
+        for (const instance of draft.instances) {
+          if (instance.mosBulkBinding?.netId === source.id) {
+            instance.mosBulkBinding.netId = target.id;
+            changedObjectIds.add(instance.id);
+          }
+        }
+        if (draft.mosBulkDefaults?.nmosNetId === source.id) {
+          draft.mosBulkDefaults.nmosNetId = target.id;
+        }
+        if (draft.mosBulkDefaults?.pmosNetId === source.id) {
+          draft.mosBulkDefaults.pmosNetId = target.id;
+        }
         for (const terminal of source.terminals) {
           if (
             !target.terminals.some(
@@ -2810,6 +2874,131 @@ export function executeTransaction(
         }
         break;
       }
+      case "set_mos_bulk_defaults": {
+        if (edit.nmosNetId === undefined && edit.pmosNetId === undefined) {
+          return rejectAt(
+            "EDIT_PRECONDITION",
+            "At least one MOS bulk default must be supplied",
+          );
+        }
+        for (const netId of [edit.nmosNetId, edit.pmosNetId]) {
+          if (netId && !draft.nets.some((net) => net.id === netId)) {
+            return rejectAt("OBJECT_NOT_FOUND", `Net does not exist: ${netId}`);
+          }
+        }
+        const defaults = { ...(draft.mosBulkDefaults ?? {}) };
+        if (edit.nmosNetId !== undefined) {
+          if (edit.nmosNetId === null) delete defaults.nmosNetId;
+          else defaults.nmosNetId = edit.nmosNetId;
+        }
+        if (edit.pmosNetId !== undefined) {
+          if (edit.pmosNetId === null) delete defaults.pmosNetId;
+          else defaults.pmosNetId = edit.pmosNetId;
+        }
+        draft.mosBulkDefaults =
+          defaults.nmosNetId || defaults.pmosNetId ? defaults : undefined;
+        connectivityChanged = true;
+        break;
+      }
+      case "reconcile_mos_bulk": {
+        const selected = edit.instanceIds ? new Set(edit.instanceIds) : null;
+        for (const instance of draft.instances) {
+          if (selected && !selected.has(instance.id)) continue;
+          const resolution = resolveMosBulkConnection(draft, instance);
+          if (
+            !resolution ||
+            resolution.materialized ||
+            resolution.status === "no-connect" ||
+            resolution.status === "unresolved"
+          ) {
+            continue;
+          }
+          let target = resolution.net;
+          if (!target) {
+            if (
+              resolution.status !== "product-fallback" ||
+              !("fallbackName" in resolution)
+            ) {
+              continue;
+            }
+            const name = resolution.fallbackName;
+            const id = name === "0" ? "net-global-0" : "net-global-vdd";
+            target = draft.nets.find((net) => net.id === id);
+            if (!target) {
+              target = {
+                id,
+                name,
+                scope: "global",
+                terminals: [],
+                ports: [],
+              };
+              draft.nets.push(target);
+              changedObjectIds.add(id);
+            }
+          }
+          target.terminals.push({ instanceId: instance.id, pinName: "B" });
+          instance.mosBulkBinding = {
+            origin:
+              resolution.status === "cell-default"
+                ? "cell-default"
+                : "product-fallback",
+            netId: target.id,
+          };
+          changedObjectIds.add(instance.id);
+          changedObjectIds.add(target.id);
+          connectivityChanged = true;
+        }
+        break;
+      }
+      case "clear_mos_bulk_default": {
+        const instance = draft.instances.find(
+          (candidate) => candidate.id === edit.instanceId,
+        );
+        if (!instance) {
+          return rejectAt(
+            "OBJECT_NOT_FOUND",
+            `Instance does not exist: ${edit.instanceId}`,
+          );
+        }
+        const binding = instance.mosBulkBinding;
+        if (!binding) {
+          return rejectAt(
+            "EDIT_PRECONDITION",
+            `MOS ${instance.id} has no default bulk binding to override`,
+          );
+        }
+        if (
+          draft.routes.some(
+            (route) =>
+              route.presentation === "bulk-dashed" &&
+              [route.from, route.to].some(
+                (endpoint) =>
+                  endpoint.kind === "terminal" &&
+                  endpoint.instanceId === instance.id &&
+                  endpoint.pinName === "B",
+              ),
+          )
+        ) {
+          return rejectAt(
+            "EDIT_PRECONDITION",
+            `MOS ${instance.id} already has visible bulk routing`,
+          );
+        }
+        const net = draft.nets.find(
+          (candidate) => candidate.id === binding.netId,
+        );
+        if (net) {
+          net.terminals = net.terminals.filter(
+            (terminal) =>
+              terminal.instanceId !== instance.id || terminal.pinName !== "B",
+          );
+          changedObjectIds.add(net.id);
+        }
+        delete instance.mosBulkBinding;
+        changedObjectIds.add(instance.id);
+        connectivityChanged = true;
+        break;
+      }
       case "disconnect_endpoint": {
         const error = validateConnectableEndpoint(
           draft,
@@ -2846,6 +3035,15 @@ export function executeTransaction(
               terminal.instanceId !== endpoint.instanceId ||
               terminal.pinName !== endpoint.pinName,
           );
+          if (endpoint.pinName === "B") {
+            const instance = draft.instances.find(
+              (candidate) => candidate.id === endpoint.instanceId,
+            );
+            if (instance?.mosBulkBinding) {
+              delete instance.mosBulkBinding;
+              changedObjectIds.add(instance.id);
+            }
+          }
         } else {
           owner.ports = owner.ports.filter(
             (portId) => portId !== endpoint.portId,

--- a/packages/model/src/schema.ts
+++ b/packages/model/src/schema.ts
@@ -94,12 +94,19 @@ export const SourceBindingEvidenceSchema = z.strictObject({
   childDocumentId: StableIdSchema.optional(),
   sourceRef: SourceSpanSchema.optional(),
 });
+export const MosBulkBindingSchema = z.strictObject({
+  origin: z.enum(["cell-default", "product-fallback"]),
+  netId: StableIdSchema,
+});
 export const InstanceSchema = z.strictObject({
   id: StableIdSchema,
   symbolId: StableIdSchema,
   symbolVariantId: StableIdSchema.optional(),
   sourceRef: SourceSpanSchema.optional(),
   binding: SourceBindingEvidenceSchema.optional(),
+  // Present only for an editor-materialized implicit body connection.
+  // Explicit SPICE/user B connections need no parallel metadata.
+  mosBulkBinding: MosBulkBindingSchema.optional(),
   placement: PlacementSchema.nullable(),
   properties: z.record(z.string(), InstancePropertyValueSchema),
 });
@@ -133,6 +140,7 @@ export const SegmentModeSchema = z.enum([
   "locked",
   "trunk",
 ]);
+export const RoutePresentationSchema = z.enum(["wire", "bulk-dashed"]);
 export const RouteBranchSchema = z
   .strictObject({
     id: StableIdSchema,
@@ -141,6 +149,9 @@ export const RouteBranchSchema = z
     to: RouteEndpointSchema,
     waypoints: z.array(PointSchema),
     segmentModes: z.array(SegmentModeSchema),
+    // Electrical connectivity is always owned by `netId` and the endpoints.
+    // This field changes only how the same editable Route is presented.
+    presentation: RoutePresentationSchema.optional(),
   })
   .superRefine((route, context) => {
     if (route.segmentModes.length !== route.waypoints.length + 1) {
@@ -433,6 +444,10 @@ export const PresentationIntentSchema = z.strictObject({
     })
     .optional(),
 });
+export const MosBulkDefaultsSchema = z.strictObject({
+  nmosNetId: StableIdSchema.optional(),
+  pmosNetId: StableIdSchema.optional(),
+});
 export const LayoutGroupSchema = z.strictObject({
   id: StableIdSchema,
   kind: z.enum([
@@ -478,6 +493,9 @@ const SchematicDocumentBaseSchema = z.strictObject({
   junctions: z.array(JunctionSchema),
   annotations: z.array(AnnotationSchema),
   presentation: PresentationIntentSchema,
+  // Stable Net references for cell-level well/substrate intent. When absent,
+  // manual MOS authoring falls back to NMOS -> ground and PMOS -> VDD.
+  mosBulkDefaults: MosBulkDefaultsSchema.optional(),
   layoutGroups: z.array(LayoutGroupSchema),
   constraints: z.array(LayoutConstraintSchema),
   noConnects: z.array(NoConnectSchema).default([]),
@@ -519,6 +537,34 @@ export const SchematicDocumentSchema = SchematicDocumentBaseSchema.superRefine(
       ...(document.drafting?.objects ?? []),
       ...(document.drafting?.guides ?? []),
     ];
+    for (const [key, netId] of Object.entries(document.mosBulkDefaults ?? {})) {
+      if (!document.nets.some((net) => net.id === netId)) {
+        context.addIssue({
+          code: "custom",
+          message: `MOS bulk default references an unknown Net: ${netId}`,
+          path: ["mosBulkDefaults", key],
+        });
+      }
+    }
+    for (const [instanceIndex, instance] of document.instances.entries()) {
+      const binding = instance.mosBulkBinding;
+      if (!binding) continue;
+      const net = document.nets.find(
+        (candidate) => candidate.id === binding.netId,
+      );
+      if (
+        !net?.terminals.some(
+          (terminal) =>
+            terminal.instanceId === instance.id && terminal.pinName === "B",
+        )
+      ) {
+        context.addIssue({
+          code: "custom",
+          message: `MOS bulk binding is not materialized on Net: ${binding.netId}`,
+          path: ["instances", instanceIndex, "mosBulkBinding"],
+        });
+      }
+    }
     reportDuplicateIds(objectCollections, "objects", context);
 
     const instanceIds = new Set(
@@ -820,12 +866,14 @@ export type SourceSpan = z.infer<typeof SourceSpanSchema>;
 export type SourceManifest = z.infer<typeof SourceManifestSchema>;
 export type SymbolLibraryLock = z.infer<typeof SymbolLibraryLockSchema>;
 export type SourceBindingEvidence = z.infer<typeof SourceBindingEvidenceSchema>;
+export type MosBulkBinding = z.infer<typeof MosBulkBindingSchema>;
 export type TerminalRef = z.infer<typeof TerminalRefSchema>;
 export type Instance = z.infer<typeof InstanceSchema>;
 export type Port = z.infer<typeof PortSchema>;
 export type Net = z.infer<typeof NetSchema>;
 export type RouteEndpoint = z.infer<typeof RouteEndpointSchema>;
 export type RouteBranch = z.infer<typeof RouteBranchSchema>;
+export type RoutePresentation = z.infer<typeof RoutePresentationSchema>;
 export type Junction = z.infer<typeof JunctionSchema>;
 export type NoConnectEndpoint = z.infer<typeof NoConnectEndpointSchema>;
 export type NoConnect = z.infer<typeof NoConnectSchema>;

--- a/packages/render-svg/src/render.test.ts
+++ b/packages/render-svg/src/render.test.ts
@@ -24,6 +24,41 @@ import { razaviTextbookProfile } from "./style-profile.js";
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
 describe("textbook monochrome SVG renderer", () => {
+  it("renders a bulk Route with the canonical wire geometry and Razavi dash", () => {
+    const document = createEmptyProject("bulk-route", "Bulk route")
+      .documents[0]!;
+    document.instances.push({
+      id: "M1",
+      symbolId: "nmos",
+      symbolVariantId: "textbook-3terminal",
+      placement: { position: { x: 40, y: 40 }, rotation: 0, mirror: "none" },
+      properties: {},
+    });
+    document.ports.push({
+      id: "VB",
+      name: "VB",
+      direction: "input",
+      position: { x: 100, y: 40 },
+    });
+    document.nets.push({
+      id: "net-vb",
+      scope: "local",
+      terminals: [{ instanceId: "M1", pinName: "B" }],
+      ports: ["VB"],
+    });
+    document.routes.push({
+      id: "route-bulk",
+      netId: "net-vb",
+      from: { kind: "terminal", instanceId: "M1", pinName: "B" },
+      to: { kind: "port", portId: "VB" },
+      waypoints: [],
+      segmentModes: ["manual"],
+      presentation: "bulk-dashed",
+    });
+    const svg = renderDocumentSvg(document, resolver);
+    expect(svg).toContain('data-route-presentation="bulk-dashed"');
+    expect(svg).toContain('stroke-dasharray="3 3"');
+  });
   it("preserves a manually formatted multi-character semantic subscript", () => {
     const document = createEmptyProject("project-rich-label", "Rich label")
       .documents[0]!;

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -500,7 +500,14 @@ export function buildSvgScene(
         geometry.endpointJoins,
         profile,
       );
-      return `<polyline data-object-id="${escapeXml(route.id)}" data-net-id="${escapeXml(route.netId)}" points="${pointList(geometry.centerline)}" fill="none" stroke="${profile.foreground}" stroke-width="${profile.strokes.wire}" stroke-linecap="${profile.lineCap}" stroke-linejoin="${profile.lineJoin}"${profileMiterAttribute(profile)}/>${terminalBridges}`;
+      const presentation = route.presentation ?? "wire";
+      const dash =
+        presentation === "bulk-dashed" ? ' stroke-dasharray="3 3"' : "";
+      const presentationAttribute =
+        presentation === "bulk-dashed"
+          ? ' data-route-presentation="bulk-dashed"'
+          : "";
+      return `<polyline data-object-id="${escapeXml(route.id)}" data-net-id="${escapeXml(route.netId)}"${presentationAttribute} points="${pointList(geometry.centerline)}" fill="none" stroke="${profile.foreground}" stroke-width="${profile.strokes.wire}" stroke-linecap="${profile.lineCap}" stroke-linejoin="${profile.lineJoin}"${dash}${profileMiterAttribute(profile)}/>${terminalBridges}`;
     })
     .join("");
   const routeAnchorBridges = renderRouteAnchorMiterBridges(

--- a/packages/symbols/assets/razavi-v1/catalog.json
+++ b/packages/symbols/assets/razavi-v1/catalog.json
@@ -201,7 +201,7 @@
       "palette": true,
       "automaticMappings": ["spice:M:nmos", "pdk:model-type:nmos"],
       "assetPath": "nmos.symbol.json",
-      "assetHash": "62fe9007af3b1c163e617b50a16c31075b621b3201c0f81a43f466d4e04133eb"
+      "assetHash": "4418daabba55eed90e21e90010cce9c1b62589a7e52ce4964d1eaf2fd5eb1e3c"
     },
     {
       "symbolId": "nmos3",
@@ -294,7 +294,7 @@
       "palette": true,
       "automaticMappings": ["spice:M:pmos", "pdk:model-type:pmos"],
       "assetPath": "pmos.symbol.json",
-      "assetHash": "30b1377d7e9fdb9105b4902a8a694b1c6a0b26c3b8d01f8fe33f425736755458"
+      "assetHash": "6d8bd29ed2d365417209dd2844ddc677355b1729cc000c29adc789dc235df20b"
     },
     {
       "symbolId": "pmos3",

--- a/packages/symbols/assets/razavi-v1/nmos.symbol.json
+++ b/packages/symbols/assets/razavi-v1/nmos.symbol.json
@@ -231,6 +231,16 @@
     {
       "id": "textbook-3terminal",
       "hiddenPinNames": ["B"],
+      "auxiliaryPins": [
+        {
+          "name": "B",
+          "at": {
+            "x": -4,
+            "y": 0
+          },
+          "direction": "east"
+        }
+      ],
       "hiddenPrimitiveParts": ["bulk-lead", "source-arrow-host"],
       "additionalPrimitives": [
         {

--- a/packages/symbols/assets/razavi-v1/pmos.symbol.json
+++ b/packages/symbols/assets/razavi-v1/pmos.symbol.json
@@ -214,6 +214,16 @@
     {
       "id": "textbook-3terminal",
       "hiddenPinNames": ["B"],
+      "auxiliaryPins": [
+        {
+          "name": "B",
+          "at": {
+            "x": -4,
+            "y": 0
+          },
+          "direction": "east"
+        }
+      ],
       "hiddenPrimitiveParts": ["bulk-lead", "source-arrow-host"],
       "additionalPrimitives": [
         {

--- a/packages/symbols/src/razavi-catalog.generated.ts
+++ b/packages/symbols/src/razavi-catalog.generated.ts
@@ -248,7 +248,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
     automaticMappings: ["spice:M:nmos", "pdk:model-type:nmos"],
     assetPath: "nmos.symbol.json",
     assetHash:
-      "62fe9007af3b1c163e617b50a16c31075b621b3201c0f81a43f466d4e04133eb",
+      "4418daabba55eed90e21e90010cce9c1b62589a7e52ce4964d1eaf2fd5eb1e3c",
   },
   {
     symbolId: "nmos3",
@@ -358,7 +358,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
     automaticMappings: ["spice:M:pmos", "pdk:model-type:pmos"],
     assetPath: "pmos.symbol.json",
     assetHash:
-      "30b1377d7e9fdb9105b4902a8a694b1c6a0b26c3b8d01f8fe33f425736755458",
+      "6d8bd29ed2d365417209dd2844ddc677355b1729cc000c29adc789dc235df20b",
   },
   {
     symbolId: "pmos3",
@@ -1554,6 +1554,16 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         id: "textbook-3terminal",
         hiddenPinNames: ["B"],
+        auxiliaryPins: [
+          {
+            name: "B",
+            at: {
+              x: -4,
+              y: 0,
+            },
+            direction: "east",
+          },
+        ],
         hiddenPrimitiveParts: ["bulk-lead", "source-arrow-host"],
         additionalPrimitives: [
           {
@@ -2334,6 +2344,16 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         id: "textbook-3terminal",
         hiddenPinNames: ["B"],
+        auxiliaryPins: [
+          {
+            name: "B",
+            at: {
+              x: -4,
+              y: 0,
+            },
+            direction: "east",
+          },
+        ],
         hiddenPrimitiveParts: ["bulk-lead", "source-arrow-host"],
         additionalPrimitives: [
           {

--- a/packages/symbols/src/schema.ts
+++ b/packages/symbols/src/schema.ts
@@ -83,6 +83,17 @@ export const SymbolPrimitiveSchema = z.discriminatedUnion("kind", [
 export const SymbolVariantSchema = z.strictObject({
   id: StableIdSchema,
   hiddenPinNames: z.array(z.string().min(1)),
+  // A hidden canonical pin may still expose a context-gated wiring anchor at
+  // artwork-specific geometry. The electrical pin itself remains unique.
+  auxiliaryPins: z
+    .array(
+      z.strictObject({
+        name: z.string().min(1),
+        at: PointSchema,
+        direction: z.enum(["north", "east", "south", "west"]),
+      }),
+    )
+    .optional(),
   hiddenPrimitiveParts: z.array(StableIdSchema).optional(),
   additionalPrimitives: z.array(SymbolPrimitiveSchema).optional(),
 });
@@ -153,6 +164,15 @@ export const SymbolDefinitionSchema = z
             code: "custom",
             message: `Variant hides an unknown electrical pin: ${pinName}`,
             path: ["variants", variantIndex, "hiddenPinNames", pinIndex],
+          });
+        }
+      }
+      for (const [pinIndex, pin] of (variant.auxiliaryPins ?? []).entries()) {
+        if (!pinNames.has(pin.name)) {
+          context.addIssue({
+            code: "custom",
+            message: `Variant exposes an unknown auxiliary pin: ${pin.name}`,
+            path: ["variants", variantIndex, "auxiliaryPins", pinIndex],
           });
         }
       }

--- a/plan/2026-08-12-global-power-net-duplicate-erc/plan.md
+++ b/plan/2026-08-12-global-power-net-duplicate-erc/plan.md
@@ -33,6 +33,9 @@ Shared dependency: model-level `powerDomainForNet()` power-symbol classifier.
    Net-name ERC rule.
 2. Add regression coverage for multiple Ground symbols and retain the existing
    ordinary duplicate-name failure case.
+3. Recognize the pre-existing canonical MOS-bulk fallback Nets
+   (`net-global-0` / `net-global-vdd`) as their corresponding power domain
+   when they share a normalized group with symbol-defined power Nets.
 
 ## Validation
 
@@ -53,9 +56,11 @@ fix(erc): accept repeated global power Nets
 ## Outcome
 
 Completed a narrow ERC correction. `ERC_DUPLICATE_NET_NAME` now exempts a
-same-name group only when every Net is global and every Net is classified from
-its symbol terminals as the same `ground` or `vdd` power domain. Ordinary
-duplicate local/signal Nets retain the existing error. Added a two-Ground
+same-name group only when every Net is global and every Net is classified as
+the same `ground` or `vdd` power domain. The classification includes the
+established `net-global-0` / `net-global-vdd` MOS-bulk fallback identities,
+which deliberately have no power-marker terminal. Ordinary duplicate
+local/signal Nets retain the existing error. Added a Ground plus bulk-fallback
 regression alongside the existing ordinary duplicate-name test.
 
 Validation passed: focused ERC tests (16), workspace typecheck, format check,

--- a/plan/2026-08-12-global-power-net-duplicate-erc/plan.md
+++ b/plan/2026-08-12-global-power-net-duplicate-erc/plan.md
@@ -1,0 +1,62 @@
+---
+status: completed
+experience: none
+---
+
+# Global power-Net duplicate ERC exemption
+
+## Goal
+
+Accept multiple independently placed Ground/VDD symbols that normalize to the
+same global power-domain name, while preserving `ERC_DUPLICATE_NET_NAME` for
+ordinary same-name local or non-power Nets.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/razavi-bulk-semantics...origin/codex/razavi-bulk-semantics
+```
+
+The worktree is clean. This target owns:
+
+- `packages/derived/src/diagnostics/erc.ts`
+- `packages/derived/src/diagnostics/erc.test.ts`
+- target plan and `plan/log.md`
+
+Shared dependency: model-level `powerDomainForNet()` power-symbol classifier.
+
+## Work
+
+1. Exempt only same-domain, global VDD or ground Net groups from the duplicate
+   Net-name ERC rule.
+2. Add regression coverage for multiple Ground symbols and retain the existing
+   ordinary duplicate-name failure case.
+
+## Validation
+
+- focused ERC tests
+- `corepack pnpm typecheck`
+- `corepack pnpm format:check`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(erc): accept repeated global power Nets
+```
+
+## Outcome
+
+Completed a narrow ERC correction. `ERC_DUPLICATE_NET_NAME` now exempts a
+same-name group only when every Net is global and every Net is classified from
+its symbol terminals as the same `ground` or `vdd` power domain. Ordinary
+duplicate local/signal Nets retain the existing error. Added a two-Ground
+regression alongside the existing ordinary duplicate-name test.
+
+Validation passed: focused ERC tests (16), workspace typecheck, format check,
+and `git diff --check`.

--- a/plan/2026-08-12-integrate-razavi-bulk-latest-main/plan.md
+++ b/plan/2026-08-12-integrate-razavi-bulk-latest-main/plan.md
@@ -58,13 +58,16 @@ close-out commit if needed.
 
 ## Outcome
 
-Merged `origin/main` commit `b7bf310` automatically as `c291ee2`. Git merged
-the shared App, CSS, interaction-specification, and maintenance-log files
-without a functional conflict; main's Library quick-place panel and this
-branch's Razavi bulk semantics coexist in the resulting tree.
+The first integration merged `origin/main` commit `b7bf310` automatically as
+`c291ee2`, preserving its Library quick-place panel with Razavi bulk semantics.
 
-Validation passed: workspace typecheck; 20 focused Derived MOS-bulk/ERC tests;
-six editor presentation/library unit tests; and nine single-worker browser
-tests covering component insertion and the Library panel. `git diff --check`
-is clean. The only expected pending work before close-out is this plan/log
-metadata commit.
+While the first PR checks ran, main advanced to `a4ef6a0` with a deliberate
+editor-Chrome restoration. The second merge had a genuine `App.tsx` conflict:
+the current main UI was selected as the structural baseline, then only the
+Razavi bulk entry materialization, endpoint, dashed-preview, explicit-route,
+and Properties hooks were reapplied. The result is merge commit `842d889`.
+
+Validation passed: workspace typecheck; 26 focused Derived/editor unit tests;
+and 63 single-worker browser tests, including the restored UI/Library coverage
+and the normal Wire workflow that draws and deletes a Razavi bulk route.
+`git diff --check` is clean. The branch is ready for the refreshed PR checks.

--- a/plan/2026-08-12-integrate-razavi-bulk-latest-main/plan.md
+++ b/plan/2026-08-12-integrate-razavi-bulk-latest-main/plan.md
@@ -1,0 +1,68 @@
+---
+status: active
+experience: none
+---
+
+# Integrate Razavi bulk semantics with latest main
+
+## Goal
+
+Merge the completed Razavi MOS bulk semantics branch with the latest published
+main branch, preserving main's component-library quick-place UI and validating
+the combined editor behavior before any main update.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/razavi-bulk-semantics...origin/codex/razavi-bulk-semantics
+```
+
+The worktree is clean. `origin/main` advanced three commits after the branch
+point. A read-only `git merge-tree --write-tree` preflight succeeded with no
+textual conflict. This target owns integration metadata and the resulting merge
+commit; functional files are changed only by Git's automatic merge.
+
+- `plan/2026-08-12-integrate-razavi-bulk-latest-main/plan.md`
+- `plan/log.md`
+
+Shared merge surface:
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/styles.css`
+- `docs/specs/editor-interaction.md`
+
+## Work
+
+1. Merge `origin/main` into the Razavi bulk branch without manual functional
+   resolution.
+2. Verify merge ancestry and absence of conflict markers.
+3. Run focused workspace validation for the merged editor and bulk semantics.
+4. Record the factual result and leave the branch ready for a reviewed main
+   update.
+
+## Validation
+
+- `corepack pnpm typecheck`
+- focused Razavi bulk and component-insert tests
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Create an explicit merge commit for `origin/main`, then a factual plan/log
+close-out commit if needed.
+
+## Outcome
+
+Merged `origin/main` commit `b7bf310` automatically as `c291ee2`. Git merged
+the shared App, CSS, interaction-specification, and maintenance-log files
+without a functional conflict; main's Library quick-place panel and this
+branch's Razavi bulk semantics coexist in the resulting tree.
+
+Validation passed: workspace typecheck; 20 focused Derived MOS-bulk/ERC tests;
+six editor presentation/library unit tests; and nine single-worker browser
+tests covering component insertion and the Library panel. `git diff --check`
+is clean. The only expected pending work before close-out is this plan/log
+metadata commit.

--- a/plan/2026-08-12-razavi-mos-bulk-semantics/plan.md
+++ b/plan/2026-08-12-razavi-mos-bulk-semantics/plan.md
@@ -1,0 +1,124 @@
+---
+status: completed
+experience: none
+---
+
+# Unify Razavi MOS Bulk Semantics
+
+## Goal
+
+Keep Razavi MOS artwork three-terminal by default while preserving the canonical
+D/G/S/B electrical model, supporting an explicit Razavi dashed bulk route, and
+resolving an omitted manual bulk through document defaults followed by the
+NMOS-to-ground / PMOS-to-VDD fallback without false floating-bulk diagnostics.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree was clean. This target owns the shared bulk-connection contract
+and its direct consumers:
+
+- `packages/model/src/`
+- `packages/derived/src/`
+- `packages/edit-engine/src/`
+- `packages/symbols/assets/razavi-v1/` and generated catalog output when needed
+- `scripts/generate-razavi-mos-assets.mjs` as the authoritative MOS asset generator
+- `packages/render-svg/src/`
+- `packages/spice/src/` tests needed to demonstrate D/G/S/B preservation
+- `apps/editor/src/`
+- generated Agent API fixtures under `fixtures/agent-api/`
+- relevant normative documentation, including `docs/specs/agent-api.md`
+- this target plan and `plan/log.md`
+
+Shared dependencies are the persisted Project schema, Net membership, Route
+contract, Symbol DSL, topology hash, Agent snapshot, and SPICE round-trip. Any
+schema change must include migration/compatibility handling. Unrelated Razavi
+geometry, reference images, netlist fixtures, and binary assets remain outside
+the target.
+
+The generated Agent API schemas were added to the owned set after the
+deterministic artifact check reported them stale from the new typed bulk edits;
+they are regenerated mechanically and remain reviewable against the adapter
+source.
+
+The MOS generator was added after its staleness gate proved that editing only
+the generated symbol JSON would be overwritten. The generator owns only the
+new auxiliary B anchor metadata; calibrated primitive geometry remains
+unchanged.
+
+## Work
+
+1. Characterize the current MOS bulk, Route, schema, rendering, placement, and
+   SPICE contracts with focused tests.
+2. Add one derived bulk resolver that classifies explicit, document-default,
+   product-fallback, model-internal, and unresolved states without guessing
+   from presentation visibility.
+3. Persist document bulk defaults by stable Net ID and make manual placement
+   materialize the resolved B membership atomically through the Edit Engine.
+4. Rework ERC and editor inspection to consume the resolver; a connected
+   body-bias or B=S connection must never be called floating.
+5. Add the Razavi visible-B anchor/variant and reuse the canonical Route model
+   with a dashed bulk presentation for editing, selection, deletion, undo,
+   highlight, and export.
+6. Add focused regression tests for imported four-node MOS, manual fallback,
+   explicit overrides, deletion/default restoration, ERC, rendering, and GUI
+   behavior. Update the normative contract.
+
+## Validation
+
+- focused Vitest suites for model, symbols, derived ERC/bulk resolution,
+  edit-engine, render-svg, SPICE, and editor behavior
+- workspace typecheck for affected packages
+- `git diff --check`
+- `git status --short --branch`
+
+Because this crosses the persisted model and shared connectivity contract,
+expand to the workspace test suite after focused checks are green. Visual
+pixel-reference recalibration is not required: the target adds a semantic
+anchor and route style but does not retune existing approved geometry.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat: unify Razavi MOS bulk connectivity
+```
+
+## Outcome
+
+Implemented one Razavi MOS bulk contract across persisted model, Derived,
+Edit Engine, symbol variants, rendering, editor, Agent API, and normative docs.
+Canonical MOS remains D/G/S/B; manual three-terminal authoring materializes a
+Cell Net-ID default or NMOS-to-0 / PMOS-to-VDD fallback before editor history is
+installed, while source-bound imports remain unresolved rather than guessed.
+Explicit body-bias exposes the same B terminal at a context-gated auxiliary
+anchor and uses the normal Route/Net machinery with `bulk-dashed`
+presentation. The common route-deletion planner removes a connected dashed
+chain, disconnects explicit B, and reconciles fallback atomically for every UI
+deletion path. ERC and Agent Snapshot consume the shared resolver instead of
+reimplementing safe-Net guesses.
+
+Validation passed:
+
+- `corepack pnpm test`: 101 files, 606 tests
+- `corepack pnpm exec playwright test --workers=8`: 86 tests
+- `corepack pnpm typecheck`
+- `corepack pnpm format:check`
+- `corepack pnpm references:check`
+- `corepack pnpm symbols:razavi-mos:check`
+- `corepack pnpm symbols:razavi:check`
+- `corepack pnpm agent-api:artifacts:check`
+- `corepack pnpm build`
+- `git diff --check`
+
+The first full browser run exposed and protected one recovery-boundary bug:
+load-time fallback materialization initially looked like an unsaved human edit.
+Moving that deterministic upgrade before the history/recovery graph fixed it;
+the final full run passed. No visual pixel retuning or SPICE terminal-order
+change was made.

--- a/plan/log.md
+++ b/plan/log.md
@@ -5500,3 +5500,16 @@ contracts (WP-R1)`.
   from `body.analytics-body` onward remains byte-identical to `main`.
 - Commit status: ready to commit on `codex/merge-pr14-safe` as
   `feat(editor): integrate safe library quick-place improvements`.
+
+## 2026-08-12 - Razavi bulk reconciliation with restored editor UI
+
+- Target: refresh the Razavi bulk candidate after main restored the editor
+  Chrome, using current main's UI structure as the baseline.
+- Changed areas: two-parent reconciliation merge; Razavi bulk initialization,
+  endpoint, dashed-route and Properties hooks reapplied to the restored UI;
+  integration plan outcome.
+- Validation: workspace typecheck; 26 focused unit tests; 63 single-worker
+  browser tests including the Library/restored UI and full manual bulk-route
+  workflow; `git diff --check` clean.
+- Commit status: merge commit `842d889` created locally; refreshed PR branch
+  pending push and required CI checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -5424,6 +5424,17 @@ contracts (WP-R1)`.
 - Commit status: ready to commit on `codex/construction-line-k-shortcut` as
   `fix(connectivity): normalize symbol-defined power Nets`.
 
+## 2026-08-12 - Global power-Net duplicate ERC exemption
+
+- Target: accept repeated global Ground/VDD symbol Nets without weakening
+  duplicate-name diagnostics for ordinary signal Nets.
+- Changed areas: ERC grouping predicate and focused regression, target plan,
+  and maintenance log.
+- Validation: 16 focused ERC tests; workspace typecheck; format check;
+  `git diff --check`.
+- Commit status: ready to commit on `codex/razavi-bulk-semantics` as
+  `fix(erc): accept repeated global power Nets`.
+
 ## 2026-08-12 - Unified Net Label binding and deletion
 
 - Target: eliminate conflicting Route/Junction/Net interpretations of Label

--- a/plan/log.md
+++ b/plan/log.md
@@ -1,5 +1,20 @@
 # Maintenance Log
 
+## 2026-08-12 - Razavi MOS bulk semantics
+
+- Target: preserve canonical D/G/S/B while making three-terminal Razavi MOS
+  authoring electrically complete through Cell defaults, product fallback, and
+  an explicit dashed body-route workflow.
+- Changed areas: model/Derived/Edit Engine bulk contract; Razavi auxiliary B
+  anchor and generated catalog; route rendering/deletion/clipboard; editor
+  Selection and entry-boundary preparation; ERC; Agent Snapshot/API artifacts;
+  normative product and interaction docs.
+- Validation: 606 unit tests; 86 browser E2E tests; workspace typecheck,
+  formatting, references, MOS/catalog/API generated-artifact checks, production
+  build, and `git diff --check` all passed.
+- Commit status: ready to commit on `codex/razavi-bulk-semantics` as
+  `feat: unify Razavi MOS bulk connectivity`.
+
 ## 2026-08-12 - Net deletion selection closure
 
 - Target: prevent a removed Net Label's stale selection ID from rolling back

--- a/plan/log.md
+++ b/plan/log.md
@@ -5509,6 +5509,18 @@ contracts (WP-R1)`.
   at one worker, and the complete suite passed 85/85 at eight workers.
 - Commit status: integration branch validated and ready to fast-forward main.
 
+## 2026-08-12 - Razavi bulk / latest-main integration
+
+- Target: combine Razavi MOS bulk semantics with the published component
+  Library quick-place work without discarding either editor surface.
+- Changed areas: automatic two-parent integration commit; factual integration
+  target record. No functional conflict required manual resolution.
+- Validation: workspace typecheck; 20 focused Derived MOS-bulk/ERC tests; six
+  editor presentation/library unit tests; nine single-worker component-Library
+  browser tests; `git diff --check` clean.
+- Commit status: merge commit `c291ee2` created locally; close-out metadata is
+  ready to commit on `codex/razavi-bulk-semantics`.
+
 ## 2026-08-12 - Safe PR 14 improvements
 
 - Target: retain the useful PR #14 Library and direct-inspection behavior on

--- a/plan/log.md
+++ b/plan/log.md
@@ -5435,6 +5435,16 @@ contracts (WP-R1)`.
 - Commit status: ready to commit on `codex/razavi-bulk-semantics` as
   `fix(erc): accept repeated global power Nets`.
 
+## 2026-08-12 - Global ground ERC fallback follow-up
+
+- Target: include canonical MOS-bulk fallback Net `net-global-0` in the
+  same global-ground ERC exemption as visible Ground marker Nets.
+- Changed areas: ERC power-domain grouping and the existing focused regression.
+- Validation: 16 focused ERC tests; workspace typecheck; format check;
+  `git diff --check`.
+- Commit status: ready to commit on `codex/razavi-bulk-semantics` as
+  `fix(erc): recognize canonical power fallback Nets`.
+
 ## 2026-08-12 - Unified Net Label binding and deletion
 
 - Target: eliminate conflicting Route/Junction/Net interpretations of Label

--- a/scripts/generate-razavi-mos-assets.mjs
+++ b/scripts/generate-razavi-mos-assets.mjs
@@ -15,12 +15,23 @@ const manifestPath = resolve(referenceRoot, "manifest.json");
 const geometryPath = resolve(referenceRoot, "mos-geometry.json");
 const check = process.argv.includes("--check");
 
-const PIN_CONTRACT = [
-  ["D", "drain", "north", { x: 10, y: -20 }],
-  ["G", "gate", "west", { x: -20, y: 0 }],
-  ["S", "source", "south", { x: 10, y: 20 }],
-  ["B", "bulk", "east", { x: 20, y: 0 }],
-];
+function pinContract(polarity) {
+  // PMOS keeps the approved schematic-facing D/S semantics even though the
+  // sole screenshot raster names its upper/lower pixel anchors oppositely.
+  return polarity === "pmos"
+    ? [
+        ["D", "drain", "south", { x: 10, y: 20 }],
+        ["G", "gate", "west", { x: -20, y: 0 }],
+        ["S", "source", "north", { x: 10, y: -20 }],
+        ["B", "bulk", "east", { x: 20, y: 0 }],
+      ]
+    : [
+        ["D", "drain", "north", { x: 10, y: -20 }],
+        ["G", "gate", "west", { x: -20, y: 0 }],
+        ["S", "source", "south", { x: 10, y: 20 }],
+        ["B", "bulk", "east", { x: 20, y: 0 }],
+      ];
+}
 const normal = { strokeRole: "normal", lineCap: "butt", lineJoin: "miter" };
 
 function fail(message) {
@@ -144,10 +155,17 @@ function sourceArrowPrimitives(measurement, polarity) {
   ];
 }
 
-function pins(measurement, threeTerminal) {
-  return PIN_CONTRACT.filter(([name]) => !threeTerminal || name !== "B").map(
-    ([name, role, direction, expected]) => {
-      const actual = logicalPoint(measurement, measurement.pinsPx[name]);
+function pins(measurement, polarity, threeTerminal) {
+  return pinContract(polarity)
+    .filter(([name]) => !threeTerminal || name !== "B")
+    .map(([name, role, direction, expected]) => {
+      const rasterName =
+        polarity === "pmos" && name === "D"
+          ? "S"
+          : polarity === "pmos" && name === "S"
+            ? "D"
+            : name;
+      const actual = logicalPoint(measurement, measurement.pinsPx[rasterName]);
       if (actual.x !== expected.x || actual.y !== expected.y) {
         fail(
           `${name} pixel anchor maps to ${actual.x},${actual.y}; expected ${expected.x},${expected.y}`,
@@ -160,8 +178,7 @@ function pins(measurement, threeTerminal) {
         direction,
         presentation: { visibility: "visible", leadLength: 10 },
       };
-    },
-  );
+    });
 }
 
 function basePrimitives(measurement, polarity, threeTerminal) {
@@ -237,7 +254,7 @@ function symbol(polarity, measurement, threeTerminal, bodyMeasurement) {
     id,
     name: `${polarity === "nmos" ? "NMOS" : "PMOS"}${threeTerminal ? " (3-terminal)" : ""}`,
     viewBox: { x: 0, y: 0, width: 1, height: 1 },
-    pins: pins(measurement, threeTerminal),
+    pins: pins(measurement, polarity, threeTerminal),
     primitives,
     variants: threeTerminal
       ? []
@@ -245,6 +262,11 @@ function symbol(polarity, measurement, threeTerminal, bodyMeasurement) {
           {
             id: "textbook-3terminal",
             hiddenPinNames: ["B"],
+            // Context-gated Razavi body connection. This names the canonical
+            // electrical B pin without modifying calibrated symbol artwork.
+            auxiliaryPins: [
+              { name: "B", at: { x: -4, y: 0 }, direction: "east" },
+            ],
             hiddenPrimitiveParts: ["bulk-lead", "source-arrow-host"],
             additionalPrimitives: sourceArrowPrimitives(measurement, polarity),
           },


### PR DESCRIPTION
## Summary

- adds unified Razavi three-terminal MOS bulk semantics with NMOS �� 0 and PMOS �� VDD defaults
- supports optional dashed, routable bulk connections from the Razavi bulk anchor
- preserves the latest component Library quick-place panel from `main`
- records the integration as an explicit merge commit

## Validation

- `corepack pnpm typecheck`
- 20 focused MOS-bulk/ERC unit tests
- 6 editor presentation/library unit tests
- 9 component Library browser tests (single worker)
- `git diff --check`