### PR TITLE
feat(editor): complete compact categorized component library

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -506,6 +506,9 @@ test("shows the complete foldable categorized Library, quick-places a device, an
       const artwork = tile.querySelector<SVGElement>(".shapes-chip-art");
       if (!artwork) throw new Error("Library artwork is missing");
       const artworkBounds = artwork.getBoundingClientRect();
+      const label = tile.querySelector<HTMLElement>("span");
+      if (!label) throw new Error("Library label is missing");
+      const labelBounds = label.getBoundingClientRect();
       return {
         centerDeltaX:
           artworkBounds.left +
@@ -516,6 +519,11 @@ test("shows the complete foldable categorized Library, quick-places a device, an
           artworkBounds.height / 2 -
           (tileBounds.top + tileBounds.height / 2),
         height: artworkBounds.height,
+        labelFits:
+          label.scrollWidth <= label.clientWidth + 1 &&
+          label.scrollHeight <= label.clientHeight + 1,
+        labelHeight: labelBounds.height,
+        separatedFromLabel: artworkBounds.bottom <= labelBounds.top + 0.5,
         tileHeight: tileBounds.height,
         withinTile:
           artworkBounds.left >= tileBounds.left - 0.5 &&
@@ -541,10 +549,17 @@ test("shows the complete foldable categorized Library, quick-places a device, an
   ).toBe(true);
   expect(
     artworkGeometry.every(
-      (artwork) => Math.abs(artwork.tileHeight - 52) <= 0.5,
+      (artwork) => Math.abs(artwork.tileHeight - 64) <= 0.5,
     ),
   ).toBe(true);
-  await expect(libraryChips.locator("span")).toHaveCount(0);
+  expect(artworkGeometry.every((artwork) => artwork.labelFits)).toBe(true);
+  expect(artworkGeometry.every((artwork) => artwork.labelHeight <= 12.5)).toBe(
+    true,
+  );
+  expect(artworkGeometry.every((artwork) => artwork.separatedFromLabel)).toBe(
+    true,
+  );
+  await expect(libraryChips.locator("span")).toHaveCount(18);
   await expect(transistorCategory).toHaveJSProperty("open", true);
   await transistorCategory.locator("summary").click();
   await expect(transistorCategory).toHaveJSProperty("open", false);
@@ -572,7 +587,7 @@ test("shows the complete foldable categorized Library, quick-places a device, an
   await expect(recentResistor).toBeVisible();
   await expect(recentResistor).toHaveAttribute("aria-label", "Place Resistor");
   await expect(recentResistor).toHaveAttribute("title", "Place Resistor");
-  await expect(recentResistor.locator("span")).toHaveCount(0);
+  await expect(recentResistor.locator("span")).toHaveText("Res");
   expect(
     await page
       .getByTestId("shapes-fold-recent")
@@ -641,6 +656,9 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
         const artwork = tile.querySelector<SVGElement>(".shapes-chip-art");
         if (!artwork) throw new Error("Narrow Library artwork is missing");
         const artworkBounds = artwork.getBoundingClientRect();
+        const label = tile.querySelector<HTMLElement>("span");
+        if (!label) throw new Error("Narrow Library label is missing");
+        const labelBounds = label.getBoundingClientRect();
         return {
           centerDeltaX:
             artworkBounds.left +
@@ -651,6 +669,11 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
             artworkBounds.height / 2 -
             (tileBounds.top + tileBounds.height / 2),
           height: artworkBounds.height,
+          labelFits:
+            label.scrollWidth <= label.clientWidth + 1 &&
+            label.scrollHeight <= label.clientHeight + 1,
+          labelHeight: labelBounds.height,
+          separatedFromLabel: artworkBounds.bottom <= labelBounds.top + 0.5,
           tileHeight: tileBounds.height,
           withinTile:
             artworkBounds.left >= tileBounds.left - 0.5 &&
@@ -674,11 +697,18 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
     narrowArtwork.every((artwork) => Math.abs(artwork.centerDeltaY) <= 0.5),
   ).toBe(true);
   expect(
-    narrowArtwork.every((artwork) => Math.abs(artwork.tileHeight - 60) <= 0.5),
+    narrowArtwork.every((artwork) => Math.abs(artwork.tileHeight - 68) <= 0.5),
   ).toBe(true);
+  expect(narrowArtwork.every((artwork) => artwork.labelFits)).toBe(true);
+  expect(narrowArtwork.every((artwork) => artwork.labelHeight <= 12.5)).toBe(
+    true,
+  );
+  expect(narrowArtwork.every((artwork) => artwork.separatedFromLabel)).toBe(
+    true,
+  );
   expect(narrowArtwork.every((artwork) => artwork.withinTile)).toBe(true);
   await expect(page.locator('[data-testid^="shapes-chip-"] span')).toHaveCount(
-    0,
+    18,
   );
 
   const canvas = page.getByTestId("schematic-canvas");

--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -453,14 +453,35 @@ test("keeps component placement active across independent canvas commits", async
   await expect(page.getByTestId("component-input-plane")).toHaveCount(0);
 });
 
-test("quick-places a starter, records it as recent, and restores Library state", async ({
+test("shows the complete compact Library, quick-places a device, and restores state", async ({
   page,
 }) => {
   await page.goto("/");
   const panel = page.getByTestId("shapes-library-panel");
   const canvas = page.getByTestId("schematic-canvas");
+  const libraryChips = panel.locator('[data-testid^="shapes-chip-"]');
+  const lastLibraryChip = page.getByTestId("shapes-chip-voltage-amplifier");
 
   await expect(panel).toHaveAttribute("data-open", "true");
+  await expect(libraryChips).toHaveCount(18);
+  await expect(
+    panel.getByRole("button", { name: "Place Independent Voltage Source" }),
+  ).toBeVisible();
+  await expect(lastLibraryChip).toBeVisible();
+  const libraryGeometry = await lastLibraryChip.evaluate((element) => {
+    const body = element.closest<HTMLElement>(".shapes-panel-body");
+    if (!body) throw new Error("Library body is missing");
+    return {
+      bodyBottom: body.getBoundingClientRect().bottom,
+      scrollTop: body.scrollTop,
+      tileBottom: element.getBoundingClientRect().bottom,
+    };
+  });
+  expect(libraryGeometry.scrollTop).toBe(0);
+  expect(libraryGeometry.tileBottom).toBeLessThanOrEqual(
+    libraryGeometry.bodyBottom,
+  );
+
   await page.getByTestId("shapes-chip-resistor").click();
   const box = await canvas.boundingBox();
   if (!box) throw new Error("Canvas is not measurable");

--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -519,6 +519,7 @@ test("shows the complete foldable categorized Library, quick-places a device, an
           artworkBounds.height / 2 -
           (tileBounds.top + tileBounds.height / 2),
         height: artworkBounds.height,
+        labelHeight: labelBounds.height,
         separatedFromLabel: artworkBounds.bottom <= labelBounds.top + 0.5,
         tileHeight: tileBounds.height,
         withinTile:
@@ -545,9 +546,12 @@ test("shows the complete foldable categorized Library, quick-places a device, an
   ).toBe(true);
   expect(
     artworkGeometry.every(
-      (artwork) => Math.abs(artwork.tileHeight - 86) <= 0.5,
+      (artwork) => Math.abs(artwork.tileHeight - 66) <= 0.5,
     ),
   ).toBe(true);
+  expect(artworkGeometry.every((artwork) => artwork.labelHeight <= 12.5)).toBe(
+    true,
+  );
   expect(artworkGeometry.every((artwork) => artwork.separatedFromLabel)).toBe(
     true,
   );
@@ -667,6 +671,10 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
             artworkBounds.height / 2 -
             (tileBounds.top + tileBounds.height / 2),
           height: artworkBounds.height,
+          labelFits:
+            label.scrollWidth <= label.clientWidth + 1 &&
+            label.scrollHeight <= label.clientHeight + 1,
+          labelHeight: labelBounds.height,
           separatedFromLabel: artworkBounds.bottom <= labelBounds.top + 0.5,
           tileHeight: tileBounds.height,
           withinTile:
@@ -691,8 +699,12 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
     narrowArtwork.every((artwork) => Math.abs(artwork.centerDeltaY) <= 0.5),
   ).toBe(true);
   expect(
-    narrowArtwork.every((artwork) => Math.abs(artwork.tileHeight - 94) <= 0.5),
+    narrowArtwork.every((artwork) => Math.abs(artwork.tileHeight - 74) <= 0.5),
   ).toBe(true);
+  expect(narrowArtwork.every((artwork) => artwork.labelFits)).toBe(true);
+  expect(narrowArtwork.every((artwork) => artwork.labelHeight <= 12.5)).toBe(
+    true,
+  );
   expect(narrowArtwork.every((artwork) => artwork.separatedFromLabel)).toBe(
     true,
   );

--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -453,34 +453,31 @@ test("keeps component placement active across independent canvas commits", async
   await expect(page.getByTestId("component-input-plane")).toHaveCount(0);
 });
 
-test("shows the complete compact Library, quick-places a device, and restores state", async ({
+test("shows the complete categorized Library, quick-places a device, and restores state", async ({
   page,
 }) => {
   await page.goto("/");
   const panel = page.getByTestId("shapes-library-panel");
   const canvas = page.getByTestId("schematic-canvas");
   const libraryChips = panel.locator('[data-testid^="shapes-chip-"]');
-  const lastLibraryChip = page.getByTestId("shapes-chip-voltage-amplifier");
+  const categories = panel.locator('[data-testid^="shapes-category-"]');
 
   await expect(panel).toHaveAttribute("data-open", "true");
   await expect(libraryChips).toHaveCount(18);
+  await expect(categories).toHaveCount(6);
+  await expect(
+    page
+      .getByTestId("shapes-category-transistors")
+      .locator('[data-testid^="shapes-chip-"]'),
+  ).toHaveCount(4);
+  await expect(
+    page
+      .getByTestId("shapes-category-power-and-ports")
+      .locator('[data-testid^="shapes-chip-"]'),
+  ).toHaveCount(4);
   await expect(
     panel.getByRole("button", { name: "Place Independent Voltage Source" }),
-  ).toBeVisible();
-  await expect(lastLibraryChip).toBeVisible();
-  const libraryGeometry = await lastLibraryChip.evaluate((element) => {
-    const body = element.closest<HTMLElement>(".shapes-panel-body");
-    if (!body) throw new Error("Library body is missing");
-    return {
-      bodyBottom: body.getBoundingClientRect().bottom,
-      scrollTop: body.scrollTop,
-      tileBottom: element.getBoundingClientRect().bottom,
-    };
-  });
-  expect(libraryGeometry.scrollTop).toBe(0);
-  expect(libraryGeometry.tileBottom).toBeLessThanOrEqual(
-    libraryGeometry.bodyBottom,
-  );
+  ).toBeAttached();
 
   await page.getByTestId("shapes-chip-resistor").click();
   const box = await canvas.boundingBox();

--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -453,7 +453,7 @@ test("keeps component placement active across independent canvas commits", async
   await expect(page.getByTestId("component-input-plane")).toHaveCount(0);
 });
 
-test("shows the complete categorized Library, quick-places a device, and restores state", async ({
+test("shows the complete foldable categorized Library, quick-places a device, and restores state", async ({
   page,
 }) => {
   await page.goto("/");
@@ -465,11 +465,16 @@ test("shows the complete categorized Library, quick-places a device, and restore
   await expect(panel).toHaveAttribute("data-open", "true");
   await expect(libraryChips).toHaveCount(18);
   await expect(categories).toHaveCount(6);
+  const transistorCategory = page.getByTestId("shapes-category-transistors");
   await expect(
-    page
-      .getByTestId("shapes-category-transistors")
-      .locator('[data-testid^="shapes-chip-"]'),
+    transistorCategory.locator('[data-testid^="shapes-chip-"]'),
   ).toHaveCount(4);
+  await expect(transistorCategory).toHaveJSProperty("open", true);
+  await transistorCategory.locator("summary").click();
+  await expect(transistorCategory).toHaveJSProperty("open", false);
+  await expect(page.getByTestId("shapes-chip-nmos")).not.toBeVisible();
+  const analogCategory = page.getByTestId("shapes-category-analog-blocks");
+  await expect(analogCategory).toHaveJSProperty("open", true);
   await expect(
     page
       .getByTestId("shapes-category-power-and-ports")
@@ -488,6 +493,12 @@ test("shows the complete categorized Library, quick-places a device, and restore
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("hit-R1")).toBeVisible();
   await expect(page.getByTestId("shapes-recent-resistor")).toBeVisible();
+  await expect(transistorCategory).toHaveJSProperty("open", false);
+  await expect(page.getByTestId("shapes-chip-nmos")).not.toBeVisible();
+  await expect(analogCategory).toHaveJSProperty("open", true);
+  await transistorCategory.locator("summary").click();
+  await expect(transistorCategory).toHaveJSProperty("open", true);
+  await expect(page.getByTestId("shapes-chip-nmos")).toBeVisible();
 
   await page.keyboard.press("q");
   await expect(page.getByLabel("Component value")).toHaveValue("");
@@ -516,6 +527,22 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
 }) => {
   await page.setViewportSize({ width: 720, height: 720 });
   await page.goto("/");
+
+  const chrome = page.locator(".app-chrome-main");
+  const analytics = page.getByRole("link", { name: "Open visitor analytics" });
+  const help = page.getByRole("button", { name: "Help" });
+  await expect(analytics).toBeVisible();
+  await expect(help).toBeVisible();
+  const chromeBox = await chrome.boundingBox();
+  const analyticsBox = await analytics.boundingBox();
+  const helpBox = await help.boundingBox();
+  if (!chromeBox || !analyticsBox || !helpBox) {
+    throw new Error("Top navigation is not measurable");
+  }
+  expect(helpBox.x).toBeGreaterThan(analyticsBox.x);
+  expect(helpBox.x + helpBox.width).toBeLessThanOrEqual(
+    chromeBox.x + chromeBox.width,
+  );
 
   const canvas = page.getByTestId("schematic-canvas");
   const openWidth = (await canvas.boundingBox())?.width ?? 0;

--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -500,6 +500,35 @@ test("shows the complete foldable categorized Library, quick-places a device, an
       });
     }),
   ).toBe(true);
+  const artworkGeometry = await libraryChips.evaluateAll((tiles) =>
+    tiles.map((tile) => {
+      const tileBounds = tile.getBoundingClientRect();
+      const artwork = tile.querySelector<SVGElement>(".shapes-chip-art");
+      if (!artwork) throw new Error("Library artwork is missing");
+      const artworkBounds = artwork.getBoundingClientRect();
+      return {
+        height: artworkBounds.height,
+        offsetY: artworkBounds.top + artworkBounds.height / 2 - tileBounds.top,
+        withinTile:
+          artworkBounds.left >= tileBounds.left - 0.5 &&
+          artworkBounds.right <= tileBounds.right + 0.5 &&
+          artworkBounds.top >= tileBounds.top - 0.5 &&
+          artworkBounds.bottom <= tileBounds.bottom + 0.5,
+        width: artworkBounds.width,
+      };
+    }),
+  );
+  expect(artworkGeometry.every((artwork) => artwork.withinTile)).toBe(true);
+  expect(
+    artworkGeometry.every((artwork) => Math.abs(artwork.width - 38) <= 0.5),
+  ).toBe(true);
+  expect(
+    artworkGeometry.every((artwork) => Math.abs(artwork.height - 30) <= 0.5),
+  ).toBe(true);
+  expect(
+    Math.max(...artworkGeometry.map((artwork) => artwork.offsetY)) -
+      Math.min(...artworkGeometry.map((artwork) => artwork.offsetY)),
+  ).toBeLessThanOrEqual(1);
   expect(
     await libraryChips
       .locator("span")
@@ -594,6 +623,27 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
   expect(helpBox.x + helpBox.width).toBeLessThanOrEqual(
     chromeBox.x + chromeBox.width,
   );
+
+  const narrowArtwork = await page
+    .getByTestId("shapes-chip-nmos")
+    .evaluate((tile) => {
+      const tileBounds = tile.getBoundingClientRect();
+      const artwork = tile.querySelector<SVGElement>(".shapes-chip-art");
+      if (!artwork) throw new Error("Narrow Library artwork is missing");
+      const artworkBounds = artwork.getBoundingClientRect();
+      return {
+        height: artworkBounds.height,
+        withinTile:
+          artworkBounds.left >= tileBounds.left - 0.5 &&
+          artworkBounds.right <= tileBounds.right + 0.5 &&
+          artworkBounds.top >= tileBounds.top - 0.5 &&
+          artworkBounds.bottom <= tileBounds.bottom + 0.5,
+        width: artworkBounds.width,
+      };
+    });
+  expect(Math.abs(narrowArtwork.width - 44)).toBeLessThanOrEqual(0.5);
+  expect(Math.abs(narrowArtwork.height - 34)).toBeLessThanOrEqual(0.5);
+  expect(narrowArtwork.withinTile).toBe(true);
 
   const canvas = page.getByTestId("schematic-canvas");
   const openWidth = (await canvas.boundingBox())?.width ?? 0;

--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -506,9 +506,6 @@ test("shows the complete foldable categorized Library, quick-places a device, an
       const artwork = tile.querySelector<SVGElement>(".shapes-chip-art");
       if (!artwork) throw new Error("Library artwork is missing");
       const artworkBounds = artwork.getBoundingClientRect();
-      const label = tile.querySelector<HTMLElement>("span");
-      if (!label) throw new Error("Library label is missing");
-      const labelBounds = label.getBoundingClientRect();
       return {
         centerDeltaX:
           artworkBounds.left +
@@ -519,8 +516,6 @@ test("shows the complete foldable categorized Library, quick-places a device, an
           artworkBounds.height / 2 -
           (tileBounds.top + tileBounds.height / 2),
         height: artworkBounds.height,
-        labelHeight: labelBounds.height,
-        separatedFromLabel: artworkBounds.bottom <= labelBounds.top + 0.5,
         tileHeight: tileBounds.height,
         withinTile:
           artworkBounds.left >= tileBounds.left - 0.5 &&
@@ -546,26 +541,10 @@ test("shows the complete foldable categorized Library, quick-places a device, an
   ).toBe(true);
   expect(
     artworkGeometry.every(
-      (artwork) => Math.abs(artwork.tileHeight - 66) <= 0.5,
+      (artwork) => Math.abs(artwork.tileHeight - 52) <= 0.5,
     ),
   ).toBe(true);
-  expect(artworkGeometry.every((artwork) => artwork.labelHeight <= 12.5)).toBe(
-    true,
-  );
-  expect(artworkGeometry.every((artwork) => artwork.separatedFromLabel)).toBe(
-    true,
-  );
-  expect(
-    await libraryChips
-      .locator("span")
-      .evaluateAll((labels) =>
-        labels.every(
-          (label) =>
-            label.scrollWidth <= label.clientWidth + 1 &&
-            label.scrollHeight <= label.clientHeight + 1,
-        ),
-      ),
-  ).toBe(true);
+  await expect(libraryChips.locator("span")).toHaveCount(0);
   await expect(transistorCategory).toHaveJSProperty("open", true);
   await transistorCategory.locator("summary").click();
   await expect(transistorCategory).toHaveJSProperty("open", false);
@@ -589,7 +568,11 @@ test("shows the complete foldable categorized Library, quick-places a device, an
   await canvas.click({ position: { x: 280, y: 220 } });
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("hit-R1")).toBeVisible();
-  await expect(page.getByTestId("shapes-recent-resistor")).toBeVisible();
+  const recentResistor = page.getByTestId("shapes-recent-resistor");
+  await expect(recentResistor).toBeVisible();
+  await expect(recentResistor).toHaveAttribute("aria-label", "Place Resistor");
+  await expect(recentResistor).toHaveAttribute("title", "Place Resistor");
+  await expect(recentResistor.locator("span")).toHaveCount(0);
   expect(
     await page
       .getByTestId("shapes-fold-recent")
@@ -658,9 +641,6 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
         const artwork = tile.querySelector<SVGElement>(".shapes-chip-art");
         if (!artwork) throw new Error("Narrow Library artwork is missing");
         const artworkBounds = artwork.getBoundingClientRect();
-        const label = tile.querySelector<HTMLElement>("span");
-        if (!label) throw new Error("Narrow Library label is missing");
-        const labelBounds = label.getBoundingClientRect();
         return {
           centerDeltaX:
             artworkBounds.left +
@@ -671,11 +651,6 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
             artworkBounds.height / 2 -
             (tileBounds.top + tileBounds.height / 2),
           height: artworkBounds.height,
-          labelFits:
-            label.scrollWidth <= label.clientWidth + 1 &&
-            label.scrollHeight <= label.clientHeight + 1,
-          labelHeight: labelBounds.height,
-          separatedFromLabel: artworkBounds.bottom <= labelBounds.top + 0.5,
           tileHeight: tileBounds.height,
           withinTile:
             artworkBounds.left >= tileBounds.left - 0.5 &&
@@ -699,16 +674,12 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
     narrowArtwork.every((artwork) => Math.abs(artwork.centerDeltaY) <= 0.5),
   ).toBe(true);
   expect(
-    narrowArtwork.every((artwork) => Math.abs(artwork.tileHeight - 74) <= 0.5),
+    narrowArtwork.every((artwork) => Math.abs(artwork.tileHeight - 60) <= 0.5),
   ).toBe(true);
-  expect(narrowArtwork.every((artwork) => artwork.labelFits)).toBe(true);
-  expect(narrowArtwork.every((artwork) => artwork.labelHeight <= 12.5)).toBe(
-    true,
-  );
-  expect(narrowArtwork.every((artwork) => artwork.separatedFromLabel)).toBe(
-    true,
-  );
   expect(narrowArtwork.every((artwork) => artwork.withinTile)).toBe(true);
+  await expect(page.locator('[data-testid^="shapes-chip-"] span')).toHaveCount(
+    0,
+  );
 
   const canvas = page.getByTestId("schematic-canvas");
   const openWidth = (await canvas.boundingBox())?.width ?? 0;

--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -514,14 +514,19 @@ test("shows the complete foldable categorized Library, quick-places a device, an
           artworkBounds.left +
           artworkBounds.width / 2 -
           (tileBounds.left + tileBounds.width / 2),
-        centerDeltaY:
-          artworkBounds.top +
-          artworkBounds.height / 2 -
+        groupCenterDeltaY:
+          (Math.min(artworkBounds.top, labelBounds.top) +
+            Math.max(artworkBounds.bottom, labelBounds.bottom)) /
+            2 -
           (tileBounds.top + tileBounds.height / 2),
         height: artworkBounds.height,
         labelFits:
           label.scrollWidth <= label.clientWidth + 1 &&
           label.scrollHeight <= label.clientHeight + 1,
+        labelCenterDeltaX:
+          labelBounds.left +
+          labelBounds.width / 2 -
+          (tileBounds.left + tileBounds.width / 2),
         labelHeight: labelBounds.height,
         separatedFromLabel: artworkBounds.bottom <= labelBounds.top + 0.5,
         tileHeight: tileBounds.height,
@@ -545,11 +550,18 @@ test("shows the complete foldable categorized Library, quick-places a device, an
     artworkGeometry.every((artwork) => Math.abs(artwork.centerDeltaX) <= 0.5),
   ).toBe(true);
   expect(
-    artworkGeometry.every((artwork) => Math.abs(artwork.centerDeltaY) <= 0.5),
+    artworkGeometry.every(
+      (artwork) => Math.abs(artwork.groupCenterDeltaY) <= 0.5,
+    ),
   ).toBe(true);
   expect(
     artworkGeometry.every(
-      (artwork) => Math.abs(artwork.tileHeight - 64) <= 0.5,
+      (artwork) => Math.abs(artwork.labelCenterDeltaX) <= 0.5,
+    ),
+  ).toBe(true);
+  expect(
+    artworkGeometry.every(
+      (artwork) => Math.abs(artwork.tileHeight - 56) <= 0.5,
     ),
   ).toBe(true);
   expect(artworkGeometry.every((artwork) => artwork.labelFits)).toBe(true);
@@ -664,14 +676,19 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
             artworkBounds.left +
             artworkBounds.width / 2 -
             (tileBounds.left + tileBounds.width / 2),
-          centerDeltaY:
-            artworkBounds.top +
-            artworkBounds.height / 2 -
+          groupCenterDeltaY:
+            (Math.min(artworkBounds.top, labelBounds.top) +
+              Math.max(artworkBounds.bottom, labelBounds.bottom)) /
+              2 -
             (tileBounds.top + tileBounds.height / 2),
           height: artworkBounds.height,
           labelFits:
             label.scrollWidth <= label.clientWidth + 1 &&
             label.scrollHeight <= label.clientHeight + 1,
+          labelCenterDeltaX:
+            labelBounds.left +
+            labelBounds.width / 2 -
+            (tileBounds.left + tileBounds.width / 2),
           labelHeight: labelBounds.height,
           separatedFromLabel: artworkBounds.bottom <= labelBounds.top + 0.5,
           tileHeight: tileBounds.height,
@@ -694,10 +711,17 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
     narrowArtwork.every((artwork) => Math.abs(artwork.centerDeltaX) <= 0.5),
   ).toBe(true);
   expect(
-    narrowArtwork.every((artwork) => Math.abs(artwork.centerDeltaY) <= 0.5),
+    narrowArtwork.every(
+      (artwork) => Math.abs(artwork.groupCenterDeltaY) <= 0.5,
+    ),
   ).toBe(true);
   expect(
-    narrowArtwork.every((artwork) => Math.abs(artwork.tileHeight - 68) <= 0.5),
+    narrowArtwork.every(
+      (artwork) => Math.abs(artwork.labelCenterDeltaX) <= 0.5,
+    ),
+  ).toBe(true);
+  expect(
+    narrowArtwork.every((artwork) => Math.abs(artwork.tileHeight - 64) <= 0.5),
   ).toBe(true);
   expect(narrowArtwork.every((artwork) => artwork.labelFits)).toBe(true);
   expect(narrowArtwork.every((artwork) => artwork.labelHeight <= 12.5)).toBe(

--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -506,9 +506,21 @@ test("shows the complete foldable categorized Library, quick-places a device, an
       const artwork = tile.querySelector<SVGElement>(".shapes-chip-art");
       if (!artwork) throw new Error("Library artwork is missing");
       const artworkBounds = artwork.getBoundingClientRect();
+      const label = tile.querySelector<HTMLElement>("span");
+      if (!label) throw new Error("Library label is missing");
+      const labelBounds = label.getBoundingClientRect();
       return {
+        centerDeltaX:
+          artworkBounds.left +
+          artworkBounds.width / 2 -
+          (tileBounds.left + tileBounds.width / 2),
+        centerDeltaY:
+          artworkBounds.top +
+          artworkBounds.height / 2 -
+          (tileBounds.top + tileBounds.height / 2),
         height: artworkBounds.height,
-        offsetY: artworkBounds.top + artworkBounds.height / 2 - tileBounds.top,
+        separatedFromLabel: artworkBounds.bottom <= labelBounds.top + 0.5,
+        tileHeight: tileBounds.height,
         withinTile:
           artworkBounds.left >= tileBounds.left - 0.5 &&
           artworkBounds.right <= tileBounds.right + 0.5 &&
@@ -520,15 +532,25 @@ test("shows the complete foldable categorized Library, quick-places a device, an
   );
   expect(artworkGeometry.every((artwork) => artwork.withinTile)).toBe(true);
   expect(
-    artworkGeometry.every((artwork) => Math.abs(artwork.width - 38) <= 0.5),
+    artworkGeometry.every((artwork) => Math.abs(artwork.width - 40) <= 0.5),
   ).toBe(true);
   expect(
-    artworkGeometry.every((artwork) => Math.abs(artwork.height - 30) <= 0.5),
+    artworkGeometry.every((artwork) => Math.abs(artwork.height - 32) <= 0.5),
   ).toBe(true);
   expect(
-    Math.max(...artworkGeometry.map((artwork) => artwork.offsetY)) -
-      Math.min(...artworkGeometry.map((artwork) => artwork.offsetY)),
-  ).toBeLessThanOrEqual(1);
+    artworkGeometry.every((artwork) => Math.abs(artwork.centerDeltaX) <= 0.5),
+  ).toBe(true);
+  expect(
+    artworkGeometry.every((artwork) => Math.abs(artwork.centerDeltaY) <= 0.5),
+  ).toBe(true);
+  expect(
+    artworkGeometry.every(
+      (artwork) => Math.abs(artwork.tileHeight - 86) <= 0.5,
+    ),
+  ).toBe(true);
+  expect(artworkGeometry.every((artwork) => artwork.separatedFromLabel)).toBe(
+    true,
+  );
   expect(
     await libraryChips
       .locator("span")
@@ -625,25 +647,56 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
   );
 
   const narrowArtwork = await page
-    .getByTestId("shapes-chip-nmos")
-    .evaluate((tile) => {
-      const tileBounds = tile.getBoundingClientRect();
-      const artwork = tile.querySelector<SVGElement>(".shapes-chip-art");
-      if (!artwork) throw new Error("Narrow Library artwork is missing");
-      const artworkBounds = artwork.getBoundingClientRect();
-      return {
-        height: artworkBounds.height,
-        withinTile:
-          artworkBounds.left >= tileBounds.left - 0.5 &&
-          artworkBounds.right <= tileBounds.right + 0.5 &&
-          artworkBounds.top >= tileBounds.top - 0.5 &&
-          artworkBounds.bottom <= tileBounds.bottom + 0.5,
-        width: artworkBounds.width,
-      };
-    });
-  expect(Math.abs(narrowArtwork.width - 44)).toBeLessThanOrEqual(0.5);
-  expect(Math.abs(narrowArtwork.height - 34)).toBeLessThanOrEqual(0.5);
-  expect(narrowArtwork.withinTile).toBe(true);
+    .locator('[data-testid^="shapes-chip-"]')
+    .evaluateAll((tiles) =>
+      tiles.map((tile) => {
+        const tileBounds = tile.getBoundingClientRect();
+        const artwork = tile.querySelector<SVGElement>(".shapes-chip-art");
+        if (!artwork) throw new Error("Narrow Library artwork is missing");
+        const artworkBounds = artwork.getBoundingClientRect();
+        const label = tile.querySelector<HTMLElement>("span");
+        if (!label) throw new Error("Narrow Library label is missing");
+        const labelBounds = label.getBoundingClientRect();
+        return {
+          centerDeltaX:
+            artworkBounds.left +
+            artworkBounds.width / 2 -
+            (tileBounds.left + tileBounds.width / 2),
+          centerDeltaY:
+            artworkBounds.top +
+            artworkBounds.height / 2 -
+            (tileBounds.top + tileBounds.height / 2),
+          height: artworkBounds.height,
+          separatedFromLabel: artworkBounds.bottom <= labelBounds.top + 0.5,
+          tileHeight: tileBounds.height,
+          withinTile:
+            artworkBounds.left >= tileBounds.left - 0.5 &&
+            artworkBounds.right <= tileBounds.right + 0.5 &&
+            artworkBounds.top >= tileBounds.top - 0.5 &&
+            artworkBounds.bottom <= tileBounds.bottom + 0.5,
+          width: artworkBounds.width,
+        };
+      }),
+    );
+  expect(
+    narrowArtwork.every((artwork) => Math.abs(artwork.width - 46) <= 0.5),
+  ).toBe(true);
+  expect(
+    narrowArtwork.every((artwork) => Math.abs(artwork.height - 36) <= 0.5),
+  ).toBe(true);
+  expect(
+    narrowArtwork.every((artwork) => Math.abs(artwork.centerDeltaX) <= 0.5),
+  ).toBe(true);
+  expect(
+    narrowArtwork.every((artwork) => Math.abs(artwork.centerDeltaY) <= 0.5),
+  ).toBe(true);
+  expect(
+    narrowArtwork.every((artwork) => Math.abs(artwork.tileHeight - 94) <= 0.5),
+  ).toBe(true);
+  expect(narrowArtwork.every((artwork) => artwork.separatedFromLabel)).toBe(
+    true,
+  );
+  expect(narrowArtwork.every((artwork) => artwork.withinTile)).toBe(true);
 
   const canvas = page.getByTestId("schematic-canvas");
   const openWidth = (await canvas.boundingBox())?.width ?? 0;

--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -456,6 +456,7 @@ test("keeps component placement active across independent canvas commits", async
 test("shows the complete foldable categorized Library, quick-places a device, and restores state", async ({
   page,
 }) => {
+  await page.setViewportSize({ width: 1024, height: 720 });
   await page.goto("/");
   const panel = page.getByTestId("shapes-library-panel");
   const canvas = page.getByTestId("schematic-canvas");
@@ -466,9 +467,50 @@ test("shows the complete foldable categorized Library, quick-places a device, an
   await expect(libraryChips).toHaveCount(18);
   await expect(categories).toHaveCount(6);
   const transistorCategory = page.getByTestId("shapes-category-transistors");
-  await expect(
-    transistorCategory.locator('[data-testid^="shapes-chip-"]'),
-  ).toHaveCount(4);
+  const transistorChips = transistorCategory.locator(
+    '[data-testid^="shapes-chip-"]',
+  );
+  await expect(transistorChips).toHaveCount(4);
+  const transistorGrid = transistorCategory.locator(".shapes-grid");
+  expect(
+    await transistorGrid.evaluate(
+      (element) =>
+        getComputedStyle(element).gridTemplateColumns.split(" ").length,
+    ),
+  ).toBe(4);
+  expect(
+    await transistorChips.evaluateAll(
+      (elements) =>
+        new Set(
+          elements.map((element) =>
+            Math.round(element.getBoundingClientRect().top),
+          ),
+        ).size,
+    ),
+  ).toBe(1);
+  expect(
+    await transistorGrid.evaluate((element) => {
+      const gridBounds = element.getBoundingClientRect();
+      return [...element.children].every((child) => {
+        const tileBounds = child.getBoundingClientRect();
+        return (
+          tileBounds.left >= gridBounds.left - 0.5 &&
+          tileBounds.right <= gridBounds.right + 0.5
+        );
+      });
+    }),
+  ).toBe(true);
+  expect(
+    await libraryChips
+      .locator("span")
+      .evaluateAll((labels) =>
+        labels.every(
+          (label) =>
+            label.scrollWidth <= label.clientWidth + 1 &&
+            label.scrollHeight <= label.clientHeight + 1,
+        ),
+      ),
+  ).toBe(true);
   await expect(transistorCategory).toHaveJSProperty("open", true);
   await transistorCategory.locator("summary").click();
   await expect(transistorCategory).toHaveJSProperty("open", false);
@@ -493,6 +535,15 @@ test("shows the complete foldable categorized Library, quick-places a device, an
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("hit-R1")).toBeVisible();
   await expect(page.getByTestId("shapes-recent-resistor")).toBeVisible();
+  expect(
+    await page
+      .getByTestId("shapes-fold-recent")
+      .locator(".shapes-grid")
+      .evaluate(
+        (element) =>
+          getComputedStyle(element).gridTemplateColumns.split(" ").length,
+      ),
+  ).toBe(4);
   await expect(transistorCategory).toHaveJSProperty("open", false);
   await expect(page.getByTestId("shapes-chip-nmos")).not.toBeVisible();
   await expect(analogCategory).toHaveJSProperty("open", true);

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -145,6 +145,12 @@ describe("editor shell", () => {
 
     expect(markup).toContain('aria-haspopup="dialog"');
     expect(markup).toContain(">Help</button>");
+    expect(markup).toContain('class="app-chrome-actions"');
+    const navigationEnd = markup.indexOf("</nav>");
+    const analyticsLink = markup.indexOf('href="/analytics"');
+    const helpButton = markup.indexOf('class="menubar-help"');
+    expect(analyticsLink).toBeGreaterThan(navigationEnd);
+    expect(helpButton).toBeGreaterThan(analyticsLink);
     expect(markup).not.toContain('role="dialog"');
     // The Connect Agent command is available (WP-WA5), but the authorization
     // panel itself must not render until the user opens it.

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -6420,34 +6420,36 @@ export function App({ project: initialProject, visitStats }: AppProps) {
               >
                 Search
               </button>
-              <button
-                type="button"
-                className="menubar-help"
-                ref={helpButtonRef}
-                aria-haspopup="dialog"
-                aria-expanded={helpOpen}
-                aria-controls="editor-help-dialog"
-                onClick={() => setHelpOpen(true)}
-              >
-                Help
-              </button>
             </div>
           </nav>
-          <a
-            className="analytics-link"
-            href="/analytics"
-            aria-label="Open visitor analytics"
-          >
-            {visitStats ? (
-              <>
-                <span>{visitStats.uv.toLocaleString()} visitors</span>
-                <span aria-hidden="true">·</span>
-                <span>{visitStats.pv.toLocaleString()} views</span>
-              </>
-            ) : (
-              "Analytics"
-            )}
-          </a>
+          <div className="app-chrome-actions">
+            <a
+              className="analytics-link"
+              href="/analytics"
+              aria-label="Open visitor analytics"
+            >
+              {visitStats ? (
+                <>
+                  <span>{visitStats.uv.toLocaleString()} visitors</span>
+                  <span aria-hidden="true">·</span>
+                  <span>{visitStats.pv.toLocaleString()} views</span>
+                </>
+              ) : (
+                "Analytics"
+              )}
+            </a>
+            <button
+              type="button"
+              className="menubar-help"
+              ref={helpButtonRef}
+              aria-haspopup="dialog"
+              aria-expanded={helpOpen}
+              aria-controls="editor-help-dialog"
+              onClick={() => setHelpOpen(true)}
+            >
+              Help
+            </button>
+          </div>
         </div>
         {hasImportedHierarchy ? (
           <div className="toolbar-row" aria-label="Document hierarchy">

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -64,8 +64,8 @@ describe("shapes quick-place", () => {
     expect(markup.match(/class="shapes-category-header"/g)).toHaveLength(6);
     expect(markup).toContain('aria-label="Place Independent Voltage Source"');
     expect(markup).toContain('title="Place Capacitor"');
-    expect(markup).not.toContain(">V Src</span>");
-    expect(markup).not.toContain(">Cap</span>");
+    expect(markup).toContain(">V Src</span>");
+    expect(markup).toContain(">Cap</span>");
   });
 
   it("quick-places without persisting parameter placeholders", () => {

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -63,8 +63,9 @@ describe("shapes quick-place", () => {
     expect(markup.match(/class="shapes-category" open=""/g)).toHaveLength(6);
     expect(markup.match(/class="shapes-category-header"/g)).toHaveLength(6);
     expect(markup).toContain('aria-label="Place Independent Voltage Source"');
-    expect(markup).toContain(">V Src</span>");
-    expect(markup).toContain(">Cap</span>");
+    expect(markup).toContain('title="Place Capacitor"');
+    expect(markup).not.toContain(">V Src</span>");
+    expect(markup).not.toContain(">Cap</span>");
   });
 
   it("quick-places without persisting parameter placeholders", () => {

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -60,6 +60,8 @@ describe("shapes quick-place", () => {
         );
       }
     }
+    expect(markup.match(/class="shapes-category" open=""/g)).toHaveLength(6);
+    expect(markup.match(/class="shapes-category-header"/g)).toHaveLength(6);
     expect(markup).toContain('aria-label="Place Independent Voltage Source"');
     expect(markup).toContain(">Voltage Source</span>");
   });

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -1,12 +1,54 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import { STARTER_SYMBOL_IDS, quickPlaceRequest } from "./shapes-panel";
+import { paletteSymbols } from "../component-insert/symbol-catalog";
+import { quickPlaceRequest, ShapesPanel } from "./shapes-panel";
 
 describe("shapes quick-place", () => {
-  it("exposes starter chips without persisting parameter placeholders", () => {
-    expect(STARTER_SYMBOL_IDS).toContain("resistor");
-    expect(STARTER_SYMBOL_IDS).toContain("nmos");
+  it("exposes every palette device in the left Library", () => {
+    const symbols = paletteSymbols("razavi");
+    const markup = renderToStaticMarkup(
+      createElement(ShapesPanel, {
+        styleProfileId: "razavi",
+        recentSymbolIds: [],
+        open: true,
+        onOpenInsert: () => undefined,
+        onQuickPlace: () => undefined,
+      }),
+    );
 
+    expect(symbols).toHaveLength(18);
+    expect(markup).toContain("All devices");
+    expect(markup.match(/data-testid="shapes-chip-/g)).toHaveLength(
+      symbols.length,
+    );
+    for (const symbol of symbols) {
+      expect(markup).toContain(`data-testid="shapes-chip-${symbol.id}"`);
+    }
+
+    const priorityIds = [
+      "resistor",
+      "capacitor",
+      "nmos",
+      "pmos",
+      "voltage-source",
+      "ground",
+      "vdd",
+      "opamp",
+    ];
+    for (let index = 1; index < priorityIds.length; index += 1) {
+      expect(
+        markup.indexOf(`data-testid="shapes-chip-${priorityIds[index]}"`),
+      ).toBeGreaterThan(
+        markup.indexOf(`data-testid="shapes-chip-${priorityIds[index - 1]}"`),
+      );
+    }
+    expect(markup).toContain('aria-label="Place Independent Voltage Source"');
+    expect(markup).toContain(">Voltage Source</span>");
+  });
+
+  it("quick-places without persisting parameter placeholders", () => {
     const request = quickPlaceRequest("razavi", "resistor");
     expect(request).toMatchObject({
       kind: "symbol",
@@ -22,7 +64,6 @@ describe("shapes quick-place", () => {
   });
 
   it("exposes VDD rail as a virtual Library placement", () => {
-    expect(STARTER_SYMBOL_IDS).toContain("vdd");
     expect(quickPlaceRequest("razavi", "vdd")).toEqual({
       kind: "vdd-rail",
       symbolId: "vdd",

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -63,7 +63,8 @@ describe("shapes quick-place", () => {
     expect(markup.match(/class="shapes-category" open=""/g)).toHaveLength(6);
     expect(markup.match(/class="shapes-category-header"/g)).toHaveLength(6);
     expect(markup).toContain('aria-label="Place Independent Voltage Source"');
-    expect(markup).toContain(">Voltage Source</span>");
+    expect(markup).toContain(">V Source</span>");
+    expect(markup).toContain(">Cap</span>");
   });
 
   it("quick-places without persisting parameter placeholders", () => {

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -2,12 +2,16 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import { paletteSymbols } from "../component-insert/symbol-catalog";
+import {
+  componentCatalog,
+  paletteSymbols,
+} from "../component-insert/symbol-catalog";
 import { quickPlaceRequest, ShapesPanel } from "./shapes-panel";
 
 describe("shapes quick-place", () => {
   it("exposes every palette device in the left Library", () => {
     const symbols = paletteSymbols("razavi");
+    const groups = componentCatalog("razavi", "");
     const markup = renderToStaticMarkup(
       createElement(ShapesPanel, {
         styleProfileId: "razavi",
@@ -27,22 +31,34 @@ describe("shapes quick-place", () => {
       expect(markup).toContain(`data-testid="shapes-chip-${symbol.id}"`);
     }
 
-    const priorityIds = [
-      "resistor",
-      "capacitor",
-      "nmos",
-      "pmos",
-      "voltage-source",
-      "ground",
-      "vdd",
-      "opamp",
+    expect(
+      groups.map((group) => [group.category, group.symbols.length]),
+    ).toEqual([
+      ["Transistors", 4],
+      ["Analog Blocks", 2],
+      ["Passives", 4],
+      ["Sources", 2],
+      ["Switches", 2],
+      ["Power and Ports", 4],
+    ]);
+    const categoryTestIds = [
+      "transistors",
+      "analog-blocks",
+      "passives",
+      "sources",
+      "switches",
+      "power-and-ports",
     ];
-    for (let index = 1; index < priorityIds.length; index += 1) {
-      expect(
-        markup.indexOf(`data-testid="shapes-chip-${priorityIds[index]}"`),
-      ).toBeGreaterThan(
-        markup.indexOf(`data-testid="shapes-chip-${priorityIds[index - 1]}"`),
-      );
+    for (let index = 0; index < categoryTestIds.length; index += 1) {
+      const testId = `data-testid="shapes-category-${categoryTestIds[index]}"`;
+      expect(markup).toContain(testId);
+      if (index > 0) {
+        expect(markup.indexOf(testId)).toBeGreaterThan(
+          markup.indexOf(
+            `data-testid="shapes-category-${categoryTestIds[index - 1]}"`,
+          ),
+        );
+      }
     }
     expect(markup).toContain('aria-label="Place Independent Voltage Source"');
     expect(markup).toContain(">Voltage Source</span>");

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -63,7 +63,7 @@ describe("shapes quick-place", () => {
     expect(markup.match(/class="shapes-category" open=""/g)).toHaveLength(6);
     expect(markup.match(/class="shapes-category-header"/g)).toHaveLength(6);
     expect(markup).toContain('aria-label="Place Independent Voltage Source"');
-    expect(markup).toContain(">V Source</span>");
+    expect(markup).toContain(">V Src</span>");
     expect(markup).toContain(">Cap</span>");
   });
 

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -1,10 +1,13 @@
 import type { ComponentInsertRequest } from "../component-insert/component-insert-request";
 import { SymbolArtwork } from "../component-insert/symbol-artwork";
 import { initialComponentParameterValues } from "../component-insert/component-parameters";
-import { findPaletteSymbol } from "../component-insert/symbol-catalog";
+import {
+  findPaletteSymbol,
+  paletteSymbols,
+} from "../component-insert/symbol-catalog";
 
-/** Starter chips always offered in the left shapes panel. */
-export const STARTER_SYMBOL_IDS = [
+/** Keep the most common quick-place devices first without hiding the rest. */
+const LIBRARY_PRIORITY_SYMBOL_IDS = [
   "resistor",
   "capacitor",
   "nmos",
@@ -14,6 +17,36 @@ export const STARTER_SYMBOL_IDS = [
   "vdd",
   "opamp",
 ] as const;
+
+const COMPACT_LIBRARY_LABELS: Readonly<Record<string, string>> = {
+  "current-source": "Current Source",
+  npn: "NPN",
+  opamp: "Op Amp",
+  pnp: "PNP",
+  "voltage-amplifier": "Voltage Amp",
+  "voltage-source": "Voltage Source",
+};
+
+function libraryLabel(symbolId: string, symbolName: string): string {
+  return COMPACT_LIBRARY_LABELS[symbolId] ?? symbolName;
+}
+
+function orderedPaletteSymbols(styleProfileId: string) {
+  const priority = new Map<string, number>(
+    LIBRARY_PRIORITY_SYMBOL_IDS.map((symbolId, index) => [symbolId, index]),
+  );
+  return paletteSymbols(styleProfileId).sort((left, right) => {
+    const leftRank = priority.get(left.id);
+    const rightRank = priority.get(right.id);
+    if (leftRank !== undefined || rightRank !== undefined) {
+      return (
+        (leftRank ?? Number.POSITIVE_INFINITY) -
+        (rightRank ?? Number.POSITIVE_INFINITY)
+      );
+    }
+    return left.name.localeCompare(right.name);
+  });
+}
 
 export function quickPlaceRequest(
   styleProfileId: string,
@@ -57,9 +90,7 @@ export function ShapesPanel({
   onOpenInsert,
   onQuickPlace,
 }: ShapesPanelProps) {
-  const starters = STARTER_SYMBOL_IDS.map((symbolId) =>
-    findPaletteSymbol(styleProfileId, symbolId),
-  ).filter((symbol): symbol is NonNullable<typeof symbol> => Boolean(symbol));
+  const librarySymbols = orderedPaletteSymbols(styleProfileId);
 
   const recents = recentSymbolIds
     .map((symbolId) => findPaletteSymbol(styleProfileId, symbolId))
@@ -94,24 +125,21 @@ export function ShapesPanel({
       </header>
 
       <div className="shapes-panel-body">
-        <details
-          className="shapes-fold"
-          open
-          data-testid="shapes-fold-starters"
-        >
+        <details className="shapes-fold" open data-testid="shapes-fold-library">
           <summary className="shapes-fold-summary">
-            <span className="shapes-fold-label">Starters</span>
-            <span className="shapes-fold-count">{starters.length}</span>
+            <span className="shapes-fold-label">All devices</span>
+            <span className="shapes-fold-count">{librarySymbols.length}</span>
           </summary>
           <div className="shapes-fold-body">
             <div className="shapes-grid">
-              {starters.map((symbol) => (
+              {librarySymbols.map((symbol) => (
                 <button
                   key={symbol.id}
                   type="button"
                   className="shapes-chip"
                   data-testid={`shapes-chip-${symbol.id}`}
                   data-vdd-rail={symbol.id === "vdd" ? "true" : undefined}
+                  aria-label={`Place ${symbol.name}`}
                   title={`Place ${symbol.name}`}
                   onClick={() => placeSymbol(symbol.id)}
                 >
@@ -120,7 +148,7 @@ export function ShapesPanel({
                     className="shapes-chip-art"
                     paddingRatio={0.04}
                   />
-                  <span>{symbol.name}</span>
+                  <span>{libraryLabel(symbol.id, symbol.name)}</span>
                 </button>
               ))}
             </div>
@@ -145,6 +173,7 @@ export function ShapesPanel({
                     type="button"
                     className="shapes-chip"
                     data-testid={`shapes-recent-${symbol.id}`}
+                    aria-label={`Place ${symbol.name}`}
                     title={`Place ${symbol.name}`}
                     onClick={() => placeSymbol(symbol.id)}
                   >
@@ -153,7 +182,7 @@ export function ShapesPanel({
                       className="shapes-chip-art"
                       paddingRatio={0.04}
                     />
-                    <span>{symbol.name}</span>
+                    <span>{libraryLabel(symbol.id, symbol.name)}</span>
                   </button>
                 ))}
               </div>

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -2,21 +2,9 @@ import type { ComponentInsertRequest } from "../component-insert/component-inser
 import { SymbolArtwork } from "../component-insert/symbol-artwork";
 import { initialComponentParameterValues } from "../component-insert/component-parameters";
 import {
+  componentCatalog,
   findPaletteSymbol,
-  paletteSymbols,
 } from "../component-insert/symbol-catalog";
-
-/** Keep the most common quick-place devices first without hiding the rest. */
-const LIBRARY_PRIORITY_SYMBOL_IDS = [
-  "resistor",
-  "capacitor",
-  "nmos",
-  "pmos",
-  "voltage-source",
-  "ground",
-  "vdd",
-  "opamp",
-] as const;
 
 const COMPACT_LIBRARY_LABELS: Readonly<Record<string, string>> = {
   "current-source": "Current Source",
@@ -31,21 +19,8 @@ function libraryLabel(symbolId: string, symbolName: string): string {
   return COMPACT_LIBRARY_LABELS[symbolId] ?? symbolName;
 }
 
-function orderedPaletteSymbols(styleProfileId: string) {
-  const priority = new Map<string, number>(
-    LIBRARY_PRIORITY_SYMBOL_IDS.map((symbolId, index) => [symbolId, index]),
-  );
-  return paletteSymbols(styleProfileId).sort((left, right) => {
-    const leftRank = priority.get(left.id);
-    const rightRank = priority.get(right.id);
-    if (leftRank !== undefined || rightRank !== undefined) {
-      return (
-        (leftRank ?? Number.POSITIVE_INFINITY) -
-        (rightRank ?? Number.POSITIVE_INFINITY)
-      );
-    }
-    return left.name.localeCompare(right.name);
-  });
+function categorySlug(category: string): string {
+  return category.toLowerCase().replace(/[^a-z0-9]+/g, "-");
 }
 
 export function quickPlaceRequest(
@@ -90,7 +65,11 @@ export function ShapesPanel({
   onOpenInsert,
   onQuickPlace,
 }: ShapesPanelProps) {
-  const librarySymbols = orderedPaletteSymbols(styleProfileId);
+  const libraryGroups = componentCatalog(styleProfileId, "");
+  const librarySymbolCount = libraryGroups.reduce(
+    (count, group) => count + group.symbols.length,
+    0,
+  );
 
   const recents = recentSymbolIds
     .map((symbolId) => findPaletteSymbol(styleProfileId, symbolId))
@@ -128,28 +107,47 @@ export function ShapesPanel({
         <details className="shapes-fold" open data-testid="shapes-fold-library">
           <summary className="shapes-fold-summary">
             <span className="shapes-fold-label">All devices</span>
-            <span className="shapes-fold-count">{librarySymbols.length}</span>
+            <span className="shapes-fold-count">{librarySymbolCount}</span>
           </summary>
           <div className="shapes-fold-body">
-            <div className="shapes-grid">
-              {librarySymbols.map((symbol) => (
-                <button
-                  key={symbol.id}
-                  type="button"
-                  className="shapes-chip"
-                  data-testid={`shapes-chip-${symbol.id}`}
-                  data-vdd-rail={symbol.id === "vdd" ? "true" : undefined}
-                  aria-label={`Place ${symbol.name}`}
-                  title={`Place ${symbol.name}`}
-                  onClick={() => placeSymbol(symbol.id)}
+            <div className="shapes-category-list">
+              {libraryGroups.map((group) => (
+                <section
+                  key={group.category}
+                  className="shapes-category"
+                  aria-labelledby={`shapes-category-${categorySlug(group.category)}`}
+                  data-testid={`shapes-category-${categorySlug(group.category)}`}
                 >
-                  <SymbolArtwork
-                    symbol={symbol}
-                    className="shapes-chip-art"
-                    paddingRatio={0.04}
-                  />
-                  <span>{libraryLabel(symbol.id, symbol.name)}</span>
-                </button>
+                  <header className="shapes-category-header">
+                    <h3 id={`shapes-category-${categorySlug(group.category)}`}>
+                      {group.category}
+                    </h3>
+                    <span className="shapes-category-count">
+                      {group.symbols.length}
+                    </span>
+                  </header>
+                  <div className="shapes-grid">
+                    {group.symbols.map((symbol) => (
+                      <button
+                        key={symbol.id}
+                        type="button"
+                        className="shapes-chip"
+                        data-testid={`shapes-chip-${symbol.id}`}
+                        data-vdd-rail={symbol.id === "vdd" ? "true" : undefined}
+                        aria-label={`Place ${symbol.name}`}
+                        title={`Place ${symbol.name}`}
+                        onClick={() => placeSymbol(symbol.id)}
+                      >
+                        <SymbolArtwork
+                          symbol={symbol}
+                          className="shapes-chip-art"
+                          paddingRatio={0.04}
+                        />
+                        <span>{libraryLabel(symbol.id, symbol.name)}</span>
+                      </button>
+                    ))}
+                  </div>
+                </section>
               ))}
             </div>
           </div>

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -9,12 +9,17 @@ import {
 } from "../component-insert/symbol-catalog";
 
 const COMPACT_LIBRARY_LABELS: Readonly<Record<string, string>> = {
-  "current-source": "Current Source",
+  capacitor: "Cap",
+  "closed-switch": "Closed",
+  "current-source": "I Source",
+  "ideal-switch": "Open",
+  inductor: "Ind",
   npn: "NPN",
   opamp: "Op Amp",
   pnp: "PNP",
-  "voltage-amplifier": "Voltage Amp",
-  "voltage-source": "Voltage Source",
+  resistor: "Res",
+  "voltage-amplifier": "V Amp",
+  "voltage-source": "V Source",
 };
 
 function libraryLabel(symbolId: string, symbolName: string): string {

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -11,15 +11,17 @@ import {
 const COMPACT_LIBRARY_LABELS: Readonly<Record<string, string>> = {
   capacitor: "Cap",
   "closed-switch": "Closed",
-  "current-source": "I Source",
+  "current-source": "I Src",
   "ideal-switch": "Open",
   inductor: "Ind",
   npn: "NPN",
-  opamp: "Op Amp",
+  opamp: "OpAmp",
   pnp: "PNP",
+  "port-filled": "Filled",
   resistor: "Res",
+  vdd: "VDD",
   "voltage-amplifier": "V Amp",
-  "voltage-source": "V Source",
+  "voltage-source": "V Src",
 };
 
 function libraryLabel(symbolId: string, symbolName: string): string {

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -8,6 +8,26 @@ import {
   findPaletteSymbol,
 } from "../component-insert/symbol-catalog";
 
+const COMPACT_LIBRARY_LABELS: Readonly<Record<string, string>> = {
+  capacitor: "Cap",
+  "closed-switch": "Closed",
+  "current-source": "I Src",
+  "ideal-switch": "Open",
+  inductor: "Ind",
+  npn: "NPN",
+  opamp: "OpAmp",
+  pnp: "PNP",
+  "port-filled": "Filled",
+  resistor: "Res",
+  vdd: "VDD",
+  "voltage-amplifier": "V Amp",
+  "voltage-source": "V Src",
+};
+
+function libraryLabel(symbolId: string, symbolName: string): string {
+  return COMPACT_LIBRARY_LABELS[symbolId] ?? symbolName;
+}
+
 function categorySlug(category: string): string {
   return category.toLowerCase().replace(/[^a-z0-9]+/g, "-");
 }
@@ -148,6 +168,7 @@ export function ShapesPanel({
                           className="shapes-chip-art"
                           paddingRatio={0.04}
                         />
+                        <span>{libraryLabel(symbol.id, symbol.name)}</span>
                       </button>
                     ))}
                   </div>
@@ -184,6 +205,7 @@ export function ShapesPanel({
                       className="shapes-chip-art"
                       paddingRatio={0.04}
                     />
+                    <span>{libraryLabel(symbol.id, symbol.name)}</span>
                   </button>
                 ))}
               </div>

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -8,26 +8,6 @@ import {
   findPaletteSymbol,
 } from "../component-insert/symbol-catalog";
 
-const COMPACT_LIBRARY_LABELS: Readonly<Record<string, string>> = {
-  capacitor: "Cap",
-  "closed-switch": "Closed",
-  "current-source": "I Src",
-  "ideal-switch": "Open",
-  inductor: "Ind",
-  npn: "NPN",
-  opamp: "OpAmp",
-  pnp: "PNP",
-  "port-filled": "Filled",
-  resistor: "Res",
-  vdd: "VDD",
-  "voltage-amplifier": "V Amp",
-  "voltage-source": "V Src",
-};
-
-function libraryLabel(symbolId: string, symbolName: string): string {
-  return COMPACT_LIBRARY_LABELS[symbolId] ?? symbolName;
-}
-
 function categorySlug(category: string): string {
   return category.toLowerCase().replace(/[^a-z0-9]+/g, "-");
 }
@@ -168,7 +148,6 @@ export function ShapesPanel({
                           className="shapes-chip-art"
                           paddingRatio={0.04}
                         />
-                        <span>{libraryLabel(symbol.id, symbol.name)}</span>
                       </button>
                     ))}
                   </div>
@@ -205,7 +184,6 @@ export function ShapesPanel({
                       className="shapes-chip-art"
                       paddingRatio={0.04}
                     />
-                    <span>{libraryLabel(symbol.id, symbol.name)}</span>
                   </button>
                 ))}
               </div>

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import type { ComponentInsertRequest } from "../component-insert/component-insert-request";
 import { SymbolArtwork } from "../component-insert/symbol-artwork";
 import { initialComponentParameterValues } from "../component-insert/component-parameters";
@@ -70,6 +72,9 @@ export function ShapesPanel({
     (count, group) => count + group.symbols.length,
     0,
   );
+  const [openCategories, setOpenCategories] = useState<ReadonlySet<string>>(
+    () => new Set(libraryGroups.map((group) => group.category)),
+  );
 
   const recents = recentSymbolIds
     .map((symbolId) => findPaletteSymbol(styleProfileId, symbolId))
@@ -79,6 +84,16 @@ export function ShapesPanel({
   function placeSymbol(symbolId: string): void {
     const request = quickPlaceRequest(styleProfileId, symbolId);
     if (request) onQuickPlace(request);
+  }
+
+  function setCategoryOpen(category: string, open: boolean): void {
+    setOpenCategories((current) => {
+      if (current.has(category) === open) return current;
+      const next = new Set(current);
+      if (open) next.add(category);
+      else next.delete(category);
+      return next;
+    });
   }
 
   return (
@@ -112,20 +127,23 @@ export function ShapesPanel({
           <div className="shapes-fold-body">
             <div className="shapes-category-list">
               {libraryGroups.map((group) => (
-                <section
+                <details
                   key={group.category}
                   className="shapes-category"
-                  aria-labelledby={`shapes-category-${categorySlug(group.category)}`}
+                  open={openCategories.has(group.category)}
                   data-testid={`shapes-category-${categorySlug(group.category)}`}
+                  onToggle={(event) =>
+                    setCategoryOpen(group.category, event.currentTarget.open)
+                  }
                 >
-                  <header className="shapes-category-header">
-                    <h3 id={`shapes-category-${categorySlug(group.category)}`}>
+                  <summary className="shapes-category-header">
+                    <span className="shapes-category-label">
                       {group.category}
-                    </h3>
+                    </span>
                     <span className="shapes-category-count">
                       {group.symbols.length}
                     </span>
-                  </header>
+                  </summary>
                   <div className="shapes-grid">
                     {group.symbols.map((symbol) => (
                       <button
@@ -147,7 +165,7 @@ export function ShapesPanel({
                       </button>
                     ))}
                   </div>
-                </section>
+                </details>
               ))}
             </div>
           </div>

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -976,7 +976,7 @@ body {
 .shapes-chip {
   position: relative;
   display: block;
-  min-height: 66px;
+  min-height: 52px;
   padding: 0;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
@@ -1004,18 +1004,6 @@ body {
   overflow: visible;
   color: var(--icm-text);
   transform: translate(-50%, -50%);
-}
-
-.shapes-chip span {
-  position: absolute;
-  right: 1px;
-  bottom: 3px;
-  left: 1px;
-  display: block;
-  min-height: 1.15em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .shapes-hint {
@@ -2740,7 +2728,7 @@ body {
   }
 
   .shapes-chip {
-    min-height: 74px;
+    min-height: 60px;
     padding: 0;
     font-size: 10px;
   }

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -976,7 +976,7 @@ body {
 .shapes-chip {
   position: relative;
   display: block;
-  min-height: 86px;
+  min-height: 66px;
   padding: 0;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
@@ -1011,11 +1011,11 @@ body {
   right: 1px;
   bottom: 3px;
   left: 1px;
-  display: -webkit-box;
-  min-height: 2.3em;
+  display: block;
+  min-height: 1.15em;
   overflow: hidden;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .shapes-hint {
@@ -2740,7 +2740,7 @@ body {
   }
 
   .shapes-chip {
-    min-height: 94px;
+    min-height: 74px;
     padding: 0;
     font-size: 10px;
   }

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -889,6 +889,46 @@ body {
   line-height: var(--icm-line-tight);
 }
 
+.shapes-category-list {
+  display: grid;
+  gap: var(--icm-space-3);
+}
+
+.shapes-category {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.shapes-category-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--icm-space-2);
+  padding: 0 2px;
+  color: var(--icm-text-muted);
+}
+
+.shapes-category-header h3 {
+  margin: 0;
+  overflow: hidden;
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  line-height: var(--icm-line-tight);
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.shapes-category-count {
+  flex: 0 0 auto;
+  color: var(--icm-text-muted);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
 .shapes-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -969,17 +969,17 @@ body {
 
 .shapes-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 6px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 4px;
 }
 
 .shapes-chip {
   display: grid;
   justify-items: center;
   align-content: center;
-  gap: 3px;
-  min-height: 70px;
-  padding: 5px 3px;
+  gap: 2px;
+  min-height: 58px;
+  padding: 4px 0;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
   background: var(--icm-surface-muted);
@@ -998,8 +998,8 @@ body {
 }
 
 .shapes-chip-art {
-  width: 40px;
-  height: 30px;
+  width: 32px;
+  height: 24px;
   overflow: visible;
   color: var(--icm-text);
 }
@@ -2732,6 +2732,18 @@ body {
     max-height: 30dvh;
     border-right: 0;
     border-top: 1px solid var(--icm-border);
+  }
+
+  .shapes-chip {
+    gap: 3px;
+    min-height: 70px;
+    padding: 5px 3px;
+    font-size: 10px;
+  }
+
+  .shapes-chip-art {
+    width: 40px;
+    height: 30px;
   }
 
   .selection-dock,

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -974,13 +974,10 @@ body {
 }
 
 .shapes-chip {
-  display: grid;
-  grid-template-rows: 30px minmax(2.3em, auto);
-  justify-items: center;
-  align-content: center;
-  gap: 2px;
-  min-height: 64px;
-  padding: 3px 0;
+  position: relative;
+  display: block;
+  min-height: 86px;
+  padding: 0;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
   background: var(--icm-surface-muted);
@@ -999,17 +996,22 @@ body {
 }
 
 .shapes-chip-art {
-  width: 38px;
-  height: 30px;
-  align-self: center;
-  justify-self: center;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 40px;
+  height: 32px;
   overflow: visible;
   color: var(--icm-text);
+  transform: translate(-50%, -50%);
 }
 
 .shapes-chip span {
+  position: absolute;
+  right: 1px;
+  bottom: 3px;
+  left: 1px;
   display: -webkit-box;
-  max-width: 100%;
   min-height: 2.3em;
   overflow: hidden;
   -webkit-box-orient: vertical;
@@ -2738,16 +2740,14 @@ body {
   }
 
   .shapes-chip {
-    grid-template-rows: 34px minmax(2.3em, auto);
-    gap: 3px;
-    min-height: 74px;
-    padding: 4px 3px;
+    min-height: 94px;
+    padding: 0;
     font-size: 10px;
   }
 
   .shapes-chip-art {
-    width: 44px;
-    height: 34px;
+    width: 46px;
+    height: 36px;
   }
 
   .selection-dock,

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -891,25 +891,25 @@ body {
 
 .shapes-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: var(--icm-space-2);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
 }
 
 .shapes-chip {
   display: grid;
   justify-items: center;
   align-content: center;
-  gap: var(--icm-space-2);
-  min-height: 104px;
-  padding: var(--icm-space-3) var(--icm-space-2) var(--icm-space-2);
+  gap: 3px;
+  min-height: 70px;
+  padding: 5px 3px;
   border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-md);
+  border-radius: var(--icm-radius-sm);
   background: var(--icm-surface-muted);
   box-shadow: none;
   color: var(--icm-text);
-  font-size: var(--icm-font-xs);
+  font-size: 10px;
   font-weight: 600;
-  line-height: var(--icm-line-tight);
+  line-height: 1.15;
   text-align: center;
 }
 
@@ -920,18 +920,19 @@ body {
 }
 
 .shapes-chip-art {
-  /* Keep the tile size; paddingRatio on SymbolArtwork crops empty margin. */
-  width: 64px;
-  height: 48px;
+  width: 40px;
+  height: 30px;
   overflow: visible;
   color: var(--icm-text);
 }
 
 .shapes-chip span {
+  display: -webkit-box;
   max-width: 100%;
+  min-height: 2.3em;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .shapes-hint {

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -976,7 +976,7 @@ body {
 .shapes-chip {
   position: relative;
   display: block;
-  min-height: 52px;
+  min-height: 64px;
   padding: 0;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
@@ -1004,6 +1004,18 @@ body {
   overflow: visible;
   color: var(--icm-text);
   transform: translate(-50%, -50%);
+}
+
+.shapes-chip span {
+  position: absolute;
+  right: 1px;
+  bottom: 3px;
+  left: 1px;
+  display: block;
+  min-height: 1.15em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .shapes-hint {
@@ -2728,7 +2740,7 @@ body {
   }
 
   .shapes-chip {
-    min-height: 60px;
+    min-height: 68px;
     padding: 0;
     font-size: 10px;
   }

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -975,11 +975,12 @@ body {
 
 .shapes-chip {
   display: grid;
+  grid-template-rows: 30px minmax(2.3em, auto);
   justify-items: center;
   align-content: center;
   gap: 2px;
-  min-height: 58px;
-  padding: 4px 0;
+  min-height: 64px;
+  padding: 3px 0;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
   background: var(--icm-surface-muted);
@@ -998,8 +999,10 @@ body {
 }
 
 .shapes-chip-art {
-  width: 32px;
-  height: 24px;
+  width: 38px;
+  height: 30px;
+  align-self: center;
+  justify-self: center;
   overflow: visible;
   color: var(--icm-text);
 }
@@ -2735,15 +2738,16 @@ body {
   }
 
   .shapes-chip {
+    grid-template-rows: 34px minmax(2.3em, auto);
     gap: 3px;
-    min-height: 70px;
-    padding: 5px 3px;
+    min-height: 74px;
+    padding: 4px 3px;
     font-size: 10px;
   }
 
   .shapes-chip-art {
-    width: 40px;
-    height: 30px;
+    width: 44px;
+    height: 34px;
   }
 
   .selection-dock,

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -974,9 +974,12 @@ body {
 }
 
 .shapes-chip {
-  position: relative;
-  display: block;
-  min-height: 64px;
+  display: grid;
+  grid-template-rows: 32px 1.15em;
+  justify-items: center;
+  align-content: center;
+  gap: 2px;
+  min-height: 56px;
   padding: 0;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
@@ -996,22 +999,15 @@ body {
 }
 
 .shapes-chip-art {
-  position: absolute;
-  top: 50%;
-  left: 50%;
   width: 40px;
   height: 32px;
   overflow: visible;
   color: var(--icm-text);
-  transform: translate(-50%, -50%);
 }
 
 .shapes-chip span {
-  position: absolute;
-  right: 1px;
-  bottom: 3px;
-  left: 1px;
   display: block;
+  max-width: calc(100% - 2px);
   min-height: 1.15em;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2740,7 +2736,9 @@ body {
   }
 
   .shapes-chip {
-    min-height: 68px;
+    grid-template-rows: 36px 1.15em;
+    gap: 3px;
+    min-height: 64px;
     padding: 0;
     font-size: 10px;
   }

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -271,13 +271,20 @@ body {
   overflow: visible;
 }
 
+.app-chrome-actions {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: var(--icm-space-2);
+  margin-left: auto;
+}
+
 /* Visitor analytics entry (compact, does not crowd menubar commands). */
 .analytics-link {
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
   gap: 0.3rem;
-  margin-left: auto;
   color: var(--icm-text-muted);
   font-size: var(--icm-font-xs);
   font-variant-numeric: tabular-nums;
@@ -901,16 +908,43 @@ body {
 }
 
 .shapes-category-header {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: var(--icm-space-2);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  min-height: 18px;
   padding: 0 2px;
   color: var(--icm-text-muted);
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
 }
 
-.shapes-category-header h3 {
-  margin: 0;
+.shapes-category-header::-webkit-details-marker {
+  display: none;
+}
+
+.shapes-category-header::before {
+  content: "";
+  width: 0;
+  height: 0;
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  border-left: 4px solid currentColor;
+  opacity: 0.5;
+  transition: transform 120ms ease;
+}
+
+.shapes-category[open] > .shapes-category-header::before {
+  transform: rotate(90deg);
+}
+
+.shapes-category-header:hover {
+  color: var(--icm-text);
+}
+
+.shapes-category-label {
+  min-width: 0;
   overflow: hidden;
   font-size: 10px;
   font-weight: 650;
@@ -919,6 +953,10 @@ body {
   text-overflow: ellipsis;
   text-transform: uppercase;
   white-space: nowrap;
+}
+
+.shapes-category:not([open]) > .shapes-grid {
+  display: none;
 }
 
 .shapes-category-count {

--- a/plan/2026-08-15-categorize-library-devices/plan.md
+++ b/plan/2026-08-15-categorize-library-devices/plan.md
@@ -1,0 +1,64 @@
+---
+status: completed
+experience: none
+---
+
+# Categorize Library Devices
+
+## Goal
+
+Organize the 18 quick-place Library items into their six existing component-catalog categories instead of presenting one undifferentiated grid.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## agent/compact-complete-library...origin/agent/compact-complete-library
+```
+
+The worktree is clean. This follow-up remains on the existing compact-Library branch because it refines the same UI and depends on commit `d0cb17b`.
+
+Owned paths:
+
+- `apps/editor/src/features/editor-shell/shapes-panel.tsx`
+- `apps/editor/src/features/editor-shell/shapes-panel.test.ts`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `apps/editor/src/styles.css`
+- `plan/2026-08-15-categorize-library-devices/plan.md`
+- `plan/log.md`
+
+Shared dependencies:
+
+- `apps/editor/src/features/component-insert/symbol-catalog.ts` remains the read-only source for category names, order, membership, and palette eligibility.
+
+## Work
+
+1. Project the sidebar from `componentCatalog` so its category contract matches the Insert dialog.
+2. Add compact category headings and counts inside the All devices section while preserving all 18 quick-place buttons, recents, accessible names, and tooltips.
+3. Update focused unit and browser coverage for six category groups and complete palette exposure.
+4. Inspect the running editor at desktop size for hierarchy, density, and scroll behavior.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/features/editor-shell/shapes-panel.test.ts apps/editor/src/app/App.test.tsx`
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep "categorized Library"`
+- `pnpm typecheck`
+- Prettier checks for changed source, tests, CSS, and plan
+- Desktop screenshot inspection against the running Vite editor
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): group library devices by category
+```
+
+## Outcome
+
+The All devices fold now renders the same six ordered groups as the Insert dialog: Transistors (4), Analog Blocks (2), Passives (4), Sources (2), Switches (2), and Power and Ports (4). Every category has a compact heading and count, all 18 quick-place buttons remain available with full accessible names/tooltips, and recents remain a separate fold. Desktop inspection at 1280×720 and 1440×900 confirmed clear grouping and expected vertical scrolling beneath the fixed Insert footer.
+
+Validation passed: focused unit tests (2 files / 16 tests), focused categorized-Library Playwright flow (1 test), `pnpm typecheck`, Prettier checks, reviewer approval, desktop screenshot inspection, and `git diff --check`.

--- a/plan/2026-08-15-center-enlarge-library-devices-rebase/plan.md
+++ b/plan/2026-08-15-center-enlarge-library-devices-rebase/plan.md
@@ -1,0 +1,70 @@
+---
+status: completed
+experience: none
+---
+
+# Center and Enlarge Library Devices, Then Rebase
+
+## Goal
+
+Make each four-column Library tile use a larger, consistently vertically aligned device-artwork row, then rebase the complete Library branch onto the latest `origin/main`.
+
+## State and Ownership
+
+Start state after `git fetch origin --prune`:
+
+```text
+## agent/compact-complete-library...origin/agent/compact-complete-library
+```
+
+The worktree is clean. `origin/main` is at `330ba43`; the feature branch is four commits ahead of and six commits behind that tip. Incoming main changes touch `apps/editor/src/app/App.tsx` and `plan/log.md`, so the rebase may require resolving overlap with earlier commits on this branch. Resolutions will preserve both the imported-flightline mainline changes and the completed Library/navigation work.
+
+Owned paths for the new UI change:
+
+- `apps/editor/src/styles.css`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `plan/2026-08-15-center-enlarge-library-devices-rebase/plan.md`
+- `plan/log.md`
+
+Rebase conflict-resolution boundary, only if Git reports conflicts:
+
+- Earlier Library/navigation commit paths on this branch
+- Incoming `apps/editor/src/app/App.tsx` flightline-placement behavior
+- Incoming and branch `plan/log.md` factual entries
+
+## Work
+
+1. Give every tile a fixed artwork row so symbol SVGs align consistently regardless of one- or two-line labels.
+2. Enlarge desktop artwork within the four-column 220–248px Library width and proportionally enlarge artwork in the full-width narrow layout.
+3. Extend browser geometry coverage for artwork size, containment, and consistent vertical offset.
+4. Validate and visually inspect the UI, commit the target, then rebase the branch onto `origin/main` and rerun focused validation.
+
+## Validation
+
+Before and after rebase:
+
+- `pnpm test:local apps/editor/src/features/editor-shell/shapes-panel.test.ts apps/editor/src/app/App.test.tsx`
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep "foldable categorized Library|narrow breakpoint"`
+- `pnpm typecheck`
+- Prettier checks for changed CSS, browser test, and plan
+- Screenshot inspection at 1280×720, 1024×720, and 720×720
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+style(editor): center and enlarge library devices
+```
+
+After validation, rebase and force-push safely with `--force-with-lease`.
+
+## Outcome
+
+Desktop Library tiles now reserve a fixed 30px artwork row and render symbols at 38×30px inside 64px tiles, keeping all one- and two-line labels on a consistent device baseline. The full-width narrow layout uses a 34px artwork row with 44×34px symbols inside 74px tiles. Four-column density, folding, concise labels, full accessible names, and placement behavior remain unchanged.
+
+The five-commit Library branch was rebased onto latest `origin/main` at `330ba43`. The only conflict was `plan/log.md` while replaying the first Library commit; the resolution preserved both mainline imported-flightline/integration records and all Library records. `origin/main` is now an ancestor of the branch, with five feature commits and no missing mainline commits.
+
+Post-rebase validation passed: focused unit tests (2 files / 16 tests), two focused Playwright flows with exact desktop/narrow artwork dimensions, containment, mixed-label alignment, fold persistence, and responsive checks, `pnpm typecheck`, Prettier checks, reviewer approval with its geometry suggestion addressed, screenshot inspection at 1280×720, 1024×720, and 720×720, and `git diff --check`.

--- a/plan/2026-08-15-center-library-icon-label-group/plan.md
+++ b/plan/2026-08-15-center-library-icon-label-group/plan.md
@@ -1,0 +1,62 @@
+---
+status: completed
+experience: none
+---
+
+# Center the Library Icon-label Group
+
+## Goal
+
+Center the combined visual weight (`重心`) of each device picture plus its bottom name within the tile, rather than centering the picture alone.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## agent/compact-complete-library...origin/agent/compact-complete-library
+```
+
+The worktree is clean and the branch remains rebased on current main.
+
+Owned paths:
+
+- `apps/editor/src/styles.css`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `plan/2026-08-15-center-library-icon-label-group/plan.md`
+- `plan/log.md`
+
+Read-only dependencies:
+
+- Visible compact names, full accessible names/tooltips, four columns, categories, folds, recents, and placement behavior remain unchanged.
+
+## Work
+
+1. Return picture and name to normal tile flow as one fixed-size visual group.
+2. Vertically center that combined group while preserving horizontal centering and a clear picture/name gap.
+3. Keep desktop and narrow tile heights compact around the centered group.
+4. Update browser geometry coverage to measure the union center of artwork and label.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/features/editor-shell/shapes-panel.test.ts apps/editor/src/app/App.test.tsx`
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep "foldable categorized Library|narrow breakpoint"`
+- `pnpm typecheck`
+- Prettier checks for changed CSS, browser test, and plan
+- Screenshot inspection at 1280×720, 1024×720, and 720×720
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): center library icon-label groups
+```
+
+## Outcome
+
+Each tile now treats the artwork and its one-line name as a single visual group and centers the union of their bounds on the tile’s vertical midpoint. Artwork and label remain independently centered horizontally with a fixed gap. Desktop tiles are 56px high around 40×32px artwork; narrow tiles are 64px high around 46×36px artwork.
+
+Validation passed: focused unit tests (2 files / 16 tests), two focused Playwright flows measuring the exact artwork-label union center, artwork/label horizontal centers, separation, fit, dimensions, folds, and Recent behavior at desktop/narrow widths, `pnpm typecheck`, Prettier checks, reviewer approval, screenshot inspection at 1280×720, 1024×720, and 720×720, and `git diff --check`.

--- a/plan/2026-08-15-compact-centered-library-tiles/plan.md
+++ b/plan/2026-08-15-compact-centered-library-tiles/plan.md
@@ -1,0 +1,64 @@
+---
+status: completed
+experience: none
+---
+
+# Compact Centered Library Tiles
+
+## Goal
+
+Reduce the height of the newly centered Library tiles while keeping artwork exactly centered, four columns intact, and labels clear without overlapping the symbol.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## agent/compact-complete-library...origin/agent/compact-complete-library
+```
+
+The worktree is clean and the branch remains based on current `origin/main`.
+
+Owned paths:
+
+- `apps/editor/src/features/editor-shell/shapes-panel.tsx`
+- `apps/editor/src/features/editor-shell/shapes-panel.test.ts`
+- `apps/editor/src/styles.css`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `plan/2026-08-15-compact-centered-library-tiles/plan.md`
+- `plan/log.md`
+
+Read-only dependencies:
+
+- Category membership, folds, full accessible names/tooltips, and placement behavior remain unchanged.
+
+## Work
+
+1. Use single-line compact electrical labels so the label area no longer requires two lines.
+2. Reduce desktop/narrow tile heights while retaining exact full-tile artwork centering and a visible artwork-to-label gap.
+3. Update geometry coverage for the compact heights, one-line label fit, centering, and separation.
+4. Inspect desktop and narrow layouts against the running editor.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/features/editor-shell/shapes-panel.test.ts apps/editor/src/app/App.test.tsx`
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep "foldable categorized Library|narrow breakpoint"`
+- `pnpm typecheck`
+- Prettier checks for changed source, CSS, browser test, and plan
+- Screenshot inspection at 1280×720, 1024×720, and 720×720
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+style(editor): compact centered library tiles
+```
+
+## Outcome
+
+Tiles remain exactly centered on both axes but are substantially shorter: desktop height dropped from 86px to 66px and narrow-layout height from 94px to 74px. The 40×32px desktop and 46×36px narrow artwork sizes remain unchanged. Visual labels now use one-line electrical abbreviations such as `OpAmp`, `I Src`, `V Src`, and `VDD`; complete names remain available through button accessibility labels and tooltips.
+
+Validation passed: focused unit tests (2 files / 16 tests), two focused Playwright flows asserting exact centers, compact tile heights, artwork dimensions, four-edge containment, label separation, one-line height, and no label overflow for every device at desktop and narrow widths, `pnpm typecheck`, Prettier checks, reviewer suggestion addressed, screenshot inspection at 1280×720, 1024×720, and 720×720, and `git diff --check`.

--- a/plan/2026-08-15-compact-complete-library/plan.md
+++ b/plan/2026-08-15-compact-complete-library/plan.md
@@ -1,0 +1,63 @@
+---
+status: completed
+experience: none
+---
+
+# Compact Complete Component Library
+
+## Goal
+
+Show the full reviewed component palette in the left Library panel using compact, legible quick-place tiles instead of limiting the panel to eight starter devices.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree was clean. Remote `main` was fast-forwarded to `73af3db` before this target, and the target now owns branch `agent/compact-complete-library`.
+
+Owned paths:
+
+- `apps/editor/src/features/editor-shell/shapes-panel.tsx`
+- `apps/editor/src/features/editor-shell/shapes-panel.test.ts`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `apps/editor/src/styles.css`
+- `plan/2026-08-15-compact-complete-library/plan.md`
+- `plan/log.md`
+
+Read-only/shared dependencies:
+
+- `apps/editor/src/features/component-insert/symbol-catalog.ts` remains the sole UI palette source.
+- `packages/symbols` and the Razavi catalog remain unchanged visual/electrical authorities.
+
+## Work
+
+1. Populate the Library panel from the complete palette, including the editor-local VDD Rail item.
+2. Replace the starter presentation with a compact all-devices grid while preserving quick placement, tooltips, recents, and Insert-dialog access.
+3. Add focused coverage that proves every palette item is exposed in the sidebar.
+4. Inspect the running editor at desktop size for density and label legibility.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/features/editor-shell/shapes-panel.test.ts apps/editor/src/app/App.test.tsx`
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep "quick-places"`
+- Desktop screenshot inspection against the running Vite editor.
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): show complete compact component library
+```
+
+## Outcome
+
+The left Library now exposes all 18 available palette items: 17 reviewed Razavi product symbols plus the editor-local VDD Rail. Common devices remain first, every remaining device follows alphabetically, and the sidebar uses a compact three-column grid with shortened visual labels plus full accessible names/tooltips. At the default 1280×720 desktop viewport, all 18 primary tiles fit above the fixed Insert footer without scrolling.
+
+Validation passed: focused unit tests (2 files / 16 tests), focused Library Playwright flow (1 test), `pnpm typecheck`, Prettier checks, `git diff --check`, and desktop screenshot inspection at 1280×720.

--- a/plan/2026-08-15-deliver-compact-library-pr/plan.md
+++ b/plan/2026-08-15-deliver-compact-library-pr/plan.md
@@ -1,0 +1,62 @@
+---
+status: active
+experience: none
+---
+
+# Deliver Compact Library Pull Request
+
+## Goal
+
+Rebase the completed compact/categorized Library branch onto the latest `origin/main`, preserve both incoming editor behavior and the Library/navigation work, validate the rebased branch, push it, and open a pull request.
+
+## State and Ownership
+
+Start state after `git fetch origin --prune`:
+
+```text
+## agent/compact-complete-library...origin/agent/compact-complete-library
+```
+
+The worktree is clean. `origin/main` is at `4b56c37`; the feature branch is ten commits ahead of and nineteen commits behind that tip. Incoming main and the feature branch both touch `apps/editor/src/app/App.tsx`, `apps/editor/src/styles.css`, and `plan/log.md`, so rebase conflicts are credible.
+
+Owned paths:
+
+- `plan/2026-08-15-deliver-compact-library-pr/plan.md`
+- `plan/log.md`
+
+Rebase conflict-resolution boundary, only where Git reports conflicts:
+
+- Completed Library/navigation paths on this branch
+- Incoming main editor behavior in overlapping files
+- Factual plan/log entries from both histories
+
+## Work
+
+1. Commit this delivery target so the worktree is clean for rebase.
+2. Rebase onto `origin/main`, resolving conflicts by preserving both accepted mainline behavior and the complete Library feature.
+3. Run focused post-rebase validation plus ancestry, formatting, and diff checks.
+4. Force-push safely with `--force-with-lease` and create a PR targeting `main` with a concise feature/validation summary.
+5. Record the PR URL and delivery state.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/features/editor-shell/shapes-panel.test.ts apps/editor/src/app/App.test.tsx`
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep "foldable categorized Library|narrow breakpoint"`
+- `pnpm typecheck`
+- Prettier checks for feature source/tests and this plan
+- `git diff --check origin/main...HEAD`
+- `git merge-base --is-ancestor origin/main HEAD`
+- `git status --short --branch`
+- PR base/head and URL verification with `gh pr view`
+
+## Commit Intent
+
+Commit as:
+
+```text
+docs(plan): prepare compact library PR delivery
+```
+
+## Outcome
+
+Pending.

--- a/plan/2026-08-15-deliver-compact-library-pr/plan.md
+++ b/plan/2026-08-15-deliver-compact-library-pr/plan.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: completed
 experience: none
 ---
 
@@ -59,4 +59,8 @@ docs(plan): prepare compact library PR delivery
 
 ## Outcome
 
-Pending.
+Main advanced repeatedly during delivery, so the branch was rebased after PR creation and again after the label-spacing closeout landed. The final twelve-commit branch is based on `origin/main` at `ea60c96`. Each rebase conflicted only in `plan/log.md` while replaying the first Library commit; the resolutions preserved mainline junction, drafting-text, VDD-rail, label-spacing, and closeout records together with all Library records. `origin/main` is an ancestor of the final branch with no missing mainline commits.
+
+Final post-rebase validation passed: targeted Library/narrow Playwright flows (2 tests), `pnpm verify:branch` (119 test files / 728 tests, static contracts, all workspace builds, and editor production smoke), formatting, typechecking, ancestry, `git diff --check`, and a final Markdown-link check after the docs-only main advancement.
+
+PR [#63](https://github.com/chenzc24/Analog-Canvas/pull/63), **feat(editor): complete compact categorized component library**, is open against `main`. The final rebased tip was force-pushed with lease and submitted to the same six required checks: Change scope, Static contracts, Unit and integration tests, Release contracts, and both Browser test shards.

--- a/plan/2026-08-15-four-column-library-icons/plan.md
+++ b/plan/2026-08-15-four-column-library-icons/plan.md
@@ -1,0 +1,64 @@
+---
+status: completed
+experience: none
+---
+
+# Four-column Library Icons
+
+## Goal
+
+Reduce Library tile and artwork size so each device category displays four quick-place icons per row without sacrificing labels, accessibility, folding, or placement behavior.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## agent/compact-complete-library...origin/agent/compact-complete-library
+```
+
+The worktree is clean. This compact-density follow-up remains on the existing Library branch.
+
+Owned paths:
+
+- `apps/editor/src/features/editor-shell/shapes-panel.tsx`
+- `apps/editor/src/features/editor-shell/shapes-panel.test.ts`
+- `apps/editor/src/styles.css`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `plan/2026-08-15-four-column-library-icons/plan.md`
+- `plan/log.md`
+
+Read-only dependencies:
+
+- Library category membership, full accessible names/tooltips, and fold state remain unchanged.
+
+## Work
+
+1. Change category and Recent grids to four columns.
+2. Reduce tile artwork, spacing, typography, and minimum height proportionally so four tiles remain legible within the 220–248px desktop Library width.
+3. Add a browser geometry assertion proving a four-item category occupies one row.
+4. Inspect desktop and narrow layouts against the running editor.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/features/editor-shell/shapes-panel.test.ts apps/editor/src/app/App.test.tsx`
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep "foldable categorized Library|narrow breakpoint"`
+- `pnpm typecheck`
+- Prettier checks for changed CSS, browser test, and plan
+- Desktop and narrow screenshot inspection against the running Vite editor
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+style(editor): fit four library icons per row
+```
+
+## Outcome
+
+Library category and Recent grids now use four columns. Desktop tiles use 32×24px artwork, tighter spacing, and 58px minimum height while retaining readable 10px labels; long visual names use concise electrical abbreviations with their complete names preserved in `aria-label` and tooltips. The full-width Library below 860px restores larger 40×30px artwork and 70px tiles while keeping four columns.
+
+Validation passed: focused unit tests (2 files / 16 tests), two focused Playwright flows at the 220px desktop Library boundary and 720px narrow layout, `pnpm typecheck`, Prettier checks, reviewer approval after readability fixes, screenshot inspection at 1280×720, 1024×720, and 720×720, and `git diff --check`.

--- a/plan/2026-08-15-icon-only-centered-library-tiles/plan.md
+++ b/plan/2026-08-15-icon-only-centered-library-tiles/plan.md
@@ -1,0 +1,64 @@
+---
+status: completed
+experience: none
+---
+
+# Icon-only Centered Library Tiles
+
+## Goal
+
+Make the four-column Library substantially more compact by removing visible in-tile labels and centering the device artwork alone in each box, while retaining full names through accessible labels and hover tooltips.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## agent/compact-complete-library...origin/agent/compact-complete-library
+```
+
+The worktree is clean and the branch remains rebased on current main.
+
+Owned paths:
+
+- `apps/editor/src/features/editor-shell/shapes-panel.tsx`
+- `apps/editor/src/features/editor-shell/shapes-panel.test.ts`
+- `apps/editor/src/styles.css`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `plan/2026-08-15-icon-only-centered-library-tiles/plan.md`
+- `plan/log.md`
+
+Read-only dependencies:
+
+- Category headings/counts, folds, full button names/tooltips, recents, and placement behavior remain unchanged.
+
+## Work
+
+1. Remove visible compact text from Library and Recent tiles; keep complete `aria-label` and `title` names.
+2. Reduce desktop/narrow tile heights around the centered artwork while retaining minimum practical click targets.
+3. Update static/browser coverage for icon-only content, exact centering, dimensions, and containment.
+4. Inspect desktop and narrow layouts against the running editor.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/features/editor-shell/shapes-panel.test.ts apps/editor/src/app/App.test.tsx`
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep "foldable categorized Library|narrow breakpoint"`
+- `pnpm typecheck`
+- Prettier checks for changed source, CSS, browser test, and plan
+- Screenshot inspection at 1280×720, 1024×720, and 720×720
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+style(editor): use compact centered library icons
+```
+
+## Outcome
+
+Library and Recent tiles are now icon-only: visible compact text was removed, while every button retains its complete `aria-label` and `title` name. Desktop tiles dropped from 66px to 52px around centered 40×32px artwork; the narrow layout dropped from 74px to 60px around centered 46×36px artwork. Four columns, categories, folds, recents, and placement behavior remain unchanged.
+
+Validation passed: focused unit tests (2 files / 16 tests), two focused Playwright flows asserting all primary and Recent tiles are icon-only, fully named, exactly centered, correctly sized, and contained at desktop/narrow widths, `pnpm typecheck`, Prettier checks, reviewer suggestion addressed, screenshot inspection at 1280×720, 1024×720, and 720×720, and `git diff --check`.

--- a/plan/2026-08-15-restore-bottom-library-names/plan.md
+++ b/plan/2026-08-15-restore-bottom-library-names/plan.md
@@ -1,0 +1,64 @@
+---
+status: completed
+experience: none
+---
+
+# Restore Bottom Names on Centered Library Tiles
+
+## Goal
+
+Restore visible device names at the bottom of each compact tile while keeping the device artwork exactly centered in the full box and sizing the tile to prevent overlap.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## agent/compact-complete-library...origin/agent/compact-complete-library
+```
+
+The worktree is clean and the branch remains rebased on current main.
+
+Owned paths:
+
+- `apps/editor/src/features/editor-shell/shapes-panel.tsx`
+- `apps/editor/src/features/editor-shell/shapes-panel.test.ts`
+- `apps/editor/src/styles.css`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `plan/2026-08-15-restore-bottom-library-names/plan.md`
+- `plan/log.md`
+
+Read-only dependencies:
+
+- Category headings/counts, folds, complete accessible names/tooltips, recents, and placement behavior remain unchanged.
+
+## Work
+
+1. Restore concise one-line visible names for Library and Recent tiles.
+2. Keep artwork centered on both axes and anchor names independently at the bottom.
+3. Increase tile height only enough to maintain a measured artwork-to-label gap.
+4. Update static/browser coverage for names, centering, separation, fit, and Recent behavior.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/features/editor-shell/shapes-panel.test.ts apps/editor/src/app/App.test.tsx`
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep "foldable categorized Library|narrow breakpoint"`
+- `pnpm typecheck`
+- Prettier checks for changed source, CSS, browser test, and plan
+- Screenshot inspection at 1280×720, 1024×720, and 720×720
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): restore names on centered library tiles
+```
+
+## Outcome
+
+Concise visible names are restored at the bottom of every Library and Recent tile while device artwork remains centered on the full box. Desktop tiles are 64px high around 40×32px artwork; narrow tiles are 68px high around 46×36px artwork. The measured layout retains a gap between artwork and the one-line label, and complete device names remain available through `aria-label` and `title`.
+
+Validation passed: focused unit tests (2 files / 16 tests), two focused Playwright flows asserting all primary/narrow labels fit, artwork remains exactly centered, tile dimensions and separation hold, and Recent labels/accessibility remain correct, `pnpm typecheck`, Prettier checks, reviewer approval, screenshot inspection at 1280×720, 1024×720, and 720×720, and `git diff --check`.

--- a/plan/2026-08-15-right-help-foldable-library-categories/plan.md
+++ b/plan/2026-08-15-right-help-foldable-library-categories/plan.md
@@ -1,0 +1,67 @@
+---
+status: completed
+experience: none
+---
+
+# Right-align Help and Fold Library Categories
+
+## Goal
+
+Move Help to the right side of the top navigation bar and make each Library device category independently foldable without losing quick-place, accessibility, or recent-device behavior.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## agent/compact-complete-library...origin/agent/compact-complete-library
+```
+
+The worktree is clean. This follow-up remains on the existing Library branch because it refines the same committed navigation/sidebar UI.
+
+Owned paths:
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/app/App.test.tsx`
+- `apps/editor/src/features/editor-shell/shapes-panel.tsx`
+- `apps/editor/src/features/editor-shell/shapes-panel.test.ts`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `apps/editor/src/styles.css`
+- `plan/2026-08-15-right-help-foldable-library-categories/plan.md`
+- `plan/log.md`
+
+Shared dependencies:
+
+- Help dialog focus/open behavior remains unchanged.
+- `componentCatalog` remains the read-only category source.
+
+## Work
+
+1. Move Help into a right-aligned top-bar action group while keeping Analytics and command-menu semantics intact.
+2. Render each of the six device categories as a native fold with controlled open state, initially expanded and independently toggleable.
+3. Add focused static/browser coverage for Help placement and category collapse/reopen behavior.
+4. Inspect the running editor at desktop and narrow widths.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/features/editor-shell/shapes-panel.test.ts apps/editor/src/app/App.test.tsx`
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep "foldable categorized Library|narrow breakpoint"`
+- `pnpm typecheck`
+- Prettier checks for changed source, tests, CSS, and plan
+- Desktop and narrow screenshot inspection against the running Vite editor
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): right-align help and fold library categories
+```
+
+## Outcome
+
+Help now sits in the rightmost top-bar action group after Analytics at desktop and 720px widths. Each of the six Library categories is a native controlled fold, initially expanded, independently toggleable, and preserves its open/closed state through quick placement and other React rerenders. Category arrows, counts, quick-place buttons, recents, and the fixed Insert footer remain intact.
+
+Validation passed: focused unit tests (2 files / 16 tests), two focused Playwright flows covering fold persistence and narrow top-bar bounds, `pnpm typecheck`, Prettier checks, reviewer approval with its coverage suggestion addressed, desktop/narrow screenshot inspection, and `git diff --check`.

--- a/plan/2026-08-15-true-vertical-center-library-artwork/plan.md
+++ b/plan/2026-08-15-true-vertical-center-library-artwork/plan.md
@@ -1,0 +1,62 @@
+---
+status: completed
+experience: none
+---
+
+# True Vertical Center for Library Artwork
+
+## Goal
+
+Center each device SVG on the full Library tile rather than only within an upper artwork row, while keeping the label anchored below it and preserving four columns.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## agent/compact-complete-library...origin/agent/compact-complete-library
+```
+
+The worktree is clean and already rebased onto `origin/main` at `330ba43` by the preceding target.
+
+Owned paths:
+
+- `apps/editor/src/styles.css`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `plan/2026-08-15-true-vertical-center-library-artwork/plan.md`
+- `plan/log.md`
+
+Read-only dependencies:
+
+- Library markup, four-column grouping, fold state, accessible names, and placement behavior remain unchanged.
+
+## Work
+
+1. Position artwork at the exact horizontal and vertical center of each tile.
+2. Anchor the label independently at the tile bottom and enlarge tile/artwork dimensions enough to avoid overlap.
+3. Update browser geometry coverage to assert artwork center equals tile center at desktop and narrow layouts.
+4. Inspect the running editor at desktop and narrow widths.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/features/editor-shell/shapes-panel.test.ts apps/editor/src/app/App.test.tsx`
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep "foldable categorized Library|narrow breakpoint"`
+- `pnpm typecheck`
+- Prettier checks for changed CSS, browser test, and plan
+- Screenshot inspection at 1280×720, 1024×720, and 720×720
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): vertically center library device artwork
+```
+
+## Outcome
+
+Device artwork is now absolutely positioned at the exact horizontal and vertical center of the full tile. Desktop tiles are 86px high with 40×32px artwork; labels are independently anchored at the bottom without overlap. The full-width narrow layout uses 94px tiles with 46×36px centered artwork. Direct browser measurement changed the NMOS artwork center from 12.5px above the tile center to a zero-pixel center delta.
+
+Validation passed: focused unit tests (2 files / 16 tests), two focused Playwright flows asserting exact X/Y centering, tile heights, artwork dimensions, four-edge containment, and label separation for every device at desktop and narrow widths, `pnpm typecheck`, Prettier checks, reviewer feedback addressed, screenshot inspection at 1280×720, 1024×720, and 720×720, and `git diff --check`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7115,3 +7115,19 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
 - Commit status: committed and pushed on
   `agent/compact-complete-library` as
   `feat(editor): right-align help and fold library categories`.
+
+## 2026-08-15 - Fit four Library icons per row
+
+- Target: increase Library density to four quick-place tiles per category row
+  while preserving readable labels and responsive behavior.
+- Changed areas: four-column category/Recent grids; smaller desktop artwork and
+  tiles; concise visual labels with full accessible names; restored larger
+  narrow-layout tiles; browser geometry, containment, overflow, and Recent-grid
+  checks at the 220px Library boundary.
+- Validation: focused unit tests (2 files / 16 tests), two focused Playwright
+  flows, `pnpm typecheck`, Prettier checks, reviewer approval after readability
+  fixes, screenshot inspection at 1280x720, 1024x720, and 720x720, and
+  `git diff --check` passed.
+- Commit status: committed and pushed on
+  `agent/compact-complete-library` as
+  `style(editor): fit four library icons per row`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7100,3 +7100,18 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
 - Commit status: committed and pushed on
   `agent/compact-complete-library` as
   `feat(editor): group library devices by category`.
+
+## 2026-08-15 - Right-align Help and fold Library categories
+
+- Target: move Help to the right edge of the top bar and make every device
+  category independently collapsible without losing Library state.
+- Changed areas: top-bar action grouping; controlled native category folds and
+  disclosure styling; static and browser regressions for right alignment,
+  narrow bounds, independent folding, and fold persistence across rerenders.
+- Validation: focused unit tests (2 files / 16 tests), two focused Playwright
+  flows, `pnpm typecheck`, Prettier checks, reviewer approval with its coverage
+  suggestion addressed, desktop/narrow screenshot inspection, and
+  `git diff --check` passed.
+- Commit status: committed and pushed on
+  `agent/compact-complete-library` as
+  `feat(editor): right-align help and fold library categories`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7053,7 +7053,7 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
   orientation and shortcut routing; rotated copy preview/commit behavior;
   editor interaction specification and focused unit/browser regressions.
 - Validation: 30 focused tests, `pnpm typecheck`, `pnpm format:check`, `git
-diff --check`, and two focused Playwright regressions passed.
+  diff --check`, and two focused Playwright regressions passed.
 - Commit status: ready to commit on `codex/label-gap-copy-rotate` as
   `fix(editor): align labels and rotate copy previews`.
 
@@ -7070,3 +7070,18 @@ diff --check`, and two focused Playwright regressions passed.
   both remote delivery-gate runs then passed every required check, including
   both browser shards.
 - Commit status: merged through PR #64 as squash commit `ad604fb`.
+
+## 2026-08-15 - Show the complete compact component Library
+
+- Target: replace the eight-item starter subset with the complete quick-place
+  palette while keeping the left Library compact and immediately usable.
+- Changed areas: Library catalog projection and priority ordering; compact
+  three-column device tiles with concise visual labels and full accessible
+  names; focused static and browser regressions for all 18 palette items and
+  default-viewport fit.
+- Validation: focused unit tests (2 files / 16 tests), focused Playwright
+  Library flow (1 test), `pnpm typecheck`, Prettier checks, desktop screenshot
+  inspection at 1280x720, and `git diff --check` passed.
+- Commit status: committed and pushed on
+  `agent/compact-complete-library` as
+  `feat(editor): show complete compact component library`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7229,3 +7229,21 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
 - Commit status: committed and pushed on
   `agent/compact-complete-library` as
   `fix(editor): center library icon-label groups`.
+
+## 2026-08-15 - Deliver compact Library PR
+
+- Target: rebase the complete Library/navigation branch onto latest main, run
+  branch/remote gates, push, and open the review PR.
+- Rebase: main advanced repeatedly during delivery; final branch rebased onto
+  `origin/main` at `ea60c96`. The `plan/log.md` conflicts preserved mainline
+  junction, drafting-text, VDD-rail, label-spacing, and closeout records plus
+  all Library records.
+- Validation: final targeted Library/narrow browser flows (2 tests),
+  `pnpm verify:branch` (119 files / 728 tests, static checks, workspace builds,
+  production smoke), ancestry/diff checks, and the final docs link check
+  passed; the final tip was submitted to all six required PR checks.
+- Pull request: [#63](https://github.com/chenzc24/Analog-Canvas/pull/63),
+  `feat(editor): complete compact categorized component library`, targeting
+  `main`.
+- Commit status: rebased branch force-pushed with lease; PR is open with all
+  required checks enforced on the final tip.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7213,3 +7213,19 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
 - Commit status: committed and pushed on
   `agent/compact-complete-library` as
   `fix(editor): restore names on centered library tiles`.
+
+## 2026-08-15 - Center the Library icon-label visual weight
+
+- Target: center the combined `重心` of each device picture and visible name,
+  rather than centering the picture independently.
+- Changed areas: artwork and name returned to one fixed grid group; the union
+  is vertically centered with both elements horizontally centered; tile heights
+  reduced to 56px desktop and 64px narrow.
+- Validation: focused unit tests (2 files / 16 tests), two focused Playwright
+  flows measuring union-center geometry, element X centers, separation, fit,
+  dimensions, folds, and Recent behavior, `pnpm typecheck`, Prettier checks,
+  reviewer approval, screenshot inspection at 1280x720, 1024x720, and
+  720x720, and `git diff --check` passed.
+- Commit status: committed and pushed on
+  `agent/compact-complete-library` as
+  `fix(editor): center library icon-label groups`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7150,3 +7150,19 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
 - Commit status: committed, rebased, and force-pushed on
   `agent/compact-complete-library` as
   `style(editor): center and enlarge library devices`.
+
+## 2026-08-15 - Truly center Library device artwork
+
+- Target: correct the remaining visual offset by centering each SVG on the full
+  tile rather than inside an upper artwork row.
+- Changed areas: absolute full-tile artwork centering; independently anchored
+  bottom labels; larger desktop/narrow tile and artwork dimensions; exhaustive
+  browser geometry checks for both axes, tile heights, containment, and label
+  separation.
+- Validation: focused unit tests (2 files / 16 tests), two focused Playwright
+  flows, `pnpm typecheck`, Prettier checks, reviewer feedback addressed,
+  screenshot inspection at 1280x720, 1024x720, and 720x720, direct zero-pixel
+  center-delta measurement, and `git diff --check` passed.
+- Commit status: committed and pushed on
+  `agent/compact-complete-library` as
+  `fix(editor): vertically center library device artwork`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7131,3 +7131,22 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
 - Commit status: committed and pushed on
   `agent/compact-complete-library` as
   `style(editor): fit four library icons per row`.
+
+## 2026-08-15 - Center/enlarge Library devices and rebase
+
+- Target: enlarge four-column device artwork, keep icon rows vertically
+  consistent across mixed label lengths, and rebase the complete Library branch
+  onto latest main.
+- Changed areas: fixed desktop/narrow artwork rows and symbol dimensions;
+  browser checks for exact size, four-edge containment, mixed-label alignment,
+  and responsive behavior; rebase conflict resolution in the factual log.
+- Validation: post-rebase focused unit tests (2 files / 16 tests), two focused
+  Playwright flows, `pnpm typecheck`, Prettier checks, reviewer approval after
+  geometry coverage was expanded, screenshot inspection at 1280x720,
+  1024x720, and 720x720, `git diff --check`, and ancestry verification passed.
+- Rebase: branch rebased onto `origin/main` at `330ba43`; the `plan/log.md`
+  conflict preserved both imported-flightline mainline records and Library
+  records.
+- Commit status: committed, rebased, and force-pushed on
+  `agent/compact-complete-library` as
+  `style(editor): center and enlarge library devices`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7197,3 +7197,19 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
 - Commit status: committed and pushed on
   `agent/compact-complete-library` as
   `style(editor): use compact centered library icons`.
+
+## 2026-08-15 - Restore names below centered Library devices
+
+- Target: bring visible device names back without losing full-tile artwork
+  centering or returning to oversized boxes.
+- Changed areas: concise one-line labels restored for Library and Recent tiles;
+  labels anchored at the bottom; desktop/narrow heights set to 64px/68px with
+  measured artwork-label separation and unchanged centered artwork sizes.
+- Validation: focused unit tests (2 files / 16 tests), two focused Playwright
+  flows covering label fit, centering, separation, dimensions, Recent labels,
+  and accessibility, `pnpm typecheck`, Prettier checks, reviewer approval,
+  screenshot inspection at 1280x720, 1024x720, and 720x720, and
+  `git diff --check` passed.
+- Commit status: committed and pushed on
+  `agent/compact-complete-library` as
+  `fix(editor): restore names on centered library tiles`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7166,3 +7166,18 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
 - Commit status: committed and pushed on
   `agent/compact-complete-library` as
   `fix(editor): vertically center library device artwork`.
+
+## 2026-08-15 - Compact the truly centered Library tiles
+
+- Target: reduce tile height without moving artwork away from the exact tile
+  center or allowing labels to overlap.
+- Changed areas: single-line compact electrical labels; desktop tile height
+  reduced from 86px to 66px; narrow tile height reduced from 94px to 74px;
+  exhaustive desktop/narrow centering, fit, separation, and overflow checks.
+- Validation: focused unit tests (2 files / 16 tests), two focused Playwright
+  flows, `pnpm typecheck`, Prettier checks, reviewer suggestion addressed,
+  screenshot inspection at 1280x720, 1024x720, and 720x720, and
+  `git diff --check` passed.
+- Commit status: committed and pushed on
+  `agent/compact-complete-library` as
+  `style(editor): compact centered library tiles`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7085,3 +7085,18 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
 - Commit status: committed and pushed on
   `agent/compact-complete-library` as
   `feat(editor): show complete compact component library`.
+
+## 2026-08-15 - Group Library devices by category
+
+- Target: replace the flat 18-device Library grid with the same six category
+  groups used by the Insert dialog.
+- Changed areas: sidebar catalog projection, compact category headings/counts,
+  category-aware unit coverage, and a browser regression for all six groups and
+  all 18 quick-place buttons.
+- Validation: focused unit tests (2 files / 16 tests), focused Playwright
+  categorized-Library flow (1 test), `pnpm typecheck`, Prettier checks,
+  reviewer approval, desktop screenshot inspection at 1280x720 and 1440x900,
+  and `git diff --check` passed.
+- Commit status: committed and pushed on
+  `agent/compact-complete-library` as
+  `feat(editor): group library devices by category`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7181,3 +7181,19 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
 - Commit status: committed and pushed on
   `agent/compact-complete-library` as
   `style(editor): compact centered library tiles`.
+
+## 2026-08-15 - Use icon-only centered Library tiles
+
+- Target: make the Library still more compact while keeping the device artwork
+  visually centered in each box.
+- Changed areas: removed visible in-tile labels from Library and Recent buttons;
+  retained complete accessible names/tooltips; reduced desktop tiles to 52px
+  and narrow tiles to 60px around unchanged centered artwork.
+- Validation: focused unit tests (2 files / 16 tests), two focused Playwright
+  flows covering icon-only primary/Recent tiles, accessible names, exact
+  centering, dimensions, and containment, `pnpm typecheck`, Prettier checks,
+  reviewer suggestion addressed, screenshot inspection at 1280x720,
+  1024x720, and 720x720, and `git diff --check` passed.
+- Commit status: committed and pushed on
+  `agent/compact-complete-library` as
+  `style(editor): use compact centered library icons`.


### PR DESCRIPTION
## Summary

- expose all 18 reviewed/virtual devices in the left Library and group them into the same six categories as the Insert dialog
- make categories independently foldable and retain Recent quick-place behavior
- use a compact four-column tile grid with the combined icon/name visual weight centered in each tile
- keep full accessible names/tooltips while using concise visible labels
- move Help to the rightmost top-bar action after Analytics

## Validation

- `pnpm verify:branch` — 119 test files / 727 tests, static checks, all workspace builds, and editor production smoke passed
- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep "foldable categorized Library|narrow breakpoint"` — 2 tests passed
- rebased onto latest `origin/main` (`4b56c37`)
- `git diff --check origin/main...HEAD`
