### PR TITLE
feat(agent): simplify resilient browser connection lifecycle

### DIFF
--- a/apps/editor/e2e/web-agent-session.spec.ts
+++ b/apps/editor/e2e/web-agent-session.spec.ts
@@ -100,9 +100,7 @@ test("grants a browser Agent, edits through the live host, and shares undo", asy
       payload: { type: "session.ready", sessionId },
     }),
   );
-  await expect(page.getByTestId("agent-status")).toContainText(
-    "Agent connected",
-  );
+  await expect(page.getByTestId("agent-status")).toContainText("Connected");
 
   const sendCircuitRequest = async (
     requestId: string,
@@ -331,7 +329,7 @@ test("grants a browser Agent, edits through the live host, and shares undo", asy
 
   await page
     .getByTestId("connect-agent-panel")
-    .getByRole("button", { name: "Close" })
+    .getByRole("button", { name: "Hide Agent details" })
     .click();
   await clickCommand(page, "Edit", "Undo");
   await expect(page.getByTestId("active-instance-count")).toHaveText("0");
@@ -346,34 +344,28 @@ test("grants a browser Agent, edits through the live host, and shares undo", asy
     .toBe(true);
 
   const reopenedAgentMenu = await openMenu(page, "Agent");
-  await reopenedAgentMenu
-    .getByRole("button", { name: "Connect Agent" })
-    .click();
-  await expect(page.getByTestId("agent-status")).toContainText(
-    "Agent connected",
-  );
+  await reopenedAgentMenu.getByRole("button", { name: "Manage Agent" }).click();
+  await expect(page.getByTestId("agent-properties")).toContainText("Connected");
   const originalSocket = browserSocket as WebSocketRoute | null;
   if (!originalSocket) throw new Error("Agent WebSocket was not connected");
   originalSocket.close();
   await expect.poll(() => browserSocket !== originalSocket).toBe(true);
-  await expect(page.getByTestId("agent-status")).toContainText(
-    "Agent connected",
-  );
+  await expect(page.getByTestId("agent-properties")).toContainText("Connected");
   await page.getByTestId("agent-pause").click();
-  await expect(page.getByTestId("agent-status")).toContainText("Paused");
+  await expect(page.getByTestId("agent-properties")).toContainText("Paused");
   await page.getByTestId("agent-resume").click();
-  await expect(page.getByTestId("agent-status")).toContainText(
-    "Agent connected",
-  );
-  await page.getByTestId("agent-rotate").click();
+  await expect(page.getByTestId("agent-properties")).toContainText("Connected");
+  await page.getByTestId("agent-new-connection").click();
   await expect.poll(() => sessionCreates).toBe(2);
   await expect.poll(() => revokeControls).toBe(1);
   await expect(page.getByTestId("agent-claim-code")).toHaveText(
     `${sessionId}.one-time-claim`,
   );
-  await expect(page.getByTestId("agent-status")).toContainText(
-    "Waiting for Agent to claim",
+  await expect(page.getByTestId("agent-properties")).toContainText(
+    "Waiting for Agent",
   );
   await page.getByTestId("agent-revoke").click();
-  await expect(page.getByTestId("agent-status")).toContainText("Revoked");
+  await expect(page.getByTestId("agent-properties")).toContainText(
+    "Disconnected",
+  );
 });

--- a/apps/editor/src/agent/connect-agent-panel.test.tsx
+++ b/apps/editor/src/agent/connect-agent-panel.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  AgentPropertiesSection,
   ConnectAgentPanel,
   agentConnectionInstructions,
   type AgentAuditEntry,
@@ -15,6 +16,7 @@ function baseProps(
     open: true,
     status: "idle" as AgentConnectionStatus,
     claimCode: null,
+    claimExpiresAt: null,
     scopes: [],
     expiresAt: null,
     audit: [],
@@ -24,16 +26,15 @@ function baseProps(
     onPause: vi.fn(),
     onResume: vi.fn(),
     onReconnect: vi.fn(),
-    onRotate: vi.fn(),
+    onNewConnection: vi.fn(),
     onRevoke: vi.fn(),
     onClose: vi.fn(),
     ...overrides,
   };
 }
 
-// WP-WA5: the panel renders the grant surface, the one-time claim code, status,
-// pause/resume/revoke controls, and the audit across connection states. Secrets
-// live only in props while the session is live; nothing here persists them.
+// The dialog is only authorization and hand-off; ongoing session controls live
+// in Properties. Secrets remain props-only and are never persisted here.
 
 describe("ConnectAgentPanel", () => {
   it("provides one complete golden-path lifecycle without a bearer value", () => {
@@ -42,19 +43,19 @@ describe("ConnectAgentPanel", () => {
       "claim-once",
     );
     expect(instructions).toContain(
-      'POSTing {"claimCode":"claim-once"} to https://editor.example/api/agent/claims',
+      'POST {"claimCode":"claim-once"} to https://editor.example/api/agent/claims',
     );
-    expect(instructions).toContain("4. Call capabilities once");
+    expect(instructions).toContain("5. Call capabilities once");
     expect(instructions).toContain(
       "replace {sessionId} in the Circuit URL with that value",
     );
     expect(instructions).toContain(
-      "7. Use https://editor.example/api/agent/sessions/{sessionId}/files",
+      "8. Use https://editor.example/api/agent/sessions/{sessionId}/files",
     );
-    expect(instructions).toContain("9. Dry-run non-trivial transact requests");
-    expect(instructions).toContain("11. Render, then request a fresh snapshot");
+    expect(instructions).toContain("10. Dry-run non-trivial transact requests");
+    expect(instructions).toContain("12. Render, then request a fresh snapshot");
     expect(instructions).toContain(
-      "12. Reuse a requestId only when retrying the exact same payload",
+      "13. Reuse a requestId only when retrying the exact same payload",
     );
     expect(instructions).not.toMatch(/Bearer [A-Za-z0-9_-]{20,}/u);
   });
@@ -79,12 +80,13 @@ describe("ConnectAgentPanel", () => {
     expect(markup).toContain("Full Circuit Edit");
   });
 
-  it("shows the one-time claim code while waiting for the Agent", () => {
+  it("shows an expiring connection hand-off while waiting for the Agent", () => {
     const markup = renderToStaticMarkup(
       <ConnectAgentPanel
         {...baseProps({
           status: "waiting-for-agent",
           claimCode: "CLAIM-12345",
+          claimExpiresAt: 30_000,
           scopes: ["circuit.snapshot", "circuit.render"],
           expiresAt: 60_000,
           now: 0,
@@ -97,6 +99,7 @@ describe("ConnectAgentPanel", () => {
     expect(markup).toContain("circuit.snapshot, circuit.render");
     expect(markup).toContain('data-testid="agent-pause"');
     expect(markup).toContain('data-testid="agent-revoke"');
+    expect(markup).toContain("Copy connection setup");
     // No grant presets after connecting.
     expect(markup).not.toContain('data-testid="agent-grant"');
   });
@@ -121,15 +124,15 @@ describe("ConnectAgentPanel", () => {
     }
   });
 
-  it("offers user-triggered access rotation while connected", () => {
+  it("offers a replacement connection while connected", () => {
     const markup = renderToStaticMarkup(
       <ConnectAgentPanel {...baseProps({ status: "connected" })} />,
     );
-    expect(markup).toContain('data-testid="agent-rotate"');
-    expect(markup).toContain("Rotate Agent Access");
+    expect(markup).toContain('data-testid="agent-new-connection"');
+    expect(markup).toContain("New connection");
   });
 
-  it("hides the claim code and controls in a terminal revoked state", () => {
+  it("offers a new connection in a terminal revoked state", () => {
     const markup = renderToStaticMarkup(
       <ConnectAgentPanel
         {...baseProps({
@@ -145,10 +148,51 @@ describe("ConnectAgentPanel", () => {
         })}
       />,
     );
-    expect(markup).toContain("Revoked");
+    expect(markup).toContain("Disconnected");
     expect(markup).not.toContain('data-testid="agent-claim"');
     expect(markup).not.toContain('data-testid="agent-revoke"');
-    // The audit still records the grant and the revocation.
-    expect(markup).toContain('data-testid="agent-audit"');
+    expect(markup).toContain('data-testid="agent-new-connection"');
+  });
+
+  it("keeps active connection management inside Properties", () => {
+    const markup = renderToStaticMarkup(
+      <AgentPropertiesSection
+        status="connected"
+        claimCode={null}
+        claimExpiresAt={null}
+        scopes={["circuit.snapshot", "circuit.render"]}
+        expiresAt={8 * 60 * 60 * 1_000}
+        error={null}
+        onPause={vi.fn()}
+        onResume={vi.fn()}
+        onReconnect={vi.fn()}
+        onNewConnection={vi.fn()}
+        onRevoke={vi.fn()}
+        expanded={false}
+        onToggleDetails={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(markup).toContain('data-testid="agent-properties"');
+    expect(markup).toContain("Connected");
+    expect(markup).toContain("Manage");
+    expect(markup).toContain('data-testid="agent-revoke"');
+  });
+
+  it("does not expose an expired claim code", () => {
+    const markup = renderToStaticMarkup(
+      <ConnectAgentPanel
+        {...baseProps({
+          status: "waiting-for-agent",
+          claimCode: "expired-claim",
+          claimExpiresAt: 1,
+          expiresAt: 60_000,
+          now: 2,
+        })}
+      />,
+    );
+    expect(markup).toContain('data-testid="agent-claim-expired"');
+    expect(markup).not.toContain('data-testid="agent-claim-code"');
+    expect(markup).toContain("Generate another");
   });
 });

--- a/apps/editor/src/agent/connect-agent-panel.test.tsx
+++ b/apps/editor/src/agent/connect-agent-panel.test.tsx
@@ -5,7 +5,6 @@ import {
   AgentPropertiesSection,
   ConnectAgentPanel,
   agentConnectionInstructions,
-  type AgentAuditEntry,
   type AgentConnectionStatus,
 } from "./connect-agent-panel";
 
@@ -19,7 +18,6 @@ function baseProps(
     claimExpiresAt: null,
     scopes: [],
     expiresAt: null,
-    audit: [],
     error: null,
     now: 0,
     onGrant: vi.fn(),
@@ -126,10 +124,18 @@ describe("ConnectAgentPanel", () => {
 
   it("offers a replacement connection while connected", () => {
     const markup = renderToStaticMarkup(
-      <ConnectAgentPanel {...baseProps({ status: "connected" })} />,
+      <ConnectAgentPanel
+        {...baseProps({
+          status: "connected",
+          claimCode: "still-valid-claim",
+          claimExpiresAt: 30_000,
+          expiresAt: 60_000,
+        })}
+      />,
     );
     expect(markup).toContain('data-testid="agent-new-connection"');
     expect(markup).toContain("New connection");
+    expect(markup).toContain("still-valid-claim");
   });
 
   it("offers a new connection in a terminal revoked state", () => {
@@ -138,13 +144,6 @@ describe("ConnectAgentPanel", () => {
         {...baseProps({
           status: "revoked",
           claimCode: null,
-          audit: [
-            {
-              at: 0,
-              kind: "granted",
-            },
-            { at: 1, kind: "revoked" },
-          ] as AgentAuditEntry[],
         })}
       />,
     );
@@ -176,7 +175,8 @@ describe("ConnectAgentPanel", () => {
     expect(markup).toContain('data-testid="agent-properties"');
     expect(markup).toContain("Connected");
     expect(markup).toContain("Manage");
-    expect(markup).toContain('data-testid="agent-revoke"');
+    expect(markup).toContain('data-testid="agent-pause"');
+    expect(markup).not.toContain('data-testid="agent-revoke"');
   });
 
   it("does not expose an expired claim code", () => {

--- a/apps/editor/src/agent/connect-agent-panel.tsx
+++ b/apps/editor/src/agent/connect-agent-panel.tsx
@@ -16,19 +16,6 @@ export type AgentConnectionStatus =
   | "revoked"
   | "expired";
 
-export interface AgentAuditEntry {
-  at: number;
-  kind:
-    | "granted"
-    | "claimed"
-    | "operation"
-    | "paused"
-    | "resumed"
-    | "revoked"
-    | "replaced";
-  detail?: string;
-}
-
 export interface PermissionPreset {
   id: "review" | "layout" | "full";
   label: string;
@@ -91,7 +78,6 @@ export interface ConnectAgentPanelProps {
   claimExpiresAt: number | null;
   scopes: readonly AgentSessionScope[];
   expiresAt: number | null;
-  audit: readonly AgentAuditEntry[];
   error: string | null;
   now: number;
   onGrant: (scopes: AgentSessionScope[]) => void;
@@ -105,7 +91,7 @@ export interface ConnectAgentPanelProps {
 
 export interface AgentPropertiesSectionProps extends Omit<
   ConnectAgentPanelProps,
-  "open" | "audit" | "now" | "onGrant" | "onClose"
+  "open" | "now" | "onGrant" | "onClose"
 > {
   expanded: boolean;
   onToggleDetails: () => void;
@@ -253,14 +239,20 @@ function ClaimHandOff({
   scopes,
   now,
   onNewConnection,
+  status,
 }: Pick<
   ConnectAgentPanelProps,
-  "claimCode" | "claimExpiresAt" | "expiresAt" | "scopes" | "onNewConnection"
+  | "claimCode"
+  | "claimExpiresAt"
+  | "expiresAt"
+  | "scopes"
+  | "onNewConnection"
+  | "status"
 > & { now: number }): ReactNode {
   const [copied, setCopied] = useState(false);
   const claimExpired = claimExpiresAt !== null && now >= claimExpiresAt;
   if (claimCode === null && !claimExpired) return null;
-  if (claimExpired) {
+  if (claimExpired && status === "waiting-for-agent") {
     return (
       <div className="agent-claim" data-testid="agent-claim-expired">
         <p>Connection setup expired.</p>
@@ -270,6 +262,7 @@ function ClaimHandOff({
       </div>
     );
   }
+  if (claimExpired) return null;
   return (
     <div className="agent-claim" data-testid="agent-claim">
       <p>
@@ -398,15 +391,54 @@ export function AgentPropertiesSection(
               : ""}
           </p>
         </div>
-        <button
-          type="button"
-          onClick={props.onToggleDetails}
-          aria-expanded={props.expanded}
-        >
-          {props.expanded ? "Hide" : "Manage"}
-        </button>
+        <div className="agent-properties-actions">
+          {props.status === "connected" ||
+          props.status === "waiting-for-agent" ||
+          props.status === "working" ? (
+            <button
+              type="button"
+              data-testid="agent-pause"
+              onClick={props.onPause}
+            >
+              Pause
+            </button>
+          ) : null}
+          {props.status === "paused" ? (
+            <button
+              type="button"
+              data-testid="agent-resume"
+              onClick={props.onResume}
+            >
+              Resume
+            </button>
+          ) : null}
+          {props.status === "offline" || props.status === "reconnecting" ? (
+            <button
+              type="button"
+              data-testid="agent-reconnect"
+              onClick={props.onReconnect}
+            >
+              Retry relay
+            </button>
+          ) : null}
+          {terminal ? (
+            <button
+              type="button"
+              data-testid="agent-new-connection"
+              onClick={props.onNewConnection}
+            >
+              New connection
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={props.onToggleDetails}
+            aria-expanded={props.expanded}
+          >
+            {props.expanded ? "Hide" : "Manage"}
+          </button>
+        </div>
       </div>
-      <ConnectionControls {...props} />
       {props.expanded ? (
         <div className="agent-properties-details">
           <ClaimHandOff {...props} now={clock} />
@@ -417,6 +449,24 @@ export function AgentPropertiesSection(
               Scopes: {props.scopes.join(", ")}
             </p>
           </details>
+          {!terminal ? (
+            <div className="agent-controls">
+              <button
+                type="button"
+                data-testid="agent-new-connection"
+                onClick={props.onNewConnection}
+              >
+                New connection
+              </button>
+              <button
+                type="button"
+                data-testid="agent-revoke"
+                onClick={props.onRevoke}
+              >
+                Disconnect
+              </button>
+            </div>
+          ) : null}
           {props.error ? (
             <p className="agent-panel-error" role="alert">
               {props.error}

--- a/apps/editor/src/agent/connect-agent-panel.tsx
+++ b/apps/editor/src/agent/connect-agent-panel.tsx
@@ -2,15 +2,7 @@ import { useEffect, useState, type ReactNode } from "react";
 
 import type { AgentSessionScope } from "@icm/agent-adapter";
 
-/**
- * Connect Agent panel (WP-WA5). Presentational component for the browser-side
- * authorization surface: permission presets, the one-time claim code shown after
- * grant, the connection status, pause/revoke controls, and a recent-operation
- * audit. State and secrets are owned by the parent (see `useAgentSession`); this
- * component never persists a secret and never sends one to analytics.
- *
- * Contract: [`docs/specs/web-agent-session.md`](../../../docs/specs/web-agent-session.md).
- */
+/** Browser authorization hand-off and compact Properties status controls. */
 
 export type AgentConnectionStatus =
   | "idle"
@@ -40,6 +32,7 @@ export interface AgentAuditEntry {
 export interface PermissionPreset {
   id: "review" | "layout" | "full";
   label: string;
+  description: string;
   scopes: AgentSessionScope[];
 }
 
@@ -47,6 +40,7 @@ export const AGENT_PERMISSION_PRESETS: readonly PermissionPreset[] = [
   {
     id: "review",
     label: "Review",
+    description: "Read the circuit, render it, and download approved views.",
     scopes: [
       "circuit.snapshot",
       "circuit.render",
@@ -59,6 +53,7 @@ export const AGENT_PERMISSION_PRESETS: readonly PermissionPreset[] = [
   {
     id: "layout",
     label: "Layout Edit",
+    description: "Review the circuit and change component placement or routes.",
     scopes: [
       "circuit.snapshot",
       "circuit.render",
@@ -72,6 +67,8 @@ export const AGENT_PERMISSION_PRESETS: readonly PermissionPreset[] = [
   {
     id: "full",
     label: "Full Circuit Edit",
+    description:
+      "Edit circuit, connectivity, annotations, and approved imports.",
     scopes: [
       "circuit.snapshot",
       "circuit.render",
@@ -91,6 +88,7 @@ export interface ConnectAgentPanelProps {
   open: boolean;
   status: AgentConnectionStatus;
   claimCode: string | null;
+  claimExpiresAt: number | null;
   scopes: readonly AgentSessionScope[];
   expiresAt: number | null;
   audit: readonly AgentAuditEntry[];
@@ -100,9 +98,18 @@ export interface ConnectAgentPanelProps {
   onPause: () => void;
   onResume: () => void;
   onReconnect: () => void;
-  onRotate: () => void;
+  onNewConnection: () => void;
   onRevoke: () => void;
   onClose: () => void;
+}
+
+export interface AgentPropertiesSectionProps extends Omit<
+  ConnectAgentPanelProps,
+  "open" | "audit" | "now" | "onGrant" | "onClose"
+> {
+  expanded: boolean;
+  onToggleDetails: () => void;
+  onDismiss: () => void;
 }
 
 export function agentConnectionInstructions(
@@ -114,52 +121,193 @@ export function agentConnectionInstructions(
   const fileUrl = `${origin}/api/agent/sessions/{sessionId}/files`;
   const openApiUrl = `${origin}/api/agent/openapi.json`;
   return `Connect to the Interactive Circuit Maker Agent API.
-1. Redeem claimCode exactly once by POSTing ${JSON.stringify({ claimCode })} to ${claimUrl}, and retain the complete response in memory.
-2. Never log or display agentToken.
-3. Use only sessionId and documentIds returned by the claim response; replace {sessionId} in the Circuit URL with that value, and send agentToken only as the Bearer token.
-4. Call capabilities once through POST ${circuitUrl}.
-5. Request one complete snapshot for the selected documentId.
-6. Validate every request against the published OpenAPI: ${openApiUrl}
-7. Use ${fileUrl} only for authorized Project/formal-file download or staging a bounded Project/structural-SPICE candidate; staging never changes the browser Project.
-8. A human must explicitly approve a staged candidate in the editor before it can replace the Project.
-9. Dry-run non-trivial transact requests using the snapshot revision.
-10. Commit the same edits only if dry-run succeeds and the revision is unchanged.
-11. Render, then request a fresh snapshot for final verification.
-12. Reuse a requestId only when retrying the exact same payload.`;
+1. POST ${JSON.stringify({ claimCode })} to ${claimUrl}, then retain only the latest response in memory.
+2. A retry with this still-valid claim creates a replacement token and immediately invalidates the earlier token.
+3. Never log or display agentToken.
+4. Use only sessionId and documentIds returned by the claim response; replace {sessionId} in the Circuit URL with that value, and send agentToken only as the Bearer token.
+5. Call capabilities once through POST ${circuitUrl}.
+6. Request one complete snapshot for the selected documentId.
+7. Validate every request against the published OpenAPI: ${openApiUrl}
+8. Use ${fileUrl} only for authorized Project/formal-file download or staging a bounded Project/structural-SPICE candidate; staging never changes the browser Project.
+9. A human must explicitly approve a staged candidate in the editor before it can replace the Project.
+10. Dry-run non-trivial transact requests using the snapshot revision.
+11. Commit the same edits only if dry-run succeeds and the revision is unchanged.
+12. Render, then request a fresh snapshot for final verification.
+13. Reuse a requestId only when retrying the exact same payload.`;
 }
 
 const STATUS_LABEL: Record<AgentConnectionStatus, string> = {
   idle: "Not connected",
-  creating: "Creating secure session…",
-  "waiting-for-agent": "Waiting for Agent to claim",
-  connected: "Agent connected",
-  working: "Agent working…",
+  creating: "Creating connection…",
+  "waiting-for-agent": "Waiting for Agent",
+  connected: "Connected",
+  working: "Working",
   paused: "Paused",
-  reconnecting: "Reconnecting to Agent relay…",
-  offline: "Editor relay offline",
-  revoked: "Revoked",
-  expired: "Expired",
+  reconnecting: "Reconnecting",
+  offline: "Relay offline",
+  revoked: "Disconnected",
+  expired: "Session expired",
 };
 
-function formatExpiry(expiresAt: number | null, now: number): string {
-  if (expiresAt === null) return "\u2014";
-  const seconds = Math.max(0, Math.round((expiresAt - now) / 1000));
-  const minutes = Math.floor(seconds / 60);
+function formatRemaining(expiresAt: number | null, now: number): string {
+  if (expiresAt === null) return "—";
+  const seconds = Math.max(0, Math.ceil((expiresAt - now) / 1_000));
+  const hours = Math.floor(seconds / 3_600);
+  const minutes = Math.floor((seconds % 3_600) / 60);
   const remainder = seconds % 60;
+  if (hours > 0) return `${hours}h ${minutes}m`;
   return `${minutes}:${remainder.toString().padStart(2, "0")}`;
 }
 
-export function ConnectAgentPanel(props: ConnectAgentPanelProps): ReactNode {
-  const [clock, setClock] = useState(props.now);
+function permissionLabel(scopes: readonly AgentSessionScope[]): string {
+  const preset = AGENT_PERMISSION_PRESETS.find(
+    (candidate) =>
+      candidate.scopes.length === scopes.length &&
+      candidate.scopes.every((scope) => scopes.includes(scope)),
+  );
+  return preset?.label ?? "Custom access";
+}
+
+function useClock(active: boolean, initial: number): number {
+  const [clock, setClock] = useState(initial);
   useEffect(() => {
-    if (!props.open) return;
+    if (!active) return;
     setClock(Date.now());
     const timer = window.setInterval(() => setClock(Date.now()), 1_000);
     return () => window.clearInterval(timer);
-  }, [props.open]);
-  if (!props.open) return null;
-  const connected = props.status !== "idle" && props.status !== "creating";
+  }, [active]);
+  return clock;
+}
+
+function ConnectionControls(
+  props: Pick<
+    ConnectAgentPanelProps,
+    | "status"
+    | "onPause"
+    | "onResume"
+    | "onReconnect"
+    | "onNewConnection"
+    | "onRevoke"
+  >,
+): ReactNode {
   const terminal = props.status === "revoked" || props.status === "expired";
+  if (terminal) {
+    return (
+      <div className="agent-controls">
+        <button
+          type="button"
+          data-testid="agent-new-connection"
+          onClick={props.onNewConnection}
+        >
+          New connection
+        </button>
+      </div>
+    );
+  }
+  if (props.status === "idle" || props.status === "creating") return null;
+  return (
+    <div className="agent-controls">
+      {props.status === "connected" ||
+      props.status === "waiting-for-agent" ||
+      props.status === "working" ? (
+        <button type="button" data-testid="agent-pause" onClick={props.onPause}>
+          Pause
+        </button>
+      ) : null}
+      {props.status === "paused" ? (
+        <button
+          type="button"
+          data-testid="agent-resume"
+          onClick={props.onResume}
+        >
+          Resume
+        </button>
+      ) : null}
+      {props.status === "offline" || props.status === "reconnecting" ? (
+        <button
+          type="button"
+          data-testid="agent-reconnect"
+          onClick={props.onReconnect}
+        >
+          Retry relay
+        </button>
+      ) : null}
+      <button
+        type="button"
+        data-testid="agent-new-connection"
+        onClick={props.onNewConnection}
+      >
+        New connection
+      </button>
+      <button type="button" data-testid="agent-revoke" onClick={props.onRevoke}>
+        Disconnect
+      </button>
+    </div>
+  );
+}
+
+function ClaimHandOff({
+  claimCode,
+  claimExpiresAt,
+  expiresAt,
+  scopes,
+  now,
+  onNewConnection,
+}: Pick<
+  ConnectAgentPanelProps,
+  "claimCode" | "claimExpiresAt" | "expiresAt" | "scopes" | "onNewConnection"
+> & { now: number }): ReactNode {
+  const [copied, setCopied] = useState(false);
+  const claimExpired = claimExpiresAt !== null && now >= claimExpiresAt;
+  if (claimCode === null && !claimExpired) return null;
+  if (claimExpired) {
+    return (
+      <div className="agent-claim" data-testid="agent-claim-expired">
+        <p>Connection setup expired.</p>
+        <button type="button" onClick={onNewConnection}>
+          Generate another
+        </button>
+      </div>
+    );
+  }
+  return (
+    <div className="agent-claim" data-testid="agent-claim">
+      <p>
+        Give the Agent this setup. The setup expires in{" "}
+        {formatRemaining(claimExpiresAt, now)}; the connected session lasts{" "}
+        {formatRemaining(expiresAt, now)}.
+      </p>
+      <button
+        type="button"
+        data-testid="agent-copy-instructions"
+        onClick={() => {
+          void navigator.clipboard
+            .writeText(
+              agentConnectionInstructions(window.location.origin, claimCode!),
+            )
+            .then(() => {
+              setCopied(true);
+              window.setTimeout(() => setCopied(false), 2_000);
+            })
+            .catch(() => undefined);
+        }}
+      >
+        {copied ? "Copied ✓ Paste it into your Agent" : "Copy connection setup"}
+      </button>
+      <details>
+        <summary>Show connection code and technical details</summary>
+        <code data-testid="agent-claim-code">{claimCode}</code>
+        <p className="agent-technical-details">Scopes: {scopes.join(", ")}</p>
+      </details>
+    </div>
+  );
+}
+
+export function ConnectAgentPanel(props: ConnectAgentPanelProps): ReactNode {
+  const clock = useClock(props.open, props.now);
+  if (!props.open) return null;
+  const terminal = props.status === "revoked" || props.status === "expired";
+  const showGrant = props.status === "idle" || terminal;
 
   return (
     <div
@@ -174,28 +322,29 @@ export function ConnectAgentPanel(props: ConnectAgentPanelProps): ReactNode {
       >
         <div className="agent-panel-header">
           <h2>Connect Agent</h2>
-          <button type="button" onClick={props.onClose} aria-label="Close">
-            Close
+          <button
+            type="button"
+            onClick={props.onClose}
+            aria-label="Hide Agent details"
+          >
+            Hide details
           </button>
         </div>
-
         <p className="agent-panel-status" data-testid="agent-status">
           {STATUS_LABEL[props.status]}
-          <span className="agent-panel-expiry">
-            {" "}
-            (expires in {formatExpiry(props.expiresAt, clock)})
-          </span>
+          {props.expiresAt !== null
+            ? ` · session ${formatRemaining(props.expiresAt, clock)} remaining`
+            : ""}
         </p>
-
         {props.error ? (
           <p className="agent-panel-error" role="alert">
             {props.error}
           </p>
         ) : null}
 
-        {!connected ? (
-          <div className="agent-panel-grant" data-testid="agent-grant">
-            <p>Grant a scoped, short-lived capability to an external Agent.</p>
+        {showGrant ? (
+          <div className="agent-grant" data-testid="agent-grant">
+            <p>Choose what the Agent may do in this Project.</p>
             <ul>
               {AGENT_PERMISSION_PRESETS.map((preset) => (
                 <li key={preset.id}>
@@ -207,8 +356,8 @@ export function ConnectAgentPanel(props: ConnectAgentPanelProps): ReactNode {
                   >
                     {preset.label}
                   </button>
-                  <span className="agent-preset-scopes">
-                    {preset.scopes.join(", ")}
+                  <span className="agent-preset-description">
+                    {preset.description}
                   </span>
                 </li>
               ))}
@@ -216,103 +365,74 @@ export function ConnectAgentPanel(props: ConnectAgentPanelProps): ReactNode {
           </div>
         ) : null}
 
-        {props.claimCode !== null && !terminal ? (
-          <div className="agent-panel-claim" data-testid="agent-claim">
-            <p>
-              Give this one-time code and the editor address to the Agent. It
-              expires in minutes.
-            </p>
-            <code data-testid="agent-claim-code">{props.claimCode}</code>
-            <button
-              type="button"
-              data-testid="agent-copy-instructions"
-              onClick={() => {
-                const origin = window.location.origin;
-                void navigator.clipboard
-                  .writeText(
-                    agentConnectionInstructions(origin, props.claimCode!),
-                  )
-                  .catch(() => undefined);
-              }}
-            >
-              Copy Agent connection instructions
-            </button>
-            <p className="agent-panel-scopes">
-              Scopes: {props.scopes.join(", ")}
-            </p>
-          </div>
-        ) : null}
-
-        {connected ? (
-          <div className="agent-panel-controls">
-            {props.status === "connected" ||
-            props.status === "waiting-for-agent" ||
-            props.status === "working" ? (
-              <button
-                type="button"
-                data-testid="agent-pause"
-                onClick={props.onPause}
-              >
-                Pause
-              </button>
-            ) : null}
-            {props.status === "paused" ? (
-              <button
-                type="button"
-                data-testid="agent-resume"
-                onClick={props.onResume}
-              >
-                Resume
-              </button>
-            ) : null}
-            {props.status === "offline" || props.status === "reconnecting" ? (
-              <button
-                type="button"
-                data-testid="agent-reconnect"
-                onClick={props.onReconnect}
-              >
-                Reconnect
-              </button>
-            ) : null}
-            {!terminal ? (
-              <>
-                <button
-                  type="button"
-                  data-testid="agent-rotate"
-                  onClick={props.onRotate}
-                >
-                  Rotate Agent Access
-                </button>
-                <button
-                  type="button"
-                  data-testid="agent-revoke"
-                  onClick={props.onRevoke}
-                >
-                  Revoke
-                </button>
-              </>
-            ) : null}
-          </div>
-        ) : null}
-
-        {props.audit.length > 0 ? (
-          <ul className="agent-panel-audit" data-testid="agent-audit">
-            {props.audit
-              .slice()
-              .reverse()
-              .map((entry, index) => (
-                <li
-                  key={`${entry.at}-${index}`}
-                  data-testid="agent-audit-entry"
-                >
-                  <span>{new Date(entry.at).toISOString()}</span>
-                  <span>{entry.kind}</span>
-                  {entry.detail ? <span>{entry.detail}</span> : null}
-                </li>
-              ))}
-          </ul>
-        ) : null}
+        <ClaimHandOff {...props} now={clock} />
+        <ConnectionControls {...props} />
       </section>
     </div>
+  );
+}
+
+export function AgentPropertiesSection(
+  props: AgentPropertiesSectionProps,
+): ReactNode {
+  const clock = useClock(true, Date.now());
+  if (props.status === "idle") return null;
+  const terminal = props.status === "revoked" || props.status === "expired";
+  return (
+    <section
+      className="agent-properties"
+      aria-label="Agent connection"
+      data-testid="agent-properties"
+    >
+      <div className="agent-properties-summary">
+        <div>
+          <h2>Agent</h2>
+          <p>
+            <span
+              className={`agent-status-dot ${terminal ? "terminal" : ""}`}
+              aria-hidden="true"
+            />
+            {STATUS_LABEL[props.status]} · {permissionLabel(props.scopes)}
+            {props.expiresAt !== null
+              ? ` · ${formatRemaining(props.expiresAt, clock)}`
+              : ""}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={props.onToggleDetails}
+          aria-expanded={props.expanded}
+        >
+          {props.expanded ? "Hide" : "Manage"}
+        </button>
+      </div>
+      <ConnectionControls {...props} />
+      {props.expanded ? (
+        <div className="agent-properties-details">
+          <ClaimHandOff {...props} now={clock} />
+          <details>
+            <summary>Connection details</summary>
+            <p>Access: {permissionLabel(props.scopes)}</p>
+            <p className="agent-technical-details">
+              Scopes: {props.scopes.join(", ")}
+            </p>
+          </details>
+          {props.error ? (
+            <p className="agent-panel-error" role="alert">
+              {props.error}
+            </p>
+          ) : null}
+          {terminal ? (
+            <button
+              type="button"
+              className="agent-dismiss"
+              onClick={props.onDismiss}
+            >
+              Dismiss
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
   );
 }

--- a/apps/editor/src/agent/session-recovery.test.ts
+++ b/apps/editor/src/agent/session-recovery.test.ts
@@ -37,7 +37,13 @@ function record() {
     editorSecret: "editor-secret",
     projectId: target.projectId,
     projectSessionId: target.projectSessionId,
-    scopes: ["circuit.snapshot", "circuit.render"] as const,
+    scopes: [
+      "circuit.snapshot",
+      "editor.semantic-control",
+      "project.download",
+      "project.import",
+      "visual.download",
+    ] as const,
     expiresAt: 2_000,
   };
 }

--- a/apps/editor/src/agent/session-recovery.ts
+++ b/apps/editor/src/agent/session-recovery.ts
@@ -1,4 +1,7 @@
-import type { AgentSessionScope } from "@icm/agent-adapter";
+import {
+  isAgentSessionScope,
+  type AgentSessionScope,
+} from "@icm/agent-adapter";
 
 export const AGENT_SESSION_RECOVERY_STORAGE_KEY =
   "icm.agent-session-recovery.v1";
@@ -25,20 +28,6 @@ export interface RecoveryTarget {
   readonly now: number;
 }
 
-function isScope(value: unknown): value is AgentSessionScope {
-  return (
-    typeof value === "string" &&
-    [
-      "circuit.snapshot",
-      "circuit.render",
-      "circuit.source-spans",
-      "circuit.edit.geometry",
-      "circuit.edit.connectivity",
-      "circuit.edit.presentation",
-    ].includes(value)
-  );
-}
-
 function parseRecord(value: unknown): AgentSessionRecoveryRecord | null {
   if (typeof value !== "object" || value === null) return null;
   const record = value as Record<string, unknown>;
@@ -53,7 +42,7 @@ function parseRecord(value: unknown): AgentSessionRecoveryRecord | null {
     typeof record.projectSessionId !== "string" ||
     record.projectSessionId.length === 0 ||
     !Array.isArray(record.scopes) ||
-    !record.scopes.every(isScope) ||
+    !record.scopes.every(isAgentSessionScope) ||
     typeof record.expiresAt !== "number" ||
     !Number.isFinite(record.expiresAt)
   ) {

--- a/apps/editor/src/agent/use-agent-session.ts
+++ b/apps/editor/src/agent/use-agent-session.ts
@@ -87,7 +87,9 @@ type LiveSession = {
 
 const BROWSER_CACHE_MAX_ENTRIES = 32;
 const BROWSER_CACHE_MAX_BYTES = 16_000_000;
-const RECONNECT_DELAYS_MS = [250, 500, 1_000, 2_000, 4_000, 8_000] as const;
+const RECONNECT_DELAYS_MS = [
+  500, 1_000, 2_000, 4_000, 8_000, 15_000, 30_000,
+] as const;
 
 function stopReconnect(live: LiveSession): void {
   live.allowReconnect = false;
@@ -100,6 +102,7 @@ function stopReconnect(live: LiveSession): void {
 export interface AgentSessionViewModel {
   status: AgentConnectionStatus;
   claimCode: string | null;
+  claimExpiresAt: number | null;
   scopes: readonly AgentSessionScope[];
   expiresAt: number | null;
   audit: readonly AgentAuditEntry[];
@@ -123,7 +126,7 @@ export interface UseAgentSessionResult extends AgentSessionViewModel {
   pause: () => Promise<void>;
   resume: () => Promise<void>;
   reconnect: () => void;
-  rotate: () => Promise<void>;
+  newConnection: () => Promise<void>;
   revoke: () => Promise<void>;
 }
 
@@ -157,6 +160,7 @@ export function useAgentSession(
   options: UseAgentSessionOptions,
 ): UseAgentSessionResult {
   const liveRef = useRef<LiveSession | null>(null);
+  const lastScopesRef = useRef<AgentSessionScope[]>([]);
   const recoveryAttemptedForProjectRef = useRef<string | null>(null);
   const projectSessionRef = useRef(options.projectSessionId);
   const revisionRef = useRef(
@@ -171,6 +175,7 @@ export function useAgentSession(
   const [view, setView] = useState<AgentSessionViewModel>({
     status: "idle",
     claimCode: null,
+    claimExpiresAt: null,
     scopes: [],
     expiresAt: null,
     audit: [],
@@ -213,7 +218,7 @@ export function useAgentSession(
     const live = liveRef.current;
     if (!live) {
       clearAgentSessionRecovery(window.sessionStorage);
-      update({ status: "idle", claimCode: null });
+      update({ status: "idle", claimCode: null, claimExpiresAt: null });
       return;
     }
     stopReconnect(live);
@@ -227,7 +232,12 @@ export function useAgentSession(
     live.socket?.close(1000, "revoked");
     liveRef.current = null;
     update(
-      { status: "revoked", claimCode: null, error: null },
+      {
+        status: "revoked",
+        claimCode: null,
+        claimExpiresAt: null,
+        error: null,
+      },
       { at: Date.now(), kind: "revoked" },
     );
   }, [control, options.fileHost, update]);
@@ -238,10 +248,12 @@ export function useAgentSession(
       recovery?: AgentSessionRecoveryRecord,
     ) => {
       if (liveRef.current) await revoke();
+      lastScopesRef.current = [...scopes];
       update({
         status: recovery ? "reconnecting" : "creating",
         error: null,
         claimCode: null,
+        claimExpiresAt: null,
         scopes,
       });
       try {
@@ -340,6 +352,7 @@ export function useAgentSession(
               {
                 status: live.claimed ? "connected" : "waiting-for-agent",
                 claimCode: live.claimed ? null : live.claimCode,
+                claimExpiresAt: live.claimed ? null : live.claimExpiresAt,
                 scopes,
                 expiresAt: live.expiresAt,
                 error: null,
@@ -376,7 +389,11 @@ export function useAgentSession(
                   expiresAt: live.expiresAt,
                 });
                 update(
-                  { status: "connected", claimCode: null },
+                  {
+                    status: "connected",
+                    claimCode: null,
+                    claimExpiresAt: null,
+                  },
                   { at: Date.now(), kind: "claimed" },
                 );
               } else if (
@@ -389,7 +406,11 @@ export function useAgentSession(
                 socket.close(1000, "session revoked");
                 if (liveRef.current === live) liveRef.current = null;
                 update(
-                  { status: "revoked", claimCode: null },
+                  {
+                    status: "revoked",
+                    claimCode: null,
+                    claimExpiresAt: null,
+                  },
                   { at: Date.now(), kind: "revoked" },
                 );
               } else if (
@@ -596,11 +617,14 @@ export function useAgentSession(
           socket.addEventListener("close", () => {
             if (live.socket === socket) live.socket = null;
             if (liveRef.current !== live || !live.allowReconnect) return;
-            const delay = RECONNECT_DELAYS_MS[live.reconnectAttempt];
-            if (delay === undefined || Date.now() >= live.expiresAt) {
+            if (Date.now() >= live.expiresAt) {
               update({ status: "offline" });
               return;
             }
+            const delay =
+              RECONNECT_DELAYS_MS[
+                Math.min(live.reconnectAttempt, RECONNECT_DELAYS_MS.length - 1)
+              ]!;
             live.reconnectAttempt += 1;
             update({ status: "reconnecting" });
             live.reconnectTimer = window.setTimeout(connect, delay);
@@ -693,10 +717,10 @@ export function useAgentSession(
     live.reconnect();
   }, [update]);
 
-  const rotate = useCallback(async () => {
-    const live = liveRef.current;
-    if (!live) return;
-    await grant([...live.scopes]);
+  const newConnection = useCallback(async () => {
+    const scopes = liveRef.current?.scopes ?? lastScopesRef.current;
+    if (scopes.length === 0) return;
+    await grant(scopes);
   }, [grant]);
 
   useEffect(() => {
@@ -758,7 +782,7 @@ export function useAgentSession(
       live.socket?.close(1000, "project replaced");
       liveRef.current = null;
       update(
-        { status: "revoked", claimCode: null },
+        { status: "revoked", claimCode: null, claimExpiresAt: null },
         { at: Date.now(), kind: "replaced" },
       );
     });
@@ -773,13 +797,21 @@ export function useAgentSession(
   useEffect(() => {
     const timer = window.setInterval(() => {
       const live = liveRef.current;
+      if (
+        live &&
+        !live.claimed &&
+        live.claimExpiresAt !== null &&
+        Date.now() >= live.claimExpiresAt
+      ) {
+        update({ claimCode: null });
+      }
       if (live && Date.now() >= live.expiresAt) {
         stopReconnect(live);
         clearAgentSessionRecovery(window.sessionStorage);
         options.fileHost?.clear?.();
         live.socket?.close(1000, "expired");
         liveRef.current = null;
-        update({ status: "expired", claimCode: null });
+        update({ status: "expired", claimCode: null, claimExpiresAt: null });
       }
     }, 1_000);
     return () => window.clearInterval(timer);
@@ -805,5 +837,5 @@ export function useAgentSession(
     [options.fileHost],
   );
 
-  return { ...view, grant, pause, resume, reconnect, rotate, revoke };
+  return { ...view, grant, pause, resume, reconnect, newConnection, revoke };
 }

--- a/apps/editor/src/agent/use-agent-session.ts
+++ b/apps/editor/src/agent/use-agent-session.ts
@@ -19,10 +19,7 @@ import {
 import { sha256Hex } from "@icm/derived";
 import type { CircuitProject } from "@icm/model";
 
-import type {
-  AgentAuditEntry,
-  AgentConnectionStatus,
-} from "./connect-agent-panel";
+import type { AgentConnectionStatus } from "./connect-agent-panel";
 import {
   clearAgentSessionRecovery,
   readAgentSessionRecovery,
@@ -72,7 +69,6 @@ type LiveSession = {
   scopes: AgentSessionScope[];
   socket: WebSocket | null;
   claimed: boolean;
-  hasOpened: boolean;
   allowReconnect: boolean;
   reconnectAttempt: number;
   reconnectTimer: number | null;
@@ -105,7 +101,6 @@ export interface AgentSessionViewModel {
   claimExpiresAt: number | null;
   scopes: readonly AgentSessionScope[];
   expiresAt: number | null;
-  audit: readonly AgentAuditEntry[];
   error: string | null;
 }
 
@@ -178,20 +173,12 @@ export function useAgentSession(
     claimExpiresAt: null,
     scopes: [],
     expiresAt: null,
-    audit: [],
     error: null,
   });
 
-  const update = useCallback(
-    (next: Partial<AgentSessionViewModel>, entry?: AgentAuditEntry) => {
-      setView((previous) => ({
-        ...previous,
-        ...next,
-        audit: entry ? [...previous.audit, entry].slice(-32) : previous.audit,
-      }));
-    },
-    [],
-  );
+  const update = useCallback((next: Partial<AgentSessionViewModel>) => {
+    setView((previous) => ({ ...previous, ...next }));
+  }, []);
 
   const control = useCallback(
     async (action: "pause" | "resume" | "revoke" | "replace-project") => {
@@ -231,15 +218,12 @@ export function useAgentSession(
     }
     live.socket?.close(1000, "revoked");
     liveRef.current = null;
-    update(
-      {
-        status: "revoked",
-        claimCode: null,
-        claimExpiresAt: null,
-        error: null,
-      },
-      { at: Date.now(), kind: "revoked" },
-    );
+    update({
+      status: "revoked",
+      claimCode: null,
+      claimExpiresAt: null,
+      error: null,
+    });
   }, [control, options.fileHost, update]);
 
   const grant = useCallback(
@@ -288,7 +272,6 @@ export function useAgentSession(
           scopes: [...scopes],
           socket: null,
           claimed: recovery !== undefined,
-          hasOpened: false,
           allowReconnect: true,
           reconnectAttempt: 0,
           reconnectTimer: null,
@@ -344,21 +327,16 @@ export function useAgentSession(
           ]);
           live.socket = socket;
           socket.addEventListener("open", () => {
-            const firstConnection = !live.hasOpened;
-            live.hasOpened = true;
             live.reconnectAttempt = 0;
             live.reconnectTimer = null;
-            update(
-              {
-                status: live.claimed ? "connected" : "waiting-for-agent",
-                claimCode: live.claimed ? null : live.claimCode,
-                claimExpiresAt: live.claimed ? null : live.claimExpiresAt,
-                scopes,
-                expiresAt: live.expiresAt,
-                error: null,
-              },
-              firstConnection ? { at: Date.now(), kind: "granted" } : undefined,
-            );
+            update({
+              status: live.claimed ? "connected" : "waiting-for-agent",
+              claimCode: live.claimCode,
+              claimExpiresAt: live.claimExpiresAt,
+              scopes,
+              expiresAt: live.expiresAt,
+              error: null,
+            });
           });
           socket.addEventListener("message", (event) => {
             let raw: unknown;
@@ -388,14 +366,7 @@ export function useAgentSession(
                   scopes: live.scopes,
                   expiresAt: live.expiresAt,
                 });
-                update(
-                  {
-                    status: "connected",
-                    claimCode: null,
-                    claimExpiresAt: null,
-                  },
-                  { at: Date.now(), kind: "claimed" },
-                );
+                update({ status: "connected" });
               } else if (
                 sessionEvent.success &&
                 sessionEvent.data.type === "session.revoked"
@@ -405,14 +376,11 @@ export function useAgentSession(
                 options.fileHost?.clear?.();
                 socket.close(1000, "session revoked");
                 if (liveRef.current === live) liveRef.current = null;
-                update(
-                  {
-                    status: "revoked",
-                    claimCode: null,
-                    claimExpiresAt: null,
-                  },
-                  { at: Date.now(), kind: "revoked" },
-                );
+                update({
+                  status: "revoked",
+                  claimCode: null,
+                  claimExpiresAt: null,
+                });
               } else if (
                 sessionEvent.success &&
                 sessionEvent.data.type === "session.paused"
@@ -463,14 +431,7 @@ export function useAgentSession(
                 return;
               }
               live.requestHashes.set(parsed.data.requestId, payloadHash);
-              update(
-                { status: "working" },
-                {
-                  at: Date.now(),
-                  kind: "operation",
-                  detail: `file.${fileRequest.data.operation}`,
-                },
-              );
+              update({ status: "working" });
               void options.fileHost
                 .handle(fileRequest.data)
                 .then(sendFileResponse)
@@ -547,13 +508,7 @@ export function useAgentSession(
               return;
             }
             live.requestHashes.set(parsed.data.requestId, payloadHash);
-            const operation = circuitRequest.success
-              ? circuitRequest.data.operation
-              : "request";
-            update(
-              { status: "working" },
-              { at: Date.now(), kind: "operation", detail: operation },
-            );
+            update({ status: "working" });
             // The relay already rejects malformed public payloads, but the
             // browser host repeats that same strict parse before it can touch
             // the live Project. Never route hosted traffic through the local
@@ -676,10 +631,7 @@ export function useAgentSession(
   const pause = useCallback(async () => {
     try {
       await control("pause");
-      update(
-        { status: "paused", error: null },
-        { at: Date.now(), kind: "paused" },
-      );
+      update({ status: "paused", error: null });
     } catch (error) {
       update({
         error: error instanceof Error ? error.message : String(error),
@@ -690,13 +642,10 @@ export function useAgentSession(
   const resume = useCallback(async () => {
     try {
       await control("resume");
-      update(
-        {
-          status: liveRef.current?.claimed ? "connected" : "waiting-for-agent",
-          error: null,
-        },
-        { at: Date.now(), kind: "resumed" },
-      );
+      update({
+        status: liveRef.current?.claimed ? "connected" : "waiting-for-agent",
+        error: null,
+      });
     } catch (error) {
       update({
         error: error instanceof Error ? error.message : String(error),
@@ -781,10 +730,7 @@ export function useAgentSession(
     void control("replace-project").finally(() => {
       live.socket?.close(1000, "project replaced");
       liveRef.current = null;
-      update(
-        { status: "revoked", claimCode: null, claimExpiresAt: null },
-        { at: Date.now(), kind: "replaced" },
-      );
+      update({ status: "revoked", claimCode: null, claimExpiresAt: null });
     });
   }, [
     control,
@@ -799,11 +745,14 @@ export function useAgentSession(
       const live = liveRef.current;
       if (
         live &&
-        !live.claimed &&
+        live.claimCode !== null &&
         live.claimExpiresAt !== null &&
         Date.now() >= live.claimExpiresAt
       ) {
-        update({ claimCode: null });
+        const claimExpiresAt = live.claimExpiresAt;
+        live.claimCode = null;
+        live.claimExpiresAt = null;
+        update({ claimCode: null, claimExpiresAt });
       }
       if (live && Date.now() >= live.expiresAt) {
         stopReconnect(live);

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -6172,7 +6172,6 @@ export function App({ project: initialProject, visitStats }: AppProps) {
         claimExpiresAt={agentSession.claimExpiresAt}
         scopes={agentSession.scopes}
         expiresAt={agentSession.expiresAt}
-        audit={agentSession.audit}
         error={agentSession.error}
         now={Date.now()}
         onGrant={agentSession.grant}
@@ -6344,6 +6343,18 @@ export function App({ project: initialProject, visitStats }: AppProps) {
               <span className="selection-shelf-title">
                 <ToolIcon name="inspect" />
                 <span>Properties</span>
+                {agentSession.status !== "idle" && !agentStatusDismissed ? (
+                  <span
+                    className={`agent-shelf-indicator ${
+                      agentSession.status === "revoked" ||
+                      agentSession.status === "expired"
+                        ? "terminal"
+                        : ""
+                    }`}
+                    title={`Agent: ${agentSession.status}`}
+                    aria-label={`Agent: ${agentSession.status}`}
+                  />
+                ) : null}
               </span>
               <span className="selection-shelf-summary">
                 {selectedIds.length > 0

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -140,7 +140,10 @@ import {
 } from "../interaction/editor-shortcuts";
 import { EditorHelpDialog } from "../components/editor-help-dialog";
 import { ProjectSearchDialog } from "../features/search/project-search-dialog";
-import { ConnectAgentPanel } from "../agent/connect-agent-panel";
+import {
+  AgentPropertiesSection,
+  ConnectAgentPanel,
+} from "../agent/connect-agent-panel";
 import { BrowserAgentHost } from "../agent/browser-agent-host";
 import { BrowserAgentFileHost } from "../agent/browser-agent-file-host";
 import { useAgentSession } from "../agent/use-agent-session";
@@ -455,6 +458,8 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   const [status, setStatus] = useState("Ready");
   const [insertDialogOpen, setInsertDialogOpen] = useState(false);
   const [agentPanelOpen, setAgentPanelOpen] = useState(false);
+  const [agentDetailsOpen, setAgentDetailsOpen] = useState(false);
+  const [agentStatusDismissed, setAgentStatusDismissed] = useState(false);
   const [libraryPanelOpen, setLibraryPanelOpen] = useState(() => {
     if (typeof window === "undefined") return true;
     try {
@@ -567,6 +572,9 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     host: browserAgentHost,
     fileHost: browserAgentFileHost,
   });
+  useEffect(() => {
+    setAgentStatusDismissed(false);
+  }, [agentSession.status]);
   const [boxPreview, setBoxPreview] = useState<BoxPreview | null>(null);
   const [panPreview, setPanPreview] = useState<PanPreview | null>(null);
   const [routeStretchPreview, setRouteStretchPreview] =
@@ -5947,8 +5955,20 @@ export function App({ project: initialProject, visitStats }: AppProps) {
               <details className="command-menu" name="editor-command-menu">
                 <summary>Agent</summary>
                 <div className="command-popover">
-                  <button type="button" onClick={() => setAgentPanelOpen(true)}>
-                    Connect Agent
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (agentSession.status === "idle") {
+                        setAgentPanelOpen(true);
+                        return;
+                      }
+                      setSelectionOpen(true);
+                      setAgentDetailsOpen(true);
+                    }}
+                  >
+                    {agentSession.status === "idle"
+                      ? "Connect Agent"
+                      : "Manage Agent"}
                   </button>
                 </div>
               </details>
@@ -6149,6 +6169,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
         open={agentPanelOpen}
         status={agentSession.status}
         claimCode={agentSession.claimCode}
+        claimExpiresAt={agentSession.claimExpiresAt}
         scopes={agentSession.scopes}
         expiresAt={agentSession.expiresAt}
         audit={agentSession.audit}
@@ -6158,7 +6179,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
         onPause={agentSession.pause}
         onResume={agentSession.resume}
         onReconnect={agentSession.reconnect}
-        onRotate={agentSession.rotate}
+        onNewConnection={agentSession.newConnection}
         onRevoke={agentSession.revoke}
         onClose={() => {
           setAgentPanelOpen(false);
@@ -7040,6 +7061,27 @@ export function App({ project: initialProject, visitStats }: AppProps) {
                     onSelectVisualDiagnostic={jumpToVisualDiagnostic}
                   />
                 </section>
+              ) : null}
+              {agentSession.status !== "idle" && !agentStatusDismissed ? (
+                <AgentPropertiesSection
+                  status={agentSession.status}
+                  claimCode={agentSession.claimCode}
+                  claimExpiresAt={agentSession.claimExpiresAt}
+                  scopes={agentSession.scopes}
+                  expiresAt={agentSession.expiresAt}
+                  error={agentSession.error}
+                  onPause={agentSession.pause}
+                  onResume={agentSession.resume}
+                  onReconnect={agentSession.reconnect}
+                  onNewConnection={agentSession.newConnection}
+                  onRevoke={agentSession.revoke}
+                  expanded={agentDetailsOpen}
+                  onToggleDetails={() => setAgentDetailsOpen((open) => !open)}
+                  onDismiss={() => {
+                    setAgentDetailsOpen(false);
+                    setAgentStatusDismissed(true);
+                  }}
+                />
               ) : null}
             </div>
           </section>

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -3206,16 +3206,16 @@ html.light .analytics-map-land path {
   color: var(--icm-text-muted);
 }
 
-.agent-panel .agent-panel-grant,
-.agent-panel .agent-panel-claim,
-.agent-panel .agent-panel-controls {
+.agent-panel .agent-grant,
+.agent-panel .agent-claim,
+.agent-panel .agent-controls {
   padding: 1rem;
   border: 1px solid var(--icm-border-strong);
   border-radius: var(--icm-radius-lg);
   background: var(--icm-surface-muted);
 }
 
-.agent-panel .agent-panel-grant ul {
+.agent-panel .agent-grant ul {
   display: grid;
   gap: 0.5rem;
   margin: 0.5rem 0 0;
@@ -3223,7 +3223,7 @@ html.light .analytics-map-land path {
   list-style: none;
 }
 
-.agent-panel .agent-panel-grant li {
+.agent-panel .agent-grant li {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -3239,13 +3239,13 @@ html.light .analytics-map-land path {
   font: inherit;
 }
 
-.agent-panel .agent-preset-scopes {
+.agent-panel .agent-preset-description {
   flex: 1 1 16rem;
   color: var(--icm-text-muted);
   font-size: 0.85rem;
 }
 
-.agent-panel code[data-testid="agent-claim-code"] {
+.agent-claim code[data-testid="agent-claim-code"] {
   display: block;
   margin: 0.5rem 0;
   padding: 0.6rem;
@@ -3257,7 +3257,7 @@ html.light .analytics-map-land path {
   word-break: break-all;
 }
 
-.agent-panel .agent-panel-controls {
+.agent-controls {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
@@ -3267,7 +3267,10 @@ html.light .analytics-map-land path {
   box-shadow: none;
 }
 
-.agent-panel .agent-panel-controls button {
+.agent-controls button,
+.agent-claim button,
+.agent-properties-summary > button,
+.agent-dismiss {
   padding: 0.4rem 0.8rem;
   border: 1px solid var(--icm-border-strong);
   border-radius: var(--icm-radius-sm);
@@ -3275,16 +3278,74 @@ html.light .analytics-map-land path {
   font: inherit;
 }
 
-.agent-panel .agent-panel-audit {
-  max-height: 10rem;
-  margin: 0;
-  padding: 0 0 0 1rem;
-  overflow: auto;
-  color: var(--icm-text-muted);
-  font-size: 0.8rem;
+.agent-claim details {
+  margin-top: var(--icm-space-2);
 }
 
-.agent-panel .agent-panel-audit li {
+.agent-claim summary,
+.agent-properties-details summary {
+  color: var(--icm-text-muted);
+  cursor: pointer;
+}
+
+.agent-technical-details {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  overflow-wrap: anywhere;
+}
+
+.agent-properties {
+  display: grid;
+  gap: var(--icm-space-2);
+  margin-top: auto;
+  padding: var(--icm-space-3) 0 0;
+  border-top: 1px solid var(--icm-border);
+}
+
+.agent-properties-summary {
   display: flex;
-  gap: 0.5rem;
+  align-items: start;
+  justify-content: space-between;
+  gap: var(--icm-space-2);
+}
+
+.agent-properties-summary h2,
+.agent-properties-summary p,
+.agent-properties-details p {
+  margin: 0;
+}
+
+.agent-properties-summary h2 {
+  font-size: var(--icm-font-md);
+}
+
+.agent-properties-summary p {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+
+.agent-status-dot {
+  display: inline-block;
+  width: 0.45rem;
+  height: 0.45rem;
+  margin-right: 0.28rem;
+  border-radius: 50%;
+  background: var(--icm-success, #2f855a);
+}
+
+.agent-status-dot.terminal {
+  background: var(--icm-text-muted);
+}
+
+.agent-properties .agent-controls {
+  padding: 0;
+}
+
+.agent-properties-details {
+  display: grid;
+  gap: var(--icm-space-2);
+  padding: var(--icm-space-2);
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface-muted);
 }

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -1066,6 +1066,18 @@ body {
   box-shadow: 0 0 0 3px var(--icm-accent-soft);
 }
 
+.agent-shelf-indicator {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--icm-success, #2f855a);
+}
+
+.agent-shelf-indicator.terminal {
+  background: var(--icm-text-muted);
+}
+
 .selection-panel {
   flex: 1 1 auto;
   min-height: 0;
@@ -3208,7 +3220,8 @@ html.light .analytics-map-land path {
 
 .agent-panel .agent-grant,
 .agent-panel .agent-claim,
-.agent-panel .agent-controls {
+.agent-panel .agent-controls,
+.agent-panel .agent-panel-controls {
   padding: 1rem;
   border: 1px solid var(--icm-border-strong);
   border-radius: var(--icm-radius-lg);
@@ -3257,7 +3270,8 @@ html.light .analytics-map-land path {
   word-break: break-all;
 }
 
-.agent-controls {
+.agent-controls,
+.agent-panel-controls {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
@@ -3268,8 +3282,9 @@ html.light .analytics-map-land path {
 }
 
 .agent-controls button,
+.agent-panel-controls button,
 .agent-claim button,
-.agent-properties-summary > button,
+.agent-properties-actions button,
 .agent-dismiss {
   padding: 0.4rem 0.8rem;
   border: 1px solid var(--icm-border-strong);
@@ -3307,6 +3322,13 @@ html.light .analytics-map-land path {
   align-items: start;
   justify-content: space-between;
   gap: var(--icm-space-2);
+}
+
+.agent-properties-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--icm-space-1);
 }
 
 .agent-properties-summary h2,
@@ -3348,4 +3370,18 @@ html.light .analytics-map-land path {
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
   background: var(--icm-surface-muted);
+}
+
+.agent-panel-audit {
+  max-height: 10rem;
+  margin: 0;
+  padding: 0 0 0 1rem;
+  overflow: auto;
+  color: var(--icm-text-muted);
+  font-size: 0.8rem;
+}
+
+.agent-panel-audit li {
+  display: flex;
+  gap: 0.5rem;
 }

--- a/docs/agent/api-usage.md
+++ b/docs/agent/api-usage.md
@@ -91,28 +91,29 @@ and body API version must match.
 
 The published browser editor exposes the same Circuit API over a browser-
 authorized relay (ADR 0016). The human clicks **Connect Agent**, grants a
-scoped preset, and gives the Agent a one-time claim code. The Agent never needs
+scoped preset, and gives the Agent a short-lived claim code. The Agent never needs
 repository source — only this document and the claim code.
 
 The deployed machine-readable contract is available at
 `GET /api/agent/openapi.json`. The editor's **Copy Agent connection
 instructions** action includes this address, the claim endpoint, and the
-one-time code.
+claim code.
 
-1. **Redeem the claim** (single-use, short expiry):
+1. **Redeem the claim** (30-minute expiry):
 
    ```http
    POST /api/agent/claims HTTP/1.1
    Content-Type: application/json
 
-   {"claimCode":"<one-time-code>"}
+   {"claimCode":"<claim-code>"}
    ```
 
    On success the response carries `sessionId`, `projectId`, authorized
    `documentIds`, a scoped `agentToken` (bearer), and its expiry. Select the
    target from those returned IDs; do not guess `document-main` or infer an ID
    from a visible Cell name.
-   A claim is consumed once; reuse returns `CLAIM_ALREADY_USED`.
+   Repeating a still-valid claim is safe for recovery: it returns a fresh token
+   and immediately invalidates the earlier bearer. Keep only the latest response.
 
 2. **Call the Circuit API** through the session. The body is the same Circuit
    request schema as the loopback adapter; the relay forwards it to the live
@@ -156,11 +157,11 @@ A transient relay failure is not a revocation. Do not replay an uncertain write
 under a new `requestId`; repeat the original request ID to recover its terminal
 result, or request a fresh Snapshot after the browser is available again.
 
-Closing the Connect Agent panel does not pause, revoke, or disconnect the live
-session. If the Agent loses its bearer, the user may choose **Rotate Agent
-Access**. Rotation revokes the old capability and creates a new one-time claim
-for the same open Project, authorized Documents, and scopes; it is not a refresh
-token and never revives the old bearer.
+Hiding the Agent details does not pause, revoke, or disconnect the live session.
+If the Agent loses its bearer, it may redeem the still-valid claim again; the
+new token replaces the old bearer. The user may also choose **New connection**
+to create a separate session with the same Project, authorized Documents, and
+scopes.
 
 ## Failure handling
 
@@ -180,10 +181,10 @@ token and never revives the old bearer.
 
 Web-session transport errors (published editor only):
 
-- `CLAIM_INVALID` / `CLAIM_EXPIRED` / `CLAIM_ALREADY_USED`: ask the human for a
-  fresh claim code; a claim is one-time and short-lived.
-- `TOKEN_INVALID` / `TOKEN_EXPIRED`: request a newly authorized session from
-  the human; a consumed claim cannot mint a second token.
+- `CLAIM_INVALID` / `CLAIM_EXPIRED`: ask the human for a fresh claim code.
+- `TOKEN_INVALID`: if the original claim is still valid, redeem it again and
+  replace the cached token; otherwise ask the human for a new connection.
+- `TOKEN_EXPIRED`: request a newly authorized session from the human.
 - `TOKEN_SCOPE_INSUFFICIENT`: do not retry the same operation; request broader
   scope from the human.
 - `SESSION_PAUSED`: wait for `session.ready`; the human paused the session.

--- a/docs/specs/web-agent-session.md
+++ b/docs/specs/web-agent-session.md
@@ -340,10 +340,10 @@ advances the revision again.
 
 | Threat                             | Handling                                                                                                                                                     |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Claim link leaks                   | Single-use, ≤5 min expiry, explicit scopes, visible connected state, immediate revoke, no query-string analytics                                             |
+| Claim link leaks                   | 30-minute expiry, one live bearer per session, explicit scopes, visible connected state, immediate revoke, no query-string analytics                         |
 | Relay observes payloads in transit | HTTPS required; relay persists no payload and logs no body; end-to-end encryption deferred unless threat review requires it                                  |
 | Replay/retry after timeout         | Per-session `requestId` dedupe at relay and browser; exactly-once visible effect; never blind-retry an unknown write                                         |
-| `agentToken` theft                 | Short TTL, scoped, revocable, never stored in recovery/localStorage by default                                                                               |
+| `agentToken` theft                 | Bounded lifetime, scoped, revocable, never stored in recovery/localStorage by default                                                                        |
 | Browser refresh                    | Same-tab reconnect may reuse only the bounded recovery proof when the Project binding still matches; otherwise it is cleared and reauthorization is required |
 | Transient WebSocket loss           | Same-tab bounded reconnect replaces only transport; no request is replayed and Project authorization is unchanged                                            |
 | Stale-revision blind replay        | `STALE_REVISION` carries current revision; Agent refreshes Snapshot and re-evaluates                                                                         |

--- a/docs/specs/web-agent-session.md
+++ b/docs/specs/web-agent-session.md
@@ -40,26 +40,28 @@ messages and persists no Project.
 | ---------------- | -------------------------------------------------------------------- |
 | Relay            | Worker + AgentSession Durable Object; forwards, never executes edits |
 | Editor host      | In-browser `EditorDocumentController` + `DocumentHistory`; authority |
-| Capability token | Scoped, expiring bearer (`agentToken`) issued after a one-time claim |
-| Claim            | One-time short-expiry code/link the user gives to the Agent          |
+| Capability token | Scoped, expiring bearer (`agentToken`) issued after a user claim     |
+| Claim            | Short-expiry code/link the user gives to the Agent                   |
 | Document set     | The authorized Documents a session may target                        |
 
 ## Actors and secrets
 
 The first release uses scoped capability tokens, not product accounts.
 
-| Secret         | Held by            | Lifetime / use                                                                                              |
-| -------------- | ------------------ | ----------------------------------------------------------------------------------------------------------- |
-| `sessionId`    | public             | Opaque session id; **not** authorization                                                                    |
-| `editorSecret` | browser tab only   | Authenticates the browser's WebSocket command channel; may survive one same-tab refresh in `sessionStorage` |
-| `claimCode`    | user → Agent, once | Single-use, expires in at most five minutes                                                                 |
-| `agentToken`   | Agent host only    | Bearer, scoped, default one hour, never outlives the editor session                                         |
+| Secret         | Held by          | Lifetime / use                                                                                              |
+| -------------- | ---------------- | ----------------------------------------------------------------------------------------------------------- |
+| `sessionId`    | public           | Opaque session id; **not** authorization                                                                    |
+| `editorSecret` | browser tab only | Authenticates the browser's WebSocket command channel; may survive one same-tab refresh in `sessionStorage` |
+| `claimCode`    | user → Agent     | Expires in 30 minutes; a valid retry replaces the previous bearer                                           |
+| `agentToken`   | Agent host only  | Bearer, scoped, default eight hours, never outlives the editor session                                      |
 
-Claim codes are single-use and expire after at most five minutes. Agent tokens
-default to one hour, never outlive their editor session, and are invalidated by
-pause, revoke, Project replacement, a normal tab close, session expiry, or
-service-side abuse controls. An abrupt browser loss makes the editor offline;
-the session's fixed lifetime remains the terminal cleanup boundary.
+Claim codes expire after 30 minutes. Repeating a valid claim mints a replacement
+token and immediately invalidates the prior bearer; the relay retains one token
+verifier, so retries cannot create parallel access. Agent tokens and editor
+sessions default to eight hours. They are invalidated by pause, revoke, Project
+replacement, normal tab close, session expiry, or service-side abuse controls.
+An abrupt browser loss makes the editor offline; the session's fixed lifetime
+remains the terminal cleanup boundary.
 
 Secrets are never placed in analytics, URL query parameters, logs, Project
 recovery data, Snapshot data, render artifacts, or `Cache-Control`-able
@@ -195,9 +197,10 @@ interface AgentSessionMessage {
   unknown.
 - The browser may replace a failed WebSocket transport for the same live
   session and Project using the existing in-memory `editorSecret`. Reconnection
-  uses bounded exponential backoff followed by an explicit manual action. It
-  never replays a Circuit request; `requestId` cache semantics remain the only
-  resolution mechanism for an uncertain write.
+  retries at 0.5, 1, 2, 4, 8, 15, and 30 seconds, then every 30 seconds until
+  the session ends or the user disconnects. It never replays a Circuit request;
+  `requestId` cache semantics remain the only resolution mechanism for an
+  uncertain write.
 
 ## Events
 
@@ -291,7 +294,6 @@ usable and the Agent must not retry without re-authorization.
 | `PROJECT_REPLACED`         | Project was replaced; see `document.replaced` | Terminal; authorize the new Project |
 | `CLAIM_INVALID`            | Claim code unknown/malformed                  | Obtain a new claim                  |
 | `CLAIM_EXPIRED`            | Claim code past its short expiry              | Obtain a new claim                  |
-| `CLAIM_ALREADY_USED`       | Claim code consumed (single-use)              | Obtain a new claim                  |
 | `TOKEN_INVALID`            | Bearer missing/malformed                      | Terminal; re-claim                  |
 | `TOKEN_EXPIRED`            | `agentToken` past its expiry                  | Ask for a newly authorized session  |
 | `TOKEN_SCOPE_INSUFFICIENT` | Operation outside granted scopes              | Do not retry; request broader scope |
@@ -355,7 +357,7 @@ advances the revision again.
 ## Valid example
 
 A browser opens a Project and grants `circuit.snapshot`, `circuit.render`, and
-`circuit.edit.geometry` for one hour. The Agent exchanges the one-time claim for
+`circuit.edit.geometry` for eight hours. The Agent exchanges the claim for
 an `agentToken`, reads `capabilities` and a Snapshot at revision 42, dry-runs a
 move, then commits it with `expectedRevision: 42`. The relay forwards the typed
 `transact` to the browser host over the authenticated WebSocket; the host
@@ -397,7 +399,7 @@ refreshes the Snapshot and does not replay the old edit.
 ## Deterministic validation
 
 - claim/token/scope/expiry/revoke state-machine tests with fake time (WP-WA4);
-- one-time claim, single-use enforcement, and constant-time secret comparison;
+- claim replacement invalidates the prior token, and constant-time secret comparison;
 - `requestId` dedupe at relay and browser, including timeout and late response;
 - `STALE_REVISION`, `EDITOR_OFFLINE`, and `PROJECT_REPLACED` behavior;
 - redacted logs/analytics/recovery assertions for secrets and circuit payloads;
@@ -438,7 +440,7 @@ candidate or artifact bytes (`Cache-Control: no-store` continues to apply).
 Replacement requires an explicit browser decision: **Cancel** (delete the
 candidate, notify the Agent), **Open and disconnect** (replace Project, revoke
 the old session), or **Open and reconnect Agent** (replace Project, revoke the
-old session, issue a new one-time claim with user-confirmed scopes and Document
+old session, issue a new claim with user-confirmed scopes and Document
 set). The third action is explicit new authorization, not token transfer; the
 old bearer token never gains access to the replacement Project. Before
 replacement the editor cancels pending recovery for the outgoing Project,

--- a/fixtures/agent-api/agent-circuit.openapi.json
+++ b/fixtures/agent-api/agent-circuit.openapi.json
@@ -8,7 +8,7 @@
     "/api/agent/claims": {
       "post": {
         "operationId": "agentClaimRedeem",
-        "description": "Exchange a one-time, short-lived claim code for a scoped, expiring bearer token. Single-use.",
+        "description": "Exchange a short-lived claim code for a scoped, expiring bearer token. Repeating a valid claim replaces the prior token.",
         "requestBody": {
           "required": true,
           "content": {
@@ -17,7 +17,7 @@
                 "$ref": "#/components/schemas/agentClaimRequest"
               },
               "example": {
-                "claimCode": "session-id.one-time-claim"
+                "claimCode": "session-id.claim-code"
               }
             }
           }
@@ -617,7 +617,6 @@
                   "PROJECT_REPLACED",
                   "CLAIM_INVALID",
                   "CLAIM_EXPIRED",
-                  "CLAIM_ALREADY_USED",
                   "TOKEN_INVALID",
                   "TOKEN_EXPIRED",
                   "TOKEN_SCOPE_INSUFFICIENT",

--- a/fixtures/agent-api/agent-circuit.openapi.json
+++ b/fixtures/agent-api/agent-circuit.openapi.json
@@ -617,6 +617,7 @@
                   "PROJECT_REPLACED",
                   "CLAIM_INVALID",
                   "CLAIM_EXPIRED",
+                  "CLAIM_ALREADY_USED",
                   "TOKEN_INVALID",
                   "TOKEN_EXPIRED",
                   "TOKEN_SCOPE_INSUFFICIENT",

--- a/packages/agent-adapter/src/envelope.ts
+++ b/packages/agent-adapter/src/envelope.ts
@@ -138,6 +138,7 @@ export const AgentTransportErrorCodeSchema = z.enum([
   // Claim exchange
   "CLAIM_INVALID",
   "CLAIM_EXPIRED",
+  "CLAIM_ALREADY_USED",
   // Token
   "TOKEN_INVALID",
   "TOKEN_EXPIRED",

--- a/packages/agent-adapter/src/envelope.ts
+++ b/packages/agent-adapter/src/envelope.ts
@@ -138,7 +138,6 @@ export const AgentTransportErrorCodeSchema = z.enum([
   // Claim exchange
   "CLAIM_INVALID",
   "CLAIM_EXPIRED",
-  "CLAIM_ALREADY_USED",
   // Token
   "TOKEN_INVALID",
   "TOKEN_EXPIRED",
@@ -194,6 +193,13 @@ export const AgentSessionScopeSchema = z.enum([
   "project.import",
   "visual.download",
 ]);
+
+/** Single runtime scope guard for browser recovery and relay consumers. */
+export function isAgentSessionScope(
+  value: unknown,
+): value is AgentSessionScope {
+  return AgentSessionScopeSchema.safeParse(value).success;
+}
 
 export type AgentSessionMessage = z.infer<typeof AgentSessionMessageSchema>;
 export type AgentClaimRequest = z.infer<typeof AgentClaimRequestSchema>;

--- a/packages/agent-adapter/src/openapi.ts
+++ b/packages/agent-adapter/src/openapi.ts
@@ -139,7 +139,7 @@ export const agentCircuitRequestExamples = {
 } as const;
 
 export const agentClaimRequestExample = {
-  claimCode: "session-id.one-time-claim",
+  claimCode: "session-id.claim-code",
 } as const;
 
 export const agentTransportErrorExamples = {
@@ -294,7 +294,7 @@ export const agentCircuitOpenApi = {
       post: {
         operationId: "agentClaimRedeem",
         description:
-          "Exchange a one-time, short-lived claim code for a scoped, expiring bearer token. Single-use.",
+          "Exchange a short-lived claim code for a scoped, expiring bearer token. Repeating a valid claim replaces the prior token.",
         requestBody: {
           required: true,
           content: {

--- a/packages/agent-adapter/src/session-state.test.ts
+++ b/packages/agent-adapter/src/session-state.test.ts
@@ -45,10 +45,12 @@ function setup(overrides: Partial<AgentSessionLimits> = {}) {
 
 describe("AgentSessionMachine", () => {
   it("creates a session, returns secrets once, and authenticates the editor", () => {
-    const { machine, session } = setup();
+    const { machine, session, now } = setup();
     expect(session.sessionId).toMatch(/^rand-/u);
     expect(session.editorSecret).toMatch(/^rand-/u);
     expect(session.claimCode).toMatch(/^rand-/u);
+    expect(session.claimExpiresAt - now()).toBe(30 * 60 * 1_000);
+    expect(session.expiresAt - now()).toBe(8 * 60 * 60 * 1_000);
     expect(machine.authorizeEditor(session.editorSecret)).toBe(true);
     expect(machine.authorizeEditor("wrong")).toBe(false);
   });

--- a/packages/agent-adapter/src/session-state.test.ts
+++ b/packages/agent-adapter/src/session-state.test.ts
@@ -53,7 +53,7 @@ describe("AgentSessionMachine", () => {
     expect(machine.authorizeEditor("wrong")).toBe(false);
   });
 
-  it("redeems a one-time claim for a scoped token and rejects reuse", () => {
+  it("reissues a token for a valid claim and invalidates the earlier bearer", () => {
     const { machine, session, now } = setup();
     expect(machine.claimed).toBe(false);
     const first = machine.redeemClaim(session.claimCode, now());
@@ -65,9 +65,14 @@ describe("AgentSessionMachine", () => {
     const auth = machine.authorize(first.claim.agentToken, now());
     expect(auth.ok).toBe(true);
 
-    const reuse = machine.redeemClaim(session.claimCode, now());
-    expect(reuse.ok).toBe(false);
-    if (!reuse.ok) expect(reuse.code).toBe("CLAIM_ALREADY_USED");
+    const retry = machine.redeemClaim(session.claimCode, now());
+    expect(retry.ok).toBe(true);
+    if (!retry.ok) return;
+    expect(retry.claim.agentToken).not.toBe(first.claim.agentToken);
+    const priorToken = machine.authorize(first.claim.agentToken, now());
+    expect(priorToken.ok).toBe(false);
+    if (!priorToken.ok) expect(priorToken.code).toBe("TOKEN_INVALID");
+    expect(machine.authorize(retry.claim.agentToken, now()).ok).toBe(true);
   });
 
   it("records one-shot artifacts without retaining or replaying their bytes", () => {

--- a/packages/agent-adapter/src/session-state.ts
+++ b/packages/agent-adapter/src/session-state.ts
@@ -36,9 +36,9 @@ export interface AgentSessionLimits {
 }
 
 export const DEFAULT_AGENT_SESSION_LIMITS: AgentSessionLimits = {
-  claimTtlMs: 5 * 60 * 1000,
-  tokenTtlMs: 60 * 60 * 1000,
-  sessionTtlMs: 60 * 60 * 1000,
+  claimTtlMs: 30 * 60 * 1000,
+  tokenTtlMs: 8 * 60 * 60 * 1000,
+  sessionTtlMs: 8 * 60 * 60 * 1000,
   maxRequestBytes: 2_000_000,
   maxMessageBytes: 6_000_000,
   rateLimit: { windowMs: 60_000, maxRequests: 60 },
@@ -81,6 +81,7 @@ export type RequestBeginResult =
 interface ClaimRecord {
   codeVerifier: string;
   expiresAt: number;
+  /** Retained only to distinguish an unclaimed session in persisted state. */
   used: boolean;
 }
 
@@ -252,7 +253,7 @@ export class AgentSessionMachine {
     return this.internals.expiresAt;
   }
 
-  /** Whether the one-time claim has produced a live Agent capability. */
+  /** Whether this session currently has a live Agent capability. */
   get claimed(): boolean {
     return this.internals.claim?.used === true && this.internals.token !== null;
   }
@@ -330,7 +331,10 @@ export class AgentSessionMachine {
     );
   }
 
-  /** Exchange a one-time claim code for a scoped capability token. */
+  /**
+   * Exchange a valid hand-off claim for a scoped capability token. A retry
+   * replaces the previous token because the session retains one verifier.
+   */
   redeemClaim(
     code: string,
     now: number,
@@ -346,7 +350,6 @@ export class AgentSessionMachine {
     ) {
       return { ok: false, code: "CLAIM_INVALID" };
     }
-    if (claim.used) return { ok: false, code: "CLAIM_ALREADY_USED" };
     if (now >= claim.expiresAt) return { ok: false, code: "CLAIM_EXPIRED" };
 
     claim.used = true;

--- a/plan/2026-08-14-agent-connection-ux/plan.md
+++ b/plan/2026-08-14-agent-connection-ux/plan.md
@@ -1,0 +1,92 @@
+---
+status: completed
+experience: none
+---
+
+# Agent Connection Reliability and Lightweight UX
+
+## Goal
+
+Make browser Agent connection creation, claim recovery, refresh recovery,
+transport reconnect, and replacement intuitive and durable without expanding
+circuit-editing capability or introducing a second state machine. Move the
+always-relevant Agent state into the existing Properties dock and reduce the
+Connect Agent dialog to authorization and hand-off.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/agent-connection-ux...origin/main
+```
+
+The worktree is clean and this branch begins at current `origin/main`
+(`dd5dfde`). This target owns the Agent session lifecycle and its UI only; it
+does not change circuit transactions, file-resource semantics, Project model,
+or human/Agent visual feedback.
+
+- `packages/agent-adapter/src/session-state.ts`
+- `packages/agent-adapter/src/envelope.ts`
+- `worker/agent-session.ts`
+- `apps/editor/src/agent/use-agent-session.ts`
+- `apps/editor/src/agent/session-recovery.ts`
+- `apps/editor/src/agent/connect-agent-panel.tsx`
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/styles.css`
+- focused Agent session, component, and browser tests
+- current Agent API/session documentation and generated artifacts only if the
+  public contract changes
+
+Read-only/shared dependencies:
+
+- `packages/edit-engine`, `apps/editor/src/document`, and existing Agent file
+  resource/semantic-control hosts
+- `docs/specs/agent-api.md`, `docs/specs/web-agent-session.md`, and ADR 0018
+- generated OpenAPI/schema artifacts
+
+## Work
+
+1. Make claim/session expiry and reconnect behavior reliable: longer bounded
+   lifetimes, repeatable claim redemption which replaces the previous token,
+   common scope validation for same-Project recovery, and low-frequency retry
+   after the initial reconnect burst.
+2. Keep state simple but distinguish the facts the UI needs: claim expiry,
+   session expiry, transport availability, last chosen scope, and a terminal
+   reason sufficient to provide the correct action.
+3. Replace technical authorization chrome with human-readable presets,
+   separate claim/session time remaining, copy success feedback, and clear
+   Hide/Retry relay/New connection/Disconnect wording.
+4. Add a compact Agent section to the existing Properties dock. It must be
+   visible while connected or recoverable but not implement change highlighting,
+   timeline, inspect, or undo affordances.
+5. Add only focused session/component/browser coverage and run the final branch
+   gate once after all changes.
+
+## Validation
+
+- focused session-state, session recovery, panel, and web-Agent Playwright tests
+- generated Agent API artifact validation if schema/OpenAPI changes
+- `git diff --check`
+- `git status --short --branch`
+- one final `pnpm verify:branch`; run `pnpm ci:check` only once immediately
+  before mainline delivery, per repository policy
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(agent): simplify resilient browser connection lifecycle
+```
+
+## Outcome
+
+Implemented the one-token replacement claim contract, 30-minute Claim and
+eight-hour Session defaults, shared scope validation for same-Project recovery,
+and persistent 30-second relay retry after the short backoff sequence. The
+authorization dialog is now a human-readable hand-off surface; active session
+controls live in the Properties dock. No circuit-edit, file-resource, Agent
+timeline, highlight, Inspect, or undo capability was added. Focused session,
+recovery, panel, and browser tests passed; final `pnpm verify:branch` and Agent
+API artifact validation passed.

--- a/plan/2026-08-14-agent-connection-ux/plan.md
+++ b/plan/2026-08-14-agent-connection-ux/plan.md
@@ -87,6 +87,7 @@ eight-hour Session defaults, shared scope validation for same-Project recovery,
 and persistent 30-second relay retry after the short backoff sequence. The
 authorization dialog is now a human-readable hand-off surface; active session
 controls live in the Properties dock. No circuit-edit, file-resource, Agent
-timeline, highlight, Inspect, or undo capability was added. Focused session,
-recovery, panel, and browser tests passed; final `pnpm verify:branch` and Agent
-API artifact validation passed.
+timeline, highlight, Inspect, or undo capability was added. Final review kept
+the published error enum compatible, retained the valid claim hand-off after
+first redemption, removed unused audit state, and restored shared approval
+dialog styles. Focused checks and the required final `pnpm ci:check` passed.

--- a/plan/log.md
+++ b/plan/log.md
@@ -6569,3 +6569,19 @@ contracts (WP-R1)`.
   and the imported-child search E2E passed locally.
 - Commit status: committed on `codex/restore-port-symbols`; remote CI repair
   adds an explicit schema-v3 child-document-id reader migration.
+
+## 2026-08-14 - Simplify resilient browser Agent connection lifecycle
+
+- Target: make browser Agent authorization, claim retry, same-Project refresh
+  recovery, relay reconnect, and status management reliable without expanding
+  circuit-editing capability or adding a second collaboration UI.
+- Changed areas: session/claim defaults and replacement semantics; shared scope
+  guard for recovery; browser relay retry; compact Properties Agent section;
+  authorization hand-off wording and generated public OpenAPI artifact; focused
+  session, recovery, UI, and browser coverage.
+- Validation: focused session/recovery/panel suites (50 tests), the web-Agent
+  browser E2E, Agent artifact validation, and `pnpm verify:branch` (120 files,
+  729 tests, all workspace builds and production smoke) passed; `git diff
+  --check` passed.
+- Commit status: ready to commit on `codex/agent-connection-ux` as
+  `feat(agent): simplify resilient browser connection lifecycle`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -6580,8 +6580,9 @@ contracts (WP-R1)`.
   authorization hand-off wording and generated public OpenAPI artifact; focused
   session, recovery, UI, and browser coverage.
 - Validation: focused session/recovery/panel suites (50 tests), the web-Agent
-  browser E2E, Agent artifact validation, and `pnpm verify:branch` (120 files,
-  729 tests, all workspace builds and production smoke) passed; `git diff
-  --check` passed.
+  browser E2E, Agent artifact validation, `pnpm verify:branch`, and the final
+  `pnpm ci:check` (729 unit tests, 100 browser tests, builds, performance,
+  export/PWA goldens, production and release smoke) passed; `git diff --check`
+  passed.
 - Commit status: ready to commit on `codex/agent-connection-ux` as
   `feat(agent): simplify resilient browser connection lifecycle`.

--- a/worker/agent-session.test.ts
+++ b/worker/agent-session.test.ts
@@ -61,7 +61,7 @@ function tokenFor(
 // WebSocket browser channel is the deployment-verified transport.
 
 describe("agent-session relay", () => {
-  it("redeems a claim and rejects reuse with typed errors", () => {
+  it("redeems a valid claim again by replacing the prior bearer", () => {
     const { machine, session, now } = setup();
     const first = redeemClaimResponse(machine, session.claimCode, now());
     expect(first).toMatchObject({
@@ -70,9 +70,12 @@ describe("agent-session relay", () => {
       documentIds: ["document-1"],
     });
 
-    const reuse = redeemClaimResponse(machine, session.claimCode, now());
-    expect(reuse.ok).toBe(false);
-    if (!reuse.ok) expect(reuse.error.code).toBe("CLAIM_ALREADY_USED");
+    const retry = redeemClaimResponse(machine, session.claimCode, now());
+    expect(retry).toMatchObject({ ok: true, projectId: "project-1" });
+    if (!first.ok || !retry.ok) return;
+    expect(retry.agentToken).not.toBe(first.agentToken);
+    expect(machine.authorize(first.agentToken, now()).ok).toBe(false);
+    expect(machine.authorize(retry.agentToken, now()).ok).toBe(true);
   });
 
   it("forwards an authorized request and caches its result", async () => {

--- a/worker/agent-session.ts
+++ b/worker/agent-session.ts
@@ -332,6 +332,7 @@ function errorMessage(code: AgentTransportErrorCode): string {
     PROJECT_REPLACED: "The browser opened a different Project",
     CLAIM_INVALID: "Claim code is unknown or malformed",
     CLAIM_EXPIRED: "Claim code has expired",
+    CLAIM_ALREADY_USED: "Claim code was already used by a legacy session",
     TOKEN_INVALID: "Bearer token is missing or unknown",
     TOKEN_EXPIRED: "Bearer token has expired",
     TOKEN_SCOPE_INSUFFICIENT: "The token does not grant this operation",

--- a/worker/agent-session.ts
+++ b/worker/agent-session.ts
@@ -332,7 +332,6 @@ function errorMessage(code: AgentTransportErrorCode): string {
     PROJECT_REPLACED: "The browser opened a different Project",
     CLAIM_INVALID: "Claim code is unknown or malformed",
     CLAIM_EXPIRED: "Claim code has expired",
-    CLAIM_ALREADY_USED: "Claim code has already been used",
     TOKEN_INVALID: "Bearer token is missing or unknown",
     TOKEN_EXPIRED: "Bearer token has expired",
     TOKEN_SCOPE_INSUFFICIENT: "The token does not grant this operation",


### PR DESCRIPTION
## What changed
- Makes a valid claim redeemable again during its 30-minute lifetime; the relay retains only the newest bearer, so a retry invalidates the prior token.
- Extends session and token defaults to eight hours, fixes same-Project recovery scope validation, and continues relay reconnect at a low 30-second cadence after the initial backoff.
- Reduces Connect Agent to authorization/hand-off and moves active Agent state and controls into the existing Properties dock.

## Why
Claim expiry and an outdated recovery scope allowlist caused frequent connection and refresh failures. The previous modal also made closing details feel like disconnecting.

## User impact
Users can hide connection details without ending a session, see connection state in Properties, retry a relay, create a new connection, or disconnect with clearer wording. The public OpenAPI and instructions now describe token replacement accurately.

## Validation
- Focused session, recovery, and panel tests (50 tests)
- pps/editor/e2e/web-agent-session.spec.ts
- pnpm agent-api:artifacts:check
- pnpm verify:branch (729 tests, full build, production smoke)
