### PR TITLE
docs(plan): close flightline coordinate integration

### DIFF
--- a/plan/2026-08-15-integrate-coordinate-flightline/plan.md
+++ b/plan/2026-08-15-integrate-coordinate-flightline/plan.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: completed
 experience: none
 ---
 
@@ -61,4 +61,13 @@ chore(integration): rebase flightline guidance on coordinate domains
 
 ## Outcome
 
-Pending.
+Rebased the imported-flightline guidance change on the coordinate-domain/grid
+normalization work. The resolved editor keeps both policies, while the
+transaction layer retains both coordinate validation and guidance dismissal.
+The Linux MCP package hash was recalculated from the required release check.
+
+Focused engine/SPICE tests (24), isolated flightline browser tests (3),
+typecheck, workspace build, formatting, distribution validation, and local
+release verification passed. The full local `ci:check` reached browser tests
+but had one unrelated pre-existing download timeout; all six required remote
+checks passed on PR #54 before merge.

--- a/plan/log.md
+++ b/plan/log.md
@@ -6867,3 +6867,14 @@ contracts (WP-R1)`.
   passed.
 - Commit status: committed as `59bba32` on `codex/import-flightline-guidance`;
   pushed as PR #54. The MCP release checksum was refreshed after the package changed.
+
+## 2026-08-15 - Integrate imported flightline guidance on coordinate domains
+
+- Target: rebase imported-SPICE flightline guidance on the coordinate-domain
+  contract and deliver the combined change through required CI.
+- Changed areas: resolved `App.tsx` and transaction-layer integration;
+  refreshed the Linux MCP package SHA-256 release pin.
+- Validation: 24 focused engine/SPICE tests, 3 isolated browser flightline
+  tests, typecheck, workspace build, formatting, distribution/release checks,
+  and all six PR #54 GitHub Actions checks passed.
+- Commit status: PR #54 merged to `main` as `354cf3a`.


### PR DESCRIPTION
Closes the completed integration plan and factual log after PR #54 merged. Documentation-only.