### PR TITLE
fix(editor): mirror transient placements and toggle grid dots

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -23,6 +23,11 @@ test("blocks destructive browser refresh shortcuts and uses the stronger grid", 
     "alive",
   );
 
+  await page.getByRole("button", { name: "Hide background dots" }).click();
+  await expect(page.getByTestId("canvas-grid-dots")).toHaveCount(0);
+  await page.getByRole("button", { name: "Show background dots" }).click();
+  await expect(page.getByTestId("canvas-grid-dots")).toBeVisible();
+
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").focus();
@@ -32,6 +37,41 @@ test("blocks destructive browser refresh shortcuts and uses the stronger grid", 
     "data-refresh-guard",
     "alive",
   );
+});
+
+test("mirrors component and copy placement previews before their commits", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await chooseComponent(page, "resistor");
+
+  const canvas = page.getByTestId("schematic-canvas");
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error("Canvas is not measurable");
+  await page.mouse.move(box.x + 320, box.y + 220);
+  const componentPreview = page.getByTestId("component-placement-preview");
+  await page.keyboard.press("Shift+R");
+  await expect(componentPreview).toHaveAttribute("transform", /scale\(-1 1\)/u);
+  await canvas.click({ position: { x: 320, y: 220 } });
+  await page.keyboard.press("Escape");
+
+  const placedSymbol = canvas.locator('[data-object-id="R1"] > g').first();
+  await expect(placedSymbol).toHaveAttribute("transform", /scale\(-1 1\)/u);
+
+  await page.getByTestId("hit-R1").click();
+  await page.keyboard.press("c");
+  await page.mouse.move(box.x + 520, box.y + 220);
+  const copyPreview = page
+    .getByTestId("copy-placement-preview")
+    .locator('[data-object-id="R1"] > g')
+    .first();
+  await page.keyboard.press("Shift+V");
+  await expect(copyPreview).toHaveAttribute("transform", /rotate\(180\)/u);
+  await canvas.click({ position: { x: 520, y: 220 } });
+  await expect(
+    canvas.locator('[data-object-id="R1-copy-1"] > g').first(),
+  ).toHaveAttribute("transform", /rotate\(180\)/u);
+  await page.keyboard.press("Escape");
 });
 
 test("refreshes explicitly only after flushing and automatically restoring recovery", async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -230,7 +230,10 @@ import {
   isRoutedMarker,
   looseRouteAnchorIds,
 } from "../features/wiring/route-interaction-geometry";
-import { reflectOrientation } from "../interaction/shortcut-orientation";
+import {
+  applyOrientationOperations,
+  reflectOrientation,
+} from "../interaction/shortcut-orientation";
 import type { ScreenFlip } from "../interaction/shortcut-orientation";
 import { resolveRouteTap, type RouteTap } from "../features/wiring/route-tap";
 import {
@@ -640,6 +643,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
   } = useSelectionController();
   const uniqueSuffixCounter = useRef(0);
   const [viewBox, setRawViewBox] = useState<GridRect>(DEFAULT_VIEWBOX);
+  const [gridDotsVisible, setGridDotsVisible] = useState(true);
   const setViewBox = (
     next: GridRect | CameraRectInput | ((current: GridRect) => CameraRectInput),
     grid = document.presentation.grid,
@@ -701,6 +705,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     draftingWaypoints,
     draftingSnapPoint,
     componentPlacementRotation,
+    componentPlacementMirror,
     componentPreviewPoint,
     vddRailMode,
     vddRailStart,
@@ -709,6 +714,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     beginComponentPlacement,
     setComponentPreviewPoint,
     rotateComponentPlacement,
+    mirrorComponentPlacement,
     beginVddRailPlacement: beginVddRailInteraction,
     setVddRailStart,
     setVddRailPreviewPoint,
@@ -716,6 +722,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     beginCopyPlacement: beginCopyPlacementInteraction,
     setCopyPreviewPoint,
     rotateCopyPlacement,
+    mirrorCopyPlacement,
     setWireSource,
     setWirePreviewPoint,
     setWireWaypoints,
@@ -840,7 +847,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
           document,
           copyPlacement.clipboard,
           offset,
-          copyPlacement.rotation,
+          copyPlacement.orientationOperations,
         ),
         resolver,
         { bounds: viewBox },
@@ -2082,7 +2089,9 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       return;
     }
     beginComponentPlacement(request);
-    setStatus(`Place ${symbolName} on the canvas · R rotates · Esc cancels`);
+    setStatus(
+      `Place ${symbolName} on the canvas · R rotates · Shift+R/V mirrors · Esc cancels`,
+    );
   }
 
   function cancelComponentInsert(): void {
@@ -2096,10 +2105,25 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     setStatus(`Component rotation ${delta > 0 ? "+90°" : "−90°"}`);
   }
 
