### PR TITLE
feat(editor): per-type designators, copy label increment, right-drag zoom box

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -69,7 +69,7 @@ test("mirrors component and copy placement previews before their commits", async
   await expect(copyPreview).toHaveAttribute("transform", /rotate\(180\)/u);
   await canvas.click({ position: { x: 520, y: 220 } });
   await expect(
-    canvas.locator('[data-object-id="R1-copy-1"] > g').first(),
+    canvas.locator('[data-object-id="R2"] > g').first(),
   ).toHaveAttribute("transform", /rotate\(180\)/u);
   await page.keyboard.press("Escape");
 });
@@ -270,7 +270,7 @@ test("copies a MOS whose bulk belongs to a shared supply Net", async ({
   await canvas.hover({ position: { x: 620, y: 340 } });
   await expect(page.getByTestId("copy-placement-preview")).toBeVisible();
   await canvas.click({ position: { x: 620, y: 340 } });
-  await expect(page.getByTestId("hit-M1-copy-1")).toBeVisible();
+  await expect(page.getByTestId("hit-M3")).toBeVisible();
   await expect(
     page.getByRole("heading", { name: "Circuit Maker" }),
   ).toBeVisible();

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -409,25 +409,25 @@ test("treats hollow and filled Ports as ordinary wired components", async ({
   await placeComponent(page, "port-filled", { x: 260, y: 300 });
 
   await clickCommand(page, "Draw", "Wire (W)");
-  await page.getByTestId("terminal-P2-P").click();
+  await page.getByTestId("terminal-P1-P").click();
   await page.getByTestId("terminal-R1-1").click();
   await page.keyboard.press("Escape");
   await clickCommand(page, "Draw", "Wire (W)");
-  await page.getByTestId("terminal-P3-P").click();
+  await page.getByTestId("terminal-P2-P").click();
   await page.getByTestId("terminal-R1-2").click();
   await page.keyboard.press("Escape");
 
   await expect(page.locator('[data-testid^="route-hit-"]')).toHaveCount(2);
-  await dragBy(page.getByTestId("hit-P2"), { x: 40, y: 0 });
-  await dragBy(page.getByTestId("hit-P3"), { x: 40, y: 20 });
+  await dragBy(page.getByTestId("hit-P1"), { x: 40, y: 0 });
+  await dragBy(page.getByTestId("hit-P2"), { x: 40, y: 20 });
   await expect(page.locator('[data-testid^="route-hit-"]')).toHaveCount(2);
 
+  await page.getByTestId("hit-P1").click();
+  await page.keyboard.press("Delete");
+  await expect(page.getByTestId("hit-P1")).toHaveCount(0);
   await page.getByTestId("hit-P2").click();
   await page.keyboard.press("Delete");
   await expect(page.getByTestId("hit-P2")).toHaveCount(0);
-  await page.getByTestId("hit-P3").click();
-  await page.keyboard.press("Delete");
-  await expect(page.getByTestId("hit-P3")).toHaveCount(0);
   const saved = JSON.parse(
     (await downloadBytes(page, "File", "Save Project")).toString("utf8"),
   ) as {
@@ -444,13 +444,13 @@ test("treats hollow and filled Ports as ordinary wired components", async ({
     document.nets
       .flatMap((net) => net.terminals)
       .map((item) => item.instanceId),
-  ).not.toEqual(expect.arrayContaining(["P2", "P3"]));
+  ).not.toEqual(expect.arrayContaining(["P1", "P2"]));
   expect(
     document.routes.flatMap((route) => [route.from, route.to]),
   ).not.toEqual(
     expect.arrayContaining([
+      expect.objectContaining({ instanceId: "P1" }),
       expect.objectContaining({ instanceId: "P2" }),
-      expect.objectContaining({ instanceId: "P3" }),
     ]),
   );
 });
@@ -465,8 +465,8 @@ test("authors components and connectivity manually from an empty canvas", async 
   await placeComponent(page, "resistor", { x: 340, y: 220 });
   await placeComponent(page, "nmos", { x: 560, y: 220 });
   await expect(page.getByTestId("hit-R1")).toBeVisible();
-  await expect(page.getByTestId("hit-M2")).toBeVisible();
-  await expect(page.getByTestId("terminal-M2-B")).toHaveCount(0);
+  await expect(page.getByTestId("hit-M1")).toBeVisible();
+  await expect(page.getByTestId("terminal-M1-B")).toHaveCount(0);
   await expect(page.getByTestId("revision")).toHaveText("2");
   await expect(page.getByTestId("source-status")).toHaveText(
     "connectivity-modified",
@@ -474,7 +474,7 @@ test("authors components and connectivity manually from an empty canvas", async 
 
   await clickCommand(page, "Draw", "Wire (W)");
   await page.getByTestId("terminal-R1-2").click();
-  await page.getByTestId("terminal-M2-G").click();
+  await page.getByTestId("terminal-M1-G").click();
   await expect(page.getByTestId("revision")).toHaveText("3");
   await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(1);
   await page.keyboard.press("Escape");
@@ -745,12 +745,12 @@ test("turns an off-axis tap near a route bend into an exact junction", async ({
   await placeComponent(page, "resistor", { x: 680, y: 360 });
   await clickCommand(page, "Draw", "Wire (W)");
   await page.getByTestId("terminal-M1-D").click();
-  await page.getByTestId("terminal-R2-1").click();
+  await page.getByTestId("terminal-R1-1").click();
   const points = await readRoutePoints(page, "route-ui-1");
   expect(points.length).toBeGreaterThanOrEqual(3);
 
   await clickCommand(page, "Draw", "Wire (W)");
-  await page.getByTestId("terminal-R3-1").click();
+  await page.getByTestId("terminal-R2-1").click();
   await clickRouteVertexWithScreenOffset(page, "route-ui-1", 1, {
     x: 3,
     y: 3,
@@ -784,7 +784,7 @@ test("materializes a MOS supply default and lets a dashed bulk route override it
     "supply-default",
   );
   await page.getByRole("button", { name: "Draw bulk connection" }).click();
-  await page.getByTestId("terminal-GND2-0").click();
+  await page.getByTestId("terminal-GND1-0").click();
   await page.keyboard.press("Escape");
 
   const saved = JSON.parse(
@@ -814,7 +814,7 @@ test("materializes a MOS supply default and lets a dashed bulk route override it
   ).toEqual(
     expect.arrayContaining([
       { instanceId: "M1", pinName: "B" },
-      { instanceId: "GND2", pinName: "0" },
+      { instanceId: "GND1", pinName: "0" },
     ]),
   );
 });
@@ -927,7 +927,7 @@ test("keeps direct device pin corners on-grid and deletes a selected junction", 
   await placeComponent(page, "resistor", { x: 540, y: 160 });
   await clickCommand(page, "Draw", "Wire (W)");
   await page.getByTestId("terminal-M1-D").click();
-  await page.getByTestId("terminal-R2-1").click();
+  await page.getByTestId("terminal-R1-1").click();
 
   const terminalRoute = await readRoutePoints(page, "route-ui-1");
   expect(terminalRoute).toHaveLength(3);
@@ -1000,7 +1000,7 @@ test("connects copied multi-pin groups through a manually bent wire", async ({
   await page
     .getByTestId("schematic-canvas")
     .click({ position: { x: 460, y: 500 } });
-  await page.getByTestId("terminal-M2-copy-1-S").click();
+  await page.getByTestId("terminal-M4-S").click();
 
   await expect(page.getByTestId("status")).toContainText("Committed route");
   await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(3);
@@ -1594,12 +1594,63 @@ test("R rotates a copy preview before committing the copied component", async ({
   await expect(previewSymbol).toHaveAttribute("transform", /rotate\(0\)/);
 
   await page.keyboard.press("r");
-  await expect(previewSymbol).toHaveAttribute("transform", /rotate\(90\)/);
+  await expect(previewSymbol).toHaveAttribute("transform", /rotate\(90\)/u);
   await canvas.click({ position: { x: 560, y: 340 } });
   await expect(
-    canvas.locator('[data-object-id="R1-copy-1"] > g').first(),
-  ).toHaveAttribute("transform", /rotate\(90\)/);
+    canvas.locator('[data-object-id="R2"] > g').first(),
+  ).toHaveAttribute("transform", /rotate\(90\)/u);
+  // The pasted designator and its visible label both read R2.
+  await expect(canvas.getByText("R2", { exact: true })).toBeVisible();
   await page.keyboard.press("Escape");
+});
+
+test("numbers placed components per device type instead of globally", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await placeComponent(page, "nmos", { x: 320, y: 200 });
+  await placeComponent(page, "nmos", { x: 520, y: 200 });
+  await placeComponent(page, "resistor", { x: 720, y: 200 });
+  await placeComponent(page, "capacitor", { x: 320, y: 400 });
+
+  await expect(page.getByTestId("hit-M1")).toBeVisible();
+  await expect(page.getByTestId("hit-M2")).toBeVisible();
+  await expect(page.getByTestId("hit-R1")).toBeVisible();
+  await expect(page.getByTestId("hit-C1")).toBeVisible();
+  await expect(page.getByTestId("instance-count")).toHaveText("4");
+});
+
+test("right-drag frames a region and fits the camera to it transiently", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await placeComponent(page, "resistor", { x: 320, y: 200 });
+
+  const canvas = page.getByTestId("schematic-canvas");
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error("Canvas is not measurable");
+  const before = await canvas.getAttribute("viewBox");
+
+  await page.mouse.move(box.x + 220, box.y + 160);
+  await page.mouse.down({ button: "right" });
+  await page.mouse.move(box.x + 420, box.y + 320, { steps: 4 });
+  await expect(page.getByTestId("zoom-box")).toBeVisible();
+  await page.mouse.up({ button: "right" });
+
+  await expect(page.getByTestId("zoom-box")).toHaveCount(0);
+  await expect(canvas).not.toHaveAttribute("viewBox", before!);
+  await expect(page.getByTestId("status")).toHaveText(
+    "Zoomed to framed region",
+  );
+  // Framing is a camera gesture: the document revision must not move.
+  await expect(page.getByTestId("revision")).toHaveText("1");
+
+  // A right click that never framed must not change the camera either.
+  const framed = await canvas.getAttribute("viewBox");
+  await page.mouse.move(box.x + 300, box.y + 240);
+  await page.mouse.down({ button: "right" });
+  await page.mouse.up({ button: "right" });
+  await expect(canvas).toHaveAttribute("viewBox", framed!);
 });
 
 test("keeps copy placement active for repeated commits until Escape", async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -97,6 +97,7 @@ import { startCanvasDragSession } from "../canvas/canvas-drag-session";
 import {
   fitCameraToBounds,
   normalizeCameraRect,
+  zoomCameraAtAnchor,
   type CameraRectInput,
 } from "../canvas/fit-view";
 import type { CanvasDragSession } from "../canvas/canvas-drag-session";
@@ -125,7 +126,11 @@ import {
   componentParameters,
   effectiveComponentParameterValue,
 } from "../features/component-insert/component-parameters";
-import { initialInstanceNetlist } from "../features/netlist-export/netlist-authoring";
+import {
+  initialInstanceNetlist,
+  netlistReferenceMatchesPlacement,
+  nextInstanceDesignator,
+} from "../features/netlist-export/netlist-authoring";
 import { ToolIcon } from "../features/editor-shell/tool-icon";
 import { ShapesPanel } from "../features/editor-shell/shapes-panel";
 import { useDocumentController } from "../document/document-controller";
@@ -270,6 +275,8 @@ interface BoxPreview {
   start: DerivedPoint;
   end: DerivedPoint;
   pointerId: number;
+  /** Left-drag selects what the box touches; right-drag zooms to fit it. */
+  intent: "select" | "zoom";
 }
 
 interface PanPreview {
@@ -792,7 +799,6 @@ export function App({
   } | null>(null);
   const routeCounter = useRef(0);
   const canvasDragSessionRef = useRef<CanvasDragSession | null>(null);
-  const instanceCounter = useRef(0);
   const copyCounter = useRef(0);
   const suppressInstanceClick = useRef(false);
   const projectInputRef = useRef<HTMLInputElement>(null);
@@ -3289,23 +3295,7 @@ export function App({
     position: Point,
     placementRequest: NonNullable<typeof pendingComponentPlacement>,
   ): void {
-    instanceCounter.current += 1;
-    const prefix: Record<string, string> = {
-      resistor: "R",
-      capacitor: "C",
-      nmos: "M",
-      pmos: "M",
-      "voltage-source": "V",
-      "current-source": "I",
-      ground: "GND",
-      port: "P",
-      "port-filled": "P",
-    };
-    let id = `${prefix[symbolId] ?? "X"}${instanceCounter.current}`;
-    while (document.instances.some((instance) => instance.id === id)) {
-      instanceCounter.current += 1;
-      id = `${prefix[symbolId] ?? "X"}${instanceCounter.current}`;
-    }
+    const id = nextInstanceDesignator(document, symbolId);
     const symbolVariantId = defaultRazaviSymbolVariantId(symbolId);
     const instance = {
       id,
@@ -3321,6 +3311,7 @@ export function App({
         document,
         symbolId,
         placementRequest.properties,
+        netlistReferenceMatchesPlacement(symbolId) ? id : undefined,
       ),
     };
     // The persisted annotation is the only visible instance-label authority.
@@ -3416,8 +3407,6 @@ export function App({
   }
 
   function placeVddRail(start: Point, end: Point): void {
-    instanceCounter.current += 1;
-    let instanceId = `VDD${instanceCounter.current}`;
     const vddRailIdsExist = (candidate: string): boolean => {
       const key = candidate.toLowerCase();
       return (
@@ -3433,10 +3422,9 @@ export function App({
         )
       );
     };
-    while (vddRailIdsExist(instanceId)) {
-      instanceCounter.current += 1;
-      instanceId = `VDD${instanceCounter.current}`;
-    }
+    let sequence = 1;
+    while (vddRailIdsExist(`VDD${sequence}`)) sequence += 1;
+    const instanceId = `VDD${sequence}`;
     const routeId = `route-${instanceId.toLowerCase()}-rail`;
     const existingVddNet =
       document.nets.find(
@@ -5177,26 +5165,9 @@ export function App({
   }
 
   function zoomViewAtCenter(factor: number): void {
-    setViewBox((current) => {
-      const center = {
-        x: current.x + current.width / 2,
-        y: current.y + current.height / 2,
-      };
-      const width = Math.max(
-        120,
-        Math.min(5000, Math.round(current.width * factor)),
-      );
-      const height = Math.max(
-        80,
-        Math.min(3500, Math.round(current.height * factor)),
-      );
-      return {
-        x: Math.round(center.x - width / 2),
-        y: Math.round(center.y - height / 2),
-        width,
-        height,
-      };
-    });
+    setViewBox((current) =>
+      zoomCameraAtAnchor(current, factor, { x: 0.5, y: 0.5 }),
+    );
   }
 
   function handleWheel(event: React.WheelEvent<SVGSVGElement>): void {
@@ -5206,27 +5177,12 @@ export function App({
     if (event.ctrlKey || event.metaKey) return;
     event.preventDefault();
     const bounds = event.currentTarget.getBoundingClientRect();
-    const ratioX = (event.clientX - bounds.left) / bounds.width;
-    const ratioY = (event.clientY - bounds.top) / bounds.height;
+    const anchor = {
+      x: (event.clientX - bounds.left) / bounds.width,
+      y: (event.clientY - bounds.top) / bounds.height,
+    };
     const factor = event.deltaY < 0 ? 0.88 : 1.14;
-    setViewBox((current) => {
-      const width = Math.max(
-        120,
-        Math.min(5000, Math.round(current.width * factor)),
-      );
-      const height = Math.max(
-        80,
-        Math.min(3500, Math.round(current.height * factor)),
-      );
-      const cursorX = current.x + ratioX * current.width;
-      const cursorY = current.y + ratioY * current.height;
-      return {
-        x: Math.round(cursorX - ratioX * width),
-        y: Math.round(cursorY - ratioY * height),
-        width,
-        height,
-      };
-    });
+    setViewBox((current) => zoomCameraAtAnchor(current, factor, anchor));
   }
 
   function beginCanvasGesture(event: ReactPointerEvent<SVGSVGElement>): void {
@@ -5237,6 +5193,41 @@ export function App({
         clientStart: { x: event.clientX, y: event.clientY },
         viewBoxStart: viewBox,
         pointerId: event.pointerId,
+      });
+      return;
+    }
+    if (event.button === 2) {
+      // Right-drag from empty canvas frames a region and fits the camera to
+      // it. Modes that commit on the next left click, and the drafting/wire
+      // tools whose right click cancels them, stay outside this gesture.
+      if (
+        (pendingSymbolId && pendingComponentPlacement) ||
+        vddRailMode ||
+        copyPlacement !== null ||
+        tool === "wire" ||
+        tool === "construction-line" ||
+        tool === "arrow" ||
+        tool === "rectangle"
+      ) {
+        return;
+      }
+      if (
+        event.target !== event.currentTarget &&
+        (event.target as Element).tagName !== "rect"
+      ) {
+        return;
+      }
+      const zoomStart = pointFromClient(
+        event.clientX,
+        event.clientY,
+        event.currentTarget,
+      );
+      event.currentTarget.setPointerCapture(event.pointerId);
+      setBoxPreview({
+        start: zoomStart,
+        end: zoomStart,
+        pointerId: event.pointerId,
+        intent: "zoom",
       });
       return;
     }
@@ -5272,7 +5263,12 @@ export function App({
     )
       return;
     event.currentTarget.setPointerCapture(event.pointerId);
-    setBoxPreview({ start: point, end: point, pointerId: event.pointerId });
+    setBoxPreview({
+      start: point,
+      end: point,
+      pointerId: event.pointerId,
+      intent: "select",
+    });
   }
 
   function continueCanvasGesture(
@@ -5366,6 +5362,19 @@ export function App({
     }
     if (boxPreview?.pointerId !== event.pointerId) return;
     event.currentTarget.releasePointerCapture(event.pointerId);
+    if (boxPreview.intent === "zoom") {
+      const rect = normalizedRect(boxPreview.start, boxPreview.end);
+      setBoxPreview(null);
+      // A right press barely moved is an ordinary right click, not a frame.
+      if (
+        rect.width > document.presentation.grid &&
+        rect.height > document.presentation.grid
+      ) {
+        setViewBox(fitCameraToBounds(rect, document.presentation.grid));
+        setStatus("Zoomed to framed region");
+      }
+      return;
+    }
     const rect = normalizedRect(boxPreview.start, boxPreview.end);
     const clicked =
       rect.width <= document.presentation.grid &&
@@ -8816,8 +8825,12 @@ export function App({
                 : null}
               {boxPreview ? (
                 <rect
-                  data-testid="selection-box"
-                  className="selection-box"
+                  data-testid={
+                    boxPreview.intent === "zoom" ? "zoom-box" : "selection-box"
+                  }
+                  className={
+                    boxPreview.intent === "zoom" ? "zoom-box" : "selection-box"
+                  }
                   {...normalizedRect(boxPreview.start, boxPreview.end)}
                 />
               ) : null}

--- a/apps/editor/src/canvas/fit-view.test.ts
+++ b/apps/editor/src/canvas/fit-view.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { fitCameraToBounds, normalizeCameraRect } from "./fit-view";
+import {
+  CAMERA_ZOOM_LIMITS,
+  fitCameraToBounds,
+  normalizeCameraRect,
+  zoomCameraAtAnchor,
+} from "./fit-view";
 
 describe("fitCameraToBounds", () => {
   it("rounds fractional visual bounds outward to the editor grid", () => {
@@ -22,5 +27,51 @@ describe("fitCameraToBounds", () => {
         10,
       ),
     ).toEqual({ x: 100, y: -40, width: 60, height: 20 });
+  });
+});
+
+describe("zoomCameraAtAnchor", () => {
+  it("keeps the anchor point fixed in world space while zooming", () => {
+    const current = { x: 0, y: 0, width: 1000, height: 600 };
+    expect(zoomCameraAtAnchor(current, 0.5, { x: 0.25, y: 0.5 })).toEqual({
+      x: 125,
+      y: 150,
+      width: 500,
+      height: 300,
+    });
+  });
+
+  it("treats a centered anchor as ordinary center zoom", () => {
+    const current = { x: 100, y: 60, width: 800, height: 480 };
+    const center = { x: 0.5, y: 0.5 };
+    expect(zoomCameraAtAnchor(current, 0.5, center)).toEqual({
+      x: 300,
+      y: 180,
+      width: 400,
+      height: 240,
+    });
+    expect(zoomCameraAtAnchor(current, 2, center)).toEqual({
+      x: -300,
+      y: -180,
+      width: 1600,
+      height: 960,
+    });
+  });
+
+  it("clamps zoomed extents to the camera limits", () => {
+    const shrunk = zoomCameraAtAnchor(
+      { x: 0, y: 0, width: 100, height: 60 },
+      0.5,
+      { x: 0.5, y: 0.5 },
+    );
+    expect(shrunk.width).toBe(CAMERA_ZOOM_LIMITS.minWidth);
+    expect(shrunk.height).toBe(CAMERA_ZOOM_LIMITS.minHeight);
+    const grown = zoomCameraAtAnchor(
+      { x: 0, y: 0, width: 4000, height: 3000 },
+      4,
+      { x: 0.5, y: 0.5 },
+    );
+    expect(grown.width).toBe(CAMERA_ZOOM_LIMITS.maxWidth);
+    expect(grown.height).toBe(CAMERA_ZOOM_LIMITS.maxHeight);
   });
 });

--- a/apps/editor/src/canvas/fit-view.ts
+++ b/apps/editor/src/canvas/fit-view.ts
@@ -74,3 +74,46 @@ export function fitCameraToBounds(bounds: DerivedRect, grid: number): GridRect {
     height: Math.max(grid, bottom - y),
   };
 }
+
+export interface CameraZoomLimits {
+  minWidth: number;
+  maxWidth: number;
+  minHeight: number;
+  maxHeight: number;
+}
+
+export const CAMERA_ZOOM_LIMITS: CameraZoomLimits = {
+  minWidth: 120,
+  maxWidth: 5000,
+  minHeight: 80,
+  maxHeight: 3500,
+};
+
+/**
+ * Scales the camera rect around a viewport-relative anchor (0..1 in each
+ * axis), the shared core of cursor-anchored wheel zoom and center-anchored
+ * button zoom. The anchor point stays fixed in world space.
+ */
+export function zoomCameraAtAnchor(
+  current: GridRect,
+  factor: number,
+  anchor: { x: number; y: number },
+  limits: CameraZoomLimits = CAMERA_ZOOM_LIMITS,
+): GridRect {
+  const width = Math.max(
+    limits.minWidth,
+    Math.min(limits.maxWidth, Math.round(current.width * factor)),
+  );
+  const height = Math.max(
+    limits.minHeight,
+    Math.min(limits.maxHeight, Math.round(current.height * factor)),
+  );
+  const anchorX = current.x + anchor.x * current.width;
+  const anchorY = current.y + anchor.y * current.height;
+  return {
+    x: Math.round(anchorX - anchor.x * width),
+    y: Math.round(anchorY - anchor.y * height),
+    width,
+    height,
+  };
+}

--- a/apps/editor/src/features/clipboard/clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard.test.ts
@@ -1,5 +1,10 @@
 import { executeTransaction } from "@icm/edit-engine";
-import { createEmptyDocument } from "@icm/model";
+import type { Annotation, Instance } from "@icm/model";
+import {
+  createEmptyDocument,
+  flattenRichText,
+  semanticTextDocument,
+} from "@icm/model";
 import { buildSvgScene } from "@icm/render-svg";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
@@ -91,8 +96,8 @@ describe("schematic clipboard", () => {
     expect(result.document.nets[0]?.terminals).toHaveLength(4);
     expect(result.document.routes[1]).toMatchObject({
       netId: "net-signal",
-      from: { instanceId: "R1-copy-1" },
-      to: { instanceId: "R2-copy-1" },
+      from: { instanceId: "R3" },
+      to: { instanceId: "R4" },
     });
     expect(result.document.routes[1]?.waypoints).toEqual([{ x: 120, y: 100 }]);
   });
@@ -148,6 +153,168 @@ describe("schematic clipboard", () => {
       rotation: 0,
       mirror: "x",
     });
+  });
+
+  function resistorInstance(
+    id: string,
+    reference: string | undefined,
+  ): Instance {
+    return {
+      id,
+      symbolId: "resistor",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0,
+        mirror: "none",
+      },
+      properties: {},
+      ...(reference ? { netlist: { reference, parameters: {} } } : {}),
+    };
+  }
+
+  function instanceLabel(instanceId: string, text: string): Annotation {
+    return {
+      id: `instance-label-${instanceId}`,
+      kind: "instance-label",
+      // Match production labels: semantic base + subscript runs, not one
+      // flat text leaf.
+      content: semanticTextDocument(text, "instance-label"),
+      anchor: {
+        kind: "object",
+        objectId: instanceId,
+        localOffset: { x: 0, y: -20 },
+        fallbackPosition: { x: 100, y: 80 },
+      },
+      alignment: "middle",
+      rotation: 0,
+      locked: false,
+    };
+  }
+
+  it("adopts the incremented reference as the pasted id and label text", () => {
+    const document = createEmptyDocument("document-main", "Designator paste");
+    document.instances.push(resistorInstance("R1", "R1"));
+    document.annotations.push(instanceLabel("R1", "R1"));
+
+    const copied = copySelection(document, ["R1"]);
+    const proposal = proposePaste(document, copied!, { x: 20, y: 0 }, 1);
+    expect(proposal.instanceIds).toEqual(["R2"]);
+    // Executing the paste proves the rewritten label stays schema-valid.
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "paste-designator",
+        documentId: document.id,
+        expectedRevision: 0,
+        actor: { kind: "human", id: "test" },
+        edits: proposal.edits,
+      },
+      { symbolResolver: resolver },
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.document.instances).toHaveLength(2);
+    expect(result.document.instances[1]).toMatchObject({
+      id: "R2",
+      netlist: { reference: "R2" },
+    });
+    expect(
+      result.document.annotations
+        .filter((annotation) => annotation.kind === "instance-label")
+        .map((annotation) => flattenRichText(annotation.content)),
+    ).toEqual(["R1", "R2"]);
+  });
+
+  it("increments batch-copied designators without collisions", () => {
+    const document = createEmptyDocument("document-main", "Batch paste");
+    document.instances.push(resistorInstance("R1", "R1"));
+    document.annotations.push(instanceLabel("R1", "R1"));
+
+    let pasted = proposePaste(
+      document,
+      copySelection(document, ["R1"])!,
+      {
+        x: 20,
+        y: 0,
+      },
+      1,
+    );
+    expect(pasted.instanceIds).toEqual(["R2"]);
+    const once = executeTransaction(
+      document,
+      {
+        transactionId: "paste-first",
+        documentId: document.id,
+        expectedRevision: 0,
+        actor: { kind: "human", id: "test" },
+        edits: pasted.edits,
+      },
+      { symbolResolver: resolver },
+    );
+    if (!once.ok) throw new Error("first paste failed");
+
+    pasted = proposePaste(
+      once.document,
+      copySelection(document, ["R1"])!,
+      {
+        x: 40,
+        y: 0,
+      },
+      2,
+    );
+    expect(pasted.instanceIds).toEqual(["R3"]);
+  });
+
+  it("preserves hand-edited label text on paste", () => {
+    const document = createEmptyDocument("document-main", "Custom label");
+    document.instances.push(resistorInstance("R1", "R1"));
+    document.annotations.push(instanceLabel("R1", "R_load"));
+
+    const proposal = proposePaste(
+      document,
+      copySelection(document, ["R1"])!,
+      { x: 20, y: 0 },
+      1,
+    );
+    // "R" + subscript "load" is not the copied reference R1, so it survives.
+    const pastedLabel = proposal.edits.find(
+      (
+        edit,
+      ): edit is Extract<
+        typeof edit,
+        { kind: "upsert_schematic_annotation" }
+      > => edit.kind === "upsert_schematic_annotation",
+    );
+    expect(flattenRichText(pastedLabel!.annotation.content)).toBe("Rload");
+    expect(proposal.instanceIds).toEqual(["R2"]);
+  });
+
+  it("falls back to an opaque copy id when the source id diverges", () => {
+    const document = createEmptyDocument("document-main", "Diverged id");
+    document.instances.push(resistorInstance("custom-1", "R1"));
+    document.annotations.push(instanceLabel("custom-1", "R1"));
+
+    const proposal = proposePaste(
+      document,
+      copySelection(document, ["custom-1"])!,
+      { x: 20, y: 0 },
+      1,
+    );
+    expect(proposal.instanceIds).toEqual(["custom-1-copy-1"]);
+    const pastedInstance = proposal.edits.find(
+      (edit): edit is Extract<typeof edit, { kind: "add_instance" }> =>
+        edit.kind === "add_instance",
+    );
+    expect(pastedInstance?.instance.netlist?.reference).toBe("R2");
+    const pastedLabel = proposal.edits.find(
+      (
+        edit,
+      ): edit is Extract<
+        typeof edit,
+        { kind: "upsert_schematic_annotation" }
+      > => edit.kind === "upsert_schematic_annotation",
+    );
+    expect(flattenRichText(pastedLabel!.annotation.content)).toBe("R2");
   });
 
   it("remaps an internal NoConnect to the copied instance", () => {

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -10,7 +10,11 @@ import type {
   RouteEndpoint,
   SchematicDocument,
 } from "@icm/model";
-import { transformPoint } from "@icm/model";
+import {
+  flattenRichText,
+  semanticTextDocument,
+  transformPoint,
+} from "@icm/model";
 
 import {
   applyOrientationOperations,
@@ -221,6 +225,63 @@ function uniqueCopyReference(
   return candidate;
 }
 
+/**
+ * A pasted instance whose source id equals its source reference keeps the
+ * designator convention: it adopts the freshly allocated reference (copy R1
+ * becomes R2) so the visible label, the id, and the netlist reference stay a
+ * single fact. Anything else (custom ids, reference-less instances) falls
+ * back to the opaque `-copy-N` id.
+ */
+function pastedInstanceId(
+  source: Instance,
+  nextReference: string | undefined,
+  sequence: number,
+  occupied: Set<string>,
+): string {
+  if (
+    nextReference !== undefined &&
+    source.id === source.netlist?.reference &&
+    !occupied.has(nextReference)
+  ) {
+    occupied.add(nextReference);
+    return nextReference;
+  }
+  return uniqueCopyId(source.id, sequence, occupied);
+}
+
+/**
+ * Rewrites a pasted instance-label whose text is still the copied reference
+ * (or copied id) to the new reference, so a pasted R1 reads R2 on canvas.
+ * The replacement content is rebuilt exactly like a freshly placed label
+ * (semantic base + subscript runs). Hand-edited label text is preserved
+ * verbatim.
+ */
+function rewriteInstanceLabelText(
+  annotation: Annotation,
+  source: Instance | undefined,
+  nextId: string,
+  nextReference: string | undefined,
+): void {
+  if (
+    source === undefined ||
+    annotation.kind !== "instance-label" ||
+    annotation.anchor.kind !== "object"
+  ) {
+    return;
+  }
+  const plain = flattenRichText(annotation.content);
+  if (
+    plain !== source.id &&
+    (source.netlist === undefined || plain !== source.netlist.reference)
+  ) {
+    return;
+  }
+  annotation.content = semanticTextDocument(
+    nextReference ?? nextId,
+    "instance-label",
+  );
+}
+
 function movePoint(point: Point, offset: Point): Point {
   return { x: point.x + offset.x, y: point.y + offset.y };
 }
@@ -268,12 +329,6 @@ export function proposePaste(
       ...document.constraints,
     ].map((object) => object.id),
   );
-  const instanceIds = new Map(
-    clipboard.instances.map((instance) => [
-      instance.id,
-      uniqueCopyId(instance.id, sequence, occupied),
-    ]),
-  );
   const occupiedReferences = new Set(
     document.instances.flatMap((instance) =>
       instance.netlist ? [instance.netlist.reference.toLowerCase()] : [],
@@ -293,6 +348,17 @@ export function proposePaste(
           ]
         : [],
     ),
+  );
+  const instanceIds = new Map(
+    clipboard.instances.map((instance) => [
+      instance.id,
+      pastedInstanceId(
+        instance,
+        instanceReferences.get(instance.id),
+        sequence,
+        occupied,
+      ),
+    ]),
   );
   const routeIds = new Map(
     clipboard.routes.map((route) => [
@@ -459,44 +525,58 @@ export function proposePaste(
       ...(route.presentation ? { presentation: route.presentation } : {}),
     })),
   );
+  const sourceInstancesById = new Map(
+    clipboard.instances.map((instance) => [instance.id, instance]),
+  );
   edits.push(
-    ...clipboard.annotations.map((annotation): SchematicEdit => ({
-      kind: "upsert_schematic_annotation",
-      annotation: {
-        ...structuredClone(annotation),
-        id: uniqueCopyId(annotation.id, sequence, occupied),
-        ...(annotation.netId
-          ? { netId: netIds.get(annotation.netId) ?? annotation.netId }
-          : {}),
-        anchor:
-          annotation.anchor.kind === "free"
-            ? {
-                kind: "free",
-                position: movePoint(annotation.anchor.position, offset),
-              }
-            : annotation.anchor.kind === "object"
+    ...clipboard.annotations.map((annotation): SchematicEdit => {
+      const clone = structuredClone(annotation);
+      if (clone.anchor.kind === "object") {
+        rewriteInstanceLabelText(
+          clone,
+          sourceInstancesById.get(clone.anchor.objectId),
+          objectIds.get(clone.anchor.objectId) ?? clone.anchor.objectId,
+          instanceReferences.get(clone.anchor.objectId),
+        );
+      }
+      return {
+        kind: "upsert_schematic_annotation",
+        annotation: {
+          ...clone,
+          id: uniqueCopyId(annotation.id, sequence, occupied),
+          ...(annotation.netId
+            ? { netId: netIds.get(annotation.netId) ?? annotation.netId }
+            : {}),
+          anchor:
+            annotation.anchor.kind === "free"
               ? {
-                  ...annotation.anchor,
-                  objectId:
-                    objectIds.get(annotation.anchor.objectId) ??
-                    annotation.anchor.objectId,
-                  fallbackPosition: movePoint(
-                    annotation.anchor.fallbackPosition,
-                    offset,
-                  ),
+                  kind: "free",
+                  position: movePoint(annotation.anchor.position, offset),
                 }
-              : {
-                  ...annotation.anchor,
-                  routeId:
-                    routeIds.get(annotation.anchor.routeId) ??
-                    annotation.anchor.routeId,
-                  fallbackPosition: movePoint(
-                    annotation.anchor.fallbackPosition,
-                    offset,
-                  ),
-                },
-      },
-    })),
+              : annotation.anchor.kind === "object"
+                ? {
+                    ...annotation.anchor,
+                    objectId:
+                      objectIds.get(annotation.anchor.objectId) ??
+                      annotation.anchor.objectId,
+                    fallbackPosition: movePoint(
+                      annotation.anchor.fallbackPosition,
+                      offset,
+                    ),
+                  }
+                : {
+                    ...annotation.anchor,
+                    routeId:
+                      routeIds.get(annotation.anchor.routeId) ??
+                      annotation.anchor.routeId,
+                    fallbackPosition: movePoint(
+                      annotation.anchor.fallbackPosition,
+                      offset,
+                    ),
+                  },
+        },
+      };
+    }),
   );
   return { edits, instanceIds: [...instanceIds.values()], errors };
 }

--- a/apps/editor/src/features/netlist-export/netlist-authoring.test.ts
+++ b/apps/editor/src/features/netlist-export/netlist-authoring.test.ts
@@ -4,7 +4,10 @@ import { describe, expect, it } from "vitest";
 import {
   bindingForEditedModel,
   initialInstanceNetlist,
+  netlistReferenceMatchesPlacement,
+  nextInstanceDesignator,
   nextInstanceReference,
+  placementReferencePrefix,
 } from "./netlist-authoring";
 
 describe("netlist authoring", () => {
@@ -28,6 +31,57 @@ describe("netlist authoring", () => {
     );
     expect(nextInstanceReference(document, "resistor")).toBe("R2");
     expect(nextInstanceReference(document, "nmos")).toBe("M1");
+  });
+
+  it("allocates the lowest unused designator per placement prefix", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.instances.push(
+      {
+        id: "R1",
+        symbolId: "resistor",
+        placement: null,
+        properties: {},
+        netlist: { reference: "R1", parameters: {} },
+      },
+      {
+        id: "M1",
+        symbolId: "nmos",
+        placement: null,
+        properties: {},
+        netlist: { reference: "M1", parameters: {} },
+      },
+      {
+        id: "R3",
+        symbolId: "resistor",
+        placement: null,
+        properties: {},
+        netlist: { reference: "R3", parameters: {} },
+      },
+    );
+    expect(nextInstanceDesignator(document, "resistor")).toBe("R2");
+    expect(nextInstanceDesignator(document, "nmos")).toBe("M2");
+    // nmos and pmos share the M prefix; neither call mutates the document.
+    expect(nextInstanceDesignator(document, "pmos")).toBe("M2");
+    expect(nextInstanceDesignator(document, "capacitor")).toBe("C1");
+  });
+
+  it("keeps schematic-only marker prefixes and id/reference agreement flags", () => {
+    const document = createEmptyDocument("main", "Main");
+    expect(nextInstanceDesignator(document, "ground")).toBe("GND1");
+    expect(nextInstanceDesignator(document, "port")).toBe("P1");
+    expect(placementReferencePrefix("inductor")).toBe("L");
+    expect(placementReferencePrefix("unknown-symbol")).toBe("X");
+    expect(netlistReferenceMatchesPlacement("resistor")).toBe(true);
+    expect(netlistReferenceMatchesPlacement("pmos")).toBe(true);
+    expect(netlistReferenceMatchesPlacement("ground")).toBe(false);
+    expect(netlistReferenceMatchesPlacement("port")).toBe(false);
+  });
+
+  it("accepts an explicit reference so placement id and reference agree", () => {
+    const document = createEmptyDocument("main", "Main");
+    expect(
+      initialInstanceNetlist(document, "resistor", { value: "10k" }, "R7"),
+    ).toMatchObject({ reference: "R7" });
   });
 
   it("creates typed primitive facts while leaving MOS model explicit", () => {

--- a/apps/editor/src/features/netlist-export/netlist-authoring.ts
+++ b/apps/editor/src/features/netlist-export/netlist-authoring.ts
@@ -10,6 +10,57 @@ function referencePrefix(symbolId: string): string {
   return deviceNetlistDefinition(symbolId)?.referencePrefix ?? "X";
 }
 
+/**
+ * Prefixes used for on-canvas placement labels. Schematic-only markers keep
+ * their label prefixes here; real devices inherit the reviewed netlist
+ * reference prefix so a placed label and its netlist reference agree.
+ */
+const placementPrefixOverrides: Record<string, string> = {
+  ground: "GND",
+  port: "P",
+  "port-filled": "P",
+};
+
+export function placementReferencePrefix(symbolId: string): string {
+  return placementPrefixOverrides[symbolId] ?? referencePrefix(symbolId);
+}
+
+/**
+ * Lowest unused per-prefix designator across the union of instance ids and
+ * netlist references, so the visible label, the instance id, and the netlist
+ * reference never collide with either domain (undo, reload, and deletion all
+ * re-scan the live document, and freed numbers are reused).
+ */
+export function nextInstanceDesignator(
+  document: SchematicDocument,
+  symbolId: string,
+): string {
+  const prefix = placementReferencePrefix(symbolId);
+  const used = new Set<string>();
+  for (const instance of document.instances) {
+    used.add(instance.id.toLowerCase());
+    if (instance.netlist?.reference) {
+      used.add(instance.netlist.reference.toLowerCase());
+    }
+  }
+  let index = 1;
+  while (used.has(`${prefix}${index}`.toLowerCase())) index += 1;
+  return `${prefix}${index}`;
+}
+
+/**
+ * Whether the placement label prefix equals the netlist reference prefix, so
+ * one designator can serve as both the instance id and its netlist reference.
+ */
+export function netlistReferenceMatchesPlacement(symbolId: string): boolean {
+  const netlistPrefix = deviceNetlistDefinition(symbolId)?.referencePrefix;
+  if (!netlistPrefix) return false;
+  return (
+    netlistPrefix.toLowerCase() ===
+    placementReferencePrefix(symbolId).toLowerCase()
+  );
+}
+
 export function nextInstanceReference(
   document: SchematicDocument,
   symbolId: string,
@@ -65,10 +116,11 @@ export function initialInstanceNetlist(
   document: SchematicDocument,
   symbolId: string,
   properties: Readonly<Instance["properties"]>,
+  reference?: string,
 ): InstanceNetlistData {
   const binding = defaultBinding(symbolId);
   return {
-    reference: nextInstanceReference(document, symbolId),
+    reference: reference ?? nextInstanceReference(document, symbolId),
     ...(binding ? { binding } : {}),
     parameters: rawParameters(properties),
   };

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -1816,6 +1816,16 @@ body {
   vector-effect: non-scaling-stroke;
 }
 
+/* Right-drag camera frame: hints navigation, not selection. */
+.zoom-box {
+  fill: var(--icm-accent-soft);
+  stroke: var(--icm-accent);
+  stroke-width: 1.5;
+  stroke-dasharray: 2 3;
+  pointer-events: none;
+  vector-effect: non-scaling-stroke;
+}
+
 .drafting-create-preview {
   stroke: var(--icm-accent);
   stroke-width: 1.5;

--- a/plan/2026-08-15-instance-designators-and-camera-zoom/plan.md
+++ b/plan/2026-08-15-instance-designators-and-camera-zoom/plan.md
@@ -1,0 +1,146 @@
+---
+status: completed
+experience: none
+---
+
+# Per-type instance designators and unified camera zoom-box
+
+## Goal
+
+Three related editor interaction fixes agreed with the user:
+
+1. Placement labels increment per device type (R1, R2, M1) instead of one
+   global counter (R1, M2, R3).
+2. Right-button drag draws a zoom box and fits the camera to it, reusing the
+   fit-view math. Zoom/fit/wheel math is first unified behind shared pure
+   camera functions (protocol: `(current rect, gesture params, limits) ->
+   next rect`); no class hierarchy, per design discussion.
+3. Copy (`c`) of components increments the visible label (copy R1 -> R2),
+   including batch copy. Pasted instances whose source id equals their
+   netlist reference adopt the new reference as their instance id; pasted
+   instance-label annotations whose text equals the old id/reference are
+   rewritten to the new reference. Custom label text is preserved verbatim.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+Worktree clean at branch creation; branch `agent/per-type-designators-zoom-box`
+created from `main` before editing.
+
+**Concurrent worker (recorded mid-target):** while this target was in flight,
+a second worker started `plan/2026-08-15-unified-schematic-move/` in the same
+working tree (selection-move-plan module + selection-controller,
+routing-planner, docs/specs edits, and App.tsx wiring for a selection move
+plan). Both change sets coexist; no edits were lost. Decision per AGENTS.md:
+the two targets share only `App.tsx`, whose hunks are cleanly separable
+(one mixed hunk at the DragPreview/BoxPreview interfaces is split manually).
+This target proceeds; the commit stages only this target's files and only
+this target's `App.tsx` hunks via `git apply --cached`, leaving the other
+worker's dirty state exactly as found. Workspace-wide `pnpm typecheck`
+currently reports two errors inside the other worker's untracked
+`selection-move-plan.test.ts`; they are not caused by this target.
+
+- Owned: `apps/editor/src/app/App.tsx` (this target's hunks only),
+  `apps/editor/src/features/netlist-export/netlist-authoring.ts` (+ test),
+  `apps/editor/src/features/clipboard/clipboard.ts` (+ test),
+  `apps/editor/src/canvas/fit-view.ts` (+ test),
+  `apps/editor/src/styles.css`,
+  `apps/editor/e2e/manual-editor.spec.ts`,
+  `apps/editor/e2e/component-insert.spec.ts`
+- Read-only: `packages/symbols/src/netlist.ts` (prefix definitions consumed,
+  not changed), `packages/model`, `packages/edit-engine`
+- Shared contracts affected: instance id allocation semantics (e2e specs pin
+  specific ids — updated deliberately per the new contract); pasted instance
+  id format (`R1-copy-1` -> `R2` when source id == source reference).
+
+## Work
+
+1. `netlist-authoring.ts`: add `placementReferencePrefix` (single prefix
+   source: GND/port overrides, then device netlist prefix, else `X`),
+   `nextInstanceDesignator` (lowest free index per prefix across the union of
+   instance ids and netlist references), `netlistReferenceMatchesPlacement`
+   (whether id and reference share a prefix so both can use the designator);
+   `initialInstanceNetlist` gains an optional reference override.
+2. `App.tsx` placement: `placeNewComponent` allocates id via
+   `nextInstanceDesignator` and passes it as the netlist reference when
+   prefixes match; delete the local prefix table and `instanceCounter`.
+   `placeVddRail` scans for the lowest free `VDD{n}` instead of using the
+   global counter.
+3. `clipboard.ts`: compute new references first, then pasted ids (designator
+   `newReference` when source id === source reference and free, else existing
+   `-copy-N` fallback); rewrite pasted `instance-label` annotation text when
+   it equals the source id or reference. Batch copy stays correct via the
+   shared occupied sets.
+4. `fit-view.ts`: add `CAMERA_ZOOM_LIMITS` and `zoomCameraAtAnchor` (pure,
+   anchor in 0..1 viewport space); migrate `zoomViewAtCenter`, wheel zoom,
+   and fit onto them (no behavior change for existing inputs).
+5. Right-drag zoom box: `BoxPreview` gains `intent: "select" | "zoom"`;
+   button-2 drag from empty canvas starts it, finish commits
+   `fitCameraToBounds(rect)` when both extents exceed one grid cell;
+   distinct `.zoom-box` style; tool/placement modes keep existing
+   right-click cancel behavior.
+6. Update pinned e2e assertions for per-type numbering and designator paste
+   ids; add e2e coverage for right-drag zoom and unit tests for the new
+   pure functions.
+
+## Validation
+
+- `git diff --check`, `git status --short --branch`
+- `pnpm test:local apps/editor/src/features/netlist-export/netlist-authoring.test.ts apps/editor/src/features/clipboard/clipboard.test.ts apps/editor/src/canvas/fit-view.test.ts`
+- `pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts apps/editor/e2e/component-insert.spec.ts`
+- Focused checks cover changed behavior; broader suite only if failures
+  leak beyond these files.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): per-type designators, copy label increment, right-drag zoom box
+```
+
+## Outcome
+
+Delivered all three requested behaviors on branch
+`agent/per-type-designators-zoom-box`:
+
+1. Placement labels now increment per type (`nextInstanceDesignator` scans
+   the union of instance ids and netlist references for the lowest free
+   per-prefix number; the single prefix source is
+   `placementReferencePrefix` with GND/port overrides over device netlist
+   prefixes). The global `instanceCounter` and the duplicated inline prefix
+   map are gone; `placeVddRail` scans for the lowest free `VDD{n}`.
+   When label and netlist prefixes agree the designator is also the netlist
+   reference, so label, id, and reference are one fact. Freed numbers are
+   reused (undo/reload-safe by construction).
+2. Zoom math is unified behind pure camera functions in `fit-view.ts`
+   (`zoomCameraAtAnchor` + shared `CAMERA_ZOOM_LIMITS`); center zoom, wheel
+   zoom, and the new right-drag zoom box all derive from them, and the box
+   commit reuses `fitCameraToBounds` exactly like Fit View. Right-drag from
+   empty canvas frames a region (`.zoom-box` preview); sub-grid right drags
+   stay ordinary right clicks; drafting/wire right-click cancel behavior is
+   unchanged. Camera-only: no revision change.
+3. Copy (`c`) increments visible labels: a pasted instance whose source
+   id equals its reference adopts the incremented reference as its id
+   (copy R1 -> R2; batch R1+R2 -> R3+R4 via shared occupied sets), and its
+   instance-label annotation is rebuilt with `semanticTextDocument` so the
+   canvas label reads the new reference with correct base/subscript runs.
+   Hand-edited labels and diverged ids keep the opaque `-copy-N` fallback.
+
+Validation: 20/20 focused unit tests (netlist-authoring, clipboard,
+fit-view); Playwright 17/17 component-insert, 65/65 manual-editor (incl. two
+new tests: per-type numbering, right-drag framing), 6/6 crash-safety +
+recovery, 25/25 drafting; `git diff --cached --check` clean. Workspace
+typecheck passes except two pre-existing errors inside the concurrent
+worker's untracked `selection-move-plan.test.ts` (documented above; not from
+this target, and not part of the commit). Commit staged only this target's
+files plus this target's `App.tsx` hunks; the concurrent worker's dirty
+state was left untouched.
+
+status: completed
+experience: none

--- a/plan/log.md
+++ b/plan/log.md
@@ -7341,3 +7341,22 @@ diff --check`, and two focused Playwright regressions passed.
   `codex/placement-mirror-grid-toggle`.
 - Mainline delivery: PR #72 passed all six required GitHub Actions checks and
   squash-merged to `main` as `7db4a06`.
+
+# 2026-08-15 - Per-type instance designators and right-drag camera framing
+
+- Target: per-type placement numbering, unified camera zoom protocol with a
+  right-drag zoom box, and copy-paste label increment (including batch).
+- Changed areas: netlist-authoring designator allocation; App placement and
+  VDD rail ids; clipboard paste ids and instance-label rewrite; fit-view
+  camera math unification; canvas right-drag gesture and zoom-box style;
+  focused unit and Playwright coverage (two new browser tests).
+- Validation: 20/20 focused unit tests; Playwright 17/17 component-insert,
+  65/65 manual-editor, 6/6 crash-safety+recovery, 25/25 drafting;
+  `git diff --cached --check`; typecheck clean for this target (two
+  remaining errors belong to a concurrent worker's untracked WIP file,
+  recorded in the plan).
+- Commit status: committed on `agent/per-type-designators-zoom-box` as
+  `feat(editor): per-type designators, copy label increment, right-drag zoom
+  box`; branch pushed for review. A concurrent worker's overlapping App.tsx
+  hunks were excluded from the commit via selective staging and left dirty
+  in the working tree.


### PR DESCRIPTION
## Summary

Three editor interaction improvements:

1. **Per-type placement numbering** — new components get the lowest free designator for their prefix (R1, R2, M1 instead of the old global counter R1, M2, R3). Allocation scans the union of instance ids and netlist references, so the visible label, instance id, and netlist reference agree and stay correct across undo/reload/deletion. The duplicated inline prefix map and the shared `instanceCounter` are gone; VDD rails scan for the lowest free `VDD{n}`.

2. **Unified camera protocol + right-drag zoom box** — zoom/fit/wheel math now derives from one pure function (`zoomCameraAtAnchor` + shared `CAMERA_ZOOM_LIMITS`) instead of two inline copies. Right-drag on empty canvas frames a region and fits the camera to it, reusing the Fit View rect math (`fitCameraToBounds`); sub-grid right drags stay ordinary right clicks and drafting/wire right-click cancel behavior is unchanged. Camera-only — no revision change.

3. **Copy increments visible labels** — copying R1 yields R2: the pasted instance adopts its incremented reference as its id and its label (batch R1+R2 → R3+R4 without collisions; repeated pastes keep counting). Label content is rebuilt via `semanticTextDocument` (base + subscript runs, schema-valid). Hand-edited label text is preserved; instances whose id diverges from their reference keep the opaque `-copy-N` fallback.

## Validation

- Unit: 20/20 focused tests (netlist-authoring, clipboard, fit-view).
- Playwright: 17/17 component-insert, 65/65 manual-editor (incl. two new tests: per-type numbering and right-drag framing), 6/6 crash-safety + recovery, 25/25 drafting.
- `git diff --check` clean; Prettier clean for all committed files.

## Note for reviewers

A concurrent workstream (unified schematic move) shares `App.tsx` in the working tree; only this target's hunks are committed here, and that workstream's in-flight edits remain uncommitted locally.