### PR TITLE
fix(wiring): move junctions with dragged wire segments

### DIFF
--- a/packages/derived/src/stretch.ts
+++ b/packages/derived/src/stretch.ts
@@ -57,24 +57,13 @@ export interface WireSegmentDragProposal {
   junctions: JunctionMoveProposal[];
 }
 
-function routeJunctionDegree(
-  document: SchematicDocument,
-  junctionId: string,
-): number {
-  return document.routes.filter(
-    (route) =>
-      (route.from.kind === "junction" &&
-        route.from.junctionId === junctionId) ||
-      (route.to.kind === "junction" && route.to.junctionId === junctionId),
-  ).length;
-}
-
 /**
- * Persisted Route boundaries are not automatically visual anchors. A
- * degree-one/two route-anchor is editable geometry; terminals, ports, legacy
- * branch records, and degree-three-or-greater Junctions remain hard anchors.
+ * A persisted Junction is a topological vertex, not an absolute geometric
+ * anchor. Dragging a segment that terminates at one therefore moves the vertex
+ * and lets every incident Route stretch around it. Terminals remain hard
+ * anchors: their positions belong to their Symbols.
  */
-function softRouteAnchorId(
+function movableSegmentJunctionId(
   document: SchematicDocument,
   endpoint: SchematicDocument["routes"][number]["from"],
 ): string | null {
@@ -83,15 +72,7 @@ function softRouteAnchorId(
     (candidate) => candidate.id === endpoint.junctionId,
   );
   if (!junction) return null;
-  const degree = routeJunctionDegree(document, junction.id);
-  if (degree > 2) return null;
-  if (junction.role === "route-anchor") return junction.id;
-  // GUI Projects created before route-anchor roles used an implicit branch
-  // record for a dangling end. Preserve that established loose-end behavior.
-  if ((junction.role ?? "branch") === "branch" && degree === 1) {
-    return junction.id;
-  }
-  return null;
+  return junction.id;
 }
 
 function protectedMode(mode: SegmentMode | undefined): boolean {
@@ -212,21 +193,21 @@ export function proposeWireSegmentDrag(
   }
 
   const lastPointIndex = selectedPolyline.points.length - 1;
-  const selectedEndpointAnchor = (pointIndex: number): string | null => {
+  const selectedEndpointJunction = (pointIndex: number): string | null => {
     if (pointIndex === 0) {
-      return softRouteAnchorId(document, selectedRoute.from);
+      return movableSegmentJunctionId(document, selectedRoute.from);
     }
     if (pointIndex === lastPointIndex) {
-      return softRouteAnchorId(document, selectedRoute.to);
+      return movableSegmentJunctionId(document, selectedRoute.to);
     }
     return null;
   };
-  const leftAnchorId = selectedEndpointAnchor(segmentIndex);
-  const rightAnchorId = selectedEndpointAnchor(segmentIndex + 1);
+  const leftAnchorId = selectedEndpointJunction(segmentIndex);
+  const rightAnchorId = selectedEndpointJunction(segmentIndex + 1);
 
   // Ordinary single-Route bends keep the established dogleg behavior. The
-  // topology-aware path is required only when a soft persisted endpoint makes
-  // the storage partition observable.
+  // topology-aware path is required only when a persisted Junction makes the
+  // graph vertex observable.
   if (!leftAnchorId && !rightAnchorId) {
     return {
       routes: [
@@ -289,8 +270,8 @@ export function proposeWireSegmentDrag(
 
   for (const route of document.routes) {
     if (route.id === routeId) continue;
-    const fromAnchor = softRouteAnchorId(document, route.from);
-    const toAnchor = softRouteAnchorId(document, route.to);
+    const fromAnchor = movableSegmentJunctionId(document, route.from);
+    const toAnchor = movableSegmentJunctionId(document, route.to);
     const movedFrom = fromAnchor ? movedJunctions.get(fromAnchor) : undefined;
     const movedTo = toAnchor ? movedJunctions.get(toAnchor) : undefined;
     if (!movedFrom && !movedTo) continue;

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -218,6 +218,104 @@ describe("routing Edit Engine", () => {
     expect(moved.ok).toBe(true);
   });
 
+  it("moves a three-way Junction with its dragged segment", () => {
+    const document = createEmptyDocument("junction-follow", "Junction follow");
+    document.nets.push({ id: "net-j", scope: "local", terminals: [] });
+    document.junctions.push(
+      { id: "junction-center", netId: "net-j", position: { x: 100, y: 100 } },
+      {
+        id: "junction-right",
+        netId: "net-j",
+        position: { x: 300, y: 100 },
+        role: "route-anchor",
+      },
+      { id: "junction-top", netId: "net-j", position: { x: 100, y: 20 } },
+      { id: "junction-left", netId: "net-j", position: { x: 20, y: 100 } },
+    );
+    document.routes.push(
+      {
+        id: "route-main",
+        netId: "net-j",
+        from: { kind: "junction", junctionId: "junction-center" },
+        to: { kind: "junction", junctionId: "junction-right" },
+        waypoints: [],
+        segmentModes: ["manual"],
+      },
+      {
+        id: "route-top",
+        netId: "net-j",
+        from: { kind: "junction", junctionId: "junction-top" },
+        to: { kind: "junction", junctionId: "junction-center" },
+        waypoints: [],
+        segmentModes: ["manual"],
+      },
+      {
+        id: "route-left",
+        netId: "net-j",
+        from: { kind: "junction", junctionId: "junction-left" },
+        to: { kind: "junction", junctionId: "junction-center" },
+        waypoints: [],
+        segmentModes: ["manual"],
+      },
+    );
+
+    const proposal = proposeWireSegmentMove(
+      document,
+      resolver,
+      "route-main",
+      0,
+      { x: 200, y: 60 },
+    );
+    expect(
+      proposal.edits.filter((edit) => edit.kind === "move_junction"),
+    ).toEqual([
+      {
+        kind: "move_junction",
+        junctionId: "junction-center",
+        position: { x: 100, y: 60 },
+      },
+      {
+        kind: "move_junction",
+        junctionId: "junction-right",
+        position: { x: 300, y: 60 },
+      },
+    ]);
+
+    const moved = executeTransaction(
+      document,
+      transaction(document.id, 0, proposal.edits),
+      context,
+    );
+    expect(moved.ok).toBe(true);
+    if (!moved.ok) return;
+    expect(
+      moved.document.junctions.find(
+        (junction) => junction.id === "junction-center",
+      )?.position,
+    ).toEqual({ x: 100, y: 60 });
+    expect(
+      routePolyline(
+        moved.document,
+        resolver,
+        moved.document.routes.find((route) => route.id === "route-main")!,
+      )?.points,
+    ).toEqual([
+      { x: 100, y: 60 },
+      { x: 300, y: 60 },
+    ]);
+    expect(
+      routePolyline(
+        moved.document,
+        resolver,
+        moved.document.routes.find((route) => route.id === "route-left")!,
+      )?.points,
+    ).toEqual([
+      { x: 20, y: 100 },
+      { x: 100, y: 100 },
+      { x: 100, y: 60 },
+    ]);
+  });
+
   it("plans internal group route follow as one engine edit proposal", () => {
     const document = documentFixture();
     const routed = executeTransaction(

--- a/plan/2026-08-15-junction-segment-follow/plan.md
+++ b/plan/2026-08-15-junction-segment-follow/plan.md
@@ -1,0 +1,66 @@
+---
+status: completed
+experience: none
+---
+
+# Junction Follow During Wire-Segment Movement
+
+## Goal
+
+Make direct wire-segment movement treat a visible Junction as a movable
+topological vertex, rather than an absolute geometry anchor. Moving a segment
+that ends at a Junction must move that Junction and orthogonally stretch every
+incident route, including terminal branches.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/junction-stretch-semantics...origin/main
+```
+
+The worktree is clean. This target owns the wire-segment stretch proposal,
+editor preview if required for parity, focused tests, and plan/log records.
+
+- `packages/derived/src/stretch.ts`
+- `packages/edit-engine/src/routing-planner.ts`
+- `packages/edit-engine/src/routing.test.ts`
+- `apps/editor/src/app/App.tsx` only if preview needs the same proposal
+- `plan/`
+
+Read-only shared contracts: route normalization, edit-transaction validation,
+and rendered route geometry. No electrical Net membership changes are allowed.
+
+## Work
+
+1. Replace the degree-based hard-anchor heuristic with vertex-follow behavior
+   for Junction endpoints of a dragged segment.
+2. Preserve orthogonality by applying one Junction move plus endpoint stretch
+   proposals to every incident route in one transaction.
+3. Add regression coverage for a three-way Junction whose horizontal segment
+   is moved perpendicular to itself.
+
+## Validation
+
+- `pnpm test:local packages/derived/src/derived.test.ts packages/edit-engine/src/routing.test.ts`
+- relevant editor interaction/browser test if preview changes
+- `pnpm typecheck`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+```text
+fix(wiring): move junctions with dragged wire segments
+```
+
+## Outcome
+
+Segment dragging now treats every Junction endpoint as a movable topological
+vertex. The transaction moves that vertex and orthogonally stretches all of its
+incident Routes; terminal endpoints remain fixed. A three-way-junction
+regression covers the previously anchored horizontal-segment case.
+
+Focused derived/edit-engine tests (34), typecheck, Prettier, and diff checks
+passed.

--- a/plan/log.md
+++ b/plan/log.md
@@ -6878,3 +6878,14 @@ contracts (WP-R1)`.
   tests, typecheck, workspace build, formatting, distribution/release checks,
   and all six PR #54 GitHub Actions checks passed.
 - Commit status: PR #54 merged to `main` as `354cf3a`.
+
+## 2026-08-15 - Make junctions follow dragged wire segments
+
+- Target: correct direct segment movement so a Junction is moved as a
+  topological vertex instead of remaining an absolute geometry anchor.
+- Changed areas: derived wire-segment stretch policy and an edit-engine
+  regression for a three-way Junction with an orthogonally stretched branch.
+- Validation: focused derived/edit-engine suite (34 tests), typecheck,
+  Prettier, and `git diff --check` passed.
+- Commit status: committed as `a345129` on `codex/junction-stretch-semantics`;
+  remote CI pending.


### PR DESCRIPTION
A dragged segment now moves any Junction endpoint as a topology vertex and orthogonally stretches every incident Route. Includes a three-way Junction regression.\n\nLocal focused tests, typecheck, release verification passed. Full local browser suite encountered the existing drafting download timeout; remote browser checks required before merge.