### PR TITLE
fix(release): scope MCP checksum verification to publishing

### DIFF
--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -26,7 +26,7 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
       - run: pnpm install --frozen-lockfile
-      - run: pnpm mcp:package
+      - run: pnpm mcp:release:package
       - run: pnpm mcp:distribution:check
       - name: Read release declaration
         id: distribution

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "mcp:resources": "pnpm --filter @icm/agent-adapter... build && node scripts/generate-mcp-resources.mjs",
     "mcp:resources:check": "pnpm --filter @icm/agent-adapter... build && node scripts/generate-mcp-resources.mjs --check",
     "mcp:package": "pnpm build && node scripts/package-mcp.mjs",
+    "mcp:release:package": "pnpm build && node scripts/package-mcp.mjs --verify-declared-release-sha",
     "mcp:distribution:check": "node scripts/check-mcp-distribution.mjs",
     "mcp:smoke": "node scripts/mcp-release-smoke.mjs",
     "dev": "pnpm --filter @icm/editor dev",

--- a/plan/2026-08-20-mcp-release-sha-gate/plan.md
+++ b/plan/2026-08-20-mcp-release-sha-gate/plan.md
@@ -1,0 +1,80 @@
+---
+status: active
+experience: none
+---
+
+# Scope MCP SHA enforcement to explicit publishing
+
+## Goal
+
+Prevent ordinary CI from comparing a development MCP tarball to the SHA-256 of
+the last published release. Preserve that comparison for the manually invoked
+MCP publishing workflow.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+?? .pnpm-store/
+?? .worktrees/
+```
+
+`.pnpm-store/` and `.worktrees/` are user-owned/unrelated local state and will
+not be modified. This target owns:
+
+- `scripts/package-mcp.mjs`
+- `scripts/lib/mcp-release-integrity.mjs`
+- `scripts/lib/mcp-release-integrity.test.mjs`
+- `package.json`
+- `.github/workflows/mcp-release.yml`
+- `plan/2026-08-20-mcp-release-sha-gate/plan.md`
+- `plan/log.md`
+
+Read-only shared contracts: `config/agent-mcp-distribution.json`, the public
+MCP bootstrap manifest, and the immutable GitHub Release assets.
+
+## Work
+
+1. Extract the optional declared-release SHA check into a small tested helper.
+2. Make normal MCP packaging emit the current artifact checksum without
+   comparing it to the last published release.
+3. Add an explicit release-package command and use it only in the manual
+   Publish MCP workflow.
+
+## Validation
+
+- Focused integrity-helper Vitest contract.
+- `pnpm mcp:package`
+- Linux GitHub Publish MCP workflow validates the explicit release command.
+- `pnpm ci:static`
+- `pnpm test:impact -- --base origin/main`
+- `git diff --check`
+- Canonical GitHub Actions checks before merge.
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: development packaging does not bind to a published artifact SHA;
+  explicit release packaging rejects a mismatched declared SHA.
+- Primary checks: integrity-helper Vitest contract and GitHub Release contracts.
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(release): scope MCP checksum verification to publishing
+```
+
+## Outcome
+
+Implemented explicit release-only SHA verification. Ordinary MCP packaging now
+emits its current checksum without comparing it to the checksum of the last
+published artifact; the manual Publish MCP workflow is the sole caller of the
+declared-checksum command.
+
+Validation passed locally: focused helper contract (5 tests), normal MCP
+package, static contracts, test-impact, and the full `pnpm ci:check` gate.
+GitHub Actions validation remains pending before completion.

--- a/plan/log.md
+++ b/plan/log.md
@@ -3621,3 +3621,14 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   and diff check passed locally.
 - Commit status: pending push and replacement remote checks on
   `codex/octilinear-route-protocol`.
+
+## 2026-08-20 - Scope MCP SHA verification to publishing
+
+- Changed areas: MCP package checksum verification is now an explicit
+  release-only command; ordinary release contracts retain package generation,
+  smoke, and production checks without binding development output to the last
+  published asset.
+- Validation: focused integrity contract (5 tests); MCP package; static
+  contracts; test-impact; and full `pnpm ci:check` (including browser and
+  release verification) passed locally. Linux workflow validation is pending.
+- Commit status: pending commit and PR checks on `codex/mcp-release-sha-gate`.

