### PR TITLE
ci: use prebuilt Playwright browser image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,15 @@ jobs:
     name: Release contracts
     needs: changes
     runs-on: ubuntu-latest
+    # Do not pull the browser image for documentation-only pull requests, which
+    # intentionally run only the placeholder step below.  `needs` is available
+    # when GitHub evaluates a job container image.
+    container:
+      image: ${{ needs.changes.outputs.heavy == 'true' && 'mcr.microsoft.com/playwright:v1.62.1-noble@sha256:dcc5531e97840b9b5e794f2814476b21571c5124a3fca2267d73041f56e7580e' || 'node:24-bookworm' }}
+      options: --ipc=host
+    defaults:
+      run:
+        shell: bash
     timeout-minutes: 25
     steps:
       - if: needs.changes.outputs.heavy != 'true'
@@ -129,12 +138,22 @@ jobs:
       - if: needs.changes.outputs.heavy == 'true'
         run: pnpm install --frozen-lockfile
       - if: needs.changes.outputs.heavy == 'true'
-        run: pnpm ci:release
+        # The version-matched image already provides Chromium and its Linux
+        # dependencies. Keep `ci:release` for self-sufficient local checks.
+        run: pnpm release:verify
 
   e2e:
     name: Browser tests (${{ matrix.shard }})
     needs: changes
     runs-on: ubuntu-latest
+    # Keep documentation-only pull requests light while running executable
+    # changes in the immutable Playwright browser environment.
+    container:
+      image: ${{ needs.changes.outputs.heavy == 'true' && 'mcr.microsoft.com/playwright:v1.62.1-noble@sha256:dcc5531e97840b9b5e794f2814476b21571c5124a3fca2267d73041f56e7580e' || 'node:24-bookworm' }}
+      options: --ipc=host
+    defaults:
+      run:
+        shell: bash
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -159,6 +178,4 @@ jobs:
       - if: needs.changes.outputs.heavy == 'true'
         run: pnpm install --frozen-lockfile
       - if: needs.changes.outputs.heavy == 'true'
-        run: pnpm exec playwright install --with-deps chromium
-      - if: needs.changes.outputs.heavy == 'true'
-        run: pnpm ci:e2e -- --shard=${{ matrix.shard }}
+        run: pnpm ci:e2e --shard=${{ matrix.shard }}

--- a/plan/2026-08-19-prebuilt-playwright-ci/plan.md
+++ b/plan/2026-08-19-prebuilt-playwright-ci/plan.md
@@ -1,0 +1,92 @@
+---
+status: active
+experience: none
+---
+
+# Run browser CI in a prebuilt Playwright environment
+
+## Goal
+
+Remove per-job Chromium download and Linux dependency installation from
+browser-dependent GitHub Actions jobs by using the official Playwright image
+that exactly matches this repository's `@playwright/test@1.62.1` dependency.
+Keep local validation commands self-sufficient.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+?? .worktrees/
+```
+
+`.worktrees/` is user-owned and unrelated. It will not be modified. This target
+owns:
+
+- `.github/workflows/ci.yml`
+- `plan/2026-08-19-prebuilt-playwright-ci/plan.md`
+- `plan/log.md`
+
+Read-only dependencies: `playwright.config.ts`, release-smoke scripts, and the
+Playwright image manifest. The image must match the package version and expose
+Node 24, Chromium, and required Linux dependencies.
+
+## Work
+
+1. Verify the official `mcr.microsoft.com/playwright:v1.62.1-noble` image and
+   record an immutable Linux amd64 reference in CI.
+2. Run release and E2E jobs in that image, remove their runtime Chromium install
+   steps, and preserve a local browser-installing release command.
+3. Correct the E2E argument forwarding so each declared browser shard runs its
+   assigned half of the suite rather than the complete suite.
+4. Add focused static command coverage and validate the workflow on GitHub.
+
+## Validation
+
+- Container preflight: Node version, Playwright version, and Chromium launch.
+- `pnpm ci:static`
+- `pnpm test:impact -- --base origin/main`
+- `pnpm ci:e2e --shard=1/2`
+- `git diff --check`
+- GitHub required checks for the review branch.
+
+## Test Impact
+
+- Decision: no-test-change
+- Contracts: CI browser jobs use an immutable, version-matched environment;
+  local release validation remains able to provision its own browser.
+- Primary checks: workflow static validation plus branch GitHub Actions E2E and
+  release checks.
+
+## Commit Intent
+
+Commit as:
+
+```text
+ci: use prebuilt Playwright browser image
+```
+
+## Outcome
+
+Implemented the immutable `v1.62.1-noble` Playwright image for the release and
+browser jobs, preserving the documentation-only fast path with a lightweight
+Node image. The image tag was resolved to
+`sha256:dcc5531e97840b9b5e794f2814476b21571c5124a3fca2267d73041f56e7580e`.
+Release no longer performs a browser installation in CI; the local
+`ci:release` command remains self-sufficient.
+
+The browser matrix command had an extra argument separator, which made every
+declared shard run the whole suite. It now forwards `--shard` correctly; the
+first shard selects 77 tests.
+
+Validated locally: Prettier, `pnpm ci:static`, test-impact, `pnpm
+release:verify`, an all-suite single-worker browser run (154/154), and a
+shard-list check. On this Windows host, the default 16-worker browser run has
+unrelated resource timeouts (61/77 when running the correct first shard), so
+the stable local command was used for browser validation. Docker Desktop is not
+running, so the container launch preflight and Linux runner behavior await the
+review-branch GitHub Actions run.
+
+The implementation commit is pushed on `codex/prebuilt-playwright-ci`; remote
+validation is pending before this target can be marked completed.

--- a/plan/log.md
+++ b/plan/log.md
@@ -3378,4 +3378,17 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   and production-smoke contracts). PR #126 required checks passed.
 - Commit status: committed on `codex/cell-pin-edit-exit`; merge to `main` is
   requested.
+
+## 2026-08-19 - Prebuilt Playwright CI environment
+
+- Changed areas: release and browser GitHub Actions jobs now select a
+  digest-pinned, package-version-matched Playwright image for executable
+  changes, preserve the documentation-only fast path, remove runtime browser
+  installation, and correctly forward the browser shard argument.
+- Validation: Prettier; static contracts; test-impact; release verification;
+  single-worker browser suite (154/154); and Playwright shard-list verification
+  (77 tests for `1/2`). The Windows-host default 16-worker shard had resource
+  timeouts; container and Linux runner validation are pending GitHub Actions.
+- Commit status: pushed on `codex/prebuilt-playwright-ci`; review-branch remote
+  validation is pending.
 ```


### PR DESCRIPTION
## What changed

- Run Release and browser jobs in the digest-pinned, version-matched Playwright image.
- Remove runtime Chromium and system-dependency installation from those jobs.
- Preserve the lightweight documentation-only CI path.
- Correct E2E shard forwarding so each matrix job runs one half of the suite.

## Why

The previous browser provisioning step occasionally stalled while downloading or installing Chromium. The matrix command also forwarded an extra argument separator, causing both shards to run the full suite.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm ci:check` (891 unit tests, 154 browser tests)
- Focused release and shard argument checks
