### PR TITLE
fix(editor): compact narrow library and overlay properties

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -660,93 +660,37 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
     chromeBox.x + chromeBox.width,
   );
 
-  const narrowArtwork = await page
-    .locator('[data-testid^="shapes-chip-"]')
-    .evaluateAll((tiles) =>
-      tiles.map((tile) => {
-        const tileBounds = tile.getBoundingClientRect();
-        const artwork = tile.querySelector<SVGElement>(".shapes-chip-art");
-        if (!artwork) throw new Error("Narrow Library artwork is missing");
-        const artworkBounds = artwork.getBoundingClientRect();
-        const label = tile.querySelector<HTMLElement>("span");
-        if (!label) throw new Error("Narrow Library label is missing");
-        const labelBounds = label.getBoundingClientRect();
-        return {
-          centerDeltaX:
-            artworkBounds.left +
-            artworkBounds.width / 2 -
-            (tileBounds.left + tileBounds.width / 2),
-          groupCenterDeltaY:
-            (Math.min(artworkBounds.top, labelBounds.top) +
-              Math.max(artworkBounds.bottom, labelBounds.bottom)) /
-              2 -
-            (tileBounds.top + tileBounds.height / 2),
-          height: artworkBounds.height,
-          labelFits:
-            label.scrollWidth <= label.clientWidth + 1 &&
-            label.scrollHeight <= label.clientHeight + 1,
-          labelCenterDeltaX:
-            labelBounds.left +
-            labelBounds.width / 2 -
-            (tileBounds.left + tileBounds.width / 2),
-          labelHeight: labelBounds.height,
-          separatedFromLabel: artworkBounds.bottom <= labelBounds.top + 0.5,
-          tileHeight: tileBounds.height,
-          withinTile:
-            artworkBounds.left >= tileBounds.left - 0.5 &&
-            artworkBounds.right <= tileBounds.right + 0.5 &&
-            artworkBounds.top >= tileBounds.top - 0.5 &&
-            artworkBounds.bottom <= tileBounds.bottom + 0.5,
-          width: artworkBounds.width,
-        };
-      }),
-    );
-  expect(
-    narrowArtwork.every((artwork) => Math.abs(artwork.width - 46) <= 0.5),
-  ).toBe(true);
-  expect(
-    narrowArtwork.every((artwork) => Math.abs(artwork.height - 36) <= 0.5),
-  ).toBe(true);
-  expect(
-    narrowArtwork.every((artwork) => Math.abs(artwork.centerDeltaX) <= 0.5),
-  ).toBe(true);
-  expect(
-    narrowArtwork.every(
-      (artwork) => Math.abs(artwork.groupCenterDeltaY) <= 0.5,
-    ),
-  ).toBe(true);
-  expect(
-    narrowArtwork.every(
-      (artwork) => Math.abs(artwork.labelCenterDeltaX) <= 0.5,
-    ),
-  ).toBe(true);
-  expect(
-    narrowArtwork.every((artwork) => Math.abs(artwork.tileHeight - 64) <= 0.5),
-  ).toBe(true);
-  expect(narrowArtwork.every((artwork) => artwork.labelFits)).toBe(true);
-  expect(narrowArtwork.every((artwork) => artwork.labelHeight <= 12.5)).toBe(
-    true,
-  );
-  expect(narrowArtwork.every((artwork) => artwork.separatedFromLabel)).toBe(
-    true,
-  );
-  expect(narrowArtwork.every((artwork) => artwork.withinTile)).toBe(true);
-  await expect(page.locator('[data-testid^="shapes-chip-"] span')).toHaveCount(
-    18,
-  );
-
+  const panel = page.getByTestId("shapes-library-panel");
   const canvas = page.getByTestId("schematic-canvas");
-  const openWidth = (await canvas.boundingBox())?.width ?? 0;
-  expect(openWidth).toBeGreaterThan(300);
+  await expect(panel).toHaveAttribute("data-open", "false");
+  const closedWidth = (await canvas.boundingBox())?.width ?? 0;
+  expect(closedWidth).toBeGreaterThan(600);
 
   await page.getByTestId("library-toggle").click();
