### PR TITLE
feat(editor): add Library project examples

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -774,6 +774,46 @@ test("shows the complete foldable categorized Library, quick-places a device, an
     .toContain("resistor");
 });
 
+test("opens named full-width Project examples from Library", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1024, height: 720 });
+  await page.goto("/");
+
+  const panel = page.getByTestId("shapes-library-panel");
+  const exampleList = panel.locator(".shapes-example-list");
+  const examples = exampleList.locator(".shapes-example-card");
+  await expect(panel.getByTestId("shapes-fold-examples")).toHaveJSProperty(
+    "open",
+    true,
+  );
+  await expect(examples).toHaveCount(2);
+  expect(
+    await exampleList.evaluate(
+      (element) =>
+        getComputedStyle(element).gridTemplateColumns.split(" ").length,
+    ),
+  ).toBe(1);
+  await expect(
+    panel.getByTestId("shapes-example-common-source-amplifier"),
+  ).toContainText("Common-Source Amplifier");
+  await expect(
+    panel.getByTestId("shapes-example-two-stage-op-amp"),
+  ).toContainText("Two-Stage Op Amp");
+
+  await panel.getByTestId("shapes-example-common-source-amplifier").click();
+  await expect(page.getByTestId("status")).toHaveText(
+    "Opened example: Common-Source Amplifier",
+  );
+  await expect(page.getByTestId("hit-M2")).toBeVisible();
+
+  await panel.getByTestId("shapes-example-two-stage-op-amp").click();
+  await expect(page.getByTestId("status")).toHaveText(
+    "Opened example: Two-Stage Op Amp",
+  );
+  await expect(page.getByTestId("hit-X7")).toBeVisible();
+});
+
 test("keeps a usable canvas while toggling Library at the narrow breakpoint", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -202,6 +202,9 @@ describe("editor shell", () => {
     expect(markup).toContain('data-testid="shapes-insert"');
     expect(markup).toContain('data-testid="library-toggle"');
     expect(markup).toContain('data-testid="shapes-library-panel"');
+    expect(markup).toContain('data-testid="shapes-fold-examples"');
+    expect(markup).toContain("Common-Source Amplifier");
+    expect(markup).toContain("Two-Stage Op Amp");
     expect(markup).toContain('data-open="true"');
     expect(markup).toContain(">Library</span>");
     expect(markup).toContain('class="app-statusbar"');

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -144,6 +144,10 @@ import {
   quickPlaceRequest,
   ShapesPanel,
 } from "../features/editor-shell/shapes-panel";
+import {
+  createLibraryExampleProject,
+  type LibraryProjectExample,
+} from "../examples/library-examples";
 import { useDocumentController } from "../document/document-controller";
 import {
   applyDraftingHandle,
@@ -2190,6 +2194,20 @@ export function App({
     cancelAllTransientInteraction();
     setInsertDialogOpen(true);
     setStatus("Choose a component to place");
+  }
+
+  function openLibraryExample(example: LibraryProjectExample): void {
+    void guardDirtyReplacement(`Open ${example.name} example`, () => {
+      const nextProject = createLibraryExampleProject(example.id);
+      if (!nextProject) {
+        setStatus(`Example is unavailable: ${example.name}`);
+        return;
+      }
+      replaceActiveProject(nextProject);
+      setImportDiagnostics([]);
+      setImportReviewOpen(false);
+      setStatus(`Opened example: ${example.name}`);
+    });
   }
 
   function beginInsertedComponentPlacement(
@@ -7759,6 +7777,7 @@ export function App({
           recentSymbolIds={recentSymbolIds}
           open={visibleLibraryPanelOpen}
           onOpenInsert={openInsertComponentDialog}
+          onOpenExample={openLibraryExample}
           onQuickPlace={beginInsertedComponentPlacement}
         />
         <aside

--- a/apps/editor/src/examples/common-source-amplifier.icproj.json
+++ b/apps/editor/src/examples/common-source-amplifier.icproj.json
@@ -1018,10 +1018,7 @@
           },
           "id": "route-ui-5",
           "netId": "net-ui-5",
-          "segmentModes": [
-            "manual",
-            "manual"
-          ],
+          "segmentModes": ["manual", "manual"],
           "to": {
             "instanceId": "R3-copy-5",
             "kind": "terminal",
@@ -1042,9 +1039,7 @@
           },
           "id": "route-ui-8-a-10",
           "netId": "net-split-1143160ec6fc8d88",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "junctionId": "junction-ui-10",
             "kind": "junction"
@@ -1058,9 +1053,7 @@
           },
           "id": "route-ui-8-b-10",
           "netId": "net-split-1143160ec6fc8d88",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "instanceId": "C1",
             "kind": "terminal",
@@ -1075,9 +1068,7 @@
           },
           "id": "route-ui-11-a-12",
           "netId": "net-split-1143160ec6fc8d88",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "junctionId": "junction-ui-12",
             "kind": "junction"
@@ -1091,9 +1082,7 @@
           },
           "id": "route-ui-11-b-12-a-26",
           "netId": "net-split-1143160ec6fc8d88",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "junctionId": "junction-ui-26",
             "kind": "junction"
@@ -1107,9 +1096,7 @@
           },
           "id": "route-ui-11-b-12-b-26-a-29",
           "netId": "net-split-1143160ec6fc8d88",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "junctionId": "junction-ui-29",
             "kind": "junction"
@@ -1123,9 +1110,7 @@
           },
           "id": "route-ui-11-b-12-b-26-b-29",
           "netId": "net-split-1143160ec6fc8d88",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "instanceId": "M2",
             "kind": "terminal",
@@ -1141,9 +1126,7 @@
           },
           "id": "route-ui-19",
           "netId": "net-global-0",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "instanceId": "GND5-copy-2",
             "kind": "terminal",
@@ -1159,9 +1142,7 @@
           "id": "route-vdd7-rail-a-21",
           "netId": "net-power-vdd7",
           "presentation": "power-rail",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "junctionId": "junction-ui-21",
             "kind": "junction"
@@ -1176,9 +1157,7 @@
           "id": "route-vdd7-rail-b-21",
           "netId": "net-power-vdd7",
           "presentation": "power-rail",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "junctionId": "junction-vdd7-end",
             "kind": "junction"
@@ -1192,9 +1171,7 @@
           },
           "id": "route-ui-22",
           "netId": "net-power-vdd7",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "instanceId": "R3",
             "kind": "terminal",
