### PR TITLE
feat(editor,model): text system visibility, auto-commit, and movable net labels

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -1552,11 +1552,163 @@ test("L edits a selected route Net Label without opening Properties", async ({
 
   await clickRoute(page, "route-ui-1", 0.5, 0);
   await page.keyboard.press("l");
-  await editor.getByRole("textbox", { name: "Net Label" }).fill("CANCEL");
+  await editor.getByRole("textbox", { name: "Net Label" }).fill("ESCSAVE");
+  // Escape saves the edit like Enter does instead of discarding it.
   await editor.getByRole("textbox", { name: "Net Label" }).press("Escape");
+  await expect(page.locator('[data-layer="annotations"]')).toContainText(
+    "ESCSAVE",
+  );
+  await clickRoute(page, "route-ui-1", 0.5, 0);
+  await page.keyboard.press("l");
+  await editor.getByRole("textbox", { name: "Net Label" }).fill("");
+  await editor.getByRole("textbox", { name: "Net Label" }).press("Enter");
   await expect(
     page.getByTestId("annotation-hit-net-label-route-ui-1"),
   ).toHaveCount(0);
+});
+
+test("Properties toggles reference label visibility for one or many components", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await placeComponent(page, "resistor", { x: 280, y: 180 });
+  await placeComponent(page, "resistor", { x: 480, y: 180 });
+
+  await page.getByTestId("hit-R1").click();
+  await openSelectionShelf(page);
+  const singleToggle = page.getByRole("checkbox", {
+    name: "Show reference label",
+  });
+  await expect(singleToggle).toBeChecked();
+  await singleToggle.uncheck();
+  await expect(
+    page.getByTestId("annotation-hit-instance-label-R1"),
+  ).toHaveCount(0);
+  await expect(
+    page.locator('[data-object-id="instance-label-R1"]'),
+  ).toHaveCount(0);
+  await expect(
+    page.getByTestId("annotation-hit-instance-label-R2"),
+  ).toHaveCount(1);
+  // Hiding is recoverable: the annotation is still in the project.
+  await singleToggle.check();
+  await expect(
+    page.getByTestId("annotation-hit-instance-label-R1"),
+  ).toHaveCount(1);
+
+  // Marquee both components and toggle the whole group.
+  const canvas = page.getByTestId("schematic-canvas");
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error("Canvas is not measurable");
+  await page.mouse.move(box.x + 200, box.y + 80);
+  await page.mouse.down();
+  await page.mouse.move(box.x + 620, box.y + 320, { steps: 6 });
+  await page.mouse.up();
+  const groupToggle = page.getByRole("checkbox", {
+    name: "Show reference labels",
+  });
+  await expect(groupToggle).toBeVisible();
+  await expect(groupToggle).toBeChecked();
+  await groupToggle.uncheck();
+  await expect(
+    page.getByTestId("annotation-hit-instance-label-R1"),
+  ).toHaveCount(0);
+  await expect(
+    page.getByTestId("annotation-hit-instance-label-R2"),
+  ).toHaveCount(0);
+  await groupToggle.check();
+  await expect(
+    page.getByTestId("annotation-hit-instance-label-R1"),
+  ).toHaveCount(1);
+  await expect(
+    page.getByTestId("annotation-hit-instance-label-R2"),
+  ).toHaveCount(1);
+});
+
+test("property edits commit on blank click and Escape instead of vanishing", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await placeComponent(page, "resistor", { x: 320, y: 200 });
+  const canvas = page.getByTestId("schematic-canvas");
+
+  await page.getByTestId("hit-R1").click();
+  await openSelectionShelf(page);
+  const value = page.getByLabel("Component value");
+  await value.click();
+  await value.fill("33k");
+  await canvas.click({ position: { x: 60, y: 60 } });
+  await expect(page.getByTestId("revision")).toHaveText("2");
+
+  await page.getByTestId("hit-R1").click();
+  await openSelectionShelf(page);
+  await expect(page.getByLabel("Component value")).toHaveValue("33k");
+
+  await page.getByLabel("Component value").click();
+  await page.getByLabel("Component value").fill("47k");
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("revision")).toHaveText("3");
+
+  await canvas.click({ position: { x: 60, y: 60 } });
+  await page.getByTestId("hit-R1").click();
+  await openSelectionShelf(page);
+  await expect(page.getByLabel("Component value")).toHaveValue("47k");
+});
+
+test("canvas text editor commits on Escape and on an outside click", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await placeComponent(page, "resistor", { x: 420, y: 280 });
+  const rendered = page.locator('[data-object-id="instance-label-R1"]');
+
+  await page.getByTestId("annotation-hit-instance-label-R1").dblclick();
+  await page.keyboard.press("Control+a");
+  await page.keyboard.type("RA");
+  await page.keyboard.press("Escape");
+  await expect(rendered).toContainText("RA");
+  await expect(page.getByTestId("revision")).toHaveText("2");
+
+  await page.getByTestId("annotation-hit-instance-label-R1").dblclick();
+  await page.keyboard.press("Control+a");
+  await page.keyboard.type("RB");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 60, y: 60 } });
+  await expect(rendered).toContainText("RB");
+  await expect(page.getByTestId("revision")).toHaveText("3");
+});
+
+test("a dragged Net label re-anchors along its route and stays released", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await placeComponent(page, "resistor", { x: 280, y: 180 });
+  await placeComponent(page, "resistor", { x: 520, y: 180 });
+  await clickCommand(page, "Draw", "Wire (W)");
+  await page.getByTestId("terminal-R1-2").click();
+  await page.getByTestId("terminal-R2-1").click();
+  await page.keyboard.press("Escape");
+
+  await clickRoute(page, "route-ui-1", 0.5, 0);
+  await page.keyboard.press("l");
+  const editor = page.getByTestId("net-label-editor");
+  await editor.getByRole("textbox", { name: "Net Label" }).fill("NETA");
+  await editor.getByRole("textbox", { name: "Net Label" }).press("Enter");
+
+  const label = page.getByTestId("annotation-hit-net-label-route-ui-1");
+  const renderedLabel = page.locator('[data-object-id="net-label-route-ui-1"]');
+  await expect(label).toBeVisible();
+  const before = await renderedLabel.boundingBox();
+  if (!before) throw new Error("Net label is not measurable");
+  const revisionBefore = await page.getByTestId("revision").textContent();
+
+  // Well past the old +/-30 clamp: the label must stay below the wire.
+  await dragBy(label, { x: 0, y: 80 });
+  await expect(page.getByTestId("revision")).not.toHaveText(revisionBefore!);
+  const after = await renderedLabel.boundingBox();
+  if (!after) throw new Error("Net label vanished after the drag");
+  expect(after.y - before.y).toBeGreaterThan(60);
 });
 
 test("selects and moves multiple instances while viewport gestures stay transient", async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -244,12 +244,14 @@ import {
   annotationHitBox,
   attachmentAtPoint,
   defaultInstanceLabel,
+  dragNetLabelAttachmentAtPoint,
   dragRouteAttachmentAtPoint,
   effectiveRouteAttachment,
   endpointNetId,
   instanceHitBox,
   isRoutedMarker,
   looseRouteAnchorIds,
+  NET_LABEL_MAX_NORMAL_OFFSET,
 } from "../features/wiring/route-interaction-geometry";
 import {
   applyOrientationOperations,
@@ -519,6 +521,18 @@ function isTypingTarget(target: EventTarget | null): boolean {
   return (
     target instanceof Element &&
     Boolean(target.closest("input, textarea, select, [contenteditable='true']"))
+  );
+}
+
+function instanceLabelAnnotationFor(
+  document: SchematicDocument,
+  instanceId: string,
+): Annotation | undefined {
+  return document.annotations.find(
+    (annotation) =>
+      annotation.kind === "instance-label" &&
+      annotation.anchor.kind === "object" &&
+      annotation.anchor.objectId === instanceId,
   );
 }
 
@@ -799,6 +813,7 @@ export function App({
     null,
   );
   const [netLabelDraft, setNetLabelDraft] = useState("");
+  const netLabelDraftRouteRef = useRef<string | null>(null);
   const [netLabelEditorOpen, setNetLabelEditorOpen] = useState(false);
   const [instancePropertyDraft, setInstancePropertyDraft] = useState<{
     instanceId: string | null;
@@ -1031,6 +1046,15 @@ export function App({
     selectedDrafting ||
     selectedEndpoint,
   );
+  const selectedInstanceLabel = selectedInstance
+    ? instanceLabelAnnotationFor(document, selectedInstance.id)
+    : undefined;
+  const selectedGroupLabelsAllVisible =
+    selectedIds.length > 1 &&
+    selectedIds.every((id) => {
+      const label = instanceLabelAnnotationFor(document, id);
+      return label !== undefined && label.visible !== false;
+    });
   const styleProfile = resolveSchematicStyleProfile(
     document.presentation.styleProfileId,
   );
@@ -1361,6 +1385,9 @@ export function App({
   }, [document, visualSelection]);
 
   useEffect(() => {
+    // Leaving a route (selection cleared or moved on) commits a pending Net
+    // label draft instead of silently discarding it.
+    commitPendingNetLabelDraft();
     if (!selectedRoute) {
       setNetLabelDraft("");
       setNetLabelEditorOpen(false);
@@ -1371,9 +1398,21 @@ export function App({
         ? flattenRichText(selectedRouteNetLabel.content)
         : "",
     );
+    netLabelDraftRouteRef.current = selectedRoute.id;
   }, [selectedRoute, selectedRouteNetLabel]);
 
+  const lastSelectedInstanceIdRef = useRef<string | null>(null);
   useEffect(() => {
+    // Leaving a component (selection cleared or moved to another instance)
+    // commits pending property edits instead of silently discarding them.
+    // Keying on the id, not the record, keeps unrelated document updates
+    // from replaying a stale draft.
+    const previousInstanceId = lastSelectedInstanceIdRef.current;
+    lastSelectedInstanceIdRef.current = selectedInstance?.id ?? null;
+    if ((selectedInstance?.id ?? null) !== previousInstanceId) {
+      const pending = instancePropertyEdits(instancePropertyDraft);
+      if (pending.edits.length > 0) transact(pending.edits);
+    }
     if (!selectedInstance) {
       setInstancePropertyDraft({
         instanceId: null,
@@ -2789,8 +2828,16 @@ export function App({
       if (closest) {
         return snapGridPoint(
           {
-            x: clamp(candidate.x, closest.x - 30, closest.x + 30),
-            y: clamp(candidate.y, closest.y - 30, closest.y + 30),
+            x: clamp(
+              candidate.x,
+              closest.x - NET_LABEL_MAX_NORMAL_OFFSET,
+              closest.x + NET_LABEL_MAX_NORMAL_OFFSET,
+            ),
+            y: clamp(
+              candidate.y,
+              closest.y - NET_LABEL_MAX_NORMAL_OFFSET,
+              closest.y + NET_LABEL_MAX_NORMAL_OFFSET,
+            ),
           },
           document.presentation.grid,
         );
@@ -2825,6 +2872,24 @@ export function App({
       return {
         ...annotation,
         anchor,
+      };
+    }
+    if (annotation.kind === "net-label" && annotation.anchor.kind === "route") {
+      const attached = dragNetLabelAttachmentAtPoint(
+        routePolylines,
+        candidate,
+        annotation.anchor.routeId,
+      );
+      if (!attached) return annotation;
+      return {
+        ...annotation,
+        anchor: {
+          ...annotation.anchor,
+          segmentIndex: attached.segmentIndex,
+          t: attached.t,
+          normalOffset: attached.normalOffset,
+          fallbackPosition: attached.labelPosition,
+        },
       };
     }
 
@@ -5074,42 +5139,51 @@ export function App({
     }
   }
 
-  function applyNetLabel(): void {
-    if (!selectedRoute) return;
-    const net = document.nets.find(
-      (candidate) => candidate.id === selectedRoute.netId,
+  function netLabelForRoute(
+    route: SchematicDocument["routes"][number],
+  ): Annotation | undefined {
+    const candidates = document.annotations.filter(
+      (annotation) =>
+        annotation.kind === "net-label" && annotation.netId === route.netId,
     );
-    if (!net) return;
-    const existingLabel = selectedRouteNetLabel;
-    const labelId = existingLabel?.id ?? `net-label-${selectedRoute.id}`;
-    const name = netLabelDraft.trim();
+    return (
+      candidates.find(
+        (annotation) => annotation.id === `net-label-${route.id}`,
+      ) ??
+      candidates.find(
+        (annotation) =>
+          resolveNetLabelBinding(document, resolver, annotation)?.routeId ===
+          route.id,
+      )
+    );
+  }
+
+  function netLabelEditsForRoute(
+    route: SchematicDocument["routes"][number],
+    rawName: string,
+  ): SchematicEdit[] | null {
+    const net = document.nets.find((candidate) => candidate.id === route.netId);
+    if (!net) return null;
+    const existingLabel = netLabelForRoute(route);
+    const name = rawName.trim();
     if (!name) {
-      if (existingLabel) {
-        const result = transact([
-          {
-            kind: "remove_schematic_annotation",
-            annotationId: existingLabel.id,
-          },
-        ]);
-        if (result.ok) {
-          replaceSelectionKind("annotation", []);
-          setStatus(
-            `Deleted Net Label ${flattenRichText(existingLabel.content)}`,
-          );
-        }
-      } else {
-        setStatus("Selected Route has no Net Label");
-      }
-      return;
+      return existingLabel
+        ? [
+            {
+              kind: "remove_schematic_annotation",
+              annotationId: existingLabel.id,
+            },
+          ]
+        : null;
     }
     const sameNameNet = document.nets.find(
       (candidate) => candidate.id !== net.id && candidate.name === name,
     );
     const targetNetId = sameNameNet?.id ?? net.id;
     const polyline = routePolylines.find(
-      ({ route }) => route.id === selectedRoute.id,
+      ({ route: candidate }) => candidate.id === route.id,
     )?.polyline;
-    if (!polyline) return;
+    if (!polyline) return null;
     const segment = Math.max(0, Math.floor((polyline.points.length - 1) / 2));
     const from = polyline.points[segment]!;
     const to = polyline.points[segment + 1] ?? from;
@@ -5124,6 +5198,11 @@ export function App({
       },
       document.presentation.grid,
     );
+    const previousAnchor =
+      existingLabel?.anchor.kind === "route" &&
+      existingLabel.anchor.routeId === route.id
+        ? existingLabel.anchor
+        : null;
     const edits: SchematicEdit[] = sameNameNet
       ? [
           {
@@ -5136,34 +5215,80 @@ export function App({
     edits.push({
       kind: "upsert_schematic_annotation",
       annotation: {
-        id: labelId,
+        id: existingLabel?.id ?? `net-label-${route.id}`,
         kind: "net-label",
         content: semanticTextDocument(name, "net-label"),
         netId: targetNetId,
-        anchor: {
-          kind: "route",
-          routeId: selectedRoute.id,
-          segmentIndex: segment,
-          t: 0.5,
-          normalOffset: -8,
-          direction: "forward",
-          orientation: "follow",
-          fallbackPosition: position,
-        },
+        // A dragged route anchor survives a name edit; new labels start at
+        // the middle segment with the default normal offset.
+        anchor: previousAnchor
+          ? { ...previousAnchor, fallbackPosition: position }
+          : {
+              kind: "route",
+              routeId: route.id,
+              segmentIndex: segment,
+              t: 0.5,
+              normalOffset: -8,
+              direction: "forward",
+              orientation: "follow",
+              fallbackPosition: position,
+            },
         alignment: "middle",
         rotation: 0,
         locked: false,
       },
     });
+    return edits;
+  }
+
+  function commitPendingNetLabelDraft(): void {
+    const routeId = netLabelDraftRouteRef.current;
+    netLabelDraftRouteRef.current = null;
+    if (!routeId) return;
+    const route = document.routes.find((candidate) => candidate.id === routeId);
+    if (!route) return;
+    const existing = netLabelForRoute(route);
+    const draftName = netLabelDraft.trim();
+    const currentName = existing
+      ? flattenRichText(existing.content).trim()
+      : "";
+    if (existing ? draftName === currentName : draftName === "") return;
+    const edits = netLabelEditsForRoute(route, netLabelDraft);
+    if (!edits) return;
     const result = transact(edits);
     if (result.ok) {
-      replaceSelectionKind("annotation", [labelId]);
       setStatus(
-        sameNameNet
-          ? `Connected Nets through label ${name}`
-          : `Named Net ${name}`,
+        draftName ? `Saved Net Label ${draftName}` : "Removed Net Label",
       );
     }
+  }
+
+  function applyNetLabel(): void {
+    if (!selectedRoute) return;
+    const existingLabel = netLabelForRoute(selectedRoute);
+    const name = netLabelDraft.trim();
+    if (!name && !existingLabel) {
+      setStatus("Selected Route has no Net Label");
+      return;
+    }
+    const edits = netLabelEditsForRoute(selectedRoute, netLabelDraft);
+    if (!edits) return;
+    const result = transact(edits);
+    if (!result.ok) return;
+    netLabelDraftRouteRef.current = null;
+    if (!name) {
+      replaceSelectionKind("annotation", []);
+      setStatus(`Deleted Net Label ${flattenRichText(existingLabel!.content)}`);
+      return;
+    }
+    replaceSelectionKind("annotation", [
+      existingLabel?.id ?? `net-label-${selectedRoute.id}`,
+    ]);
+    setStatus(
+      edits.some((edit) => edit.kind === "merge_nets")
+        ? `Connected Nets through label ${name}`
+        : `Named Net ${name}`,
+    );
   }
 
   function deleteSelectedRouteNetLabel(): void {
@@ -5187,26 +5312,73 @@ export function App({
     }
   }
 
-  function applyInstanceProperties(): void {
-    if (
-      !selectedInstance ||
-      instancePropertyDraft.instanceId !== selectedInstance.id
-    ) {
+  function setReferenceLabelsVisible(
+    instanceIds: readonly string[],
+    visible: boolean,
+  ): void {
+    const edits: SchematicEdit[] = [];
+    for (const instanceId of instanceIds) {
+      const instance = document.instances.find(
+        (item) => item.id === instanceId,
+      );
+      if (!instance) continue;
+      const label = instanceLabelAnnotationFor(document, instanceId);
+      if (label) {
+        const { visible: _currentVisibility, ...rest } = label;
+        edits.push({
+          kind: "upsert_schematic_annotation",
+          annotation: visible ? rest : { ...rest, visible: false },
+        });
+      } else if (visible) {
+        const created = defaultInstanceLabel(
+          document,
+          instance,
+          resolver,
+          styleProfile,
+        );
+        if (created) {
+          edits.push({
+            kind: "upsert_schematic_annotation",
+            annotation: created,
+          });
+        }
+      }
+    }
+    if (edits.length === 0) {
+      setStatus(
+        visible
+          ? "No reference labels are available for this selection"
+          : "Selected components have no reference labels",
+      );
       return;
     }
+    const result = transact(edits);
+    if (result.ok) {
+      setStatus(
+        `${visible ? "Showing" : "Hiding"} reference labels on ${edits.length} component${edits.length === 1 ? "" : "s"}`,
+      );
+    }
+  }
+
+  function instancePropertyEdits(draft: {
+    instanceId: string | null;
+    parameters: Record<string, string>;
+    x: string;
+    y: string;
+    rotation: "0" | "90" | "180" | "270";
+  }): { edits: SchematicEdit[]; invalidPosition: boolean } {
+    if (!draft.instanceId) return { edits: [], invalidPosition: false };
+    const instance = document.instances.find(
+      (item) => item.id === draft.instanceId,
+    );
+    if (!instance) return { edits: [], invalidPosition: false };
     const edits: SchematicEdit[] = [];
     const baseNetlist =
-      selectedInstance.netlist ??
-      initialInstanceNetlist(
-        document,
-        selectedInstance.symbolId,
-        selectedInstance.properties,
-      );
+      instance.netlist ??
+      initialInstanceNetlist(document, instance.symbolId, instance.properties);
     const netlistParameters = { ...baseNetlist.parameters };
-    for (const parameter of componentParameters(selectedInstance.symbolId)) {
-      const value = (
-        instancePropertyDraft.parameters[parameter.key] ?? ""
-      ).trim();
+    for (const parameter of componentParameters(instance.symbolId)) {
+      const value = (draft.parameters[parameter.key] ?? "").trim();
       if (value === "") delete netlistParameters[parameter.key];
       else netlistParameters[parameter.key] = value;
     }
@@ -5215,48 +5387,70 @@ export function App({
       ...baseNetlist,
       parameters: netlistParameters,
     };
-    if (
-      JSON.stringify(nextNetlist) !== JSON.stringify(selectedInstance.netlist)
-    ) {
+    if (JSON.stringify(nextNetlist) !== JSON.stringify(instance.netlist)) {
       edits.push({
         kind: "set_instance_netlist",
-        instanceId: selectedInstance.id,
+        instanceId: instance.id,
         netlist: nextNetlist,
       });
     }
 
-    if (selectedInstance.placement) {
-      const x = Number(instancePropertyDraft.x);
-      const y = Number(instancePropertyDraft.y);
+    let invalidPosition = false;
+    if (instance.placement) {
+      const x = Number(draft.x);
+      const y = Number(draft.y);
       if (!Number.isFinite(x) || !Number.isFinite(y)) {
-        setStatus("Position must contain finite X and Y coordinates");
-        return;
+        invalidPosition = true;
+      } else {
+        const position = {
+          x: snapCoordinate(x, document.presentation.grid),
+          y: snapCoordinate(y, document.presentation.grid),
+        };
+        if (
+          position.x !== instance.placement.position.x ||
+          position.y !== instance.placement.position.y
+        ) {
+          edits.push({
+            kind: "move_instance",
+            instanceId: instance.id,
+            position,
+          });
+        }
       }
-      const position = {
-        x: snapCoordinate(x, document.presentation.grid),
-        y: snapCoordinate(y, document.presentation.grid),
-      };
-      if (
-        position.x !== selectedInstance.placement.position.x ||
-        position.y !== selectedInstance.placement.position.y
-      ) {
-        edits.push({
-          kind: "move_instance",
-          instanceId: selectedInstance.id,
-          position,
-        });
-      }
-      const rotation = Number(instancePropertyDraft.rotation) as
-        0 | 90 | 180 | 270;
-      if (rotation !== selectedInstance.placement.rotation) {
+      const rotation = Number(draft.rotation) as 0 | 90 | 180 | 270;
+      if (rotation !== instance.placement.rotation) {
         edits.push({
           kind: "rotate_instance",
-          instanceId: selectedInstance.id,
+          instanceId: instance.id,
           rotation,
         });
       }
     }
+    return { edits, invalidPosition };
+  }
 
+  function commitInstancePropertyDraft(): boolean {
+    const { edits, invalidPosition } = instancePropertyEdits(
+      instancePropertyDraft,
+    );
+    if (invalidPosition || edits.length === 0) return false;
+    return transact(edits).ok;
+  }
+
+  function applyInstanceProperties(): void {
+    if (
+      !selectedInstance ||
+      instancePropertyDraft.instanceId !== selectedInstance.id
+    ) {
+      return;
+    }
+    const { edits, invalidPosition } = instancePropertyEdits(
+      instancePropertyDraft,
+    );
+    if (invalidPosition) {
+      setStatus("Position must contain finite X and Y coordinates");
+      return;
+    }
     if (edits.length === 0) {
       setStatus("Component properties are unchanged");
       return;
@@ -5773,22 +5967,24 @@ export function App({
             .filter((junction) => pointInRect(junction.position, rect))
             .map((junction) => junction.id),
           annotationIds: document.annotations
-            .filter((annotation) =>
-              rectsIntersect(
-                annotationHitBox(
-                  annotation,
-                  annotationAnchor(
-                    document,
-                    resolver,
+            .filter(
+              (annotation) =>
+                annotation.visible !== false &&
+                rectsIntersect(
+                  annotationHitBox(
                     annotation,
+                    annotationAnchor(
+                      document,
+                      resolver,
+                      annotation,
+                      routePolylines,
+                      styleProfile,
+                    ),
                     routePolylines,
                     styleProfile,
                   ),
-                  routePolylines,
-                  styleProfile,
+                  rect,
                 ),
-                rect,
-              ),
             )
             .map((annotation) => annotation.id),
           draftingIds: (document.drafting?.objects ?? [])
@@ -6409,7 +6605,9 @@ export function App({
         textEditing &&
         !targetElement?.closest('[data-testid="canvas-text-editor"]')
       ) {
-        setTextEditing(null);
+        // Leaving the canvas text editor commits the session; emptying the
+        // text still deletes the annotation, matching the Apply button.
+        commitTextEditing();
       }
       const openMenus = Array.from(
         globalThis.document.querySelectorAll<HTMLDetailsElement>(
@@ -6458,8 +6656,23 @@ export function App({
       }
       if (event.key === "Escape" && textEditing) {
         event.preventDefault();
-        setTextEditing(null);
-        setStatus("Cancelled text editing");
+        // Escape commits the session; emptying the text still deletes the
+        // annotation, matching the Apply button.
+        commitTextEditing();
+        return;
+      }
+      if (
+        event.key === "Escape" &&
+        isTypingTarget(event.target) &&
+        event.target instanceof Element &&
+        event.target.closest(".selection-dock") !== null
+      ) {
+        // Escape inside Properties commits pending drafts instead of losing
+        // them; a second Escape resumes normal canvas cancel behavior.
+        event.preventDefault();
+        commitInstancePropertyDraft();
+        commitPendingNetLabelDraft();
+        if (event.target instanceof HTMLElement) event.target.blur();
         return;
       }
       const currentInteraction = getCurrentInteractionState();
@@ -7416,6 +7629,19 @@ export function App({
                   <span>Component group</span>
                   <h2>{selectedIds.length} components</h2>
                   <p>{selectedIds.join(", ")}</p>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={selectedGroupLabelsAllVisible}
+                      onChange={(event) =>
+                        setReferenceLabelsVisible(
+                          selectedIds,
+                          event.currentTarget.checked,
+                        )
+                      }
+                    />{" "}
+                    Show reference labels
+                  </label>
                 </section>
               ) : null}
               {selectedInstance?.placement ? (
@@ -7434,6 +7660,22 @@ export function App({
                   aria-label="Component properties"
                 >
                   <h2>Component properties</h2>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={
+                        selectedInstanceLabel !== undefined &&
+                        selectedInstanceLabel.visible !== false
+                      }
+                      onChange={(event) =>
+                        setReferenceLabelsVisible(
+                          [selectedInstance.id],
+                          event.currentTarget.checked,
+                        )
+                      }
+                    />{" "}
+                    Show reference label
+                  </label>
                   {componentParameters(selectedInstance.symbolId).map(
                     (parameter, index) => (
                       <label key={parameter.key} title={parameter.help}>
@@ -8017,23 +8259,18 @@ export function App({
                   </button>
                 </section>
               ) : null}
-              {selectedAnnotation && !isRoutedMarker(selectedAnnotation) ? (
+              {selectedAnnotation &&
+              !isRoutedMarker(selectedAnnotation) &&
+              selectedNetLabelBinding ? (
                 <section
                   className="context-actions"
                   aria-label="Annotation actions"
                 >
                   <h2>Annotation</h2>
-                  {selectedNetLabelBinding ? (
-                    <button type="button" onClick={toggleHighlightedNet}>
-                      {selectedHighlightIsActive
-                        ? "Clear Net highlight (H)"
-                        : "Highlight Net (H)"}
-                    </button>
-                  ) : null}
-                  <button type="button" onClick={deleteSelectedAnnotation}>
-                    {selectedAnnotation.kind === "net-label"
-                      ? "Delete selected Net label"
-                      : "Delete annotation"}
+                  <button type="button" onClick={toggleHighlightedNet}>
+                    {selectedHighlightIsActive
+                      ? "Clear Net highlight (H)"
+                      : "Highlight Net (H)"}
                   </button>
                 </section>
               ) : null}
@@ -8540,6 +8777,8 @@ export function App({
                             onKeyDown={(event) => {
                               if (event.key === "Escape") {
                                 event.preventDefault();
+                                // Escape saves the edit like Enter does.
+                                applyNetLabel();
                                 setNetLabelEditorOpen(false);
                               }
                             }}
@@ -8865,48 +9104,50 @@ export function App({
                   />
                 );
               })}
-              {document.annotations.map((annotation) => {
-                const anchor = annotationAnchor(
-                  document,
-                  resolver,
-                  annotation,
-                  routePolylines,
-                  styleProfile,
-                );
-                const hitBox = annotationHitBox(
-                  annotation,
-                  anchor,
-                  routePolylines,
-                  styleProfile,
-                );
-                const selected =
-                  selectedAnnotationId === annotation.id ||
-                  supplementalSelection.annotationIds.includes(annotation.id);
-                return (
-                  <rect
-                    key={`annotation-hit-${annotation.id}`}
-                    data-testid={`annotation-hit-${annotation.id}`}
-                    data-canvas-hit-kind="annotation"
-                    data-canvas-hit-id={annotation.id}
-                    data-drag-object-id={annotation.id}
-                    className={
-                      selected
-                        ? "hit-target annotation-text-hit selected"
-                        : "hit-target annotation-text-hit"
-                    }
-                    {...hitBox}
-                    onClick={(event) => event.stopPropagation()}
-                    onPointerDown={(event) =>
-                      beginAnnotationDrag(event, annotation)
-                    }
-                    pointerEvents={tool === "wire" ? "none" : undefined}
-                    onDoubleClick={(event) => {
-                      event.stopPropagation();
-                      beginAnnotationTextEditing(annotation);
-                    }}
-                  />
-                );
-              })}
+              {document.annotations
+                .filter((annotation) => annotation.visible !== false)
+                .map((annotation) => {
+                  const anchor = annotationAnchor(
+                    document,
+                    resolver,
+                    annotation,
+                    routePolylines,
+                    styleProfile,
+                  );
+                  const hitBox = annotationHitBox(
+                    annotation,
+                    anchor,
+                    routePolylines,
+                    styleProfile,
+                  );
+                  const selected =
+                    selectedAnnotationId === annotation.id ||
+                    supplementalSelection.annotationIds.includes(annotation.id);
+                  return (
+                    <rect
+                      key={`annotation-hit-${annotation.id}`}
+                      data-testid={`annotation-hit-${annotation.id}`}
+                      data-canvas-hit-kind="annotation"
+                      data-canvas-hit-id={annotation.id}
+                      data-drag-object-id={annotation.id}
+                      className={
+                        selected
+                          ? "hit-target annotation-text-hit selected"
+                          : "hit-target annotation-text-hit"
+                      }
+                      {...hitBox}
+                      onClick={(event) => event.stopPropagation()}
+                      onPointerDown={(event) =>
+                        beginAnnotationDrag(event, annotation)
+                      }
+                      pointerEvents={tool === "wire" ? "none" : undefined}
+                      onDoubleClick={(event) => {
+                        event.stopPropagation();
+                        beginAnnotationTextEditing(annotation);
+                      }}
+                    />
+                  );
+                })}
               {(document.drafting?.objects ?? []).map((object) => {
                 // WP-R5/P1: every drafting object gets a selectable/deletable hit
                 // shape derived from the shared geometry. P1: use the object's
@@ -9330,7 +9571,6 @@ export function App({
                   disabled={textEditingLocked}
                   onUpdate={updateTextEditing}
                   onCommit={commitTextEditing}
-                  onCancel={() => setTextEditing(null)}
                   onDelete={deleteTextEditing}
                   {...(editingAnnotation &&
                   isRoutedMarker(editingAnnotation) &&

--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
@@ -14,7 +14,6 @@ export interface CanvasTextEditorOverlayProps {
   disabled: boolean;
   onUpdate(change: TextEditingUpdate): void;
   onCommit(): void;
-  onCancel(): void;
   onDelete(): void;
   onReverseCurrentArrow?(): void;
 }
@@ -54,7 +53,6 @@ export function CanvasTextEditorOverlay({
   disabled,
   onUpdate,
   onCommit,
-  onCancel,
   onDelete,
   onReverseCurrentArrow,
 }: CanvasTextEditorOverlayProps) {
@@ -86,7 +84,6 @@ export function CanvasTextEditorOverlay({
         onChange={(content) => onUpdate({ content })}
         onSizeChange={(sizeScale) => onUpdate({ sizeScale })}
         onCommit={onCommit}
-        onCancel={onCancel}
         onDelete={onDelete}
         {...(onReverseCurrentArrow ? { onReverseCurrentArrow } : {})}
       />

--- a/apps/editor/src/features/text-editing/rich-text-editor.tsx
+++ b/apps/editor/src/features/text-editing/rich-text-editor.tsx
@@ -11,7 +11,6 @@ export interface RichTextEditorProps {
   onChange(content: RichTextDocument): void;
   onSizeChange(sizeScale: number): void;
   onCommit(): void;
-  onCancel(): void;
   onDelete(): void;
   onReverseCurrentArrow?(): void;
 }
@@ -100,7 +99,6 @@ export function RichTextEditor({
   onChange,
   onSizeChange,
   onCommit,
-  onCancel,
   onDelete,
   onReverseCurrentArrow,
 }: RichTextEditorProps) {
@@ -265,7 +263,8 @@ export function RichTextEditor({
         onKeyDown={(event) => {
           if (event.key === "Escape") {
             event.preventDefault();
-            onCancel();
+            // Escape saves the session, matching click-away and Ctrl+Enter.
+            onCommit();
           } else if (event.key === "Enter" && event.ctrlKey) {
             event.preventDefault();
             onCommit();

--- a/apps/editor/src/features/text-editing/text-editing.ts
+++ b/apps/editor/src/features/text-editing/text-editing.ts
@@ -109,7 +109,7 @@ export function proposeTextEditingCommit(
       sizeScale: session.sizeScale,
     };
     if (
-      annotation.sizeScale === next.sizeScale &&
+      (annotation.sizeScale ?? 1) === next.sizeScale &&
       richTextEqual(annotation.content, next.content)
     ) {
       return { kind: "unchanged" };
@@ -130,8 +130,10 @@ export function proposeTextEditingCommit(
       sizeScale: session.sizeScale,
     },
   };
+  // Sessions normalize an absent scale to 1; compare the same way so an
+  // untouched session stays revision-free.
   if (
-    object.styleOverride?.sizeScale === next.styleOverride.sizeScale &&
+    (object.styleOverride?.sizeScale ?? 1) === next.styleOverride.sizeScale &&
     richTextEqual(object.content, next.content)
   ) {
     return { kind: "unchanged" };

--- a/apps/editor/src/features/wiring/route-interaction-geometry.test.ts
+++ b/apps/editor/src/features/wiring/route-interaction-geometry.test.ts
@@ -8,6 +8,7 @@ import {
   annotationAnchor,
   attachmentAtPoint,
   defaultInstanceLabel,
+  dragNetLabelAttachmentAtPoint,
   dragRouteAttachmentAtPoint,
   effectiveRouteAttachment,
   looseRouteAnchorIds,
@@ -167,6 +168,42 @@ describe("route interaction geometry", () => {
       dragRouteAttachmentAtPoint([record], { x: 60, y: 90 }, current)
         ?.routeAttachment,
     ).toMatchObject({ t: 0.6, normalOffset: 40 });
+  });
+
+  it("slides a dragged Net label along its route in a wide offset band", () => {
+    const document = looseRouteDocument();
+    const record = {
+      route: document.routes[0]!,
+      polyline: {
+        routeId: "route-1",
+        netId: "net-1",
+        points: [
+          { x: 0, y: 0 },
+          { x: 100, y: 0 },
+          { x: 100, y: 100 },
+        ],
+        segmentModes: ["manual" as const, "manual" as const],
+      },
+    };
+    // Above the first segment, well past the old +/-30 clamp.
+    expect(
+      dragNetLabelAttachmentAtPoint([record], { x: 30, y: -40 }, "route-1"),
+    ).toMatchObject({ segmentIndex: 0, t: 0.3, normalOffset: -40 });
+    // Near or across the conductor keeps a readable offset and flips sides.
+    expect(
+      dragNetLabelAttachmentAtPoint([record], { x: 40, y: -2 }, "route-1"),
+    ).toMatchObject({ normalOffset: -8 });
+    // The band tops out at the generous maximum.
+    expect(
+      dragNetLabelAttachmentAtPoint([record], { x: 30, y: -500 }, "route-1"),
+    ).toMatchObject({ normalOffset: -200 });
+    // Around the corner the nearest segment wins.
+    expect(
+      dragNetLabelAttachmentAtPoint([record], { x: 108, y: 40 }, "route-1"),
+    ).toMatchObject({ segmentIndex: 1, t: 0.4, normalOffset: -8 });
+    expect(
+      dragNetLabelAttachmentAtPoint([record], { x: 0, y: 0 }, "route-2"),
+    ).toBeNull();
   });
 
   it("builds an implicit instance label only while no explicit label exists", () => {

--- a/apps/editor/src/features/wiring/route-interaction-geometry.ts
+++ b/apps/editor/src/features/wiring/route-interaction-geometry.ts
@@ -285,8 +285,7 @@ export function dragNetLabelAttachmentAtPoint(
           // label-position metric lets a perpendicular segment's clamped
           // endpoint steal the drag.
           distanceSquared:
-            (position.x - candidate.x) ** 2 +
-            (position.y - candidate.y) ** 2,
+            (position.x - candidate.x) ** 2 + (position.y - candidate.y) ** 2,
         },
       ];
     })

--- a/apps/editor/src/features/wiring/route-interaction-geometry.ts
+++ b/apps/editor/src/features/wiring/route-interaction-geometry.ts
@@ -27,6 +27,10 @@ export interface RoutePolylineRecord {
 
 export const ROUTED_MARKER_MIN_NORMAL_OFFSET = 12;
 export const ROUTED_MARKER_MAX_NORMAL_OFFSET = 40;
+// Net labels keep their electrical binding to the route but may be placed in
+// a much wider band around it than the tight current-marker label band.
+export const NET_LABEL_MIN_NORMAL_OFFSET = 8;
+export const NET_LABEL_MAX_NORMAL_OFFSET = 200;
 
 export function endpointNetId(
   document: SchematicDocument,
@@ -218,6 +222,79 @@ export function dragRouteAttachmentAtPoint(
         position: closest.position,
       }
     : null;
+}
+
+/**
+ * Reposition a route-attached Net label from the desired label position. The
+ * label stays bound to its own route: it may slide along any segment and
+ * offset across the conductor within the generous Net-label band. Crossing
+ * the conductor flips the offset side directly, unlike the sticky
+ * current-marker band.
+ */
+export function dragNetLabelAttachmentAtPoint(
+  routePolylines: readonly RoutePolylineRecord[],
+  candidate: Point,
+  routeId: string,
+): {
+  segmentIndex: number;
+  t: number;
+  normalOffset: number;
+  labelPosition: Point;
+} | null {
+  const record = routePolylines.find(({ route }) => route.id === routeId);
+  if (!record) return null;
+  const candidates = record.polyline.points
+    .slice(0, -1)
+    .flatMap((from, segmentIndex) => {
+      const to = record.polyline.points[segmentIndex + 1]!;
+      const position = closestPointOnSegment(candidate, from, to);
+      const dx = to.x - from.x;
+      const dy = to.y - from.y;
+      const lengthSquared = dx * dx + dy * dy;
+      if (lengthSquared === 0) return [];
+      const length = Math.sqrt(lengthSquared);
+      const t = clamp(
+        ((position.x - from.x) * dx + (position.y - from.y) * dy) /
+          lengthSquared,
+        0,
+        1,
+      );
+      const normal = { x: -dy / length, y: dx / length };
+      const rawNormalOffset =
+        (candidate.x - position.x) * normal.x +
+        (candidate.y - position.y) * normal.y;
+      const normalOffset =
+        Math.sign(rawNormalOffset || 1) *
+        clamp(
+          Math.abs(rawNormalOffset),
+          NET_LABEL_MIN_NORMAL_OFFSET,
+          NET_LABEL_MAX_NORMAL_OFFSET,
+        );
+      const labelPosition = {
+        x: Math.round(position.x + normal.x * normalOffset),
+        y: Math.round(position.y + normal.y * normalOffset),
+      };
+      return [
+        {
+          segmentIndex,
+          t,
+          normalOffset,
+          labelPosition,
+          // Pick the segment whose on-conductor projection is nearest to the
+          // pointer, not the nearest final label position: near corners the
+          // label-position metric lets a perpendicular segment's clamped
+          // endpoint steal the drag.
+          distanceSquared:
+            (position.x - candidate.x) ** 2 +
+            (position.y - candidate.y) ** 2,
+        },
+      ];
+    })
+    .sort((left, right) => left.distanceSquared - right.distanceSquared);
+  const closest = candidates[0];
+  if (!closest) return null;
+  const { segmentIndex, t, normalOffset, labelPosition } = closest;
+  return { segmentIndex, t, normalOffset, labelPosition };
 }
 
 export function effectiveRouteAttachment(

--- a/config/agent-mcp-distribution.json
+++ b/config/agent-mcp-distribution.json
@@ -11,6 +11,6 @@
     "repository": "chenzc24/Analog-Canvas",
     "tag": "mcp-v0.1.0",
     "asset": "analog-canvas-mcp-server-0.1.0.tgz",
-    "sha256": "5e4171ee5bb1ed886e4d213c1ef4d9fdf86d0abd20647391e1a0ae36ef00c102"
+    "sha256": "1284cd96fec9708ec196003db122889c6703b032c4688f20d1653022df7e81ee"
   }
 }

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -167,11 +167,17 @@ without requiring an Alt cycle.
 Every visible editable label is one persisted RichText annotation. Component
 insertion creates an `instance-label` only when reference display is requested.
 The renderer never synthesizes text from Instance IDs and no empty suppressor
-label exists. Net/power labels carry Net identity separately from their visual
-anchor. A resolved anchor drives both the glyph and every text hit/marquee
-surface; its fallback is only for an orphaned target, never an editor-local
-alternate position. Selecting a `power-rail` together with its power label is
-one visual deletion: the label removal is planned once, so the atomic
+label exists. Reference label display is a Properties toggle for one or many
+selected components: hiding sets the annotation's optional `visible: false`
+flag, which renderers and hit/marquee surfaces skip while the annotation stays
+in the Project, so hiding is recoverable and a missing label can be re-created
+from the same toggle. Net/power labels carry Net identity separately from their
+visual anchor. A resolved anchor drives both the glyph and every text
+hit/marquee surface; its fallback is only for an orphaned target, never an
+editor-local alternate position. Dragging a route-anchored Net label re-anchors
+it along its own Route (segment, t, and a generous normal-offset band) instead
+of moving a fallback position. Selecting a `power-rail` together with its power
+label is one visual deletion: the label removal is planned once, so the atomic
 transaction cannot reject a duplicated annotation removal. Drafting text has
 no electrical meaning.
 

--- a/packages/model/src/schema.test.ts
+++ b/packages/model/src/schema.test.ts
@@ -119,4 +119,23 @@ describe("CircuitProject schema", () => {
     };
     expect(CircuitProjectSchema.safeParse(project).success).toBe(false);
   });
+  it("accepts an optional presentation-only visible flag on annotations", () => {
+    const project = createEmptyProject("project-visible", "Visible");
+    const document = project.documents[0]!;
+    const label = {
+      id: "label-1",
+      kind: "instance-label" as const,
+      content: { runs: [{ kind: "text" as const, value: "R1" }] },
+      anchor: { kind: "free" as const, position: { x: 20, y: 20 } },
+      alignment: "middle" as const,
+      rotation: 0 as const,
+      locked: false,
+    };
+    document.annotations.push(label);
+    expect(CircuitProjectSchema.safeParse(project).success).toBe(true);
+    document.annotations[0] = { ...label, visible: false };
+    expect(CircuitProjectSchema.safeParse(project).success).toBe(true);
+    document.annotations[0] = { ...label, visible: true };
+    expect(CircuitProjectSchema.safeParse(project).success).toBe(true);
+  });
 });

--- a/packages/model/src/schema.ts
+++ b/packages/model/src/schema.ts
@@ -362,6 +362,9 @@ export const AnnotationSchema = z
     sizeScale: z.number().finite().positive().optional(),
     // SchematicAnnotation route-marker discriminator (ADR 0010).
     markerKind: RouteMarkerKindSchema.optional(),
+    // Presentation-only switch: hidden annotations stay in the document
+    // (recoverable) but renderers and hit surfaces skip them.
+    visible: z.boolean().optional(),
   })
   .superRefine((annotation, context) => {
     if (annotation.markerKind && annotation.kind !== "route-marker") {

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -587,6 +587,7 @@ export function buildSvgScene(
     })
     .join("");
   const annotations = [...document.annotations]
+    .filter((annotation) => annotation.visible !== false)
     .sort((left, right) => left.id.localeCompare(right.id, "en"))
     .map((annotation) => {
       const attachment = ` data-anchor-kind="${annotation.anchor.kind}"`;

--- a/plan/2026-08-16-text-system-improvements/plan.md
+++ b/plan/2026-08-16-text-system-improvements/plan.md
@@ -1,0 +1,141 @@
+---
+status: completed
+experience: none
+---
+
+# Text system: annotation visibility, edit auto-commit, movable net labels
+
+## Goal
+
+Three user-requested text-system behaviors, aligned with Virtuoso conventions:
+
+1. Component reference annotations become visibility-toggleable from
+   Properties, for one or many selected instances (Virtuoso model: the `q`
+   properties form carries per-label Display controls that also apply to a
+   multi-selection). The buggy annotation-section "Delete annotation" button
+   (only surfaces on multi-select, deletes exactly one label, and offers no
+   re-show path) is removed outright.
+2. Text/property editing commits on exit: clicking blank canvas or pressing
+   Escape saves pending edits instead of discarding them. Explicit Apply
+   stays.
+3. Route-attached net labels (`L` labels) become properly movable: dragging
+   re-anchors them along their route (segment/t/normalOffset) with a generous
+   range instead of the current silent spring-back (release writes only the
+   unused `fallbackPosition`).
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+?? .worktrees/
+```
+
+Worktree clean except the unrelated untracked `.worktrees/` directory.
+
+Owned paths:
+
+- `packages/model/src/schema.ts` (+ its test) — optional `visible` on
+  `AnnotationSchema` (default visible; backward-compatible optional field).
+- `packages/render-svg/src/render.ts` — skip `visible === false` annotations.
+- `apps/editor/src/app/App.tsx` — visibility toggles (single + group), delete
+  the annotation delete button, commit-on-exit for `instancePropertyDraft` /
+  `netLabelDraft` / `textEditing`, net-label drag re-anchoring and clamp
+  range.
+- `apps/editor/src/features/wiring/route-interaction-geometry.ts` — net-label
+  slide/clamp constants shared with the drag path.
+- `apps/editor/e2e/manual-editor.spec.ts`, `component-insert.spec.ts` and
+  affected unit specs.
+- `docs/specs/editor-interaction.md` — the "hiding a label == deleting the
+  annotation" contract line is superseded by the `visible` flag.
+
+Shared dependencies with credible overlap:
+
+- `AnnotationSchema` is a persisted project contract (`upsert_schematic_annotation`,
+  renderer, import/export). The field is optional and additive; goldens are
+  unaffected because no fixture carries hidden labels.
+- The route-panel "Delete Net label" action and empty-name L-editor deletion
+  remain the supported net-label deletion paths after the annotation-section
+  delete button is removed.
+
+## Work
+
+1. Model: `AnnotationSchema.visible?: boolean`; renderer, editor hit targets,
+   and marquee selection skip annotations with `visible === false`. Upsert
+   semantics preserve the flag.
+2. Properties UI: a "Show reference label" checkbox in the single-instance
+   section (creates a missing default label when switched on, via
+   `defaultInstanceLabel`) and a group checkbox in the multi-select overview
+   applying to every selected instance. Remove the annotation-section delete
+   button (read-only info stays).
+3. Commit-on-exit: commit dirty `instancePropertyDraft`/`netLabelDraft` before
+   their selection-driven reload effects discard them; Escape inside Properties
+   inputs commits; the floating rich-text editor commits on outside-pointerdown
+   and Escape instead of discarding; the L floating editor commits on Escape.
+   Insert dialog modal semantics stay cancel-on-Escape.
+4. Net-label drag: in `draggedAnnotationAtPosition`, route-anchored net labels
+   re-anchor via the nearest point on their own route (segmentIndex/t/signed
+   normalOffset) using widened clamp constants; `constrainAnnotationPosition`
+   net-label clamp widened to match.
+5. Tests: unit contracts for schema/render skip and geometry; e2e for
+   single+group visibility toggling (including re-show), blank-click and
+   Escape commits, and a net-label drag that survives release.
+
+## Validation
+
+- `pnpm test:local` on: model schema, render-svg, editor App + affected
+  feature specs (`route-interaction-geometry`, `text-editing`).
+- `pnpm typecheck`
+- `pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts` (label/editing
+  surface) and `apps/editor/e2e/component-insert.spec.ts`
+- Prettier on changed files
+- `git diff --check`, `git status --short --branch`
+- Mainline gate before merge (clean `pnpm ci:check` + green required checks)
+
+## Commit Intent
+
+Committed as one commit — the three features share the App.tsx properties
+panel and draft-effect surfaces, so hunk-level splitting would be artificial:
+
+```text
+feat(editor,model): text system visibility, auto-commit, and movable net labels
+```
+
+## Outcome
+
+Delivered all three behaviors:
+
+1. `AnnotationSchema.visible?: boolean` (optional, backward compatible);
+   renderer, editor hit targets, and marquee skip `visible === false`.
+   Properties gains "Show reference label" (single) and "Show reference
+   labels" (group) checkboxes — hiding keeps the annotation in the Project,
+   showing re-creates a missing label via `defaultInstanceLabel`. The
+   annotation-section "Delete annotation"/"Delete selected Net label" button
+   is removed (route-panel deletion and empty-name L deletion remain; keyboard
+   Delete still works).
+2. Edits commit on exit: instance-property drafts commit when the selected
+   instance id changes (keyed by id, not record, so unrelated transactions
+   never replay a stale draft); Net label drafts commit when their route
+   selection changes; Escape inside Properties inputs commits and blurs; the
+   L floating editor and the canvas rich-text editor commit on Escape and on
+   outside clicks instead of discarding. Fixing this surfaced a latent
+   revision bug: `proposeTextEditingCommit` compared an absent sizeScale
+   (undefined) against the session-normalized 1, so an untouched session
+   committed a phantom style update; both sides now normalize with `?? 1`.
+3. Route-anchored Net labels re-anchor on drag via
+   `dragNetLabelAttachmentAtPoint` (segment/t/normalOffset, band ±[8, 200],
+   signed side flips freely), replacing the silent fallback-only spring-back;
+   the free-label constrain clamp widened to match. Segment choice uses the
+   nearest on-conductor projection so corners cannot steal nearby drags.
+   Name edits now preserve a dragged route anchor.
+
+Validation: 511 unit tests across editor/model/render-svg/edit-engine/derived
+(including new schema `visible` and net-label slide contracts), workspace
+typecheck, Prettier, and Playwright: full manual-editor spec (74), full
+drafting spec (25), full component-insert spec (18), covering the new
+visibility-toggle, commit-on-exit, text-editor commit, and net-label drag
+contracts plus the rewritten L-editor Escape contract. `git diff --check`
+clean.
+
+Experience signal: `none`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7570,3 +7570,20 @@ box`; branch pushed for review. A concurrent worker's overlapping App.tsx
   contracts, and `git diff --check` passed.
 - Commit status: merged to `main` via #93 after the mainline gate (clean-state
   local `pnpm ci:check` and green GitHub Actions checks).
+
+## 2026-08-16 - Text system: label visibility, edit auto-commit, movable net labels
+
+- Target: Virtuoso-style reference-label visibility toggles in Properties for
+  single and multi selection (replacing the broken annotation delete button),
+  commit-on-exit for all text/property editing (blank click and Escape save),
+  and draggable route-anchored Net labels with a generous band.
+- Changed areas: model annotation `visible` flag, render/hit/marquee skip,
+  Properties panel toggles, instance/net-label draft commit effects and
+  Escape handlers, canvas text editor commit semantics (plus a latent
+  phantom-revision fix in `proposeTextEditingCommit`), net-label drag
+  re-anchoring geometry, editor-interaction spec, and focused contracts.
+- Validation: 511 unit tests across editor/model/render-svg/edit-engine/
+  derived, workspace typecheck, Prettier, full manual-editor (74), drafting
+  (25), and component-insert (18) Playwright specs, `git diff --check`.
+- Commit status: committed on `zcode/text-system-improvements`; mainline
+  merge awaits the delivery gate.


### PR DESCRIPTION
## Summary
Three user-requested text-system behaviors (Virtuoso-aligned):

1. **Reference label visibility in Properties** — `Annotation.visible?: boolean` (optional, backward compatible); renderer, hit targets, and marquee skip hidden annotations. Properties gains "Show reference label" (single selection) and "Show reference labels" (multi selection) checkboxes; hiding keeps the annotation in the Project (fully recoverable), showing re-creates a missing default label. The broken annotation-section "Delete annotation" button is removed (route-panel deletion, empty-name L deletion, and keyboard Delete remain).
2. **Edits commit on exit** — pending component-property drafts commit when the selection moves away (keyed by instance id), Net label drafts commit when their route selection changes, Escape inside Properties inputs commits, and the canvas rich-text editor plus the L floating editor commit on Escape/outside clicks instead of discarding. Includes a latent bug fix: untouched text sessions no longer commit a phantom style update (absent sizeScale vs normalized 1).
3. **Movable Net labels** — dragging a route-anchored Net label re-anchors it along its own route (segment/t/normalOffset, ±8..200 band) instead of silently springing back; name edits preserve a dragged anchor.

## Validation
- 511 unit tests across editor/model/render-svg/edit-engine/derived (new schema `visible` and net-label slide contracts)
- `pnpm typecheck`, Prettier
- Playwright: full manual-editor (74), drafting (25), component-insert (18) — including new visibility-toggle, commit-on-exit, text-editor commit, and net-label drag contracts
- `git diff --check`

Plan: `plan/2026-08-16-text-system-improvements/plan.md`