### PR TITLE
docs(readme): add project citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,26 @@ retain their provenance. The reference manifest under
 hash-pins are the only visual authority. PDF vector evidence is permitted only
 through the compatible manifest protocol defined by
 [`docs/adr/0012-pdf-vector-evidence-for-razavi-assets.md`](docs/adr/0012-pdf-vector-evidence-for-razavi-assets.md).
+
+## Citation
+
+If you use Interactive Circuit Maker in research, teaching, or another
+published project, please cite the software as:
+
+> Zengchun Chen and Zhishuai Zhang. _Interactive Circuit Maker: A
+> Connectivity-Aware Schematic Editor for Human–Agent Collaboration_. 2026.
+> Available at: https://github.com/chenzc24/interactive-circuit-maker
+
+For reproducible work, also include the release tag or commit hash used.
+
+BibTeX:
+
+```bibtex
+@software{chen2026interactivecircuitmaker,
+  author = {Chen, Zengchun and Zhang, Zhishuai},
+  title = {Interactive Circuit Maker: A Connectivity-Aware Schematic Editor for Human--Agent Collaboration},
+  year = {2026},
+  url = {https://github.com/chenzc24/interactive-circuit-maker},
+  note = {Software repository}
+}
+```

--- a/plan/2026-08-13-readme-citation/plan.md
+++ b/plan/2026-08-13-readme-citation/plan.md
@@ -1,0 +1,52 @@
+---
+status: completed
+experience: none
+---
+
+# Add README Citation
+
+## Goal
+
+Add a polished citation section to the README naming Zengchun Chen and
+Zhishuai Zhang as the project authors.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree was clean. This documentation-only target owns:
+
+- `README.md`
+- `plan/2026-08-13-readme-citation/plan.md`
+- `plan/log.md`
+
+## Work
+
+1. Add a concise human-readable citation and copyable BibTeX entry.
+2. Keep the entry stable for the evolving software by citing the repository
+   rather than inventing a publication venue or version.
+
+## Validation
+
+- Inspect the rendered Markdown structure and citation spelling.
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+docs(readme): add project citation
+```
+
+## Outcome
+
+Added a reader-facing citation and a copyable BibTeX software entry naming
+Zengchun Chen and Zhishuai Zhang, plus guidance to record the release tag or
+commit hash for reproducibility. Markdown formatting and `git diff --check`
+passed.

--- a/plan/log.md
+++ b/plan/log.md
@@ -5953,3 +5953,13 @@ contracts (WP-R1)`.
   build, performance, export, PWA, packaging, and release-smoke gates.
 - Commit status: ready to commit on `codex/agent-contract-compaction` as
   `refactor(agent): compact and unify generated contracts`.
+
+## 2026-08-13 - README citation
+
+- Target: add a clear citation method naming Zengchun Chen and Zhishuai Zhang
+  as the project authors.
+- Changed areas: README human-readable citation, BibTeX entry, and
+  reproducibility guidance; target plan.
+- Validation: targeted Markdown formatting and `git diff --check` passed.
+- Commit status: ready to commit on `codex/add-readme-citation` as
+  `docs(readme): add project citation`.


### PR DESCRIPTION
## Summary

- add a polished human-readable citation for Interactive Circuit Maker
- name Zengchun Chen and Zhishuai Zhang as authors
- provide a copyable BibTeX software entry
- recommend recording the release tag or commit hash for reproducibility

## Validation

- targeted Prettier check
- `git diff --check`

Documentation only; no runtime behavior changes.