@@ -1210,9 +1187,7 @@
           },
           "id": "route-ui-23",
           "netId": "net-split-315c27b4f6e1c409",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "junctionId": "junction-ui-15",
             "kind": "junction"
@@ -1226,9 +1201,7 @@
           },
           "id": "route-ui-24",
           "netId": "net-split-315c27b4f6e1c409",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "instanceId": "M2",
             "kind": "terminal",
@@ -1243,10 +1216,7 @@
           },
           "id": "route-ui-25",
           "netId": "net-split-315c27b4f6e1c409",
-          "segmentModes": [
-            "manual",
-            "manual"
-          ],
+          "segmentModes": ["manual", "manual"],
           "to": {
             "instanceId": "GND5",
             "kind": "terminal",
@@ -1267,10 +1237,7 @@
           },
           "id": "route-ui-30",
           "netId": "net-split-1143160ec6fc8d88",
-          "segmentModes": [
-            "manual",
-            "manual"
-          ],
+          "segmentModes": ["manual", "manual"],
           "to": {
             "junctionId": "junction-ui-29",
             "kind": "junction"
@@ -1290,9 +1257,7 @@
           },
           "id": "route-ui-31",
           "netId": "net-split-315c27b4f6e1c409",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "junctionId": "junction-ui-15",
             "kind": "junction"