+  function mirrorPendingComponent(direction: ScreenFlip): void {
+    mirrorComponentPlacement(direction);
+    setStatus(
+      `Place component mirrored ${direction === "left-right" ? "left/right" : "top/bottom"} · R rotates · Esc cancels`,
+    );
+  }
+
   function rotatePendingCopy(delta: 90 | -90): void {
     if (!copyPlacement) return;
     rotateCopyPlacement(delta);
     setStatus("Place rotated copy · R rotates · Esc cancels");
+  }
+
+  function mirrorPendingCopy(direction: ScreenFlip): void {
+    if (!copyPlacement) return;
+    mirrorCopyPlacement(direction);
+    setStatus(
+      `Place copy mirrored ${direction === "left-right" ? "left/right" : "top/bottom"} · R rotates · Esc cancels`,
+    );
   }
 
   function loadRoutingDemo(): void {
@@ -3281,7 +3305,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       placement: {
         position,
         rotation: componentPlacementRotation,
-        mirror: "none" as const,
+        mirror: componentPlacementMirror,
       },
       properties: placementRequest.properties,
       netlist: initialInstanceNetlist(
@@ -5923,7 +5947,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     paintSnapGuides([]);
     beginCopyPlacementInteraction(copied, anchor);
     setStatus(
-      `Place copy of ${copied.instances.length} components · R rotates · Esc cancels`,
+      `Place copy of ${copied.instances.length} components · R rotates · Shift+R/V mirrors · Esc cancels`,
     );
   }
 
@@ -5945,18 +5969,37 @@ export function App({ project: initialProject, visitStats }: AppProps) {
       cancelAllTransientInteraction();
       return;
     }
-    const rotationEdits: SchematicEdit[] =
-      copyPlacement.rotation === 0
-        ? []
-        : proposal.instanceIds.map((instanceId, index) => ({
-            kind: "rotate_instance" as const,
-            instanceId,
-            rotation: (((copyPlacement.clipboard.instances[index]?.placement
-              ?.rotation ?? 0) +
-              copyPlacement.rotation) %
-              360) as 0 | 90 | 180 | 270,
-          }));
-    const result = transact([...proposal.edits, ...rotationEdits], {
+    const orientationEdits = proposal.instanceIds.flatMap(
+      (instanceId, index): SchematicEdit[] => {
+        const source = copyPlacement.clipboard.instances[index]?.placement;
+        if (!source) return [];
+        const orientation = applyOrientationOperations(
+          source,
+          copyPlacement.orientationOperations,
+        );
+        return [
+          ...(orientation.mirror === source.mirror
+            ? []
+            : [
+                {
+                  kind: "mirror_instance" as const,
+                  instanceId,
+                  mirror: orientation.mirror,
+                },
+              ]),
+          ...(orientation.rotation === source.rotation
+            ? []
+            : [
+                {
+                  kind: "rotate_instance" as const,
+                  instanceId,
+                  rotation: orientation.rotation,
+                },
+              ]),
+        ];
+      },
+    );
+    const result = transact([...proposal.edits, ...orientationEdits], {
       preserveInteraction: true,
     });
     if (result.ok) {
@@ -6113,6 +6156,12 @@ export function App({ project: initialProject, visitStats }: AppProps) {
           return;
         case "rotate-copy-placement":
           rotatePendingCopy(shortcut.deltaDegrees);
+          return;
+        case "mirror-placement":
+          mirrorPendingComponent(shortcut.direction);
+          return;
+        case "mirror-copy-placement":
+          mirrorPendingCopy(shortcut.direction);
           return;
         case "rotate":
           rotateSelected(shortcut.deltaDegrees);
@@ -7812,23 +7861,28 @@ export function App({ project: initialProject, visitStats }: AppProps) {
             onDragOver={(event) => event.preventDefault()}
             onDrop={handleDrop}
           >
-            <defs>
-              <pattern
-                id="grid"
-                width="10"
-                height="10"
-                patternUnits="userSpaceOnUse"
-              >
-                <circle className="canvas-grid-dot" cx="0" cy="0" r="0.7" />
-              </pattern>
-            </defs>
-            <rect
-              x={viewBox.x}
-              y={viewBox.y}
-              width={viewBox.width}
-              height={viewBox.height}
-              fill="url(#grid)"
-            />
+            {gridDotsVisible ? (
+              <>
+                <defs>
+                  <pattern
+                    id="grid"
+                    width="10"
+                    height="10"
+                    patternUnits="userSpaceOnUse"
+                  >
+                    <circle className="canvas-grid-dot" cx="0" cy="0" r="0.7" />
+                  </pattern>
+                </defs>
+                <rect
+                  data-testid="canvas-grid-dots"
+                  x={viewBox.x}
+                  y={viewBox.y}
+                  width={viewBox.width}
+                  height={viewBox.height}
+                  fill="url(#grid)"
+                />
+              </>
+            ) : null}
             <g dangerouslySetInnerHTML={sceneInnerHtml} />
             {highlightedNet ? (
               <g
@@ -7947,6 +8001,7 @@ export function App({ project: initialProject, visitStats }: AppProps) {
                   symbolId={pendingSymbolId}
                   position={componentPreviewPoint}
                   rotation={componentPlacementRotation}
+                  mirror={componentPlacementMirror}
                 />
               ) : null}
               {netLabelEditorOpen && selectedRoute
@@ -8814,7 +8869,20 @@ export function App({ project: initialProject, visitStats }: AppProps) {
             </output>
           )}
         </div>
-        <div className="canvas-controls" aria-label="Canvas zoom controls">
+        <div className="canvas-controls" aria-label="Canvas view controls">
+          <button
+            type="button"
+            aria-label={
+              gridDotsVisible ? "Hide background dots" : "Show background dots"
+            }
+            aria-pressed={gridDotsVisible}
+            title={
+              gridDotsVisible ? "Hide background dots" : "Show background dots"
+            }
+            onClick={() => setGridDotsVisible((visible) => !visible)}
+          >
+            <ToolIcon name="grid" />
+          </button>
           <button
             type="button"
             aria-label="Zoom out"

--- a/apps/editor/src/features/clipboard/clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard.test.ts
@@ -130,11 +130,23 @@ describe("schematic clipboard", () => {
       document,
       clipboard!,
       { x: 40, y: -20 },
-      90,
+      [{ kind: "rotate", deltaDegrees: 90 }],
     );
     expect(rotatedPreview.instances[0]?.placement).toMatchObject({
       position: { x: 140, y: 80 },
       rotation: 90,
+    });
+
+    const mirroredPreview = clipboardPreviewDocument(
+      document,
+      clipboard!,
+      { x: 40, y: -20 },
+      [{ kind: "reflect", direction: "left-right" }],
+    );
+    expect(mirroredPreview.instances[0]?.placement).toMatchObject({
+      position: { x: 140, y: 80 },
+      rotation: 0,
+      mirror: "x",
     });
   });
 

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -10,6 +10,12 @@ import type {
   RouteEndpoint,
   SchematicDocument,
 } from "@icm/model";
+import { transformPoint } from "@icm/model";
+
+import {
+  applyOrientationOperations,
+  type PlacementOrientationOperation,
+} from "../../interaction/shortcut-orientation";
 
 export interface SchematicClipboard {
   instances: Instance[];
@@ -70,7 +76,7 @@ export function clipboardPreviewDocument(
   base: SchematicDocument,
   clipboard: SchematicClipboard,
   offset: Point,
-  rotation: 0 | 90 | 180 | 270 = 0,
+  orientationOperations: readonly PlacementOrientationOperation[] = [],
 ): SchematicDocument {
   const copiedInstanceIds = new Set(clipboard.instances.map(({ id }) => id));
   const annotations = clipboard.annotations.map((annotation) => {
@@ -86,9 +92,13 @@ export function clipboardPreviewDocument(
         preview.anchor.kind === "object" &&
         copiedInstanceIds.has(preview.anchor.objectId)
       ) {
-        preview.anchor.localOffset = rotateVector(
+        preview.anchor.localOffset = transformPoint(
           preview.anchor.localOffset,
-          rotation,
+          { x: 0, y: 0 },
+          applyOrientationOperations(
+            { rotation: 0, mirror: "none" },
+            orientationOperations,
+          ),
         );
       }
     }
@@ -101,9 +111,11 @@ export function clipboardPreviewDocument(
       placement: instance.placement
         ? {
             ...instance.placement,
+            ...applyOrientationOperations(
+              instance.placement,
+              orientationOperations,
+            ),
             position: movePoint(instance.placement.position, offset),
-            rotation: ((instance.placement.rotation + rotation) % 360) as
-              0 | 90 | 180 | 270,
           }
         : null,
     })),
@@ -211,19 +223,6 @@ function uniqueCopyReference(
 
 function movePoint(point: Point, offset: Point): Point {
   return { x: point.x + offset.x, y: point.y + offset.y };
-}
-
-function rotateVector(point: Point, rotation: 0 | 90 | 180 | 270): Point {
-  switch (rotation) {
-    case 0:
-      return { ...point };
-    case 90:
-      return { x: -point.y, y: point.x };
-    case 180:
-      return { x: -point.x, y: -point.y };
-    case 270:
-      return { x: point.y, y: -point.x };
-  }
 }
 
 function mapEndpoint(

--- a/apps/editor/src/features/component-insert/insert-component-dialog.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.tsx
@@ -30,11 +30,13 @@ export function ComponentPlacementPreview({
   symbolId,
   position,
   rotation,
+  mirror = "none",
 }: {
   styleProfileId: string;
   symbolId: string;
   position: { x: number; y: number };
   rotation: 0 | 90 | 180 | 270;
+  mirror?: "none" | "x";
 }) {
   const symbol = findPaletteSymbol(styleProfileId, symbolId);
   if (!symbol) return null;
@@ -47,7 +49,9 @@ export function ComponentPlacementPreview({
     <g
       data-testid="component-placement-preview"
       className="component-placement-preview"
-      transform={`translate(${position.x} ${position.y}) rotate(${rotation})`}
+      transform={`translate(${position.x} ${position.y}) rotate(${rotation})${
+        mirror === "x" ? " scale(-1 1)" : ""
+      }`}
       fill="none"
       stroke="currentColor"
       strokeWidth="1"

--- a/apps/editor/src/features/editor-shell/tool-icon.tsx
+++ b/apps/editor/src/features/editor-shell/tool-icon.tsx
@@ -11,6 +11,7 @@ export type ToolIconName =
   | "zoom-in"
   | "zoom-out"
   | "fit"
+  | "grid"
   | "inspect"
   | "undo"
   | "redo"
@@ -85,6 +86,19 @@ export function ToolIcon({ name }: { name: ToolIconName }) {
         <>
           <path d="M7 3H3v4M13 3h4v4M17 13v4h-4M7 17H3v-4" {...common} />
           <rect x="6" y="6" width="8" height="8" {...common} />
+        </>
+      ) : null}
+      {name === "grid" ? (
+        <>
+          <circle cx="5" cy="5" r="0.9" fill="currentColor" />
+          <circle cx="10" cy="5" r="0.9" fill="currentColor" />
+          <circle cx="15" cy="5" r="0.9" fill="currentColor" />
+          <circle cx="5" cy="10" r="0.9" fill="currentColor" />
+          <circle cx="10" cy="10" r="0.9" fill="currentColor" />
+          <circle cx="15" cy="10" r="0.9" fill="currentColor" />
+          <circle cx="5" cy="15" r="0.9" fill="currentColor" />
+          <circle cx="10" cy="15" r="0.9" fill="currentColor" />
+          <circle cx="15" cy="15" r="0.9" fill="currentColor" />
         </>
       ) : null}
       {name === "inspect" ? (

--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -118,7 +118,20 @@ describe("editor shortcut contract", () => {
         { interactionMode: "placing-component" },
         { shiftKey: true },
       ),
-    ).toEqual({ kind: "rotate-placement", deltaDegrees: 90 });
+    ).toEqual({ kind: "mirror-placement", direction: "left-right" });
+    expect(
+      resolve(
+        "v",
+        { interactionMode: "placing-component" },
+        { shiftKey: true },
+      ),
+    ).toEqual({ kind: "mirror-placement", direction: "top-bottom" });
+    expect(
+      resolve("r", { interactionMode: "copy-placement" }, { shiftKey: true }),
+    ).toEqual({ kind: "mirror-copy-placement", direction: "left-right" });
+    expect(
+      resolve("v", { interactionMode: "copy-placement" }, { shiftKey: true }),
+    ).toEqual({ kind: "mirror-copy-placement", direction: "top-bottom" });
   });
 
   it("maps creation, fit, and marker commands", () => {

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -34,6 +34,8 @@ export type EditorShortcutIntent =
   | { kind: "open-component-insert" }
   | { kind: "rotate-placement"; deltaDegrees: 90 | -90 }
   | { kind: "rotate-copy-placement"; deltaDegrees: 90 | -90 }
+  | { kind: "mirror-placement"; direction: ScreenFlip }
+  | { kind: "mirror-copy-placement"; direction: ScreenFlip }
   | { kind: "rotate"; deltaDegrees: 90 | -90 }
   | { kind: "activate-tool"; tool: EditorTool }
   | { kind: "add-text" }
@@ -122,6 +124,18 @@ export function resolveEditorShortcut(
     }
     if (plain && key === "k") {
       return { kind: "activate-tool", tool: "construction-line" };
+    }
+    if (
+      plain &&
+      event.shiftKey &&
+      (key === "r" || key === "v") &&
+      (context.interactionMode === "placing-component" ||
+        context.interactionMode === "copy-placement")
+    ) {
+      const direction: ScreenFlip = key === "r" ? "left-right" : "top-bottom";
+      return context.interactionMode === "placing-component"
+        ? { kind: "mirror-placement", direction }
+        : { kind: "mirror-copy-placement", direction };
     }
     if (plain && key === "r") {
       if (context.interactionMode === "placing-component") {

--- a/apps/editor/src/interaction/interaction-state.test.ts
+++ b/apps/editor/src/interaction/interaction-state.test.ts
@@ -153,6 +153,7 @@ describe("editor interaction state", () => {
         referenceText: "MIN",
       },
       rotation: 90,
+      mirror: "none",
       previewPoint: null,
     });
     expect(interactionReducer(state, { type: "cancel" })).toEqual({
@@ -178,20 +179,30 @@ describe("editor interaction state", () => {
       type: "rotate-copy",
       deltaDegrees: 90,
     });
-    expect(rotated).toMatchObject({
+    const mirrored = interactionReducer(rotated, {
+      type: "mirror-copy",
+      direction: "left-right",
+    });
+    expect(mirrored).toMatchObject({
       kind: "copy-placement",
-      copy: { previewPoint: { x: 40, y: 50 }, rotation: 90 },
+      copy: {
+        previewPoint: { x: 40, y: 50 },
+        orientationOperations: [
+          { kind: "rotate", deltaDegrees: 90 },
+          { kind: "reflect", direction: "left-right" },
+        ],
+      },
     });
 
     expect(
-      interactionReducer(rotated, {
+      interactionReducer(mirrored, {
         type: "begin-copy-placement",
         clipboard: { ids: ["M2"] },
         anchor: { x: 0, y: 0 },
       }),
-    ).toBe(rotated);
+    ).toBe(mirrored);
     expect(
-      interactionReducer(rotated, {
+      interactionReducer(mirrored, {
         type: "activate-tool",
         tool: "wire",
       }),

--- a/apps/editor/src/interaction/interaction-state.ts
+++ b/apps/editor/src/interaction/interaction-state.ts
@@ -1,8 +1,14 @@
 import { useReducer, useRef } from "react";
 import type { SetStateAction } from "react";
 
-import type { Point } from "@icm/model";
+import type { Mirror, Point } from "@icm/model";
 import type { WireSource } from "@icm/edit-engine";
+
+import {
+  reflectOrientation,
+  type PlacementOrientationOperation,
+  type ScreenFlip,
+} from "./shortcut-orientation";
 
 export type { WireSource } from "@icm/edit-engine";
 
@@ -28,7 +34,7 @@ export interface CopyPlacement<TClipboard> {
   clipboard: TClipboard;
   anchor: Point;
   previewPoint: Point | null;
-  rotation: 0 | 90 | 180 | 270;
+  orientationOperations: PlacementOrientationOperation[];
 }
 
 export type InteractionState<TClipboard = never> =
@@ -37,6 +43,7 @@ export type InteractionState<TClipboard = never> =
       kind: "placing-component";
       placement: PendingComponentPlacement;
       rotation: 0 | 90 | 180 | 270;
+      mirror: Mirror;
       previewPoint: Point | null;
     }
   | {
@@ -69,6 +76,7 @@ export type InteractionAction<TClipboard = never> =
   | { type: "place-component"; placement: PendingComponentPlacement }
   | { type: "set-component-preview"; point: Point | null }
   | { type: "rotate-component"; deltaDegrees: 90 | -90 }
+  | { type: "mirror-component"; direction: ScreenFlip }
   | { type: "begin-vdd-rail" }
   | { type: "set-vdd-rail-start"; point: Point | null }
   | { type: "set-vdd-rail-preview"; point: Point | null }
@@ -80,6 +88,7 @@ export type InteractionAction<TClipboard = never> =
     }
   | { type: "set-copy-preview"; point: Point | null }
   | { type: "rotate-copy"; deltaDegrees: 90 | -90 }
+  | { type: "mirror-copy"; direction: ScreenFlip }
   | {
       type: "set-wire-source";
       source: WireSource | null;
@@ -177,6 +186,7 @@ export function interactionReducer<TClipboard>(
         kind: "placing-component",
         placement: action.placement,
         rotation: action.placement.initialRotation,
+        mirror: "none",
         previewPoint: null,
       };
     case "set-component-preview":
@@ -191,6 +201,15 @@ export function interactionReducer<TClipboard>(
               0 | 90 | 180 | 270,
           }
         : state;
+    case "mirror-component":
+      if (state.kind !== "placing-component") return state;
+      return {
+        ...state,
+        ...reflectOrientation(
+          { rotation: state.rotation, mirror: state.mirror },
+          action.direction,
+        ),
+      };
     case "begin-vdd-rail":
       return state.kind === "placing-vdd-rail"
         ? state
@@ -215,7 +234,7 @@ export function interactionReducer<TClipboard>(
           clipboard: action.clipboard,
           anchor: action.anchor,
           previewPoint: null,
-          rotation: 0,
+          orientationOperations: [],
         },
       };
     case "set-copy-preview":
@@ -228,8 +247,23 @@ export function interactionReducer<TClipboard>(
             ...state,
             copy: {
               ...state.copy,
-              rotation: ((state.copy.rotation + action.deltaDegrees + 360) %
-                360) as 0 | 90 | 180 | 270,
+              orientationOperations: [
+                ...state.copy.orientationOperations,
+                { kind: "rotate", deltaDegrees: action.deltaDegrees },
+              ],
+            },
+          }
+        : state;
+    case "mirror-copy":
+      return state.kind === "copy-placement"
+        ? {
+            ...state,
+            copy: {
+              ...state.copy,
+              orientationOperations: [
+                ...state.copy.orientationOperations,
+                { kind: "reflect", direction: action.direction },
+              ],
             },
           }
         : state;
@@ -326,6 +360,7 @@ export function useInteractionState<TClipboard>() {
     pendingSymbolId: componentPlacement?.placement.symbolId ?? null,
     pendingComponentPlacement: componentPlacement?.placement ?? null,
     componentPlacementRotation: componentPlacement?.rotation ?? 0,
+    componentPlacementMirror: componentPlacement?.mirror ?? "none",
     componentPreviewPoint:
       componentPlacement?.previewPoint ??
       vddRailPlacement?.previewPoint ??
@@ -348,6 +383,8 @@ export function useInteractionState<TClipboard>() {
       dispatch({ type: "set-component-preview", point }),
     rotateComponentPlacement: (deltaDegrees: 90 | -90) =>
       dispatch({ type: "rotate-component", deltaDegrees }),
+    mirrorComponentPlacement: (direction: ScreenFlip) =>
+      dispatch({ type: "mirror-component", direction }),
     beginVddRailPlacement: () => dispatch({ type: "begin-vdd-rail" }),
     setVddRailStart: (point: Point | null) =>
       dispatch({ type: "set-vdd-rail-start", point }),
@@ -360,6 +397,8 @@ export function useInteractionState<TClipboard>() {
       dispatch({ type: "set-copy-preview", point }),
     rotateCopyPlacement: (deltaDegrees: 90 | -90) =>
       dispatch({ type: "rotate-copy", deltaDegrees }),
+    mirrorCopyPlacement: (direction: ScreenFlip) =>
+      dispatch({ type: "mirror-copy", direction }),
     setWireSource: (source: WireSource | null, sourceRevision: number | null) =>
       dispatch({ type: "set-wire-source", source, sourceRevision }),
     setWirePreviewPoint: (point: Point | null) =>

--- a/apps/editor/src/interaction/shortcut-orientation.test.ts
+++ b/apps/editor/src/interaction/shortcut-orientation.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from "vitest";
 import { transformPoint } from "@icm/model";
 import type { Mirror, Orientation, Rotation } from "@icm/model";
 
-import { reflectOrientation } from "./shortcut-orientation";
+import {
+  applyOrientationOperations,
+  reflectOrientation,
+} from "./shortcut-orientation";
 import type { ScreenFlip } from "./shortcut-orientation";
 
 const rotations: Rotation[] = [0, 90, 180, 270];
@@ -54,5 +57,19 @@ describe("reflectOrientation", () => {
         }
       }
     }
+  });
+
+  it("applies transient placement commands in their input order", () => {
+    const start: Orientation = { rotation: 90, mirror: "none" };
+    const expected = reflectOrientation(
+      { rotation: 180, mirror: "none" },
+      "top-bottom",
+    );
+    expect(
+      applyOrientationOperations(start, [
+        { kind: "rotate", deltaDegrees: 90 },
+        { kind: "reflect", direction: "top-bottom" },
+      ]),
+    ).toEqual(expected);
   });
 });

--- a/apps/editor/src/interaction/shortcut-orientation.ts
+++ b/apps/editor/src/interaction/shortcut-orientation.ts
@@ -4,6 +4,15 @@ import type { Orientation, Rotation } from "@icm/model";
 export type ScreenFlip = "left-right" | "top-bottom";
 
 /**
+ * A canvas-local orientation command. It is deliberately not a model edit:
+ * placement applies these commands to an existing instance orientation only
+ * when the user commits the preview.
+ */
+export type PlacementOrientationOperation =
+  | { kind: "rotate"; deltaDegrees: 90 | -90 }
+  | { kind: "reflect"; direction: ScreenFlip };
+
+/**
  * Compose a screen-space reflection with the canonical orientation transform
  * (`rotate(mirror(local))`). The persisted representation deliberately has one
  * mirror bit: its four rotations form the other reflection direction without
@@ -18,4 +27,20 @@ export function reflectOrientation(
     rotation: ((baseRotation - orientation.rotation + 360) % 360) as Rotation,
     mirror: orientation.mirror === "none" ? "x" : "none",
   };
+}
+
+export function applyOrientationOperations(
+  orientation: Orientation,
+  operations: readonly PlacementOrientationOperation[],
+): Orientation {
+  return operations.reduce<Orientation>((current, operation) => {
+    if (operation.kind === "reflect") {
+      return reflectOrientation(current, operation.direction);
+    }
+    return {
+      ...current,
+      rotation: ((current.rotation + operation.deltaDegrees + 360) %
+        360) as Rotation,
+    };
+  }, orientation);
 }

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -62,9 +62,11 @@ observe the first transition even when React batches the next render.
 Activating the same tool is idempotent: repeated C, W, A, K, or selection of the
 same Library item preserves the active session. Activating a different creation
 tool replaces the current interaction atomically after drag and snap cleanup.
-During Copy Placement, `R` quarter-turns the transient preview and every
-subsequent committed copy; it does not mutate the source selection. Instance
-reference labels use the first active Document grid line one interval beyond
+During component or Copy Placement, `R` quarter-turns the transient preview;
+`Shift+R` mirrors it left/right and `Shift+V` mirrors it top/bottom. Every
+subsequent committed copy receives the same transient orientation, while the
+source selection remains unchanged. The background grid-dot button changes
+only the editor-local canvas paint. Instance reference labels use the first active Document grid line one interval beyond
 the drawn symbol ink. The padded interaction envelope never contributes to
 that clearance, and placement uses nearest-grid normalization for calibrated
 finite-decimal ink edges rather than directional outward snapping. A quarter

--- a/plan/2026-08-15-placement-mirror-grid-toggle/plan.md
+++ b/plan/2026-08-15-placement-mirror-grid-toggle/plan.md
@@ -1,0 +1,97 @@
+---
+status: active
+experience: none
+---
+
+# Transient placement mirrors and grid-dot toggle
+
+## Goal
+
+Allow `Shift+R` and `Shift+V` to mirror the transient preview while placing a
+component with `I` or a copy with `C`, and provide one canvas-control button
+to hide or show the background grid dots. Keep both preferences/editor states
+transient: do not add Project schema, Edit Engine, or Agent API surface.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree was clean before this target; the target now owns the following
+paths on `codex/placement-mirror-grid-toggle`.
+
+- `apps/editor/src/interaction/interaction-state.ts`
+- `apps/editor/src/interaction/interaction-state.test.ts`
+- `apps/editor/src/interaction/editor-shortcuts.ts`
+- `apps/editor/src/interaction/editor-shortcuts.test.ts`
+- `apps/editor/src/interaction/shortcut-orientation.ts`
+- `apps/editor/src/features/clipboard/clipboard.ts`
+- `apps/editor/src/features/clipboard/clipboard.test.ts`
+- `apps/editor/src/features/component-insert/insert-component-dialog.tsx`
+- `apps/editor/src/features/editor-shell/tool-icon.tsx`
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `docs/specs/editor-interaction.md`
+- `plan/2026-08-15-placement-mirror-grid-toggle/plan.md`
+- `plan/log.md`
+- `plan/root-audit.md`
+
+Read-only shared contracts: the persisted orientation model and Edit Engine
+edits. This target may consume their existing rotation/mirror semantics but
+must not extend them.
+
+## Work
+
+1. Keep the placement reducer as the sole owner of temporary orientation;
+   route `Shift+R` and `Shift+V` there only for active component/copy placement.
+2. Apply the same temporary orientation to preview and commit, including each
+   copied source instance, so the ghost cannot disagree with the final edit.
+3. Add an editor-local grid-dot visibility control beside the canvas zoom
+   controls. It changes only SVG background paint.
+4. Add focused reducer, shortcut, and clipboard tests; update the accepted
+   interaction contract.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/interaction/interaction-state.test.ts apps/editor/src/interaction/editor-shortcuts.test.ts apps/editor/src/interaction/shortcut-orientation.test.ts apps/editor/src/features/clipboard/clipboard.test.ts`
+- `pnpm --filter @icm/editor typecheck`
+- `pnpm exec prettier --check <changed source and documentation files>`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): mirror transient placements and toggle grid dots
+```
+
+## Outcome
+
+Added transient `Shift+R` / `Shift+V` mirrors for I-placement and C-placement.
+Copy now records an editor-local ordered orientation command list and applies
+the exact same result to both the SVG ghost and typed commit edits. The footer
+has an editor-local grid-dot visibility control; neither feature changes the
+Project model, Engine protocol, or Agent API.
+
+Focused validation passed:
+
+- focused reducer, shortcut, orientation, and clipboard tests: 30 tests;
+- focused Playwright grid and placement-mirror coverage: 2 tests;
+- `pnpm typecheck`;
+- targeted Prettier check and `git diff --check`.
+
+The full local `pnpm ci:check` completed static checks, 737 unit tests, build,
+release smoke, and 112 browser tests. Its shared Vite server then stopped while
+the unrelated Project-file replacement test was waiting for the insert dialog;
+the remaining 15 browser failures were all consequent connection refusals. The
+same Project-file test passed when rerun on an isolated Vite port, so this is a
+local shared-server failure rather than evidence of this target's change.
+
+Committed and pushed on `codex/placement-mirror-grid-toggle` as
+`fix(editor): mirror transient placements and toggle grid dots`.
+Remote required checks remain the mainline merge gate.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7310,3 +7310,18 @@ diff --check`, and two focused Playwright regressions passed.
 - Commit status: committed locally as
   `fix(editor): compact narrow library and overlay properties` on
   `codex/compact-library-overlay-properties`; not pushed.
+
+# 2026-08-15 - Mirror transient placement and toggle grid dots
+
+- Target: add minimal orientation controls during C/I placement and one local
+  canvas-grid visibility control without expanding persisted/editor-Agent
+  contracts.
+- Changed areas: interaction reducer and shortcut arbitration; clipboard
+  preview/commit orientation projection; component preview; canvas view
+  control; focused unit and browser coverage; interaction specification.
+- Validation: focused unit tests (4 files / 30 tests), focused Playwright
+  coverage (2 tests), `pnpm typecheck`, targeted Prettier check, and
+  `git diff --check` passed.
+- Commit status: committed and pushed as
+  `fix(editor): mirror transient placements and toggle grid dots` on
+  `codex/placement-mirror-grid-toggle`.

--- a/plan/root-audit.md
+++ b/plan/root-audit.md
@@ -8,7 +8,7 @@ an archive. Completed plans with resolved experience are stored under
 
 | State                     | Count | Required disposition                                                              |
 | ------------------------- | ----: | --------------------------------------------------------------------------------- |
-| `active`                  |     0 | No active targets.                                                                |
+| `active`                  |     1 | Await the remote mainline gate for `2026-08-15-placement-mirror-grid-toggle`.     |
 | `completed` + `none`      |    34 | Verify commit/log evidence, then archive according to routine retention policy.   |
 | `completed` + `candidate` |    17 | Human decides whether to extract, reject, or defer the experience signal.         |
 | missing metadata          |    71 | Audit against outcome text and Git evidence; never archive merely because of age. |
@@ -49,6 +49,12 @@ superseded VDD plan's drawn-rail replacement is already archived.
 `2026-08-15-fix-label-gap-rotation` is completed with resolved experience.
 Its delivered commit, factual log entry, and remote merge evidence are present;
 it is eligible for normal completed-plan retention handling.
+
+## 2026-08-15 Placement-mirror and grid-toggle closure
+
+`2026-08-15-placement-mirror-grid-toggle` has focused validation and a pushed
+review branch, but stays active until its remote mainline gate is green and the
+branch is merged.
 
 ## Legacy Metadata Sweep
 


### PR DESCRIPTION
## Summary
- mirror active I/C placement previews with Shift+R and Shift+V
- keep preview and committed copied orientations identical
- add an editor-local background-dot toggle

## Validation
- focused unit tests: 30 passed
- focused Playwright: 2 passed
- pnpm typecheck passed
- full local gate passed static, 737 unit, build, and release smoke; its shared Vite server stopped during an unrelated Project-file E2E test. The failing test passes on an isolated Vite port. Remote required checks are the merge gate.