### PR TITLE
Editor runtime crash safety (minimal three layers)

### DIFF
--- a/apps/editor/e2e/runtime-crash-safety.spec.ts
+++ b/apps/editor/e2e/runtime-crash-safety.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  chooseComponent,
+  emulateDownloadOnlyBrowser,
+} from "./editor-fixtures.js";
+
+test.beforeEach(async ({ page }) => {
+  await emulateDownloadOnlyBrowser(page);
+});
+
+test("a render crash shows the recovery screen instead of a blank page", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.getByTestId("schematic-canvas")).toBeVisible();
+
+  // Arm the DEV-only render crash probe and force one more App render.
+  page.on("pageerror", (error) => console.log("PAGEERROR:", error.message));
+  await page.evaluate(() => {
+    window.__ICM_TEST_RENDER_CRASH__ = true;
+  });
+  await page.keyboard.press("i");
+
+  const crashScreen = page.getByTestId("editor-crash-screen");
+  await expect(crashScreen).toBeVisible();
+  await expect(crashScreen).toContainText(
+    "The editor hit an unexpected problem",
+  );
+  await expect(crashScreen).toContainText("render crashed (test hook)");
+
+  // Reloading brings the editor back without the transient crash flag.
+  await crashScreen.getByRole("button", { name: "Reload editor" }).click();
+  await expect(page.getByTestId("schematic-canvas")).toBeVisible();
+});
+
+test("a scene build failure degrades to the last good view and recovers", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await chooseComponent(page, "resistor");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 360, y: 230 } });
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("hit-R1")).toBeVisible();
+  await expect(page.getByTestId("revision")).toHaveText("1");
+
+  // Break formal scene building: further commits must not crash the page,
+  // the canvas keeps showing the last good scene, and the model still edits.
+  await page.evaluate(() => {
+    window.__ICM_TEST_SCENE_CRASH__ = true;
+  });
+  await chooseComponent(page, "resistor");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 520, y: 230 } });
+  await expect(page.getByTestId("revision")).toHaveText("2");
+  // The degraded status fires on the commit itself; assert it before the
+  // closing Escape overwrites the status line.
+  await expect(page.getByTestId("status")).toContainText(
+    "Scene rendering failed",
+  );
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("hit-R1")).toBeVisible();
+  // Hit targets are React-rendered, but the formal scene stays at the last
+  // good view, so R2's painted symbol must be absent from it.
+  await expect(
+    page.locator('[data-layer="symbols"] [data-object-id="R2"]'),
+  ).toHaveCount(0);
+
+  // Once scene building works again, the next commit renders fresh content.
+  await page.evaluate(() => {
+    window.__ICM_TEST_SCENE_CRASH__ = false;
+  });
+  await chooseComponent(page, "resistor");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 640, y: 230 } });
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("revision")).toHaveText("3");
+  await expect(page.getByTestId("hit-R3")).toBeVisible();
+  await expect(
+    page.locator('[data-layer="symbols"] [data-object-id="R2"]'),
+  ).toBeVisible();
+  await expect(
+    page.locator('[data-layer="symbols"] [data-object-id="R3"]'),
+  ).toBeVisible();
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -83,6 +83,8 @@ import type {
 import { buildSvgScene } from "@icm/render-svg";
 import { importSpiceSources } from "@icm/spice";
 import type { SpiceDiagnostic } from "@icm/spice";
+import { renderCrashRequested, sceneCrashRequested } from "./crash-test-hooks";
+import { buildSceneSafely } from "./scene-safety";
 import { builtInSymbols, findUnsupportedProjectSymbolIds } from "@icm/symbols";
 import {
   clipboardPlacementAnchor,
@@ -480,6 +482,14 @@ function isTypingTarget(target: EventTarget | null): boolean {
   );
 }
 
+/**
+ * DEV-only probe that throws during render so browser tests can exercise the
+ * root error boundary. Never mounted in production builds.
+ */
+function RenderCrashProbe(): never {
+  throw new Error("render crashed (test hook)");
+}
+
 export function App({ project: initialProject, visitStats }: AppProps) {
   const [preparedInitialProject] = useState(
     () =>
@@ -755,10 +765,27 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       },
     };
   }, [document, draftingHandlePreview]);
