### PR TITLE
Fix instance label grid gap and rotation drift

### DIFF
--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -64,10 +64,13 @@ same Library item preserves the active session. Activating a different creation
 tool replaces the current interaction atomically after drag and snap cleanup.
 During Copy Placement, `R` quarter-turns the transient preview and every
 subsequent committed copy; it does not mutate the source selection. Instance
-reference labels occupy at least one full active Document grid interval outside
-the visible symbol edge, with directional outward snapping rather than nearest
-grid rounding. Opening I cancels the current canvas interaction before showing
-the dialog.
+reference labels use the first active Document grid line one interval beyond
+the drawn symbol ink. The padded interaction envelope never contributes to
+that clearance, and placement uses nearest-grid normalization for calibrated
+finite-decimal ink edges rather than directional outward snapping. A quarter
+turn reflows a canonical label from its local side at that fixed spacing; four
+quarter turns return its position and alignment to the initial values. Opening
+I cancels the current canvas interaction before showing the dialog.
 Escape, Document switch, Project replacement, Clear Canvas, restore, and Agent
 focus reset all use the same transient-cancellation boundary.
 

--- a/packages/derived/src/instance-label-placement.test.ts
+++ b/packages/derived/src/instance-label-placement.test.ts
@@ -8,7 +8,7 @@ import {
   isMosSymbol,
 } from "./instance-label-placement.js";
 import { resolveSchematicStyleProfile } from "./style-profile.js";
-import { visibleSymbolLocalBounds } from "./visual.js";
+import { visibleSymbolInkBounds } from "./visual.js";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 const profile = resolveSchematicStyleProfile("razavi-textbook-v1");
@@ -74,9 +74,9 @@ describe("instance label placement", () => {
           y: expect.any(Number),
         },
       });
