### PR TITLE
feat(editor): add about panel and compact-layout help

### DIFF
--- a/apps/editor/e2e/chrome-isolation.spec.ts
+++ b/apps/editor/e2e/chrome-isolation.spec.ts
@@ -39,3 +39,17 @@ test("dismisses Help with Escape or a backdrop pointer", async ({ page }) => {
   await page.locator(".help-backdrop").click({ position: { x: 4, y: 4 } });
   await expect(help).toHaveCount(0);
 });
+
+test("opens About with the version and repository link", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "About" }).click();
+
+  const about = page.getByRole("dialog", { name: "About" });
+  await expect(about).toContainText("Analog Canvas");
+  await expect(about).toContainText("Version 0.1.0");
+  await expect(
+    about.getByRole("link", { name: "GitHub repository" }),
+  ).toHaveAttribute("href", "https://github.com/chenzc24/Analog-Canvas");
+  await page.keyboard.press("Escape");
+  await expect(about).toHaveCount(0);
+});

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -139,18 +139,21 @@ describe("editor shell", () => {
     expect(markup).toContain("Main (top)");
   });
 
-  it("provides a local-editor quick-start help entry without rendering it by default", () => {
+  it("provides Help and About entries without rendering either dialog by default", () => {
     const project = createEmptyProject("help-tutorial", "Help Tutorial");
     const markup = renderToStaticMarkup(<App project={project} />);
 
     expect(markup).toContain('aria-haspopup="dialog"');
+    expect(markup).toContain(">About</button>");
     expect(markup).toContain(">Help</button>");
     expect(markup).toContain('class="app-chrome-actions"');
     const navigationEnd = markup.indexOf("</nav>");
     const analyticsLink = markup.indexOf('href="/analytics"');
-    const helpButton = markup.indexOf('class="menubar-help"');
+    const aboutButton = markup.indexOf(">About</button>");
+    const helpButton = markup.indexOf(">Help</button>");
     expect(analyticsLink).toBeGreaterThan(navigationEnd);
-    expect(helpButton).toBeGreaterThan(analyticsLink);
+    expect(aboutButton).toBeGreaterThan(analyticsLink);
+    expect(helpButton).toBeGreaterThan(aboutButton);
     expect(markup).not.toContain('role="dialog"');
     // The Connect Agent command is available (WP-WA5), but the authorization
     // panel itself must not render until the user opens it.

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -160,6 +160,7 @@ import {
   stepBoundedScale,
 } from "../interaction/editor-shortcuts";
 import { EditorHelpDialog } from "../components/editor-help-dialog";
+import { EditorAboutDialog } from "../components/editor-about-dialog";
 import { ReplaceGuardDialog } from "../components/replace-guard-dialog";
 import { RecentRecoveryDialog } from "../components/recent-recovery-dialog";
 import {
@@ -798,6 +799,7 @@ export function App({
     null,
   );
   const [helpOpen, setHelpOpen] = useState(false);
+  const [aboutOpen, setAboutOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [highlightedNetOrigin, setHighlightedNetOrigin] = useState<{
@@ -816,6 +818,8 @@ export function App({
   const netLabelEditorInputRef = useRef<HTMLInputElement>(null);
   const helpButtonRef = useRef<HTMLButtonElement>(null);
   const helpCloseRef = useRef<HTMLButtonElement>(null);
+  const aboutButtonRef = useRef<HTMLButtonElement>(null);
+  const aboutCloseRef = useRef<HTMLButtonElement>(null);
   const documentViewBoxes = useRef(new Map<string, GridRect>());
   const renderedDocument = useMemo(() => {
     if (!draftingHandlePreview || !document.drafting) return document;
@@ -6155,7 +6159,7 @@ export function App({
             tool === "construction-line" ||
             tool === "rectangle") &&
           draftingSource !== null,
-        helpOpen,
+        helpOpen: helpOpen || aboutOpen,
         canvasDragActive: canvasDragSessionRef.current !== null,
         hasClearableDraftingSelection:
           selectedDrafting?.kind === "arrow" ||
@@ -6286,7 +6290,8 @@ export function App({
           finishDraftingCreate();
           return;
         case "close-help":
-          closeHelp();
+          if (helpOpen) closeHelp();
+          else closeAbout();
           return;
         case "cancel-canvas-drag":
           canvasDragSessionRef.current?.cancel();
@@ -6339,9 +6344,18 @@ export function App({
     if (helpOpen) helpCloseRef.current?.focus();
   }, [helpOpen]);
 
+  useEffect(() => {
+    if (aboutOpen) aboutCloseRef.current?.focus();
+  }, [aboutOpen]);
+
   function closeHelp(): void {
     setHelpOpen(false);
     requestAnimationFrame(() => helpButtonRef.current?.focus());
+  }
+
+  function closeAbout(): void {
+    setAboutOpen(false);
+    requestAnimationFrame(() => aboutButtonRef.current?.focus());
   }
 
   function closeSearch(): void {
@@ -6654,6 +6668,17 @@ export function App({
             <button
               type="button"
               className="menubar-help"
+              ref={aboutButtonRef}
+              aria-haspopup="dialog"
+              aria-expanded={aboutOpen}
+              aria-controls="editor-about-dialog"
+              onClick={() => setAboutOpen(true)}
+            >
+              About
+            </button>
+            <button
+              type="button"
+              className="menubar-help"
               ref={helpButtonRef}
               aria-haspopup="dialog"
               aria-expanded={helpOpen}
@@ -6754,6 +6779,12 @@ export function App({
       </header>
       {helpOpen ? (
         <EditorHelpDialog closeButtonRef={helpCloseRef} onClose={closeHelp} />
+      ) : null}
+      {aboutOpen ? (
+        <EditorAboutDialog
+          closeButtonRef={aboutCloseRef}
+          onClose={closeAbout}
+        />
       ) : null}
       {recoveryReady &&
       recoverySessions.length > 0 &&

--- a/apps/editor/src/components/editor-about-dialog.test.tsx
+++ b/apps/editor/src/components/editor-about-dialog.test.tsx
@@ -1,0 +1,23 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { EditorAboutDialog } from "./editor-about-dialog";
+
+describe("EditorAboutDialog", () => {
+  it("identifies the editor, package version, and repository", () => {
+    const markup = renderToStaticMarkup(
+      <EditorAboutDialog
+        closeButtonRef={{ current: null }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain('role="dialog"');
+    expect(markup).toContain('aria-labelledby="about-title"');
+    expect(markup).toContain("Analog Canvas");
+    expect(markup).toContain("Version <strong>0.1.0</strong>");
+    expect(markup).toContain(
+      'href="https://github.com/chenzc24/Analog-Canvas"',
+    );
+  });
+});

--- a/apps/editor/src/components/editor-about-dialog.tsx
+++ b/apps/editor/src/components/editor-about-dialog.tsx
@@ -1,0 +1,59 @@
+import type { RefObject } from "react";
+
+import editorPackage from "../../package.json";
+
+const REPOSITORY_URL = "https://github.com/chenzc24/Analog-Canvas";
+
+export interface EditorAboutDialogProps {
+  closeButtonRef: RefObject<HTMLButtonElement | null>;
+  onClose(): void;
+}
+
+export function EditorAboutDialog({
+  closeButtonRef,
+  onClose,
+}: EditorAboutDialogProps) {
+  return (
+    <div
+      className="help-backdrop"
+      onPointerDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <section
+        className="help-dialog"
+        id="editor-about-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="about-title"
+      >
+        <header className="help-dialog-header">
+          <div>
+            <p className="help-kicker">Interactive Circuit Maker</p>
+            <h2 id="about-title">About</h2>
+          </div>
+          <button
+            type="button"
+            ref={closeButtonRef}
+            onClick={onClose}
+            aria-label="Close about"
+          >
+            Close
+          </button>
+        </header>
+        <div className="help-dialog-content">
+          <p>
+            <strong>Analog Canvas</strong> is a local-first schematic editor for
+            editable circuit design in the browser.
+          </p>
+          <p>
+            Version <strong>{editorPackage.version}</strong>
+          </p>
+          <p>
+            <a href={REPOSITORY_URL}>GitHub repository</a>
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/editor/src/components/editor-help-dialog.tsx
+++ b/apps/editor/src/components/editor-help-dialog.tsx
@@ -68,11 +68,14 @@ export function EditorHelpDialog({
             </p>
             <h3>Place, select, and connect</h3>
             <p>
-              Select a symbol in the left library, or a drawing tool from
-              <strong>Draw</strong>, then click the canvas to place or draw.
-              Select objects to move them or reveal selection actions. Choose
-              Wire (or <kbd>W</kbd>), click a terminal to start, click to add
-              bends, then press <kbd>Enter</kbd> to finish. <kbd>Delete</kbd> or
+              Select a symbol in the left Library, or a drawing tool from
+              <strong>Draw</strong>, then click the canvas to place or draw. On
+              compact screens, Library starts folded; use the left
+              <strong>Library</strong> button to open its single-column list.
+              Selecting an object opens Properties on the right; it overlays the
+              canvas and closes Library while compact. Choose Wire (or
+              <kbd>W</kbd>), click a terminal to start, click to add bends, then
+              press <kbd>Enter</kbd> to finish. <kbd>Delete</kbd> or
               <kbd>Backspace</kbd> removes the selection, or removes the latest
               wire bend while drawing.
             </p>

--- a/plan/2026-08-15-add-about-help-panel/plan.md
+++ b/plan/2026-08-15-add-about-help-panel/plan.md
@@ -1,0 +1,72 @@
+---
+status: completed
+experience: none
+---
+
+# Add About Panel and Compact-Layout Help
+
+## Goal
+
+Add a concise About entry with repository information and the editor version,
+and update Help to explain the compact Library and Properties behavior.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+?? .worktrees/
+```
+
+`main` was fast-forwarded from `origin/main` before this branch was created.
+The untracked `.worktrees/` directory is user-owned and unrelated to the editor
+source paths below; it will not be inspected, staged, or modified.
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/components/editor-help-dialog.tsx`
+- `apps/editor/src/components/editor-about-dialog.tsx`
+- `apps/editor/src/components/editor-about-dialog.test.tsx`
+- `apps/editor/src/styles.css`
+- `apps/editor/src/app/App.test.tsx`
+- `plan/2026-08-15-add-about-help-panel/plan.md`
+- `plan/log.md`
+
+Read-only shared dependencies: root/editor package metadata supplies the
+version; the existing Help dialog's focus and close behavior is the interaction
+model to preserve.
+
+## Work
+
+1. Add a top-bar About button and concise accessible dialog with version and
+   repository link.
+2. Update Help's placement/selection guidance for compact Library and overlay
+   Properties behavior.
+3. Cover the rendered About metadata and top-bar entry with focused tests.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/components/editor-about-dialog.test.tsx apps/editor/src/app/App.test.tsx`
+- `pnpm test:e2e:local apps/editor/e2e/chrome-isolation.spec.ts`
+- `pnpm typecheck`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): add about panel and compact-layout help
+```
+
+## Outcome
+
+Added an `About` button between Analytics and Help. Its dialog gives the
+Analog Canvas identity, package-derived version, and GitHub repository link,
+with the existing dialog backdrop and focus-return behavior. Help now explains
+the compact Library and overlay Properties behavior.
+
+Validation passed: focused About/App unit tests (14 tests), the full
+chrome-isolation browser spec (3 tests), workspace typecheck, Prettier, and
+`git diff --check`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7395,7 +7395,7 @@ diff --check`, and two focused Playwright regressions passed.
   recorded in the plan).
 - Commit status: committed on `agent/per-type-designators-zoom-box` as
   `feat(editor): per-type designators, copy label increment, right-drag zoom
-  box`; branch pushed for review. A concurrent worker's overlapping App.tsx
+box`; branch pushed for review. A concurrent worker's overlapping App.tsx
   hunks were excluded from the commit via selective staging and left dirty
   in the working tree.
 - Mainline delivery: after PR #76 landed, the branch merged `origin/main`
@@ -7455,3 +7455,16 @@ diff --check`, and two focused Playwright regressions passed.
   `feat(editor): alt-drag frame-zoom alias for blocked right buttons`.
 - Mainline delivery: PR #82 passed all six required GitHub Actions checks and
   squash-merged to `main` as `45f5820`.
+
+## 2026-08-15 - Add About panel and compact-layout Help
+
+- Target: make editor identity/version/repository information discoverable and
+  document the compact Library/Properties behavior in Help.
+- Changed areas: top-bar About entry and dialog, package-derived version,
+  repository link, Help placement guidance, and focused unit/browser coverage.
+- Validation: focused About/App unit tests (2 files / 14 tests), full
+  chrome-isolation Playwright spec (3 tests), `pnpm typecheck`, Prettier, and
+  `git diff --check` passed.
+- Commit status: committed locally as
+  `feat(editor): add about panel and compact-layout help` on
+  `codex/add-about-help-panel`; not pushed.


### PR DESCRIPTION
## What changed

- Added an About button between Analytics and Help.
- Added a concise About dialog with the package-derived editor version and GitHub repository link.
- Updated Help to explain compact Library and right-side overlay Properties behavior.

## Why

Editor identity and repository information were not discoverable in the GUI, and Help did not describe the compact half-screen layout.

## Validation

- pnpm ci:check
- Focused About/App unit tests
- Chrome-isolation Playwright coverage