### PR TITLE
Allow wire snapping to rectangle edge centers

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -270,6 +270,7 @@ import type { ScreenFlip } from "../interaction/shortcut-orientation";
 import {
   buildDraftingAnchors,
   buildInstanceAnchors,
+  buildRectangleEdgeSnapAnchors,
   buildSceneSnapTargets,
   endpointSnapAnchor,
 } from "../snap/candidates";
@@ -3292,6 +3293,10 @@ export function App({
       source,
       anchor: endpointSnapAnchor(source),
     }));
+    const rectangleEdgeTargets = buildRectangleEdgeSnapAnchors(
+      document,
+      resolver,
+    );
     const activeSourceAnchorId = wireSource
       ? endpointSnapAnchor(wireSource).id
       : null;
@@ -3300,6 +3305,7 @@ export function App({
       [
         ...endpointTargets.map((candidate) => candidate.anchor),
         ...routeTargets.map((candidate) => candidate.anchor),
+        ...rectangleEdgeTargets,
       ],
       {
         grid: document.presentation.grid,

--- a/apps/editor/src/snap/candidates.test.ts
+++ b/apps/editor/src/snap/candidates.test.ts
@@ -2,7 +2,10 @@ import { createEmptyDocument } from "@icm/model";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
-import { buildSceneSnapTargets } from "./candidates";
+import {
+  buildRectangleEdgeSnapAnchors,
+  buildSceneSnapTargets,
+} from "./candidates";
 
 describe("snap candidate builder", () => {
   it("excludes every moving instance from static snap targets", () => {
@@ -28,5 +31,53 @@ describe("snap candidate builder", () => {
     expect(targets.some((target) => target.id.startsWith("instance:R1:"))).toBe(
       false,
     );
+  });
+
+  it("builds one Wire snap anchor at each rectangle edge center", () => {
+    const document = createEmptyDocument("doc", "Snap");
+    document.drafting = {
+      objects: [
+        {
+          id: "rectangle-1",
+          kind: "rectangle",
+          locked: false,
+          zIndex: 0,
+          anchor: { kind: "free", position: { x: 100, y: 100 } },
+          center: { x: 100, y: 100 },
+          width: 40,
+          height: 20,
+          rotation: 0,
+          lineStyle: "solid",
+        },
+      ],
+    };
+
+    const targets = buildRectangleEdgeSnapAnchors(
+      document,
+      new InMemorySymbolResolver(builtInSymbols),
+    );
+
+    expect(targets).toEqual([
+      {
+        id: "drafting:rectangle-1:edge-center:0",
+        point: { x: 100, y: 90 },
+        kind: "drafting",
+      },
+      {
+        id: "drafting:rectangle-1:edge-center:1",
+        point: { x: 120, y: 100 },
+        kind: "drafting",
+      },
+      {
+        id: "drafting:rectangle-1:edge-center:2",
+        point: { x: 100, y: 110 },
+        kind: "drafting",
+      },
+      {
+        id: "drafting:rectangle-1:edge-center:3",
+        point: { x: 80, y: 100 },
+        kind: "drafting",
+      },
+    ]);
   });
 });

--- a/apps/editor/src/snap/candidates.ts
+++ b/apps/editor/src/snap/candidates.ts
@@ -106,6 +106,28 @@ export function buildDraftingAnchors(
   });
 }
 
+export function buildRectangleEdgeSnapAnchors(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+): SnapAnchor[] {
+  return (document.drafting?.objects ?? []).flatMap((object) => {
+    if (object.kind !== "rectangle") return [];
+    const geometry = resolveDraftingObjectGeometry(document, resolver, object);
+    if (geometry.kind !== "rectangle") return [];
+    return geometry.corners.map((corner, index): SnapAnchor => {
+      const next = geometry.corners[(index + 1) % geometry.corners.length]!;
+      return {
+        id: `drafting:${object.id}:edge-center:${index}`,
+        point: {
+          x: (corner.x + next.x) / 2,
+          y: (corner.y + next.y) / 2,
+        },
+        kind: "drafting",
+      };
+    });
+  });
+}
+
 export function buildInstanceAnchors(
   document: SchematicDocument,
   resolver: SymbolResolver,

--- a/apps/editor/src/snap/engine.test.ts
+++ b/apps/editor/src/snap/engine.test.ts
@@ -341,6 +341,18 @@ describe("unified Snap Engine", () => {
     expect(result.pointMatch?.id).toBe("pin");
   });
 
+  it("lets Wire snap to drafting geometry without creating an electrical match", () => {
+    const result = resolvePointSnap(
+      { x: 12, y: 12 },
+      [{ id: "rectangle-edge", point: { x: 10, y: 10 }, kind: "drafting" }],
+      { grid: 10, tolerance: 4, profile: SNAP_PROFILES.wire },
+    );
+
+    expect(result.delta).toEqual({ x: -2, y: -2 });
+    expect(result.pointMatch?.id).toBe("rectangle-edge");
+    expect(result.electricalMatch).toBeUndefined();
+  });
+
   it("excludes the active Wire source and reports equal coincident targets", () => {
     const result = resolvePointSnap(
       { x: 10, y: 10 },

--- a/apps/editor/src/snap/engine.ts
+++ b/apps/editor/src/snap/engine.ts
@@ -115,7 +115,13 @@ export const SNAP_PROFILES = {
     gridAlignedTranslation: false,
   },
   wire: {
-    kinds: new Set<SnapTargetKind>(["grid", "pin", "junction", "route"]),
+    kinds: new Set<SnapTargetKind>([
+      "grid",
+      "pin",
+      "junction",
+      "route",
+      "drafting",
+    ]),
     exactElectrical: true,
     gridAlignedTranslation: false,
   },

--- a/plan/2026-08-17-wire-snap-rectangle-edge-centers/plan.md
+++ b/plan/2026-08-17-wire-snap-rectangle-edge-centers/plan.md
@@ -1,0 +1,76 @@
+---
+status: completed
+experience: none
+---
+
+# Wire Snap to Rectangle Edge Centers
+
+## Goal
+
+Allow the Wire tool to geometrically snap to the midpoint of each drafting
+rectangle edge without turning the rectangle or the snapped point into an
+electrical contact.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree is clean. This target owns:
+
+- `apps/editor/src/snap/candidates.ts`
+- `apps/editor/src/snap/candidates.test.ts`
+- `apps/editor/src/snap/engine.ts`
+- `apps/editor/src/snap/engine.test.ts`
+- `apps/editor/src/app/App.tsx`
+- `plan/2026-08-17-wire-snap-rectangle-edge-centers/plan.md`
+- `plan/log.md`
+
+Shared contract: drafting geometry remains non-electrical; only explicit
+terminals, Junctions, and Route taps create contact.
+
+## Work
+
+1. Derive deterministic snap anchors at the four edge midpoints of each
+   drafting rectangle.
+2. Admit those drafting anchors to Wire point snapping while leaving contact
+   resolution limited to electrical endpoints and Routes.
+3. Add focused regression tests for edge-center generation and non-electrical
+   Wire snapping.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/snap/candidates.test.ts apps/editor/src/snap/engine.test.ts`
+- `pnpm test:impact -- --base origin/main`
+- `pnpm typecheck`
+- `pnpm build`
+- `pnpm exec prettier --check apps/editor/src/app/App.tsx apps/editor/src/snap/candidates.ts apps/editor/src/snap/candidates.test.ts apps/editor/src/snap/engine.ts apps/editor/src/snap/engine.test.ts plan/2026-08-17-wire-snap-rectangle-edge-centers/plan.md`
+- `git diff --check`
+- `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: Wire snaps geometrically to rectangle edge centers without
+  creating an electrical match.
+- Primary checks: `apps/editor/src/snap/candidates.test.ts`,
+  `apps/editor/src/snap/engine.test.ts`
+
+## Commit Intent
+
+Commit as:
+
+```text
+Allow wire snapping to rectangle edge centers
+```
+
+## Outcome
+
+Wire now includes the four edge midpoints of every drafting rectangle in its
+geometric snap candidates. These anchors have no electrical reference, so a
+snapped Wire endpoint remains a free point and cannot create implicit contact.
+The two focused Snap suites passed (15 tests), as did test-impact, formatting,
+TypeScript, and the root workspace build.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7903,3 +7903,15 @@ box`; branch pushed for review. A concurrent worker's overlapping App.tsx
   and `git diff --check` passed.
 - Commit status: committed and pushed as
   `feat(editor): add Library project examples` on `codex/library-examples`.
+
+## 2026-08-17 - Snap Wire to rectangle edge centers
+
+- Target: let Wire geometry snap to the midpoint of each drafting rectangle
+  edge without creating implicit electrical contact.
+- Changed areas: Editor Snap candidate construction, Wire snap profile and
+  target collection, focused Snap regression tests, and target plan.
+- Validation: focused Snap suites (2 files / 15 tests), `pnpm typecheck`,
+  `pnpm build`, formatting check, `pnpm test:impact -- --base origin/main`, and
+  `git diff --check` passed.
+- Commit status: committed on `codex/wire-snap-rectangle-edge-centers`;
+  remote required checks remain the mainline delivery gate.


### PR DESCRIPTION
## Summary
- add four geometric Wire snap anchors at drafting rectangle edge centers
- keep rectangle snapping non-electrical so no implicit Net or Junction is created
- add focused candidate and Snap Engine regression tests

## Validation
- pnpm test:local apps/editor/src/snap/candidates.test.ts apps/editor/src/snap/engine.test.ts
- pnpm test:impact -- --base origin/main
- pnpm typecheck
- pnpm build
- focused Prettier check
- git diff --check