### PR TITLE
docs(plan): close CI contract integration

### DIFF
--- a/plan/2026-08-13-integrate-ci-contract-cleanup/plan.md
+++ b/plan/2026-08-13-integrate-ci-contract-cleanup/plan.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: completed
 experience: none
 ---
 
@@ -70,4 +70,15 @@ bounded conflict-resolution/closeout commits when required.
 
 ## Outcome
 
-Pending integration and validation.
+Merged `origin/codex/ci-contract-cleanup` into the Agent contract hardening
+branch as `3ecda02`, preserving canonical Project diagnostics, shared Wire
+intent, contact-aware junction rendering, the consolidated RichText contract,
+and the cleanup branch's CI/API reductions. Regenerated Agent API artifacts
+from the merged source contract.
+
+Focused validation passed across 16 files and 132 tests. A frozen install and
+full `pnpm ci:check` also passed with 668 unit/integration tests and 99
+Playwright tests, plus build, export, PWA, release-smoke, and performance gates.
+All six required GitHub checks passed. PR #25 merged into `main` as `e9782e4`,
+and post-merge ancestry confirmed that integration commit `3ecda02` is present
+on `origin/main`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -5927,3 +5927,16 @@ contracts (WP-R1)`.
   `git diff --check` passed.
 - Commit status: ready to commit on `codex/ci-contract-cleanup` as
   `refactor(rich-text): consolidate the active text contract`.
+
+## 2026-08-13 - CI cleanup and Agent contract integration
+
+- Target: combine `codex/ci-contract-cleanup` with Agent contract hardening in
+  one reviewed delivery without losing either branch's accepted contracts.
+- Changed areas: resolved editor and SVG integration conflicts; regenerated
+  Agent API artifacts; retained consolidated RichText, canonical diagnostics,
+  shared Wire intent, and contact-aware junction behavior.
+- Validation: 132 focused tests; frozen install; full `pnpm ci:check` with 668
+  unit/integration and 99 Playwright tests; all six required GitHub checks;
+  post-merge ancestry verification.
+- Commit status: integration commit `3ecda02` merged through PR #25 into
+  `main` as `e9782e4`.


### PR DESCRIPTION
## Summary
- close the CI cleanup and Agent contract integration target
- record the combined validation and PR #25 merge evidence

## Validation
- git diff --check
- documentation-only change