### PR TITLE
docs(plan): complete Playwright CI delivery

### DIFF
--- a/plan/2026-08-19-prebuilt-playwright-ci/plan.md
+++ b/plan/2026-08-19-prebuilt-playwright-ci/plan.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: completed
 experience: none
 ---
 
@@ -88,5 +88,7 @@ the stable local command was used for browser validation. Docker Desktop is not
 running, so the container launch preflight and Linux runner behavior await the
 review-branch GitHub Actions run.
 
-The implementation commit is pushed on `codex/prebuilt-playwright-ci`; remote
-validation is pending before this target can be marked completed.
+The implementation was merged to `main` by PR #127. GitHub Actions completed
+successfully: static (30s), unit (49s), release (1m 03s), browser shard 1/2
+(3m 16s), and browser shard 2/2 (3m 45s). The container image initialized
+successfully in all browser-dependent jobs.

--- a/plan/log.md
+++ b/plan/log.md
@@ -3388,7 +3388,7 @@ Keep reusable lessons in `docs/experience/`, not in this log.
 - Validation: Prettier; static contracts; test-impact; release verification;
   single-worker browser suite (154/154); and Playwright shard-list verification
   (77 tests for `1/2`). The Windows-host default 16-worker shard had resource
-  timeouts; container and Linux runner validation are pending GitHub Actions.
-- Commit status: pushed on `codex/prebuilt-playwright-ci`; review-branch remote
-  validation is pending.
+  timeouts; all GitHub Actions jobs passed in the prebuilt Linux environment
+  (static 30s, unit 49s, release 1m 03s, browser shards 3m 16s and 3m 45s).
+- Commit status: PR #127 merged to `main` as `92e63ea`.
 ```


### PR DESCRIPTION
Records the completed prebuilt Playwright CI delivery and its GitHub Actions results. No product or workflow behavior changes.