--- a/apps/editor/src/examples/common-source-amplifier.icproj.json
+++ b/apps/editor/src/examples/common-source-amplifier.icproj.json
@@ -1,0 +1,1321 @@
+{
+  "documents": [
+    {
+      "annotations": [
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 400,
+              "y": 340
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 10
+            },
+            "objectId": "C1"
+          },
+          "content": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "C"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  },
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "GS"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "subscript"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-C1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1.1
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 480,
+              "y": 220
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 0,
+              "y": -20
+            },
+            "objectId": "C1-copy-1"
+          },
+          "content": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "C"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  },
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "GD"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "subscript"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-C1-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1.1
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 540,
+              "y": 300
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "M2"
+          },
+          "content": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "M"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "1"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "subscript"
+              }
+            ]
+          },
+          "id": "instance-label-M2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 560,
+              "y": 210
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 30,
+              "y": 10
+            },
+            "objectId": "R3"
+          },
+          "content": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "R"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  },
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "D"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "subscript"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-R3",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1.1
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 340,
+              "y": 270
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 0,
+              "y": -20
+            },
+            "objectId": "R3-copy-5"
+          },
+          "content": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "R"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  },
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "S"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "subscript"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-R3-copy-5",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1.1
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 280,
+              "y": 340
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -10,
+              "y": 10
+            },
+            "objectId": "V6"
+          },
+          "content": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "V"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  },
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "in"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "subscript"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-V6",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1.1
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 550,
+              "y": 160
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 10
+            },
+            "objectId": "junction-vdd7-end"
+          },
+          "content": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "V"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "children": [
+                          {
+                            "kind": "text",
+                            "value": "DD"
+                          }
+                        ],
+                        "kind": "span",
+                        "style": "italic"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "subscript"
+              }
+            ]
+          },
+          "id": "label-VDD7",
+          "kind": "power-label",
+          "locked": false,
+          "netId": "net-power-vdd7",
+          "rotation": 0,
+          "sizeScale": 1.1
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "direction": "forward",
+            "fallbackPosition": {
+              "x": 590,
+              "y": 270
+            },
+            "kind": "route",
+            "normalOffset": -40,
+            "orientation": "follow",
+            "routeId": "route-ui-25",
+            "segmentIndex": 1,
+            "t": 0.6996025085449219
+          },
+          "content": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "I"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  },
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "out "
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "subscript"
+                  },
+                  {
+                    "kind": "text",
+                    "value": "= 0"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "current-4",
+          "kind": "route-marker",
+          "locked": false,
+          "markerKind": "current",
+          "rotation": 0,
+          "sizeScale": 1.1
+        }
+      ],
+      "constraints": [],
+      "drafting": {
+        "objects": [
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 480,
+                "y": 310
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "kind": "text",
+                  "value": "+"
+                }
+              ]
+            },
+            "id": "note-5",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 500,
+                "y": 350
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "kind": "text",
+                  "value": "_"
+                }
+              ]
+            },
+            "id": "note-6",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 490,
+                "y": 340
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "V"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "italic"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "bold"
+                },
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "1"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "subscript"
+                }
+              ]
+            },
+            "id": "note-7",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1.2
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          }
+        ]
+      },
+      "id": "document-main",
+      "instances": [
+        {
+          "id": "C1",
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "C1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 390,
+              "y": 330
+            },
+            "rotation": 0
+          },
+          "properties": {},
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "C1-copy-1",
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "C2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 480,
+              "y": 240
+            },
+            "rotation": 90
+          },
+          "properties": {},
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "M2",
+          "mosBulkBinding": {
+            "netId": "net-global-0",
+            "origin": "supply-default"
+          },
+          "netlist": {
+            "parameters": {},
+            "reference": "M1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 520,
+              "y": 290
+            },
+            "rotation": 0
+          },
+          "properties": {},
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "R3",
+          "netlist": {
+            "binding": {
+              "deviceClass": "resistor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "R1"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 530,
+              "y": 200
+            },
+            "rotation": 0
+          },
+          "properties": {},
+          "symbolId": "resistor"
+        },
+        {
+          "id": "VDD4",
+          "netlist": {
+            "binding": {
+              "deviceClass": "net-marker",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "PWR1"
+          },
+          "placement": null,
+          "properties": {},
+          "symbolId": "vdd-port"
+        },
+        {
+          "id": "GND5",
+          "netlist": {
+            "binding": {
+              "deviceClass": "net-marker",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "PWR2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 590,
+              "y": 290
+            },
+            "rotation": 0
+          },
+          "properties": {},
+          "symbolId": "ground"
+        },
+        {
+          "id": "GND5-copy-2",
+          "netlist": {
+            "binding": {
+              "deviceClass": "net-marker",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "PWR3"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 530,
+              "y": 360
+            },
+            "rotation": 0
+          },
+          "properties": {},
+          "symbolId": "ground"
+        },
+        {
+          "id": "GND5-copy-2-copy-3",
+          "netlist": {
+            "binding": {
+              "deviceClass": "net-marker",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "PWR4"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 390,
+              "y": 360
+            },
+            "rotation": 0
+          },
+          "properties": {},
+          "symbolId": "ground"
+        },
+        {
+          "id": "GND5-copy-2-copy-3-copy-4",
+          "netlist": {
+            "binding": {
+              "deviceClass": "net-marker",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "PWR5"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 290,
+              "y": 360
+            },
+            "rotation": 0
+          },
+          "properties": {},
+          "symbolId": "ground"
+        },
+        {
+          "id": "R3-copy-5",
+          "netlist": {
+            "binding": {
+              "deviceClass": "resistor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "R2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 340,
+              "y": 290
+            },
+            "rotation": 90
+          },
+          "properties": {},
+          "symbolId": "resistor"
+        },
+        {
+          "id": "V6",
+          "netlist": {
+            "parameters": {},
+            "reference": "V1"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 290,
+              "y": 330
+            },
+            "rotation": 0
+          },
+          "properties": {},
+          "symbolId": "voltage-source"
+        },
+        {
+          "id": "VDD7",
+          "netlist": {
+            "binding": {
+              "deviceClass": "net-marker",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "PWR6"
+          },
+          "placement": null,
+          "properties": {},
+          "symbolId": "vdd-port"
+        }
+      ],
+      "junctions": [
+        {
+          "id": "junction-vdd4-end",
+          "netId": "net-power-vdd7",
+          "position": {
+            "x": 540,
+            "y": 160
+          },
+          "role": "route-anchor"
+        },
+        {
+          "id": "junction-ui-10",
+          "netId": "net-split-1143160ec6fc8d88",
+          "position": {
+            "x": 390,
+            "y": 290
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-12",
+          "netId": "net-split-1143160ec6fc8d88",
+          "position": {
+            "x": 430,
+            "y": 290
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-15",
+          "netId": "net-split-315c27b4f6e1c409",
+          "position": {
+            "x": 530,
+            "y": 240
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-vdd7-start",
+          "netId": "net-power-vdd7",
+          "position": {
+            "x": 520,
+            "y": 160
+          },
+          "role": "route-anchor"
+        },
+        {
+          "id": "junction-vdd7-end",
+          "netId": "net-power-vdd7",
+          "position": {
+            "x": 540,
+            "y": 160
+          },
+          "role": "route-anchor"
+        },
+        {
+          "id": "junction-ui-21",
+          "netId": "net-power-vdd7",
+          "position": {
+            "x": 530,
+            "y": 160
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-26",
+          "netId": "net-split-1143160ec6fc8d88",
+          "position": {
+            "x": 440,
+            "y": 290
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-29",
+          "netId": "net-split-1143160ec6fc8d88",
+          "position": {
+            "x": 450,
+            "y": 290
+          },
+          "role": "branch"
+        }
+      ],
+      "layoutGroups": [],
+      "name": "Main",
+      "netlist": {
+        "name": "Main",
+        "terminals": []
+      },
+      "nets": [
+        {
+          "id": "net-global-0",
+          "name": "0",
+          "powerDomain": "ground",
+          "scope": "global",
+          "terminals": [
+            {
+              "instanceId": "M2",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "GND5-copy-2",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "S"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-4",
+          "powerDomain": "ground",
+          "scope": "global",
+          "terminals": [
+            {
+              "instanceId": "GND5-copy-2-copy-3-copy-4",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "V6",
+              "pinName": "-"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-5",
+          "powerDomain": "none",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "V6",
+              "pinName": "+"
+            },
+            {
+              "instanceId": "R3-copy-5",
+              "pinName": "2"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-9",
+          "powerDomain": "ground",
+          "scope": "global",
+          "terminals": [
+            {
+              "instanceId": "C1",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "GND5-copy-2-copy-3",
+              "pinName": "0"
+            }
+          ]
+        },
+        {
+          "id": "net-split-315c27b4f6e1c409",
+          "powerDomain": "ground",
+          "scope": "global",
+          "terminals": [
+            {
+              "instanceId": "R3",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "C1-copy-1",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "GND5",
+              "pinName": "0"
+            }
+          ]
+        },
+        {
+          "id": "net-power-vdd7",
+          "name": "VDD",
+          "powerDomain": "vdd",
+          "scope": "global",
+          "terminals": [
+            {
+              "instanceId": "VDD7",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "VDD4",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "R3",
+              "pinName": "1"
+            }
+          ]
+        },
+        {
+          "id": "net-split-1143160ec6fc8d88",
+          "powerDomain": "none",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "C1-copy-1",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "R3-copy-5",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "C1",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "G"
+            }
+          ]
+        }
+      ],
+      "noConnects": [],
+      "presentation": {
+        "compactness": "normal",
+        "grid": 10,
+        "styleProfileId": "razavi-textbook-v1"
+      },
+      "revision": 166,
+      "routes": [
+        {
+          "from": {
+            "instanceId": "V6",
+            "kind": "terminal",
+            "pinName": "+"
+          },
+          "id": "route-ui-5",
+          "netId": "net-ui-5",
+          "segmentModes": [
+            "manual",
+            "manual"
+          ],
+          "to": {
+            "instanceId": "R3-copy-5",
+            "kind": "terminal",
+            "pinName": "2"
+          },
+          "waypoints": [
+            {
+              "x": 290,
+              "y": 290
+            }
+          ]
+        },
+        {
+          "from": {
+            "instanceId": "R3-copy-5",
+            "kind": "terminal",
+            "pinName": "1"
+          },
+          "id": "route-ui-8-a-10",
+          "netId": "net-split-1143160ec6fc8d88",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-10",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-10",
+            "kind": "junction"
+          },
+          "id": "route-ui-8-b-10",
+          "netId": "net-split-1143160ec6fc8d88",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "C1",
+            "kind": "terminal",
+            "pinName": "1"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-10",
+            "kind": "junction"
+          },
+          "id": "route-ui-11-a-12",
+          "netId": "net-split-1143160ec6fc8d88",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-12",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-12",
+            "kind": "junction"
+          },
+          "id": "route-ui-11-b-12-a-26",
+          "netId": "net-split-1143160ec6fc8d88",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-26",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-26",
+            "kind": "junction"
+          },
+          "id": "route-ui-11-b-12-b-26-a-29",
+          "netId": "net-split-1143160ec6fc8d88",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-29",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-29",
+            "kind": "junction"
+          },
+          "id": "route-ui-11-b-12-b-26-b-29",
+          "netId": "net-split-1143160ec6fc8d88",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M2",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M2",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "id": "route-ui-19",
+          "netId": "net-global-0",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "GND5-copy-2",
+            "kind": "terminal",
+            "pinName": "0"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-vdd7-start",
+            "kind": "junction"
+          },
+          "id": "route-vdd7-rail-a-21",
+          "netId": "net-power-vdd7",
+          "presentation": "power-rail",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-21",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-21",
+            "kind": "junction"
+          },
+          "id": "route-vdd7-rail-b-21",
+          "netId": "net-power-vdd7",
+          "presentation": "power-rail",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-vdd7-end",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-21",
+            "kind": "junction"
+          },
+          "id": "route-ui-22",
+          "netId": "net-power-vdd7",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "R3",
+            "kind": "terminal",
+            "pinName": "1"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "R3",
+            "kind": "terminal",
+            "pinName": "2"
+          },
+          "id": "route-ui-23",
+          "netId": "net-split-315c27b4f6e1c409",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-15",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-15",
+            "kind": "junction"
+          },
+          "id": "route-ui-24",
+          "netId": "net-split-315c27b4f6e1c409",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M2",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-15",
+            "kind": "junction"
+          },
+          "id": "route-ui-25",
+          "netId": "net-split-315c27b4f6e1c409",
+          "segmentModes": [
+            "manual",
+            "manual"
+          ],
+          "to": {
+            "instanceId": "GND5",
+            "kind": "terminal",
+            "pinName": "0"
+          },
+          "waypoints": [
+            {
+              "x": 590,
+              "y": 240
+            }
+          ]
+        },
+        {
+          "from": {
+            "instanceId": "C1-copy-1",
+            "kind": "terminal",
+            "pinName": "2"
+          },
+          "id": "route-ui-30",
+          "netId": "net-split-1143160ec6fc8d88",
+          "segmentModes": [
+            "manual",
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-29",
+            "kind": "junction"
+          },
+          "waypoints": [
+            {
+              "x": 450,
+              "y": 240
+            }
+          ]
+        },
+        {
+          "from": {
+            "instanceId": "C1-copy-1",
+            "kind": "terminal",
+            "pinName": "1"
+          },
+          "id": "route-ui-31",
+          "netId": "net-split-315c27b4f6e1c409",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-15",
+            "kind": "junction"
+          },
+          "waypoints": []
+        }
+      ],
+      "sourceStatus": "connectivity-modified"
+    }
+  ],
+  "id": "project-main",
+  "name": "New Circuit",
+  "schemaVersion": 11,
+  "source": {
+    "dialect": "none",
+    "entry": null,
+    "files": [],
+    "sourcePolicy": "copy"
+  },
+  "symbolLibrary": {
+    "hash": "razavi-reference-v1",
+    "id": "razavi-symbols",
+    "version": "1"
+  },
+  "topDocumentId": "document-main"
+}

