### PR TITLE
feat(editor): unify keyboard and pointer selection move

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -400,6 +400,26 @@ test("cancels VDD rail placement before or after its first endpoint", async ({
   ).toHaveCount(0);
 });
 
+test("uses M to arm the existing connectivity-aware move gesture", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await placeComponent(page, "resistor", { x: 340, y: 220 });
+  const resistor = page.getByTestId("hit-R1");
+  await resistor.click();
+  const before = await resistor.boundingBox();
+  if (!before) throw new Error("Placed resistor is not measurable");
+
+  await page.keyboard.press("m");
+  await expect(page.getByTestId("status")).toContainText("Move:");
+  await dragBy(resistor, { x: 40, y: 20 });
+
+  const after = await resistor.boundingBox();
+  if (!after) throw new Error("Moved resistor is not measurable");
+  expect(after.x).toBeGreaterThan(before.x + 20);
+  expect(after.y).toBeGreaterThan(before.y + 5);
+});
+
 test("treats hollow and filled Ports as ordinary wired components", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -757,6 +757,7 @@ export function App({
     setDraftingWaypoints,
     setDraftingSnapPoint,
     clearDraftingCreate,
+    beginSelectionMove: beginSelectionMoveInteraction,
     cancelInteraction,
   } = useInteractionState<SchematicClipboard>();
   const [draftingInspectorSegment, setDraftingInspectorSegment] = useState<{
@@ -2401,6 +2402,14 @@ export function App({
     hitTarget: SVGElement = event.currentTarget,
   ): void {
     if (vddRailMode || (pendingSymbolId && pendingComponentPlacement)) return;
+    if (
+      getCurrentInteractionState().kind === "moving-selection" &&
+      selectedIds.length > 0
+    ) {
+      const primaryInstanceId = selectedIds.at(-1);
+      if (primaryInstanceId) beginMove(event, primaryInstanceId, hitTarget);
+      return;
+    }
     event.stopPropagation();
     if (event.altKey) {
       setStatus("Snap suppressed while Alt is held");
@@ -2410,7 +2419,7 @@ export function App({
       (candidate) => candidate.route.id === routeId,
     );
     if (!routeRecord) return;
-    const svg = hitTarget.ownerSVGElement!;
+    const svg = (hitTarget.ownerSVGElement ?? hitTarget) as SVGSVGElement;
     const pointer = pointFromClient(event.clientX, event.clientY, svg, false);
     const tap = resolveRouteTap(
       routeRecord.polyline.points,
@@ -2419,6 +2428,14 @@ export function App({
     );
     if (tool === "pointer") {
       const segmentIndex = tap?.segmentIndex ?? 0;
+      if (getCurrentInteractionState().kind === "moving-selection") {
+        const movePlan = planSelectionMove(document, visualSelection);
+        if (movePlan.previewObjectIds.length > 0) {
+          beginVisualSelectionMove(event, visualSelection, hitTarget);
+          return;
+        }
+        cancelInteraction();
+      }
       selectRoute(routeId, segmentIndex);
       beginRouteStretch(
         event,
@@ -2831,6 +2848,12 @@ export function App({
     hitTarget: SVGElement = event.currentTarget,
   ): void {
     if (event.button !== 0) return;
+    if (getCurrentInteractionState().kind === "moving-selection") {
+      const primaryInstanceId = selectedIds.at(-1);
+      if (primaryInstanceId) beginMove(event, primaryInstanceId, hitTarget);
+      else beginVisualSelectionMove(event, visualSelection, hitTarget);
+      return;
+    }
     event.stopPropagation();
     selectOnly("annotation", [annotation.id]);
     setSelectedEndpoint(null);
@@ -3214,6 +3237,15 @@ export function App({
     ) {
       return;
     }
+    if (getCurrentInteractionState().kind === "moving-selection") {
+      const primaryInstanceId = selectedIds.at(-1);
+      if (primaryInstanceId) {
+        beginMove(event, primaryInstanceId, event.currentTarget);
+      } else {
+        beginVisualSelectionMove(event, visualSelection, event.currentTarget);
+      }
+      return;
+    }
     if (tool !== "pointer" || event.button !== 0) return;
     if ((event.target as Element).closest(".draft-handle, .route-handle")) {
       return;
@@ -3492,6 +3524,9 @@ export function App({
     hitTarget: SVGElement = event.currentTarget,
   ): void {
     if (tool !== "pointer" || event.button !== 0) return;
+    if (getCurrentInteractionState().kind === "moving-selection") {
+      cancelInteraction();
+    }
     event.stopPropagation();
     const instance = document.instances.find(
       (candidate) => candidate.id === instanceId,
@@ -3522,7 +3557,7 @@ export function App({
     if (!selectedIds.includes(instanceId)) selectInstance(instanceId, false);
     if (movingIds.length === 0) return;
     canvasDragSessionRef.current?.cancel();
-    const svg = hitTarget.ownerSVGElement!;
+    const svg = (hitTarget.ownerSVGElement ?? hitTarget) as SVGSVGElement;
     const pointerStart = pointFromClient(
       event.clientX,
       event.clientY,
@@ -3591,6 +3626,143 @@ export function App({
         paintSnapGuides([]);
       },
     });
+  }
+
+  /**
+   * Move selections that contain no placed instance.  Instance-led selections
+   * retain the richer electrical snap path above; visual-only selections still
+   * share the same SelectionMovePlan and one typed transaction on release.
+   */
+  function beginVisualSelectionMove(
+    event: ReactPointerEvent<SVGElement>,
+    selection: VisualSelection,
+    hitTarget: SVGElement = event.currentTarget,
+  ): void {
+    if (tool !== "pointer" || event.button !== 0) return;
+    const movePlan = planSelectionMove(document, selection);
+    if (movePlan.previewObjectIds.length === 0) {
+      cancelInteraction();
+      setStatus("Selected objects are attached or locked and cannot move");
+      return;
+    }
+    cancelInteraction();
+    event.preventDefault();
+    event.stopPropagation();
+    canvasDragSessionRef.current?.cancel();
+    const svg = (hitTarget.ownerSVGElement ?? hitTarget) as SVGSVGElement;
+    const start = pointFromClient(event.clientX, event.clientY, svg, false);
+    let visual: ReturnType<typeof startCanvasDragVisual> | null = null;
+    const dragVisual = () =>
+      (visual ??= startCanvasDragVisual(svg, movePlan.previewObjectIds));
+    const deltaAt = (client: Point) => {
+      const point = pointFromClient(client.x, client.y, svg, false);
+      return {
+        x: snapCoordinate(point.x - start.x, document.presentation.grid),
+        y: snapCoordinate(point.y - start.y, document.presentation.grid),
+      };
+    };
+    canvasDragSessionRef.current = startCanvasDragSession({
+      target: hitTarget,
+      pointerId: event.pointerId,
+      startClient: { x: event.clientX, y: event.clientY },
+      thresholdPx: DRAG_START_DISTANCE_PX,
+      onPreview: (client) => {
+        const delta = deltaAt(client);
+        dragVisual().translate(delta);
+        paintSnapGuides([]);
+      },
+      onFinish: ({ client, dragged }) => {
+        canvasDragSessionRef.current = null;
+        visual?.restore();
+        paintSnapGuides([]);
+        if (dragged) completeVisualSelectionMove(movePlan, deltaAt(client));
+      },
+      onCancel: () => {
+        canvasDragSessionRef.current = null;
+        visual?.restore();
+        paintSnapGuides([]);
+      },
+    });
+  }
+
+  function selectionVisualMoveEdits(
+    movePlan: SelectionMovePlan,
+    delta: Point,
+  ): SchematicEdit[] {
+    return [
+      ...movePlan.freeAnnotationIds.flatMap((annotationId) => {
+        const annotation = document.annotations.find(
+          (candidate) => candidate.id === annotationId,
+        );
+        if (!annotation || annotation.anchor.kind !== "free") return [];
+        return [
+          {
+            kind: "upsert_schematic_annotation" as const,
+            annotation: {
+              ...annotation,
+              anchor: {
+                kind: "free" as const,
+                position: snapGridPoint(
+                  {
+                    x: annotation.anchor.position.x + delta.x,
+                    y: annotation.anchor.position.y + delta.y,
+                  },
+                  document.presentation.grid,
+                ),
+              },
+            },
+          },
+        ];
+      }),
+      ...movePlan.draftingIds.flatMap((draftingId) => {
+        const object = document.drafting?.objects.find(
+          (candidate) => candidate.id === draftingId,
+        );
+        return object
+          ? [
+              {
+                kind: "upsert_drafting_object" as const,
+                object: translateDraftingObject(
+                  object,
+                  delta,
+                  document.presentation.grid,
+                ),
+              },
+            ]
+          : [];
+      }),
+    ];
+  }
+
+  function completeVisualSelectionMove(
+    movePlan: SelectionMovePlan,
+    delta: Point,
+  ): void {
+    if (delta.x === 0 && delta.y === 0) return;
+    const looseRouteEdits = movePlan.looseRouteIds.flatMap(
+      (routeId) => proposeLooseRouteTranslation(document, routeId, delta).edits,
+    );
+    const result = transact([
+      ...looseRouteEdits,
+      ...selectionVisualMoveEdits(movePlan, delta),
+    ]);
+    if (result.ok && movePlan.fixedObjectIds.length > 0) {
+      setStatus(
+        `Moved selection; ${movePlan.fixedObjectIds.length} attached object(s) remained fixed`,
+      );
+    }
+  }
+
+  function beginKeyboardSelectionMove(): void {
+    const movePlan = planSelectionMove(document, visualSelection);
+    if (movePlan.previewObjectIds.length === 0 && !selectedRoute) {
+      setStatus("Selected objects are attached or locked and cannot move");
+      return;
+    }
+    beginSelectionMoveInteraction();
+    setStatus(
+      "Move: drag the selected objects to a new position (Esc to cancel)",
+    );
   }
 
   function instanceMoveAt(
@@ -3765,46 +3937,7 @@ export function App({
           (routeId) =>
             proposeLooseRouteTranslation(document, routeId, delta).edits,
         );
-        const visualEdits: SchematicEdit[] = [
-          ...preview.movePlan.freeAnnotationIds.flatMap((annotationId) => {
-            const annotation = document.annotations.find(
-              (candidate) => candidate.id === annotationId,
-            );
-            if (!annotation || annotation.anchor.kind !== "free") return [];
-            return [
-              {
-                kind: "upsert_schematic_annotation" as const,
-                annotation: {
-                  ...annotation,
-                  anchor: {
-                    kind: "free" as const,
-                    position: {
-                      x: annotation.anchor.position.x + delta.x,
-                      y: annotation.anchor.position.y + delta.y,
-                    },
-                  },
-                },
-              },
-            ];
-          }),
-          ...preview.movePlan.draftingIds.flatMap((draftingId) => {
-            const object = document.drafting?.objects.find(
-              (candidate) => candidate.id === draftingId,
-            );
-            return object
-              ? [
-                  {
-                    kind: "upsert_drafting_object" as const,
-                    object: translateDraftingObject(
-                      object,
-                      delta,
-                      document.presentation.grid,
-                    ),
-                  },
-                ]
-              : [];
-          }),
-        ];
+        const visualEdits = selectionVisualMoveEdits(preview.movePlan, delta);
         const movingElectrical = electricalMatch?.moving.electrical;
         const targetElectrical = electricalMatch?.target.electrical;
         const projected = structuredClone(document);
@@ -4233,6 +4366,12 @@ export function App({
     hitTarget: SVGElement = event.currentTarget,
   ): void {
     if (event.button !== 0 || object.locked) return;
+    if (getCurrentInteractionState().kind === "moving-selection") {
+      const primaryInstanceId = selectedIds.at(-1);
+      if (primaryInstanceId) beginMove(event, primaryInstanceId, hitTarget);
+      else beginVisualSelectionMove(event, visualSelection, hitTarget);
+      return;
+    }
     const origin = draftingDragOrigin(object);
     if (!origin) {
       selectDraftingObject(object.id);
@@ -6151,6 +6290,7 @@ export function App({
         hasRotatableSelection,
         hasDraftingSelection: Boolean(selectedDrafting),
         hasInspectableSelection,
+        hasMoveSelection: hasVisualSelection(visualSelection),
         hasRouteSelection: Boolean(selectedRoute),
         hasHighlightableNet: selectedHighlightNetId !== null,
         wireReadyToFinish: Boolean(wireSource && wirePreviewPoint),
@@ -6189,6 +6329,12 @@ export function App({
           return;
         case "copy":
           beginCopyPlacement();
+          return;
+        case "begin-selection-move":
+          beginKeyboardSelectionMove();
+          return;
+        case "move-selection-required":
+          setStatus("Select objects before moving them");
           return;
         case "save":
           saveProjectFile();

--- a/apps/editor/src/components/editor-help-dialog.tsx
+++ b/apps/editor/src/components/editor-help-dialog.tsx
@@ -92,8 +92,10 @@ export function EditorHelpDialog({
               With no rotatable selection, <kbd>R</kbd> starts Rectangle; with a
               component or drawing selected it rotates clockwise.{" "}
               <kbd>Shift+R</kbd> mirrors left/right; <kbd>Shift+V</kbd> mirrors
-              top/bottom. <kbd>F</kbd> always fits the circuit in view.{" "}
-              <kbd>C</kbd> starts a mouse-following copy; click places it and
+              top/bottom. <kbd>M</kbd> arms a connectivity-aware move for the
+              current selection; drag to place it, or press <kbd>Esc</kbd> to
+              cancel. <kbd>F</kbd> always fits the circuit in view. <kbd>C</kbd>{" "}
+              starts a mouse-following copy; click places it and
               <kbd>Esc</kbd> cancels.
             </p>
           </section>
@@ -115,7 +117,8 @@ export function EditorHelpDialog({
                 <dd>
                   <kbd>Ctrl</kbd> + <kbd>A</kbd> selects all placed components;
                   <kbd>C</kbd> copy-place (click to place, <kbd>Esc</kbd> to
-                  cancel); <kbd>R</kbd> rotate; <kbd>Shift</kbd> + <kbd>R</kbd>
+                  cancel); <kbd>M</kbd> move/stretch the current selection;
+                  <kbd>R</kbd> rotate; <kbd>Shift</kbd> + <kbd>R</kbd>
                   mirror left/right; <kbd>Shift</kbd> + <kbd>V</kbd> mirror
                   top/bottom; <kbd>F</kbd> fit view;
                   <kbd>Delete</kbd> or <kbd>Backspace</kbd> delete.

--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -13,6 +13,7 @@ const baseContext: EditorShortcutContext = {
   hasRotatableSelection: false,
   hasDraftingSelection: false,
   hasInspectableSelection: false,
+  hasMoveSelection: false,
   hasRouteSelection: false,
   hasHighlightableNet: false,
   wireReadyToFinish: false,
@@ -142,6 +143,10 @@ describe("editor shortcut contract", () => {
       tool: "construction-line",
     });
     expect(resolve("p")).toBeNull();
+    expect(resolve("m")).toEqual({ kind: "move-selection-required" });
+    expect(resolve("m", { hasMoveSelection: true })).toEqual({
+      kind: "begin-selection-move",
+    });
     expect(resolve("l")).toEqual({ kind: "net-label-selection-required" });
     expect(resolve("l", { hasRouteSelection: true })).toEqual({
       kind: "edit-net-label",
@@ -246,6 +251,13 @@ describe("editor shortcut contract", () => {
     });
     expect(resolve("c", { interactionMode: "copy-placement" })).toEqual({
       kind: "copy",
+    });
+    expect(resolve("m", active)).toEqual({
+      kind: "blocked-interaction-command",
+      command: "Move",
+    });
+    expect(resolve("m", { interactionMode: "moving-selection" })).toEqual({
+      kind: "begin-selection-move",
     });
     expect(resolve("q", active)).toEqual({
       kind: "blocked-interaction-command",

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -16,6 +16,7 @@ export interface EditorShortcutContext {
   hasRotatableSelection: boolean;
   hasDraftingSelection: boolean;
   hasInspectableSelection: boolean;
+  hasMoveSelection: boolean;
   hasRouteSelection: boolean;
   hasHighlightableNet: boolean;
   wireReadyToFinish: boolean;
@@ -30,6 +31,7 @@ export type EditorShortcutIntent =
   | { kind: "block-browser-refresh" }
   | { kind: "undo" | "redo" }
   | { kind: "copy" | "save" | "open" | "select-all" }
+  | { kind: "begin-selection-move" | "move-selection-required" }
   | { kind: "reverse-current-marker" }
   | { kind: "open-component-insert" }
   | { kind: "rotate-placement"; deltaDegrees: 90 | -90 }
@@ -115,6 +117,11 @@ export function resolveEditorShortcut(
         ? { kind: "copy" }
         : { kind: "blocked-interaction-command", command: "Copy" };
     }
+    if (plain && key === "m") {
+      return context.interactionMode === "moving-selection"
+        ? { kind: "begin-selection-move" }
+        : { kind: "blocked-interaction-command", command: "Move" };
+    }
     if (plain && key === "i") return { kind: "open-component-insert" };
     if (plain && key === "w") {
       return { kind: "activate-tool", tool: "wire" };
@@ -173,6 +180,7 @@ export function resolveEditorShortcut(
       c: "Copy",
       q: "Properties",
       l: "Net Label",
+      m: "Move",
       t: "Text",
       h: "Net Highlight",
       x: "Current Marker",
@@ -193,6 +201,11 @@ export function resolveEditorShortcut(
     return { kind: "reverse-current-marker" };
   }
   if (plain && key === "c") return { kind: "copy" };
+  if (plain && key === "m") {
+    return context.hasMoveSelection
+      ? { kind: "begin-selection-move" }
+      : { kind: "move-selection-required" };
+  }
   if (plain && key === "i") return { kind: "open-component-insert" };
   if (plain && key === "r") {
     if (context.interactionMode === "placing-component") {

--- a/apps/editor/src/interaction/interaction-state.test.ts
+++ b/apps/editor/src/interaction/interaction-state.test.ts
@@ -242,4 +242,19 @@ describe("editor interaction state", () => {
       kind: "idle",
     });
   });
+
+  it("owns keyboard selection move as one cancellable pointer-mode interaction", () => {
+    const moving = interactionReducer(
+      { kind: "idle" },
+      { type: "begin-selection-move" },
+    );
+    expect(moving).toEqual({ kind: "moving-selection" });
+    expect(interactionTool(moving)).toBe("pointer");
+    expect(interactionReducer(moving, { type: "begin-selection-move" })).toBe(
+      moving,
+    );
+    expect(interactionReducer(moving, { type: "cancel" })).toEqual({
+      kind: "idle",
+    });
+  });
 });

--- a/apps/editor/src/interaction/interaction-state.ts
+++ b/apps/editor/src/interaction/interaction-state.ts
@@ -55,6 +55,7 @@ export type InteractionState<TClipboard = never> =
       kind: "copy-placement";
       copy: CopyPlacement<TClipboard>;
     }
+  | { kind: "moving-selection" }
   | {
       kind: "wire";
       source: WireSource | null;
@@ -89,6 +90,7 @@ export type InteractionAction<TClipboard = never> =
   | { type: "set-copy-preview"; point: Point | null }
   | { type: "rotate-copy"; deltaDegrees: 90 | -90 }
   | { type: "mirror-copy"; direction: ScreenFlip }
+  | { type: "begin-selection-move" }
   | {
       type: "set-wire-source";
       source: WireSource | null;
@@ -267,6 +269,10 @@ export function interactionReducer<TClipboard>(
             },
           }
         : state;
+    case "begin-selection-move":
+      return state.kind === "moving-selection"
+        ? state
+        : { kind: "moving-selection" };
     case "set-wire-source":
       return state.kind === "wire"
         ? {
@@ -324,6 +330,7 @@ export function interactionTool<TClipboard>(
     case "placing-component":
     case "placing-vdd-rail":
     case "copy-placement":
+    case "moving-selection":
       return "pointer";
     case "wire":
       return "wire";
@@ -399,6 +406,7 @@ export function useInteractionState<TClipboard>() {
       dispatch({ type: "rotate-copy", deltaDegrees }),
     mirrorCopyPlacement: (direction: ScreenFlip) =>
       dispatch({ type: "mirror-copy", direction }),
+    beginSelectionMove: () => dispatch({ type: "begin-selection-move" }),
     setWireSource: (source: WireSource | null, sourceRevision: number | null) =>
       dispatch({ type: "set-wire-source", source, sourceRevision }),
     setWirePreviewPoint: (point: Point | null) =>

--- a/plan/2026-08-16-unified-selection-move/plan.md
+++ b/plan/2026-08-16-unified-selection-move/plan.md
@@ -1,0 +1,87 @@
+---
+status: completed
+experience: none
+---
+
+# Unified Selection Move
+
+## Goal
+
+Make `M` a keyboard entry point for the editor's existing connectivity-aware
+move behavior, without narrowing mixed visual selection. Direct dragging and
+`M` must share one selection move planner and committed edit path.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## agent/refine-about-repository-link...origin/agent/refine-about-repository-link
+?? .worktrees/
+```
+
+The untracked `.worktrees/` directory is unrelated local workspace state and
+will not be touched. This target starts from updated `main` on
+`codex/unified-selection-move`.
+
+Owned paths:
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/interaction/editor-shortcuts.ts`
+- `apps/editor/src/interaction/editor-shortcuts.test.ts`
+- `apps/editor/src/interaction/interaction-state.ts`
+- `apps/editor/src/components/editor-help-dialog.tsx`
+- `apps/editor/e2e/manual-editor.spec.ts`
+- `apps/editor/src/features/selection/selection-move-plan.ts`
+- `apps/editor/src/features/selection/selection-move-plan.test.ts`
+- focused editor interaction tests when a matching suite exists
+- `plan/2026-08-16-unified-selection-move/plan.md`
+- `plan/log.md`
+
+Read-only shared dependencies:
+
+- `@icm/edit-engine` group move and route stretch proposals
+- model grid-coordinate contract
+
+## Work
+
+1. Generalize the selection move plan so a movable visual selection need not
+   contain an instance; preserve topology constraints for attached routes,
+   locked objects, and attachment-following labels.
+2. Extract one move-session entry point consumed by pointer dragging and `M`.
+   Keep the existing instance electrical snap behavior and add deterministic
+   visual-only movement without a parallel transaction path.
+3. Add `M` shortcut arbitration and an armed canvas interaction that can be
+   cancelled safely. Do not alter the agreed existing key bindings.
+4. Add focused unit/browser coverage for shortcut mapping, mixed planning,
+   keyboard movement cancellation, and one-transaction commit behavior.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/features/selection/selection-move-plan.test.ts apps/editor/src/interaction/editor-shortcuts.test.ts`
+- focused editor browser tests covering move behavior if available
+- `pnpm typecheck`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): unify keyboard and pointer selection move
+```
+
+## Outcome
+
+Implemented a cancellable `moving-selection` interaction state and mapped `M`
+to it. Pointer dragging and `M` now consume the same `VisualSelection` and
+`SelectionMovePlan`; instance-led groups retain electrical snapping/stretch,
+while visual-only selections use the same loose-route, free-annotation, and
+drafting-object commit helpers. A selected non-loose Route still enters its
+existing segment-stretch behavior. Root-SVG keyboard entry was normalized after
+browser coverage exposed the old child-element-only assumption.
+
+Validation passed: focused unit tests (38), focused Playwright `M` test, the
+complete manual-editor Playwright suite (67), workspace typecheck, Prettier,
+and `git diff --check`.

--- a/plan/2026-08-16-unified-selection-move/plan.md
+++ b/plan/2026-08-16-unified-selection-move/plan.md
@@ -85,3 +85,7 @@ browser coverage exposed the old child-element-only assumption.
 Validation passed: focused unit tests (38), focused Playwright `M` test, the
 complete manual-editor Playwright suite (67), workspace typecheck, Prettier,
 and `git diff --check`.
+
+Committed as `f07c65c` (`feat(editor): unify keyboard and pointer selection
+move`) and pushed to `codex/unified-selection-move-20260816` after an existing
+remote branch claimed the shorter name.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7489,4 +7489,6 @@ box`; branch pushed for review. A concurrent worker's overlapping App.tsx
 - Validation: 38 focused unit tests, focused `M` Playwright test, complete
   manual-editor Playwright suite (67 tests), workspace typecheck, Prettier,
   and `git diff --check` passed.
-- Commit status: pending commit on `codex/unified-selection-move`.
+- Commit status: committed as `f07c65c`
+  (`feat(editor): unify keyboard and pointer selection move`) and pushed to
+  `codex/unified-selection-move-20260816`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7478,3 +7478,15 @@ box`; branch pushed for review. A concurrent worker's overlapping App.tsx
 - Commit status: committed locally as
   `fix(editor): refine about repository link` on
   `codex/refine-about-repository-link`; not pushed.
+
+## 2026-08-16 - Unify keyboard and pointer selection move
+
+- Target: add `M` as a safe, connectivity-aware entry to existing movement
+  without rejecting mixed visual selection.
+- Changed areas: editor interaction state and shortcut arbitration; shared
+  visual-move edit helper; root-SVG-safe move entry; Help and focused browser
+  regression coverage.
+- Validation: 38 focused unit tests, focused `M` Playwright test, complete
+  manual-editor Playwright suite (67 tests), workspace typecheck, Prettier,
+  and `git diff --check` passed.
+- Commit status: pending commit on `codex/unified-selection-move`.


### PR DESCRIPTION
## What changed\n- Adds M as a cancellable, connectivity-aware move/stretch entry.\n- Keeps mixed visual selection on the existing move plan and typed-edit path.\n- Shares visual movement edits between keyboard and direct-drag entry points.\n\n## Validation\n- pnpm install --frozen-lockfile && pnpm ci:check\n- Focused unit and browser coverage, including the complete manual editor suite (67 tests).