### PR TITLE
docs(readme): shorten citation title

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ through the compatible manifest protocol defined by
 If you use Interactive Circuit Maker in research, teaching, or another
 published project, please cite the software as:
 
-> Zengchun Chen and Zhishuai Zhang. _Interactive Circuit Maker: A
-> Connectivity-Aware Schematic Editor for Human–Agent Collaboration_. 2026.
+> Zengchun Chen and Zhishuai Zhang. _analog-canvas_. 2026.
 > Available at: https://github.com/chenzc24/interactive-circuit-maker
 
 For reproducible work, also include the release tag or commit hash used.
@@ -95,9 +94,9 @@ For reproducible work, also include the release tag or commit hash used.
 BibTeX:
 
 ```bibtex
-@software{chen2026interactivecircuitmaker,
+@software{chen2026analogcanvas,
   author = {Chen, Zengchun and Zhang, Zhishuai},
-  title = {Interactive Circuit Maker: A Connectivity-Aware Schematic Editor for Human--Agent Collaboration},
+  title = {analog-canvas},
   year = {2026},
   url = {https://github.com/chenzc24/interactive-circuit-maker},
   note = {Software repository}

--- a/plan/2026-08-13-shorten-citation-title/plan.md
+++ b/plan/2026-08-13-shorten-citation-title/plan.md
@@ -1,0 +1,43 @@
+---
+status: completed
+experience: none
+---
+
+# Shorten Citation Title
+
+## Goal
+
+Use the exact short project title `analog-canvas` throughout the README
+citation.
+
+## State and Ownership
+
+The worktree was clean and synchronized with `origin/main`. This
+documentation-only target owns:
+
+- `README.md`
+- `plan/2026-08-13-shorten-citation-title/plan.md`
+- `plan/log.md`
+
+## Work
+
+Replace the descriptive citation title in both the prose citation and BibTeX
+entry while preserving authors, year, URL, and reproducibility guidance.
+
+## Validation
+
+- Targeted Markdown formatting check
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+```text
+docs(readme): shorten citation title
+```
+
+## Outcome
+
+Updated both citation forms to the exact title `analog-canvas`; preserved the
+authors, year, repository URL, and reproducibility note. Targeted formatting
+and `git diff --check` passed.

--- a/plan/log.md
+++ b/plan/log.md
@@ -5963,3 +5963,12 @@ contracts (WP-R1)`.
 - Validation: targeted Markdown formatting and `git diff --check` passed.
 - Commit status: ready to commit on `codex/add-readme-citation` as
   `docs(readme): add project citation`.
+
+## 2026-08-13 - Citation title correction
+
+- Target: use the user-specified short project title `analog-canvas` in the
+  README citation.
+- Changed areas: prose citation, BibTeX key/title, and target plan.
+- Validation: targeted Markdown formatting and `git diff --check` passed.
+- Commit status: ready to commit on `codex/shorten-citation-title` as
+  `docs(readme): shorten citation title`.


### PR DESCRIPTION
## Summary

- use the exact short title `analog-canvas` in the prose citation
- align the BibTeX title and citation key
- preserve authors, year, repository URL, and reproducibility guidance

## Validation

- targeted Prettier check
- `git diff --check`

Documentation only.