### PR TITLE
fix(editor): stabilize MOS copy transition and VDD rail

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -174,6 +174,44 @@ test("reopens I and starts Copy from retained selection without stacking modes",
   ).toBeVisible();
 });
 
+test("publishes placement cancellation synchronously before rapid Copy", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const canvas = page.getByTestId("schematic-canvas");
+  const symbols = ["nmos", "pmos", "resistor"] as const;
+
+  await page.evaluate(() => {
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "c" }));
+  });
+  await expect(
+    page.getByRole("heading", { name: "Circuit Maker" }),
+  ).toBeVisible();
+
+  for (const [index, symbolId] of symbols.entries()) {
+    await chooseComponent(page, symbolId);
+    await canvas.click({ position: { x: 320 + index * 150, y: 240 } });
+
+    // A fast physical Esc -> C sequence can arrive before React publishes a
+    // render between the two native events. The command state must still see
+    // the reducer transition synchronously, especially after MOS bulk-default
+    // reconciliation makes the committed scene more expensive to derive.
+    await page.evaluate(() => {
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+      document.body.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "c", bubbles: true }),
+      );
+    });
+
+    await canvas.hover({ position: { x: 400 + index * 130, y: 380 } });
+    await expect(page.getByTestId("copy-placement-preview")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("copy-placement-preview")).toHaveCount(0);
+  }
+});
+
 test("carries a manual Value through placement and Q property editing", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -433,9 +433,9 @@ function polylineBounds(points: readonly Point[]): Rect {
 }
 
 function isTypingTarget(target: EventTarget | null): boolean {
-  const element = target as HTMLElement | null;
-  return Boolean(
-    element?.closest("input, textarea, select, [contenteditable='true']"),
+  return (
+    target instanceof Element &&
+    Boolean(target.closest("input, textarea, select, [contenteditable='true']"))
   );
 }
 
@@ -570,7 +570,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     useState<Annotation | null>(null);
   const snapGuideLayerRef = useRef<SVGGElement | null>(null);
   const {
-    state: interactionState,
+    getCurrentState: getCurrentInteractionState,
     tool,
     pendingSymbolId,
     pendingComponentPlacement,
@@ -1739,15 +1739,16 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   ): EditTransactionResult {
     const result = transactDocument(edits);
     applyResult(result);
+    const currentInteraction = getCurrentInteractionState();
     const preservesCurrentInteraction =
       options.preserveInteraction ||
-      (interactionState.kind === "wire" && options.completesWireSession);
+      (currentInteraction.kind === "wire" && options.completesWireSession);
     if (
       result.ok &&
-      interactionState.kind !== "idle" &&
+      currentInteraction.kind !== "idle" &&
       !preservesCurrentInteraction
     ) {
-      const cancelledKind = interactionState.kind;
+      const cancelledKind = currentInteraction.kind;
       cancelAllTransientInteraction();
       setStatus(
         cancelledKind === "wire"
@@ -1795,11 +1796,12 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   }
 
   function activateTool(nextTool: EditorTool): void {
+    const currentInteraction = getCurrentInteractionState();
     const alreadyActive =
-      (nextTool === "wire" && interactionState.kind === "wire") ||
-      (interactionState.kind === "drawing" &&
-        interactionState.tool === nextTool) ||
-      (nextTool === "pointer" && interactionState.kind === "idle");
+      (nextTool === "wire" && currentInteraction.kind === "wire") ||
+      (currentInteraction.kind === "drawing" &&
+        currentInteraction.tool === nextTool) ||
+      (nextTool === "pointer" && currentInteraction.kind === "idle");
     if (alreadyActive) return;
     canvasDragSessionRef.current?.cancel();
     clearTransientCanvasState();
@@ -5336,11 +5338,12 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   }
 
   function beginCopyPlacement(): void {
-    if (interactionState.kind === "copy-placement") {
+    const currentInteraction = getCurrentInteractionState();
+    if (currentInteraction.kind === "copy-placement") {
       setStatus("Copy placement is already active · Esc cancels");
       return;
     }
-    if (interactionState.kind !== "idle") {
+    if (currentInteraction.kind !== "idle") {
       setStatus("Finish or cancel the active tool before copying");
       return;
     }
@@ -5448,9 +5451,10 @@ export function App({ project: initialProject, visitStats }: AppProps) {
         setStatus("Cancelled text editing");
         return;
       }
+      const currentInteraction = getCurrentInteractionState();
       const shortcut = resolveEditorShortcut(event, {
         isTyping: isTypingTarget(event.target),
-        interactionMode: interactionState.kind,
+        interactionMode: currentInteraction.kind,
         hasRoutedMarkerSelection: Boolean(
           selectedAnnotation && isRoutedMarker(selectedAnnotation),
         ),
@@ -5594,7 +5598,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
           setStatus("Cancelled canvas drag");
           return;
         case "cancel-interaction": {
-          const cancelledKind = interactionState.kind;
+          const cancelledKind = getCurrentInteractionState().kind;
           cancelAllTransientInteraction();
           setStatus(
             cancelledKind === "copy-placement"

--- a/apps/editor/src/features/component-insert/vdd-rail.test.ts
+++ b/apps/editor/src/features/component-insert/vdd-rail.test.ts
@@ -86,11 +86,23 @@ describe("drawn VDD rail construction", () => {
         kind: "power-label",
         content: {
           runs: [
-            { kind: "text", value: "V" },
             {
               kind: "span",
-              style: "subscript",
-              children: [{ kind: "text", value: "DD" }],
+              style: "italic",
+              children: [
+                {
+                  kind: "span",
+                  style: "bold",
+                  children: [
+                    { kind: "text", value: "V" },
+                    {
+                      kind: "span",
+                      style: "subscript",
+                      children: [{ kind: "text", value: "DD" }],
+                    },
+                  ],
+                },
+              ],
             },
           ],
         },

--- a/apps/editor/src/interaction/interaction-state.ts
+++ b/apps/editor/src/interaction/interaction-state.ts
@@ -1,4 +1,4 @@
-import { useReducer } from "react";
+import { useReducer, useRef } from "react";
 import type { SetStateAction } from "react";
 
 import type { Point } from "@icm/model";
@@ -285,15 +285,29 @@ export function interactionTool<TClipboard>(
 }
 
 export function useInteractionState<TClipboard>() {
-  const [state, dispatch] = useReducer(
+  const [state, reactDispatch] = useReducer(
     interactionReducer<TClipboard>,
     IDLE_INTERACTION_STATE as InteractionState<TClipboard>,
   );
+  // React may batch two native key events before rendering the first reducer
+  // transition. Keep the reducer's authoritative current value available to
+  // command arbitration synchronously, while React owns render publication.
+  // Queued actions are reduced in the same order on both paths.
+  const currentStateRef = useRef(state);
+  currentStateRef.current = state;
+  const dispatch = (action: InteractionAction<TClipboard>): void => {
+    currentStateRef.current = interactionReducer(
+      currentStateRef.current,
+      action,
+    );
+    reactDispatch(action);
+  };
   const componentPlacement = state.kind === "placing-component" ? state : null;
   const vddRailPlacement = state.kind === "placing-vdd-rail" ? state : null;
   const copyPlacement = state.kind === "copy-placement" ? state.copy : null;
   return {
     state,
+    getCurrentState: () => currentStateRef.current,
     tool: interactionTool(state),
     pendingSymbolId: componentPlacement?.placement.symbolId ?? null,
     pendingComponentPlacement: componentPlacement?.placement ?? null,

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -32,7 +32,9 @@ product Symbol Resolver. Before the first click the artwork follows the
 pointer; after the first click the preview becomes the horizontal rail. The
 second click creates/reuses an explicit global VDD Net, creates two route-anchor
 Junctions and one `power-rail` Route, and persists one RichText power-label
-annotation. It creates no VDD Instance and exits placement after the commit.
+annotation. The Route is the only rail geometry: the annotation adds no supply
+bar or terminal stub, and its complete `V_DD` text is bold italic with `DD` as
+a subscript. It creates no VDD Instance and exits placement after the commit.
 Deleting the rail also deletes its power label and rail-only Junctions while
 preserving a VDD Net still used elsewhere.
 
@@ -53,6 +55,9 @@ Box selection, selection move, pan, and text-edit sessions remain bounded
 gesture owners, but every reset boundary cancels them together with the
 canonical interaction. No component preview, rail endpoint, clipboard, Wire
 waypoint, drawing point, or snap guide is stored in a parallel React mode flag.
+Command arbitration reads the reducer's synchronously advanced state, not the
+last rendered React closure, so consecutive native events such as `Escape -> C`
+observe the first transition even when React batches the next render.
 
 Activating the same tool is idempotent: repeated C, W, A, K, or selection of the
 same Library item preserves the active session. Activating a different creation
@@ -105,10 +110,12 @@ topology hash, history, recovery, or formal export.
 ## Deterministic validation
 
 - state-transition, shortcut focus-guard, and command-by-interaction matrix
-  tests, including repeated C/W/A/K and I/Escape/re-entry;
+  tests, including repeated C/W/A/K, I/Escape/re-entry, and render-free
+  `Escape -> C` bursts after NMOS, PMOS, and passive placement;
 - component placement and ordinary terminal connectivity for both Port assets;
 - VDD rail picker/Library preview, cancellation at both phases, creation with no
-  VDD Instance, default exit, selection, and complete visual deletion;
+  VDD Instance or annotation-owned stub, bold italic subscript label, default
+  exit, selection, and complete visual deletion;
 - canonical MOS default-variant and explicit bulk behavior;
 - move/stretch, segment tap, crossing non-connectivity, cancel, delete, and
   undo/redo tests;

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -2951,11 +2951,23 @@ export function executeTransaction(
             kind: "power-label",
             content: {
               runs: [
-                { kind: "text", value: "V" },
                 {
                   kind: "span",
-                  style: "subscript",
-                  children: [{ kind: "text", value: "DD" }],
+                  style: "italic",
+                  children: [
+                    {
+                      kind: "span",
+                      style: "bold",
+                      children: [
+                        { kind: "text", value: "V" },
+                        {
+                          kind: "span",
+                          style: "subscript",
+                          children: [{ kind: "text", value: "DD" }],
+                        },
+                      ],
+                    },
+                  ],
                 },
               ],
             },

--- a/packages/render-svg/src/current-contract.test.ts
+++ b/packages/render-svg/src/current-contract.test.ts
@@ -60,4 +60,84 @@ describe("current rendering contract", () => {
     expect(svg).toContain("V_in");
     expect(svg).not.toContain(">VOUT<");
   });
+
+  it("renders a VDD rail as one thick route with a wholly bold italic label", () => {
+    const document = createEmptyDocument("doc", "Power rail");
+    document.nets.push({
+      id: "net-vdd",
+      name: "VDD",
+      scope: "global",
+      powerDomain: "vdd",
+      terminals: [],
+    });
+    document.junctions.push(
+      {
+        id: "rail-left",
+        netId: "net-vdd",
+        position: { x: 40, y: 80 },
+        role: "route-anchor",
+      },
+      {
+        id: "rail-right",
+        netId: "net-vdd",
+        position: { x: 180, y: 80 },
+        role: "route-anchor",
+      },
+    );
+    document.routes.push({
+      id: "rail",
+      netId: "net-vdd",
+      from: { kind: "junction", junctionId: "rail-left" },
+      to: { kind: "junction", junctionId: "rail-right" },
+      waypoints: [],
+      segmentModes: ["manual"],
+      presentation: "power-rail",
+    });
+    document.annotations.push({
+      id: "rail-label",
+      kind: "power-label",
+      content: {
+        runs: [
+          {
+            kind: "span",
+            style: "italic",
+            children: [
+              {
+                kind: "span",
+                style: "bold",
+                children: [
+                  { kind: "text", value: "V" },
+                  {
+                    kind: "span",
+                    style: "subscript",
+                    children: [{ kind: "text", value: "DD" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      netId: "net-vdd",
+      anchor: {
+        kind: "object",
+        objectId: "rail-right",
+        localOffset: { x: 6, y: 5 },
+        fallbackPosition: { x: 186, y: 85 },
+      },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    });
+
+    const svg = renderDocumentSvg(document, resolver);
+    expect(svg).toContain('data-route-presentation="power-rail"');
+    expect(svg).not.toContain('data-role="supply-bar"');
+    expect(svg).toContain(
+      'style="font-style:italic;font-weight:700">V<tspan data-text-run="subscript"',
+    );
+    expect(svg).toContain(
+      'data-text-run="subscript" dx="0.046em" font-size="76%" baseline-shift="-0.28em" style="font-style:italic;font-weight:700">DD',
+    );
+  });
 });

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -659,18 +659,10 @@ export function buildSvgScene(
         profile.id !== "textbook-monochrome-v1" &&
         annotation.kind === "power-label"
       ) {
-        const annotationAnchor = annotation.anchor;
-        const junction =
-          annotationAnchor.kind === "object"
-            ? document.junctions.find(
-                (candidate) => candidate.id === annotationAnchor.objectId,
-              )
-            : undefined;
-        const supplyBar =
-          junction?.position && profile.annotations.supplyBarWidth > 0
-            ? `<line data-role="supply-bar" x1="${junction.position.x - profile.annotations.supplyBarWidth / 2}" y1="${junction.position.y}" x2="${junction.position.x + profile.annotations.supplyBarWidth / 2}" y2="${junction.position.y}" transform="rotate(${rotation} ${junction.position.x} ${junction.position.y})" stroke="${profile.foreground}" stroke-width="${profile.strokes.supply}" stroke-linecap="${profile.lineCap}"/>`
-            : "";
-        return `<g ${attributes}>${supplyBar}<text x="${position.x}" y="${position.y}" text-anchor="${annotation.alignment}" transform="${transform}"${schematicTextSizeAttribute("power-label", profile, annotation.sizeScale)}>${renderAnnotationText(annotation, profile)}</text></g>`;
+        // The power-rail Route is the complete supply bar. Drawing a second,
+        // thinner annotation-owned bar at its endpoint creates the visible
+        // terminal stub and makes hit geometry disagree with presentation.
+        return `<g ${attributes}><text x="${position.x}" y="${position.y}" text-anchor="${annotation.alignment}" transform="${transform}"${schematicTextSizeAttribute("power-label", profile, annotation.sizeScale)}>${renderAnnotationText(annotation, profile)}</text></g>`;
       }
       if (
         profile.id !== "textbook-monochrome-v1" &&

--- a/plan/2026-08-14-mos-copy-vdd-visual-fix/plan.md
+++ b/plan/2026-08-14-mos-copy-vdd-visual-fix/plan.md
@@ -1,0 +1,105 @@
+---
+status: completed
+experience: none
+---
+
+# Fix MOS Copy Transition and VDD Rail Presentation
+
+## Goal
+
+Eliminate the remaining rapid `I`-placement to `C` failure for NMOS/PMOS by
+fixing the underlying placement/selection/derived-connectivity transition, not
+by adding key-specific guards. Correct the committed and preview VDD Rail
+presentation so it is a single thick rail with no thin terminal stub and a
+bold italic `V_DD` label.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree was clean at merge commit `f346695`; this target starts on the
+isolated branch `codex/mos-copy-vdd-visual-fix`. It owns the editor placement
+transition, MOS placement regressions, VDD Rail preview/renderer presentation,
+and directly related tests and interaction documentation.
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/interaction/**`
+- `apps/editor/src/features/component-insert/**`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `apps/editor/e2e/manual-editor.spec.ts`
+- `packages/render-svg/src/**`
+- `packages/edit-engine/src/transaction.ts`
+- `packages/edit-engine/src/transaction.test.ts`
+- `docs/specs/editor-interaction.md`
+- `plan/2026-08-14-mos-copy-vdd-visual-fix/plan.md`
+- `plan/log.md`
+- `plan/root-audit.md`
+
+Shared read-only dependencies include the model MOS supply binding contract.
+The Edit Engine transaction authoring path is owned only for the VDD label AST;
+MOS supply and connectivity semantics remain read-only.
+
+## Work
+
+1. Reproduce rapid `I -> place NMOS/PMOS -> C` and compare it with passive
+   components, including selection, revision, supply-default reconciliation,
+   placement continuation, preview teardown, and copy clipboard construction.
+2. Make placement completion and command transition atomic for every component
+   class. No delayed MOS-specific mutation or stale selection may outlive the
+   committed transaction; configured shortcut keys remain unchanged.
+3. Remove the thin end stub from both VDD Rail preview and committed rendering.
+   Render the complete `V_DD` label in bold italic mathematical styling while
+   keeping it separate from electrical geometry and hit testing.
+4. Add focused reducer/browser regressions for NMOS, PMOS, and a passive
+   control, plus VDD geometry and text-style assertions.
+5. Update the accepted interaction specification if the placement completion
+   contract changes.
+
+## Validation
+
+- Focused interaction/component/VDD/render unit tests.
+- Focused browser tests for rapid MOS placement-to-copy and VDD appearance.
+- `pnpm typecheck`
+- `pnpm verify:branch` if the fix crosses editor and renderer boundaries.
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): stabilize MOS copy transition and VDD rail
+```
+
+## Outcome
+
+Reproduced the remaining rapid-command failure as a render-publication race:
+React could receive `Escape` and `C` before publishing the first reducer
+transition, so the keyboard handler read a stale placement mode. MOS placement
+made the vulnerable interval more visible because its commit also reconciles a
+bulk supply default. The interaction hook now advances a synchronous current
+state through the same reducer before queueing React publication, and every
+command boundary reads that current value. A related unsafe assumption in
+`isTypingTarget()` was also removed so keyboard events targeting Window or
+Document cannot throw and blank the application.
+
+VDD Rail now renders only its thick `power-rail` Route. The redundant
+annotation-owned thin `supply-bar` was removed, and newly authored VDD labels
+persist one nested RichText span that keeps both `V` and subscript `DD` bold
+italic. Live browser inspection confirmed zero supply bars, one 3.24-width
+route, and italic/700 weight on both text portions.
+
+Validation completed:
+
+- 31 focused interaction, VDD, and renderer unit tests passed.
+- The focused rapid NMOS/PMOS/passive `Escape -> C` and VDD browser tests
+  passed (2/2); the full component-insert browser suite passed (15/15).
+- `pnpm verify:branch` passed: formatting/docs/reference checks, typecheck, 102
+  unit-test files / 558 tests, every workspace build, and production smoke.
+- `git diff --check` passed before completion metadata and is repeated at
+  handoff.

--- a/plan/log.md
+++ b/plan/log.md
@@ -6640,3 +6640,18 @@ contracts (WP-R1)`.
   workspace builds and production smoke), and `git diff --check` passed.
 - Commit status: ready to commit on `codex/interaction-state-machine` as
   `refactor(editor): unify transient interaction state`.
+
+## 2026-08-14 - Stabilize rapid MOS Copy and VDD rail presentation
+
+- Target: make render-free `Escape -> C` command bursts observe the canonical
+  interaction transition after NMOS/PMOS placement, and remove the VDD Rail's
+  thin terminal stub while styling all of `V_DD` bold italic.
+- Changed areas: synchronous interaction-state publication and safe keyboard
+  target detection; VDD label RichText authoring; power-label rendering;
+  focused unit/browser regressions and accepted interaction specification.
+- Validation: 31 focused unit tests, 2 focused browser tests, all 15 component
+  insertion browser tests, `pnpm verify:branch` (558 unit tests, all workspace
+  builds and production smoke), live VDD DOM inspection, and
+  `git diff --check` passed.
+- Commit status: ready to commit on `codex/mos-copy-vdd-visual-fix` as
+  `fix(editor): stabilize MOS copy transition and VDD rail`.

--- a/plan/root-audit.md
+++ b/plan/root-audit.md
@@ -9,6 +9,7 @@ an archive. Completed plans with resolved experience are stored under
 | State                     | Count | Required disposition                                                              |
 | ------------------------- | ----: | --------------------------------------------------------------------------------- |
 | `active`                  |     0 | No active target remains in the root queue.                                       |
+| `completed` + `none`      |    31 | Verify commit/log evidence, then archive according to routine retention policy.   |
 | `completed` + `candidate` |    17 | Human decides whether to extract, reject, or defer the experience signal.         |
 | missing metadata          |    71 | Audit against outcome text and Git evidence; never archive merely because of age. |
 


### PR DESCRIPTION
## Summary
- publish the canonical interaction reducer state synchronously for rapid native keyboard transitions
- make non-Element keyboard event targets safe
- render VDD as one thick rail and persist a wholly bold-italic V_DD label

## Validation
- pnpm install --frozen-lockfile
- pnpm ci:check (558 unit tests, 102 browser tests, builds, release smoke)