### PR TITLE
Close MCP bootstrap distribution target

### DIFF
--- a/plan/2026-08-14-mcp-bootstrap-distribution/plan.md
+++ b/plan/2026-08-14-mcp-bootstrap-distribution/plan.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: completed
 experience: none
 ---
 
@@ -76,4 +76,16 @@ feat(agent): publish self-bootstrapping MCP distribution
 
 ## Outcome
 
-Pending.
+PR #50 merged the self-bootstrapping MCP distribution into `main`. The
+production Worker now serves the versioned manifest used by **Copy to Agent**;
+the same declaration drives package/release metadata and host setup. GitHub
+Release `mcp-v0.1.0` publishes the 90.5 kB tarball, release metadata, and
+checksums. Its public tarball SHA-256 is
+`0383d9d26d4665339a89e80a9d8ecff91edcecb3022b268a038503260643dfda`.
+
+Focused tests, typecheck, frozen install, local `pnpm ci:check` (649 unit and
+integration tests plus 103 browser tests), all six PR checks, production
+Cloudflare deployment, canonical Linux packaging, public download/hash
+verification, and an `npx` MCP initialize against the Release URL passed.
+The repository has no npm credential, so npm publication was truthfully
+skipped and the manifest selects the fully working GitHub Release path.

--- a/plan/log.md
+++ b/plan/log.md
@@ -6795,3 +6795,18 @@ contracts (WP-R1)`.
 - Commit status: implementation committed and pushed on
   `codex/agent-mcp-adapter` as `0b36b78`; PR #49 remains open and unmerged by
   request.
+
+## 2026-08-14 - Publish self-bootstrapping MCP distribution
+
+- Target: let a first-time external Agent install or discover Analog Canvas
+  MCP from the editor's existing copied handoff, with immediate Agent Kit
+  fallback and no circuit API expansion.
+- Changed areas: shared distribution declaration; public Worker bootstrap
+  manifest; editor copy/setup text; MCP and application release packaging;
+  GitHub Release/optional npm workflow; installation documentation.
+- Validation: 32 focused editor/Worker tests, typecheck, public `npx`
+  initialize, frozen install plus `pnpm ci:check` (649 unit/integration and
+  103 browser tests), all six PR #50 checks, production Cloudflare deployment,
+  Release SHA-256 verification, and public Release URL initialize passed.
+- Commit status: implementation `b3f4d70`, canonical integrity fix
+  `fe6ea74`, merged as PR #50; GitHub Release `mcp-v0.1.0` published.


### PR DESCRIPTION
## What changed

Closes the MCP bootstrap distribution target with the actual PR, production deployment, public GitHub Release, checksum, and public npx initialize evidence. Adds the matching factual maintenance-log entry.

## Validation

- Markdown link check passed
- git diff check passed
- implementation and release evidence is recorded from PR #50 and mcp-v0.1.0
