### PR TITLE
Remove annotation text outline feedback

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -1317,6 +1317,23 @@ test("selects an attached label without selecting its host", async ({
   );
 });
 
+test("keeps selected annotation text free of accent outline feedback", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await placeComponent(page, "resistor", { x: 320, y: 220 });
+
+  const label = page.getByTestId("annotation-hit-instance-label-R1");
+  await label.hover();
+  await expect(label).toHaveCSS("stroke", "rgba(0, 0, 0, 0)");
+  await expect(label).toHaveCSS("stroke-dasharray", "none");
+
+  await label.click({ modifiers: ["Alt"] });
+  await expect(label).toHaveClass(/selected/u);
+  await expect(label).toHaveCSS("stroke", "rgba(0, 0, 0, 0)");
+  await expect(label).toHaveCSS("stroke-dasharray", "none");
+});
+
 test("moves an explicitly selected attached label", async ({ page }) => {
   await page.goto("/");
   await placeComponent(page, "resistor", { x: 320, y: 220 });

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -2560,6 +2560,17 @@ body {
   stroke-dasharray: 3 5;
 }
 
+/* Annotation text remains selectable and draggable, but its invisible hit box
+   must not turn into a second blue text-outline cue. The canvas marquee and
+   selection shelf already communicate selection without competing with the
+   formal Razavi typography. Keep this after the generic hit-target hover rule
+   so it wins at equal selector specificity. */
+.annotation-text-hit.selected,
+.annotation-text-hit:hover:not(.selected) {
+  stroke: transparent;
+  stroke-dasharray: none;
+}
+
 .canvas-empty-state {
   position: absolute;
   z-index: 3;

--- a/plan/2026-08-15-remove-annotation-text-outline/plan.md
+++ b/plan/2026-08-15-remove-annotation-text-outline/plan.md
@@ -1,0 +1,67 @@
+---
+status: completed
+experience: none
+---
+
+# Remove annotation text-outline feedback
+
+## Goal
+
+Keep the existing annotation selection and editing behavior, while removing the
+blue hover/selected outline drawn by the invisible text hit surface. Selection
+state and the canvas marquee remain the sole visible selection feedback.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/remove-annotation-text-outline...origin/main
+```
+
+The repository root is checked out on an unrelated `add-about-help-panel`
+branch and contains an unrelated untracked `.worktrees/unified-move/`
+directory. This target uses its own clean worktree from `origin/main` and does
+not modify either item.
+
+- `apps/editor/src/styles.css`
+- `apps/editor/e2e/manual-editor.spec.ts`
+- `plan/2026-08-15-remove-annotation-text-outline/plan.md`
+- `plan/root-audit.md`
+- `plan/log.md`
+
+Read-only/shared dependencies: `VisualSelection`, annotation hit-testing, and
+the formal SVG renderer. This target must not change their behavior or their
+persisted contracts.
+
+## Work
+
+1. Override the generic hit-target hover/selected paint only for text
+   annotation hit surfaces, leaving their pointer events and selection state
+   intact.
+2. Add a browser assertion that an explicitly selected instance annotation is
+   still selectable but has no accent stroke or dash pattern.
+3. Record the completed delivery and run focused editor validation.
+
+## Validation
+
+- `pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts --grep <annotation feedback regression>`
+- `pnpm format:check`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): remove annotation text outline feedback
+```
+
+## Outcome
+
+Added a local CSS override after the generic hit-target hover rule. Annotation
+text hit surfaces remain selectable, draggable, and editable, but their hover
+and selected states now keep a transparent, undashed stroke. Focused browser
+coverage verifies both the visual rule and the existing label selection, move,
+and edit paths.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7441,3 +7441,15 @@ diff --check`, and two focused Playwright regressions passed.
 - Validation: 44 focused unit tests, focused Playwright BJT base-wire test,
   workspace typecheck, and `git diff --check` passed.
 - Commit status: pending commit on `codex/bjt-base-solid-wire`.
+
+## 2026-08-15 - Remove annotation text-outline feedback
+
+- Target: remove blue hover/selected outlines from text annotation hit surfaces
+  while preserving the existing annotation selection, movement, and editing
+  behavior.
+- Changed areas: editor-only CSS cascade and targeted browser coverage.
+- Validation: isolated focused visual-feedback test plus three existing
+  annotation selection/move/edit browser tests passed; Prettier and
+  `git diff --check` passed.
+- Commit status: committed delivery pending on
+  `codex/remove-annotation-text-outline`.

--- a/plan/root-audit.md
+++ b/plan/root-audit.md
@@ -9,7 +9,7 @@ an archive. Completed plans with resolved experience are stored under
 | State                     | Count | Required disposition                                                              |
 | ------------------------- | ----: | --------------------------------------------------------------------------------- |
 | `active`                  |     0 | No active targets.                                                                |
-| `completed` + `none`      |    34 | Verify commit/log evidence, then archive according to routine retention policy.   |
+| `completed` + `none`      |    35 | Verify commit/log evidence, then archive according to routine retention policy.   |
 | `completed` + `candidate` |    17 | Human decides whether to extract, reject, or defer the experience signal.         |
 | missing metadata          |    71 | Audit against outcome text and Git evidence; never archive merely because of age. |
 
@@ -54,6 +54,12 @@ it is eligible for normal completed-plan retention handling.
 
 `2026-08-15-placement-mirror-grid-toggle` passed its remote gate and merged as
 PR #72; its completed delivery record is present.
+
+## 2026-08-15 Annotation text-outline closure
+
+`2026-08-15-remove-annotation-text-outline` is completed with resolved
+experience. Its CSS-only visual feedback change retains the existing annotation
+selection and editing contract.
 
 ## Legacy Metadata Sweep
 


### PR DESCRIPTION
Keep annotation text selection, dragging, and editing intact while removing its blue hover and selected outline. Includes focused browser coverage.