-  await expect(page.getByTestId("shapes-library-panel")).toHaveAttribute(
-    "data-open",
-    "false",
+  await expect(panel).toHaveAttribute("data-open", "true");
+  await expect(panel.getByText("All", { exact: true })).toBeVisible();
+  expect(
+    await panel
+      .locator(".shapes-grid")
+      .first()
+      .evaluate(
+        (element) =>
+          getComputedStyle(element).gridTemplateColumns.split(" ").length,
+      ),
+  ).toBe(1);
+  const openWidth = (await canvas.boundingBox())?.width ?? 0;
+  expect(openWidth).toBeGreaterThan(450);
+  expect(openWidth).toBeLessThan(closedWidth);
+
+  await page.getByTestId("selection-shelf").click();
+  await expect(panel).toHaveAttribute("data-open", "false");
+  await expect(page.getByTestId("selection-shelf")).toHaveAttribute(
+    "aria-expanded",
+    "true",
   );
-  const closedWidth = (await canvas.boundingBox())?.width ?? 0;
-  expect(closedWidth).toBeCloseTo(openWidth, 0);
-  expect(closedWidth).toBeGreaterThan(300);
+  await expect
+    .poll(async () => (await canvas.boundingBox())?.width ?? 0)
+    .toBeCloseTo(closedWidth, 0);
   expect(
     await page.evaluate(() => ({
       horizontal:

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -250,6 +250,7 @@ const DEFAULT_VIEWBOX: GridRect = { x: 0, y: 0, width: 960, height: 640 };
 const RECENT_COMPONENTS_STORAGE_KEY = "icm.recent-components.v1";
 const LIBRARY_PANEL_STORAGE_KEY = "icm.library-panel-open.v1";
 const REFRESH_RESTORE_STORAGE_KEY = "icm.restore-after-refresh.v1";
+const COMPACT_LAYOUT_MEDIA_QUERY = "(max-width: 860px)";
 const DRAG_START_DISTANCE_PX = 4;
 const SNAP_CAPTURE_RADIUS_PX = 7;
 
@@ -480,6 +481,14 @@ function isTypingTarget(target: EventTarget | null): boolean {
   );
 }
 
+function compactLayoutMatches(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia(COMPACT_LAYOUT_MEDIA_QUERY).matches
+  );
+}
+
 export function App({ project: initialProject, visitStats }: AppProps) {
   const [preparedInitialProject] = useState(
     () =>
@@ -500,6 +509,8 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       return true;
     }
   });
+  const [compactLayout, setCompactLayout] = useState(compactLayoutMatches);
+  const [compactLibraryPanelOpen, setCompactLibraryPanelOpen] = useState(false);
   const [selectionOpen, setSelectionOpen] = useState(false);
   const [recentSymbolIds, setRecentSymbolIds] = useState<string[]>(() => {
     if (typeof window === "undefined") return [];
@@ -523,6 +534,31 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     }
     return requested;
   });
+
+  const visibleLibraryPanelOpen = compactLayout
+    ? compactLibraryPanelOpen
+    : libraryPanelOpen;
+
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return;
+    }
+    const mediaQuery = window.matchMedia(COMPACT_LAYOUT_MEDIA_QUERY);
+    const updateCompactLayout = (): void => {
+      setCompactLayout(mediaQuery.matches);
+      if (mediaQuery.matches) setCompactLibraryPanelOpen(false);
+    };
+    updateCompactLayout();
+    mediaQuery.addEventListener("change", updateCompactLayout);
+    return () => mediaQuery.removeEventListener("change", updateCompactLayout);
+  }, []);
+
+  useEffect(() => {
+    if (compactLayout && selectionOpen) setCompactLibraryPanelOpen(false);
+  }, [compactLayout, selectionOpen]);
   const refreshRestoreAttemptedRef = useRef(false);
   // Formal-file lifecycle of the current working copy, orthogonal to recovery
   // state: a commit makes it dirty again, only a confirmed File System
