### PR TITLE
feat(editor): alt-drag frame-zoom alias for blocked right buttons

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -1673,6 +1673,23 @@ test("right-drag frames a region and fits the camera to it transiently", async (
   await page.mouse.down({ button: "right" });
   await page.mouse.up({ button: "right" });
   await expect(canvas).toHaveAttribute("viewBox", framed!);
+
+  // Alt+left-drag frames the same region for environments whose system
+  // software hooks the right button before the browser sees the drag.
+  await page.keyboard.down("Alt");
+  await page.mouse.move(box.x + 200, box.y + 140);
+  await page.mouse.down();
+  await page.mouse.move(box.x + 460, box.y + 340, { steps: 4 });
+  await expect(page.getByTestId("zoom-box")).toBeVisible();
+  await page.mouse.up();
+  await page.keyboard.up("Alt");
+
+  await expect(page.getByTestId("zoom-box")).toHaveCount(0);
+  await expect(canvas).not.toHaveAttribute("viewBox", framed!);
+  await expect(page.getByTestId("status")).toHaveText(
+    "Zoomed to framed region",
+  );
+  await expect(page.getByTestId("revision")).toHaveText("1");
 });
 
 test("keeps copy placement active for repeated commits until Escape", async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -285,7 +285,10 @@ interface BoxPreview {
   start: DerivedPoint;
   end: DerivedPoint;
   pointerId: number;
-  /** Left-drag selects what the box touches; right-drag zooms to fit it. */
+  /**
+   * Left-drag selects what the box touches; right-drag (or Alt+left-drag)
+   * zooms to fit it.
+   */
   intent: "select" | "zoom";
 }
 
@@ -5226,10 +5229,14 @@ export function App({
       });
       return;
     }
