### PR TITLE
fix(editor): preserve imported flightline guidance during placement

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -597,7 +597,9 @@ test("hides flightlines after manually deleting an imported Route", async ({
   await expect(page.getByTestId("flightline")).toHaveCount(0);
 });
 
-test("uses a flightline as direct Wire guidance", async ({ page }) => {
+test("keeps remaining imported flightlines after routing one guided connection", async ({
+  page,
+}) => {
   const project = createRoutingDemoProject();
   project.documents[0]!.sourceBinding = {
     cellName: "routing_demo",
@@ -625,10 +627,12 @@ test("uses a flightline as direct Wire guidance", async ({ page }) => {
   await hint.click({ force: true });
   await expect(page.getByTestId("active-tool")).toHaveText("wire");
   await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(1);
-  await expect(page.getByTestId("flightline")).toHaveCount(0);
+  await expect(page.getByTestId("flightline")).toHaveCount(2);
 });
 
-test("focuses imported flightlines on the selected Net", async ({ page }) => {
+test("hides imported flightlines while a Net is highlighted", async ({
+  page,
+}) => {
   const project = createRoutingDemoProject();
   project.documents[0]!.routes.push({
     id: "route-imported-h",
@@ -661,7 +665,7 @@ test("focuses imported flightlines on the selected Net", async ({ page }) => {
     "data-net-id",
     "net-h",
   );
-  await expect(page.getByTestId("flightline")).toHaveCount(1);
+  await expect(page.getByTestId("flightline")).toHaveCount(0);
   await page.keyboard.press("h");
   await expect(page.getByTestId("net-highlight-overlay")).toHaveCount(0);
   await expect(page.getByTestId("flightline")).toHaveCount(2);

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -891,21 +891,19 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     [document.id, document.nets, projectConnectivityIndex],
   );
   const displayedFlightlines = useMemo(() => {
-    // Flightlines are migration guidance for an untouched SPICE import only.
-    // A human-created document has no source binding, and any later edit of an
-    // import changes sourceStatus; neither state should be cluttered with
-    // inferred dashed connectivity.
-    if (!document.sourceBinding || document.sourceStatus !== "in-sync") {
+    // Flightlines guide placement and partial routing of imported topology.
+    // They are intentionally independent from sourceStatus: placement changes
+    // geometry without changing the imported electrical intent. A deliberate
+    // geometry/Net-label edit dismisses guidance through the persisted state.
+    // Net highlighting already provides a stronger complete-conductor overlay.
+    if (
+      !document.sourceBinding ||
+      document.flightlineGuidance === "dismissed" ||
+      highlightedNetId
+    ) {
       return [];
     }
-    // A highlighted Net is already presented as a strong complete conductor
-    // overlay. Do not also draw its dashed incomplete-routing guidance.
-    const unhighlightedFlightlines = highlightedNetId
-      ? flightlines.filter(
-          (flightline) => flightline.netId !== highlightedNetId,
-        )
-      : flightlines;
-    return unhighlightedFlightlines;
+    return flightlines;
   }, [document, flightlines, highlightedNetId]);
   const crossings = useMemo(
     () => deriveCrossings(document, resolver),

--- a/config/agent-mcp-distribution.json
+++ b/config/agent-mcp-distribution.json
@@ -11,6 +11,6 @@
     "repository": "chenzc24/Analog-Canvas",
     "tag": "mcp-v0.1.0",
     "asset": "analog-canvas-mcp-server-0.1.0.tgz",
-    "sha256": "2bfaf3c78593fe7a26c82542a084b3ccafce80b5d453f6d37e0f1ed96145cd3a"
+    "sha256": "acd143b2e89272e54dfe7cbf1dc6c1604762ce7c945b629f5c1267caae3f7723"
   }
 }

--- a/packages/edit-engine/src/transaction.test.ts
+++ b/packages/edit-engine/src/transaction.test.ts
@@ -245,6 +245,132 @@ describe("Edit Transaction envelope", () => {
     });
   });
 
+  it("keeps imported flightline guidance through placement and Wire, then dismisses it for a Net Label", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.sourceBinding = {
+      cellName: "main",
+      sourceRef: {
+        fileId: "main.sp",
+        start: { offset: 0, line: 1, column: 1 },
+        end: { offset: 1, line: 1, column: 2 },
+      },
+    };
+    document.flightlineGuidance = "active";
+    document.instances.push(
+      {
+        id: "A",
+        symbolId: "port",
+        placement: null,
+        properties: {},
+      },
+      {
+        id: "B",
+        symbolId: "port",
+        placement: {
+          position: { x: 200, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+        properties: {},
+      },
+    );
+
+    const placed = executeTransaction(
+      document,
+      {
+        ...transaction(),
+        edits: [
+          {
+            kind: "place_instance",
+            instanceId: "A",
+            placement: {
+              position: { x: 100, y: 100 },
+              rotation: 0,
+              mirror: "none",
+            },
+          },
+        ],
+      },
+      { symbolResolver: resolver },
+    );
+    expect(placed).toMatchObject({
+      ok: true,
+      document: { flightlineGuidance: "active" },
+    });
+    if (!placed.ok) return;
+
+    const moved = executeTransaction(placed.document, {
+      ...transaction(placed.document.revision),
+      transactionId: "transaction-move",
+      edits: [
+        {
+          kind: "move_instance",
+          instanceId: "A",
+          position: { x: 110, y: 100 },
+        },
+      ],
+    });
+    expect(moved).toMatchObject({
+      ok: true,
+      document: { flightlineGuidance: "dismissed" },
+    });
+
+    const wired = executeTransaction(
+      placed.document,
+      {
+        ...transaction(placed.document.revision),
+        transactionId: "transaction-wire",
+        edits: [
+          {
+            kind: "connect_endpoints",
+            from: { kind: "terminal", instanceId: "A", pinName: "P" },
+            to: { kind: "terminal", instanceId: "B", pinName: "P" },
+            newNetId: "net-ab",
+          },
+          {
+            kind: "set_route_points",
+            routeId: "route-ab",
+            netId: "net-ab",
+            from: { kind: "terminal", instanceId: "A", pinName: "P" },
+            to: { kind: "terminal", instanceId: "B", pinName: "P" },
+            waypoints: [],
+            segmentModes: ["manual"],
+          },
+        ],
+      },
+      { symbolResolver: resolver },
+    );
+    expect(wired).toMatchObject({
+      ok: true,
+      document: { flightlineGuidance: "active" },
+    });
+    if (!wired.ok) return;
+
+    const labelled = executeTransaction(wired.document, {
+      ...transaction(wired.document.revision),
+      transactionId: "transaction-label",
+      edits: [
+        {
+          kind: "upsert_schematic_annotation",
+          annotation: {
+            id: "label-ab",
+            kind: "net-label",
+            content: { runs: [{ kind: "text", value: "AB" }] },
+            netId: "net-ab",
+            anchor: { kind: "free", position: { x: 150, y: 100 } },
+            alignment: "middle",
+            rotation: 0,
+            locked: false,
+          },
+        },
+      ],
+    });
+    expect(labelled).toMatchObject({
+      ok: true,
+      document: { flightlineGuidance: "dismissed" },
+    });
+  });
+
   it("rejects a stale revision without changing the Document", () => {
     const document = createEmptyDocument("document-main", "Main");
     const before = JSON.stringify(document);

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -512,6 +512,50 @@ function snapPointToDocumentGrid(point: Point, grid: number): Point {
   };
 }
 
+/**
+ * Source synchronization and routing guidance have different lifetimes. An
+ * imported Document starts with dashed guidance active; placing its initially
+ * unplaced symbols or committing ordinary Wire must not dismiss the remaining
+ * imported Nets. Deliberate presentation/geometry interventions do dismiss it
+ * so a manually revised drawing is never repopulated with inferred guidance.
+ */
+function transactionDismissesFlightlineGuidance(
+  document: SchematicDocument,
+  edits: readonly SchematicEdit[],
+): boolean {
+  if (!document.sourceBinding || document.flightlineGuidance === "dismissed") {
+    return false;
+  }
+  const isWireCommit = edits.some((edit) => edit.kind === "connect_endpoints");
+  return edits.some((edit) => {
+    switch (edit.kind) {
+      case "upsert_schematic_annotation":
+        return edit.annotation.kind === "net-label";
+      case "remove_schematic_annotation":
+        return (
+          document.annotations.find(
+            (annotation) => annotation.id === edit.annotationId,
+          )?.kind === "net-label"
+        );
+      case "move_instance":
+      case "rotate_instance":
+      case "mirror_instance":
+      case "align_instances":
+      case "move_junction":
+      case "cut_connection":
+      case "make_flightline":
+        return true;
+      case "set_route_points":
+      case "route_orthogonal":
+      case "add_junction":
+      case "attach_endpoint_to_route":
+        return !isWireCommit;
+      default:
+        return false;
+    }
+  });
+}
+
 function isHistoryEdit(
   edit: SchematicEdit,
 ): edit is Extract<SchematicEdit, { kind: "undo" | "redo" }> {
@@ -3818,6 +3862,9 @@ export function executeTransaction(
     draft.sourceStatus = "connectivity-modified";
   } else if (geometryChanged && draft.sourceStatus === "in-sync") {
     draft.sourceStatus = "geometry-only-changed";
+  }
+  if (transactionDismissesFlightlineGuidance(document, transaction.edits)) {
+    draft.flightlineGuidance = "dismissed";
   }
   draft.revision = proposedRevision;
 

--- a/packages/model/src/schema.ts
+++ b/packages/model/src/schema.ts
@@ -618,6 +618,12 @@ export const SourceBindingSchema = z.strictObject({
   cellName: z.string().min(1),
   sourceRef: SourceSpanSchema,
 });
+/**
+ * Imported SPICE topology can remain electrically authoritative after manual
+ * placement and partial routing. This state owns only the optional dashed
+ * routing guidance; it must not be inferred from source synchronization.
+ */
+export const FlightlineGuidanceSchema = z.enum(["active", "dismissed"]);
 export const CellNetlistTerminalSchema = z.strictObject({
   name: NetlistIdentifierSchema,
   netId: StableIdSchema,
@@ -637,6 +643,7 @@ const SchematicDocumentBaseSchema = z.strictObject({
     "geometry-only-changed",
     "connectivity-modified",
   ]),
+  flightlineGuidance: FlightlineGuidanceSchema.optional(),
   netlist: CellNetlistInterfaceSchema.optional(),
   instances: z.array(InstanceSchema),
   nets: z.array(NetSchema),

--- a/packages/spice/src/compiler.test.ts
+++ b/packages/spice/src/compiler.test.ts
@@ -27,6 +27,7 @@ Q2 collector base emitter QPREF
       name: "__flat__",
       terminals: [],
     });
+    expect(imported.project?.documents[0]?.flightlineGuidance).toBe("active");
     expect(
       imported.project?.documents[0]?.instances.map((instance) => [
         instance.netlist?.reference,

--- a/packages/spice/src/importer.ts
+++ b/packages/spice/src/importer.ts
@@ -318,6 +318,7 @@ function importDocument(
     revision: 0,
     sourceBinding: { cellName: cell.name, sourceRef: cell.sourceRef },
     sourceStatus: "in-sync",
+    flightlineGuidance: "active",
     netlist: {
       name: cell.name,
       terminals: cell.ports.map((port) => ({

--- a/plan/2026-08-14-import-flightline-guidance/plan.md
+++ b/plan/2026-08-14-import-flightline-guidance/plan.md
@@ -1,0 +1,77 @@
+---
+status: completed
+experience: none
+---
+
+# Restore imported-net flightline guidance during placement
+
+## Goal
+
+Keep SPICE-imported, still-unrouted Nets visible as flightline guidance while
+their initially unplaced symbols are being placed and wired. Preserve the
+agreed dismissal behavior: a Net Label, Net highlight, or ordinary geometry
+edit hides the guidance; routing one imported Net must not hide guidance for
+the remaining imported Nets.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/import-flightline-guidance...origin/main
+```
+
+The dedicated worktree is clean. The parent worktree has unrelated recovery
+work and is not touched.
+
+- `packages/model/src/schema.ts`
+- `packages/model/src/factories.ts`
+- `packages/edit-engine/src/transaction.ts`
+- `apps/editor/src/app/App.tsx`
+- focused unit/browser tests and this plan/log entry
+
+Read-only shared dependencies:
+
+- `docs/specs/connectivity-and-routing.md`
+- `packages/derived/src/connectivity.ts`
+- SPICE importer source-binding contract
+
+## Work
+
+1. Add a small persisted per-Document imported-flightline guidance state so
+   source provenance and routing-guidance visibility are not overloaded into
+   `sourceStatus`.
+2. Keep guidance active across `place_instance` and ordinary Wire commits,
+   letting derived connected components remove only satisfied flightlines.
+3. Dismiss guidance on Net Label authoring/removal and ordinary geometry edits;
+   hide all guidance while a Net is highlighted.
+4. Add focused contracts for the placement, routing, dismissal, and highlight
+   paths.
+
+## Validation
+
+- focused model/edit-engine unit tests
+- `pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts --grep "flightline"`
+- `pnpm typecheck`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): preserve imported flightline guidance during placement
+```
+
+## Outcome
+
+Added a persisted imported-flightline guidance state. New SPICE imports start
+active; placement and normal Wire commits retain guidance so derived topology
+removes only satisfied flightlines. Net Label changes, route/instance geometry
+edits, and visual route deletion dismiss it. Net highlight hides every
+flightline only while the highlight is active.
+
+Validation passed: focused edit-engine/SPICE tests (24 tests), isolated
+flightline browser tests (3 tests), full workspace build, typecheck, Prettier,
+and `git diff --check`.

--- a/plan/2026-08-15-integrate-coordinate-flightline/plan.md
+++ b/plan/2026-08-15-integrate-coordinate-flightline/plan.md
@@ -1,0 +1,64 @@
+---
+status: active
+experience: none
+---
+
+# Integrate Coordinate Domains with Flightline Guidance
+
+## Goal
+
+Rebase the imported-SPICE flightline-guidance change onto current `main`,
+preserving the coordinate-domain/grid-normalization contract while retaining
+the imported-document guidance policy and repaired MCP release checksum.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/import-flightline-guidance...origin/codex/import-flightline-guidance
+```
+
+The worktree is clean. This target owns the conflict resolution and its
+delivery record:
+
+- `apps/editor/src/app/App.tsx`
+- `packages/model/src/schema.ts`
+- `packages/spice/src/importer.ts`
+- `packages/edit-engine/src/transaction.ts`
+- focused tests and `plan/`
+- `config/agent-mcp-distribution.json`
+
+Shared dependencies: the coordinate-domain contract on current `main` and the
+MCP release artifact checksum. Their accepted behavior is preserved rather
+than rewritten.
+
+## Work
+
+1. Rebase onto `origin/main` and resolve `App.tsx` by retaining both coordinate
+   normalization and the flightline display policy.
+2. Run focused flightline tests, static checks, and the required delivery gate;
+   record unrelated pre-existing failures if they recur.
+3. Update the factual log, push the rebased branch, wait for required remote
+   checks, and merge only when they pass.
+
+## Validation
+
+- `pnpm test:local packages/edit-engine/src/transaction.test.ts packages/spice/src/compiler.test.ts`
+- isolated browser flightline tests
+- `pnpm install --frozen-lockfile`
+- `pnpm ci:check`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit any conflict-resolution metadata as:
+
+```text
+chore(integration): rebase flightline guidance on coordinate domains
+```
+
+## Outcome
+
+Pending.

--- a/plan/log.md
+++ b/plan/log.md
@@ -6854,3 +6854,16 @@ contracts (WP-R1)`.
   cases passed locally.
 - Commit status: pending follow-up commit on
   `codex/coordinate-domain-contract`; remote PR checks will decide merge.
+## 2026-08-14 - Restore imported flightline guidance during placement
+
+- Target: keep SPICE-imported routing guidance usable after placement and
+  partial Wire authoring, while dismissing it after Net-label or ordinary
+  geometry intervention and hiding it during Net highlight.
+- Changed areas: Document guidance schema/import initialization; edit-engine
+  lifecycle policy; editor flightline visibility; focused SPICE/engine/browser
+  contracts.
+- Validation: 24 focused engine/SPICE tests, isolated browser flightline suite
+  (3 tests), workspace build, typecheck, Prettier, and `git diff --check`
+  passed.
+- Commit status: committed as `59bba32` on `codex/import-flightline-guidance`;
+  pushed as PR #54. The MCP release checksum was refreshed after the package changed.


### PR DESCRIPTION
## Summary
- retain SPICE-imported flightline guidance while initially placing symbols and routing individual Nets
- dismiss guidance after Net-label or ordinary geometry intervention; hide it while a Net is highlighted
- cover importer, edit-engine lifecycle, and browser behavior

## Root cause
Flightline visibility was tied to document-level sourceStatus. Import starts unplaced, but placing the first symbol changes sourceStatus and hid all guidance before it could be used.

## Validation
- focused engine/SPICE tests (24)
- isolated browser flightline tests (3)
- workspace build and typecheck