### PR TITLE
Unify topology-aware schematic movement

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -101,7 +101,10 @@ import {
 } from "../canvas/fit-view";
 import type { CanvasDragSession } from "../canvas/canvas-drag-session";
 import { startCanvasDragVisual } from "../canvas/canvas-drag-visual";
-import { resolveCanvasHitAtPoint } from "../canvas/canvas-hit-resolver";
+import {
+  rankCanvasHits,
+  resolveCanvasHitAtPoint,
+} from "../canvas/canvas-hit-resolver";
 import {
   centerOfBounds,
   clamp,
@@ -7842,6 +7845,30 @@ export function App({
             }}
             onDoubleClick={(event) => {
               const target = event.target as Element;
+              if (tool === "pointer") {
+                // Movement ranks electrical geometry before labels, but a
+                // deliberate double-click is an editing request. Look through
+                // the same point candidates for text instead of forcing users
+                // to Alt-cycle a route-attached label before editing it.
+                const annotationHit = rankCanvasHits(
+                  event.currentTarget.ownerDocument.elementsFromPoint(
+                    event.clientX,
+                    event.clientY,
+                  ),
+                ).find((hit) => hit.kind === "annotation");
+                const annotation = annotationHit
+                  ? document.annotations.find(
+                      (candidate) => candidate.id === annotationHit.id,
+                    )
+                  : undefined;
+                if (annotation) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  canvasDragSessionRef.current?.cancel();
+                  beginAnnotationTextEditing(annotation);
+                  return;
+                }
+              }
               if (
                 tool === "arrow" ||
                 tool === "construction-line" ||

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -221,6 +221,7 @@ import {
 import type { VisualSelection } from "../features/selection/visual-selection";
 import {
   planSelectionMove,
+  type SchematicMoveIntent,
   type SelectionMovePlan,
 } from "../features/selection/selection-move-plan";
 import {
@@ -286,12 +287,7 @@ interface PanPreview {
 interface RouteStretchPreview {
   routeId: string;
   segmentIndex: number;
-  kind:
-    | "segment"
-    | "translate"
-    | "power-rail-translate"
-    | "power-rail-resize-start"
-    | "power-rail-resize-end";
+  intent: Exclude<SchematicMoveIntent, "move-selection">;
   start: DerivedPoint;
   point: DerivedPoint;
 }
@@ -2411,10 +2407,10 @@ export function App({
         routeId,
         segmentIndex,
         routeRecord.route.presentation === "power-rail"
-          ? "power-rail-translate"
+          ? "move-power-rail"
           : looseRouteAnchorIds(document, routeRecord.route) !== null
-            ? "translate"
-            : "segment",
+            ? "move-loose-route"
+            : "stretch-segment",
         hitTarget,
       );
       return;
@@ -2492,7 +2488,7 @@ export function App({
     event: ReactPointerEvent<SVGElement>,
     routeId: string,
     segmentIndex: number,
-    kind: RouteStretchPreview["kind"] = "segment",
+    intent: RouteStretchPreview["intent"] = "stretch-segment",
     hitTarget: SVGElement = event.currentTarget,
   ): void {
     if (event.button !== 0) return;
@@ -2505,17 +2501,17 @@ export function App({
     );
     if (!record) return;
     const powerRail =
-      kind === "power-rail-translate" ||
-      kind === "power-rail-resize-start" ||
-      kind === "power-rail-resize-end"
+      intent === "move-power-rail" ||
+      intent === "resize-power-rail-start" ||
+      intent === "resize-power-rail-end"
         ? derivePowerRailComponent(document, routeId)
         : null;
     const anchorIds =
-      kind === "translate"
+      intent === "move-loose-route"
         ? (looseRouteAnchorIds(document, record.route) ?? [])
         : (powerRail?.junctionIds ?? []);
     const translatedRouteIds =
-      kind === "power-rail-translate"
+      intent === "move-power-rail"
         ? (powerRail?.routeIds ?? [routeId])
         : [routeId];
     let visual: ReturnType<typeof startCanvasDragVisual> | null = null;
@@ -2527,7 +2523,7 @@ export function App({
     const preview: RouteStretchPreview = {
       routeId,
       segmentIndex,
-      kind,
+      intent,
       start,
       point: start,
     };
@@ -2539,7 +2535,7 @@ export function App({
       thresholdPx: DRAG_START_DISTANCE_PX,
       onPreview: (client) => {
         const point = pointFromClient(client.x, client.y, svg, false);
-        if (kind === "translate" || kind === "power-rail-translate") {
+        if (intent === "move-loose-route" || intent === "move-power-rail") {
           dragVisual().translate({
             x: point.x - start.x,
             y: point.y - start.y,
@@ -2547,8 +2543,8 @@ export function App({
           return;
         }
         if (
-          kind === "power-rail-resize-start" ||
-          kind === "power-rail-resize-end"
+          intent === "resize-power-rail-start" ||
+          intent === "resize-power-rail-end"
         ) {
           // The persisted proposal resizes the outer rail fragment, which may
           // differ from the selected fragment after a tap. Avoid previewing a
@@ -2598,7 +2594,7 @@ export function App({
     );
     if (!record) return;
     try {
-      if (preview.kind === "translate") {
+      if (preview.intent === "move-loose-route") {
         const anchorIds = looseRouteAnchorIds(document, record.route);
         if (!anchorIds) {
           throw new Error(
@@ -2622,7 +2618,7 @@ export function App({
           );
           if (result.ok) setStatus(`Moved loose route ${record.route.id}`);
         }
-      } else if (preview.kind === "power-rail-translate") {
+      } else if (preview.intent === "move-power-rail") {
         const delta = {
           x: snapCoordinate(
             point.x - preview.start.x,
@@ -2645,15 +2641,15 @@ export function App({
           if (result.ok) setStatus(`Moved VDD rail ${record.route.id}`);
         }
       } else if (
-        preview.kind === "power-rail-resize-start" ||
-        preview.kind === "power-rail-resize-end"
+        preview.intent === "resize-power-rail-start" ||
+        preview.intent === "resize-power-rail-end"
       ) {
         const result = transact(
           proposePowerRailEndpointResize(
             document,
             resolver,
             record.route.id,
-            preview.kind === "power-rail-resize-start" ? "start" : "end",
+            preview.intent === "resize-power-rail-start" ? "start" : "end",
             snapCoordinate(point.x, document.presentation.grid),
           ).edits,
         );
@@ -8177,7 +8173,7 @@ export function App({
                       : null;
                   const handlePointerDown = (
                     event: ReactPointerEvent<SVGElement>,
-                    kind: RouteStretchPreview["kind"],
+                    intent: RouteStretchPreview["intent"],
                   ) => {
                     const primaryInstanceId = selectedIds.at(-1);
                     if (
@@ -8187,7 +8183,7 @@ export function App({
                       beginMove(event, primaryInstanceId);
                       return;
                     }
-                    beginRouteStretch(event, route.id, segmentIndex, kind);
+                    beginRouteStretch(event, route.id, segmentIndex, intent);
                   };
                   return (
                     <g key={`handle-${route.id}`}>
@@ -8219,10 +8215,10 @@ export function App({
                           handlePointerDown(
                             event,
                             powerRail
-                              ? "power-rail-translate"
+                              ? "move-power-rail"
                               : translatesWholeRoute
-                                ? "translate"
-                                : "segment",
+                                ? "move-loose-route"
+                                : "stretch-segment",
                           )
                         }
                         pointerEvents={tool === "wire" ? "none" : undefined}
@@ -8241,8 +8237,8 @@ export function App({
                             handlePointerDown(
                               event,
                               index === 0
-                                ? "power-rail-resize-start"
-                                : "power-rail-resize-end",
+                                ? "resize-power-rail-start"
+                                : "resize-power-rail-end",
                             )
                           }
                           pointerEvents={tool === "wire" ? "none" : undefined}
@@ -8402,8 +8398,8 @@ export function App({
                           selectedRoute.id,
                           selectedRouteSegmentIndex ?? 0,
                           powerRailEndIndex === 0
-                            ? "power-rail-resize-start"
-                            : "power-rail-resize-end",
+                            ? "resize-power-rail-start"
+                            : "resize-power-rail-end",
                         );
                         return;
                       }

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -220,6 +220,10 @@ import {
 } from "../features/selection/visual-selection";
 import type { VisualSelection } from "../features/selection/visual-selection";
 import {
+  planSelectionMove,
+  type SelectionMovePlan,
+} from "../features/selection/selection-move-plan";
+import {
   annotationAnchor,
   annotationHitBox,
   attachmentAtPoint,
@@ -265,6 +269,7 @@ interface DragPreview {
   primaryInstanceId: string;
   originalPositions: Record<string, Point>;
   pointerStart: DerivedPoint;
+  movePlan: SelectionMovePlan;
 }
 interface BoxPreview {
   start: DerivedPoint;
@@ -3507,10 +3512,19 @@ export function App({
       setStatus(`Selected ${instanceId}`);
       return;
     }
-    const movingIds = selectedIds.includes(instanceId)
-      ? selectedIds
-      : [instanceId];
+    const movingSelection: VisualSelection = selectedIds.includes(instanceId)
+      ? visualSelection
+      : {
+          instanceIds: [instanceId],
+          routeIds: [],
+          junctionIds: [],
+          annotationIds: [],
+          draftingIds: [],
+        };
+    const movePlan = planSelectionMove(document, movingSelection);
+    const movingIds = movePlan.instanceIds;
     if (!selectedIds.includes(instanceId)) selectInstance(instanceId, false);
+    if (movingIds.length === 0) return;
     canvasDragSessionRef.current?.cancel();
     const svg = hitTarget.ownerSVGElement!;
     const pointerStart = pointFromClient(
@@ -3529,45 +3543,11 @@ export function App({
         }),
       ),
       pointerStart,
+      movePlan,
     };
-    const attachedAnnotationIds = document.annotations
-      .filter(
-        (annotation) =>
-          annotation.anchor.kind === "object" &&
-          movingIds.includes(annotation.anchor.objectId),
-      )
-      .map((annotation) => annotation.id);
-    const movingInternalSelection = deriveInternalGroupSelection(
-      document,
-      movingIds,
-    );
-    const movingInternalObjectIds = new Set([
-      ...movingInternalSelection.netIds,
-      ...movingInternalSelection.routeIds,
-      ...movingInternalSelection.junctionIds,
-    ]);
-    const movingInternalAnnotationIds = document.annotations
-      .filter((annotation) => {
-        const routeAttachment = effectiveRouteAttachment(annotation);
-        return (
-          (annotation.anchor.kind === "object" &&
-            movingInternalObjectIds.has(annotation.anchor.objectId)) ||
-          (routeAttachment !== null &&
-            movingInternalSelection.routeIds.includes(routeAttachment.routeId))
-        );
-      })
-      .map((annotation) => annotation.id);
     let visual: ReturnType<typeof startCanvasDragVisual> | null = null;
     const dragVisual = () =>
-      (visual ??= startCanvasDragVisual(svg, [
-        ...new Set([
-          ...movingIds,
-          ...movingInternalSelection.routeIds,
-          ...movingInternalSelection.junctionIds,
-          ...attachedAnnotationIds,
-          ...movingInternalAnnotationIds,
-        ]),
-      ]));
+      (visual ??= startCanvasDragVisual(svg, movePlan.previewObjectIds));
     const tolerance = logicalRadiusForPixels(svg, SNAP_CAPTURE_RADIUS_PX);
     let lastSnap: SnapResult | undefined;
     canvasDragSessionRef.current = startCanvasDragSession({
@@ -3785,6 +3765,50 @@ export function App({
     if (delta.x !== 0 || delta.y !== 0) {
       try {
         const groupMove = proposeGroupMoveEdits(document, resolver, moves);
+        const looseRouteEdits = preview.movePlan.looseRouteIds.flatMap(
+          (routeId) =>
+            proposeLooseRouteTranslation(document, routeId, delta).edits,
+        );
+        const visualEdits: SchematicEdit[] = [
+          ...preview.movePlan.freeAnnotationIds.flatMap((annotationId) => {
+            const annotation = document.annotations.find(
+              (candidate) => candidate.id === annotationId,
+            );
+            if (!annotation || annotation.anchor.kind !== "free") return [];
+            return [
+              {
+                kind: "upsert_schematic_annotation" as const,
+                annotation: {
+                  ...annotation,
+                  anchor: {
+                    kind: "free" as const,
+                    position: {
+                      x: annotation.anchor.position.x + delta.x,
+                      y: annotation.anchor.position.y + delta.y,
+                    },
+                  },
+                },
+              },
+            ];
+          }),
+          ...preview.movePlan.draftingIds.flatMap((draftingId) => {
+            const object = document.drafting?.objects.find(
+              (candidate) => candidate.id === draftingId,
+            );
+            return object
+              ? [
+                  {
+                    kind: "upsert_drafting_object" as const,
+                    object: translateDraftingObject(
+                      object,
+                      delta,
+                      document.presentation.grid,
+                    ),
+                  },
+                ]
+              : [];
+          }),
+        ];
         const movingElectrical = electricalMatch?.moving.electrical;
         const targetElectrical = electricalMatch?.target.electrical;
         const projected = structuredClone(document);
@@ -3819,7 +3843,12 @@ export function App({
                   },
                 ]
               : [];
-        const result = transact([...groupMove.edits, ...contactEdits]);
+        const result = transact([
+          ...groupMove.edits,
+          ...looseRouteEdits,
+          ...visualEdits,
+          ...contactEdits,
+        ]);
         if (result.ok && electricalMatch) {
           setStatus("Snapped pin endpoints and connected them without a wire");
         }
@@ -5387,7 +5416,15 @@ export function App({
       : {
           routeIds: routePolylines
             .filter(({ polyline }) =>
-              rectsIntersect(polylineBounds(polyline.points), rect),
+              polyline.points
+                .slice(0, -1)
+                .some((from, index) =>
+                  segmentIntersectsRect(
+                    from,
+                    polyline.points[index + 1]!,
+                    rect,
+                  ),
+                ),
             )
             .map(({ route }) => route.id),
           junctionIds: document.junctions

--- a/apps/editor/src/canvas/canvas-hit-resolver.test.ts
+++ b/apps/editor/src/canvas/canvas-hit-resolver.test.ts
@@ -15,10 +15,14 @@ function element(kind: string, id: string, selected = false): Element {
 }
 
 describe("resolveCanvasHit", () => {
-  it("uses semantic priority instead of SVG paint order", () => {
+  it("prefers electrical geometry over incidental text in ordinary selection", () => {
     const route = element("route", "wire-1");
     const annotation = element("annotation", "label-1");
     expect(resolveCanvasHit([route, annotation])).toMatchObject({
+      kind: "route",
+      id: "wire-1",
+    });
+    expect(resolveCanvasHit([route, annotation], 1)).toMatchObject({
       kind: "annotation",
       id: "label-1",
     });

--- a/apps/editor/src/canvas/canvas-hit-resolver.ts
+++ b/apps/editor/src/canvas/canvas-hit-resolver.ts
@@ -16,12 +16,12 @@ export interface CanvasHit {
 
 const KIND_PRIORITY: Record<CanvasHitKind, number> = {
   handle: 70,
-  annotation: 60,
-  "instance-label": 55,
-  instance: 50,
+  instance: 60,
+  route: 55,
+  junction: 50,
+  annotation: 45,
+  "instance-label": 44,
   drafting: 40,
-  route: 40,
-  junction: 30,
 };
 const SELECTED_BONUS = 25;
 

--- a/apps/editor/src/features/selection/selection-controller.test.ts
+++ b/apps/editor/src/features/selection/selection-controller.test.ts
@@ -22,14 +22,14 @@ describe("selectionReducer", () => {
     ).toEqual({ ...EMPTY_VISUAL_SELECTION, routeIds: ["route-2"] });
   });
 
-  it("toggles additive instance selection while clearing other kinds", () => {
+  it("toggles additive instance selection while preserving mixed marquee kinds", () => {
     const added = selectionReducer(mixedSelection, {
       type: "select-instance",
       id: "M2",
       additive: true,
     });
     expect(added).toEqual({
-      ...EMPTY_VISUAL_SELECTION,
+      ...mixedSelection,
       instanceIds: ["M1", "M2"],
     });
     expect(

--- a/apps/editor/src/features/selection/selection-controller.ts
+++ b/apps/editor/src/features/selection/selection-controller.ts
@@ -49,10 +49,7 @@ export function selectionReducer(
       const instanceIds = selection.instanceIds.includes(action.id)
         ? selection.instanceIds.filter((id) => id !== action.id)
         : [...selection.instanceIds, action.id];
-      return {
-        ...EMPTY_VISUAL_SELECTION,
-        instanceIds,
-      };
+      return normalizeVisualSelection({ ...selection, instanceIds });
     }
     case "clear-kinds":
       return clearVisualSelectionKinds(selection, action.kinds);

--- a/apps/editor/src/features/selection/selection-move-plan.test.ts
+++ b/apps/editor/src/features/selection/selection-move-plan.test.ts
@@ -84,6 +84,7 @@ describe("selection move plan", () => {
       draftingIds: [],
     });
 
+    expect(plan.intent).toBe("move-selection");
     expect(plan.translatedRouteIds).toEqual(["wire-left", "wire-right"]);
     expect(plan.translatedJunctionIds).toEqual(["J1"]);
     expect(plan.previewObjectIds).toEqual(
@@ -112,6 +113,7 @@ describe("selection move plan", () => {
       annotationIds: [],
       draftingIds: [],
     });
+    expect(plan.intent).toBe("move-selection");
     expect(plan.translatedJunctionIds).toEqual([]);
     expect(plan.fixedObjectIds).toEqual(["J1"]);
   });

--- a/apps/editor/src/features/selection/selection-move-plan.test.ts
+++ b/apps/editor/src/features/selection/selection-move-plan.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { createEmptyDocument } from "@icm/model";
+
+import { planSelectionMove } from "./selection-move-plan";
+
+describe("selection move plan", () => {
+  it("keeps an internal wire, its Junction, and anchored labels in one visual closure", () => {
+    const document = createEmptyDocument("doc", "Doc");
+    document.instances.push(
+      {
+        id: "R1",
+        symbolId: "resistor",
+        properties: {},
+        placement: {
+          position: { x: 100, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        id: "R2",
+        symbolId: "resistor",
+        properties: {},
+        placement: {
+          position: { x: 300, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+    );
+    document.nets.push({
+      id: "n1",
+      name: "n1",
+      scope: "local",
+      terminals: [
+        { instanceId: "R1", pinName: "1" },
+        { instanceId: "R2", pinName: "1" },
+      ],
+    });
+    document.junctions.push({
+      id: "J1",
+      netId: "n1",
+      position: { x: 200, y: 100 },
+    });
+    document.routes.push(
+      {
+        id: "wire-left",
+        netId: "n1",
+        from: { kind: "terminal", instanceId: "R1", pinName: "1" },
+        to: { kind: "junction", junctionId: "J1" },
+        waypoints: [],
+        segmentModes: ["manual"],
+      },
+      {
+        id: "wire-right",
+        netId: "n1",
+        from: { kind: "junction", junctionId: "J1" },
+        to: { kind: "terminal", instanceId: "R2", pinName: "1" },
+        waypoints: [],
+        segmentModes: ["manual"],
+      },
+    );
+    document.annotations.push({
+      id: "label-r1",
+      kind: "instance-label",
+      content: { runs: [{ kind: "text", value: "R1" }] },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+      anchor: {
+        kind: "object",
+        objectId: "R1",
+        localOffset: { x: 10, y: 10 },
+        fallbackPosition: { x: 110, y: 110 },
+      },
+    });
+
+    const plan = planSelectionMove(document, {
+      instanceIds: ["R1", "R2"],
+      routeIds: [],
+      junctionIds: [],
+      annotationIds: [],
+      draftingIds: [],
+    });
+
+    expect(plan.translatedRouteIds).toEqual(["wire-left", "wire-right"]);
+    expect(plan.translatedJunctionIds).toEqual(["J1"]);
+    expect(plan.previewObjectIds).toEqual(
+      expect.arrayContaining([
+        "R1",
+        "R2",
+        "J1",
+        "wire-left",
+        "wire-right",
+        "label-r1",
+      ]),
+    );
+  });
+
+  it("does not treat a selected boundary Junction as independently movable", () => {
+    const document = createEmptyDocument("doc", "Doc");
+    document.junctions.push({
+      id: "J1",
+      netId: "n1",
+      position: { x: 100, y: 100 },
+    });
+    const plan = planSelectionMove(document, {
+      instanceIds: [],
+      routeIds: [],
+      junctionIds: ["J1"],
+      annotationIds: [],
+      draftingIds: [],
+    });
+    expect(plan.translatedJunctionIds).toEqual([]);
+    expect(plan.fixedObjectIds).toEqual(["J1"]);
+  });
+});

--- a/apps/editor/src/features/selection/selection-move-plan.ts
+++ b/apps/editor/src/features/selection/selection-move-plan.ts
@@ -1,0 +1,134 @@
+import { deriveInternalGroupSelection } from "@icm/derived";
+import type { Annotation, SchematicDocument } from "@icm/model";
+
+import {
+  effectiveRouteAttachment,
+  looseRouteAnchorIds,
+} from "../wiring/route-interaction-geometry";
+import type { VisualSelection } from "./visual-selection";
+
+/**
+ * A transient, editor-only description of what moves in one direct-manipulation
+ * gesture. It intentionally contains no geometry or persisted state: Route
+ * geometry remains planned by the Edit Engine and the Document remains the
+ * sole source of electrical truth.
+ */
+export interface SelectionMovePlan {
+  instanceIds: string[];
+  translatedRouteIds: string[];
+  translatedJunctionIds: string[];
+  looseRouteIds: string[];
+  previewObjectIds: string[];
+  freeAnnotationIds: string[];
+  draftingIds: string[];
+  fixedObjectIds: string[];
+}
+
+function stable(ids: Iterable<string>): string[] {
+  return [...new Set(ids)].sort((left, right) =>
+    left.localeCompare(right, "en"),
+  );
+}
+
+function followsTranslatedObject(
+  annotation: Annotation,
+  instanceIds: ReadonlySet<string>,
+  junctionIds: ReadonlySet<string>,
+  routeIds: ReadonlySet<string>,
+): boolean {
+  if (annotation.anchor.kind === "object") {
+    return (
+      instanceIds.has(annotation.anchor.objectId) ||
+      junctionIds.has(annotation.anchor.objectId)
+    );
+  }
+  const attachment = effectiveRouteAttachment(annotation);
+  return attachment !== null && routeIds.has(attachment.routeId);
+}
+
+/**
+ * Derive one movement closure from one visual selection. Instances determine
+ * electrical closure: internal Routes/Junctions translate intact and boundary
+ * Routes remain the Edit Engine's stretch responsibility. A separately
+ * selected loose Route may translate only with both of its loose Junction
+ * anchors. Other explicitly selected Routes remain fixed rather than silently
+ * detaching or changing connectivity.
+ */
+export function planSelectionMove(
+  document: SchematicDocument,
+  selection: VisualSelection,
+): SelectionMovePlan {
+  const instanceIds = stable(
+    selection.instanceIds.filter((id) =>
+      document.instances.some(
+        (instance) => instance.id === id && instance.placement,
+      ),
+    ),
+  );
+  const internal = deriveInternalGroupSelection(document, instanceIds);
+  const translatedRouteIds = new Set(internal.routeIds);
+  const translatedJunctionIds = new Set(internal.junctionIds);
+  const looseRouteIds = new Set<string>();
+  const fixedObjectIds = new Set<string>();
+
+  for (const routeId of selection.routeIds) {
+    if (translatedRouteIds.has(routeId)) continue;
+    const route = document.routes.find((candidate) => candidate.id === routeId);
+    if (!route) continue;
+    const anchors = looseRouteAnchorIds(document, route);
+    if (!anchors) {
+      fixedObjectIds.add(routeId);
+      continue;
+    }
+    looseRouteIds.add(routeId);
+    translatedRouteIds.add(routeId);
+    translatedJunctionIds.add(anchors[0]);
+    translatedJunctionIds.add(anchors[1]);
+  }
+
+  for (const junctionId of selection.junctionIds) {
+    if (!translatedJunctionIds.has(junctionId)) fixedObjectIds.add(junctionId);
+  }
+
+  const instanceIdSet = new Set(instanceIds);
+  const followingAnnotationIds = document.annotations
+    .filter((annotation) =>
+      followsTranslatedObject(
+        annotation,
+        instanceIdSet,
+        translatedJunctionIds,
+        translatedRouteIds,
+      ),
+    )
+    .map((annotation) => annotation.id);
+  const freeAnnotationIds = selection.annotationIds.filter((id) => {
+    const annotation = document.annotations.find(
+      (candidate) => candidate.id === id,
+    );
+    return annotation?.anchor.kind === "free" && !annotation.locked;
+  });
+  const draftingIds = selection.draftingIds.filter((id) => {
+    const object = document.drafting?.objects.find(
+      (candidate) => candidate.id === id,
+    );
+    return Boolean(object && !object.locked);
+  });
+
+  return {
+    instanceIds,
+    translatedRouteIds: stable(translatedRouteIds),
+    translatedJunctionIds: stable(translatedJunctionIds),
+    looseRouteIds: stable(looseRouteIds),
+    previewObjectIds: stable([
+      ...instanceIds,
+      ...translatedRouteIds,
+      ...translatedJunctionIds,
+      ...followingAnnotationIds,
+      ...freeAnnotationIds,
+      ...draftingIds,
+    ]),
+    freeAnnotationIds: stable(freeAnnotationIds),
+    draftingIds: stable(draftingIds),
+    fixedObjectIds: stable(fixedObjectIds),
+  };
+}

--- a/apps/editor/src/features/selection/selection-move-plan.ts
+++ b/apps/editor/src/features/selection/selection-move-plan.ts
@@ -8,12 +8,26 @@ import {
 import type { VisualSelection } from "./visual-selection";
 
 /**
+ * The finite direct-manipulation vocabulary. These are transient editor
+ * intents, not persisted commands: all committed changes remain existing typed
+ * edits. No intent requests path search or global rerouting.
+ */
+export type SchematicMoveIntent =
+  | "move-selection"
+  | "stretch-segment"
+  | "move-loose-route"
+  | "move-power-rail"
+  | "resize-power-rail-start"
+  | "resize-power-rail-end";
+
+/**
  * A transient, editor-only description of what moves in one direct-manipulation
  * gesture. It intentionally contains no geometry or persisted state: Route
  * geometry remains planned by the Edit Engine and the Document remains the
  * sole source of electrical truth.
  */
 export interface SelectionMovePlan {
+  intent: "move-selection";
   instanceIds: string[];
   translatedRouteIds: string[];
   translatedJunctionIds: string[];
@@ -115,6 +129,7 @@ export function planSelectionMove(
   });
 
   return {
+    intent: "move-selection",
     instanceIds,
     translatedRouteIds: stable(translatedRouteIds),
     translatedJunctionIds: stable(translatedJunctionIds),

--- a/docs/specs/edit-engine.md
+++ b/docs/specs/edit-engine.md
@@ -133,9 +133,10 @@ Phase 8 topology operations have these preconditions:
   unowned, or attaches an unowned endpoint to the other endpoint's Net.
 - `set_net_name` requires a non-empty trimmed name. A name already owned by a
   different Net is rejected; the caller must explicitly `merge_nets`.
-- `move_junction` preserves topology and must be paired with any required
-  `set_route_points` edits in the same transaction. Routes protected by locked
-  geometry reject the move.
+- `move_junction` preserves topology and must be paired with `set_route_points`
+  edits for every incident Route whose geometry changes in the same
+  transaction. GUI movement planners always author those Route edits; Routes
+  protected by locked geometry reject the move.
 - `move_instance` stretches unprotected connected Routes to keep them
   orthogonal (ADR 0009). A Route with a locked/trunk adjacent segment is
   skipped; if the caller does not re-point it in the same transaction, the

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -100,6 +100,37 @@ atomic transaction. Hover, geometric crossing, selection, and preview never
 change connectivity. A wire endpoint or explicit segment tap is required to
 create contact.
 
+## Movement closure
+
+Every direct-manipulation selection move first derives one transient,
+editor-only `SelectionMovePlan`. It is neither Project data nor an Edit Engine
+or Agent API payload. The plan is the shared authority for the live preview and
+the typed edits committed on pointer release; no pointer handler may invent an
+independent follow set.
+
+The visual marquee is the user's explicit intent. Electrical closure then
+classifies that intent without changing connectivity:
+
+- selected Instances translate together;
+- a Route/Junction component whose terminal endpoints are all selected is
+  internal and translates intact;
+- a Route with exactly one selected Instance endpoint is a boundary Route and
+  is stretched while preserving its external endpoint;
+- an explicitly selected loose Route may translate only together with both of
+  its loose Junction anchors;
+- an ordinary connected Route or Junction that does not meet one of those
+  conditions is fixed for a group move. It is edited through the explicit
+  segment/branch tools, never silently detached or reconnected;
+- object- and route-anchored annotations follow their resolved target; free
+  annotations and free drafting objects translate only when explicitly
+  selected.
+
+The planner authors the resulting geometry for every planned Route in the
+same transaction. Engine instance-follow remains the safe single-instance
+fallback, not a second progressive planner for a group gesture. Marquee Route
+selection tests actual polyline segments against the rectangle, rather than
+selecting a distant bend solely because its bounding box overlaps the gesture.
+
 ## Text and presentation
 
 Every visible editable label is one persisted RichText annotation. Component

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -131,6 +131,26 @@ fallback, not a second progressive planner for a group gesture. Marquee Route
 selection tests actual polyline segments against the rectangle, rather than
 selecting a distant bend solely because its bounding box overlaps the gesture.
 
+## No-reroute movement boundary
+
+The editor's finite direct-manipulation vocabulary is transient only:
+`move-selection`, `stretch-segment`, `move-loose-route`, `move-power-rail`,
+and the two explicit power-rail endpoint resizes. It is not Project data, an
+Edit Engine command, or an Agent API extension; each intent compiles to the
+existing typed edits.
+
+No movement intent searches for a new path. An internal Route translates every
+point by one common delta. A boundary stretch may alter only geometry adjacent
+to the moved endpoint (or add one local orthogonal elbow); remote waypoints
+remain untouched. A protected adjacent `locked` or `trunk` segment rejects the
+gesture rather than being rerouted. Power rails use their explicit translate
+and endpoint-resize intents, never an inferred route search.
+
+Normal canvas hit ranking prefers a symbol, Route, or Junction over an
+overlapping label so routine moves do not accidentally drag text. Text remains
+individually selectable when it is the only hit, and Alt cycling deliberately
+selects an overlapping label.
+
 ## Text and presentation
 
 Every visible editable label is one persisted RichText annotation. Component

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -149,7 +149,9 @@ and endpoint-resize intents, never an inferred route search.
 Normal canvas hit ranking prefers a symbol, Route, or Junction over an
 overlapping label so routine moves do not accidentally drag text. Text remains
 individually selectable when it is the only hit, and Alt cycling deliberately
-selects an overlapping label.
+selects an overlapping label. A deliberate double-click is an editing intent,
+not a movement intent: it resolves an overlapping editable annotation directly
+without requiring an Alt cycle.
 
 ## Text and presentation
 

--- a/packages/derived/src/derived.test.ts
+++ b/packages/derived/src/derived.test.ts
@@ -228,4 +228,38 @@ describe("derived connectivity and route geometry", () => {
       proposeLocalStretch(document, resolver, "A", { x: 140, y: 360 }),
     ).toThrow(/protected adjacent segment/u);
   });
+
+  it("changes only endpoint-adjacent geometry during a local stretch", () => {
+    const document = documentFixture();
+    document.routes = [
+      {
+        id: "route-h",
+        netId: "net-h",
+        from: terminal("A"),
+        to: terminal("B"),
+        waypoints: [
+          { x: 180, y: 300 },
+          { x: 180, y: 260 },
+          { x: 420, y: 260 },
+          { x: 420, y: 300 },
+        ],
+        segmentModes: ["manual", "manual", "manual", "manual", "manual"],
+      },
+    ];
+
+    expect(
+      proposeLocalStretch(document, resolver, "A", { x: 140, y: 360 }),
+    ).toEqual([
+      {
+        routeId: "route-h",
+        waypoints: [
+          { x: 180, y: 360 },
+          { x: 180, y: 260 },
+          { x: 420, y: 260 },
+          { x: 420, y: 300 },
+        ],
+        segmentModes: ["manual", "manual", "manual", "manual", "manual"],
+      },
+    ]);
+  });
 });

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -127,22 +127,6 @@ export function proposeGroupMoveEdits(
   moves: readonly { instanceId: string; position: Point }[],
 ): GroupMoveEditProposal {
   const proposal = proposeGroupMove(document, resolver, moves);
-  const movedJunctionIds = new Set(
-    proposal.junctions.map((move) => move.junctionId),
-  );
-  const routesRequiringExplicitGeometry = proposal.routes.filter(
-    (routeMove) => {
-      const route = document.routes.find(
-        (candidate) => candidate.id === routeMove.routeId,
-      );
-      return (
-        (route?.from.kind === "junction" &&
-          movedJunctionIds.has(route.from.junctionId)) ||
-        (route?.to.kind === "junction" &&
-          movedJunctionIds.has(route.to.junctionId))
-      );
-    },
-  );
   return {
     edits: [
       ...moves.map((move): SchematicEdit => ({
@@ -153,7 +137,11 @@ export function proposeGroupMoveEdits(
         kind: "move_junction",
         ...move,
       })),
-      ...routeEdits(document, routesRequiringExplicitGeometry),
+      // A group plan is the sole geometry authority. Emitting every planned
+      // Route prevents move_instance from progressively re-stretching an
+      // internal wire once per selected Instance, which otherwise makes a
+      // group translation depend on transaction edit order.
+      ...routeEdits(document, proposal.routes),
       ...proposal.annotations.flatMap((move): SchematicEdit[] => {
         const annotation = document.annotations.find(
           (candidate) => candidate.id === move.annotationId,

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -450,7 +450,7 @@ describe("routing Edit Engine", () => {
     ]);
   });
 
-  it("plans internal group route follow as one engine edit proposal", () => {
+  it("authors every planned internal Route so group geometry is order-independent", () => {
     const document = documentFixture();
     const routed = executeTransaction(
       document,
@@ -477,9 +477,11 @@ describe("routing Edit Engine", () => {
     expect(
       plan.edits.filter((edit) => edit.kind === "move_instance"),
     ).toHaveLength(3);
-    expect(plan.edits.some((edit) => edit.kind === "set_route_points")).toBe(
-      false,
-    );
+    expect(
+      plan.edits
+        .filter((edit) => edit.kind === "set_route_points")
+        .map((edit) => edit.routeId),
+    ).toEqual(["route-h"]);
     const moved = executeTransaction(
       routed.document,
       transaction(document.id, 1, plan.edits),
@@ -488,7 +490,7 @@ describe("routing Edit Engine", () => {
     expect(moved.ok).toBe(true);
   });
 
-  it("authors route geometry only where a group move also moves a Junction", () => {
+  it("authors group Route geometry when a group move also moves a Junction", () => {
     const document = documentFixture();
     document.junctions.push({
       id: "junction-h",

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -54,6 +54,63 @@ function transaction(documentId: string, revision: number, edits: unknown[]) {
 }
 
 describe("routing Edit Engine", () => {
+  it("rejects a Junction move that would leave an incident Route geometry stale", () => {
+    const document = createEmptyDocument("junction-integrity", "Junction");
+    document.nets.push({ id: "n1", scope: "local", terminals: [] });
+    document.junctions.push(
+      {
+        id: "J1",
+        netId: "n1",
+        position: { x: 100, y: 100 },
+        role: "route-anchor",
+      },
+      {
+        id: "J2",
+        netId: "n1",
+        position: { x: 200, y: 100 },
+        role: "route-anchor",
+      },
+    );
+    document.routes.push({
+      id: "wire-1",
+      netId: "n1",
+      from: { kind: "junction", junctionId: "J1" },
+      to: { kind: "junction", junctionId: "J2" },
+      waypoints: [],
+      segmentModes: ["manual"],
+    });
+
+    const rejected = executeTransaction(
+      document,
+      transaction(document.id, 0, [
+        {
+          kind: "move_junction",
+          junctionId: "J1",
+          position: { x: 120, y: 100 },
+        },
+      ]),
+      context,
+    );
+    expect(rejected).toMatchObject({
+      ok: false,
+      error: {
+        code: "EDIT_PRECONDITION",
+      },
+      diagnostics: [{ objectIds: ["J1", "wire-1"] }],
+    });
+
+    const proposal = proposeLooseRouteTranslation(document, "wire-1", {
+      x: 20,
+      y: 0,
+    });
+    const moved = executeTransaction(
+      document,
+      transaction(document.id, 0, proposal.edits),
+      context,
+    );
+    expect(moved.ok).toBe(true);
+  });
+
   it("keeps a tapped VDD rail contiguous when it is resized or moved", () => {
     const document = createEmptyDocument("vdd-manipulation", "VDD edit");
     document.nets.push({

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -2762,6 +2762,24 @@ export function executeTransaction(
             `Junction does not exist: ${edit.junctionId}`,
           );
         }
+        const incidentRoutes = draft.routes.filter(
+          (route) =>
+            (route.from.kind === "junction" &&
+              route.from.junctionId === junction.id) ||
+            (route.to.kind === "junction" &&
+              route.to.junctionId === junction.id),
+        );
+        const routeWithoutGeometry = incidentRoutes.find(
+          (route) => !explicitlyAuthoredRouteIds.has(route.id),
+        );
+        if (routeWithoutGeometry) {
+          return rejectAt(
+            "EDIT_PRECONDITION",
+            `Moving Junction ${junction.id} requires explicit geometry for incident Route ${routeWithoutGeometry.id}`,
+            [],
+            [junction.id, routeWithoutGeometry.id],
+          );
+        }
         const protectedRoute = draft.routes.find(
           (route) =>
             ((route.from.kind === "junction" &&

--- a/plan/2026-08-15-junction-move-integrity/plan.md
+++ b/plan/2026-08-15-junction-move-integrity/plan.md
@@ -1,0 +1,65 @@
+---
+status: completed
+experience: none
+---
+
+# Junction move integrity
+
+## Goal
+
+Make the existing `move_junction` typed edit reject atomically when it would
+leave any incident Route with stale authored waypoint geometry. This implements
+the existing Edit Engine contract without adding a new API shape.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/unified-move-plan...origin/codex/unified-move-plan
+```
+
+The isolated worktree is clean. This follow-up is limited to the transaction
+integrity boundary and its direct regression test.
+
+- `packages/edit-engine/src/transaction.ts`
+- `packages/edit-engine/src/routing.test.ts`
+- `plan/2026-08-15-junction-move-integrity/plan.md`
+- `plan/log.md`
+
+Read-only shared dependencies: Edit schemas, Agent action compiler, model
+route validation, and routing planners. Existing planners already pair
+Junction moves with Route geometry; no Agent/API schema change is authorized.
+
+## Work
+
+1. Require an explicit `set_route_points` or `route_orthogonal` edit for every
+   Route incident to a moved Junction in the same transaction.
+2. Return a typed atomic precondition failure naming the missing Route.
+3. Cover rejection and planner-generated paired success.
+
+## Validation
+
+- `pnpm test:local packages/edit-engine/src/routing.test.ts packages/edit-engine/src/authoring.test.ts`
+- `pnpm typecheck`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(edit-engine): require geometry with junction moves
+```
+
+## Outcome
+
+`move_junction` now checks every incident Route before mutation. If a Route is
+not explicitly authored by `set_route_points` or `route_orthogonal` elsewhere
+in the same transaction, the complete transaction rejects with a localized
+`EDIT_PRECONDITION` diagnostic naming both the Junction and Route. Existing
+route planners already satisfy this requirement.
+
+Validation passed: Edit Engine routing and authoring tests (40/40), workspace
+typecheck, Prettier, and `git diff --check`.

--- a/plan/2026-08-15-move-intent-no-reroute/plan.md
+++ b/plan/2026-08-15-move-intent-no-reroute/plan.md
@@ -1,0 +1,77 @@
+---
+status: completed
+experience: none
+---
+
+# Move intent without rerouting
+
+## Goal
+
+Make the editor's existing direct-manipulation routes explicit as a bounded
+`MoveIntent` vocabulary, protect ordinary selection from accidental text hits,
+and freeze the no-reroute local-stretch boundary with deterministic tests.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/unified-move-plan...origin/codex/unified-move-plan
+```
+
+The isolated worktree is clean. This target extends the same internal movement
+module but does not add persisted state, a public command endpoint, a router,
+or a partial-selection toggle whose Engine effects would be incomplete.
+
+- `apps/editor/src/features/selection/selection-move-plan.ts`
+- `apps/editor/src/features/selection/selection-move-plan.test.ts`
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/canvas/canvas-hit-resolver.ts`
+- `apps/editor/src/canvas/canvas-hit-resolver.test.ts`
+- `packages/derived/src/derived.test.ts`
+- `docs/specs/editor-interaction.md`
+- `plan/2026-08-15-move-intent-no-reroute/plan.md`
+- `plan/log.md`
+
+Read-only shared dependencies: persisted model, Agent API, Edit Engine schema,
+Route normalization, and selection reducer. Existing routing planners remain
+the mutation authority.
+
+## Work
+
+1. Give the editor-local plan an explicit move/segment/loose-route/rail intent
+   vocabulary and use the selection intent for instance-group gestures.
+2. Make ordinary hit ranking prefer electrical geometry over labels while
+   retaining Alt cycling for deliberate text selection.
+3. Add a local-stretch regression proving a boundary move preserves remote
+   waypoints and does not invoke global rerouting.
+4. Record the no-reroute geometry boundary in the editor interaction contract.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/features/selection/selection-move-plan.test.ts apps/editor/src/canvas/canvas-hit-resolver.test.ts packages/derived/src/derived.test.ts`
+- `pnpm typecheck`
+- `pnpm format:check`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+refactor(editor): make movement intent explicit
+```
+
+## Outcome
+
+Completed the editor-local `SchematicMoveIntent` vocabulary and connected the
+existing selection, loose-route, segment, and power-rail gestures to it without
+changing persisted or public protocols. Normal hit selection now chooses
+electrical geometry before overlapping labels; Alt cycling remains the
+deliberate label path. A derived-geometry regression freezes the local stretch
+boundary: only the endpoint-adjacent waypoint can change and remote waypoints
+are preserved.
+
+Validation passed: 12 focused unit tests, workspace TypeScript, Prettier,
+Markdown-link validation, and `git diff --check`.

--- a/plan/2026-08-15-move-intent-no-reroute/plan.md
+++ b/plan/2026-08-15-move-intent-no-reroute/plan.md
@@ -28,6 +28,7 @@ or a partial-selection toggle whose Engine effects would be incomplete.
 - `apps/editor/src/app/App.tsx`
 - `apps/editor/src/canvas/canvas-hit-resolver.ts`
 - `apps/editor/src/canvas/canvas-hit-resolver.test.ts`
+- `apps/editor/e2e/manual-editor.spec.ts`
 - `packages/derived/src/derived.test.ts`
 - `docs/specs/editor-interaction.md`
 - `plan/2026-08-15-move-intent-no-reroute/plan.md`
@@ -46,6 +47,8 @@ the mutation authority.
 3. Add a local-stretch regression proving a boundary move preserves remote
    waypoints and does not invoke global rerouting.
 4. Record the no-reroute geometry boundary in the editor interaction contract.
+5. Keep direct double-click text editing separate from ordinary move-hit
+   priority, with browser coverage for an overlapping route label.
 
 ## Validation
 
@@ -73,5 +76,7 @@ deliberate label path. A derived-geometry regression freezes the local stretch
 boundary: only the endpoint-adjacent waypoint can change and remote waypoints
 are preserved.
 
-Validation passed: 12 focused unit tests, workspace TypeScript, Prettier,
-Markdown-link validation, and `git diff --check`.
+Focused validation passed. Mainline validation exposed a text-editing regression
+after hit-ranking changed; the repair separates deliberate double-click text
+editing from move-hit priority. The repaired full gate passed: 744 unit tests,
+127 browser tests, build, release smoke, static checks, and `git diff --check`.

--- a/plan/2026-08-15-unified-schematic-move/plan.md
+++ b/plan/2026-08-15-unified-schematic-move/plan.md
@@ -1,0 +1,94 @@
+---
+status: completed
+experience: none
+---
+
+# Unified schematic move plan
+
+## Goal
+
+Replace the editor's divergent instance-group drag closure with one pure,
+topology-aware movement plan. A marquee selection may contain instances,
+Routes, Junctions, annotations, and drafting objects; the same plan must drive
+its preview and its one atomic typed-edit commit without changing persisted
+Project schema or the Agent API.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The source worktree was clean. This target is on
+`codex/unified-move-plan`, created directly from current `main`.
+
+- `packages/edit-engine/src/routing-planner.ts`
+- `packages/edit-engine/src/routing.test.ts`
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/features/selection/selection-controller.ts`
+- `apps/editor/src/features/selection/selection-controller.test.ts`
+- `docs/specs/editor-interaction.md`
+- `docs/specs/edit-engine.md`
+- `plan/2026-08-15-unified-schematic-move/plan.md`
+- `plan/log.md`
+
+Read-only shared dependencies: `packages/model` schema, Agent adapter schema,
+resolved route geometry, Symbol Resolver, and browser test harness. No
+persisted model or Agent contract changes are authorized in this target.
+
+## Work
+
+1. Add a pure editor-local `SelectionMovePlan` that classifies explicit visual
+   roots into whole-object translation, safe internal Route/Junction
+   translation, boundary Route stretching, dynamic anchored following,
+   explicit free visual translation, and fixed unsafe geometry.
+2. Make group route edits authoritative for every planned Route rather than
+   relying on progressive per-instance Engine route following.
+3. Route mixed marquee drags through the plan, retain route segment editing as
+   a distinct explicit operation, and make modifier selection preserve a mixed
+   visual selection.
+4. Make marquee Route selection test actual polyline/rectangle intersection,
+   not only its bounding box; retain current crossing-style selection behavior
+   for this bounded change.
+5. Make preview consume the plan's visual closure, including object- and
+   route-anchored annotations plus explicitly selected drafting/free objects.
+6. Document the internal-only movement contract and add focused regression
+   coverage for internal group translation, boundary stretch, mixed selection,
+   and unsafe Junction movement.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/features/selection/selection-move-plan.test.ts apps/editor/src/features/selection/selection-controller.test.ts packages/edit-engine/src/routing.test.ts`
+- `pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts --grep "moves internal wiring with a selected group|keeps an internal junction with the live group preview"`
+- `pnpm --filter @icm/editor build`
+- `pnpm format:check`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+refactor(editor): unify topology-aware movement
+```
+
+## Outcome
+
+Implemented an editor-local `SelectionMovePlan` that supplies one visual
+closure for mixed component drags: internal Route/Junction components and
+their anchored annotations translate together, explicitly selected free text
+and drafting records move by the same delta, and explicitly selected loose
+Routes move only with their loose endpoint Junctions. Connected non-loose
+Route/Junction roots remain fixed rather than being silently detached.
+
+Group movement now authors every planned Route geometry in the same
+transaction, so the Engine does not progressively re-stretch internal wiring
+per instance. Additive instance selection preserves an existing mixed marquee,
+and marquee Route selection now tests actual segments instead of only bounds.
+
+Validation passed: workspace build, `pnpm typecheck`, focused unit tests
+(36/36), focused Playwright group-move coverage (2/2), Prettier, Markdown-link
+validation, and `git diff --check`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7371,8 +7371,11 @@ diff --check`, and two focused Playwright regressions passed.
   Agent API, and typed-edit protocols flat.
 - Changed areas: transient `SchematicMoveIntent`, route gesture wiring,
   electrical-first canvas hit ranking with Alt label cycling, local-stretch
-  regression coverage, and editor interaction contract.
-- Validation: 12 focused unit tests, workspace typecheck, Prettier,
-  Markdown-link validation, and `git diff --check` passed.
+  regression coverage, and editor interaction contract. Follow-up repair keeps
+  a deliberate double-click on an overlapping label as direct text editing.
+- Validation: 12 focused unit tests, focused overlapping-label browser test,
+  and the full mainline gate (744 unit tests, 127 browser tests, build and
+  release smoke), plus static checks and `git diff --check`, passed.
 - Commit status: committed on `codex/unified-move-plan` as
-  `refactor(editor): make movement intent explicit`.
+  `refactor(editor): make movement intent explicit`, followed by
+  `fix(editor): preserve direct label editing`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7341,3 +7341,16 @@ diff --check`, and two focused Playwright regressions passed.
   `codex/placement-mirror-grid-toggle`.
 - Mainline delivery: PR #72 passed all six required GitHub Actions checks and
   squash-merged to `main` as `7db4a06`.
+
+# 2026-08-15 - Unify topology-aware schematic movement
+
+- Target: give mixed marquee movement one transient editor-local closure and
+  eliminate progressive internal-wire geometry changes during group moves.
+- Changed areas: `SelectionMovePlan`, mixed selection preservation, precise
+  polyline marquee selection, authoritative group Route edits, movement
+  interaction and contracts.
+- Validation: workspace build, typecheck, 36 focused unit tests, 2 focused
+  Playwright group-move tests, Prettier, Markdown-link validation, and
+  `git diff --check` passed.
+- Commit status: committed on `codex/unified-move-plan` as
+  `refactor(editor): unify topology-aware movement`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7354,3 +7354,13 @@ diff --check`, and two focused Playwright regressions passed.
   `git diff --check` passed.
 - Commit status: committed on `codex/unified-move-plan` as
   `refactor(editor): unify topology-aware movement`.
+
+# 2026-08-15 - Protect Junction route geometry
+
+- Target: reject a raw Junction move before it can leave an incident Route's
+  waypoint geometry stale.
+- Changed areas: transaction precondition and routing regression coverage.
+- Validation: 40 focused Edit Engine tests, workspace typecheck, Prettier, and
+  `git diff --check` passed.
+- Commit status: committed on `codex/unified-move-plan` as
+  `fix(edit-engine): require geometry with junction moves`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7364,3 +7364,15 @@ diff --check`, and two focused Playwright regressions passed.
   `git diff --check` passed.
 - Commit status: committed on `codex/unified-move-plan` as
   `fix(edit-engine): require geometry with junction moves`.
+
+# 2026-08-15 - Make movement intent explicit without rerouting
+
+- Target: make direct-manipulation routes explicit while keeping the Project,
+  Agent API, and typed-edit protocols flat.
+- Changed areas: transient `SchematicMoveIntent`, route gesture wiring,
+  electrical-first canvas hit ranking with Alt label cycling, local-stretch
+  regression coverage, and editor interaction contract.
+- Validation: 12 focused unit tests, workspace typecheck, Prettier,
+  Markdown-link validation, and `git diff --check` passed.
+- Commit status: committed on `codex/unified-move-plan` as
+  `refactor(editor): make movement intent explicit`.


### PR DESCRIPTION
Unifies group movement through a transient SelectionMovePlan and explicit editor-local movement intents. Internal wiring and junctions now move atomically with their selected group; boundary geometry stays local and is never rerouted. Normal drag hit-testing favors electrical geometry, while a deliberate double-click still opens an overlapping label for editing.\n\nValidated locally with pnpm ci:check: 744 unit tests, 127 browser tests, build, release smoke, static checks, and format/diff checks.