### PR TITLE
fix(editor): unify wire sessions and move geometry

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -350,6 +350,28 @@ test("keeps Wire input above labels and resolves a screen-tolerant route tap", a
   );
 });
 
+test("keeps a Wire source across repeated activation and cancels it after undo", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await placeComponent(page, "resistor", { x: 340, y: 220 });
+  await placeComponent(page, "resistor", { x: 660, y: 220 });
+
+  await clickCommand(page, "Draw", "Wire (W)");
+  await page.getByTestId("terminal-R1-2").click();
+  await page.keyboard.press("w");
+  await page.getByTestId("terminal-R2-1").click();
+  await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(1);
+
+  await clickCommand(page, "Draw", "Wire (W)");
+  await page.getByTestId("terminal-R1-1").click();
+  await page.keyboard.press("Control+z");
+  await expect(page.getByTestId("active-tool")).toHaveText("pointer");
+  await expect(page.getByTestId("status")).toContainText(
+    "Wire cancelled because the circuit changed",
+  );
+});
+
 test("deletes a wire without exposing Unroute", async ({ page }) => {
   await page.goto("/");
   await placeComponent(page, "resistor", { x: 340, y: 220 });

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -964,21 +964,6 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     return [...byKey.values()];
   }, [visibleBulkEndpoints, visibleEndpoints]);
   useEffect(() => {
-    if (
-      !wireSource ||
-      wireSourceRevision === null ||
-      wireSourceRevision === document.revision
-    ) {
-      return;
-    }
-    clearTransientCanvasState();
-    cancelInteraction();
-    setBulkDrawInstanceId(null);
-    setStatus(
-      `Wire cancelled because the circuit changed from revision ${wireSourceRevision} to ${document.revision}`,
-    );
-  }, [document.revision, wireSource, wireSourceRevision]);
-  useEffect(() => {
     const normalizationEdits = powerNetNormalizations(document).length
       ? [{ kind: "normalize_power_nets" as const }]
       : [];
@@ -1462,9 +1447,20 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     );
   }
 
-  function transact(edits: SchematicEdit[]): EditTransactionResult {
+  function transact(
+    edits: SchematicEdit[],
+    options: { completesWireSession?: boolean } = {},
+  ): EditTransactionResult {
     const result = transactDocument(edits);
     applyResult(result);
+    if (result.ok && wireSource && !options.completesWireSession) {
+      clearTransientCanvasState();
+      cancelInteraction();
+      setBulkDrawInstanceId(null);
+      setStatus(
+        `Committed revision ${result.revision}; Wire cancelled because the circuit changed`,
+      );
+    }
     return result;
   }
 
@@ -1617,6 +1613,13 @@ export function App({ project: initialProject, visitStats }: AppProps) {
 
   function commitWire(candidate: WireSource): void {
     if (!wireSource) return;
+    if (wireSourceRevision !== document.revision) {
+      clearTransientCanvasState();
+      cancelInteraction();
+      setBulkDrawInstanceId(null);
+      setStatus("Wire cancelled because its source revision is stale");
+      return;
+    }
     const suffix = nextRoutingSuffix();
     const proposal = proposeWireCommit(
       wireSource,
@@ -1657,7 +1660,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
           }),
         ]
       : proposal.edits;
-    const result = transact(edits);
+    const result = transact(edits, { completesWireSession: true });
     if (result.ok) {
       setWireSource(null, null);
       setWirePreviewPoint(null);

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -519,6 +519,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     pendingSymbolId,
     pendingComponentPlacement,
     wireSource,
+    wireSourceRevision,
     wirePreviewPoint,
     wireWaypoints,
     draftingSource,
@@ -962,6 +963,21 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     }
     return [...byKey.values()];
   }, [visibleBulkEndpoints, visibleEndpoints]);
+  useEffect(() => {
+    if (
+      !wireSource ||
+      wireSourceRevision === null ||
+      wireSourceRevision === document.revision
+    ) {
+      return;
+    }
+    clearTransientCanvasState();
+    cancelInteraction();
+    setBulkDrawInstanceId(null);
+    setStatus(
+      `Wire cancelled because the circuit changed from revision ${wireSourceRevision} to ${document.revision}`,
+    );
+  }, [document.revision, wireSource, wireSourceRevision]);
   useEffect(() => {
     const normalizationEdits = powerNetNormalizations(document).length
       ? [{ kind: "normalize_power_nets" as const }]
@@ -1544,7 +1560,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     }
     setTool("wire");
     if (!wireSource) {
-      setWireSource(candidate);
+      setWireSource(candidate, document.revision);
       setWirePreviewPoint(candidate.point);
       setWireWaypoints([]);
       setStatus(`Wire source: ${endpointTestId(candidate.endpoint)}`);
@@ -1593,7 +1609,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       }
       return;
     }
-    setWireSource(from);
+    setWireSource(from, document.revision);
     setWirePreviewPoint(to.point);
     setWireWaypoints([]);
     setStatus(`Wire source: flightline on ${flightline.netId}`);
@@ -1643,7 +1659,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       : proposal.edits;
     const result = transact(edits);
     if (result.ok) {
-      setWireSource(null);
+      setWireSource(null, null);
       setWirePreviewPoint(null);
       setWireWaypoints([]);
       setTool("pointer");
@@ -1694,7 +1710,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     };
     setBulkDrawInstanceId(selectedInstance.id);
     setTool("wire");
-    setWireSource(source);
+    setWireSource(source, document.revision);
     setWirePreviewPoint(source.point);
     setWireWaypoints([]);
     setStatus(`Drawing ${selectedInstance.id}.B bulk connection`);
@@ -1712,7 +1728,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     if (!wireSource) {
       const netId = `net-ui-${nextRoutingSuffix()}`;
       const source = freeWireAnchor(point, netId, true);
-      setWireSource(source);
+      setWireSource(source, document.revision);
       setWirePreviewPoint(point);
       setWireWaypoints([]);
       setStatus("Wire source: free grid point");
@@ -1813,7 +1829,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     }
     const anchor = routeAnchor(routeId, tap.point, tap.segmentIndex);
     if (!wireSource) {
-      setWireSource(anchor);
+      setWireSource(anchor, document.revision);
       setWirePreviewPoint(tap.point);
       setWireWaypoints([]);
       setStatus(`Wire source: route ${routeId}`);
@@ -2351,6 +2367,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     point: Point;
     endpoint?: WireSource;
     route?: { routeId: string; segmentIndex: number; point: Point };
+    ambiguous?: boolean;
     guides: SnapGuideLine[];
   } {
     if (suppressSnap) return { point, guides: [] };
@@ -2369,10 +2386,13 @@ export function App({ project: initialProject, visitStats }: AppProps) {
         segmentIndex,
       })),
     );