-    if (event.button === 2) {
-      // Right-drag from empty canvas frames a region and fits the camera to
-      // it. Modes that commit on the next left click, and the drafting/wire
-      // tools whose right click cancels them, stay outside this gesture.
+    // Frame-zoom entry: right-drag, or Alt+left-drag for environments whose
+    // system software (screenshot tools, mouse-driver gestures) hooks the
+    // right button before the browser can see the drag. Modes that commit on
+    // the next left click, and the drafting/wire tools whose right click
+    // cancels them, stay outside this gesture.
+    const frameZoomDrag =
+      event.button === 2 || (event.button === 0 && event.altKey);
+    if (frameZoomDrag) {
       if (
         (pendingSymbolId && pendingComponentPlacement) ||
         vddRailMode ||

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -95,6 +95,15 @@ all pass through the same camera normalizer. The viewport remains transient,
 but it cannot carry derived float bounds into the renderer's integer grid
 camera contract.
 
+Frame-zoom is one camera gesture with two entry buttons: right-drag from
+empty canvas, or Alt+left-drag for environments where system software
+(screenshot tools, mouse-driver gestures) hooks the right button before the
+browser receives the drag. A webpage cannot block system-level mouse hooks,
+so the Alt alias is the portable entry. Both draw the same transient frame
+preview and fit the camera to the framed region without touching the
+Document revision; a press that never exceeded one grid cell stays an
+ordinary click.
+
 Escape cancels the active preview without mutation. A committed gesture is one
 atomic transaction. Hover, geometric crossing, selection, and preview never
 change connectivity. A wire endpoint or explicit segment tap is required to

--- a/plan/2026-08-15-alt-frame-zoom/plan.md
+++ b/plan/2026-08-15-alt-frame-zoom/plan.md
@@ -1,0 +1,81 @@
+---
+status: completed
+experience: none
+---
+
+# Alt+drag frame-zoom alias
+
+## Goal
+
+The right-drag frame zoom shipped in PR #75 is unusable on machines whose
+system-level software (screenshot tools, mouse-driver gestures) hooks
+right-button drag before the browser receives the events. A webpage cannot
+block system-level mouse hooks, so add an in-app equivalent gesture that
+does not depend on the right button: **Alt + left-drag** from empty canvas
+frames a region and fits the camera, sharing the existing zoom-box pipeline
+and preview. Right-drag remains the primary gesture.
+
+## State and Ownership
+
+Start state from `git status --short --branch` in the isolated worktree
+`.worktrees/alt-frame-zoom` (branch `agent/alt-frame-zoom` from `origin/main`
+at `3a616d9`):
+
+```text
+## agent/alt-frame-zoom
+```
+
+Clean. The main checkout is parked on another worker's branch
+(`codex/add-about-help-panel`), so this target works in a dedicated worktree
+to avoid ownership collisions; only `node_modules`/tooling state differs.
+
+- Owned: `apps/editor/src/app/App.tsx` (gesture branch only),
+  `apps/editor/e2e/manual-editor.spec.ts` (zoom test only),
+  `docs/specs/editor-interaction.md` (gesture contract note)
+- Read-only: camera math (`fit-view.ts`), clipboard, netlist-authoring
+- Shared contracts: none beyond the editor-interaction spec text
+
+## Work
+
+1. `beginCanvasGesture`: treat `button === 0 && altKey` (empty canvas, no
+   active placement/tool mode — same guards as the right-button branch) as
+   the zoom-frame intent, entering the same `boxPreview` zoom pipeline.
+2. Extend the manual-editor zoom e2e test with an Alt+left-drag variant that
+   asserts the frame preview, the camera change, and unchanged revision.
+3. Document both gestures in `docs/specs/editor-interaction.md`.
+
+## Validation
+
+- `git diff --check`, `git status --short --branch`
+- `pnpm typecheck`, Prettier on touched files
+- `pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts --grep "frames a region"`
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): alt-drag frame-zoom alias for blocked right buttons
+```
+
+## Outcome
+
+Delivered: Alt+left-drag from empty canvas now enters the same frame-zoom
+pipeline as right-drag (one shared `frameZoomDrag` entry in
+`beginCanvasGesture`; identical guards, preview, and commit). The gesture
+contract is documented in `docs/specs/editor-interaction.md`, and the
+manual-editor frame-zoom e2e test gained an Alt-drag variant asserting the
+preview, camera change, and unchanged revision.
+
+Validation: typecheck 0 errors; Prettier clean; Playwright frame-zoom test
+(right-drag + Alt-drag) passed, plus full manual-editor 66/66 and
+component-insert 17/17. One environmental trap was hit and resolved: a
+zombie vite dev server on port 4173 (left over from a half-removed worktree)
+served stale modules and made the first Alt-drag run fail; killing the
+process and rerunning against the correct server passed. Playwright test
+discovery also ignores specs under gitignored paths, so this target's
+worktree lives as a sibling directory (`interactive Circuit maker-alt-frame-zoom`),
+matching the repository's existing multi-worktree convention.
+
+status: completed
+experience: none

--- a/plan/log.md
+++ b/plan/log.md
@@ -7441,3 +7441,15 @@ diff --check`, and two focused Playwright regressions passed.
 - Validation: 44 focused unit tests, focused Playwright BJT base-wire test,
   workspace typecheck, and `git diff --check` passed.
 - Commit status: pending commit on `codex/bjt-base-solid-wire`.
+
+# 2026-08-15 - Alt+drag frame-zoom alias
+
+- Target: keep frame-zoom usable when system software hooks the right mouse
+  button before the browser receives the drag; a webpage cannot block
+  system-level mouse hooks, so add Alt+left-drag as an equivalent entry.
+- Changed areas: canvas gesture entry (`frameZoomDrag`), frame-zoom e2e
+  coverage, editor interaction contract note.
+- Validation: typecheck, Prettier, frame-zoom Playwright test (right-drag +
+  Alt-drag), full manual-editor 66/66 and component-insert 17/17 passed.
+- Commit status: committed on `agent/alt-frame-zoom` as
+  `feat(editor): alt-drag frame-zoom alias for blocked right buttons`.


### PR DESCRIPTION
## Summary

Some environments (screenshot tools, mouse-driver gestures) hook right-button drag at the system level before the browser receives the events; a webpage cannot block system-level mouse hooks. This adds **Alt+left-drag from empty canvas** as an equivalent frame-zoom entry sharing the existing right-drag pipeline (same guards, same zoom-box preview, same `fitCameraToBounds` commit, still camera-only).

- One shared `frameZoomDrag` entry in `beginCanvasGesture` for both buttons.
- e2e: the frame-zoom test now also covers the Alt-drag variant (preview visible, camera changes, revision untouched).
- Docs: gesture contract documented in `docs/specs/editor-interaction.md`.

## Validation

typecheck 0 errors; Prettier clean; frame-zoom Playwright test passed; full manual-editor 66/66; component-insert 17/17.