### PR TITLE
docs(plan): close phase 2 remote integration

### DIFF
--- a/plan/2026-08-21-phase2-netlist-mainline-integration/plan.md
+++ b/plan/2026-08-21-phase2-netlist-mainline-integration/plan.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: completed
 experience: none
 ---
 
@@ -72,5 +72,7 @@ Local `main` fast-forwarded from `14fe2d54` to `e11de334`, incorporating
 `88a997df`, `8d62fe21`, and `e11de334` without a merge conflict. The required
 candidate mainline CI check passed: static contracts, 159 unit-test files / 956
 tests, workspace builds, release and production smoke checks, and 162 browser
-E2E tests. Remote review-branch checks and the authorized `origin/main` push
-remain pending.
+E2E tests. PR #134 then passed GitHub Actions (change scope, static, unit,
+release, and both browser shards) and merged to `origin/main` as `51075420`.
+Local `main` is synchronized to that remote merge. This closing record is
+documentation only.

--- a/plan/log.md
+++ b/plan/log.md
@@ -3726,5 +3726,5 @@ Keep reusable lessons in `docs/experience/`, not in this log.
 - Validation: `pnpm install --frozen-lockfile` and complete `pnpm ci:check`
   passed: static contracts, 159 unit-test files / 956 tests, workspace build,
   release and production smoke checks, and 162 browser E2E tests.
-- Commit status: local `main` is now at `d4cdbce8`; remote review-branch
-  checks and the authorized `origin/main` integration are pending.
+- Commit status: merged to `origin/main` through PR #134 as `51075420` after
+  all GitHub Actions checks passed; local `main` is synchronized.


### PR DESCRIPTION
## Summary
- publish the final Phase 2 integration close-out record after PR #134 merged the implementation

## Validation
- pnpm docs:check
- pnpm test:impact -- --base HEAD