### PR TITLE
fix(hierarchy): exit Cell symbol layout predictably

### DIFF
--- a/apps/editor/e2e/hierarchy.spec.ts
+++ b/apps/editor/e2e/hierarchy.spec.ts
@@ -213,6 +213,41 @@ test("declares and places a Cell Port on a new local Net", async ({ page }) => {
   await expect(page.getByTestId("status")).toContainText(
     "Moved Cell symbol pin",
   );
+
+  // Closing Properties must leave the transient grip mode too; otherwise the
+  // selected Cell keeps suppressing its ordinary hit target.
+  await layoutShelf.click();
+  await expect(layoutOverlay).toBeHidden();
+  await expect(page.getByTestId("hit-X1")).toBeVisible();
+
+  await layoutShelf.click();
+  await layout
+    .getByRole("button", { name: "Edit symbol layout on canvas" })
+    .click();
+  await expect(layoutOverlay).toBeVisible();
+
+  // A normal canvas click exits the mode before normal pointer handling. The
+  // Cell can then use its normal direct-manipulation path again.
+  await canvas.click({ position: { x: 40, y: 420 } });
+  await expect(layoutOverlay).toBeHidden();
+  const instanceHit = page.getByTestId("hit-X1");
+  const beforeMove = await instanceHit.boundingBox();
+  expect(beforeMove).not.toBeNull();
+  if (beforeMove) {
+    await page.mouse.move(
+      beforeMove.x + beforeMove.width / 2,
+      beforeMove.y + beforeMove.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      beforeMove.x + beforeMove.width / 2 + 40,
+      beforeMove.y + beforeMove.height / 2,
+    );
+    await page.mouse.up();
+    await expect
+      .poll(async () => (await instanceHit.boundingBox())?.x ?? 0)
+      .toBeGreaterThan(beforeMove.x + 10);
+  }
 });
 
 test("deletes a wired child Cell Port through the ordinary instance path", async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -571,6 +571,10 @@ export function App({
   }, [agentSession.status, publicAgentUiEnabled]);
   const [boxPreview, setBoxPreview] = useState<BoxPreview | null>(null);
   const [cellSymbolLayoutEnabled, setCellSymbolLayoutEnabled] = useState(false);
+  const [
+    cellSymbolLayoutTargetInstanceId,
+    setCellSymbolLayoutTargetInstanceId,
+  ] = useState<string | null>(null);
   const [cellSymbolLayoutDrag, setCellSymbolLayoutDrag] = useState<{
     kind: "body" | "pin";
     pointerId: number;
@@ -1506,6 +1510,27 @@ export function App({
   }, [selectedRouteId]);
 
   useEffect(() => {
+    if (!cellSymbolLayoutEnabled) return;
+    // Symbol geometry is definition-level, but its canvas grips belong to one
+    // selected parent instance. Do not let them survive a selection change.
+    if (
+      selectedInstance?.id !== cellSymbolLayoutTargetInstanceId ||
+      !selectedHierarchyCell?.netlist
+    ) {
+      exitCellSymbolLayout();
+    }
+  }, [
+    cellSymbolLayoutEnabled,
+    cellSymbolLayoutTargetInstanceId,
+    selectedHierarchyCell?.netlist,
+    selectedInstance?.id,
+  ]);
+
+  useEffect(() => {
+    if (!selectionOpen && cellSymbolLayoutEnabled) exitCellSymbolLayout();
+  }, [cellSymbolLayoutEnabled, selectionOpen]);
+
+  useEffect(() => {
     const pruned = pruneVisualSelection(visualSelection, document);
     if (pruned !== visualSelection) replaceSelection(pruned);
   }, [document, visualSelection]);
@@ -1540,6 +1565,7 @@ export function App({
   }
 
   function resetInteractionState(): void {
+    exitCellSymbolLayout();
     cancelAllTransientInteraction();
     resetSelection();
     setSelectedRouteSegmentIndex(null);
@@ -1743,6 +1769,22 @@ export function App({
           : "Could not move Cell symbol pin",
       );
     }
+  }
+
+  function exitCellSymbolLayout(): void {
+    setCellSymbolLayoutDrag(null);
+    setCellSymbolLayoutEnabled(false);
+    setCellSymbolLayoutTargetInstanceId(null);
+  }
+
+  function toggleCellSymbolLayout(): void {
+    if (cellSymbolLayoutEnabled) {
+      exitCellSymbolLayout();
+      return;
+    }
+    if (!selectedHierarchyCell || !selectedInstance?.placement) return;
+    setCellSymbolLayoutTargetInstanceId(selectedInstance.id);
+    setCellSymbolLayoutEnabled(true);
   }
 
   function beginCellSymbolLayoutDrag(
@@ -2553,6 +2595,7 @@ export function App({
         currentInteraction.tool === nextTool) ||
       (nextTool === "pointer" && currentInteraction.kind === "idle");
     if (alreadyActive) return;
+    exitCellSymbolLayout();
     canvasDragSessionRef.current?.cancel();
     clearTransientCanvasState();
     paintSnapGuides([]);
@@ -5869,6 +5912,7 @@ export function App({
           openProperties();
           return;
         case "close-properties":
+          exitCellSymbolLayout();
           setSelectionOpen(false);
           setImportReviewOpen(false);
           return;
@@ -6714,6 +6758,7 @@ export function App({
               data-testid="selection-shelf"
               aria-expanded={selectionOpen}
               onClick={() => {
+                if (selectionOpen) exitCellSymbolLayout();
                 setSelectionOpen((current) => !current);
                 if (selectionOpen) setImportReviewOpen(false);
               }}
@@ -6832,9 +6877,7 @@ export function App({
                         type="button"
                         className="cell-symbol-layout-toggle"
                         aria-pressed={cellSymbolLayoutEnabled}
-                        onClick={() =>
-                          setCellSymbolLayoutEnabled((enabled) => !enabled)
-                        }
+                        onClick={toggleCellSymbolLayout}
                       >
                         {cellSymbolLayoutEnabled
                           ? "Done editing canvas layout"
@@ -7709,6 +7752,12 @@ export function App({
                 target.closest('[data-testid="cell-symbol-layout-overlay"]')
               ) {
                 return;
+              }
+              if (cellSymbolLayoutEnabled) {
+                // Layout grips are a short-lived edit mode. Any ordinary
+                // canvas action leaves it first, so the next hit can use the
+                // regular selection and movement rules.
+                exitCellSymbolLayout();
               }
               if (getCurrentInteractionState().kind === "moving-selection") {
                 event.stopPropagation();

--- a/plan/2026-08-19-cell-pin-edit-exit/plan.md
+++ b/plan/2026-08-19-cell-pin-edit-exit/plan.md
@@ -1,0 +1,78 @@
+---
+status: completed
+experience: none
+---
+
+# Exit transient Cell symbol pin editing predictably
+
+## Goal
+
+Make Cell symbol pin/body layout editing a scoped canvas mode that exits when
+the user leaves its context, so it cannot interfere with ordinary selection or
+device movement.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+?? .worktrees/
+```
+
+`.worktrees/` is user-owned, untracked, and unrelated to this target. It will
+not be modified. This target owns:
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/e2e/hierarchy.spec.ts`
+- `plan/2026-08-19-cell-pin-edit-exit/plan.md`
+- `plan/log.md`
+
+Shared dependencies: the existing hierarchy symbol presentation and canvas hit
+testing contracts are read and preserved; no project protocol change is in
+scope.
+
+## Work
+
+1. Bind the canvas layout mode to the selected Cell instance and centralize its
+   exit path.
+2. Exit automatically on a non-layout canvas action, Properties collapse,
+   selection/document/context changes, and tool changes.
+3. Add browser coverage proving the mode closes and ordinary component movement
+   resumes.
+
+## Validation
+
+- `pnpm test:e2e:local apps/editor/e2e/hierarchy.spec.ts`
+- `pnpm test:impact -- --base origin/main`
+- `git diff --check`
+- `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: Cell symbol layout grips are exclusive only while their owning
+  instance remains selected; leaving that context restores normal canvas hit
+  and movement behavior.
+- Primary checks: `apps/editor/e2e/hierarchy.spec.ts` through the local browser
+  test runner.
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(hierarchy): exit Cell symbol layout predictably
+```
+
+## Outcome
+
+Cell symbol canvas layout now records its owning instance and exits through one
+path when the selection/context changes, Properties closes, a tool changes, or
+the user begins any ordinary canvas action. The hierarchy browser regression
+also verifies that the normal Cell hit target and direct drag return after both
+Properties collapse and a blank-canvas click.
+
+Validation passed: `pnpm test:e2e:local apps/editor/e2e/hierarchy.spec.ts`
+(6 scenarios), `pnpm typecheck`, `pnpm test:impact -- --base origin/main`, and
+`git diff --check`.

--- a/plan/2026-08-19-cell-pin-edit-exit/plan.md
+++ b/plan/2026-08-19-cell-pin-edit-exit/plan.md
@@ -1,5 +1,5 @@
 ---
-status: completed
+status: active
 experience: none
 ---
 
@@ -76,3 +76,7 @@ Properties collapse and a blank-canvas click.
 Validation passed: `pnpm test:e2e:local apps/editor/e2e/hierarchy.spec.ts`
 (6 scenarios), `pnpm typecheck`, `pnpm test:impact -- --base origin/main`, and
 `git diff --check`.
+
+Mainline delivery is in progress at the user's request: run the canonical CI
+gate, open a GitHub pull request, wait for its required checks, then merge to
+`main`.

--- a/plan/2026-08-19-cell-pin-edit-exit/plan.md
+++ b/plan/2026-08-19-cell-pin-edit-exit/plan.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: completed
 experience: none
 ---
 
@@ -77,6 +77,7 @@ Validation passed: `pnpm test:e2e:local apps/editor/e2e/hierarchy.spec.ts`
 (6 scenarios), `pnpm typecheck`, `pnpm test:impact -- --base origin/main`, and
 `git diff --check`.
 
-Mainline delivery is in progress at the user's request: run the canonical CI
-gate, open a GitHub pull request, wait for its required checks, then merge to
-`main`.
+Mainline delivery gate passed with `pnpm install --frozen-lockfile` followed
+by `pnpm ci:check` (891 unit tests and 154 browser tests, plus static, build,
+release, packaging, and production-smoke contracts). PR #126 also passed all
+required GitHub checks before merge.

--- a/plan/log.md
+++ b/plan/log.md
@@ -3366,4 +3366,13 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   at its configured 15-minute timeout while running the unchanged full gate.
   The target remains active while a 25-minute timeout-budget correction reruns
   the same gate.
+
+## 2026-08-19 - Predictable Cell symbol layout exit
+
+- Changed areas: scoped Cell symbol layout ownership, automatic exit on
+  Properties/context/tool/canvas changes, and hierarchy browser regression
+  coverage for restored normal Cell movement.
+- Validation: hierarchy Playwright (6 scenarios), TypeScript typecheck,
+  test-impact against `origin/main`, and diff check passed.
+- Commit status: pending local commit on `codex/cell-pin-edit-exit`.
 ```

--- a/plan/log.md
+++ b/plan/log.md
@@ -3373,6 +3373,9 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   Properties/context/tool/canvas changes, and hierarchy browser regression
   coverage for restored normal Cell movement.
 - Validation: hierarchy Playwright (6 scenarios), TypeScript typecheck,
-  test-impact against `origin/main`, and diff check passed.
-- Commit status: pending local commit on `codex/cell-pin-edit-exit`.
+  test-impact against `origin/main`, diff check, and the canonical local gate
+  passed (891 unit tests and 154 browser tests, static/build/release/packaging
+  and production-smoke contracts). PR #126 required checks passed.
+- Commit status: committed on `codex/cell-pin-edit-exit`; merge to `main` is
+  requested.
 ```


### PR DESCRIPTION
## What changed

- Bind transient Cell symbol layout editing to the selected hierarchy instance.
- Exit layout mode when Properties closes, the selection or hierarchy context changes, a tool changes, or an ordinary canvas action begins.
- Restore the normal instance hit target immediately after exit so direct component movement remains available.

## Why

The former global layout toggle could remain active after leaving its UI context. Its overlay/hit-test rules then continued to compete with ordinary canvas interaction.

## Validation

- `pnpm install --frozen-lockfile && pnpm ci:check`
  - 891 unit tests passed
  - 154 browser tests passed
  - static checks, build, release packaging, and production smoke passed
- Focused hierarchy browser regression and TypeScript check passed.