### PR TITLE
docs(readme): capitalize citation title

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ through the compatible manifest protocol defined by
 If you use Interactive Circuit Maker in research, teaching, or another
 published project, please cite the software as:
 
-> Zengchun Chen and Zhishuai Zhang. _analog-canvas_. 2026.
+> Zengchun Chen and Zhishuai Zhang. _Analog Canvas_. 2026.
 > Available at: https://github.com/chenzc24/interactive-circuit-maker
 
 For reproducible work, also include the release tag or commit hash used.
@@ -96,7 +96,7 @@ BibTeX:
 ```bibtex
 @software{chen2026analogcanvas,
   author = {Chen, Zengchun and Zhang, Zhishuai},
-  title = {analog-canvas},
+  title = {Analog Canvas},
   year = {2026},
   url = {https://github.com/chenzc24/interactive-circuit-maker},
   note = {Software repository}

--- a/plan/2026-08-13-capitalize-citation-title/plan.md
+++ b/plan/2026-08-13-capitalize-citation-title/plan.md
@@ -1,0 +1,38 @@
+---
+status: completed
+experience: none
+---
+
+# Capitalize Citation Title
+
+## Goal
+
+Correct the README citation title to the publication-style capitalization
+`Analog Canvas`.
+
+## State and Ownership
+
+The worktree was clean and synchronized with `origin/main`. This
+documentation-only target owns `README.md`, this plan, and `plan/log.md`.
+
+## Work
+
+Capitalize the prose and BibTeX titles while preserving the stable BibTeX key,
+authors, year, URL, and reproducibility guidance.
+
+## Validation
+
+- Targeted Markdown formatting check
+- `git diff --check`
+- GitHub Actions documentation-only checks
+
+## Commit Intent
+
+```text
+docs(readme): capitalize citation title
+```
+
+## Outcome
+
+Updated both citation displays to the exact title `Analog Canvas`. Targeted
+formatting and `git diff --check` passed.

--- a/plan/log.md
+++ b/plan/log.md
@@ -5972,3 +5972,11 @@ contracts (WP-R1)`.
 - Validation: targeted Markdown formatting and `git diff --check` passed.
 - Commit status: ready to commit on `codex/shorten-citation-title` as
   `docs(readme): shorten citation title`.
+
+## 2026-08-13 - Citation title capitalization
+
+- Target: correct the citation's publication-style title to `Analog Canvas`.
+- Changed areas: prose and BibTeX titles; target plan.
+- Validation: targeted Markdown formatting and `git diff --check` passed.
+- Commit status: ready to commit on `codex/capitalize-citation-title` as
+  `docs(readme): capitalize citation title`.


### PR DESCRIPTION
## Summary

- capitalize the citation title as `Analog Canvas`
- apply the same title to the prose and BibTeX forms

## Validation

- targeted Prettier check
- `git diff --check`

Documentation only.