### PR TITLE
refactor(editor): unify transient interaction state

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -126,6 +126,54 @@ test("inserts from the master-detail dialog with keyboard and live placement pre
   );
 });
 
+test("offers VDD rail in I with preview-only symbol artwork", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.keyboard.press("i");
+  const dialog = page.getByRole("dialog", { name: "Insert Component" });
+  await dialog.getByLabel("Component search").fill("vdd");
+  await dialog.getByTestId("insert-component-vdd").click();
+  await expect(dialog.locator("svg.insert-symbol-artwork")).toBeVisible();
+  await expect(dialog.getByLabel("Placement options")).toHaveCount(0);
+  await dialog.getByRole("button", { name: "Apply" }).click();
+
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.hover({ position: { x: 260, y: 140 } });
+  await expect(page.getByTestId("component-placement-preview")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("component-input-plane")).toHaveCount(0);
+  await expect(page.getByTestId("instance-count")).toHaveText("0");
+});
+
+test("reopens I and starts Copy from retained selection without stacking modes", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await chooseComponent(page, "resistor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.click({ position: { x: 360, y: 230 } });
+  await page.keyboard.press("Escape");
+  await page.getByTestId("hit-R1").click();
+
+  await page.keyboard.press("i");
+  await expect(
+    page.getByRole("dialog", { name: "Insert Component" }),
+  ).toBeVisible();
+  await page.keyboard.press("Escape");
+  await page.keyboard.press("c");
+  await page.keyboard.press("c");
+  await canvas.hover({ position: { x: 560, y: 330 } });
+  await expect(page.getByTestId("copy-placement-preview")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("copy-placement-preview")).toHaveCount(0);
+
+  await page.keyboard.press("i");
+  await expect(
+    page.getByRole("dialog", { name: "Insert Component" }),
+  ).toBeVisible();
+});
+
 test("carries a manual Value through placement and Q property editing", async ({
   page,
 }) => {

--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -225,6 +225,31 @@ test("switching creation tools discards the incompatible draft session", async (
   await expect(page.getByTestId("active-tool")).toHaveText("pointer");
 });
 
+test("repeating A or K preserves the current drafting session", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const canvas = page.getByTestId("schematic-canvas");
+
+  await page.keyboard.press("a");
+  await canvas.click({ position: { x: 220, y: 220 } });
+  await canvas.hover({ position: { x: 420, y: 260 } });
+  await expect(page.getByTestId("drafting-create-preview")).toBeVisible();
+  await page.keyboard.press("a");
+  await expect(page.getByTestId("drafting-create-preview")).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  await page.keyboard.press("k");
+  await canvas.click({ position: { x: 220, y: 300 } });
+  await canvas.hover({ position: { x: 420, y: 340 } });
+  await expect(page.getByTestId("drafting-create-preview")).toBeVisible();
+  await page.keyboard.press("k");
+  await expect(page.getByTestId("drafting-create-preview")).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  await expect(page.getByTestId("revision")).toHaveText("0");
+});
+
 // Moving an existing drafting object commits exactly one transaction, so one
 // Ctrl+Z restores its original persisted anchor.
 test("existing text drag commits once and undoes atomically", async ({

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -237,9 +237,11 @@ test("shows faithful symbol previews for the reviewed Razavi palette", async ({
 
 test("constructs VDD as a drawn dotless power rail", async ({ page }) => {
   await page.goto("/");
-  await page.getByTestId("shapes-tool-vdd-rail").click();
+  await page.getByTestId("shapes-chip-vdd").click();
   const canvas = page.getByTestId("schematic-canvas");
 
+  await canvas.hover({ position: { x: 180, y: 120 } });
+  await expect(page.getByTestId("component-placement-preview")).toBeVisible();
   await canvas.click({ position: { x: 180, y: 120 } });
   await canvas.hover({ position: { x: 520, y: 120 } });
   const preview = page.getByTestId("vdd-rail-preview");
@@ -261,6 +263,11 @@ test("constructs VDD as a drawn dotless power rail", async ({ page }) => {
   await expect(page.getByTestId("hit-VDD1")).toHaveCount(0);
   await expect(canvas.locator('[data-symbol-id="vdd"]')).toHaveCount(0);
   await expect(canvas.getByText("VDD", { exact: true })).toHaveCount(1);
+  await expect(page.getByTestId("component-input-plane")).toHaveCount(0);
+
+  await page.keyboard.press("Delete");
+  await expect(page.getByTestId("route-hit-route-vdd1-rail")).toHaveCount(0);
+  await expect(canvas.getByText("VDD", { exact: true })).toHaveCount(0);
 });
 
 test("reuses the PMOS bulk supply Net when drawing a VDD rail", async ({
@@ -268,7 +275,7 @@ test("reuses the PMOS bulk supply Net when drawing a VDD rail", async ({
 }) => {
   await page.goto("/");
   await placeComponent(page, "pmos", { x: 360, y: 260 });
-  await page.getByTestId("shapes-tool-vdd-rail").click();
+  await page.getByTestId("shapes-chip-vdd").click();
   const canvas = page.getByTestId("schematic-canvas");
   await canvas.click({ position: { x: 240, y: 100 } });
   await canvas.click({ position: { x: 520, y: 100 } });
@@ -300,6 +307,32 @@ test("reuses the PMOS bulk supply Net when drawing a VDD rail", async ({
       presentation: "power-rail",
     }),
   );
+});
+
+test("cancels VDD rail placement before or after its first endpoint", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const canvas = page.getByTestId("schematic-canvas");
+
+  await page.getByTestId("shapes-chip-vdd").click();
+  await canvas.hover({ position: { x: 180, y: 120 } });
+  await expect(page.getByTestId("component-placement-preview")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("component-input-plane")).toHaveCount(0);
+
+  await page.getByTestId("shapes-chip-vdd").click();
+  await canvas.click({ position: { x: 180, y: 120 } });
+  await canvas.hover({ position: { x: 520, y: 120 } });
+  await expect(page.getByTestId("vdd-rail-preview")).toHaveAttribute(
+    "stroke-width",
+    "3.24",
+  );
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("vdd-rail-preview")).toHaveCount(0);
+  await expect(
+    page.locator('[data-route-presentation="power-rail"]'),
+  ).toHaveCount(0);
 });
 
 test("treats hollow and filled Ports as ordinary wired components", async ({
@@ -1442,6 +1475,8 @@ test("C previews one copy and Escape cancels without a revision", async ({
   if (!box) throw new Error("Canvas is not measurable");
   await page.keyboard.press("c");
   await page.mouse.move(box.x + 560, box.y + 340);
+  await expect(page.getByTestId("copy-placement-preview")).toBeVisible();
+  await page.keyboard.press("c");
   await expect(page.getByTestId("copy-placement-preview")).toBeVisible();
   await page.keyboard.press("Escape");
 

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -240,11 +240,6 @@ interface PanPreview {
   pointerId: number;
 }
 
-interface CopyPlacement {
-  clipboard: SchematicClipboard;
-  anchor: Point;
-}
-
 interface RouteStretchPreview {
   routeId: string;
   segmentIndex: number;
@@ -465,13 +460,6 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     }
   });
   const [selectionOpen, setSelectionOpen] = useState(false);
-  const [componentPreviewPoint, setComponentPreviewPoint] =
-    useState<Point | null>(null);
-  const [componentPlacementRotation, setComponentPlacementRotation] = useState<
-    0 | 90 | 180 | 270
-  >(0);
-  const [vddRailStart, setVddRailStart] = useState<Point | null>(null);
-  const [vddRailMode, setVddRailMode] = useState(false);
   const [recentSymbolIds, setRecentSymbolIds] = useState<string[]>(() => {
     if (typeof window === "undefined") return [];
     try {
@@ -594,8 +582,21 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     draftingHover,
     draftingWaypoints,
     draftingSnapPoint,
+    componentPlacementRotation,
+    componentPreviewPoint,
+    vddRailMode,
+    vddRailStart,
+    copyPlacement,
     setTool,
     beginComponentPlacement,
+    setComponentPreviewPoint,
+    rotateComponentPlacement,
+    beginVddRailPlacement: beginVddRailInteraction,
+    setVddRailStart,
+    setVddRailPreviewPoint,
+    completeVddRailPlacement,
+    beginCopyPlacement: beginCopyPlacementInteraction,
+    setCopyPreviewPoint,
     setWireSource,
     setWirePreviewPoint,
     setWireWaypoints,
@@ -606,7 +607,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     setDraftingSnapPoint,
     clearDraftingCreate,
     cancelInteraction,
-  } = useInteractionState();
+  } = useInteractionState<SchematicClipboard>();
   const [draftingInspectorSegment, setDraftingInspectorSegment] = useState<{
     objectId: string;
     index: number;
@@ -658,10 +659,6 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   const canvasDragSessionRef = useRef<CanvasDragSession | null>(null);
   const instanceCounter = useRef(0);
   const copyCounter = useRef(0);
-  const [copyPlacement, setCopyPlacement] = useState<CopyPlacement | null>(
-    null,
-  );
-  const [copyPreviewPoint, setCopyPreviewPoint] = useState<Point | null>(null);
   const suppressInstanceClick = useRef(false);
   const projectInputRef = useRef<HTMLInputElement>(null);
   const selectionShelfRef = useRef<HTMLButtonElement>(null);
@@ -701,17 +698,17 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     [renderedDocument, resolver, viewBox],
   );
   const copyPreviewScene = useMemo(() => {
-    if (!copyPlacement || !copyPreviewPoint) return null;
+    if (!copyPlacement || !copyPlacement.previewPoint) return null;
     const offset = {
-      x: copyPreviewPoint.x - copyPlacement.anchor.x,
-      y: copyPreviewPoint.y - copyPlacement.anchor.y,
+      x: copyPlacement.previewPoint.x - copyPlacement.anchor.x,
+      y: copyPlacement.previewPoint.y - copyPlacement.anchor.y,
     };
     return buildSvgScene(
       clipboardPreviewDocument(document, copyPlacement.clipboard, offset),
       resolver,
       { bounds: viewBox },
     );
-  }, [copyPlacement, copyPreviewPoint, document, resolver, viewBox]);
+  }, [copyPlacement, document, resolver, viewBox]);
   const unplaced = document.instances.filter(
     (instance) => instance.placement === null,
   );
@@ -1230,13 +1227,20 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   }
 
   function resetInteractionState(): void {
-    clearTransientCanvasState();
+    cancelAllTransientInteraction();
     resetSelection();
     setSelectedRouteSegmentIndex(null);
     setTextEditing(null);
     setSelectedEndpoint(null);
+  }
+
+  function cancelAllTransientInteraction(): void {
+    canvasDragSessionRef.current?.cancel();
+    clearTransientCanvasState();
+    paintSnapGuides([]);
     cancelInteraction();
     setBulkDrawInstanceId(null);
+    setBoxPreview(null);
   }
 
   function selectEndpoint(candidate: WireSource): void {
@@ -1291,12 +1295,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     }
     setDocumentStack([...hierarchyPath]);
     setViewBox(documentViewBoxes.current.get(opened.id) ?? DEFAULT_VIEWBOX);
-    clearTransientCanvasState();
-    resetSelection();
-    setSelectedRouteSegmentIndex(null);
-    setTextEditing(null);
-    setSelectedEndpoint(null);
-    cancelInteraction();
+    resetInteractionState();
 
     const focusPoint = (point: Point) =>
       setViewBox({
@@ -1733,16 +1732,27 @@ export function App({ project: initialProject, visitStats }: AppProps) {
 
   function transact(
     edits: SchematicEdit[],
-    options: { completesWireSession?: boolean } = {},
+    options: {
+      completesWireSession?: boolean;
+      preserveInteraction?: boolean;
+    } = {},
   ): EditTransactionResult {
     const result = transactDocument(edits);
     applyResult(result);
-    if (result.ok && wireSource && !options.completesWireSession) {
-      clearTransientCanvasState();
-      cancelInteraction();
-      setBulkDrawInstanceId(null);
+    const preservesCurrentInteraction =
+      options.preserveInteraction ||
+      (interactionState.kind === "wire" && options.completesWireSession);
+    if (
+      result.ok &&
+      interactionState.kind !== "idle" &&
+      !preservesCurrentInteraction
+    ) {
+      const cancelledKind = interactionState.kind;
+      cancelAllTransientInteraction();
       setStatus(
-        `Committed revision ${result.revision}; Wire cancelled because the circuit changed`,
+        cancelledKind === "wire"
+          ? `Committed revision ${result.revision}; Wire cancelled because the circuit changed`
+          : `Committed revision ${result.revision}; active tool cancelled because the circuit changed`,
       );
     }
     return result;
@@ -1785,13 +1795,19 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   }
 
   function activateTool(nextTool: EditorTool): void {
+    const alreadyActive =
+      (nextTool === "wire" && interactionState.kind === "wire") ||
+      (interactionState.kind === "drawing" &&
+        interactionState.tool === nextTool) ||
+      (nextTool === "pointer" && interactionState.kind === "idle");
+    if (alreadyActive) return;
+    canvasDragSessionRef.current?.cancel();
+    clearTransientCanvasState();
     paintSnapGuides([]);
-    setVddRailMode(false);
-    setVddRailStart(null);
-    setComponentPreviewPoint(null);
     setTool(nextTool);
     if (nextTool !== "pointer") {
-      replaceSelectionKind("route", []);
+      resetSelection();
+      setSelectedEndpoint(null);
       setSelectedRouteSegmentIndex(null);
     }
     setStatus(
@@ -1808,12 +1824,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   }
 
   function openInsertComponentDialog(): void {
-    clearTransientCanvasState();
-    cancelInteraction();
-    setComponentPreviewPoint(null);
-    setComponentPlacementRotation(0);
-    setVddRailStart(null);
-    setVddRailMode(false);
+    cancelAllTransientInteraction();
     setInsertDialogOpen(true);
     setStatus("Choose a component to place");
   }
@@ -1821,7 +1832,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   function beginInsertedComponentPlacement(
     request: ComponentInsertRequest,
   ): void {
-    const { symbolId, symbolName, initialRotation } = request;
+    const { symbolId, symbolName } = request;
     const nextRecent = [
       symbolId,
       ...recentSymbolIds.filter((candidate) => candidate !== symbolId),
@@ -1837,35 +1848,26 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       // convenience-only and must never block component placement.
     }
     setInsertDialogOpen(false);
-    setComponentPlacementRotation(initialRotation);
-    setComponentPreviewPoint(null);
-    setVddRailStart(null);
-    setVddRailMode(false);
+    canvasDragSessionRef.current?.cancel();
+    clearTransientCanvasState();
+    paintSnapGuides([]);
+    if (request.kind === "vdd-rail") {
+      beginVddRailInteraction();
+      setStatus("Place VDD Rail: click the first end · Esc cancels");
+      return;
+    }
     beginComponentPlacement(request);
     setStatus(`Place ${symbolName} on the canvas · R rotates · Esc cancels`);
   }
 
   function cancelComponentInsert(): void {
     setInsertDialogOpen(false);
-    setVddRailStart(null);
-    setVddRailMode(false);
+    cancelAllTransientInteraction();
     setStatus("Component insertion cancelled");
   }
 
-  function beginVddRailPlacement(): void {
-    clearTransientCanvasState();
-    cancelInteraction();
-    setInsertDialogOpen(false);
-    setComponentPreviewPoint(null);
-    setVddRailStart(null);
-    setVddRailMode(true);
-    setStatus("VDD rail: click the first end (Esc cancels)");
-  }
-
   function rotatePendingComponent(delta: 90 | -90): void {
-    setComponentPlacementRotation(
-      (current) => ((current + delta + 360) % 360) as 0 | 90 | 180 | 270,
-    );
+    rotateComponentPlacement(delta);
     setStatus(`Component rotation ${delta > 0 ? "+90°" : "−90°"}`);
   }
 
@@ -3041,23 +3043,26 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       projectedDocument,
       projectedDocument.instances,
     );
-    const result = transact([
-      {
-        kind: "add_instance",
-        instance,
-      },
-      ...contact.edits,
-      ...standalonePower.edits,
-      ...bulkEdits,
-      ...(instanceLabel
-        ? [
-            {
-              kind: "upsert_schematic_annotation" as const,
-              annotation: instanceLabel,
-            },
-          ]
-        : []),
-    ]);
+    const result = transact(
+      [
+        {
+          kind: "add_instance",
+          instance,
+        },
+        ...contact.edits,
+        ...standalonePower.edits,
+        ...bulkEdits,
+        ...(instanceLabel
+          ? [
+              {
+                kind: "upsert_schematic_annotation" as const,
+                annotation: instanceLabel,
+              },
+            ]
+          : []),
+      ],
+      { preserveInteraction: true },
+    );
     if (result.ok) {
       selectOnly("instance", [id]);
       setComponentPreviewPoint(position);
@@ -3074,7 +3079,22 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   function placeVddRail(start: Point, end: Point): void {
     instanceCounter.current += 1;
     let instanceId = `VDD${instanceCounter.current}`;
-    while (document.instances.some((instance) => instance.id === instanceId)) {
+    const vddRailIdsExist = (candidate: string): boolean => {
+      const key = candidate.toLowerCase();
+      return (
+        document.instances.some((instance) => instance.id === candidate) ||
+        document.routes.some((route) => route.id === `route-${key}-rail`) ||
+        document.junctions.some(
+          (junction) =>
+            junction.id === `junction-${key}-start` ||
+            junction.id === `junction-${key}-end`,
+        ) ||
+        document.annotations.some(
+          (annotation) => annotation.id === `label-${candidate}`,
+        )
+      );
+    };
+    while (vddRailIdsExist(instanceId)) {
       instanceCounter.current += 1;
       instanceId = `VDD${instanceCounter.current}`;
     }
@@ -3100,18 +3120,15 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     );
     if (!result.ok) return;
     selectOnly("route", [routeId]);
-    setComponentPreviewPoint(null);
-    setVddRailStart(null);
-    setStatus(
-      `Added VDD rail ${instanceId} · click to place another · Esc exits`,
-    );
+    completeVddRailPlacement();
+    setStatus(`Added VDD rail ${instanceId}`);
   }
 
   function commitPendingPlacementAt(point: Point): void {
     if (vddRailMode) {
       if (!vddRailStart) {
         setVddRailStart(point);
-        setComponentPreviewPoint(point);
+        setVddRailPreviewPoint(point);
         setStatus("VDD rail: click the right end (Esc cancels)");
       } else if (point.x === vddRailStart.x) {
         setStatus("VDD rail needs a non-zero horizontal length");
@@ -4703,7 +4720,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       event.currentTarget,
     );
     if (vddRailMode) {
-      setComponentPreviewPoint(
+      setVddRailPreviewPoint(
         vddRailStart
           ? {
               x: snapCoordinate(point.x, document.presentation.grid),
@@ -5319,6 +5336,14 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   }
 
   function beginCopyPlacement(): void {
+    if (interactionState.kind === "copy-placement") {
+      setStatus("Copy placement is already active · Esc cancels");
+      return;
+    }
+    if (interactionState.kind !== "idle") {
+      setStatus("Finish or cancel the active tool before copying");
+      return;
+    }
     const copied = copySelection(document, selectedIds);
     if (!copied) {
       setStatus("Select at least one component to copy");
@@ -5329,9 +5354,10 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       setStatus("Selected components have no placeable origin");
       return;
     }
-    cancelInteraction();
-    setCopyPlacement({ clipboard: copied, anchor });
-    setCopyPreviewPoint(null);
+    canvasDragSessionRef.current?.cancel();
+    clearTransientCanvasState();
+    paintSnapGuides([]);
+    beginCopyPlacementInteraction(copied, anchor);
     setStatus(
       `Place copy of ${copied.instances.length} components · Esc cancels`,
     );
@@ -5349,7 +5375,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       },
       copyCounter.current,
     );
-    const result = transact(proposal.edits);
+    const result = transact(proposal.edits, { preserveInteraction: true });
     if (result.ok) {
       selectOnly("instance", proposal.instanceIds);
       setCopyPreviewPoint(point);
@@ -5357,13 +5383,6 @@ export function App({ project: initialProject, visitStats }: AppProps) {
         `Copied ${proposal.instanceIds.length} components · click to place another · Esc exits`,
       );
     }
-  }
-
-  function cancelCopyPlacement(): void {
-    if (!copyPlacement) return;
-    setCopyPlacement(null);
-    setCopyPreviewPoint(null);
-    setStatus("Copy placement cancelled");
   }
 
   useEffect(() => {
@@ -5431,7 +5450,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       }
       const shortcut = resolveEditorShortcut(event, {
         isTyping: isTypingTarget(event.target),
-        componentPlacementActive: interactionState.kind === "placing-component",
+        interactionMode: interactionState.kind,
         hasRoutedMarkerSelection: Boolean(
           selectedAnnotation && isRoutedMarker(selectedAnnotation),
         ),
@@ -5440,7 +5459,6 @@ export function App({ project: initialProject, visitStats }: AppProps) {
         hasInspectableSelection,
         hasRouteSelection: Boolean(selectedRoute),
         hasHighlightableNet: selectedHighlightNetId !== null,
-        wireSessionActive: interactionState.kind === "wire",
         wireReadyToFinish: Boolean(wireSource && wirePreviewPoint),
         draftingReadyToFinish:
           (tool === "arrow" ||
@@ -5449,8 +5467,6 @@ export function App({ project: initialProject, visitStats }: AppProps) {
           draftingSource !== null,
         helpOpen,
         canvasDragActive: canvasDragSessionRef.current !== null,
-        interactionActive:
-          interactionState.kind !== "idle" || copyPlacement !== null,
         hasClearableDraftingSelection:
           selectedDrafting?.kind === "arrow" ||
           selectedDrafting?.kind === "construction-line" ||
@@ -5577,24 +5593,22 @@ export function App({ project: initialProject, visitStats }: AppProps) {
           canvasDragSessionRef.current?.cancel();
           setStatus("Cancelled canvas drag");
           return;
-        case "cancel-interaction":
-          if (copyPlacement) {
-            cancelCopyPlacement();
-            return;
-          }
-          clearTransientCanvasState();
-          cancelInteraction();
-          setComponentPreviewPoint(null);
-          setComponentPlacementRotation(0);
-          setVddRailStart(null);
-          setVddRailMode(false);
-          setBoxPreview(null);
+        case "cancel-interaction": {
+          const cancelledKind = interactionState.kind;
+          cancelAllTransientInteraction();
           setStatus(
-            interactionState.kind === "drawing"
-              ? "Drawing cancelled"
-              : "Cancelled active tool",
+            cancelledKind === "copy-placement"
+              ? "Copy placement cancelled"
+              : cancelledKind === "placing-vdd-rail"
+                ? "VDD rail cancelled"
+                : cancelledKind === "placing-component"
+                  ? "Component placement cancelled"
+                  : cancelledKind === "drawing"
+                    ? "Drawing cancelled"
+                    : "Cancelled active tool",
           );
           return;
+        }
         case "clear-drafting-selection":
           replaceSelectionKind("drafting", []);
           setStatus("Cleared drawing selection");
@@ -5607,6 +5621,11 @@ export function App({ project: initialProject, visitStats }: AppProps) {
         case "remove-wire-waypoint":
           setWireWaypoints(wireWaypoints.slice(0, -1));
           setStatus("Removed last wire bend");
+          return;
+        case "blocked-interaction-command":
+          setStatus(
+            `${shortcut.command} is unavailable while an active tool owns the canvas · Esc cancels`,
+          );
           return;
         case "delete-selection":
           deleteSelection();
@@ -6209,7 +6228,6 @@ export function App({ project: initialProject, visitStats }: AppProps) {
           open={libraryPanelOpen}
           onOpenInsert={openInsertComponentDialog}
           onQuickPlace={beginInsertedComponentPlacement}
-          onPlaceVddRail={beginVddRailPlacement}
         />
         <aside
           className={selectionOpen ? "selection-dock open" : "selection-dock"}
@@ -7035,8 +7053,8 @@ export function App({ project: initialProject, visitStats }: AppProps) {
             onPointerDown={beginCanvasGesture}
             onPointerMove={continueCanvasGesture}
             onPointerLeave={() => {
-              if (pendingSymbolId || vddRailMode)
-                setComponentPreviewPoint(null);
+              if (pendingSymbolId) setComponentPreviewPoint(null);
+              if (vddRailMode) setVddRailPreviewPoint(null);
               if (copyPlacement) setCopyPreviewPoint(null);
             }}
             onPointerUp={finishCanvasGesture}
@@ -7286,6 +7304,13 @@ export function App({ project: initialProject, visitStats }: AppProps) {
                     x2={componentPreviewPoint.x}
                     y2={vddRailStart.y}
                     strokeWidth={styleProfile.strokes.powerRail}
+                  />
+                ) : componentPreviewPoint ? (
+                  <ComponentPlacementPreview
+                    styleProfileId={document.presentation.styleProfileId}
+                    symbolId="vdd"
+                    position={componentPreviewPoint}
+                    rotation={0}
                   />
                 ) : null
               ) : pendingSymbolId && componentPreviewPoint ? (

--- a/apps/editor/src/features/component-insert/component-insert-request.ts
+++ b/apps/editor/src/features/component-insert/component-insert-request.ts
@@ -1,4 +1,5 @@
-export interface ComponentInsertRequest {
+export interface SymbolInsertRequest {
+  kind: "symbol";
   symbolId: string;
   symbolName: string;
   properties: Record<string, string>;
@@ -6,3 +7,11 @@ export interface ComponentInsertRequest {
   showReference: boolean;
   referenceText: string | null;
 }
+
+export interface VddRailInsertRequest {
+  kind: "vdd-rail";
+  symbolId: "vdd";
+  symbolName: "VDD Rail";
+}
+
+export type ComponentInsertRequest = SymbolInsertRequest | VddRailInsertRequest;

--- a/apps/editor/src/features/component-insert/insert-component-dialog.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.tsx
@@ -97,6 +97,7 @@ export function InsertComponentDialog({
   const symbols = useMemo(() => flattenComponentCatalog(groups), [groups]);
   const selected =
     symbols.find((symbol) => symbol.id === selectedId) ?? symbols[0] ?? null;
+  const selectedIsVddRail = selected?.id === "vdd";
   const parameters = componentParameters(selected?.id ?? "");
 
   useEffect(() => {
@@ -143,6 +144,7 @@ export function InsertComponentDialog({
   };
 
   const rotatePreview = (): void => {
+    if (selectedIsVddRail) return;
     setInitialRotation(
       (current) => ((current + 90) % 360) as 0 | 90 | 180 | 270,
     );
@@ -150,6 +152,14 @@ export function InsertComponentDialog({
 
   const apply = (): void => {
     if (!selected) return;
+    if (selectedIsVddRail) {
+      onApply({
+        kind: "vdd-rail",
+        symbolId: "vdd",
+        symbolName: "VDD Rail",
+      });
+      return;
+    }
     const properties = Object.fromEntries(
       Object.entries(parameterValues)
         .map(([key, value]) => [key, value.trim()] as const)
@@ -157,6 +167,7 @@ export function InsertComponentDialog({
     );
     const trimmedReference = referenceText.trim();
     onApply({
+      kind: "symbol",
       symbolId: selected.id,
       symbolName: selected.name,
       properties,
@@ -305,49 +316,51 @@ export function InsertComponentDialog({
               ) : null}
             </section>
 
-            <section
-              className="insert-placement-options"
-              aria-label="Placement options"
-            >
-              <label className="insert-rotation-control">
-                <span>Rotate</span>
-                <select
-                  aria-label="Initial rotation"
-                  value={initialRotation}
-                  onChange={(event) =>
-                    setInitialRotation(
-                      Number(event.currentTarget.value) as 0 | 90 | 180 | 270,
-                    )
-                  }
-                >
-                  <option value="0">0°</option>
-                  <option value="90">90°</option>
-                  <option value="180">180°</option>
-                  <option value="270">270°</option>
-                </select>
-              </label>
-              <div className="insert-label-control">
-                <label className="insert-reference-toggle">
-                  <input
-                    type="checkbox"
-                    checked={showReference}
+            {!selectedIsVddRail ? (
+              <section
+                className="insert-placement-options"
+                aria-label="Placement options"
+              >
+                <label className="insert-rotation-control">
+                  <span>Rotate</span>
+                  <select
+                    aria-label="Initial rotation"
+                    value={initialRotation}
                     onChange={(event) =>
-                      setShowReference(event.currentTarget.checked)
+                      setInitialRotation(
+                        Number(event.currentTarget.value) as 0 | 90 | 180 | 270,
+                      )
+                    }
+                  >
+                    <option value="0">0°</option>
+                    <option value="90">90°</option>
+                    <option value="180">180°</option>
+                    <option value="270">270°</option>
+                  </select>
+                </label>
+                <div className="insert-label-control">
+                  <label className="insert-reference-toggle">
+                    <input
+                      type="checkbox"
+                      checked={showReference}
+                      onChange={(event) =>
+                        setShowReference(event.currentTarget.checked)
+                      }
+                    />
+                    <span>Label</span>
+                  </label>
+                  <input
+                    aria-label="Label name"
+                    value={referenceText}
+                    disabled={!showReference}
+                    placeholder="Name (auto)"
+                    onChange={(event) =>
+                      setReferenceText(event.currentTarget.value)
                     }
                   />
-                  <span>Label</span>
-                </label>
-                <input
-                  aria-label="Label name"
-                  value={referenceText}
-                  disabled={!showReference}
-                  placeholder="Name (auto)"
-                  onChange={(event) =>
-                    setReferenceText(event.currentTarget.value)
-                  }
-                />
-              </div>
-            </section>
+                </div>
+              </section>
+            ) : null}
 
             {parameters.length > 0 ? (
               <section
@@ -406,9 +419,7 @@ export function InsertComponentDialog({
         </div>
 
         <footer className="insert-dialog-actions">
-          <small>
-            Type to search · ↑↓ choose · R rotate · Enter place · Esc cancel
-          </small>
+          <small>Type to search · ↑↓ choose · Enter place · Esc cancel</small>
           <div>
             <button type="button" onClick={onCancel}>
               Cancel

--- a/apps/editor/src/features/component-insert/symbol-catalog.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.ts
@@ -1,6 +1,8 @@
 import { razaviProductSymbols } from "@icm/symbols";
 import type { SymbolDefinition } from "@icm/symbols";
 
+import { vddRailPreviewSymbol } from "./vdd-rail-preview-symbol";
+
 const CATEGORY_ORDER = [
   "Transistors",
   "Analog Blocks",
@@ -35,7 +37,7 @@ export function symbolCategory(symbolId: string): string {
 }
 
 export function paletteSymbols(_styleProfileId: string): SymbolDefinition[] {
-  return [...razaviProductSymbols];
+  return [vddRailPreviewSymbol, ...razaviProductSymbols];
 }
 
 function searchableText(symbol: SymbolDefinition): string {

--- a/apps/editor/src/features/component-insert/vdd-rail-preview-symbol.ts
+++ b/apps/editor/src/features/component-insert/vdd-rail-preview-symbol.ts
@@ -1,0 +1,47 @@
+import type { SymbolDefinition } from "@icm/symbols";
+
+/**
+ * Editor-only artwork for the virtual VDD Rail Library item. This definition
+ * is deliberately absent from the product Symbol Resolver: it may be rendered
+ * in the picker and placement preview, but it can never become an Instance.
+ */
+export const vddRailPreviewSymbol = {
+  schemaVersion: 1,
+  id: "vdd",
+  name: "VDD Rail",
+  viewBox: { x: -12, y: -2, width: 24, height: 26 },
+  pins: [
+    {
+      name: "P",
+      role: "power",
+      at: { x: 0, y: 20 },
+      direction: "south",
+      presentation: { visibility: "visible", leadLength: 10 },
+    },
+  ],
+  primitives: [
+    {
+      kind: "line",
+      from: { x: 0, y: 20 },
+      to: { x: 0, y: 1.5 },
+      style: {
+        strokeRole: "normal",
+        lineCap: "butt",
+        lineJoin: "miter",
+      },
+    },
+    {
+      kind: "polygon",
+      points: [
+        { x: -10, y: -0.88 },
+        { x: 10, y: -0.88 },
+        { x: 10, y: 2.36 },
+        { x: -10, y: 2.36 },
+      ],
+      fill: "foreground",
+      stroke: "none",
+    },
+  ],
+  variants: [],
+  labelVisibility: "hidden",
+} satisfies SymbolDefinition;

--- a/apps/editor/src/features/component-insert/vdd-rail.test.ts
+++ b/apps/editor/src/features/component-insert/vdd-rail.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { executeTransaction } from "@icm/edit-engine";
+import {
+  executeTransaction,
+  proposeVisualRouteDeletion,
+} from "@icm/edit-engine";
 import { createEmptyDocument } from "@icm/model";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 
@@ -145,5 +148,56 @@ describe("drawn VDD rail construction", () => {
         presentation: "power-rail",
       }),
     );
+  });
+
+  it("deletes a power rail with its label and rail-only junctions", () => {
+    const document = createEmptyDocument("main", "Main");
+    const created = executeTransaction(
+      document,
+      {
+        transactionId: "create-vdd-rail-for-delete",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: constructVddRailEdits({
+          instanceId: "VDD1",
+          start: { x: 40, y: 20 },
+          end: { x: 180, y: 20 },
+        }),
+      },
+      { symbolResolver: resolver },
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    const proposal = proposeVisualRouteDeletion(
+      created.document,
+      ["route-vdd1-rail"],
+      [],
+    );
+    expect(proposal.edits[0]).toEqual({
+      kind: "remove_schematic_annotation",
+      annotationId: "label-VDD1",
+    });
+    const deleted = executeTransaction(
+      created.document,
+      {
+        transactionId: "delete-vdd-rail",
+        documentId: document.id,
+        expectedRevision: created.document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: proposal.edits,
+      },
+      { symbolResolver: resolver },
+    );
+
+    expect(deleted.ok).toBe(true);
+    if (!deleted.ok) return;
+    expect(deleted.document.routes).toEqual([]);
+    expect(deleted.document.junctions).toEqual([]);
+    expect(deleted.document.annotations).toEqual([]);
+    expect(deleted.document.nets).toMatchObject([
+      { name: "VDD", scope: "global", powerDomain: "vdd" },
+    ]);
   });
 });

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -9,13 +9,25 @@ describe("shapes quick-place", () => {
 
     const request = quickPlaceRequest("razavi", "resistor");
     expect(request).toMatchObject({
+      kind: "symbol",
       symbolId: "resistor",
       symbolName: "Resistor",
       initialRotation: 0,
       showReference: true,
       referenceText: null,
     });
-    expect(request?.properties.value).toBe("");
+    expect(request?.kind === "symbol" ? request.properties.value : null).toBe(
+      "",
+    );
+  });
+
+  it("exposes VDD rail as a virtual Library placement", () => {
+    expect(STARTER_SYMBOL_IDS).toContain("vdd");
+    expect(quickPlaceRequest("razavi", "vdd")).toEqual({
+      kind: "vdd-rail",
+      symbolId: "vdd",
+      symbolName: "VDD Rail",
+    });
   });
 
   it("returns null for unknown symbols", () => {

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -11,6 +11,7 @@ export const STARTER_SYMBOL_IDS = [
   "pmos",
   "voltage-source",
   "ground",
+  "vdd",
   "opamp",
 ] as const;
 
@@ -20,7 +21,15 @@ export function quickPlaceRequest(
 ): ComponentInsertRequest | null {
   const symbol = findPaletteSymbol(styleProfileId, symbolId);
   if (!symbol) return null;
+  if (symbolId === "vdd") {
+    return {
+      kind: "vdd-rail",
+      symbolId: "vdd",
+      symbolName: "VDD Rail",
+    };
+  }
   return {
+    kind: "symbol",
     symbolId: symbol.id,
     symbolName: symbol.name,
     // Quick-place follows the full Insert dialog's existing blank-value
@@ -39,7 +48,6 @@ export interface ShapesPanelProps {
   open: boolean;
   onOpenInsert(): void;
   onQuickPlace(request: ComponentInsertRequest): void;
-  onPlaceVddRail(): void;
 }
 
 export function ShapesPanel({
@@ -48,7 +56,6 @@ export function ShapesPanel({
   open,
   onOpenInsert,
   onQuickPlace,
-  onPlaceVddRail,
 }: ShapesPanelProps) {
   const starters = STARTER_SYMBOL_IDS.map((symbolId) =>
     findPaletteSymbol(styleProfileId, symbolId),
@@ -98,31 +105,13 @@ export function ShapesPanel({
           </summary>
           <div className="shapes-fold-body">
             <div className="shapes-grid">
-              <button
-                type="button"
-                className="shapes-chip"
-                data-testid="shapes-tool-vdd-rail"
-                title="Draw VDD rail"
-                onClick={onPlaceVddRail}
-              >
-                <svg
-                  className="shapes-chip-art"
-                  viewBox="0 0 80 50"
-                  aria-hidden="true"
-                >
-                  <path d="M 8 24 H 72" />
-                  <text x="54" y="18">
-                    VDD
-                  </text>
-                </svg>
-                <span>VDD Rail</span>
-              </button>
               {starters.map((symbol) => (
                 <button
                   key={symbol.id}
                   type="button"
                   className="shapes-chip"
                   data-testid={`shapes-chip-${symbol.id}`}
+                  data-vdd-rail={symbol.id === "vdd" ? "true" : undefined}
                   title={`Place ${symbol.name}`}
                   onClick={() => placeSymbol(symbol.id)}
                 >

--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -8,19 +8,17 @@ import type {
 
 const baseContext: EditorShortcutContext = {
   isTyping: false,
-  componentPlacementActive: false,
+  interactionMode: "idle",
   hasRoutedMarkerSelection: false,
   hasRotatableSelection: false,
   hasDraftingSelection: false,
   hasInspectableSelection: false,
   hasRouteSelection: false,
   hasHighlightableNet: false,
-  wireSessionActive: false,
   wireReadyToFinish: false,
   draftingReadyToFinish: false,
   helpOpen: false,
   canvasDragActive: false,
-  interactionActive: false,
   hasClearableDraftingSelection: false,
   hasRemovableWireWaypoint: false,
 };
@@ -106,12 +104,16 @@ describe("editor shortcut contract", () => {
     expect(resolve("i")).toEqual({ kind: "open-component-insert" });
     expect(
       resolve("r", {
-        componentPlacementActive: true,
+        interactionMode: "placing-component",
         hasRotatableSelection: true,
       }),
     ).toEqual({ kind: "rotate-placement", deltaDegrees: 90 });
     expect(
-      resolve("r", { componentPlacementActive: true }, { shiftKey: true }),
+      resolve(
+        "r",
+        { interactionMode: "placing-component" },
+        { shiftKey: true },
+      ),
     ).toEqual({ kind: "rotate-placement", deltaDegrees: 90 });
   });
 
@@ -128,8 +130,11 @@ describe("editor shortcut contract", () => {
       kind: "edit-net-label",
     });
     expect(
-      resolve("l", { hasRouteSelection: true, wireSessionActive: true }),
-    ).toBeNull();
+      resolve("l", { hasRouteSelection: true, interactionMode: "wire" }),
+    ).toEqual({
+      kind: "blocked-interaction-command",
+      command: "Net Label",
+    });
     expect(resolve("h")).toBeNull();
     expect(resolve("h", { hasHighlightableNet: true })).toEqual({
       kind: "toggle-net-highlight",
@@ -190,17 +195,17 @@ describe("editor shortcut contract", () => {
       resolve("Escape", {
         helpOpen: true,
         canvasDragActive: true,
-        interactionActive: true,
+        interactionMode: "wire",
         hasClearableDraftingSelection: true,
       }),
     ).toEqual({ kind: "close-help" });
     expect(
       resolve("Escape", {
         canvasDragActive: true,
-        interactionActive: true,
+        interactionMode: "wire",
       }),
     ).toEqual({ kind: "cancel-canvas-drag" });
-    expect(resolve("Escape", { interactionActive: true })).toEqual({
+    expect(resolve("Escape", { interactionMode: "wire" })).toEqual({
       kind: "cancel-interaction",
     });
     expect(resolve("Escape", { hasClearableDraftingSelection: true })).toEqual({
@@ -214,6 +219,52 @@ describe("editor shortcut contract", () => {
       kind: "remove-wire-waypoint",
     });
     expect(resolve("Backspace")).toEqual({ kind: "delete-selection" });
+  });
+
+  it("arbitrates competing commands while one interaction owns the canvas", () => {
+    const active = { interactionMode: "drawing" as const };
+    expect(resolve("c", active)).toEqual({
+      kind: "blocked-interaction-command",
+      command: "Copy",
+    });
+    expect(resolve("c", { interactionMode: "copy-placement" })).toEqual({
+      kind: "copy",
+    });
+    expect(resolve("q", active)).toEqual({
+      kind: "blocked-interaction-command",
+      command: "Properties",
+    });
+    expect(resolve("Delete", active)).toEqual({
+      kind: "blocked-interaction-command",
+      command: "Delete",
+    });
+    expect(
+      resolve("Delete", {
+        interactionMode: "wire",
+        hasInspectableSelection: true,
+      }),
+    ).toEqual({ kind: "delete-selection" });
+    expect(resolve("i", active)).toEqual({ kind: "open-component-insert" });
+    expect(resolve("w", active)).toEqual({
+      kind: "activate-tool",
+      tool: "wire",
+    });
+    expect(resolve("f", active)).toEqual({ kind: "fit-view" });
+  });
+
+  it("does not rotate a stale selection underneath another active tool", () => {
+    expect(
+      resolve("r", {
+        interactionMode: "drawing",
+        hasRotatableSelection: true,
+      }),
+    ).toEqual({ kind: "activate-tool", tool: "rectangle" });
+    expect(
+      resolve("r", {
+        interactionMode: "placing-component",
+        hasRotatableSelection: true,
+      }),
+    ).toEqual({ kind: "rotate-placement", deltaDegrees: 90 });
   });
 
   it("suppresses every global shortcut while typing", () => {

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -1,4 +1,4 @@
-import type { EditorTool } from "./interaction-state";
+import type { EditorTool, InteractionMode } from "./interaction-state";
 import type { ScreenFlip } from "./shortcut-orientation";
 
 export interface EditorShortcutKey {
@@ -11,19 +11,17 @@ export interface EditorShortcutKey {
 
 export interface EditorShortcutContext {
   isTyping: boolean;
-  componentPlacementActive: boolean;
+  interactionMode: InteractionMode;
   hasRoutedMarkerSelection: boolean;
   hasRotatableSelection: boolean;
   hasDraftingSelection: boolean;
   hasInspectableSelection: boolean;
   hasRouteSelection: boolean;
   hasHighlightableNet: boolean;
-  wireSessionActive: boolean;
   wireReadyToFinish: boolean;
   draftingReadyToFinish: boolean;
   helpOpen: boolean;
   canvasDragActive: boolean;
-  interactionActive: boolean;
   hasClearableDraftingSelection: boolean;
   hasRemovableWireWaypoint: boolean;
 }
@@ -57,7 +55,8 @@ export type EditorShortcutIntent =
         | "clear-drafting-selection"
         | "cancel-passive";
     }
-  | { kind: "remove-wire-waypoint" | "delete-selection" };
+  | { kind: "remove-wire-waypoint" | "delete-selection" }
+  | { kind: "blocked-interaction-command"; command: string };
 
 export function stepBoundedScale<T extends number>(
   current: T,
@@ -82,6 +81,7 @@ export function resolveEditorShortcut(
   if (context.isTyping) return null;
 
   const plain = !event.ctrlKey && !event.metaKey && !event.altKey;
+  const interactionActive = context.interactionMode !== "idle";
 
   if (plain && key === "u") {
     return { kind: event.shiftKey ? "redo" : "undo" };
@@ -92,6 +92,83 @@ export function resolveEditorShortcut(
   if (event.ctrlKey && key === "y") return { kind: "redo" };
   if (event.ctrlKey && key === "s") return { kind: "save" };
   if (event.ctrlKey && key === "o") return { kind: "open" };
+
+  if (event.key === "Escape") {
+    if (context.helpOpen) return { kind: "close-help" };
+    if (context.canvasDragActive) return { kind: "cancel-canvas-drag" };
+    if (interactionActive) return { kind: "cancel-interaction" };
+    if (context.hasClearableDraftingSelection) {
+      return { kind: "clear-drafting-selection" };
+    }
+    return { kind: "cancel-passive" };
+  }
+
+  if (interactionActive) {
+    if (event.ctrlKey && key === "a") {
+      return { kind: "blocked-interaction-command", command: "Select All" };
+    }
+    if (plain && key === "c") {
+      return context.interactionMode === "copy-placement"
+        ? { kind: "copy" }
+        : { kind: "blocked-interaction-command", command: "Copy" };
+    }
+    if (plain && key === "i") return { kind: "open-component-insert" };
+    if (plain && key === "w") {
+      return { kind: "activate-tool", tool: "wire" };
+    }
+    if (plain && key === "a") {
+      return { kind: "activate-tool", tool: "arrow" };
+    }
+    if (plain && key === "k") {
+      return { kind: "activate-tool", tool: "construction-line" };
+    }
+    if (plain && key === "r") {
+      if (context.interactionMode === "placing-component") {
+        return { kind: "rotate-placement", deltaDegrees: 90 };
+      }
+      if (!event.shiftKey) return { kind: "activate-tool", tool: "rectangle" };
+    }
+    if (plain && key === "f" && !event.shiftKey) {
+      return { kind: "fit-view" };
+    }
+    if (plain && key === "home") return { kind: "fit-view" };
+    if (event.key === "Enter" && context.wireReadyToFinish) {
+      return { kind: "finish-wire" };
+    }
+    if (event.key === "Enter" && context.draftingReadyToFinish) {
+      return { kind: "finish-drafting" };
+    }
+    if (
+      (event.key === "Delete" || event.key === "Backspace") &&
+      context.hasRemovableWireWaypoint
+    ) {
+      return { kind: "remove-wire-waypoint" };
+    }
+    if (
+      (event.key === "Delete" || event.key === "Backspace") &&
+      context.interactionMode === "wire" &&
+      context.hasInspectableSelection
+    ) {
+      return { kind: "delete-selection" };
+    }
+    const blockedCommands: Record<string, string> = {
+      c: "Copy",
+      q: "Properties",
+      l: "Net Label",
+      t: "Text",
+      h: "Net Highlight",
+      x: "Current Marker",
+      r: "Rotate or Mirror",
+      v: "Mirror",
+      "[": "Drafting Style",
+      "]": "Drafting Style",
+      delete: "Delete",
+      backspace: "Delete",
+    };
+    const command = blockedCommands[key];
+    return command ? { kind: "blocked-interaction-command", command } : null;
+  }
+
   if (event.ctrlKey && key === "a") return { kind: "select-all" };
 
   if (plain && key === "x" && context.hasRoutedMarkerSelection) {
@@ -100,7 +177,7 @@ export function resolveEditorShortcut(
   if (plain && key === "c") return { kind: "copy" };
   if (plain && key === "i") return { kind: "open-component-insert" };
   if (plain && key === "r") {
-    if (context.componentPlacementActive) {
+    if (context.interactionMode === "placing-component") {
       return {
         kind: "rotate-placement",
         deltaDegrees: 90,
@@ -127,7 +204,7 @@ export function resolveEditorShortcut(
   if (plain && key === "a") {
     return { kind: "activate-tool", tool: "arrow" };
   }
-  if (plain && key === "l" && !context.wireSessionActive) {
+  if (plain && key === "l" && context.interactionMode !== "wire") {
     return context.hasRouteSelection
       ? { kind: "edit-net-label" }
       : { kind: "net-label-selection-required" };
@@ -161,15 +238,6 @@ export function resolveEditorShortcut(
   }
   if (event.key === "Enter" && context.draftingReadyToFinish) {
     return { kind: "finish-drafting" };
-  }
-  if (event.key === "Escape") {
-    if (context.helpOpen) return { kind: "close-help" };
-    if (context.canvasDragActive) return { kind: "cancel-canvas-drag" };
-    if (context.interactionActive) return { kind: "cancel-interaction" };
-    if (context.hasClearableDraftingSelection) {
-      return { kind: "clear-drafting-selection" };
-    }
-    return { kind: "cancel-passive" };
   }
   if (event.key === "Delete" || event.key === "Backspace") {
     return context.hasRemovableWireWaypoint

--- a/apps/editor/src/interaction/interaction-state.test.ts
+++ b/apps/editor/src/interaction/interaction-state.test.ts
@@ -48,6 +48,22 @@ describe("editor interaction state", () => {
     ).toBe(state);
   });
 
+  it("keeps in-progress drawing geometry when the same tool is activated", () => {
+    let state = activateInteractionTool("arrow");
+    state = interactionReducer(state, {
+      type: "set-drawing-source",
+      point: { x: 10, y: 20 },
+    });
+    state = interactionReducer(state, {
+      type: "set-drawing-hover",
+      point: { x: 80, y: 20 },
+    });
+
+    expect(
+      interactionReducer(state, { type: "activate-tool", tool: "arrow" }),
+    ).toBe(state);
+  });
+
   it("cancels every creation mode to one idle state", () => {
     for (const tool of [
       "wire",
@@ -136,8 +152,74 @@ describe("editor interaction state", () => {
         showReference: false,
         referenceText: "MIN",
       },
+      rotation: 90,
+      previewPoint: null,
     });
     expect(interactionReducer(state, { type: "cancel" })).toEqual({
+      kind: "idle",
+    });
+  });
+
+  it("keeps repeated Copy idempotent and replaces it atomically with a tool", () => {
+    const clipboard = { ids: ["M1"] };
+    const copying = interactionReducer<{ ids: string[] }>(
+      { kind: "idle" },
+      {
+        type: "begin-copy-placement",
+        clipboard,
+        anchor: { x: 10, y: 20 },
+      },
+    );
+    const previewing = interactionReducer(copying, {
+      type: "set-copy-preview",
+      point: { x: 40, y: 50 },
+    });
+
+    expect(
+      interactionReducer(previewing, {
+        type: "begin-copy-placement",
+        clipboard: { ids: ["M2"] },
+        anchor: { x: 0, y: 0 },
+      }),
+    ).toBe(previewing);
+    expect(
+      interactionReducer(previewing, {
+        type: "activate-tool",
+        tool: "wire",
+      }),
+    ).toEqual({
+      kind: "wire",
+      source: null,
+      sourceRevision: null,
+      previewPoint: null,
+      waypoints: [],
+    });
+  });
+
+  it("owns the complete VDD rail gesture and exits after commit", () => {
+    let state = interactionReducer(
+      { kind: "idle" },
+      { type: "begin-vdd-rail" },
+    );
+    state = interactionReducer(state, {
+      type: "set-vdd-rail-preview",
+      point: { x: 20, y: 30 },
+    });
+    state = interactionReducer(state, {
+      type: "set-vdd-rail-start",
+      point: { x: 20, y: 30 },
+    });
+    state = interactionReducer(state, {
+      type: "set-vdd-rail-preview",
+      point: { x: 120, y: 30 },
+    });
+
+    expect(state).toEqual({
+      kind: "placing-vdd-rail",
+      start: { x: 20, y: 30 },
+      previewPoint: { x: 120, y: 30 },
+    });
+    expect(interactionReducer(state, { type: "complete-vdd-rail" })).toEqual({
       kind: "idle",
     });
   });

--- a/apps/editor/src/interaction/interaction-state.ts
+++ b/apps/editor/src/interaction/interaction-state.ts
@@ -14,6 +14,8 @@ export type DrawingTool = Extract<
   "construction-line" | "arrow" | "rectangle"
 >;
 
+export type InteractionMode = InteractionState<unknown>["kind"];
+
 export interface PendingComponentPlacement {
   symbolId: string;
   properties: Record<string, string>;
@@ -22,11 +24,28 @@ export interface PendingComponentPlacement {
   referenceText: string | null;
 }
 
-export type InteractionState =
+export interface CopyPlacement<TClipboard> {
+  clipboard: TClipboard;
+  anchor: Point;
+  previewPoint: Point | null;
+}
+
+export type InteractionState<TClipboard = never> =
   | { kind: "idle" }
   | {
       kind: "placing-component";
       placement: PendingComponentPlacement;
+      rotation: 0 | 90 | 180 | 270;
+      previewPoint: Point | null;
+    }
+  | {
+      kind: "placing-vdd-rail";
+      start: Point | null;
+      previewPoint: Point | null;
+    }
+  | {
+      kind: "copy-placement";
+      copy: CopyPlacement<TClipboard>;
     }
   | {
       kind: "wire";
@@ -44,9 +63,21 @@ export type InteractionState =
       snapPoint: Point | null;
     };
 
-export type InteractionAction =
+export type InteractionAction<TClipboard = never> =
   | { type: "activate-tool"; tool: EditorTool }
   | { type: "place-component"; placement: PendingComponentPlacement }
+  | { type: "set-component-preview"; point: Point | null }
+  | { type: "rotate-component"; deltaDegrees: 90 | -90 }
+  | { type: "begin-vdd-rail" }
+  | { type: "set-vdd-rail-start"; point: Point | null }
+  | { type: "set-vdd-rail-preview"; point: Point | null }
+  | { type: "complete-vdd-rail" }
+  | {
+      type: "begin-copy-placement";
+      clipboard: TClipboard;
+      anchor: Point;
+    }
+  | { type: "set-copy-preview"; point: Point | null }
   | {
       type: "set-wire-source";
       source: WireSource | null;
@@ -64,7 +95,9 @@ export type InteractionAction =
 
 export const IDLE_INTERACTION_STATE: InteractionState = { kind: "idle" };
 
-function drawingState(tool: DrawingTool): InteractionState {
+function drawingState<TClipboard>(
+  tool: DrawingTool,
+): InteractionState<TClipboard> {
   return {
     kind: "drawing",
     tool,
@@ -75,7 +108,9 @@ function drawingState(tool: DrawingTool): InteractionState {
   };
 }
 
-export function activateInteractionTool(tool: EditorTool): InteractionState {
+export function activateInteractionTool<TClipboard>(
+  tool: EditorTool,
+): InteractionState<TClipboard> {
   switch (tool) {
     case "pointer":
       return IDLE_INTERACTION_STATE;
@@ -94,25 +129,96 @@ export function activateInteractionTool(tool: EditorTool): InteractionState {
   }
 }
 
+function sameComponentPlacement(
+  left: PendingComponentPlacement,
+  right: PendingComponentPlacement,
+): boolean {
+  if (
+    left.symbolId !== right.symbolId ||
+    left.initialRotation !== right.initialRotation ||
+    left.showReference !== right.showReference ||
+    left.referenceText !== right.referenceText
+  ) {
+    return false;
+  }
+  const leftEntries = Object.entries(left.properties);
+  const rightEntries = Object.entries(right.properties);
+  return (
+    leftEntries.length === rightEntries.length &&
+    leftEntries.every(([key, value]) => right.properties[key] === value)
+  );
+}
+
 function applyUpdate<T>(value: T, update: SetStateAction<T>): T {
   return typeof update === "function"
     ? (update as (current: T) => T)(value)
     : update;
 }
 
-export function interactionReducer(
-  state: InteractionState,
-  action: InteractionAction,
-): InteractionState {
+export function interactionReducer<TClipboard>(
+  state: InteractionState<TClipboard>,
+  action: InteractionAction<TClipboard>,
+): InteractionState<TClipboard> {
   switch (action.type) {
     case "activate-tool":
       if (action.tool === "wire" && state.kind === "wire") return state;
-      return activateInteractionTool(action.tool);
+      if (state.kind === "drawing" && state.tool === action.tool) return state;
+      return activateInteractionTool<TClipboard>(action.tool);
     case "place-component":
+      if (
+        state.kind === "placing-component" &&
+        sameComponentPlacement(state.placement, action.placement)
+      ) {
+        return state;
+      }
       return {
         kind: "placing-component",
         placement: action.placement,
+        rotation: action.placement.initialRotation,
+        previewPoint: null,
       };
+    case "set-component-preview":
+      return state.kind === "placing-component"
+        ? { ...state, previewPoint: action.point }
+        : state;
+    case "rotate-component":
+      return state.kind === "placing-component"
+        ? {
+            ...state,
+            rotation: ((state.rotation + action.deltaDegrees + 360) % 360) as
+              0 | 90 | 180 | 270,
+          }
+        : state;
+    case "begin-vdd-rail":
+      return state.kind === "placing-vdd-rail"
+        ? state
+        : { kind: "placing-vdd-rail", start: null, previewPoint: null };
+    case "set-vdd-rail-start":
+      return state.kind === "placing-vdd-rail"
+        ? { ...state, start: action.point }
+        : state;
+    case "set-vdd-rail-preview":
+      return state.kind === "placing-vdd-rail"
+        ? { ...state, previewPoint: action.point }
+        : state;
+    case "complete-vdd-rail":
+      return state.kind === "placing-vdd-rail"
+        ? (IDLE_INTERACTION_STATE as InteractionState<TClipboard>)
+        : state;
+    case "begin-copy-placement":
+      if (state.kind === "copy-placement") return state;
+      return {
+        kind: "copy-placement",
+        copy: {
+          clipboard: action.clipboard,
+          anchor: action.anchor,
+          previewPoint: null,
+        },
+      };
+    case "set-copy-preview":
+      return state.kind === "copy-placement"
+        ? { ...state, copy: { ...state.copy, previewPoint: action.point } }
+        : state;
     case "set-wire-source":
       return state.kind === "wire"
         ? {
@@ -162,10 +268,14 @@ export function interactionReducer(
   }
 }
 
-export function interactionTool(state: InteractionState): EditorTool {
+export function interactionTool<TClipboard>(
+  state: InteractionState<TClipboard>,
+): EditorTool {
   switch (state.kind) {
     case "idle":
     case "placing-component":
+    case "placing-vdd-rail":
+    case "copy-placement":
       return "pointer";
     case "wire":
       return "wire";
@@ -174,18 +284,27 @@ export function interactionTool(state: InteractionState): EditorTool {
   }
 }
 
-export function useInteractionState() {
+export function useInteractionState<TClipboard>() {
   const [state, dispatch] = useReducer(
-    interactionReducer,
-    IDLE_INTERACTION_STATE,
+    interactionReducer<TClipboard>,
+    IDLE_INTERACTION_STATE as InteractionState<TClipboard>,
   );
+  const componentPlacement = state.kind === "placing-component" ? state : null;
+  const vddRailPlacement = state.kind === "placing-vdd-rail" ? state : null;
+  const copyPlacement = state.kind === "copy-placement" ? state.copy : null;
   return {
     state,
     tool: interactionTool(state),
-    pendingSymbolId:
-      state.kind === "placing-component" ? state.placement.symbolId : null,
-    pendingComponentPlacement:
-      state.kind === "placing-component" ? state.placement : null,
+    pendingSymbolId: componentPlacement?.placement.symbolId ?? null,
+    pendingComponentPlacement: componentPlacement?.placement ?? null,
+    componentPlacementRotation: componentPlacement?.rotation ?? 0,
+    componentPreviewPoint:
+      componentPlacement?.previewPoint ??
+      vddRailPlacement?.previewPoint ??
+      null,
+    vddRailMode: vddRailPlacement !== null,
+    vddRailStart: vddRailPlacement?.start ?? null,
+    copyPlacement,
     wireSource: state.kind === "wire" ? state.source : null,
     wireSourceRevision: state.kind === "wire" ? state.sourceRevision : null,
     wirePreviewPoint: state.kind === "wire" ? state.previewPoint : null,
@@ -197,6 +316,20 @@ export function useInteractionState() {
     setTool: (tool: EditorTool) => dispatch({ type: "activate-tool", tool }),
     beginComponentPlacement: (placement: PendingComponentPlacement) =>
       dispatch({ type: "place-component", placement }),
+    setComponentPreviewPoint: (point: Point | null) =>
+      dispatch({ type: "set-component-preview", point }),
+    rotateComponentPlacement: (deltaDegrees: 90 | -90) =>
+      dispatch({ type: "rotate-component", deltaDegrees }),
+    beginVddRailPlacement: () => dispatch({ type: "begin-vdd-rail" }),
+    setVddRailStart: (point: Point | null) =>
+      dispatch({ type: "set-vdd-rail-start", point }),
+    setVddRailPreviewPoint: (point: Point | null) =>
+      dispatch({ type: "set-vdd-rail-preview", point }),
+    completeVddRailPlacement: () => dispatch({ type: "complete-vdd-rail" }),
+    beginCopyPlacement: (clipboard: TClipboard, anchor: Point) =>
+      dispatch({ type: "begin-copy-placement", clipboard, anchor }),
+    setCopyPreviewPoint: (point: Point | null) =>
+      dispatch({ type: "set-copy-preview", point }),
     setWireSource: (source: WireSource | null, sourceRevision: number | null) =>
       dispatch({ type: "set-wire-source", source, sourceRevision }),
     setWirePreviewPoint: (point: Point | null) =>

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -25,22 +25,49 @@ and connects B to the selected Net in the same transaction. Imported MOS
 instances do not receive a guessed fourth node.
 
 Ground is the `ground` component connected through pin `0`; placement reuses an
-existing global ground supply Net. VDD Rail is a separate two-click
-construction tool. It creates/reuses an explicit global VDD Net, creates two
-route-anchor Junctions and one `power-rail` Route, and persists one RichText
-power-label annotation. It creates no VDD Instance.
+existing global ground supply Net. VDD Rail is a virtual Library item presented
+through the same I-dialog, Library, and placement input plane as components.
+Its editor-local VDD artwork is preview-only and is not registered with the
+product Symbol Resolver. Before the first click the artwork follows the
+pointer; after the first click the preview becomes the horizontal rail. The
+second click creates/reuses an explicit global VDD Net, creates two route-anchor
+Junctions and one `power-rail` Route, and persists one RichText power-label
+annotation. It creates no VDD Instance and exits placement after the commit.
+Deleting the rail also deletes its power label and rail-only Junctions while
+preserving a VDD Net still used elsewhere.
 
 ## Interaction states
 
+The canonical reducer owns exactly one exclusive canvas interaction:
+
 ```text
-Pointer
-  -> BoxSelect -> Pointer
-  -> MoveSelection -> Pointer
-  -> ComponentDialog -> PlaceComponent -> Pointer
-  -> Wire -> Pointer
-  -> VddRail(first point) -> VddRail(second point) -> Pointer
-  -> TextEdit -> Pointer
+Idle
+  -> SymbolPlacement(preview, rotation)
+  -> VddRailPlacement(preview, optional first point)
+  -> CopyPlacement(clipboard, anchor, preview)
+  -> Wire(source, waypoints, preview)
+  -> Drawing(tool, source, waypoints, preview, snap)
 ```
+
+Box selection, selection move, pan, and text-edit sessions remain bounded
+gesture owners, but every reset boundary cancels them together with the
+canonical interaction. No component preview, rail endpoint, clipboard, Wire
+waypoint, drawing point, or snap guide is stored in a parallel React mode flag.
+
+Activating the same tool is idempotent: repeated C, W, A, K, or selection of the
+same Library item preserves the active session. Activating a different creation
+tool replaces the current interaction atomically after drag and snap cleanup.
+Opening I cancels the current canvas interaction before showing the dialog.
+Escape, Document switch, Project replacement, Clear Canvas, restore, and Agent
+focus reset all use the same transient-cancellation boundary.
+
+Shortcut arbitration is centralized. Escape, viewport pan/zoom, same-tool
+re-entry, and explicit creation-tool switches are valid while an interaction
+owns the canvas. Selection-dependent commands such as Copy, Delete, Q, L,
+rotate, mirror, and marker editing cannot act on a stale selection underneath
+another active interaction. Undo/Redo may mutate the Document and therefore
+cancel a snapshot-dependent active interaction. Shortcut key assignments are
+independent of this state policy and remain unchanged.
 
 Escape cancels the active preview without mutation. A committed gesture is one
 atomic transaction. Hover, geometric crossing, selection, and preview never
@@ -77,9 +104,11 @@ topology hash, history, recovery, or formal export.
 
 ## Deterministic validation
 
-- state-transition and shortcut focus-guard unit tests;
+- state-transition, shortcut focus-guard, and command-by-interaction matrix
+  tests, including repeated C/W/A/K and I/Escape/re-entry;
 - component placement and ordinary terminal connectivity for both Port assets;
-- VDD rail creation with no VDD Instance and one explicit VDD Net;
+- VDD rail picker/Library preview, cancellation at both phases, creation with no
+  VDD Instance, default exit, selection, and complete visual deletion;
 - canonical MOS default-variant and explicit bulk behavior;
 - move/stretch, segment tap, crossing non-connectivity, cancel, delete, and
   undo/redo tests;

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -382,6 +382,21 @@ export function proposeVisualRouteDeletion(
   const sortedJunctionIds = [...junctionsToRemove].sort((a, b) =>
     a.localeCompare(b, "en"),
   );
+  const removedPowerLabelIds = document.annotations
+    .filter(
+      (annotation) =>
+        annotation.kind === "power-label" &&
+        annotation.anchor.kind === "object" &&
+        sortedJunctionIds.includes(annotation.anchor.objectId) &&
+        document.routes.some(
+          (route) =>
+            routesToRemove.has(route.id) &&
+            route.presentation === "power-rail" &&
+            route.netId === annotation.netId,
+        ),
+    )
+    .map((annotation) => annotation.id)
+    .sort((a, b) => a.localeCompare(b, "en"));
   // `cut_connection` removes a junction that becomes orphaned. Only a selected
   // junction already detached before this transaction needs an explicit edit;
   // otherwise a second remove would reject the transaction.
@@ -429,6 +444,10 @@ export function proposeVisualRouteDeletion(
     routeIds: sortedRouteIds,
     junctionIds: sortedJunctionIds,
     edits: [
+      ...removedPowerLabelIds.map((annotationId): SchematicEdit => ({
+        kind: "remove_schematic_annotation",
+        annotationId,
+      })),
       ...sortedRouteIds.map((routeId): SchematicEdit => ({
         kind: "cut_connection",
         routeId,

--- a/plan/2026-08-14-unify-editor-interaction-state/plan.md
+++ b/plan/2026-08-14-unify-editor-interaction-state/plan.md
@@ -1,0 +1,149 @@
+---
+status: completed
+experience: none
+---
+
+# Unify Editor Interaction State
+
+## Goal
+
+Replace the editor's parallel placement flags with one canonical transient
+interaction state machine. Copy, symbol placement, VDD-rail placement, Wire,
+and drafting must be mutually exclusive; entry, re-entry, cancellation,
+document reset, transaction invalidation, and shortcut dispatch must be
+deterministic. Preserve the configured shortcut keys while removing the stale
+mode combinations behind repeated `C`, `I` re-entry, and VDD-rail failures.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/interaction-state-machine...origin/main
+```
+
+This worktree was created clean from `origin/main` at `12f0dab`. It is isolated
+from the concurrent model/VisualAnchor worktree. This target owns the editor
+interaction state, keyboard dispatcher, App integration, interaction contract,
+and directly related regressions.
+
+- `apps/editor/src/interaction/interaction-state.ts`
+- `apps/editor/src/interaction/interaction-state.test.ts`
+- `apps/editor/src/interaction/editor-shortcuts.ts`
+- `apps/editor/src/interaction/editor-shortcuts.test.ts`
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/features/component-insert/component-insert-request.ts`
+- `apps/editor/src/features/component-insert/insert-component-dialog.tsx`
+- `apps/editor/src/features/component-insert/symbol-artwork.tsx`
+- `apps/editor/src/features/component-insert/symbol-catalog.ts`
+- `apps/editor/src/features/component-insert/vdd-rail.ts`
+- `apps/editor/src/features/component-insert/vdd-rail-preview-symbol.ts`
+- `apps/editor/src/features/component-insert/vdd-rail.test.ts`
+- `apps/editor/src/features/editor-shell/shapes-panel.tsx`
+- `apps/editor/src/features/editor-shell/shapes-panel.test.ts`
+- `apps/editor/e2e/manual-editor.spec.ts`
+- `apps/editor/e2e/drafting.spec.ts`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `packages/edit-engine/src/routing-planner.ts`
+- `packages/edit-engine/src/routing.test.ts`
+- `docs/specs/editor-interaction.md`
+- `plan/2026-08-14-unify-editor-interaction-state/plan.md`
+- `plan/log.md`
+
+Read-only dependencies:
+
+- `apps/editor/src/features/clipboard/clipboard.ts` remains the pure copy/paste
+  data proposal owner; the interaction machine holds its payload generically.
+- `apps/editor/src/canvas/canvas-drag-session.ts` remains the drag owner.
+
+## Work
+
+1. Define one exclusive union for `idle`, symbol placement, VDD-rail placement,
+   copy placement, Wire, and drafting. The union owns every preview coordinate,
+   rotation, rail endpoint, clipboard payload, waypoint, and snap point used by
+   those modes; remove the corresponding parallel React state.
+2. Route every mode entry through reducer transitions. Same-mode re-entry is
+   idempotent (`C -> C`, `A -> A`, `K -> K`, `W -> W`, repeated selection of the
+   same Library item); a different mode replaces the previous mode atomically
+   after canvas drag/snap cleanup.
+3. Make VDD rail a virtual Library placement item. Restore the old VDD artwork
+   as an editor-local preview definition for I-dialog, Library, and
+   pre-first-click preview only; do not register it with the product Symbol
+   Resolver and never persist a VDD symbol instance. First click starts the
+   horizontal rail preview, second click commits `add_power_rail`, and
+   successful placement exits by default.
+4. Make cancellation total. Escape, Document switch, Project replacement,
+   Clear Canvas, import, recovery restore, and Agent semantic focus reset all
+   reach one `cancelAllTransientInteraction()` boundary that also cancels canvas
+   drag and clears snap guides.
+5. Centralize shortcut arbitration without changing key assignments. Active
+   exclusive modes accept Escape, pan, and zoom; same-mode shortcuts are inert;
+   explicit tool switches replace the mode; selection-dependent commands such
+   as Copy, Delete, Q, L, rotate, and mirror cannot operate on stale selection
+   underneath an active placement.
+6. Invalidate snapshot-dependent copy placement after any successful mutation
+   not produced by that copy session, including Undo/Redo, Delete, Clear,
+   import, Agent edits, and document/project changes. A committed copy refreshes
+   its clipboard/revision or exits when the continuation cannot be proven safe.
+7. Define VDD-rail deletion as one visual closure: remove its route, associated
+   power label, and rail-only junctions; preserve the global VDD Net when it is
+   still used. Do not preserve the current incorrect orphan objects for
+   compatibility.
+8. Add reducer, shortcut, edit-engine, and browser matrix regressions covering:
+   repeated `C`; `I -> Esc -> I`; `I -> Esc -> same item`; Copy plus every
+   competing tool; Document/Project/Clear during placement; repeated W/A/K;
+   VDD Library/I preview, two-click commit, Escape before/after first click,
+   default exit, selection, and complete deletion.
+9. Update the interaction contract to make the state/command matrix and virtual
+   VDD placement boundary normative.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/interaction/interaction-state.test.ts apps/editor/src/interaction/editor-shortcuts.test.ts apps/editor/src/features/clipboard/clipboard.test.ts apps/editor/src/features/component-insert/vdd-rail.test.ts packages/edit-engine/src/routing.test.ts`
+- `pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts apps/editor/e2e/drafting.spec.ts apps/editor/e2e/component-insert.spec.ts --grep "copy|Copy|repeated|creation tools|VDD|component insert"`
+- `pnpm --filter @icm/editor build`
+- `pnpm verify:branch` because this changes shared editor interaction flow
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+refactor(editor): unify transient interaction state
+```
+
+## Outcome
+
+Completed the clean interaction-state consolidation without changing shortcut
+assignments. Copy, component insertion, virtual VDD-rail placement, Wire, and
+drafting now share one exclusive reducer-owned state; same-mode re-entry is
+idempotent, mode replacement is atomic, and every project/document/reset path
+uses the same total transient-interaction cancellation boundary.
+
+VDD Rail is again presented through the ordinary Library and `I` insertion
+flow using an editor-only preview symbol, while committing its existing
+electrical rail edit rather than persisting a fake component instance. Its
+placement exits after commit, Escape works before or after the first point,
+and deletion removes the route, power label, and rail-only junctions as one
+visual unit.
+
+Shortcut arbitration now prevents commands from acting on stale selections
+under an active mode. Repeated `C`, `W`, `A`, and `K` preserve the active
+session, and successful unrelated mutations invalidate snapshot-dependent
+placement state. Focused reducer, shortcut, VDD/edit-engine, and browser
+regressions cover the previously crashing `I -> Escape -> C -> C -> I` and VDD
+placement/deletion paths.
+
+Validation completed:
+
+- Focused interaction, shortcut, clipboard, VDD, and routing unit tests passed.
+- Focused browser regressions passed (9/9). The broader affected GUI run first
+  passed 97/98; its one stale-selection deletion regression was fixed and the
+  failing case then passed on rerun.
+- `pnpm verify:branch` passed: formatting and documentation checks, typecheck,
+  102 unit-test files / 557 tests, all workspace builds, and production preview
+  smoke.
+- `git diff --check` passed before completion metadata was recorded and is
+  repeated at handoff.

--- a/plan/log.md
+++ b/plan/log.md
@@ -6625,3 +6625,18 @@ contracts (WP-R1)`.
   browser E2E tests passed; `git diff --check` passed.
 - Commit status: committed on `codex/agent-transport-watchdog` as `5d2d640`
   (`fix(mos): restore overridable supply bulk defaults`).
+
+## 2026-08-14 - Unify transient editor interaction state
+
+- Target: remove parallel placement modes behind repeated-C/I crashes and
+  restore VDD Rail through the ordinary insertion flow without persisting it as
+  a component instance or changing shortcut assignments.
+- Changed areas: exclusive editor interaction reducer and shortcut arbitration;
+  App cancellation/mutation boundaries; virtual VDD preview catalog entry;
+  atomic VDD visual deletion; focused unit and browser regressions; accepted
+  editor interaction specification.
+- Validation: focused interaction and VDD suites, 9 focused browser
+  regressions, `pnpm verify:branch` (102 unit-test files / 557 tests, all
+  workspace builds and production smoke), and `git diff --check` passed.
+- Commit status: ready to commit on `codex/interaction-state-machine` as
+  `refactor(editor): unify transient interaction state`.


### PR DESCRIPTION
## Summary
- consolidate copy, component, VDD rail, wire, and drafting into one exclusive interaction reducer
- restore VDD rail through the regular Library / Insert flow using preview-only symbol artwork
- centralize shortcut arbitration and total transient cancellation without changing configured shortcut keys
- delete VDD rail routes, labels, and rail-only junctions atomically

## Validation
- pnpm install --frozen-lockfile
- pnpm ci:check (557 unit tests, 101 browser tests, all builds and release smoke)