### PR TITLE
fix(editor): avoid full scene redraw during current marker drag

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -1170,6 +1170,12 @@ test("drags a current marker directly along and around its route", async ({
   const paintedMarker = page.locator(
     '[data-layer="annotations"] [data-object-id="current-1"]',
   );
+  // A live current-marker preview must not replace the formal SVG scene. A
+  // private marker on the existing node lets this assertion distinguish the
+  // intended local transform from a freshly rendered lookalike node.
+  await paintedMarker.evaluate((element) =>
+    element.setAttribute("data-preview-node", "preserved"),
+  );
   const paintedBefore = await paintedMarker.boundingBox();
   await page.mouse.move(start.x, start.y);
   await page.mouse.down();
@@ -1177,6 +1183,7 @@ test("drags a current marker directly along and around its route", async ({
   await expect
     .poll(async () => (await paintedMarker.boundingBox())?.x)
     .not.toBe(paintedBefore?.x);
+  await expect(paintedMarker).toHaveAttribute("data-preview-node", "preserved");
   await expect(page.getByTestId("revision")).toHaveText("4");
   await page.mouse.up();
   const after = await hit.boundingBox();

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -640,8 +640,6 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     useState<RouteStretchPreview | null>(null);
   const [draftingHandlePreview, setDraftingHandlePreview] =
     useState<DraftingHandlePreview | null>(null);
-  const [annotationDragPreview, setAnnotationDragPreview] =
-    useState<Annotation | null>(null);
   const snapGuideLayerRef = useRef<SVGGElement | null>(null);
   const {
     getCurrentState: getCurrentInteractionState,
@@ -744,30 +742,19 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   const helpCloseRef = useRef<HTMLButtonElement>(null);
   const documentViewBoxes = useRef(new Map<string, GridRect>());
   const renderedDocument = useMemo(() => {
-    if (!draftingHandlePreview && !annotationDragPreview) return document;
+    if (!draftingHandlePreview || !document.drafting) return document;
     return {
       ...document,
-      annotations: annotationDragPreview
-        ? document.annotations.map((annotation) =>
-            annotation.id === annotationDragPreview.id
-              ? annotationDragPreview
-              : annotation,
-          )
-        : document.annotations,
-      ...(draftingHandlePreview && document.drafting
-        ? {
-            drafting: {
-              ...document.drafting,
-              objects: document.drafting.objects.map((object) =>
-                object.id === draftingHandlePreview.objectId
-                  ? draftingHandlePreview.object
-                  : object,
-              ),
-            },
-          }
-        : {}),
+      drafting: {
+        ...document.drafting,
+        objects: document.drafting.objects.map((object) =>
+          object.id === draftingHandlePreview.objectId
+            ? draftingHandlePreview.object
+            : object,
+        ),
+      },
     };
-  }, [annotationDragPreview, document, draftingHandlePreview]);
+  }, [document, draftingHandlePreview]);
   const scene = useMemo(
     () => buildSvgScene(renderedDocument, resolver, { bounds: viewBox }),
     [renderedDocument, resolver, viewBox],
@@ -2739,12 +2726,12 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       thresholdPx: DRAG_START_DISTANCE_PX,
       onPreview: (client) => {
         const position = positionAt(client.x, client.y);
-        if (isRoutedMarker(annotation)) {
-          setAnnotationDragPreview(
-            draggedAnnotationAtPosition(annotation, position),
-          );
-          return;
-        }
+        // Route-attached current markers used to preview by replacing their
+        // annotation in `renderedDocument`. That invalidated and rebuilt the
+        // whole formal SVG scene once per pointer frame. A marker is one
+        // indivisible visual object, so a lightweight temporary translation is
+        // sufficient during the gesture; the exact route attachment is still
+        // resolved and persisted once on pointer release below.
         dragVisual().translate({
           x: position.x - preview.originalPosition.x,
           y: position.y - preview.originalPosition.y,
@@ -2753,7 +2740,6 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       onFinish: ({ client, dragged }) => {
         canvasDragSessionRef.current = null;
         visual?.restore();
-        setAnnotationDragPreview(null);
         if (dragged) {
           completeAnnotationDrag(preview, positionAt(client.x, client.y));
         }
@@ -2761,7 +2747,6 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       onCancel: () => {
         canvasDragSessionRef.current = null;
         visual?.restore();
-        setAnnotationDragPreview(null);
       },
     });
   }

--- a/plan/2026-08-15-current-marker-drag-stability/plan.md
+++ b/plan/2026-08-15-current-marker-drag-stability/plan.md
@@ -1,0 +1,73 @@
+---
+status: completed
+experience: none
+---
+
+# Current marker drag stability
+
+## Goal
+
+Keep route-attached current-arrow movement responsive and stable on dense
+schematics without changing its existing single-marker semantics: dragging may
+slide the arrow and its label together along the attached route, but does not
+create an independently movable text object.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree was clean. This target branches from `origin/main` as
+`codex/fix-current-marker-drag-stability`.
+
+Owned paths:
+
+- `apps/editor/src/app/App.tsx`
+- focused current-marker coverage in `apps/editor/e2e/manual-editor.spec.ts`
+- this plan and the factual close-out entry in `plan/log.md`
+
+Read-only:
+
+- persisted `route-marker` schema and route attachment geometry
+- formal SVG marker rendering and rich-text content contract
+- generic canvas drag-session and drag-visual helpers
+
+## Work
+
+1. Stop changing the rendered Document during pointer-move preview for a
+   route-attached current marker, so a pointer frame cannot rebuild the whole
+   formal SVG tree.
+2. Reuse the existing imperative drag visual for a lightweight, temporary
+   marker translation; restore it before the one typed attachment transaction
+   on pointer release.
+3. Protect the behavior with a browser regression that verifies a dragged
+   marker stays in the same formal SVG node through preview and commits only on
+   release.
+
+## Validation
+
+- `pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts --grep "drags a current marker"`
+- editor TypeScript check and production build
+- changed-file formatting
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): avoid full scene redraw during current marker drag
+```
+
+## Outcome
+
+The current-marker preview now uses the existing local drag transform and no
+longer changes `renderedDocument`, so moving it does not rebuild the formal SVG
+scene per pointer frame. Its route attachment still resolves once on release.
+The focused browser regression proved that the formal marker node remains in
+place through preview, and the editor TypeScript check and production build
+passed. No reusable experience signal was identified.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7053,7 +7053,7 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
   orientation and shortcut routing; rotated copy preview/commit behavior;
   editor interaction specification and focused unit/browser regressions.
 - Validation: 30 focused tests, `pnpm typecheck`, `pnpm format:check`, `git
-  diff --check`, and two focused Playwright regressions passed.
+diff --check`, and two focused Playwright regressions passed.
 - Commit status: ready to commit on `codex/label-gap-copy-rotate` as
   `fix(editor): align labels and rotate copy previews`.
 
@@ -7261,3 +7261,17 @@ ci:check` (651 unit tests, 104 browser tests, builds and release smoke) all
   `main`.
 - Commit status: rebased branch force-pushed with lease; PR is open with all
   required checks enforced on the final tip.
+
+## 2026-08-15 - Stabilize route current-marker dragging
+
+- Target: prevent a route-attached current arrow from rebuilding the full
+  formal SVG scene while it is dragged.
+- Changed areas: removed annotation-level React preview state for marker
+  movement; the existing imperative visual now temporarily transforms only the
+  marker and its hit target, then restores it before the single route-attachment
+  transaction on release. The focused browser regression asserts the original
+  formal marker node survives preview.
+- Validation: changed-file Prettier, focused current-marker Playwright 1/1,
+  editor TypeScript, editor production build, and `git diff --check` passed.
+- Commit status: prepared on `codex/fix-current-marker-drag-stability` for
+  focused commit and push.


### PR DESCRIPTION
## Summary

Keep route-attached current-marker dragging local to its existing SVG node during preview. The exact route attachment is still resolved and committed once on pointer release.

## Validation

- Focused current-marker Playwright: passed (1/1)
- TypeScript and editor production build: passed
- pnpm install --frozen-lockfile plus pnpm ci:check: static checks, 729 unit tests, all workspace builds, release smoke, and the first 77 browser tests passed. The local Vite test server exited after test 77; the remaining 47 browser failures are all ERR_CONNECTION_REFUSED. Remote required checks are the merge gate.