--- a/apps/editor/src/examples/library-examples.test.ts
+++ b/apps/editor/src/examples/library-examples.test.ts
@@ -1,0 +1,33 @@
+import { serializeProject } from "@icm/project-protocol";
+import { describe, expect, it } from "vitest";
+
+import {
+  createLibraryExampleProject,
+  libraryProjectExamples,
+} from "./library-examples";
+
+describe("bundled Library Project examples", () => {
+  it("ships two canonical, schema-valid Projects", () => {
+    expect(libraryProjectExamples.map((example) => example.name)).toEqual([
+      "Common-Source Amplifier",
+      "Two-Stage Op Amp",
+    ]);
+    for (const example of libraryProjectExamples) {
+      expect(serializeProject(example.project)).toContain(
+        '"schemaVersion": 11',
+      );
+      expect(example.project.documents).toHaveLength(1);
+    }
+  });
+
+  it("returns a fresh Project snapshot for every selected example", () => {
+    const first = createLibraryExampleProject("common-source-amplifier");
+    const second = createLibraryExampleProject("common-source-amplifier");
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    if (!first || !second) return;
+    first.name = "Changed only in this snapshot";
+    expect(second.name).toBe("New Circuit");
+    expect(createLibraryExampleProject("missing-example")).toBeNull();
+  });
+});

