### PR TITLE
fix(editor): normalize fit view bounds to grid

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -176,6 +176,29 @@ test("adds formatted drafting text and undo/redo restores it", async ({
   await expect(page.getByTestId("revision")).toHaveText("6");
 });
 
+test("fits drafting text with F using an integer grid camera", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await clickCommand(page, "Draw", "Text");
+  const draftInput = page.getByRole("textbox", {
+    name: "Canvas text editor",
+  });
+  await draftInput.fill("Vout");
+  await page.getByRole("button", { name: "Apply text changes" }).click();
+
+  const canvas = page.getByTestId("schematic-canvas");
+  await page.keyboard.press("f");
+  await expect(page.getByTestId("status")).toHaveText("Fit Document");
+  const camera = (await canvas.getAttribute("viewBox"))!.split(" ").map(Number);
+  expect(camera).toHaveLength(4);
+  expect(camera.every((value) => Number.isInteger(value))).toBe(true);
+  expect(camera.every((value) => value % 10 === 0)).toBe(true);
+  await expect(
+    page.getByRole("heading", { name: "Circuit Maker" }),
+  ).toBeVisible();
+});
+
 test("text floating editor closes on Escape or an outside pointer", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -87,6 +87,7 @@ import {
 } from "../features/clipboard/clipboard";
 import type { SchematicClipboard } from "../features/clipboard/clipboard";
 import { startCanvasDragSession } from "../canvas/canvas-drag-session";
+import { fitCameraToBounds } from "../canvas/fit-view";
 import type { CanvasDragSession } from "../canvas/canvas-drag-session";
 import { startCanvasDragVisual } from "../canvas/canvas-drag-visual";
 import { resolveCanvasHitAtPoint } from "../canvas/canvas-hit-resolver";
@@ -4600,8 +4601,9 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   }
 
   function fitView(): void {
-    const box = contentScene.viewBox;
-    setViewBox({ ...box });
+    setViewBox(
+      fitCameraToBounds(contentScene.viewBox, document.presentation.grid),
+    );
     setStatus("Fit Document");
   }
 

--- a/apps/editor/src/canvas/fit-view.test.ts
+++ b/apps/editor/src/canvas/fit-view.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { fitCameraToBounds } from "./fit-view";
+
+describe("fitCameraToBounds", () => {
+  it("rounds fractional visual bounds outward to the editor grid", () => {
+    expect(
+      fitCameraToBounds({ x: 97.55, y: -43.2, width: 61.3, height: 16.7 }, 10),
+    ).toEqual({ x: 90, y: -50, width: 70, height: 30 });
+  });
+
+  it("preserves an already aligned camera rectangle", () => {
+    expect(
+      fitCameraToBounds({ x: -40, y: 20, width: 960, height: 640 }, 10),
+    ).toEqual({ x: -40, y: 20, width: 960, height: 640 });
+  });
+});

--- a/apps/editor/src/canvas/fit-view.ts
+++ b/apps/editor/src/canvas/fit-view.ts
@@ -1,0 +1,44 @@
+import type { Rect } from "@icm/model";
+
+export interface DerivedBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Converts renderer-derived bounds into the editor camera's grid-domain Rect.
+ *
+ * Rendering bounds may be fractional (text metrics, curves, and rotated
+ * geometry), while the camera is deliberately constrained to integer grid
+ * coordinates. Rounding outward preserves every visible pixel of the formal
+ * scene without letting derived floats enter editor state.
+ */
+export function fitCameraToBounds(bounds: DerivedBounds, grid: number): Rect {
+  if (
+    !Number.isInteger(grid) ||
+    grid <= 0 ||
+    !Number.isFinite(bounds.x) ||
+    !Number.isFinite(bounds.y) ||
+    !Number.isFinite(bounds.width) ||
+    !Number.isFinite(bounds.height) ||
+    bounds.width <= 0 ||
+    bounds.height <= 0
+  ) {
+    throw new Error(
+      "Fit View requires finite positive bounds and an integer grid",
+    );
+  }
+
+  const x = Math.floor(bounds.x / grid) * grid;
+  const y = Math.floor(bounds.y / grid) * grid;
+  const right = Math.ceil((bounds.x + bounds.width) / grid) * grid;
+  const bottom = Math.ceil((bounds.y + bounds.height) / grid) * grid;
+  return {
+    x,
+    y,
+    width: Math.max(grid, right - x),
+    height: Math.max(grid, bottom - y),
+  };
+}

