### PR TITLE
fix(editor): make VDD rails stretchable after taps

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -277,6 +277,64 @@ test("constructs VDD as a drawn dotless power rail", async ({ page }) => {
   await expect(canvas.getByText("VDD", { exact: true })).toHaveCount(0);
 });
 
+test("keeps a tapped VDD rail movable and stretchable as one supply bar", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const canvas = page.getByTestId("schematic-canvas");
+  await page.getByTestId("shapes-chip-vdd").click();
+  await canvas.click({ position: { x: 180, y: 120 } });
+  await canvas.click({ position: { x: 520, y: 120 } });
+  await placeComponent(page, "resistor", { x: 360, y: 300 });
+
+  await clickCommand(page, "Draw", "Wire (W)");
+  await clickRoute(page, "route-vdd1-rail");
+  await page.locator('[data-testid^="terminal-R"][data-testid$="-1"]').click();
+  await page.keyboard.press("Escape");
+
+  const railHits = page.locator('[data-testid^="route-hit-route-vdd1-rail"]');
+  await expect(railHits).toHaveCount(2);
+  const selectedTestId = await railHits.first().getAttribute("data-testid");
+  if (!selectedTestId) throw new Error("Tapped VDD rail is not selectable");
+  const selectedRailId = selectedTestId.replace(/^route-hit-/u, "");
+  const railIds = await railHits.evaluateAll((elements) =>
+    elements.map((element) =>
+      element.getAttribute("data-testid")!.replace(/^route-hit-/u, ""),
+    ),
+  );
+  const beforeMove = await Promise.all(
+    railIds.map((id) => readRoutePoints(page, id)),
+  );
+
+  await clickRoute(page, selectedRailId);
+  await dragBy(page.getByTestId(`route-handle-${selectedRailId}`), {
+    x: 30,
+    y: 40,
+  });
+  await expect(page.getByTestId("status")).toContainText("Moved VDD rail");
+  const afterMove = await Promise.all(
+    railIds.map((id) => readRoutePoints(page, id)),
+  );
+  expect(Math.min(...afterMove.flat().map((point) => point.y))).toBeGreaterThan(
+    Math.min(...beforeMove.flat().map((point) => point.y)),
+  );
+
+  const beforeResizeRight = Math.max(
+    ...afterMove.flat().map((point) => point.x),
+  );
+  await dragBy(page.getByTestId("junction-junction-vdd1-end"), {
+    x: 80,
+    y: 0,
+  });
+  await expect(page.getByTestId("status")).toContainText("Resized VDD rail");
+  const afterResize = await Promise.all(
+    railIds.map((id) => readRoutePoints(page, id)),
+  );
+  expect(
+    Math.max(...afterResize.flat().map((point) => point.x)),
+  ).toBeGreaterThan(beforeResizeRight);
+});
+
 test("reuses the PMOS bulk supply Net when drawing a VDD rail", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -16,6 +16,8 @@ import {
   proposeEndpointRouteAttachment,
   proposeGroupMoveEdits,
   proposeLooseRouteTranslation,
+  proposePowerRailEndpointResize,
+  proposePowerRailTranslation,
   proposeWireCommitThroughContacts,
   proposeWireSegmentMove,
   proposeVisualRouteDeletion,
@@ -33,6 +35,7 @@ import {
   buildProjectSearchIndex,
   deriveCrossings,
   deriveInternalGroupSelection,
+  derivePowerRailComponent,
   diagnoseVisualQuality,
   endpointKey,
   findHierarchyPath,
@@ -271,7 +274,12 @@ interface PanPreview {
 interface RouteStretchPreview {
   routeId: string;
   segmentIndex: number;
-  kind: "segment" | "translate";
+  kind:
+    | "segment"
+    | "translate"
+    | "power-rail-translate"
+    | "power-rail-resize-start"
+    | "power-rail-resize-end";
   start: DerivedPoint;
   point: DerivedPoint;
 }
@@ -2255,9 +2263,11 @@ export function App({ project: initialProject, visitStats }: AppProps) {
         event,
         routeId,
         segmentIndex,
-        looseRouteAnchorIds(document, routeRecord.route) !== null
-          ? "translate"
-          : "segment",
+        routeRecord.route.presentation === "power-rail"
+          ? "power-rail-translate"
+          : looseRouteAnchorIds(document, routeRecord.route) !== null
+            ? "translate"
+            : "segment",
         hitTarget,
       );
       return;
@@ -2335,7 +2345,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     event: ReactPointerEvent<SVGElement>,
     routeId: string,
     segmentIndex: number,
-    kind: "segment" | "translate" = "segment",
+    kind: RouteStretchPreview["kind"] = "segment",
     hitTarget: SVGElement = event.currentTarget,
   ): void {
     if (event.button !== 0) return;
@@ -2347,13 +2357,26 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       (candidate) => candidate.route.id === routeId,
     );
     if (!record) return;
+    const powerRail =
+      kind === "power-rail-translate" ||
+      kind === "power-rail-resize-start" ||
+      kind === "power-rail-resize-end"
+        ? derivePowerRailComponent(document, routeId)
+        : null;
     const anchorIds =
       kind === "translate"
         ? (looseRouteAnchorIds(document, record.route) ?? [])
-        : [];
+        : (powerRail?.junctionIds ?? []);
+    const translatedRouteIds =
+      kind === "power-rail-translate"
+        ? (powerRail?.routeIds ?? [routeId])
+        : [routeId];
     let visual: ReturnType<typeof startCanvasDragVisual> | null = null;
     const dragVisual = () =>
-      (visual ??= startCanvasDragVisual(svg, [routeId, ...anchorIds]));
+      (visual ??= startCanvasDragVisual(svg, [
+        ...translatedRouteIds,
+        ...anchorIds,
+      ]));
     const preview: RouteStretchPreview = {
       routeId,
       segmentIndex,
@@ -2369,11 +2392,20 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       thresholdPx: DRAG_START_DISTANCE_PX,
       onPreview: (client) => {
         const point = pointFromClient(client.x, client.y, svg, false);
-        if (kind === "translate") {
+        if (kind === "translate" || kind === "power-rail-translate") {
           dragVisual().translate({
             x: point.x - start.x,
             y: point.y - start.y,
           });
+          return;
+        }
+        if (
+          kind === "power-rail-resize-start" ||
+          kind === "power-rail-resize-end"
+        ) {
+          // The persisted proposal resizes the outer rail fragment, which may
+          // differ from the selected fragment after a tap. Avoid previewing a
+          // misleading single-segment drag; the end handle remains the cue.
           return;
         }
         try {
@@ -2443,6 +2475,42 @@ export function App({ project: initialProject, visitStats }: AppProps) {
           );
           if (result.ok) setStatus(`Moved loose route ${record.route.id}`);
         }
+      } else if (preview.kind === "power-rail-translate") {
+        const delta = {
+          x: snapCoordinate(
+            point.x - preview.start.x,
+            document.presentation.grid,
+          ),
+          y: snapCoordinate(
+            point.y - preview.start.y,
+            document.presentation.grid,
+          ),
+        };
+        if (delta.x !== 0 || delta.y !== 0) {
+          const result = transact(
+            proposePowerRailTranslation(
+              document,
+              resolver,
+              record.route.id,
+              delta,
+            ).edits,
+          );
+          if (result.ok) setStatus(`Moved VDD rail ${record.route.id}`);
+        }
+      } else if (
+        preview.kind === "power-rail-resize-start" ||
+        preview.kind === "power-rail-resize-end"
+      ) {
+        const result = transact(
+          proposePowerRailEndpointResize(
+            document,
+            resolver,
+            record.route.id,
+            preview.kind === "power-rail-resize-start" ? "start" : "end",
+            snapCoordinate(point.x, document.presentation.grid),
+          ).edits,
+        );
+        if (result.ok) setStatus(`Resized VDD rail ${record.route.id}`);
       } else {
         const proposal = proposeWireSegmentMove(
           document,
@@ -7834,6 +7902,21 @@ export function App({ project: initialProject, visitStats }: AppProps) {
                   const to = polyline.points[segmentIndex + 1]!;
                   const translatesWholeRoute =
                     looseRouteAnchorIds(document, route) !== null;
+                  const powerRail =
+                    route.presentation === "power-rail"
+                      ? derivePowerRailComponent(document, route.id)
+                      : null;
+                  const powerRailEnds = powerRail?.endpointJunctionIds
+                    .map((junctionId) =>
+                      document.junctions.find(
+                        (junction) => junction.id === junctionId,
+                      ),
+                    )
+                    .filter(
+                      (junction): junction is NonNullable<typeof junction> =>
+                        Boolean(junction),
+                    )
+                    .sort((left, right) => left.position.x - right.position.x);
                   const routeCenter = centerOfBounds(
                     polylineBounds(polyline.points),
                   );
@@ -7841,46 +7924,80 @@ export function App({ project: initialProject, visitStats }: AppProps) {
                     routeStretchPreview?.routeId === route.id
                       ? routeStretchPreview.point
                       : null;
+                  const handlePointerDown = (
+                    event: ReactPointerEvent<SVGElement>,
+                    kind: RouteStretchPreview["kind"],
+                  ) => {
+                    const primaryInstanceId = selectedIds.at(-1);
+                    if (
+                      primaryInstanceId &&
+                      compositeSelectionOwnsHit("route", route.id)
+                    ) {
+                      beginMove(event, primaryInstanceId);
+                      return;
+                    }
+                    beginRouteStretch(event, route.id, segmentIndex, kind);
+                  };
                   return (
-                    <circle
-                      key={`handle-${route.id}`}
-                      data-testid={`route-handle-${route.id}`}
-                      data-canvas-hit-kind="handle"
-                      data-canvas-hit-id={`route-handle-${route.id}`}
-                      className="route-handle"
-                      cx={
-                        translatesWholeRoute
-                          ? (preview?.x ?? routeCenter.x)
-                          : from.y === to.y
-                            ? (from.x + to.x) / 2
-                            : (preview?.x ?? (from.x + to.x) / 2)
-                      }
-                      cy={
-                        translatesWholeRoute
-                          ? (preview?.y ?? routeCenter.y)
-                          : from.x === to.x
-                            ? (from.y + to.y) / 2
-                            : (preview?.y ?? (from.y + to.y) / 2)
-                      }
-                      r="6"
-                      onPointerDown={(event) => {
-                        const primaryInstanceId = selectedIds.at(-1);
-                        if (
-                          primaryInstanceId &&
-                          compositeSelectionOwnsHit("route", route.id)
-                        ) {
-                          beginMove(event, primaryInstanceId);
-                          return;
+                    <g key={`handle-${route.id}`}>
+                      <circle
+                        data-testid={`route-handle-${route.id}`}
+                        data-canvas-hit-kind="handle"
+                        data-canvas-hit-id={`route-handle-${route.id}`}
+                        className="route-handle"
+                        cx={
+                          powerRail
+                            ? routeCenter.x
+                            : translatesWholeRoute
+                              ? (preview?.x ?? routeCenter.x)
+                              : from.y === to.y
+                                ? (from.x + to.x) / 2
+                                : (preview?.x ?? (from.x + to.x) / 2)
                         }
-                        beginRouteStretch(
-                          event,
-                          route.id,
-                          segmentIndex,
-                          translatesWholeRoute ? "translate" : "segment",
-                        );
-                      }}
-                      pointerEvents={tool === "wire" ? "none" : undefined}
-                    />
+                        cy={
+                          powerRail
+                            ? routeCenter.y
+                            : translatesWholeRoute
+                              ? (preview?.y ?? routeCenter.y)
+                              : from.x === to.x
+                                ? (from.y + to.y) / 2
+                                : (preview?.y ?? (from.y + to.y) / 2)
+                        }
+                        r="6"
+                        onPointerDown={(event) =>
+                          handlePointerDown(
+                            event,
+                            powerRail
+                              ? "power-rail-translate"
+                              : translatesWholeRoute
+                                ? "translate"
+                                : "segment",
+                          )
+                        }
+                        pointerEvents={tool === "wire" ? "none" : undefined}
+                      />
+                      {powerRailEnds?.map((junction, index) => (
+                        <circle
+                          key={`power-rail-handle-${route.id}-${index}`}
+                          data-testid={`power-rail-handle-${route.id}-${index === 0 ? "start" : "end"}`}
+                          data-canvas-hit-kind="handle"
+                          data-canvas-hit-id={`power-rail-handle-${route.id}-${index === 0 ? "start" : "end"}`}
+                          className="route-handle"
+                          cx={junction.position.x}
+                          cy={junction.position.y}
+                          r="6"
+                          onPointerDown={(event) =>
+                            handlePointerDown(
+                              event,
+                              index === 0
+                                ? "power-rail-resize-start"
+                                : "power-rail-resize-end",
+                            )
+                          }
+                          pointerEvents={tool === "wire" ? "none" : undefined}
+                        />
+                      ))}
+                    </g>
                   );
                 })}
               {document.instances
@@ -7950,66 +8067,111 @@ export function App({ project: initialProject, visitStats }: AppProps) {
                   onClick={(event) => event.stopPropagation()}
                 />
               ))}
-              {wiringEndpoints.map((candidate) => (
-                <circle
-                  key={`${candidate.netId}:${endpointTestId(candidate.endpoint)}`}
-                  data-testid={endpointTestId(candidate.endpoint)}
-                  data-canvas-hit-kind={
-                    candidate.endpoint.kind === "junction"
-                      ? "junction"
-                      : undefined
-                  }
-                  data-canvas-hit-id={
-                    candidate.endpoint.kind === "junction"
-                      ? candidate.endpoint.junctionId
-                      : undefined
-                  }
-                  data-drag-object-id={
-                    candidate.endpoint.kind === "junction"
-                      ? candidate.endpoint.junctionId
-                      : undefined
-                  }
-                  className={
-                    tool === "wire" ||
-                    (candidate.endpoint.kind === "junction" &&
-                      supplementalSelection.junctionIds.includes(
-                        candidate.endpoint.junctionId,
-                      )) ||
-                    (selectedEndpoint?.endpoint.kind === "junction" &&
-                      candidate.endpoint.kind === "junction" &&
-                      selectedEndpoint.endpoint.junctionId ===
-                        candidate.endpoint.junctionId)
-                      ? "endpoint-hit active"
-                      : "endpoint-hit"
-                  }
-                  cx={candidate.point.x}
-                  cy={candidate.point.y}
-                  r={4}
-                  onClick={(event) => event.stopPropagation()}
-                  onContextMenu={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    selectEndpoint(candidate);
-                    setStatus(
-                      `Endpoint actions: ${endpointTestId(candidate.endpoint)}`,
-                    );
-                  }}
-                  onPointerDown={(event) => {
-                    if (
-                      tool === "pointer" &&
+              {wiringEndpoints.map((candidate) => {
+                const powerRailEnds =
+                  selectedRoute?.presentation === "power-rail"
+                    ? (derivePowerRailComponent(document, selectedRoute.id)
+                        ?.endpointJunctionIds.map((junctionId) =>
+                          document.junctions.find(
+                            (junction) => junction.id === junctionId,
+                          ),
+                        )
+                        .filter(
+                          (
+                            junction,
+                          ): junction is NonNullable<typeof junction> =>
+                            Boolean(junction),
+                        )
+                        .sort(
+                          (left, right) => left.position.x - right.position.x,
+                        ) ?? [])
+                    : [];
+                const candidateJunctionId =
+                  candidate.endpoint.kind === "junction"
+                    ? candidate.endpoint.junctionId
+                    : null;
+                const powerRailEndIndex =
+                  candidateJunctionId !== null
+                    ? powerRailEnds.findIndex(
+                        (junction) => junction.id === candidateJunctionId,
+                      )
+                    : -1;
+                return (
+                  <circle
+                    key={`${candidate.netId}:${endpointTestId(candidate.endpoint)}`}
+                    data-testid={endpointTestId(candidate.endpoint)}
+                    data-canvas-hit-kind={
                       candidate.endpoint.kind === "junction"
-                    ) {
+                        ? "junction"
+                        : undefined
+                    }
+                    data-canvas-hit-id={
+                      candidate.endpoint.kind === "junction"
+                        ? candidate.endpoint.junctionId
+                        : undefined
+                    }
+                    data-drag-object-id={
+                      candidate.endpoint.kind === "junction"
+                        ? candidate.endpoint.junctionId
+                        : undefined
+                    }
+                    className={
+                      tool === "wire" ||
+                      (candidate.endpoint.kind === "junction" &&
+                        supplementalSelection.junctionIds.includes(
+                          candidate.endpoint.junctionId,
+                        )) ||
+                      (selectedEndpoint?.endpoint.kind === "junction" &&
+                        candidate.endpoint.kind === "junction" &&
+                        selectedEndpoint.endpoint.junctionId ===
+                          candidate.endpoint.junctionId)
+                        ? "endpoint-hit active"
+                        : "endpoint-hit"
+                    }
+                    cx={candidate.point.x}
+                    cy={candidate.point.y}
+                    r={4}
+                    onClick={(event) => event.stopPropagation()}
+                    onContextMenu={(event) => {
+                      event.preventDefault();
                       event.stopPropagation();
                       selectEndpoint(candidate);
                       setStatus(
-                        `Selected ${endpointTestId(candidate.endpoint)}`,
+                        `Endpoint actions: ${endpointTestId(candidate.endpoint)}`,
                       );
-                      return;
-                    }
-                    handleWireEndpoint(event, candidate);
-                  }}
-                />
-              ))}
+                    }}
+                    onPointerDown={(event) => {
+                      if (
+                        tool === "pointer" &&
+                        selectedRoute &&
+                        powerRailEndIndex >= 0
+                      ) {
+                        beginRouteStretch(
+                          event,
+                          selectedRoute.id,
+                          selectedRouteSegmentIndex ?? 0,
+                          powerRailEndIndex === 0
+                            ? "power-rail-resize-start"
+                            : "power-rail-resize-end",
+                        );
+                        return;
+                      }
+                      if (
+                        tool === "pointer" &&
+                        candidate.endpoint.kind === "junction"
+                      ) {
+                        event.stopPropagation();
+                        selectEndpoint(candidate);
+                        setStatus(
+                          `Selected ${endpointTestId(candidate.endpoint)}`,
+                        );
+                        return;
+                      }
+                      handleWireEndpoint(event, candidate);
+                    }}
+                  />
+                );
+              })}
               {document.annotations.map((annotation) => {
                 const anchor = annotationAnchor(
                   document,

--- a/packages/derived/src/stretch.ts
+++ b/packages/derived/src/stretch.ts
@@ -58,6 +58,81 @@ export interface WireSegmentDragProposal {
 }
 
 /**
+ * The visually continuous subset of a VDD rail. A wire tap splits one stored
+ * Route in two, but it must not turn the two resulting supply segments into
+ * independent editor objects.
+ */
+export interface PowerRailComponent {
+  routeIds: string[];
+  junctionIds: string[];
+  endpointJunctionIds: string[];
+}
+
+/**
+ * Find the connected `power-rail` component containing `routeId`.
+ *
+ * Connectivity deliberately traverses only other power-rail fragments on the
+ * same Net. Normal wires meeting a rail at a branch Junction remain branches,
+ * rather than making every VDD conductor in the document one draggable rail.
+ */
+export function derivePowerRailComponent(
+  document: SchematicDocument,
+  routeId: string,
+): PowerRailComponent | null {
+  const seed = document.routes.find((route) => route.id === routeId);
+  if (!seed || seed.presentation !== "power-rail") return null;
+  const candidates = document.routes.filter(
+    (route) =>
+      route.netId === seed.netId && route.presentation === "power-rail",
+  );
+  const byJunction = new Map<string, typeof candidates>();
+  for (const route of candidates) {
+    for (const endpoint of [route.from, route.to]) {
+      if (endpoint.kind !== "junction") continue;
+      const incident = byJunction.get(endpoint.junctionId) ?? [];
+      incident.push(route);
+      byJunction.set(endpoint.junctionId, incident);
+    }
+  }
+
+  const visited = new Set<string>([seed.id]);
+  const queue = [seed];
+  while (queue.length > 0) {
+    const route = queue.shift()!;
+    for (const endpoint of [route.from, route.to]) {
+      if (endpoint.kind !== "junction") continue;
+      for (const incident of byJunction.get(endpoint.junctionId) ?? []) {
+        if (visited.has(incident.id)) continue;
+        visited.add(incident.id);
+        queue.push(incident);
+      }
+    }
+  }
+
+  const railRoutes = candidates.filter((route) => visited.has(route.id));
+  const degreeByJunction = new Map<string, number>();
+  for (const route of railRoutes) {
+    for (const endpoint of [route.from, route.to]) {
+      if (endpoint.kind !== "junction") continue;
+      degreeByJunction.set(
+        endpoint.junctionId,
+        (degreeByJunction.get(endpoint.junctionId) ?? 0) + 1,
+      );
+    }
+  }
+  const order = (left: string, right: string) =>
+    left.localeCompare(right, "en");
+  const junctionIds = [...degreeByJunction.keys()].sort(order);
+  return {
+    routeIds: railRoutes.map((route) => route.id).sort(order),
+    junctionIds,
+    endpointJunctionIds: junctionIds
+      .filter((junctionId) => degreeByJunction.get(junctionId) === 1)
+      .sort(order),
+  };
+}
+
+/**
  * A persisted Junction is a topological vertex, not an absolute geometric
  * anchor. Dragging a segment that terminates at one therefore moves the vertex
  * and lets every incident Route stretch around it. Terminals remain hard
@@ -148,10 +223,118 @@ function stretchRouteEndpoint(
   if (stillAligned) return;
 
   const insertIndex = side === "from" ? 1 : points.length - 1;
-  points.splice(insertIndex, 0, { ...originalPoint });
+  // A direct Route needs an orthogonal elbow when its Junction moves in both
+  // axes. Re-inserting the old endpoint would create a diagonal segment.
+  points.splice(
+    insertIndex,
+    0,
+    originallyVertical
+      ? { x: neighbor.x, y: movedPoint.y }
+      : { x: movedPoint.x, y: neighbor.y },
+  );
   const modeIndex = side === "from" ? 0 : modes.length - 1;
   const mode = modes[modeIndex]!;
   modes.splice(modeIndex, 1, mode, mode);
+}
+
+/**
+ * Move an explicit set of Junctions and reshape every incident Route in one
+ * topology-preserving proposal. Routes wholly inside the moved set translate;
+ * routes leaving it grow a local orthogonal dogleg at their moved end.
+ */
+export function proposeJunctionGroupTranslation(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  moves: readonly JunctionMoveProposal[],
+): WireSegmentDragProposal {
+  const movedJunctions = new Map(
+    moves.map((move) => [move.junctionId, move.position] as const),
+  );
+  for (const junctionId of movedJunctions.keys()) {
+    if (!document.junctions.some((junction) => junction.id === junctionId)) {
+      throw new Error(`Junction not found: ${junctionId}`);
+    }
+  }
+  const routingGeometry = resolveDocumentRoutingGeometry(document, resolver);
+  const proposals = new Map<string, RouteStretchProposal>();
+  for (const route of document.routes) {
+    const movedFrom =
+      route.from.kind === "junction"
+        ? movedJunctions.get(route.from.junctionId)
+        : undefined;
+    const movedTo =
+      route.to.kind === "junction"
+        ? movedJunctions.get(route.to.junctionId)
+        : undefined;
+    if (!movedFrom && !movedTo) continue;
+
+    const polyline = routePolylineFromGeometry(routingGeometry, route.id);
+    if (!polyline) throw new Error(`Route ${route.id} has unresolved geometry`);
+    const points = polyline.points.map((point) => ({ ...point }));
+    const modes = [...polyline.segmentModes];
+    const fromDelta = movedFrom
+      ? {
+          x: movedFrom.x - polyline.points[0]!.x,
+          y: movedFrom.y - polyline.points[0]!.y,
+        }
+      : null;
+    const toDelta = movedTo
+      ? {
+          x: movedTo.x - polyline.points.at(-1)!.x,
+          y: movedTo.y - polyline.points.at(-1)!.y,
+        }
+      : null;
+    if (
+      fromDelta &&
+      toDelta &&
+      fromDelta.x === toDelta.x &&
+      fromDelta.y === toDelta.y
+    ) {
+      if (modes.some(protectedMode)) {
+        throw new Error(`Route ${route.id} contains a protected segment`);
+      }
+      proposals.set(route.id, {
+        routeId: route.id,
+        waypoints: route.waypoints.map((point) => ({
+          x: point.x + fromDelta.x,
+          y: point.y + fromDelta.y,
+        })),
+        segmentModes: modes,
+      });
+      continue;
+    }
+    if (movedFrom) {
+      stretchRouteEndpoint(
+        route.id,
+        points,
+        modes,
+        "from",
+        polyline.points[0]!,
+        movedFrom,
+      );
+    }
+    if (movedTo) {
+      stretchRouteEndpoint(
+        route.id,
+        points,
+        modes,
+        "to",
+        polyline.points.at(-1)!,
+        movedTo,
+      );
+    }
+    proposals.set(route.id, normalizeProposal(route.id, points, modes));
+  }
+  return {
+    routes: [...proposals.values()].sort((left, right) =>
+      left.routeId.localeCompare(right.routeId, "en"),
+    ),
+    junctions: [...movedJunctions.entries()]
+      .map(([junctionId, position]) => ({ junctionId, position }))
+      .sort((left, right) =>
+        left.junctionId.localeCompare(right.junctionId, "en"),
+      ),
+  };
 }
 
 /**

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -1,6 +1,8 @@
 import {
+  derivePowerRailComponent,
   normalizeRouteGeometry,
   proposeGroupMove,
+  proposeJunctionGroupTranslation,
   proposeWireSegmentDrag,
   resolveEndpointPoint,
   type SegmentMode,
@@ -298,6 +300,95 @@ export function proposeLooseRouteTranslation(
         segmentModes: [...route.segmentModes],
         ...(route.presentation ? { presentation: route.presentation } : {}),
       },
+    ],
+  };
+}
+
+/**
+ * Translate every fragment and Junction belonging to one visually continuous
+ * VDD rail. Ordinary branch wires are not translated wholesale: they are
+ * reshaped around the moved rail Junction instead.
+ */
+export function proposePowerRailTranslation(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  routeId: string,
+  delta: Point,
+): WireManipulationProposal {
+  const component = derivePowerRailComponent(document, routeId);
+  if (!component) {
+    throw new Error(`Route ${routeId} is not a power rail`);
+  }
+  if (delta.x === 0 && delta.y === 0) return { routeId, edits: [] };
+  const proposal = proposeJunctionGroupTranslation(
+    document,
+    resolver,
+    component.junctionIds.map((junctionId) => {
+      const junction = document.junctions.find(
+        (candidate) => candidate.id === junctionId,
+      )!;
+      return {
+        junctionId,
+        position: {
+          x: junction.position.x + delta.x,
+          y: junction.position.y + delta.y,
+        },
+      };
+    }),
+  );
+  return {
+    routeId,
+    edits: [
+      ...proposal.junctions.map((move): SchematicEdit => ({
+        kind: "move_junction",
+        ...move,
+      })),
+      ...routeEdits(document, proposal.routes),
+    ],
+  };
+}
+
+/** Resize the left or right visual end of a continuous horizontal VDD rail. */
+export function proposePowerRailEndpointResize(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  routeId: string,
+  side: "start" | "end",
+  x: number,
+): WireManipulationProposal {
+  const component = derivePowerRailComponent(document, routeId);
+  if (!component || component.endpointJunctionIds.length !== 2) {
+    throw new Error("VDD rail must have exactly two editable ends");
+  }
+  const endpoints = component.endpointJunctionIds
+    .map((junctionId) =>
+      document.junctions.find((junction) => junction.id === junctionId)!,
+    )
+    .sort((left, right) => left.position.x - right.position.x);
+  const start = endpoints[0]!;
+  const end = endpoints[1]!;
+  const target = side === "start" ? start : end;
+  const fixed = side === "start" ? end : start;
+  if (
+    (side === "start" && x >= fixed.position.x) ||
+    (side === "end" && x <= fixed.position.x)
+  ) {
+    throw new Error("VDD rail must retain a non-zero horizontal length");
+  }
+  const proposal = proposeJunctionGroupTranslation(document, resolver, [
+    {
+      junctionId: target.id,
+      position: { x, y: target.position.y },
+    },
+  ]);
+  return {
+    routeId,
+    edits: [
+      ...proposal.junctions.map((move): SchematicEdit => ({
+        kind: "move_junction",
+        ...move,
+      })),
+      ...routeEdits(document, proposal.routes),
     ],
   };
 }

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -16,6 +16,8 @@ import {
   proposeGroupMoveEdits,
   proposeEndpointRouteAttachment,
   proposeLooseRouteTranslation,
+  proposePowerRailEndpointResize,
+  proposePowerRailTranslation,
   proposeVisualRouteDeletion,
   proposeWireSegmentMove,
 } from "./routing-planner.js";
@@ -52,6 +54,138 @@ function transaction(documentId: string, revision: number, edits: unknown[]) {
 }
 
 describe("routing Edit Engine", () => {
+  it("keeps a tapped VDD rail contiguous when it is resized or moved", () => {
+    const document = createEmptyDocument("vdd-manipulation", "VDD edit");
+    document.nets.push({
+      id: "VDD",
+      scope: "global",
+      powerDomain: "vdd",
+      terminals: [],
+    });
+    document.junctions.push(
+      {
+        id: "vdd-start",
+        netId: "VDD",
+        position: { x: 0, y: 0 },
+        role: "route-anchor",
+      },
+      {
+        id: "vdd-tap",
+        netId: "VDD",
+        position: { x: 50, y: 0 },
+        role: "branch",
+      },
+      {
+        id: "vdd-end",
+        netId: "VDD",
+        position: { x: 100, y: 0 },
+        role: "route-anchor",
+      },
+      {
+        id: "branch-end",
+        netId: "VDD",
+        position: { x: 50, y: 100 },
+        role: "branch",
+      },
+    );
+    document.routes.push(
+      {
+        id: "rail-left",
+        netId: "VDD",
+        from: { kind: "junction", junctionId: "vdd-start" },
+        to: { kind: "junction", junctionId: "vdd-tap" },
+        waypoints: [],
+        segmentModes: ["manual"],
+        presentation: "power-rail",
+      },
+      {
+        id: "rail-right",
+        netId: "VDD",
+        from: { kind: "junction", junctionId: "vdd-tap" },
+        to: { kind: "junction", junctionId: "vdd-end" },
+        waypoints: [],
+        segmentModes: ["manual"],
+        presentation: "power-rail",
+      },
+      {
+        id: "branch",
+        netId: "VDD",
+        from: { kind: "junction", junctionId: "vdd-tap" },
+        to: { kind: "junction", junctionId: "branch-end" },
+        waypoints: [],
+        segmentModes: ["manual"],
+      },
+    );
+
+    const resizedProposal = proposePowerRailEndpointResize(
+      document,
+      resolver,
+      "rail-left",
+      "end",
+      160,
+    );
+    const resized = executeTransaction(
+      document,
+      transaction(document.id, 0, resizedProposal.edits),
+      context,
+    );
+    expect(resized.ok).toBe(true);
+    if (!resized.ok) return;
+    expect(
+      resized.document.junctions.find((junction) => junction.id === "vdd-end"),
+    ).toMatchObject({ position: { x: 160, y: 0 } });
+    expect(
+      routePolyline(
+        resized.document,
+        resolver,
+        resized.document.routes.find((route) => route.id === "rail-right")!,
+      )?.points,
+    ).toEqual([
+      { x: 50, y: 0 },
+      { x: 160, y: 0 },
+    ]);
+
+    const movedProposal = proposePowerRailTranslation(
+      resized.document,
+      resolver,
+      "rail-right",
+      { x: 20, y: 20 },
+    );
+    const moved = executeTransaction(
+      resized.document,
+      transaction(resized.document.id, 1, movedProposal.edits),
+      context,
+    );
+    expect(moved.ok).toBe(true);
+    if (!moved.ok) return;
+    expect(
+      moved.document.junctions.find((junction) => junction.id === "vdd-tap"),
+    ).toMatchObject({ position: { x: 70, y: 20 } });
+    expect(
+      moved.document.junctions.find((junction) => junction.id === "branch-end"),
+    ).toMatchObject({ position: { x: 50, y: 100 } });
+    const railFragments = moved.document.routes.filter(
+      (route) => route.presentation === "power-rail",
+    );
+    expect(railFragments).toHaveLength(2);
+    for (const route of railFragments) {
+      expect(routePolyline(moved.document, resolver, route)?.points).toSatisfy(
+        (points: Array<{ x: number; y: number }>) => isOrthogonal(points),
+      );
+    }
+    expect(
+      routePolyline(
+        moved.document,
+        resolver,
+        moved.document.routes.find((route) => route.id === "branch")!,
+      )?.points,
+    ).toEqual([
+      { x: 70, y: 20 },
+      { x: 50, y: 20 },
+      { x: 50, y: 100 },
+    ]);
+  });
+
   it("plans a power rail and its label as one visual deletion", () => {
     const document = createEmptyDocument("vdd-delete", "VDD delete");
     document.nets.push({

--- a/plan/2026-08-15-vdd-rail-manipulation/plan.md
+++ b/plan/2026-08-15-vdd-rail-manipulation/plan.md
@@ -1,0 +1,83 @@
+---
+status: completed
+experience: none
+---
+
+# Make VDD rails stretchable and junction-aware
+
+## Goal
+
+Make a selected VDD `power-rail` remain one editable supply bar after ordinary
+wires attach to it: drag its visible ends to resize the rail, and drag the bar
+to translate every junction on it while attached non-rail wires stretch
+topology-preservingly.
+
+## State and Ownership
+
+Start state from `git status --short --branch` in the dedicated worktree:
+
+```text
+## codex/vdd-rail-editing...origin/main
+```
+
+The user-facing worktree is dirty on `codex/label-gap-copy-rotate`, including
+`App.tsx`; this target uses a clean worktree created from `origin/main` so it
+does not overwrite that concurrent target.
+
+- `packages/derived/src/stretch.ts`
+- `packages/derived/src/stretch.test.ts`
+- `packages/edit-engine/src/routing-planner.ts`
+- `packages/edit-engine/src/routing.test.ts`
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/e2e/manual-editor.spec.ts`
+- `plan/root-audit.md`
+- `plan/log.md`
+
+Read-only/shared dependencies: the persisted `RoutePresentation` contract,
+`add_power_rail` transaction, canonical route geometry, and editor selection
+and canvas-drag systems. No electrical net membership or VDD rail file format
+changes are in scope.
+
+## Work
+
+1. Derive the connected set of `power-rail` fragments from a selected rail,
+   including junctions introduced when an ordinary wire taps the rail.
+2. Add a topology-preserving junction-group translation proposal: rail
+   fragments and their junctions move together; a non-rail route sharing one
+   of those junctions reshapes locally to keep its other endpoint fixed.
+3. Give selected VDD rails endpoint resize handles and a bar translation
+   handle, and use the rail-specific proposal rather than the loose-route-only
+   path.
+4. Add unit and browser regressions for resize and movement after a rail tap.
+
+## Validation
+
+- `pnpm test:local packages/derived/src/stretch.test.ts packages/edit-engine/src/routing.test.ts`
+- `pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts --grep "VDD rail"`
+- `pnpm typecheck`
+- `pnpm format:check`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): make VDD rails stretchable after taps
+```
+
+## Outcome
+
+Implemented a connected `power-rail` component derivation and a
+topology-preserving Junction-group translation proposal. Selected VDD rails
+now provide a central move handle and two end resize handles even after a wire
+tap split the stored rail into fragments. Attached ordinary wires keep their
+far endpoint fixed and gain an orthogonal dogleg as needed; the VDD power label
+continues to follow its endpoint Junction through its existing object anchor.
+
+Validation passed: focused routing contracts, VDD browser regressions,
+typecheck, Prettier, `git diff --check`, and clean branch status. The initial
+browser regression exposed an end-handle hit-layer collision with Junctions;
+the endpoint hit layer now routes a selected rail's two endpoint drags to the
+resize operation while preserving normal Junction selection otherwise.

--- a/plan/log.md
+++ b/plan/log.md
@@ -1,5 +1,17 @@
 # Maintenance Log
 
+## 2026-08-15 - Make tapped VDD rails stretchable and junction-aware
+
+- Target: restore usable direct manipulation for VDD rails after an ordinary
+  wire tap splits the stored rail at a Junction.
+- Changed areas: connected `power-rail` component derivation; Junction-group
+  route stretching; VDD whole-rail move/end-resize editor gestures; focused
+  routing and browser regressions.
+- Validation: focused routing tests (29), VDD browser regression, typecheck,
+  Prettier, `git diff --check`, and clean branch status passed.
+- Commit status: pending `fix(editor): make VDD rails stretchable after taps`
+  on `codex/vdd-rail-editing`.
+
 ## 2026-08-14 - WP-5 browser hardening and release delivery
 
 - Target: prove the failure matrix (abrupt tab death, two tabs, quota,

--- a/plan/root-audit.md
+++ b/plan/root-audit.md
@@ -1,6 +1,6 @@
 # Root Plan Audit
 
-Snapshot: 2026-08-14. The root `plan/` directory is an operational queue, not
+Snapshot: 2026-08-15. The root `plan/` directory is an operational queue, not
 an archive. Completed plans with resolved experience are stored under
 [`archived/2026-08/`](archived/2026-08/).
 
@@ -8,13 +8,12 @@ an archive. Completed plans with resolved experience are stored under
 
 | State                     | Count | Required disposition                                                              |
 | ------------------------- | ----: | --------------------------------------------------------------------------------- |
-| `active`                  |     0 | No active targets.                                                               |
-| `completed` + `none`      |    31 | Verify commit/log evidence, then archive according to routine retention policy.   |
+| `active`                  |     0 | No active targets.                                                                |
+| `completed` + `none`      |    32 | Verify commit/log evidence, then archive according to routine retention policy.   |
 | `completed` + `candidate` |    17 | Human decides whether to extract, reject, or defer the experience signal.         |
 | missing metadata          |    71 | Audit against outcome text and Git evidence; never archive merely because of age. |
 
 ### Completed plans awaiting an experience decision
-
 
 - `2026-08-14-current-contract-clean-break`
 - `2026-08-11-correct-closed-switch-pdf-crop`


### PR DESCRIPTION
## What changed

- Makes a VDD `power-rail` a connected visual editing component after ordinary wire taps split its persisted route geometry.
- Adds whole-rail translation and left/right endpoint resizing.
- Moves rail junctions with the bar while attached ordinary wires stretch orthogonally to their fixed far endpoints.

## Why

Previously, a tap junction made the rail fail the loose-route test, so interaction degraded to one fragment at a time and the VDD bar could not be moved or resized coherently.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm ci:check`
- Focused routing and VDD browser regressions
