### PR TITLE
feat(editor): hide public Agent controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Analog Canvas
 
-Analog Canvas is a local-first, connectivity-aware schematic editor for human
-and Agent collaboration. Import structural SPICE, edit a typed circuit model in
-the browser, save one portable Project file, export formal drawings, or grant a
-bounded external Agent access to the same revisioned edit engine.
+Analog Canvas is a local-first, connectivity-aware schematic editor. Import
+structural SPICE, edit a typed circuit model in the browser, save one portable
+Project file, and export formal drawings.
 
 ## Start here
 
@@ -15,8 +14,6 @@ bounded external Agent access to the same revisioned edit engine.
 - **Develop or contribute:** [working rules](AGENTS.md),
   [current development reading set](docs/current/README.md), and
   [validation commands](#validation).
-- **Connect an Agent:** [Agent workflow](docs/agent/workflow.md) and
-  [public API usage](docs/agent/api-usage.md).
 
 ## Run locally
 
@@ -32,10 +29,10 @@ files. Use **File / Save Project** to download the authoritative
 
 ## What the repository contains
 
-- `apps/editor/`: React/SVG editor and browser-authoritative Agent host.
+- `apps/editor/`: React/SVG editor.
 - `apps/local-host/`: loopback-only production host for the installable PWA.
 - `packages/model/` and `packages/edit-engine/`: persisted circuit model and
-  atomic human/Agent mutation boundary.
+  atomic mutation boundary.
 - `packages/spice/`, `packages/symbols/`, and `packages/netlist/`: structural
   SPICE import, symbol semantics, and deterministic design-netlist export.
 - `packages/exporters/` and `packages/render-svg/`: formal SVG, PNG, and PDF

--- a/apps/editor/src/agent/public-agent-ui.test.ts
+++ b/apps/editor/src/agent/public-agent-ui.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { resolvePublicAgentUiEnabled } from "./public-agent-ui";
+
+describe("resolvePublicAgentUiEnabled", () => {
+  it("keeps local development available but makes production human-only", () => {
+    expect(resolvePublicAgentUiEnabled({ production: false })).toBe(true);
+    expect(resolvePublicAgentUiEnabled({ production: true })).toBe(false);
+  });
+
+  it("allows an explicit staging or local override", () => {
+    expect(
+      resolvePublicAgentUiEnabled({ production: true, configured: "enabled" }),
+    ).toBe(true);
+    expect(
+      resolvePublicAgentUiEnabled({
+        production: false,
+        configured: "disabled",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/editor/src/agent/public-agent-ui.ts
+++ b/apps/editor/src/agent/public-agent-ui.ts
@@ -1,0 +1,20 @@
+/**
+ * Controls whether the browser exposes the human-facing Agent connection UI.
+ *
+ * The machine API and the MCP adapter intentionally do not depend on this
+ * flag.  A production deployment is human-only by default; local development
+ * and staging can opt in with VITE_ICM_AGENT_UI=enabled.
+ */
+export function resolvePublicAgentUiEnabled(input: {
+  production: boolean;
+  configured?: string;
+}): boolean {
+  if (input.configured === "enabled") return true;
+  if (input.configured === "disabled") return false;
+  return !input.production;
+}
+
+export const PUBLIC_AGENT_UI_ENABLED = resolvePublicAgentUiEnabled({
+  production: import.meta.env.PROD,
+  configured: import.meta.env.VITE_ICM_AGENT_UI,
+});

--- a/apps/editor/src/agent/use-agent-session.ts
+++ b/apps/editor/src/agent/use-agent-session.ts
@@ -128,6 +128,12 @@ export interface AgentSessionViewModel {
 }
 
 export interface UseAgentSessionOptions {
+  /**
+   * Disables all browser-side Agent lifecycle work.  This is deliberately a
+   * UI/host switch, not an API gate: MCP and loopback deployments remain
+   * independently available.
+   */
+  enabled: boolean;
   project: CircuitProject;
   projectSessionId: string;
   host: AgentOperationHost;
@@ -211,6 +217,7 @@ export function useAgentSession(
 
   const control = useCallback(
     async (action: "pause" | "resume" | "revoke" | "replace-project") => {
+      if (!options.enabled) return;
       const live = liveRef.current;
       if (!live) return;
       const response = await fetch(
@@ -227,10 +234,11 @@ export function useAgentSession(
       if (!response.ok)
         throw new Error(`Session control failed (${response.status})`);
     },
-    [],
+    [options.enabled],
   );
 
   const revoke = useCallback(async () => {
+    if (!options.enabled) return;
     const live = liveRef.current;
     if (!live) {
       clearAgentSessionRecovery(window.localStorage);
@@ -253,13 +261,14 @@ export function useAgentSession(
       claimExpiresAt: null,
       error: null,
     });
-  }, [control, options.fileHost, update]);
+  }, [control, options.enabled, options.fileHost, update]);
 
   const grant = useCallback(
     async (
       scopes: readonly AgentSessionScope[],
       recovery?: AgentSessionRecoveryRecord,
     ) => {
+      if (!options.enabled) return;
       if (liveRef.current) await revoke();
       lastScopesRef.current = [...scopes];
       update({
@@ -663,6 +672,7 @@ export function useAgentSession(
     },
     [
       options.fileHost,
+      options.enabled,
       options.host,
       options.project,
       options.projectSessionId,
@@ -672,6 +682,7 @@ export function useAgentSession(
   );
 
   useEffect(() => {
+    if (!options.enabled) return;
     if (recoveryAttemptedForProjectRef.current === options.projectSessionId) {
       return;
     }
@@ -682,9 +693,10 @@ export function useAgentSession(
       now: Date.now(),
     });
     if (recovery) void grant(recovery.scopes, recovery);
-  }, [grant, options.project.id, options.projectSessionId]);
+  }, [grant, options.enabled, options.project.id, options.projectSessionId]);
 
   const pause = useCallback(async () => {
+    if (!options.enabled) return;
     try {
       await control("pause");
       update({ status: "paused", error: null });
@@ -693,9 +705,10 @@ export function useAgentSession(
         error: error instanceof Error ? error.message : String(error),
       });
     }
-  }, [control, update]);
+  }, [control, options.enabled, update]);
 
   const resume = useCallback(async () => {
+    if (!options.enabled) return;
     try {
       await control("resume");
       update({
@@ -707,9 +720,10 @@ export function useAgentSession(
         error: error instanceof Error ? error.message : String(error),
       });
     }
-  }, [control, update]);
+  }, [control, options.enabled, update]);
 
   const reconnect = useCallback(() => {
+    if (!options.enabled) return;
     const live = liveRef.current;
     if (!live || Date.now() >= live.expiresAt) return;
     if (live.reconnectTimer !== null) {
@@ -720,9 +734,10 @@ export function useAgentSession(
     live.reconnectAttempt = 0;
     update({ status: "reconnecting", error: null });
     live.reconnect();
-  }, [update]);
+  }, [options.enabled, update]);
 
   useEffect(() => {
+    if (!options.enabled) return;
     const wakeTransport = () => {
       const live = liveRef.current;
       if (!live || !live.allowReconnect || Date.now() >= live.expiresAt) {
@@ -760,15 +775,17 @@ export function useAgentSession(
       window.removeEventListener("online", wakeTransport);
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, [update]);
+  }, [options.enabled, update]);
 
   const newConnection = useCallback(async () => {
+    if (!options.enabled) return;
     const scopes = liveRef.current?.scopes ?? lastScopesRef.current;
     if (scopes.length === 0) return;
     await grant(scopes);
-  }, [grant]);
+  }, [grant, options.enabled]);
 
   useEffect(() => {
+    if (!options.enabled) return;
     if (projectSessionRef.current !== options.projectSessionId) return;
     const live = liveRef.current;
     for (const document of options.project.documents) {
@@ -805,9 +822,10 @@ export function useAgentSession(
         }),
       );
     }
-  }, [options.project, options.projectSessionId]);
+  }, [options.enabled, options.project, options.projectSessionId]);
 
   useEffect(() => {
+    if (!options.enabled) return;
     if (projectSessionRef.current === options.projectSessionId) return;
     projectSessionRef.current = options.projectSessionId;
     recoveryAttemptedForProjectRef.current = options.projectSessionId;
@@ -830,6 +848,7 @@ export function useAgentSession(
     });
   }, [
     control,
+    options.enabled,
     options.fileHost,
     options.project,
     options.projectSessionId,
@@ -837,6 +856,7 @@ export function useAgentSession(
   ]);
 
   useEffect(() => {
+    if (!options.enabled) return;
     const timer = window.setInterval(() => {
       const live = liveRef.current;
       if (
@@ -860,10 +880,11 @@ export function useAgentSession(
       }
     }, 1_000);
     return () => window.clearInterval(timer);
-  }, [options.fileHost, update]);
+  }, [options.enabled, options.fileHost, update]);
 
   useEffect(
     () => () => {
+      if (!options.enabled) return;
       const live = liveRef.current;
       options.fileHost?.clear?.();
       if (live) {
@@ -879,7 +900,7 @@ export function useAgentSession(
         live.socket?.close(1000, "tab closed");
       }
     },
-    [options.fileHost],
+    [options.enabled, options.fileHost],
   );
 
   return { ...view, grant, pause, resume, reconnect, newConnection, revoke };

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -158,6 +158,20 @@ describe("editor shell", () => {
     expect(markup).not.toContain('data-testid="connect-agent-panel"');
   });
 
+  it("removes all public Agent controls and accessibility affordances when dormant", () => {
+    const project = createEmptyProject("agent-ui-dormant", "Dormant");
+    const markup = renderToStaticMarkup(
+      <App project={project} publicAgentUiEnabled={false} />,
+    );
+
+    expect(markup).not.toContain("<summary>Agent</summary>");
+    expect(markup).not.toContain("Connect Agent");
+    expect(markup).not.toContain("Manage Agent");
+    expect(markup).not.toContain("agent-shelf-indicator");
+    expect(markup).not.toContain("Agent:");
+    expect(markup).not.toContain("Approve Agent file import");
+  });
+
   it("links to first-party visitor analytics without crowding editor commands", () => {
     const project = createEmptyProject("analytics-entry", "Analytics Entry");
     const markup = renderToStaticMarkup(

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -165,6 +165,7 @@ import {
 } from "../agent/connect-agent-panel";
 import { BrowserAgentHost } from "../agent/browser-agent-host";
 import { BrowserAgentFileHost } from "../agent/browser-agent-file-host";
+import { PUBLIC_AGENT_UI_ENABLED } from "../agent/public-agent-ui";
 import { useAgentSession } from "../agent/use-agent-session";
 import type { AgentFileCandidateSummary } from "@icm/agent-adapter";
 import { referencedDocumentId } from "../document/editor-session";
@@ -321,6 +322,8 @@ interface ReplaceGuardState {
 export interface AppProps {
   project?: CircuitProject;
   visitStats?: { pv: number; uv: number } | null;
+  /** Test/staging seam; production defaults to a human-only editor. */
+  publicAgentUiEnabled?: boolean;
 }
 
 function dismissOpenCommandMenus(): boolean {
@@ -502,7 +505,11 @@ function compactLayoutMatches(): boolean {
   );
 }
 
-export function App({ project: initialProject, visitStats }: AppProps) {
+export function App({
+  project: initialProject,
+  visitStats,
+  publicAgentUiEnabled = PUBLIC_AGENT_UI_ENABLED,
+}: AppProps) {
   const [preparedInitialProject] = useState(
     () =>
       materializeRazaviProjectBulkConnections(
@@ -676,14 +683,16 @@ export function App({ project: initialProject, visitStats }: AppProps) {
     [editorDocumentController, projectSessionId],
   );
   const agentSession = useAgentSession({
+    enabled: publicAgentUiEnabled,
     project,
     projectSessionId,
     host: browserAgentHost,
     fileHost: browserAgentFileHost,
   });
   useEffect(() => {
+    if (!publicAgentUiEnabled) return;
     setAgentStatusDismissed(false);
-  }, [agentSession.status]);
+  }, [agentSession.status, publicAgentUiEnabled]);
   const [boxPreview, setBoxPreview] = useState<BoxPreview | null>(null);
   const [panPreview, setPanPreview] = useState<PanPreview | null>(null);
   const [routeStretchPreview, setRouteStretchPreview] =
@@ -6490,26 +6499,28 @@ export function App({ project: initialProject, visitStats }: AppProps) {
                   ) : null}
                 </div>
               </details>
-              <details className="command-menu" name="editor-command-menu">
-                <summary>Agent</summary>
-                <div className="command-popover">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (agentSession.status === "idle") {
-                        setAgentPanelOpen(true);
-                        return;
-                      }
-                      setSelectionOpen(true);
-                      setAgentDetailsOpen(true);
-                    }}
-                  >
-                    {agentSession.status === "idle"
-                      ? "Connect Agent"
-                      : "Manage Agent"}
-                  </button>
-                </div>
-              </details>
+              {publicAgentUiEnabled ? (
+                <details className="command-menu" name="editor-command-menu">
+                  <summary>Agent</summary>
+                  <div className="command-popover">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (agentSession.status === "idle") {
+                          setAgentPanelOpen(true);
+                          return;
+                        }
+                        setSelectionOpen(true);
+                        setAgentDetailsOpen(true);
+                      }}
+                    >
+                      {agentSession.status === "idle"
+                        ? "Connect Agent"
+                        : "Manage Agent"}
+                    </button>
+                  </div>
+                </details>
+              ) : null}
               <details className="command-menu" name="editor-command-menu">
                 <summary>Draw</summary>
                 <div className="command-popover">
@@ -6748,26 +6759,28 @@ export function App({ project: initialProject, visitStats }: AppProps) {
         onApply={beginInsertedComponentPlacement}
         onCancel={cancelComponentInsert}
       />
-      <ConnectAgentPanel
-        open={agentPanelOpen}
-        status={agentSession.status}
-        claimCode={agentSession.claimCode}
-        claimExpiresAt={agentSession.claimExpiresAt}
-        scopes={agentSession.scopes}
-        expiresAt={agentSession.expiresAt}
-        error={agentSession.error}
-        now={Date.now()}
-        onGrant={agentSession.grant}
-        onPause={agentSession.pause}
-        onResume={agentSession.resume}
-        onReconnect={agentSession.reconnect}
-        onNewConnection={agentSession.newConnection}
-        onRevoke={agentSession.revoke}
-        onClose={() => {
-          setAgentPanelOpen(false);
-        }}
-      />
-      {agentFileCandidate ? (
+      {publicAgentUiEnabled ? (
+        <ConnectAgentPanel
+          open={agentPanelOpen}
+          status={agentSession.status}
+          claimCode={agentSession.claimCode}
+          claimExpiresAt={agentSession.claimExpiresAt}
+          scopes={agentSession.scopes}
+          expiresAt={agentSession.expiresAt}
+          error={agentSession.error}
+          now={Date.now()}
+          onGrant={agentSession.grant}
+          onPause={agentSession.pause}
+          onResume={agentSession.resume}
+          onReconnect={agentSession.reconnect}
+          onNewConnection={agentSession.newConnection}
+          onRevoke={agentSession.revoke}
+          onClose={() => {
+            setAgentPanelOpen(false);
+          }}
+        />
+      ) : null}
+      {publicAgentUiEnabled && agentFileCandidate ? (
         <div className="agent-panel" data-testid="agent-file-approval">
           <section
             className="agent-dialog"
@@ -6928,7 +6941,9 @@ export function App({ project: initialProject, visitStats }: AppProps) {
               <span className="selection-shelf-title">
                 <ToolIcon name="inspect" />
                 <span>Properties</span>
-                {agentSession.status !== "idle" && !agentStatusDismissed ? (
+                {publicAgentUiEnabled &&
+                agentSession.status !== "idle" &&
+                !agentStatusDismissed ? (
                   <span
                     className={`agent-shelf-indicator ${
                       agentSession.status === "revoked" ||
@@ -7637,7 +7652,9 @@ export function App({ project: initialProject, visitStats }: AppProps) {
                   />
                 </section>
               ) : null}
-              {agentSession.status !== "idle" && !agentStatusDismissed ? (
+              {publicAgentUiEnabled &&
+              agentSession.status !== "idle" &&
+              !agentStatusDismissed ? (
                 <AgentPropertiesSection
                   status={agentSession.status}
                   claimCode={agentSession.claimCode}

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -30,6 +30,13 @@ For an MCP session: start the adapter, call `connect` with a Claim Code, read
 declared by [`resource-manifest.json`](resource-manifest.json); the same
 manifest projects the shared sources into the HTTP Kit.
 
+## Browser-host availability
+
+The public production editor is human-only by default and does not expose a
+claim UI or reconnect a prior browser session. Trusted development or staging
+builds can enable that browser surface with `VITE_ICM_AGENT_UI=enabled`; the
+API and MCP contracts themselves are unchanged.
+
 ## External Agent bootstrap (no MCP)
 
 An Agent without this repository receives a connection setup from the editor.

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -43,6 +43,6 @@ does not accept a LAN address. Use `pnpm dev` for a different development port.
 
 The static host does not enable the optional loopback Agent adapter. Start that
 adapter explicitly, use a token of at least 32 characters, and send requests
-only to its loopback JSON endpoint. For the published browser editor, use
-**Connect Agent** and the [browser-session instructions](../agent/api-usage.md)
-instead.
+only to its loopback JSON endpoint. The published editor currently exposes no
+Agent connection controls; its browser relay is reserved for explicitly enabled
+development and staging deployments.

--- a/plan/2026-08-15-public-agent-ui-dormant/plan.md
+++ b/plan/2026-08-15-public-agent-ui-dormant/plan.md
@@ -1,0 +1,88 @@
+---
+status: completed
+experience: none
+---
+
+# Public Agent UI Dormant Mode
+
+## Goal
+
+Make the production editor publicly human-only while retaining the Agent API,
+MCP package, and local/staging development path. Production must not render or
+expose Agent controls, status, dialogs, or recovery/reconnect behavior.
+Existing Agent sessions naturally become offline when an old page reloads; this
+target does not introduce server-side global revocation or API blocking.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree was clean. Work starts from current `origin/main` on
+`agent/public-agent-ui-dormant`.
+
+- `apps/editor/src/agent/` public UI mode and session lifecycle
+- `apps/editor/src/app/App.tsx` and focused App tests
+- `apps/editor/e2e/` only if a focused production-hidden browser assertion is
+  required
+- user-facing editor help/docs if Agent commands are surfaced there
+- `plan/2026-08-15-public-agent-ui-dormant/plan.md` and `plan/log.md`
+
+Read-only shared dependencies: Worker Agent endpoints, MCP package, Agent Kit,
+Agent helper, and typed circuit/edit contracts. They remain operational and
+must not change.
+
+## Work
+
+1. Add a build-time public Agent UI mode: production defaults disabled; local
+   development defaults enabled; explicit environment values can enable staging
+   or disable local testing.
+2. Gate every editor Agent surface as one feature: menu, connect/manage dialog,
+   file approval dialog, shelf indicator, and Properties section.
+3. Make disabled mode inert in `useAgentSession`: no recovery read, socket,
+   heartbeat, reconnect, revision event, timer, or cleanup request may begin.
+4. Add focused tests proving a disabled public App contains no Agent controls
+   or accessible labels and that the mode resolver has safe production/local
+   defaults. Preserve existing enabled-mode Agent contracts.
+5. Update user-visible product wording only where it advertises a now-hidden
+   connection feature; retain internal/developer MCP documentation.
+
+## Validation
+
+- focused Agent/App unit tests
+- focused production-hidden browser test or equivalent compiled-mode assertion
+- `pnpm typecheck`
+- `git diff --check`
+- `git status --short --branch`
+- `pnpm verify:branch` before delivery because the change crosses editor
+  startup, session lifecycle, and browser behavior
+- required remote checks before merging to `main`
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): hide public Agent controls
+```
+
+## Outcome
+
+Implemented production-dormant Agent UI mode. The production editor hides all
+Agent controls, dialogs, status indicators, Properties affordances, and file
+approval UI. `useAgentSession` becomes inert while disabled: it performs no
+recovery read, browser transport, heartbeat/reconnect, revision notification,
+expiry timer, or cleanup request. Local development remains enabled by default;
+trusted staging can opt in with `VITE_ICM_AGENT_UI=enabled`.
+
+The MCP/API/worker contracts and existing development Agent tests remain
+unchanged. User-facing README and troubleshooting wording no longer advertises
+the hidden production connection flow.
+
+Validation: focused resolver/App tests (15/15), production smoke check,
+`pnpm typecheck`, `pnpm docs:check`, `pnpm format:check`, `git diff --check`,
+and `pnpm verify:branch` (123 files / 740 tests, workspace build, production
+smoke) passed.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7311,6 +7311,20 @@ diff --check`, and two focused Playwright regressions passed.
   `fix(editor): compact narrow library and overlay properties` on
   `codex/compact-library-overlay-properties`; not pushed.
 
+# 2026-08-15 - Make public Agent UI dormant
+
+- Target: keep the deployed editor human-only without disabling internal
+  API/MCP/local Agent integrations.
+- Changed areas: production-default UI mode resolver; App-level removal of the
+  Agent menu, connection and file-approval dialogs, Properties status/details;
+  inert disabled browser session lifecycle; focused tests; public-facing README
+  and troubleshooting wording.
+- Validation: focused resolver/App tests (15/15), typecheck, docs/format,
+  production smoke, `git diff --check`, and `pnpm verify:branch` (123 files /
+  740 tests, workspace build, production smoke) passed.
+- Commit status: committed on `agent/public-agent-ui-dormant` as
+  `feat(editor): hide public Agent controls`.
+
 # 2026-08-15 - Mirror transient placement and toggle grid dots
 
 - Target: add minimal orientation controls during C/I placement and one local


### PR DESCRIPTION
## Summary

Makes the public production editor human-only while retaining the existing Agent API, MCP package, and local/staging integration path.

- Production defaults to no Agent menu, dialogs, status affordances, Properties section, or file-approval UI.
- Disabled browser sessions are inert: no recovery read, WebSocket, heartbeat, reconnect, revision event, timer, or cleanup request.
- Local development stays enabled by default; trusted staging can opt in with `VITE_ICM_AGENT_UI=enabled`.
- Updates public-facing product/troubleshooting wording without changing internal Agent/MCP contracts.

## Validation

- `pnpm verify:branch` — 123 test files / 740 tests, workspace build, production smoke
- Focused resolver/App tests — 15/15
- `pnpm typecheck`, documentation and formatting checks
