### PR TITLE
Fix connected wire move and branch deletion

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -863,9 +863,11 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
           getComputedStyle(element).gridTemplateColumns.split(" ").length,
       ),
   ).toBe(1);
+  await expect
+    .poll(async () => (await canvas.boundingBox())?.width ?? 0)
+    .toBeLessThan(closedWidth);
   const openWidth = (await canvas.boundingBox())?.width ?? 0;
   expect(openWidth).toBeGreaterThan(450);
-  expect(openWidth).toBeLessThan(closedWidth);
 
   await page.getByTestId("selection-shelf").click();
   await expect(panel).toHaveAttribute("data-open", "false");

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -1121,6 +1121,39 @@ test("moves a selected wire segment and deletes a connected component safely", a
   );
 });
 
+test("previews a connected Wire while its Instance moves", async ({ page }) => {
+  await page.goto("/");
+  await placeComponent(page, "resistor", { x: 320, y: 220 });
+  await placeComponent(page, "resistor", { x: 520, y: 220 });
+  await clickCommand(page, "Draw", "Wire (W)");
+  await page.getByTestId("terminal-R1-2").click();
+  await page.getByTestId("terminal-R2-1").click();
+  await page.keyboard.press("Escape");
+
+  const before = await readRoutePoints(page, "route-ui-1");
+  const hit = page.getByTestId("hit-R1");
+  const box = await hit.boundingBox();
+  if (!box) throw new Error("Connected Instance is not measurable");
+  const start = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(start.x + 70, start.y + 50, { steps: 4 });
+
+  await expect(page.getByTestId("revision")).toHaveText("3");
+  await expect
+    .poll(() => readRoutePoints(page, "route-ui-1"))
+    .not.toEqual(before);
+  const during = await readRoutePoints(page, "route-ui-1");
+  expect(during[0]).not.toEqual(before[0]);
+  expect(during.at(-1)).toEqual(before.at(-1));
+
+  await page.mouse.up();
+  await expect(page.getByTestId("revision")).toHaveText("4");
+  const after = await readRoutePoints(page, "route-ui-1");
+  expect(after[0]).toEqual(during[0]);
+  expect(after.at(-1)).toEqual(before.at(-1));
+});
+
 test("moves internal wiring with a selected group and copies the routed subgraph", async ({
   page,
 }) => {
@@ -1148,9 +1181,9 @@ test("moves internal wiring with a selected group and copies the routed subgraph
     0.35,
     0,
     async () => {
-      await expect(
-        page.locator('[data-layer="routes"] [data-object-id="route-ui-1"]'),
-      ).toHaveAttribute("transform", /translate/u);
+      await expect
+        .poll(() => readRoutePoints(page, "route-ui-1"))
+        .not.toEqual(before);
       await expect(
         page.locator('[data-layer="symbols"] [data-object-id="R1"]'),
       ).toHaveAttribute("transform", /translate/u);

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -211,6 +211,7 @@ import {
 import {
   explicitAnnotationRemovals,
   proposeConnectedInstanceDeletion,
+  proposeSelectionRouteDeletion,
 } from "../features/selection/delete-selection";
 import { createRoutingDemoProject } from "../demos/routing-demo";
 import { createVisualDemoProject } from "../demos/visual-demo";
@@ -3809,8 +3810,52 @@ export function App({
       movePlan,
     };
     let visual: ReturnType<typeof startCanvasDragVisual> | null = null;
+    let routeVisual: ReturnType<typeof startCanvasDragVisual> | null = null;
+    const routeIdSet = new Set(document.routes.map((route) => route.id));
     const dragVisual = () =>
-      (visual ??= startCanvasDragVisual(svg, movePlan.previewObjectIds));
+      (visual ??= startCanvasDragVisual(
+        svg,
+        movePlan.previewObjectIds.filter((id) => !routeIdSet.has(id)),
+      ));
+    const paintMovePreview = (
+      moves: readonly { instanceId: string; position: Point }[],
+      delta: Point,
+    ) => {
+      dragVisual().translate(delta);
+      const groupMove = proposeGroupMoveEdits(document, resolver, moves);
+      if (groupMove.preview.routes.length === 0) return;
+      routeVisual ??= startCanvasDragVisual(
+        svg,
+        groupMove.preview.routes.map((route) => route.routeId),
+      );
+      const projected = structuredClone(document);
+      for (const move of moves) {
+        const instance = projected.instances.find(
+          (candidate) => candidate.id === move.instanceId,
+        );
+        if (instance?.placement) instance.placement.position = move.position;
+      }
+      for (const move of groupMove.preview.junctions) {
+        const junction = projected.junctions.find(
+          (candidate) => candidate.id === move.junctionId,
+        );
+        if (junction) junction.position = move.position;
+      }
+      for (const routeMove of groupMove.preview.routes) {
+        const route = projected.routes.find(
+          (candidate) => candidate.id === routeMove.routeId,
+        );
+        if (!route) continue;
+        const from = resolveEndpointPoint(projected, resolver, route.from);
+        const to = resolveEndpointPoint(projected, resolver, route.to);
+        if (!from || !to) continue;
+        routeVisual.setObjectPolyline(route.id, [
+          from,
+          ...routeMove.waypoints,
+          to,
+        ]);
+      }
+    };
     const tolerance = logicalRadiusForPixels(svg, SNAP_CAPTURE_RADIUS_PX);
     let lastSnap: SnapResult | undefined;
     canvasDragSessionRef.current = startCanvasDragSession({
@@ -3833,14 +3878,24 @@ export function App({
           (move) => move.instanceId === preview.primaryInstanceId,
         )!;
         const original = preview.originalPositions[preview.primaryInstanceId]!;
-        dragVisual().translate({
-          x: primary.position.x - original.x,
-          y: primary.position.y - original.y,
-        });
+        try {
+          paintMovePreview(resolved.moves, {
+            x: primary.position.x - original.x,
+            y: primary.position.y - original.y,
+          });
+        } catch {
+          // The transaction reports protected or unresolved geometry on
+          // release; keep the Instance preview responsive in the meantime.
+          dragVisual().translate({
+            x: primary.position.x - original.x,
+            y: primary.position.y - original.y,
+          });
+        }
       },
       onFinish: ({ client, dragged }) => {
         canvasDragSessionRef.current = null;
         visual?.restore();
+        routeVisual?.restore();
         paintSnapGuides([]);
         if (dragged) {
           completeInstanceMove(
@@ -3855,6 +3910,7 @@ export function App({
       onCancel: () => {
         canvasDragSessionRef.current = null;
         visual?.restore();
+        routeVisual?.restore();
         paintSnapGuides([]);
       },
     });
@@ -6560,7 +6616,7 @@ export function App({
       return;
     }
     if (hasMixedSelection) {
-      const visualRouteDeletion = proposeVisualRouteDeletion(
+      const visualRouteDeletion = proposeSelectionRouteDeletion(
         document,
         [...initialRouteIds],
         [...selectedJunctionIds],

--- a/apps/editor/src/canvas/canvas-drag-visual.test.ts
+++ b/apps/editor/src/canvas/canvas-drag-visual.test.ts
@@ -50,16 +50,22 @@ describe("startCanvasDragVisual", () => {
       "data-object-id": "route-1",
       points: "0,0 10,0",
     });
+    const sibling = new FakeElement({
+      "data-object-id": "route-2",
+      points: "0,10 10,10",
+    });
     const root = {
-      querySelectorAll: () => [route],
+      querySelectorAll: () => [route, sibling],
     } as unknown as ParentNode;
-    const visual = startCanvasDragVisual(root, ["route-1"]);
-    visual.setPolyline([
+    const visual = startCanvasDragVisual(root, ["route-1", "route-2"]);
+    visual.setObjectPolyline("route-1", [
       { x: 0, y: 5 },
       { x: 10, y: 5 },
     ]);
     expect(route.getAttribute("points")).toBe("0,5 10,5");
+    expect(sibling.getAttribute("points")).toBe("0,10 10,10");
     visual.restore();
     expect(route.getAttribute("points")).toBe("0,0 10,0");
+    expect(sibling.getAttribute("points")).toBe("0,10 10,10");
   });
 });

--- a/apps/editor/src/canvas/canvas-drag-visual.ts
+++ b/apps/editor/src/canvas/canvas-drag-visual.ts
@@ -3,11 +3,13 @@ import type { Point } from "@icm/model";
 export interface CanvasDragVisual {
   translate(delta: Point): void;
   setPolyline(points: readonly Point[]): void;
+  setObjectPolyline(objectId: string, points: readonly Point[]): void;
   restore(): void;
 }
 
 interface SavedElement {
   element: Element;
+  objectId: string;
   transform: string | null;
   points: string | null;
 }
@@ -36,6 +38,9 @@ export function startCanvasDragVisual(
   });
   const saved: SavedElement[] = elements.map((element) => ({
     element,
+    objectId:
+      element.getAttribute("data-drag-object-id") ??
+      element.getAttribute("data-object-id")!,
     transform: element.getAttribute("transform"),
     points: element.getAttribute("points"),
   }));
@@ -54,6 +59,14 @@ export function startCanvasDragVisual(
       const value = pointList(points);
       for (const item of saved) {
         if (item.points !== null) item.element.setAttribute("points", value);
+      }
+    },
+    setObjectPolyline(objectId, points) {
+      const value = pointList(points);
+      for (const item of saved) {
+        if (item.objectId === objectId && item.points !== null) {
+          item.element.setAttribute("points", value);
+        }
       }
     },
     restore() {

--- a/apps/editor/src/features/selection/delete-selection.test.ts
+++ b/apps/editor/src/features/selection/delete-selection.test.ts
@@ -10,6 +10,7 @@ import {
   collectVisualRouteDeletion,
   explicitAnnotationRemovals,
   proposeConnectedInstanceDeletion,
+  proposeSelectionRouteDeletion,
 } from "./delete-selection";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
@@ -159,6 +160,50 @@ function documentWithJunctionRoute() {
   return document;
 }
 
+function documentWithBranchedJunction() {
+  const document = createEmptyProject("delete-branch", "Delete branch")
+    .documents[0]!;
+  document.nets.push({
+    id: "net-1",
+    name: "N1",
+    scope: "local",
+    terminals: [],
+  });
+  document.junctions.push(
+    { id: "junction-center", netId: "net-1", position: { x: 100, y: 100 } },
+    { id: "junction-left", netId: "net-1", position: { x: 0, y: 100 } },
+    { id: "junction-right", netId: "net-1", position: { x: 200, y: 100 } },
+    { id: "junction-bottom", netId: "net-1", position: { x: 100, y: 200 } },
+  );
+  document.routes.push(
+    {
+      id: "route-left",
+      netId: "net-1",
+      from: { kind: "junction", junctionId: "junction-left" },
+      to: { kind: "junction", junctionId: "junction-center" },
+      waypoints: [],
+      segmentModes: ["manual"],
+    },
+    {
+      id: "route-right",
+      netId: "net-1",
+      from: { kind: "junction", junctionId: "junction-center" },
+      to: { kind: "junction", junctionId: "junction-right" },
+      waypoints: [],
+      segmentModes: ["manual"],
+    },
+    {
+      id: "route-branch",
+      netId: "net-1",
+      from: { kind: "junction", junctionId: "junction-center" },
+      to: { kind: "junction", junctionId: "junction-bottom" },
+      waypoints: [],
+      segmentModes: ["manual"],
+    },
+  );
+  return document;
+}
+
 describe("collectVisualRouteDeletion", () => {
   it("cleans both orphan junction endpoints when a route is deleted", () => {
     expect(
@@ -179,6 +224,47 @@ describe("collectVisualRouteDeletion", () => {
     ).toEqual({
       routeIds: ["route-1"],
       junctionIds: ["junction-left", "junction-right"],
+    });
+  });
+
+  it("deletes only the selected branch when its shared Junction is also inside the marquee", () => {
+    const document = documentWithBranchedJunction();
+    expect(
+      collectVisualRouteDeletion(
+        document,
+        ["route-branch"],
+        ["junction-center"],
+      ),
+    ).toEqual({
+      routeIds: ["route-branch"],
+      junctionIds: ["junction-bottom"],
+    });
+    const proposal = proposeSelectionRouteDeletion(
+      document,
+      ["route-branch"],
+      ["junction-center"],
+    );
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "delete-one-branch",
+        documentId: document.id,
+        expectedRevision: 0,
+        actor: { kind: "human", id: "test" },
+        edits: proposal.edits,
+      },
+      { symbolResolver: resolver },
+    );
+    expect(result).toMatchObject({
+      ok: true,
+      document: {
+        routes: [{ id: "route-left" }, { id: "route-right" }],
+        junctions: [
+          { id: "junction-center" },
+          { id: "junction-left" },
+          { id: "junction-right" },
+        ],
+      },
     });
   });
 

--- a/apps/editor/src/features/selection/delete-selection.ts
+++ b/apps/editor/src/features/selection/delete-selection.ts
@@ -18,8 +18,31 @@ export function collectVisualRouteDeletion(
   routeIds: readonly string[],
   junctionIds: readonly string[],
 ): { routeIds: string[]; junctionIds: string[] } {
-  const proposal = proposeVisualRouteDeletion(document, routeIds, junctionIds);
+  const proposal = proposeSelectionRouteDeletion(
+    document,
+    routeIds,
+    junctionIds,
+  );
   return { routeIds: proposal.routeIds, junctionIds: proposal.junctionIds };
+}
+
+/**
+ * Route geometry is the authoritative deletion target whenever the visual
+ * selection contains a Route. A marquee commonly includes the shared
+ * Junction dot at a selected branch endpoint; treating that incidental dot as
+ * an independent Junction deletion would expand into every sibling Route.
+ * Junction-only deletion retains the explicit topology-vertex behavior.
+ */
+export function proposeSelectionRouteDeletion(
+  document: SchematicDocument,
+  routeIds: readonly string[],
+  junctionIds: readonly string[],
+) {
+  return proposeVisualRouteDeletion(
+    document,
+    routeIds,
+    routeIds.length > 0 ? [] : junctionIds,
+  );
 }
 
 export function proposeConnectedInstanceDeletion(

--- a/packages/edit-engine/src/route-operations.ts
+++ b/packages/edit-engine/src/route-operations.ts
@@ -467,45 +467,29 @@ export function proposeLocalStretch(
     const newFrom = resolveEndpointPoint(movedDocument, resolver, route.from);
     const newTo = resolveEndpointPoint(movedDocument, resolver, route.to);
     if (!original || !newFrom || !newTo) continue;
-    const adjacentMode = movesFrom
-      ? route.segmentModes[0]
-      : route.segmentModes.at(-1);
-    if (adjacentMode === "locked" || adjacentMode === "trunk") {
-      throw new Error(`Route ${route.id} has a protected adjacent segment`);
-    }
-    const waypoints = route.waypoints.map((point) => ({ ...point }));
-    let modes = [...route.segmentModes];
-    if (waypoints.length === 0) {
-      if (newFrom.x !== newTo.x && newFrom.y !== newTo.y) {
-        waypoints.push({ x: newTo.x, y: newFrom.y });
-        const mode = route.segmentModes[0] ?? "escape";
-        modes = [mode, mode];
-      }
-    } else if (movesFrom) {
-      const oldFrom = original.points[0]!;
-      const first = waypoints[0]!;
-      if (oldFrom.x === first.x) first.x = newFrom.x;
-      else first.y = newFrom.y;
-    } else if (movesTo) {
-      const oldTo = original.points.at(-1)!;
-      const last = waypoints.at(-1)!;
-      if (oldTo.x === last.x) last.x = newTo.x;
-      else last.y = newTo.y;
-    }
-    const normalized = normalizeRouteGeometry(
-      [newFrom, ...waypoints, newTo],
-      modes,
-    );
-    if (!isOrthogonal(normalized.points)) {
-      throw new Error(
-        `Local stretch would make route ${route.id} non-orthogonal`,
+    const points = original.points.map((point) => ({ ...point }));
+    const modes = [...original.segmentModes];
+    if (movesFrom) {
+      stretchRouteEndpoint(
+        route.id,
+        points,
+        modes,
+        "from",
+        original.points[0]!,
+        newFrom,
       );
     }
-    proposals.push({
-      routeId: route.id,
-      waypoints: normalized.points.slice(1, -1),
-      segmentModes: normalized.segmentModes,
-    });
+    if (movesTo) {
+      stretchRouteEndpoint(
+        route.id,
+        points,
+        modes,
+        "to",
+        original.points.at(-1)!,
+        newTo,
+      );
+    }
+    proposals.push(normalizeProposal(route.id, points, modes));
   }
   return proposals.sort((left, right) =>
     left.routeId.localeCompare(right.routeId, "en"),
@@ -554,6 +538,7 @@ export function proposeGroupMove(
   ]);
   const internalNetIds = new Set(internalSelection.netIds);
   const movableJunctionIds = new Set(internalSelection.junctionIds);
+  const routingGeometry = resolveDocumentRoutingGeometry(document, resolver);
 
   const proposals = new Map<string, RouteStretchProposal>();
   for (const route of document.routes) {
@@ -600,18 +585,25 @@ export function proposeGroupMove(
         `Route ${route.id} cannot stretch endpoints by different group deltas`,
       );
     }
-    const instanceId =
-      route.from.kind === "terminal" &&
-      moveByInstance.has(route.from.instanceId)
-        ? route.from.instanceId
-        : route.to.kind === "terminal"
-          ? route.to.instanceId
-          : null;
-    if (!instanceId) continue;
-    const position = moveByInstance.get(instanceId)!;
-    const local = proposeLocalStretch(document, resolver, instanceId, position);
-    const proposal = local.find((candidate) => candidate.routeId === route.id);
-    if (proposal) proposals.set(route.id, proposal);
+    const original = routeEditPathFromGeometry(routingGeometry, route.id);
+    if (!original) throw new Error(`Route ${route.id} has unresolved geometry`);
+    const points = original.points.map((point) => ({ ...point }));
+    const modes = [...original.segmentModes];
+    if (resolvedFromDelta) {
+      const from = original.points[0]!;
+      stretchRouteEndpoint(route.id, points, modes, "from", from, {
+        x: from.x + resolvedFromDelta.x,
+        y: from.y + resolvedFromDelta.y,
+      });
+    }
+    if (toDelta) {
+      const to = original.points.at(-1)!;
+      stretchRouteEndpoint(route.id, points, modes, "to", to, {
+        x: to.x + toDelta.x,
+        y: to.y + toDelta.y,
+      });
+    }
+    proposals.set(route.id, normalizeProposal(route.id, points, modes));
   }
   const internalRouteIds = internalSelection.routeIds;
   const internallyMovedObjectIds = new Set<string>([

--- a/packages/edit-engine/src/routing-geometry.integration.test.ts
+++ b/packages/edit-engine/src/routing-geometry.integration.test.ts
@@ -210,7 +210,7 @@ describe("derived connectivity and route geometry", () => {
     ).toEqual([
       {
         routeId: "route-h",
-        waypoints: [{ x: 450, y: 360 }],
+        waypoints: [{ x: 150, y: 300 }],
         segmentModes: ["manual", "manual"],
       },
     ]);

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -131,6 +131,10 @@ export interface RouteEditPlan {
 
 export interface GroupMoveEditProposal {
   edits: SchematicEdit[];
+  preview: {
+    routes: readonly RouteStretchProposal[];
+    junctions: readonly JunctionMoveProposal[];
+  };
 }
 
 /** Plan instance-group movement and all internal route/Junction/label follow edits. */
@@ -141,6 +145,10 @@ export function proposeGroupMoveEdits(
 ): GroupMoveEditProposal {
   const proposal = proposeGroupMove(document, resolver, moves);
   return {
+    preview: {
+      routes: proposal.routes,
+      junctions: proposal.junctions,
+    },
     edits: [
       ...moves.map((move): SchematicEdit => ({
         kind: "move_instance",

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -716,6 +716,56 @@ describe("routing Edit Engine", () => {
     }
   });
 
+  it("keeps the fixed side of a direct Route in place during a local move", () => {
+    const document = documentFixture();
+    const routed = executeTransaction(
+      document,
+      transaction(document.id, 0, [
+        {
+          kind: "set_route_points",
+          routeId: "route-h",
+          netId: "net-h",
+          from: terminal("A"),
+          to: terminal("B"),
+          waypoints: [],
+          segmentModes: ["manual"],
+        },
+      ]),
+      context,
+    );
+    expect(routed.ok).toBe(true);
+    if (!routed.ok) return;
+
+    const plan = proposeGroupMoveEdits(routed.document, resolver, [
+      { instanceId: "A", position: { x: 160, y: 320 } },
+    ]);
+    expect(plan.preview.routes).toEqual([
+      {
+        routeId: "route-h",
+        waypoints: [{ x: 170, y: 300 }],
+        segmentModes: ["manual", "manual"],
+      },
+    ]);
+    const moved = executeTransaction(
+      routed.document,
+      transaction(routed.document.id, 1, plan.edits),
+      context,
+    );
+    expect(moved.ok).toBe(true);
+    if (!moved.ok) return;
+    expect(
+      resolveRouteGeometry(
+        moved.document,
+        resolver,
+        moved.document.routes.find((route) => route.id === "route-h")!,
+      )?.centerline,
+    ).toEqual([
+      { x: 170, y: 320 },
+      { x: 170, y: 300 },
+      { x: 450, y: 300 },
+    ]);
+  });
+
   it("moves a net label with its reshaped wire segment", () => {
     const document = documentFixture();
     const routed = executeTransaction(

--- a/plan/2026-08-17-connected-wire-move-delete/plan.md
+++ b/plan/2026-08-17-connected-wire-move-delete/plan.md
@@ -1,0 +1,96 @@
+---
+status: completed
+experience: none
+---
+
+# Stabilize connected Wire move and deletion
+
+## Goal
+
+Keep connected Wire geometry local and predictable when an Instance moves, and
+ensure deleting one selected Route never expands to unselected sibling Routes
+through stale or implicit Junction selection.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree was clean. This target owns the connected-move planning, visual
+selection deletion normalization, their focused tests, and its plan/log record:
+
+- `packages/edit-engine/src/route-operations.ts`
+- `packages/edit-engine/src/routing-planner.ts`
+- `packages/edit-engine/src/routing.test.ts`
+- `packages/edit-engine/src/routing-geometry.integration.test.ts`
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/canvas/canvas-drag-visual.ts`
+- `apps/editor/src/canvas/canvas-drag-visual.test.ts`
+- `apps/editor/src/features/selection/delete-selection.ts`
+- `apps/editor/src/features/selection/delete-selection.test.ts`
+- `apps/editor/src/features/selection/selection-move-plan.test.ts`
+- `apps/editor/e2e/manual-editor.spec.ts`
+- `plan/2026-08-17-connected-wire-move-delete/plan.md`
+- `plan/root-audit.md`
+- `plan/log.md`
+
+Shared contracts are the persisted Route/Junction topology and the Edit Engine
+transaction boundary. Read-only authorities are
+`docs/specs/editor-interaction.md` and
+`docs/specs/connectivity-and-routing.md`.
+
+## Work
+
+1. Add focused regressions for a moved endpoint preserving the fixed side of a
+   direct Route, live per-Route preview geometry, and deleting one branch from
+   a shared Junction.
+2. Correct local endpoint stretch geometry, preview affected Routes during the
+   drag, and prevent Route deletion from expanding through a co-selected
+   shared Junction.
+3. Run focused and impact validation, then deliver through the review gate.
+
+## Validation
+
+- `pnpm test:local packages/edit-engine/src/routing.test.ts apps/editor/src/features/selection/delete-selection.test.ts apps/editor/src/features/selection/selection-move-plan.test.ts`
+- `pnpm test:impact -- --base origin/main`
+- `pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts --grep "previews a connected Wire while its Instance moves"`
+- `pnpm install --frozen-lockfile`
+- `pnpm ci:check`
+- `git diff --check`
+- `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: moving one connected terminal changes only endpoint-adjacent
+  geometry; deleting one selected Route preserves sibling Routes and a shared
+  Junction.
+- Primary checks: Edit Engine routing tests plus Editor selection-deletion and
+  move-plan tests.
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): stabilize connected wire editing
+```
+
+## Outcome
+
+Connected Instance drags now preview the exact per-Route geometry that will be
+committed. Direct and boundary Routes use one local endpoint-stretch primitive,
+which preserves the fixed-side track instead of moving the elbow to the remote
+terminal. Visual deletion now gives explicitly selected Routes priority over
+incidental shared Junction dots, so sibling branches survive.
+
+Focused route/selection suites passed (46 tests), the new browser drag scenario
+and the existing group-move preview scenario passed, typecheck/build/release
+verification passed, all 824 unit/integration tests passed, test-impact and
+diff checks passed, and 145 of 146 full browser tests passed. The sole browser
+failure was the unrelated pre-existing narrow Library layout timing assertion;
+its isolated rerun passed and it is being stabilized as a separate target
+before delivery. Remote required checks remain the mainline gate.

--- a/plan/2026-08-17-connected-wire-move-delete/plan.md
+++ b/plan/2026-08-17-connected-wire-move-delete/plan.md
@@ -93,4 +93,5 @@ verification passed, all 824 unit/integration tests passed, test-impact and
 diff checks passed, and 145 of 146 full browser tests passed. The sole browser
 failure was the unrelated pre-existing narrow Library layout timing assertion;
 its isolated rerun passed and it is being stabilized as a separate target
-before delivery. Remote required checks remain the mainline gate.
+before delivery. The target was committed as `4c11e7a`; remote required checks
+remain the mainline gate.

--- a/plan/2026-08-17-stabilize-narrow-library-e2e/plan.md
+++ b/plan/2026-08-17-stabilize-narrow-library-e2e/plan.md
@@ -1,0 +1,63 @@
+---
+status: completed
+experience: none
+---
+
+# Stabilize narrow Library layout browser assertion
+
+## Goal
+
+Make the existing narrow-breakpoint Library browser test wait for its
+asynchronous layout change instead of sampling the canvas width too early.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/connected-wire-move-delete
+```
+
+The worktree was clean after commit `4c11e7a`. This separate test-maintenance
+target owns only:
+
+- `apps/editor/e2e/component-insert.spec.ts`
+- `plan/2026-08-17-stabilize-narrow-library-e2e/plan.md`
+- `plan/root-audit.md`
+- `plan/log.md`
+
+## Work
+
+1. Replace the immediate post-toggle width read with a bounded Playwright poll.
+2. Repeat the focused scenario, then rerun the full local delivery gate.
+
+## Validation
+
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep "keeps a usable canvas while toggling Library" --repeat-each=3`
+- `pnpm test:impact -- --base origin/main`
+- `pnpm ci:check`
+- `git diff --check`
+- `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: the existing Library-open layout assertion remains unchanged; the
+  test now observes it after layout settles.
+- Primary checks: repeated focused Playwright scenario and the full local gate.
+
+## Commit Intent
+
+Commit as:
+
+```text
+test(editor): wait for narrow Library layout
+```
+
+## Outcome
+
+The narrow Library test now polls until the canvas contracts after the panel
+opens, then retains the same minimum-width and restore assertions. The focused
+scenario passed three consecutive runs, and the complete local delivery gate
+passed: static contracts, 824 unit/integration tests, build/release checks, and
+all 146 browser tests.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7939,5 +7939,18 @@ box`; branch pushed for review. A concurrent worker's overlapping App.tsx
   typecheck, build/release verification, test-impact, formatting, and diff
   checks passed. The full browser run passed 145/146; its sole unrelated narrow
   Library timing failure passed in isolation and is tracked separately.
-- Commit status: ready to commit on `codex/connected-wire-move-delete`; remote
-  required checks remain the mainline delivery gate.
+- Commit status: committed as `4c11e7a` on
+  `codex/connected-wire-move-delete`; remote required checks remain the
+  mainline delivery gate.
+
+## 2026-08-17 - Stabilize narrow Library browser timing
+
+- Target: remove an immediate layout-width sample from the existing narrow
+  Library browser test without changing its product assertion.
+- Changed areas: Playwright Library layout timing assertion and target records.
+- Validation: the focused scenario passed three repeated runs; the complete
+  `pnpm ci:check` gate passed static contracts, 824 unit/integration tests,
+  build/release verification, and all 146 browser tests.
+- Commit status: ready to commit separately on
+  `codex/connected-wire-move-delete`; remote required checks remain the
+  mainline delivery gate.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7927,3 +7927,17 @@ box`; branch pushed for review. A concurrent worker's overlapping App.tsx
   `git diff --check` passed.
 - Commit status: committed on `codex/wire-snap-rectangle-edge-fractions`;
   remote required checks remain the mainline delivery gate.
+
+## 2026-08-17 - Stabilize connected Wire move and deletion
+
+- Target: make connected Routes follow Instance drags predictably and isolate
+  deletion to explicitly selected Wire branches.
+- Changed areas: Edit Engine endpoint/group stretch planning; Editor live Route
+  preview and visual deletion normalization; focused unit and browser coverage.
+- Validation: focused route/selection suites (4 files / 46 tests), targeted
+  connected and group-move browser scenarios, all 824 unit/integration tests,
+  typecheck, build/release verification, test-impact, formatting, and diff
+  checks passed. The full browser run passed 145/146; its sole unrelated narrow
+  Library timing failure passed in isolation and is tracked separately.
+- Commit status: ready to commit on `codex/connected-wire-move-delete`; remote
+  required checks remain the mainline delivery gate.

--- a/plan/root-audit.md
+++ b/plan/root-audit.md
@@ -132,7 +132,13 @@ plan retention handling.
 `2026-08-17-connected-wire-move-delete` is completed with resolved experience.
 Connected Route drag previews, local endpoint stretch, and branch-isolated
 visual deletion have focused unit and browser regression evidence; the target
-is ready for its review commit and remote required checks.
+is committed as `4c11e7a` and awaits remote required checks.
+
+## 2026-08-17 Narrow Library browser-test stabilization closure
+
+`2026-08-17-stabilize-narrow-library-e2e` is completed with resolved
+experience. Its layout poll passed three repeated focused runs and the complete
+local delivery gate, and is ready for its separate test-only commit.
 
 ## Legacy Metadata Sweep
 

--- a/plan/root-audit.md
+++ b/plan/root-audit.md
@@ -127,6 +127,13 @@ placed the Examples entry in the far-left tool rail, passed local and remote
 delivery gates, and merged as `f7d961c`; it is eligible for normal completed-
 plan retention handling.
 
+## 2026-08-17 Connected-Wire editing stabilization closure
+
+`2026-08-17-connected-wire-move-delete` is completed with resolved experience.
+Connected Route drag previews, local endpoint stretch, and branch-isolated
+visual deletion have focused unit and browser regression evidence; the target
+is ready for its review commit and remote required checks.
+
 ## Legacy Metadata Sweep
 
 The first 50 oldest pre-metadata records were individually classified on


### PR DESCRIPTION
Summary:
- preview connected Route geometry live while dragging an Instance
- keep local endpoint stretch near the moved component and preserve the fixed-side track
- delete only explicitly selected Route branches when a shared Junction is also inside a marquee
- stabilize the narrow Library layout browser assertion exposed by the full gate

Validation:
- pnpm ci:check: 824 unit/integration tests and 146 browser tests passed
- focused connected Wire browser and route/deletion regressions passed
- pnpm test:impact -- --base origin/main passed