### PR TITLE
feat(editor): move Examples beside Library

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -774,18 +774,30 @@ test("shows the complete foldable categorized Library, quick-places a device, an
     .toContain("resistor");
 });
 
-test("opens named full-width Project examples from Library", async ({
+test("opens named full-width Project examples beside Library", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1024, height: 720 });
   await page.goto("/");
 
-  const panel = page.getByTestId("shapes-library-panel");
+  const libraryPanel = page.getByTestId("shapes-library-panel");
+  const libraryTab = libraryPanel.getByTestId("library-panel-tab");
+  const examplesToggle = libraryPanel.getByTestId("examples-panel-toggle");
+  const libraryTabBox = await libraryTab.boundingBox();
+  const examplesToggleBox = await examplesToggle.boundingBox();
+  if (!libraryTabBox || !examplesToggleBox) {
+    throw new Error("Library and Examples controls are not measurable");
+  }
+  expect(examplesToggleBox.x).toBeGreaterThan(libraryTabBox.x);
+
+  await examplesToggle.click();
+  const panel = page.getByTestId("examples-panel");
   const exampleList = panel.locator(".shapes-example-list");
   const examples = exampleList.locator(".shapes-example-card");
-  await expect(panel.getByTestId("shapes-fold-examples")).toHaveJSProperty(
-    "open",
-    true,
+  await expect(panel).toHaveAttribute("data-open", "true");
+  await expect(panel.getByTestId("examples-panel-tab")).toHaveAttribute(
+    "aria-current",
+    "page",
   );
   await expect(examples).toHaveCount(2);
   expect(

--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -774,31 +774,28 @@ test("shows the complete foldable categorized Library, quick-places a device, an
     .toContain("resistor");
 });
 
-test("opens named full-width Project examples beside Library", async ({
+test("opens named full-width Project examples from the left tool rail", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1024, height: 720 });
   await page.goto("/");
 
-  const libraryPanel = page.getByTestId("shapes-library-panel");
-  const libraryTab = libraryPanel.getByTestId("library-panel-tab");
-  const examplesToggle = libraryPanel.getByTestId("examples-panel-toggle");
-  const libraryTabBox = await libraryTab.boundingBox();
+  const libraryToggle = page.getByTestId("library-toggle");
+  const examplesToggle = page.getByTestId("examples-toggle");
+  const libraryTabBox = await libraryToggle.boundingBox();
   const examplesToggleBox = await examplesToggle.boundingBox();
   if (!libraryTabBox || !examplesToggleBox) {
     throw new Error("Library and Examples controls are not measurable");
   }
-  expect(examplesToggleBox.x).toBeGreaterThan(libraryTabBox.x);
+  expect(examplesToggleBox.x).toBeLessThanOrEqual(8);
+  expect(examplesToggleBox.x).toBe(libraryTabBox.x);
+  expect(examplesToggleBox.y).toBeLessThan(libraryTabBox.y);
 
   await examplesToggle.click();
   const panel = page.getByTestId("examples-panel");
   const exampleList = panel.locator(".shapes-example-list");
   const examples = exampleList.locator(".shapes-example-card");
   await expect(panel).toHaveAttribute("data-open", "true");
-  await expect(panel.getByTestId("examples-panel-tab")).toHaveAttribute(
-    "aria-current",
-    "page",
-  );
   await expect(examples).toHaveCount(2);
   expect(
     await exampleList.evaluate(

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -202,8 +202,7 @@ describe("editor shell", () => {
     expect(markup).toContain('data-testid="shapes-insert"');
     expect(markup).toContain('data-testid="library-toggle"');
     expect(markup).toContain('data-testid="shapes-library-panel"');
-    expect(markup).toContain('data-testid="library-panel-tab"');
-    expect(markup).toContain('data-testid="examples-panel-toggle"');
+    expect(markup).toContain('data-testid="examples-toggle"');
     expect(markup).not.toContain('data-testid="shapes-fold-examples"');
     expect(markup).not.toContain("Common-Source Amplifier");
     expect(markup).not.toContain("Two-Stage Op Amp");

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -202,9 +202,11 @@ describe("editor shell", () => {
     expect(markup).toContain('data-testid="shapes-insert"');
     expect(markup).toContain('data-testid="library-toggle"');
     expect(markup).toContain('data-testid="shapes-library-panel"');
-    expect(markup).toContain('data-testid="shapes-fold-examples"');
-    expect(markup).toContain("Common-Source Amplifier");
-    expect(markup).toContain("Two-Stage Op Amp");
+    expect(markup).toContain('data-testid="library-panel-tab"');
+    expect(markup).toContain('data-testid="examples-panel-toggle"');
+    expect(markup).not.toContain('data-testid="shapes-fold-examples"');
+    expect(markup).not.toContain("Common-Source Amplifier");
+    expect(markup).not.toContain("Two-Stage Op Amp");
     expect(markup).toContain('data-open="true"');
     expect(markup).toContain(">Library</span>");
     expect(markup).toContain('class="app-statusbar"');

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -7737,6 +7737,23 @@ export function App({
         <aside className="tool-rail" aria-label="Tool rail">
           <button
             type="button"
+            className="tool-rail-button examples-toggle"
+            title="Show circuit examples"
+            aria-pressed={
+              leftPanelMode === "examples" && visibleLibraryPanelOpen
+            }
+            aria-controls="examples-panel"
+            aria-expanded={
+              leftPanelMode === "examples" && visibleLibraryPanelOpen
+            }
+            data-testid="examples-toggle"
+            onClick={showExamplesPanel}
+          >
+            <ToolIcon name="examples" />
+            <span>Examples</span>
+          </button>
+          <button
+            type="button"
             className="tool-rail-button"
             title={
               visibleLibraryPanelOpen
@@ -7815,7 +7832,6 @@ export function App({
         ) : (
           <ExamplesPanel
             open={visibleLibraryPanelOpen}
-            onShowLibrary={showLibraryPanel}
             onOpenExample={openLibraryExample}
           />
         )}

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -7826,7 +7826,6 @@ export function App({
             recentSymbolIds={recentSymbolIds}
             open={visibleLibraryPanelOpen}
             onOpenInsert={openInsertComponentDialog}
-            onShowExamples={showExamplesPanel}
             onQuickPlace={beginInsertedComponentPlacement}
           />
         ) : (

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -144,6 +144,7 @@ import {
   quickPlaceRequest,
   ShapesPanel,
 } from "../features/editor-shell/shapes-panel";
+import { ExamplesPanel } from "../features/editor-shell/examples-panel";
 import {
   createLibraryExampleProject,
   type LibraryProjectExample,
@@ -609,6 +610,9 @@ export function App({
   });
   const [compactLayout, setCompactLayout] = useState(compactLayoutMatches);
   const [compactLibraryPanelOpen, setCompactLibraryPanelOpen] = useState(false);
+  const [leftPanelMode, setLeftPanelMode] = useState<"library" | "examples">(
+    "library",
+  );
   const [selectionOpen, setSelectionOpen] = useState(false);
   const [recentSymbolIds, setRecentSymbolIds] = useState<string[]>(() => {
     if (typeof window === "undefined") return [];
@@ -1517,6 +1521,10 @@ export function App({
   }
 
   function toggleLibraryPanel(): void {
+    if (leftPanelMode === "examples") {
+      showLibraryPanel();
+      return;
+    }
     if (compactLayout) {
       setCompactLibraryPanelOpen((current) => {
         const next = !current;
@@ -1534,6 +1542,29 @@ export function App({
       }
       return next;
     });
+  }
+
+  function showLeftPanel(mode: "library" | "examples"): void {
+    setLeftPanelMode(mode);
+    if (compactLayout) {
+      setCompactLibraryPanelOpen(true);
+      setSelectionOpen(false);
+      return;
+    }
+    setLibraryPanelOpen(true);
+    try {
+      window.localStorage.setItem(LIBRARY_PANEL_STORAGE_KEY, "true");
+    } catch {
+      // The left panel remains usable when storage is unavailable.
+    }
+  }
+
+  function showLibraryPanel(): void {
+    showLeftPanel("library");
+  }
+
+  function showExamplesPanel(): void {
+    showLeftPanel("examples");
   }
 
   function resetInteractionState(): void {
@@ -7772,14 +7803,22 @@ export function App({
             <span>Rect</span>
           </button>
         </aside>
-        <ShapesPanel
-          styleProfileId={document.presentation.styleProfileId}
-          recentSymbolIds={recentSymbolIds}
-          open={visibleLibraryPanelOpen}
-          onOpenInsert={openInsertComponentDialog}
-          onOpenExample={openLibraryExample}
-          onQuickPlace={beginInsertedComponentPlacement}
-        />
+        {leftPanelMode === "library" ? (
+          <ShapesPanel
+            styleProfileId={document.presentation.styleProfileId}
+            recentSymbolIds={recentSymbolIds}
+            open={visibleLibraryPanelOpen}
+            onOpenInsert={openInsertComponentDialog}
+            onShowExamples={showExamplesPanel}
+            onQuickPlace={beginInsertedComponentPlacement}
+          />
+        ) : (
+          <ExamplesPanel
+            open={visibleLibraryPanelOpen}
+            onShowLibrary={showLibraryPanel}
+            onOpenExample={openLibraryExample}
+          />
+        )}
         <aside
           className={selectionOpen ? "selection-dock open" : "selection-dock"}
           aria-label="Properties"

--- a/apps/editor/src/features/editor-shell/examples-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/examples-panel.test.ts
@@ -10,15 +10,11 @@ describe("ExamplesPanel", () => {
     const markup = renderToStaticMarkup(
       createElement(ExamplesPanel, {
         open: true,
-        onShowLibrary: () => undefined,
         onOpenExample: () => undefined,
       }),
     );
 
     expect(markup).toContain('data-testid="examples-panel"');
-    expect(markup).toContain('data-testid="library-panel-tab"');
-    expect(markup).toContain('data-testid="examples-panel-tab"');
-    expect(markup).toContain('aria-current="page"');
     expect(markup).not.toContain('data-testid="shapes-fold-library"');
     expect(markup.match(/data-testid="shapes-example-/g)).toHaveLength(
       libraryProjectExamples.length,

--- a/apps/editor/src/features/editor-shell/examples-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/examples-panel.test.ts
@@ -1,0 +1,31 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { libraryProjectExamples } from "../../examples/library-examples";
+import { ExamplesPanel } from "./examples-panel";
+
+describe("ExamplesPanel", () => {
+  it("presents every bundled example outside the Library device panel", () => {
+    const markup = renderToStaticMarkup(
+      createElement(ExamplesPanel, {
+        open: true,
+        onShowLibrary: () => undefined,
+        onOpenExample: () => undefined,
+      }),
+    );
+
+    expect(markup).toContain('data-testid="examples-panel"');
+    expect(markup).toContain('data-testid="library-panel-tab"');
+    expect(markup).toContain('data-testid="examples-panel-tab"');
+    expect(markup).toContain('aria-current="page"');
+    expect(markup).not.toContain('data-testid="shapes-fold-library"');
+    expect(markup.match(/data-testid="shapes-example-/g)).toHaveLength(
+      libraryProjectExamples.length,
+    );
+    for (const example of libraryProjectExamples) {
+      expect(markup).toContain(`data-testid="shapes-example-${example.id}"`);
+      expect(markup).toContain(example.name);
+    }
+  });
+});

--- a/apps/editor/src/features/editor-shell/examples-panel.tsx
+++ b/apps/editor/src/features/editor-shell/examples-panel.tsx
@@ -5,15 +5,10 @@ import {
 
 export interface ExamplesPanelProps {
   open: boolean;
-  onShowLibrary(): void;
   onOpenExample(example: LibraryProjectExample): void;
 }
 
-export function ExamplesPanel({
-  open,
-  onShowLibrary,
-  onOpenExample,
-}: ExamplesPanelProps) {
+export function ExamplesPanel({ open, onOpenExample }: ExamplesPanelProps) {
   return (
     <aside
       id="examples-panel"
@@ -27,26 +22,9 @@ export function ExamplesPanel({
       data-open={open ? "true" : "false"}
     >
       <header className="shapes-panel-header">
-        <div className="left-panel-tabs" aria-label="Library panels">
-          <button
-            type="button"
-            className="left-panel-tab"
-            data-testid="library-panel-tab"
-            onClick={onShowLibrary}
-            title="Show component library"
-          >
-            Library
-          </button>
-          <button
-            type="button"
-            className="left-panel-tab active"
-            data-testid="examples-panel-tab"
-            aria-current="page"
-            title="Circuit examples"
-          >
-            <span className="shapes-kicker">Quick place</span>
-            <span className="shapes-panel-heading">Examples</span>
-          </button>
+        <div className="shapes-panel-static-title">
+          <span className="shapes-kicker">Quick place</span>
+          <span className="shapes-panel-heading">Examples</span>
         </div>
       </header>
 

--- a/apps/editor/src/features/editor-shell/examples-panel.tsx
+++ b/apps/editor/src/features/editor-shell/examples-panel.tsx
@@ -1,0 +1,78 @@
+import {
+  libraryProjectExamples,
+  type LibraryProjectExample,
+} from "../../examples/library-examples";
+
+export interface ExamplesPanelProps {
+  open: boolean;
+  onShowLibrary(): void;
+  onOpenExample(example: LibraryProjectExample): void;
+}
+
+export function ExamplesPanel({
+  open,
+  onShowLibrary,
+  onOpenExample,
+}: ExamplesPanelProps) {
+  return (
+    <aside
+      id="examples-panel"
+      className={
+        open ? "shapes-panel examples-panel" : "shapes-panel collapsed"
+      }
+      aria-label="Examples"
+      aria-hidden={!open}
+      inert={!open ? true : undefined}
+      data-testid="examples-panel"
+      data-open={open ? "true" : "false"}
+    >
+      <header className="shapes-panel-header">
+        <div className="left-panel-tabs" aria-label="Library panels">
+          <button
+            type="button"
+            className="left-panel-tab"
+            data-testid="library-panel-tab"
+            onClick={onShowLibrary}
+            title="Show component library"
+          >
+            Library
+          </button>
+          <button
+            type="button"
+            className="left-panel-tab active"
+            data-testid="examples-panel-tab"
+            aria-current="page"
+            title="Circuit examples"
+          >
+            <span className="shapes-kicker">Quick place</span>
+            <span className="shapes-panel-heading">Examples</span>
+          </button>
+        </div>
+      </header>
+
+      <div className="shapes-panel-body">
+        <div className="shapes-example-list">
+          {libraryProjectExamples.map((example) => (
+            <button
+              key={example.id}
+              type="button"
+              className="shapes-example-card"
+              data-testid={`shapes-example-${example.id}`}
+              aria-label={`Open example ${example.name}`}
+              title={`Open ${example.name}`}
+              onClick={() => onOpenExample(example)}
+            >
+              <span className="shapes-example-copy">
+                <span className="shapes-example-kicker">Example</span>
+                <span className="shapes-example-name">{example.name}</span>
+                <span className="shapes-example-description">
+                  {example.description}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -18,7 +18,6 @@ describe("shapes quick-place", () => {
         recentSymbolIds: [],
         open: true,
         onOpenInsert: () => undefined,
-        onShowExamples: () => undefined,
         onQuickPlace: () => undefined,
       }),
     );
@@ -67,7 +66,6 @@ describe("shapes quick-place", () => {
     expect(markup).toContain('title="Place Capacitor"');
     expect(markup).toContain(">V Src</span>");
     expect(markup).toContain(">Cap</span>");
-    expect(markup).toContain('data-testid="examples-panel-toggle"');
     expect(markup).not.toContain('data-testid="shapes-example-');
   });
 

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -6,7 +6,6 @@ import {
   componentCatalog,
   paletteSymbols,
 } from "../component-insert/symbol-catalog";
-import { libraryProjectExamples } from "../../examples/library-examples";
 import { quickPlaceRequest, ShapesPanel } from "./shapes-panel";
 
 describe("shapes quick-place", () => {
@@ -19,7 +18,7 @@ describe("shapes quick-place", () => {
         recentSymbolIds: [],
         open: true,
         onOpenInsert: () => undefined,
-        onOpenExample: () => undefined,
+        onShowExamples: () => undefined,
         onQuickPlace: () => undefined,
       }),
     );
@@ -68,15 +67,8 @@ describe("shapes quick-place", () => {
     expect(markup).toContain('title="Place Capacitor"');
     expect(markup).toContain(">V Src</span>");
     expect(markup).toContain(">Cap</span>");
-    expect(markup).toContain('data-testid="shapes-fold-examples"');
-    expect(markup.match(/data-testid="shapes-example-/g)).toHaveLength(
-      libraryProjectExamples.length,
-    );
-    for (const example of libraryProjectExamples) {
-      expect(markup).toContain(`data-testid="shapes-example-${example.id}"`);
-      expect(markup).toContain(example.name);
-    }
-    expect(markup).toContain('class="shapes-example-card"');
+    expect(markup).toContain('data-testid="examples-panel-toggle"');
+    expect(markup).not.toContain('data-testid="shapes-example-');
   });
 
   it("quick-places without persisting parameter placeholders", () => {

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -66,7 +66,6 @@ export interface ShapesPanelProps {
   recentSymbolIds: readonly string[];
   open: boolean;
   onOpenInsert(): void;
-  onShowExamples(): void;
   onQuickPlace(request: ComponentInsertRequest): void;
 }
 
@@ -75,7 +74,6 @@ export function ShapesPanel({
   recentSymbolIds,
   open,
   onOpenInsert,
-  onShowExamples,
   onQuickPlace,
 }: ShapesPanelProps) {
   const libraryGroups = componentCatalog(styleProfileId, "");
@@ -118,28 +116,15 @@ export function ShapesPanel({
       data-open={open ? "true" : "false"}
     >
       <header className="shapes-panel-header">
-        <div className="left-panel-tabs" aria-label="Library panels">
-          <button
-            type="button"
-            className="left-panel-tab active"
-            data-testid="library-panel-tab"
-            aria-current="page"
-            onClick={onOpenInsert}
-            title="Open insert dialog (I)"
-          >
-            <span className="shapes-kicker">Quick place</span>
-            <span className="shapes-panel-heading">Library</span>
-          </button>
-          <button
-            type="button"
-            className="left-panel-tab"
-            data-testid="examples-panel-toggle"
-            onClick={onShowExamples}
-            title="Show circuit examples"
-          >
-            Examples
-          </button>
-        </div>
+        <button
+          type="button"
+          className="shapes-panel-title"
+          onClick={onOpenInsert}
+          title="Open insert dialog (I)"
+        >
+          <span className="shapes-kicker">Quick place</span>
+          <span className="shapes-panel-heading">Library</span>
+        </button>
       </header>
 
       <div className="shapes-panel-body">

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -1,9 +1,5 @@
 import { useState } from "react";
 
-import {
-  libraryProjectExamples,
-  type LibraryProjectExample,
-} from "../../examples/library-examples";
 import type { ComponentInsertRequest } from "../component-insert/component-insert-request";
 import { SymbolArtwork } from "../component-insert/symbol-artwork";
 import { initialComponentParameterValues } from "../component-insert/component-parameters";
@@ -70,7 +66,7 @@ export interface ShapesPanelProps {
   recentSymbolIds: readonly string[];
   open: boolean;
   onOpenInsert(): void;
-  onOpenExample(example: LibraryProjectExample): void;
+  onShowExamples(): void;
   onQuickPlace(request: ComponentInsertRequest): void;
 }
 
@@ -79,7 +75,7 @@ export function ShapesPanel({
   recentSymbolIds,
   open,
   onOpenInsert,
-  onOpenExample,
+  onShowExamples,
   onQuickPlace,
 }: ShapesPanelProps) {
   const libraryGroups = componentCatalog(styleProfileId, "");
@@ -122,54 +118,31 @@ export function ShapesPanel({
       data-open={open ? "true" : "false"}
     >
       <header className="shapes-panel-header">
-        <button
-          type="button"
-          className="shapes-panel-title"
-          onClick={onOpenInsert}
-          title="Open insert dialog (I)"
-        >
-          <span className="shapes-kicker">Quick place</span>
-          <span className="shapes-panel-heading">Library</span>
-        </button>
+        <div className="left-panel-tabs" aria-label="Library panels">
+          <button
+            type="button"
+            className="left-panel-tab active"
+            data-testid="library-panel-tab"
+            aria-current="page"
+            onClick={onOpenInsert}
+            title="Open insert dialog (I)"
+          >
+            <span className="shapes-kicker">Quick place</span>
+            <span className="shapes-panel-heading">Library</span>
+          </button>
+          <button
+            type="button"
+            className="left-panel-tab"
+            data-testid="examples-panel-toggle"
+            onClick={onShowExamples}
+            title="Show circuit examples"
+          >
+            Examples
+          </button>
+        </div>
       </header>
 
       <div className="shapes-panel-body">
-        <details
-          className="shapes-fold"
-          open
-          data-testid="shapes-fold-examples"
-        >
-          <summary className="shapes-fold-summary">
-            <span className="shapes-fold-label">Examples</span>
-            <span className="shapes-fold-count">
-              {libraryProjectExamples.length}
-            </span>
-          </summary>
-          <div className="shapes-fold-body">
-            <div className="shapes-example-list">
-              {libraryProjectExamples.map((example) => (
-                <button
-                  key={example.id}
-                  type="button"
-                  className="shapes-example-card"
-                  data-testid={`shapes-example-${example.id}`}
-                  aria-label={`Open example ${example.name}`}
-                  title={`Open ${example.name}`}
-                  onClick={() => onOpenExample(example)}
-                >
-                  <span className="shapes-example-copy">
-                    <span className="shapes-example-kicker">Example</span>
-                    <span className="shapes-example-name">{example.name}</span>
-                    <span className="shapes-example-description">
-                      {example.description}
-                    </span>
-                  </span>
-                </button>
-              ))}
-            </div>
-          </div>
-        </details>
-
         <details className="shapes-fold" open data-testid="shapes-fold-library">
           <summary className="shapes-fold-summary">
             <span className="shapes-fold-label">

--- a/apps/editor/src/features/editor-shell/tool-icon.tsx
+++ b/apps/editor/src/features/editor-shell/tool-icon.tsx
@@ -1,6 +1,7 @@
 export type ToolIconName =
   | "insert"
   | "library"
+  | "examples"
   | "wire"
   | "text"
   | "arrow"
@@ -41,6 +42,13 @@ export function ToolIcon({ name }: { name: ToolIconName }) {
           <rect x="11" y="3.5" width="6" height="6" rx="1" {...common} />
           <rect x="3" y="10.5" width="6" height="6" rx="1" {...common} />
           <rect x="11" y="10.5" width="6" height="6" rx="1" {...common} />
+        </>
+      ) : null}
+      {name === "examples" ? (
+        <>
+          <rect x="3" y="4" width="10" height="11" rx="1" {...common} />
+          <path d="M6 7h4M6 10h4M6 13h3" {...common} />
+          <rect x="8" y="6" width="9" height="10" rx="1" {...common} />
         </>
       ) : null}
       {name === "wire" ? (

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -716,6 +716,41 @@ body {
   border-bottom: 1px solid var(--icm-border);
 }
 
+.left-panel-tabs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  width: 100%;
+  gap: var(--icm-space-1);
+}
+
+.left-panel-tab {
+  display: grid;
+  align-content: center;
+  min-width: 0;
+  min-height: 44px;
+  padding: var(--icm-space-2);
+  border: 1px solid transparent;
+  border-radius: var(--icm-radius-sm);
+  background: transparent;
+  box-shadow: none;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-sm);
+  font-weight: 600;
+  line-height: var(--icm-line-tight);
+  text-align: left;
+}
+
+.left-panel-tab:hover:not(:disabled) {
+  background: var(--icm-surface-hover);
+  color: var(--icm-text);
+}
+
+.left-panel-tab.active {
+  border-color: var(--icm-border);
+  background: var(--icm-surface-muted);
+  color: var(--icm-text);
+}
+
 .shapes-panel-header h2,
 .shapes-panel-header p,
 .shapes-panel-heading,

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -663,6 +663,11 @@ body {
   white-space: nowrap;
 }
 
+.tool-rail-button.examples-toggle {
+  font-size: 9px;
+  letter-spacing: 0;
+}
+
 .tool-rail-divider {
   height: 1px;
   margin: var(--icm-space-1) var(--icm-space-2);
@@ -707,6 +712,13 @@ body {
   background: var(--icm-surface-hover);
 }
 
+.shapes-panel-static-title {
+  display: grid;
+  gap: 2px;
+  width: 100%;
+  padding: var(--icm-space-1);
+}
+
 .shapes-panel-header {
   display: flex;
   align-items: flex-start;
@@ -714,41 +726,6 @@ body {
   gap: var(--icm-space-2);
   padding: var(--icm-space-3) var(--icm-space-3) var(--icm-space-2);
   border-bottom: 1px solid var(--icm-border);
-}
-
-.left-panel-tabs {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  width: 100%;
-  gap: var(--icm-space-1);
-}
-
-.left-panel-tab {
-  display: grid;
-  align-content: center;
-  min-width: 0;
-  min-height: 44px;
-  padding: var(--icm-space-2);
-  border: 1px solid transparent;
-  border-radius: var(--icm-radius-sm);
-  background: transparent;
-  box-shadow: none;
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-sm);
-  font-weight: 600;
-  line-height: var(--icm-line-tight);
-  text-align: left;
-}
-
-.left-panel-tab:hover:not(:disabled) {
-  background: var(--icm-surface-hover);
-  color: var(--icm-text);
-}
-
-.left-panel-tab.active {
-  border-color: var(--icm-border);
-  background: var(--icm-surface-muted);
-  color: var(--icm-text);
 }
 
 .shapes-panel-header h2,

--- a/plan/2026-08-17-examples-rail/plan.md
+++ b/plan/2026-08-17-examples-rail/plan.md
@@ -7,8 +7,8 @@ experience: none
 
 ## Goal
 
-Present Examples as its own left-side panel selected by a top-level control to
-the right of Library, rather than as a fold inside the Library device panel.
+Present Examples as its own left-side panel selected from the far-left tool
+rail alongside Library, rather than as a fold inside the Library device panel.
 
 ## State and Ownership
 
@@ -26,6 +26,7 @@ Library/Examples panel composition and its direct coverage.
 
 - `apps/editor/src/app/App.tsx`
 - `apps/editor/src/app/App.test.tsx`
+- `apps/editor/src/features/editor-shell/tool-icon.tsx`
 - `apps/editor/src/features/editor-shell/shapes-panel.tsx`
 - `apps/editor/src/features/editor-shell/shapes-panel.test.ts`
 - `apps/editor/src/features/editor-shell/examples-panel.tsx`
@@ -45,8 +46,8 @@ Library/Examples panel composition and its direct coverage.
 
 1. Extract the examples display into an independent left panel while retaining
    the existing Project-open behavior.
-2. Put a top-level Examples control to the right of Library and make the two
-   controls switch the shared left-panel slot.
+2. Put a top-level Examples control in the far-left tool rail alongside
+   Library and make the two controls switch the shared left-panel slot.
 3. Preserve desktop and compact layout behavior, then cover the control
    placement and direct example-open path.
 
@@ -61,8 +62,8 @@ Library/Examples panel composition and its direct coverage.
 ## Test Impact
 
 - Decision: tests-updated
-- Contracts: Examples is a separate left-panel surface reached by the control
-  beside Library; selecting an example still uses the guarded Project-open
+- Contracts: Examples is a separate left-panel surface reached by a far-left
+  tool-rail button alongside Library; selecting an example still uses the guarded Project-open
   lifecycle.
 - Primary checks: App/panel unit tests and the Examples browser workflow.
 

--- a/plan/2026-08-17-examples-rail/plan.md
+++ b/plan/2026-08-17-examples-rail/plan.md
@@ -1,0 +1,79 @@
+---
+status: active
+experience: none
+---
+
+# Move Examples Beside Library
+
+## Goal
+
+Present Examples as its own left-side panel selected by a top-level control to
+the right of Library, rather than as a fold inside the Library device panel.
+
+## State and Ownership
+
+Start state from `git status --short --branch` before creating the target
+branch:
+
+```text
+## main...origin/main
+?? .worktrees/
+```
+
+The untracked `.worktrees/` directory is unrelated and will remain untouched.
+This target is isolated on `codex/examples-rail` and owns the Editor's
+Library/Examples panel composition and its direct coverage.
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/app/App.test.tsx`
+- `apps/editor/src/features/editor-shell/shapes-panel.tsx`
+- `apps/editor/src/features/editor-shell/shapes-panel.test.ts`
+- `apps/editor/src/features/editor-shell/examples-panel.tsx`
+- `apps/editor/src/features/editor-shell/examples-panel.test.ts`
+- `apps/editor/src/styles.css`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `plan/2026-08-17-examples-rail/plan.md`
+- `plan/log.md` (close-out entry only)
+- `plan/root-audit.md` (close-out entry only)
+
+- Read-only: `apps/editor/src/examples/library-examples.ts`, the two bundled
+  schema-11 projects, and the existing dirty-replacement lifecycle
+- Shared: the left workspace grid, compact Library behavior, and Project-open
+  recovery guard
+
+## Work
+
+1. Extract the examples display into an independent left panel while retaining
+   the existing Project-open behavior.
+2. Put a top-level Examples control to the right of Library and make the two
+   controls switch the shared left-panel slot.
+3. Preserve desktop and compact layout behavior, then cover the control
+   placement and direct example-open path.
+
+## Validation
+
+- `pnpm test:local` for affected App/panel/example tests
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep <Examples panel>`
+- `pnpm test:impact -- --base origin/main`
+- `git diff --check`
+- `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: Examples is a separate left-panel surface reached by the control
+  beside Library; selecting an example still uses the guarded Project-open
+  lifecycle.
+- Primary checks: App/panel unit tests and the Examples browser workflow.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): move Examples beside Library
+```
+
+## Outcome
+
+Pending.


### PR DESCRIPTION
Moves bundled circuit examples out of the Library device panel into an independent Examples panel. Library and Examples now appear as parallel top-level controls, with Examples on the right. Includes focused unit and browser coverage.