### PR TITLE
Record instance value mainline merge

### DIFF
--- a/plan/log.md
+++ b/plan/log.md
@@ -23,8 +23,9 @@
   (model + regenerated artifacts), `5df0c4e` (presentation), `ecb30c5`
   (editor), `c4f67d7` (e2e), `0399660` (plan records), `28e11b3` (MCP
   tarball sha256 refresh after the CI-reported Linux digest); all six
-  required remote checks passed. Merge to `main` left to the human per the
-  delivery gate.
+  required remote checks passed and a clean-state local
+  `pnpm install --frozen-lockfile` + `pnpm ci:check` was green before the
+  human merged PR #97 to `main` as `7027f57`.
 
 ## 2026-08-16 - Restore the VDD power-port device beside the rail
 

--- a/plan/root-audit.md
+++ b/plan/root-audit.md
@@ -8,8 +8,8 @@ an archive. Completed plans with resolved experience are stored under
 
 | State                     | Count | Required disposition                                                              |
 | ------------------------- | ----: | --------------------------------------------------------------------------------- |
-| `active`                  |     0 | `2026-08-16-instance-value-display` completed on `zcode/instance-value-display`; awaiting PR/CI delivery. |
-| `completed` + `none`      |    34 | Verify commit/log evidence, then archive according to routine retention policy.   |
+| `active`                  |     0 | `2026-08-16-instance-value-display` delivered: PR #97 merged to `main` as `7027f57`. |
+| `completed` + `none`      |    35 | Verify commit/log evidence, then archive according to routine retention policy.   |
 | `completed` + `candidate` |    17 | Human decides whether to extract, reject, or defer the experience signal.         |
 | missing metadata          |    71 | Audit against outcome text and Git evidence; never archive merely because of age. |
 


### PR DESCRIPTION
Closes the delivery record for PR #97 (instance value display): marks the target merged to `main` as `7027f57` in the maintenance log and root audit. Documentation only.