### PR TITLE
feat(editor): keep Q a pure Properties toggle without input auto-focus

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -378,10 +378,11 @@ test("carries a manual Value through placement and Q property editing", async ({
     page.locator(".selection-overview").filter({ hasText: "ComponentR1" }),
   ).not.toContainText("Position");
   const propertyValue = page.getByLabel("Component value");
-  await expect(propertyValue).toBeFocused();
+  // Opening focuses the shelf header, never the first field: Q stays a pure
+  // toggle and editing starts only when the user clicks an input.
+  await expect(page.getByTestId("selection-shelf")).toBeFocused();
+  await expect(propertyValue).not.toBeFocused();
   await expect(propertyValue).toHaveValue("10k");
-  // Q toggles the dock closed even while focus sits in the value input, and
-  // the swallowed keypress never types into the field.
   await page.keyboard.press("q");
   await expect(page.getByTestId("selection-shelf")).toHaveAttribute(
     "aria-expanded",
@@ -392,8 +393,10 @@ test("carries a manual Value through placement and Q property editing", async ({
     "aria-expanded",
     "true",
   );
-  await expect(propertyValue).toBeFocused();
+  await expect(propertyValue).not.toBeFocused();
   await expect(propertyValue).toHaveValue("10k");
+  await propertyValue.click();
+  await expect(propertyValue).toBeFocused();
   await propertyValue.fill("12k");
   await page
     .getByRole("button", { name: "Apply component properties" })

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -1406,14 +1406,10 @@ export function App({
   function openProperties(): void {
     setImportReviewOpen(false);
     setSelectionOpen(true);
+    // Focus the header, not the first field: Q stays a pure toggle and
+    // editing starts only when the user clicks an input.
     requestAnimationFrame(() => {
-      if (selectedRoute) {
-        netLabelPropertyInputRef.current?.focus();
-      } else if (selectedInstance) {
-        instanceValueInputRef.current?.focus();
-      } else {
-        selectionShelfRef.current?.focus();
-      }
+      selectionShelfRef.current?.focus();
     });
   }
 
@@ -6495,10 +6491,6 @@ export function App({
           wireSource && wireWaypoints.length > 0,
         ),
         propertiesOpen: selectionOpen,
-        typingInProperties:
-          isTypingTarget(event.target) &&
-          event.target instanceof Element &&
-          event.target.closest('[data-testid="selection-dock"]') !== null,
       });
       if (!shortcut) return;
 
@@ -7369,7 +7361,6 @@ export function App({
           className={selectionOpen ? "selection-dock open" : "selection-dock"}
           aria-label="Properties"
           role="complementary"
-          data-testid="selection-dock"
         >
           <section className="selection-shelf" aria-label="Selection">
             <button

--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -23,7 +23,6 @@ const baseContext: EditorShortcutContext = {
   hasClearableDraftingSelection: false,
   hasRemovableWireWaypoint: false,
   propertiesOpen: false,
-  typingInProperties: false,
 };
 
 function key(
@@ -321,25 +320,8 @@ describe("editor shortcut contract", () => {
     expect(resolve("s", { isTyping: true }, { ctrlKey: true })).toBeNull();
   });
 
-  it("closes an open Properties dock with Q while typing inside it", () => {
-    expect(
-      resolve("q", {
-        propertiesOpen: true,
-        isTyping: true,
-        typingInProperties: true,
-      }),
-    ).toEqual({ kind: "close-properties" });
+  it("keeps typing suppressed with the Properties dock open, and Q blocked while interacting", () => {
     expect(resolve("q", { propertiesOpen: true, isTyping: true })).toBeNull();
-    expect(
-      resolve(
-        "q",
-        { propertiesOpen: true, isTyping: true, typingInProperties: true },
-        { shiftKey: true },
-      ),
-    ).toBeNull();
-    expect(
-      resolve("q", { isTyping: true, typingInProperties: true }),
-    ).toBeNull();
     expect(
       resolve("q", { propertiesOpen: true, interactionMode: "drawing" }),
     ).toEqual({ kind: "blocked-interaction-command", command: "Properties" });

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -26,7 +26,6 @@ export interface EditorShortcutContext {
   hasClearableDraftingSelection: boolean;
   hasRemovableWireWaypoint: boolean;
   propertiesOpen: boolean;
-  typingInProperties: boolean;
 }
 
 export type EditorShortcutIntent =
@@ -112,19 +111,9 @@ export function resolveEditorShortcut(
       : { kind: "block-browser-bookmark" };
   }
 
+  if (context.isTyping) return null;
+
   const plain = !event.ctrlKey && !event.metaKey && !event.altKey;
-  // Q toggles the Properties dock: while typing inside the dock, plain q
-  // still closes it; Shift+Q keeps typing an uppercase letter.
-  const closesPropertiesWhileTyping =
-    plain &&
-    !event.shiftKey &&
-    key === "q" &&
-    context.interactionMode === "idle" &&
-    context.propertiesOpen &&
-    context.typingInProperties;
-
-  if (context.isTyping && !closesPropertiesWhileTyping) return null;
-
   const interactionActive = context.interactionMode !== "idle";
 
   if (plain && key === "u") {

--- a/plan/2026-08-16-q-open-without-input-focus/plan.md
+++ b/plan/2026-08-16-q-open-without-input-focus/plan.md
@@ -1,0 +1,90 @@
+---
+status: completed
+experience: none
+---
+
+# Q opens Properties without stealing focus into the first input
+
+## Goal
+
+`Q` currently opens the Properties dock and auto-focuses the first text input
+(for a MOS, the W parameter input). The user wants `Q` to behave as a pure
+toggle: opening must not move focus into a text field — focus the shelf header
+instead — and typing only begins when the user clicks an input. The previous
+"swallow Q while typing inside the dock" interception is removed so that once
+the user deliberately clicks into a field, keys type normally. The toggle
+semantics (Q opens when closed, closes when open) stay.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+?? .worktrees/
+```
+
+Worktree clean except the unrelated untracked `.worktrees/` directory.
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/interaction/editor-shortcuts.ts`
+- `apps/editor/src/interaction/editor-shortcuts.test.ts`
+- `apps/editor/e2e/component-insert.spec.ts`
+
+Read-only: `plan/log.md` gets a new entry only. The double-click inspect path
+(`inspectInstance`) keeps its input auto-focus on purpose: it is an explicit
+edit gesture, not the Q toggle.
+
+## Work
+
+1. `openProperties()`: focus `selectionShelfRef` (header button) instead of
+   `netLabelPropertyInputRef` / `instanceValueInputRef`.
+2. Resolver: drop the `typingInProperties` typing exception and context field;
+   restore uniform "typing suppresses every shortcut". Keep `propertiesOpen`
+   and the `close-properties` toggle intent.
+3. App: remove the `typingInProperties` context wiring and the
+   `data-testid="selection-dock"` hook that only served it.
+4. Unit tests: replace the in-dock typing-close contract with "typing stays
+   suppressed even while the dock is open"; keep the toggle contracts.
+5. E2E: the "Q property editing" contract now asserts the value input is NOT
+   focused after Q opens (shelf header is), that Q still toggles closed/open,
+   and that clicking the input starts editing.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/interaction/editor-shortcuts.test.ts apps/editor/src/app/App.test.tsx`
+- `pnpm typecheck`
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep "Q property editing"`
+- `pnpm test:e2e:local apps/editor/e2e/drafting.spec.ts --grep "follows selection and closes"`
+- Prettier check on changed files
+- `git diff --check`
+- `git status --short --branch`
+
+The Q toggle and its focus contract are fully covered by these focused checks;
+the drafting grep guards the other Q-open flow that shares `openProperties`.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): keep Q a pure Properties toggle without input auto-focus
+```
+
+## Outcome
+
+`openProperties()` now focuses the shelf header button only; the first text
+input (a MOS W field in the reported case) no longer receives focus, so Q is a
+pure toggle. The previous in-input Q interception (`typingInProperties` and the
+dock testid) was removed: typing anywhere, including a deliberately clicked
+Properties field, suppresses every shortcut uniformly. The double-click inspect
+path keeps its input auto-focus. Toggle semantics and interaction arbitration
+are unchanged.
+
+Validation: 28 focused unit tests, workspace typecheck, Prettier, the reworked
+"Q property editing" Playwright contract (shelf focused, input not focused,
+Q close/reopen, click-to-edit), the drafting dock contract, the double-click
+inspect contract, `git diff --check`, and `git status --short --branch` passed.
+
+Experience signal: `none` — behavior adjustment within the existing shortcut
+contract, covered by focused checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7555,3 +7555,18 @@ box`; branch pushed for review. A concurrent worker's overlapping App.tsx
   component-insert Q tests, and `git diff --check` passed.
 - Commit status: merged to `main` via #91 after the mainline gate (clean-state
   local `pnpm ci:check` and green GitHub Actions checks).
+
+## 2026-08-16 - Q opens Properties without input auto-focus
+
+- Target: stop `Q`-opened Properties from focusing the first text input (e.g.
+  the MOS W field); focus the shelf header instead so Q stays a pure toggle,
+  and remove the previous in-input Q interception so clicked fields type
+  normally.
+- Changed areas: `openProperties` focus target, shortcut typing-suppression
+  revert (`typingInProperties` removed), shortcut unit contracts, and the
+  Q property-editing Playwright focus contract.
+- Validation: 28 focused unit tests, workspace typecheck, Prettier, Q
+  property-editing + drafting dock + double-click inspect Playwright
+  contracts, and `git diff --check` passed.
+- Commit status: committed on `zcode/q-open-without-input-focus`; mainline
+  merge awaits the delivery gate.


### PR DESCRIPTION
## Summary
- Q-opened Properties no longer focuses the first text input (e.g. the MOS W field); focus lands on the Properties shelf header instead, so Q is a pure open/close toggle and keys are never swallowed by an input.
- Removed the previous in-input Q interception (`typingInProperties`): clicking into a field and typing now behaves normally — typing suppresses all shortcuts uniformly, anywhere.
- The double-click inspect path keeps its input auto-focus (explicit edit gesture). Toggle semantics and interaction arbitration unchanged.

## Validation
- `pnpm test:local apps/editor/src/interaction/editor-shortcuts.test.ts apps/editor/src/app/App.test.tsx` (28 passed)
- `pnpm typecheck`, Prettier check on changed files
- `pnpm test:e2e:local`: "Q property editing" (shelf focused, input not focused, Q close/reopen, click-to-edit), drafting dock contract, double-click inspect contract
- `git diff --check`

Plan: `plan/2026-08-16-q-open-without-input-focus/plan.md`