### PR TITLE
Show origins map above daily traffic on analytics

### DIFF
--- a/apps/editor/src/components/analytics-page.tsx
+++ b/apps/editor/src/components/analytics-page.tsx
@@ -239,6 +239,19 @@ export function AnalyticsPage() {
 
           <section
             className="analytics-section"
+            aria-labelledby="analytics-map-h"
+          >
+            <SectionHead
+              title="Origins"
+              id="analytics-map-h"
+              aside="Map"
+              meta={<p className="analytics-note">≈1° request buckets</p>}
+            />
+            <WorldHeatmap points={summary?.points ?? []} />
+          </section>
+
+          <section
+            className="analytics-section"
             aria-labelledby="analytics-chart-h"
           >
             <SectionHead
@@ -302,19 +315,6 @@ export function AnalyticsPage() {
               <span className="analytics-range-hint">UTC</span>
             </form>
             <DailyChart days={visibleDays} />
-          </section>
-
-          <section
-            className="analytics-section"
-            aria-labelledby="analytics-map-h"
-          >
-            <SectionHead
-              title="Origins"
-              id="analytics-map-h"
-              aside="Map"
-              meta={<p className="analytics-note">≈1° request buckets</p>}
-            />
-            <WorldHeatmap points={summary?.points ?? []} />
           </section>
 
           <div className="analytics-cols">

--- a/plan/2026-08-13-analytics-map-above-traffic/plan.md
+++ b/plan/2026-08-13-analytics-map-above-traffic/plan.md
@@ -1,0 +1,61 @@
+---
+status: completed
+experience: none
+---
+
+# Show origins map above daily traffic
+
+## Goal
+
+Put the analytics Origins map above the Daily traffic chart so the dashboard
+matches the sibling Analog Arena / tokenzhang.com layout. The countries heading
+is already `ISO 3166 Code` and stays unchanged.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree is clean. This target owns:
+
+- `apps/editor/src/components/analytics-page.tsx`
+- `plan/2026-08-13-analytics-map-above-traffic/plan.md`
+- `plan/log.md`
+
+- Read-only: `apps/editor/e2e/manual-editor.spec.ts` (heading presence already
+  asserted; no order contract exists)
+- Shared: none. Markup order only; analytics API and breakdown tables are
+  untouched.
+
+## Work
+
+1. Move the Origins / world-heatmap section above the Daily traffic section.
+2. Leave the `ISO 3166 Code` heading and all other dashboard sections in place.
+3. Record the factual log and close the plan.
+
+## Validation
+
+- `git diff --check`
+- `git status --short --branch`
+- Confirm the JSX source order is map, then daily traffic, then breakdowns.
+
+No new test: the existing analytics e2e still covers heading presence and
+behavior. A full suite is not justified for a section reorder.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(analytics): show origins map above daily traffic
+```
+
+## Outcome
+
+Moved the Origins heatmap above Daily traffic in `analytics-page.tsx`. The
+countries heading was already `ISO 3166 Code` and was left unchanged.
+`git diff --check` is clean. Existing analytics e2e heading checks remain
+valid; no new test was added for markup order.

--- a/plan/log.md
+++ b/plan/log.md
@@ -1,5 +1,15 @@
 # Maintenance Log
 
+## 2026-08-13 - Show origins map above daily traffic
+
+- Target: put the analytics Origins heatmap above the Daily traffic chart.
+- Changed areas: `apps/editor/src/components/analytics-page.tsx` section order.
+- Validation: source-order review and `git diff --check` passed. Existing
+  analytics e2e heading checks still apply; no new test for markup order.
+- Commit status: prepared as
+  `feat(analytics): show origins map above daily traffic` on
+  `agent/analytics-map-above-traffic`.
+
 ## 2026-08-13 - Remove compatibility re-export layers
 
 - Target: make wiring, style, label-placement, and markup callers depend on


### PR DESCRIPTION
## What changed

- move the analytics Origins heatmap above the Daily traffic chart
- record the target plan and factual log for the reorder

The countries heading was already `ISO 3166 Code` and is unchanged.

## Why

Match the Analog Arena / tokenzhang.com analytics layout: map first, then the daily traffic bars.

## Validation

- source-order review: Origins, then Daily traffic, then breakdown tables
- `git diff --check`
- existing analytics e2e heading checks still apply; no new test for markup order