-    const endpointTargets = visibleEndpoints.map((source) => ({
+    const endpointTargets = wiringEndpoints.map((source) => ({
       source,
       anchor: endpointSnapAnchor(source),
     }));
+    const activeSourceAnchorId = wireSource
+      ? endpointSnapAnchor(wireSource).id
+      : null;
     const resolved = resolvePointSnap(
       point,
       [
@@ -2383,20 +2403,30 @@ export function App({ project: initialProject, visitStats }: AppProps) {
         grid: document.presentation.grid,
         tolerance: logicalRadiusForPixels(svg, SNAP_CAPTURE_RADIUS_PX),
         profile: SNAP_PROFILES.wire,
+        ...(activeSourceAnchorId
+          ? { excludedTargetIds: new Set([activeSourceAnchorId]) }
+          : {}),
       },
     );
     const snappedPoint = {
       x: point.x + resolved.delta.x,
       y: point.y + resolved.delta.y,
     };
-    const endpoint = endpointTargets.find(
-      (candidate) => candidate.anchor.id === resolved.pointMatch?.id,
-    )?.source;
-    const route = routeTargets.find(
-      (candidate) => candidate.anchor.id === resolved.pointMatch?.id,
+    const bestTargetIds = new Set(
+      (resolved.pointMatches ?? []).map((target) => target.id),
     );
+    const matchingEndpoints = endpointTargets.filter((candidate) =>
+      bestTargetIds.has(candidate.anchor.id),
+    );
+    const matchingRoutes = routeTargets.filter((candidate) =>
+      bestTargetIds.has(candidate.anchor.id),
+    );
+    const ambiguous = matchingEndpoints.length + matchingRoutes.length > 1;
+    const endpoint = ambiguous ? undefined : matchingEndpoints[0]?.source;
+    const route = ambiguous ? undefined : matchingRoutes[0];
     return {
       point: snappedPoint,
+      ...(ambiguous ? { ambiguous: true } : {}),
       ...(endpoint ? { endpoint } : {}),
       ...(route
         ? {
@@ -2419,9 +2449,15 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   ): void {
     const resolved = resolveWireCanvasSnap(rawPoint, svg, suppressSnap);
     paintSnapGuides([]);
+    if (resolved.ambiguous) {
+      setStatus(
+        "Ambiguous connection: choose one endpoint or conductor away from the overlap",
+      );
+      return;
+    }
     if (resolved.endpoint) {
       if (!wireSource) {
-        setWireSource(resolved.endpoint);
+        setWireSource(resolved.endpoint, document.revision);
         setWirePreviewPoint(resolved.endpoint.point);
         setWireWaypoints([]);
       } else if (
@@ -2429,6 +2465,8 @@ export function App({ project: initialProject, visitStats }: AppProps) {
         endpointKey(resolved.endpoint.endpoint)
       ) {
         commitWire(resolved.endpoint);
+      } else {
+        setStatus("Choose a different endpoint");
       }
       return;
     }
@@ -2439,7 +2477,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
         resolved.route.segmentIndex,
       );
       if (!wireSource) {
-        setWireSource(anchor);
+        setWireSource(anchor, document.revision);
         setWirePreviewPoint(anchor.point);
         setWireWaypoints([]);
       } else {
@@ -6774,7 +6812,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
                 return;
               }
               if (wireSource) {
-                setWireSource(null);
+                setWireSource(null, null);
                 setWirePreviewPoint(null);
                 setWireWaypoints([]);
                 setTool("pointer");

--- a/apps/editor/src/interaction/interaction-state.test.ts
+++ b/apps/editor/src/interaction/interaction-state.test.ts
@@ -18,10 +18,34 @@ describe("editor interaction state", () => {
     expect(wiring).toEqual({
       kind: "wire",
       source: null,
+      sourceRevision: null,
       previewPoint: null,
       waypoints: [],
     });
     expect(interactionTool(wiring)).toBe("wire");
+  });
+
+  it("keeps an in-progress wire when Wire is activated again", () => {
+    const source = {
+      endpoint: { kind: "junction" as const, junctionId: "J1" },
+      netId: "n1",
+      point: { x: 10, y: 20 },
+      preludeEdits: [],
+    };
+    let state = activateInteractionTool("wire");
+    state = interactionReducer(state, {
+      type: "set-wire-source",
+      source,
+      sourceRevision: 7,
+    });
+    state = interactionReducer(state, {
+      type: "set-wire-waypoints",
+      update: [{ x: 30, y: 20 }],
+    });
+
+    expect(
+      interactionReducer(state, { type: "activate-tool", tool: "wire" }),
+    ).toBe(state);
   });
 
   it("cancels every creation mode to one idle state", () => {

--- a/apps/editor/src/interaction/interaction-state.ts
+++ b/apps/editor/src/interaction/interaction-state.ts
@@ -32,6 +32,7 @@ export type InteractionState =
   | {
       kind: "wire";
       source: WireSource | null;
+      sourceRevision: number | null;
       previewPoint: Point | null;
       waypoints: Point[];
     }
@@ -48,7 +49,11 @@ export type InteractionState =
 export type InteractionAction =
   | { type: "activate-tool"; tool: EditorTool }
   | { type: "place-component"; placement: PendingComponentPlacement }
-  | { type: "set-wire-source"; source: WireSource | null }
+  | {
+      type: "set-wire-source";
+      source: WireSource | null;
+      sourceRevision: number | null;
+    }
   | { type: "set-wire-preview"; point: Point | null }
   | { type: "set-wire-waypoints"; update: SetStateAction<Point[]> }
   | { type: "set-drawing-source"; point: Point | null }
@@ -79,6 +84,7 @@ export function activateInteractionTool(tool: EditorTool): InteractionState {
       return {
         kind: "wire",
         source: null,
+        sourceRevision: null,
         previewPoint: null,
         waypoints: [],
       };
@@ -103,6 +109,7 @@ export function interactionReducer(
 ): InteractionState {
   switch (action.type) {
     case "activate-tool":
+      if (action.tool === "wire" && state.kind === "wire") return state;
       return activateInteractionTool(action.tool);
     case "place-component":
       return {
@@ -111,7 +118,11 @@ export function interactionReducer(
       };
     case "set-wire-source":
       return state.kind === "wire"
-        ? { ...state, source: action.source }
+        ? {
+            ...state,
+            source: action.source,
+            sourceRevision: action.source ? action.sourceRevision : null,
+          }
         : state;
     case "set-wire-preview":
       return state.kind === "wire"
@@ -171,6 +182,7 @@ export function useInteractionState() {
     pendingComponentPlacement:
       state.kind === "placing-component" ? state.placement : null,
     wireSource: state.kind === "wire" ? state.source : null,
+    wireSourceRevision: state.kind === "wire" ? state.sourceRevision : null,
     wirePreviewPoint: state.kind === "wire" ? state.previewPoint : null,
     wireWaypoints: state.kind === "wire" ? state.waypoints : [],
     draftingSource: state.kind === "drawing" ? state.source : null,
@@ -180,8 +192,8 @@ export function useInteractionState() {
     setTool: (tool: EditorTool) => dispatch({ type: "activate-tool", tool }),
     beginComponentPlacement: (placement: PendingComponentPlacement) =>
       dispatch({ type: "place-component", placement }),
-    setWireSource: (source: WireSource | null) =>
-      dispatch({ type: "set-wire-source", source }),
+    setWireSource: (source: WireSource | null, sourceRevision: number | null) =>
+      dispatch({ type: "set-wire-source", source, sourceRevision }),
     setWirePreviewPoint: (point: Point | null) =>
       dispatch({ type: "set-wire-preview", point }),
     setWireWaypoints: (update: SetStateAction<Point[]>) =>

--- a/apps/editor/src/snap/engine.test.ts
+++ b/apps/editor/src/snap/engine.test.ts
@@ -240,4 +240,27 @@ describe("unified Snap Engine", () => {
     expect(result.electricalMatch).toBeUndefined();
     expect(result.pointMatch?.id).toBe("pin");
   });
+
+  it("excludes the active Wire source and reports equal coincident targets", () => {
+    const result = resolvePointSnap(
+      { x: 10, y: 10 },
+      [
+        { id: "source", point: { x: 10, y: 10 }, kind: "pin" },
+        { id: "target-a", point: { x: 10, y: 10 }, kind: "pin" },
+        { id: "target-b", point: { x: 10, y: 10 }, kind: "pin" },
+      ],
+      {
+        grid: 10,
+        tolerance: 4,
+        profile: SNAP_PROFILES.wire,
+        excludedTargetIds: new Set(["source"]),
+      },
+    );
+
+    expect(result.pointMatch?.id).toBe("target-a");
+    expect(result.pointMatches?.map((target) => target.id)).toEqual([
+      "target-a",
+      "target-b",
+    ]);
+  });
 });

--- a/apps/editor/src/snap/engine.ts
+++ b/apps/editor/src/snap/engine.ts
@@ -60,6 +60,7 @@ export interface SnapResult {
   yMatch?: SnapMatch;
   electricalMatch?: ElectricalSnapMatch;
   pointMatch?: SnapAnchor;
+  pointMatches?: readonly SnapAnchor[];
   guides: SnapGuideLine[];
 }
 
@@ -473,6 +474,7 @@ export function resolvePointSnap(
     tolerance: number;
     profile: SnapProfile;
     previous?: SnapResult;
+    excludedTargetIds?: ReadonlySet<string>;
   },
 ): SnapResult {
   const pointKinds = new Set<SnapTargetKind>([
@@ -482,9 +484,10 @@ export function resolvePointSnap(
     "route",
     "drafting",
   ]);
-  const pointMatch = targetAnchors
+  const pointCandidates = targetAnchors
     .filter(
       (target) =>
+        !options.excludedTargetIds?.has(target.id) &&
         options.profile.kinds.has(target.kind) &&
         pointKinds.has(target.kind) &&
         axes(target).includes("x") &&
@@ -500,8 +503,20 @@ export function resolvePointSnap(
         KIND_PRIORITY[left.target.kind] - KIND_PRIORITY[right.target.kind] ||
         left.distance - right.distance ||
         left.target.id.localeCompare(right.target.id),
-    )[0]?.target;
-  if (pointMatch) {
+    );
+  const bestCandidate = pointCandidates[0];
+  if (bestCandidate) {
+    const pointMatch = bestCandidate.target;
+    const pointMatches = pointCandidates
+      .filter(
+        (candidate) =>
+          KIND_PRIORITY[candidate.target.kind] ===
+            KIND_PRIORITY[pointMatch.kind] &&
+          Math.abs(candidate.distance - bestCandidate.distance) < 1e-9 &&
+          Math.abs(candidate.target.point.x - pointMatch.point.x) < 1e-9 &&
+          Math.abs(candidate.target.point.y - pointMatch.point.y) < 1e-9,
+      )
+      .map((candidate) => candidate.target);
     const makeMatch = (axis: SnapAxis): SnapMatch => ({
       axis,
       movingAnchorId: "pointer",
@@ -518,6 +533,7 @@ export function resolvePointSnap(
       xMatch: makeMatch("x"),
       yMatch: makeMatch("y"),
       pointMatch,
+      pointMatches,
       guides: [],
     };
   }

--- a/docs/adr/0009-move-stretches-connected-routes.md
+++ b/docs/adr/0009-move-stretches-connected-routes.md
@@ -40,6 +40,10 @@ topology-preserving logic as `proposeLocalStretch`. Specifically:
   pattern working: a caller that re-points the protected Route in the same
   batch is not blocked by the stretch skipping it. Stretching never breaks a
   lock.
+- A Route named by `set_route_points` or `route_orthogonal` anywhere in the
+  same transaction is excluded from automatic instance follow. That explicit
+  edit is the transaction's sole geometry authority for the Route, avoiding an
+  intermediate auto-stretch that is later overwritten.
 - Stretching preserves Route topology (same endpoint identity, same number of
   bends unless the original was a zero-waypoint direct Route that now needs one
   L-bend to stay orthogonal, mirroring `proposeLocalStretch`'s existing
@@ -115,8 +119,14 @@ invariant.
 - No Project file-format change. Existing Projects are unaffected.
 - No Agent API change beyond the already-added `resolvedRoutes` field, which now
   also reports stretch-affected Routes.
-- The editor UI's own `proposeGroupMove` path is unchanged for group moves;
-  this ADR covers single-instance moves in the Engine.
+- Group moves rely on Engine follow for Routes whose movement is completely
+  described by terminal transforms. They emit explicit Route geometry only
+  when a moved Junction participates, because `move_junction` intentionally
+  has no independent auto-follow behavior.
+- Internal group geometry is derived per connected Route component, not per
+  logical Net. A component moves only when it contains a selected terminal and
+  no port or unselected terminal. Net-attached annotations remain conservative
+  and move only when the complete logical Net is internal.
 - `set_route_points` remains the escape hatch for any case the stretch does not
   cover.
 
@@ -131,6 +141,10 @@ invariant.
 - Canonical topology (Net membership, endpoint identity) is unchanged after a
   stretch.
 - Deterministic: the same move produces the same stretched waypoints.
+- A disconnected remote Route on the same logical Net stays fixed; a shared
+  Junction leading to an unselected terminal is a selection boundary.
+- Group plans contain no redundant `set_route_points` for terminal-only
+  follow, while moved-Junction routes retain explicit geometry.
 
 ## Related documents
 

--- a/docs/specs/connectivity-and-routing.md
+++ b/docs/specs/connectivity-and-routing.md
@@ -172,11 +172,21 @@ derived local-stretch proposal:
 - locked adjacent segments reject the proposal;
 - when no waypoint exists, a deterministic elbow is introduced if needed.
 
-For an equal-delta group move, all Routes and Junctions wholly internal to the
-selected instances translate by the same delta, including their attached Net,
-Route, and Junction annotations. Only Routes that cross the selection boundary
-use local endpoint stretch. A protected route or one whose endpoints request
-different deltas rejects the complete transaction.
+Automatic instance follow is transaction-aware. If the transaction explicitly
+authors a Route through `set_route_points` or `route_orthogonal`, the Engine
+does not also stretch that Route. In a group move, terminal-only and
+terminal-to-fixed-endpoint Routes use Engine follow; explicit Route geometry is
+reserved for Routes incident to a Junction moved by the same plan.
+
+For an equal-delta group move, a connected Route component is internal when it
+contains at least one selected terminal and contains no port or terminal owned
+by an unselected instance. Its Routes and Junctions translate by the same
+delta, including attached Route and Junction annotations. A disconnected
+component on the same logical Net remains fixed. Net annotations move only
+when the whole logical Net has no ports and all its terminals are selected.
+Routes that cross the component boundary use local endpoint stretch. A
+protected route or one whose endpoints request different deltas rejects the
+complete transaction.
 
 Direct segment movement keeps both Route endpoints fixed. The selected segment
 moves only perpendicular to its orientation; adjacent vertices stretch or a

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -385,6 +385,9 @@ The core rule is:
 - Starting from a pin, existing Junction, Route segment, or blank grid point
   opens a wire session. A blank-grid source creates no Document records until
   the session commits.
+- Activating Wire again while a session is open is idempotent: it preserves the
+  source and uncommitted bends. The active source is excluded from automatic
+  endpoint snap candidates, so a coincident destination can still be reached.
 - A blank-canvas click fixes an orthogonal bend. Double-click or `Enter`
   terminates at the current grid point as a dangling Junction. `Backspace`
   removes the latest uncommitted bend.
@@ -401,6 +404,9 @@ The core rule is:
   the opposite proposed endpoint.
 - A wire end that geometrically hits more than one route segment is rejected as
   ambiguous. The user must choose one conductor away from the crossing.
+- Equal-priority endpoint or conductor candidates at the same snapped point are
+  likewise rejected as ambiguous; candidate array or object-ID ordering never
+  decides electrical connectivity.
 - Deleting a connected instance converts each routed pin endpoint into a
   Junction at the former pin coordinate, removes that terminal from its Net,
   and removes the instance atomically. Remaining Route geometry and Net
@@ -434,7 +440,10 @@ The core rule is:
 
 `Alt` temporarily suppresses snapping. `Escape` or secondary-click cancels the
 uncommitted wire session. Undo restores the complete pre-transaction topology,
-route geometry, source status, and revision-visible state.
+route geometry, source status, and revision-visible state. A Wire source is
+resolved against one Document revision; any other transaction that changes the
+revision explicitly cancels the transient session instead of reusing stale
+endpoint or route-split references.
 
 ## Automation boundary
 

--- a/packages/derived/src/stretch.test.ts
+++ b/packages/derived/src/stretch.test.ts
@@ -3,6 +3,7 @@ import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
 import {
+  deriveInternalGroupSelection,
   proposeGroupMove,
   proposeGroupStretch,
   proposeWireSegmentDrag,
@@ -210,6 +211,91 @@ describe("group route stretch", () => {
         { routeId: "route-1", waypoints: [] },
         { routeId: "route-2", waypoints: [] },
       ],
+    });
+  });
+
+  it("moves only the selected connected component of a shared logical Net", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.nets.push({
+      id: "net-shared",
+      scope: "local",
+      terminals: [
+        { instanceId: "R1", pinName: "2" },
+        { instanceId: "R2", pinName: "1" },
+        { instanceId: "R3", pinName: "1" },
+      ],
+      ports: [],
+    });
+    document.junctions.push({
+      id: "junction-remote",
+      netId: "net-shared",
+      position: { x: 500, y: 100 },
+    });
+    document.routes.push(
+      {
+        id: "route-selected",
+        netId: "net-shared",
+        from: { kind: "terminal", instanceId: "R1", pinName: "2" },
+        to: { kind: "terminal", instanceId: "R2", pinName: "1" },
+        waypoints: [],
+        segmentModes: ["manual"],
+      },
+      {
+        id: "route-remote",
+        netId: "net-shared",
+        from: { kind: "terminal", instanceId: "R3", pinName: "1" },
+        to: { kind: "junction", junctionId: "junction-remote" },
+        waypoints: [],
+        segmentModes: ["manual"],
+      },
+    );
+
+    expect(deriveInternalGroupSelection(document, ["R1", "R2"])).toEqual({
+      netIds: [],
+      routeIds: ["route-selected"],
+      junctionIds: [],
+    });
+  });
+
+  it("keeps a shared junction fixed when its component reaches an unselected terminal", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.nets.push({
+      id: "net-branch",
+      scope: "local",
+      terminals: [
+        { instanceId: "R1", pinName: "2" },
+        { instanceId: "R2", pinName: "1" },
+      ],
+      ports: [],
+    });
+    document.junctions.push({
+      id: "junction-branch",
+      netId: "net-branch",
+      position: { x: 180, y: 100 },
+    });
+    document.routes.push(
+      {
+        id: "route-inside",
+        netId: "net-branch",
+        from: { kind: "terminal", instanceId: "R1", pinName: "2" },
+        to: { kind: "junction", junctionId: "junction-branch" },
+        waypoints: [],
+        segmentModes: ["manual"],
+      },
+      {
+        id: "route-boundary",
+        netId: "net-branch",
+        from: { kind: "junction", junctionId: "junction-branch" },
+        to: { kind: "terminal", instanceId: "R2", pinName: "1" },
+        waypoints: [],
+        segmentModes: ["manual"],
+      },
+    );
+
+    expect(deriveInternalGroupSelection(document, ["R1"])).toEqual({
+      netIds: [],
+      routeIds: [],
+      junctionIds: [],
     });
   });
 });

--- a/packages/derived/src/stretch.ts
+++ b/packages/derived/src/stretch.ts
@@ -1,7 +1,7 @@
-import type { Point, SchematicDocument } from "@icm/model";
+import type { Point, RouteBranch, SchematicDocument } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 
-import { resolveEndpointPoint } from "./endpoint.js";
+import { endpointKey, resolveEndpointPoint } from "./endpoint.js";
 import {
   resolveDocumentRoutingGeometry,
   type ResolvedDocumentRoutingGeometry,
@@ -348,17 +348,81 @@ export function deriveInternalGroupSelection(
     )
     .map((net) => net.id)
     .sort((left, right) => left.localeCompare(right, "en"));
-  const netIdSet = new Set(netIds);
+  const internalRouteIds = new Set<string>();
+  const internalJunctionIds = new Set<string>();
+  const routesByNetId = new Map<string, RouteBranch[]>();
+  for (const route of document.routes) {
+    const netRoutes = routesByNetId.get(route.netId) ?? [];
+    netRoutes.push(route);
+    routesByNetId.set(route.netId, netRoutes);
+  }
+
+  for (const net of document.nets) {
+    const netRoutes = [...(routesByNetId.get(net.id) ?? [])].sort(
+      (left, right) => left.id.localeCompare(right.id, "en"),
+    );
+    const routesByEndpoint = new Map<string, typeof netRoutes>();
+    for (const route of netRoutes) {
+      for (const endpoint of [route.from, route.to]) {
+        const key = endpointKey(endpoint);
+        const incident = routesByEndpoint.get(key) ?? [];
+        incident.push(route);
+        routesByEndpoint.set(key, incident);
+      }
+    }
+
+    const unvisited = new Set(netRoutes.map((route) => route.id));
+    for (const seed of netRoutes) {
+      if (!unvisited.has(seed.id)) continue;
+      const component = [] as typeof netRoutes;
+      const queue = [seed];
+      unvisited.delete(seed.id);
+      while (queue.length > 0) {
+        const route = queue.shift()!;
+        component.push(route);
+        for (const endpoint of [route.from, route.to]) {
+          for (const incident of routesByEndpoint.get(endpointKey(endpoint)) ??
+            []) {
+            if (!unvisited.delete(incident.id)) continue;
+            queue.push(incident);
+          }
+        }
+      }
+
+      const componentEndpoints = new Map(
+        component
+          .flatMap((route) => [route.from, route.to])
+          .map((endpoint) => [endpointKey(endpoint), endpoint] as const),
+      );
+      let hasSelectedTerminal = false;
+      let crossesSelectionBoundary = false;
+      for (const endpoint of componentEndpoints.values()) {
+        if (endpoint.kind === "port") {
+          crossesSelectionBoundary = true;
+        } else if (endpoint.kind === "terminal") {
+          if (selectedIds.has(endpoint.instanceId)) hasSelectedTerminal = true;
+          else crossesSelectionBoundary = true;
+        }
+      }
+      if (!hasSelectedTerminal || crossesSelectionBoundary) continue;
+
+      for (const route of component) internalRouteIds.add(route.id);
+      for (const endpoint of componentEndpoints.values()) {
+        if (endpoint.kind === "junction") {
+          internalJunctionIds.add(endpoint.junctionId);
+        }
+      }
+    }
+  }
+
   return {
     netIds,
-    routeIds: document.routes
-      .filter((route) => netIdSet.has(route.netId))
-      .map((route) => route.id)
-      .sort((left, right) => left.localeCompare(right, "en")),
-    junctionIds: document.junctions
-      .filter((junction) => netIdSet.has(junction.netId))
-      .map((junction) => junction.id)
-      .sort((left, right) => left.localeCompare(right, "en")),
+    routeIds: [...internalRouteIds].sort((left, right) =>
+      left.localeCompare(right, "en"),
+    ),
+    junctionIds: [...internalJunctionIds].sort((left, right) =>
+      left.localeCompare(right, "en"),
+    ),
   };
 }
 

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -59,6 +59,22 @@ export function proposeGroupMoveEdits(
   moves: readonly { instanceId: string; position: Point }[],
 ): GroupMoveEditProposal {
   const proposal = proposeGroupMove(document, resolver, moves);
+  const movedJunctionIds = new Set(
+    proposal.junctions.map((move) => move.junctionId),
+  );
+  const routesRequiringExplicitGeometry = proposal.routes.filter(
+    (routeMove) => {
+      const route = document.routes.find(
+        (candidate) => candidate.id === routeMove.routeId,
+      );
+      return (
+        (route?.from.kind === "junction" &&
+          movedJunctionIds.has(route.from.junctionId)) ||
+        (route?.to.kind === "junction" &&
+          movedJunctionIds.has(route.to.junctionId))
+      );
+    },
+  );
   return {
     edits: [
       ...moves.map((move): SchematicEdit => ({
@@ -69,7 +85,7 @@ export function proposeGroupMoveEdits(
         kind: "move_junction",
         ...move,
       })),
-      ...routeEdits(document, proposal.routes),
+      ...routeEdits(document, routesRequiringExplicitGeometry),
       ...proposal.annotations.flatMap((move): SchematicEdit[] => {
         const annotation = document.annotations.find(
           (candidate) => candidate.id === move.annotationId,

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -255,11 +255,62 @@ describe("routing Edit Engine", () => {
       plan.edits.filter((edit) => edit.kind === "move_instance"),
     ).toHaveLength(3);
     expect(plan.edits.some((edit) => edit.kind === "set_route_points")).toBe(
-      true,
+      false,
     );
     const moved = executeTransaction(
       routed.document,
       transaction(document.id, 1, plan.edits),
+      context,
+    );
+    expect(moved.ok).toBe(true);
+  });
+
+  it("authors route geometry only where a group move also moves a Junction", () => {
+    const document = documentFixture();
+    document.junctions.push({
+      id: "junction-h",
+      netId: "net-h",
+      position: { x: 300, y: 300 },
+    });
+    document.routes.push(
+      {
+        id: "route-h-left",
+        netId: "net-h",
+        from: terminal("A"),
+        to: { kind: "junction", junctionId: "junction-h" },
+        waypoints: [],
+        segmentModes: ["manual"],
+      },
+      {
+        id: "route-h-right",
+        netId: "net-h",
+        from: { kind: "junction", junctionId: "junction-h" },
+        to: terminal("B"),
+        waypoints: [],
+        segmentModes: ["manual"],
+      },
+    );
+
+    const plan = proposeGroupMoveEdits(document, resolver, [
+      { instanceId: "A", position: { x: 160, y: 320 } },
+      { instanceId: "B", position: { x: 480, y: 320 } },
+    ]);
+    expect(plan.edits.filter((edit) => edit.kind === "move_junction")).toEqual([
+      {
+        kind: "move_junction",
+        junctionId: "junction-h",
+        position: { x: 320, y: 320 },
+      },
+    ]);
+    expect(
+      plan.edits
+        .filter((edit) => edit.kind === "set_route_points")
+        .map((edit) => edit.routeId),
+    ).toEqual(["route-h-left", "route-h-right"]);
+
+    const moved = executeTransaction(
+      document,
+      transaction(document.id, 0, plan.edits),
       context,
     );
     expect(moved.ok).toBe(true);

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -1375,9 +1375,11 @@ function applyInstanceRouteFollow(
   originalDocument: SchematicDocument,
   resolver: SymbolResolver,
   instanceId: string,
+  explicitlyAuthoredRouteIds: ReadonlySet<string>,
 ): string[] {
   const changed: string[] = [];
   for (const originalRoute of originalDocument.routes) {
+    if (explicitlyAuthoredRouteIds.has(originalRoute.id)) continue;
     const movesFrom = endpointBelongsToInstance(originalRoute.from, instanceId);
     const movesTo = endpointBelongsToInstance(originalRoute.to, instanceId);
     if (!movesFrom && !movesTo) continue;
@@ -1420,9 +1422,10 @@ function applyInstanceRouteFollow(
         );
       }
     } catch {
-      // Preserve the established move+set_route_points escape hatch. A later
-      // explicit edit may provide valid geometry; otherwise final validation
-      // rejects this transaction and names the affected Route.
+      // Protected or otherwise non-followable geometry remains unchanged;
+      // final validation rejects the transaction and names the affected Route.
+      // Routes explicitly authored anywhere in this transaction were skipped
+      // above, so their edit is the sole geometry authority.
       continue;
     }
 
@@ -1652,6 +1655,13 @@ export function executeTransaction(
 
   const proposedRevision = document.revision + 1;
   const draft = structuredClone(document);
+  const explicitlyAuthoredRouteIds = new Set(
+    transaction.edits.flatMap((edit) =>
+      edit.kind === "set_route_points" || edit.kind === "route_orthogonal"
+        ? [edit.routeId]
+        : [],
+    ),
+  );
   const changedObjectIds = new Set<string>();
   const resolver = context.symbolResolver;
   const originalRouteStates = new Map(
@@ -2002,6 +2012,7 @@ export function executeTransaction(
             beforeTransform,
             resolver,
             edit.instanceId,
+            explicitlyAuthoredRouteIds,
           );
           for (const routeId of stretched) changedObjectIds.add(routeId);
         }
@@ -2053,6 +2064,7 @@ export function executeTransaction(
             beforeTransform,
             rotateResolver,
             edit.instanceId,
+            explicitlyAuthoredRouteIds,
           )) {
             changedObjectIds.add(routeId);
           }
@@ -2105,6 +2117,7 @@ export function executeTransaction(
             beforeTransform,
             mirrorResolver,
             edit.instanceId,
+            explicitlyAuthoredRouteIds,
           )) {
             changedObjectIds.add(routeId);
           }

--- a/plan/2026-08-13-move-planner-consistency/plan.md
+++ b/plan/2026-08-13-move-planner-consistency/plan.md
@@ -81,4 +81,5 @@ moved Junction, and those explicit Route IDs are excluded from automatic
 follow. Internal Route/Junction movement is based on actual connected
 components, while logical-Net annotations retain the stricter whole-Net rule.
 The 36 focused routing/stretch tests, consumer checks, all 620 unit tests,
-typecheck, and build validations passed.
+typecheck, and build validations passed. The final clean `pnpm ci:check` also
+passed all 92 browser scenarios and every release gate.

--- a/plan/2026-08-13-move-planner-consistency/plan.md
+++ b/plan/2026-08-13-move-planner-consistency/plan.md
@@ -1,0 +1,84 @@
+---
+status: completed
+experience: none
+---
+
+# Unify Instance and Route Move Planning
+
+## Goal
+
+Make component/group movement deterministic by giving explicit Route geometry
+one transaction-wide authority, while deriving internal wiring from connected
+Route components instead of treating every Route on a logical Net as one
+movable block.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/wire-move-consistency
+```
+
+The worktree is clean after commit `6aa57cd`. The isolated worktree remains
+separate from the unrelated dirty authoring-input target in the original path.
+
+- `packages/edit-engine/src/transaction.ts`
+- `packages/edit-engine/src/routing-planner.ts`
+- `packages/edit-engine/src/routing.test.ts`
+- `packages/derived/src/stretch.ts`
+- `packages/derived/src/stretch.test.ts`
+- `docs/adr/0009-move-stretches-connected-routes.md`
+- `docs/specs/connectivity-and-routing.md`
+- `plan/2026-08-13-move-planner-consistency/plan.md`
+- `plan/log.md`
+
+Read-only consumers checked for compatibility:
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/features/clipboard/clipboard.ts`
+
+Shared contracts are the typed edit transaction, Route endpoint identity, and
+the existing single-instance/group/segment/whole-route gestures. No Project
+schema or public edit kind is added.
+
+## Work
+
+1. Predeclare all explicitly authored Route geometries in a transaction and
+   suppress automatic instance route-follow for those Route IDs. Group moves
+   emit explicit geometry only for Routes incident to a moved Junction; the
+   Engine remains authoritative for terminal-follow geometry.
+2. Replace Net-wide internal group selection with connected Route-component
+   closure: a component moves only when it contains a selected terminal and
+   contains no port or terminal owned by an unselected instance.
+3. Keep Net annotations conservative: they move only when the complete logical
+   Net remains internal, while Route/Junction annotations follow the movable
+   component.
+4. Add order-independence, disconnected-same-Net, and boundary-branch
+   regressions; update the movement contract without removing existing tools.
+
+## Validation
+
+- `corepack pnpm exec vitest run packages/derived/src/stretch.test.ts packages/edit-engine/src/routing.test.ts`
+- `corepack pnpm typecheck`
+- `corepack pnpm build`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(routing): unify move and route geometry ownership
+```
+
+## Outcome
+
+Group movement now has one geometry owner per Route. Terminal-follow stays in
+the Edit Engine; plans emit explicit geometry only for Routes incident to a
+moved Junction, and those explicit Route IDs are excluded from automatic
+follow. Internal Route/Junction movement is based on actual connected
+components, while logical-Net annotations retain the stricter whole-Net rule.
+The 36 focused routing/stretch tests, consumer checks, all 620 unit tests,
+typecheck, and build validations passed.

--- a/plan/2026-08-13-wire-session-snap-consistency/plan.md
+++ b/plan/2026-08-13-wire-session-snap-consistency/plan.md
@@ -1,0 +1,78 @@
+---
+status: completed
+experience: none
+---
+
+# Stabilize Wire Sessions and Snap Resolution
+
+## Goal
+
+Eliminate intermittent manual-Wire failures by making Wire activation idempotent,
+preventing a draft from silently using stale document references, excluding its
+own source from endpoint snapping, and rejecting genuinely ambiguous coincident
+targets instead of choosing one by incidental ordering.
+
+## State and Ownership
+
+Start state from `git status --short --branch` in the isolated worktree:
+
+```text
+## codex/wire-move-consistency
+```
+
+The original worktree contains unrelated, uncommitted authoring-input changes
+that overlap this target. They are left untouched. This target runs from the
+clean `origin/main` commit in `E:\interactive Circuit maker-wire-move-consistency`.
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/interaction/interaction-state.ts`
+- `apps/editor/src/interaction/interaction-state.test.ts`
+- `apps/editor/src/snap/engine.ts`
+- `apps/editor/src/snap/engine.test.ts`
+- `apps/editor/e2e/manual-editor.spec.ts`
+- `docs/specs/editor-interaction.md`
+- `plan/2026-08-13-wire-session-snap-consistency/plan.md`
+- `plan/log.md`
+
+Shared contracts:
+
+- `packages/edit-engine/src/routing-planner.ts` defines persisted WireSource
+  references and is read-only for this target.
+- `docs/specs/connectivity-and-routing.md` and ADR 0014 define route ambiguity
+  and geometry semantics and are read-only for this target.
+
+## Work
+
+1. Preserve an active Wire session when Wire is reactivated and attach the
+   document revision at which its source was resolved.
+2. Cancel the draft explicitly when a different transaction changes that
+   revision, avoiding stale route-tap and endpoint references.
+3. Exclude the active source from snap candidates and surface equal best
+   coincident candidates as ambiguity instead of silently selecting by ID.
+4. Add reducer, snap-engine, and editor regression coverage and document the
+   accepted interaction behavior.
+
+## Validation
+
+- `corepack pnpm exec vitest run apps/editor/src/interaction/interaction-state.test.ts apps/editor/src/snap/engine.test.ts`
+- Focused Playwright cases added to `apps/editor/e2e/manual-editor.spec.ts`
+- `corepack pnpm typecheck`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): stabilize wire sessions and snap targets
+```
+
+## Outcome
+
+Wire reactivation now preserves the active source and bends. Every source is
+tagged with its resolving Document revision and is cancelled explicitly if an
+unrelated transaction changes that revision. Point snap excludes the source,
+returns all equal best coincident targets, and the editor rejects ambiguous
+electrical completion instead of choosing by object ID. Focused unit tests,
+typecheck, build, and the new browser regression passed.

--- a/plan/2026-08-13-wire-session-snap-consistency/plan.md
+++ b/plan/2026-08-13-wire-session-snap-consistency/plan.md
@@ -77,4 +77,5 @@ commit validates the source revision and declares itself as the completing
 transaction. Point snap excludes the source, returns all equal best coincident
 targets, and rejects ambiguity instead of choosing by object ID. Focused unit,
 typecheck, build, and browser regressions passed; the full gate's initial status
-race was fixed and its four affected scenarios pass together.
+race was fixed and its four affected scenarios pass together. The final clean
+`pnpm ci:check` passed all 620 unit and 92 browser tests plus release gates.

--- a/plan/2026-08-13-wire-session-snap-consistency/plan.md
+++ b/plan/2026-08-13-wire-session-snap-consistency/plan.md
@@ -71,8 +71,10 @@ fix(editor): stabilize wire sessions and snap targets
 ## Outcome
 
 Wire reactivation now preserves the active source and bends. Every source is
-tagged with its resolving Document revision and is cancelled explicitly if an
-unrelated transaction changes that revision. Point snap excludes the source,
-returns all equal best coincident targets, and the editor rejects ambiguous
-electrical completion instead of choosing by object ID. Focused unit tests,
-typecheck, build, and the new browser regression passed.
+tagged with its resolving Document revision. The shared transaction boundary
+synchronously cancels a draft after any other successful mutation, while Wire
+commit validates the source revision and declares itself as the completing
+transaction. Point snap excludes the source, returns all equal best coincident
+targets, and rejects ambiguity instead of choosing by object ID. Focused unit,
+typecheck, build, and browser regressions passed; the full gate's initial status
+race was fixed and its four affected scenarios pass together.

--- a/plan/log.md
+++ b/plan/log.md
@@ -1,5 +1,16 @@
 # Maintenance Log
 
+## 2026-08-13 - Wire session and snap consistency
+
+- Target: remove intermittent manual-Wire failures caused by tool reactivation,
+  stale source references, self-snap, and coincident-candidate ordering.
+- Changed areas: editor interaction state; point-snap result contract; Wire
+  canvas integration; interaction specification; unit and browser regressions.
+- Validation: 15 focused unit tests; workspace typecheck and build; focused
+  Playwright regression; Prettier check and `git diff --check` clean.
+- Commit status: ready to commit on `codex/wire-move-consistency` as
+  `fix(editor): stabilize wire sessions and snap targets`.
+
 ## 2026-08-12 - Drawn VDD rail mainline delivery
 
 - Target: deliver drawn VDD rail and capacitor refinements to remote main by

--- a/plan/log.md
+++ b/plan/log.md
@@ -1,5 +1,19 @@
 # Maintenance Log
 
+## 2026-08-13 - Move planner and Route geometry ownership
+
+- Target: remove double planning between GUI group moves and Edit Engine route
+  follow, and stop disconnected geometry on one logical Net from moving as one
+  block.
+- Changed areas: transaction-wide explicit Route authority; group-move edit
+  planner; connected-component internal selection; movement contracts and
+  focused regressions.
+- Validation: 36 routing/stretch tests, 5 clipboard/marker consumer tests, and
+  all 620 unit tests; workspace typecheck and build; Prettier and
+  `git diff --check` clean.
+- Commit status: ready to commit on `codex/wire-move-consistency` as
+  `fix(routing): unify move and route geometry ownership`.
+
 ## 2026-08-13 - Wire session and snap consistency
 
 - Target: remove intermittent manual-Wire failures caused by tool reactivation,

--- a/plan/log.md
+++ b/plan/log.md
@@ -21,7 +21,9 @@
 - Changed areas: editor interaction state; point-snap result contract; Wire
   canvas integration; interaction specification; unit and browser regressions.
 - Validation: 15 focused unit tests; workspace typecheck and build; focused
-  Playwright regression; Prettier check and `git diff --check` clean.
+  Playwright regression plus four transaction/status scenarios. The initial
+  full-gate run exposed and drove removal of an effect-ordering race; Prettier
+  check and `git diff --check` clean.
 - Commit status: ready to commit on `codex/wire-move-consistency` as
   `fix(editor): stabilize wire sessions and snap targets`.
 

--- a/plan/log.md
+++ b/plan/log.md
@@ -9,10 +9,10 @@
   planner; connected-component internal selection; movement contracts and
   focused regressions.
 - Validation: 36 routing/stretch tests, 5 clipboard/marker consumer tests, and
-  all 620 unit tests; workspace typecheck and build; Prettier and
-  `git diff --check` clean.
-- Commit status: ready to commit on `codex/wire-move-consistency` as
-  `fix(routing): unify move and route geometry ownership`.
+  all 620 unit tests; final clean `pnpm ci:check` including 92 browser tests
+  and every release gate; `git diff --check` clean.
+- Commit status: implementation commit `0af19d1` on
+  `codex/wire-move-consistency`; final validation recorded before push.
 
 ## 2026-08-13 - Wire session and snap consistency
 
@@ -22,10 +22,11 @@
   canvas integration; interaction specification; unit and browser regressions.
 - Validation: 15 focused unit tests; workspace typecheck and build; focused
   Playwright regression plus four transaction/status scenarios. The initial
-  full-gate run exposed and drove removal of an effect-ordering race; Prettier
-  check and `git diff --check` clean.
-- Commit status: ready to commit on `codex/wire-move-consistency` as
-  `fix(editor): stabilize wire sessions and snap targets`.
+  full-gate run exposed and drove removal of an effect-ordering race; final
+  clean `pnpm ci:check` passed all 620 unit and 92 browser tests plus release
+  gates; `git diff --check` clean.
+- Commit status: implementation commits `6aa57cd` and `34b4ad3` on
+  `codex/wire-move-consistency`; final validation recorded before push.
 
 ## 2026-08-12 - Drawn VDD rail mainline delivery
 


### PR DESCRIPTION
## Summary

- keep repeated Wire activation from discarding an active draft and cancel stale drafts at Document revision boundaries
- make snap target choice deterministic while excluding the source endpoint
- unify group movement and Route geometry ownership across the GUI and Edit Engine
- move only actually connected internal Route components while preserving existing component, group, segment, and whole-Route movement

## Why

Wire drafting and routed group movement had overlapping GUI/Edit Engine ownership and ambiguous snap behavior. That produced stale drafts, unstable target selection, and remote same-Net Routes moving with unrelated groups.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `CI=1 corepack pnpm ci:check`
- combined local integration with `codex/web-agent-session-architecture`
- 108 test files / 674 unit tests
- 93 Playwright scenarios
- build, performance, export, PWA, production preview, package, and release smoke checks