### PR TITLE
feat(model): add rolling schema-v10 project compatibility

### DIFF
--- a/apps/editor/e2e/project-file.spec.ts
+++ b/apps/editor/e2e/project-file.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import {
@@ -34,6 +35,36 @@ test("downloads the canonical Project when File System Access is unavailable", a
   await expect
     .poll(() => recoveryProjectTexts(page))
     .toContain('"revision": 1');
+});
+
+test("upgrades a schema-10 Project and saves it as schema 11", async ({
+  page,
+}) => {
+  const source = JSON.parse(
+    readFileSync(
+      resolve(process.cwd(), "fixtures/projects/minimal/project.icproj.json"),
+      "utf8",
+    ),
+  ) as Record<string, unknown>;
+  source.schemaVersion = 10;
+
+  await page.goto("/");
+  await page.getByTestId("project-file").setInputFiles({
+    name: "minimal-v10.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(source)),
+  });
+  await expect(page.getByTestId("status")).toContainText(
+    "upgraded minimal-v10.icproj.json from schema 10 to schema 11",
+  );
+  await expect
+    .poll(() => recoveryProjectTexts(page))
+    .toContain('"schemaVersion": 11');
+
+  const saved = JSON.parse(
+    (await downloadBytes(page, "File", "Save Project")).toString("utf8"),
+  ) as { schemaVersion: number };
+  expect(saved.schemaVersion).toBe(11);
 });
 
 test("reports a confirmed File System Access save", async ({ page }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -4638,10 +4638,13 @@ export function App({
         source: "opened-file",
         formalFileHint: { name: staged.fileName },
       });
+      if (staged.migrated) setFileState("dirty");
       setImportDiagnostics([]);
       setImportReviewOpen(false);
       setStatus(
-        `Opened ${staged.fileName} at revision ${staged.topDocumentRevision}`,
+        staged.migrated
+          ? `Opened and upgraded ${staged.fileName} from schema ${staged.sourceSchemaVersion} to schema ${staged.project.schemaVersion} — save the Project to keep the upgrade`
+          : `Opened ${staged.fileName} at revision ${staged.topDocumentRevision}`,
       );
     });
   }

--- a/apps/editor/src/document/browser-recovery-contract.test.ts
+++ b/apps/editor/src/document/browser-recovery-contract.test.ts
@@ -184,6 +184,23 @@ describe("reviewBrowserRecoveryProject", () => {
     }
   });
 
