### PR TITLE
fix(editor): refine about repository link

### DIFF
--- a/apps/editor/e2e/chrome-isolation.spec.ts
+++ b/apps/editor/e2e/chrome-isolation.spec.ts
@@ -47,9 +47,14 @@ test("opens About with the version and repository link", async ({ page }) => {
   const about = page.getByRole("dialog", { name: "About" });
   await expect(about).toContainText("Analog Canvas");
   await expect(about).toContainText("Version 0.1.0");
-  await expect(
-    about.getByRole("link", { name: "GitHub repository" }),
-  ).toHaveAttribute("href", "https://github.com/chenzc24/Analog-Canvas");
+  const repositoryLink = about.getByRole("link", {
+    name: "https://github.com/chenzc24/Analog-Canvas",
+  });
+  await expect(repositoryLink).toHaveAttribute(
+    "href",
+    "https://github.com/chenzc24/Analog-Canvas",
+  );
+  await expect(repositoryLink).toHaveAttribute("target", "_blank");
   await page.keyboard.press("Escape");
   await expect(about).toHaveCount(0);
 });

--- a/apps/editor/src/components/editor-about-dialog.test.tsx
+++ b/apps/editor/src/components/editor-about-dialog.test.tsx
@@ -15,9 +15,12 @@ describe("EditorAboutDialog", () => {
     expect(markup).toContain('role="dialog"');
     expect(markup).toContain('aria-labelledby="about-title"');
     expect(markup).toContain("Analog Canvas");
+    expect(markup).not.toContain("in the browser");
     expect(markup).toContain("Version <strong>0.1.0</strong>");
     expect(markup).toContain(
       'href="https://github.com/chenzc24/Analog-Canvas"',
     );
+    expect(markup).toContain('target="_blank"');
+    expect(markup).toContain('rel="noreferrer"');
   });
 });

--- a/apps/editor/src/components/editor-about-dialog.tsx
+++ b/apps/editor/src/components/editor-about-dialog.tsx
@@ -44,13 +44,15 @@ export function EditorAboutDialog({
         <div className="help-dialog-content">
           <p>
             <strong>Analog Canvas</strong> is a local-first schematic editor for
-            editable circuit design in the browser.
+            editable circuit design.
           </p>
           <p>
             Version <strong>{editorPackage.version}</strong>
           </p>
           <p>
-            <a href={REPOSITORY_URL}>GitHub repository</a>
+            <a href={REPOSITORY_URL} target="_blank" rel="noreferrer">
+              {REPOSITORY_URL}
+            </a>
           </p>
         </div>
       </section>

--- a/plan/2026-08-15-refine-about-repository-link/plan.md
+++ b/plan/2026-08-15-refine-about-repository-link/plan.md
@@ -1,0 +1,60 @@
+---
+status: completed
+experience: none
+---
+
+# Refine About Repository Link
+
+## Goal
+
+Show the repository URL directly in About, open it in a new tab, and shorten
+the product description by removing the browser-specific phrase.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+?? .worktrees/
+```
+
+The untracked `.worktrees/` directory is user-owned and unrelated; it will not
+be inspected, staged, or modified.
+
+- `apps/editor/src/components/editor-about-dialog.tsx`
+- `apps/editor/src/components/editor-about-dialog.test.tsx`
+- `apps/editor/e2e/chrome-isolation.spec.ts`
+- `plan/2026-08-15-refine-about-repository-link/plan.md`
+- `plan/log.md`
+
+## Work
+
+1. Replace the generic About repository link label with the visible URL.
+2. Make the link open safely in a new tab and update its automated contract.
+3. Remove the browser-specific wording from the About description.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/components/editor-about-dialog.test.tsx`
+- `pnpm test:e2e:local apps/editor/e2e/chrome-isolation.spec.ts --grep "About"`
+- `pnpm typecheck`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): refine about repository link
+```
+
+## Outcome
+
+About now displays the full GitHub repository URL and opens it in a new tab
+with `noreferrer`, so navigation does not replace the active editor. The
+description now ends at “editable circuit design.”
+
+Validation passed: focused About unit test, focused About Playwright test,
+workspace typecheck, Prettier, and `git diff --check`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7468,3 +7468,13 @@ box`; branch pushed for review. A concurrent worker's overlapping App.tsx
 - Commit status: committed locally as
   `feat(editor): add about panel and compact-layout help` on
   `codex/add-about-help-panel`; not pushed.
+## 2026-08-15 - Refine About repository link
+
+- Target: keep repository navigation from replacing the active editor page.
+- Changed areas: visible About URL, new-tab/noreferrer link behavior, shortened
+  description, and focused unit/browser coverage.
+- Validation: focused About unit and Playwright tests, `pnpm typecheck`,
+  Prettier, and `git diff --check` passed.
+- Commit status: committed locally as
+  `fix(editor): refine about repository link` on
+  `codex/refine-about-repository-link`; not pushed.


### PR DESCRIPTION
## What changed

- Display the complete repository URL in About.
- Open the link in a new tab with noreferrer.
- Shorten the About description.

## Validation

- pnpm ci:check
- Focused About unit and browser tests