--- a/scripts/lib/mcp-release-integrity.mjs
+++ b/scripts/lib/mcp-release-integrity.mjs
@@ -1,0 +1,29 @@
+export const VERIFY_DECLARED_RELEASE_SHA_FLAG = "--verify-declared-release-sha";
+
+/**
+ * Check a declared release digest only for an explicit publishing operation.
+ * Development builds still emit their SHA-256, but are not releases yet.
+ */
+export function assertDeclaredReleaseSha({
+  verify,
+  platform,
+  buildPlatform,
+  expectedSha,
+  actualSha,
+}) {
+  if (!verify) return false;
+  if (platform !== buildPlatform) {
+    throw new Error(
+      `Declared MCP release SHA-256 must be verified on ${buildPlatform}; received ${platform}`,
+    );
+  }
+  if (!expectedSha) {
+    throw new Error("Declared MCP release SHA-256 is required for publishing");
+  }
+  if (actualSha !== expectedSha) {
+    throw new Error(
+      `MCP tarball SHA-256 mismatch: expected ${expectedSha}, received ${actualSha}`,
+    );
+  }
+  return true;
+}

--- a/scripts/lib/mcp-release-integrity.test.mjs
+++ b/scripts/lib/mcp-release-integrity.test.mjs
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertDeclaredReleaseSha,
+  VERIFY_DECLARED_RELEASE_SHA_FLAG,
+} from "./mcp-release-integrity.mjs";
+
+const expectedSha = "a".repeat(64);
+
+describe("MCP release integrity", () => {
+  it("does not bind ordinary development packages to a published release", () => {
+    expect(
+      assertDeclaredReleaseSha({
+        verify: false,
+        platform: "linux",
+        buildPlatform: "linux",
+        expectedSha,
+        actualSha: "b".repeat(64),
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts a declared SHA only for a matching Linux release artifact", () => {
+    expect(
+      assertDeclaredReleaseSha({
+        verify: true,
+        platform: "linux",
+        buildPlatform: "linux",
+        expectedSha,
+        actualSha: expectedSha,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a mismatched declared release SHA", () => {
+    expect(() =>
+      assertDeclaredReleaseSha({
+        verify: true,
+        platform: "linux",
+        buildPlatform: "linux",
+        expectedSha,
+        actualSha: "b".repeat(64),
+      }),
+    ).toThrow("MCP tarball SHA-256 mismatch");
+  });
+
+  it("requires the declared release check to run on its release platform", () => {
+    expect(() =>
+      assertDeclaredReleaseSha({
+        verify: true,
+        platform: "win32",
+        buildPlatform: "linux",
+        expectedSha,
+        actualSha: expectedSha,
+      }),
+    ).toThrow("must be verified on linux");
+  });
+
+  it("keeps the publishing switch explicit", () => {
+    expect(VERIFY_DECLARED_RELEASE_SHA_FLAG).toBe(
+      "--verify-declared-release-sha",
+    );
+  });
+});

--- a/scripts/package-mcp.mjs
+++ b/scripts/package-mcp.mjs
@@ -4,6 +4,11 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { build } from "vite";
 
+import {
+  assertDeclaredReleaseSha,
+  VERIFY_DECLARED_RELEASE_SHA_FLAG,
+} from "./lib/mcp-release-integrity.mjs";
+
 const root = resolve(import.meta.dirname, "..");
 const distribution = JSON.parse(
   await readFile(resolve(root, "config/agent-mcp-distribution.json"), "utf8"),
@@ -81,15 +86,13 @@ const tarball = resolve(outputRoot, distribution.release.asset);
 const digest = createHash("sha256")
   .update(await readFile(tarball))
   .digest("hex");
-if (
-  process.platform === distribution.release.buildPlatform &&
-  distribution.release.sha256 &&
-  digest !== distribution.release.sha256
-) {
-  throw new Error(
-    `MCP tarball SHA-256 mismatch: expected ${distribution.release.sha256}, received ${digest}`,
-  );
-}
+assertDeclaredReleaseSha({
+  verify: process.argv.includes(VERIFY_DECLARED_RELEASE_SHA_FLAG),
+  platform: process.platform,
+  buildPlatform: distribution.release.buildPlatform,
+  expectedSha: distribution.release.sha256,
+  actualSha: digest,
+});
 await writeFile(
   resolve(outputRoot, "SHA256SUMS.txt"),
   `${digest}  ${distribution.release.asset}\n`,


### PR DESCRIPTION
## What changed

- Normal MCP packaging now emits the current artifact SHA without comparing it to the last published release.
- The declared SHA comparison is enabled only by `mcp:release:package`.
- The manual Publish MCP workflow is the sole caller of that release-only command.

## Why

Development changes to the MCP bundle must not require rewriting the checksum of an immutable, previously published release. The published-release guard remains active for an explicit publish.

## Validation

- Focused MCP release-integrity contract (5 tests)
- `pnpm mcp:package`
- `pnpm ci:static`
- `pnpm test:impact -- --base origin/main`
- `pnpm install --frozen-lockfile && pnpm ci:check`