### PR TITLE
Add manual hierarchical Cell editing

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -636,6 +636,87 @@ test("R creates a selectable, styleable rectangle with four resize handles", asy
   expect(await rectangle.getAttribute("points")).not.toBe(pointsBeforeResize);
 });
 
+test("E converts a rectangle into a navigable hierarchical Cell", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.keyboard.press("r");
+  await clickCreate(page, { x: 220, y: 220 }, { x: 380, y: 320 });
+
+  const rectangleHit = page.getByTestId(/^drafting-hit-rectangle-/);
+  const edge = await rectangleHit.evaluate((element) => {
+    const polygon = element as SVGPolygonElement;
+    const matrix = polygon.getScreenCTM();
+    if (!matrix || polygon.points.numberOfItems < 2) return null;
+    const first = polygon.points.getItem(0);
+    const second = polygon.points.getItem(1);
+    const midpoint = new DOMPoint(
+      (first.x + second.x) / 2,
+      (first.y + second.y) / 2,
+    ).matrixTransform(matrix);
+    return { x: midpoint.x, y: midpoint.y };
+  });
+  if (!edge) throw new Error("Rectangle edge is not measurable");
+  await page.mouse.click(edge.x, edge.y);
+  await page.keyboard.press("e");
+
+  await expect(page.getByTestId("document-count")).toHaveText("2");
+  await expect(page.getByTestId("active-document-id")).toHaveText(
+    "document-cell-1",
+  );
+  await expect(page.getByTestId("active-instance-count")).toHaveText("0");
+  await expect(page.getByTestId("status")).toHaveText(
+    "Created and entered Cell Cell1",
+  );
+  await expect(page.getByTestId("cell-navigation")).toBeVisible();
+
+  await page.keyboard.press("Shift+E");
+  await expect(page.getByTestId("active-document-id")).toHaveText(
+    "document-main",
+  );
+  await expect(page.getByTestId("hit-X1")).toBeVisible();
+
+  await page.getByTestId("hit-X1").click();
+  await page.keyboard.press("e");
+  await expect(page.getByTestId("active-document-id")).toHaveText(
+    "document-cell-1",
+  );
+
+  await page.getByRole("button", { name: "Up" }).click();
+  await page.getByTestId("hit-X1").dblclick();
+  await expect(page.getByTestId("active-document-id")).toHaveText(
+    "document-cell-1",
+  );
+
+  const projectBytes = await downloadBytes(page, "File", "Save Project");
+  const project = JSON.parse(projectBytes.toString("utf8"));
+  expect(project.documents).toHaveLength(2);
+  expect(project.documents[0].drafting.objects).toEqual([]);
+  expect(project.documents[0].instances[0]).toMatchObject({
+    id: "X1",
+    netlist: {
+      binding: {
+        kind: "subcircuit",
+        name: "Cell1",
+        childDocumentId: "document-cell-1",
+      },
+    },
+  });
+
+  await page.getByTestId("project-file").setInputFiles({
+    name: "hierarchical-cell.icproj.json",
+    mimeType: "application/json",
+    buffer: projectBytes,
+  });
+  await expect(page.getByTestId("active-document-id")).toHaveText(
+    "document-main",
+  );
+  await page.getByTestId("hit-X1").dblclick();
+  await expect(page.getByTestId("active-document-id")).toHaveText(
+    "document-cell-1",
+  );
+});
+
 // Dragging an arrow endpoint handle moves just that endpoint in one
 // transaction; undo restores it.
 test("arrow endpoint handle drag moves the tip", async ({ page }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -145,6 +145,7 @@ import {
   ShapesPanel,
 } from "../features/editor-shell/shapes-panel";
 import { ExamplesPanel } from "../features/editor-shell/examples-panel";
+import { convertRectangleToHierarchy } from "../features/hierarchy/rectangle-to-cell";
 import {
   createLibraryExampleProject,
   type LibraryProjectExample,
@@ -701,6 +702,7 @@ export function App({
     canRedo,
     openDocument,
     replaceProject,
+    commitProjectStructure,
     transact: transactDocument,
     controller: editorDocumentController,
     projectSessionId,
@@ -1015,7 +1017,7 @@ export function App({
     selectedIds.length === 1
       ? document.instances.find((instance) => instance.id === selectedId)
       : undefined;
-  const hasImportedHierarchy = useMemo(
+  const hasHierarchy = useMemo(
     () =>
       project.documents.some((candidate) =>
         candidate.instances.some(
@@ -1060,6 +1062,10 @@ export function App({
         (object) => object.id === selectedDraftingId,
       )
     : undefined;
+  const hasHierarchyEnterSelection = Boolean(
+    (selectedInstance && referencedDocumentId(project, selectedInstance)) ||
+    selectedDrafting?.kind === "rectangle",
+  );
   const hasRotatableSelection =
     selectedIds.some((id) =>
       document.instances.some(
@@ -1949,7 +1955,7 @@ export function App({
     );
     const targetId = instance ? referencedDocumentId(project, instance) : null;
     if (!targetId) {
-      setStatus(`${instanceId} has no imported child Cell`);
+      setStatus(`${instanceId} has no child Cell`);
       return;
     }
     setDocumentStack((current) => [
@@ -1961,6 +1967,47 @@ export function App({
       },
     ]);
     switchDocument(targetId);
+  }
+
+  function enterSelectedHierarchy(): void {
+    if (
+      selectedInstance &&
+      referencedDocumentId(project, selectedInstance) !== null
+    ) {
+      enterHierarchy(selectedInstance.id);
+      return;
+    }
+    if (selectedDrafting?.kind !== "rectangle") {
+      setStatus(
+        "Select a rectangle or hierarchical block before entering a Cell",
+      );
+      return;
+    }
+
+    try {
+      const converted = convertRectangleToHierarchy(
+        project,
+        document.id,
+        selectedDrafting.id,
+      );
+      commitProjectStructure(converted.project, document.id);
+      setDocumentStack((current) => [
+        ...current,
+        {
+          parentDocumentId: converted.parentDocumentId,
+          instanceId: converted.instanceId,
+          childDocumentId: converted.childDocumentId,
+        },
+      ]);
+      switchDocument(converted.childDocumentId);
+      setStatus(`Created and entered Cell ${converted.cellName}`);
+    } catch (error) {
+      setStatus(
+        `Could not create Cell: ${
+          error instanceof Error ? error.message : "unexpected failure"
+        }`,
+      );
+    }
   }
 
   function returnToParentDocument(): void {
@@ -7006,6 +7053,8 @@ export function App({
           wireSource && wireWaypoints.length > 0,
         ),
         propertiesOpen: selectionOpen,
+        hasHierarchyEnterSelection,
+        canReturnToParent: documentStack.length > 0,
       });
       if (!shortcut) return;
 
@@ -7122,6 +7171,17 @@ export function App({
           return;
         case "toggle-net-highlight":
           toggleHighlightedNet();
+          return;
+        case "enter-hierarchy":
+          enterSelectedHierarchy();
+          return;
+        case "return-to-parent":
+          returnToParentDocument();
+          return;
+        case "hierarchy-selection-required":
+          setStatus(
+            "Select a rectangle or hierarchical block before entering a Cell",
+          );
           return;
         case "fit-view":
           fitView();
@@ -7555,18 +7615,18 @@ export function App({
             </button>
           </div>
         </div>
-        {hasImportedHierarchy ? (
+        {hasHierarchy ? (
           <div className="toolbar-row" aria-label="Document hierarchy">
             <div
               className="document-nav"
-              aria-label="Imported cell navigation"
+              aria-label="Cell navigation"
               data-testid="cell-navigation"
             >
               <button
                 type="button"
                 onClick={returnToParentDocument}
                 disabled={documentStack.length === 0}
-                title="Return to the parent imported cell"
+                title="Return to the parent Cell (Shift+E)"
               >
                 Up
               </button>
@@ -7574,12 +7634,12 @@ export function App({
                 type="button"
                 onClick={returnToTopDocument}
                 disabled={document.id === project.topDocumentId}
-                title="Return to the top imported cell"
+                title="Return to the top Cell"
               >
                 Top
               </button>
               <select
-                aria-label="Imported Cells"
+                aria-label="Cells"
                 data-testid="document-selector"
                 value={document.id}
                 onChange={(event) => {
@@ -7597,14 +7657,9 @@ export function App({
               </select>
               <button
                 type="button"
-                onClick={() =>
-                  selectedInstance && enterHierarchy(selectedInstance.id)
-                }
-                disabled={
-                  !selectedInstance ||
-                  referencedDocumentId(project, selectedInstance) === null
-                }
-                title="Enter the selected imported subcircuit"
+                onClick={enterSelectedHierarchy}
+                disabled={!hasHierarchyEnterSelection}
+                title="Enter the selected Cell, or create one from a rectangle (E)"
               >
                 Enter Cell
               </button>

--- a/apps/editor/src/components/editor-help-dialog.tsx
+++ b/apps/editor/src/components/editor-help-dialog.tsx
@@ -84,6 +84,14 @@ export function EditorHelpDialog({
               active Cell in one operation. It asks for confirmation and can be
               restored with Undo.
             </p>
+            <h3>Hierarchical Cells</h3>
+            <p>
+              Select a rectangle and press <kbd>E</kbd> to convert it into a
+              hierarchical block and enter its new child Cell. Select an
+              existing hierarchical block and press <kbd>E</kbd>, or
+              double-click it, to enter it. Use <strong>Up</strong> or
+              <kbd>Shift+E</kbd> to return to the parent Cell.
+            </p>
             <h3>View and drawing tools</h3>
             <p>
               With the pointer over the canvas, use the mouse wheel to zoom and
@@ -122,6 +130,8 @@ export function EditorHelpDialog({
                   mirror left/right; <kbd>Ctrl</kbd> + <kbd>R</kbd> mirror
                   top/bottom; <kbd>Ctrl</kbd> + <kbd>D</kbd> deselect;{" "}
                   <kbd>F</kbd> fit view;
+                  <kbd>E</kbd> enter or create a hierarchical Cell;{" "}
+                  <kbd>Shift</kbd> + <kbd>E</kbd> return to its parent;
                   <kbd>Delete</kbd> or <kbd>Backspace</kbd> delete.
                 </dd>
               </div>

--- a/apps/editor/src/document/document-controller.test.ts
+++ b/apps/editor/src/document/document-controller.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { createEmptyProject } from "@icm/model";
+import { createEmptyDocument, createEmptyProject } from "@icm/model";
 import type { SchematicDocument } from "@icm/model";
+import { hierarchicalSymbolId } from "@icm/symbols";
 
 import { EditorDocumentController } from "./document-controller";
 
@@ -98,6 +99,45 @@ describe("EditorDocumentController", () => {
     expect(controller.projectSessionId).not.toBe(originalSessionId);
     expect(controller.canUndo).toBe(false);
     expect(controller.canRedo).toBe(false);
+  });
+
+  it("commits a new child Cell without replacing the Project session", () => {
+    const controller = new EditorDocumentController(hierarchicalProject());
+    const sessionId = controller.projectSessionId;
+    controller.transact([{ kind: "add_instance", instance: instance("Rold") }]);
+    const project = structuredClone(controller.project);
+    const child = createEmptyDocument("document-cell-1", "Cell1");
+    project.documents.push(child);
+    project.documents[0]!.instances.push({
+      id: "X1",
+      symbolId: hierarchicalSymbolId("Cell1"),
+      placement: {
+        position: { x: 0, y: 0 },
+        rotation: 0,
+        mirror: "none",
+      },
+      properties: {},
+      netlist: {
+        reference: "X1",
+        parameters: {},
+        terminals: [],
+        binding: {
+          kind: "subcircuit",
+          name: "Cell1",
+          childDocumentId: child.id,
+        },
+      },
+    });
+
+    const active = controller.commitProjectStructure(project);
+
+    expect(active.id).toBe(controller.project.topDocumentId);
+    expect(controller.projectSessionId).toBe(sessionId);
+    expect(
+      controller.resolver.resolve(hierarchicalSymbolId("Cell1")),
+    ).toBeDefined();
+    expect(controller.canUndo).toBe(false);
+    expect(controller.openDocument(child.id)?.id).toBe(child.id);
   });
 
   it("dispatches an Agent transaction as one undo item and refreshes state", () => {

--- a/apps/editor/src/document/document-controller.ts
+++ b/apps/editor/src/document/document-controller.ts
@@ -156,6 +156,39 @@ export class EditorDocumentController {
     return document;
   }
 
+  /**
+   * Commit a validated structural update within the current Project session.
+   * Adding a child Document changes the symbol resolver and invalidates every
+   * DocumentHistory context, so histories are deliberately rebuilt while the
+   * active Document and recovery/session identity remain stable.
+   */
+  commitProjectStructure(
+    nextProject: CircuitProject,
+    activeDocumentId = this.activeDocumentIdValue,
+  ): SchematicDocument {
+    const parsed = CircuitProjectSchema.parse(structuredClone(nextProject));
+    if (parsed.id !== this.projectValue.id) {
+      throw new Error(
+        `Structural commit cannot replace Project ${this.projectValue.id} with ${parsed.id}`,
+      );
+    }
+    if (
+      !parsed.documents.some((document) => document.id === activeDocumentId)
+    ) {
+      throw new Error(
+        `Document ${activeDocumentId} is not present in the Project`,
+      );
+    }
+    this.projectValue = parsed;
+    this.activeDocumentIdValue = activeDocumentId;
+    this.resolverValue = createProjectSymbolResolver(
+      this.projectValue,
+      builtInSymbols,
+    );
+    this.resetHistoriesFromProject();
+    return this.document;
+  }
+
   transact(edits: readonly SchematicEdit[]): EditTransactionResult {
     this.transactionCounter += 1;
     return this.dispatchTransaction({
@@ -292,6 +325,18 @@ export function useDocumentController(
     replaceProject: (project: CircuitProject) => {
       const document = controller.replaceProject(project);
       synchronize();
+      return document;
+    },
+    commitProjectStructure: (
+      project: CircuitProject,
+      activeDocumentId?: string,
+    ) => {
+      const document = controller.commitProjectStructure(
+        project,
+        activeDocumentId,
+      );
+      synchronize();
+      onCommittedRef.current(controller.project);
       return document;
     },
     transact: (edits: readonly SchematicEdit[]) => {

--- a/apps/editor/src/document/editor-session.ts
+++ b/apps/editor/src/document/editor-session.ts
@@ -27,7 +27,7 @@ export function resolveActiveDocument(
   );
 }
 
-/** Resolve only the stable imported hierarchy link written by the importer. */
+/** Resolve a stable persisted hierarchy link to a child Document. */
 export function referencedDocumentId(
   project: CircuitProject,
   instance: SchematicDocument["instances"][number],

--- a/apps/editor/src/features/hierarchy/rectangle-to-cell.test.ts
+++ b/apps/editor/src/features/hierarchy/rectangle-to-cell.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createEmptyDocument,
+  createEmptyProject,
+  type DraftRectangle,
+} from "@icm/model";
+import { createProjectSymbolResolver, builtInSymbols } from "@icm/symbols";
+
+import { convertRectangleToHierarchy } from "./rectangle-to-cell";
+
+function rectangle(locked = false): DraftRectangle {
+  return {
+    id: "rectangle-1",
+    kind: "rectangle",
+    locked,
+    zIndex: 0,
+    anchor: { kind: "free", position: { x: 100, y: 120 } },
+    center: { x: 100, y: 120 },
+    width: 120,
+    height: 80,
+    rotation: 90,
+    lineStyle: "solid",
+  };
+}
+
+describe("rectangle to hierarchical Cell conversion", () => {
+  it("atomically replaces a rectangle with a formal child Cell instance", () => {
+    const source = createEmptyProject("manual-hierarchy", "Manual hierarchy");
+    source.documents[0]!.drafting!.objects.push(rectangle());
+
+    const converted = convertRectangleToHierarchy(
+      source,
+      source.topDocumentId,
+      "rectangle-1",
+    );
+    const parent = converted.project.documents.find(
+      (document) => document.id === source.topDocumentId,
+    )!;
+    const child = converted.project.documents.find(
+      (document) => document.id === converted.childDocumentId,
+    )!;
+
+    expect(source.documents).toHaveLength(1);
+    expect(parent.revision).toBe(1);
+    expect(parent.drafting?.objects).toEqual([]);
+    expect(child).toMatchObject({
+      id: "document-cell-1",
+      name: "Cell1",
+      netlist: { name: "Cell1", terminals: [] },
+      instances: [],
+    });
+    expect(child.presentation).toEqual(parent.presentation);
+    expect(parent.instances).toEqual([
+      expect.objectContaining({
+        id: "X1",
+        placement: {
+          position: { x: 100, y: 120 },
+          rotation: 90,
+          mirror: "none",
+        },
+        netlist: expect.objectContaining({
+          reference: "X1",
+          binding: {
+            kind: "subcircuit",
+            name: "Cell1",
+            childDocumentId: "document-cell-1",
+          },
+        }),
+      }),
+    ]);
+    const resolver = createProjectSymbolResolver(
+      converted.project,
+      builtInSymbols,
+    );
+    expect(
+      resolver.resolve(parent.instances[0]!.symbolId)?.definition.pins,
+    ).toEqual([]);
+  });
+
+  it("allocates collision-free Cell, Document, and instance identities", () => {
+    const source = createEmptyProject("manual-hierarchy", "Manual hierarchy");
+    source.documents.push(createEmptyDocument("document-cell-1", "Cell1"));
+    source.documents[0]!.instances.push({
+      id: "X1",
+      symbolId: "resistor",
+      placement: null,
+      properties: {},
+      netlist: { reference: "X1", parameters: {} },
+    });
+    source.documents[0]!.drafting!.objects.push(rectangle());
+
+    const converted = convertRectangleToHierarchy(
+      source,
+      source.topDocumentId,
+      "rectangle-1",
+    );
+
+    expect(converted).toMatchObject({
+      cellName: "Cell2",
+      childDocumentId: "document-cell-2",
+      instanceId: "X2",
+    });
+  });
+
+  it("rejects a locked rectangle without mutating the source Project", () => {
+    const source = createEmptyProject("manual-hierarchy", "Manual hierarchy");
+    source.documents[0]!.drafting!.objects.push(rectangle(true));
+
+    expect(() =>
+      convertRectangleToHierarchy(source, source.topDocumentId, "rectangle-1"),
+    ).toThrow("Unlock rectangle rectangle-1");
+    expect(source.documents).toHaveLength(1);
+    expect(source.documents[0]!.drafting?.objects).toHaveLength(1);
+  });
+});

--- a/apps/editor/src/features/hierarchy/rectangle-to-cell.ts
+++ b/apps/editor/src/features/hierarchy/rectangle-to-cell.ts
@@ -1,0 +1,199 @@
+import { executeTransaction } from "@icm/edit-engine";
+import {
+  CircuitProjectSchema,
+  createEmptyDocument,
+  type CircuitProject,
+  type Rotation,
+  type SchematicDocument,
+} from "@icm/model";
+import {
+  builtInSymbols,
+  createProjectSymbolResolver,
+  hierarchicalSymbolId,
+} from "@icm/symbols";
+
+export interface RectangleToCellConversion {
+  project: CircuitProject;
+  parentDocumentId: string;
+  childDocumentId: string;
+  instanceId: string;
+  cellName: string;
+}
+
+function nextCellIdentity(project: CircuitProject): {
+  cellName: string;
+  documentId: string;
+} {
+  const cellNames = new Set(
+    project.documents.flatMap((document) =>
+      document.netlist?.name ? [document.netlist.name.toLowerCase()] : [],
+    ),
+  );
+  const documentIds = new Set(
+    project.documents.map((document) => document.id.toLowerCase()),
+  );
+  let index = 1;
+  while (
+    cellNames.has(`cell${index}`) ||
+    documentIds.has(`document-cell-${index}`)
+  ) {
+    index += 1;
+  }
+  return {
+    cellName: `Cell${index}`,
+    documentId: `document-cell-${index}`,
+  };
+}
+
+function allDocumentObjectIds(document: SchematicDocument): Set<string> {
+  return new Set(
+    [
+      ...document.instances,
+      ...document.nets,
+      ...document.routes,
+      ...document.junctions,
+      ...document.noConnects,
+      ...document.annotations,
+      ...document.layoutGroups,
+      ...document.constraints,
+      ...(document.drafting?.objects ?? []),
+    ].map((object) => object.id.toLowerCase()),
+  );
+}
+
+function nextHierarchyInstanceId(document: SchematicDocument): string {
+  const usedIds = allDocumentObjectIds(document);
+  const usedReferences = new Set(
+    document.instances.flatMap((instance) =>
+      instance.netlist?.reference
+        ? [instance.netlist.reference.toLowerCase()]
+        : [],
+    ),
+  );
+  let index = 1;
+  while (usedIds.has(`x${index}`) || usedReferences.has(`x${index}`)) {
+    index += 1;
+  }
+  return `X${index}`;
+}
+
+function nearestOrthogonalRotation(rotation: number): Rotation {
+  const normalized = ((rotation % 360) + 360) % 360;
+  const choices = [0, 90, 180, 270] as const;
+  return choices.reduce((best, candidate) => {
+    const bestDistance = Math.min(
+      Math.abs(normalized - best),
+      360 - Math.abs(normalized - best),
+    );
+    const candidateDistance = Math.min(
+      Math.abs(normalized - candidate),
+      360 - Math.abs(normalized - candidate),
+    );
+    return candidateDistance < bestDistance ? candidate : best;
+  }, choices[0]);
+}
+
+/**
+ * Convert one unlocked drafting rectangle into a persisted subcircuit
+ * instance and create its empty child Document. The parent mutation still
+ * crosses the typed Edit Engine boundary; Project validation then commits the
+ * new Document and edited parent as one structural value.
+ */
+export function convertRectangleToHierarchy(
+  sourceProject: CircuitProject,
+  parentDocumentId: string,
+  rectangleId: string,
+): RectangleToCellConversion {
+  const project = CircuitProjectSchema.parse(structuredClone(sourceProject));
+  const parent = project.documents.find(
+    (document) => document.id === parentDocumentId,
+  );
+  if (!parent) throw new Error(`Document not found: ${parentDocumentId}`);
+
+  const object = parent.drafting?.objects.find(
+    (candidate) => candidate.id === rectangleId,
+  );
+  if (!object || object.kind !== "rectangle") {
+    throw new Error(`Rectangle not found: ${rectangleId}`);
+  }
+  if (object.locked) {
+    throw new Error(`Unlock rectangle ${rectangleId} before creating a Cell`);
+  }
+
+  const { cellName, documentId: childDocumentId } = nextCellIdentity(project);
+  const child = createEmptyDocument(childDocumentId, cellName);
+  child.presentation = structuredClone(parent.presentation);
+  const projectWithChild = CircuitProjectSchema.parse({
+    ...project,
+    documents: [...project.documents, child],
+  });
+  const instanceId = nextHierarchyInstanceId(parent);
+  const instance: SchematicDocument["instances"][number] = {
+    id: instanceId,
+    symbolId: hierarchicalSymbolId(cellName),
+    placement: {
+      position: object.center,
+      rotation: nearestOrthogonalRotation(object.rotation),
+      mirror: "none",
+    },
+    properties: {},
+    netlist: {
+      reference: instanceId,
+      parameters: {},
+      terminals: [],
+      binding: {
+        kind: "subcircuit",
+        name: cellName,
+        childDocumentId,
+      },
+    },
+  };
+  const resolverProject = CircuitProjectSchema.parse({
+    ...projectWithChild,
+    documents: projectWithChild.documents.map((document) =>
+      document.id === parent.id
+        ? { ...document, instances: [...document.instances, instance] }
+        : document,
+    ),
+  });
+  const resolver = createProjectSymbolResolver(resolverProject, builtInSymbols);
+  const transaction = executeTransaction(
+    parent,
+    {
+      transactionId: `rectangle-to-cell-${parent.id}-${rectangleId}`,
+      documentId: parent.id,
+      expectedRevision: parent.revision,
+      actor: { kind: "human", id: "human-local" },
+      edits: [
+        { kind: "remove_drafting_object", objectId: rectangleId },
+        {
+          kind: "add_instance",
+          instance,
+        },
+      ],
+    },
+    { symbolResolver: resolver },
+  );
+  if (!transaction.ok || !transaction.applied) {
+    const detail = transaction.diagnostics[0]?.message;
+    throw new Error(
+      !transaction.ok
+        ? `${transaction.error.message}${detail ? ` — ${detail}` : ""}`
+        : "Rectangle conversion did not commit",
+    );
+  }
+
+  const nextProject = CircuitProjectSchema.parse({
+    ...projectWithChild,
+    documents: projectWithChild.documents.map((document) =>
+      document.id === parent.id ? transaction.document : document,
+    ),
+  });
+  return {
+    project: nextProject,
+    parentDocumentId: parent.id,
+    childDocumentId,
+    instanceId,
+    cellName,
+  };
+}

--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -23,6 +23,8 @@ const baseContext: EditorShortcutContext = {
   hasClearableDraftingSelection: false,
   hasRemovableWireWaypoint: false,
   propertiesOpen: false,
+  hasHierarchyEnterSelection: false,
+  canReturnToParent: false,
 };
 
 function key(
@@ -193,6 +195,17 @@ describe("editor shortcut contract", () => {
     expect(resolve("x")).toBeNull();
   });
 
+  it("enters a selected Cell with E and returns to its parent with Shift+E", () => {
+    expect(resolve("e")).toEqual({ kind: "hierarchy-selection-required" });
+    expect(resolve("e", { hasHierarchyEnterSelection: true })).toEqual({
+      kind: "enter-hierarchy",
+    });
+    expect(
+      resolve("e", { canReturnToParent: true }, { shiftKey: true }),
+    ).toEqual({ kind: "return-to-parent" });
+    expect(resolve("e", {}, { shiftKey: true })).toBeNull();
+  });
+
   it("gives Ctrl+A selection precedence over the plain Arrow shortcut", () => {
     expect(resolve("a", {}, { ctrlKey: true })).toEqual({
       kind: "select-all",
@@ -279,6 +292,10 @@ describe("editor shortcut contract", () => {
     expect(resolve("q", active)).toEqual({
       kind: "blocked-interaction-command",
       command: "Properties",
+    });
+    expect(resolve("e", active)).toEqual({
+      kind: "blocked-interaction-command",
+      command: "Enter Cell",
     });
     expect(resolve("Delete", active)).toEqual({
       kind: "blocked-interaction-command",

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -26,6 +26,8 @@ export interface EditorShortcutContext {
   hasClearableDraftingSelection: boolean;
   hasRemovableWireWaypoint: boolean;
   propertiesOpen: boolean;
+  hasHierarchyEnterSelection: boolean;
+  canReturnToParent: boolean;
 }
 
 export type EditorShortcutIntent =
@@ -50,6 +52,10 @@ export type EditorShortcutIntent =
     }
   | { kind: "edit-net-label" | "net-label-selection-required" }
   | { kind: "toggle-net-highlight" }
+  | {
+      kind:
+        "enter-hierarchy" | "return-to-parent" | "hierarchy-selection-required";
+    }
   | { kind: "mirror"; direction: ScreenFlip }
   | { kind: "fit-view" }
   | {
@@ -211,6 +217,7 @@ export function resolveEditorShortcut(
       t: "Text",
       h: "Net Highlight",
       x: "Current Marker",
+      e: "Enter Cell",
       r: "Rotate or Mirror",
       "[": "Drafting Style",
       "]": "Drafting Style",
@@ -222,6 +229,15 @@ export function resolveEditorShortcut(
   }
 
   if (event.ctrlKey && key === "a") return { kind: "select-all" };
+
+  if (plain && key === "e") {
+    if (event.shiftKey) {
+      return context.canReturnToParent ? { kind: "return-to-parent" } : null;
+    }
+    return context.hasHierarchyEnterSelection
+      ? { kind: "enter-hierarchy" }
+      : { kind: "hierarchy-selection-required" };
+  }
 
   if (plain && key === "x" && context.hasRoutedMarkerSelection) {
     return { kind: "reverse-current-marker" };

--- a/packages/symbols/src/hierarchical-block-geometry.ts
+++ b/packages/symbols/src/hierarchical-block-geometry.ts
@@ -1,6 +1,7 @@
 import type { SymbolDefinition, SymbolPin } from "./schema.js";
 
 function distribute(count: number, start: number, end: number): number[] {
+  if (count === 0) return [];
   if (count <= 1) return [(start + end) / 2];
   return Array.from(
     { length: count },
@@ -12,8 +13,8 @@ function distribute(count: number, start: number, end: number): number[] {
 export function createHierarchicalBlockGeometry(
   pinCount: number,
 ): SymbolDefinition {
-  if (!Number.isInteger(pinCount) || pinCount < 1) {
-    throw new Error("Hierarchical block pin count must be positive");
+  if (!Number.isInteger(pinCount) || pinCount < 0) {
+    throw new Error("Hierarchical block pin count must be non-negative");
   }
   const leftCount = Math.ceil(pinCount / 2);
   const rightCount = pinCount - leftCount;

--- a/packages/symbols/src/hierarchical-block.test.ts
+++ b/packages/symbols/src/hierarchical-block.test.ts
@@ -25,4 +25,18 @@ describe("hierarchical block formal terminals", () => {
 
     expect(symbol?.pins.map((pin) => pin.name)).toEqual(["IN", "OUT"]);
   });
+
+  it("creates a formal zero-terminal block for a manual Cell", () => {
+    const symbol = createHierarchicalBlockSymbol({
+      name: "Cell1",
+      netlist: { name: "Cell1", terminals: [] },
+    });
+
+    expect(symbol).toMatchObject({
+      name: "Cell1",
+      hierarchicalBlock: true,
+      viewBox: { x: -40, y: -20, width: 80, height: 40 },
+      pins: [],
+    });
+  });
 });

--- a/packages/symbols/src/hierarchical-block.ts
+++ b/packages/symbols/src/hierarchical-block.ts
@@ -12,9 +12,9 @@ export function hierarchicalSymbolId(cellName: string): string {
 export function createHierarchicalBlockSymbol(
   document: Pick<SchematicDocument, "name" | "sourceBinding" | "netlist">,
 ): SymbolDefinition | null {
-  const cellName = document.sourceBinding?.cellName;
+  const cellName = document.sourceBinding?.cellName ?? document.netlist?.name;
   const terminals = document.netlist?.terminals ?? [];
-  if (!cellName || terminals.length === 0) return null;
+  if (!cellName) return null;
   const positional = createHierarchicalBlockGeometry(terminals.length);
   const implicitSupplyPins = terminals
     .map((terminal) => terminal.name)
@@ -23,6 +23,7 @@ export function createHierarchicalBlockSymbol(
     ...positional,
     id: hierarchicalSymbolId(cellName),
     name: document.name,
+    hierarchicalBlock: true,
     pins: positional.pins.map((pin, index) => ({
       ...pin,
       name: terminals[index]!.name,
@@ -47,7 +48,18 @@ export function createHierarchicalBlockSymbol(
 export function createProjectHierarchicalSymbols(
   project: Pick<CircuitProject, "documents">,
 ): SymbolDefinition[] {
+  const referencedChildIds = new Set(
+    project.documents.flatMap((document) =>
+      document.instances.flatMap((instance) => {
+        const binding = instance.netlist?.binding;
+        return binding?.kind === "subcircuit" ? [binding.childDocumentId] : [];
+      }),
+    ),
+  );
   return project.documents.flatMap((document) => {
+    if (!document.sourceBinding && !referencedChildIds.has(document.id)) {
+      return [];
+    }
     const definition = createHierarchicalBlockSymbol(document);
     return definition ? [definition] : [];
   });

--- a/packages/symbols/src/resolver.test.ts
+++ b/packages/symbols/src/resolver.test.ts
@@ -84,4 +84,13 @@ describe("Symbol Resolver boundary", () => {
       "diode",
     ]);
   });
+
+  it("does not derive an unreferenced manual top Cell over a catalog symbol", () => {
+    const project = createEmptyProject("coverage", "Coverage");
+    project.documents[0]!.netlist = { name: "resistor", terminals: [] };
+
+    const resolver = createProjectSymbolResolver(project, [resistor]);
+
+    expect(resolver.resolve("resistor")?.definition.name).toBe("Resistor");
+  });
 });

--- a/packages/symbols/src/schema.ts
+++ b/packages/symbols/src/schema.ts
@@ -112,8 +112,18 @@ export const SymbolDefinitionSchema = z
     // ADR 0010: a decorative symbol is a non-electrical catalog entry usable
     // only as a DraftFloatingSymbol. It must carry no terminals (pins).
     decorative: z.boolean().optional(),
+    // A derived subcircuit container may legitimately expose an empty formal
+    // interface before ports are authored in its child Cell.
+    hierarchicalBlock: z.literal(true).optional(),
   })
   .superRefine((symbol, context) => {
+    if (symbol.decorative && symbol.hierarchicalBlock) {
+      context.addIssue({
+        code: "custom",
+        path: ["hierarchicalBlock"],
+        message: "A decorative symbol cannot be a hierarchical block",
+      });
+    }
     if (symbol.decorative && symbol.pins.length > 0) {
       context.addIssue({
         code: "custom",
@@ -121,7 +131,11 @@ export const SymbolDefinitionSchema = z
         message: "A decorative symbol must contain no terminals (pins)",
       });
     }
-    if (!symbol.decorative && symbol.pins.length === 0) {
+    if (
+      !symbol.decorative &&
+      !symbol.hierarchicalBlock &&
+      symbol.pins.length === 0
+    ) {
       context.addIssue({
         code: "custom",
         path: ["pins"],

--- a/plan/2026-08-17-manual-hierarchy-from-rectangle/plan.md
+++ b/plan/2026-08-17-manual-hierarchy-from-rectangle/plan.md
@@ -1,0 +1,92 @@
+---
+status: completed
+experience: none
+---
+
+# Create and enter hierarchical Cells from rectangles
+
+## Goal
+
+Allow a selected drafting rectangle to become a formal hierarchical block on
+the first `E` press, immediately enter its newly created child Cell, return to
+the parent with Up or `Shift+E`, and re-enter existing blocks with `E` or a
+double-click.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+```
+
+The worktree was clean and `main` was current before the target branch was
+created. This target owns the manual hierarchy conversion/navigation surface,
+its model-controller integration, hierarchical symbol generation, focused
+tests, and its plan/log records.
+
+- `apps/editor/src/features/hierarchy/`
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/interaction/editor-shortcuts.ts`
+- `apps/editor/src/interaction/editor-shortcuts.test.ts`
+- `apps/editor/src/document/`
+- `packages/symbols/src/hierarchical-block*`
+- `packages/symbols/src/resolver.test.ts`
+- `packages/symbols/src/schema.ts`
+- `apps/editor/e2e/`
+- `plan/2026-08-17-manual-hierarchy-from-rectangle/plan.md`
+- `plan/root-audit.md`
+- `plan/log.md`
+
+Shared contracts are Project validation, typed Document edits, symbol
+resolution (including the explicit zero-terminal hierarchical-block marker),
+per-document history, and persisted subcircuit bindings.
+
+## Work
+
+1. Add a validated rectangle-to-child-Cell conversion with collision-free Cell,
+   Document, and instance identities.
+2. Allow formal zero-terminal manual hierarchical blocks and refresh the
+   controller's Project structure without starting a new Project session.
+3. Wire `E`, `Shift+E`, Up, and double-click navigation into the Editor and
+   present hierarchy navigation without import-only language.
+4. Add focused unit and browser regression coverage, including save/reload.
+
+## Validation
+
+- Focused hierarchy, shortcut, controller, and browser tests
+- `pnpm test:impact -- --base origin/main`
+- `pnpm install --frozen-lockfile`
+- `pnpm ci:check`
+- `git diff --check`
+- `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: formal rectangle conversion, zero-terminal hierarchy symbol
+  resolution, navigation shortcuts, parent return, re-entry, and persistence
+- Primary checks: affected Vitest suites and a focused Playwright hierarchy flow
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): add manual hierarchical Cell editing
+```
+
+## Outcome
+
+Delivered formal manual hierarchy authoring: an unlocked selected rectangle is
+atomically replaced by a persisted subcircuit instance and a new empty child
+Cell, then opened immediately. `E`, `Shift+E`, Up, and double-click cover entry
+and return navigation; zero-terminal child Cells resolve as explicitly typed
+hierarchical blocks without weakening ordinary symbol validation. Structural
+creation keeps the current Project/recovery session and rebuilds per-Document
+histories because their symbol-resolver context changed.
+
+Focused validation passed 39 unit tests and the save/reopen browser scenario.
+`pnpm test:impact -- --base origin/main`, `pnpm install --frozen-lockfile`, and
+the complete `pnpm ci:check` gate passed, including 831 unit/integration tests,
+147 browser tests, build, release verification, and production smoke checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -7954,3 +7954,18 @@ box`; branch pushed for review. A concurrent worker's overlapping App.tsx
 - Commit status: ready to commit separately on
   `codex/connected-wire-move-delete`; remote required checks remain the
   mainline delivery gate.
+
+## 2026-08-17 - Add manual hierarchical Cell editing
+
+- Target: convert a selected rectangle into a formal child Cell and provide
+  direct keyboard, toolbar, and double-click hierarchy navigation.
+- Changed areas: validated Project-structure conversion, zero-terminal
+  hierarchy symbols, Editor controller/session integration, shortcuts, Help,
+  and focused unit/browser coverage including save and reopen.
+- Validation: 39 focused unit tests, the focused hierarchy browser flow,
+  `pnpm test:impact -- --base origin/main`, locked dependency installation,
+  and the complete `pnpm ci:check` gate (831 unit/integration tests and 147
+  browser tests) passed.
+- Commit status: ready to commit on
+  `codex/manual-hierarchy-from-rectangle`; remote required checks remain the
+  mainline delivery gate.

--- a/plan/root-audit.md
+++ b/plan/root-audit.md
@@ -13,6 +13,13 @@ an archive. Completed plans with resolved experience are stored under
 | `completed` + `candidate` |    17 | Human decides whether to extract, reject, or defer the experience signal.         |
 | missing metadata          |    71 | Audit against outcome text and Git evidence; never archive merely because of age. |
 
+## 2026-08-17 Manual hierarchical Cell editing closure
+
+`2026-08-17-manual-hierarchy-from-rectangle` is completed with resolved
+experience. Rectangle-to-Cell conversion, formal hierarchy navigation, and
+save/reopen regression coverage passed the complete local delivery gate and
+are ready for remote review.
+
 ### Completed plans awaiting an experience decision
 
 - `2026-08-14-current-contract-clean-break`


### PR DESCRIPTION
Implements rectangle-to-Cell conversion and hierarchy navigation with E, Shift+E, Up, and double-click. Adds zero-terminal hierarchical block support plus unit and browser persistence coverage. Local pnpm ci:check passed: 831 unit/integration tests and 147 browser tests.