### PR TITLE
Enlarge the grid-dots toggle icon

### DIFF
--- a/apps/editor/src/features/editor-shell/tool-icon.tsx
+++ b/apps/editor/src/features/editor-shell/tool-icon.tsx
@@ -90,15 +90,18 @@ export function ToolIcon({ name }: { name: ToolIconName }) {
       ) : null}
       {name === "grid" ? (
         <>
-          <circle cx="5" cy="5" r="0.9" fill="currentColor" />
-          <circle cx="10" cy="5" r="0.9" fill="currentColor" />
-          <circle cx="15" cy="5" r="0.9" fill="currentColor" />
-          <circle cx="5" cy="10" r="0.9" fill="currentColor" />
-          <circle cx="10" cy="10" r="0.9" fill="currentColor" />
-          <circle cx="15" cy="10" r="0.9" fill="currentColor" />
-          <circle cx="5" cy="15" r="0.9" fill="currentColor" />
-          <circle cx="10" cy="15" r="0.9" fill="currentColor" />
-          <circle cx="15" cy="15" r="0.9" fill="currentColor" />
+          {/* 3x3 dot field = background-dots toggle; the 0.9-radius dots
+              collapsed to ~1.4px at the 16px icon and read as noise, so the
+              dots are calibrated to r=1.4 (~2.2px, still clearly spaced). */}
+          <circle cx="5" cy="5" r="1.4" fill="currentColor" />
+          <circle cx="10" cy="5" r="1.4" fill="currentColor" />
+          <circle cx="15" cy="5" r="1.4" fill="currentColor" />
+          <circle cx="5" cy="10" r="1.4" fill="currentColor" />
+          <circle cx="10" cy="10" r="1.4" fill="currentColor" />
+          <circle cx="15" cy="10" r="1.4" fill="currentColor" />
+          <circle cx="5" cy="15" r="1.4" fill="currentColor" />
+          <circle cx="10" cy="15" r="1.4" fill="currentColor" />
+          <circle cx="15" cy="15" r="1.4" fill="currentColor" />
         </>
       ) : null}
       {name === "inspect" ? (


### PR DESCRIPTION
User feedback: the background-dots toggle in the bottom-right canvas controls has an unclear icon. Root cause: its 3×3 dots at `r=0.9` collapse to ~1.4px at the 16px `.tool-icon` render — nine faint specks that read as noise.

### Change
- The grid icon's dots are calibrated to `r=1.4` (~2.2px at 16px), a clear 3×3 dot field that reads as "background dots" while staying in the thin-stroke icon family (zoom/fit unchanged).
- `aria-label` (`Show/Hide background dots`) untouched, so the e2e contract holds.

### Verification
- Pixel measurement: new icon = 9 solid ~2px dot clusters; old icon = 0 visible clusters (sub-threshold anti-aliasing — the reported unclarity).
- Editor unit tests 305/305, grid e2e 1/1, typecheck + Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)