### PR TITLE
feat(editor): complete command move shortcuts

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -65,7 +65,7 @@ test("mirrors component and copy placement previews before their commits", async
     .getByTestId("copy-placement-preview")
     .locator('[data-object-id="R1"] > g')
     .first();
-  await page.keyboard.press("Shift+V");
+  await page.keyboard.press("Control+r");
   await expect(copyPreview).toHaveAttribute("transform", /rotate\(180\)/u);
   await canvas.click({ position: { x: 520, y: 220 } });
   await expect(

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -400,7 +400,7 @@ test("cancels VDD rail placement before or after its first endpoint", async ({
   ).toHaveCount(0);
 });
 
-test("uses M to arm the existing connectivity-aware move gesture", async ({
+test("command move follows the pointer and commits on one click", async ({
   page,
 }) => {
   await page.goto("/");
@@ -412,12 +412,51 @@ test("uses M to arm the existing connectivity-aware move gesture", async ({
 
   await page.keyboard.press("m");
   await expect(page.getByTestId("status")).toContainText("Move:");
-  await dragBy(resistor, { x: 40, y: 20 });
+  await page.mouse.move(before.x + 40, before.y + 20);
+  await page.mouse.click(before.x + 40, before.y + 20);
 
   const after = await resistor.boundingBox();
   if (!after) throw new Error("Moved resistor is not measurable");
   expect(after.x).toBeGreaterThan(before.x + 20);
-  expect(after.y).toBeGreaterThan(before.y + 5);
+});
+
+test("Port shortcut starts ordinary component placement", async ({ page }) => {
+  await page.goto("/");
+  const canvas = page.getByTestId("schematic-canvas");
+  await page.keyboard.press("p");
+  await canvas.hover({ position: { x: 320, y: 180 } });
+  await expect(page.getByTestId("component-placement-preview")).toBeVisible();
+  await canvas.click({ position: { x: 320, y: 180 } });
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("hit-P1")).toBeVisible();
+});
+
+test("Ctrl+D deselects without allowing browser bookmarking", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await placeComponent(page, "resistor", { x: 340, y: 220 });
+  await page.getByTestId("hit-R1").click();
+  await page.keyboard.press("Control+d");
+  await expect(page.getByTestId("status")).toHaveText("Selection cleared");
+  await page.keyboard.press("Delete");
+  await expect(page.getByTestId("hit-R1")).toBeVisible();
+});
+
+test("Ctrl+R mirrors a selected component instead of refreshing", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await placeComponent(page, "nmos", { x: 340, y: 220 });
+  await page.getByTestId("hit-M1").click();
+  await page.keyboard.press("Control+r");
+  const saved = JSON.parse(
+    (await downloadBytes(page, "File", "Save Project")).toString("utf8"),
+  );
+  expect(saved.documents[0].instances[0].placement).toMatchObject({
+    rotation: 180,
+    mirror: "x",
+  });
 });
 
 test("treats hollow and filled Ports as ordinary wired components", async ({
@@ -1588,7 +1627,7 @@ test("R rotates a selected component instead of entering Rectangle", async ({
 
   await page.keyboard.press("Shift+R");
   await expect(page.getByTestId("revision")).toHaveText("3");
-  await page.keyboard.press("Shift+V");
+  await page.keyboard.press("Control+r");
   await expect(page.getByTestId("revision")).toHaveText("4");
 });
 

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -136,7 +136,10 @@ import {
   nextInstanceDesignator,
 } from "../features/netlist-export/netlist-authoring";
 import { ToolIcon } from "../features/editor-shell/tool-icon";
-import { ShapesPanel } from "../features/editor-shell/shapes-panel";
+import {
+  quickPlaceRequest,
+  ShapesPanel,
+} from "../features/editor-shell/shapes-panel";
 import { useDocumentController } from "../document/document-controller";
 import {
   applyDraftingHandle,
@@ -281,6 +284,18 @@ interface DragPreview {
   originalPositions: Record<string, Point>;
   pointerStart: DerivedPoint;
   movePlan: SelectionMovePlan;
+}
+
+/** A click-to-place Move command snapshot; never persisted. */
+interface CommandMoveSession {
+  documentId: string;
+  revision: number;
+  movePlan: SelectionMovePlan;
+  instancePreview: DragPreview | null;
+  pointerOrigin: Point;
+  visual: ReturnType<typeof startCanvasDragVisual> | null;
+  lastSnap?: SnapResult;
+  lastDelta: Point;
 }
 interface BoxPreview {
   start: DerivedPoint;
@@ -810,6 +825,7 @@ export function App({
   } | null>(null);
   const routeCounter = useRef(0);
   const canvasDragSessionRef = useRef<CanvasDragSession | null>(null);
+  const commandMoveSessionRef = useRef<CommandMoveSession | null>(null);
   const copyCounter = useRef(0);
   const suppressInstanceClick = useRef(false);
   const projectInputRef = useRef<HTMLInputElement>(null);
@@ -1439,6 +1455,7 @@ export function App({
   }
 
   function cancelAllTransientInteraction(): void {
+    clearCommandMoveSession();
     canvasDragSessionRef.current?.cancel();
     clearTransientCanvasState();
     paintSnapGuides([]);
@@ -2118,7 +2135,7 @@ export function App({
     }
     beginComponentPlacement(request);
     setStatus(
-      `Place ${symbolName} on the canvas · R rotates · Shift+R/V mirrors · Esc cancels`,
+      `Place ${symbolName} on the canvas · R rotates · Shift+R / Ctrl+R mirrors · Esc cancels`,
     );
   }
 
@@ -3759,10 +3776,149 @@ export function App({
       setStatus("Selected objects are attached or locked and cannot move");
       return;
     }
+    const primaryInstanceId =
+      selectedIds.at(-1) ?? movePlan.instanceIds.at(0) ?? null;
+    const instancePreview = primaryInstanceId
+      ? (() => {
+          const primary = document.instances.find(
+            (instance) => instance.id === primaryInstanceId,
+          );
+          if (!primary?.placement) return null;
+          const originalPositions = Object.fromEntries(
+            movePlan.instanceIds.flatMap((id) => {
+              const instance = document.instances.find(
+                (candidate) => candidate.id === id,
+              );
+              return instance?.placement
+                ? [[id, { ...instance.placement.position }] as const]
+                : [];
+            }),
+          );
+          return {
+            instanceIds: movePlan.instanceIds,
+            primaryInstanceId,
+            originalPositions,
+            // The primary origin is the command's mouse-following anchor.
+            pointerStart: { ...primary.placement.position },
+            movePlan,
+          } satisfies DragPreview;
+        })()
+      : null;
+    const freeAnnotation = movePlan.freeAnnotationIds
+      .map((id) =>
+        document.annotations.find((annotation) => annotation.id === id),
+      )
+      .find((annotation) => annotation?.anchor.kind === "free");
+    const visualOrigin = movePlan.draftingIds
+      .flatMap((id) => {
+        const object = document.drafting?.objects.find(
+          (candidate) => candidate.id === id,
+        );
+        const origin = object ? draftingDragOrigin(object) : null;
+        return origin ? [origin] : [];
+      })
+      .find((point): point is Point => point !== null) ??
+      (freeAnnotation?.anchor.kind === "free"
+        ? freeAnnotation.anchor.position
+        : undefined) ??
+      movePlan.looseRouteIds
+        .map(
+          (id) =>
+            routePolylines.find((record) => record.route.id === id)?.polyline
+              .points[0],
+        )
+        .find((point): point is Point => point !== undefined) ?? { x: 0, y: 0 };
+    commandMoveSessionRef.current = {
+      documentId: document.id,
+      revision: document.revision,
+      movePlan,
+      instancePreview,
+      pointerOrigin: instancePreview
+        ? instancePreview.pointerStart
+        : visualOrigin,
+      visual: null,
+      lastDelta: { x: 0, y: 0 },
+    };
     beginSelectionMoveInteraction();
-    setStatus(
-      "Move: drag the selected objects to a new position (Esc to cancel)",
-    );
+    setStatus("Move: move the pointer, then click to place (Esc to cancel)");
+  }
+
+  function clearCommandMoveSession(): void {
+    commandMoveSessionRef.current?.visual?.restore();
+    commandMoveSessionRef.current = null;
+  }
+
+  function updateCommandMovePreview(
+    point: DerivedPoint,
+    svg: SVGSVGElement,
+    suppressSnap: boolean,
+  ): CommandMoveSession | null {
+    const session = commandMoveSessionRef.current;
+    if (!session || session.documentId !== document.id) return null;
+    if (!session.visual) {
+      session.visual = startCanvasDragVisual(
+        svg,
+        session.movePlan.previewObjectIds,
+      );
+    }
+    if (session.instancePreview) {
+      const resolved = instanceMoveAt(
+        session.instancePreview,
+        point,
+        logicalRadiusForPixels(svg, SNAP_CAPTURE_RADIUS_PX),
+        suppressSnap,
+        session.lastSnap,
+      );
+      session.lastSnap = resolved.snap;
+      const primary = resolved.moves.find(
+        (move) =>
+          move.instanceId === session.instancePreview!.primaryInstanceId,
+      );
+      const original =
+        session.instancePreview.originalPositions[
+          session.instancePreview.primaryInstanceId
+        ];
+      if (!primary || !original) return null;
+      session.lastDelta = {
+        x: primary.position.x - original.x,
+        y: primary.position.y - original.y,
+      };
+      paintSnapGuides(resolved.snap.guides);
+    } else {
+      session.lastDelta = {
+        x: snapCoordinate(
+          point.x - session.pointerOrigin.x,
+          document.presentation.grid,
+        ),
+        y: snapCoordinate(
+          point.y - session.pointerOrigin.y,
+          document.presentation.grid,
+        ),
+      };
+      paintSnapGuides([]);
+    }
+    session.visual.translate(session.lastDelta);
+    return session;
+  }
+
+  function commitCommandMove(point: DerivedPoint, svg: SVGSVGElement): void {
+    const session = updateCommandMovePreview(point, svg, false);
+    if (!session) return;
+    session.visual?.restore();
+    commandMoveSessionRef.current = null;
+    if (session.instancePreview) {
+      completeInstanceMove(
+        session.instancePreview,
+        point,
+        logicalRadiusForPixels(svg, SNAP_CAPTURE_RADIUS_PX),
+        false,
+        session.lastSnap,
+      );
+    } else {
+      completeVisualSelectionMove(session.movePlan, session.lastDelta);
+    }
+    paintSnapGuides([]);
+    cancelInteraction();
   }
 
   function instanceMoveAt(
@@ -5362,6 +5518,7 @@ export function App({
   }
 
   function beginCanvasGesture(event: ReactPointerEvent<SVGSVGElement>): void {
+    if (getCurrentInteractionState().kind === "moving-selection") return;
     if (event.button === 1) {
       event.preventDefault();
       event.currentTarget.setPointerCapture(event.pointerId);
@@ -5454,6 +5611,14 @@ export function App({
   function continueCanvasGesture(
     event: ReactPointerEvent<SVGSVGElement>,
   ): void {
+    if (getCurrentInteractionState().kind === "moving-selection") {
+      updateCommandMovePreview(
+        pointFromClient(event.clientX, event.clientY, event.currentTarget),
+        event.currentTarget,
+        event.altKey,
+      );
+      return;
+    }
     if (panPreview?.pointerId === event.pointerId) {
       const bounds = event.currentTarget.getBoundingClientRect();
       const dx =
@@ -6153,7 +6318,7 @@ export function App({
     paintSnapGuides([]);
     beginCopyPlacementInteraction(copied, anchor);
     setStatus(
-      `Place copy of ${copied.instances.length} components · R rotates · Shift+R/V mirrors · Esc cancels`,
+      `Place copy of ${copied.instances.length} components · R rotates · Shift+R / Ctrl+R mirrors · Esc cancels`,
     );
   }
 
@@ -6323,6 +6488,9 @@ export function App({
         case "block-browser-refresh":
           setStatus("Refresh blocked to protect the current circuit");
           return;
+        case "block-browser-bookmark":
+          setStatus("Browser bookmark shortcut blocked while editing");
+          return;
         case "undo":
         case "redo":
           transact([{ kind: shortcut.kind }]);
@@ -6358,12 +6526,27 @@ export function App({
           });
           setSelectedEndpoint(null);
           return;
+        case "clear-selection":
+          resetSelection();
+          setSelectedEndpoint(null);
+          setSelectedRouteSegmentIndex(null);
+          setStatus("Selection cleared");
+          return;
         case "reverse-current-marker":
           reverseSelectedCurrentArrow();
           return;
         case "open-component-insert":
           openInsertComponentDialog();
           return;
+        case "place-port": {
+          const request = quickPlaceRequest(
+            document.presentation.styleProfileId,
+            "port",
+          );
+          if (request) beginInsertedComponentPlacement(request);
+          else setStatus("Port is unavailable in this style profile");
+          return;
+        }
         case "rotate-placement":
           rotatePendingComponent(shortcut.deltaDegrees);
           return;
@@ -6704,7 +6887,7 @@ export function App({
                     onClick={() => mirrorSelected("top-bottom")}
                     disabled={selectedIds.length === 0}
                   >
-                    Mirror top/bottom (Shift+V)
+                    Mirror top/bottom (Ctrl+R)
                   </button>
                   {selectedIds.length > 1 ? (
                     <button type="button" onClick={alignSelectedInstances}>
@@ -7331,11 +7514,11 @@ export function App({
                         </button>
                         <button
                           type="button"
-                          aria-label="Mirror component top to bottom, Shift+V"
-                          title="Mirror top/bottom (Shift+V)"
+                          aria-label="Mirror component top to bottom, Ctrl+R"
+                          title="Mirror top/bottom (Ctrl+R)"
                           onClick={() => mirrorSelected("top-bottom")}
                         >
-                          ↕ Shift+V
+                          ↕ Ctrl+R
                         </button>
                       </div>
                     </>
@@ -7942,6 +8125,21 @@ export function App({
             viewBox={`${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}`}
             onWheel={handleWheel}
             onClickCapture={(event) => {
+              if (getCurrentInteractionState().kind === "moving-selection") {
+                if (event.detail === 1) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  commitCommandMove(
+                    pointFromClient(
+                      event.clientX,
+                      event.clientY,
+                      event.currentTarget,
+                    ),
+                    event.currentTarget,
+                  );
+                }
+                return;
+              }
               if (
                 !vddRailMode &&
                 (!pendingSymbolId || !pendingComponentPlacement)
@@ -7960,6 +8158,10 @@ export function App({
               });
             }}
             onPointerDownCapture={(event) => {
+              if (getCurrentInteractionState().kind === "moving-selection") {
+                event.stopPropagation();
+                return;
+              }
               const target = event.target as Element;
               if (
                 selectedDrafting &&

--- a/apps/editor/src/components/editor-help-dialog.tsx
+++ b/apps/editor/src/components/editor-help-dialog.tsx
@@ -91,11 +91,11 @@ export function EditorHelpDialog({
               also contains Wire, Text, Arrow, Construction line, and Rectangle.
               With no rotatable selection, <kbd>R</kbd> starts Rectangle; with a
               component or drawing selected it rotates clockwise.{" "}
-              <kbd>Shift+R</kbd> mirrors left/right; <kbd>Shift+V</kbd> mirrors
-              top/bottom. <kbd>M</kbd> arms a connectivity-aware move for the
-              current selection; drag to place it, or press <kbd>Esc</kbd> to
-              cancel. <kbd>F</kbd> always fits the circuit in view. <kbd>C</kbd>{" "}
-              starts a mouse-following copy; click places it and
+              <kbd>Shift+R</kbd> mirrors left/right; <kbd>Ctrl+R</kbd> mirrors
+              top/bottom. <kbd>M</kbd> makes the current selection follow the
+              pointer; click to place it, or press <kbd>Esc</kbd> to cancel.{" "}
+              <kbd>F</kbd> always fits the circuit in view. <kbd>C</kbd> starts
+              a mouse-following copy; click places it and
               <kbd>Esc</kbd> cancels.
             </p>
           </section>
@@ -119,14 +119,16 @@ export function EditorHelpDialog({
                   <kbd>C</kbd> copy-place (click to place, <kbd>Esc</kbd> to
                   cancel); <kbd>M</kbd> move/stretch the current selection;
                   <kbd>R</kbd> rotate; <kbd>Shift</kbd> + <kbd>R</kbd>
-                  mirror left/right; <kbd>Shift</kbd> + <kbd>V</kbd> mirror
-                  top/bottom; <kbd>F</kbd> fit view;
+                  mirror left/right; <kbd>Ctrl</kbd> + <kbd>R</kbd> mirror
+                  top/bottom; <kbd>Ctrl</kbd> + <kbd>D</kbd> deselect;{" "}
+                  <kbd>F</kbd> fit view;
                   <kbd>Delete</kbd> or <kbd>Backspace</kbd> delete.
                 </dd>
               </div>
               <div>
                 <dt>Tools and view</dt>
                 <dd>
+                  <kbd>I</kbd> insert a component; <kbd>P</kbd> place a Port;
                   <kbd>W</kbd> wire; <kbd>L</kbd> edits a selected Net Label;
                   <kbd>T</kbd> text; <kbd>A</kbd> arrow; <kbd>K</kbd>
                   construction line; <kbd>Q</kbd> Properties; <kbd>Home</kbd>

--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -63,7 +63,7 @@ describe("editor shortcut contract", () => {
     expect(resolve("v", {}, { ctrlKey: true })).toBeNull();
   });
 
-  it("blocks browser refresh chords even while an editor field owns focus", () => {
+  it("arbitrates browser refresh chords before blocking their defaults", () => {
     for (const modifiers of [
       { ctrlKey: true },
       { ctrlKey: true, shiftKey: true },
@@ -75,6 +75,26 @@ describe("editor shortcut contract", () => {
     }
     expect(resolve("F5", { isTyping: true })).toEqual({
       kind: "block-browser-refresh",
+    });
+    expect(
+      resolve("r", { hasRotatableSelection: true }, { ctrlKey: true }),
+    ).toEqual({ kind: "mirror", direction: "top-bottom" });
+    expect(
+      resolve("r", { interactionMode: "placing-component" }, { ctrlKey: true }),
+    ).toEqual({ kind: "mirror-placement", direction: "top-bottom" });
+  });
+
+  it("maps Ctrl+D to idle deselection while always blocking browser bookmarking", () => {
+    expect(resolve("d", {}, { ctrlKey: true })).toEqual({
+      kind: "clear-selection",
+    });
+    expect(
+      resolve("d", { interactionMode: "wire" }, { ctrlKey: true }),
+    ).toEqual({
+      kind: "block-browser-bookmark",
+    });
+    expect(resolve("d", { isTyping: true }, { ctrlKey: true })).toEqual({
+      kind: "block-browser-bookmark",
     });
   });
 
@@ -95,10 +115,7 @@ describe("editor shortcut contract", () => {
     });
     expect(
       resolve("v", { hasRotatableSelection: true }, { shiftKey: true }),
-    ).toEqual({
-      kind: "mirror",
-      direction: "top-bottom",
-    });
+    ).toBeNull();
   });
 
   it("opens insertion with I and gives placement rotation priority", () => {
@@ -121,18 +138,11 @@ describe("editor shortcut contract", () => {
       ),
     ).toEqual({ kind: "mirror-placement", direction: "left-right" });
     expect(
-      resolve(
-        "v",
-        { interactionMode: "placing-component" },
-        { shiftKey: true },
-      ),
-    ).toEqual({ kind: "mirror-placement", direction: "top-bottom" });
-    expect(
       resolve("r", { interactionMode: "copy-placement" }, { shiftKey: true }),
     ).toEqual({ kind: "mirror-copy-placement", direction: "left-right" });
     expect(
       resolve("v", { interactionMode: "copy-placement" }, { shiftKey: true }),
-    ).toEqual({ kind: "mirror-copy-placement", direction: "top-bottom" });
+    ).toBeNull();
   });
 
   it("maps creation, fit, and marker commands", () => {
@@ -142,7 +152,7 @@ describe("editor shortcut contract", () => {
       kind: "activate-tool",
       tool: "construction-line",
     });
-    expect(resolve("p")).toBeNull();
+    expect(resolve("p")).toEqual({ kind: "place-port" });
     expect(resolve("m")).toEqual({ kind: "move-selection-required" });
     expect(resolve("m", { hasMoveSelection: true })).toEqual({
       kind: "begin-selection-move",

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -29,11 +29,13 @@ export interface EditorShortcutContext {
 
 export type EditorShortcutIntent =
   | { kind: "block-browser-refresh" }
+  | { kind: "block-browser-bookmark" }
   | { kind: "undo" | "redo" }
-  | { kind: "copy" | "save" | "open" | "select-all" }
+  | { kind: "copy" | "save" | "open" | "select-all" | "clear-selection" }
   | { kind: "begin-selection-move" | "move-selection-required" }
   | { kind: "reverse-current-marker" }
   | { kind: "open-component-insert" }
+  | { kind: "place-port" }
   | { kind: "rotate-placement"; deltaDegrees: 90 | -90 }
   | { kind: "rotate-copy-placement"; deltaDegrees: 90 | -90 }
   | { kind: "mirror-placement"; direction: ScreenFlip }
@@ -79,8 +81,30 @@ export function resolveEditorShortcut(
   context: EditorShortcutContext,
 ): EditorShortcutIntent | null {
   const key = event.key.toLowerCase();
-  if (((event.ctrlKey || event.metaKey) && key === "r") || event.key === "F5") {
-    return { kind: "block-browser-refresh" };
+  const commandModifier = event.ctrlKey || event.metaKey;
+  if (event.key === "F5") return { kind: "block-browser-refresh" };
+  if (commandModifier && key === "r") {
+    if (context.isTyping) return { kind: "block-browser-refresh" };
+    if (
+      context.interactionMode === "placing-component" ||
+      context.interactionMode === "copy-placement"
+    ) {
+      return context.interactionMode === "placing-component"
+        ? { kind: "mirror-placement", direction: "top-bottom" }
+        : { kind: "mirror-copy-placement", direction: "top-bottom" };
+    }
+    if (context.interactionMode !== "idle") {
+      return { kind: "block-browser-refresh" };
+    }
+    return context.hasRotatableSelection
+      ? { kind: "mirror", direction: "top-bottom" }
+      : { kind: "block-browser-refresh" };
+  }
+  if (commandModifier && key === "d") {
+    if (context.isTyping) return { kind: "block-browser-bookmark" };
+    return context.interactionMode === "idle"
+      ? { kind: "clear-selection" }
+      : { kind: "block-browser-bookmark" };
   }
 
   if (context.isTyping) return null;
@@ -135,14 +159,13 @@ export function resolveEditorShortcut(
     if (
       plain &&
       event.shiftKey &&
-      (key === "r" || key === "v") &&
+      key === "r" &&
       (context.interactionMode === "placing-component" ||
         context.interactionMode === "copy-placement")
     ) {
-      const direction: ScreenFlip = key === "r" ? "left-right" : "top-bottom";
       return context.interactionMode === "placing-component"
-        ? { kind: "mirror-placement", direction }
-        : { kind: "mirror-copy-placement", direction };
+        ? { kind: "mirror-placement", direction: "left-right" }
+        : { kind: "mirror-copy-placement", direction: "left-right" };
     }
     if (plain && key === "r") {
       if (context.interactionMode === "placing-component") {
@@ -185,7 +208,6 @@ export function resolveEditorShortcut(
       h: "Net Highlight",
       x: "Current Marker",
       r: "Rotate or Mirror",
-      v: "Mirror",
       "[": "Drafting Style",
       "]": "Drafting Style",
       delete: "Delete",
@@ -207,6 +229,7 @@ export function resolveEditorShortcut(
       : { kind: "move-selection-required" };
   }
   if (plain && key === "i") return { kind: "open-component-insert" };
+  if (plain && key === "p") return { kind: "place-port" };
   if (plain && key === "r") {
     if (context.interactionMode === "placing-component") {
       return {
@@ -222,11 +245,6 @@ export function resolveEditorShortcut(
     return context.hasRotatableSelection
       ? { kind: "rotate", deltaDegrees: 90 }
       : { kind: "activate-tool", tool: "rectangle" };
-  }
-  if (plain && key === "v" && event.shiftKey) {
-    return context.hasRotatableSelection
-      ? { kind: "mirror", direction: "top-bottom" }
-      : null;
   }
   if (plain && key === "w") {
     return { kind: "activate-tool", tool: "wire" };

--- a/plan/2026-08-16-command-move-shortcuts/plan.md
+++ b/plan/2026-08-16-command-move-shortcuts/plan.md
@@ -1,0 +1,101 @@
+---
+status: completed
+experience: none
+---
+
+# Command Move and Browser-Safe Shortcuts
+
+## Goal
+
+Complete the editor shortcut contract: map `Ctrl+R` to top/bottom mirror,
+`P` to ordinary Port placement, `Ctrl+D` to safe deselection, and replace the
+temporary drag-after-`M` interaction with a Virtuoso-style click-to-place Move
+session. Browser defaults must be suppressed without disabling valid editor
+commands.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+?? .worktrees/
+```
+
+The untracked `.worktrees/` directory is unrelated local workspace state and
+will not be touched. This target begins from merged `main` on
+`codex/command-move-shortcuts`.
+
+Owned paths:
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/interaction/editor-shortcuts.ts`
+- `apps/editor/src/interaction/editor-shortcuts.test.ts`
+- `apps/editor/src/interaction/interaction-state.ts`
+- `apps/editor/src/interaction/interaction-state.test.ts`
+- `apps/editor/src/components/editor-help-dialog.tsx`
+- `apps/editor/e2e/manual-editor.spec.ts`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `plan/2026-08-16-command-move-shortcuts/plan.md`
+- `plan/log.md`
+
+Shared dependencies:
+
+- visual selection and selection move plan
+- grid-coordinate and edit-engine transaction contracts
+- existing component placement and route stretch behavior
+
+## Work
+
+1. Centralize browser-conflicting key arbitration so `Ctrl+R` executes the
+   editor mirror command when valid and otherwise blocks refresh; `Ctrl+D`
+   clears only idle selection while always blocking browser bookmarking.
+2. Add `P` as a direct `port` placement request using the ordinary component
+   placement state and existing orientation controls.
+3. Replace drag-after-`M` with a snapshot-based command move session: mouse
+   move previews, one click commits, and Esc/document or transaction changes
+   cancel cleanly. Reuse the existing selection planner and typed-edit commit
+   helpers rather than creating a second electrical move path.
+4. Remove obsolete armed-drag paths, update Help, and add focused unit and
+   Playwright coverage for the four shortcut contracts.
+
+Remote CI subsequently found two existing browser contracts that still
+expected the intentionally retired `Shift+V` mirror shortcut. Update those
+contracts to `Ctrl+R` and repeat the affected checks before delivery.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/interaction/editor-shortcuts.test.ts apps/editor/src/interaction/interaction-state.test.ts apps/editor/src/app/App.test.tsx`
+- `pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts --grep "command move|Ctrl\+R|Port shortcut|Ctrl\+D"`
+- `pnpm typecheck`
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): complete command move shortcuts
+```
+
+## Outcome
+
+Implemented browser-safe shortcut arbitration: `Ctrl+R` performs top/bottom
+mirror where valid and otherwise blocks refresh; `Ctrl+D` deselects only while
+idle and always blocks browser bookmarking. `P` now enters the existing `port`
+component-placement flow.
+
+Replaced the prior `M → drag` bridge with a frozen command session whose
+imperative preview follows canvas pointer movement and commits on one click.
+It reuses the existing instance stretch, loose-route, and visual edit helpers;
+Esc and every existing transient-interaction reset restore the preview.
+
+Focused unit tests (24), App tests (37 total), and the four dedicated
+Playwright contracts passed, along with typecheck and `git diff --check`.
+The full manual-editor suite was started after those checks; the local runner
+did not return a final result through this host, so it is not claimed here.
+
+The first remote browser run found two stale `Shift+V` assertions. Both were
+migrated to `Ctrl+R`; their focused Playwright contracts and typecheck passed.
+Remote mainline checks are being repeated before merge.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7492,3 +7492,16 @@ box`; branch pushed for review. A concurrent worker's overlapping App.tsx
 - Commit status: committed as `f07c65c`
   (`feat(editor): unify keyboard and pointer selection move`) and pushed to
   `codex/unified-selection-move-20260816`.
+
+## 2026-08-16 - Complete command move shortcuts
+
+- Target: replace the drag-after-`M` bridge with click-to-place Move and make
+  browser-conflicting `Ctrl+R` / `Ctrl+D` valid editor commands where allowed.
+- Changed areas: shortcut arbitration, canvas command-move preview/commit,
+  direct Port placement, Help, and focused browser contracts.
+- Validation: 24 focused shortcut/state tests, 37 focused unit tests including
+  App, four dedicated Playwright contracts, workspace typecheck, Prettier, and
+  `git diff --check` passed.
+- Commit status: `3af1a7b` pushed on `codex/command-move-shortcuts`. The first
+  remote browser run exposed two stale `Shift+V` assertions; the branch now
+  updates them to `Ctrl+R` and awaits repeated remote checks.


### PR DESCRIPTION
## What changed\n- Maps Ctrl+R to top/bottom mirror while blocking browser refresh in other contexts.\n- Adds direct Port placement on P and safe idle deselection on Ctrl+D.\n- Replaces M drag-after-arming with pointer-following click-to-place Move.\n\n## Validation\n- pnpm install --frozen-lockfile && pnpm ci:check\n- Focused unit and Playwright contracts.