### PR TITLE
feat(editor): expand insert dialog component list by default

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -156,7 +156,7 @@ test("inserts from the master-detail dialog with keyboard and live placement pre
 
   await page.keyboard.press("i");
   const reopened = page.getByRole("dialog", { name: "Insert Component" });
-  await reopened.getByRole("button", { name: "Expand component list" }).click();
+  await expect(reopened.locator(".insert-component-options")).toBeVisible();
   const passives = reopened
     .locator(".insert-option-group")
     .filter({ hasText: "Passives" });
@@ -359,7 +359,9 @@ test("keeps preview fixed while the compact catalog expands and collapses", asyn
   const artwork = dialog.locator(".insert-symbol-artwork");
   const cancel = dialog.getByRole("button", { name: "Cancel" });
   const apply = dialog.getByRole("button", { name: "Apply" });
-  const toggle = dialog.getByRole("button", { name: "Expand component list" });
+  const toggle = dialog.getByRole("button", {
+    name: "Collapse component list",
+  });
 
   const measure = () =>
     dialog.evaluate((element) => {
@@ -387,14 +389,16 @@ test("keeps preview fixed while the compact catalog expands and collapses", asyn
   await expect(cancel).toBeVisible();
   await expect(apply).toBeVisible();
   expect(before.footer.bottom).toBeLessThanOrEqual(before.dialog.bottom);
-  await expect(dialog.locator(".insert-component-options")).toHaveCount(0);
-
-  await toggle.click();
   const options = dialog.locator(".insert-component-options");
   await expect(options).toBeVisible();
   expect(
     await options.evaluate((element) => getComputedStyle(element).overflowY),
   ).toBe("auto");
+
+  await toggle.click();
+  await expect(options).toHaveCount(0);
+  await dialog.getByRole("button", { name: "Expand component list" }).click();
+  await expect(options).toBeVisible();
   await dialog.getByTestId("insert-component-inductor").click();
   const after = await measure();
   expect(after.dialog.height).toBeCloseTo(before.dialog.height, 0);

--- a/apps/editor/src/features/component-insert/insert-component-dialog.test.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { InsertComponentDialog } from "./insert-component-dialog";
 
 describe("InsertComponentDialog", () => {
-  it("renders a collapsed picker, device controls, and one authoritative preview", () => {
+  it("renders an expanded picker, device controls, and one authoritative preview", () => {
     const markup = renderToStaticMarkup(
       <InsertComponentDialog
         open
@@ -18,8 +18,9 @@ describe("InsertComponentDialog", () => {
     expect(markup).toContain('role="dialog"');
     expect(markup).toContain('role="combobox"');
     expect(markup).toContain('aria-label="Component search"');
-    expect(markup).toContain('aria-expanded="false"');
-    expect(markup).toContain('aria-label="Expand component list"');
+    expect(markup).toContain('aria-expanded="true"');
+    expect(markup).toContain('aria-label="Collapse component list"');
+    expect(markup).toContain('role="listbox"');
     expect(markup).toContain('class="insert-symbol-artwork"');
     expect(markup).toContain('aria-label="Component w"');
     expect(markup).toContain('aria-label="Component l"');

--- a/apps/editor/src/features/component-insert/insert-component-dialog.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.tsx
@@ -83,7 +83,7 @@ export function InsertComponentDialog({
     [recentSymbolIds, styleProfileId],
   );
   const [query, setQuery] = useState("");
-  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(true);
   const [selectedId, setSelectedId] = useState(
     () => initialSymbols[0]?.id ?? null,
   );
@@ -107,7 +107,7 @@ export function InsertComponentDialog({
   useEffect(() => {
     if (!open) return;
     setQuery("");
-    setPickerOpen(false);
+    setPickerOpen(true);
     setSelectedId(initialSymbols[0]?.id ?? null);
     setInitialRotation(0);
     setShowReference(true);

--- a/plan/2026-08-16-insert-dialog-list-default-expanded/plan.md
+++ b/plan/2026-08-16-insert-dialog-list-default-expanded/plan.md
@@ -1,0 +1,68 @@
+---
+status: active
+experience: none
+---
+
+# Insert dialog component list default expanded
+
+## Goal
+
+Make the component list in the `I` (Insert Component) dialog expanded by
+default each time the dialog opens. No other behavior changes: the collapse
+toggle, search re-open, and select-to-collapse interactions stay as they are.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/command-move-shortcuts...origin/codex/command-move-shortcuts
+?? .worktrees/
+```
+
+Worktree is clean except the untracked `.worktrees/` directory, which is
+unrelated to this target and safe to leave untouched. Branching from
+`origin/main` (7e144c5).
+
+- Owned: `apps/editor/src/features/component-insert/insert-component-dialog.tsx`
+- Owned: `apps/editor/src/features/component-insert/insert-component-dialog.test.tsx`
+- Owned: `apps/editor/e2e/component-insert.spec.ts`
+- Owned: `plan/2026-08-16-insert-dialog-list-default-expanded/plan.md`, `plan/log.md`
+
+Read-only: everything else. No shared package contracts are touched.
+
+## Work
+
+1. Change `pickerOpen` initial state and the dialog-open reset from `false`
+   to `true` so the list renders expanded on open.
+2. Update the unit test contract that asserted the collapsed default.
+3. Update the two e2e spots that assumed the list starts collapsed.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/features/component-insert/insert-component-dialog.test.tsx`
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts`
+- `git diff --check`
+- `git status --short --branch`
+- Mainline gate before merge to main: `pnpm install --frozen-lockfile` +
+  `pnpm ci:check`, then push branch and wait for required GitHub Actions
+  checks before merging.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): expand insert dialog component list by default
+```
+
+## Outcome
+
+Changed `pickerOpen` initial state and the dialog-open reset to `true` so the
+component list renders expanded whenever the Insert Component dialog opens.
+Collapse toggle, search re-open, and select-to-collapse behavior unchanged.
+Updated the unit contract to assert the expanded default and adapted two e2e
+spots that assumed a collapsed start.
+
+Validation: unit test 2/2 passed; e2e `component-insert.spec.ts` 17/17 passed;
+`git diff --check` clean. Delivered via PR merge to `main`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7505,3 +7505,14 @@ box`; branch pushed for review. A concurrent worker's overlapping App.tsx
 - Commit status: `3af1a7b` pushed on `codex/command-move-shortcuts`. The first
   remote browser run exposed two stale `Shift+V` assertions; the branch now
   updates them to `Ctrl+R` and awaits repeated remote checks.
+
+## 2026-08-16 - Insert dialog component list default expanded
+
+- Target: make the `I` (Insert Component) dialog open with its device list
+  expanded; no other behavior change.
+- Changed areas: insert dialog picker default state plus its unit and e2e
+  contracts.
+- Validation: insert-dialog unit test (2/2), full `component-insert.spec.ts`
+  Playwright run (17/17), and `git diff --check` passed.
+- Commit status: committed on `codex/insert-dialog-list-default-expanded` and
+  merged to `main` after the mainline gate.


### PR DESCRIPTION
## Summary
- The `I` (Insert Component) dialog now opens with its device list expanded by default (`pickerOpen` initial state and open-reset changed to `true`).
- No other behavior changes: collapse toggle, search re-open, and select-to-collapse stay as before.
- Updated the unit contract and two e2e spots that assumed a collapsed start.

## Validation
- `pnpm test:local apps/editor/src/features/component-insert/insert-component-dialog.test.tsx` (2/2)
- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts` (17/17)
- `pnpm ci:check` (local gate)