--- a/apps/editor/src/examples/library-examples.ts
+++ b/apps/editor/src/examples/library-examples.ts
@@ -1,0 +1,45 @@
+import type { CircuitProject } from "@icm/model";
+import { parseProject } from "@icm/project-protocol";
+
+import commonSourceAmplifier from "./common-source-amplifier.icproj.json";
+import twoStageOpAmp from "./two-stage-op-amp.icproj.json";
+
+export interface LibraryProjectExample {
+  id: string;
+  name: string;
+  description: string;
+  project: CircuitProject;
+}
+
+function bundledProject(source: unknown): CircuitProject {
+  return parseProject(JSON.stringify(source));
+}
+
+/**
+ * Curated, browser-bundled Projects shown in the left Library. Each asset is
+ * parsed at module initialization so an invalid example fails during the
+ * editor build rather than replacing a user's live Project at runtime.
+ */
+export const libraryProjectExamples: readonly LibraryProjectExample[] = [
+  {
+    id: "common-source-amplifier",
+    name: "Common-Source Amplifier",
+    description: "Small-signal NMOS gain stage",
+    project: bundledProject(commonSourceAmplifier),
+  },
+  {
+    id: "two-stage-op-amp",
+    name: "Two-Stage Op Amp",
+    description: "Miller-compensated amplifier",
+    project: bundledProject(twoStageOpAmp),
+  },
+];
+
+export function createLibraryExampleProject(
+  exampleId: string,
+): CircuitProject | null {
+  const example = libraryProjectExamples.find(
+    (candidate) => candidate.id === exampleId,
+  );
+  return example ? structuredClone(example.project) : null;
+}

--- a/apps/editor/src/examples/two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/two-stage-op-amp.icproj.json
@@ -532,9 +532,7 @@
           },
           "id": "route-ui-2-a-3",
           "netId": "net-ui-1",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "junctionId": "junction-ui-3",
             "kind": "junction"
@@ -548,9 +546,7 @@
           },
           "id": "route-ui-2-b-3",
           "netId": "net-ui-1",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "instanceId": "X8",
             "kind": "terminal",
@@ -566,10 +562,7 @@
           },
           "id": "route-ui-4",
           "netId": "net-ui-1",
-          "segmentModes": [
-            "manual",
-            "manual"
-          ],
+          "segmentModes": ["manual", "manual"],
           "to": {
             "junctionId": "junction-ui-3",
             "kind": "junction"
@@ -589,9 +582,7 @@
           },
           "id": "route-ui-5-a-10",
           "netId": "net-contact-p13",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "junctionId": "junction-ui-10",
             "kind": "junction"
@@ -605,9 +596,7 @@
           },
           "id": "route-ui-5-b-10",
           "netId": "net-contact-p13",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "instanceId": "P12",
             "kind": "terminal",
@@ -622,9 +611,7 @@
           },
           "id": "route-ui-11-a-13",
           "netId": "net-contact-p13",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "junctionId": "junction-ui-13",
             "kind": "junction"
@@ -638,9 +625,7 @@
           },
           "id": "route-ui-11-b-13",
           "netId": "net-contact-p13",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "instanceId": "C9",
             "kind": "terminal",
@@ -656,11 +641,7 @@
           },
           "id": "route-ui-15",
           "netId": "net-contact-p13",
-          "segmentModes": [
-            "manual",
-            "manual",
-            "manual"
-          ],
+          "segmentModes": ["manual", "manual", "manual"],
           "to": {
             "junctionId": "junction-ui-13",
             "kind": "junction"
@@ -684,10 +665,7 @@
           },
           "id": "route-ui-16",
           "netId": "net-contact-p13",
