### PR TITLE
Default drafting text to Razavi typography

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -59,6 +59,7 @@ import type {
 } from "@icm/derived";
 import {
   createEmptyProject,
+  defaultDraftTextDocument,
   flattenRichText,
   powerNetNormalizations,
   snapGridPoint,
@@ -4397,7 +4398,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       locked: false,
       zIndex: 0,
       anchor: { kind: "free", position },
-      content: { runs: [{ kind: "text", value: "Design note" }] },
+      content: defaultDraftTextDocument("Design note"),
       alignment: "middle",
       rotation: 0,
       typographyToken: "label",

--- a/packages/model/src/semantic-text.test.ts
+++ b/packages/model/src/semantic-text.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultDraftTextDocument } from "./semantic-text.js";
+
+describe("defaultDraftTextDocument", () => {
+  it("uses Razavi bold italic text and a bold upright subscript", () => {
+    expect(defaultDraftTextDocument("V_out")).toEqual({
+      runs: [
+        {
+          kind: "span",
+          style: "italic",
+          children: [
+            {
+              kind: "span",
+              style: "bold",
+              children: [{ kind: "text", value: "V" }],
+            },
+          ],
+        },
+        {
+          kind: "span",
+          style: "subscript",
+          children: [
+            {
+              kind: "span",
+              style: "bold",
+              children: [{ kind: "text", value: "out" }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("styles ordinary free text as a Razavi math base", () => {
+    expect(defaultDraftTextDocument("Design note")).toEqual({
+      runs: [
+        {
+          kind: "span",
+          style: "italic",
+          children: [
+            {
+              kind: "span",
+              style: "bold",
+              children: [{ kind: "text", value: "Design note" }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/packages/model/src/semantic-text.ts
+++ b/packages/model/src/semantic-text.ts
@@ -28,6 +28,24 @@ function mathSubscript(value: string): RichTextRun {
   return span([span([{ kind: "text", value }], "bold")], "subscript");
 }
 
+/** Construct the initial Razavi-style RichText for a free drafting label. */
+export function defaultDraftTextDocument(value: string): RichTextDocument {
+  if (value.length === 0) return { runs: [{ kind: "line-break" }] };
+  if (/[\\{}^]/u.test(value)) return { runs: [{ kind: "text", value }] };
+
+  const underscore = value.indexOf("_");
+  if (underscore > 0 && underscore < value.length - 1) {
+    return {
+      runs: [
+        mathBase(value.slice(0, underscore)),
+        mathSubscript(value.slice(underscore + 1)),
+      ],
+    };
+  }
+
+  return { runs: [mathBase(value)] };
+}
+
 /** Construct current-authoring RichText for a conventional semantic label. */
 export function semanticTextDocument(
   value: string,

--- a/packages/render-svg/src/current-contract.test.ts
+++ b/packages/render-svg/src/current-contract.test.ts
@@ -137,7 +137,7 @@ describe("current rendering contract", () => {
       'style="font-style:italic;font-weight:700">V<tspan data-text-run="subscript"',
     );
     expect(svg).toContain(
-      'data-text-run="subscript" dx="0.046em" font-size="76%" baseline-shift="-0.28em" style="font-style:italic;font-weight:700">DD',
+      'data-text-run="subscript" dx="0.046em" font-size="76%" baseline-shift="-0.28em" style="font-style:normal;font-weight:700">DD',
     );
   });
 });

--- a/packages/render-svg/src/rich-text.test.ts
+++ b/packages/render-svg/src/rich-text.test.ts
@@ -87,6 +87,37 @@ describe("renderRichTextDocument", () => {
     expect(svg).toContain('dx="0.046em"');
   });
 
+  it("keeps a script upright when it occurs inside bold italic text", () => {
+    const svg = renderRichTextDocument(
+      {
+        runs: [
+          {
+            kind: "span",
+            style: "italic",
+            children: [
+              {
+                kind: "span",
+                style: "bold",
+                children: [
+                  { kind: "text", value: "V" },
+                  {
+                    kind: "span",
+                    style: "subscript",
+                    children: [{ kind: "text", value: "out" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      razaviTextbookProfile,
+    );
+    expect(svg).toContain(
+      'data-text-run="subscript" dx="0.046em" font-size="76%" baseline-shift="-0.28em" style="font-style:normal;font-weight:700">out</tspan>',
+    );
+  });
+
   it("renders a line break", () => {
     const svg = renderRichTextDocument(
       {

--- a/packages/render-svg/src/rich-text.ts
+++ b/packages/render-svg/src/rich-text.ts
@@ -85,5 +85,9 @@ function renderSpan(
       : typography.subscriptBaselineShiftEm;
   const dx =
     node.style === "subscript" ? typography.subscriptHorizontalGapEm : 0;
-  return `<tspan data-text-run="${node.style}" dx="${dx}em" font-size="${percent}%" baseline-shift="${shift}em" style="${styleAttribute(ctx)}">${renderRuns(node.children, ctx)}</tspan>`;
+  // Scripts in the Razavi profile are upright by default. They retain the
+  // surrounding weight so a bold math base has a bold upright subscript; an
+  // explicit nested italic span remains an intentional user override.
+  const scriptCtx: RenderContext = { ...ctx, italic: false };
+  return `<tspan data-text-run="${node.style}" dx="${dx}em" font-size="${percent}%" baseline-shift="${shift}em" style="${styleAttribute(scriptCtx)}">${renderRuns(node.children, scriptCtx)}</tspan>`;
 }

--- a/plan/2026-08-15-default-drafting-text-razavi/plan.md
+++ b/plan/2026-08-15-default-drafting-text-razavi/plan.md
@@ -1,0 +1,85 @@
+---
+status: completed
+experience: none
+---
+
+# Default drafting text uses Razavi typography
+
+## Goal
+
+Make text created with `T` begin with the same Razavi typography composition as
+schematic annotations: 15.116-unit label size, bold italic main text, and a
+bold upright subscript when the user applies subscript formatting.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree was clean. This target is on the dedicated branch
+`codex/default-text-razavi-style` and owns:
+
+- `apps/editor/src/app/App.tsx`
+- `packages/model/src/semantic-text.ts`
+- `packages/model/src/semantic-text.test.ts`
+- `packages/render-svg/src/rich-text.ts`
+- `packages/render-svg/src/rich-text.test.ts`
+- `packages/render-svg/src/current-contract.test.ts`
+- `plan/2026-08-15-default-drafting-text-razavi/plan.md`
+- `plan/log.md`
+
+Read-only shared dependencies:
+
+- `packages/derived/src/style-profile.ts` defines the authority-approved
+  typography tokens.
+- `docs/specs/razavi-visual-contract.md` is the visual authority contract.
+
+## Work
+
+1. Add one semantic factory for default drafting text instead of duplicating
+   the annotation AST in the editor.
+2. Use that factory for `T` text creation with the existing `label`
+   typography token.
+3. Ensure a subscript span resets italic styling while retaining bold styling,
+   matching the accepted annotation composition.
+4. Add focused model, renderer, and editor regression assertions.
+5. Update the Razavi power-label renderer contract after its previous
+   italic-subscript expectation is disproved by the approved text style.
+
+## Validation
+
+- `pnpm test:local packages/model/src/semantic-text.test.ts packages/render-svg/src/rich-text.test.ts apps/editor/src/app/App.test.tsx`
+- `pnpm test:local packages/render-svg/src/current-contract.test.ts`
+- `pnpm -C packages/model build`
+- `pnpm -C packages/render-svg build`
+- `pnpm -C apps/editor build`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): default drafting text to Razavi typography
+```
+
+## Outcome
+
+- Added `defaultDraftTextDocument()` as the sole initial-content factory for
+  free drafting text. It composes ordinary text as bold italic and recognizes
+  one conventional underscore suffix as bold upright subscript.
+- `T` now uses that factory while retaining its existing `label` token, whose
+  Razavi size is 15.116 units.
+- Script rendering now resets inherited italic style but retains inherited
+  weight, so a selection converted to subscript inside default text renders as
+  the same bold upright form as an annotation.
+- Validation passed: 20 focused model/renderer/editor tests; model,
+  render-svg, and editor builds; Prettier; and `git diff --check`. The first
+  full gate correctly found one stale power-label contract expectation, which
+  was repaired and retested. The clean-tree `pnpm install --frozen-lockfile &&
+pnpm ci:check` gate then passed: static checks, 726 unit/integration tests,
+  workspace build, release smoke, and 121 browser tests.

--- a/plan/log.md
+++ b/plan/log.md
@@ -6997,3 +6997,16 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
   Prettier, and `git diff --check` passed.
 - Commit status: PR #57 merged to `main` as `16ad036` after all required
   GitHub Actions checks passed.
+
+## 2026-08-15 - Default drafting text to Razavi typography
+
+- Target: make `T`-created free text begin with the same bold-italic main and
+  bold-upright subscript composition as existing Razavi annotations.
+- Changed areas: semantic text factory, drafting-text creation, and RichText
+  script rendering with focused regression tests.
+- Validation: 20 focused model/renderer/editor tests, stale power-label
+  contract regression, and clean-tree `pnpm ci:check` all passed (static,
+  726 unit/integration tests, workspace build/release smoke, 121 browser
+  tests).
+- Commit status: committed on `codex/default-text-razavi-style`; remote CI and
+  merge remain pending.


### PR DESCRIPTION
## What changed

New free text created with T now starts from the same canonical RichText composition as Razavi annotations: a 15.116-unit label token with bold italic main text and bold upright subscripts.

## Why

DraftText previously started as a bare text run, so it rendered normal weight and normal style even though existing schematic annotations used the approved Razavi math composition.

## Validation

- pnpm test:local packages/model/src/semantic-text.test.ts packages/render-svg/src/rich-text.test.ts apps/editor/src/app/App.test.tsx
- pnpm test:local packages/render-svg/src/current-contract.test.ts
- Clean-tree pnpm install --frozen-lockfile && pnpm ci:check (726 unit/integration tests and 121 browser tests)