### PR TITLE
docs(log): record razavi fraction mainline merge

### DIFF
--- a/plan/log.md
+++ b/plan/log.md
@@ -24,11 +24,14 @@
   inspection confirmed M1/M3 stacked fractions with a visible bar stay
   upright at 0°/90°/180°/270° with no overlap; live-toggle screenshot
   confirmed typing `150n` then checking Value shows bold `150nF` immediately.
-- Commit status: branch `zcode/instance-value-razavi-fraction` pushed for PR
-  review; commits `a13a6ba` (model + regenerated artifacts), `b51cb5b`
-  (presentation), `a075da5` (render), `ca8d49d` (editor + e2e), `a7984e8`
-  (plan records). The MCP tarball sha256 pin refresh waits for the
-  CI-reported Linux digest per the instance-value precedent (`28e11b3`).
+- Commit status: PR #99 (`zcode/instance-value-razavi-fraction`), commits
+  `a13a6ba` (model + regenerated artifacts), `b51cb5b` (presentation),
+  `a075da5` (render), `ca8d49d` (editor + e2e), `60abe11` (plan records),
+  `9bbc64a` (MCP tarball sha256 refresh after the CI-reported Linux digest);
+  all six required remote checks passed on PR #99 before the human merged it
+  to `main` as `452099e`. Local pre-delivery validation: 789 unit tests,
+  full e2e 143/143, `pnpm ci:static`, `pnpm verify:branch`,
+  `release:verify:built`, and `git diff --check` all clean.
 
 ## 2026-08-16 - Instance value display and property annotations
 

--- a/plan/root-audit.md
+++ b/plan/root-audit.md
@@ -8,7 +8,7 @@ an archive. Completed plans with resolved experience are stored under
 
 | State                     | Count | Required disposition                                                              |
 | ------------------------- | ----: | --------------------------------------------------------------------------------- |
-| `active`                  |     0 | `2026-08-16-instance-value-display` delivered: PR #97 merged to `main` as `7027f57`. |
+| `active`                  |     0 | `2026-08-16-instance-value-display` delivered: PR #97 merged to `main` as `7027f57`. `2026-08-16-instance-value-razavi-fraction` delivered: PR #99 merged to `main` as `452099e`. |
 | `completed` + `none`      |    35 | Verify commit/log evidence, then archive according to routine retention policy.   |
 | `completed` + `candidate` |    17 | Human decides whether to extract, reject, or defer the experience signal.         |
 | missing metadata          |    71 | Audit against outcome text and Git evidence; never archive merely because of age. |


### PR DESCRIPTION
Post-merge delivery record for PR #99 (Razavi fraction values, engineering units, live Value toggle), merged to `main` as `452099e`.

- `plan/log.md`: commit status updated with the PR number, the CI-reported MCP checksum refresh (`9bbc64a`), and the merge sha; also corrects the plan-records commit reference from `a7984e8` to the amended `60abe11`.
- `plan/root-audit.md`: `active` disposition notes the razavi-fraction delivery.

Docs-only change; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)