### PR TITLE
Align label spacing and grid-safe drafting

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -181,6 +181,40 @@ test("adds formatted drafting text and undo/redo restores it", async ({
   await expect(page.getByTestId("revision")).toHaveText("6");
 });
 
+test("snaps quick Text creation after a non-grid viewport zoom", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.hover({ position: { x: 317, y: 243 } });
+  await page.mouse.wheel(0, -120);
+  await page.mouse.wheel(0, -120);
+
+  const zoomedViewBox = (await canvas.getAttribute("viewBox"))!
+    .split(" ")
+    .map(Number);
+  const [x, y, width, height] = zoomedViewBox;
+  const unsnappedTextPosition = {
+    x: Math.round(x! + width! / 2),
+    y: Math.round(y! + height! - 20),
+  };
+  expect(
+    Object.values(unsnappedTextPosition).some((value) => value % 10 !== 0),
+  ).toBe(true);
+
+  await clickCommand(page, "Draw", "Text");
+  await expect(page.getByTestId("revision")).toHaveText("1");
+  await expect(page.getByTestId("status")).toContainText("Added drafting text");
+
+  const projectBytes = await downloadBytes(page, "File", "Save Project");
+  const project = JSON.parse(projectBytes.toString("utf8"));
+  const textObject = project.documents[0].drafting.objects.find(
+    (object: { kind: string }) => object.kind === "text",
+  );
+  expect(textObject.anchor.position.x % 10).toBe(0);
+  expect(textObject.anchor.position.y % 10).toBe(0);
+});
+
 test("fits drafting text with F using an integer grid camera", async ({
   page,
 }) => {

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -1510,6 +1510,33 @@ test("C previews one copy and Escape cancels without a revision", async ({
   );
 });
 
+test("R rotates a copy preview before committing the copied component", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await placeComponent(page, "resistor", { x: 360, y: 220 });
+  await page.getByTestId("hit-R1").click();
+  const canvas = page.getByTestId("schematic-canvas");
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error("Canvas is not measurable");
+
+  await page.keyboard.press("c");
+  await page.mouse.move(box.x + 560, box.y + 340);
+  const previewSymbol = page
+    .getByTestId("copy-placement-preview")
+    .locator('[data-object-id="R1"] > g')
+    .first();
+  await expect(previewSymbol).toHaveAttribute("transform", /rotate\(0\)/);
+
+  await page.keyboard.press("r");
+  await expect(previewSymbol).toHaveAttribute("transform", /rotate\(90\)/);
+  await canvas.click({ position: { x: 560, y: 340 } });
+  await expect(
+    canvas.locator('[data-object-id="R1-copy-1"] > g').first(),
+  ).toHaveAttribute("transform", /rotate\(90\)/);
+  await page.keyboard.press("Escape");
+});
+
 test("keeps copy placement active for repeated commits until Escape", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -4400,10 +4400,13 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   function addPlainText(): void {
     uniqueSuffixCounter.current += 1;
     const id = `note-${uniqueSuffixCounter.current}`;
-    const position = {
-      x: Math.round(viewBox.x + viewBox.width / 2),
-      y: Math.round(viewBox.y + viewBox.height - 20),
-    };
+    const position = snapGridPoint(
+      {
+        x: Math.round(viewBox.x + viewBox.width / 2),
+        y: Math.round(viewBox.y + viewBox.height - 20),
+      },
+      document.presentation.grid,
+    );
     const textObject: Extract<DraftingObject, { kind: "text" }> = {
       id,
       kind: "text",
@@ -4430,10 +4433,13 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   function addConstructionLine(): void {
     uniqueSuffixCounter.current += 1;
     const id = `construction-${uniqueSuffixCounter.current}`;
-    const center = {
-      x: Math.round(viewBox.x + viewBox.width / 2),
-      y: Math.round(viewBox.y + viewBox.height / 2),
-    };
+    const center = snapGridPoint(
+      {
+        x: Math.round(viewBox.x + viewBox.width / 2),
+        y: Math.round(viewBox.y + viewBox.height / 2),
+      },
+      document.presentation.grid,
+    );
     const result = transact([
       {
         kind: "upsert_drafting_object",
@@ -4457,10 +4463,13 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   function addFreeArrow(): void {
     uniqueSuffixCounter.current += 1;
     const id = `arrow-${uniqueSuffixCounter.current}`;
-    const center = {
-      x: Math.round(viewBox.x + viewBox.width / 2),
-      y: Math.round(viewBox.y + viewBox.height / 2),
-    };
+    const center = snapGridPoint(
+      {
+        x: Math.round(viewBox.x + viewBox.width / 2),
+        y: Math.round(viewBox.y + viewBox.height / 2),
+      },
+      document.presentation.grid,
+    );
     const result = transact([
       {
         kind: "upsert_drafting_object",
@@ -5398,6 +5407,8 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     end: Point,
   ): void {
     uniqueSuffixCounter.current += 1;
+    const snappedStart = snapGridPoint(start, document.presentation.grid);
+    const snappedEnd = snapGridPoint(end, document.presentation.grid);
     if (activeTool === "construction-line") {
       const id = `construction-${uniqueSuffixCounter.current}`;
       const result = transact([
@@ -5408,11 +5419,8 @@ export function App({ project: initialProject, visitStats }: AppProps) {
             kind: "construction-line",
             locked: false,
             zIndex: 0,
-            anchor: { kind: "free", position: start },
-            points: [
-              { x: Math.round(start.x), y: Math.round(start.y) },
-              { x: Math.round(end.x), y: Math.round(end.y) },
-            ],
+            anchor: { kind: "free", position: snappedStart },
+            points: [snappedStart, snappedEnd],
             lineStyle: "dashed",
           },
         },
@@ -5428,31 +5436,34 @@ export function App({ project: initialProject, visitStats }: AppProps) {
             kind: "arrow",
             locked: false,
             zIndex: 0,
-            anchor: { kind: "free", position: start },
+            anchor: { kind: "free", position: snappedStart },
             from: {
               kind: "free",
-              position: { x: Math.round(start.x), y: Math.round(start.y) },
+              position: snappedStart,
             },
             to: {
               kind: "free",
-              position: { x: Math.round(end.x), y: Math.round(end.y) },
+              position: snappedEnd,
             },
           },
         },
       ]);
       if (result.ok) setStatus(`Added free arrow ${id}`);
     } else if (activeTool === "rectangle") {
-      const width = Math.round(Math.abs(end.x - start.x));
-      const height = Math.round(Math.abs(end.y - start.y));
+      const width = Math.round(Math.abs(snappedEnd.x - snappedStart.x));
+      const height = Math.round(Math.abs(snappedEnd.y - snappedStart.y));
       if (width < 1 || height < 1) {
         setStatus("Rectangle needs non-zero width and height");
         return;
       }
       const id = `rectangle-${uniqueSuffixCounter.current}`;
-      const center = {
-        x: Math.round((start.x + end.x) / 2),
-        y: Math.round((start.y + end.y) / 2),
-      };
+      const center = snapGridPoint(
+        {
+          x: Math.round((snappedStart.x + snappedEnd.x) / 2),
+          y: Math.round((snappedStart.y + snappedEnd.y) / 2),
+        },
+        document.presentation.grid,
+      );
       const result = transact([
         {
           kind: "upsert_drafting_object",
@@ -5480,6 +5491,9 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     if (points.length < 2) return;
     uniqueSuffixCounter.current += 1;
     const id = `construction-${uniqueSuffixCounter.current}`;
+    const snappedPoints = points.map((point) =>
+      snapGridPoint(point, document.presentation.grid),
+    );
     const result = transact([
       {
         kind: "upsert_drafting_object",
@@ -5488,11 +5502,8 @@ export function App({ project: initialProject, visitStats }: AppProps) {
           kind: "construction-line",
           locked: false,
           zIndex: 0,
-          anchor: { kind: "free", position: points[0]! },
-          points: points.map((point) => ({
-            x: Math.round(point.x),
-            y: Math.round(point.y),
-          })),
+          anchor: { kind: "free", position: snappedPoints[0]! },
+          points: snappedPoints,
           lineStyle: "dashed",
         },
       },

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -663,6 +663,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     completeVddRailPlacement,
     beginCopyPlacement: beginCopyPlacementInteraction,
     setCopyPreviewPoint,
+    rotateCopyPlacement,
     setWireSource,
     setWirePreviewPoint,
     setWireWaypoints,
@@ -776,7 +777,12 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       y: copyPlacement.previewPoint.y - copyPlacement.anchor.y,
     };
     return buildSvgScene(
-      clipboardPreviewDocument(document, copyPlacement.clipboard, offset),
+      clipboardPreviewDocument(
+        document,
+        copyPlacement.clipboard,
+        offset,
+        copyPlacement.rotation,
+      ),
       resolver,
       { bounds: viewBox },
     );
@@ -1983,6 +1989,12 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   function rotatePendingComponent(delta: 90 | -90): void {
     rotateComponentPlacement(delta);
     setStatus(`Component rotation ${delta > 0 ? "+90°" : "−90°"}`);
+  }
+
+  function rotatePendingCopy(delta: 90 | -90): void {
+    if (!copyPlacement) return;
+    rotateCopyPlacement(delta);
+    setStatus("Place rotated copy · R rotates · Esc cancels");
   }
 
   function loadRoutingDemo(): void {
@@ -5734,7 +5746,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     paintSnapGuides([]);
     beginCopyPlacementInteraction(copied, anchor);
     setStatus(
-      `Place copy of ${copied.instances.length} components · Esc cancels`,
+      `Place copy of ${copied.instances.length} components · R rotates · Esc cancels`,
     );
   }
 
@@ -5756,7 +5768,20 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       cancelAllTransientInteraction();
       return;
     }
-    const result = transact(proposal.edits, { preserveInteraction: true });
+    const rotationEdits: SchematicEdit[] =
+      copyPlacement.rotation === 0
+        ? []
+        : proposal.instanceIds.map((instanceId, index) => ({
+            kind: "rotate_instance" as const,
+            instanceId,
+            rotation: (((copyPlacement.clipboard.instances[index]?.placement
+              ?.rotation ?? 0) +
+              copyPlacement.rotation) %
+              360) as 0 | 90 | 180 | 270,
+          }));
+    const result = transact([...proposal.edits, ...rotationEdits], {
+      preserveInteraction: true,
+    });
     if (result.ok) {
       selectOnly("instance", proposal.instanceIds);
       setCopyPreviewPoint(point);
@@ -5908,6 +5933,9 @@ export function App({ project: initialProject, visitStats }: AppProps) {
           return;
         case "rotate-placement":
           rotatePendingComponent(shortcut.deltaDegrees);
+          return;
+        case "rotate-copy-placement":
+          rotatePendingCopy(shortcut.deltaDegrees);
           return;
         case "rotate":
           rotateSelected(shortcut.deltaDegrees);

--- a/apps/editor/src/features/clipboard/clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard.test.ts
@@ -125,6 +125,17 @@ describe("schematic clipboard", () => {
       x: 100,
       y: 100,
     });
+
+    const rotatedPreview = clipboardPreviewDocument(
+      document,
+      clipboard!,
+      { x: 40, y: -20 },
+      90,
+    );
+    expect(rotatedPreview.instances[0]?.placement).toMatchObject({
+      position: { x: 140, y: 80 },
+      rotation: 90,
+    });
   });
 
   it("remaps an internal NoConnect to the copied instance", () => {

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -70,7 +70,9 @@ export function clipboardPreviewDocument(
   base: SchematicDocument,
   clipboard: SchematicClipboard,
   offset: Point,
+  rotation: 0 | 90 | 180 | 270 = 0,
 ): SchematicDocument {
+  const copiedInstanceIds = new Set(clipboard.instances.map(({ id }) => id));
   const annotations = clipboard.annotations.map((annotation) => {
     const preview = structuredClone(annotation);
     if (preview.anchor.kind === "free") {
@@ -80,6 +82,15 @@ export function clipboardPreviewDocument(
         preview.anchor.fallbackPosition,
         offset,
       );
+      if (
+        preview.anchor.kind === "object" &&
+        copiedInstanceIds.has(preview.anchor.objectId)
+      ) {
+        preview.anchor.localOffset = rotateVector(
+          preview.anchor.localOffset,
+          rotation,
+        );
+      }
     }
     return preview;
   });
@@ -91,6 +102,8 @@ export function clipboardPreviewDocument(
         ? {
             ...instance.placement,
             position: movePoint(instance.placement.position, offset),
+            rotation: ((instance.placement.rotation + rotation) % 360) as
+              0 | 90 | 180 | 270,
           }
         : null,
     })),
@@ -198,6 +211,19 @@ function uniqueCopyReference(
 
 function movePoint(point: Point, offset: Point): Point {
   return { x: point.x + offset.x, y: point.y + offset.y };
+}
+
+function rotateVector(point: Point, rotation: 0 | 90 | 180 | 270): Point {
+  switch (rotation) {
+    case 0:
+      return { ...point };
+    case 90:
+      return { x: -point.y, y: point.x };
+    case 180:
+      return { x: -point.x, y: -point.y };
+    case 270:
+      return { x: point.y, y: -point.x };
+  }
 }
 
 function mapEndpoint(

--- a/apps/editor/src/features/wiring/route-interaction-geometry.test.ts
+++ b/apps/editor/src/features/wiring/route-interaction-geometry.test.ts
@@ -220,8 +220,8 @@ describe("route interaction geometry", () => {
       defaultInstanceLabel(document, instance, resolver, profile),
     ).toMatchObject({
       anchor: {
-        localOffset: { x: -10, y: 30 },
-        fallbackPosition: { x: 90, y: 130 },
+        localOffset: { x: -10, y: 40 },
+        fallbackPosition: { x: 90, y: 140 },
       },
       alignment: "middle",
     });

--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -108,6 +108,10 @@ describe("editor shortcut contract", () => {
         hasRotatableSelection: true,
       }),
     ).toEqual({ kind: "rotate-placement", deltaDegrees: 90 });
+    expect(resolve("r", { interactionMode: "copy-placement" })).toEqual({
+      kind: "rotate-copy-placement",
+      deltaDegrees: 90,
+    });
     expect(
       resolve(
         "r",

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -33,6 +33,7 @@ export type EditorShortcutIntent =
   | { kind: "reverse-current-marker" }
   | { kind: "open-component-insert" }
   | { kind: "rotate-placement"; deltaDegrees: 90 | -90 }
+  | { kind: "rotate-copy-placement"; deltaDegrees: 90 | -90 }
   | { kind: "rotate"; deltaDegrees: 90 | -90 }
   | { kind: "activate-tool"; tool: EditorTool }
   | { kind: "add-text" }
@@ -125,6 +126,9 @@ export function resolveEditorShortcut(
     if (plain && key === "r") {
       if (context.interactionMode === "placing-component") {
         return { kind: "rotate-placement", deltaDegrees: 90 };
+      }
+      if (context.interactionMode === "copy-placement") {
+        return { kind: "rotate-copy-placement", deltaDegrees: 90 };
       }
       if (!event.shiftKey) return { kind: "activate-tool", tool: "rectangle" };
     }

--- a/apps/editor/src/interaction/interaction-state.test.ts
+++ b/apps/editor/src/interaction/interaction-state.test.ts
@@ -174,16 +174,24 @@ describe("editor interaction state", () => {
       type: "set-copy-preview",
       point: { x: 40, y: 50 },
     });
+    const rotated = interactionReducer(previewing, {
+      type: "rotate-copy",
+      deltaDegrees: 90,
+    });
+    expect(rotated).toMatchObject({
+      kind: "copy-placement",
+      copy: { previewPoint: { x: 40, y: 50 }, rotation: 90 },
+    });
 
     expect(
-      interactionReducer(previewing, {
+      interactionReducer(rotated, {
         type: "begin-copy-placement",
         clipboard: { ids: ["M2"] },
         anchor: { x: 0, y: 0 },
       }),
-    ).toBe(previewing);
+    ).toBe(rotated);
     expect(
-      interactionReducer(previewing, {
+      interactionReducer(rotated, {
         type: "activate-tool",
         tool: "wire",
       }),

--- a/apps/editor/src/interaction/interaction-state.ts
+++ b/apps/editor/src/interaction/interaction-state.ts
@@ -28,6 +28,7 @@ export interface CopyPlacement<TClipboard> {
   clipboard: TClipboard;
   anchor: Point;
   previewPoint: Point | null;
+  rotation: 0 | 90 | 180 | 270;
 }
 
 export type InteractionState<TClipboard = never> =
@@ -78,6 +79,7 @@ export type InteractionAction<TClipboard = never> =
       anchor: Point;
     }
   | { type: "set-copy-preview"; point: Point | null }
+  | { type: "rotate-copy"; deltaDegrees: 90 | -90 }
   | {
       type: "set-wire-source";
       source: WireSource | null;
@@ -213,11 +215,23 @@ export function interactionReducer<TClipboard>(
           clipboard: action.clipboard,
           anchor: action.anchor,
           previewPoint: null,
+          rotation: 0,
         },
       };
     case "set-copy-preview":
       return state.kind === "copy-placement"
         ? { ...state, copy: { ...state.copy, previewPoint: action.point } }
+        : state;
+    case "rotate-copy":
+      return state.kind === "copy-placement"
+        ? {
+            ...state,
+            copy: {
+              ...state.copy,
+              rotation: ((state.copy.rotation + action.deltaDegrees + 360) %
+                360) as 0 | 90 | 180 | 270,
+            },
+          }
         : state;
     case "set-wire-source":
       return state.kind === "wire"
@@ -344,6 +358,8 @@ export function useInteractionState<TClipboard>() {
       dispatch({ type: "begin-copy-placement", clipboard, anchor }),
     setCopyPreviewPoint: (point: Point | null) =>
       dispatch({ type: "set-copy-preview", point }),
+    rotateCopyPlacement: (deltaDegrees: 90 | -90) =>
+      dispatch({ type: "rotate-copy", deltaDegrees }),
     setWireSource: (source: WireSource | null, sourceRevision: number | null) =>
       dispatch({ type: "set-wire-source", source, sourceRevision }),
     setWirePreviewPoint: (point: Point | null) =>

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -62,7 +62,12 @@ observe the first transition even when React batches the next render.
 Activating the same tool is idempotent: repeated C, W, A, K, or selection of the
 same Library item preserves the active session. Activating a different creation
 tool replaces the current interaction atomically after drag and snap cleanup.
-Opening I cancels the current canvas interaction before showing the dialog.
+During Copy Placement, `R` quarter-turns the transient preview and every
+subsequent committed copy; it does not mutate the source selection. Instance
+reference labels occupy at least one full active Document grid interval outside
+the visible symbol edge, with directional outward snapping rather than nearest
+grid rounding. Opening I cancels the current canvas interaction before showing
+the dialog.
 Escape, Document switch, Project replacement, Clear Canvas, restore, and Agent
 focus reset all use the same transient-cancellation boundary.
 

--- a/packages/derived/src/instance-label-placement.test.ts
+++ b/packages/derived/src/instance-label-placement.test.ts
@@ -76,11 +76,11 @@ describe("instance label placement", () => {
       });
       const localBounds = visibleSymbolLocalBounds(resolved);
       expect(label!.position.x).toBe(
-        Math.round(
+        Math.ceil(
           (instance.placement.position.x +
             localBounds.x +
             localBounds.width +
-            1.5) /
+            10) /
             10,
         ) * 10,
       );
@@ -108,45 +108,45 @@ describe("instance label placement", () => {
 
   it("places passive, source, and Port labels on their semantic sides", () => {
     expect(placedDefaultLabel("resistor")).toMatchObject({
-      position: { x: 110, y: 110 },
+      position: { x: 120, y: 110 },
       alignment: "start",
     });
     expect(placedDefaultLabel("voltage-source")).toMatchObject({
-      position: { x: 110, y: 110 },
+      position: { x: 130, y: 110 },
       alignment: "start",
     });
     expect(placedDefaultLabel("capacitor", 90)).toMatchObject({
-      position: { x: 90, y: 130 },
+      position: { x: 90, y: 140 },
       alignment: "middle",
     });
     expect(placedDefaultLabel("port")).toMatchObject({
-      position: { x: 90, y: 110 },
+      position: { x: 70, y: 110 },
       alignment: "end",
     });
   });
 
   it("uses visible MOS edges through variants, rotations, and mirrors", () => {
     expect(placedDefaultLabel("nmos")).toMatchObject({
-      position: { x: 110, y: 110 },
+      position: { x: 130, y: 110 },
       alignment: "start",
     });
     expect(
       placedDefaultLabel("nmos", 0, "none", "textbook-3terminal"),
-    ).toMatchObject({ position: { x: 110, y: 110 }, alignment: "start" });
+    ).toMatchObject({ position: { x: 130, y: 110 }, alignment: "start" });
     expect(
       placedDefaultLabel("nmos", 90, "none", "textbook-3terminal"),
     ).toMatchObject({
-      position: { x: 90, y: 130 },
+      position: { x: 90, y: 140 },
       alignment: "middle",
     });
     expect(
       placedDefaultLabel("nmos", 270, "none", "textbook-3terminal"),
     ).toMatchObject({
-      position: { x: 110, y: 80 },
+      position: { x: 110, y: 70 },
       alignment: "middle",
     });
     expect(placedDefaultLabel("nmos", 0, "x")).toMatchObject({
-      position: { x: 90, y: 110 },
+      position: { x: 70, y: 110 },
       alignment: "end",
     });
   });

--- a/packages/derived/src/instance-label-placement.ts
+++ b/packages/derived/src/instance-label-placement.ts
@@ -168,7 +168,7 @@ export function placeUprightInstanceLabel(
   localSide: InstanceLabelSide,
   grid: number,
   sizeScale = 1,
-  minimumClearance = 1.5,
+  minimumClearance = grid,
 ): InstanceLabelPlacement | null {
   if (!instance.placement) return null;
   const localBounds = visibleSymbolLocalBounds(resolved);
@@ -186,11 +186,13 @@ export function placeUprightInstanceLabel(
   );
   const fontSize = profile.typography.instanceFontSize * sizeScale;
   const snap = (value: number) => Math.round(value / grid) * grid;
+  const snapOutward = (value: number, direction: -1 | 1) =>
+    (direction < 0 ? Math.floor(value / grid) : Math.ceil(value / grid)) * grid;
   switch (worldSide) {
     case "right":
       return {
         position: {
-          x: snap(worldBounds.x + worldBounds.width + clearance),
+          x: snapOutward(worldBounds.x + worldBounds.width + clearance, 1),
           y: snap(semanticPosition.y),
         },
         alignment: "start",
@@ -198,7 +200,7 @@ export function placeUprightInstanceLabel(
     case "left":
       return {
         position: {
-          x: snap(worldBounds.x - clearance),
+          x: snapOutward(worldBounds.x - clearance, -1),
           y: snap(semanticPosition.y),
         },
         alignment: "end",
@@ -207,8 +209,9 @@ export function placeUprightInstanceLabel(
       return {
         position: {
           x: snap(semanticPosition.x),
-          y: snap(
+          y: snapOutward(
             worldBounds.y + worldBounds.height + clearance + fontSize * 1.05,
+            1,
           ),
         },
         alignment: "middle",
@@ -217,7 +220,7 @@ export function placeUprightInstanceLabel(
       return {
         position: {
           x: snap(semanticPosition.x),
-          y: snap(worldBounds.y - clearance - fontSize * 0.3),
+          y: snapOutward(worldBounds.y - clearance - fontSize * 0.3, -1),
         },
         alignment: "middle",
       };
@@ -235,7 +238,10 @@ export function defaultInstanceLabelPlacement(
   const localBounds = visibleSymbolLocalBounds(resolved);
   const middleY = localBounds.y + localBounds.height / 2;
   const middleX = localBounds.x + localBounds.width / 2;
-  const compactSideGap = 1.5;
+  // A label gap is a grid-space rule, not a raw-coordinate optical tweak.
+  // The outward-only snap in placeUprightInstanceLabel preserves this full
+  // grid unit even when a symbol edge is itself not grid-aligned.
+  const compactSideGap = grid;
   const baselineOffset = profile.typography.instanceFontSize * 0.35;
 
   if (instance.symbolId === "port" || instance.symbolId === "port-filled") {

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -845,26 +845,26 @@ describe("routing Edit Engine", () => {
       const expected = [
         {
           rotation: 90 as const,
-          position: { x: 90, y: 130 },
-          offset: { x: -10, y: 30 },
+          position: { x: 90, y: 140 },
+          offset: { x: -10, y: 40 },
           alignment: "middle" as const,
         },
         {
           rotation: 180 as const,
-          position: { x: 90, y: 90 },
-          offset: { x: -10, y: -10 },
+          position: { x: 70, y: 90 },
+          offset: { x: -30, y: -10 },
           alignment: "end" as const,
         },
         {
           rotation: 270 as const,
-          position: { x: 110, y: 80 },
-          offset: { x: 10, y: -20 },
+          position: { x: 110, y: 60 },
+          offset: { x: 10, y: -40 },
           alignment: "middle" as const,
         },
         {
           rotation: 0 as const,
-          position: { x: 120, y: 110 },
-          offset: { x: 20, y: 10 },
+          position: { x: 140, y: 110 },
+          offset: { x: 40, y: 10 },
           alignment: "start" as const,
         },
       ];

--- a/packages/edit-engine/src/transaction.test.ts
+++ b/packages/edit-engine/src/transaction.test.ts
@@ -686,17 +686,16 @@ describe("Edit Transaction envelope", () => {
     const bottom = Math.max(...worldCorners.map((point) => point.y));
     const label = rotated.document.annotations[0]!;
     expect(label).toMatchObject({ alignment: "middle", rotation: 0 });
-    // The persisted semantic anchor is integer-rounded, so permit the one
-    // pixel rounding difference while requiring the glyph edge to stay clear.
+    // The persisted semantic anchor is grid-snapped.  Assert the visible glyph
+    // edge, not the raw baseline: the label must retain at least one whole
+    // Document-grid interval outside the rotated symbol.
     if (label.anchor.kind === "free") {
       throw new Error("Rotated instance label must retain an object anchor");
     }
     const fallback = label.anchor.fallbackPosition;
-    expect(fallback.y).toBeGreaterThanOrEqual(
-      Math.floor(bottom + profile.typography.instanceFontSize * 1.05 + 1.5),
-    );
-    expect(fallback.y).toBeLessThanOrEqual(
-      Math.ceil(bottom + profile.typography.instanceFontSize * 1.05 + 2.5),
+    const glyphTop = fallback.y - profile.typography.instanceFontSize * 1.05;
+    expect(glyphTop).toBeGreaterThanOrEqual(
+      bottom + document.presentation.grid,
     );
   });
 

--- a/plan/2026-08-15-grid-safe-quick-drafting/plan.md
+++ b/plan/2026-08-15-grid-safe-quick-drafting/plan.md
@@ -1,0 +1,76 @@
+---
+status: completed
+experience: none
+---
+
+# Grid-safe quick drafting creation
+
+## Goal
+
+Ensure every toolbar quick-create Drafting object uses Document-grid coordinates
+even after transient pan or zoom leaves the viewport at non-grid coordinates.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/label-gap-copy-rotate...origin/codex/label-gap-copy-rotate
+```
+
+The worktree is clean. This is a new, bounded target on the user-selected
+branch; the prior label-gap/copy-rotate target is committed and read-only.
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/e2e/drafting.spec.ts`
+- `plan/2026-08-15-grid-safe-quick-drafting/plan.md`
+- `plan/log.md`
+
+Read-only shared dependencies:
+
+- `packages/model/src/coordinate-domain.ts` owns grid snapping.
+- `packages/edit-engine/src/transaction.ts` correctly rejects off-grid edits.
+- `docs/specs/editor-interaction.md` defines the persistent-coordinate rule.
+
+## Work
+
+1. Snap viewport-derived Text, Arrow, and Construction Line starting points
+   before they enter a transaction. Arrow and Line are presently dormant
+   helpers with no UI call site, but remain safe if re-exposed.
+2. Add a final snapping boundary in the drafting creation commit helpers so a
+   future caller cannot convert merely rounded derived coordinates into page
+   coordinates.
+3. Add browser coverage that deliberately uses a non-grid viewport and creates
+   the user-reachable Text object without a transaction rejection.
+
+## Validation
+
+- `pnpm test:e2e:local apps/editor/e2e/drafting.spec.ts --grep <quick drafting grid regression>`
+- `pnpm test:local apps/editor/src/app/App.test.tsx`
+- `pnpm typecheck`
+- `pnpm format:check`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): snap quick drafting creation to grid
+```
+
+## Outcome
+
+- Text, dormant quick Construction Line, and dormant quick Arrow helpers now
+  snap their viewport-derived creation anchors to the active Document grid.
+- The two phase drafting commit helpers snap all persisted endpoints and
+  vertices at their final transaction boundary. Rectangle centers are snapped
+  too, preventing half-grid midpoints from violating the page-coordinate
+  contract.
+- Added a browser regression that zooms to a viewport whose raw Text position
+  is off-grid, then verifies successful creation and grid-aligned persisted
+  anchor coordinates.
+- Validation passed: targeted browser regression; complete drafting browser
+  suite (25/25); editor App unit test (12/12); `pnpm typecheck`; `pnpm
+format:check`; and `git diff --check`.

--- a/plan/2026-08-15-label-gap-copy-rotate/plan.md
+++ b/plan/2026-08-15-label-gap-copy-rotate/plan.md
@@ -1,0 +1,82 @@
+---
+status: completed
+experience: none
+---
+
+# Fix label grid clearance and copy-preview rotation
+
+## Goal
+
+Keep newly placed and rotated instance labels exactly one Document grid unit
+outside the visible symbol, and let `R` rotate a Copy Placement preview before
+its first (or repeated) commit.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree was clean before creating
+`codex/label-gap-copy-rotate`. This target owns the label placement policy and
+transient editor copy interaction. It does not change persisted schema, Agent
+API, electrical connectivity, or shortcut meanings outside active copy
+placement.
+
+- `packages/derived/src/instance-label-placement.ts`
+- `packages/derived/src/instance-label-placement.test.ts`
+- `apps/editor/src/features/wiring/route-interaction-geometry.ts`
+- `apps/editor/src/features/clipboard/clipboard.ts`
+- `apps/editor/src/features/clipboard/clipboard.test.ts`
+- `apps/editor/src/interaction/interaction-state.ts`
+- `apps/editor/src/interaction/*test.ts`
+- `apps/editor/src/interaction/editor-shortcuts.ts`
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/e2e/manual-editor.spec.ts`
+- `docs/specs/editor-interaction.md`
+- `plan/root-audit.md`
+- `plan/log.md`
+
+Read-only/shared dependencies: model orientation transform, edit-engine
+annotation follow semantics, and the canonical grid coordinate contract.
+
+## Work
+
+1. Replace raw-coordinate `1.5` label gaps plus nearest-grid rounding with a
+   one-grid-unit, outward-only visual clearance rule for all four sides.
+2. Extend the transient Copy Placement state with quarter-turn orientation;
+   make `R` rotate its preview and make committed copies use the same rotation.
+3. Cover initial versus rotated label clearance and preview/commit copy
+   rotation with unit and browser regressions; document both interaction rules.
+
+## Validation
+
+- `pnpm test:local <affected derived, clipboard, interaction, and editor tests>`
+- `pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts --grep <label/copy rotation regressions>`
+- `pnpm typecheck`
+- `pnpm format:check`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): align labels and rotate copy previews
+```
+
+## Outcome
+
+Replaced the raw `1.5` label clearance and nearest-grid rounding with a full
+Document-grid interval and outward-only snapping. Added transient copy
+quarter-turn state: `R` now rotates the preview and commits the corresponding
+orientation without changing the source selection. The preview also turns
+object-attached label offsets so its temporary text remains on the device side.
+
+Validation passed: 30 focused derived/clipboard/interaction tests,
+`pnpm typecheck`, `pnpm format:check`, `git diff --check`, and two focused
+Playwright regressions covering label-distance stability and copy-preview
+rotation.

--- a/plan/2026-08-15-label-gap-copy-rotate/plan.md
+++ b/plan/2026-08-15-label-gap-copy-rotate/plan.md
@@ -1,5 +1,5 @@
 ---
-status: completed
+status: active
 experience: none
 ---
 
@@ -28,6 +28,9 @@ placement.
 - `packages/derived/src/instance-label-placement.ts`
 - `packages/derived/src/instance-label-placement.test.ts`
 - `apps/editor/src/features/wiring/route-interaction-geometry.ts`
+- `apps/editor/src/features/wiring/route-interaction-geometry.test.ts`
+- `packages/edit-engine/src/routing.test.ts`
+- `packages/edit-engine/src/transaction.test.ts`
 - `apps/editor/src/features/clipboard/clipboard.ts`
 - `apps/editor/src/features/clipboard/clipboard.test.ts`
 - `apps/editor/src/interaction/interaction-state.ts`
@@ -50,6 +53,10 @@ annotation follow semantics, and the canonical grid coordinate contract.
    make `R` rotate its preview and make committed copies use the same rotation.
 3. Cover initial versus rotated label clearance and preview/commit copy
    rotation with unit and browser regressions; document both interaction rules.
+4. Align downstream edit-engine and editor geometry contracts with the
+   completed full-grid outward-clearance policy.  The integration gate exposed
+   stale raw-coordinate expectations (old 30-unit baseline placement) rather
+   than a behavioral regression.
 
 ## Validation
 
@@ -80,3 +87,12 @@ Validation passed: 30 focused derived/clipboard/interaction tests,
 `pnpm typecheck`, `pnpm format:check`, `git diff --check`, and two focused
 Playwright regressions covering label-distance stability and copy-preview
 rotation.
+
+## Integration follow-up
+
+The first full `pnpm ci:check` after the later grid-safe drafting target found
+four stale label-placement assertions in the owned edit-engine/editor
+contracts.  This target is re-opened solely to replace those old optical-gap
+constants with the intended full-grid visible-glyph-clearance contract, then
+repeat the delivery gate before merge.  No model, routing, or interaction
+behavior is being expanded.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7033,3 +7033,17 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
 diff --check`, and two focused Playwright regressions passed.
 - Commit status: ready to commit on `codex/label-gap-copy-rotate` as
   `fix(editor): align labels and rotate copy previews`.
+
+## 2026-08-15 - Align label-clearance integration contracts
+
+- Target: reconcile the downstream Edit Engine and editor geometry assertions
+  with the completed one-grid visible-glyph clearance policy.
+- Changed areas: MOS rotation placement expectations and the BJT clearance
+  assertion, which now checks the rendered glyph edge rather than an obsolete
+  raw baseline offset.
+- Validation: 51 focused derived/Edit Engine/editor geometry tests, typecheck,
+  Prettier, and `git diff --check` passed. Two overlapping local full-gate
+  E2E runs were stopped because they contended for the same preview port;
+  remote required CI remains the delivery gate.
+- Commit status: active on `codex/label-gap-copy-rotate`; pending commit,
+  push, review, and required GitHub Actions checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7011,6 +7011,17 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
 - Commit status: all six PR #60 GitHub Actions checks passed; squash-merged to
   `main` as `0f45ba5`.
 
+## 2026-08-15 - Snap quick drafting creation to grid
+
+- Target: prevent transient viewport coordinates from causing `T` and drafting
+  creation commits to violate the persisted Document-grid contract.
+- Changed areas: quick drafting creation and final drafting commit boundaries,
+  with a zoomed-viewport Text browser regression.
+- Validation: targeted browser regression, complete drafting suite (25/25),
+  App unit test (12/12), typecheck, formatting, and `git diff --check` passed.
+- Commit status: committed on `codex/label-gap-copy-rotate`; push and review
+  remain pending.
+
 ## 2026-08-15 - Align instance labels and rotate copy previews
 
 - Target: make initial and transformed instance labels retain one full grid
@@ -7019,6 +7030,6 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
   orientation and shortcut routing; rotated copy preview/commit behavior;
   editor interaction specification and focused unit/browser regressions.
 - Validation: 30 focused tests, `pnpm typecheck`, `pnpm format:check`, `git
-  diff --check`, and two focused Playwright regressions passed.
+diff --check`, and two focused Playwright regressions passed.
 - Commit status: ready to commit on `codex/label-gap-copy-rotate` as
   `fix(editor): align labels and rotate copy previews`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7010,3 +7010,15 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
   tests).
 - Commit status: all six PR #60 GitHub Actions checks passed; squash-merged to
   `main` as `0f45ba5`.
+
+## 2026-08-15 - Align instance labels and rotate copy previews
+
+- Target: make initial and transformed instance labels retain one full grid
+  interval from the visible symbol, and permit `R` before copy placement.
+- Changed areas: derived label clearance/snap policy; transient Copy Placement
+  orientation and shortcut routing; rotated copy preview/commit behavior;
+  editor interaction specification and focused unit/browser regressions.
+- Validation: 30 focused tests, `pnpm typecheck`, `pnpm format:check`, `git
+  diff --check`, and two focused Playwright regressions passed.
+- Commit status: ready to commit on `codex/label-gap-copy-rotate` as
+  `fix(editor): align labels and rotate copy previews`.

--- a/plan/root-audit.md
+++ b/plan/root-audit.md
@@ -16,6 +16,7 @@ an archive. Completed plans with resolved experience are stored under
 ### Completed plans awaiting an experience decision
 
 
+
 - `2026-08-14-current-contract-clean-break`
 - `2026-08-11-correct-closed-switch-pdf-crop`
 - `2026-08-11-correct-common-razavi-assets`


### PR DESCRIPTION
## Summary
- Keep instance labels one complete Document grid outside their visible symbol through rotate and mirror operations.
- Let R rotate copy-placement previews before commit.
- Snap quick and tool-based drafting creation to the Document grid, preventing EDIT_PRECONDITION failures after viewport changes.
- Update downstream label-placement contracts to assert visible glyph clearance rather than obsolete raw baseline coordinates.

## Validation
- pnpm test:local packages/edit-engine/src/routing.test.ts packages/edit-engine/src/transaction.test.ts apps/editor/src/features/wiring/route-interaction-geometry.test.ts (51 passed)
- pnpm typecheck
- pnpm format:check
- git diff --check

The local full gate was started, but its overlapping Playwright invocations contended for the shared preview port. Required GitHub Actions checks are the merge gate.