### PR TITLE
docs(plan): record alt frame-zoom delivery (#82)

### DIFF
--- a/plan/log.md
+++ b/plan/log.md
@@ -7453,3 +7453,5 @@ diff --check`, and two focused Playwright regressions passed.
   Alt-drag), full manual-editor 66/66 and component-insert 17/17 passed.
 - Commit status: committed on `agent/alt-frame-zoom` as
   `feat(editor): alt-drag frame-zoom alias for blocked right buttons`.
+- Mainline delivery: PR #82 passed all six required GitHub Actions checks and
+  squash-merged to `main` as `45f5820`.


### PR DESCRIPTION
Records the mainline delivery of PR #82 in `plan/log.md`. Docs-only.