-  const scene = useMemo(
-    () => buildSvgScene(renderedDocument, resolver, { bounds: viewBox }),
-    [renderedDocument, resolver, viewBox],
+  const lastGoodSceneRef = useRef<ReturnType<typeof buildSvgScene> | null>(
+    null,
   );
+  const sceneState = useMemo(() => {
+    const outcome = buildSceneSafely(() => {
+      if (sceneCrashRequested()) {
+        throw new Error("scene build crashed (test hook)");
+      }
+      return buildSvgScene(renderedDocument, resolver, { bounds: viewBox });
+    }, lastGoodSceneRef.current);
+    if (!outcome.degraded) lastGoodSceneRef.current = outcome.scene;
+    return outcome;
+  }, [renderedDocument, resolver, viewBox]);
+  const scene = sceneState.scene;
+  useEffect(() => {
+    if (sceneState.degraded) {
+      setStatus(
+        `Scene rendering failed; showing the last good view — ${sceneState.message}`,
+      );
+    }
+  }, [sceneState.degraded, sceneState.message]);
   // React compares dangerouslySetInnerHTML by prop identity, and an inline
   // `{ __html }` literal would force an innerHTML replacement on every App
   // re-render — destroying live drag previews (and pointer capture) whenever
@@ -771,16 +798,21 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       x: copyPlacement.previewPoint.x - copyPlacement.anchor.x,
       y: copyPlacement.previewPoint.y - copyPlacement.anchor.y,
     };
-    return buildSvgScene(
-      clipboardPreviewDocument(
-        document,
-        copyPlacement.clipboard,
-        offset,
-        copyPlacement.rotation,
-      ),
-      resolver,
-      { bounds: viewBox },
-    );
+    try {
+      return buildSvgScene(
+        clipboardPreviewDocument(
+          document,
+          copyPlacement.clipboard,
+          offset,
+          copyPlacement.rotation,
+        ),
+        resolver,
+        { bounds: viewBox },
+      );
+    } catch {
+      // A transient copy preview is never worth crashing the render for.
+      return null;
+    }
   }, [copyPlacement, document, resolver, viewBox]);
   const copyPreviewInnerHtml = useMemo(
     () =>
@@ -1175,7 +1207,16 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     (count, candidate) => count + candidate.instances.length,
     0,
   );
-  const contentScene = buildSvgScene(document, resolver);
+  const contentScene = useMemo(() => {
+    try {
+      return buildSvgScene(document, resolver);
+    } catch {
+      // Fit view falls back to the default framing when the bounds scene
+      // cannot be built; the canvas itself renders through the guarded
+      // formal-scene pipeline above.
+      return null;
+    }
+  }, [document, resolver]);
   const zoomPercent = Math.round((DEFAULT_VIEWBOX.width / viewBox.width) * 100);
   const canvasIsEmpty =
     document.instances.every((instance) => instance.placement === null) &&
