### PR TITLE
fix(editor): preserve shared MOS bulk nets during copy

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -212,6 +212,30 @@ test("publishes placement cancellation synchronously before rapid Copy", async (
   }
 });
 
+test("copies a MOS whose bulk belongs to a shared supply Net", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const canvas = page.getByTestId("schematic-canvas");
+
+  await chooseComponent(page, "nmos");
+  await canvas.click({ position: { x: 280, y: 220 } });
+  await page.keyboard.press("Escape");
+  await chooseComponent(page, "nmos");
+  await canvas.click({ position: { x: 460, y: 220 } });
+  await page.keyboard.press("Escape");
+
+  await page.getByTestId("hit-M1").click();
+  await page.keyboard.press("c");
+  await canvas.hover({ position: { x: 620, y: 340 } });
+  await expect(page.getByTestId("copy-placement-preview")).toBeVisible();
+  await canvas.click({ position: { x: 620, y: 340 } });
+  await expect(page.getByTestId("hit-M1-copy-1")).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Circuit Maker" }),
+  ).toBeVisible();
+});
+
 test("carries a manual Value through placement and Q property editing", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -5378,6 +5378,12 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       },
       copyCounter.current,
     );
+    if (proposal.errors.length > 0) {
+      copyCounter.current -= 1;
+      setStatus(proposal.errors[0]!);
+      cancelAllTransientInteraction();
+      return;
+    }
     const result = transact(proposal.edits, { preserveInteraction: true });
     if (result.ok) {
       selectOnly("instance", proposal.instanceIds);

--- a/apps/editor/src/features/clipboard/clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard.test.ts
@@ -1,5 +1,6 @@
 import { executeTransaction } from "@icm/edit-engine";
 import { createEmptyDocument } from "@icm/model";
+import { buildSvgScene } from "@icm/render-svg";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
@@ -161,6 +162,84 @@ describe("schematic clipboard", () => {
     expect(result.document.noConnects).toContainEqual({
       id: "nc-r1-1-copy-1",
       endpoint: { kind: "terminal", instanceId: "R1-copy-1", pinName: "1" },
+    });
+  });
+
+  it("keeps a copied MOS connected to its shared external bulk Net", () => {
+    const document = createEmptyDocument("document-main", "Shared MOS bulk");
+    document.instances.push(
+      {
+        id: "M1",
+        symbolId: "nmos",
+        mosBulkBinding: { origin: "supply-default", netId: "net-global-0" },
+        placement: {
+          position: { x: 100, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+        properties: {},
+      },
+      {
+        id: "M2",
+        symbolId: "nmos",
+        mosBulkBinding: { origin: "supply-default", netId: "net-global-0" },
+        placement: {
+          position: { x: 220, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+        properties: {},
+      },
+    );
+    document.nets.push({
+      id: "net-global-0",
+      name: "0",
+      scope: "global",
+      powerDomain: "ground",
+      terminals: [
+        { instanceId: "M1", pinName: "B" },
+        { instanceId: "M2", pinName: "B" },
+      ],
+    });
+
+    const copied = copySelection(document, ["M1"]);
+    expect(copied?.nets).toEqual([]);
+    expect(copied?.boundaryNets).toEqual([
+      expect.objectContaining({
+        id: "net-global-0",
+        terminals: [{ instanceId: "M1", pinName: "B" }],
+      }),
+    ]);
+
+    const preview = clipboardPreviewDocument(document, copied!, {
+      x: 80,
+      y: 0,
+    });
+    expect(() => buildSvgScene(preview, resolver)).not.toThrow();
+
+    const proposal = proposePaste(document, copied!, { x: 80, y: 0 }, 1);
+    expect(proposal.errors).toEqual([]);
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "paste-shared-mos-bulk",
+        documentId: document.id,
+        expectedRevision: 0,
+        actor: { kind: "human", id: "test" },
+        edits: proposal.edits,
+      },
+      { symbolResolver: resolver },
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.document.nets[0]?.terminals).toEqual([
+      { instanceId: "M1", pinName: "B" },
+      { instanceId: "M2", pinName: "B" },
+      { instanceId: "M1-copy-1", pinName: "B" },
+    ]);
+    expect(result.document.instances[2]?.mosBulkBinding).toEqual({
+      origin: "supply-default",
+      netId: "net-global-0",
     });
   });
 });

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -13,7 +13,18 @@ import type {
 
 export interface SchematicClipboard {
   instances: Instance[];
+  /**
+   * Nets entirely inside the copied selection. They are duplicated (or merged
+   * by name) when the copy is committed.
+   */
   nets: Net[];
+  /**
+   * A projection of Nets that cross the selection boundary. Only terminals on
+   * copied instances are retained. These Nets make the isolated preview a
+   * valid document and, on paste, reconnect the copied terminals to the
+   * already-existing Net instead of cloning it.
+   */
+  boundaryNets: Net[];
   routes: RouteBranch[];
   junctions: SchematicDocument["junctions"];
   annotations: Annotation[];
@@ -23,6 +34,7 @@ export interface SchematicClipboard {
 export interface PasteProposal {
   edits: SchematicEdit[];
   instanceIds: string[];
+  errors: string[];
 }
 
 /**
@@ -82,7 +94,7 @@ export function clipboardPreviewDocument(
           }
         : null,
     })),
-    nets: structuredClone(clipboard.nets),
+    nets: structuredClone([...clipboard.nets, ...clipboard.boundaryNets]),
     routes: clipboard.routes.map((route) => ({
       ...structuredClone(route),
       waypoints: route.waypoints.map((point) => movePoint(point, offset)),
@@ -119,6 +131,20 @@ export function copySelection(
   return structuredClone({
     instances,
     nets: document.nets.filter((net) => netIds.has(net.id)),
+    boundaryNets: document.nets
+      .filter(
+        (net) =>
+          !netIds.has(net.id) &&
+          net.terminals.some((terminal) =>
+            selectedIds.has(terminal.instanceId),
+          ),
+      )
+      .map((net) => ({
+        ...net,
+        terminals: net.terminals.filter((terminal) =>
+          selectedIds.has(terminal.instanceId),
+        ),
+      })),
     routes: document.routes.filter((route) => routeIds.has(route.id)),
     junctions: document.junctions.filter((junction) =>
       junctionIds.has(junction.id),
@@ -263,6 +289,7 @@ export function proposePaste(
     ]),
   );
   const existingAnchors = new Map<string, RouteEndpoint>();
+  const errors: string[] = [];
   for (const net of clipboard.nets) {
     const existing = net.name
       ? document.nets.find((candidate) => candidate.name === net.name)
@@ -348,6 +375,27 @@ export function proposePaste(
       }
     }
   }
+  for (const boundaryNet of clipboard.boundaryNets) {
+    const target = document.nets.find(
+      (candidate) => candidate.id === boundaryNet.id,
+    );
+    const anchor = target ? firstNetEndpoint(target) : null;
+    if (!anchor) {
+      errors.push(
+        `Cannot paste: external Net ${boundaryNet.name ?? boundaryNet.id} is no longer available`,
+      );
+      continue;
+    }
+    for (const terminal of boundaryNet.terminals) {
+      const instanceId = instanceIds.get(terminal.instanceId);
+      if (!instanceId) continue;
+      edits.push({
+        kind: "connect_endpoints",
+        from: anchor,
+        to: { kind: "terminal", instanceId, pinName: terminal.pinName },
+      });
+    }
+  }
   edits.push(
     ...clipboard.noConnects.map((noConnect): SchematicEdit => {
       if (noConnect.endpoint.kind !== "terminal") {
@@ -425,5 +473,5 @@ export function proposePaste(
       },
     })),
   );
-  return { edits, instanceIds: [...instanceIds.values()] };
+  return { edits, instanceIds: [...instanceIds.values()], errors };
 }

--- a/plan/2026-08-14-fix-mos-external-net-copy/plan.md
+++ b/plan/2026-08-14-fix-mos-external-net-copy/plan.md
@@ -1,0 +1,80 @@
+---
+status: completed
+experience: none
+---
+
+# Preserve external MOS bulk connectivity during copy preview and paste
+
+## Goal
+
+Prevent copying an NMOS or PMOS whose implicit body connection belongs to a
+shared external Net from invalidating the transient copy-preview document or
+creating an invalid pasted circuit.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+?? .codex-main-dev.stderr.log
+?? .codex-main-dev.stdout.log
+```
+
+The two untracked development-server logs were created during this diagnosis
+and will be removed. The tracked worktree is otherwise clean. This target owns:
+
+- `apps/editor/src/features/clipboard/clipboard.ts`
+- `apps/editor/src/features/clipboard/clipboard.test.ts`
+- `apps/editor/e2e/component-insert.spec.ts` when a browser regression test is
+  needed
+- `plan/2026-08-14-fix-mos-external-net-copy/plan.md`
+- `plan/log.md`
+
+Read-only dependencies:
+
+- `packages/model/src/schema.ts`: transient preview documents must satisfy its
+  materialized MOS bulk-binding invariant.
+- `packages/render-svg/src/render.ts`: validates the preview before rendering.
+- `apps/editor/src/interaction/interaction-state.ts`: interaction ownership is
+  not changed by this target.
+
+## Work
+
+1. Model clipboard membership so a selected instance may retain a connection
+   to an external named/global Net without pretending that Net was internal.
+2. Build a schema-valid preview for that selection and emit paste edits which
+   explicitly join copied terminals to existing external Nets.
+3. Add regression coverage for a MOS selected from a shared bulk Net, covering
+   preview construction and commit behavior; add a browser check only if it
+   directly protects the production crash path.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/features/clipboard/clipboard.test.ts`
+- Focused editor browser test for MOS insert/copy when added
+- `pnpm typecheck`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): preserve shared MOS bulk nets during copy
+```
+
+## Outcome
+
+Clipboard selections now retain a projected boundary Net for every selected
+terminal whose electrical Net also reaches outside the copied group. The
+preview therefore remains schema-valid, and paste reconnects each new terminal
+to its existing external Net. A missing boundary Net is reported as a normal
+cancelled placement rather than producing invalid edits.
+
+Validation passed: focused clipboard unit tests, the full component-insert
+browser spec (including the shared-MOS regression), `pnpm typecheck`,
+`pnpm format:check`, `pnpm install --frozen-lockfile`, and the full
+`pnpm ci:check` (559 unit tests, 103 browser tests, builds, performance,
+export/PWA goldens, production and release smoke), plus `git diff --check`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -6655,3 +6655,18 @@ contracts (WP-R1)`.
   `git diff --check` passed.
 - Commit status: ready to commit on `codex/mos-copy-vdd-visual-fix` as
   `fix(editor): stabilize MOS copy transition and VDD rail`.
+
+## 2026-08-14 - Preserve shared MOS bulk Nets during copy
+
+- Target: prevent a copied NMOS/PMOS with a shared implicit bulk Net from
+  invalidating the transient preview document or creating an electrically
+  incomplete pasted instance.
+- Changed areas: clipboard boundary-Net projection and paste reconnection;
+  graceful stale-boundary handling; focused unit and browser regression
+  coverage.
+- Validation: focused clipboard unit tests, full component-insert browser spec,
+  `pnpm typecheck`, frozen-lockfile install, and full `pnpm ci:check` (559 unit
+  tests, 103 browser tests, builds, performance/export/PWA/release smoke)
+  passed; `git diff --check` passed.
+- Commit status: committed on `codex/fix-mos-external-net-copy` as `766c098`
+  (`fix(editor): preserve shared MOS bulk nets during copy`).


### PR DESCRIPTION
## Root cause\nCopy preview omitted a shared external MOS bulk Net, so a selected MOS retained mosBulkBinding pointing at a Net absent from the schema-validated preview document. Rendering then threw and unmounted the editor.\n\n## Fix\n- retain projected boundary Nets in clipboard state\n- reconnect pasted copied terminals to their original external Net\n- cancel cleanly if that external Net disappears before commit\n- add unit and browser regressions for two NMOS devices sharing the global bulk Net\n\n## Validation\n- pnpm ci:check (559 unit, 103 browser tests; build/release smoke)\n