-          "segmentModes": [
-            "manual",
-            "manual"
-          ],
+          "segmentModes": ["manual", "manual"],
           "to": {
             "junctionId": "junction-ui-10",
             "kind": "junction"

--- a/apps/editor/src/examples/two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/two-stage-op-amp.icproj.json
@@ -1,0 +1,721 @@
+{
+  "documents": [
+    {
+      "annotations": [
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 430,
+              "y": 180
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 0,
+              "y": -30
+            },
+            "objectId": "X7"
+          },
+          "content": {
+            "runs": [
+              {
+                "kind": "text",
+                "value": " "
+              }
+            ]
+          },
+          "id": "instance-label-X7",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 530,
+              "y": 260
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 0,
+              "y": 30
+            },
+            "objectId": "X8"
+          },
+          "content": {
+            "runs": [
+              {
+                "kind": "text",
+                "value": " "
+              }
+            ]
+          },
+          "id": "instance-label-X8",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 590,
+              "y": 280
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 0
+            },
+            "objectId": "C9"
+          },
+          "content": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "C"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  },
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "L"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "subscript"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-C9",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 530,
+              "y": 140
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 0,
+              "y": -20
+            },
+            "objectId": "C10"
+          },
+          "content": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "C"
+                      },
+                      {
+                        "children": [
+                          {
+                            "kind": "text",
+                            "value": "C"
+                          }
+                        ],
+                        "kind": "span",
+                        "style": "subscript"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              }
+            ]
+          },
+          "id": "instance-label-C10",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 610,
+              "y": 210
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 0
+            },
+            "objectId": "P12"
+          },
+          "content": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "V"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  },
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "out"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "subscript"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-P12",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 360,
+              "y": 210
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -10,
+              "y": 10
+            },
+            "objectId": "P13"
+          },
+          "content": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "V"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  },
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "in"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "subscript"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-P13",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1
+        }
+      ],
+      "constraints": [],
+      "drafting": {
+        "objects": []
+      },
+      "id": "document-main",
+      "instances": [
+        {
+          "id": "X7",
+          "netlist": {
+            "parameters": {},
+            "reference": "X1"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 430,
+              "y": 210
+            },
+            "rotation": 180
+          },
+          "properties": {},
+          "symbolId": "opamp"
+        },
+        {
+          "id": "X8",
+          "netlist": {
+            "parameters": {},
+            "reference": "X2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 530,
+              "y": 210
+            },
+            "rotation": 0
+          },
+          "properties": {},
+          "symbolId": "voltage-amplifier"
+        },
+        {
+          "id": "C9",
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "C1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 580,
+              "y": 280
+            },
+            "rotation": 0
+          },
+          "properties": {},
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "C10",
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "C2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 530,
+              "y": 160
+            },
+            "rotation": 270
+          },
+          "properties": {},
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "GND11",
+          "netlist": {
+            "binding": {
+              "deviceClass": "net-marker",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "PWR1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 580,
+              "y": 310
+            },
+            "rotation": 0
+          },
+          "properties": {},
+          "symbolId": "ground"
+        },
+        {
+          "id": "P12",
+          "netlist": {
+            "parameters": {},
+            "reference": "X3"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 600,
+              "y": 210
+            },
+            "rotation": 180
+          },
+          "properties": {},
+          "symbolId": "port"
+        },
+        {
+          "id": "P13",
+          "netlist": {
+            "parameters": {},
+            "reference": "X4"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 370,
+              "y": 200
+            },
+            "rotation": 0
+          },
+          "properties": {},
+          "symbolId": "port"
+        }
+      ],
+      "junctions": [
+        {
+          "id": "junction-ui-3",
+          "netId": "net-ui-1",
+          "position": {
+            "x": 480,
+            "y": 210
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-10",
+          "netId": "net-contact-p13",
+          "position": {
+            "x": 580,
+            "y": 210
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-13",
+          "netId": "net-contact-p13",
+          "position": {
+            "x": 580,
+            "y": 250
+          },
+          "role": "branch"
+        }
+      ],
+      "layoutGroups": [],
+      "name": "Main",
+      "netlist": {
+        "name": "Main",
+        "terminals": []
+      },
+      "nets": [
+        {
+          "id": "net-global-vdd",
+          "name": "VDD",
+          "powerDomain": "none",
+          "scope": "global",
+          "terminals": []
+        },
+        {
+          "id": "net-contact-gnd11",
+          "name": "0",
+          "powerDomain": "ground",
+          "scope": "global",
+          "terminals": [
+            {
+              "instanceId": "GND11",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "C9",
+              "pinName": "2"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-1",
+          "powerDomain": "none",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "X7",
+              "pinName": "OUT"
+            },
+            {
+              "instanceId": "X8",
+              "pinName": "IN"
+            },
+            {
+              "instanceId": "C10",
+              "pinName": "1"
+            }
+          ]
+        },
+        {
+          "id": "net-contact-p13",
+          "powerDomain": "none",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "P13",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "X7",
+              "pinName": "IN-"
+            },
+            {
+              "instanceId": "X8",
+              "pinName": "OUT"
+            },
+            {
+              "instanceId": "P12",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "C9",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "C10",
+              "pinName": "2"
+            }
+          ]
+        },
+        {
+          "id": "net-split-f9c443f2edef6e67",
+          "powerDomain": "none",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "X7",
+              "pinName": "IN+"
+            }
+          ]
+        }
+      ],
+      "noConnects": [],
+      "presentation": {
+        "compactness": "normal",
+        "grid": 10,
+        "styleProfileId": "razavi-textbook-v1"
+      },
+      "revision": 80,
+      "routes": [
+        {
+          "from": {
+            "instanceId": "X7",
+            "kind": "terminal",
+            "pinName": "OUT"
+          },
+          "id": "route-ui-2-a-3",
+          "netId": "net-ui-1",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-3",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-3",
+            "kind": "junction"
+          },
+          "id": "route-ui-2-b-3",
+          "netId": "net-ui-1",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "X8",
+            "kind": "terminal",
+            "pinName": "IN"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "C10",
+            "kind": "terminal",
+            "pinName": "1"
+          },
+          "id": "route-ui-4",
+          "netId": "net-ui-1",
+          "segmentModes": [
+            "manual",
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-3",
+            "kind": "junction"
+          },
+          "waypoints": [
+            {
+              "x": 480,
+              "y": 160
+            }
+          ]
+        },
+        {
+          "from": {
+            "instanceId": "X8",
+            "kind": "terminal",
+            "pinName": "OUT"
+          },
+          "id": "route-ui-5-a-10",
+          "netId": "net-contact-p13",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-10",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-10",
+            "kind": "junction"
+          },
+          "id": "route-ui-5-b-10",
+          "netId": "net-contact-p13",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "P12",
+            "kind": "terminal",
+            "pinName": "P"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-10",
+            "kind": "junction"
+          },
+          "id": "route-ui-11-a-13",
+          "netId": "net-contact-p13",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-13",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-13",
+            "kind": "junction"
+          },
+          "id": "route-ui-11-b-13",
+          "netId": "net-contact-p13",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "C9",
+            "kind": "terminal",
+            "pinName": "1"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "X7",
+            "kind": "terminal",
+            "pinName": "IN-"
+          },
+          "id": "route-ui-15",
+          "netId": "net-contact-p13",
+          "segmentModes": [
+            "manual",
+            "manual",
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-13",
+            "kind": "junction"
+          },
+          "waypoints": [
+            {
+              "x": 370,
+              "y": 220
+            },
+            {
+              "x": 370,
+              "y": 250
+            }
+          ]
+        },
+        {
+          "from": {
+            "instanceId": "C10",
+            "kind": "terminal",
+            "pinName": "2"
+          },
+          "id": "route-ui-16",
+          "netId": "net-contact-p13",
+          "segmentModes": [
+            "manual",
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-10",
+            "kind": "junction"
+          },
+          "waypoints": [
+            {
+              "x": 580,
+              "y": 160
+            }
+          ]
+        }
+      ],
+      "sourceStatus": "connectivity-modified"
+    }
+  ],
+  "id": "project-main",
+  "name": "New Circuit",
+  "schemaVersion": 11,
+  "source": {
+    "dialect": "none",
+    "entry": null,
+    "files": [],
+    "sourcePolicy": "copy"
+  },
+  "symbolLibrary": {
+    "hash": "razavi-reference-v1",
+    "id": "razavi-symbols",
+    "version": "1"
+  },
+  "topDocumentId": "document-main"
+}

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -6,6 +6,7 @@ import {
   componentCatalog,
   paletteSymbols,
 } from "../component-insert/symbol-catalog";