--- a/plan/2026-08-14-fix-fit-view-grid-bounds/plan.md
+++ b/plan/2026-08-14-fix-fit-view-grid-bounds/plan.md
@@ -1,0 +1,79 @@
+---
+status: completed
+experience: none
+---
+
+# Normalize Fit View bounds into the editor grid camera
+
+## Goal
+
+Prevent `F`, `Home`, and the Fit View button from crashing the editor when
+derived visual bounds contain fractional values from text, curves, or rotation.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree was clean before this target. This target owns:
+
+- `apps/editor/src/canvas/fit-view.ts`
+- `apps/editor/src/canvas/fit-view.test.ts`
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/e2e/drafting.spec.ts` for the keyboard regression
+- `plan/2026-08-14-fix-fit-view-grid-bounds/plan.md`
+- `plan/log.md`
+
+Read-only dependencies:
+
+- `packages/render-svg/src/render.ts`: derives export/visual bounds that may
+  be fractional.
+- `packages/model/src/schema.ts`: editor camera bounds must satisfy integer
+  `RectSchema`.
+- `apps/editor/src/interaction/editor-shortcuts.ts`: owns the existing F/Home
+  command mapping and is not changed by this target.
+
+## Work
+
+1. Add one explicit derived-bounds-to-grid-camera conversion that rounds
+   outward and guarantees a positive, integer, grid-aligned `Rect`.
+2. Use it only at the Fit View editor boundary.
+3. Cover fractional bounds in a unit test and `F` after drafting text in a
+   browser regression.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/canvas/fit-view.test.ts`
+- `pnpm test:e2e:local apps/editor/e2e/drafting.spec.ts --grep "fits drafting text with F"`
+- `pnpm typecheck`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): normalize fit view bounds to grid
+```
+
+## Outcome
+
+Added a single editor-boundary adapter that rounds fractional renderer bounds
+outward to the current grid before they become the camera `viewBox`. `F`,
+`Home`, and the Fit View button retain their existing command path and now
+share this safe conversion. Added unit coverage for fractional and aligned
+bounds, plus a browser regression that creates drafting text and presses `F`.
+
+Validation passed:
+
+- `pnpm test:local apps/editor/src/canvas/fit-view.test.ts` (2 tests)
+- `pnpm test:e2e:local apps/editor/e2e/drafting.spec.ts --grep "fits drafting text with F"` (1 test)
+- `pnpm typecheck`
+- `pnpm format:check`
+- `pnpm test:e2e:local apps/editor/e2e/drafting.spec.ts` (24 tests)
+- `pnpm ci:check` (651 unit tests, 104 browser tests, builds, release smoke)
+- `git diff --check`

--- a/plan/log.md
+++ b/plan/log.md
@@ -6810,3 +6810,16 @@ contracts (WP-R1)`.
   Release SHA-256 verification, and public Release URL initialize passed.
 - Commit status: implementation `b3f4d70`, canonical integrity fix
   `fe6ea74`, merged as PR #50; GitHub Release `mcp-v0.1.0` published.
+
+## 2026-08-14 - Normalize Fit View bounds to the editor grid
+
+- Target: prevent Fit View (`F`, `Home`, and the command button) from feeding
+  fractional renderer geometry back into the integer-grid editor camera.
+- Changed areas: one derived-bounds-to-camera adapter in the editor, its unit
+  contract, and a browser regression that fits drafted text through `F`.
+- Validation: focused unit and browser checks, `pnpm typecheck`, formatting,
+  full drafting E2E (24 tests), `git diff --check`, and canonical `pnpm
+  ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
+  passed.
+- Commit status: committed on `codex/fix-fit-view-grid-bounds`; remote CI and
+  merge remain pending.


### PR DESCRIPTION
## Summary`n- round renderer-derived Fit View bounds outward to the current editor grid before updating the camera`n- retain the existing F/Home/button command surface`n- cover fractional bounds and pressing F after drafting text`n`n## Validation`n- pnpm ci:check (651 unit tests, 104 browser tests)`n- pnpm test:e2e:local apps/editor/e2e/drafting.spec.ts (24 tests)