### PR TITLE
Expand rectangle edge wire snap points

### DIFF
--- a/apps/editor/src/snap/candidates.test.ts
+++ b/apps/editor/src/snap/candidates.test.ts
@@ -7,6 +7,17 @@ import {
   buildSceneSnapTargets,
 } from "./candidates";
 
+function expectPointsCloseTo(
+  actual: Array<{ x: number; y: number }>,
+  expected: Array<{ x: number; y: number }>,
+): void {
+  expect(actual).toHaveLength(expected.length);
+  actual.forEach((point, index) => {
+    expect(point.x).toBeCloseTo(expected[index]!.x);
+    expect(point.y).toBeCloseTo(expected[index]!.y);
+  });
+}
+
 describe("snap candidate builder", () => {
   it("excludes every moving instance from static snap targets", () => {
     const document = createEmptyDocument("doc", "Snap");
@@ -33,7 +44,7 @@ describe("snap candidate builder", () => {
     );
   });
 
-  it("builds one Wire snap anchor at each rectangle edge center", () => {
+  it("builds the requested fractional Wire anchors on every rectangle edge", () => {
     const document = createEmptyDocument("doc", "Snap");
     document.drafting = {
       objects: [
@@ -57,27 +68,73 @@ describe("snap candidate builder", () => {
       new InMemorySymbolResolver(builtInSymbols),
     );
 
-    expect(targets).toEqual([
-      {
-        id: "drafting:rectangle-1:edge-center:0",
-        point: { x: 100, y: 90 },
-        kind: "drafting",
-      },
-      {
-        id: "drafting:rectangle-1:edge-center:1",
-        point: { x: 120, y: 100 },
-        kind: "drafting",
-      },
-      {
-        id: "drafting:rectangle-1:edge-center:2",
-        point: { x: 100, y: 110 },
-        kind: "drafting",
-      },
-      {
-        id: "drafting:rectangle-1:edge-center:3",
-        point: { x: 80, y: 100 },
-        kind: "drafting",
-      },
-    ]);
+    expect(targets).toHaveLength(20);
+    expect(targets.map((target) => target.id)).toEqual(
+      [0, 1, 2, 3].flatMap((edge) =>
+        ["quarter", "third", "center", "two-thirds", "three-quarters"].map(
+          (fraction) => `drafting:rectangle-1:edge-${edge}:${fraction}`,
+        ),
+      ),
+    );
+    expectPointsCloseTo(
+      targets.slice(0, 5).map((target) => target.point),
+      [
+        { x: 90, y: 90 },
+        { x: 80 + 40 / 3, y: 90 },
+        { x: 100, y: 90 },
+        { x: 80 + 80 / 3, y: 90 },
+        { x: 110, y: 90 },
+      ],
+    );
+    expectPointsCloseTo(
+      targets.slice(5, 10).map((target) => target.point),
+      [
+        { x: 120, y: 95 },
+        { x: 120, y: 90 + 20 / 3 },
+        { x: 120, y: 100 },
+        { x: 120, y: 90 + 40 / 3 },
+        { x: 120, y: 105 },
+      ],
+    );
+    expect(targets.every((target) => target.kind === "drafting")).toBe(true);
+    expect(targets.every((target) => target.electrical === undefined)).toBe(
+      true,
+    );
+  });
+
+  it("derives fractional anchors from rotated rectangle edges", () => {
+    const document = createEmptyDocument("doc", "Snap");
+    document.drafting = {
+      objects: [
+        {
+          id: "rectangle-rotated",
+          kind: "rectangle",
+          locked: false,
+          zIndex: 0,
+          anchor: { kind: "free", position: { x: 100, y: 100 } },
+          center: { x: 100, y: 100 },
+          width: 40,
+          height: 20,
+          rotation: 90,
+          lineStyle: "solid",
+        },
+      ],
+    };
+
+    const targets = buildRectangleEdgeSnapAnchors(
+      document,
+      new InMemorySymbolResolver(builtInSymbols),
+    );
+
+    expectPointsCloseTo(
+      targets.slice(0, 5).map((target) => target.point),
+      [
+        { x: 110, y: 90 },
+        { x: 110, y: 80 + 40 / 3 },
+        { x: 110, y: 100 },
+        { x: 110, y: 80 + 80 / 3 },
+        { x: 110, y: 110 },
+      ],
+    );
   });
 });

--- a/apps/editor/src/snap/candidates.ts
+++ b/apps/editor/src/snap/candidates.ts
@@ -110,20 +110,27 @@ export function buildRectangleEdgeSnapAnchors(
   document: SchematicDocument,
   resolver: SymbolResolver,
 ): SnapAnchor[] {
+  const fractions = [
+    { id: "quarter", value: 1 / 4 },
+    { id: "third", value: 1 / 3 },
+    { id: "center", value: 1 / 2 },
+    { id: "two-thirds", value: 2 / 3 },
+    { id: "three-quarters", value: 3 / 4 },
+  ] as const;
   return (document.drafting?.objects ?? []).flatMap((object) => {
     if (object.kind !== "rectangle") return [];
     const geometry = resolveDraftingObjectGeometry(document, resolver, object);
     if (geometry.kind !== "rectangle") return [];
-    return geometry.corners.map((corner, index): SnapAnchor => {
+    return geometry.corners.flatMap((corner, index): SnapAnchor[] => {
       const next = geometry.corners[(index + 1) % geometry.corners.length]!;
-      return {
-        id: `drafting:${object.id}:edge-center:${index}`,
+      return fractions.map(({ id, value }) => ({
+        id: `drafting:${object.id}:edge-${index}:${id}`,
         point: {
-          x: (corner.x + next.x) / 2,
-          y: (corner.y + next.y) / 2,
+          x: corner.x + (next.x - corner.x) * value,
+          y: corner.y + (next.y - corner.y) * value,
         },
         kind: "drafting",
-      };
+      }));
     });
   });
 }

--- a/plan/2026-08-17-wire-snap-rectangle-edge-fractions/plan.md
+++ b/plan/2026-08-17-wire-snap-rectangle-edge-fractions/plan.md
@@ -1,0 +1,70 @@
+---
+status: completed
+experience: none
+---
+
+# Wire Snap to Rectangle Edge Fractions
+
+## Goal
+
+Expand Wire's non-electrical rectangle-edge snapping from only the midpoint to
+the `1/4`, `1/3`, `1/2`, `2/3`, and `3/4` positions on every edge.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree is clean and `main` is current. This target owns:
+
+- `apps/editor/src/snap/candidates.ts`
+- `apps/editor/src/snap/candidates.test.ts`
+- `plan/2026-08-17-wire-snap-rectangle-edge-fractions/plan.md`
+- `plan/log.md`
+
+Shared contract: drafting rectangles and their fractional snap points remain
+non-electrical.
+
+## Work
+
+1. Generate the five requested fractional anchors on each resolved rectangle
+   edge, including rotated rectangles.
+2. Extend the focused candidate regression test to prove all 20 anchors and
+   their deterministic positions.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/snap/candidates.test.ts apps/editor/src/snap/engine.test.ts`
+- `pnpm test:impact -- --base origin/main`
+- `pnpm typecheck`
+- `pnpm build`
+- `pnpm exec prettier --check apps/editor/src/snap/candidates.ts apps/editor/src/snap/candidates.test.ts plan/2026-08-17-wire-snap-rectangle-edge-fractions/plan.md`
+- `git diff --check`
+- `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: each rectangle edge exposes Wire snap points at `1/4`, `1/3`,
+  `1/2`, `2/3`, and `3/4`, without electrical metadata.
+- Primary checks: `apps/editor/src/snap/candidates.test.ts`,
+  `apps/editor/src/snap/engine.test.ts`
+
+## Commit Intent
+
+Commit as:
+
+```text
+Expand rectangle edge wire snap points
+```
+
+## Outcome
+
+Every rectangle edge now exposes deterministic non-electrical Wire snap
+anchors at `1/4`, `1/3`, `1/2`, `2/3`, and `3/4`. The interpolation uses the
+resolved corners, so rotated rectangles follow the same contract. Focused Snap
+tests passed (2 files / 16 tests), together with formatting, test-impact,
+TypeScript, and the root workspace build.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7915,3 +7915,15 @@ box`; branch pushed for review. A concurrent worker's overlapping App.tsx
   `git diff --check` passed.
 - Commit status: committed on `codex/wire-snap-rectangle-edge-centers`;
   remote required checks remain the mainline delivery gate.
+
+## 2026-08-17 - Expand rectangle-edge Wire snap fractions
+
+- Target: expose `1/4`, `1/3`, `1/2`, `2/3`, and `3/4` Wire snap positions on
+  every drafting rectangle edge while preserving the non-electrical boundary.
+- Changed areas: rectangle-edge Snap candidate interpolation, axis-aligned and
+  rotated regression coverage, and target plan.
+- Validation: focused Snap suites (2 files / 16 tests), `pnpm typecheck`,
+  `pnpm build`, formatting check, `pnpm test:impact -- --base origin/main`, and
+  `git diff --check` passed.
+- Commit status: committed on `codex/wire-snap-rectangle-edge-fractions`;
+  remote required checks remain the mainline delivery gate.


### PR DESCRIPTION
## Summary
- expose Wire snap points at 1/4, 1/3, 1/2, 2/3, and 3/4 on every drafting rectangle edge
- derive points from resolved corners so rotated rectangles follow the same contract
- preserve non-electrical snapping with no implicit Net or Junction

## Validation
- pnpm test:local apps/editor/src/snap/candidates.test.ts apps/editor/src/snap/engine.test.ts
- pnpm test:impact -- --base origin/main
- pnpm typecheck
- pnpm build
- focused Prettier check
- git diff --check