+  it("accepts a schema-10 recovery envelope after upgrading its Project", () => {
+    const previousText = JSON.stringify({
+      ...JSON.parse(projectText),
+      schemaVersion: 10,
+    });
+    const review = reviewBrowserRecoveryProject(
+      finalizeBrowserRecoveryRecord(
+        draft({ projectText: previousText, projectSchemaVersion: 10 }),
+      ),
+    );
+
+    expect(review.status).toBe("valid");
+    if (review.status === "valid") {
+      expect(review.project.schemaVersion).toBe(11);
+    }
+  });
+
   it("classifies envelope disagreement as corrupt", () => {
     expect(
       reviewBrowserRecoveryProject(

--- a/apps/editor/src/document/browser-recovery-contract.ts
+++ b/apps/editor/src/document/browser-recovery-contract.ts
@@ -17,7 +17,7 @@
 // Storage (WP-1) and React coordination (WP-2) build on these functions; they
 // must not re-implement the rules independently.
 
-import { parseProject } from "@icm/model";
+import { parseProjectWithMetadata } from "@icm/model";
 import type { CircuitProject } from "@icm/model";
 import { ProjectFormatError } from "@icm/model";
 
@@ -285,14 +285,15 @@ export function reviewBrowserRecoveryProject(
   record: BrowserRecoveryRecordV2,
 ): BrowserRecoveryProjectReview {
   try {
-    const project = parseProject(record.projectText);
+    const parsed = parseProjectWithMetadata(record.projectText);
+    const project = parsed.project;
     if (project.id !== record.projectId) {
       return {
         status: "corrupt",
         message: "record projectId does not match the stored Project",
       };
     }
-    if (project.schemaVersion !== record.projectSchemaVersion) {
+    if (parsed.sourceSchemaVersion !== record.projectSchemaVersion) {
       return {
         status: "corrupt",
         message: "record schema version does not match the stored Project",

--- a/apps/editor/src/document/browser-recovery-store.test.ts
+++ b/apps/editor/src/document/browser-recovery-store.test.ts
@@ -532,6 +532,20 @@ describe("migrateLegacyProjectRecovery", () => {
     expect(firstSession(read).latest?.source).toBe("recovered");
   });
 
+  it("stores a schema-10 legacy slot as internally consistent schema 11", async () => {
+    const { store } = freshStore();
+    const previousText = JSON.stringify({
+      ...JSON.parse(projectText),
+      schemaVersion: 10,
+    });
+    const storage = memoryStorage({ [PROJECT_RECOVERY_KEY]: previousText });
+
+    expect(await migrate(storage, store)).toMatchObject({ status: "migrated" });
+    const latest = firstSession(await store.readAll()).latest!;
+    expect(latest.projectSchemaVersion).toBe(11);
+    expect(JSON.parse(latest.projectText).schemaVersion).toBe(11);
+  });
+
   it("retains an unsupported-schema legacy slot", async () => {
     const { store } = freshStore();
     const futureText = JSON.stringify({

--- a/apps/editor/src/document/browser-recovery-store.ts
+++ b/apps/editor/src/document/browser-recovery-store.ts
@@ -10,7 +10,7 @@
 // database or object store. Records left undecodable by a future format
 // change are left untouched rather than deleted.
 
-import { parseProject, ProjectFormatError } from "@icm/model";
+import { parseProject, ProjectFormatError, serializeProject } from "@icm/model";
 
 import {
   BROWSER_RECOVERY_MAX_RECORD_BYTES,
@@ -552,7 +552,7 @@ export async function migrateLegacyProjectRecovery(
     documentRevisions,
     source: "recovered",
     updatedAt: seams.now?.() ?? new Date().toISOString(),
-    projectText: legacyText,
+    projectText: serializeProject(project),
   });
 
   const outcome = await seams.store.writeRecord(record);

--- a/apps/editor/src/document/project-file-service.test.ts
+++ b/apps/editor/src/document/project-file-service.test.ts
@@ -239,6 +239,27 @@ describe("stageProjectFile", () => {
       status: "opened",
       fileName: "amp.icproj.json",
       topDocumentRevision: 0,
+      sourceSchemaVersion: 11,
+      migrated: false,
+    });
+  });
+
+  it("stages schema 10 as an upgraded schema-11 Project", async () => {
+    const previousText = JSON.stringify({
+      ...JSON.parse(serializeProject(project)),
+      schemaVersion: 10,
+    });
+    const outcome = await stageProjectFile(
+      fakeFile("amp-v10.icproj.json", previousText),
+      () => [],
+    );
+
+    expect(outcome).toMatchObject({
+      status: "opened",
+      fileName: "amp-v10.icproj.json",
+      sourceSchemaVersion: 10,
+      migrated: true,
+      project: { schemaVersion: 11 },
     });
   });
 

--- a/apps/editor/src/document/project-file-service.ts
+++ b/apps/editor/src/document/project-file-service.ts
@@ -19,7 +19,7 @@
 // handle into Project JSON or a recovery record.
 
 import {
-  parseProject,
+  parseProjectWithMetadata,
   serializeProject,
   ProjectFormatError,
   type CircuitProject,
@@ -50,6 +50,8 @@ export type ProjectFileOpenOutcome =
       project: CircuitProject;
       fileName: string;
       topDocumentRevision: number;
+      sourceSchemaVersion: number;
+      migrated: boolean;
     }
   | { status: "rejected"; diagnostics: ProjectFileOpenDiagnostic[] };
 
@@ -328,9 +330,9 @@ export async function stageProjectFile(
       diagnostics: [{ code: "READ_FAILED", message: errorMessage(error) }],
     };
   }
-  let project: CircuitProject;
+  let parsedProject;
   try {
-    project = parseProject(serialized);
+    parsedProject = parseProjectWithMetadata(serialized);
   } catch (error) {
     if (error instanceof ProjectFormatError) {
       return {
@@ -354,6 +356,7 @@ export async function stageProjectFile(
       ],
     };
   }
+  const project = parsedProject.project;
   const unsupported = findUnsupportedSymbols(project);
   if (unsupported.length > 0) {
     return {
@@ -385,6 +388,8 @@ export async function stageProjectFile(
     project,
     fileName: file.name,
     topDocumentRevision: topDocument.revision,
+    sourceSchemaVersion: parsedProject.sourceSchemaVersion,
+    migrated: parsedProject.migrated,
   };
 }
 

--- a/docs/adr/0023-rolling-previous-project-compatibility.md
+++ b/docs/adr/0023-rolling-previous-project-compatibility.md
@@ -1,0 +1,112 @@
+# 0023 - Rolling previous Project compatibility
+
+Status: `accepted`
+
+Date: `2026-08-17`
+
+Owners: `packages/model`, editor Project file and recovery boundaries
+
+## Context
+
+ADR 0022 established one schema-11 Project shape and rejected every other
+version. That kept legacy shapes out of runtime, but also prevented a schema-10
+user file from opening even though schema 11 only adds the RichText `fraction`
+run and every valid schema-10 value remains valid after advancing its version.
+
+The retired schema-1-to-8 registry accumulated sequential migration code,
+tests, and historic Project assets. Restoring an unbounded chain would recreate
+that maintenance and misuse risk. Keeping a Project in an old in-memory mode
+would instead make every editor and renderer a multi-version consumer.
+
+## Decision
+
+The Project reader supports a rolling two-version window: the current Project
+schema and exactly one explicitly named previous schema. Both produce the sole
+current `CircuitProject` shape. Validation and serialization remain current
+only; no compatibility-shaped Project enters the editor or is written back.
+
+Schema 10 upgrades directly to schema 11 by changing only `schemaVersion`, then
+validating the complete result against `CircuitProjectSchema`. User-authored
+RichText is preserved exactly; slash text is not guessed or re-projected into a
+fraction. Once loaded, the Project has all schema-11 capabilities, including
+authoring and persisting new fraction runs.
+
+The read boundary reports the source schema and whether migration occurred.
+Opening a migrated formal file marks it as needing save and never silently
+overwrites the user's source. App-owned browser recovery may store canonical
+schema-11 text after successful migration, but must compare a stored envelope
+against the source version encoded in its text before doing so.
+
+When the current schema advances, the previous-version constant, direct
+adapter, and focused tests must be replaced together. They are not appended to
+an accumulating registry. Versions older than the rolling window and all future
+versions remain unsupported. A future non-additive adapter may perform only
+deterministic, semantics-preserving rewrites; ambiguous electrical data is
+rejected rather than inferred.
+
+## Alternatives considered
+
+### Restore the sequential migration registry
+
+- Benefits: users could skip arbitrarily many releases.
+- Costs: retains every historic transformation and compatibility asset and
+  expands the supported-state matrix indefinitely.
+- Reason not selected: the product currently promises only previous-version
+  compatibility and needs one current runtime contract.
+
+### Continue rejecting schema 10
+
+- Benefits: no reader change.
+- Costs: rejects structurally compatible user data at the release boundary.
+- Reason not selected: the schema-10-to-11 transformation is deterministic and
+  lossless.
+
+### Keep schema 10 live after open
+
+- Benefits: avoids an immediate version rewrite.
+- Costs: every edit, render, recovery, and export path must understand multiple
+  Project shapes.
+- Reason not selected: compatibility belongs at ingestion, not throughout the
+  application.
+
+## Consequences
+
+### Positive
+
+- Schema-10 Projects open without retaining a schema-10 model or fixture set.
+- Migrated Projects immediately receive all schema-11 authoring capabilities.
+- Formal files change only after an explicit save.
+- The supported compatibility surface stays bounded and reviewable.
+
+### Negative or limiting
+
+- A user who skips more than one Project schema release cannot upgrade directly.
+- Each schema release must deliberately replace and validate the direct adapter.
+- General RichText fraction insertion remains a separate editor feature; this
+  decision supplies the model capability but does not add that UI.
+
+## Compatibility and migration
+
+Canonical repository fixtures remain schema 11. Focused tests synthesize a
+schema-10 input from a minimal current Project, prove content preservation and
+the direct upgrade, then add a schema-11 fraction and prove save/reopen
+stability. No historic Project asset is retained as a production input.
+
+This decision supersedes only ADR 0022's clauses that reject every older
+Project and prohibit a compatibility reader. ADR 0022's sole current
+schema-11 in-memory Project shape and all unrelated Port, edit-union, and credential decisions
+remain accepted.
+
+## Validation
+
+- focused model parsing, preservation, fraction round-trip, and rejection tests;
+- staged file-open migration metadata and diagnostics tests;
+- browser recovery envelope and canonical-storage migration tests;
+- current documentation drift, type, and branch validation.
+
+## Related documents
+
+- [`0022-current-protocol-baseline.md`](0022-current-protocol-baseline.md)
+- [`../specs/project-file-format.md`](../specs/project-file-format.md)
+- [`../specs/persistence-and-recovery.md`](../specs/persistence-and-recovery.md)
+- [`../../plan/2026-08-17-v10-v11-project-compatibility/plan.md`](../../plan/2026-08-17-v10-v11-project-compatibility/plan.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,6 +40,9 @@ The current Project schema, ordinary Port-symbol Instance, typed-edit, and
 Agent credential-lifetime baseline—partially superseding clauses in ADR
 0010/0013/0014/0015/0016—is
 [`0022-current-protocol-baseline.md`](0022-current-protocol-baseline.md).
+The rolling current-and-previous Project read policy, superseding ADR 0022's
+current-only compatibility clause, is
+[`0023-rolling-previous-project-compatibility.md`](0023-rolling-previous-project-compatibility.md).
 
 Use [`adr.template.md`](adr.template.md) for new decisions.
 

--- a/docs/current/README.md
+++ b/docs/current/README.md
@@ -8,8 +8,10 @@ repository search, completed roadmaps, target plans, or `docs/archive/`.
 1. [`../overall-product-plan.md`](../overall-product-plan.md) — product
    boundary, system shape, and source-of-truth map.
 2. [`../adr/0022-current-protocol-baseline.md`](../adr/0022-current-protocol-baseline.md)
-   — current Project schema, Port-symbol, edit-union, and Agent credential
-   contract; identifies the superseded clauses in older ADRs.
+   and [`../adr/0023-rolling-previous-project-compatibility.md`](../adr/0023-rolling-previous-project-compatibility.md)
+   — current Project shape, rolling previous-version read policy, Port-symbol,
+   edit-union, and Agent credential contract; identify superseded clauses in
+   older ADRs.
 3. [`../adr/0011-retire-visio-vss-as-visual-authority.md`](../adr/0011-retire-visio-vss-as-visual-authority.md)
    and [`../specs/razavi-visual-contract.md`](../specs/razavi-visual-contract.md)
    — the Razavi raster is the sole visual authority.

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -198,8 +198,9 @@ no electrical meaning.
 Open, demo load, restore, and human-approved staged import replace the entire
 Project through one replacement boundary; they are not Edit Engine
 transactions. Replacement cancels pending recovery for the outgoing Project
-and terminates its Agent session. Only complete schema-11 Projects are accepted;
-the editor performs no migration.
+and terminates its Agent session. A complete schema-10 Project may be upgraded
+at the read boundary and then enters the editor only as schema-11; migrated
+formal files are marked as needing save.
 
 Selection, viewport, active tool, previews, Agent tokens, and approval UI are
 transient and never enter Project JSON. Recovery is scheduled only after a

--- a/docs/specs/persistence-and-recovery.md
+++ b/docs/specs/persistence-and-recovery.md
@@ -6,11 +6,13 @@ Primary owner: `packages/model` and the editor document lifecycle
 
 Portable Projects use canonical schema-11 `.icproj.json`. Persistence validates
 the complete current schema before open or save and writes atomically where the
-platform supports it. Non-current versions are rejected; no migration or
-compatibility reader runs during open, recovery, staging, or save.
+platform supports it. Schema 10 reads through one direct content-preserving
+upgrade to schema 11; older and future versions are rejected. Migration runs
+only at ingestion, and serialization remains schema 11.
 
-Recovery state is a non-authoritative browser safety copy. It may restore only
-a complete schema-11 Project associated with a recorded working-copy session.
+Recovery state is a non-authoritative browser safety copy. It may restore a
+complete schema-11 Project or a schema-10 record that validates after the direct
+upgrade, associated with a recorded working-copy session.
 Corrupt, incompatible, or partial recovery data is discarded or retained as raw
 data without changing the live Project. Credentials, Agent bearer tokens,
 selection, viewport, overlays, and pending external approvals are never

--- a/docs/specs/project-file-format.md
+++ b/docs/specs/project-file-format.md
@@ -7,9 +7,11 @@ Current Project schema: `11`
 Primary owner: `packages/model`
 
 An `.icproj.json` file is canonical JSON for one complete `CircuitProject`.
-`parseProject` accepts exactly Project schema 11, validates the full strict
-schema, and rejects every older or newer version. There is no migration
-registry, compatibility reader, or second in-memory Project shape.
+`parseProject` accepts Project schema 11 and schema 10. Schema 10 advances
+directly to 11 without rewriting content, then passes the full strict current
+validation. Every reader returns the sole schema-11 in-memory Project shape;
+schema 9 and older and all future versions are rejected. There is no sequential
+migration registry or second in-memory Project shape.
 
 ## Current authorities
 
@@ -32,14 +34,18 @@ registry, compatibility reader, or second in-memory Project shape.
 ## Read and write
 
 ```text
-read text -> parse JSON -> require Project schema 11
--> strict validation -> open
+read text -> parse JSON -> require Project schema 10 or 11
+-> direct v10-to-v11 upgrade when needed -> strict schema-11 validation -> open
 save -> strict validation -> canonical key ordering -> atomic write
 ```
 
 An invalid candidate never replaces the current browser Project. File Resource
 staging is non-mutating; a staged Project can replace the live Project only
 after explicit human approval in the editor.
+
+A migrated formal file is marked as needing save. The editor does not silently
+overwrite the source selected through the browser file input. Browser recovery
+records may be canonicalized to v11 only after a successful validated write.
 
 Canonical serialization ends with one newline and is byte-stable across
 save/load/save. The current corpus is listed in

--- a/docs/specs/schematic-model.md
+++ b/docs/specs/schematic-model.md
@@ -87,4 +87,5 @@ objects are visual-only and cannot create connectivity.
 
 Mutation occurs only through atomic Edit Engine transactions against an exact
 Document revision. GUI and Agent writes use the same schema and invariants.
-Persistence accepts and writes only schema 11; no migration is performed.
+Persistence writes only schema 11. It accepts schema 10 through the bounded
+direct upgrade defined by ADR 0023; no compatibility shape enters the model.

--- a/docs/user/project-compatibility.md
+++ b/docs/user/project-compatibility.md
@@ -3,13 +3,18 @@
 The released Project schema version is `11` (v10 added the `instance-value`
 annotation kind; v11 restores the RichText `fraction` run). A canonical v11
 file can be opened, saved, reopened, and saved again without byte drift.
-Older and newer schema versions are rejected; the editor has no compatibility
-reader or migration registry.
+Schema v10 is accepted through one direct, lossless upgrade to v11. It does not
+remain a v10 Project in the editor: all subsequent edits can use v11 features,
+including RichText fractions, and the next save writes v11. The original file
+is never overwritten silently. Schema v9 and older, and versions newer than
+v11, are rejected; there is no accumulating migration registry.
 
-The current-only corpus at
+The canonical-current corpus at
 [`fixtures/projects/compatibility-corpus.json`](../../fixtures/projects/compatibility-corpus.json)
 lists every shipped Project fixture. It distinguishes byte-stable accepted
-files from named rejected inputs. Retired fields such as first-class
+files from named rejected inputs. Previous-version compatibility uses a
+focused synthetic regression instead of retaining historic Project assets.
+Retired fields such as first-class
 `Document.ports`, `Net.ports`, `spice.*`, and `routeAttachment` are invalid.
 
 An incompatible Project is rejected before it can replace the current browser

--- a/fixtures/projects/compatibility-corpus.json
+++ b/fixtures/projects/compatibility-corpus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "description": "Current-only Project corpus. Every accepted file is canonical schema-v11; older versions are unsupported.",
+  "description": "Canonical current Project corpus. Every listed accepted file is schema-v11; rolling schema-v10 read compatibility is covered by synthesized tests rather than retained historic assets.",
   "current": [
     "fixtures/projects/minimal/project.icproj.json",
     "fixtures/projects/phase-1-manual/project.icproj.json",

--- a/packages/model/src/persistence.test.ts
+++ b/packages/model/src/persistence.test.ts
@@ -8,6 +8,7 @@ import {
   ProjectFormatError,
   loadProject,
   parseProject,
+  parseProjectWithMetadata,
   saveProject,
   serializeProject,
   type ProjectStorage,
@@ -69,13 +70,75 @@ describe("Project persistence", () => {
     }
   });
 
-  it("rejects every non-current schema version", () => {
+  it("directly upgrades schema 10 and reports its source version", () => {
+    const project = createEmptyProject("project-test", "Test Project");
+    const source = {
+      ...JSON.parse(serializeProject(project)),
+      schemaVersion: 10,
+    };
+    source.documents[0].annotations.push({
+      id: "plain-v10-value",
+      kind: "instance-value",
+      content: { runs: [{ kind: "text", value: "20u/1u" }] },
+      anchor: { kind: "free", position: { x: 0, y: 0 } },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    });
+    const parsed = parseProjectWithMetadata(JSON.stringify(source));
+
+    expect(parsed).toMatchObject({
+      sourceSchemaVersion: 10,
+      migrated: true,
+      project: { schemaVersion: 11 },
+    });
+    expect({ ...parsed.project, schemaVersion: 10 }).toEqual(source);
+  });
+
+  it("lets an upgraded schema-10 Project author and persist a schema-11 fraction", () => {
+    const source = {
+      ...JSON.parse(
+        serializeProject(createEmptyProject("project-test", "Test Project")),
+      ),
+      schemaVersion: 10,
+    };
+    const project = parseProject(JSON.stringify(source));
+    project.documents[0]!.annotations.push({
+      id: "value-fraction",
+      kind: "instance-value",
+      content: {
+        runs: [
+          {
+            kind: "fraction",
+            numerator: { runs: [{ kind: "text", value: "10um" }] },
+            denominator: { runs: [{ kind: "text", value: "150nm" }] },
+          },
+        ],
+      },
+      anchor: { kind: "free", position: { x: 0, y: 0 } },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    });
+
+    const reopened = parseProject(serializeProject(project));
+    expect(reopened.schemaVersion).toBe(11);
+    expect(
+      reopened.documents[0]!.annotations[0]?.content.runs[0],
+    ).toMatchObject({
+      kind: "fraction",
+      numerator: { runs: [{ value: "10um" }] },
+      denominator: { runs: [{ value: "150nm" }] },
+    });
+  });
+
+  it("rejects schemas outside the rolling current-and-previous window", () => {
     const project = createEmptyProject("project-test", "Test Project");
     expect(() =>
       parseProject(JSON.stringify({ ...project, schemaVersion: 99 })),
-    ).toThrow(/exactly 11/);
+    ).toThrow(/must be 10 or 11/);
     expect(() =>
       parseProject(JSON.stringify({ ...project, schemaVersion: 9 })),
-    ).toThrow(/exactly 11/);
+    ).toThrow(/must be 10 or 11/);
   });
 });

--- a/packages/model/src/persistence.ts
+++ b/packages/model/src/persistence.ts
@@ -10,6 +10,19 @@ export interface ProjectDiagnostic {
   path: ReadonlyArray<string | number>;
 }
 
+/**
+ * The rolling compatibility window is deliberately explicit. Advancing the
+ * current schema must replace this adapter rather than accidentally extending
+ * an unbounded migration chain.
+ */
+export const PREVIOUS_PROJECT_SCHEMA_VERSION = 10;
+
+export interface ProjectParseResult {
+  readonly project: CircuitProject;
+  readonly sourceSchemaVersion: number;
+  readonly migrated: boolean;
+}
+
 export class ProjectFormatError extends Error {
   readonly diagnostics: readonly ProjectDiagnostic[];
 
@@ -56,7 +69,9 @@ export function validateProject(input: unknown): CircuitProject {
   return result.data;
 }
 
-export function parseProject(serialized: string): CircuitProject {
+export function parseProjectWithMetadata(
+  serialized: string,
+): ProjectParseResult {
   let parsed: unknown;
   try {
     parsed = JSON.parse(serialized) as unknown;
@@ -70,19 +85,48 @@ export function parseProject(serialized: string): CircuitProject {
       },
     ]);
   }
-  if (
-    !isRecord(parsed) ||
-    parsed.schemaVersion !== CURRENT_PROJECT_SCHEMA_VERSION
-  ) {
+  if (!isRecord(parsed) || !Number.isInteger(parsed.schemaVersion)) {
     throw new ProjectFormatError([
       {
         code: "UNSUPPORTED_SCHEMA_VERSION",
-        message: `Project schemaVersion must be exactly ${CURRENT_PROJECT_SCHEMA_VERSION}`,
+        message: "Project schemaVersion must be an integer",
         path: ["schemaVersion"],
       },
     ]);
   }
-  return validateProject(parsed);
+
+  const sourceSchemaVersion = parsed.schemaVersion as number;
+  if (sourceSchemaVersion === CURRENT_PROJECT_SCHEMA_VERSION) {
+    return {
+      project: validateProject(parsed),
+      sourceSchemaVersion,
+      migrated: false,
+    };
+  }
+  if (sourceSchemaVersion === PREVIOUS_PROJECT_SCHEMA_VERSION) {
+    // Schema 11 adds the RichText `fraction` variant. Every valid schema-10
+    // value is already a valid schema-11 value after advancing the version;
+    // preserve user-authored text exactly rather than re-projecting it.
+    return {
+      project: validateProject({
+        ...parsed,
+        schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION,
+      }),
+      sourceSchemaVersion,
+      migrated: true,
+    };
+  }
+  throw new ProjectFormatError([
+    {
+      code: "UNSUPPORTED_SCHEMA_VERSION",
+      message: `Project schemaVersion must be ${PREVIOUS_PROJECT_SCHEMA_VERSION} or ${CURRENT_PROJECT_SCHEMA_VERSION}`,
+      path: ["schemaVersion"],
+    },
+  ]);
+}
+
+export function parseProject(serialized: string): CircuitProject {
+  return parseProjectWithMetadata(serialized).project;
 }
 
 export function serializeProject(project: CircuitProject): string {

--- a/packages/model/src/protocol-documentation.test.ts
+++ b/packages/model/src/protocol-documentation.test.ts
@@ -13,7 +13,7 @@ function readRepositoryText(relativePath: string): string {
 }
 
 describe("Project protocol documentation", () => {
-  it("tracks the executable current-only Project schema", () => {
+  it("tracks the executable current Project schema and rolling read policy", () => {
     const version = CURRENT_PROJECT_SCHEMA_VERSION;
     const expectations = [
       ["docs/overall-product-plan.md", `schema-${version}`],
@@ -22,8 +22,8 @@ describe("Project protocol documentation", () => {
       ["docs/specs/project-file-format.md", `Project schema: \`${version}\``],
       ["docs/specs/editor-interaction.md", `schema-${version}`],
       [
-        "docs/adr/0022-current-protocol-baseline.md",
-        `Project format is schema ${version}`,
+        "docs/adr/0023-rolling-previous-project-compatibility.md",
+        `schema-${version} in-memory Project shape`,
       ],
       [
         "docs/user/project-compatibility.md",

--- a/plan/2026-08-17-v10-v11-project-compatibility/plan.md
+++ b/plan/2026-08-17-v10-v11-project-compatibility/plan.md
@@ -56,6 +56,23 @@ and this plan is updated first.
 5. Synchronize the review branch with the latest `main`, resolve overlapping
    protocol/test-governance documentation deliberately, repeat required local
    validation, and wait for required remote checks before mainline merge.
+6. Record the required test-impact declaration introduced by the synchronized
+   main branch, validate it against `origin/main`, and repeat remote delivery
+   checks before merging.
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: schema-10 Project preservation and direct schema-11 upgrade;
+  migrated formal-file dirty/save behavior; recovery source-version and
+  canonical-text consistency; post-migration RichText fraction authoring and
+  save/reopen round-trip; rejection of unsupported Project versions.
+- Primary checks: `packages/model/src/persistence.test.ts`;
+  `apps/editor/src/document/project-file-service.test.ts`;
+  `apps/editor/src/document/browser-recovery-contract.test.ts`;
+  `apps/editor/src/document/browser-recovery-store.test.ts`;
+  `apps/editor/e2e/project-file.spec.ts` (schema-10 upgrade flow);
+  `pnpm test:impact -- --base origin/main`.
 
 ## Validation
 
@@ -102,4 +119,7 @@ both factual log histories, and repeated the clean-state mainline gate from a
 frozen install. Final local `pnpm ci:check` passed static contracts, 132 test
 files / 809 unit tests, all workspace builds, performance and golden checks,
 release/package smoke, and 144 Playwright tests. PR #106 carries the completed
-target for required GitHub Actions verification and merge.
+target for required GitHub Actions verification and merge. After main's
+test-impact governance was applied to this target, its explicit
+`tests-updated` declaration passed against `origin/main`; required GitHub
+Actions verification remains the final mainline gate.

--- a/plan/2026-08-17-v10-v11-project-compatibility/plan.md
+++ b/plan/2026-08-17-v10-v11-project-compatibility/plan.md
@@ -1,0 +1,95 @@
+---
+status: completed
+experience: none
+---
+
+# Add Rolling v10 to v11 Project Compatibility
+
+## Goal
+
+Allow schema-v10 Project JSON to open through one direct, semantics-preserving
+upgrade to the sole schema-v11 in-memory model. Preserve v10 content, expose
+migration metadata to file and recovery callers, require an explicit formal
+save for upgraded user files, and prove that a migrated Project can use and
+persist new v11 RichText fractions.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## chore/unify-current-protocol-baseline
+?? .worktrees/
+```
+
+The untracked `.worktrees/` directory predates this target and is unrelated;
+it remains untouched. This target owns:
+
+- `packages/model/src/persistence.ts` and focused persistence tests
+- `apps/editor/src/document/` compatibility metadata and recovery handling
+- focused editor file/recovery tests and the minimal App file-state wiring
+- `apps/editor/e2e/project-file.spec.ts` for the migrated-open/save boundary
+- current Project compatibility documentation and a superseding ADR
+- `fixtures/projects/compatibility-corpus.json` description only, because its
+  current-only wording would otherwise contradict the read adapter
+- this target plan, `plan/log.md`, and `plan/root-audit.md`
+
+Shared dependencies are the schema-v11 `CircuitProjectSchema`, browser
+recovery record consistency, Project file-state semantics, and Agent/file
+callers of `parseProject`. The schema shape, RichText editor UX, canonical
+Project payload fixtures, generated Agent artifacts, and `.worktrees/` are
+read-only unless validation proves a required compatibility-contract update
+and this plan is updated first.
+
+## Work
+
+1. Add a bounded v10-to-v11 read adapter that rewrites only the version and
+   validates the result against the current strict schema; reject v9 and future
+   schemas and retain current-only serialization.
+2. Return source-version/migration metadata for staged file opens, mark an
+   upgraded formal file as needing save, and keep ordinary v11 opens unchanged.
+3. Make browser recovery compare source metadata correctly and store canonical
+   v11 text after migration rather than mismatched legacy bytes.
+4. Add focused regressions for content preservation, post-migration fraction
+   authoring/round-trip, file staging, recovery consistency, and rejection
+   boundaries; document the rolling N-1 policy.
+
+## Validation
+
+- `pnpm test:local packages/model/src/persistence.test.ts apps/editor/src/document/project-file-service.test.ts apps/editor/src/document/browser-recovery-contract.test.ts apps/editor/src/document/browser-recovery-store.test.ts`
+- focused App test only if file-state behavior requires App wiring
+- `pnpm test:e2e:local apps/editor/e2e/project-file.spec.ts --grep "upgrades a schema-10 Project"`
+- `pnpm typecheck`
+- `pnpm docs:check`
+- `pnpm verify:branch`, justified because the read policy crosses model,
+  formal-file, recovery, browser, and normative documentation boundaries
+- `git diff --check`
+- `git status --short --branch`
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(model): accept schema v10 through a direct v11 upgrade
+```
+
+## Outcome
+
+Added one explicit schema-10-to-11 read adapter while retaining schema 11 as
+the sole validated in-memory and serialized Project. The adapter reports its
+source version, preserves schema-10 content without re-projecting slash text,
+and rejects schema 9, older, and future versions. Migrated formal files are
+marked dirty with an explicit save prompt; browser recovery validates its
+source-version envelope and canonicalizes app-owned legacy storage to
+internally consistent schema-11 text.
+
+Focused tests prove preservation of a schema-10 `instance-value`, authoring and
+save/reopen of a new schema-11 fraction after migration, file staging metadata,
+recovery consistency, and rejection boundaries. The targeted browser flow
+proved v10 upload, v11 recovery seeding, and v11 save output. Validation passed
+101 affected unit tests, the dedicated Playwright contract, typecheck,
+documentation and formatting checks, and `pnpm verify:branch` with 798 unit
+tests, all workspace builds, and production editor smoke. General RichText
+fraction insertion remains a separate editor feature as documented by ADR
+0023.

--- a/plan/2026-08-17-v10-v11-project-compatibility/plan.md
+++ b/plan/2026-08-17-v10-v11-project-compatibility/plan.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: completed
 experience: none
 ---
 
@@ -97,4 +97,9 @@ tests, all workspace builds, and production editor smoke. General RichText
 fraction insertion remains a separate editor feature as documented by ADR
 0023. The implementation commit was pushed as `e037a08`; mainline delivery was
 reopened after PR #106 reported conflicts with the newer merged protocol/test
-system baseline.
+system baseline. The branch then merged current `main` at `3dbf743`, retained
+both factual log histories, and repeated the clean-state mainline gate from a
+frozen install. Final local `pnpm ci:check` passed static contracts, 132 test
+files / 809 unit tests, all workspace builds, performance and golden checks,
+release/package smoke, and 144 Playwright tests. PR #106 carries the completed
+target for required GitHub Actions verification and merge.

--- a/plan/2026-08-17-v10-v11-project-compatibility/plan.md
+++ b/plan/2026-08-17-v10-v11-project-compatibility/plan.md
@@ -1,5 +1,5 @@
 ---
-status: completed
+status: active
 experience: none
 ---
 
@@ -53,6 +53,9 @@ and this plan is updated first.
 4. Add focused regressions for content preservation, post-migration fraction
    authoring/round-trip, file staging, recovery consistency, and rejection
    boundaries; document the rolling N-1 policy.
+5. Synchronize the review branch with the latest `main`, resolve overlapping
+   protocol/test-governance documentation deliberately, repeat required local
+   validation, and wait for required remote checks before mainline merge.
 
 ## Validation
 
@@ -92,4 +95,6 @@ proved v10 upload, v11 recovery seeding, and v11 save output. Validation passed
 documentation and formatting checks, and `pnpm verify:branch` with 798 unit
 tests, all workspace builds, and production editor smoke. General RichText
 fraction insertion remains a separate editor feature as documented by ADR
-0023.
+0023. The implementation commit was pushed as `e037a08`; mainline delivery was
+reopened after PR #106 reported conflicts with the newer merged protocol/test
+system baseline.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7706,14 +7706,15 @@ box`; branch pushed for review. A concurrent worker's overlapping App.tsx
 - Changed areas: model parsing metadata and v10 adapter; formal-file staging,
   dirty/save UX, recovery envelope/storage consistency; accepted ADR 0023 and
   current compatibility documentation; focused unit and browser contracts.
-- Validation: 101 affected unit tests; dedicated v10 upload/recovery/v11-save
-  Playwright flow; typecheck, documentation links, and formatting; full
-  `pnpm verify:branch` with 798 unit tests, all workspace builds, and production
-  editor smoke; `git diff --check`.
-- Commit status: committed with this target close-out on
-  `chore/unify-current-protocol-baseline` as
-  `feat(model): accept schema v10 through a direct v11 upgrade`; push status is
-  recorded in the handoff.
+- Validation: 101 affected unit tests and the dedicated v10
+  upload/recovery/v11-save Playwright flow; after synchronizing current `main`,
+  frozen install plus full `pnpm ci:check` passed static contracts, 132 test
+  files / 809 unit tests, all builds, performance/golden checks, release and
+  package smoke, and 144 Playwright tests; `git diff --check` passed.
+- Commit status: implementation `e037a08` plus the reviewed `main` integration
+  are carried by PR #106 on `chore/unify-current-protocol-baseline`; required
+  GitHub Actions checks and merge are the remaining delivery gate.
+
 ## 2026-08-17 - Test-system rationalization
 
 - Target: make test responsibility explicit and enforce an evidence-based

--- a/plan/log.md
+++ b/plan/log.md
@@ -7697,3 +7697,20 @@ box`; branch pushed for review. A concurrent worker's overlapping App.tsx
 - Commit status: committed locally as
   `docs(protocol): ratify current schema and agent contracts` on
   `chore/unify-current-protocol-baseline`; not pushed.
+
+## 2026-08-17 - Add rolling schema-10 Project compatibility
+
+- Target: open schema-10 Project JSON through one direct, content-preserving
+  upgrade to the sole schema-11 runtime and save format, without restoring the
+  historic sequential migration registry or fixture archive.
+- Changed areas: model parsing metadata and v10 adapter; formal-file staging,
+  dirty/save UX, recovery envelope/storage consistency; accepted ADR 0023 and
+  current compatibility documentation; focused unit and browser contracts.
+- Validation: 101 affected unit tests; dedicated v10 upload/recovery/v11-save
+  Playwright flow; typecheck, documentation links, and formatting; full
+  `pnpm verify:branch` with 798 unit tests, all workspace builds, and production
+  editor smoke; `git diff --check`.
+- Commit status: committed with this target close-out on
+  `chore/unify-current-protocol-baseline` as
+  `feat(model): accept schema v10 through a direct v11 upgrade`; push status is
+  recorded in the handoff.

--- a/plan/root-audit.md
+++ b/plan/root-audit.md
@@ -9,7 +9,7 @@ an archive. Completed plans with resolved experience are stored under
 | State                     | Count | Required disposition                                                              |
 | ------------------------- | ----: | --------------------------------------------------------------------------------- |
 | `active`                  |     0 | `2026-08-16-instance-value-display` delivered: PR #97 merged to `main` as `7027f57`. `2026-08-16-instance-value-razavi-fraction` delivered: PR #99 merged to `main` as `452099e`. |
-| `completed` + `none`      |    36 | Verify commit/log evidence, then archive according to routine retention policy.   |
+| `completed` + `none`      |    37 | Verify commit/log evidence, then archive according to routine retention policy.   |
 | `completed` + `candidate` |    17 | Human decides whether to extract, reject, or defer the experience signal.         |
 | missing metadata          |    71 | Audit against outcome text and Git evidence; never archive merely because of age. |
 
@@ -61,6 +61,14 @@ PR #72; its completed delivery record is present.
 ADR 0022, current specs, generated Agent knowledge, deterministic drift tests,
 and branch-verification evidence are present; the local target commit is ready
 for normal completed-plan retention handling.
+
+## 2026-08-17 Rolling Project compatibility closure
+
+`2026-08-17-v10-v11-project-compatibility` is completed with resolved
+experience. ADR 0023, the direct model adapter, formal-file and recovery
+integration, synthetic compatibility tests, browser evidence, and branch-wide
+verification are present; it is eligible for normal completed-plan retention
+handling after commit evidence is recorded.
 
 ## Legacy Metadata Sweep
 


### PR DESCRIPTION
## Summary

- ratify schema 11 and the current protocol baseline
- accept schema-10 Project JSON through one direct, content-preserving upgrade to the sole schema-11 runtime shape
- mark upgraded formal files as needing save and keep browser recovery metadata/text consistent
- prove migrated Projects can author, save, and reopen new schema-11 RichText fractions
- document the rolling N-1 policy in ADR 0023 without restoring the historic migration registry or fixture archive

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm ci:check`
  - 798 unit tests
  - 144 Playwright tests
  - all workspace builds
  - performance, golden, PWA, release packaging, production and MCP smoke checks