### PR TITLE
docs(plan): close drawn VDD rail delivery

### DIFF
--- a/plan/2026-08-12-deliver-drawn-vdd-rail-main/plan.md
+++ b/plan/2026-08-12-deliver-drawn-vdd-rail-main/plan.md
@@ -55,5 +55,6 @@ The current branch already contains latest remote main. A frozen install and
 complete `pnpm ci:check` passed after updating the capacitor's rotated-label
 boundary expectation from `y=125` to `y=126`, which follows its intentionally
 expanded visible extent. The gate passed 615 unit tests, release/performance/
-export/PWA/release-smoke stages, and 91 browser tests. Ready to push the final
-delivery metadata, open a PR, wait for remote required checks, and merge.
+export/PWA/release-smoke stages, and 91 browser tests. PR #19 was merged after
+all five required GitHub Actions checks passed; remote main reached merge
+commit `8bd0670` on 2026-08-12.

--- a/plan/log.md
+++ b/plan/log.md
@@ -8,8 +8,8 @@
   delivery target record.
 - Validation: frozen install and full `pnpm ci:check` passed: 615 unit tests,
   release/performance/export/PWA/release smoke, and 91 browser tests.
-- Commit status: ready to push/open PR from `codex/vdd-drawn-rail`; wait for
-  GitHub required checks before merging main.
+- Commit status: PR #19 merged as `8bd0670` after five required GitHub Actions
+  checks passed; remote `main` verified at that merge commit.
 
 ## 2026-08-12 - Capacitor plate contraction
 


### PR DESCRIPTION
Closes the delivery record after PR #19 was merged. Documentation-only; records the merged commit and successful required checks.