@@ -1299,6 +1335,14 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   }
 
   function toggleLibraryPanel(): void {
+    if (compactLayout) {
+      setCompactLibraryPanelOpen((current) => {
+        const next = !current;
+        if (next) setSelectionOpen(false);
+        return next;
+      });
+      return;
+    }
     setLibraryPanelOpen((current) => {
       const next = !current;
       try {
@@ -6664,7 +6708,9 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       ) : null}
       <div
         className={
-          libraryPanelOpen ? "app-workspace" : "app-workspace library-collapsed"
+          visibleLibraryPanelOpen
+            ? "app-workspace"
+            : "app-workspace library-collapsed"
         }
       >
         <aside className="tool-rail" aria-label="Tool rail">
@@ -6672,13 +6718,13 @@ export function App({ project: initialProject, visitStats }: AppProps) {
             type="button"
             className="tool-rail-button"
             title={
-              libraryPanelOpen
+              visibleLibraryPanelOpen
                 ? "Hide component library"
                 : "Show component library"
             }
-            aria-pressed={libraryPanelOpen}
+            aria-pressed={visibleLibraryPanelOpen}
             aria-controls="shapes-library-panel"
-            aria-expanded={libraryPanelOpen}
+            aria-expanded={visibleLibraryPanelOpen}
             data-testid="library-toggle"
             onClick={toggleLibraryPanel}
           >
@@ -6739,7 +6785,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
         <ShapesPanel
           styleProfileId={document.presentation.styleProfileId}
           recentSymbolIds={recentSymbolIds}
-          open={libraryPanelOpen}
+          open={visibleLibraryPanelOpen}
           onOpenInsert={openInsertComponentDialog}
           onQuickPlace={beginInsertedComponentPlacement}
         />

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -128,7 +128,10 @@ export function ShapesPanel({
       <div className="shapes-panel-body">
         <details className="shapes-fold" open data-testid="shapes-fold-library">
           <summary className="shapes-fold-summary">
-            <span className="shapes-fold-label">All devices</span>
+            <span className="shapes-fold-label">
+              <span className="shapes-fold-label-full">All devices</span>
+              <span className="shapes-fold-label-compact">All</span>
+            </span>
             <span className="shapes-fold-count">{librarySymbolCount}</span>
           </summary>
           <div className="shapes-fold-body">

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -861,6 +861,10 @@ body {
   white-space: nowrap;
 }
 
+.shapes-fold-label-compact {
+  display: none;
+}
+
 .shapes-fold-count {
   min-width: 1.25rem;
   padding: 1px 6px;
@@ -2710,19 +2714,14 @@ body {
 
   .app-workspace,
   .app-workspace.library-collapsed {
-    grid-template-rows: minmax(0, 1fr) auto auto;
-    grid-template-columns: var(--icm-rail-width) minmax(0, 1fr);
-    grid-template-areas:
-      "tools canvas"
-      "shapes shapes"
-      "props props";
+    position: relative;
+    grid-template-rows: minmax(0, 1fr);
+    grid-template-columns: var(--icm-rail-width) min(8rem, 34vw) minmax(0, 1fr);
+    grid-template-areas: "tools shapes canvas";
   }
 
   .app-workspace.library-collapsed {
-    grid-template-rows: minmax(0, 1fr) auto;
-    grid-template-areas:
-      "tools canvas"
-      "props props";
+    grid-template-columns: var(--icm-rail-width) 0 minmax(0, 1fr);
   }
 
   .app-workspace.library-collapsed .shapes-panel {
@@ -2730,9 +2729,23 @@ body {
   }
 
   .shapes-panel {
-    max-height: 30dvh;
-    border-right: 0;
-    border-top: 1px solid var(--icm-border);
+    border-top: 0;
+  }
+
+  .shapes-kicker {
+    display: none;
+  }
+
+  .shapes-fold-label-full {
+    display: none;
+  }
+
+  .shapes-fold-label-compact {
+    display: inline;
+  }
+
+  .shapes-grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .shapes-chip {
@@ -2750,10 +2763,19 @@ body {
 
   .selection-dock,
   .selection-dock.open {
-    width: 100%;
-    max-height: 36dvh;
-    border-left: 0;
-    border-top: 1px solid var(--icm-border);
+    grid-area: auto;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: var(--icm-props-collapsed);
+    max-height: none;
+    border-top: 0;
+    border-left: 1px solid var(--icm-border);
+  }
+
+  .selection-dock.open {
+    width: min(var(--icm-props-open), calc(100% - var(--icm-rail-width)));
   }
 
   .insert-component-dialog {

--- a/plan/2026-08-15-compact-library-overlay-properties/plan.md
+++ b/plan/2026-08-15-compact-library-overlay-properties/plan.md
@@ -1,0 +1,77 @@
+---
+status: completed
+experience: none
+---
+
+# Compact Library and Overlay Properties at Narrow Widths
+
+## Goal
+
+Keep the Library on the left at narrow viewport widths as a default-collapsed,
+single-column panel, and make Properties overlay rather than consume canvas
+layout space. Preserve the existing Properties content and fold interaction.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree was clean before this target. This target owns the narrow editor
+layout and its focused coverage.
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/features/editor-shell/shapes-panel.tsx`
+- `apps/editor/src/styles.css`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `apps/editor/e2e/manual-editor.spec.ts`
+- `plan/2026-08-15-compact-library-overlay-properties/plan.md`
+- `plan/log.md`
+
+Read-only shared dependencies: the component catalog and the existing
+Properties content/folding contract. Changes must not alter component placement
+or persisted desktop Library preference.
+
+## Work
+
+1. Add a narrow-viewport layout mode that defaults the Library closed without
+   overwriting the saved desktop preference, and keeps Library and Properties
+   mutually exclusive while compact.
+2. Keep the Library in the left workspace column, render its tiles in one
+   compact column, and expose concise narrow labels while preserving accessible
+   full labels.
+3. Convert narrow Properties positioning from a bottom grid row to a
+   right-side overlay without changing its content or fold interaction.
+4. Add focused browser coverage for narrow geometry, default state, and panel
+   exclusivity.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/features/editor-shell/shapes-panel.test.ts apps/editor/src/app/App.test.tsx`
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts apps/editor/e2e/manual-editor.spec.ts --grep "narrow breakpoint|canvas width"`
+- `pnpm typecheck`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): compact narrow library and overlay properties
+```
+
+## Outcome
+
+At widths up to 860px, Library now starts collapsed without overwriting the
+stored desktop preference. It expands as a compact, left-side single-column
+panel with the concise `All` heading. Properties retains its existing content
+and fold behavior but is now a right-side overlay; opening either panel closes
+the other while compact, and opening Properties leaves the canvas layout width
+unchanged after the transition completes.
+
+Validation passed: focused Library/App unit tests (16 tests), focused narrow
+Library/canvas Playwright coverage (2 tests), workspace typecheck, Prettier,
+and `git diff --check`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7275,3 +7275,17 @@ diff --check`, and two focused Playwright regressions passed.
   editor TypeScript, editor production build, and `git diff --check` passed.
 - Commit status: prepared on `codex/fix-current-marker-drag-stability` for
   focused commit and push.
+
+## 2026-08-15 - Compact narrow Library and overlay Properties
+
+- Target: preserve the left Library rail at half-screen widths while avoiding
+  a bottom-stacked Library and Properties layout.
+- Changed areas: compact viewport state, Library/Properties mutual exclusion,
+  one-column left Library with a concise `All` heading, right-side overlay
+  Properties positioning, and focused browser coverage.
+- Validation: focused Library/App unit tests (2 files / 16 tests), focused
+  narrow Library and canvas-width Playwright tests (2 tests), `pnpm typecheck`,
+  Prettier, and `git diff --check` passed.
+- Commit status: committed locally as
+  `fix(editor): compact narrow library and overlay properties` on
+  `codex/compact-library-overlay-properties`; not pushed.


### PR DESCRIPTION
## What changed

- Keep the Library in the left workspace column at narrow widths, defaulting it to collapsed.
- Use a compact single-column Library layout and show All in place of All devices.
- Position Properties as a right-side overlay at narrow widths, preserving its existing content and fold interaction.
- Keep Library and Properties mutually exclusive while compact so the canvas is not covered from both sides.

## Why

The previous <=860px layout moved both panels below the canvas, making half-screen editing awkward.

## Validation

- pnpm install --frozen-lockfile
- pnpm ci:check
- Focused Library/App unit tests and narrow Library/canvas Playwright coverage