-      const localBounds = visibleSymbolLocalBounds(resolved);
+      const localBounds = visibleSymbolInkBounds(resolved);
       expect(label!.position.x).toBe(
-        Math.ceil(
+        Math.round(
           (instance.placement.position.x +
             localBounds.x +
             localBounds.width +
@@ -112,27 +112,27 @@ describe("instance label placement", () => {
       alignment: "start",
     });
     expect(placedDefaultLabel("voltage-source")).toMatchObject({
-      position: { x: 130, y: 110 },
+      position: { x: 120, y: 110 },
       alignment: "start",
     });
     expect(placedDefaultLabel("capacitor", 90)).toMatchObject({
-      position: { x: 90, y: 140 },
+      position: { x: 90, y: 130 },
       alignment: "middle",
     });
     expect(placedDefaultLabel("port")).toMatchObject({
-      position: { x: 70, y: 110 },
+      position: { x: 80, y: 110 },
       alignment: "end",
     });
   });
 
   it("uses visible MOS edges through variants, rotations, and mirrors", () => {
     expect(placedDefaultLabel("nmos")).toMatchObject({
-      position: { x: 130, y: 110 },
+      position: { x: 120, y: 110 },
       alignment: "start",
     });
     expect(
       placedDefaultLabel("nmos", 0, "none", "textbook-3terminal"),
-    ).toMatchObject({ position: { x: 130, y: 110 }, alignment: "start" });
+    ).toMatchObject({ position: { x: 120, y: 110 }, alignment: "start" });
     expect(
       placedDefaultLabel("nmos", 90, "none", "textbook-3terminal"),
     ).toMatchObject({
@@ -146,7 +146,7 @@ describe("instance label placement", () => {
       alignment: "middle",
     });
     expect(placedDefaultLabel("nmos", 0, "x")).toMatchObject({
-      position: { x: 70, y: 110 },
+      position: { x: 80, y: 110 },
       alignment: "end",
     });
   });

--- a/packages/derived/src/instance-label-placement.ts
+++ b/packages/derived/src/instance-label-placement.ts
@@ -3,7 +3,7 @@ import type { Point, Rect, SchematicDocument } from "@icm/model";
 import type { ResolvedSymbol } from "@icm/symbols";
 
 import type { SchematicStyleProfile } from "./style-profile.js";
-import { visibleSymbolLocalBounds } from "./visual.js";
+import { visibleSymbolInkBounds } from "./visual.js";
 
 export interface InstanceLabelPlacement {
   readonly position: Point;
@@ -119,23 +119,6 @@ export function inferInstanceLabelSide(
   return displacement.y > 0 ? "bottom" : "top";
 }
 
-function sideClearance(
-  localAnchor: Point,
-  localBounds: Rect,
-  side: InstanceLabelSide,
-): number {
-  switch (side) {
-    case "left":
-      return localBounds.x - localAnchor.x;
-    case "right":
-      return localAnchor.x - (localBounds.x + localBounds.width);
-    case "top":
-      return localBounds.y - localAnchor.y;
-    case "bottom":
-      return localAnchor.y - (localBounds.y + localBounds.height);
-  }
-}
-
 function transformedSide(
   side: InstanceLabelSide,
   instance: SchematicDocument["instances"][number],
@@ -157,8 +140,12 @@ function transformedSide(
 
 /**
  * Places horizontal SVG text around the active symbol variant. Vertical sides
- * convert the internal clearance point to the upright glyph baseline before
- * returning it, so persisted object anchors have one visible position.
+ * convert one grid interval from the drawn edge to the upright glyph baseline
+ * before returning it. Coordinates are then snapped once to the active grid.
+ * Critically, this is nearest-grid snapping rather than outward snapping:
+ * the 1-unit padded interaction envelope is excluded from the calculation, so
+ * a label never gains a second grid cell merely because a symbol edge uses
+ * finite calibrated coordinates.
  */
 export function placeUprightInstanceLabel(
   instance: SchematicDocument["instances"][number],
@@ -168,10 +155,9 @@ export function placeUprightInstanceLabel(
   localSide: InstanceLabelSide,
   grid: number,
   sizeScale = 1,
-  minimumClearance = grid,
 ): InstanceLabelPlacement | null {
   if (!instance.placement) return null;
-  const localBounds = visibleSymbolLocalBounds(resolved);
+  const localBounds = visibleSymbolInkBounds(resolved);
   const worldBounds = transformedBounds(localBounds, instance);
   const worldSide = transformedSide(localSide, instance);
   if (!worldBounds || !worldSide) return null;
@@ -180,19 +166,18 @@ export function placeUprightInstanceLabel(
     instance.placement.position,
     instance.placement,
   );
-  const clearance = Math.max(
-    minimumClearance,
-    sideClearance(localAnchor, localBounds, localSide),
-  );
+  // `localAnchor` carries the preferred cross-axis position and semantic
+  // side. Its previous distance from the edge is not a visual constraint:
+  // retaining a reconstructed, snapped distance was the source of one-grid
+  // outward drift on each repeated quarter turn.
+  const clearance = grid;
   const fontSize = profile.typography.instanceFontSize * sizeScale;
   const snap = (value: number) => Math.round(value / grid) * grid;
-  const snapOutward = (value: number, direction: -1 | 1) =>
-    (direction < 0 ? Math.floor(value / grid) : Math.ceil(value / grid)) * grid;
   switch (worldSide) {
     case "right":
       return {
         position: {
-          x: snapOutward(worldBounds.x + worldBounds.width + clearance, 1),
+          x: snap(worldBounds.x + worldBounds.width + clearance),
           y: snap(semanticPosition.y),
         },
         alignment: "start",
@@ -200,7 +185,7 @@ export function placeUprightInstanceLabel(
     case "left":
       return {
         position: {
-          x: snapOutward(worldBounds.x - clearance, -1),
+          x: snap(worldBounds.x - clearance),
           y: snap(semanticPosition.y),
         },
         alignment: "end",
@@ -209,9 +194,8 @@ export function placeUprightInstanceLabel(
       return {
         position: {
           x: snap(semanticPosition.x),
-          y: snapOutward(
+          y: snap(
             worldBounds.y + worldBounds.height + clearance + fontSize * 1.05,
-            1,
           ),
         },
         alignment: "middle",
@@ -220,7 +204,7 @@ export function placeUprightInstanceLabel(
       return {
         position: {
           x: snap(semanticPosition.x),
-          y: snapOutward(worldBounds.y - clearance - fontSize * 0.3, -1),
+          y: snap(worldBounds.y - clearance - fontSize * 0.3),
         },
         alignment: "middle",
       };
@@ -235,12 +219,11 @@ export function defaultInstanceLabelPlacement(
   grid: number,
 ): InstanceLabelPlacement | null {
   if (!instance.placement) return null;
-  const localBounds = visibleSymbolLocalBounds(resolved);
+  const localBounds = visibleSymbolInkBounds(resolved);
   const middleY = localBounds.y + localBounds.height / 2;
   const middleX = localBounds.x + localBounds.width / 2;
-  // A label gap is a grid-space rule, not a raw-coordinate optical tweak.
-  // The outward-only snap in placeUprightInstanceLabel preserves this full
-  // grid unit even when a symbol edge is itself not grid-aligned.
+  // A label gap is a grid-space visual rule, measured from drawn ink rather
+  // than the padded hit envelope.
   const compactSideGap = grid;
   const baselineOffset = profile.typography.instanceFontSize * 0.35;
 

--- a/packages/derived/src/visual.ts
+++ b/packages/derived/src/visual.ts
@@ -203,7 +203,14 @@ function primitivePoints(primitive: SymbolPrimitive): Point[] | null {
   }
 }
 
-export function visibleSymbolLocalBounds(resolved: ResolvedSymbol): Rect {
+/**
+ * Tight bounds of the symbol geometry actually drawn on the canvas.
+ *
+ * This deliberately excludes interaction tolerance. Use it for visual
+ * relationships such as label clearance; callers that need a forgiving hit or
+ * diagnostic envelope must use `visibleSymbolLocalBounds` below.
+ */
+export function visibleSymbolInkBounds(resolved: ResolvedSymbol): Rect {
   const hiddenParts = new Set(resolved.variant?.hiddenPrimitiveParts ?? []);
   const hiddenPins = new Set(resolved.variant?.hiddenPinNames ?? []);
   const primitives = [
@@ -221,12 +228,27 @@ export function visibleSymbolLocalBounds(resolved: ResolvedSymbol): Rect {
       .map((pin) => pin.at),
   ];
   if (points.length === 0) return resolved.definition.viewBox;
-  const padding = 1;
-  const x = Math.min(...points.map((point) => point.x)) - padding;
-  const y = Math.min(...points.map((point) => point.y)) - padding;
-  const right = Math.max(...points.map((point) => point.x)) + padding;
-  const bottom = Math.max(...points.map((point) => point.y)) + padding;
+  const x = Math.min(...points.map((point) => point.x));
+  const y = Math.min(...points.map((point) => point.y));
+  const right = Math.max(...points.map((point) => point.x));
+  const bottom = Math.max(...points.map((point) => point.y));
   return { x, y, width: right - x, height: bottom - y };
+}
+
+/**
+ * Forgiving envelope used for pointer interaction and visual diagnostics.
+ * It must not be used to position visible text: doing so turns its padding
+ * into an unintended extra label gap when the result is snapped to the grid.
+ */
+export function visibleSymbolLocalBounds(resolved: ResolvedSymbol): Rect {
+  const ink = visibleSymbolInkBounds(resolved);
+  const padding = 1;
+  return {
+    x: ink.x - padding,
+    y: ink.y - padding,
+    width: ink.width + padding * 2,
+    height: ink.height + padding * 2,
+  };
 }
 
 function pointOnSegment(point: Point, from: Point, to: Point): boolean {

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -901,7 +901,7 @@ describe("routing Edit Engine", () => {
         localOffset: { x: 20, y: -40 },
         fallbackPosition: { x: 180, y: 280 },
       },
-      alignment: "start",
+      alignment: "middle",
       rotation: 0,
     });
 
@@ -934,7 +934,7 @@ describe("routing Edit Engine", () => {
         localOffset: { x: 20, y: 40 },
         fallbackPosition: { x: 180, y: 360 },
       },
-      alignment: "start",
+      alignment: "middle",
       rotation: 0,
     });
     expect(mirrored.diff.changedObjectIds).toEqual(
@@ -943,7 +943,7 @@ describe("routing Edit Engine", () => {
   });
 
   it.each(["nmos", "pmos"])(
-    "preserves a materialized %s label side through a full rotation",
+    "preserves a manually positioned %s label vector through a full rotation",
     (symbolId) => {
       const document = documentFixture();
       document.instances.push({
@@ -959,8 +959,9 @@ describe("routing Edit Engine", () => {
         },
         properties: {},
       });
-      // This is the canonical Razavi MOS label materialized by the editor when
-      // the user edits or explicitly moves the otherwise renderer-owned label.
+      // This deliberately differs from the canonical default and represents a
+      // label explicitly moved by the user. Its coordinates are still on the
+      // Document grid, as all persisted anchors must be.
       document.annotations.push({
         id: "instance-label-M1",
         kind: "instance-label",
@@ -968,8 +969,8 @@ describe("routing Edit Engine", () => {
         anchor: {
           kind: "object",
           objectId: "M1",
-          localOffset: { x: 16, y: 8 },
-          fallbackPosition: { x: 116, y: 108 },
+          localOffset: { x: 40, y: 20 },
+          fallbackPosition: { x: 140, y: 120 },
         },
         alignment: "start",
         rotation: 0,
@@ -979,26 +980,26 @@ describe("routing Edit Engine", () => {
       const expected = [
         {
           rotation: 90 as const,
-          position: { x: 90, y: 140 },
-          offset: { x: -10, y: 40 },
-          alignment: "middle" as const,
+          position: { x: 80, y: 140 },
+          offset: { x: -20, y: 40 },
+          alignment: "start" as const,
         },
         {
           rotation: 180 as const,
-          position: { x: 70, y: 90 },
-          offset: { x: -30, y: -10 },
-          alignment: "end" as const,
+          position: { x: 60, y: 80 },
+          offset: { x: -40, y: -20 },
+          alignment: "start" as const,
         },
         {
           rotation: 270 as const,
-          position: { x: 110, y: 60 },
-          offset: { x: 10, y: -40 },
-          alignment: "middle" as const,
+          position: { x: 120, y: 60 },
+          offset: { x: 20, y: -40 },
+          alignment: "start" as const,
         },
         {
           rotation: 0 as const,
-          position: { x: 140, y: 110 },
-          offset: { x: 40, y: 10 },
+          position: { x: 140, y: 120 },
+          offset: { x: 40, y: 20 },
           alignment: "start" as const,
         },
       ];

--- a/packages/edit-engine/src/transaction.test.ts
+++ b/packages/edit-engine/src/transaction.test.ts
@@ -699,6 +699,72 @@ describe("Edit Transaction envelope", () => {
     );
   });
 
+  it("returns a canonical instance label to its initial position after four quarter turns", () => {
+    let document = createEmptyDocument("document-main", "Stable label");
+    const instance = {
+      id: "M1",
+      symbolId: "nmos",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0 as const,
+        mirror: "none" as const,
+      },
+      properties: {},
+    };
+    document.instances.push(instance);
+    const resolved = resolver.resolve("nmos", "textbook-3terminal");
+    if (!resolved) throw new Error("missing nmos");
+    const initial = defaultInstanceLabelPlacement(
+      instance,
+      resolved,
+      resolveSchematicStyleProfile(document.presentation.styleProfileId),
+      document.presentation.grid,
+    );
+    if (!initial) throw new Error("missing default label placement");
+    document.annotations.push({
+      id: "instance-label-M1",
+      kind: "instance-label",
+      content: { runs: [{ kind: "text", value: "M1" }] },
+      anchor: {
+        kind: "object",
+        objectId: "M1",
+        localOffset: {
+          x: initial.position.x - instance.placement.position.x,
+          y: initial.position.y - instance.placement.position.y,
+        },
+        fallbackPosition: initial.position,
+      },
+      alignment: initial.alignment,
+      rotation: 0,
+      locked: false,
+    });
+
+    for (const rotation of [90, 180, 270, 0] as const) {
+      const result = executeTransaction(
+        document,
+        {
+          ...transaction(document.revision),
+          edits: [{ kind: "rotate_instance", instanceId: "M1", rotation }],
+        },
+        { symbolResolver: resolver },
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      document = result.document;
+    }
+
+    const label = document.annotations[0]!;
+    if (label.anchor.kind !== "object") {
+      throw new Error("Canonical instance label must keep an object anchor");
+    }
+    expect(label.anchor.localOffset).toEqual({
+      x: initial.position.x - instance.placement.position.x,
+      y: initial.position.y - instance.placement.position.y,
+    });
+    expect(label.anchor.fallbackPosition).toEqual(initial.position);
+    expect(label.alignment).toBe(initial.alignment);
+  });
+
   it("rejects a multi-edit transaction atomically after a later precondition failure", () => {
     const document = documentWithInstance();
     const before = JSON.stringify(document);

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -36,6 +36,7 @@ import type {
 } from "@icm/model";
 import {
   buildOrthogonalEscapeRoute,
+  defaultInstanceLabelPlacement,
   endpointKey,
   endpointBelongsToNet,
   inferInstanceLabelSide,
@@ -48,7 +49,7 @@ import {
   resolveMosBulkConnection,
   resolveSchematicStyleProfile,
   routePolyline,
-  visibleSymbolLocalBounds,
+  visibleSymbolInkBounds,
 } from "@icm/derived";
 import type { SymbolResolver } from "@icm/symbols";
 import { z } from "zod";
@@ -1555,90 +1556,44 @@ function translateObjectAnchoredAnnotation(
 }
 
 /**
- * Object anchors persist the *visible* upright-label baseline. Before a later
- * rotation we recover the side-clearance point used by the label placer.
- * That keeps the baseline correction from being treated as authored geometry
- * on the next 90-degree turn.
+ * A reference label is renderer-managed only while it exactly agrees with the
+ * current canonical default. A user-moved label remains an authored
+ * object-relative vector and must not be pulled back onto the automatic side
+ * when its instance is rotated or mirrored.
  */
-function instanceLabelSemanticAnchor(
+function isCanonicalInstanceLabel(
+  annotation: Annotation,
   instance: SchematicDocument["instances"][number],
   resolved: NonNullable<ReturnType<SymbolResolver["resolve"]>>,
-  profile: ReturnType<typeof resolveSchematicStyleProfile>,
-  visiblePosition: Point,
-): Point {
-  const placement = instance.placement;
-  if (!placement) return visiblePosition;
-  const localBounds = visibleSymbolLocalBounds(resolved);
-  const corners = [
-    { x: localBounds.x, y: localBounds.y },
-    { x: localBounds.x + localBounds.width, y: localBounds.y },
-    {
-      x: localBounds.x + localBounds.width,
-      y: localBounds.y + localBounds.height,
-    },
-    { x: localBounds.x, y: localBounds.y + localBounds.height },
-  ].map((point) => transformPoint(point, placement.position, placement));
-  const left = Math.min(...corners.map((point) => point.x));
-  const right = Math.max(...corners.map((point) => point.x));
-  const top = Math.min(...corners.map((point) => point.y));
-  const bottom = Math.max(...corners.map((point) => point.y));
-  const candidates = [
-    { side: "left" as const, distance: left - visiblePosition.x },
-    { side: "right" as const, distance: visiblePosition.x - right },
-    { side: "top" as const, distance: top - visiblePosition.y },
-    { side: "bottom" as const, distance: visiblePosition.y - bottom },
-  ].filter((candidate) => candidate.distance > 0);
-  const side = candidates.sort(
-    (first, second) => second.distance - first.distance,
-  )[0]?.side;
-  if (!side) return visiblePosition;
-  const clearance =
-    side === "left"
-      ? left - visiblePosition.x
-      : side === "right"
-        ? visiblePosition.x - right
-        : side === "top"
-          ? top -
-            visiblePosition.y -
-            Math.round(profile.typography.instanceFontSize * 0.3)
-          : visiblePosition.y -
-            bottom -
-            Math.round(profile.typography.instanceFontSize * 1.05);
-  const baselineCorrected = {
-    x: visiblePosition.x,
-    y:
-      side === "bottom"
-        ? visiblePosition.y -
-          Math.round(profile.typography.instanceFontSize * 1.05)
-        : side === "top"
-          ? visiblePosition.y +
-            Math.round(profile.typography.instanceFontSize * 0.3)
-          : visiblePosition.y,
+  document: SchematicDocument,
+  oldPosition: Point,
+  oldOrientation: Orientation,
+): boolean {
+  if (
+    annotation.kind !== "instance-label" ||
+    annotation.anchor.kind !== "object"
+  ) {
+    return false;
+  }
+  const placement = { position: oldPosition, ...oldOrientation };
+  const expected = defaultInstanceLabelPlacement(
+    { ...instance, placement },
+    resolved,
+    resolveSchematicStyleProfile(document.presentation.styleProfileId),
+    document.presentation.grid,
+  );
+  if (!expected) return false;
+  const visiblePosition = {
+    x: oldPosition.x + annotation.anchor.localOffset.x,
+    y: oldPosition.y + annotation.anchor.localOffset.y,
   };
-  const local = inverseTransformPoint(
-    baselineCorrected,
-    placement.position,
-    placement,
+  return (
+    annotation.alignment === expected.alignment &&
+    visiblePosition.x === expected.position.x &&
+    visiblePosition.y === expected.position.y &&
+    annotation.anchor.fallbackPosition.x === expected.position.x &&
+    annotation.anchor.fallbackPosition.y === expected.position.y
   );
-  const worldDirection =
-    side === "left"
-      ? { x: -1, y: 0 }
-      : side === "right"
-        ? { x: 1, y: 0 }
-        : side === "top"
-          ? { x: 0, y: -1 }
-          : { x: 0, y: 1 };
-  const localDirection = inverseTransformPoint(
-    worldDirection,
-    { x: 0, y: 0 },
-    placement,
-  );
-  if (localDirection.x < 0) local.x = localBounds.x - clearance;
-  else if (localDirection.x > 0)
-    local.x = localBounds.x + localBounds.width + clearance;
-  else if (localDirection.y < 0) local.y = localBounds.y - clearance;
-  else local.y = localBounds.y + localBounds.height + clearance;
-  return transformPoint(local, placement.position, placement);
 }
 
 function followAttachedAnnotations(
@@ -1708,23 +1663,8 @@ function followAttachedAnnotations(
       x: oldPosition.x + annotation.anchor.localOffset.x,
       y: oldPosition.y + annotation.anchor.localOffset.y,
     };
-    const hasCanonicalVisibleOffset =
-      annotation.anchor.fallbackPosition.x === visiblePosition.x &&
-      annotation.anchor.fallbackPosition.y === visiblePosition.y;
-    const semanticAnchor =
-      annotation.kind === "instance-label" &&
-      instance &&
-      resolved &&
-      hasCanonicalVisibleOffset
-        ? instanceLabelSemanticAnchor(
-            instance,
-            resolved,
-            resolveSchematicStyleProfile(draft.presentation.styleProfileId),
-            visiblePosition,
-          )
-        : visiblePosition;
     const local = inverseTransformPoint(
-      semanticAnchor,
+      visiblePosition,
       oldPosition,
       oldOrientation,
     );
@@ -1735,10 +1675,22 @@ function followAttachedAnnotations(
     );
     let position = transformedAnchor;
     let transformedAlignment: "start" | "middle" | "end" | null = null;
-    if (annotation.kind === "instance-label" && instance && resolved) {
+    if (
+      annotation.kind === "instance-label" &&
+      instance &&
+      resolved &&
+      isCanonicalInstanceLabel(
+        annotation,
+        instance,
+        resolved,
+        draft,
+        oldPosition,
+        oldOrientation,
+      )
+    ) {
       const localSide = inferInstanceLabelSide(
         local,
-        visibleSymbolLocalBounds(resolved),
+        visibleSymbolInkBounds(resolved),
       );
       if (localSide) {
         try {
@@ -1763,23 +1715,19 @@ function followAttachedAnnotations(
     }
     annotation.anchor = {
       ...annotation.anchor,
-      localOffset: snapPointToDocumentGrid(
-        {
-          // Object anchors resolve localOffset directly in world space. Persist
-          // the upright glyph baseline, not its pre-baseline semantic point.
-          x: position.x - newPosition.x,
-          y: position.y - newPosition.y,
-        },
-        draft.presentation.grid,
-      ),
-      fallbackPosition: snapPointToDocumentGrid(
-        position,
-        draft.presentation.grid,
-      ),
+      // Object anchors resolve localOffset directly in world space. Persist
+      // the reflowed upright glyph baseline without a second grid snap. The
+      // label placer already performed the one authoritative grid snap;
+      // re-snapping a recovered anchor is what previously accumulated drift.
+      localOffset: {
+        x: position.x - newPosition.x,
+        y: position.y - newPosition.y,
+      },
+      fallbackPosition: position,
     };
     if (annotation.kind === "instance-label") {
       annotation.rotation = 0;
-      annotation.alignment = transformedAlignment ?? "middle";
+      annotation.alignment = transformedAlignment ?? annotation.alignment;
     } else {
       const oldDirection = directionForRotation(annotation.rotation);
       const localDirection = inverseTransformPoint(

--- a/plan/2026-08-15-fix-label-gap-rotation/plan.md
+++ b/plan/2026-08-15-fix-label-gap-rotation/plan.md
@@ -1,0 +1,93 @@
+---
+status: completed
+experience: none
+---
+
+# Repair exact instance-label gap and rotation stability
+
+## Goal
+
+Restore one exact active-Document grid interval between the rendered instance
+label and the rendered symbol edge, and make repeated quarter-turn rotations
+stable rather than outwardly drifting the automatic label.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/close-label-gap-delivery...origin/main [ahead 1, behind 1]
+```
+
+The worktree is clean. This target continues on the user-selected delivery
+branch. It owns derived instance-label geometry and the edit-engine follow
+logic plus their focused contracts. The pending one-commit `main` divergence
+is a VDD-only change and will be merged before delivery; it does not overlap
+the owned implementation paths.
+
+- `packages/derived/src/visual.ts`
+- `packages/derived/src/instance-label-placement.ts`
+- `packages/derived/src/*label-placement*.test.ts`
+- `packages/edit-engine/src/transaction.ts`
+- `packages/edit-engine/src/*transaction*.test.ts`
+- `packages/edit-engine/src/routing.test.ts`
+- `docs/specs/editor-interaction.md`
+- `plan/2026-08-15-fix-label-gap-rotation/plan.md`
+- `plan/root-audit.md`
+- `plan/log.md`
+
+Read-only/shared dependencies: model transforms and grid contract, SVG text
+metrics, editor annotation rendering, and the current Razavi visual contract.
+
+## Work
+
+1. Expose an unpadded visible-ink symbol bound while retaining the existing
+   padded bound for interaction/hit safety.
+2. Use the ink bound for automatic instance-label placement, with a fixed
+   one-grid visual clearance and no outward re-snap of the text baseline.
+3. Reconstruct only the label side during instance rotation; reflow canonical
+   labels with the fixed gap rather than deriving and preserving a clearance
+   from a previously snapped baseline. Preserve an explicitly moved label as a
+   rigid object-relative offset rather than silently reclassifying it as an
+   automatic label.
+4. Update the editor interaction contract from outward hit-envelope snapping
+   to the first canonical grid line from drawn ink; add focused regressions
+   for initial/rotated placement and return-to-origin after four quarter turns.
+5. Integrate latest `main`, run the mainline delivery gate, update factual
+   records, and merge this reviewed branch to `main`.
+
+## Validation
+
+- `pnpm test:local packages/derived/src/instance-label-placement.test.ts packages/edit-engine/src/transaction.test.ts`
+- `pnpm typecheck`
+- `pnpm format:check`
+- `pnpm install --frozen-lockfile`
+- `pnpm ci:check`
+- required remote GitHub Actions checks after push
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(labels): stabilize visual grid clearance on rotation
+```
+
+## Outcome
+
+Separated rendered symbol ink bounds from the padded interaction envelope and
+made automatic reference labels use the nearest canonical grid line one cell
+from ink. Repeated rotations no longer reconstruct or retain a rounded
+clearance. A label that still equals the current default is reflowed at that
+fixed spacing; a user-positioned, grid-aligned label retains its rigid
+object-relative vector and alignment.
+
+Validation passed: focused derived/Edit Engine contracts (52 tests),
+typecheck, formatting, `git diff --check`, frozen install, and the complete
+isolated-port `pnpm ci:check` gate (728 unit/integration tests, build and
+release verification, and 124 browser tests). The first complete browser run
+lost its shared port-4173 preview process after test 59; the same full suite
+passed on isolated port 4174, confirming a local port-host conflict rather
+than a product regression.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7070,3 +7070,17 @@ diff --check`, and two focused Playwright regressions passed.
   both remote delivery-gate runs then passed every required check, including
   both browser shards.
 - Commit status: merged through PR #64 as squash commit `ad604fb`.
+
+## 2026-08-15 - Stabilize label clearance and repeated rotation
+
+- Target: remove the interaction-padding-derived extra label grid cell and
+  make automatic label rotation idempotent, while preserving explicitly moved
+  labels as rigid object-relative offsets.
+- Changed areas: derived ink versus hit bounds, instance-label grid placement,
+  Edit Engine follow behavior, label/routing regressions, and the editor
+  interaction contract.
+- Validation: focused 52-test derived/Edit Engine suite, typecheck, Prettier,
+  `git diff --check`, frozen install, and isolated-port `pnpm ci:check`
+  (728 unit/integration tests, build/release verification, 124 browser tests).
+- Commit status: committed as `3a7719e` on
+  `codex/close-label-gap-delivery`; push and remote review checks pending.

--- a/plan/root-audit.md
+++ b/plan/root-audit.md
@@ -9,7 +9,7 @@ an archive. Completed plans with resolved experience are stored under
 | State                     | Count | Required disposition                                                              |
 | ------------------------- | ----: | --------------------------------------------------------------------------------- |
 | `active`                  |     0 | No active targets.                                                                |
-| `completed` + `none`      |    33 | Verify commit/log evidence, then archive according to routine retention policy.   |
+| `completed` + `none`      |    34 | Verify commit/log evidence, then archive according to routine retention policy.   |
 | `completed` + `candidate` |    17 | Human decides whether to extract, reject, or defer the experience signal.         |
 | missing metadata          |    71 | Audit against outcome text and Git evidence; never archive merely because of age. |
 
@@ -43,6 +43,12 @@ entries reconstruct the full record. The formerly active plans had completed
 Outcomes and corresponding implementation commits; the legacy WP-A1 proposal
 was confirmed as completed from its A1a/A1b/schema-gate log evidence; and the
 superseded VDD plan's drawn-rail replacement is already archived.
+
+## 2026-08-15 Label-placement closure
+
+`2026-08-15-fix-label-gap-rotation` is completed with resolved experience.
+It remains in the root queue until its delivered commit, factual log entry, and
+remote merge evidence are all present.
 
 ## Legacy Metadata Sweep
 


### PR DESCRIPTION
## Summary\n- measure automatic label placement from drawn ink, not padded hit bounds\n- make canonical label rotation idempotent and preserve manually positioned labels\n- add rotation and routing regressions\n\n## Validation\n- pnpm ci:check (isolated port 4174): 728 unit/integration tests and 124 browser tests passed