### PR TITLE
docs(plan): close VDD rail delivery

### DIFF
--- a/plan/2026-08-15-deliver-vdd-rail-main/plan.md
+++ b/plan/2026-08-15-deliver-vdd-rail-main/plan.md
@@ -1,0 +1,58 @@
+---
+status: completed
+experience: none
+---
+
+# Deliver junction-aware VDD rail editing to main
+
+## Goal
+
+Deliver `01655dc fix(editor): make VDD rails stretchable after taps` from
+`codex/vdd-rail-editing` to protected remote `main` through the required local
+and GitHub Actions gates.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/vdd-rail-editing...origin/codex/vdd-rail-editing
+```
+
+The dedicated delivery worktree is clean. The user's original worktree remains
+dirty on a separate label/copy target and is not edited.
+
+- `plan/2026-08-15-deliver-vdd-rail-main/plan.md`
+- `plan/root-audit.md`
+- `plan/log.md`
+
+Read-only/shared dependencies: commit `01655dc`, protected `main`, lockfile,
+GitHub Actions required checks, and the existing completed implementation plan.
+
+## Work
+
+1. Run frozen install and the canonical `pnpm ci:check` gate from the clean
+   delivery worktree.
+2. Create a PR from the already pushed review branch and wait for all required
+   checks to pass.
+3. Merge through the protected-branch PR path, synchronize local `main`, and
+   record factual delivery evidence.
+
+## Validation
+
+- `pnpm install --frozen-lockfile`
+- `pnpm ci:check`
+- GitHub Actions required checks for the delivery PR
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit delivery records only if needed after the product PR is merged.
+
+## Outcome
+
+The clean dependency gate passed `pnpm install --frozen-lockfile` followed by
+the complete `pnpm ci:check`. PR #62 then passed Change scope, static, unit,
+release, and both browser shards before merging through protected `main` as
+`81d1e8dfbcf1e47a7ac8c219395471609fb3f55c`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -1,5 +1,16 @@
 # Maintenance Log
 
+## 2026-08-15 - Junction-aware VDD rail mainline delivery
+
+- Target: deliver stretchable, junction-aware VDD rail editing from
+  `codex/vdd-rail-editing` through the protected-main gate.
+- Changed areas: delivery evidence only; product change is `01655dc`.
+- Validation: clean frozen install plus complete `pnpm ci:check`; all six PR
+  #62 required GitHub Actions checks passed (scope, static, unit, release, and
+  two browser shards).
+- Commit status: PR #62 merged to `main` as `81d1e8d`; the delivery-record
+  closure remains on this documentation-only commit.
+
 ## 2026-08-15 - Make tapped VDD rails stretchable and junction-aware
 
 - Target: restore usable direct manipulation for VDD rails after an ordinary

--- a/plan/root-audit.md
+++ b/plan/root-audit.md
@@ -9,7 +9,7 @@ an archive. Completed plans with resolved experience are stored under
 | State                     | Count | Required disposition                                                              |
 | ------------------------- | ----: | --------------------------------------------------------------------------------- |
 | `active`                  |     0 | No active targets.                                                                |
-| `completed` + `none`      |    32 | Verify commit/log evidence, then archive according to routine retention policy.   |
+| `completed` + `none`      |    33 | Verify commit/log evidence, then archive according to routine retention policy.   |
 | `completed` + `candidate` |    17 | Human decides whether to extract, reject, or defer the experience signal.         |
 | missing metadata          |    71 | Audit against outcome text and Git evidence; never archive merely because of age. |
 


### PR DESCRIPTION
Closes the delivery record for PR #62. This PR contains only plan/log evidence: the frozen local gate, all required remote checks, and merge commit `81d1e8d`.
