### PR TITLE
feat(editor): make Q toggle the Properties dock closed

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -380,6 +380,20 @@ test("carries a manual Value through placement and Q property editing", async ({
   const propertyValue = page.getByLabel("Component value");
   await expect(propertyValue).toBeFocused();
   await expect(propertyValue).toHaveValue("10k");
+  // Q toggles the dock closed even while focus sits in the value input, and
+  // the swallowed keypress never types into the field.
+  await page.keyboard.press("q");
+  await expect(page.getByTestId("selection-shelf")).toHaveAttribute(
+    "aria-expanded",
+    "false",
+  );
+  await page.keyboard.press("q");
+  await expect(page.getByTestId("selection-shelf")).toHaveAttribute(
+    "aria-expanded",
+    "true",
+  );
+  await expect(propertyValue).toBeFocused();
+  await expect(propertyValue).toHaveValue("10k");
   await propertyValue.fill("12k");
   await page
     .getByRole("button", { name: "Apply component properties" })

--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -757,7 +757,16 @@ test("drawing Properties follows selection and closes with the dock", async ({
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("drafting-properties")).toHaveCount(0);
 
+  // Escape leaves the dock open, so reselecting restores Properties without
+  // Q, and the next Q collapses the dock instead of reopening it.
   await hit.click({ force: true });
+  await expect(page.getByTestId("drafting-properties")).toBeVisible();
+  await page.keyboard.press("q");
+  await expect(page.getByTestId("selection-shelf")).toHaveAttribute(
+    "aria-expanded",
+    "false",
+  );
+  await expect(page.getByTestId("drafting-properties")).toBeHidden();
   await page.keyboard.press("q");
   await expect(page.getByTestId("drafting-properties")).toBeVisible();
   await page

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -6494,6 +6494,11 @@ export function App({
         hasRemovableWireWaypoint: Boolean(
           wireSource && wireWaypoints.length > 0,
         ),
+        propertiesOpen: selectionOpen,
+        typingInProperties:
+          isTypingTarget(event.target) &&
+          event.target instanceof Element &&
+          event.target.closest('[data-testid="selection-dock"]') !== null,
       });
       if (!shortcut) return;
 
@@ -6594,6 +6599,10 @@ export function App({
           return;
         case "open-properties":
           openProperties();
+          return;
+        case "close-properties":
+          setSelectionOpen(false);
+          setImportReviewOpen(false);
           return;
         case "property-selection-required":
           setStatus("Select an object before opening Properties");
@@ -7360,6 +7369,7 @@ export function App({
           className={selectionOpen ? "selection-dock open" : "selection-dock"}
           aria-label="Properties"
           role="complementary"
+          data-testid="selection-dock"
         >
           <section className="selection-shelf" aria-label="Selection">
             <button

--- a/apps/editor/src/components/editor-help-dialog.tsx
+++ b/apps/editor/src/components/editor-help-dialog.tsx
@@ -131,8 +131,9 @@ export function EditorHelpDialog({
                   <kbd>I</kbd> insert a component; <kbd>P</kbd> place a Port;
                   <kbd>W</kbd> wire; <kbd>L</kbd> edits a selected Net Label;
                   <kbd>T</kbd> text; <kbd>A</kbd> arrow; <kbd>K</kbd>
-                  construction line; <kbd>Q</kbd> Properties; <kbd>Home</kbd>
-                  fit view; <kbd>X</kbd> reverses a selected current arrow.
+                  construction line; <kbd>Q</kbd> Properties open/close;{" "}
+                  <kbd>Home</kbd> fit view; <kbd>X</kbd> reverses a selected
+                  current arrow.
                 </dd>
               </div>
               <div>

--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -22,6 +22,8 @@ const baseContext: EditorShortcutContext = {
   canvasDragActive: false,
   hasClearableDraftingSelection: false,
   hasRemovableWireWaypoint: false,
+  propertiesOpen: false,
+  typingInProperties: false,
 };
 
 function key(
@@ -175,6 +177,12 @@ describe("editor shortcut contract", () => {
     expect(resolve("q", { hasInspectableSelection: true })).toEqual({
       kind: "open-properties",
     });
+    expect(
+      resolve("q", { propertiesOpen: true, hasInspectableSelection: true }),
+    ).toEqual({ kind: "close-properties" });
+    expect(resolve("q", { propertiesOpen: true })).toEqual({
+      kind: "close-properties",
+    });
     expect(resolve("g")).toBeNull();
     expect(resolve("t")).toEqual({ kind: "add-text" });
     expect(resolve("f")).toEqual({ kind: "fit-view" });
@@ -307,9 +315,33 @@ describe("editor shortcut contract", () => {
   });
 
   it("suppresses every global shortcut while typing", () => {
-    for (const value of ["i", "r", "Escape", "Delete", "Enter"]) {
+    for (const value of ["i", "r", "Escape", "Delete", "Enter", "q"]) {
       expect(resolve(value, { isTyping: true })).toBeNull();
     }
     expect(resolve("s", { isTyping: true }, { ctrlKey: true })).toBeNull();
+  });
+
+  it("closes an open Properties dock with Q while typing inside it", () => {
+    expect(
+      resolve("q", {
+        propertiesOpen: true,
+        isTyping: true,
+        typingInProperties: true,
+      }),
+    ).toEqual({ kind: "close-properties" });
+    expect(resolve("q", { propertiesOpen: true, isTyping: true })).toBeNull();
+    expect(
+      resolve(
+        "q",
+        { propertiesOpen: true, isTyping: true, typingInProperties: true },
+        { shiftKey: true },
+      ),
+    ).toBeNull();
+    expect(
+      resolve("q", { isTyping: true, typingInProperties: true }),
+    ).toBeNull();
+    expect(
+      resolve("q", { propertiesOpen: true, interactionMode: "drawing" }),
+    ).toEqual({ kind: "blocked-interaction-command", command: "Properties" });
   });
 });

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -25,6 +25,8 @@ export interface EditorShortcutContext {
   canvasDragActive: boolean;
   hasClearableDraftingSelection: boolean;
   hasRemovableWireWaypoint: boolean;
+  propertiesOpen: boolean;
+  typingInProperties: boolean;
 }
 
 export type EditorShortcutIntent =
@@ -43,7 +45,10 @@ export type EditorShortcutIntent =
   | { kind: "rotate"; deltaDegrees: 90 | -90 }
   | { kind: "activate-tool"; tool: EditorTool }
   | { kind: "add-text" }
-  | { kind: "open-properties" | "property-selection-required" }
+  | {
+      kind:
+        "open-properties" | "close-properties" | "property-selection-required";
+    }
   | { kind: "edit-net-label" | "net-label-selection-required" }
   | { kind: "toggle-net-highlight" }
   | { kind: "mirror"; direction: ScreenFlip }
@@ -107,9 +112,19 @@ export function resolveEditorShortcut(
       : { kind: "block-browser-bookmark" };
   }
 
-  if (context.isTyping) return null;
-
   const plain = !event.ctrlKey && !event.metaKey && !event.altKey;
+  // Q toggles the Properties dock: while typing inside the dock, plain q
+  // still closes it; Shift+Q keeps typing an uppercase letter.
+  const closesPropertiesWhileTyping =
+    plain &&
+    !event.shiftKey &&
+    key === "q" &&
+    context.interactionMode === "idle" &&
+    context.propertiesOpen &&
+    context.typingInProperties;
+
+  if (context.isTyping && !closesPropertiesWhileTyping) return null;
+
   const interactionActive = context.interactionMode !== "idle";
 
   if (plain && key === "u") {
@@ -265,6 +280,7 @@ export function resolveEditorShortcut(
     return { kind: "activate-tool", tool: "construction-line" };
   }
   if (plain && key === "q") {
+    if (context.propertiesOpen) return { kind: "close-properties" };
     return context.hasInspectableSelection
       ? { kind: "open-properties" }
       : { kind: "property-selection-required" };

--- a/plan/2026-08-16-q-toggles-properties/plan.md
+++ b/plan/2026-08-16-q-toggles-properties/plan.md
@@ -1,0 +1,95 @@
+---
+status: completed
+experience: none
+---
+
+# Q toggles the Properties dock closed
+
+## Goal
+
+Pressing `Q` currently only opens the Properties dock (`open-properties`).
+Because opening focuses the first text input, a second `Q` is typed into that
+input instead of closing the dock. Make `Q` a toggle: when the dock is open,
+`Q` closes it — including when keyboard focus is inside a Properties input,
+where the keypress must be swallowed instead of typing `q`. `Shift+Q` keeps
+typing an uppercase letter into the field.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+?? .worktrees/
+```
+
+Worktree is clean except the untracked `.worktrees/` directory, which is
+unrelated infrastructure state and untouched by this target.
+
+- `apps/editor/src/interaction/editor-shortcuts.ts`
+- `apps/editor/src/interaction/editor-shortcuts.test.ts`
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/components/editor-help-dialog.tsx`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `apps/editor/e2e/drafting.spec.ts`
+
+Read-only: `plan/log.md` gets a new entry only.
+
+## Work
+
+1. Extend `EditorShortcutContext` with `propertiesOpen` and
+   `typingInProperties`; add a `close-properties` intent.
+2. Resolver: plain `q` closes when the dock is open (idle mode only; active
+   interactions keep the existing `blocked-interaction-command` behavior).
+   While typing, `q` closes only when the typing target is inside the
+   Properties dock and Shift is not held; typing elsewhere still suppresses
+   every shortcut.
+3. App: pass the new context fields, tag the dock aside with
+   `data-testid="selection-dock"` for the containment check, and handle
+   `close-properties` by collapsing the dock (mirroring the shelf button,
+   including closing import review).
+4. Help dialog: document `Q` as Properties open/close.
+5. Unit tests: toggle contract including typing-inside-dock, Shift escape
+   hatch, typing elsewhere, and active-interaction precedence.
+6. E2E: extend the Q property-editing test with a close/reopen cycle while
+   focus is in the value input; rewrite the drafting "follows selection and
+   closes with the dock" test whose second `Q` press relied on idempotent
+   reopen.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/interaction/editor-shortcuts.test.ts apps/editor/src/app/App.test.tsx`
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep "Q property editing"`
+- `pnpm test:e2e:local apps/editor/e2e/drafting.spec.ts --grep "follows selection and closes"`
+- TypeScript contract check covering the changed context interface
+- `git diff --check`
+- `git status --short --branch`
+
+The resolver contract and the browser toggle flow are the two behavior
+surfaces changed; the e2e picks cover both including the typing-swallow path.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): make Q toggle the Properties dock closed
+```
+
+## Outcome
+
+Implemented Q as a Properties toggle. Idle-mode plain `q` now returns
+`close-properties` when the dock is open, and while typing inside the dock the
+keypress is intercepted (swallowed) so it closes instead of typing `q`;
+`Shift+Q` still types an uppercase letter. Active interactions keep the
+existing blocked-command arbitration, and typing outside the dock still
+suppresses every shortcut. Help now reads "Properties open/close".
+
+Validation: 28 focused unit tests (shortcuts + App), workspace typecheck,
+Prettier, the extended "Q property editing" Playwright contract (close/reopen
+while focused in the value input), the rewritten drafting dock contract, the
+full drafting spec (25 tests), the two remaining Q-pressing component-insert
+tests, `git diff --check`, and `git status --short --branch` all passed.
+
+Experience signal: `none` — routine shortcut-arbitration change fully covered
+by existing focused checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7540,3 +7540,18 @@ box`; branch pushed for review. A concurrent worker's overlapping App.tsx
   Playwright run (17/17), and `git diff --check` passed.
 - Commit status: committed on `codex/insert-dialog-list-default-expanded` and
   merged to `main` after the mainline gate.
+
+## 2026-08-16 - Q toggles the Properties dock closed
+
+- Target: make `Q` close the open Properties dock as well as open it,
+  including while focus sits in a dock text input (keypress swallowed;
+  `Shift+Q` still types).
+- Changed areas: shortcut arbitration (`close-properties` intent with
+  `propertiesOpen` / `typingInProperties` context), App dispatch and dock
+  testid, Help wording, shortcut unit contracts, and two Q-touching Playwright
+  specs (one rewritten for toggle semantics).
+- Validation: 28 focused unit tests, workspace typecheck, Prettier, extended
+  Q property-editing contract, full drafting spec (25), two remaining
+  component-insert Q tests, and `git diff --check` passed.
+- Commit status: committed on `zcode/q-toggles-properties`; mainline merge
+  awaits the delivery gate.


### PR DESCRIPTION
## Summary
- Pressing Q now closes an open Properties dock instead of only opening it; pressing Q again reopens it.
- When focus sits in a dock text input (the state right after opening), the Q keypress is intercepted and swallowed, so it closes the dock instead of typing "q" into the field. Shift+Q still types an uppercase letter.
- Active interactions keep the existing "Properties is unavailable while a tool owns the canvas" arbitration; typing outside the dock still suppresses all shortcuts.
- Help dialog now documents Q as "Properties open/close".

## Validation
- `pnpm test:local apps/editor/src/interaction/editor-shortcuts.test.ts apps/editor/src/app/App.test.tsx` (28 passed)
- `pnpm typecheck`
- Prettier check on changed files
- `pnpm test:e2e:local`: extended "Q property editing" contract (close/reopen while focused in the value input), full `drafting.spec.ts` (25 passed), and the two remaining component-insert Q tests
- `git diff --check`

Plan: `plan/2026-08-16-q-toggles-properties/plan.md`