@@ -1850,8 +1891,33 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       preserveInteraction?: boolean;
     } = {},
   ): EditTransactionResult {
-    const result = transactDocument(edits);
+    let result: EditTransactionResult;
+    try {
+      result = transactDocument(edits);
+    } catch (error) {
+      // The controller fence normally converts engine failures into typed
+      // rejections; this catch covers the thin React wrapper around it.
+      // Either way the committed circuit is unchanged, so only the transient
+      // interaction state needs to be dropped.
+      cancelAllTransientInteraction();
+      const message =
+        error instanceof Error ? error.message : "unexpected failure";
+      setStatus(
+        `INTERNAL_ERROR: ${message} — operation cancelled; circuit unchanged`,
+      );
+      return {
+        ok: false,
+        applied: false,
+        revision: document.revision,
+        document,
+        error: { code: "INTERNAL_ERROR", message },
+        diagnostics: [],
+      };
+    }
     applyResult(result);
+    if (!result.ok && result.error.code === "INTERNAL_ERROR") {
+      cancelAllTransientInteraction();
+    }
     const currentInteraction = getCurrentInteractionState();
     const preservesCurrentInteraction =
       options.preserveInteraction ||
@@ -5025,7 +5091,10 @@ export function App({ project: initialProject, visitStats }: AppProps) {
 
   function fitView(): void {
     setViewBox(
-      fitCameraToBounds(contentScene.viewBox, document.presentation.grid),
+      fitCameraToBounds(
+        contentScene?.viewBox ?? DEFAULT_VIEWBOX,
+        document.presentation.grid,
+      ),
     );
     setStatus("Fit Document");
   }
@@ -6175,6 +6244,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
 
   return (
     <main className="app-shell">
+      {renderCrashRequested() ? <RenderCrashProbe /> : null}
       <header className="app-chrome">
         <div className="app-chrome-main">
           <div className="app-brand">

--- a/apps/editor/src/app/crash-test-hooks.ts
+++ b/apps/editor/src/app/crash-test-hooks.ts
@@ -1,0 +1,34 @@
+// DEV-only crash injection hooks for browser tests of the runtime safety
+// layers. Every reference is guarded by `import.meta.env.DEV`, so production
+// builds eliminate the checks and the hooks cannot be triggered in deployed
+// editors.
+//
+// - `__ICM_TEST_RENDER_CRASH__` mounts a probe component that throws during
+//   render, exercising the root error boundary.
+// - `__ICM_TEST_SCENE_CRASH__` makes formal scene building throw, exercising
+//   the last-good-scene fallback.
+
+declare global {
+  interface Window {
+    __ICM_TEST_RENDER_CRASH__?: boolean;
+    __ICM_TEST_SCENE_CRASH__?: boolean;
+  }
+}
+
+type CrashFlag = "__ICM_TEST_RENDER_CRASH__" | "__ICM_TEST_SCENE_CRASH__";
+
+function crashFlagRequested(flag: CrashFlag): boolean {
+  return (
+    import.meta.env.DEV &&
+    typeof window !== "undefined" &&
+    window[flag] === true
+  );
+}
+
+export function renderCrashRequested(): boolean {
+  return crashFlagRequested("__ICM_TEST_RENDER_CRASH__");
+}
+
+export function sceneCrashRequested(): boolean {
+  return crashFlagRequested("__ICM_TEST_SCENE_CRASH__");
+}

--- a/apps/editor/src/app/scene-safety.test.ts
+++ b/apps/editor/src/app/scene-safety.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSceneSafely } from "./scene-safety";
+
+describe("buildSceneSafely", () => {
+  it("returns the built scene when building succeeds", () => {
+    const outcome = buildSceneSafely(() => ({ id: 1 }), null);
+    expect(outcome).toEqual({ scene: { id: 1 }, degraded: false });
+  });
+
+  it("falls back to the last good scene with the failure reason", () => {
+    const outcome = buildSceneSafely(
+      () => {
+        throw new Error("bad geometry");
+      },
+      { id: 0 },
+    );
+    expect(outcome).toEqual({
+      scene: { id: 0 },
+      degraded: true,
+      message: "bad geometry",
+    });
+  });
+
+  it("rethrows when there is no last good scene to fall back to", () => {
+    expect(() =>
+      buildSceneSafely(() => {
+        throw new Error("first render");
+      }, null),
+    ).toThrowError("first render");
+  });
+
+  it("reports non-Error throws with a generic message", () => {
+    const outcome = buildSceneSafely(
+      () => {
+        throw "plain string";
+      },
+      { id: 0 },
+    );
+    expect(outcome.degraded).toBe(true);
+    expect(outcome.message).toBe("scene build failed");
+  });
+});

--- a/apps/editor/src/app/scene-safety.ts
+++ b/apps/editor/src/app/scene-safety.ts
@@ -1,0 +1,32 @@
+// Last-good-scene fallback for formal scene building.
+//
+// Scene building is the one confirmed render-phase white-screen path: it runs
+// in an App-level useMemo over arbitrary committed geometry, symbol, and
+// derivation code. When it throws, this helper returns the last successfully
+// built scene so the canvas keeps showing a coherent (stale) view plus a
+// visible degraded status, instead of unmounting the editor. With no last
+// good scene (the very first render), the error is rethrown and the root
+// error boundary owns the failure.
+
+export interface SafeSceneOutcome<Scene> {
+  scene: Scene;
+  degraded: boolean;
+  /** Failure reason when `degraded` is true. */
+  message?: string;
+}
+
+export function buildSceneSafely<Scene>(
+  build: () => Scene,
+  lastGood: Scene | null,
+): SafeSceneOutcome<Scene> {
+  try {
+    return { scene: build(), degraded: false };
+  } catch (error) {
+    if (lastGood === null) throw error;
+    return {
+      scene: lastGood,
+      degraded: true,
+      message: error instanceof Error ? error.message : "scene build failed",
+    };
+  }
+}

--- a/apps/editor/src/components/editor-error-boundary.test.tsx
+++ b/apps/editor/src/components/editor-error-boundary.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { EditorCrashScreen } from "./editor-error-boundary";
+
+describe("EditorCrashScreen", () => {
+  it("renders an alert with the failure reason and a reload action", () => {
+    const html = renderToStaticMarkup(
+      <EditorCrashScreen
+        message="boom in scene build"
+        onReload={() => undefined}
+      />,
+    );
+    expect(html).toContain("The editor hit an unexpected problem");
+    expect(html).toContain("boom in scene build");
+    expect(html).toContain("Reload editor");
+    expect(html).toContain("Recover recent work");
+  });
+});

--- a/apps/editor/src/components/editor-error-boundary.tsx
+++ b/apps/editor/src/components/editor-error-boundary.tsx
@@ -1,0 +1,85 @@
+import { Component } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+
+export interface EditorErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface EditorErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Last-resort boundary around the whole editor: an exception thrown during
+ * rendering shows a recovery screen instead of an unmounted blank page. The
+ * screen keeps the user actionable — reload the editor, knowing that recent
+ * committed work is kept in the browser recovery copies — while the error is
+ * logged for diagnosis.
+ */
+export class EditorErrorBoundary extends Component<
+  EditorErrorBoundaryProps,
+  EditorErrorBoundaryState
+> {
+  override state: EditorErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): EditorErrorBoundaryState {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error(
+      "Editor crashed during rendering:",
+      error,
+      info.componentStack,
+    );
+  }
+
+  override render(): ReactNode {
+    if (this.state.error !== null) {
+      return (
+        <EditorCrashScreen
+          message={this.state.error.message}
+          onReload={() => window.location.reload()}
+        />
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export interface EditorCrashScreenProps {
+  message: string;
+  onReload(): void;
+}
+
+export function EditorCrashScreen({
+  message,
+  onReload,
+}: EditorCrashScreenProps) {
+  return (
+    <div
+      className="editor-crash-screen"
+      data-testid="editor-crash-screen"
+      role="alert"
+      aria-labelledby="editor-crash-title"
+    >
+      <div className="editor-crash-panel">
+        <h1 id="editor-crash-title">The editor hit an unexpected problem</h1>
+        <p>
+          Rendering stopped with an internal error. Your recent committed work
+          is kept in this browser's recovery copies.
+        </p>
+        <p>
+          <code>{message}</code>
+        </p>
+        <button type="button" onClick={onReload}>
+          Reload editor
+        </button>
+        <p className="editor-crash-note">
+          After reloading, use File / Recover recent work… if your latest
+          changes are missing.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/editor/src/document/document-controller-internal-error.test.ts
+++ b/apps/editor/src/document/document-controller-internal-error.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createEmptyProject } from "@icm/model";
+
+import { DocumentHistory } from "@icm/edit-engine";
+
+vi.mock("./editor-session", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./editor-session")>();
+  return {
+    ...actual,
+    replaceProjectDocument: vi.fn(actual.replaceProjectDocument),
+  };
+});
+
+import { EditorDocumentController } from "./document-controller";
+import { replaceProjectDocument } from "./editor-session";
+
+function instance(id: string) {
+  return {
+    id,
+    symbolId: "resistor",
+    placement: null,
+    properties: {},
+  };
+}
+
+describe("EditorDocumentController internal-error fence", () => {
+  it("converts an engine exception into an INTERNAL_ERROR rejection with an unchanged Project", () => {
+    const controller = new EditorDocumentController(
+      createEmptyProject("controller", "Controller"),
+    );
+    const first = controller.transact([
+      { kind: "add_instance", instance: instance("R1") },
+    ]);
+    expect(first.ok && first.applied).toBe(true);
+    expect(controller.canUndo).toBe(true);
+    const revisionBefore = controller.document.revision;
+    const projectBefore = structuredClone(controller.project);
+
+    const transactSpy = vi
+      .spyOn(DocumentHistory.prototype, "transact")
+      .mockImplementationOnce(() => {
+        throw new Error("engine exploded");
+      });
+    const rejected = controller.transact([
+      { kind: "add_instance", instance: instance("R2") },
+    ]);
+    transactSpy.mockRestore();
+
+    expect(rejected.ok).toBe(false);
+    if (!rejected.ok) {
+      expect(rejected.error.code).toBe("INTERNAL_ERROR");
+      expect(rejected.error.message).toContain("engine exploded");
+      expect(rejected.revision).toBe(revisionBefore);
+    }
+    expect(controller.document.revision).toBe(revisionBefore);
+    expect(controller.document.instances.map((entry) => entry.id)).toEqual([
+      "R1",
+    ]);
+    expect(controller.canUndo).toBe(false);
+    expect(controller.project).toEqual(projectBefore);
+
+    // The histories were rebuilt from the unchanged Project, so the next
+    // transaction continues from a consistent revision.
+    const next = controller.transact([
+      { kind: "add_instance", instance: instance("R2") },
+    ]);
+    expect(next.ok && next.applied).toBe(true);
+    expect(controller.document.revision).toBe(revisionBefore + 1);
+    expect(controller.document.instances.map((entry) => entry.id)).toEqual([
+      "R1",
+      "R2",
+    ]);
+  });
+
+  it("converts a post-commit re-validation failure into an INTERNAL_ERROR rejection", () => {
+    const controller = new EditorDocumentController(
+      createEmptyProject("controller", "Controller"),
+    );
+    const revisionBefore = controller.document.revision;
+
+    const replaceMock = vi.mocked(replaceProjectDocument);
+    replaceMock.mockImplementationOnce(() => {
+      throw new Error("schema validation failed");
+    });
+    const rejected = controller.transact([
+      { kind: "add_instance", instance: instance("R1") },
+    ]);
+
+    expect(rejected.ok).toBe(false);
+    if (!rejected.ok) {
+      expect(rejected.error.code).toBe("INTERNAL_ERROR");
+      expect(rejected.error.message).toContain(
+        "Committed document could not be re-validated",
+      );
+    }
+    expect(controller.document.revision).toBe(revisionBefore);
+    expect(controller.document.instances).toHaveLength(0);
+
+    const next = controller.transact([
+      { kind: "add_instance", instance: instance("R1") },
+    ]);
+    expect(next.ok && next.applied).toBe(true);
+    expect(controller.document.revision).toBe(revisionBefore + 1);
+  });
+});

--- a/apps/editor/src/document/document-controller.ts
+++ b/apps/editor/src/document/document-controller.ts
@@ -175,6 +175,12 @@ export class EditorDocumentController {
    * a human commit. `dryRun` mutates no history, Project, resolver, or undo
    * state. Opening or viewing another Document neither retargets nor cancels an
    * explicit dispatch.
+   *
+   * Unexpected runtime exceptions from the engine or from post-commit Project
+   * re-validation are converted into typed `INTERNAL_ERROR` rejections: the
+   * Project and revision keep their previous values and the histories are
+   * rebuilt from that unchanged Project, so a later transaction continues from
+   * a consistent state.
    */
   dispatchTransaction(
     request: EditorTransactionRequest,
@@ -187,18 +193,57 @@ export class EditorDocumentController {
         `Document ${request.documentId} is not present in the Project`,
       );
     }
-    const result = history.transact(request);
-    if (result.ok && result.applied) {
-      this.projectValue = replaceProjectDocument(
-        this.projectValue,
-        result.document,
-      );
-      this.resolverValue = createProjectSymbolResolver(
-        this.projectValue,
-        builtInSymbols,
+    let result: EditTransactionResult;
+    try {
+      result = history.transact(request);
+    } catch (error) {
+      this.resetHistoriesFromProject();
+      return rejectTransaction(
+        this.document,
+        "INTERNAL_ERROR",
+        `Transaction failed with an internal error: ${
+          error instanceof Error ? error.message : "unknown failure"
+        }`,
       );
     }
+    if (result.ok && result.applied) {
+      const previousProject = this.projectValue;
+      try {
+        this.projectValue = replaceProjectDocument(
+          this.projectValue,
+          result.document,
+        );
+        this.resolverValue = createProjectSymbolResolver(
+          this.projectValue,
+          builtInSymbols,
+        );
+      } catch (error) {
+        this.projectValue = previousProject;
+        this.resetHistoriesFromProject();
+        return rejectTransaction(
+          this.document,
+          "INTERNAL_ERROR",
+          `Committed document could not be re-validated into a Project: ${
+            error instanceof Error ? error.message : "unknown failure"
+          }`,
+        );
+      }
+    }
     return result;
+  }
+
+  /**
+   * Rebuild every history from the current (unchanged) Project after an
+   * internal error. The undo history is deliberately sacrificed here: the
+   * histories may hold a partially applied document, and model consistency
+   * outranks undo depth on this rare path.
+   */
+  private resetHistoriesFromProject(): void {
+    const document = this.document;
+    this.historyValue = new DocumentHistory(document, {
+      symbolResolver: this.resolverValue,
+    });
+    this.histories = new Map([[document.id, this.historyValue]]);
   }
 
   /**

--- a/apps/editor/src/main.tsx
+++ b/apps/editor/src/main.tsx
@@ -2,6 +2,7 @@ import { lazy, StrictMode, Suspense, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 
 import { App } from "./app/App";
+import { EditorErrorBoundary } from "./components/editor-error-boundary";
 import "./styles.css";
 
 const container = document.getElementById("root");
@@ -77,7 +78,9 @@ function Root() {
 
 createRoot(container).render(
   <StrictMode>
-    <Root />
+    <EditorErrorBoundary>
+      <Root />
+    </EditorErrorBoundary>
   </StrictMode>,
 );
 

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -3662,3 +3662,43 @@ html.light .analytics-map-land path {
   display: flex;
   gap: 0.5rem;
 }
+
+/* Root crash screen shown by the editor error boundary. */
+.editor-crash-screen {
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+  padding: 1.5rem;
+  background: var(--icm-surface);
+}
+
+.editor-crash-panel {
+  display: grid;
+  gap: 0.75rem;
+  width: min(34rem, 100%);
+  padding: 1.5rem;
+  border: 1px solid #b91c1c;
+  border-radius: var(--icm-radius-lg);
+  background: #fef2f2;
+  box-shadow: var(--icm-shadow-lg);
+}
+
+.editor-crash-panel h1 {
+  margin: 0;
+  font-size: var(--icm-font-lg);
+}
+
+.editor-crash-panel p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.editor-crash-panel code {
+  font-size: var(--icm-font-sm);
+  overflow-wrap: anywhere;
+}
+
+.editor-crash-note {
+  color: #5f6b7a;
+  font-size: var(--icm-font-sm);
+}

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -372,7 +372,10 @@ export type EditErrorCode =
   | "EDIT_CONTEXT_REQUIRED"
   | "HISTORY_CONTEXT_REQUIRED"
   | "HISTORY_EMPTY"
-  | "INVALID_RESULT";
+  | "INVALID_RESULT"
+  /** An unexpected runtime exception inside the engine or the editor's
+   * transaction fence; the Project and revision are unchanged. */
+  | "INTERNAL_ERROR";
 
 export interface EditDiagnostic {
   code: string;

--- a/plan/2026-08-15-editor-runtime-crash-safety/plan.md
+++ b/plan/2026-08-15-editor-runtime-crash-safety/plan.md
@@ -1,0 +1,125 @@
+---
+status: active
+experience: none
+---
+
+# Editor Runtime Crash Safety - Minimal Three Layers
+
+## Goal
+
+Keep the editor page alive when rendering or transaction code throws, using
+the evidence-bounded minimum agreed in review instead of the full four-layer
+proposal:
+
+1. a root Error Boundary so a render crash shows a recovery screen instead
+   of a blank page;
+2. a last-good-scene fallback for formal scene building (the one confirmed
+   white-screen path) with a visible degraded status;
+3. an `INTERNAL_ERROR` transaction fence at the document-controller choke
+   point: unknown engine or re-validation exceptions become typed rejections
+   with Project, revision, and histories left consistent, and the UI clears
+   transient interaction state on that code.
+
+Explicitly deferred (no observed failure they would catch): the stable-shell
+workspace split, a full `runCommand` executor, and commit-time render
+preflight.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## agent/editor-runtime-crash-safety
+```
+
+The main worktree holds another worker's active dirty target
+(`codex/compact-library-overlay-properties`), so this target runs in a
+dedicated worktree checked out from main `da43d33`; that worktree is clean
+and untouched.
+
+Owned paths (in the worktree):
+
+- `packages/edit-engine/src/transaction.ts` (additive `INTERNAL_ERROR`
+  error-code member only)
+- `apps/editor/src/document/document-controller.ts` and its test
+- `apps/editor/src/app/App.tsx` (scene guards, transact fence, crash probe)
+- `apps/editor/src/app/scene-safety.ts` (new) and its test
+- `apps/editor/src/app/crash-test-hooks.ts` (new, DEV-only test hooks)
+- `apps/editor/src/components/editor-error-boundary.tsx` (new) and its test
+- `apps/editor/src/main.tsx`, `apps/editor/src/styles.css`
+- `apps/editor/e2e/runtime-crash-safety.spec.ts` (new)
+- this plan and `plan/log.md`
+
+Read-only: recovery coordinator/store/contract, file service, edit-engine
+semantics beyond the additive code, PWA assets, CI definitions.
+
+## Work
+
+1. `EditorErrorBoundary` class component with a `role="alert"` crash screen
+   (message + Reload editor button) mounted in `main.tsx` around `Root`;
+   log `componentDidCatch` to console.
+2. `buildSceneSafely` pure helper; App wraps `buildSvgScene` (formal scene,
+   copy preview) with a last-good ref and a degraded status effect; the
+   fit-view `contentScene` falls back to the default framing; no fallback on
+   the very first render (the root boundary owns that case).
+3. `INTERNAL_ERROR`: document-controller catches throws from
+   `history.transact` and from post-commit Project re-validation, resets
+   histories from the unchanged Project, and returns a typed rejection; the
+   App transact wrapper also converts wrapper-level throws into synthetic
+   rejections and clears transient interaction state on `INTERNAL_ERROR`.
+4. DEV-only crash hooks (`__ICM_TEST_RENDER_CRASH__`,
+   `__ICM_TEST_SCENE_CRASH__`) so browser tests can force each failure mode;
+   production builds eliminate them via `import.meta.env.DEV`.
+5. Tests: controller INTERNAL_ERROR (engine throw and post-commit
+   re-validation throw, Project/revision/undo consistency, subsequent
+   transact still applies), scene-safety helper outcomes, crash-screen
+   static render, and browser tests for boundary reload and degraded-scene
+   recovery.
+
+## Validation
+
+- `git diff --check`
+- `git status --short --branch`
+- `pnpm test:local packages/edit-engine/src/transaction.test.ts apps/editor/src/document/document-controller.test.ts apps/editor/src/app/scene-safety.test.ts apps/editor/src/components/editor-error-boundary.test.tsx`
+- `corepack pnpm typecheck`
+- `pnpm test:e2e:local apps/editor/e2e/runtime-crash-safety.spec.ts`
+- `pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts --grep "recovery"`
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): keep the page alive through render and transaction crashes
+```
+
+## Outcome
+
+Delivered the three evidence-bounded layers. `EditorErrorBoundary` in
+`main.tsx` shows a `role="alert"` recovery screen (reason + Reload editor +
+recovery guidance) instead of a blank page. Formal scene building runs
+through `buildSceneSafely` with a last-good-scene ref: a build failure keeps
+the canvas at the previous coherent view, sets a visible degraded status,
+rethrows only on the very first render (the root boundary owns that), and
+recovers fresh rendering as soon as building succeeds again; the copy
+preview and the fit-view bounds scene fall back quietly. The document
+controller converts engine exceptions and post-commit re-validation failures
+into typed `INTERNAL_ERROR` rejections (additive `EditErrorCode` member) and
+rebuilds the histories from the unchanged Project so the next transaction
+continues from a consistent revision; the App transact wrapper also converts
+wrapper-level throws and clears transient interaction state on
+`INTERNAL_ERROR`. DEV-only window hooks (`__ICM_TEST_RENDER_CRASH__`,
+`__ICM_TEST_SCENE_CRASH__`) drive the browser tests and are eliminated from
+production builds via `import.meta.env.DEV`. Tests: 3 scene-safety outcomes +
+crash-screen static render, 2 controller INTERNAL_ERROR cases (engine throw
+via prototype spy, re-validation throw via partial module mock, both
+asserting unchanged Project/revision and a successful follow-up transaction),
+and 2 browser tests (boundary reload round-trip; degraded stale-scene commit
+that resumes fresh rendering). Validation: 736 unit tests green; 106 E2E
+tests across runtime-crash-safety, drafting, component-insert, and the full
+manual-editor spec green; typecheck, prettier, `git diff --check` clean.
+Deferred by design: stable-shell split, full runCommand executor, and
+commit-time render preflight (no observed failure they would catch).
+
+status: completed
+experience: none

--- a/plan/log.md
+++ b/plan/log.md
@@ -1,5 +1,26 @@
 # Maintenance Log
 
+## 2026-08-15 - Editor runtime crash safety (minimal three layers)
+
+- Target: keep the page alive through render and transaction crashes with the
+  evidence-bounded minimum — root error boundary, last-good-scene fallback,
+  and an INTERNAL_ERROR transaction fence; full shell split, runCommand
+  executor, and render preflight deliberately deferred
+  (`plan/2026-08-15-editor-runtime-crash-safety/`). Executed in a dedicated
+  worktree because the main worktree holds another worker's active dirty
+  target.
+- Changed areas: new `editor-error-boundary.tsx`, `scene-safety.ts`,
+  `crash-test-hooks.ts` (DEV-only), `runtime-crash-safety.spec.ts`; additive
+  `INTERNAL_ERROR` in `EditErrorCode`; `document-controller.ts` fence +
+  history rebuild; `App.tsx` scene guards and transact fence; `main.tsx`
+  boundary mount; crash-screen CSS.
+- Validation: 736 unit tests green (7 new); 106 E2E green (2 new + drafting,
+  component-insert, full manual-editor); typecheck, prettier,
+  `git diff --check` clean.
+- Commit status: committed as
+  `feat(editor): keep the page alive through render and transaction crashes`
+  on `agent/editor-runtime-crash-safety`.
+
 ## 2026-08-15 - Junction-aware VDD rail mainline delivery
 
 - Target: deliver stretchable, junction-aware VDD rail editing from


### PR DESCRIPTION
## Summary

Implements the evidence-bounded minimum agreed in review of the runtime-protection proposal, deferring the stable-shell split, the full `runCommand` executor, and commit-time render preflight (no observed failure they would catch):

- **Root error boundary** (`main.tsx` → `EditorErrorBoundary`): a render crash shows a `role=alert` recovery screen with the failure reason and a Reload action instead of a blank page.
- **Last-good-scene fallback** (`buildSceneSafely` in `App.tsx`): formal scene building failures keep the canvas at the previous coherent view with a visible degraded status and resume fresh rendering as soon as building succeeds; the copy preview and fit-view bounds scenes fall back quietly; a first-render failure rethrows to the root boundary.
- **INTERNAL_ERROR transaction fence** (`document-controller.ts`, additive `EditErrorCode` member): engine exceptions and post-commit re-validation failures become typed rejections with the Project, revision, and histories rebuilt from the unchanged Project, so the next transaction continues from a consistent state; the App transact wrapper converts wrapper-level throws and clears transient interaction state on that code.

DEV-only window hooks (`__ICM_TEST_RENDER_CRASH__`, `__ICM_TEST_SCENE_CRASH__`) drive the browser tests and are eliminated from production builds via `import.meta.env.DEV`.

## Validation

- 7 new unit tests (scene-safety outcomes, crash screen, two INTERNAL_ERROR injection paths with consistency follow-ups) — full suite 736 green.
- 2 new browser tests (boundary reload round-trip; degraded stale-scene commit that resumes rendering) — full E2E suite 126/126 green in `pnpm ci:check` from a clean install.
- `pnpm verify:branch` green (static, unit, build, production smoke).