+import { libraryProjectExamples } from "../../examples/library-examples";
 import { quickPlaceRequest, ShapesPanel } from "./shapes-panel";
 
 describe("shapes quick-place", () => {
@@ -18,6 +19,7 @@ describe("shapes quick-place", () => {
         recentSymbolIds: [],
         open: true,
         onOpenInsert: () => undefined,
+        onOpenExample: () => undefined,
         onQuickPlace: () => undefined,
       }),
     );
@@ -66,6 +68,15 @@ describe("shapes quick-place", () => {
     expect(markup).toContain('title="Place Capacitor"');
     expect(markup).toContain(">V Src</span>");
     expect(markup).toContain(">Cap</span>");
+    expect(markup).toContain('data-testid="shapes-fold-examples"');
+    expect(markup.match(/data-testid="shapes-example-/g)).toHaveLength(
+      libraryProjectExamples.length,
+    );
+    for (const example of libraryProjectExamples) {
+      expect(markup).toContain(`data-testid="shapes-example-${example.id}"`);
+      expect(markup).toContain(example.name);
+    }
+    expect(markup).toContain('class="shapes-example-card"');
   });
 
   it("quick-places without persisting parameter placeholders", () => {

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -1,5 +1,9 @@
 import { useState } from "react";
 
+import {
+  libraryProjectExamples,
+  type LibraryProjectExample,
+} from "../../examples/library-examples";
 import type { ComponentInsertRequest } from "../component-insert/component-insert-request";
 import { SymbolArtwork } from "../component-insert/symbol-artwork";
 import { initialComponentParameterValues } from "../component-insert/component-parameters";
@@ -66,6 +70,7 @@ export interface ShapesPanelProps {
   recentSymbolIds: readonly string[];
   open: boolean;
   onOpenInsert(): void;
+  onOpenExample(example: LibraryProjectExample): void;
   onQuickPlace(request: ComponentInsertRequest): void;
 }
 
@@ -74,6 +79,7 @@ export function ShapesPanel({
   recentSymbolIds,
   open,
   onOpenInsert,
+  onOpenExample,
   onQuickPlace,
 }: ShapesPanelProps) {
   const libraryGroups = componentCatalog(styleProfileId, "");
@@ -128,6 +134,42 @@ export function ShapesPanel({
       </header>
 
       <div className="shapes-panel-body">
+        <details
+          className="shapes-fold"
+          open
+          data-testid="shapes-fold-examples"
+        >
+          <summary className="shapes-fold-summary">
+            <span className="shapes-fold-label">Examples</span>
+            <span className="shapes-fold-count">
+              {libraryProjectExamples.length}
+            </span>
+          </summary>
+          <div className="shapes-fold-body">
+            <div className="shapes-example-list">
+              {libraryProjectExamples.map((example) => (
+                <button
+                  key={example.id}
+                  type="button"
+                  className="shapes-example-card"
+                  data-testid={`shapes-example-${example.id}`}
+                  aria-label={`Open example ${example.name}`}
+                  title={`Open ${example.name}`}
+                  onClick={() => onOpenExample(example)}
+                >
+                  <span className="shapes-example-copy">
+                    <span className="shapes-example-kicker">Example</span>
+                    <span className="shapes-example-name">{example.name}</span>
+                    <span className="shapes-example-description">
+                      {example.description}
+                    </span>
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </details>
+
         <details className="shapes-fold" open data-testid="shapes-fold-library">
           <summary className="shapes-fold-summary">
             <span className="shapes-fold-label">

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -977,6 +977,64 @@ body {
   gap: 4px;
 }
 
+.shapes-example-list {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--icm-space-2);
+}
+
+.shapes-example-card {
+  display: block;
+  width: 100%;
+  min-height: 76px;
+  padding: var(--icm-space-3);
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface-muted);
+  box-shadow: none;
+  color: var(--icm-text);
+  text-align: left;
+}
+
+.shapes-example-card:hover:not(:disabled) {
+  border-color: var(--icm-border-hover);
+  background: #fff;
+  box-shadow: var(--icm-shadow-sm);
+}
+
+.shapes-example-copy {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.shapes-example-kicker {
+  color: var(--icm-text-muted);
+  font-size: 9px;
+  font-weight: 650;
+  letter-spacing: 0.05em;
+  line-height: 1.1;
+  text-transform: uppercase;
+}
+
+.shapes-example-name {
+  overflow: hidden;
+  font-size: var(--icm-font-sm);
+  font-weight: 650;
+  line-height: var(--icm-line-tight);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shapes-example-description {
+  overflow: hidden;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  line-height: var(--icm-line-tight);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .shapes-chip {
   display: grid;
   grid-template-rows: 32px 1.15em;

--- a/plan/2026-08-17-library-examples/plan.md
+++ b/plan/2026-08-17-library-examples/plan.md
@@ -1,0 +1,94 @@
+---
+status: completed
+experience: none
+---
+
+# Add Library Examples
+
+## Goal
+
+Add a consistent left-Library Examples section that presents the two supplied
+schema-11 Projects as named, single-column, larger cards and opens a selected
+Project directly in the editor.
+
+## State and Ownership
+
+Start state from `git status --short --branch` before creating the target
+branch:
+
+```text
+## codex/device-protocol-compatibility-plan...origin/codex/device-protocol-compatibility-plan
+?? .worktrees/
+```
+
+The untracked `.worktrees/` directory is an unrelated existing worktree and
+will remain untouched. This target is isolated on
+`codex/library-examples`. The supplied downloads are read-only source assets;
+their repository copies and the Editor Library surface are owned by this
+target.
+
+- `apps/editor/src/examples/`
+- `apps/editor/src/examples/library-examples.test.ts`
+- `apps/editor/src/features/editor-shell/shapes-panel.tsx`
+- `apps/editor/src/features/editor-shell/shapes-panel.test.ts`
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/app/App.test.tsx`
+- `apps/editor/src/styles.css`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `plan/2026-08-17-library-examples/plan.md`
+- `plan/log.md` (close-out entry only)
+- Read-only: `E:/Downloads/{1,2}New Circuit.icproj.json`, current Project
+  protocol and document-controller replacement boundary
+
+## Work
+
+1. Package and validate the two supplied schema-11 Projects as browser-bundled
+   examples with descriptive names.
+2. Add an Examples fold to the left Library with one named, full-width card per
+   row, visually aligned with existing Library controls.
+3. Route card selection through the existing validated Project replacement and
+   recovery lifecycle, then preserve responsive Library behavior.
+4. Cover the Examples display and open flow with focused unit and browser
+   tests.
+
+## Validation
+
+- `pnpm test:local` for affected Editor and Project/example contracts
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep <Examples flow>`
+- `pnpm test:impact -- --base origin/codex/device-protocol-compatibility-plan`
+- `git diff --check`
+- `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: bundled Project examples stay schema-valid; each named Library
+  card replaces the current Project only through the established open lifecycle.
+- Primary checks: Editor panel/App tests and the Library browser flow.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): add Library project examples
+```
+
+## Outcome
+
+Bundled the two supplied schema-11 Projects as named Library examples. The
+Examples fold now appears above All devices, uses one larger full-width card
+per row, and opens a fresh Project clone through the existing dirty-recovery
+and Project replacement lifecycle. The card visual layout was checked in the
+running Editor at desktop width; both full names are visible.
+
+Validation passed:
+
+- `pnpm test:local apps/editor/src/examples/library-examples.test.ts apps/editor/src/features/editor-shell/shapes-panel.test.ts apps/editor/src/app/App.test.tsx`
+  (3 files, 19 tests)
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep "opens named full-width Project examples from Library"`
+  (1 browser test)
+- `pnpm test:impact -- --base origin/codex/device-protocol-compatibility-plan`
+
+Commit status: committed and pushed as
+`feat(editor): add Library project examples` on `codex/library-examples`.

--- a/plan/2026-08-17-merge-library-examples/plan.md
+++ b/plan/2026-08-17-merge-library-examples/plan.md
@@ -52,8 +52,10 @@ This target owns only its integration record and the branch/PR lifecycle.
 ## Test Impact
 
 - Decision: no-test-change
-- Evidence: this target integrates the already-tested commit without changing
-  application behavior; the required CI check re-runs the protected suite.
+- Reason: this target integrates already-tested commits without changing
+  application behavior.
+- Existing protection: `pnpm ci:check` re-runs the protected static, unit,
+  release, and browser contracts on the rebased review branch.
 
 ## Commit Intent
 

--- a/plan/2026-08-17-merge-library-examples/plan.md
+++ b/plan/2026-08-17-merge-library-examples/plan.md
@@ -1,0 +1,61 @@
+---
+status: active
+experience: none
+---
+
+# Merge Library Examples to Main
+
+## Goal
+
+Integrate the reviewed Library Project examples branch into `main` only after
+the required local and remote mainline checks pass.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/library-examples...origin/codex/library-examples
+?? .worktrees/
+```
+
+The untracked `.worktrees/` directory is unrelated and will remain untouched.
+This target owns only its integration record and the branch/PR lifecycle.
+
+- `plan/2026-08-17-merge-library-examples/plan.md`
+- `plan/log.md` (close-out entry only)
+
+- Read-only: `main`, the committed Library examples implementation, and the
+  GitHub Actions result for the review branch
+- Shared: repository mainline delivery gate and branch protection
+
+## Work
+
+1. Record the integration target and run the required clean local mainline
+   check.
+2. Create or update a review PR, wait for required remote checks, then merge
+   it into `main` through the remote provider.
+3. Confirm the merged `main` ref and record the factual outcome.
+
+## Validation
+
+- `pnpm install --frozen-lockfile`
+- `pnpm ci:check`
+- GitHub Actions required checks on the review PR
+- `git diff --check`
+- `git status --short --branch`
+
+## Test Impact
+
+- Decision: no-test-change
+- Evidence: this target integrates the already-tested commit without changing
+  application behavior; the required CI check re-runs the protected suite.
+
+## Commit Intent
+
+Commit the integration record as part of the review branch before mainline
+validation and merge.
+
+## Outcome
+
+Pending.

--- a/plan/2026-08-17-merge-library-examples/plan.md
+++ b/plan/2026-08-17-merge-library-examples/plan.md
@@ -24,6 +24,8 @@ This target owns only its integration record and the branch/PR lifecycle.
 
 - `plan/2026-08-17-merge-library-examples/plan.md`
 - `plan/log.md` (close-out entry only)
+- `apps/editor/src/examples/common-source-amplifier.icproj.json`
+- `apps/editor/src/examples/two-stage-op-amp.icproj.json`
 
 - Read-only: `main`, the committed Library examples implementation, and the
   GitHub Actions result for the review branch
@@ -33,9 +35,11 @@ This target owns only its integration record and the branch/PR lifecycle.
 
 1. Record the integration target and run the required clean local mainline
    check.
-2. Create or update a review PR, wait for required remote checks, then merge
+2. Apply the repository's deterministic JSON formatting when the mainline
+   formatter identifies a bundled example asset.
+3. Create or update a review PR, wait for required remote checks, then merge
    it into `main` through the remote provider.
-3. Confirm the merged `main` ref and record the factual outcome.
+4. Confirm the merged `main` ref and record the factual outcome.
 
 ## Validation
 

--- a/plan/log.md
+++ b/plan/log.md
@@ -7866,3 +7866,16 @@ box`; branch pushed for review. A concurrent worker's overlapping App.tsx
 - Commit status: committed as `2f210c3` and pushed to
   `origin/codex/routing-protocol-unification`; remote review checks remain the
   mainline delivery gate.
+## 2026-08-17 - Add Library Project examples
+
+- Target: expose supplied schema-11 Project fixtures as named, directly
+  openable examples in the Editor's left Library.
+- Changed areas: bundled Common-Source Amplifier and Two-Stage Op Amp Project
+  assets; Examples Library fold/cards; guarded Project replacement; focused
+  panel, App, asset, and browser-flow coverage.
+- Validation: focused Editor/example tests (3 files / 19 tests), one
+  Playwright Library-open flow, `pnpm test:impact -- --base
+  origin/codex/device-protocol-compatibility-plan`, a desktop visual review,
+  and `git diff --check` passed.
+- Commit status: committed and pushed as
+  `feat(editor): add Library project examples` on `codex/library-examples`.


### PR DESCRIPTION
Adds two bundled schema-11 circuit examples to the Editor Library as named, full-width cards, with guarded Project replacement and focused coverage.