### PR TITLE
Unify schematic lifecycle and Port naming

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -5,6 +5,7 @@ import {
   clickCommand,
   downloadBytes,
   emulateDownloadOnlyBrowser,
+  recoveryProjectTexts,
 } from "./editor-fixtures.js";
 
 test("blocks destructive browser refresh shortcuts and uses the stronger grid", async ({
@@ -77,6 +78,26 @@ test("mirrors component and copy placement previews before their commits", async
     canvas.locator('[data-object-id="R2"] > g').first(),
   ).toHaveAttribute("transform", /rotate\(180\)/u);
   await page.keyboard.press("Escape");
+});
+
+test("writes a manual netlist reference into the placed Instance", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.keyboard.press("i");
+  const dialog = page.getByRole("dialog", { name: "Insert Component" });
+  await dialog.getByLabel("Component search").fill("resistor");
+  await dialog.getByTestId("insert-component-resistor").click();
+  await dialog.getByLabel("Reference name").fill("R7");
+  await dialog.getByRole("button", { name: "Apply" }).click();
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 360, y: 220 } });
+  await page.keyboard.press("Escape");
+
+  await expect
+    .poll(() => recoveryProjectTexts(page))
+    .toContain('"reference": "R7"');
 });
 
 test("refreshes explicitly only after flushing and automatically restoring recovery", async ({
@@ -415,14 +436,19 @@ test("carries a manual Value through placement and Q property editing", async ({
     page.getByRole("button", { name: "Discard changes" }),
   ).toHaveCount(0);
   await expect(page.getByLabel("Component identity")).toContainText(
-    "Schematic nameSymbolresistorDevice classresistor",
+    "Netlist referenceSchematic aliasSymbolresistorDevice classresistor",
   );
-  const schematicName = page.getByLabel("Component schematic name");
-  await expect(schematicName).toHaveValue("R1");
-  await schematicName.fill("R7");
-  await schematicName.press("Tab");
+  const netlistReference = page.getByLabel("Component netlist reference");
+  await expect(netlistReference).toHaveValue("R1");
+  await netlistReference.fill("R7");
+  await netlistReference.press("Tab");
   await expect(page.getByTestId("revision")).toHaveText("4");
-  await expect(schematicName).toHaveValue("R7");
+  await expect(netlistReference).toHaveValue("R7");
+  const schematicAlias = page.getByLabel("Component schematic alias");
+  await expect(schematicAlias).toHaveValue("");
+  await schematicAlias.fill("Input resistor");
+  await schematicAlias.press("Tab");
+  await expect(page.getByTestId("revision")).toHaveText("5");
   await page
     .locator("summary")
     .filter({ hasText: "Advanced parameters" })
@@ -431,7 +457,7 @@ test("carries a manual Value through placement and Q property editing", async ({
   await page.getByLabel("Additional parameter name 1").fill("tc");
   await page.getByLabel("Additional parameter value 1").fill("0.1");
   await page.getByRole("button", { name: "Apply parameters" }).click();
-  await expect(page.getByTestId("revision")).toHaveText("5");
+  await expect(page.getByTestId("revision")).toHaveText("6");
   await expect(page.getByLabel("Additional parameter name 1")).toHaveValue(
     "tc",
   );

--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -100,6 +100,52 @@ test("writes a manual netlist reference into the placed Instance", async ({
     .toContain('"reference": "R7"');
 });
 
+test("returns a component to the Placement Tray and places the retained Instance again", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await chooseComponent(page, "resistor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.click({ position: { x: 320, y: 220 } });
+  await page.keyboard.press("Escape");
+  await page.getByTestId("hit-R1").click();
+  await page.getByTestId("selection-shelf").click();
+
+  await page
+    .getByRole("button", { name: "Return component to Placement Tray" })
+    .click();
+  await expect(
+    page.getByRole("region", { name: "Placement Tray" }),
+  ).toContainText("1 retained");
+  await expect(page.getByTestId("unplaced-R1")).toContainText("R1 · resistor");
+  await expect(page.getByTestId("hit-R1")).toHaveCount(0);
+
+  await page
+    .getByRole("button", { name: "Place R1 · resistor from tray" })
+    .click();
+  await canvas.hover({ position: { x: 480, y: 260 } });
+  await expect(page.getByTestId("component-placement-preview")).toBeVisible();
+  await canvas.click({ position: { x: 480, y: 260 } });
+
+  await expect(page.getByTestId("hit-R1")).toBeVisible();
+  await expect(
+    page.getByRole("region", { name: "Placement Tray" }),
+  ).toContainText("0 retained");
+  await expect(page.getByTestId("revision")).toHaveText("3");
+
+  await page.getByTestId("hit-R1").click();
+  await page
+    .getByRole("button", { name: "Return component to Placement Tray" })
+    .click();
+  await page
+    .getByRole("region", { name: "Placement Tray" })
+    .getByRole("button", { name: "Place all" })
+    .click();
+
+  await expect(page.getByTestId("hit-R1")).toBeVisible();
+  await expect(page.getByTestId("revision")).toHaveText("5");
+});
+
 test("refreshes explicitly only after flushing and automatically restoring recovery", async ({
   page,
 }) => {

--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -119,6 +119,9 @@ test("returns a component to the Placement Tray and places the retained Instance
   ).toContainText("1 retained");
   await expect(page.getByTestId("unplaced-R1")).toContainText("R1 · resistor");
   await expect(page.getByTestId("hit-R1")).toHaveCount(0);
+  await expect(
+    page.getByTestId("annotation-hit-instance-label-R1"),
+  ).toHaveCount(0);
 
   await page
     .getByRole("button", { name: "Place R1 · resistor from tray" })
@@ -128,6 +131,9 @@ test("returns a component to the Placement Tray and places the retained Instance
   await canvas.click({ position: { x: 480, y: 260 } });
 
   await expect(page.getByTestId("hit-R1")).toBeVisible();
+  await expect(
+    page.getByTestId("annotation-hit-instance-label-R1"),
+  ).toBeVisible();
   await expect(
     page.getByRole("region", { name: "Placement Tray" }),
   ).toContainText("0 retained");
@@ -482,7 +488,7 @@ test("carries a manual Value through placement and Q property editing", async ({
     page.getByRole("button", { name: "Discard changes" }),
   ).toHaveCount(0);
   await expect(page.getByLabel("Component identity")).toContainText(
-    "Netlist referenceSchematic aliasSymbolresistorDevice classresistor",
+    "Schematic labelNetlist referenceSymbolresistorDevice classresistor",
   );
   const netlistReference = page.getByLabel("Component netlist reference");
   await expect(netlistReference).toHaveValue("R1");
@@ -490,10 +496,10 @@ test("carries a manual Value through placement and Q property editing", async ({
   await netlistReference.press("Tab");
   await expect(page.getByTestId("revision")).toHaveText("4");
   await expect(netlistReference).toHaveValue("R7");
-  const schematicAlias = page.getByLabel("Component schematic alias");
-  await expect(schematicAlias).toHaveValue("");
-  await schematicAlias.fill("Input resistor");
-  await schematicAlias.press("Tab");
+  const schematicLabel = page.getByLabel("Component schematic label");
+  await expect(schematicLabel).toHaveValue("R1");
+  await schematicLabel.fill("Input resistor");
+  await schematicLabel.press("Tab");
   await expect(page.getByTestId("revision")).toHaveText("5");
   await page
     .locator("summary")

--- a/apps/editor/e2e/hierarchy.spec.ts
+++ b/apps/editor/e2e/hierarchy.spec.ts
@@ -271,8 +271,11 @@ test("returns a formal Cell Port to the Tray without deleting its interface", as
   await canvas.click({ position: { x: 300, y: 180 } });
   await page.keyboard.press("Escape");
   await expect(
-    page.getByTestId("annotation-hit-instance-reference-P1"),
+    page.getByTestId("annotation-hit-instance-label-P1"),
   ).toBeVisible();
+  await expect(
+    page.getByTestId("annotation-hit-instance-reference-P1"),
+  ).toHaveCount(0);
   await page.getByTestId("hit-P1").click();
   const shelf = page.getByTestId("selection-shelf");
   if ((await shelf.getAttribute("aria-expanded")) === "false") {

--- a/apps/editor/e2e/hierarchy.spec.ts
+++ b/apps/editor/e2e/hierarchy.spec.ts
@@ -261,6 +261,41 @@ test("declares and places a Cell Port on a new local Net", async ({ page }) => {
   }
 });
 
+test("returns a formal Cell Port to the Tray without deleting its interface", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await createCell(page, "ReusableStage");
+  const canvas = page.getByTestId("schematic-canvas");
+  await page.getByTestId("shapes-chip-port").click();
+  await canvas.click({ position: { x: 300, y: 180 } });
+  await page.keyboard.press("Escape");
+  await expect(
+    page.getByTestId("annotation-hit-instance-reference-P1"),
+  ).toBeVisible();
+  await page.getByTestId("hit-P1").click();
+  const shelf = page.getByTestId("selection-shelf");
+  if ((await shelf.getAttribute("aria-expanded")) === "false") {
+    await shelf.click();
+  }
+  await page
+    .getByRole("button", { name: "Return component to Placement Tray" })
+    .click();
+
+  await expect(page.getByTestId("status")).toContainText(
+    "Cell interfaces and electrical facts were retained",
+  );
+  await expect(page.getByTestId("unplaced-P1")).toContainText("P1 · port");
+  await expect(page.getByTestId("hit-P1")).toHaveCount(0);
+  await page
+    .getByRole("region", { name: "Placement Tray" })
+    .getByRole("button", { name: "Place all" })
+    .click();
+  await expect(page.getByTestId("hit-P1")).toBeVisible();
+  await page.getByTestId("hit-P1").click();
+  await expect(page.getByLabel("Cell Port properties")).toBeVisible();
+});
+
 test("authors formal Cell parameters without entering Cell Symbol Layout", async ({
   page,
 }) => {

--- a/apps/editor/e2e/hierarchy.spec.ts
+++ b/apps/editor/e2e/hierarchy.spec.ts
@@ -28,6 +28,36 @@ async function createCell(
   await editor.getByRole("button", { name: "Create" }).click();
 }
 
+async function beginPortPlacement(
+  page: import("@playwright/test").Page,
+  options: {
+    role: "net-port" | "cell-terminal";
+    name: string;
+    direction?: "input" | "output" | "inout" | "passive";
+  },
+): Promise<void> {
+  await page.getByTestId("shapes-chip-port").click();
+  const dialog = page.getByRole("dialog", { name: "Insert Component" });
+  await dialog
+    .getByLabel("Port role")
+    .selectOption(
+      options.role === "cell-terminal" ? "cell-terminal" : "net-port",
+    );
+  await dialog
+    .getByLabel(
+      options.role === "cell-terminal"
+        ? "New Cell terminal name"
+        : "New Net Port name",
+    )
+    .fill(options.name);
+  if (options.role === "cell-terminal") {
+    await dialog
+      .getByLabel("New Cell terminal direction")
+      .selectOption(options.direction ?? "passive");
+  }
+  await dialog.getByRole("button", { name: "Apply" }).click();
+}
+
 test("keeps direct Cell commands in one hierarchy row", async ({ page }) => {
   await page.setViewportSize({ width: 420, height: 700 });
   await page.goto("/");
@@ -115,30 +145,40 @@ test("declares and places a Cell Port on a new local Net", async ({ page }) => {
   await createCell(page, "ReusableStage");
 
   const canvas = page.getByTestId("schematic-canvas");
-  await page.getByTestId("shapes-chip-port").click();
+  await beginPortPlacement(page, {
+    role: "cell-terminal",
+    name: "Vout",
+    direction: "output",
+  });
   await canvas.click({ position: { x: 300, y: 180 } });
-  await expect(page.getByTestId("status")).toContainText("Added Cell port P1");
+  await expect(page.getByTestId("status")).toContainText(
+    "Added Cell port Vout",
+  );
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("active-instance-count")).toHaveText("1");
 
   await page.getByTestId("selection-shelf").click();
   const portProperties = page.getByLabel("Cell Port properties");
   await expect(portProperties).toBeVisible();
-  await expect(portProperties.getByLabel("Port name")).toHaveCount(0);
+  const terminalName = portProperties.getByLabel("Cell Port terminal name");
+  await expect(terminalName).toHaveValue("Vout");
   await page.getByTestId("annotation-hit-instance-label-P1").dblclick();
   const nameEditor = page.getByRole("textbox", { name: "Canvas text editor" });
-  await nameEditor.fill("Vout");
+  await expect(
+    page.getByRole("toolbar", { name: "Text formatting" }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Bold" }).click();
   await page.getByRole("button", { name: "Apply text changes" }).click();
-  await expect(page.getByTestId("status")).toContainText(
-    "Renamed formal port to Vout",
-  );
+  await page.getByTestId("hit-P1").click();
+  await expect(terminalName).toHaveValue("Vout");
   await page.getByTestId("annotation-hit-instance-label-P1").dblclick();
-  await page.getByRole("textbox", { name: "Canvas text editor" }).fill("Vout");
+  await nameEditor.fill("OUT");
   await page.getByRole("button", { name: "Apply text changes" }).click();
   await expect(page.getByTestId("status")).toContainText(
-    "Cell Port Vout is already current",
+    "Renamed formal port to OUT",
   );
   await page.getByTestId("hit-P1").click();
+  await expect(terminalName).toHaveValue("OUT");
   const shelf = page.getByTestId("selection-shelf");
   if ((await shelf.getAttribute("aria-expanded")) === "false") {
     await shelf.click();
@@ -165,7 +205,7 @@ test("declares and places a Cell Port on a new local Net", async ({ page }) => {
   await canvas.click({ position: { x: 420, y: 180 } });
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("active-instance-count")).toHaveText("1");
-  await expect(canvas.locator('[data-pin-name="Vout"]')).toHaveCount(1);
+  await expect(canvas.locator('[data-pin-name="OUT"]')).toHaveCount(1);
 
   await page.getByTestId("hit-X1").click();
   const layoutShelf = page.getByTestId("selection-shelf");
@@ -179,7 +219,7 @@ test("declares and places a Cell Port on a new local Net", async ({ page }) => {
   await expect(page.getByTestId("status")).toContainText(
     "Resized ReusableStage",
   );
-  await layout.getByLabel("Cell symbol Vout pin side").selectOption("north");
+  await layout.getByLabel("Cell symbol OUT pin side").selectOption("north");
   await expect(page.getByTestId("status")).toContainText(
     "Moved Cell symbol pin",
   );
@@ -261,13 +301,53 @@ test("declares and places a Cell Port on a new local Net", async ({ page }) => {
   }
 });
 
+test("places a free Net Port whose rich label edits the Net name", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await beginPortPlacement(page, { role: "net-port", name: "VIN" });
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 300, y: 180 } });
+  await expect(page.getByTestId("status")).toContainText(
+    "Added Free Net Port VIN",
+  );
+  await page.keyboard.press("Escape");
+  await expect(
+    page.getByTestId("annotation-hit-instance-reference-P1"),
+  ).toHaveCount(0);
+  await page.getByTestId("hit-P1").click();
+  const shelf = page.getByTestId("selection-shelf");
+  if ((await shelf.getAttribute("aria-expanded")) === "false") {
+    await shelf.click();
+  }
+  const netName = page.getByLabel("Net Port name");
+  await expect(netName).toHaveValue("VIN");
+  await expect(page.getByLabel("Cell Port properties")).toHaveCount(0);
+
+  await page.getByTestId("annotation-hit-instance-label-P1").dblclick();
+  await page.getByRole("button", { name: "Bold" }).click();
+  await page.getByRole("button", { name: "Apply text changes" }).click();
+  await page.getByTestId("hit-P1").click();
+  await expect(netName).toHaveValue("VIN");
+
+  await page.getByTestId("annotation-hit-instance-label-P1").dblclick();
+  await page.getByRole("textbox", { name: "Canvas text editor" }).fill("VINP");
+  await page.getByRole("button", { name: "Apply text changes" }).click();
+  await page.getByTestId("hit-P1").click();
+  await expect(netName).toHaveValue("VINP");
+});
+
 test("returns a formal Cell Port to the Tray without deleting its interface", async ({
   page,
 }) => {
   await page.goto("/");
   await createCell(page, "ReusableStage");
   const canvas = page.getByTestId("schematic-canvas");
-  await page.getByTestId("shapes-chip-port").click();
+  await beginPortPlacement(page, {
+    role: "cell-terminal",
+    name: "Vout",
+  });
   await canvas.click({ position: { x: 300, y: 180 } });
   await page.keyboard.press("Escape");
   await expect(
@@ -288,7 +368,7 @@ test("returns a formal Cell Port to the Tray without deleting its interface", as
   await expect(page.getByTestId("status")).toContainText(
     "Cell interfaces and electrical facts were retained",
   );
-  await expect(page.getByTestId("unplaced-P1")).toContainText("P1 · port");
+  await expect(page.getByTestId("unplaced-P1")).toContainText("Vout · port");
   await expect(page.getByTestId("hit-P1")).toHaveCount(0);
   await page
     .getByRole("region", { name: "Placement Tray" })
@@ -304,7 +384,10 @@ test("authors formal Cell parameters without entering Cell Symbol Layout", async
 }) => {
   await page.goto("/");
   await createCell(page, "ReusableStage");
-  await page.getByTestId("shapes-chip-port").click();
+  await beginPortPlacement(page, {
+    role: "cell-terminal",
+    name: "Vout",
+  });
   await page
     .getByTestId("schematic-canvas")
     .click({ position: { x: 300, y: 180 } });
@@ -312,7 +395,7 @@ test("authors formal Cell parameters without entering Cell Symbol Layout", async
 
   await runCellCommand(page, "Manage Cells…");
   const dialog = page.getByRole("dialog", { name: "Cell Manager" });
-  await expect(dialog.getByLabel("Formal terminal 1 name")).toHaveValue("P1");
+  await expect(dialog.getByLabel("Formal terminal 1 name")).toHaveValue("Vout");
   await expect(
     dialog.getByText("Cell symbol layout", { exact: false }),
   ).toHaveCount(0);
@@ -337,7 +420,10 @@ test("deletes a wired child Cell Port through the ordinary instance path", async
   await page.goto("/");
   await createCell(page, "ReusableStage");
   const canvas = page.getByTestId("schematic-canvas");
-  await page.getByTestId("shapes-chip-port").click();
+  await beginPortPlacement(page, {
+    role: "cell-terminal",
+    name: "Vout",
+  });
   await canvas.click({ position: { x: 300, y: 180 } });
   await page.keyboard.press("Escape");
   await page.getByTestId("hit-P1").click();
@@ -380,7 +466,9 @@ test("places an existing Cell and blocks deleting its shared definition", async 
   await expect(canvas.locator('[data-kind="instance-value"]')).toContainText(
     "ReusableStage",
   );
-  await expect(canvas.locator('[data-kind="instance-label"]')).toHaveCount(0);
+  await expect(canvas.locator('[data-kind="instance-label"]')).toContainText(
+    "X1",
+  );
   await page.keyboard.press("Escape");
 
   await runCellCommand(page, "Manage Cells…");

--- a/apps/editor/e2e/instance-table.spec.ts
+++ b/apps/editor/e2e/instance-table.spec.ts
@@ -17,8 +17,8 @@ test("edits compatible selected instances through the explicit Instance Table", 
   await clickCommand(page, "Netlist", "Instance Table…");
   const table = page.getByRole("dialog", { name: "Instance Table" });
   await expect(table).toBeVisible();
-  await expect(table.getByText("M1", { exact: true })).toBeVisible();
-  await expect(table.getByText("M2", { exact: true })).toBeVisible();
+  await expect(table.getByRole("button", { name: "M1" })).toBeVisible();
+  await expect(table.getByRole("button", { name: "M2" })).toBeVisible();
   await table.getByRole("button", { name: "Select visible" }).click();
   await table.getByLabel("Parameter name").fill("l");
   await table.getByLabel("Batch value").fill("120n");

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -2675,6 +2675,18 @@ R7 IN OUT 10k
       .filter({ hasText: "R7" }),
   ).toBeVisible();
   await expect(
+    page
+      .getByTestId("schematic-canvas")
+      .locator("text")
+      .filter({ hasText: "OUT" }),
+  ).toBeVisible();
+  await expect(
+    page
+      .getByTestId("schematic-canvas")
+      .locator("text")
+      .filter({ hasText: "P1" }),
+  ).toHaveCount(0);
+  await expect(
     page.getByTestId("annotation-hit-instance-label-R7"),
   ).toBeVisible();
 });
@@ -2767,7 +2779,7 @@ test("exports structural SPICE and Spectre netlists while exposing instance auth
     properties.getByLabel("Component netlist reference"),
   ).toBeVisible();
   await expect(
-    properties.getByLabel("Component schematic alias"),
+    properties.getByLabel("Component schematic label"),
   ).toBeVisible();
   await expect(properties.getByLabel("Component model target")).toBeVisible();
   await expect(properties.getByText(/^Model:/u)).toHaveCount(0);

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -53,7 +53,18 @@ async function placeComponent(
   symbolId: string,
   position: { x: number; y: number },
 ): Promise<void> {
-  await chooseComponent(page, symbolId);
+  if (symbolId === "port" || symbolId === "port-filled") {
+    await page.keyboard.press("i");
+    const dialog = page.getByRole("dialog", { name: "Insert Component" });
+    await dialog.getByLabel("Component search").fill(symbolId);
+    await dialog.getByTestId(`insert-component-${symbolId}`).click();
+    await dialog
+      .getByLabel("New Net Port name")
+      .fill(symbolId === "port" ? "NET_HOLLOW" : "NET_FILLED");
+    await dialog.getByRole("button", { name: "Apply" }).click();
+  } else {
+    await chooseComponent(page, symbolId);
+  }
   await page.getByTestId("schematic-canvas").click({ position });
   await page.keyboard.press("Escape");
 }
@@ -453,6 +464,10 @@ test("Port shortcut starts ordinary component placement", async ({ page }) => {
   await page.goto("/");
   const canvas = page.getByTestId("schematic-canvas");
   await page.keyboard.press("p");
+  const dialog = page.getByRole("dialog", { name: "Insert Component" });
+  await expect(dialog.getByLabel("Port role")).toHaveValue("net-port");
+  await dialog.getByLabel("New Net Port name").fill("PORT_IN");
+  await dialog.getByRole("button", { name: "Apply" }).click();
   await canvas.hover({ position: { x: 320, y: 180 } });
   await expect(page.getByTestId("component-placement-preview")).toBeVisible();
   await canvas.click({ position: { x: 320, y: 180 } });
@@ -1174,7 +1189,7 @@ test("moves a selected wire segment and deletes a connected component safely", a
   await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(1);
   await expect(
     page.locator('[data-testid^="junction-junction-delete-"]'),
-  ).toHaveCount(1);
+  ).toHaveCount(0);
   await expect(page.getByTestId("status")).toContainText(
     "connected wires remain dangling",
   );
@@ -1552,10 +1567,11 @@ test("edits instance, electrical Net, and free text with bounded label handles",
   const annotationEditor = page.getByRole("textbox", {
     name: "Canvas text editor",
   });
-  await expect(annotationEditor).toHaveAttribute("type", "text");
+  await expect(annotationEditor).toHaveAttribute("contenteditable", "true");
   await annotationEditor.fill("Vref");
   await annotationEditor.press("Control+a");
-  await expect(page.getByRole("button", { name: "Italic" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Italic" })).toBeVisible();
+  await page.getByRole("button", { name: "Italic" }).click();
   await page.getByRole("button", { name: "Increase text size" }).click();
   await page.getByRole("button", { name: "Apply text changes" }).click();
   await expect(page.locator('[data-layer="annotations"]')).toContainText(

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -2649,6 +2649,36 @@ X2 OUT IN EXT_MASTER l=1u nf=4
   expect(spice).toContain("X2 OUT IN EXT_MASTER l=1u nf=4");
 });
 
+test("shows imported instance references after Place all", async ({ page }) => {
+  await page.goto("/");
+  await page.getByTestId("spice-files").setInputFiles({
+    name: "circuit.spi",
+    mimeType: "application/x-spice",
+    buffer: Buffer.from(`
+.subckt top IN OUT
+R7 IN OUT 10k
+.ends top
+`),
+  });
+
+  await expect(page.getByTestId("status")).toContainText(
+    "Imported 1 Documents",
+  );
+  await page
+    .getByRole("region", { name: "Placement Tray" })
+    .getByRole("button", { name: "Place all" })
+    .click();
+  await expect(
+    page
+      .getByTestId("schematic-canvas")
+      .locator("text")
+      .filter({ hasText: "R7" }),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("annotation-hit-instance-label-R7"),
+  ).toBeVisible();
+});
+
 test("requires warning review before exporting generated NoConnect nodes", async ({
   page,
 }) => {

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -2733,7 +2733,12 @@ test("exports structural SPICE and Spectre netlists while exposing instance auth
   const properties = page.getByRole("complementary", { name: "Properties" });
   await expect(properties.getByLabel("Cell netlist name")).toHaveCount(0);
   await expect(properties.getByLabel("Cell netlist port order")).toHaveCount(0);
-  await expect(properties.getByLabel("Component schematic name")).toBeVisible();
+  await expect(
+    properties.getByLabel("Component netlist reference"),
+  ).toBeVisible();
+  await expect(
+    properties.getByLabel("Component schematic alias"),
+  ).toBeVisible();
   await expect(properties.getByLabel("Component model target")).toBeVisible();
   await expect(properties.getByText(/^Model:/u)).toHaveCount(0);
 });

--- a/apps/editor/e2e/project-file.spec.ts
+++ b/apps/editor/e2e/project-file.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
 
 import {
   chooseComponent,
@@ -29,7 +30,7 @@ test("downloads the canonical Project when File System Access is unavailable", a
   const parsed = JSON.parse(bytes.toString("utf8")) as {
     schemaVersion: number;
   };
-  expect(parsed.schemaVersion).toBe(15);
+  expect(parsed.schemaVersion).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
   await expect(page.getByTestId("status")).toContainText("Download requested");
   // A download never clears the browser recovery copies.
   await expect
@@ -37,7 +38,7 @@ test("downloads the canonical Project when File System Access is unavailable", a
     .toContain('"revision": 1');
 });
 
-test("upgrades a schema-14 Project and saves it as schema 15", async ({
+test("upgrades the previous Project schema and saves it as current", async ({
   page,
 }) => {
   const source = JSON.parse(
@@ -46,25 +47,26 @@ test("upgrades a schema-14 Project and saves it as schema 15", async ({
       "utf8",
     ),
   ) as Record<string, unknown>;
-  source.schemaVersion = 14;
+  const previousVersion = CURRENT_PROJECT_SCHEMA_VERSION - 1;
+  source.schemaVersion = previousVersion;
 
   await page.goto("/");
   await page.getByTestId("project-file").setInputFiles({
-    name: "minimal-v14.icproj.json",
+    name: `minimal-v${previousVersion}.icproj.json`,
     mimeType: "application/json",
     buffer: Buffer.from(JSON.stringify(source)),
   });
   await expect(page.getByTestId("status")).toContainText(
-    "upgraded minimal-v14.icproj.json from schema 14 to schema 15",
+    `upgraded minimal-v${previousVersion}.icproj.json from schema ${previousVersion} to schema ${CURRENT_PROJECT_SCHEMA_VERSION}`,
   );
   await expect
     .poll(() => recoveryProjectTexts(page))
-    .toContain('"schemaVersion": 15');
+    .toContain(`"schemaVersion": ${CURRENT_PROJECT_SCHEMA_VERSION}`);
 
   const saved = JSON.parse(
     (await downloadBytes(page, "File", "Save Project")).toString("utf8"),
   ) as { schemaVersion: number };
-  expect(saved.schemaVersion).toBe(15);
+  expect(saved.schemaVersion).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
 });
 
 test("reports a confirmed File System Access save", async ({ page }) => {
@@ -95,7 +97,9 @@ test("reports a confirmed File System Access save", async ({ page }) => {
         .__fsaWrites[0] ?? null,
   );
   expect(write).not.toBeNull();
-  expect(JSON.parse(write!.text).schemaVersion).toBe(15);
+  expect(JSON.parse(write!.text).schemaVersion).toBe(
+    CURRENT_PROJECT_SCHEMA_VERSION,
+  );
 });
 
 test("falls back to download when the save location is denied", async ({
@@ -109,7 +113,9 @@ test("falls back to download when the save location is denied", async ({
   });
   await page.goto("/");
   const bytes = await downloadBytes(page, "File", "Save Project");
-  expect(JSON.parse(bytes.toString("utf8")).schemaVersion).toBe(15);
+  expect(JSON.parse(bytes.toString("utf8")).schemaVersion).toBe(
+    CURRENT_PROJECT_SCHEMA_VERSION,
+  );
   await expect(page.getByTestId("status")).toContainText("Download requested");
 });
 

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -34,6 +34,7 @@ import {
   planSetCellSymbolPresentation,
   planSetCellTerminalPlacement,
   planUpdateCellTerminalDirection,
+  planInstanceUnplacement,
   proposeSetCellFormalParameters,
   proposeUpsertExternalSubcircuitDefinition,
   findCellTerminalCaller,
@@ -156,6 +157,7 @@ import {
 } from "../features/component-insert/insert-component-dialog";
 import type { ComponentInsertRequest } from "../features/component-insert/insert-component-dialog";
 import { useComponentPlacement } from "../features/component-insert/use-component-placement";
+import { planPlaceAllUnplacedInstances } from "../features/component-insert/placement-tray";
 import { DisplayToggle } from "../features/component-insert/display-toggle";
 import { constructVddRailEdits } from "../features/component-insert/vdd-rail";
 import { vddPowerLabelAnnotation } from "../features/component-insert/vdd-power-label";
@@ -786,6 +788,15 @@ export function App({
   const unplaced = document.instances.filter(
     (instance) => instance.placement === null,
   );
+  const formalPortInstanceIds = new Set(
+    (document.netlist?.terminals ?? []).map(
+      (terminal) => terminal.interfaceInstanceId,
+    ),
+  );
+  const returnablePlacedInstances = document.instances.filter(
+    (instance) =>
+      instance.placement !== null && !formalPortInstanceIds.has(instance.id),
+  );
   const selectedIds = visualSelection.instanceIds;
   const projectConnectivityIndex = useMemo(
     () => buildProjectConnectivityIndex(project, resolver),
@@ -1378,6 +1389,7 @@ export function App({
     ? resolver.resolve(pendingSymbolId)?.definition
     : undefined;
   const {
+    beginRetainedInstancePlacement: beginRetainedInstancePlacementFromHook,
     beginInsertedComponentPlacement: beginInsertedComponentPlacementFromHook,
     cancelComponentInsert: cancelComponentInsertFromHook,
     commitPendingPlacementAt: commitPendingPlacementAtFromHook,
@@ -3681,6 +3693,65 @@ export function App({
       },
     ]);
     selectOnly("instance", [instanceId]);
+  }
+
+  function placeAllFromTray(): void {
+    const edits = planPlaceAllUnplacedInstances(document, viewBox);
+    if (edits.length === 0) {
+      setStatus("The Placement Tray is empty");
+      return;
+    }
+    if (transact(edits).ok) {
+      resetSelection();
+      setStatus(
+        `Placed ${edits.length} retained ${edits.length === 1 ? "Instance" : "Instances"} in a deterministic canvas grid`,
+      );
+    }
+  }
+
+  function returnInstancesToTray(instanceIds: readonly string[]): void {
+    if (instanceIds.length === 0) {
+      setStatus("There are no returnable placed Instances");
+      return;
+    }
+    try {
+      const edits = planInstanceUnplacement(
+        document,
+        resolver,
+        instanceIds,
+        ++uniqueSuffixCounter.current,
+      );
+      if (edits.length === 0) {
+        setStatus("Those Instances are already retained in the Placement Tray");
+        return;
+      }
+      if (transact(edits).ok) {
+        resetSelection();
+        setStatus(
+          `Returned ${instanceIds.length} ${instanceIds.length === 1 ? "Instance" : "Instances"} to the Placement Tray; electrical facts were retained`,
+        );
+      }
+    } catch (error) {
+      setStatus(
+        error instanceof Error ? error.message : "Could not return to tray",
+      );
+    }
+  }
+
+  function placementTrayIdentity(
+    instance: SchematicDocument["instances"][number],
+  ): string {
+    const formalName = document.netlist?.terminals.find(
+      (terminal) => terminal.interfaceInstanceId === instance.id,
+    )?.name;
+    const schematicName = flattenRichText(
+      instance.schematicName ?? { runs: [] },
+    );
+    const primary =
+      instance.netlist?.reference ??
+      formalName ??
+      (schematicName || "Unreferenced");
+    return `${primary} · ${instance.symbolId}`;
   }
 
   function selectionVisualMoveEdits(
@@ -7859,6 +7930,17 @@ export function App({
                         >
                           Mirror top/bottom
                         </button>
+                        {!selectedFormalTerminal ? (
+                          <button
+                            type="button"
+                            aria-label="Return component to Placement Tray"
+                            onClick={() =>
+                              returnInstancesToTray([selectedInstance.id])
+                            }
+                          >
+                            Return to tray
+                          </button>
+                        ) : null}
                       </div>
                     </div>
                   ) : null}
@@ -8157,28 +8239,80 @@ export function App({
                     );
                   })()
                 : null}
-              {unplaced.length > 0 ? <h3>Unplaced Instances</h3> : null}
-              {unplaced.map((instance) => (
-                <button
-                  type="button"
-                  draggable
-                  data-testid={`unplaced-${instance.id}`}
-                  key={instance.id}
-                  onClick={() => {
-                    selectOnly("instance", [instance.id]);
-                    setStatus(`Selected ${instance.id}`);
-                  }}
-                  onDragStart={(event) => {
-                    event.dataTransfer.setData(
-                      "application/x-icm-instance",
-                      instance.id,
-                    );
-                    event.dataTransfer.effectAllowed = "move";
-                  }}
-                >
-                  {instance.id} · {instance.symbolId}
-                </button>
-              ))}
+              <section
+                className="context-actions placement-tray"
+                aria-label="Placement Tray"
+              >
+                <h2>Placement Tray</h2>
+                <p>
+                  {unplaced.length} retained · drag to the canvas, choose Place,
+                  or arrange every retained Instance in a starter grid.
+                </p>
+                <div className="component-mirror-row">
+                  <button
+                    type="button"
+                    onClick={placeAllFromTray}
+                    disabled={unplaced.length === 0}
+                  >
+                    Place all
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      returnInstancesToTray(
+                        returnablePlacedInstances.map(
+                          (instance) => instance.id,
+                        ),
+                      )
+                    }
+                    disabled={returnablePlacedInstances.length === 0}
+                  >
+                    Return all
+                  </button>
+                </div>
+                {unplaced.length === 0 ? (
+                  <small>No retained Instances.</small>
+                ) : (
+                  <div className="placement-tray-list">
+                    {unplaced.map((instance) => (
+                      <div
+                        className="placement-tray-entry"
+                        draggable
+                        data-testid={`unplaced-${instance.id}`}
+                        key={instance.id}
+                        onDragStart={(event) => {
+                          event.dataTransfer.setData(
+                            "application/x-icm-instance",
+                            instance.id,
+                          );
+                          event.dataTransfer.effectAllowed = "move";
+                        }}
+                      >
+                        <button
+                          type="button"
+                          onClick={() => {
+                            selectOnly("instance", [instance.id]);
+                            setStatus(
+                              `Selected ${placementTrayIdentity(instance)}`,
+                            );
+                          }}
+                        >
+                          {placementTrayIdentity(instance)}
+                        </button>
+                        <button
+                          type="button"
+                          aria-label={`Place ${placementTrayIdentity(instance)} from tray`}
+                          onClick={() =>
+                            beginRetainedInstancePlacementFromHook(instance.id)
+                          }
+                        >
+                          Place…
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </section>
               {selectedInstance && selectedBulkResolution ? (
                 <section
                   className="context-actions"

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -788,14 +788,8 @@ export function App({
   const unplaced = document.instances.filter(
     (instance) => instance.placement === null,
   );
-  const formalPortInstanceIds = new Set(
-    (document.netlist?.terminals ?? []).map(
-      (terminal) => terminal.interfaceInstanceId,
-    ),
-  );
   const returnablePlacedInstances = document.instances.filter(
-    (instance) =>
-      instance.placement !== null && !formalPortInstanceIds.has(instance.id),
+    (instance) => instance.placement !== null,
   );
   const selectedIds = visualSelection.instanceIds;
   const projectConnectivityIndex = useMemo(
@@ -3727,8 +3721,13 @@ export function App({
       }
       if (transact(edits).ok) {
         resetSelection();
+        const returnedFormalPort = instanceIds.some((instanceId) =>
+          document.netlist?.terminals.some(
+            (terminal) => terminal.interfaceInstanceId === instanceId,
+          ),
+        );
         setStatus(
-          `Returned ${instanceIds.length} ${instanceIds.length === 1 ? "Instance" : "Instances"} to the Placement Tray; electrical facts were retained`,
+          `Returned ${instanceIds.length} ${instanceIds.length === 1 ? "Instance" : "Instances"} to the Placement Tray; ${returnedFormalPort ? "Cell interfaces and " : ""}electrical facts were retained`,
         );
       }
     } catch (error) {
@@ -3747,11 +3746,14 @@ export function App({
     const schematicName = flattenRichText(
       instance.schematicName ?? { runs: [] },
     );
-    const primary =
-      instance.netlist?.reference ??
-      formalName ??
-      (schematicName || "Unreferenced");
-    return `${primary} · ${instance.symbolId}`;
+    const reference =
+      instance.schematicReference ?? instance.netlist?.reference ?? null;
+    const secondary = formalName ?? schematicName;
+    const identity =
+      reference && secondary && reference !== secondary
+        ? `${reference} · ${secondary}`
+        : (reference ?? secondary ?? "Unreferenced");
+    return `${identity} · ${instance.symbolId}`;
   }
 
   function selectionVisualMoveEdits(
@@ -5337,6 +5339,27 @@ export function App({
       ]).ok
     ) {
       setStatus(`Set netlist reference to ${reference}`);
+    }
+  }
+
+  function updateSelectedSchematicReference(value: string): void {
+    if (!selectedInstance) return;
+    const reference = value.trim();
+    if (!reference) {
+      setStatus("Schematic reference cannot be empty");
+      return;
+    }
+    if (reference === selectedInstance.schematicReference) return;
+    if (
+      transact([
+        {
+          kind: "set_instance_schematic_reference",
+          instanceId: selectedInstance.id,
+          reference,
+        },
+      ]).ok
+    ) {
+      setStatus(`Set schematic reference to ${reference}`);
     }
   }
 
@@ -7562,6 +7585,23 @@ export function App({
                   >
                     <div className="property-section-heading">Identity</div>
                     <dl className="component-readonly-fields">
+                      <div>
+                        <dt>Schematic reference</dt>
+                        <dd>
+                          <input
+                            key={`${selectedInstance.id}-${document.revision}-schematic-reference`}
+                            aria-label="Component schematic reference"
+                            defaultValue={
+                              selectedInstance.schematicReference ?? ""
+                            }
+                            onBlur={(event) =>
+                              updateSelectedSchematicReference(
+                                event.currentTarget.value,
+                              )
+                            }
+                          />
+                        </dd>
+                      </div>
                       {selectedInstance.netlist ? (
                         <div>
                           <dt>Netlist reference</dt>
@@ -7930,17 +7970,15 @@ export function App({
                         >
                           Mirror top/bottom
                         </button>
-                        {!selectedFormalTerminal ? (
-                          <button
-                            type="button"
-                            aria-label="Return component to Placement Tray"
-                            onClick={() =>
-                              returnInstancesToTray([selectedInstance.id])
-                            }
-                          >
-                            Return to tray
-                          </button>
-                        ) : null}
+                        <button
+                          type="button"
+                          aria-label="Return component to Placement Tray"
+                          onClick={() =>
+                            returnInstancesToTray([selectedInstance.id])
+                          }
+                        >
+                          Return to tray
+                        </button>
                       </div>
                     </div>
                   ) : null}

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -158,6 +158,7 @@ import {
 import type { ComponentInsertRequest } from "../features/component-insert/insert-component-dialog";
 import { useComponentPlacement } from "../features/component-insert/use-component-placement";
 import { planPlaceAllUnplacedInstances } from "../features/component-insert/placement-tray";
+import { missingDefaultInstanceDisplayAnnotations } from "../features/instance-display/default-instance-display";
 import { DisplayToggle } from "../features/component-insert/display-toggle";
 import { constructVddRailEdits } from "../features/component-insert/vdd-rail";
 import { vddPowerLabelAnnotation } from "../features/component-insert/vdd-power-label";
@@ -3671,20 +3672,36 @@ export function App({
     if (!instanceId) {
       return;
     }
+    const placement = {
+      position: pointFromClient(
+        event.clientX,
+        event.clientY,
+        event.currentTarget,
+      ),
+      rotation: 0 as const,
+      mirror: "none" as const,
+    };
+    const instance = document.instances.find(
+      (candidate) => candidate.id === instanceId,
+    );
+    const displayAnnotations = instance
+      ? missingDefaultInstanceDisplayAnnotations(
+          document,
+          { ...instance, placement },
+          resolver,
+          styleProfile,
+        )
+      : [];
     transact([
       {
         kind: "place_instance",
         instanceId,
-        placement: {
-          position: pointFromClient(
-            event.clientX,
-            event.clientY,
-            event.currentTarget,
-          ),
-          rotation: 0,
-          mirror: "none",
-        },
+        placement,
       },
+      ...displayAnnotations.map((annotation) => ({
+        kind: "upsert_schematic_annotation" as const,
+        annotation,
+      })),
     ]);
     selectOnly("instance", [instanceId]);
   }
@@ -3695,7 +3712,23 @@ export function App({
       setStatus("The Placement Tray is empty");
       return;
     }
-    if (transact(edits).ok) {
+    const displayEdits = edits.flatMap((edit) => {
+      if (edit.kind !== "place_instance") return [];
+      const instance = document.instances.find(
+        (candidate) => candidate.id === edit.instanceId,
+      );
+      if (!instance) return [];
+      return missingDefaultInstanceDisplayAnnotations(
+        document,
+        { ...instance, placement: edit.placement },
+        resolver,
+        styleProfile,
+      ).map((annotation) => ({
+        kind: "upsert_schematic_annotation" as const,
+        annotation,
+      }));
+    });
+    if (transact([...edits, ...displayEdits]).ok) {
       resetSelection();
       setStatus(
         `Placed ${edits.length} retained ${edits.length === 1 ? "Instance" : "Instances"} in a deterministic canvas grid`,

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -5248,6 +5248,27 @@ export function App({
     }
   }
 
+  function updateSelectedReference(value: string): void {
+    if (!selectedInstance?.netlist) return;
+    const reference = value.trim();
+    if (!reference) {
+      setStatus("Netlist reference cannot be empty");
+      return;
+    }
+    if (reference === selectedInstance.netlist.reference) return;
+    if (
+      transact([
+        {
+          kind: "set_instance_reference",
+          instanceId: selectedInstance.id,
+          reference,
+        },
+      ]).ok
+    ) {
+      setStatus(`Set netlist reference to ${reference}`);
+    }
+  }
+
   /*
    * Text sessions use one persistence proposal for both annotation and
    * drafting owners. The tagged target keeps their typed edit differences at
@@ -7470,20 +7491,34 @@ export function App({
                   >
                     <div className="property-section-heading">Identity</div>
                     <dl className="component-readonly-fields">
+                      {selectedInstance.netlist ? (
+                        <div>
+                          <dt>Netlist reference</dt>
+                          <dd>
+                            <input
+                              key={`${selectedInstance.id}-${document.revision}-netlist-reference`}
+                              aria-label="Component netlist reference"
+                              defaultValue={selectedInstance.netlist.reference}
+                              onBlur={(event) =>
+                                updateSelectedReference(
+                                  event.currentTarget.value,
+                                )
+                              }
+                            />
+                          </dd>
+                        </div>
+                      ) : null}
                       <div>
-                        <dt>Schematic name</dt>
+                        <dt>Schematic alias</dt>
                         <dd>
                           <input
                             key={`${selectedInstance.id}-${document.revision}-schematic-name`}
-                            aria-label="Component schematic name"
+                            aria-label="Component schematic alias"
                             defaultValue={flattenRichText(
                               selectedInstance.schematicName ??
-                                semanticTextDocument(
-                                  selectedInstance.netlist?.reference ??
-                                    selectedInstance.id,
-                                  "instance-label",
-                                ),
+                                defaultDraftTextDocument(""),
                             )}
+                            placeholder="Optional display alias"
                             onBlur={(event) =>
                               updateSelectedSchematicName(
                                 event.currentTarget.value,

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -32,6 +32,7 @@ import {
   planRenameCellTerminal,
   planReorderCellTerminal,
   planSetCellSymbolPresentation,
+  planEditCellTerminalAnnotation,
   planSetCellTerminalPlacement,
   planUpdateCellTerminalDirection,
   planInstanceUnplacement,
@@ -106,6 +107,7 @@ import type {
   GridRect,
   Point,
   Rect,
+  RichTextDocument,
   RouteEndpoint,
   SchematicDocument,
 } from "@icm/model";
@@ -188,10 +190,7 @@ import {
   nextInstanceDesignator,
 } from "../features/netlist-export/netlist-authoring";
 import { ToolIcon } from "../features/editor-shell/tool-icon";
-import {
-  quickPlaceRequest,
-  ShapesPanel,
-} from "../features/editor-shell/shapes-panel";
+import { ShapesPanel } from "../features/editor-shell/shapes-panel";
 import { ExamplesPanel } from "../features/editor-shell/examples-panel";
 import { convertRectangleToHierarchy } from "../features/hierarchy/rectangle-to-cell";
 import { CellManagerDialog } from "../features/hierarchy/cell-manager-dialog";
@@ -1009,21 +1008,45 @@ export function App({
       );
       if (!terminal) return false;
       try {
-        const edits = planRenameCellTerminal(
+        const {
+          content,
+          formatOverride,
+          binding: _binding,
+          ...annotationPresentation
+        } = annotation;
+        const editedContent = formatOverride ?? content;
+        const semanticContent = semanticTextDocument(name, "formal-port");
+        const normalizedAnnotation: Annotation = {
+          ...annotationPresentation,
+          binding: {
+            kind: "cell-terminal-name",
+            terminalId: terminal.id,
+          },
+          ...(editedContent &&
+          JSON.stringify(editedContent) !== JSON.stringify(semanticContent)
+            ? { formatOverride: editedContent }
+            : {}),
+        };
+        const renamed = terminal.name !== name;
+        const edits = planEditCellTerminalAnnotation(
           project,
           document.id,
           terminal.id,
+          normalizedAnnotation,
           name,
         );
         if (edits.length === 0) {
-          setStatus(`Cell Port ${name} is already current`);
+          setStatus(`Cell Port ${terminal.name} is already current`);
           return true;
         }
-        const committed = commitStructure(
-          "rename-cell-port-from-annotation",
-          edits,
-        );
-        if (committed) setStatus(`Renamed formal port to ${name}`);
+        const committed = commitStructure("edit-cell-port-label", edits);
+        if (committed) {
+          setStatus(
+            renamed
+              ? `Renamed formal port to ${name}`
+              : `Formatted Cell Port ${name}`,
+          );
+        }
         return committed;
       } catch (error) {
         setStatus(
@@ -1392,6 +1415,7 @@ export function App({
     closeInsertDialog: closeInsertDialogFromHook,
     cellInsertOnly,
     insertDialogOpen,
+    insertInitialSelectionId,
     openInsertComponentDialog: openInsertComponentDialogFromHook,
     recentSymbolIds,
     rotatePendingComponent: rotatePendingComponentFromHook,
@@ -2091,6 +2115,26 @@ export function App({
         (terminal) => terminal.interfaceInstanceId === selectedInstance.id,
       )
     : undefined;
+  const selectedPortNet =
+    selectedInstance &&
+    (selectedInstance.symbolId === "port" ||
+      selectedInstance.symbolId === "port-filled")
+      ? document.nets.find((net) =>
+          net.terminals.some(
+            (terminal) => terminal.instanceId === selectedInstance.id,
+          ),
+        )
+      : undefined;
+  function renameSelectedNetPort(name: string): void {
+    if (!selectedPortNet || selectedFormalTerminal) return;
+    name = name.trim();
+    if (!name || name === selectedPortNet.name) return;
+    if (
+      transact([{ kind: "set_net_name", netId: selectedPortNet.id, name }]).ok
+    ) {
+      setStatus(`Renamed Net Port to ${name}`);
+    }
+  }
   function renameSelectedFormalPort(name: string): void {
     if (!selectedFormalTerminal) return;
     name = name.trim();
@@ -3777,12 +3821,20 @@ export function App({
     const formalName = document.netlist?.terminals.find(
       (terminal) => terminal.interfaceInstanceId === instance.id,
     )?.name;
+    const netPortName =
+      instance.symbolId === "port" || instance.symbolId === "port-filled"
+        ? document.nets.find((net) =>
+            net.terminals.some(
+              (terminal) => terminal.instanceId === instance.id,
+            ),
+          )?.name
+        : undefined;
     const schematicName = flattenRichText(
       instance.schematicName ?? { runs: [] },
     );
     const reference =
       instance.schematicReference ?? instance.netlist?.reference ?? null;
-    const secondary = formalName ?? schematicName;
+    const secondary = formalName ?? netPortName ?? schematicName;
     const identity =
       reference && secondary && reference !== secondary
         ? `${reference} · ${secondary}`
@@ -5064,6 +5116,7 @@ export function App({
     presentation?: {
       alignment: "start" | "middle" | "end";
       sizeScale: number;
+      formatOverride?: RichTextDocument;
     },
   ): SchematicEdit[] | null {
     const net = document.nets.find((candidate) => candidate.id === route.netId);
@@ -5143,6 +5196,9 @@ export function App({
           : existingLabel?.sizeScale !== undefined
             ? { sizeScale: existingLabel.sizeScale }
             : {}),
+        ...(presentation?.formatOverride
+          ? { formatOverride: presentation.formatOverride }
+          : {}),
       },
     });
     return edits;
@@ -6391,12 +6447,7 @@ export function App({
           openInsertComponentDialogFromHook();
           return;
         case "place-port": {
-          const request = quickPlaceRequest(
-            document.presentation.styleProfileId,
-            "port",
-          );
-          if (request) beginInsertedComponentPlacementFromHook(request);
-          else setStatus("Port is unavailable in this style profile");
+          openInsertComponentDialogFromHook(false, "port");
           return;
         }
         case "rotate-placement":
@@ -7098,6 +7149,8 @@ export function App({
         cells={cellInsertCandidates}
         externalDefinitions={externalSubcircuitInsertCandidates}
         cellOnly={cellInsertOnly}
+        allowFormalPort={document.id !== project.topDocumentId}
+        initialSelectionId={insertInitialSelectionId}
         onApply={beginInsertedComponentPlacementFromHook}
         onCancel={cancelComponentInsertFromHook}
       />
@@ -7333,7 +7386,17 @@ export function App({
             recentSymbolIds={recentSymbolIds}
             open={visibleLibraryPanelOpen}
             onOpenInsert={openInsertComponentDialogFromHook}
-            onQuickPlace={beginInsertedComponentPlacementFromHook}
+            onQuickPlace={(request) => {
+              if (
+                request.kind === "symbol" &&
+                (request.symbolId === "port" ||
+                  request.symbolId === "port-filled")
+              ) {
+                openInsertComponentDialogFromHook(false, request.symbolId);
+                return;
+              }
+              beginInsertedComponentPlacementFromHook(request);
+            }}
           />
         ) : (
           <ExamplesPanel
@@ -7431,6 +7494,17 @@ export function App({
                       className="formal-port-properties"
                       aria-label="Cell Port properties"
                     >
+                      <label>
+                        <span>Terminal name</span>
+                        <input
+                          key={`${selectedFormalTerminal.id}-${document.revision}-terminal-name`}
+                          aria-label="Cell Port terminal name"
+                          defaultValue={selectedFormalTerminal.name}
+                          onBlur={(event) =>
+                            renameSelectedFormalPort(event.currentTarget.value)
+                          }
+                        />
+                      </label>
                       <label>
                         <span>Direction</span>
                         <select
@@ -7598,7 +7672,21 @@ export function App({
                   >
                     <div className="property-section-heading">Identity</div>
                     <dl className="component-readonly-fields">
-                      {!selectedFormalTerminal ? (
+                      {selectedPortNet && !selectedFormalTerminal ? (
+                        <div>
+                          <dt>Net name</dt>
+                          <dd>
+                            <input
+                              key={`${selectedPortNet.id}-${document.revision}-net-port-name`}
+                              aria-label="Net Port name"
+                              defaultValue={selectedPortNet.name ?? ""}
+                              onBlur={(event) =>
+                                renameSelectedNetPort(event.currentTarget.value)
+                              }
+                            />
+                          </dd>
+                        </div>
+                      ) : !selectedFormalTerminal ? (
                         <div>
                           <dt>Schematic label</dt>
                           <dd>
@@ -7765,7 +7853,12 @@ export function App({
                       aria-label="Component display toggles"
                     >
                       <DisplayToggle
-                        label="Reference"
+                        label={
+                          selectedInstance.symbolId === "port" ||
+                          selectedInstance.symbolId === "port-filled"
+                            ? "Port label"
+                            : "Reference"
+                        }
                         checked={
                           selectedInstanceLabel !== undefined &&
                           selectedInstanceLabel.visible !== false

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -63,6 +63,7 @@ import {
   findHierarchyPath,
   findHierarchyPaths,
   isMosBulkTerminal,
+  isSchematicAnnotationVisible,
   isVisibleEndpoint,
   resolveEndpointPoint,
   resolveDraftingObjectGeometry,
@@ -5375,27 +5376,6 @@ export function App({
     }
   }
 
-  function updateSelectedSchematicReference(value: string): void {
-    if (!selectedInstance) return;
-    const reference = value.trim();
-    if (!reference) {
-      setStatus("Schematic reference cannot be empty");
-      return;
-    }
-    if (reference === selectedInstance.schematicReference) return;
-    if (
-      transact([
-        {
-          kind: "set_instance_schematic_reference",
-          instanceId: selectedInstance.id,
-          reference,
-        },
-      ]).ok
-    ) {
-      setStatus(`Set schematic reference to ${reference}`);
-    }
-  }
-
   /*
    * Text sessions use one persistence proposal for both annotation and
    * drafting owners. The tagged target keeps their typed edit differences at
@@ -5861,7 +5841,7 @@ export function App({
           annotationIds: document.annotations
             .filter(
               (annotation) =>
-                annotation.visible !== false &&
+                isSchematicAnnotationVisible(document, annotation) &&
                 rectsIntersect(
                   annotationHitBox(
                     document,
@@ -7618,23 +7598,31 @@ export function App({
                   >
                     <div className="property-section-heading">Identity</div>
                     <dl className="component-readonly-fields">
-                      <div>
-                        <dt>Schematic reference</dt>
-                        <dd>
-                          <input
-                            key={`${selectedInstance.id}-${document.revision}-schematic-reference`}
-                            aria-label="Component schematic reference"
-                            defaultValue={
-                              selectedInstance.schematicReference ?? ""
-                            }
-                            onBlur={(event) =>
-                              updateSelectedSchematicReference(
-                                event.currentTarget.value,
-                              )
-                            }
-                          />
-                        </dd>
-                      </div>
+                      {!selectedFormalTerminal ? (
+                        <div>
+                          <dt>Schematic label</dt>
+                          <dd>
+                            <input
+                              key={`${selectedInstance.id}-${document.revision}-schematic-label`}
+                              aria-label="Component schematic label"
+                              defaultValue={flattenRichText(
+                                selectedInstance.schematicName ??
+                                  defaultDraftTextDocument(
+                                    selectedInstance.schematicReference ??
+                                      selectedInstance.netlist?.reference ??
+                                      "",
+                                  ),
+                              )}
+                              placeholder="Schematic label"
+                              onBlur={(event) =>
+                                updateSelectedSchematicName(
+                                  event.currentTarget.value,
+                                )
+                              }
+                            />
+                          </dd>
+                        </div>
+                      ) : null}
                       {selectedInstance.netlist ? (
                         <div>
                           <dt>Netlist reference</dt>
@@ -7652,25 +7640,6 @@ export function App({
                           </dd>
                         </div>
                       ) : null}
-                      <div>
-                        <dt>Schematic alias</dt>
-                        <dd>
-                          <input
-                            key={`${selectedInstance.id}-${document.revision}-schematic-name`}
-                            aria-label="Component schematic alias"
-                            defaultValue={flattenRichText(
-                              selectedInstance.schematicName ??
-                                defaultDraftTextDocument(""),
-                            )}
-                            placeholder="Optional display alias"
-                            onBlur={(event) =>
-                              updateSelectedSchematicName(
-                                event.currentTarget.value,
-                              )
-                            }
-                          />
-                        </dd>
-                      </div>
                       <div>
                         <dt>Symbol</dt>
                         <dd>{selectedInstance.symbolId}</dd>
@@ -9460,7 +9429,9 @@ export function App({
                 );
               })}
               {document.annotations
-                .filter((annotation) => annotation.visible !== false)
+                .filter((annotation) =>
+                  isSchematicAnnotationVisible(document, annotation),
+                )
                 .map((annotation) => {
                   const anchor = annotationAnchor(
                     document,

--- a/apps/editor/src/app/editor-document-helpers.test.ts
+++ b/apps/editor/src/app/editor-document-helpers.test.ts
@@ -25,7 +25,7 @@ describe("editor document helpers", () => {
     document.annotations.push({
       id: "label-R1",
       kind: "instance-label",
-      binding: { kind: "instance-designator", instanceId: "R1" },
+      binding: { kind: "instance-schematic-name", instanceId: "R1" },
       anchor: {
         kind: "object",
         objectId: "R1",
@@ -42,7 +42,7 @@ describe("editor document helpers", () => {
     expect(instanceLabelAnnotationFor(document, "R2")).toBeUndefined();
   });
 
-  it("does not confuse a master label with a designator", () => {
+  it("does not confuse a master label with a schematic label", () => {
     const document = createEmptyDocument("doc", "Doc");
     document.annotations.push({
       id: "master-R1",

--- a/apps/editor/src/app/editor-document-helpers.test.ts
+++ b/apps/editor/src/app/editor-document-helpers.test.ts
@@ -1,4 +1,4 @@
-import { createEmptyDocument, semanticTextDocument } from "@icm/model";
+import { createEmptyDocument } from "@icm/model";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -25,7 +25,7 @@ describe("editor document helpers", () => {
     document.annotations.push({
       id: "label-R1",
       kind: "instance-label",
-      content: semanticTextDocument("R1", "instance-label"),
+      binding: { kind: "instance-designator", instanceId: "R1" },
       anchor: {
         kind: "object",
         objectId: "R1",
@@ -40,6 +40,25 @@ describe("editor document helpers", () => {
     });
     expect(instanceLabelAnnotationFor(document, "R1")?.id).toBe("label-R1");
     expect(instanceLabelAnnotationFor(document, "R2")).toBeUndefined();
+  });
+
+  it("does not confuse a master label with a designator", () => {
+    const document = createEmptyDocument("doc", "Doc");
+    document.annotations.push({
+      id: "master-R1",
+      kind: "instance-label",
+      binding: { kind: "instance-master-name", instanceId: "R1" },
+      anchor: {
+        kind: "object",
+        objectId: "R1",
+        localOffset: { x: 0, y: 0 },
+        fallbackPosition: { x: 0, y: 0 },
+      },
+      rotation: 0,
+      alignment: "start",
+      locked: false,
+    });
+    expect(instanceLabelAnnotationFor(document, "R1")).toBeUndefined();
   });
 
   it("finds the highest generated routing counter across document objects", () => {

--- a/apps/editor/src/app/editor-document-helpers.ts
+++ b/apps/editor/src/app/editor-document-helpers.ts
@@ -57,7 +57,7 @@ export function instanceLabelAnnotationFor(
   return document.annotations.find(
     (annotation) =>
       annotation.kind === "instance-label" &&
-      annotation.binding?.kind === "instance-designator" &&
+      annotation.binding?.kind === "instance-schematic-name" &&
       annotation.anchor.kind === "object" &&
       annotation.anchor.objectId === instanceId,
   );

--- a/apps/editor/src/app/editor-document-helpers.ts
+++ b/apps/editor/src/app/editor-document-helpers.ts
@@ -56,8 +56,11 @@ export function instanceLabelAnnotationFor(
 ): Annotation | undefined {
   return document.annotations.find(
     (annotation) =>
-      annotation.kind === "instance-label" &&
-      annotation.binding?.kind === "instance-schematic-name" &&
+      (annotation.kind === "instance-label" ||
+        annotation.kind === "net-label") &&
+      (annotation.binding?.kind === "instance-schematic-name" ||
+        annotation.binding?.kind === "cell-terminal-name" ||
+        annotation.binding?.kind === "net-name") &&
       annotation.anchor.kind === "object" &&
       annotation.anchor.objectId === instanceId,
   );

--- a/apps/editor/src/app/editor-document-helpers.ts
+++ b/apps/editor/src/app/editor-document-helpers.ts
@@ -57,6 +57,7 @@ export function instanceLabelAnnotationFor(
   return document.annotations.find(
     (annotation) =>
       annotation.kind === "instance-label" &&
+      annotation.binding?.kind === "instance-designator" &&
       annotation.anchor.kind === "object" &&
       annotation.anchor.objectId === instanceId,
   );

--- a/apps/editor/src/demos/demo-project.ts
+++ b/apps/editor/src/demos/demo-project.ts
@@ -33,17 +33,20 @@ const demoProject = CircuitProjectSchema.parse({
           id: "M1",
           symbolId: "nmos",
           symbolVariantId: "textbook-3terminal",
+          schematicReference: "M1",
           placement: null,
         },
         {
           id: "M2",
           symbolId: "pmos",
           symbolVariantId: "textbook-3terminal",
+          schematicReference: "M2",
           placement: null,
         },
         {
           id: "R1",
           symbolId: "resistor",
+          schematicReference: "R1",
           placement: null,
           netlist: {
             reference: "R1",

--- a/apps/editor/src/demos/routing-demo.ts
+++ b/apps/editor/src/demos/routing-demo.ts
@@ -6,6 +6,7 @@ import type { CircuitProject, Instance } from "@icm/model";
 
 function instance(
   id: string,
+  schematicReference: string,
   x: number,
   y: number,
   rotation: 0 | 90 | 180 | 270,
@@ -14,6 +15,7 @@ function instance(
   return {
     id,
     symbolId: "port",
+    schematicReference,
     placement: { position: { x, y }, rotation, mirror },
   };
 }
@@ -39,11 +41,11 @@ export function createRoutingDemoProject(): CircuitProject {
         sourceStatus: "in-sync",
         netlist: { name: "Phase_3_Routing", terminals: [] },
         instances: [
-          instance("A", 140, 300, 0),
-          instance("B", 460, 300, 0, "x"),
-          instance("C", 300, 140, 90),
-          instance("D", 300, 460, 270),
-          instance("E", 340, 440, 90),
+          instance("A", "P1", 140, 300, 0),
+          instance("B", "P2", 460, 300, 0, "x"),
+          instance("C", "P3", 300, 140, 90),
+          instance("D", "P4", 300, 460, 270),
+          instance("E", "P5", 340, 440, 90),
         ],
         nets: [
           {

--- a/apps/editor/src/document/browser-recovery-contract.test.ts
+++ b/apps/editor/src/document/browser-recovery-contract.test.ts
@@ -185,20 +185,20 @@ describe("reviewBrowserRecoveryProject", () => {
     }
   });
 
-  it("accepts a schema-14 recovery envelope after upgrading its Project", () => {
+  it("accepts a schema-15 recovery envelope after upgrading its Project", () => {
     const previousText = JSON.stringify({
       ...JSON.parse(projectText),
-      schemaVersion: 14,
+      schemaVersion: 15,
     });
     const review = reviewBrowserRecoveryProject(
       finalizeBrowserRecoveryRecord(
-        draft({ projectText: previousText, projectSchemaVersion: 14 }),
+        draft({ projectText: previousText, projectSchemaVersion: 15 }),
       ),
     );
 
     expect(review.status).toBe("valid");
     if (review.status === "valid") {
-      expect(review.project.schemaVersion).toBe(15);
+      expect(review.project.schemaVersion).toBe(16);
     }
   });
 

--- a/apps/editor/src/document/browser-recovery-contract.test.ts
+++ b/apps/editor/src/document/browser-recovery-contract.test.ts
@@ -185,20 +185,20 @@ describe("reviewBrowserRecoveryProject", () => {
     }
   });
 
-  it("accepts a schema-15 recovery envelope after upgrading its Project", () => {
+  it("accepts a schema-16 recovery envelope after upgrading its Project", () => {
     const previousText = JSON.stringify({
       ...JSON.parse(projectText),
-      schemaVersion: 15,
+      schemaVersion: 16,
     });
     const review = reviewBrowserRecoveryProject(
       finalizeBrowserRecoveryRecord(
-        draft({ projectText: previousText, projectSchemaVersion: 15 }),
+        draft({ projectText: previousText, projectSchemaVersion: 16 }),
       ),
     );
 
     expect(review.status).toBe("valid");
     if (review.status === "valid") {
-      expect(review.project.schemaVersion).toBe(16);
+      expect(review.project.schemaVersion).toBe(17);
     }
   });
 

--- a/apps/editor/src/document/browser-recovery-contract.test.ts
+++ b/apps/editor/src/document/browser-recovery-contract.test.ts
@@ -185,20 +185,20 @@ describe("reviewBrowserRecoveryProject", () => {
     }
   });
 
-  it("accepts a schema-16 recovery envelope after upgrading its Project", () => {
+  it("accepts a schema-17 recovery envelope after upgrading its Project", () => {
     const previousText = JSON.stringify({
       ...JSON.parse(projectText),
-      schemaVersion: 16,
+      schemaVersion: 17,
     });
     const review = reviewBrowserRecoveryProject(
       finalizeBrowserRecoveryRecord(
-        draft({ projectText: previousText, projectSchemaVersion: 16 }),
+        draft({ projectText: previousText, projectSchemaVersion: 17 }),
       ),
     );
 
     expect(review.status).toBe("valid");
     if (review.status === "valid") {
-      expect(review.project.schemaVersion).toBe(17);
+      expect(review.project.schemaVersion).toBe(18);
     }
   });
 

--- a/apps/editor/src/document/browser-recovery-store.test.ts
+++ b/apps/editor/src/document/browser-recovery-store.test.ts
@@ -533,18 +533,18 @@ describe("migrateLegacyProjectRecovery", () => {
     expect(firstSession(read).latest?.source).toBe("recovered");
   });
 
-  it("stores a schema-15 legacy slot as internally consistent schema 16", async () => {
+  it("stores a schema-16 legacy slot as internally consistent schema 17", async () => {
     const { store } = freshStore();
     const previousText = JSON.stringify({
       ...JSON.parse(projectText),
-      schemaVersion: 15,
+      schemaVersion: 16,
     });
     const storage = memoryStorage({ [PROJECT_RECOVERY_KEY]: previousText });
 
     expect(await migrate(storage, store)).toMatchObject({ status: "migrated" });
     const latest = firstSession(await store.readAll()).latest!;
-    expect(latest.projectSchemaVersion).toBe(16);
-    expect(JSON.parse(latest.projectText).schemaVersion).toBe(16);
+    expect(latest.projectSchemaVersion).toBe(17);
+    expect(JSON.parse(latest.projectText).schemaVersion).toBe(17);
   });
 
   it("retains an unsupported-schema legacy slot", async () => {

--- a/apps/editor/src/document/browser-recovery-store.test.ts
+++ b/apps/editor/src/document/browser-recovery-store.test.ts
@@ -533,18 +533,18 @@ describe("migrateLegacyProjectRecovery", () => {
     expect(firstSession(read).latest?.source).toBe("recovered");
   });
 
-  it("stores a schema-16 legacy slot as internally consistent schema 17", async () => {
+  it("stores a schema-17 legacy slot as internally consistent schema 18", async () => {
     const { store } = freshStore();
     const previousText = JSON.stringify({
       ...JSON.parse(projectText),
-      schemaVersion: 16,
+      schemaVersion: 17,
     });
     const storage = memoryStorage({ [PROJECT_RECOVERY_KEY]: previousText });
 
     expect(await migrate(storage, store)).toMatchObject({ status: "migrated" });
     const latest = firstSession(await store.readAll()).latest!;
-    expect(latest.projectSchemaVersion).toBe(17);
-    expect(JSON.parse(latest.projectText).schemaVersion).toBe(17);
+    expect(latest.projectSchemaVersion).toBe(18);
+    expect(JSON.parse(latest.projectText).schemaVersion).toBe(18);
   });
 
   it("retains an unsupported-schema legacy slot", async () => {

--- a/apps/editor/src/document/browser-recovery-store.test.ts
+++ b/apps/editor/src/document/browser-recovery-store.test.ts
@@ -533,18 +533,18 @@ describe("migrateLegacyProjectRecovery", () => {
     expect(firstSession(read).latest?.source).toBe("recovered");
   });
 
-  it("stores a schema-14 legacy slot as internally consistent schema 15", async () => {
+  it("stores a schema-15 legacy slot as internally consistent schema 16", async () => {
     const { store } = freshStore();
     const previousText = JSON.stringify({
       ...JSON.parse(projectText),
-      schemaVersion: 14,
+      schemaVersion: 15,
     });
     const storage = memoryStorage({ [PROJECT_RECOVERY_KEY]: previousText });
 
     expect(await migrate(storage, store)).toMatchObject({ status: "migrated" });
     const latest = firstSession(await store.readAll()).latest!;
-    expect(latest.projectSchemaVersion).toBe(15);
-    expect(JSON.parse(latest.projectText).schemaVersion).toBe(15);
+    expect(latest.projectSchemaVersion).toBe(16);
+    expect(JSON.parse(latest.projectText).schemaVersion).toBe(16);
   });
 
   it("retains an unsupported-schema legacy slot", async () => {

--- a/apps/editor/src/document/project-file-service.test.ts
+++ b/apps/editor/src/document/project-file-service.test.ts
@@ -240,27 +240,27 @@ describe("stageProjectFile", () => {
       status: "opened",
       fileName: "amp.icproj.json",
       topDocumentRevision: 0,
-      sourceSchemaVersion: 17,
+      sourceSchemaVersion: 18,
       migrated: false,
     });
   });
 
-  it("stages schema 16 as an upgraded schema-17 Project", async () => {
+  it("stages schema 17 as an upgraded schema-18 Project", async () => {
     const previousText = JSON.stringify({
       ...JSON.parse(serializeProject(project)),
-      schemaVersion: 16,
+      schemaVersion: 17,
     });
     const outcome = await stageProjectFile(
-      fakeFile("amp-v16.icproj.json", previousText),
+      fakeFile("amp-v17.icproj.json", previousText),
       () => [],
     );
 
     expect(outcome).toMatchObject({
       status: "opened",
-      fileName: "amp-v16.icproj.json",
-      sourceSchemaVersion: 16,
+      fileName: "amp-v17.icproj.json",
+      sourceSchemaVersion: 17,
       migrated: true,
-      project: { schemaVersion: 17 },
+      project: { schemaVersion: 18 },
     });
   });
 

--- a/apps/editor/src/document/project-file-service.test.ts
+++ b/apps/editor/src/document/project-file-service.test.ts
@@ -240,27 +240,27 @@ describe("stageProjectFile", () => {
       status: "opened",
       fileName: "amp.icproj.json",
       topDocumentRevision: 0,
-      sourceSchemaVersion: 15,
+      sourceSchemaVersion: 16,
       migrated: false,
     });
   });
 
-  it("stages schema 14 as an upgraded schema-15 Project", async () => {
+  it("stages schema 15 as an upgraded schema-16 Project", async () => {
     const previousText = JSON.stringify({
       ...JSON.parse(serializeProject(project)),
-      schemaVersion: 14,
+      schemaVersion: 15,
     });
     const outcome = await stageProjectFile(
-      fakeFile("amp-v14.icproj.json", previousText),
+      fakeFile("amp-v15.icproj.json", previousText),
       () => [],
     );
 
     expect(outcome).toMatchObject({
       status: "opened",
-      fileName: "amp-v14.icproj.json",
-      sourceSchemaVersion: 14,
+      fileName: "amp-v15.icproj.json",
+      sourceSchemaVersion: 15,
       migrated: true,
-      project: { schemaVersion: 15 },
+      project: { schemaVersion: 16 },
     });
   });
 

--- a/apps/editor/src/document/project-file-service.test.ts
+++ b/apps/editor/src/document/project-file-service.test.ts
@@ -240,27 +240,27 @@ describe("stageProjectFile", () => {
       status: "opened",
       fileName: "amp.icproj.json",
       topDocumentRevision: 0,
-      sourceSchemaVersion: 16,
+      sourceSchemaVersion: 17,
       migrated: false,
     });
   });
 
-  it("stages schema 15 as an upgraded schema-16 Project", async () => {
+  it("stages schema 16 as an upgraded schema-17 Project", async () => {
     const previousText = JSON.stringify({
       ...JSON.parse(serializeProject(project)),
-      schemaVersion: 15,
+      schemaVersion: 16,
     });
     const outcome = await stageProjectFile(
-      fakeFile("amp-v15.icproj.json", previousText),
+      fakeFile("amp-v16.icproj.json", previousText),
       () => [],
     );
 
     expect(outcome).toMatchObject({
       status: "opened",
-      fileName: "amp-v15.icproj.json",
-      sourceSchemaVersion: 15,
+      fileName: "amp-v16.icproj.json",
+      sourceSchemaVersion: 16,
       migrated: true,
-      project: { schemaVersion: 16 },
+      project: { schemaVersion: 17 },
     });
   });
 

--- a/apps/editor/src/examples/common-source-amplifier.icproj.json
+++ b/apps/editor/src/examples/common-source-amplifier.icproj.json
@@ -562,6 +562,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "C1",
           "symbolId": "capacitor"
         },
         {
@@ -582,6 +583,7 @@
             },
             "rotation": 90
           },
+          "schematicReference": "C2",
           "symbolId": "capacitor"
         },
         {
@@ -602,6 +604,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "M1",
           "symbolId": "nmos",
           "symbolVariantId": "textbook-3terminal"
         },
@@ -623,6 +626,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "R1",
           "symbolId": "resistor"
         },
         {
@@ -636,6 +640,7 @@
             "reference": "PWR1"
           },
           "placement": null,
+          "schematicReference": "PWR1",
           "symbolId": "vdd-port"
         },
         {
@@ -656,6 +661,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "PWR2",
           "symbolId": "ground"
         },
         {
@@ -676,6 +682,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "PWR3",
           "symbolId": "ground"
         },
         {
@@ -696,6 +703,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "PWR4",
           "symbolId": "ground"
         },
         {
@@ -716,6 +724,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "PWR5",
           "symbolId": "ground"
         },
         {
@@ -736,6 +745,7 @@
             },
             "rotation": 90
           },
+          "schematicReference": "R2",
           "symbolId": "resistor"
         },
         {
@@ -752,6 +762,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "V1",
           "symbolId": "voltage-source"
         },
         {
@@ -765,6 +776,7 @@
             "reference": "PWR6"
           },
           "placement": null,
+          "schematicReference": "PWR6",
           "symbolId": "vdd-port"
         }
       ],
@@ -854,6 +866,7 @@
       "layoutGroups": [],
       "name": "Main",
       "netlist": {
+        "formalParameters": [],
         "name": "Main",
         "terminals": []
       },
@@ -1256,9 +1269,10 @@
       "sourceStatus": "connectivity-modified"
     }
   ],
+  "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 16,
+  "schemaVersion": 17,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/common-source-amplifier.icproj.json
+++ b/apps/editor/src/examples/common-source-amplifier.icproj.json
@@ -1272,7 +1272,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 17,
+  "schemaVersion": 18,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/common-source-amplifier.icproj.json
+++ b/apps/editor/src/examples/common-source-amplifier.icproj.json
@@ -562,7 +562,6 @@
             },
             "rotation": 0
           },
-          "properties": {},
           "symbolId": "capacitor"
         },
         {
@@ -583,7 +582,6 @@
             },
             "rotation": 90
           },
-          "properties": {},
           "symbolId": "capacitor"
         },
         {
@@ -604,7 +602,6 @@
             },
             "rotation": 0
           },
-          "properties": {},
           "symbolId": "nmos",
           "symbolVariantId": "textbook-3terminal"
         },
@@ -626,7 +623,6 @@
             },
             "rotation": 0
           },
-          "properties": {},
           "symbolId": "resistor"
         },
         {
@@ -640,7 +636,6 @@
             "reference": "PWR1"
           },
           "placement": null,
-          "properties": {},
           "symbolId": "vdd-port"
         },
         {
@@ -661,7 +656,6 @@
             },
             "rotation": 0
           },
-          "properties": {},
           "symbolId": "ground"
         },
         {
@@ -682,7 +676,6 @@
             },
             "rotation": 0
           },
-          "properties": {},
           "symbolId": "ground"
         },
         {
@@ -703,7 +696,6 @@
             },
             "rotation": 0
           },
-          "properties": {},
           "symbolId": "ground"
         },
         {
@@ -724,7 +716,6 @@
             },
             "rotation": 0
           },
-          "properties": {},
           "symbolId": "ground"
         },
         {
@@ -745,7 +736,6 @@
             },
             "rotation": 90
           },
-          "properties": {},
           "symbolId": "resistor"
         },
         {
@@ -762,7 +752,6 @@
             },
             "rotation": 0
           },
-          "properties": {},
           "symbolId": "voltage-source"
         },
         {
@@ -776,7 +765,6 @@
             "reference": "PWR6"
           },
           "placement": null,
-          "properties": {},
           "symbolId": "vdd-port"
         }
       ],
@@ -1270,7 +1258,7 @@
   ],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 14,
+  "schemaVersion": 16,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/library-examples.test.ts
+++ b/apps/editor/src/examples/library-examples.test.ts
@@ -14,7 +14,7 @@ describe("bundled Library Project examples", () => {
     ]);
     for (const example of libraryProjectExamples) {
       expect(serializeProject(example.project)).toContain(
-        '"schemaVersion": 16',
+        '"schemaVersion": 17',
       );
       expect(example.project.documents).toHaveLength(1);
     }

--- a/apps/editor/src/examples/library-examples.test.ts
+++ b/apps/editor/src/examples/library-examples.test.ts
@@ -14,7 +14,7 @@ describe("bundled Library Project examples", () => {
     ]);
     for (const example of libraryProjectExamples) {
       expect(serializeProject(example.project)).toContain(
-        '"schemaVersion": 15',
+        '"schemaVersion": 16',
       );
       expect(example.project.documents).toHaveLength(1);
     }

--- a/apps/editor/src/examples/library-examples.test.ts
+++ b/apps/editor/src/examples/library-examples.test.ts
@@ -14,7 +14,7 @@ describe("bundled Library Project examples", () => {
     ]);
     for (const example of libraryProjectExamples) {
       expect(serializeProject(example.project)).toContain(
-        '"schemaVersion": 17',
+        '"schemaVersion": 18',
       );
       expect(example.project.documents).toHaveLength(1);
     }

--- a/apps/editor/src/examples/two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/two-stage-op-amp.icproj.json
@@ -685,7 +685,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 17,
+  "schemaVersion": 18,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/two-stage-op-amp.icproj.json
@@ -277,7 +277,6 @@
             },
             "rotation": 180
           },
-          "properties": {},
           "symbolId": "opamp"
         },
         {
@@ -294,7 +293,6 @@
             },
             "rotation": 0
           },
-          "properties": {},
           "symbolId": "voltage-amplifier"
         },
         {
@@ -315,7 +313,6 @@
             },
             "rotation": 0
           },
-          "properties": {},
           "symbolId": "capacitor"
         },
         {
@@ -336,7 +333,6 @@
             },
             "rotation": 270
           },
-          "properties": {},
           "symbolId": "capacitor"
         },
         {
@@ -357,7 +353,6 @@
             },
             "rotation": 0
           },
-          "properties": {},
           "symbolId": "ground"
         },
         {
@@ -374,7 +369,6 @@
             },
             "rotation": 180
           },
-          "properties": {},
           "symbolId": "port"
         },
         {
@@ -391,7 +385,6 @@
             },
             "rotation": 0
           },
-          "properties": {},
           "symbolId": "port"
         }
       ],
@@ -683,7 +676,7 @@
   ],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 14,
+  "schemaVersion": 16,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/two-stage-op-amp.icproj.json
@@ -277,6 +277,7 @@
             },
             "rotation": 180
           },
+          "schematicReference": "X1",
           "symbolId": "opamp"
         },
         {
@@ -293,6 +294,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "X2",
           "symbolId": "voltage-amplifier"
         },
         {
@@ -313,6 +315,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "C1",
           "symbolId": "capacitor"
         },
         {
@@ -333,6 +336,7 @@
             },
             "rotation": 270
           },
+          "schematicReference": "C2",
           "symbolId": "capacitor"
         },
         {
@@ -353,6 +357,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "PWR1",
           "symbolId": "ground"
         },
         {
@@ -369,6 +374,7 @@
             },
             "rotation": 180
           },
+          "schematicReference": "P1",
           "symbolId": "port"
         },
         {
@@ -385,6 +391,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "P2",
           "symbolId": "port"
         }
       ],
@@ -420,6 +427,7 @@
       "layoutGroups": [],
       "name": "Main",
       "netlist": {
+        "formalParameters": [],
         "name": "Main",
         "terminals": []
       },
@@ -674,9 +682,10 @@
       "sourceStatus": "connectivity-modified"
     }
   ],
+  "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 16,
+  "schemaVersion": 17,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/features/clipboard/clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard.test.ts
@@ -164,7 +164,12 @@ describe("schematic clipboard", () => {
         rotation: 0,
         mirror: "none",
       },
-      ...(reference ? { netlist: { reference, parameters: {} } } : {}),
+      ...(reference
+        ? {
+            schematicReference: reference,
+            netlist: { reference, parameters: {} },
+          }
+        : {}),
     };
   }
 
@@ -212,6 +217,7 @@ describe("schematic clipboard", () => {
     expect(result.document.instances).toHaveLength(2);
     expect(result.document.instances[1]).toMatchObject({
       id: "R2",
+      schematicReference: "R2",
       netlist: { reference: "R2" },
     });
     expect(

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -239,6 +239,47 @@ function pastedInstanceId(
 }
 
 /**
+ * Allocate the copied schematic reference independently while preserving the
+ * common case where schematic and emitted references intentionally agree.
+ */
+function pastedSchematicReference(
+  source: Instance,
+  nextNetlistReference: string | undefined,
+  nextId: string,
+  sequence: number,
+  reserved: Set<string>,
+): string | undefined {
+  const current = source.schematicReference;
+  if (!current) return undefined;
+  const synchronized =
+    nextNetlistReference &&
+    (current === source.netlist?.reference || current === source.id)
+      ? nextNetlistReference
+      : current === source.id
+        ? nextId
+        : undefined;
+  if (synchronized) {
+    reserved.add(synchronized.toLowerCase());
+    return synchronized;
+  }
+
+  const suffix = /^(.*?)(\d+)$/u.exec(current);
+  const prefix = suffix?.[1] || `${current}-copy-`;
+  let index = suffix ? Number(suffix[2]) + 1 : sequence;
+  const candidateFor = (value: number): string => {
+    const digits = String(value);
+    return `${prefix.slice(0, Math.max(1, 128 - digits.length))}${digits}`;
+  };
+  let candidate = candidateFor(index);
+  while (reserved.has(candidate.toLowerCase())) {
+    index += 1;
+    candidate = candidateFor(index);
+  }
+  reserved.add(candidate.toLowerCase());
+  return candidate;
+}
+
+/**
  * Rewrites a pasted instance-label whose text is still the copied reference
  * (or copied id) to the new reference, so a pasted R1 reads R2 on canvas.
  * The replacement content is rebuilt exactly like a freshly placed label
@@ -358,6 +399,28 @@ export function proposePaste(
       ),
     ]),
   );
+  const reservedSchematicReferences = new Set([
+    ...document.instances.flatMap((instance) =>
+      [instance.schematicReference, instance.netlist?.reference]
+        .filter((reference): reference is string => reference !== undefined)
+        .map((reference) => reference.toLowerCase()),
+    ),
+    ...[...instanceReferences.values()].map((reference) =>
+      reference.toLowerCase(),
+    ),
+  ]);
+  const instanceSchematicReferences = new Map(
+    clipboard.instances.flatMap((instance) => {
+      const reference = pastedSchematicReference(
+        instance,
+        instanceReferences.get(instance.id),
+        instanceIds.get(instance.id)!,
+        sequence,
+        reservedSchematicReferences,
+      );
+      return reference ? [[instance.id, reference] as const] : [];
+    }),
+  );
   const routeIds = new Map(
     clipboard.routes.map((route) => [
       route.id,
@@ -403,6 +466,11 @@ export function proposePaste(
       instance: {
         ...structuredClone(instance),
         id: instanceIds.get(instance.id)!,
+        ...(instanceSchematicReferences.has(instance.id)
+          ? {
+              schematicReference: instanceSchematicReferences.get(instance.id)!,
+            }
+          : {}),
         ...(instance.netlist && instanceReferences.has(instance.id)
           ? {
               netlist: {

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -216,11 +216,10 @@ function uniqueCopyId(
 }
 
 /**
- * A pasted instance whose source id equals its source reference keeps the
- * designator convention: it adopts the freshly allocated reference (copy R1
- * becomes R2) so the visible label, the id, and the netlist reference stay a
- * single fact. Anything else (custom ids, reference-less instances) falls
- * back to the opaque `-copy-N` id.
+ * A pasted instance receives a fresh electrical designator while its internal
+ * object ID remains independently stable. Legacy projects often used the same
+ * string for both, so preserve that convenient convention only when it does
+ * not collide; presentation bindings are rewritten separately below.
  */
 function pastedInstanceId(
   source: Instance,
@@ -259,8 +258,8 @@ function rewriteInstanceLabelText(
   ) {
     return;
   }
-  if (annotation.binding?.kind === "instance-reference") {
-    annotation.binding = { kind: "instance-reference", instanceId: nextId };
+  if (annotation.binding?.kind === "instance-designator") {
+    annotation.binding = { kind: "instance-designator", instanceId: nextId };
     return;
   }
   if (!annotation.content) return;
@@ -550,10 +549,13 @@ export function proposePaste(
                   netId: netIds.get(clone.binding.netId) ?? clone.binding.netId,
                 },
               }
-            : clone.binding?.kind === "instance-value"
+            : clone.binding?.kind === "instance-value" ||
+                clone.binding?.kind === "instance-designator" ||
+                clone.binding?.kind === "instance-schematic-name" ||
+                clone.binding?.kind === "instance-master-name"
               ? {
                   binding: {
-                    kind: "instance-value" as const,
+                    kind: clone.binding.kind,
                     instanceId:
                       objectIds.get(clone.binding.instanceId) ??
                       clone.binding.instanceId,

--- a/apps/editor/src/features/component-insert/component-insert-request.ts
+++ b/apps/editor/src/features/component-insert/component-insert-request.ts
@@ -7,6 +7,9 @@ export interface SymbolInsertRequest {
   showReference: boolean;
   referenceText: string | null;
   showValue: boolean;
+  portRole?: "net-port" | "cell-terminal";
+  portName?: string;
+  portDirection?: "input" | "output" | "inout" | "passive";
 }
 
 export interface VddRailInsertRequest {

--- a/apps/editor/src/features/component-insert/component-insert-request.ts
+++ b/apps/editor/src/features/component-insert/component-insert-request.ts
@@ -36,8 +36,8 @@ export interface ExternalSubcircuitInsertRequest {
   masterName: string;
   parameters: Record<string, string>;
   initialRotation: 0 | 90 | 180 | 270;
-  showReference: false;
-  referenceText: null;
+  showReference: boolean;
+  referenceText: string | null;
   showValue: true;
 }
 

--- a/apps/editor/src/features/component-insert/insert-component-dialog.test.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.test.tsx
@@ -80,7 +80,6 @@ describe("InsertComponentDialog", () => {
     expect(markup).toContain(">Cells</h3>");
     expect(markup).toContain('data-testid="insert-cell-document-amplifier"');
     expect(markup).toContain(">Amplifier</span>");
-    expect(markup).toContain("Cell label: Amplifier");
-    expect(markup).not.toContain('aria-label="Reference name"');
+    expect(markup).toContain('aria-label="Reference name"');
   });
 });

--- a/apps/editor/src/features/component-insert/insert-component-dialog.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.tsx
@@ -23,6 +23,8 @@ export interface InsertComponentDialogProps {
   cells: readonly CellInsertCandidate[];
   externalDefinitions?: readonly ExternalSubcircuitInsertCandidate[];
   cellOnly?: boolean;
+  allowFormalPort?: boolean;
+  initialSelectionId?: string | null;
   onApply(request: ComponentInsertRequest): void;
   onCancel(): void;
 }
@@ -100,6 +102,8 @@ export function InsertComponentDialog({
   cells,
   externalDefinitions = [],
   cellOnly = false,
+  allowFormalPort = false,
+  initialSelectionId = null,
   onApply,
   onCancel,
 }: InsertComponentDialogProps) {
@@ -146,6 +150,12 @@ export function InsertComponentDialog({
   const [showReference, setShowReference] = useState(true);
   const [referenceText, setReferenceText] = useState("");
   const [showValue, setShowValue] = useState(false);
+  const [portRole, setPortRole] = useState<"net-port" | "cell-terminal">(
+    "net-port",
+  );
+  const [portDirection, setPortDirection] = useState<
+    "input" | "output" | "inout" | "passive"
+  >("passive");
   const inputRef = useRef<HTMLInputElement>(null);
   const groups = useMemo<
     { category: string; choices: InsertChoice[] }[]
@@ -243,14 +253,21 @@ export function InsertComponentDialog({
     if (!open) return;
     setQuery("");
     setPickerOpen(true);
-    setSelectedId(initialChoices[0]?.key ?? null);
+    setSelectedId(
+      initialSelectionId &&
+        initialChoices.some((choice) => choice.key === initialSelectionId)
+        ? initialSelectionId
+        : (initialChoices[0]?.key ?? null),
+    );
     setInitialRotation(0);
     setShowReference(true);
     setReferenceText("");
     setShowValue(false);
+    setPortRole(allowFormalPort ? "cell-terminal" : "net-port");
+    setPortDirection("passive");
     const frame = requestAnimationFrame(() => inputRef.current?.focus());
     return () => cancelAnimationFrame(frame);
-  }, [initialChoices, open]);
+  }, [allowFormalPort, initialChoices, initialSelectionId, open]);
 
   useEffect(() => {
     setParameterValues(
@@ -347,6 +364,22 @@ export function InsertComponentDialog({
         .filter(([, value]) => value !== ""),
     );
     const trimmedReference = referenceText.trim();
+    if (selectedIsPort) {
+      onApply({
+        kind: "symbol",
+        symbolId: selected.symbol.id,
+        symbolName: selected.symbol.name,
+        parameters: {},
+        initialRotation,
+        showReference: false,
+        referenceText: null,
+        showValue: false,
+        portRole,
+        ...(trimmedReference === "" ? {} : { portName: trimmedReference }),
+        portDirection,
+      });
+      return;
+    }
     onApply({
       kind: "symbol",
       symbolId: selected.symbol.id,
@@ -527,9 +560,64 @@ export function InsertComponentDialog({
                   </select>
                 </label>
                 {selectedIsPort ? (
-                  <p className="insert-cell-label-note">
-                    Port name and direction can be edited after placement.
-                  </p>
+                  <div className="insert-label-control">
+                    <label>
+                      <span>Port role</span>
+                      <select
+                        aria-label="Port role"
+                        value={portRole}
+                        onChange={(event) =>
+                          setPortRole(
+                            event.currentTarget.value as
+                              "net-port" | "cell-terminal",
+                          )
+                        }
+                      >
+                        <option value="net-port">Free Net Port</option>
+                        {allowFormalPort ? (
+                          <option value="cell-terminal">Formal Cell Pin</option>
+                        ) : null}
+                      </select>
+                    </label>
+                    <label>
+                      <span>
+                        {portRole === "cell-terminal"
+                          ? "Terminal name"
+                          : "Net name"}
+                      </span>
+                      <input
+                        aria-label={
+                          portRole === "cell-terminal"
+                            ? "New Cell terminal name"
+                            : "New Net Port name"
+                        }
+                        value={referenceText}
+                        placeholder="Use connected Net name"
+                        onChange={(event) =>
+                          setReferenceText(event.currentTarget.value)
+                        }
+                      />
+                    </label>
+                    {portRole === "cell-terminal" ? (
+                      <label>
+                        <span>Direction</span>
+                        <select
+                          aria-label="New Cell terminal direction"
+                          value={portDirection}
+                          onChange={(event) =>
+                            setPortDirection(
+                              event.currentTarget.value as typeof portDirection,
+                            )
+                          }
+                        >
+                          <option value="input">Input</option>
+                          <option value="output">Output</option>
+                          <option value="inout">Inout</option>
+                          <option value="passive">Passive</option>
+                        </select>
+                      </label>
+                    ) : null}
+                  </div>
                 ) : (
                   <div className="insert-label-control">
                     <DisplayToggle

--- a/apps/editor/src/features/component-insert/insert-component-dialog.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.tsx
@@ -310,6 +310,7 @@ export function InsertComponentDialog({
       return;
     }
     if (selected.kind === "cell") {
+      const trimmedReference = referenceText.trim();
       onApply({
         kind: "cell",
         symbolId: selected.symbol.id,
@@ -318,13 +319,14 @@ export function InsertComponentDialog({
         cellName: selected.cellName ?? selected.symbol.name,
         parameters: {},
         initialRotation,
-        showReference: false,
-        referenceText: null,
+        showReference,
+        referenceText: trimmedReference === "" ? null : trimmedReference,
         showValue: true,
       });
       return;
     }
     if (selected.kind === "external-subcircuit") {
+      const trimmedReference = referenceText.trim();
       onApply({
         kind: "external-subcircuit",
         symbolId: selected.symbol.id,
@@ -333,8 +335,8 @@ export function InsertComponentDialog({
         masterName: selected.masterName ?? selected.symbol.name,
         parameters: {},
         initialRotation,
-        showReference: false,
-        referenceText: null,
+        showReference,
+        referenceText: trimmedReference === "" ? null : trimmedReference,
         showValue: true,
       });
       return;
@@ -524,11 +526,7 @@ export function InsertComponentDialog({
                     <option value="270">270°</option>
                   </select>
                 </label>
-                {selected?.kind === "cell" ? (
-                  <p className="insert-cell-label-note">
-                    Cell label: {selected.cellName ?? selected.symbol.name}
-                  </p>
-                ) : selectedIsPort ? (
+                {selectedIsPort ? (
                   <p className="insert-cell-label-note">
                     Port name and direction can be edited after placement.
                   </p>

--- a/apps/editor/src/features/component-insert/placement-tray.test.ts
+++ b/apps/editor/src/features/component-insert/placement-tray.test.ts
@@ -1,0 +1,73 @@
+import { createEmptyDocument } from "@icm/model";
+import { describe, expect, it } from "vitest";
+
+import { planPlaceAllUnplacedInstances } from "./placement-tray.js";
+
+describe("Placement Tray bulk layout", () => {
+  it("places retained Instances in document order on a snapped viewport grid", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.instances.push(
+      { id: "R1", symbolId: "resistor", placement: null },
+      { id: "C1", symbolId: "capacitor", placement: null },
+      {
+        id: "R2",
+        symbolId: "resistor",
+        placement: {
+          position: { x: 700, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      { id: "M1", symbolId: "nmos", placement: null },
+    );
+
+    expect(
+      planPlaceAllUnplacedInstances(document, {
+        x: 0,
+        y: 0,
+        width: 480,
+        height: 320,
+      }),
+    ).toEqual([
+      {
+        kind: "place_instance",
+        instanceId: "R1",
+        placement: {
+          position: { x: 80, y: 240 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        kind: "place_instance",
+        instanceId: "C1",
+        placement: {
+          position: { x: 260, y: 240 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        kind: "place_instance",
+        instanceId: "M1",
+        placement: {
+          position: { x: 80, y: 380 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+    ]);
+  });
+
+  it("does not emit an edit when the tray is empty", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    expect(
+      planPlaceAllUnplacedInstances(document, {
+        x: 0,
+        y: 0,
+        width: 960,
+        height: 640,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/apps/editor/src/features/component-insert/placement-tray.ts
+++ b/apps/editor/src/features/component-insert/placement-tray.ts
@@ -1,0 +1,58 @@
+import type { SchematicEdit } from "@icm/edit-engine";
+import type { GridRect, SchematicDocument } from "@icm/model";
+
+const HORIZONTAL_PITCH = 180;
+const VERTICAL_PITCH = 140;
+const VIEW_MARGIN = 80;
+
+/**
+ * Produces a conservative, deterministic first drawing for every retained
+ * Instance. This is deliberately a placement shelf, not an analog-recognition
+ * auto-layout: it never creates, deletes, or reconnects anything.
+ */
+export function planPlaceAllUnplacedInstances(
+  document: SchematicDocument,
+  viewBox: GridRect,
+): SchematicEdit[] {
+  const unplaced = document.instances.filter(
+    (instance) => instance.placement === null,
+  );
+  if (unplaced.length === 0) return [];
+
+  const grid = document.presentation.grid;
+  const pitchX = snapUp(HORIZONTAL_PITCH, grid);
+  const pitchY = snapUp(VERTICAL_PITCH, grid);
+  const startX = snapUp(viewBox.x + VIEW_MARGIN, grid);
+  const placedBottom = document.instances.reduce(
+    (bottom, instance) =>
+      instance.placement === null
+        ? bottom
+        : Math.max(bottom, instance.placement.position.y + pitchY),
+    Number.NEGATIVE_INFINITY,
+  );
+  const startY = Math.max(
+    snapUp(viewBox.y + VIEW_MARGIN, grid),
+    Number.isFinite(placedBottom) ? snapUp(placedBottom, grid) : 0,
+  );
+  const columns = Math.max(
+    1,
+    Math.floor((viewBox.width - VIEW_MARGIN * 2) / pitchX) + 1,
+  );
+
+  return unplaced.map((instance, index): SchematicEdit => ({
+    kind: "place_instance",
+    instanceId: instance.id,
+    placement: {
+      position: {
+        x: startX + (index % columns) * pitchX,
+        y: startY + Math.floor(index / columns) * pitchY,
+      },
+      rotation: 0,
+      mirror: "none",
+    },
+  }));
+}
+
+function snapUp(value: number, grid: number): number {
+  return Math.ceil(value / grid) * grid;
+}

--- a/apps/editor/src/features/component-insert/use-component-placement.ts
+++ b/apps/editor/src/features/component-insert/use-component-placement.ts
@@ -37,7 +37,10 @@ import {
 } from "./placement-connectivity";
 import { planVddRailEdits } from "./vdd-rail";
 import { vddPowerLabelAnnotation } from "./vdd-power-label";
-import { defaultInstanceDisplayAnnotations } from "../instance-display/default-instance-display";
+import {
+  defaultInstanceDisplayAnnotations,
+  missingDefaultInstanceDisplayAnnotations,
+} from "../instance-display/default-instance-display";
 import {
   initialInstanceNetlist,
   nextInstanceDesignator,
@@ -248,16 +251,23 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       options.cancelAllTransientInteraction();
       return;
     }
+    const placement = {
+      position,
+      rotation: options.componentPlacementRotation,
+      mirror: options.componentPlacementMirror,
+    };
+    const displayAnnotations = missingDefaultInstanceDisplayAnnotations(
+      options.document,
+      { ...instance, placement },
+      options.resolver,
+      options.styleProfile,
+    );
     const result = options.transact([
-      {
-        kind: "place_instance",
-        instanceId,
-        placement: {
-          position,
-          rotation: options.componentPlacementRotation,
-          mirror: options.componentPlacementMirror,
-        },
-      },
+      { kind: "place_instance", instanceId, placement },
+      ...displayAnnotations.map((annotation) => ({
+        kind: "upsert_schematic_annotation" as const,
+        annotation,
+      })),
     ]);
     if (!result.ok) return;
     options.selectOnly("instance", [instanceId]);

--- a/apps/editor/src/features/component-insert/use-component-placement.ts
+++ b/apps/editor/src/features/component-insert/use-component-placement.ts
@@ -19,7 +19,6 @@ import {
   hierarchyReferencePolicy,
   nextReference,
 } from "@icm/devices";
-import { semanticTextDocument } from "@icm/model";
 import type {
   CircuitProject,
   Point,
@@ -103,6 +102,9 @@ export interface UseComponentPlacementOptions {
 export function useComponentPlacement(options: UseComponentPlacementOptions) {
   const [insertDialogOpen, setInsertDialogOpen] = useState(false);
   const [cellInsertOnly, setCellInsertOnly] = useState(false);
+  const [insertInitialSelectionId, setInsertInitialSelectionId] = useState<
+    string | null
+  >(null);
   const [recentSymbolIds, setRecentSymbolIds] = useState<string[]>(() => {
     if (typeof window === "undefined") return [];
     try {
@@ -415,17 +417,8 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     placementRequest: PendingComponentPlacement,
   ): void => {
     const id = nextInstanceDesignator(options.document, symbolId);
-    const formalName = placementRequest.formalName ?? id;
-    if (
-      placementRequest.kind !== "cell-port" ||
-      !placementRequest.direction ||
-      options.document.netlist?.terminals.some(
-        (terminal) => terminal.name === formalName,
-      )
-    ) {
-      options.setStatus(`Cell port ${formalName} already exists`);
+    if (placementRequest.kind !== "cell-port" || !placementRequest.direction)
       return;
-    }
     const instance = {
       id,
       symbolId,
@@ -452,6 +445,25 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       options.setStatus(
         contact.rejected ?? "Port overlaps multiple Nets; choose one contact",
       );
+      return;
+    }
+    const connectedNet = contact.netId
+      ? options.document.nets.find((net) => net.id === contact.netId)
+      : undefined;
+    const formalName =
+      placementRequest.portName?.trim() || connectedNet?.name?.trim();
+    if (!formalName) {
+      options.setStatus(
+        "A Formal Cell Pin needs a Terminal name or a named Net contact",
+      );
+      return;
+    }
+    if (
+      options.document.netlist?.terminals.some(
+        (terminal) => terminal.name === formalName,
+      )
+    ) {
+      options.setStatus(`Cell port ${formalName} already exists`);
       return;
     }
     const baseNetId = `net-cell-port-${id.toLowerCase()}`;
@@ -482,8 +494,18 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
                 pinName: "P",
               },
               newNetId: netId,
+              newNetName: formalName,
             },
           ]),
+      ...(contact.netId && !connectedNet?.name
+        ? [
+            {
+              kind: "set_net_name" as const,
+              netId: contact.netId,
+              name: formalName,
+            },
+          ]
+        : []),
     ];
     const committed = options.transactProject(
       "place-cell-port",
@@ -511,6 +533,115 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     options.setComponentPreviewPoint(position);
     options.setStatus(
       `Added Cell port ${formalName} · click to place another · Esc exits`,
+    );
+  };
+
+  const placeNewNetPort = (
+    symbolId: "port" | "port-filled",
+    position: Point,
+    placementRequest: PendingComponentPlacement,
+  ): void => {
+    if (placementRequest.kind !== "net-port") return;
+    const id = nextInstanceDesignator(options.document, symbolId);
+    const instance = {
+      id,
+      symbolId,
+      placement: {
+        position,
+        rotation: options.componentPlacementRotation,
+        mirror: options.componentPlacementMirror,
+      },
+    };
+    const contact = proposePlacementContact(
+      options.document,
+      options.resolver,
+      instance,
+      options.visibleEndpoints,
+    );
+    if (contact.rejected || contact.ambiguous) {
+      options.setStatus(
+        contact.rejected ?? "Port overlaps multiple Nets; choose one contact",
+      );
+      return;
+    }
+    const connectedNet = contact.netId
+      ? options.document.nets.find((net) => net.id === contact.netId)
+      : undefined;
+    const name =
+      placementRequest.portName?.trim() || connectedNet?.name?.trim();
+    if (!name) {
+      options.setStatus(
+        "A Free Net Port needs a Net name or a named Net contact",
+      );
+      return;
+    }
+    const baseNetId = `net-port-${id.toLowerCase()}`;
+    let netId = contact.netId ?? baseNetId;
+    let netSuffix = 2;
+    while (
+      !contact.netId &&
+      options.document.nets.some((net) => net.id.toLowerCase() === netId)
+    ) {
+      netId = `${baseNetId}-${netSuffix}`;
+      netSuffix += 1;
+    }
+    const label = defaultInstanceDisplayAnnotations(
+      options.document,
+      instance,
+      options.resolver,
+      options.styleProfile,
+    )[0];
+    if (!label) {
+      options.setStatus("Port style has no label placement");
+      return;
+    }
+    const edits: SchematicEdit[] = [
+      { kind: "add_instance", instance },
+      ...contact.edits,
+      ...(contact.matched
+        ? []
+        : [
+            {
+              kind: "connect_endpoints" as const,
+              from: {
+                kind: "terminal" as const,
+                instanceId: id,
+                pinName: "P",
+              },
+              to: {
+                kind: "terminal" as const,
+                instanceId: id,
+                pinName: "P",
+              },
+              newNetId: netId,
+              newNetName: name,
+            },
+          ]),
+      ...(contact.netId && connectedNet?.name !== name
+        ? [
+            {
+              kind: "set_net_name" as const,
+              netId: contact.netId,
+              name,
+            },
+          ]
+        : []),
+      {
+        kind: "upsert_schematic_annotation",
+        annotation: {
+          ...label,
+          kind: "net-label",
+          binding: { kind: "net-name", netId },
+          netId,
+        },
+      },
+    ];
+    const result = options.transact(edits);
+    if (!result.ok) return;
+    options.selectOnly("instance", [id]);
+    options.setComponentPreviewPoint(position);
+    options.setStatus(
+      `Added Free Net Port ${name} · click to place another · Esc exits`,
     );
   };
 
@@ -558,9 +689,13 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     options.setStatus(`Added VDD rail ${instanceId}`);
   };
 
-  const openInsertComponentDialog = (cellOnly = false): void => {
+  const openInsertComponentDialog = (
+    cellOnly = false,
+    initialSelectionId: string | null = null,
+  ): void => {
     options.cancelAllTransientInteraction();
     setCellInsertOnly(cellOnly);
+    setInsertInitialSelectionId(initialSelectionId);
     setInsertDialogOpen(true);
     options.setStatus(
       cellOnly ? "Choose a Cell to place" : "Choose a component to place",
@@ -595,18 +730,29 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     }
     const pendingRequest: PendingComponentPlacement =
       request.kind === "symbol" &&
-      options.document.id !== options.project.topDocumentId &&
       (request.symbolId === "port" || request.symbolId === "port-filled")
-        ? {
-            kind: "cell-port",
-            symbolId: request.symbolId,
-            parameters: {},
-            initialRotation: request.initialRotation,
-            showReference: false,
-            referenceText: null,
-            showValue: false,
-            direction: "passive",
-          }
+        ? request.portRole === "cell-terminal"
+          ? {
+              kind: "cell-port",
+              symbolId: request.symbolId,
+              parameters: {},
+              initialRotation: request.initialRotation,
+              showReference: false,
+              referenceText: null,
+              showValue: false,
+              direction: request.portDirection ?? "passive",
+              ...(request.portName ? { portName: request.portName } : {}),
+            }
+          : {
+              kind: "net-port",
+              symbolId: request.symbolId,
+              parameters: {},
+              initialRotation: request.initialRotation,
+              showReference: false,
+              referenceText: null,
+              showValue: false,
+              ...(request.portName ? { portName: request.portName } : {}),
+            }
         : request;
     options.beginComponentPlacement(pendingRequest);
     options.setStatus(
@@ -660,6 +806,12 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       if (instanceId) placeRetainedInstance(instanceId, point);
     } else if (options.pendingComponentPlacement.kind === "cell-port") {
       placeNewCellPort(
+        options.pendingSymbolId as "port" | "port-filled",
+        point,
+        options.pendingComponentPlacement,
+      );
+    } else if (options.pendingComponentPlacement.kind === "net-port") {
+      placeNewNetPort(
         options.pendingSymbolId as "port" | "port-filled",
         point,
         options.pendingComponentPlacement,
@@ -719,6 +871,7 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     closeInsertDialog,
     commitPendingPlacementAt,
     insertDialogOpen,
+    insertInitialSelectionId,
     mirrorPendingComponent,
     openInsertComponentDialog,
     recentSymbolIds,

--- a/apps/editor/src/features/component-insert/use-component-placement.ts
+++ b/apps/editor/src/features/component-insert/use-component-placement.ts
@@ -237,6 +237,32 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     );
   };
 
+  const placeRetainedInstance = (instanceId: string, position: Point): void => {
+    const instance = options.document.instances.find(
+      (candidate) => candidate.id === instanceId,
+    );
+    if (!instance || instance.placement !== null) {
+      options.setStatus("This Placement Tray entry is no longer available");
+      options.cancelAllTransientInteraction();
+      return;
+    }
+    const result = options.transact([
+      {
+        kind: "place_instance",
+        instanceId,
+        placement: {
+          position,
+          rotation: options.componentPlacementRotation,
+          mirror: options.componentPlacementMirror,
+        },
+      },
+    ]);
+    if (!result.ok) return;
+    options.selectOnly("instance", [instanceId]);
+    options.cancelAllTransientInteraction();
+    options.setStatus(`Placed ${instanceId} from the Placement Tray`);
+  };
+
   const placeNewCell = (
     symbolId: string,
     position: Point,
@@ -617,7 +643,10 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       return;
     }
     if (!options.pendingSymbolId || !options.pendingComponentPlacement) return;
-    if (options.pendingComponentPlacement.kind === "cell-port") {
+    if (options.pendingComponentPlacement.kind === "retained-instance") {
+      const instanceId = options.pendingComponentPlacement.instanceId;
+      if (instanceId) placeRetainedInstance(instanceId, point);
+    } else if (options.pendingComponentPlacement.kind === "cell-port") {
       placeNewCellPort(
         options.pendingSymbolId as "port" | "port-filled",
         point,
@@ -646,7 +675,32 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     }
   };
 
+  const beginRetainedInstancePlacement = (instanceId: string): void => {
+    const instance = options.document.instances.find(
+      (candidate) => candidate.id === instanceId,
+    );
+    if (!instance || instance.placement !== null) {
+      options.setStatus("This Placement Tray entry is no longer available");
+      return;
+    }
+    options.cancelAllTransientInteraction();
+    options.beginComponentPlacement({
+      kind: "retained-instance",
+      instanceId,
+      symbolId: instance.symbolId,
+      parameters: {},
+      initialRotation: 0,
+      showReference: false,
+      referenceText: null,
+      showValue: false,
+    });
+    options.setStatus(
+      `Place ${instanceId} from the Placement Tray · R rotates · Shift+R / Ctrl+R mirrors · Esc cancels`,
+    );
+  };
+
   return {
+    beginRetainedInstancePlacement,
     beginInsertedComponentPlacement,
     cancelComponentInsert,
     cellInsertOnly,

--- a/apps/editor/src/features/component-insert/use-component-placement.ts
+++ b/apps/editor/src/features/component-insert/use-component-placement.ts
@@ -131,6 +131,8 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     const instance = {
       id,
       symbolId,
+      schematicReference:
+        placementRequest.referenceText ?? netlist?.reference ?? id,
       ...(symbolVariantId ? { symbolVariantId } : {}),
       placement: {
         position,
@@ -417,6 +419,7 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     const instance = {
       id,
       symbolId,
+      schematicReference: id,
       placement: {
         position,
         rotation: options.componentPlacementRotation,

--- a/apps/editor/src/features/component-insert/use-component-placement.ts
+++ b/apps/editor/src/features/component-insert/use-component-placement.ts
@@ -19,7 +19,7 @@ import {
   hierarchyReferencePolicy,
   nextReference,
 } from "@icm/devices";
-import { defaultDraftTextDocument, semanticTextDocument } from "@icm/model";
+import { semanticTextDocument } from "@icm/model";
 import type {
   CircuitProject,
   Point,
@@ -37,10 +37,7 @@ import {
 } from "./placement-connectivity";
 import { planVddRailEdits } from "./vdd-rail";
 import { vddPowerLabelAnnotation } from "./vdd-power-label";
-import {
-  defaultInstanceLabel,
-  defaultInstanceValue,
-} from "../wiring/route-interaction-geometry";
+import { defaultInstanceDisplayAnnotations } from "../instance-display/default-instance-display";
 import {
   initialInstanceNetlist,
   nextInstanceDesignator,
@@ -129,6 +126,7 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       options.document,
       symbolId,
       placementRequest.parameters,
+      placementRequest.referenceText ?? undefined,
     );
     const instance = {
       id,
@@ -141,30 +139,16 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       },
       ...(netlist ? { netlist } : {}),
     };
-    const defaultLabel = defaultInstanceLabel(
+    const displayAnnotations = defaultInstanceDisplayAnnotations(
       options.document,
       instance,
       options.resolver,
       options.styleProfile,
+      {
+        showDesignator: placementRequest.showReference,
+        showValue: placementRequest.showValue,
+      },
     );
-    const instanceLabel =
-      placementRequest.showReference && defaultLabel
-        ? {
-            ...defaultLabel,
-            binding: {
-              kind: "instance-designator" as const,
-              instanceId: instance.id,
-            },
-          }
-        : null;
-    const instanceValue = placementRequest.showValue
-      ? defaultInstanceValue(
-          options.document,
-          instance,
-          options.resolver,
-          options.styleProfile,
-        )
-      : null;
     const contact = proposePlacementContact(
       options.document,
       options.resolver,
@@ -233,22 +217,10 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
               },
             ]
           : []),
-        ...(instanceLabel
-          ? [
-              {
-                kind: "upsert_schematic_annotation" as const,
-                annotation: instanceLabel,
-              },
-            ]
-          : []),
-        ...(instanceValue
-          ? [
-              {
-                kind: "upsert_schematic_annotation" as const,
-                annotation: instanceValue,
-              },
-            ]
-          : []),
+        ...displayAnnotations.map((annotation) => ({
+          kind: "upsert_schematic_annotation" as const,
+          annotation,
+        })),
       ],
       { contact, standalonePower },
       { preserveInteraction: true },
@@ -285,10 +257,12 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       return;
     }
     const id = nextInstanceDesignator(options.document, symbolId);
-    const reference = nextReference(
-      createReferenceIndex(options.document),
-      hierarchyReferencePolicy,
-    );
+    const reference =
+      placementRequest.referenceText ??
+      nextReference(
+        createReferenceIndex(options.document),
+        hierarchyReferencePolicy,
+      );
     if (!reference) {
       options.setStatus("Cannot allocate a hierarchy reference");
       return;
@@ -303,36 +277,23 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       },
       reference,
     );
-    const defaultLabel = defaultInstanceLabel(
+    const annotations = defaultInstanceDisplayAnnotations(
       options.document,
       instance,
       options.resolver,
       options.styleProfile,
+      {
+        showDesignator: placementRequest.showReference,
+        masterName: placementRequest.cellName,
+      },
     );
-    const instanceValue = defaultLabel
-      ? (() => {
-          // The Cell display name is literal presentation text. It is not an
-          // electrical component value and must not inherit the reference
-          // binding from the label template.
-          const { binding: _binding, ...literalLabel } = defaultLabel;
-          return {
-            ...literalLabel,
-            id: `instance-value-${instance.id}`,
-            kind: "instance-value" as const,
-            content: defaultDraftTextDocument(placementRequest.cellName),
-          };
-        })()
-      : null;
     const committed = options.transactProject(
       "place-cell-instance",
       planPlaceCellInstance(
         options.project,
         options.document.id,
         instance,
-        [instanceValue].filter(
-          (annotation): annotation is NonNullable<typeof annotation> =>
-            annotation !== null,
-        ),
+        annotations,
       ),
     );
     if (!committed) return;
@@ -361,10 +322,12 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       return;
     }
     const id = nextInstanceDesignator(options.document, symbolId);
-    const reference = nextReference(
-      createReferenceIndex(options.document),
-      hierarchyReferencePolicy,
-    );
+    const reference =
+      placementRequest.referenceText ??
+      nextReference(
+        createReferenceIndex(options.document),
+        hierarchyReferencePolicy,
+      );
     if (!reference) {
       options.setStatus("Cannot allocate an external-subcircuit reference");
       return;
@@ -379,6 +342,16 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       },
       reference,
     );
+    const annotations = defaultInstanceDisplayAnnotations(
+      options.document,
+      instance,
+      options.resolver,
+      options.styleProfile,
+      {
+        showDesignator: placementRequest.showReference,
+        masterName: definition.name,
+      },
+    );
     if (
       !options.transactProject(
         "place-external-subcircuit-instance",
@@ -386,6 +359,7 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
           options.project,
           options.document.id,
           instance,
+          annotations,
         ),
       )
     )
@@ -423,11 +397,12 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
         mirror: options.componentPlacementMirror,
       },
     };
-    const annotation = defaultInstanceLabel(
+    const annotations = defaultInstanceDisplayAnnotations(
       options.document,
       instance,
       options.resolver,
       options.styleProfile,
+      { formalTerminalId: `terminal-${id.toLowerCase()}` },
     );
     const contact = proposePlacementContact(
       options.document,
@@ -484,14 +459,10 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
           direction: placementRequest.direction,
           interfaceInstanceId: id,
         },
-        ...(annotation
+        ...(annotations[0]
           ? {
               annotation: {
-                ...annotation,
-                binding: {
-                  kind: "cell-terminal-name" as const,
-                  terminalId: `terminal-${id.toLowerCase()}`,
-                },
+                ...annotations[0],
               },
             }
           : {}),

--- a/apps/editor/src/features/component-insert/use-component-placement.ts
+++ b/apps/editor/src/features/component-insert/use-component-placement.ts
@@ -152,7 +152,7 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
         ? {
             ...defaultLabel,
             binding: {
-              kind: "instance-reference" as const,
+              kind: "instance-designator" as const,
               instanceId: instance.id,
             },
           }

--- a/apps/editor/src/features/component-insert/use-component-placement.ts
+++ b/apps/editor/src/features/component-insert/use-component-placement.ts
@@ -429,7 +429,6 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     const instance = {
       id,
       symbolId,
-      schematicReference: id,
       placement: {
         position,
         rotation: options.componentPlacementRotation,

--- a/apps/editor/src/features/instance-display/default-instance-display.test.ts
+++ b/apps/editor/src/features/instance-display/default-instance-display.test.ts
@@ -50,11 +50,12 @@ describe("default instance display annotations", () => {
     ]);
   });
 
-  it("uses the formal terminal name instead of creating a fake port reference", () => {
+  it("shows the Port reference and formal terminal name separately", () => {
     const document = createEmptyDocument("main", "Main");
     const instance = {
       id: "derived-internal-port-id",
       symbolId: "port",
+      schematicReference: "P1",
       placement: {
         position: { x: 100, y: 100 },
         rotation: 0 as const,
@@ -70,6 +71,12 @@ describe("default instance display annotations", () => {
     );
 
     expect(annotations).toEqual([
+      expect.objectContaining({
+        binding: {
+          kind: "instance-designator",
+          instanceId: "derived-internal-port-id",
+        },
+      }),
       expect.objectContaining({
         binding: { kind: "cell-terminal-name", terminalId: "terminal-input" },
       }),

--- a/apps/editor/src/features/instance-display/default-instance-display.test.ts
+++ b/apps/editor/src/features/instance-display/default-instance-display.test.ts
@@ -79,6 +79,41 @@ describe("default instance display annotations", () => {
     ]);
   });
 
+  it("materializes a free Port label from its connected Net name", () => {
+    const document = createEmptyDocument("main", "Main");
+    const instance = {
+      id: "P1",
+      symbolId: "port",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0 as const,
+        mirror: "none" as const,
+      },
+    };
+    document.instances.push(instance);
+    document.nets.push({
+      id: "net-vin",
+      name: "VIN",
+      scope: "local",
+      terminals: [{ instanceId: instance.id, pinName: "P" }],
+    });
+
+    expect(
+      missingDefaultInstanceDisplayAnnotations(
+        document,
+        instance,
+        resolver,
+        resolveSchematicStyleProfile(document.presentation.styleProfileId),
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        kind: "net-label",
+        binding: { kind: "net-name", netId: "net-vin" },
+        netId: "net-vin",
+      }),
+    ]);
+  });
+
   it("materializes an imported reference once when a retained Instance is placed", () => {
     const document = createEmptyDocument("main", "Main");
     const instance = {

--- a/apps/editor/src/features/instance-display/default-instance-display.test.ts
+++ b/apps/editor/src/features/instance-display/default-instance-display.test.ts
@@ -3,7 +3,10 @@ import { createEmptyDocument } from "@icm/model";
 import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
-import { defaultInstanceDisplayAnnotations } from "./default-instance-display";
+import {
+  defaultInstanceDisplayAnnotations,
+  missingDefaultInstanceDisplayAnnotations,
+} from "./default-instance-display";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
@@ -81,5 +84,45 @@ describe("default instance display annotations", () => {
         binding: { kind: "cell-terminal-name", terminalId: "terminal-input" },
       }),
     ]);
+  });
+
+  it("materializes an imported reference once when a retained Instance is placed", () => {
+    const document = createEmptyDocument("main", "Main");
+    const instance = {
+      id: "imported-resistor-opaque-id",
+      symbolId: "resistor",
+      schematicReference: "R7",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0 as const,
+        mirror: "none" as const,
+      },
+      netlist: { reference: "R7", parameters: { value: "10k" } },
+    };
+
+    const missing = missingDefaultInstanceDisplayAnnotations(
+      document,
+      instance,
+      resolver,
+      resolveSchematicStyleProfile(document.presentation.styleProfileId),
+    );
+    expect(missing).toEqual([
+      expect.objectContaining({
+        binding: {
+          kind: "instance-designator",
+          instanceId: "imported-resistor-opaque-id",
+        },
+      }),
+    ]);
+
+    document.annotations.push(...missing);
+    expect(
+      missingDefaultInstanceDisplayAnnotations(
+        document,
+        instance,
+        resolver,
+        resolveSchematicStyleProfile(document.presentation.styleProfileId),
+      ),
+    ).toEqual([]);
   });
 });

--- a/apps/editor/src/features/instance-display/default-instance-display.test.ts
+++ b/apps/editor/src/features/instance-display/default-instance-display.test.ts
@@ -11,7 +11,7 @@ import {
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
 describe("default instance display annotations", () => {
-  it("creates an electrical designator and master label for an external call", () => {
+  it("creates a RichText schematic label and master label for an external call", () => {
     const document = createEmptyDocument("main", "Main");
     const instance = {
       id: "opaque-import-id",
@@ -42,7 +42,7 @@ describe("default instance display annotations", () => {
       {
         kind: "instance-label",
         binding: {
-          kind: "instance-designator",
+          kind: "instance-schematic-name",
           instanceId: "opaque-import-id",
         },
       },
@@ -53,12 +53,11 @@ describe("default instance display annotations", () => {
     ]);
   });
 
-  it("shows the Port reference and formal terminal name separately", () => {
+  it("shows a formal Port terminal name as its only visible identity", () => {
     const document = createEmptyDocument("main", "Main");
     const instance = {
       id: "derived-internal-port-id",
       symbolId: "port",
-      schematicReference: "P1",
       placement: {
         position: { x: 100, y: 100 },
         rotation: 0 as const,
@@ -74,12 +73,6 @@ describe("default instance display annotations", () => {
     );
 
     expect(annotations).toEqual([
-      expect.objectContaining({
-        binding: {
-          kind: "instance-designator",
-          instanceId: "derived-internal-port-id",
-        },
-      }),
       expect.objectContaining({
         binding: { kind: "cell-terminal-name", terminalId: "terminal-input" },
       }),
@@ -109,7 +102,7 @@ describe("default instance display annotations", () => {
     expect(missing).toEqual([
       expect.objectContaining({
         binding: {
-          kind: "instance-designator",
+          kind: "instance-schematic-name",
           instanceId: "imported-resistor-opaque-id",
         },
       }),

--- a/apps/editor/src/features/instance-display/default-instance-display.test.ts
+++ b/apps/editor/src/features/instance-display/default-instance-display.test.ts
@@ -1,0 +1,78 @@
+import { resolveSchematicStyleProfile } from "@icm/derived";
+import { createEmptyDocument } from "@icm/model";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { defaultInstanceDisplayAnnotations } from "./default-instance-display";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+describe("default instance display annotations", () => {
+  it("creates an electrical designator and master label for an external call", () => {
+    const document = createEmptyDocument("main", "Main");
+    const instance = {
+      id: "opaque-import-id",
+      symbolId: "resistor",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0 as const,
+        mirror: "none" as const,
+      },
+      netlist: {
+        reference: "X1",
+        binding: {
+          kind: "external-subcircuit" as const,
+          definitionId: "master-opamp",
+        },
+        parameters: {},
+      },
+    };
+    const annotations = defaultInstanceDisplayAnnotations(
+      document,
+      instance,
+      resolver,
+      resolveSchematicStyleProfile(document.presentation.styleProfileId),
+      { masterName: "sky130_fd_pr__nfet_01v8" },
+    );
+
+    expect(annotations).toMatchObject([
+      {
+        kind: "instance-label",
+        binding: {
+          kind: "instance-designator",
+          instanceId: "opaque-import-id",
+        },
+      },
+      {
+        id: "instance-master-opaque-import-id",
+        kind: "instance-value",
+      },
+    ]);
+  });
+
+  it("uses the formal terminal name instead of creating a fake port reference", () => {
+    const document = createEmptyDocument("main", "Main");
+    const instance = {
+      id: "derived-internal-port-id",
+      symbolId: "port",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0 as const,
+        mirror: "none" as const,
+      },
+    };
+    const annotations = defaultInstanceDisplayAnnotations(
+      document,
+      instance,
+      resolver,
+      resolveSchematicStyleProfile(document.presentation.styleProfileId),
+      { formalTerminalId: "terminal-input" },
+    );
+
+    expect(annotations).toEqual([
+      expect.objectContaining({
+        binding: { kind: "cell-terminal-name", terminalId: "terminal-input" },
+      }),
+    ]);
+  });
+});

--- a/apps/editor/src/features/instance-display/default-instance-display.ts
+++ b/apps/editor/src/features/instance-display/default-instance-display.ts
@@ -1,0 +1,118 @@
+import {
+  defaultInstanceLabelPlacement,
+  displayableInstanceValue,
+  type SchematicStyleProfile,
+} from "@icm/derived";
+import { defaultDraftTextDocument } from "@icm/model";
+import type { Annotation, SchematicDocument } from "@icm/model";
+import type { SymbolResolver } from "@icm/symbols";
+
+import {
+  defaultInstanceLabel,
+  defaultInstanceValue,
+} from "../wiring/route-interaction-geometry";
+
+type Instance = SchematicDocument["instances"][number];
+
+export interface DefaultInstanceDisplayOptions {
+  readonly showDesignator?: boolean;
+  readonly showValue?: boolean;
+  readonly masterName?: string;
+  readonly formalTerminalId?: string;
+}
+
+/**
+ * One editor policy for default labels. Electrical facts remain in the typed
+ * Instance/Cell model; this factory only creates their visual projections.
+ */
+export function defaultInstanceDisplayAnnotations(
+  document: SchematicDocument,
+  instance: Instance,
+  resolver: SymbolResolver,
+  styleProfile: SchematicStyleProfile,
+  options: DefaultInstanceDisplayOptions = {},
+): readonly Annotation[] {
+  const annotations: Annotation[] = [];
+  const designator = defaultInstanceLabel(
+    document,
+    instance,
+    resolver,
+    styleProfile,
+  );
+  if (options.formalTerminalId && designator) {
+    annotations.push({
+      ...designator,
+      binding: {
+        kind: "cell-terminal-name",
+        terminalId: options.formalTerminalId,
+      },
+    });
+    return annotations;
+  }
+  if (options.showDesignator !== false && instance.netlist && designator) {
+    annotations.push(designator);
+  }
+  if (options.masterName) {
+    const master = defaultMasterNameAnnotation(
+      document,
+      instance,
+      resolver,
+      styleProfile,
+      options.masterName,
+    );
+    if (master) annotations.push(master);
+  } else if (
+    options.showValue &&
+    displayableInstanceValue(instance).kind === "displayable"
+  ) {
+    const value = defaultInstanceValue(
+      document,
+      instance,
+      resolver,
+      styleProfile,
+    );
+    if (value) annotations.push(value);
+  }
+  return annotations;
+}
+
+function defaultMasterNameAnnotation(
+  document: SchematicDocument,
+  instance: Instance,
+  resolver: SymbolResolver,
+  styleProfile: SchematicStyleProfile,
+  masterName: string,
+): Annotation | null {
+  if (!instance.placement || masterName.trim() === "") return null;
+  const resolved = resolver.resolve(
+    instance.symbolId,
+    instance.symbolVariantId,
+  );
+  if (!resolved) return null;
+  const placement = defaultInstanceLabelPlacement(
+    instance,
+    resolved,
+    styleProfile,
+    document.presentation.grid,
+    "value",
+  );
+  if (!placement) return null;
+  const position = placement.position;
+  return {
+    id: `instance-master-${instance.id}`,
+    kind: "instance-value",
+    content: defaultDraftTextDocument(masterName),
+    anchor: {
+      kind: "object",
+      objectId: instance.id,
+      localOffset: {
+        x: position.x - instance.placement.position.x,
+        y: position.y - instance.placement.position.y,
+      },
+      fallbackPosition: position,
+    },
+    alignment: placement.alignment,
+    rotation: 0,
+    locked: false,
+  };
+}

--- a/apps/editor/src/features/instance-display/default-instance-display.ts
+++ b/apps/editor/src/features/instance-display/default-instance-display.ts
@@ -91,6 +91,59 @@ export function defaultInstanceDisplayAnnotations(
   return annotations;
 }
 
+/**
+ * Materialize only the default visual labels a retained Instance lacks when it
+ * enters the canvas. Imported SPICE starts in the Placement Tray, so this
+ * keeps its already-imported Reference visible without replacing a label the
+ * user has already positioned, hidden, or edited.
+ */
+export function missingDefaultInstanceDisplayAnnotations(
+  document: SchematicDocument,
+  instance: Instance,
+  resolver: SymbolResolver,
+  styleProfile: SchematicStyleProfile,
+): readonly Annotation[] {
+  if (!instance.placement) return [];
+  const formalTerminalId = document.netlist?.terminals.find(
+    (terminal) => terminal.interfaceInstanceId === instance.id,
+  )?.id;
+  return defaultInstanceDisplayAnnotations(
+    document,
+    instance,
+    resolver,
+    styleProfile,
+    formalTerminalId ? { formalTerminalId } : {},
+  ).filter(
+    (candidate) =>
+      !document.annotations.some((existing) =>
+        isSameDefaultProjection(existing, candidate),
+      ),
+  );
+}
+
+function isSameDefaultProjection(
+  existing: Annotation,
+  candidate: Annotation,
+): boolean {
+  if (existing.id === candidate.id) return true;
+  const existingBinding = existing.binding;
+  const candidateBinding = candidate.binding;
+  if (!existingBinding || !candidateBinding) return false;
+  if (
+    existingBinding.kind === "instance-designator" &&
+    candidateBinding.kind === "instance-designator"
+  ) {
+    return existingBinding.instanceId === candidateBinding.instanceId;
+  }
+  if (
+    existingBinding.kind === "cell-terminal-name" &&
+    candidateBinding.kind === "cell-terminal-name"
+  ) {
+    return existingBinding.terminalId === candidateBinding.terminalId;
+  }
+  return false;
+}
+
 function defaultMasterNameAnnotation(
   document: SchematicDocument,
   instance: Instance,

--- a/apps/editor/src/features/instance-display/default-instance-display.ts
+++ b/apps/editor/src/features/instance-display/default-instance-display.ts
@@ -39,18 +39,33 @@ export function defaultInstanceDisplayAnnotations(
     resolver,
     styleProfile,
   );
-  if (options.formalTerminalId && designator) {
+  if (options.showDesignator !== false && designator) {
     annotations.push({
       ...designator,
-      binding: {
-        kind: "cell-terminal-name",
-        terminalId: options.formalTerminalId,
-      },
+      ...(options.formalTerminalId
+        ? { id: `instance-reference-${instance.id}` }
+        : {}),
+      binding: { kind: "instance-designator", instanceId: instance.id },
     });
-    return annotations;
   }
-  if (options.showDesignator !== false && instance.netlist && designator) {
-    annotations.push(designator);
+  if (options.formalTerminalId) {
+    const terminalName = defaultInstanceLabel(
+      document,
+      instance,
+      resolver,
+      styleProfile,
+      "value",
+    );
+    if (terminalName) {
+      annotations.push({
+        ...terminalName,
+        id: `instance-label-${instance.id}`,
+        binding: {
+          kind: "cell-terminal-name",
+          terminalId: options.formalTerminalId,
+        },
+      });
+    }
   }
   if (options.masterName) {
     const master = defaultMasterNameAnnotation(

--- a/apps/editor/src/features/instance-display/default-instance-display.ts
+++ b/apps/editor/src/features/instance-display/default-instance-display.ts
@@ -15,6 +15,7 @@ import {
 type Instance = SchematicDocument["instances"][number];
 
 export interface DefaultInstanceDisplayOptions {
+  /** Show the default user-facing schematic label. */
   readonly showDesignator?: boolean;
   readonly showValue?: boolean;
   readonly masterName?: string;
@@ -33,39 +34,35 @@ export function defaultInstanceDisplayAnnotations(
   options: DefaultInstanceDisplayOptions = {},
 ): readonly Annotation[] {
   const annotations: Annotation[] = [];
-  const designator = defaultInstanceLabel(
-    document,
-    instance,
-    resolver,
-    styleProfile,
-  );
-  if (options.showDesignator !== false && designator) {
-    annotations.push({
-      ...designator,
-      ...(options.formalTerminalId
-        ? { id: `instance-reference-${instance.id}` }
-        : {}),
-      binding: { kind: "instance-designator", instanceId: instance.id },
-    });
-  }
   if (options.formalTerminalId) {
     const terminalName = defaultInstanceLabel(
       document,
       instance,
       resolver,
       styleProfile,
-      "value",
     );
     if (terminalName) {
       annotations.push({
         ...terminalName,
-        id: `instance-label-${instance.id}`,
         binding: {
           kind: "cell-terminal-name",
           terminalId: options.formalTerminalId,
         },
       });
     }
+    return annotations;
+  }
+  const label = defaultInstanceLabel(
+    document,
+    instance,
+    resolver,
+    styleProfile,
+  );
+  if (options.showDesignator !== false && label) {
+    annotations.push({
+      ...label,
+      binding: { kind: "instance-schematic-name", instanceId: instance.id },
+    });
   }
   if (options.masterName) {
     const master = defaultMasterNameAnnotation(
@@ -130,8 +127,8 @@ function isSameDefaultProjection(
   const candidateBinding = candidate.binding;
   if (!existingBinding || !candidateBinding) return false;
   if (
-    existingBinding.kind === "instance-designator" &&
-    candidateBinding.kind === "instance-designator"
+    existingBinding.kind === "instance-schematic-name" &&
+    candidateBinding.kind === "instance-schematic-name"
   ) {
     return existingBinding.instanceId === candidateBinding.instanceId;
   }

--- a/apps/editor/src/features/instance-display/default-instance-display.ts
+++ b/apps/editor/src/features/instance-display/default-instance-display.ts
@@ -104,13 +104,30 @@ export function missingDefaultInstanceDisplayAnnotations(
   const formalTerminalId = document.netlist?.terminals.find(
     (terminal) => terminal.interfaceInstanceId === instance.id,
   )?.id;
-  return defaultInstanceDisplayAnnotations(
+  const freePortNet =
+    !formalTerminalId &&
+    (instance.symbolId === "port" || instance.symbolId === "port-filled")
+      ? document.nets.find((net) =>
+          net.terminals.some((terminal) => terminal.instanceId === instance.id),
+        )
+      : undefined;
+  const candidates = defaultInstanceDisplayAnnotations(
     document,
     instance,
     resolver,
     styleProfile,
     formalTerminalId ? { formalTerminalId } : {},
-  ).filter(
+  ).map((candidate) =>
+    freePortNet
+      ? {
+          ...candidate,
+          kind: "net-label" as const,
+          binding: { kind: "net-name" as const, netId: freePortNet.id },
+          netId: freePortNet.id,
+        }
+      : candidate,
+  );
+  return candidates.filter(
     (candidate) =>
       !document.annotations.some((existing) =>
         isSameDefaultProjection(existing, candidate),
@@ -131,6 +148,12 @@ function isSameDefaultProjection(
     candidateBinding.kind === "instance-schematic-name"
   ) {
     return existingBinding.instanceId === candidateBinding.instanceId;
+  }
+  if (
+    existingBinding.kind === "net-name" &&
+    candidateBinding.kind === "net-name"
+  ) {
+    return existingBinding.netId === candidateBinding.netId;
   }
   if (
     existingBinding.kind === "cell-terminal-name" &&

--- a/apps/editor/src/features/netlist-export/netlist-authoring.ts
+++ b/apps/editor/src/features/netlist-export/netlist-authoring.ts
@@ -32,10 +32,9 @@ export function placementReferencePrefix(symbolId: string): string {
 }
 
 /**
- * Lowest unused per-prefix designator across the union of instance ids and
- * netlist references, so the visible label, the instance id, and the netlist
- * reference never collide with either domain (undo, reload, and deletion all
- * re-scan the live document, and freed numbers are reused).
+ * Lowest unused per-prefix schematic Reference. Internal IDs and netlist
+ * references are separate authorities, so allocation scans all three domains
+ * without letting one silently overwrite another.
  */
 export function nextInstanceDesignator(
   document: SchematicDocument,
@@ -45,6 +44,9 @@ export function nextInstanceDesignator(
   const used = new Set<string>();
   for (const instance of document.instances) {
     used.add(instance.id.toLowerCase());
+    if (instance.schematicReference) {
+      used.add(instance.schematicReference.toLowerCase());
+    }
     if (instance.netlist?.reference) {
       used.add(instance.netlist.reference.toLowerCase());
     }

--- a/apps/editor/src/features/properties/instance-table-dialog.tsx
+++ b/apps/editor/src/features/properties/instance-table-dialog.tsx
@@ -196,7 +196,10 @@ export function InstanceTableDialog({
             <thead>
               <tr>
                 <th aria-label="Selection" />
+                <th>ID</th>
                 <th>Reference</th>
+                <th>Alias</th>
+                <th>Master</th>
                 <th>Symbol</th>
                 <th>Cell</th>
                 <th>Callers</th>
@@ -224,9 +227,12 @@ export function InstanceTableDialog({
                         onOpenInstance(row.documentId, row.instanceId)
                       }
                     >
-                      {row.reference ?? row.instanceId}
+                      {row.instanceId}
                     </button>
                   </td>
+                  <td>{row.reference ?? "—"}</td>
+                  <td>{row.schematicName ?? "—"}</td>
+                  <td>{row.masterName ?? "—"}</td>
                   <td>{row.symbolId}</td>
                   <td>{row.documentName}</td>
                   <td>
@@ -234,11 +240,7 @@ export function InstanceTableDialog({
                       ? "Top"
                       : `${row.callerPaths.length} definition use${row.callerPaths.length === 1 ? "" : "s"}`}
                   </td>
-                  <td>
-                    {row.binding?.kind === "model"
-                      ? row.binding.name
-                      : (row.binding?.kind ?? "—")}
-                  </td>
+                  <td>{row.binding?.kind ?? "—"}</td>
                   <td>
                     {Object.entries(row.parameters)
                       .map(([name, parameter]) => `${name}=${parameter}`)

--- a/apps/editor/src/features/properties/use-properties-editor.ts
+++ b/apps/editor/src/features/properties/use-properties-editor.ts
@@ -588,7 +588,7 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
         },
       };
       const instanceReferenceBinding =
-        boundAnnotation.binding.kind === "instance-reference"
+        boundAnnotation.binding.kind === "instance-schematic-name"
           ? boundAnnotation.binding
           : undefined;
       const schematicNameInstance = instanceReferenceBinding
@@ -656,7 +656,7 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
             setTextEditing(null);
           }
           return;
-        case "instance-reference":
+        case "instance-schematic-name":
           if (!schematicNameSourceChanged && !presentationChanged) {
             setTextEditing(null);
             return;
@@ -680,6 +680,12 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
           return;
         case "instance-value":
           options.setStatus("Edit component values in Properties");
+          return;
+        case "instance-designator":
+          options.setStatus("Edit the netlist reference in Properties");
+          return;
+        case "instance-master-name":
+          options.setStatus("Master names are defined by the instance binding");
           return;
       }
     }

--- a/apps/editor/src/features/properties/use-properties-editor.ts
+++ b/apps/editor/src/features/properties/use-properties-editor.ts
@@ -6,9 +6,14 @@ import {
   gateConnectivityProposal,
   type SchematicEdit,
 } from "@icm/edit-engine";
-import { flattenRichText } from "@icm/model";
+import { flattenRichText, semanticTextDocument } from "@icm/model";
 import { resolveAnnotationText } from "@icm/derived";
-import type { Annotation, DraftingObject, SchematicDocument } from "@icm/model";
+import type {
+  Annotation,
+  DraftingObject,
+  RichTextDocument,
+  SchematicDocument,
+} from "@icm/model";
 
 import {
   componentParameters,
@@ -104,6 +109,7 @@ export interface UsePropertiesEditorOptions {
     presentation?: {
       alignment: "start" | "middle" | "end";
       sizeScale: number;
+      formatOverride?: RichTextDocument;
     },
   ) => SchematicEdit[] | null;
   instancePropertyEdits: (draft: InstancePropertyDraft) => {
@@ -579,10 +585,36 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
       const presentationChanged =
         (boundAnnotation.sizeScale ?? 1) !== textEditing.sizeScale ||
         boundAnnotation.alignment !== textEditing.alignment;
+      const formatOverrideAllowed =
+        boundAnnotation.binding.kind === "net-name" ||
+        boundAnnotation.binding.kind === "cell-terminal-name";
+      const { formatOverride: _currentOverride, ...annotationWithoutOverride } =
+        boundAnnotation;
+      const semanticContent =
+        boundAnnotation.binding.kind === "cell-terminal-name"
+          ? semanticTextDocument(name, "formal-port")
+          : boundAnnotation.binding.kind === "net-name"
+            ? semanticTextDocument(
+                name,
+                boundAnnotation.kind === "power-label"
+                  ? "power-label"
+                  : "net-label",
+              )
+            : resolveAnnotationText(
+                options.document,
+                annotationWithoutOverride,
+              );
+      const nextFormatOverride = formatOverrideAllowed
+        ? JSON.stringify(semanticContent) ===
+          JSON.stringify(textEditing.content)
+          ? undefined
+          : textEditing.content
+        : boundAnnotation.formatOverride;
       const presentationEdit: SchematicEdit = {
         kind: "upsert_schematic_annotation",
         annotation: {
-          ...boundAnnotation,
+          ...annotationWithoutOverride,
+          ...(nextFormatOverride ? { formatOverride: nextFormatOverride } : {}),
           sizeScale: textEditing.sizeScale,
           alignment: textEditing.alignment,
         },
@@ -602,15 +634,18 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
           schematicNameInstance?.schematicName ??
             resolveAnnotationText(options.document, boundAnnotation),
         ) !== JSON.stringify(textEditing.content);
+      const formatOverrideChanged =
+        JSON.stringify(boundAnnotation.formatOverride ?? null) !==
+        JSON.stringify(nextFormatOverride ?? null);
       if (!name) {
         options.setStatus("Bound electrical names cannot be empty");
         return;
       }
-      if (name === currentName && !schematicNameSourceChanged) {
-        if (boundAnnotation.binding.kind === "cell-terminal-name") {
-          if (!options.commitCellPortAnnotation?.(boundAnnotation, name))
-            return;
-        }
+      if (
+        name === currentName &&
+        !schematicNameSourceChanged &&
+        !formatOverrideChanged
+      ) {
         if (presentationChanged && !options.transact([presentationEdit]).ok) {
           return;
         }
@@ -630,29 +665,50 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
             ? options.netLabelEditsForRoute(
                 boundRoute,
                 name,
-                presentationChanged
+                presentationChanged || formatOverrideChanged
                   ? {
                       alignment: textEditing.alignment,
                       sizeScale: textEditing.sizeScale,
+                      ...(nextFormatOverride
+                        ? { formatOverride: nextFormatOverride }
+                        : {}),
                     }
                   : undefined,
               )
             : [
-                {
-                  kind: "set_net_name" as const,
-                  netId: boundAnnotation.binding.netId,
-                  name,
-                },
-                ...(presentationChanged ? [presentationEdit] : []),
+                ...(name !== currentName
+                  ? [
+                      {
+                        kind: "set_net_name" as const,
+                        netId: boundAnnotation.binding.netId,
+                        name,
+                      },
+                    ]
+                  : []),
+                ...(presentationChanged || formatOverrideChanged
+                  ? [presentationEdit]
+                  : []),
               ];
           if (netLabelEdits && transactNamedNet(netLabelEdits)) {
             setTextEditing(null);
           }
           return;
         case "cell-terminal-name":
-          if (options.commitCellPortAnnotation?.(boundAnnotation, name)) {
-            if (presentationChanged && !options.transact([presentationEdit]).ok)
+          if (name !== currentName) {
+            if (
+              !options.commitCellPortAnnotation?.(
+                presentationEdit.annotation,
+                name,
+              )
+            )
               return;
+          } else if (
+            (presentationChanged || formatOverrideChanged) &&
+            !options.transact([presentationEdit]).ok
+          ) {
+            return;
+          }
+          {
             setTextEditing(null);
           }
           return;
@@ -712,13 +768,10 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
       proposal.edit.annotation.kind === "instance-label" &&
       proposal.edit.annotation.anchor.kind === "object"
     ) {
-      const name = flattenRichText(
-        proposal.edit.annotation.content ?? { runs: [] },
-      ).trim();
-      if (
-        !name ||
-        !options.commitCellPortAnnotation(proposal.edit.annotation, name)
-      )
+      const content = proposal.edit.annotation.content ?? { runs: [] };
+      const name = flattenRichText(content).trim();
+      if (!name) return;
+      if (!options.commitCellPortAnnotation(proposal.edit.annotation, name))
         return;
       setTextEditing(null);
       return;

--- a/apps/editor/src/features/properties/use-properties-editor.ts
+++ b/apps/editor/src/features/properties/use-properties-editor.ts
@@ -682,7 +682,7 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
           options.setStatus("Edit component values in Properties");
           return;
         case "instance-designator":
-          options.setStatus("Edit the schematic reference in Properties");
+          options.setStatus("Netlist reference is edited in Properties");
           return;
         case "instance-master-name":
           options.setStatus("Master names are defined by the instance binding");

--- a/apps/editor/src/features/properties/use-properties-editor.ts
+++ b/apps/editor/src/features/properties/use-properties-editor.ts
@@ -682,7 +682,7 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
           options.setStatus("Edit component values in Properties");
           return;
         case "instance-designator":
-          options.setStatus("Edit the netlist reference in Properties");
+          options.setStatus("Edit the schematic reference in Properties");
           return;
         case "instance-master-name":
           options.setStatus("Master names are defined by the instance binding");

--- a/apps/editor/src/features/selection/delete-selection.test.ts
+++ b/apps/editor/src/features/selection/delete-selection.test.ts
@@ -118,13 +118,13 @@ describe("connected instance deletion", () => {
         nets: [{ terminals: [{ instanceId: "R2", pinName: "1" }] }],
         junctions: [
           {
-            id: "junction-delete-1-1",
+            id: "junction-lifecycle-1-1",
             position: { x: 100, y: 120 },
           },
         ],
         routes: [
           {
-            from: { kind: "junction", junctionId: "junction-delete-1-1" },
+            from: { kind: "junction", junctionId: "junction-lifecycle-1-1" },
             to: { kind: "terminal", instanceId: "R2", pinName: "1" },
           },
         ],

--- a/apps/editor/src/features/selection/delete-selection.ts
+++ b/apps/editor/src/features/selection/delete-selection.ts
@@ -1,9 +1,10 @@
-import { endpointKey, resolveEndpointPoint } from "@icm/derived";
 import {
+  instanceOwnedAnnotationIds,
+  planInstanceDeletion,
   proposeVisualRouteDeletion,
   type SchematicEdit,
 } from "@icm/edit-engine";
-import type { RouteEndpoint, SchematicDocument } from "@icm/model";
+import type { SchematicDocument } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 
 export interface VisualDeletionSelection {
@@ -59,96 +60,7 @@ export function proposeConnectedInstanceDeletion(
   instanceIds: readonly string[],
   sequence: number,
 ): SchematicEdit[] {
-  const selected = new Set(instanceIds);
-  const replacements = new Map<string, RouteEndpoint>();
-  const junctionEdits: SchematicEdit[] = [];
-  const disconnectEdits: SchematicEdit[] = [];
-  const occupiedIds = new Set(
-    [
-      ...document.instances,
-      ...document.nets,
-      ...document.routes,
-      ...document.junctions,
-      ...document.annotations,
-      ...document.layoutGroups,
-      ...document.constraints,
-    ].map((object) => object.id),
-  );
-  let junctionCounter = 0;
-
-  for (const net of document.nets) {
-    for (const terminal of net.terminals) {
-      if (!selected.has(terminal.instanceId)) continue;
-      const endpoint: RouteEndpoint = { kind: "terminal", ...terminal };
-      const key = endpointKey(endpoint);
-      const usedByRoute = document.routes.some(
-        (route) =>
-          endpointKey(route.from) === key || endpointKey(route.to) === key,
-      );
-      if (usedByRoute) {
-        const position = resolveEndpointPoint(document, resolver, endpoint);
-        if (!position) {
-          throw new Error(`Cannot preserve unresolved endpoint ${key}`);
-        }
-        let junctionId: string;
-        do {
-          junctionCounter += 1;
-          junctionId = `junction-delete-${sequence}-${junctionCounter}`;
-        } while (occupiedIds.has(junctionId));
-        occupiedIds.add(junctionId);
-        const replacement: RouteEndpoint = { kind: "junction", junctionId };
-        replacements.set(key, replacement);
-        junctionEdits.push({
-          kind: "add_junction",
-          junctionId,
-          netId: net.id,
-          position,
-        });
-      }
-      disconnectEdits.push({ kind: "disconnect_endpoint", endpoint });
-    }
-  }
-
-  const routeEdits = document.routes.flatMap((route): SchematicEdit[] => {
-    const from = replacements.get(endpointKey(route.from)) ?? route.from;
-    const to = replacements.get(endpointKey(route.to)) ?? route.to;
-    if (from === route.from && to === route.to) return [];
-    return [
-      {
-        kind: "set_route_points",
-        routeId: route.id,
-        netId: route.netId,
-        from,
-        to,
-        waypoints: route.waypoints.map((point) => ({ ...point })),
-        segmentModes: [...route.segmentModes],
-        ...(route.presentation ? { presentation: route.presentation } : {}),
-      },
-    ];
-  });
-  const annotationEdits = document.annotations
-    .filter(
-      (annotation) =>
-        annotation.anchor.kind === "object" &&
-        selected.has(annotation.anchor.objectId),
-    )
-    .map((annotation): SchematicEdit => ({
-      kind: "remove_schematic_annotation",
-      annotationId: annotation.id,
-    }));
-  const instanceEdits = document.instances
-    .filter((instance) => selected.has(instance.id))
-    .map((instance): SchematicEdit => ({
-      kind: "remove_instance",
-      instanceId: instance.id,
-    }));
-  return [
-    ...junctionEdits,
-    ...routeEdits,
-    ...disconnectEdits,
-    ...annotationEdits,
-    ...instanceEdits,
-  ];
+  return planInstanceDeletion(document, resolver, instanceIds, sequence);
 }
 
 /**
@@ -199,24 +111,18 @@ export function proposeVisualSelectionDeletion(
 }
 
 /**
- * `proposeConnectedInstanceDeletion()` removes annotations attached to a
- * selected instance. A marquee can independently select that same label, so
- * callers must not append a second remove_schematic_annotation edit for it.
+ * `proposeConnectedInstanceDeletion()` removes every annotation owned by a
+ * selected Instance, including an instance-bound free label. A marquee can
+ * independently select that label, so callers must not append it twice.
  */
 export function explicitAnnotationRemovals(
   document: SchematicDocument,
   instanceIds: readonly string[],
   annotationIds: readonly string[],
 ): string[] {
-  const selectedInstances = new Set(instanceIds);
-  const removedWithInstances = new Set(
-    document.annotations
-      .filter(
-        (annotation) =>
-          annotation.anchor.kind === "object" &&
-          selectedInstances.has(annotation.anchor.objectId),
-      )
-      .map((annotation) => annotation.id),
+  const removedWithInstances = instanceOwnedAnnotationIds(
+    document,
+    instanceIds,
   );
   return [...new Set(annotationIds)].filter(
     (id) => !removedWithInstances.has(id),

--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
@@ -83,7 +83,10 @@ export function CanvasTextEditorOverlay({
         sizeScale={session.sizeScale}
         alignment={session.alignment}
         sourceOnly={
-          session.bound && session.bindingKind !== "instance-schematic-name"
+          session.bound &&
+          session.bindingKind !== "instance-schematic-name" &&
+          session.bindingKind !== "net-name" &&
+          session.bindingKind !== "cell-terminal-name"
         }
         multiline={!session.bound}
         onChange={(content) => onUpdate({ content })}

--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
@@ -83,7 +83,7 @@ export function CanvasTextEditorOverlay({
         sizeScale={session.sizeScale}
         alignment={session.alignment}
         sourceOnly={
-          session.bound && session.bindingKind !== "instance-reference"
+          session.bound && session.bindingKind !== "instance-schematic-name"
         }
         multiline={!session.bound}
         onChange={(content) => onUpdate({ content })}

--- a/apps/editor/src/features/text-editing/rich-text-editor.tsx
+++ b/apps/editor/src/features/text-editing/rich-text-editor.tsx
@@ -452,7 +452,7 @@ export function RichTextEditor({
           value={flattenRichText(content)}
           disabled={disabled}
           aria-label="Canvas text editor"
-          aria-description="Rename the bound schematic label"
+          aria-description="Edit the bound schematic label"
           style={{ fontSize: `${15.116 * sizeScale}px` }}
           onChange={(event) =>
             onChange({ runs: [{ kind: "text", value: event.target.value }] })

--- a/apps/editor/src/features/wiring/route-interaction-geometry.test.ts
+++ b/apps/editor/src/features/wiring/route-interaction-geometry.test.ts
@@ -204,7 +204,7 @@ describe("route interaction geometry", () => {
     expect(label).toMatchObject({
       id: "instance-label-R1",
       kind: "instance-label",
-      binding: { kind: "instance-designator", instanceId: "R1" },
+      binding: { kind: "instance-schematic-name", instanceId: "R1" },
       anchor: expect.objectContaining({ kind: "object", objectId: "R1" }),
     });
     document.annotations.push(label!);

--- a/apps/editor/src/features/wiring/route-interaction-geometry.test.ts
+++ b/apps/editor/src/features/wiring/route-interaction-geometry.test.ts
@@ -204,7 +204,7 @@ describe("route interaction geometry", () => {
     expect(label).toMatchObject({
       id: "instance-label-R1",
       kind: "instance-label",
-      binding: { kind: "instance-reference", instanceId: "R1" },
+      binding: { kind: "instance-designator", instanceId: "R1" },
       anchor: expect.objectContaining({ kind: "object", objectId: "R1" }),
     });
     document.annotations.push(label!);

--- a/apps/editor/src/features/wiring/route-interaction-geometry.ts
+++ b/apps/editor/src/features/wiring/route-interaction-geometry.ts
@@ -468,6 +468,7 @@ export function defaultInstanceLabel(
   instance: SchematicDocument["instances"][number],
   resolver: SymbolResolver,
   styleProfile: SchematicStyleProfile,
+  slot: "reference" | "value" = "reference",
 ): Annotation | null {
   if (!instance.placement) return null;
   if (
@@ -492,6 +493,7 @@ export function defaultInstanceLabel(
     resolved,
     styleProfile,
     document.presentation.grid,
+    slot,
   );
   if (!placement) return null;
   const position = placement.position;

--- a/apps/editor/src/features/wiring/route-interaction-geometry.ts
+++ b/apps/editor/src/features/wiring/route-interaction-geometry.ts
@@ -498,7 +498,7 @@ export function defaultInstanceLabel(
   return {
     id: `instance-label-${instance.id}`,
     kind: "instance-label",
-    binding: { kind: "instance-reference", instanceId: instance.id },
+    binding: { kind: "instance-designator", instanceId: instance.id },
     anchor: {
       kind: "object",
       objectId: instance.id,

--- a/apps/editor/src/features/wiring/route-interaction-geometry.ts
+++ b/apps/editor/src/features/wiring/route-interaction-geometry.ts
@@ -500,7 +500,7 @@ export function defaultInstanceLabel(
   return {
     id: `instance-label-${instance.id}`,
     kind: "instance-label",
-    binding: { kind: "instance-designator", instanceId: instance.id },
+    binding: { kind: "instance-schematic-name", instanceId: instance.id },
     anchor: {
       kind: "object",
       objectId: instance.id,

--- a/apps/editor/src/interaction/interaction-state.ts
+++ b/apps/editor/src/interaction/interaction-state.ts
@@ -28,7 +28,12 @@ export type DrawingTool = Extract<
 export type InteractionMode = InteractionState<unknown>["kind"];
 
 export interface PendingComponentPlacement {
-  kind: "symbol" | "cell" | "external-subcircuit" | "cell-port";
+  kind:
+    | "symbol"
+    | "cell"
+    | "external-subcircuit"
+    | "cell-port"
+    | "retained-instance";
   symbolId: string;
   parameters: Record<string, string>;
   initialRotation: 0 | 90 | 180 | 270;
@@ -41,6 +46,8 @@ export interface PendingComponentPlacement {
   masterName?: string;
   formalName?: string;
   direction?: "input" | "output" | "inout" | "passive";
+  /** Existing unplaced Instance being returned from the Placement Tray. */
+  instanceId?: string;
 }
 
 export interface CopyPlacement<TClipboard> {
@@ -180,7 +187,8 @@ function sameComponentPlacement(
     left.definitionId !== right.definitionId ||
     left.masterName !== right.masterName ||
     left.formalName !== right.formalName ||
-    left.direction !== right.direction
+    left.direction !== right.direction ||
+    left.instanceId !== right.instanceId
   ) {
     return false;
   }

--- a/apps/editor/src/interaction/interaction-state.ts
+++ b/apps/editor/src/interaction/interaction-state.ts
@@ -32,6 +32,7 @@ export interface PendingComponentPlacement {
     | "symbol"
     | "cell"
     | "external-subcircuit"
+    | "net-port"
     | "cell-port"
     | "retained-instance";
   symbolId: string;
@@ -45,6 +46,7 @@ export interface PendingComponentPlacement {
   definitionId?: string;
   masterName?: string;
   formalName?: string;
+  portName?: string;
   direction?: "input" | "output" | "inout" | "passive";
   /** Existing unplaced Instance being returned from the Placement Tray. */
   instanceId?: string;

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -2392,6 +2392,50 @@ body {
   box-shadow: none;
 }
 
+.placement-tray {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.placement-tray h2,
+.placement-tray p {
+  margin: 0;
+}
+
+.placement-tray p {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-sm);
+  line-height: 1.35;
+}
+
+.placement-tray-list {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.placement-tray-entry {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.placement-tray-entry button {
+  margin-top: 0;
+}
+
+.placement-tray-entry button:first-child {
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.placement-tray-entry button:last-child {
+  width: auto;
+  white-space: nowrap;
+}
+
 .context-actions label,
 .property-section label {
   display: grid;

--- a/docs/adr/0026-definition-level-cell-symbol-presentation.md
+++ b/docs/adr/0026-definition-level-cell-symbol-presentation.md
@@ -2,8 +2,8 @@
 
 Status: `accepted`
 
-Current-version note: ADR 0029 supersedes this ADR's schema-version and active
-migration statements. Readers now operate on the sole **schema-15 in-memory Project shape**.
+Current-version note: ADR 0030 supersedes this ADR's schema-version and active
+migration statements. Readers now operate on the sole **schema-16 in-memory Project shape**.
 
 Date: `2026-08-18`
 

--- a/docs/adr/0029-external-subcircuit-definition-protocol.md
+++ b/docs/adr/0029-external-subcircuit-definition-protocol.md
@@ -2,6 +2,9 @@
 
 Status: `accepted`
 
+Current-version note: ADR 0030 supersedes this ADR's rolling schema-version
+statement. Its external-definition and `X`-call decisions remain accepted.
+
 Date: `2026-08-20`
 
 Owners: `packages/model`, `packages/edit-engine`, `packages/spice`,
@@ -40,10 +43,10 @@ external `.subckt` body generation.
 
 ## Compatibility and migration
 
-Schema 15 accepts schema 14 as its sole rolling predecessor. The migration
-adds deterministic terminal IDs, passive directions and a `declared` status to
-existing external definitions. Schema 13 is outside the active compatibility
-window.
+Schema 15 accepted schema 14 as its sole rolling predecessor when this decision
+landed. Schema 16 instead accepts schema 15 through ADR 0030; schema 14 is now
+outside the active compatibility window. The external-definition migration
+evidence remains historical validation for this decision.
 
 ## Validation
 

--- a/docs/adr/0030-instance-identity-and-placement-lifecycle.md
+++ b/docs/adr/0030-instance-identity-and-placement-lifecycle.md
@@ -1,0 +1,128 @@
+# 0030 - Instance identity and placement lifecycle
+
+Status: `accepted`
+
+Date: `2026-08-21`
+
+Owners: `packages/model`, `packages/project-protocol`,
+`packages/edit-engine`, `packages/derived`, `apps/editor`
+
+## Context
+
+The structural netlist loop made imported Instances electrically complete, but
+the editor still used one ambiguous `instance-reference` label binding. It
+rendered a schematic alias when present, otherwise a netlist reference, and
+finally an internal object ID. Formal Ports have no netlist reference, so that
+fallback exposed generated IDs. Imported Instances also begin with
+`placement: null`, yet the mutation protocol described only placement and
+deletion rather than an explicit return-to-tray lifecycle.
+
+These ambiguities make Reference editing, imported external calls, default
+labels, bulk placement, and delete behavior unsafe to extend independently.
+
+## Decision
+
+Project schema 16 separates persisted semantic label bindings. The sole
+**schema-16 in-memory Project shape** has:
+
+- `instance-designator` projects only `Instance.netlist.reference`;
+- `instance-schematic-name` projects only `Instance.schematicName`;
+- `instance-master-name` projects the binding's authoritative master/Cell/model
+  name;
+- `instance-value` and `cell-terminal-name` retain their existing distinct
+  authorities.
+
+`Instance.id` remains an opaque stable object identity. It is never a default
+visible label or a fallback netlist reference. Formal Cell Ports display their
+formal terminal name and never receive a fabricated reference.
+
+The lifecycle has exactly three persisted states:
+
+```text
+instance exists + placement: null       = retained in the Placement Tray
+instance exists + placement: Placement  = placed on the canvas
+instance absent                         = deleted from the design
+```
+
+The Edit Engine gains `unplace_instance` alongside existing placement and
+removal operations. Returning an Instance retains its binding, reference,
+parameters, terminal membership, NoConnect records, and display annotations;
+visible Route endpoints are safely detached to Junctions. Deletion composes
+that route reconciliation with explicit removal of memberships, NoConnects,
+and annotations before `remove_instance`.
+
+Placement, movement, returning to the tray, and automatic initial positioning
+are presentation actions: they must not change DesignNetlistIR or structural
+SPICE/Spectre output. Reference, parameter, connectivity, and deletion edits
+remain electrical changes.
+
+## Alternatives considered
+
+### Keep `instance-reference` and improve the fallback
+
+- Benefits: avoids a schema change.
+- Costs: one label still has three contradictory meanings and formal Ports
+  remain vulnerable to internal-ID display.
+- Reason not selected: no fallback can make an ambiguous source authoritative.
+
+### Add a persisted trash collection and separate bulk edit kinds
+
+- Benefits: richer lifecycle history and direct UI-to-edit mapping.
+- Costs: duplicates existing undo history and expands the Project mutation
+  surface without electrical benefit.
+- Reason not selected: `placement: null` and atomic compositions already model
+  the required states.
+
+### Add full analog-recognition auto-layout and automatic routing
+
+- Benefits: could produce more polished diagrams.
+- Costs: guesses circuit intent and confuses imported electrical topology with
+  drawing geometry.
+- Reason not selected: this decision requires only deterministic initial
+  placement and explicit unrouted-connection guidance.
+
+## Consequences
+
+### Positive
+
+- Netlist designators, schematic aliases, master names, and formal port names
+  can be edited and displayed independently.
+- Imported external calls become legible without fabricating PDK or simulator
+  semantics.
+- The Placement Tray and delete UI can share one explicit lifecycle boundary.
+- Presentation-only operations obtain a testable netlist-invariance contract.
+
+### Negative or limiting
+
+- Schema 16 consumes the rolling migration slot and replaces the old v14-to-v15
+  reader.
+- Existing reference labels migrate according to their prior rendered value;
+  projects older than schema 15 are no longer supported at this boundary.
+- Persistent trash, auto-routing, PDK setup, simulation and layout remain out
+  of scope.
+
+## Compatibility and migration
+
+The reader accepts schema 15 and schema 16 only. A direct v15-to-v16 adapter
+maps every `instance-reference` binding to `instance-schematic-name` when its
+target Instance has a schematic alias, otherwise to `instance-designator`.
+That rule preserves the actual schema-15 projection while yielding one strict
+schema-16 runtime model. Serialization emits schema 16 only.
+
+## Validation
+
+- schema parse/save and direct migration tests;
+- designator/alias/port text-projection tests;
+- lifecycle transaction tests including Route, Net, NoConnect and annotation
+  reconciliation;
+- editor browser tests for tray, bulk placement, reference editing, deletion,
+  undo, and structural netlist invariance.
+
+## Related documents
+
+- [Project file format](../specs/project-file-format.md)
+- [Schematic model](../specs/schematic-model.md)
+- [Schematic Edit Engine](../specs/edit-engine.md)
+- [ADR 0023](0023-rolling-previous-project-compatibility.md)
+- [ADR 0027](0027-stage-1-netlist-authoring-protocol.md)
+- [ADR 0029](0029-external-subcircuit-definition-protocol.md)

--- a/docs/adr/0031-schematic-reference-and-port-lifecycle.md
+++ b/docs/adr/0031-schematic-reference-and-port-lifecycle.md
@@ -1,0 +1,67 @@
+# 0031 - Schematic reference and unified Port lifecycle
+
+Status: `accepted`
+
+Date: `2026-08-21`
+
+Owners: `packages/model`, `packages/project-protocol`,
+`packages/edit-engine`, `packages/derived`, `apps/editor`
+
+Supersedes the identity and formal-Port display clauses of
+[ADR 0030](0030-instance-identity-and-placement-lifecycle.md).
+
+## Context
+
+Schema 16 correctly separated netlist designators from aliases, but its visible
+`instance-designator` still resolved only from `Instance.netlist.reference`.
+Ports do not emit SPICE/Spectre instance lines, so they had no Reference label.
+Formal Cell Ports were additionally excluded from the editor's return-to-tray
+controls even though their stable interface mapping does not depend on canvas
+placement.
+
+## Decision
+
+Project schema 17 adds optional `Instance.schematicReference`. Current writers
+populate it for every new Instance. `instance-designator` projects this field,
+falling back to the existing netlist reference only for incomplete in-memory
+authoring objects. It never projects an internal object ID.
+
+The authorities are distinct:
+
+- `Instance.schematicReference`: editable canvas Reference for every Instance,
+  including `P1`/`P2` Ports;
+- `Instance.netlist.reference`: emitted SPICE/Spectre instance designator for
+  emitting devices and subcircuit calls only;
+- `Document.netlist.terminals[].name`: Cell interface name such as `VIN`;
+- `Instance.schematicName`: optional presentation alias;
+- `Instance.id`: opaque object identity.
+
+A formal Cell Port shows both its schematic Reference and its Cell terminal
+name. Returning any Port to the Placement Tray changes only `placement`; it
+retains terminal mapping, Net membership, and the exported Cell interface.
+Deleting a formal Port remains a Project structural operation.
+
+`place_instance` and `unplace_instance` both reject layout-locked instances.
+
+## Compatibility and migration
+
+The reader accepts schema 16 and schema 17. The direct v16-to-v17 migration
+copies an emitting netlist reference into `schematicReference`; it assigns
+deterministic prefix-based references to non-emitting instances, including
+`P#` for Ports. Serialization emits schema 17 only.
+
+## Consequences
+
+- A Port is no longer special-cased as a nameless canvas object.
+- Canvas Reference edits cannot accidentally rename netlist output.
+- Formal Port placement has the same retained/placed lifecycle as every other
+  Instance, while formal interface edits remain structural.
+- Schema 15 is outside the rolling read window.
+
+## Related documents
+
+- [Project file format](../specs/project-file-format.md)
+- [Schematic model](../specs/schematic-model.md)
+- [Schematic Edit Engine](../specs/edit-engine.md)
+- [ADR 0023](0023-rolling-previous-project-compatibility.md)
+- [ADR 0030](0030-instance-identity-and-placement-lifecycle.md)

--- a/docs/adr/0032-formal-port-display-and-retained-annotations.md
+++ b/docs/adr/0032-formal-port-display-and-retained-annotations.md
@@ -1,0 +1,73 @@
+# 0032 - Schematic label authority, formal Port display, and retained annotations
+
+Status: `accepted`
+
+Date: `2026-08-21`
+
+Owners: `packages/model`, `packages/project-protocol`, `packages/derived`,
+`packages/render-svg`, `packages/edit-engine`, `apps/editor`
+
+Supersedes the formal-Port Reference and retained-annotation display clauses of
+[ADR 0031](0031-schematic-reference-and-port-lifecycle.md).
+
+## Context
+
+`Instance.id` already owns placement, selection, connectivity, and deletion
+lifecycle, and must never be shown as a label. Making an emitted network
+designator the default text for every instance also made the visual label
+plain-text-only even though the schematic supports RichText annotations. A
+formal Cell Port's extra visible `P#` Reference duplicated its actual
+interface name (for example `Vout`) and did not serve any identity purpose.
+Separately, returning an Instance to the Placement Tray retained its
+object-anchored annotations but rendered their fallback positions as orphaned
+text.
+
+## Decision
+
+Project schema 18 makes `instance-schematic-name` the generic default label
+binding. It resolves `Instance.schematicName` as the single user-visible,
+RichText source; before the user edits it, it purely falls back to
+`schematicReference`, then `netlist.reference`, and never to `Instance.id`.
+`instance-designator` is retained only for an explicitly enabled, read-only
+network-ID display.
+
+A formal Cell Port instead uses `CellTerminal.name` as its sole visible
+identity. A formal Port has no `Instance.schematicReference`; its stable
+`Instance.id` remains the lifecycle identity. New formal Port creation, SPICE
+import, validation, and edits enforce that separation.
+
+All renderers, formal export bounds, editor hit testing, and marquee selection
+use one annotation visibility rule: an object-anchored annotation is visible
+only while its target Instance is placed. Return therefore keeps annotation
+data and user positioning intact, hides it while retained, and restores it on
+re-placement. Deletion remains the operation that removes annotations.
+
+## Compatibility and migration
+
+The reader accepts schema 17 and schema 18. The direct v17-to-v18 migration
+rewrites ordinary default `instance-designator` annotations to
+`instance-schematic-name`, preserving their placement and styling. For formal
+Cell Ports it removes `schematicReference`, replaces the designator projection
+with `cell-terminal-name`, and removes the redundant terminal-name projection.
+It retains terminal IDs, terminal names, Net mappings, and `Instance.id`.
+Serialization emits schema 18 only.
+
+## Consequences
+
+- `Vout` occupies the normal Reference slot for a formal Port; `P#` is never
+  displayed or needed for lifecycle.
+- Properties expose one primary `Schematic label` field rather than separate
+  schematic-reference and alias text fields; RichText canvas editing writes
+  `schematicName`.
+- Ordinary non-formal components and Ports may retain an internal schematic
+  reference and optional netlist designator without making either the primary
+  editable label.
+- Retained labels cannot remain as visible or clickable floating artifacts.
+- Schema 16 and older are outside the rolling read window.
+
+## Related documents
+
+- [Project file format](../specs/project-file-format.md)
+- [Schematic model](../specs/schematic-model.md)
+- [Editor interaction](../specs/editor-interaction.md)
+- [ADR 0031](0031-schematic-reference-and-port-lifecycle.md)

--- a/docs/adr/0033-port-semantic-name-and-richtext-presentation.md
+++ b/docs/adr/0033-port-semantic-name-and-richtext-presentation.md
@@ -1,0 +1,109 @@
+# 0033 - Port semantic names and RichText presentation
+
+Status: `accepted`
+
+Date: `2026-08-21`
+
+Owners: `packages/model`, `packages/derived`, `packages/edit-engine`,
+`apps/editor`
+
+Supersedes the formal-Port text-editing clause of
+[ADR 0032](0032-formal-port-display-and-retained-annotations.md) and the
+non-formal Port reference-display clause of
+[ADR 0031](0031-schematic-reference-and-port-lifecycle.md).
+
+## Context
+
+A Port symbol can represent either a free schematic Net Port or a formal Cell
+Pin. The former names a Net; the latter also declares an ordered Cell
+interface terminal. Treating the Port text as an independent alias lets its
+visible name diverge from the electrical object. Treating it as immutable
+plain text prevents the RichText formatting already supported by schematic
+annotations. Inferring the role solely from whether the active Document is a
+child also prevents a free Net Port from being placed inside a Cell.
+
+## Decision
+
+Project schema 18 keeps Port meaning and presentation in separate existing
+owners:
+
+- a free Net Port's semantic text is `Net.name`;
+- a formal Cell Pin's semantic interface text is `CellTerminal.name`;
+- the Port `Instance.id` owns geometry and lifecycle and is never visible;
+- a bound `net-name` or `cell-terminal-name` Annotation may persist
+  `formatOverride`, but its flattened text must equal the semantic source.
+
+The formatting override is not an alias. A character edit on the canvas
+renames the bound Net or CellTerminal. A formatting-only edit changes the
+Annotation. Renaming a semantic source clears stale overrides unless the same
+atomic edit supplies a new same-text override. Formal terminal renames continue
+to reconcile caller pins through the hierarchy planner.
+
+Port insertion carries an explicit `Free Net Port` or `Formal Cell Pin` intent.
+Both roles may be used in a child Document; only the free role is available in
+the top Document. An explicit inserted name wins. Otherwise a connected named
+Net supplies the initial name. Creating onto an unnamed or new Net gives that
+Net the entered Port name. A formal terminal and an already named connected
+Net may intentionally have different names; there is no permanent equality
+constraint between them.
+
+No Port receives a visible schematic `P#` reference or netlist designator.
+Legacy internal object IDs may remain lifecycle facts but never become canvas
+text.
+
+## Alternatives considered
+
+### Persist a RichText label on CellTerminal
+
+- Benefits: direct ownership appears simple for formal Ports.
+- Costs: creates a second semantic-looking name and does not cover free Ports.
+- Reason not selected: presentation belongs to the movable Annotation, and an
+  independent label can silently diverge from the Net or terminal name.
+
+### Keep child-Document role inference
+
+- Benefits: one-click placement.
+- Costs: makes free Ports unavailable inside Cells and hides interface changes
+  behind placement context.
+- Reason not selected: interface creation is a meaningful explicit action.
+
+## Consequences
+
+### Positive
+
+- Free and formal Ports share one naming/presentation protocol.
+- RichText formatting cannot change electrical meaning or export names.
+- Canvas character edits, Properties, hierarchy reconciliation, and netlist
+  export observe the same semantic owner.
+- Port lifecycle remains tied only to `Instance.id` and its bound annotation.
+
+### Negative or limiting
+
+- Bound Port formatting is valid only while its flattened text matches the
+  semantic name.
+- A semantic rename may discard prior character-level formatting when it
+  cannot be carried to the new text safely.
+- Port insertion requires a role/name decision when no named Net supplies a
+  deterministic default.
+
+## Compatibility and migration
+
+This is part of the unreleased schema-18 contract. `Annotation.formatOverride`
+is optional. Existing bound annotations without it continue to render their
+semantic source. No `CellTerminal.schematicLabel` field is introduced.
+
+## Validation
+
+Model tests reject mismatched overrides. Derived tests prove semantic fallback
+and formatted projection. Edit-engine tests prove rename invalidation and
+atomic formal-terminal edits. Browser tests cover explicit free/formal
+insertion, formatting-only edits, semantic rename, hierarchy pin
+reconciliation, and Placement Tray lifecycle.
+
+## Related documents
+
+- [Schematic model](../specs/schematic-model.md)
+- [Edit engine](../specs/edit-engine.md)
+- [Editor interaction](../specs/editor-interaction.md)
+- [Netlist export](../specs/netlist-export.md)
+- [Target plan](../../plan/2026-08-21-formal-port-richtext-label/plan.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -61,6 +61,8 @@ The project-local external interface and `X`-call preservation decision is
 The instance identity, Placement Tray lifecycle, and presentation-only
 netlist-invariance decision is
 [`0030-instance-identity-and-placement-lifecycle.md`](0030-instance-identity-and-placement-lifecycle.md).
+The schematic-reference and unified Port lifecycle decision is
+[`0031-schematic-reference-and-port-lifecycle.md`](0031-schematic-reference-and-port-lifecycle.md).
 
 Use [`adr.template.md`](adr.template.md) for new decisions.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -58,6 +58,9 @@ The single Route geometry and octilinear authoring decision is
 [`0028-octilinear-route-geometry-protocol.md`](0028-octilinear-route-geometry-protocol.md).
 The project-local external interface and `X`-call preservation decision is
 [`0029-external-subcircuit-definition-protocol.md`](0029-external-subcircuit-definition-protocol.md).
+The instance identity, Placement Tray lifecycle, and presentation-only
+netlist-invariance decision is
+[`0030-instance-identity-and-placement-lifecycle.md`](0030-instance-identity-and-placement-lifecycle.md).
 
 Use [`adr.template.md`](adr.template.md) for new decisions.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -63,6 +63,9 @@ netlist-invariance decision is
 [`0030-instance-identity-and-placement-lifecycle.md`](0030-instance-identity-and-placement-lifecycle.md).
 The schematic-reference and unified Port lifecycle decision is
 [`0031-schematic-reference-and-port-lifecycle.md`](0031-schematic-reference-and-port-lifecycle.md).
+The formal-Port terminal-name display and retained-annotation visibility
+decision is
+[`0032-formal-port-display-and-retained-annotations.md`](0032-formal-port-display-and-retained-annotations.md).
 
 Use [`adr.template.md`](adr.template.md) for new decisions.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -66,6 +66,9 @@ The schematic-reference and unified Port lifecycle decision is
 The formal-Port terminal-name display and retained-annotation visibility
 decision is
 [`0032-formal-port-display-and-retained-annotations.md`](0032-formal-port-display-and-retained-annotations.md).
+The unified free/formal Port semantic-name and same-text RichText presentation
+decision is
+[`0033-port-semantic-name-and-richtext-presentation.md`](0033-port-semantic-name-and-richtext-presentation.md).
 
 Use [`adr.template.md`](adr.template.md) for new decisions.
 

--- a/docs/current/README.md
+++ b/docs/current/README.md
@@ -15,7 +15,7 @@ repository search, completed roadmaps, target plans, or `docs/archive/`.
    [`../adr/0029-external-subcircuit-definition-protocol.md`](../adr/0029-external-subcircuit-definition-protocol.md),
    and [`../adr/0030-instance-identity-and-placement-lifecycle.md`](../adr/0030-instance-identity-and-placement-lifecycle.md)
    — current Project shape, rolling previous-version read policy, independent
-   device and compatibility boundaries, Port-symbol, edit-union, schema-16
+   device and compatibility boundaries, Port-symbol, edit-union, schema-17
    identity and placement lifecycle, and Agent credential contract; identify superseded
    clauses in older ADRs.
 3. [`../adr/0011-retire-visio-vss-as-visual-authority.md`](../adr/0011-retire-visio-vss-as-visual-authority.md)

--- a/docs/current/README.md
+++ b/docs/current/README.md
@@ -12,10 +12,11 @@ repository search, completed roadmaps, target plans, or `docs/archive/`.
    [`../adr/0024-device-protocol-and-compatibility-boundaries.md`](../adr/0024-device-protocol-and-compatibility-boundaries.md),
    [`../adr/0026-definition-level-cell-symbol-presentation.md`](../adr/0026-definition-level-cell-symbol-presentation.md),
    [`../adr/0027-stage-1-netlist-authoring-protocol.md`](../adr/0027-stage-1-netlist-authoring-protocol.md),
-   and [`../adr/0029-external-subcircuit-definition-protocol.md`](../adr/0029-external-subcircuit-definition-protocol.md)
+   [`../adr/0029-external-subcircuit-definition-protocol.md`](../adr/0029-external-subcircuit-definition-protocol.md),
+   and [`../adr/0030-instance-identity-and-placement-lifecycle.md`](../adr/0030-instance-identity-and-placement-lifecycle.md)
    — current Project shape, rolling previous-version read policy, independent
-   device and compatibility boundaries, Port-symbol, edit-union, schema-15
-   implementation target, and Agent credential contract; identify superseded
+   device and compatibility boundaries, Port-symbol, edit-union, schema-16
+   identity and placement lifecycle, and Agent credential contract; identify superseded
    clauses in older ADRs.
 3. [`../adr/0011-retire-visio-vss-as-visual-authority.md`](../adr/0011-retire-visio-vss-as-visual-authority.md)
    and [`../specs/razavi-visual-contract.md`](../specs/razavi-visual-contract.md)

--- a/docs/current/README.md
+++ b/docs/current/README.md
@@ -13,10 +13,13 @@ repository search, completed roadmaps, target plans, or `docs/archive/`.
    [`../adr/0026-definition-level-cell-symbol-presentation.md`](../adr/0026-definition-level-cell-symbol-presentation.md),
    [`../adr/0027-stage-1-netlist-authoring-protocol.md`](../adr/0027-stage-1-netlist-authoring-protocol.md),
    [`../adr/0029-external-subcircuit-definition-protocol.md`](../adr/0029-external-subcircuit-definition-protocol.md),
-   and [`../adr/0030-instance-identity-and-placement-lifecycle.md`](../adr/0030-instance-identity-and-placement-lifecycle.md)
+   [`../adr/0030-instance-identity-and-placement-lifecycle.md`](../adr/0030-instance-identity-and-placement-lifecycle.md),
+   [`../adr/0031-schematic-reference-and-port-lifecycle.md`](../adr/0031-schematic-reference-and-port-lifecycle.md),
+   and [`../adr/0032-formal-port-display-and-retained-annotations.md`](../adr/0032-formal-port-display-and-retained-annotations.md)
    — current Project shape, rolling previous-version read policy, independent
-   device and compatibility boundaries, Port-symbol, edit-union, schema-17
-   identity and placement lifecycle, and Agent credential contract; identify superseded
+   device and compatibility boundaries, Port-symbol, edit-union, schema-18
+   identity and placement lifecycle, schematic references, formal-Port display,
+   and Agent credential contract; identify superseded
    clauses in older ADRs.
 3. [`../adr/0011-retire-visio-vss-as-visual-authority.md`](../adr/0011-retire-visio-vss-as-visual-authority.md)
    and [`../specs/razavi-visual-contract.md`](../specs/razavi-visual-contract.md)

--- a/docs/current/README.md
+++ b/docs/current/README.md
@@ -15,11 +15,12 @@ repository search, completed roadmaps, target plans, or `docs/archive/`.
    [`../adr/0029-external-subcircuit-definition-protocol.md`](../adr/0029-external-subcircuit-definition-protocol.md),
    [`../adr/0030-instance-identity-and-placement-lifecycle.md`](../adr/0030-instance-identity-and-placement-lifecycle.md),
    [`../adr/0031-schematic-reference-and-port-lifecycle.md`](../adr/0031-schematic-reference-and-port-lifecycle.md),
-   and [`../adr/0032-formal-port-display-and-retained-annotations.md`](../adr/0032-formal-port-display-and-retained-annotations.md)
+   [`../adr/0032-formal-port-display-and-retained-annotations.md`](../adr/0032-formal-port-display-and-retained-annotations.md),
+   and [`../adr/0033-port-semantic-name-and-richtext-presentation.md`](../adr/0033-port-semantic-name-and-richtext-presentation.md)
    — current Project shape, rolling previous-version read policy, independent
    device and compatibility boundaries, Port-symbol, edit-union, schema-18
-   identity and placement lifecycle, schematic references, formal-Port display,
-   and Agent credential contract; identify superseded
+   identity and placement lifecycle, schematic references, Port semantic names
+   and RichText display, and Agent credential contract; identify superseded
    clauses in older ADRs.
 3. [`../adr/0011-retire-visio-vss-as-visual-authority.md`](../adr/0011-retire-visio-vss-as-visual-authority.md)
    and [`../specs/razavi-visual-contract.md`](../specs/razavi-visual-contract.md)

--- a/docs/overall-product-plan.md
+++ b/docs/overall-product-plan.md
@@ -60,7 +60,7 @@ revision, lock, or transaction invariants.
   than guessed.
 - Routes describe visible geometry; they may stretch locally during movement
   without changing logical connectivity.
-- A Project is a canonical schema-17 JSON file. Browser recovery is an
+- A Project is a canonical schema-18 JSON file. Browser recovery is an
   origin-local, non-authoritative copy.
 - Visual variants may change presentation but never remove electrical terminal
   semantics. The Razavi raster manifest is the sole visual authority; Visio/VSS

--- a/docs/overall-product-plan.md
+++ b/docs/overall-product-plan.md
@@ -60,7 +60,7 @@ revision, lock, or transaction invariants.
   than guessed.
 - Routes describe visible geometry; they may stretch locally during movement
   without changing logical connectivity.
-- A Project is a canonical schema-15 JSON file. Browser recovery is an
+- A Project is a canonical schema-16 JSON file. Browser recovery is an
   origin-local, non-authoritative copy.
 - Visual variants may change presentation but never remove electrical terminal
   semantics. The Razavi raster manifest is the sole visual authority; Visio/VSS

--- a/docs/overall-product-plan.md
+++ b/docs/overall-product-plan.md
@@ -60,7 +60,7 @@ revision, lock, or transaction invariants.
   than guessed.
 - Routes describe visible geometry; they may stretch locally during movement
   without changing logical connectivity.
-- A Project is a canonical schema-16 JSON file. Browser recovery is an
+- A Project is a canonical schema-17 JSON file. Browser recovery is an
   origin-local, non-authoritative copy.
 - Visual variants may change presentation but never remove electrical terminal
   semantics. The Razavi raster manifest is the sole visual authority; Visio/VSS

--- a/docs/specs/edit-engine.md
+++ b/docs/specs/edit-engine.md
@@ -91,8 +91,9 @@ is not another `SchematicEdit` member.
 `set_instance_reference`, `set_instance_binding`, and
 `patch_instance_netlist_parameters` are the ordinary field writers for an
 existing netlist record. `set_instance_schematic_reference` changes the visible
-Reference for any Instance, including a non-emitting Port, without changing
-netlist output. `set_instance_schematic_name` instead changes the user-owned
+Reference for any non-formal Instance, including a non-emitting Port, without
+changing netlist output; formal Cell Ports use their terminal name and reject
+this edit. `set_instance_schematic_name` instead changes the user-owned
 RichText alias shown on a schematic. `bulk_patch_instance_netlist` is the
 bounded, atomic multi-instance netlist form. `set_instance_netlist` remains
 the whole-record operation for object initialization, import, and bounded

--- a/docs/specs/edit-engine.md
+++ b/docs/specs/edit-engine.md
@@ -94,8 +94,12 @@ existing netlist record. `set_instance_schematic_reference` changes the visible
 Reference for any non-formal Instance, including a non-emitting Port, without
 changing netlist output; formal Cell Ports use their terminal name and reject
 this edit. `set_instance_schematic_name` instead changes the user-owned
-RichText alias shown on a schematic. `bulk_patch_instance_netlist` is the
-bounded, atomic multi-instance netlist form. `set_instance_netlist` remains
+RichText label shown on an ordinary schematic instance. Port character edits
+rename their bound `Net.name` or `CellTerminal.name`; a formatting-only edit
+upserts the same-text `Annotation.formatOverride`. A Cell-terminal character
+edit uses the structural hierarchy planner so caller pins and the netlist
+interface reconcile atomically. `bulk_patch_instance_netlist` is the bounded,
+atomic multi-instance netlist form. `set_instance_netlist` remains
 the whole-record operation for object initialization, import, and bounded
 migrations; product editing must not rebuild unrelated netlist facts through
 it.

--- a/docs/specs/edit-engine.md
+++ b/docs/specs/edit-engine.md
@@ -55,7 +55,8 @@ for readability; these groups do not create separate mutation endpoints:
 
 - control/history: `noop`, `clear_document`, `undo`, `redo`;
 - Instance: `add_instance`, `remove_instance`, `set_instance_symbol`,
-  `place_instance`, `move_instance`, `rotate_instance`, `mirror_instance`,
+  `place_instance`, `unplace_instance`, `move_instance`, `rotate_instance`,
+  `mirror_instance`,
   `set_instance_reference`, `set_instance_schematic_name`, `set_instance_binding`,
   `patch_instance_netlist_parameters`, `bulk_patch_instance_netlist`,
   `set_instance_netlist`;
@@ -169,7 +170,7 @@ Phase 8 topology operations have these preconditions:
   covered by an explicit one-to-one `pinMap`; the edit atomically updates Net,
   Route, and preserved `spice.pin.*` references without changing Net ownership.
 - `port` and `port-filled` use the ordinary `add_instance`, `place_instance`,
-  `move_instance`, and terminal-connectivity edit paths; there is no
+  `unplace_instance`, `move_instance`, and terminal-connectivity edit paths; there is no
   Port-specific edit kind.
 - `set_cell_symbol_presentation` changes only a Cell definition's optional
   stable-terminal visual intent. It is wrapped in a Project structural
@@ -177,6 +178,9 @@ Phase 8 topology operations have these preconditions:
   it creates no endpoint or drawing-object kind.
 - `remove_instance` requires no Net, annotation, group, or constraint
   reference.
+- `unplace_instance` returns only a placed, unlocked Instance to the Placement
+  Tray. It preserves Net membership, NoConnects, bindings, parameters, and
+  annotations, but rejects while a Route still terminates at the Instance.
 - `connect_endpoints` creates a caller-named local Net when both endpoints are
   unowned, or attaches an unowned endpoint to the other endpoint's Net.
 - `set_net_name` requires a non-empty trimmed name. A name already owned by a
@@ -210,8 +214,9 @@ Phase 8 topology operations have these preconditions:
   endpoint without a second mutation path.
 - Connected-instance deletion remains a composed transaction rather than a
   destructive `remove_instance` flag: Routes are first repointed to replacement
-  Junctions, terminals and annotations are removed explicitly, and only then is
-  the unreferenced instance removed.
+  Junctions, terminals, NoConnects, instance-owned annotations, and unlocked
+  layout references are removed explicitly, and only then is the unreferenced
+  instance removed.
 - Endpoints on different Nets require an explicit preceding `merge_nets` edit
   in the same transaction.
 - `merge_nets` retargets routes, junctions, annotations, and layout references

--- a/docs/specs/edit-engine.md
+++ b/docs/specs/edit-engine.md
@@ -57,7 +57,8 @@ for readability; these groups do not create separate mutation endpoints:
 - Instance: `add_instance`, `remove_instance`, `set_instance_symbol`,
   `place_instance`, `unplace_instance`, `move_instance`, `rotate_instance`,
   `mirror_instance`,
-  `set_instance_reference`, `set_instance_schematic_name`, `set_instance_binding`,
+  `set_instance_reference`, `set_instance_schematic_reference`,
+  `set_instance_schematic_name`, `set_instance_binding`,
   `patch_instance_netlist_parameters`, `bulk_patch_instance_netlist`,
   `set_instance_netlist`;
 - Cell interface: `add_cell_terminal`, `update_cell_terminal`,
@@ -89,9 +90,10 @@ is not another `SchematicEdit` member.
 
 `set_instance_reference`, `set_instance_binding`, and
 `patch_instance_netlist_parameters` are the ordinary field writers for an
-existing netlist record. `set_instance_schematic_name` instead changes the
-user-owned RichText alias shown on a schematic and never changes the instance's
-SPICE reference or stable identity. `bulk_patch_instance_netlist` is the
+existing netlist record. `set_instance_schematic_reference` changes the visible
+Reference for any Instance, including a non-emitting Port, without changing
+netlist output. `set_instance_schematic_name` instead changes the user-owned
+RichText alias shown on a schematic. `bulk_patch_instance_netlist` is the
 bounded, atomic multi-instance netlist form. `set_instance_netlist` remains
 the whole-record operation for object initialization, import, and bounded
 migrations; product editing must not rebuild unrelated netlist facts through
@@ -178,7 +180,8 @@ Phase 8 topology operations have these preconditions:
   it creates no endpoint or drawing-object kind.
 - `remove_instance` requires no Net, annotation, group, or constraint
   reference.
-- `unplace_instance` returns only a placed, unlocked Instance to the Placement
+- `place_instance` and `unplace_instance` require an unlocked Instance.
+  `unplace_instance` returns a placed Instance to the Placement
   Tray. It preserves Net membership, NoConnects, bindings, parameters, and
   annotations, but rejects while a Route still terminates at the Instance.
 - `connect_endpoints` creates a caller-named local Net when both endpoints are

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -29,9 +29,10 @@ Rectangle-to-Cell is likewise a convenience
 gesture that commits an ordinary hierarchical Instance; rectangles remain
 visual-only drafting objects.
 
-There is no separate Cell Interface authoring surface. A child Cell Port's
-single object-anchored annotation owns its terminal name; normal Properties own
-direction. Annotation rename reconciles callers by stable terminal identity.
+There is no separate Cell Interface authoring surface. A child Cell Port shows
+its ordinary schematic Reference and a separate object-anchored terminal-name
+annotation; normal Properties own direction. Annotation rename reconciles
+callers by stable terminal identity.
 Ordinary Delete reuses the normal instance/route deletion proposal: it retains
 wire geometry by replacing affected terminal endpoints with Junctions, then
 removes electrical memberships, NoConnects, owned labels, layout references,
@@ -43,7 +44,8 @@ tray item may be dragged, entered into the ordinary placement cursor, or placed
 with **Place all** into a deterministic starter grid in the current view.
 **Return to tray** and **Return all** use the same lifecycle planner and retain
 electrical facts; permanent Delete remains a separate action. Formal Cell Ports
-cannot be returned because their placement defines a stable interface marker.
+use the same return path: the Cell interface remains present while the Port is
+retained in the Tray.
 Definition-level pin placement data remains compatible, while
 new interfaces use deterministic direction-aware automatic layout.
 
@@ -239,8 +241,8 @@ no electrical meaning.
 Open, demo load, restore, and human-approved staged import replace the entire
 Project through one replacement boundary; they are not Edit Engine
 transactions. Replacement cancels pending recovery for the outgoing Project
-and terminates its Agent session. A complete schema-15 Project may be upgraded
-at the read boundary and then enters the editor only as schema-16; migrated
+and terminates its Agent session. A complete schema-16 Project may be upgraded
+at the read boundary and then enters the editor only as schema-17; migrated
 files are marked as needing save.
 
 Selection, viewport, active tool, previews, Agent tokens, and approval UI are

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -32,8 +32,11 @@ visual-only drafting objects.
 There is no separate Cell Interface authoring surface. A child Cell Port's
 single object-anchored annotation owns its terminal name; normal Properties own
 direction. Annotation rename reconciles callers by stable terminal identity.
-Ordinary Delete reuses the normal instance/route deletion proposal, with the
-formal-terminal and caller projection appended only by the Project transaction.
+Ordinary Delete reuses the normal instance/route deletion proposal: it retains
+wire geometry by replacing affected terminal endpoints with Junctions, then
+removes electrical memberships, NoConnects, owned labels, layout references,
+and the Instance in one transaction. The formal-terminal and caller projection
+is appended only by the Project transaction.
 Definition-level pin placement data remains compatible, while
 new interfaces use deterministic direction-aware automatic layout.
 

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -30,9 +30,10 @@ gesture that commits an ordinary hierarchical Instance; rectangles remain
 visual-only drafting objects.
 
 There is no separate Cell Interface authoring surface. A child Cell Port shows
-its ordinary schematic Reference and a separate object-anchored terminal-name
-annotation; normal Properties own direction. Annotation rename reconciles
-callers by stable terminal identity.
+only its object-anchored terminal-name annotation in the normal Reference slot;
+its stable Instance ID is not drawn and it has no schematic Reference. Normal
+Properties own direction. Annotation rename reconciles callers by stable
+terminal identity.
 Ordinary Delete reuses the normal instance/route deletion proposal: it retains
 wire geometry by replacing affected terminal endpoints with Junctions, then
 removes electrical memberships, NoConnects, owned labels, layout references,
@@ -43,9 +44,10 @@ The **Placement Tray** is the only retained-unplaced presentation surface. A
 tray item may be dragged, entered into the ordinary placement cursor, or placed
 with **Place all** into a deterministic starter grid in the current view.
 **Return to tray** and **Return all** use the same lifecycle planner and retain
-electrical facts; permanent Delete remains a separate action. Formal Cell Ports
-use the same return path: the Cell interface remains present while the Port is
-retained in the Tray.
+electrical facts; permanent Delete remains a separate action. Object-anchored
+labels are retained with an unplaced Instance but are neither rendered nor
+hit-testable until re-placement. Formal Cell Ports use the same return path:
+the Cell interface remains present while the Port is retained in the Tray.
 Definition-level pin placement data remains compatible, while
 new interfaces use deterministic direction-aware automatic layout.
 
@@ -205,14 +207,17 @@ without requiring an Alt cycle.
 ## Text and presentation
 
 Every visible editable label is one persisted RichText annotation. Component
-insertion uses one default-display policy: exportable devices receive an
-`instance-designator` label when reference display is requested; internal Cells
-and external subcircuits additionally receive their Cell/master presentation;
-formal Ports receive only `cell-terminal-name`; and parameter values use
-`instance-value` when requested and displayable. Properties exposes the
-electrical Netlist Reference separately from the presentation-only Schematic
-Alias. The renderer never synthesizes text from Instance IDs and no empty
-suppressor label exists. Reference label display is a Properties toggle for one or many
+insertion uses one default-display policy: ordinary instances receive an
+`instance-schematic-name` label, which uses RichText `schematicName` and
+otherwise falls back only to `schematicReference` or `netlist.reference`.
+Internal Cells and external subcircuits additionally receive their
+Cell/master presentation; formal Ports receive only `cell-terminal-name`; and
+parameter values use `instance-value` when requested and displayable.
+`instance-designator` is an explicitly requested, read-only network-ID
+projection, never the default editable label. Properties exposes one
+Schematic label field; RichText canvas editing materializes `schematicName`.
+The renderer never synthesizes text from Instance IDs and no empty suppressor
+label exists. Reference label display is a Properties toggle for one or many
 selected components: hiding sets the annotation's optional `visible: false`
 flag, which renderers and hit/marquee surfaces skip while the annotation stays
 in the Project, so hiding is recoverable and a missing label can be re-created
@@ -241,8 +246,8 @@ no electrical meaning.
 Open, demo load, restore, and human-approved staged import replace the entire
 Project through one replacement boundary; they are not Edit Engine
 transactions. Replacement cancels pending recovery for the outgoing Project
-and terminates its Agent session. A complete schema-16 Project may be upgraded
-at the read boundary and then enters the editor only as schema-17; migrated
+and terminates its Agent session. A complete schema-17 Project may be upgraded
+at the read boundary and then enters the editor only as schema-18; migrated
 files are marked as needing save.
 
 Selection, viewport, active tool, previews, Agent tokens, and approval UI are

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -226,8 +226,8 @@ no electrical meaning.
 Open, demo load, restore, and human-approved staged import replace the entire
 Project through one replacement boundary; they are not Edit Engine
 transactions. Replacement cancels pending recovery for the outgoing Project
-and terminates its Agent session. A complete schema-14 Project may be upgraded
-at the read boundary and then enters the editor only as schema-15; migrated
+and terminates its Agent session. A complete schema-15 Project may be upgraded
+at the read boundary and then enters the editor only as schema-16; migrated
 files are marked as needing save.
 
 Selection, viewport, active tool, previews, Agent tokens, and approval UI are

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -37,6 +37,13 @@ wire geometry by replacing affected terminal endpoints with Junctions, then
 removes electrical memberships, NoConnects, owned labels, layout references,
 and the Instance in one transaction. The formal-terminal and caller projection
 is appended only by the Project transaction.
+
+The **Placement Tray** is the only retained-unplaced presentation surface. A
+tray item may be dragged, entered into the ordinary placement cursor, or placed
+with **Place all** into a deterministic starter grid in the current view.
+**Return to tray** and **Return all** use the same lifecycle planner and retain
+electrical facts; permanent Delete remains a separate action. Formal Cell Ports
+cannot be returned because their placement defines a stable interface marker.
 Definition-level pin placement data remains compatible, while
 new interfaces use deterministic direction-aware automatic layout.
 

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -193,11 +193,14 @@ without requiring an Alt cycle.
 ## Text and presentation
 
 Every visible editable label is one persisted RichText annotation. Component
-insertion creates an `instance-label` only when reference display is requested,
-and an `instance-value` only when value display is requested and the device
-parameters have a display projection.
-The renderer never synthesizes text from Instance IDs and no empty suppressor
-label exists. Reference label display is a Properties toggle for one or many
+insertion uses one default-display policy: exportable devices receive an
+`instance-designator` label when reference display is requested; internal Cells
+and external subcircuits additionally receive their Cell/master presentation;
+formal Ports receive only `cell-terminal-name`; and parameter values use
+`instance-value` when requested and displayable. Properties exposes the
+electrical Netlist Reference separately from the presentation-only Schematic
+Alias. The renderer never synthesizes text from Instance IDs and no empty
+suppressor label exists. Reference label display is a Properties toggle for one or many
 selected components: hiding sets the annotation's optional `visible: false`
 flag, which renderers and hit/marquee surfaces skip while the annotation stays
 in the Project, so hiding is recoverable and a missing label can be re-created

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -211,11 +211,16 @@ insertion uses one default-display policy: ordinary instances receive an
 `instance-schematic-name` label, which uses RichText `schematicName` and
 otherwise falls back only to `schematicReference` or `netlist.reference`.
 Internal Cells and external subcircuits additionally receive their
-Cell/master presentation; formal Ports receive only `cell-terminal-name`; and
+Cell/master presentation; a free Net Port receives an object-anchored
+`net-name` label and a formal Cell Pin receives only `cell-terminal-name`; and
 parameter values use `instance-value` when requested and displayable.
 `instance-designator` is an explicitly requested, read-only network-ID
 projection, never the default editable label. Properties exposes one
 Schematic label field; RichText canvas editing materializes `schematicName`.
+For either Port role, a character edit renames the bound Net or terminal while
+a formatting-only edit persists a same-text annotation `formatOverride`.
+Properties exposes `Net name` for a free Port and `Terminal name` plus
+direction for a formal Pin.
 The renderer never synthesizes text from Instance IDs and no empty suppressor
 label exists. Reference label display is a Properties toggle for one or many
 selected components: hiding sets the annotation's optional `visible: false`

--- a/docs/specs/netlist-export.md
+++ b/docs/specs/netlist-export.md
@@ -98,8 +98,11 @@ rename them.
 Canvas `port` and `port-filled` symbols are ordinary single-pin Instances; they
 do not define or reorder the formal cell interface. A hierarchy instance uses
 its bound child Document and that child's explicit private interface.
-Ports have an independent canvas `schematicReference` such as `P1`, but no
-`Instance.netlist.reference` because they do not emit an instance line.
+Non-formal Ports may retain an internal `schematicReference` such as `P1`, but
+no `Instance.netlist.reference` because they do not emit an instance line.
+Their visible label is the RichText schematic label, initially derived from
+that reference. A formal Cell Port uses its ordered terminal name such as
+`Vout` as its sole visible identity and has no schematic Reference.
 
 Every manually inserted device receives an explicit reference. References are
 unique per cell and have the prefix required by their device definition. Model-

--- a/docs/specs/netlist-export.md
+++ b/docs/specs/netlist-export.md
@@ -98,11 +98,11 @@ rename them.
 Canvas `port` and `port-filled` symbols are ordinary single-pin Instances; they
 do not define or reorder the formal cell interface. A hierarchy instance uses
 its bound child Document and that child's explicit private interface.
-Non-formal Ports may retain an internal `schematicReference` such as `P1`, but
-no `Instance.netlist.reference` because they do not emit an instance line.
-Their visible label is the RichText schematic label, initially derived from
-that reference. A formal Cell Port uses its ordered terminal name such as
-`Vout` as its sole visible identity and has no schematic Reference.
+Ports do not emit instance lines and receive no visible schematic Reference or
+`Instance.netlist.reference`. A free Net Port displays and edits its bound
+`Net.name`. A formal Cell Pin uses its ordered `CellTerminal.name`, such as
+`Vout`, for interface and export identity. Either bound Annotation may retain
+same-text RichText formatting, which never changes emitted names.
 
 Every manually inserted device receives an explicit reference. References are
 unique per cell and have the prefix required by their device definition. Model-

--- a/docs/specs/netlist-export.md
+++ b/docs/specs/netlist-export.md
@@ -98,6 +98,8 @@ rename them.
 Canvas `port` and `port-filled` symbols are ordinary single-pin Instances; they
 do not define or reorder the formal cell interface. A hierarchy instance uses
 its bound child Document and that child's explicit private interface.
+Ports have an independent canvas `schematicReference` such as `P1`, but no
+`Instance.netlist.reference` because they do not emit an instance line.
 
 Every manually inserted device receives an explicit reference. References are
 unique per cell and have the prefix required by their device definition. Model-

--- a/docs/specs/persistence-and-recovery.md
+++ b/docs/specs/persistence-and-recovery.md
@@ -4,17 +4,17 @@ Status: `accepted`
 
 Primary owner: `packages/project-protocol` and the editor document lifecycle
 
-Portable Projects use canonical schema-15 `.icproj.json`. The current-only
+Portable Projects use canonical schema-16 `.icproj.json`. The current-only
 model in `packages/model` validates the normalized shape;
 `packages/project-protocol` owns parsing, rolling compatibility diagnostics,
 and canonical serialization. Persistence validates
 the complete current schema before open or save and writes atomically where the
-platform supports it. Schema 14 reads through one direct upgrade to schema 15;
+platform supports it. Schema 15 reads through one direct upgrade to schema 16;
 older and future versions are rejected. Migration runs only at ingestion, and
-serialization remains schema 15.
+serialization remains schema 16.
 
 Recovery state is a non-authoritative browser safety copy. It may restore a
-complete schema-15 Project or a schema-14 record that validates after the direct
+complete schema-16 Project or a schema-15 record that validates after the direct
 upgrade, associated with a recorded working-copy session.
 Corrupt, incompatible, or partial recovery data is discarded or retained as raw
 data without changing the live Project. Credentials, Agent bearer tokens,

--- a/docs/specs/persistence-and-recovery.md
+++ b/docs/specs/persistence-and-recovery.md
@@ -4,17 +4,17 @@ Status: `accepted`
 
 Primary owner: `packages/project-protocol` and the editor document lifecycle
 
-Portable Projects use canonical schema-17 `.icproj.json`. The current-only
+Portable Projects use canonical schema-18 `.icproj.json`. The current-only
 model in `packages/model` validates the normalized shape;
 `packages/project-protocol` owns parsing, rolling compatibility diagnostics,
 and canonical serialization. Persistence validates
 the complete current schema before open or save and writes atomically where the
-platform supports it. Schema 16 reads through one direct upgrade to schema 17;
+platform supports it. Schema 17 reads through one direct upgrade to schema 18;
 older and future versions are rejected. Migration runs only at ingestion, and
-serialization remains schema 17.
+serialization remains schema 18.
 
 Recovery state is a non-authoritative browser safety copy. It may restore a
-complete schema-17 Project or a schema-16 record that validates after the direct
+complete schema-18 Project or a schema-17 record that validates after the direct
 upgrade, associated with a recorded working-copy session.
 Corrupt, incompatible, or partial recovery data is discarded or retained as raw
 data without changing the live Project. Credentials, Agent bearer tokens,

--- a/docs/specs/persistence-and-recovery.md
+++ b/docs/specs/persistence-and-recovery.md
@@ -4,17 +4,17 @@ Status: `accepted`
 
 Primary owner: `packages/project-protocol` and the editor document lifecycle
 
-Portable Projects use canonical schema-16 `.icproj.json`. The current-only
+Portable Projects use canonical schema-17 `.icproj.json`. The current-only
 model in `packages/model` validates the normalized shape;
 `packages/project-protocol` owns parsing, rolling compatibility diagnostics,
 and canonical serialization. Persistence validates
 the complete current schema before open or save and writes atomically where the
-platform supports it. Schema 15 reads through one direct upgrade to schema 16;
+platform supports it. Schema 16 reads through one direct upgrade to schema 17;
 older and future versions are rejected. Migration runs only at ingestion, and
-serialization remains schema 16.
+serialization remains schema 17.
 
 Recovery state is a non-authoritative browser safety copy. It may restore a
-complete schema-16 Project or a schema-15 record that validates after the direct
+complete schema-17 Project or a schema-16 record that validates after the direct
 upgrade, associated with a recorded working-copy session.
 Corrupt, incompatible, or partial recovery data is discarded or retained as raw
 data without changing the live Project. Credentials, Agent bearer tokens,

--- a/docs/specs/project-file-format.md
+++ b/docs/specs/project-file-format.md
@@ -2,17 +2,16 @@
 
 Status: `accepted`
 
-Current Project schema: `16`
+Current Project schema: `17`
 
 Primary owners: `packages/model` (current shape) and
 `packages/project-protocol` (file boundary)
 
 An `.icproj.json` file is canonical JSON for one complete `CircuitProject`.
-`@icm/project-protocol` exposes `parseProject` and accepts Project schema 16
-and schema 15. Schema 15 advances directly to 16 by separating the ambiguous
-legacy reference-label projection into an electrical designator or a
-presentation-only schematic alias. Every reader returns the sole schema-16
-in-memory Project shape; schema 14 and older and all future versions are
+`@icm/project-protocol` exposes `parseProject` and accepts Project schema 17
+and schema 16. Schema 16 advances directly to 17 by adding an independent
+schematic Reference to every Instance. Every reader returns the sole schema-17
+in-memory Project shape; schema 15 and older and all future versions are
 rejected. There is no sequential migration registry or second in-memory Project
 shape.
 
@@ -25,8 +24,10 @@ shape.
   Each external definition has a stable identity, an ordered list of stable
   terminals, raw formal defaults, interface status and optional block
   presentation. It has no internal Document body.
-- `Instance.netlist` contains its reference, binding, and typed parameter
-  values. Import source order and symbol-mapping registry identity live in
+- `Instance.schematicReference` is the canvas-facing Reference for every
+  Instance. `Instance.netlist` contains the separate emitted reference,
+  binding, and typed parameter values for emitting Instances. Import source
+  order and symbol-mapping registry identity live in
   `Instance.importProvenance`; there is no persisted property bag.
 - Hierarchy is an acyclic graph of ordinary Instances whose typed subcircuit
   bindings resolve to child Documents; orphan Cell definitions are allowed.
@@ -53,8 +54,8 @@ shape.
 ## Read and write
 
 ```text
-read text -> parse JSON -> require Project schema 15 or 16
--> direct v15-to-v16 upgrade when needed -> strict schema-16 validation -> open
+read text -> parse JSON -> require Project schema 16 or 17
+-> direct v16-to-v17 upgrade when needed -> strict schema-17 validation -> open
 save -> strict validation -> canonical key ordering -> atomic write
 ```
 
@@ -64,7 +65,7 @@ after explicit human approval in the editor.
 
 A migrated formal file is marked as needing save. The editor does not silently
 overwrite the source selected through the browser file input. Browser recovery
-records may be canonicalized to v16 only after a successful validated write.
+records may be canonicalized to v17 only after a successful validated write.
 
 Project entry does not repair duplicate canonical supply Nets (`0` or `VDD`).
 Duplicate folded Net names are invalid input and remain a blocking diagnostic
@@ -73,7 +74,7 @@ until the author explicitly renames or merges the Nets.
 Canonical serialization ends with one newline and is byte-stable across
 save/load/save. The current corpus is listed in
 `fixtures/projects/compatibility-corpus.json`; its accepted entries must all be
-already canonical Project schema 16. The rejected corpus names expected
+already canonical Project schema 17. The rejected corpus names expected
 validation failures.
 
 Viewport, selection, undo history, canvas overlays, Agent credentials,

--- a/docs/specs/project-file-format.md
+++ b/docs/specs/project-file-format.md
@@ -26,9 +26,9 @@ shape.
   Each external definition has a stable identity, an ordered list of stable
   terminals, raw formal defaults, interface status and optional block
   presentation. It has no internal Document body.
-- `Instance.schematicReference` is the canvas-facing Reference for non-formal
-  Instances. A formal Cell Port instead uses its `CellTerminal.name` as its
-  sole visible identifier. `Instance.netlist` contains the separate emitted reference,
+- `Instance.schematicReference` is the canvas-facing Reference for ordinary
+  Instances. Ports use `Net.name` or `CellTerminal.name` and do not display a
+  `P#` reference. `Instance.netlist` contains the separate emitted reference,
   binding, and typed parameter values for emitting Instances. Import source
   order and symbol-mapping registry identity live in
   `Instance.importProvenance`; there is no persisted property bag.
@@ -50,7 +50,9 @@ shape.
   `instance-schematic-name`: it reads RichText `schematicName`, then falls
   back to the internal `schematicReference` or `netlist.reference`.
   `instance-designator` is optional read-only network-ID display. Renderers
-  never synthesize instance text from an internal ID.
+  never synthesize instance text from an internal ID. Bound `net-name` and
+  `cell-terminal-name` annotations may carry a RichText `formatOverride` only
+  when its flattened text equals the semantic Net or terminal name.
 - `Document.presentation.cellSymbol` is optional definition-level block intent:
   a minimum body size and stable formal-terminal side/offset placements.
   Symbol geometry remains derived and caller Instances never persist a copy.

--- a/docs/specs/project-file-format.md
+++ b/docs/specs/project-file-format.md
@@ -2,18 +2,19 @@
 
 Status: `accepted`
 
-Current Project schema: `15`
+Current Project schema: `16`
 
 Primary owners: `packages/model` (current shape) and
 `packages/project-protocol` (file boundary)
 
 An `.icproj.json` file is canonical JSON for one complete `CircuitProject`.
-`@icm/project-protocol` exposes `parseProject` and accepts Project schema 15
-and schema 14. Schema 14 advances directly to 15 by assigning stable external
-terminal identities and preserving its interface order. Every reader returns the
-sole schema-15 in-memory Project shape; schema 13 and older and all future versions
-are rejected. There is no sequential migration registry or second in-memory
-Project shape.
+`@icm/project-protocol` exposes `parseProject` and accepts Project schema 16
+and schema 15. Schema 15 advances directly to 16 by separating the ambiguous
+legacy reference-label projection into an electrical designator or a
+presentation-only schematic alias. Every reader returns the sole schema-16
+in-memory Project shape; schema 14 and older and all future versions are
+rejected. There is no sequential migration registry or second in-memory Project
+shape.
 
 ## Current authorities
 
@@ -39,8 +40,10 @@ Project shape.
   an explicit global Net by normalized name, never by symbol or fixed ID.
 - VDD uses an explicit global Net, Route/Junction rail geometry, and RichText
   annotation. There is no VDD symbol Instance.
-- Every visible editable label is a RichText annotation. Renderers do not
-  synthesize instance labels from IDs.
+- Every visible editable label is a RichText annotation. Its binding separates
+  `instance-designator`, `instance-schematic-name`, `instance-master-name`,
+  `instance-value`, and `cell-terminal-name`; renderers never synthesize
+  instance text from an internal ID.
 - `Document.presentation.cellSymbol` is optional definition-level block intent:
   a minimum body size and stable formal-terminal side/offset placements.
   Symbol geometry remains derived and caller Instances never persist a copy.
@@ -50,8 +53,8 @@ Project shape.
 ## Read and write
 
 ```text
-read text -> parse JSON -> require Project schema 14 or 15
--> direct v14-to-v15 upgrade when needed -> strict schema-15 validation -> open
+read text -> parse JSON -> require Project schema 15 or 16
+-> direct v15-to-v16 upgrade when needed -> strict schema-16 validation -> open
 save -> strict validation -> canonical key ordering -> atomic write
 ```
 
@@ -61,7 +64,7 @@ after explicit human approval in the editor.
 
 A migrated formal file is marked as needing save. The editor does not silently
 overwrite the source selected through the browser file input. Browser recovery
-records may be canonicalized to v12 only after a successful validated write.
+records may be canonicalized to v16 only after a successful validated write.
 
 Project entry does not repair duplicate canonical supply Nets (`0` or `VDD`).
 Duplicate folded Net names are invalid input and remain a blocking diagnostic
@@ -70,7 +73,7 @@ until the author explicitly renames or merges the Nets.
 Canonical serialization ends with one newline and is byte-stable across
 save/load/save. The current corpus is listed in
 `fixtures/projects/compatibility-corpus.json`; its accepted entries must all be
-already canonical Project schema 15. The rejected corpus names expected
+already canonical Project schema 16. The rejected corpus names expected
 validation failures.
 
 Viewport, selection, undo history, canvas overlays, Agent credentials,

--- a/docs/specs/project-file-format.md
+++ b/docs/specs/project-file-format.md
@@ -2,16 +2,18 @@
 
 Status: `accepted`
 
-Current Project schema: `17`
+Current Project schema: `18`
 
 Primary owners: `packages/model` (current shape) and
 `packages/project-protocol` (file boundary)
 
 An `.icproj.json` file is canonical JSON for one complete `CircuitProject`.
-`@icm/project-protocol` exposes `parseProject` and accepts Project schema 17
-and schema 16. Schema 16 advances directly to 17 by adding an independent
-schematic Reference to every Instance. Every reader returns the sole schema-17
-in-memory Project shape; schema 15 and older and all future versions are
+`@icm/project-protocol` exposes `parseProject` and accepts Project schema 18
+and schema 17. Schema 17 advances directly to 18 by converting ordinary
+default designator projections to RichText schematic-label projections and
+removing the redundant schematic Reference/designator projection from formal
+Cell Ports. Every reader returns the sole schema-18 in-memory Project shape;
+schema 16 and older and all future versions are
 rejected. There is no sequential migration registry or second in-memory Project
 shape.
 
@@ -24,8 +26,9 @@ shape.
   Each external definition has a stable identity, an ordered list of stable
   terminals, raw formal defaults, interface status and optional block
   presentation. It has no internal Document body.
-- `Instance.schematicReference` is the canvas-facing Reference for every
-  Instance. `Instance.netlist` contains the separate emitted reference,
+- `Instance.schematicReference` is the canvas-facing Reference for non-formal
+  Instances. A formal Cell Port instead uses its `CellTerminal.name` as its
+  sole visible identifier. `Instance.netlist` contains the separate emitted reference,
   binding, and typed parameter values for emitting Instances. Import source
   order and symbol-mapping registry identity live in
   `Instance.importProvenance`; there is no persisted property bag.
@@ -43,8 +46,11 @@ shape.
   annotation. There is no VDD symbol Instance.
 - Every visible editable label is a RichText annotation. Its binding separates
   `instance-designator`, `instance-schematic-name`, `instance-master-name`,
-  `instance-value`, and `cell-terminal-name`; renderers never synthesize
-  instance text from an internal ID.
+  `instance-value`, and `cell-terminal-name`. The default ordinary label is
+  `instance-schematic-name`: it reads RichText `schematicName`, then falls
+  back to the internal `schematicReference` or `netlist.reference`.
+  `instance-designator` is optional read-only network-ID display. Renderers
+  never synthesize instance text from an internal ID.
 - `Document.presentation.cellSymbol` is optional definition-level block intent:
   a minimum body size and stable formal-terminal side/offset placements.
   Symbol geometry remains derived and caller Instances never persist a copy.
@@ -54,8 +60,8 @@ shape.
 ## Read and write
 
 ```text
-read text -> parse JSON -> require Project schema 16 or 17
--> direct v16-to-v17 upgrade when needed -> strict schema-17 validation -> open
+read text -> parse JSON -> require Project schema 17 or 18
+-> direct v17-to-v18 upgrade when needed -> strict schema-18 validation -> open
 save -> strict validation -> canonical key ordering -> atomic write
 ```
 
@@ -65,7 +71,7 @@ after explicit human approval in the editor.
 
 A migrated formal file is marked as needing save. The editor does not silently
 overwrite the source selected through the browser file input. Browser recovery
-records may be canonicalized to v17 only after a successful validated write.
+records may be canonicalized to v18 only after a successful validated write.
 
 Project entry does not repair duplicate canonical supply Nets (`0` or `VDD`).
 Duplicate folded Net names are invalid input and remain a blocking diagnostic
@@ -74,7 +80,7 @@ until the author explicitly renames or merges the Nets.
 Canonical serialization ends with one newline and is byte-stable across
 save/load/save. The current corpus is listed in
 `fixtures/projects/compatibility-corpus.json`; its accepted entries must all be
-already canonical Project schema 17. The rejected corpus names expected
+already canonical Project schema 18. The rejected corpus names expected
 validation failures.
 
 Viewport, selection, undo history, canvas overlays, Agent credentials,

--- a/docs/specs/schematic-model.md
+++ b/docs/specs/schematic-model.md
@@ -5,7 +5,7 @@ Status: `accepted`
 Primary owner: `packages/model`
 
 The Project contains Documents; each Document owns revisioned electrical,
-geometric, and presentation facts. The current model is strict schema 15 and has
+geometric, and presentation facts. The current model is strict schema 16 and has
 no compatibility shape.
 
 ## Coordinate domains
@@ -89,7 +89,9 @@ route-relative and include a deterministic fallback position for dangling
 visual references. While an anchor resolves, its resolved position is the one
 text baseline used by rendering, editor hit/marquee geometry, export bounds,
 and visual diagnostics; `fallbackPosition` is used only for a dangling target.
-Renderers never derive visible instance text from IDs or properties. Drafting
+`instance-designator`, `instance-schematic-name`, `instance-master-name`,
+`instance-value`, and `cell-terminal-name` bindings resolve their own source;
+renderers never derive visible instance text from IDs or properties. Drafting
 objects are visual-only and cannot create connectivity.
 
 A Cell definition may additionally persist optional `presentation.cellSymbol`
@@ -131,6 +133,6 @@ ordinary Schematic edits inside one Project structural transaction. The
 Project's `structureRevision` protects this cross-Document boundary and the
 editor records it as one undoable structural commit.
 
-Persistence writes only schema 15. `packages/project-protocol` accepts schema
-14 through the bounded direct upgrade defined by ADR 0029, then supplies the
+Persistence writes only schema 16. `packages/project-protocol` accepts schema
+15 through the bounded direct upgrade defined by ADR 0030, then supplies the
 current model only; no compatibility shape enters `packages/model`.

--- a/docs/specs/schematic-model.md
+++ b/docs/specs/schematic-model.md
@@ -126,6 +126,13 @@ two explicit placements may occupy the same side/offset slot.
   Routes, Junctions, NoConnects, and formal cell terminals, but excludes
   placement, annotation, and drafting presentation.
 
+An Instance has three lifecycle states: retained in the Placement Tray
+(`placement: null`), placed (`placement` present), or deleted (absent). Returning
+to the Tray retains every electrical and netlist fact; any visible Route endpoint
+is first detached to a Junction at the resolved pin position. Deletion is a
+separate atomic composition that clears membership, NoConnect, owned annotation,
+and unlocked layout references before removing the Instance.
+
 Mutation occurs only through atomic Edit Engine transactions against an exact
 Document revision. GUI and Agent writes use the same schema and invariants.
 Formal-interface edits and add/remove Document operations are composed with

--- a/docs/specs/schematic-model.md
+++ b/docs/specs/schematic-model.md
@@ -5,7 +5,7 @@ Status: `accepted`
 Primary owner: `packages/model`
 
 The Project contains Documents; each Document owns revisioned electrical,
-geometric, and presentation facts. The current model is strict schema 16 and has
+geometric, and presentation facts. The current model is strict schema 17 and has
 no compatibility shape.
 
 ## Coordinate domains
@@ -29,6 +29,8 @@ migration. Invalid coordinates are rejected with their data path.
 ## Electrical authority
 
 - `Instance` selects one exact canonical symbol and optional visual variant.
+  `Instance.schematicReference` is its canvas-facing Reference, independent of
+  the optional emitted `Instance.netlist.reference`.
 - `Net.terminals` is complete logical membership. A terminal is
   `{instanceId, pinName}` and belongs to at most one Net.
 - `Route` owns editable geometry for one Net and connects terminal or Junction
@@ -140,6 +142,6 @@ ordinary Schematic edits inside one Project structural transaction. The
 Project's `structureRevision` protects this cross-Document boundary and the
 editor records it as one undoable structural commit.
 
-Persistence writes only schema 16. `packages/project-protocol` accepts schema
-15 through the bounded direct upgrade defined by ADR 0030, then supplies the
+Persistence writes only schema 17. `packages/project-protocol` accepts schema
+16 through the bounded direct upgrade defined by ADR 0031, then supplies the
 current model only; no compatibility shape enters `packages/model`.

--- a/docs/specs/schematic-model.md
+++ b/docs/specs/schematic-model.md
@@ -5,7 +5,7 @@ Status: `accepted`
 Primary owner: `packages/model`
 
 The Project contains Documents; each Document owns revisioned electrical,
-geometric, and presentation facts. The current model is strict schema 17 and has
+geometric, and presentation facts. The current model is strict schema 18 and has
 no compatibility shape.
 
 ## Coordinate domains
@@ -29,8 +29,11 @@ migration. Invalid coordinates are rejected with their data path.
 ## Electrical authority
 
 - `Instance` selects one exact canonical symbol and optional visual variant.
-  `Instance.schematicReference` is its canvas-facing Reference, independent of
-  the optional emitted `Instance.netlist.reference`.
+  `Instance.schematicReference` is its canvas-facing Reference when the
+  Instance has one, independent of the optional emitted
+  `Instance.netlist.reference`. A formal Cell Port instead uses its
+  `CellTerminal.name` as its sole visible identity and has no schematic
+  reference.
 - `Net.terminals` is complete logical membership. A terminal is
   `{instanceId, pinName}` and belongs to at most one Net.
 - `Route` owns editable geometry for one Net and connects terminal or Junction
@@ -91,10 +94,12 @@ route-relative and include a deterministic fallback position for dangling
 visual references. While an anchor resolves, its resolved position is the one
 text baseline used by rendering, editor hit/marquee geometry, export bounds,
 and visual diagnostics; `fallbackPosition` is used only for a dangling target.
-`instance-designator`, `instance-schematic-name`, `instance-master-name`,
-`instance-value`, and `cell-terminal-name` bindings resolve their own source;
-renderers never derive visible instance text from IDs or properties. Drafting
-objects are visual-only and cannot create connectivity.
+`instance-schematic-name` resolves RichText `schematicName` and only then the
+internal schematic/netlist reference; `instance-designator` resolves an
+optional, read-only network ID. `instance-master-name`, `instance-value`, and
+`cell-terminal-name` resolve their own source. Renderers never derive visible
+instance text from IDs or copied properties. Drafting objects are visual-only
+and cannot create connectivity.
 
 A Cell definition may additionally persist optional `presentation.cellSymbol`
 intent: a symbol-local minimum body size and unique `terminalId`-keyed visual
@@ -130,10 +135,12 @@ two explicit placements may occupy the same side/offset slot.
 
 An Instance has three lifecycle states: retained in the Placement Tray
 (`placement: null`), placed (`placement` present), or deleted (absent). Returning
-to the Tray retains every electrical and netlist fact; any visible Route endpoint
-is first detached to a Junction at the resolved pin position. Deletion is a
-separate atomic composition that clears membership, NoConnect, owned annotation,
-and unlocked layout references before removing the Instance.
+to the Tray retains every electrical, netlist, and object-anchored annotation
+fact, but retained-instance annotations are not rendered or hit-testable until
+the Instance is re-placed. Any visible Route endpoint is first detached to a
+Junction at the resolved pin position. Deletion is a separate atomic composition
+that clears membership, NoConnect, owned annotation, and unlocked layout
+references before removing the Instance.
 
 Mutation occurs only through atomic Edit Engine transactions against an exact
 Document revision. GUI and Agent writes use the same schema and invariants.
@@ -142,6 +149,6 @@ ordinary Schematic edits inside one Project structural transaction. The
 Project's `structureRevision` protects this cross-Document boundary and the
 editor records it as one undoable structural commit.
 
-Persistence writes only schema 17. `packages/project-protocol` accepts schema
-16 through the bounded direct upgrade defined by ADR 0031, then supplies the
+Persistence writes only schema 18. `packages/project-protocol` accepts schema
+17 through the bounded direct upgrade defined by ADR 0032, then supplies the
 current model only; no compatibility shape enters `packages/model`.

--- a/docs/specs/schematic-model.md
+++ b/docs/specs/schematic-model.md
@@ -31,9 +31,9 @@ migration. Invalid coordinates are rejected with their data path.
 - `Instance` selects one exact canonical symbol and optional visual variant.
   `Instance.schematicReference` is its canvas-facing Reference when the
   Instance has one, independent of the optional emitted
-  `Instance.netlist.reference`. A formal Cell Port instead uses its
-  `CellTerminal.name` as its sole visible identity and has no schematic
-  reference.
+  `Instance.netlist.reference`. A free Net Port instead projects `Net.name`; a
+  formal Cell Pin projects `CellTerminal.name`. Neither Port role has a visible
+  schematic reference.
 - `Net.terminals` is complete logical membership. A terminal is
   `{instanceId, pinName}` and belongs to at most one Net.
 - `Route` owns editable geometry for one Net and connects terminal or Junction
@@ -96,8 +96,10 @@ text baseline used by rendering, editor hit/marquee geometry, export bounds,
 and visual diagnostics; `fallbackPosition` is used only for a dangling target.
 `instance-schematic-name` resolves RichText `schematicName` and only then the
 internal schematic/netlist reference; `instance-designator` resolves an
-optional, read-only network ID. `instance-master-name`, `instance-value`, and
-`cell-terminal-name` resolve their own source. Renderers never derive visible
+optional, read-only network ID. `net-name` and `cell-terminal-name` resolve
+their semantic source and may use a same-text Annotation RichText
+`formatOverride`; `instance-master-name` and `instance-value` resolve their own
+source. Renderers never derive visible
 instance text from IDs or copied properties. Drafting objects are visual-only
 and cannot create connectivity.
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -16,8 +16,11 @@ palette-first manual authoring; no Project file needs to be opened first.
 ## Edit and connect
 
 - Use **+ Component** to search the categorized built-in library, choose a
-  symbol by its inline preview, and click the canvas to place it. Imported
-  unplaced instances may still be dragged onto the canvas.
+  symbol by its inline preview, and click the canvas to place it. The
+  **Placement Tray** keeps imported or returned Instances without deleting
+  their netlist facts: drag one to the canvas, select **Place…** for a cursor
+  placement, or use **Place all** for a deterministic starter grid. **Return
+  to tray** is reversible through Undo and is distinct from permanent Delete.
 - Click to select, `Shift`/`Ctrl`-click to extend the selection, or drag blank
   canvas to box-select. Dragging one selected instance moves the whole
   selection atomically.

--- a/docs/user/project-compatibility.md
+++ b/docs/user/project-compatibility.md
@@ -1,19 +1,20 @@
 # Project File Compatibility
 
-The released Project schema version is `16`. It retains schematic-only
+The released Project schema version is `17`. It retains schematic-only
 hierarchy integrity, a Project structural revision, stable formal Cell ports,
 and definition-level Cell symbol presentation. It also has one typed Instance
 netlist authority, formal Cell parameters, and Project-local external
 subcircuit definitions with stable ordered terminal identities and directions.
-A canonical v16 file can be opened, saved, reopened, and saved again without
+Every Instance also has an independent schematic Reference, including Ports. A
+canonical v17 file can be opened, saved, reopened, and saved again without
 byte drift.
 
-Schema v15 is accepted through one direct upgrade to v16. It does not remain a
-v15 Project in the editor: legacy `instance-reference` labels become either an
-electrical designator or a schematic alias according to their prior visible
-projection, and the next save writes v16. The original file is never overwritten
-silently. Schema v14 and older, and versions newer than v16, are rejected; there is no
-accumulating migration registry.
+Schema v16 is accepted through one direct upgrade to v17. It receives a
+schematic Reference for every Instance: emitting instances retain their netlist
+reference and Ports receive deterministic `P#` references. The next save writes
+v17. The original file is never overwritten silently. Schema v15 and older,
+and versions newer than v17, are rejected; there is no accumulating migration
+registry.
 
 The canonical-current corpus at
 [`fixtures/projects/compatibility-corpus.json`](../../fixtures/projects/compatibility-corpus.json)
@@ -25,7 +26,7 @@ Retired fields such as first-class
 
 An incompatible Project is rejected before it can replace the current browser
 Project. Conversion, when needed, is an explicit external operation that must
-produce and validate a complete v16 candidate before a human chooses to load it.
+produce and validate a complete v17 candidate before a human chooses to load it.
 
 The editor never silently merges duplicate canonical Ground (`0`) or VDD Nets.
 Duplicate folded Net names are invalid and remain diagnostics until the author

--- a/docs/user/project-compatibility.md
+++ b/docs/user/project-compatibility.md
@@ -1,18 +1,18 @@
 # Project File Compatibility
 
-The released Project schema version is `15`. It retains schematic-only
+The released Project schema version is `16`. It retains schematic-only
 hierarchy integrity, a Project structural revision, stable formal Cell ports,
 and definition-level Cell symbol presentation. It also has one typed Instance
 netlist authority, formal Cell parameters, and Project-local external
 subcircuit definitions with stable ordered terminal identities and directions.
-A canonical v15 file can be opened, saved, reopened, and saved again without
+A canonical v16 file can be opened, saved, reopened, and saved again without
 byte drift.
 
-Schema v14 is accepted through one direct upgrade to v15. It does not remain a
-v14 Project in the editor: external-subcircuit terminal IDs, passive
-directions, and declared interface status are added deterministically, and the
-next save writes v15. The original file is never overwritten silently. Schema
-v13 and older, and versions newer than v15, are rejected; there is no
+Schema v15 is accepted through one direct upgrade to v16. It does not remain a
+v15 Project in the editor: legacy `instance-reference` labels become either an
+electrical designator or a schematic alias according to their prior visible
+projection, and the next save writes v16. The original file is never overwritten
+silently. Schema v14 and older, and versions newer than v16, are rejected; there is no
 accumulating migration registry.
 
 The canonical-current corpus at
@@ -25,7 +25,7 @@ Retired fields such as first-class
 
 An incompatible Project is rejected before it can replace the current browser
 Project. Conversion, when needed, is an explicit external operation that must
-produce and validate a complete v15 candidate before a human chooses to load it.
+produce and validate a complete v16 candidate before a human chooses to load it.
 
 The editor never silently merges duplicate canonical Ground (`0`) or VDD Nets.
 Duplicate folded Net names are invalid and remain diagnostics until the author

--- a/docs/user/project-compatibility.md
+++ b/docs/user/project-compatibility.md
@@ -1,20 +1,23 @@
 # Project File Compatibility
 
-The released Project schema version is `17`. It retains schematic-only
+The released Project schema version is `18`. It retains schematic-only
 hierarchy integrity, a Project structural revision, stable formal Cell ports,
 and definition-level Cell symbol presentation. It also has one typed Instance
 netlist authority, formal Cell parameters, and Project-local external
 subcircuit definitions with stable ordered terminal identities and directions.
-Every Instance also has an independent schematic Reference, including Ports. A
-canonical v17 file can be opened, saved, reopened, and saved again without
+Every ordinary Instance has one RichText schematic label, initially derived
+from its internal schematic or netlist reference until the user edits it. A
+formal Cell Port is instead identified by its terminal name, such as `Vout`. A
+canonical v18 file can be opened, saved, reopened, and saved again without
 byte drift.
 
-Schema v16 is accepted through one direct upgrade to v17. It receives a
-schematic Reference for every Instance: emitting instances retain their netlist
-reference and Ports receive deterministic `P#` references. The next save writes
-v17. The original file is never overwritten silently. Schema v15 and older,
-and versions newer than v17, are rejected; there is no accumulating migration
-registry.
+Schema v17 is accepted through one direct upgrade to v18. The upgrade converts
+ordinary default designator labels into RichText schematic-label projections,
+then removes the redundant `P#` schematic Reference/designator label from each
+formal Cell Port; its stable `Instance.id` and terminal name remain unchanged.
+The next save writes v18. The original file is never overwritten silently. Schema v16
+and older, and versions newer than v18, are rejected; there is no accumulating
+migration registry.
 
 The canonical-current corpus at
 [`fixtures/projects/compatibility-corpus.json`](../../fixtures/projects/compatibility-corpus.json)
@@ -26,7 +29,7 @@ Retired fields such as first-class
 
 An incompatible Project is rejected before it can replace the current browser
 Project. Conversion, when needed, is an explicit external operation that must
-produce and validate a complete v17 candidate before a human chooses to load it.
+produce and validate a complete v18 candidate before a human chooses to load it.
 
 The editor never silently merges duplicate canonical Ground (`0`) or VDD Nets.
 Duplicate folded Net names are invalid and remain diagnostics until the author

--- a/docs/user/project-compatibility.md
+++ b/docs/user/project-compatibility.md
@@ -7,7 +7,9 @@ netlist authority, formal Cell parameters, and Project-local external
 subcircuit definitions with stable ordered terminal identities and directions.
 Every ordinary Instance has one RichText schematic label, initially derived
 from its internal schematic or netlist reference until the user edits it. A
-formal Cell Port is instead identified by its terminal name, such as `Vout`. A
+free Port is identified by its Net name; a formal Cell Pin is identified by its
+terminal name, such as `Vout`. Their bound annotations may persist same-text
+RichText formatting but cannot store a divergent alias. A
 canonical v18 file can be opened, saved, reopened, and saved again without
 byte drift.
 

--- a/docs/user/schematic-hierarchy.md
+++ b/docs/user/schematic-hierarchy.md
@@ -64,8 +64,8 @@ the Properties values remain the precise fallback. These are definition operatio
 not top-level drawing tools.
 
 Hierarchy presentation is saved as definition-level size and pin-placement
-intent in Project schema 16. Older schema-15 projects open with deterministic
-automatic pin layout; schema-11 files are outside the supported rolling
+intent in Project schema 17. Older schema-16 projects open with deterministic
+automatic pin layout; schema-15 files are outside the supported rolling
 compatibility window. The block uses a closed polygon body and the shared
 Razavi rich-text renderer for pin and Cell names; it is compatible with that
 visual grammar rather than a pixel-for-pixel textbook symbol asset.

--- a/docs/user/schematic-hierarchy.md
+++ b/docs/user/schematic-hierarchy.md
@@ -64,7 +64,7 @@ the Properties values remain the precise fallback. These are definition operatio
 not top-level drawing tools.
 
 Hierarchy presentation is saved as definition-level size and pin-placement
-intent in Project schema 15. Older schema-14 projects open with deterministic
+intent in Project schema 16. Older schema-15 projects open with deterministic
 automatic pin layout; schema-11 files are outside the supported rolling
 compatibility window. The block uses a closed polygon body and the shared
 Razavi rich-text renderer for pin and Cell names; it is compatible with that

--- a/docs/user/schematic-hierarchy.md
+++ b/docs/user/schematic-hierarchy.md
@@ -64,7 +64,7 @@ the Properties values remain the precise fallback. These are definition operatio
 not top-level drawing tools.
 
 Hierarchy presentation is saved as definition-level size and pin-placement
-intent in Project schema 17. Older schema-16 projects open with deterministic
+intent in Project schema 18. Older schema-17 projects open with deterministic
 automatic pin layout; schema-15 files are outside the supported rolling
 compatibility window. The block uses a closed polygon body and the shared
 Razavi rich-text renderer for pin and Cell names; it is compatible with that

--- a/fixtures/projects/compatibility-corpus.json
+++ b/fixtures/projects/compatibility-corpus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "description": "Canonical current Project corpus. Every listed accepted file is schema-v17; rolling schema-v16 read compatibility is covered by synthesized tests rather than retained historic assets.",
+  "description": "Canonical current Project corpus. Every listed accepted file is schema-v18; rolling schema-v17 read compatibility is covered by synthesized tests rather than retained historic assets.",
   "current": [
     "fixtures/projects/minimal/project.icproj.json",
     "fixtures/projects/phase-1-manual/project.icproj.json",

--- a/fixtures/projects/compatibility-corpus.json
+++ b/fixtures/projects/compatibility-corpus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "description": "Canonical current Project corpus. Every listed accepted file is schema-v13; rolling schema-v12 read compatibility is covered by synthesized tests rather than retained historic assets.",
+  "description": "Canonical current Project corpus. Every listed accepted file is schema-v16; rolling schema-v15 read compatibility is covered by synthesized tests rather than retained historic assets.",
   "current": [
     "fixtures/projects/minimal/project.icproj.json",
     "fixtures/projects/phase-1-manual/project.icproj.json",

--- a/fixtures/projects/compatibility-corpus.json
+++ b/fixtures/projects/compatibility-corpus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "description": "Canonical current Project corpus. Every listed accepted file is schema-v16; rolling schema-v15 read compatibility is covered by synthesized tests rather than retained historic assets.",
+  "description": "Canonical current Project corpus. Every listed accepted file is schema-v17; rolling schema-v16 read compatibility is covered by synthesized tests rather than retained historic assets.",
   "current": [
     "fixtures/projects/minimal/project.icproj.json",
     "fixtures/projects/phase-1-manual/project.icproj.json",

--- a/fixtures/projects/instance-value-display/project.icproj.json
+++ b/fixtures/projects/instance-value-display/project.icproj.json
@@ -1047,7 +1047,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "instance-value-display",
   "name": "Instance Value Display",
-  "schemaVersion": 17,
+  "schemaVersion": 18,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/instance-value-display/project.icproj.json
+++ b/fixtures/projects/instance-value-display/project.icproj.json
@@ -831,6 +831,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "M1",
           "symbolId": "nmos",
           "symbolVariantId": "textbook-3terminal"
         },
@@ -855,6 +856,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "M2",
           "symbolId": "pmos",
           "symbolVariantId": "textbook-3terminal"
         },
@@ -878,6 +880,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "R1",
           "symbolId": "resistor"
         },
         {
@@ -900,6 +903,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "R2",
           "symbolId": "resistor"
         },
         {
@@ -922,6 +926,7 @@
             },
             "rotation": 90
           },
+          "schematicReference": "C1",
           "symbolId": "capacitor"
         },
         {
@@ -944,6 +949,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "L1",
           "symbolId": "inductor"
         },
         {
@@ -966,6 +972,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "V1",
           "symbolId": "voltage-source"
         },
         {
@@ -988,6 +995,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "I1",
           "symbolId": "current-source"
         },
         {
@@ -1011,6 +1019,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "M3",
           "symbolId": "nmos",
           "symbolVariantId": "textbook-3terminal"
         }
@@ -1038,7 +1047,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "instance-value-display",
   "name": "Instance Value Display",
-  "schemaVersion": 16,
+  "schemaVersion": 17,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/instance-value-display/project.icproj.json
+++ b/fixtures/projects/instance-value-display/project.icproj.json
@@ -1038,7 +1038,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "instance-value-display",
   "name": "Instance Value Display",
-  "schemaVersion": 15,
+  "schemaVersion": 16,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/minimal/project.icproj.json
+++ b/fixtures/projects/minimal/project.icproj.json
@@ -31,7 +31,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-minimal",
   "name": "Minimal Project",
-  "schemaVersion": 15,
+  "schemaVersion": 16,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/minimal/project.icproj.json
+++ b/fixtures/projects/minimal/project.icproj.json
@@ -31,7 +31,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-minimal",
   "name": "Minimal Project",
-  "schemaVersion": 16,
+  "schemaVersion": 17,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/minimal/project.icproj.json
+++ b/fixtures/projects/minimal/project.icproj.json
@@ -31,7 +31,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-minimal",
   "name": "Minimal Project",
-  "schemaVersion": 17,
+  "schemaVersion": 18,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-1-manual/project.icproj.json
+++ b/fixtures/projects/phase-1-manual/project.icproj.json
@@ -55,7 +55,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-1-manual",
   "name": "Phase 1 Manual Editor",
-  "schemaVersion": 15,
+  "schemaVersion": 16,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-1-manual/project.icproj.json
+++ b/fixtures/projects/phase-1-manual/project.icproj.json
@@ -11,12 +11,14 @@
         {
           "id": "M1",
           "placement": null,
+          "schematicReference": "M1",
           "symbolId": "nmos",
           "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M2",
           "placement": null,
+          "schematicReference": "M2",
           "symbolId": "pmos",
           "symbolVariantId": "textbook-3terminal"
         },
@@ -29,6 +31,7 @@
             "reference": "R1"
           },
           "placement": null,
+          "schematicReference": "R1",
           "symbolId": "resistor"
         }
       ],
@@ -55,7 +58,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-1-manual",
   "name": "Phase 1 Manual Editor",
-  "schemaVersion": 16,
+  "schemaVersion": 17,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-1-manual/project.icproj.json
+++ b/fixtures/projects/phase-1-manual/project.icproj.json
@@ -58,7 +58,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-1-manual",
   "name": "Phase 1 Manual Editor",
-  "schemaVersion": 17,
+  "schemaVersion": 18,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-3-routing/project.icproj.json
+++ b/fixtures/projects/phase-3-routing/project.icproj.json
@@ -127,7 +127,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-routing",
   "name": "Phase 3 Routing Demo",
-  "schemaVersion": 15,
+  "schemaVersion": 16,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-3-routing/project.icproj.json
+++ b/fixtures/projects/phase-3-routing/project.icproj.json
@@ -132,7 +132,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-routing",
   "name": "Phase 3 Routing Demo",
-  "schemaVersion": 17,
+  "schemaVersion": 18,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-3-routing/project.icproj.json
+++ b/fixtures/projects/phase-3-routing/project.icproj.json
@@ -18,6 +18,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "P1",
           "symbolId": "port"
         },
         {
@@ -30,6 +31,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "P2",
           "symbolId": "port"
         },
         {
@@ -42,6 +44,7 @@
             },
             "rotation": 90
           },
+          "schematicReference": "P3",
           "symbolId": "port"
         },
         {
@@ -54,6 +57,7 @@
             },
             "rotation": 270
           },
+          "schematicReference": "P4",
           "symbolId": "port"
         },
         {
@@ -66,6 +70,7 @@
             },
             "rotation": 90
           },
+          "schematicReference": "P5",
           "symbolId": "port"
         }
       ],
@@ -127,7 +132,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-routing",
   "name": "Phase 3 Routing Demo",
-  "schemaVersion": 16,
+  "schemaVersion": 17,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-5-dense-analog/project.icproj.json
+++ b/fixtures/projects/phase-5-dense-analog/project.icproj.json
@@ -155,7 +155,10 @@
           "id": "group-input-pair",
           "kind": "differential-pair",
           "locked": false,
-          "objectIds": ["M1", "M2"]
+          "objectIds": [
+            "M1",
+            "M2"
+          ]
         }
       ],
       "name": "Differential Stage",
@@ -243,7 +246,9 @@
           },
           "id": "route-vinp",
           "netId": "net-vinp",
-          "segmentModes": ["manual"],
+          "segmentModes": [
+            "manual"
+          ],
           "to": {
             "instanceId": "M1",
             "kind": "terminal",
@@ -259,7 +264,10 @@
           },
           "id": "route-vout",
           "netId": "net-vout",
-          "segmentModes": ["manual", "manual"],
+          "segmentModes": [
+            "manual",
+            "manual"
+          ],
           "to": {
             "instanceId": "VOUT",
             "kind": "terminal",
@@ -280,7 +288,11 @@
           },
           "id": "route-tail-left",
           "netId": "net-tail",
-          "segmentModes": ["manual", "manual", "manual"],
+          "segmentModes": [
+            "manual",
+            "manual",
+            "manual"
+          ],
           "to": {
             "instanceId": "GND",
             "kind": "terminal",
@@ -305,7 +317,11 @@
           },
           "id": "route-tail-right",
           "netId": "net-tail",
-          "segmentModes": ["manual", "manual", "manual"],
+          "segmentModes": [
+            "manual",
+            "manual",
+            "manual"
+          ],
           "to": {
             "instanceId": "GND",
             "kind": "terminal",

--- a/fixtures/projects/phase-5-dense-analog/project.icproj.json
+++ b/fixtures/projects/phase-5-dense-analog/project.icproj.json
@@ -340,7 +340,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-5-dense-analog",
   "name": "Current Differential Stage",
-  "schemaVersion": 15,
+  "schemaVersion": 16,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-5-dense-analog/project.icproj.json
+++ b/fixtures/projects/phase-5-dense-analog/project.icproj.json
@@ -155,10 +155,7 @@
           "id": "group-input-pair",
           "kind": "differential-pair",
           "locked": false,
-          "objectIds": [
-            "M1",
-            "M2"
-          ]
+          "objectIds": ["M1", "M2"]
         }
       ],
       "name": "Differential Stage",
@@ -246,9 +243,7 @@
           },
           "id": "route-vinp",
           "netId": "net-vinp",
-          "segmentModes": [
-            "manual"
-          ],
+          "segmentModes": ["manual"],
           "to": {
             "instanceId": "M1",
             "kind": "terminal",
@@ -264,10 +259,7 @@
           },
           "id": "route-vout",
           "netId": "net-vout",
-          "segmentModes": [
-            "manual",
-            "manual"
-          ],
+          "segmentModes": ["manual", "manual"],
           "to": {
             "instanceId": "VOUT",
             "kind": "terminal",
@@ -288,11 +280,7 @@
           },
           "id": "route-tail-left",
           "netId": "net-tail",
-          "segmentModes": [
-            "manual",
-            "manual",
-            "manual"
-          ],
+          "segmentModes": ["manual", "manual", "manual"],
           "to": {
             "instanceId": "GND",
             "kind": "terminal",
@@ -317,11 +305,7 @@
           },
           "id": "route-tail-right",
           "netId": "net-tail",
-          "segmentModes": [
-            "manual",
-            "manual",
-            "manual"
-          ],
+          "segmentModes": ["manual", "manual", "manual"],
           "to": {
             "instanceId": "GND",
             "kind": "terminal",
@@ -345,7 +329,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-5-dense-analog",
   "name": "Current Differential Stage",
-  "schemaVersion": 17,
+  "schemaVersion": 18,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-5-dense-analog/project.icproj.json
+++ b/fixtures/projects/phase-5-dense-analog/project.icproj.json
@@ -93,6 +93,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "P1",
           "symbolId": "port"
         },
         {
@@ -105,6 +106,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "M1",
           "symbolId": "nmos"
         },
         {
@@ -117,6 +119,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "M2",
           "symbolId": "nmos"
         },
         {
@@ -129,6 +132,7 @@
             },
             "rotation": 180
           },
+          "schematicReference": "P2",
           "symbolId": "port-filled"
         },
         {
@@ -141,6 +145,7 @@
             },
             "rotation": 0
           },
+          "schematicReference": "GND1",
           "symbolId": "ground"
         }
       ],
@@ -340,7 +345,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-5-dense-analog",
   "name": "Current Differential Stage",
-  "schemaVersion": 16,
+  "schemaVersion": 17,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/rejected-missing-top/project.icproj.json
+++ b/fixtures/projects/rejected-missing-top/project.icproj.json
@@ -30,7 +30,7 @@
   ],
   "id": "project-rejected",
   "name": "Rejected",
-  "schemaVersion": 16,
+  "schemaVersion": 18,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/rejected-missing-top/project.icproj.json
+++ b/fixtures/projects/rejected-missing-top/project.icproj.json
@@ -30,7 +30,7 @@
   ],
   "id": "project-rejected",
   "name": "Rejected",
-  "schemaVersion": 15,
+  "schemaVersion": 16,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/packages/agent-adapter/src/service.test.ts
+++ b/packages/agent-adapter/src/service.test.ts
@@ -265,11 +265,11 @@ describe("current Agent Circuit API service", () => {
       }
     }
 
-    // The restored schema-v11 fraction run recursively unfolds into both
-    // part documents. The schema-16 placement lifecycle adds one small typed
-    // edit variant; this bound still guards accidental projection bloat.
+    // RichText recursively unfolds into both part documents. Schema 18 adds a
+    // bounded same-text Port-format override; this tight ceiling still guards
+    // accidental projection bloat.
     expect(JSON.stringify(AgentCircuitRequestJsonSchema).length).toBeLessThan(
-      121_000,
+      121_250,
     );
     expect(JSON.stringify(AgentCircuitResponseJsonSchema).length).toBeLessThan(
       180_000,

--- a/packages/agent-adapter/src/service.test.ts
+++ b/packages/agent-adapter/src/service.test.ts
@@ -216,7 +216,12 @@ describe("current Agent Circuit API service", () => {
       ]),
     );
     expect(AGENT_EDIT_KINDS).not.toEqual(
-      expect.arrayContaining(["undo", "redo", "normalize_power_nets"]),
+      expect.arrayContaining([
+        "undo",
+        "redo",
+        "unplace_instance",
+        "normalize_power_nets",
+      ]),
     );
   });
 
@@ -261,10 +266,10 @@ describe("current Agent Circuit API service", () => {
     }
 
     // The restored schema-v11 fraction run recursively unfolds into both
-    // part documents, which grows the generated projection past the old
-    // post-retirement budget; the bound still guards accidental bloat.
+    // part documents. The schema-16 placement lifecycle adds one small typed
+    // edit variant; this bound still guards accidental projection bloat.
     expect(JSON.stringify(AgentCircuitRequestJsonSchema).length).toBeLessThan(
-      120_000,
+      121_000,
     );
     expect(JSON.stringify(AgentCircuitResponseJsonSchema).length).toBeLessThan(
       180_000,

--- a/packages/agent-adapter/src/service.ts
+++ b/packages/agent-adapter/src/service.ts
@@ -155,6 +155,7 @@ export function agentEditCategory(
       return "geometry";
     case "patch_instance_netlist_parameters":
     case "set_instance_reference":
+    case "set_instance_schematic_reference":
     case "set_instance_schematic_name":
       return "presentation";
     case "set_instance_netlist":

--- a/packages/agent-adapter/src/service.ts
+++ b/packages/agent-adapter/src/service.ts
@@ -199,6 +199,10 @@ export function agentEditCategory(
       return "presentation";
     case "undo":
     case "redo":
+    // The Placement Tray is a browser-editor lifecycle surface. Its edit is
+    // kept out of the retired Agent product even though the shared typed edit
+    // union must parse it for Project protocol completeness.
+    case "unplace_instance":
       return "unsupported";
   }
 }

--- a/packages/derived/src/annotation-presentation.test.ts
+++ b/packages/derived/src/annotation-presentation.test.ts
@@ -2,7 +2,10 @@ import { createEmptyDocument } from "@icm/model";
 import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
-import { resolveAnnotationPresentation } from "./annotation-presentation.js";
+import {
+  isSchematicAnnotationVisible,
+  resolveAnnotationPresentation,
+} from "./annotation-presentation.js";
 import { resolveSchematicStyleProfile } from "./style-profile.js";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
@@ -74,5 +77,62 @@ describe("annotation presentation", () => {
       position: { x: 31, y: 41 },
       anchor: { resolved: false },
     });
+  });
+
+  it("hides retained-instance labels and suppresses obsolete formal Port designators", () => {
+    const document = createEmptyDocument("annotations", "Annotations");
+    document.instances.push({
+      id: "R1",
+      symbolId: "resistor",
+      placement: null,
+    });
+    const retainedLabel = {
+      id: "instance-label-R1",
+      kind: "instance-label" as const,
+      binding: {
+        kind: "instance-schematic-name" as const,
+        instanceId: "R1",
+      },
+      anchor: {
+        kind: "object" as const,
+        objectId: "R1",
+        localOffset: { x: 16, y: 8 },
+        fallbackPosition: { x: 900, y: 900 },
+      },
+      alignment: "start" as const,
+      rotation: 0 as const,
+      locked: false,
+    };
+    const obsoleteFormalDesignator = {
+      ...retainedLabel,
+      id: "designator-R1",
+      binding: { kind: "instance-designator" as const, instanceId: "R1" },
+    };
+    expect(
+      isSchematicAnnotationVisible(document, obsoleteFormalDesignator),
+    ).toBe(false);
+    expect(isSchematicAnnotationVisible(document, retainedLabel)).toBe(false);
+
+    document.instances[0]!.placement = {
+      position: { x: 100, y: 100 },
+      rotation: 0,
+      mirror: "none",
+    };
+    expect(isSchematicAnnotationVisible(document, retainedLabel)).toBe(true);
+
+    document.netlist = {
+      name: "Child",
+      formalParameters: [],
+      terminals: [
+        {
+          id: "terminal-r1",
+          name: "Vout",
+          netId: "net-r1",
+          direction: "output",
+          interfaceInstanceId: "R1",
+        },
+      ],
+    };
+    expect(isSchematicAnnotationVisible(document, retainedLabel)).toBe(false);
   });
 });

--- a/packages/derived/src/annotation-presentation.ts
+++ b/packages/derived/src/annotation-presentation.ts
@@ -31,6 +31,40 @@ export interface AnnotationPresentation {
   readonly bounds: DerivedRect;
 }
 
+/**
+ * Shared canvas/export visibility policy for persisted annotations. A retained
+ * Instance keeps its object-anchored labels for a later re-placement, but its
+ * labels are not floating drawing objects while the Instance is in the Tray.
+ * Formal Cell Ports use their terminal name as their sole visible identity.
+ */
+export function isSchematicAnnotationVisible(
+  document: SchematicDocument,
+  annotation: Annotation,
+): boolean {
+  if (annotation.visible === false) return false;
+  const anchoredInstanceId =
+    annotation.anchor.kind === "object"
+      ? annotation.anchor.objectId
+      : undefined;
+  if (
+    anchoredInstanceId !== undefined &&
+    document.instances.some(
+      (instance) =>
+        instance.id === anchoredInstanceId && instance.placement === null,
+    )
+  ) {
+    return false;
+  }
+  const binding = annotation.binding;
+  return !(
+    (binding?.kind === "instance-designator" ||
+      binding?.kind === "instance-schematic-name") &&
+    document.netlist?.terminals.some(
+      (terminal) => terminal.interfaceInstanceId === binding.instanceId,
+    )
+  );
+}
+
 export function resolveAnnotationPresentation(
   document: SchematicDocument,
   resolver: SymbolResolver,

--- a/packages/derived/src/annotation-text.test.ts
+++ b/packages/derived/src/annotation-text.test.ts
@@ -8,12 +8,13 @@ import { describe, expect, it } from "vitest";
 import { resolveAnnotationText } from "./annotation-text.js";
 
 describe("bound annotation text", () => {
-  it("separates the electrical designator from the user-owned schematic name", () => {
+  it("uses RichText schematicName for the default label and keeps the designator separate", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.instances.push({
       id: "M1",
       symbolId: "nmos",
       placement: null,
+      schematicReference: "M_SCHEMATIC",
       netlist: { reference: "M_INTERNAL", parameters: {} },
       schematicName: {
         runs: [
@@ -50,6 +51,37 @@ describe("bound annotation text", () => {
       }),
     ).toEqual(document.instances[0]!.schematicName);
     expect(document.instances[0]!.netlist!.reference).toBe("M_INTERNAL");
+  });
+
+  it("falls back from an unmaterialized schematic label without exposing the object ID", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.instances.push({
+      id: "opaque-object-id",
+      symbolId: "resistor",
+      placement: null,
+      schematicReference: "R7",
+      netlist: { reference: "R_NETLIST", parameters: {} },
+    });
+    const annotation = {
+      id: "instance-label-R7",
+      kind: "instance-label" as const,
+      binding: {
+        kind: "instance-schematic-name" as const,
+        instanceId: "opaque-object-id",
+      },
+      anchor: { kind: "free" as const, position: { x: 0, y: 0 } },
+      alignment: "start" as const,
+      rotation: 0 as const,
+      locked: false,
+    };
+
+    expect(resolveAnnotationText(document, annotation)).toEqual(
+      semanticTextDocument("R7", "instance-label"),
+    );
+    delete document.instances[0]!.schematicReference;
+    expect(resolveAnnotationText(document, annotation)).toEqual(
+      semanticTextDocument("R_NETLIST", "instance-label"),
+    );
   });
 
   it("projects a Net name without touching its movable route anchor", () => {

--- a/packages/derived/src/annotation-text.test.ts
+++ b/packages/derived/src/annotation-text.test.ts
@@ -1,10 +1,14 @@
-import { createEmptyDocument, flattenRichText } from "@icm/model";
+import {
+  createEmptyDocument,
+  flattenRichText,
+  semanticTextDocument,
+} from "@icm/model";
 import { describe, expect, it } from "vitest";
 
 import { resolveAnnotationText } from "./annotation-text.js";
 
 describe("bound annotation text", () => {
-  it("uses the user-owned RichText schematic name before the SPICE reference", () => {
+  it("separates the electrical designator from the user-owned schematic name", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.instances.push({
       id: "M1",
@@ -29,7 +33,7 @@ describe("bound annotation text", () => {
     const annotation = {
       id: "instance-label-M1",
       kind: "instance-label" as const,
-      binding: { kind: "instance-reference" as const, instanceId: "M1" },
+      binding: { kind: "instance-designator" as const, instanceId: "M1" },
       anchor: { kind: "free" as const, position: { x: 0, y: 0 } },
       alignment: "start" as const,
       rotation: 0 as const,
@@ -37,8 +41,14 @@ describe("bound annotation text", () => {
     };
 
     expect(resolveAnnotationText(document, annotation)).toEqual(
-      document.instances[0]!.schematicName,
+      semanticTextDocument("M_INTERNAL", "instance-label"),
     );
+    expect(
+      resolveAnnotationText(document, {
+        ...annotation,
+        binding: { kind: "instance-schematic-name", instanceId: "M1" },
+      }),
+    ).toEqual(document.instances[0]!.schematicName);
     expect(document.instances[0]!.netlist!.reference).toBe("M_INTERNAL");
   });
 
@@ -79,5 +89,35 @@ describe("bound annotation text", () => {
       "Vrefp",
     );
     expect(annotation.anchor).toEqual(before);
+  });
+
+  it("projects a master name without falling back to the internal object ID", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.instances.push({
+      id: "opaque-object-id",
+      symbolId: "nmos",
+      placement: null,
+      netlist: {
+        reference: "M1",
+        binding: { kind: "model", deviceClass: "mos", name: "sky130_nfet" },
+        parameters: {},
+      },
+    });
+    const annotation = {
+      id: "master-M1",
+      kind: "instance-label" as const,
+      binding: {
+        kind: "instance-master-name" as const,
+        instanceId: "opaque-object-id",
+      },
+      anchor: { kind: "free" as const, position: { x: 0, y: 0 } },
+      alignment: "start" as const,
+      rotation: 0 as const,
+      locked: false,
+    };
+
+    expect(flattenRichText(resolveAnnotationText(document, annotation))).toBe(
+      "sky130nfet",
+    );
   });
 });

--- a/packages/derived/src/annotation-text.test.ts
+++ b/packages/derived/src/annotation-text.test.ts
@@ -2,6 +2,7 @@ import {
   createEmptyDocument,
   flattenRichText,
   semanticTextDocument,
+  type Annotation,
 } from "@icm/model";
 import { describe, expect, it } from "vitest";
 
@@ -31,7 +32,7 @@ describe("bound annotation text", () => {
         ],
       },
     });
-    const annotation = {
+    const annotation: Annotation = {
       id: "instance-label-M1",
       kind: "instance-label" as const,
       binding: { kind: "instance-designator" as const, instanceId: "M1" },
@@ -82,6 +83,67 @@ describe("bound annotation text", () => {
     expect(resolveAnnotationText(document, annotation)).toEqual(
       semanticTextDocument("R_NETLIST", "instance-label"),
     );
+  });
+
+  it("uses a formal Port RichText label without changing its electrical terminal name", () => {
+    const document = createEmptyDocument("document-child", "Child");
+    document.instances.push({
+      id: "port-object",
+      symbolId: "port",
+      placement: null,
+    });
+    document.nets.push({
+      id: "net-vout",
+      scope: "local",
+      terminals: [{ instanceId: "port-object", pinName: "P" }],
+    });
+    document.netlist = {
+      name: "Child",
+      formalParameters: [],
+      terminals: [
+        {
+          id: "terminal-vout",
+          name: "Vout",
+          netId: "net-vout",
+          direction: "output",
+          interfaceInstanceId: "port-object",
+        },
+      ],
+    };
+    const annotation: Annotation = {
+      id: "instance-label-port-object",
+      kind: "instance-label" as const,
+      binding: {
+        kind: "cell-terminal-name" as const,
+        terminalId: "terminal-vout",
+      },
+      anchor: { kind: "free" as const, position: { x: 0, y: 0 } },
+      alignment: "start" as const,
+      rotation: 0 as const,
+      locked: false,
+    };
+
+    expect(resolveAnnotationText(document, annotation)).toEqual(
+      semanticTextDocument("Vout", "formal-port"),
+    );
+    annotation.formatOverride = {
+      runs: [
+        {
+          kind: "span",
+          style: "bold",
+          children: [{ kind: "text", value: "V" }],
+        },
+        {
+          kind: "span",
+          style: "subscript",
+          children: [{ kind: "text", value: "out" }],
+        },
+      ],
+    };
+    expect(resolveAnnotationText(document, annotation)).toEqual(
+      annotation.formatOverride,
+    );
+    expect(document.netlist.terminals[0]!.name).toBe("Vout");
   });
 
   it("projects a Net name without touching its movable route anchor", () => {

--- a/packages/derived/src/annotation-text.ts
+++ b/packages/derived/src/annotation-text.ts
@@ -26,7 +26,7 @@ export function resolveAnnotationText(
         (candidate) => candidate.id === binding.instanceId,
       );
       return semanticTextDocument(
-        instance?.netlist?.reference ?? "",
+        instance?.schematicReference ?? instance?.netlist?.reference ?? "",
         "instance-label",
       );
     }

--- a/packages/derived/src/annotation-text.ts
+++ b/packages/derived/src/annotation-text.ts
@@ -21,15 +21,32 @@ export function resolveAnnotationText(
   const binding = annotation.binding;
   if (!binding) return annotation.content ?? EMPTY_TEXT;
   switch (binding.kind) {
-    case "instance-reference": {
+    case "instance-designator": {
       const instance = document.instances.find(
         (candidate) => candidate.id === binding.instanceId,
       );
-      if (instance?.schematicName) return instance.schematicName;
       return semanticTextDocument(
-        instance?.netlist?.reference ?? instance?.id ?? "",
+        instance?.netlist?.reference ?? "",
         "instance-label",
       );
+    }
+    case "instance-schematic-name": {
+      const instance = document.instances.find(
+        (candidate) => candidate.id === binding.instanceId,
+      );
+      return instance?.schematicName ?? EMPTY_TEXT;
+    }
+    case "instance-master-name": {
+      const instance = document.instances.find(
+        (candidate) => candidate.id === binding.instanceId,
+      );
+      const bindingTarget = instance?.netlist?.binding;
+      const name =
+        bindingTarget?.kind === "model" ||
+        bindingTarget?.kind === "unresolved-subcircuit"
+          ? bindingTarget.name
+          : (instance?.importProvenance?.name ?? "");
+      return semanticTextDocument(name, "instance-label");
     }
     case "instance-value": {
       const instance = document.instances.find(

--- a/packages/derived/src/annotation-text.ts
+++ b/packages/derived/src/annotation-text.ts
@@ -20,6 +20,12 @@ export function resolveAnnotationText(
 ): RichTextDocument {
   const binding = annotation.binding;
   if (!binding) return annotation.content ?? EMPTY_TEXT;
+  if (
+    annotation.formatOverride &&
+    (binding.kind === "net-name" || binding.kind === "cell-terminal-name")
+  ) {
+    return annotation.formatOverride;
+  }
   switch (binding.kind) {
     case "instance-designator": {
       const instance = document.instances.find(

--- a/packages/derived/src/annotation-text.ts
+++ b/packages/derived/src/annotation-text.ts
@@ -26,7 +26,7 @@ export function resolveAnnotationText(
         (candidate) => candidate.id === binding.instanceId,
       );
       return semanticTextDocument(
-        instance?.schematicReference ?? instance?.netlist?.reference ?? "",
+        instance?.netlist?.reference ?? "",
         "instance-label",
       );
     }
@@ -34,7 +34,13 @@ export function resolveAnnotationText(
       const instance = document.instances.find(
         (candidate) => candidate.id === binding.instanceId,
       );
-      return instance?.schematicName ?? EMPTY_TEXT;
+      return (
+        instance?.schematicName ??
+        semanticTextDocument(
+          instance?.schematicReference ?? instance?.netlist?.reference ?? "",
+          "instance-label",
+        )
+      );
     }
     case "instance-master-name": {
       const instance = document.instances.find(

--- a/packages/derived/src/project-instance-index.test.ts
+++ b/packages/derived/src/project-instance-index.test.ts
@@ -32,4 +32,43 @@ describe("ProjectInstanceIndex", () => {
       "document-main\u0000R1",
     ]);
   });
+
+  it("keeps internal ID, electrical reference, alias and master distinct", () => {
+    const project = createEmptyProject("project", "Project");
+    project.externalSubcircuitDefinitions.push({
+      id: "master-sky130-nfet",
+      name: "sky130_fd_pr__nfet_01v8",
+      terminals: [],
+      formalParameters: [],
+      interfaceStatus: "declared",
+    });
+    project.documents[0]!.instances.push({
+      id: "imported-instance-4c3b",
+      symbolId: "generic-block-2",
+      placement: null,
+      netlist: {
+        reference: "XBIAS",
+        binding: {
+          kind: "external-subcircuit",
+          definitionId: "master-sky130-nfet",
+        },
+        parameters: {},
+      },
+      schematicName: { runs: [{ kind: "text", value: "Bias transistor" }] },
+    });
+
+    const row = buildProjectInstanceIndex(project).row(
+      "document-main",
+      "imported-instance-4c3b",
+    );
+    expect(row).toMatchObject({
+      instanceId: "imported-instance-4c3b",
+      reference: "XBIAS",
+      schematicName: "Bias transistor",
+      masterName: "sky130_fd_pr__nfet_01v8",
+    });
+    expect(
+      buildProjectInstanceIndex(project).search("bias transistor"),
+    ).toHaveLength(1);
+  });
 });

--- a/packages/derived/src/project-instance-index.ts
+++ b/packages/derived/src/project-instance-index.ts
@@ -4,7 +4,11 @@ import {
   referenceIssuesForInstance,
   type ReferenceIssue,
 } from "@icm/devices";
-import type { CircuitProject, InstanceNetlistBinding } from "@icm/model";
+import {
+  flattenRichText,
+  type CircuitProject,
+  type InstanceNetlistBinding,
+} from "@icm/model";
 
 import type { ProjectConnectivityIndex } from "./connectivity-index.js";
 import { findHierarchyPaths } from "./hierarchy-navigation.js";
@@ -21,6 +25,8 @@ export interface ProjectInstanceRow {
   readonly documentName: string;
   readonly instanceId: string;
   readonly reference?: string;
+  readonly schematicName?: string;
+  readonly masterName?: string;
   readonly symbolId: string;
   readonly deviceClass?: string;
   readonly binding?: InstanceNetlistBinding;
@@ -44,12 +50,36 @@ function rowMatches(row: ProjectInstanceRow, query: string): boolean {
     row.documentId,
     row.instanceId,
     row.reference,
+    row.schematicName,
+    row.masterName,
     row.symbolId,
     row.deviceClass,
     row.binding?.kind,
     ...(row.binding?.kind === "model" ? [row.binding.name] : []),
     ...Object.entries(row.parameters).flatMap(([name, value]) => [name, value]),
   ].some((value) => value?.toLowerCase().includes(normalized));
+}
+
+function masterNameFor(
+  project: CircuitProject,
+  binding: InstanceNetlistBinding | undefined,
+): string | undefined {
+  if (!binding) return undefined;
+  switch (binding.kind) {
+    case "model":
+    case "unresolved-subcircuit":
+      return binding.name;
+    case "external-subcircuit":
+      return project.externalSubcircuitDefinitions.find(
+        (definition) => definition.id === binding.definitionId,
+      )?.name;
+    case "subcircuit":
+      return project.documents.find(
+        (document) => document.id === binding.childDocumentId,
+      )?.netlist?.name;
+    case "primitive":
+      return binding.deviceClass;
+  }
 }
 
 /**
@@ -73,6 +103,7 @@ export function buildProjectInstanceIndex(
         : [];
       return document.instances.map((instance): ProjectInstanceRow => {
         const descriptor = deviceDescriptor(instance.symbolId);
+        const masterName = masterNameFor(project, instance.netlist?.binding);
         return {
           key: `${document.id}\u0000${instance.id}`,
           documentId: document.id,
@@ -81,6 +112,10 @@ export function buildProjectInstanceIndex(
           ...(instance.netlist?.reference
             ? { reference: instance.netlist.reference }
             : {}),
+          ...(instance.schematicName
+            ? { schematicName: flattenRichText(instance.schematicName) }
+            : {}),
+          ...(masterName ? { masterName } : {}),
           symbolId: instance.symbolId,
           ...(descriptor ? { deviceClass: descriptor.deviceClass } : {}),
           ...(instance.netlist?.binding

--- a/packages/edit-engine/src/edit-schema.ts
+++ b/packages/edit-engine/src/edit-schema.ts
@@ -89,6 +89,12 @@ export const SetInstanceReferenceEditSchema = z.strictObject({
   instanceId: StableIdSchema,
   reference: z.string().min(1).max(128),
 });
+/** Update the visible schematic reference without changing netlist identity. */
+export const SetInstanceSchematicReferenceEditSchema = z.strictObject({
+  kind: z.literal("set_instance_schematic_reference"),
+  instanceId: StableIdSchema,
+  reference: z.string().min(1).max(128),
+});
 /** Update only the user-visible, RichText schematic alias. */
 export const SetInstanceSchematicNameEditSchema = z.strictObject({
   kind: z.literal("set_instance_schematic_name"),
@@ -346,6 +352,7 @@ export const SchematicEditSchema = z.discriminatedUnion("kind", [
   MirrorInstanceEditSchema,
   PatchInstanceNetlistParametersEditSchema,
   SetInstanceReferenceEditSchema,
+  SetInstanceSchematicReferenceEditSchema,
   SetInstanceSchematicNameEditSchema,
   SetInstanceBindingEditSchema,
   SetInstanceNetlistEditSchema,

--- a/packages/edit-engine/src/edit-schema.ts
+++ b/packages/edit-engine/src/edit-schema.ts
@@ -95,7 +95,7 @@ export const SetInstanceSchematicReferenceEditSchema = z.strictObject({
   instanceId: StableIdSchema,
   reference: z.string().min(1).max(128),
 });
-/** Update only the user-visible, RichText schematic alias. */
+/** Update the default user-visible, RichText schematic label. */
 export const SetInstanceSchematicNameEditSchema = z.strictObject({
   kind: z.literal("set_instance_schematic_name"),
   instanceId: StableIdSchema,

--- a/packages/edit-engine/src/edit-schema.ts
+++ b/packages/edit-engine/src/edit-schema.ts
@@ -58,6 +58,11 @@ export const PlaceInstanceEditSchema = z.strictObject({
   instanceId: StableIdSchema,
   placement: PlacementSchema,
 });
+/** Return a placed Instance to the retained Placement Tray. */
+export const UnplaceInstanceEditSchema = z.strictObject({
+  kind: z.literal("unplace_instance"),
+  instanceId: StableIdSchema,
+});
 export const MoveInstanceEditSchema = z.strictObject({
   kind: z.literal("move_instance"),
   instanceId: StableIdSchema,
@@ -335,6 +340,7 @@ export const SchematicEditSchema = z.discriminatedUnion("kind", [
   RemoveInstanceEditSchema,
   SetInstanceSymbolEditSchema,
   PlaceInstanceEditSchema,
+  UnplaceInstanceEditSchema,
   MoveInstanceEditSchema,
   RotateInstanceEditSchema,
   MirrorInstanceEditSchema,

--- a/packages/edit-engine/src/hierarchy-planner.ts
+++ b/packages/edit-engine/src/hierarchy-planner.ts
@@ -597,6 +597,7 @@ export function planRenameCellTerminal(
     throw new Error(`Cell terminal name already exists: ${newName}`);
   }
 
+  const terminalRename = terminal.name !== newName;
   const annotationEdits = child.annotations
     .filter(
       (annotation) =>
@@ -604,18 +605,32 @@ export function planRenameCellTerminal(
         annotation.anchor.kind === "object" &&
         annotation.anchor.objectId === terminal.interfaceInstanceId,
     )
-    .filter((annotation) => annotation.binding?.kind !== "cell-terminal-name")
-    .map((annotation) => ({
-      kind: "upsert_schematic_annotation" as const,
-      annotation: {
-        ...(() => {
-          const { content: _content, ...rest } = annotation;
-          return rest;
-        })(),
-        binding: { kind: "cell-terminal-name" as const, terminalId },
-      },
-    }));
-  const terminalRename = terminal.name !== newName;
+    .flatMap((annotation) => {
+      if (annotation.binding?.kind === "cell-terminal-name") {
+        if (!terminalRename || !annotation.formatOverride) return [];
+        const { formatOverride: _formatOverride, ...rest } = annotation;
+        return [
+          {
+            kind: "upsert_schematic_annotation" as const,
+            annotation: rest,
+          },
+        ];
+      }
+      const {
+        content: _content,
+        formatOverride: _formatOverride,
+        ...rest
+      } = annotation;
+      return [
+        {
+          kind: "upsert_schematic_annotation" as const,
+          annotation: {
+            ...rest,
+            binding: { kind: "cell-terminal-name" as const, terminalId },
+          },
+        },
+      ];
+    });
   if (!terminalRename && annotationEdits.length === 0) return [];
 
   const edits: ProjectStructureEdit[] = [
@@ -692,6 +707,42 @@ export function planRenameCellTerminal(
     }
   }
   return edits;
+}
+
+/**
+ * Applies a canvas Cell-Pin text edit atomically: the semantic character
+ * change uses the hierarchy rename planner, while the same-text RichText
+ * formatting remains on the bound annotation.
+ */
+export function planEditCellTerminalAnnotation(
+  project: CircuitProject,
+  documentId: string,
+  terminalId: string,
+  annotation: Annotation,
+  newName: string,
+): ProjectStructureEdit[] {
+  const renameEdits = planRenameCellTerminal(
+    project,
+    documentId,
+    terminalId,
+    newName,
+  );
+  const annotationEdit = {
+    kind: "upsert_schematic_annotation" as const,
+    annotation,
+  };
+  const childEditIndex = renameEdits.findIndex(
+    (edit) =>
+      edit.kind === "transact_document" && edit.documentId === documentId,
+  );
+  if (childEditIndex < 0) {
+    return [transactDocument(project, documentId, [annotationEdit])];
+  }
+  return renameEdits.map((edit, index) =>
+    index === childEditIndex && edit.kind === "transact_document"
+      ? { ...edit, edits: [...edit.edits, annotationEdit] }
+      : edit,
+  );
 }
 
 export function planExposePortInstance(

--- a/packages/edit-engine/src/hierarchy-planner.ts
+++ b/packages/edit-engine/src/hierarchy-planner.ts
@@ -100,6 +100,7 @@ export function createHierarchyInstance(
   return {
     id,
     symbolId: hierarchicalSymbolId(child.netlist.name),
+    schematicReference: reference,
     placement,
     netlist: {
       reference,
@@ -122,6 +123,7 @@ export function createExternalSubcircuitInstance(
   return {
     id,
     symbolId: externalSubcircuitSymbolId(definition.id),
+    schematicReference: reference,
     placement,
     netlist: {
       reference,

--- a/packages/edit-engine/src/index.ts
+++ b/packages/edit-engine/src/index.ts
@@ -8,6 +8,7 @@ export * from "./reference-planner.js";
 export * from "./reference-batch-planner.js";
 export * from "./batch-property-planner.js";
 export * from "./connectivity-proposal.js";
+export * from "./instance-lifecycle.js";
 export * from "./transaction.js";
 export * from "./project-transaction.js";
 export * from "./hierarchy-planner.js";

--- a/packages/edit-engine/src/instance-lifecycle.test.ts
+++ b/packages/edit-engine/src/instance-lifecycle.test.ts
@@ -62,7 +62,7 @@ function lifecycleDocument() {
     {
       id: "label-r1",
       kind: "instance-label",
-      binding: { kind: "instance-designator", instanceId: "R1" },
+      binding: { kind: "instance-schematic-name", instanceId: "R1" },
       anchor: {
         kind: "object",
         objectId: "R1",
@@ -117,7 +117,6 @@ describe("Instance lifecycle planning", () => {
     document.instances.push({
       id: "P1",
       symbolId: "port",
-      schematicReference: "P1",
       placement: {
         position: { x: 80, y: 100 },
         rotation: 0,

--- a/packages/edit-engine/src/instance-lifecycle.test.ts
+++ b/packages/edit-engine/src/instance-lifecycle.test.ts
@@ -1,0 +1,207 @@
+import { createEmptyDocument } from "@icm/model";
+import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import {
+  instanceOwnedAnnotationIds,
+  planInstanceDeletion,
+  planInstanceUnplacement,
+} from "./instance-lifecycle.js";
+import { executeTransaction } from "./transaction.js";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+function lifecycleDocument() {
+  const document = createEmptyDocument("document-main", "Main");
+  document.instances.push(
+    {
+      id: "R1",
+      symbolId: "resistor",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0,
+        mirror: "none",
+      },
+      netlist: {
+        reference: "R1",
+        binding: { kind: "primitive", deviceClass: "resistor" },
+        parameters: { resistance: "10k" },
+      },
+    },
+    {
+      id: "R2",
+      symbolId: "resistor",
+      placement: {
+        position: { x: 240, y: 100 },
+        rotation: 0,
+        mirror: "none",
+      },
+    },
+  );
+  document.nets.push({
+    id: "net-1",
+    scope: "local",
+    terminals: [
+      { instanceId: "R1", pinName: "2" },
+      { instanceId: "R2", pinName: "1" },
+    ],
+  });
+  document.routes.push({
+    id: "route-1",
+    netId: "net-1",
+    from: { kind: "terminal", instanceId: "R1", pinName: "2" },
+    to: { kind: "terminal", instanceId: "R2", pinName: "1" },
+    waypoints: [{ x: 100, y: 80 }],
+    segmentModes: ["manual", "manual"],
+  });
+  document.noConnects.push({
+    id: "open-r1-1",
+    endpoint: { kind: "terminal", instanceId: "R1", pinName: "1" },
+  });
+  document.annotations.push(
+    {
+      id: "label-r1",
+      kind: "instance-label",
+      binding: { kind: "instance-designator", instanceId: "R1" },
+      anchor: {
+        kind: "object",
+        objectId: "R1",
+        localOffset: { x: 0, y: 40 },
+        fallbackPosition: { x: 100, y: 140 },
+      },
+      alignment: "middle",
+      rotation: 0,
+      locked: false,
+    },
+    {
+      id: "free-value-r1",
+      kind: "instance-value",
+      binding: { kind: "instance-value", instanceId: "R1" },
+      anchor: { kind: "free", position: { x: 130, y: 100 } },
+      alignment: "middle",
+      rotation: 0,
+      locked: false,
+    },
+  );
+  document.layoutGroups.push({
+    id: "group-r1",
+    kind: "custom",
+    objectIds: ["R1"],
+    locked: false,
+  });
+  document.constraints.push({
+    id: "align-r1-r2",
+    kind: "align-y",
+    objectIds: ["R1", "R2"],
+    locked: false,
+  });
+  return document;
+}
+
+function transaction(
+  documentId: string,
+  edits: ReturnType<typeof planInstanceDeletion>,
+) {
+  return {
+    transactionId: "instance-lifecycle",
+    documentId,
+    expectedRevision: 0,
+    actor: { kind: "human" as const, id: "test" },
+    edits,
+  };
+}
+
+describe("Instance lifecycle planning", () => {
+  it("returns an Instance to the tray without changing its electrical facts", () => {
+    const document = lifecycleDocument();
+    const edits = planInstanceUnplacement(document, resolver, ["R1"], 3);
+    expect(edits.map((edit) => edit.kind)).toEqual([
+      "add_junction",
+      "set_route_points",
+      "unplace_instance",
+    ]);
+
+    const result = executeTransaction(
+      document,
+      transaction(document.id, edits),
+      { symbolResolver: resolver },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      document: {
+        instances: [
+          {
+            id: "R1",
+            placement: null,
+            netlist: { reference: "R1", parameters: { resistance: "10k" } },
+          },
+          { id: "R2" },
+        ],
+        nets: [
+          {
+            terminals: [
+              { instanceId: "R1", pinName: "2" },
+              { instanceId: "R2", pinName: "1" },
+            ],
+          },
+        ],
+        noConnects: [{ id: "open-r1-1" }],
+        annotations: [{ id: "label-r1" }, { id: "free-value-r1" }],
+        routes: [
+          {
+            from: { kind: "junction", junctionId: "junction-lifecycle-3-1" },
+          },
+        ],
+      },
+    });
+  });
+
+  it("rejects raw unplacement while route geometry still targets the Instance", () => {
+    const document = lifecycleDocument();
+    const result = executeTransaction(
+      document,
+      transaction(document.id, [
+        { kind: "unplace_instance", instanceId: "R1" },
+      ]),
+      { symbolResolver: resolver },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining("detach routes") },
+    });
+  });
+
+  it("deletes route, NoConnect, annotation, and layout references atomically", () => {
+    const document = lifecycleDocument();
+    const edits = planInstanceDeletion(document, resolver, ["R1"], 5);
+    expect(instanceOwnedAnnotationIds(document, ["R1"])).toEqual(
+      new Set(["label-r1", "free-value-r1"]),
+    );
+
+    const result = executeTransaction(
+      document,
+      transaction(document.id, edits),
+      { symbolResolver: resolver },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      document: {
+        instances: [{ id: "R2" }],
+        nets: [{ terminals: [{ instanceId: "R2", pinName: "1" }] }],
+        noConnects: [],
+        annotations: [],
+        layoutGroups: [],
+        constraints: [],
+        routes: [
+          {
+            from: { kind: "junction", junctionId: "junction-lifecycle-5-1" },
+            to: { kind: "terminal", instanceId: "R2", pinName: "1" },
+          },
+        ],
+      },
+    });
+  });
+});

--- a/packages/edit-engine/src/instance-lifecycle.test.ts
+++ b/packages/edit-engine/src/instance-lifecycle.test.ts
@@ -112,6 +112,64 @@ function transaction(
 }
 
 describe("Instance lifecycle planning", () => {
+  it("returns a formal Cell Port without removing its exported interface", () => {
+    const document = createEmptyDocument("document-child", "Child");
+    document.instances.push({
+      id: "P1",
+      symbolId: "port",
+      schematicReference: "P1",
+      placement: {
+        position: { x: 80, y: 100 },
+        rotation: 0,
+        mirror: "none",
+      },
+    });
+    document.nets.push({
+      id: "net-vin",
+      scope: "local",
+      terminals: [{ instanceId: "P1", pinName: "P" }],
+    });
+    document.netlist = {
+      name: "Child",
+      formalParameters: [],
+      terminals: [
+        {
+          id: "terminal-vin",
+          name: "VIN",
+          netId: "net-vin",
+          direction: "input",
+          interfaceInstanceId: "P1",
+        },
+      ],
+    };
+
+    const result = executeTransaction(
+      document,
+      transaction(
+        document.id,
+        planInstanceUnplacement(document, resolver, ["P1"], 1),
+      ),
+      { symbolResolver: resolver },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      document: {
+        instances: [{ id: "P1", placement: null }],
+        netlist: {
+          terminals: [
+            {
+              name: "VIN",
+              interfaceInstanceId: "P1",
+              netId: "net-vin",
+            },
+          ],
+        },
+        nets: [{ terminals: [{ instanceId: "P1", pinName: "P" }] }],
+      },
+    });
+  });
+
   it("returns an Instance to the tray without changing its electrical facts", () => {
     const document = lifecycleDocument();
     const edits = planInstanceUnplacement(document, resolver, ["R1"], 3);

--- a/packages/edit-engine/src/instance-lifecycle.ts
+++ b/packages/edit-engine/src/instance-lifecycle.ts
@@ -1,0 +1,241 @@
+import { endpointKey, resolveEndpointPoint } from "@icm/derived";
+import type { RouteEndpoint, SchematicDocument } from "@icm/model";
+import type { SymbolResolver } from "@icm/symbols";
+
+import type { SchematicEdit } from "./edit-schema.js";
+
+/**
+ * Plans the presentation-only transition from canvas to Placement Tray.
+ * Electrical terminal membership, NoConnect declarations, and annotations
+ * remain owned by the retained Instance. Routed pins are represented by
+ * Junctions before the placement disappears, so every visible wire endpoint
+ * remains resolvable.
+ */
+export function planInstanceUnplacement(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  instanceIds: readonly string[],
+  sequence: number,
+): SchematicEdit[] {
+  const selected = selectedExistingInstanceIds(document, instanceIds);
+  if (selected.size === 0) return [];
+  return [
+    ...planRoutedTerminalDetachment(document, resolver, selected, sequence),
+    ...instancesById(document, selected).map((instance): SchematicEdit => ({
+      kind: "unplace_instance",
+      instanceId: instance.id,
+    })),
+  ];
+}
+
+/**
+ * Plans complete Instance disposal. This deliberately composes ordinary
+ * strict edits instead of adding a second destructive edit kind: routes are
+ * detached first, electrical memberships and explicit opens are removed, then
+ * annotations/layout references and the Instance itself are removed.
+ */
+export function planInstanceDeletion(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  instanceIds: readonly string[],
+  sequence: number,
+): SchematicEdit[] {
+  const selected = selectedExistingInstanceIds(document, instanceIds);
+  if (selected.size === 0) return [];
+
+  return [
+    ...planRoutedTerminalDetachment(document, resolver, selected, sequence),
+    ...planTerminalDisconnections(document, selected),
+    ...planNoConnectRemovals(document, selected),
+    ...[...instanceOwnedAnnotationIds(document, selected)].map(
+      (annotationId): SchematicEdit => ({
+        kind: "remove_schematic_annotation",
+        annotationId,
+      }),
+    ),
+    ...planLayoutReferenceRemoval(document, selected),
+    ...instancesById(document, selected).map((instance): SchematicEdit => ({
+      kind: "remove_instance",
+      instanceId: instance.id,
+    })),
+  ];
+}
+
+function selectedExistingInstanceIds(
+  document: SchematicDocument,
+  instanceIds: readonly string[],
+): ReadonlySet<string> {
+  const requested = new Set(instanceIds);
+  return new Set(
+    document.instances
+      .filter((instance) => requested.has(instance.id))
+      .map((instance) => instance.id),
+  );
+}
+
+function instancesById(
+  document: SchematicDocument,
+  selected: ReadonlySet<string>,
+) {
+  return document.instances.filter((instance) => selected.has(instance.id));
+}
+
+function planRoutedTerminalDetachment(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  selected: ReadonlySet<string>,
+  sequence: number,
+): SchematicEdit[] {
+  const replacements = new Map<string, RouteEndpoint>();
+  const junctionEdits: SchematicEdit[] = [];
+  const occupiedIds = new Set(
+    [
+      ...document.instances,
+      ...document.nets,
+      ...document.routes,
+      ...document.junctions,
+      ...document.noConnects,
+      ...document.annotations,
+      ...document.layoutGroups,
+      ...document.constraints,
+      ...(document.drafting?.objects ?? []),
+    ].map((object) => object.id),
+  );
+  let junctionCounter = 0;
+
+  for (const net of document.nets) {
+    for (const terminal of net.terminals) {
+      if (!selected.has(terminal.instanceId)) continue;
+      const endpoint: RouteEndpoint = { kind: "terminal", ...terminal };
+      const key = endpointKey(endpoint);
+      const usedByRoute = document.routes.some(
+        (route) =>
+          endpointKey(route.from) === key || endpointKey(route.to) === key,
+      );
+      if (!usedByRoute) continue;
+
+      const position = resolveEndpointPoint(document, resolver, endpoint);
+      if (!position) {
+        throw new Error(`Cannot preserve unresolved endpoint ${key}`);
+      }
+      let junctionId: string;
+      do {
+        junctionCounter += 1;
+        junctionId = `junction-lifecycle-${sequence}-${junctionCounter}`;
+      } while (occupiedIds.has(junctionId));
+      occupiedIds.add(junctionId);
+      replacements.set(key, { kind: "junction", junctionId });
+      junctionEdits.push({
+        kind: "add_junction",
+        junctionId,
+        netId: net.id,
+        position,
+      });
+    }
+  }
+
+  const routeEdits = document.routes.flatMap((route): SchematicEdit[] => {
+    const from = replacements.get(endpointKey(route.from)) ?? route.from;
+    const to = replacements.get(endpointKey(route.to)) ?? route.to;
+    if (from === route.from && to === route.to) return [];
+    return [
+      {
+        kind: "set_route_points",
+        routeId: route.id,
+        netId: route.netId,
+        from,
+        to,
+        waypoints: route.waypoints.map((point) => ({ ...point })),
+        segmentModes: [...route.segmentModes],
+        ...(route.presentation ? { presentation: route.presentation } : {}),
+      },
+    ];
+  });
+
+  return [...junctionEdits, ...routeEdits];
+}
+
+function planTerminalDisconnections(
+  document: SchematicDocument,
+  selected: ReadonlySet<string>,
+): SchematicEdit[] {
+  return document.nets.flatMap((net) =>
+    net.terminals
+      .filter((terminal) => selected.has(terminal.instanceId))
+      .map((terminal): SchematicEdit => ({
+        kind: "disconnect_endpoint",
+        endpoint: { kind: "terminal", ...terminal },
+      })),
+  );
+}
+
+function planNoConnectRemovals(
+  document: SchematicDocument,
+  selected: ReadonlySet<string>,
+): SchematicEdit[] {
+  return document.noConnects
+    .filter((noConnect) => selected.has(noConnect.endpoint.instanceId))
+    .map((noConnect): SchematicEdit => ({
+      kind: "remove_no_connect",
+      noConnectId: noConnect.id,
+    }));
+}
+
+/** Every annotation that would be orphaned by deleting any selected Instance. */
+export function instanceOwnedAnnotationIds(
+  document: SchematicDocument,
+  instanceIds: ReadonlySet<string> | readonly string[],
+): ReadonlySet<string> {
+  const selected = new Set(instanceIds);
+  return new Set(
+    document.annotations
+      .filter((annotation) => {
+        if (
+          annotation.anchor.kind === "object" &&
+          selected.has(annotation.anchor.objectId)
+        ) {
+          return true;
+        }
+        const binding = annotation.binding;
+        return (
+          binding !== undefined &&
+          binding.kind !== "net-name" &&
+          binding.kind !== "cell-terminal-name" &&
+          selected.has(binding.instanceId)
+        );
+      })
+      .map((annotation) => annotation.id),
+  );
+}
+
+function planLayoutReferenceRemoval(
+  document: SchematicDocument,
+  selected: ReadonlySet<string>,
+): SchematicEdit[] {
+  const groupEdits = document.layoutGroups.flatMap((group): SchematicEdit[] => {
+    const objectIds = group.objectIds.filter((id) => !selected.has(id));
+    if (objectIds.length === group.objectIds.length) return [];
+    if (objectIds.length === 0) {
+      return [{ kind: "remove_layout_group", groupId: group.id }];
+    }
+    return [{ kind: "set_layout_group", group: { ...group, objectIds } }];
+  });
+  const constraintEdits = document.constraints.flatMap(
+    (constraint): SchematicEdit[] => {
+      const objectIds = constraint.objectIds.filter((id) => !selected.has(id));
+      if (objectIds.length === constraint.objectIds.length) return [];
+      if (objectIds.length < 2) {
+        return [
+          { kind: "remove_layout_constraint", constraintId: constraint.id },
+        ];
+      }
+      return [
+        {
+          kind: "set_layout_constraint",
+          constraint: { ...constraint, objectIds },
+        },
+      ];
+    },
+  );
+  return [...groupEdits, ...constraintEdits];
+}

--- a/packages/edit-engine/src/project-transaction.test.ts
+++ b/packages/edit-engine/src/project-transaction.test.ts
@@ -11,6 +11,7 @@ import {
   planRenameCell,
   planRemoveCellTerminal,
   planRemoveCellTerminals,
+  planEditCellTerminalAnnotation,
   planRenameCellTerminal,
   planSetCellSymbolPresentation,
 } from "./hierarchy-planner.js";
@@ -306,7 +307,7 @@ describe("Project structural transaction", () => {
     });
   });
 
-  it("normalizes a formatting-only formal Port edit without renaming its terminal", () => {
+  it("sets a formatting-only formal Port label without renaming its terminal", () => {
     const project = createEmptyProject("project", "Project");
     const child = createEmptyDocument("document-child", "Child");
     child.instances.push({
@@ -329,7 +330,7 @@ describe("Project structural transaction", () => {
     child.annotations.push({
       id: "instance-label-port-vout",
       kind: "instance-label",
-      content: { runs: [{ kind: "text", value: "Vout" }] },
+      binding: { kind: "cell-terminal-name", terminalId: "terminal-vout" },
       anchor: {
         kind: "object",
         objectId: "port-vout",
@@ -347,17 +348,43 @@ describe("Project structural transaction", () => {
       projectId: project.id,
       expectedStructureRevision: 0,
       actor: { kind: "human", id: "human-local" },
-      edits: planRenameCellTerminal(project, child.id, "terminal-vout", "Vout"),
+      edits: planEditCellTerminalAnnotation(
+        project,
+        child.id,
+        "terminal-vout",
+        {
+          ...child.annotations[0]!,
+          formatOverride: {
+            runs: [
+              {
+                kind: "span",
+                style: "bold",
+                children: [{ kind: "text", value: "Vout" }],
+              },
+            ],
+          },
+        },
+        "Vout",
+      ),
     });
 
     expect(result).toMatchObject({
       ok: true,
       applied: true,
       project: {
-        documents: [{}, { netlist: { terminals: [{ name: "Vout" }] } }],
+        documents: [
+          {},
+          {
+            netlist: { terminals: [{ name: "Vout" }] },
+            annotations: [
+              { formatOverride: { runs: [{ kind: "span", style: "bold" }] } },
+            ],
+          },
+        ],
       },
     });
-    if (!result.ok) throw new Error("Expected formatting-only Port update");
+    if (!result.ok)
+      throw new Error("Expected formatting-only Port label update");
     expect(result.project.documents[1]!.annotations[0]!.binding).toEqual({
       kind: "cell-terminal-name",
       terminalId: "terminal-vout",

--- a/packages/edit-engine/src/transaction-instance-annotations.ts
+++ b/packages/edit-engine/src/transaction-instance-annotations.ts
@@ -149,7 +149,7 @@ export function refreshInstanceReferenceAnnotation(
 }
 
 /**
- * A reference or value label is renderer-managed only while it exactly agrees
+ * A value label is renderer-managed only while it exactly agrees
  * with the current canonical default for its slot. A user-moved label remains
  * an authored object-relative vector and must not be pulled back onto the
  * automatic side when its instance is rotated or mirrored.

--- a/packages/edit-engine/src/transaction-instance-annotations.ts
+++ b/packages/edit-engine/src/transaction-instance-annotations.ts
@@ -129,7 +129,7 @@ export function refreshInstanceReferenceAnnotation(
     ) {
       continue;
     }
-    if (annotation.binding?.kind === "instance-reference") {
+    if (annotation.binding?.kind === "instance-designator") {
       changedObjectIds.add(annotation.id);
       continue;
     }

--- a/packages/edit-engine/src/transaction.test.ts
+++ b/packages/edit-engine/src/transaction.test.ts
@@ -85,6 +85,49 @@ describe("Edit Transaction envelope", () => {
     expect(result.document.instances[0]).not.toHaveProperty("netlist");
   });
 
+  it("rejects a schematic reference on a formal Cell Port", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.instances.push({
+      id: "port-object",
+      symbolId: "port",
+      placement: null,
+    });
+    document.nets.push({
+      id: "net-vout",
+      scope: "local",
+      terminals: [{ instanceId: "port-object", pinName: "P" }],
+    });
+    document.netlist = {
+      name: "Child",
+      formalParameters: [],
+      terminals: [
+        {
+          id: "terminal-vout",
+          name: "Vout",
+          netId: "net-vout",
+          direction: "output",
+          interfaceInstanceId: "port-object",
+        },
+      ],
+    };
+
+    const result = executeTransaction(document, {
+      ...transaction(),
+      edits: [
+        {
+          kind: "set_instance_schematic_reference",
+          instanceId: "port-object",
+          reference: "P1",
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "EDIT_PRECONDITION" },
+    });
+  });
+
   it("enforces the same layout lock before placing a retained Instance", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.instances.push({

--- a/packages/edit-engine/src/transaction.test.ts
+++ b/packages/edit-engine/src/transaction.test.ts
@@ -128,6 +128,129 @@ describe("Edit Transaction envelope", () => {
     });
   });
 
+  it("updates a formal Port same-text format override without changing its interface name", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.instances.push({
+      id: "port-object",
+      symbolId: "port",
+      placement: null,
+    });
+    document.nets.push({
+      id: "net-vout",
+      scope: "local",
+      terminals: [{ instanceId: "port-object", pinName: "P" }],
+    });
+    document.netlist = {
+      name: "Child",
+      formalParameters: [],
+      terminals: [
+        {
+          id: "terminal-vout",
+          name: "Vout",
+          netId: "net-vout",
+          direction: "output",
+          interfaceInstanceId: "port-object",
+        },
+      ],
+    };
+    const formatOverride = {
+      runs: [
+        {
+          kind: "span" as const,
+          style: "overbar" as const,
+          children: [{ kind: "text" as const, value: "Vout" }],
+        },
+      ],
+    };
+
+    const result = executeTransaction(document, {
+      ...transaction(),
+      edits: [
+        {
+          kind: "upsert_schematic_annotation",
+          annotation: {
+            id: "instance-label-port-object",
+            kind: "instance-label",
+            binding: {
+              kind: "cell-terminal-name",
+              terminalId: "terminal-vout",
+            },
+            formatOverride,
+            anchor: {
+              kind: "object",
+              objectId: "port-object",
+              localOffset: { x: 0, y: 0 },
+              fallbackPosition: { x: 0, y: 0 },
+            },
+            alignment: "middle",
+            rotation: 0,
+            locked: false,
+          },
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({ ok: true });
+    if (!result.ok) return;
+    expect(result.document.netlist!.terminals[0]!.name).toBe("Vout");
+    expect(result.document.annotations[0]!.formatOverride).toEqual(
+      formatOverride,
+    );
+
+    const renamed = executeTransaction(result.document, {
+      ...transaction(),
+      expectedRevision: result.document.revision,
+      edits: [
+        {
+          kind: "update_cell_terminal",
+          terminalId: "terminal-vout",
+          name: "OUT",
+        },
+      ],
+    });
+    expect(renamed).toMatchObject({ ok: true });
+    if (!renamed.ok) return;
+    expect(renamed.document.annotations[0]!.formatOverride).toBeUndefined();
+  });
+
+  it("clears a stale Net-label format override when the Net is renamed", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.nets.push({
+      id: "net-vin",
+      name: "VIN",
+      scope: "local",
+      terminals: [],
+    });
+    document.annotations.push({
+      id: "label-vin",
+      kind: "net-label",
+      binding: { kind: "net-name", netId: "net-vin" },
+      formatOverride: {
+        runs: [
+          {
+            kind: "span",
+            style: "italic",
+            children: [{ kind: "text", value: "VIN" }],
+          },
+        ],
+      },
+      netId: "net-vin",
+      anchor: { kind: "free", position: { x: 0, y: 0 } },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    });
+
+    const result = executeTransaction(document, {
+      ...transaction(),
+      edits: [{ kind: "set_net_name", netId: "net-vin", name: "VINP" }],
+    });
+
+    expect(result).toMatchObject({ ok: true });
+    if (!result.ok) return;
+    expect(result.document.annotations[0]!.formatOverride).toBeUndefined();
+  });
+
   it("enforces the same layout lock before placing a retained Instance", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.instances.push({

--- a/packages/edit-engine/src/transaction.test.ts
+++ b/packages/edit-engine/src/transaction.test.ts
@@ -37,6 +37,7 @@ function documentWithInstance() {
   document.instances.push({
     id: "M1",
     symbolId: "nmos",
+    schematicReference: "M1",
     placement: null,
     netlist: {
       reference: "M1",
@@ -59,6 +60,66 @@ function transaction(expectedRevision = 0, dryRun = false) {
 }
 
 describe("Edit Transaction envelope", () => {
+  it("updates a Port schematic reference without creating a netlist record", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.instances.push({
+      id: "port-object",
+      symbolId: "port",
+      schematicReference: "P1",
+      placement: null,
+    });
+    const result = executeTransaction(document, {
+      ...transaction(),
+      edits: [
+        {
+          kind: "set_instance_schematic_reference",
+          instanceId: "port-object",
+          reference: "P_IN",
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({ ok: true });
+    if (!result.ok) return;
+    expect(result.document.instances[0]?.schematicReference).toBe("P_IN");
+    expect(result.document.instances[0]).not.toHaveProperty("netlist");
+  });
+
+  it("enforces the same layout lock before placing a retained Instance", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.instances.push({
+      id: "P1",
+      symbolId: "port",
+      schematicReference: "P1",
+      placement: null,
+    });
+    document.layoutGroups.push({
+      id: "locked-port",
+      kind: "custom",
+      objectIds: ["P1"],
+      locked: true,
+    });
+    const result = executeTransaction(document, {
+      ...transaction(),
+      edits: [
+        {
+          kind: "place_instance",
+          instanceId: "P1",
+          placement: {
+            position: { x: 100, y: 100 },
+            rotation: 0,
+            mirror: "none",
+          },
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: "EDIT_PRECONDITION" },
+    });
+  });
+
   it("updates a RichText schematic name without changing the SPICE reference", () => {
     const document = documentWithInstance();
     const result = executeTransaction(document, {
@@ -780,7 +841,7 @@ describe("Edit Transaction envelope", () => {
     });
   });
 
-  it("enforces Cell reference policy and refreshes only a canonical label", () => {
+  it("keeps the schematic reference independent from the netlist reference", () => {
     const document = documentWithInstance();
     document.instances.push({
       id: "M2",
@@ -834,7 +895,7 @@ describe("Edit Transaction envelope", () => {
     if (!renamed.ok) return;
     expect(renamed.document.instances[0]?.netlist?.reference).toBe("M3");
     expect(flattenRichText(renamed.document.annotations[0]!.content!)).toBe(
-      "M3",
+      "M1",
     );
   });
 

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -1223,7 +1223,19 @@ export function executeTransaction(
             `Cell terminal does not exist: ${edit.terminalId}`,
           );
         }
-        if (edit.name !== undefined) terminal.name = edit.name;
+        if (edit.name !== undefined) {
+          terminal.name = edit.name;
+          for (const annotation of draft.annotations) {
+            if (
+              annotation.binding?.kind === "cell-terminal-name" &&
+              annotation.binding.terminalId === terminal.id &&
+              annotation.formatOverride
+            ) {
+              delete annotation.formatOverride;
+              changedObjectIds.add(annotation.id);
+            }
+          }
+        }
         if (edit.direction !== undefined) terminal.direction = edit.direction;
         changedObjectIds.add(terminal.id);
         connectivityChanged = true;
@@ -2211,6 +2223,16 @@ export function executeTransaction(
         }
         net.name = edit.name;
         changedObjectIds.add(net.id);
+        for (const annotation of draft.annotations) {
+          if (
+            annotation.binding?.kind === "net-name" &&
+            annotation.binding.netId === net.id &&
+            annotation.formatOverride
+          ) {
+            delete annotation.formatOverride;
+            changedObjectIds.add(annotation.id);
+          }
+        }
         connectivityChanged = true;
         break;
       }

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -55,7 +55,6 @@ import {
 } from "./transaction-route-follow.js";
 import {
   followAttachedAnnotations,
-  refreshInstanceReferenceAnnotation,
   refreshInstanceValueAnnotation,
   translateObjectAnchoredAnnotation,
 } from "./transaction-instance-annotations.js";
@@ -542,6 +541,13 @@ export function executeTransaction(
             [edit.instanceId],
           );
         }
+        const lockOwner = lockedLayoutOwner(draft, edit.instanceId);
+        if (lockOwner) {
+          return rejectAt(
+            "EDIT_PRECONDITION",
+            `Instance ${edit.instanceId} is locked by layout intent ${lockOwner}`,
+          );
+        }
         if (instance.placement !== null) {
           return rejectAt(
             "EDIT_PRECONDITION",
@@ -876,20 +882,59 @@ export function executeTransaction(
             [edit.instanceId],
           );
         }
-        const before: SchematicDocument["instances"][number] =
-          structuredClone(instance);
         instance.netlist.reference = edit.reference;
         const failure = referencePolicyFailure(draft, instance.id);
         if (failure) {
           return rejectAt("EDIT_PRECONDITION", failure, [], [instance.id]);
         }
-        refreshInstanceReferenceAnnotation(
-          draft,
-          before,
-          edit.instanceId,
-          changedObjectIds,
-        );
         changedObjectIds.add(edit.instanceId);
+        break;
+      }
+      case "set_instance_schematic_reference": {
+        const instance = draft.instances.find(
+          (candidate) => candidate.id === edit.instanceId,
+        );
+        if (!instance) {
+          return rejectAt(
+            "OBJECT_NOT_FOUND",
+            `Instance does not exist: ${edit.instanceId}`,
+            [],
+            [edit.instanceId],
+          );
+        }
+        if (instance.schematicReference === edit.reference) {
+          return rejectAt(
+            "EDIT_PRECONDITION",
+            "Schematic reference edit does not change the instance",
+            [],
+            [edit.instanceId],
+          );
+        }
+        const duplicate = draft.instances.find(
+          (candidate) =>
+            candidate.id !== instance.id &&
+            (
+              candidate.schematicReference ?? candidate.netlist?.reference
+            )?.toLowerCase() === edit.reference.toLowerCase(),
+        );
+        if (duplicate) {
+          return rejectAt(
+            "EDIT_PRECONDITION",
+            `Schematic reference is already in use: ${edit.reference}`,
+            [],
+            [duplicate.id],
+          );
+        }
+        instance.schematicReference = edit.reference;
+        changedObjectIds.add(instance.id);
+        for (const annotation of draft.annotations) {
+          if (
+            annotation.binding?.kind === "instance-designator" &&
+            annotation.binding.instanceId === instance.id
+          ) {
+            changedObjectIds.add(annotation.id);
+          }
+        }
         break;
       }
       case "set_instance_schematic_name": {
@@ -1106,14 +1151,6 @@ export function executeTransaction(
               `Bulk netlist patch does not change ${instance.id}`,
               [],
               [instance.id],
-            );
-          }
-          if (assignment.reference !== undefined) {
-            refreshInstanceReferenceAnnotation(
-              draft,
-              before,
-              instance.id,
-              changedObjectIds,
             );
           }
           if (parametersChanged) {

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -876,7 +876,7 @@ export function executeTransaction(
         changedObjectIds.add(edit.instanceId);
         for (const annotation of draft.annotations) {
           if (
-            annotation.binding?.kind === "instance-reference" &&
+            annotation.binding?.kind === "instance-schematic-name" &&
             annotation.binding.instanceId === instance.id
           ) {
             changedObjectIds.add(annotation.id);

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -552,6 +552,49 @@ export function executeTransaction(
         changedObjectIds.add(edit.instanceId);
         break;
       }
+      case "unplace_instance": {
+        const instance = draft.instances.find(
+          (candidate) => candidate.id === edit.instanceId,
+        );
+        if (!instance) {
+          return rejectAt(
+            "OBJECT_NOT_FOUND",
+            `Instance does not exist: ${edit.instanceId}`,
+            [],
+            [edit.instanceId],
+          );
+        }
+        const lockOwner = lockedLayoutOwner(draft, edit.instanceId);
+        if (lockOwner) {
+          return rejectAt(
+            "EDIT_PRECONDITION",
+            `Instance ${edit.instanceId} is locked by layout intent ${lockOwner}`,
+          );
+        }
+        if (instance.placement === null) {
+          return rejectAt(
+            "EDIT_PRECONDITION",
+            `Instance is already unplaced: ${edit.instanceId}`,
+          );
+        }
+        if (
+          draft.routes.some((route) =>
+            [route.from, route.to].some(
+              (endpoint) =>
+                endpoint.kind === "terminal" &&
+                endpoint.instanceId === edit.instanceId,
+            ),
+          )
+        ) {
+          return rejectAt(
+            "EDIT_PRECONDITION",
+            `Instance has routed terminals; detach routes before unplacing: ${edit.instanceId}`,
+          );
+        }
+        instance.placement = null;
+        changedObjectIds.add(edit.instanceId);
+        break;
+      }
       case "move_instance": {
         const instance = draft.instances.find(
           (candidate) => candidate.id === edit.instanceId,

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -902,6 +902,18 @@ export function executeTransaction(
             [edit.instanceId],
           );
         }
+        if (
+          draft.netlist?.terminals.some(
+            (terminal) => terminal.interfaceInstanceId === instance.id,
+          )
+        ) {
+          return rejectAt(
+            "EDIT_PRECONDITION",
+            "A formal Cell Port is identified by its Cell terminal name, not a schematic reference",
+            [],
+            [instance.id],
+          );
+        }
         if (instance.schematicReference === edit.reference) {
           return rejectAt(
             "EDIT_PRECONDITION",
@@ -929,7 +941,7 @@ export function executeTransaction(
         changedObjectIds.add(instance.id);
         for (const annotation of draft.annotations) {
           if (
-            annotation.binding?.kind === "instance-designator" &&
+            annotation.binding?.kind === "instance-schematic-name" &&
             annotation.binding.instanceId === instance.id
           ) {
             changedObjectIds.add(annotation.id);

--- a/packages/model/src/protocol-documentation.test.ts
+++ b/packages/model/src/protocol-documentation.test.ts
@@ -26,6 +26,10 @@ describe("Project protocol documentation", () => {
         `Project schema ${version} makes`,
       ],
       [
+        "docs/adr/0033-port-semantic-name-and-richtext-presentation.md",
+        `Project schema ${version} keeps`,
+      ],
+      [
         "docs/user/project-compatibility.md",
         `schema version is \`${version}\``,
       ],

--- a/packages/model/src/protocol-documentation.test.ts
+++ b/packages/model/src/protocol-documentation.test.ts
@@ -22,7 +22,7 @@ describe("Project protocol documentation", () => {
       ["docs/specs/project-file-format.md", `Project schema: \`${version}\``],
       ["docs/specs/editor-interaction.md", `schema-${version}`],
       [
-        "docs/adr/0026-definition-level-cell-symbol-presentation.md",
+        "docs/adr/0030-instance-identity-and-placement-lifecycle.md",
         `schema-${version} in-memory Project shape`,
       ],
       [

--- a/packages/model/src/protocol-documentation.test.ts
+++ b/packages/model/src/protocol-documentation.test.ts
@@ -22,8 +22,8 @@ describe("Project protocol documentation", () => {
       ["docs/specs/project-file-format.md", `Project schema: \`${version}\``],
       ["docs/specs/editor-interaction.md", `schema-${version}`],
       [
-        "docs/adr/0031-schematic-reference-and-port-lifecycle.md",
-        `Project schema ${version} adds`,
+        "docs/adr/0032-formal-port-display-and-retained-annotations.md",
+        `Project schema ${version} makes`,
       ],
       [
         "docs/user/project-compatibility.md",

--- a/packages/model/src/protocol-documentation.test.ts
+++ b/packages/model/src/protocol-documentation.test.ts
@@ -22,8 +22,8 @@ describe("Project protocol documentation", () => {
       ["docs/specs/project-file-format.md", `Project schema: \`${version}\``],
       ["docs/specs/editor-interaction.md", `schema-${version}`],
       [
-        "docs/adr/0030-instance-identity-and-placement-lifecycle.md",
-        `schema-${version} in-memory Project shape`,
+        "docs/adr/0031-schematic-reference-and-port-lifecycle.md",
+        `Project schema ${version} adds`,
       ],
       [
         "docs/user/project-compatibility.md",

--- a/packages/model/src/schema.test.ts
+++ b/packages/model/src/schema.test.ts
@@ -129,6 +129,20 @@ describe("CircuitProject schema", () => {
       terminalId: "terminal-vout",
     };
     expect(SchematicDocumentSchema.safeParse(document).success).toBe(true);
+    document.annotations[0]!.formatOverride = {
+      runs: [
+        {
+          kind: "span",
+          style: "bold",
+          children: [{ kind: "text", value: "Vout" }],
+        },
+      ],
+    };
+    expect(SchematicDocumentSchema.safeParse(document).success).toBe(true);
+    document.annotations[0]!.formatOverride = {
+      runs: [{ kind: "text", value: "Different alias" }],
+    };
+    expect(SchematicDocumentSchema.safeParse(document).success).toBe(false);
   });
 
   it("rejects a persisted page point that is not aligned to its Document grid", () => {

--- a/packages/model/src/schema.test.ts
+++ b/packages/model/src/schema.test.ts
@@ -80,6 +80,57 @@ describe("CircuitProject schema", () => {
     );
   });
 
+  it("rejects a schematic Reference on a formal Cell Port", () => {
+    const document = createEmptyProject("formal-port", "Formal Port")
+      .documents[0]!;
+    document.instances.push({
+      id: "port-object",
+      symbolId: "port",
+      schematicReference: "P1",
+      placement: null,
+    });
+    document.nets.push({
+      id: "net-vout",
+      scope: "local",
+      terminals: [{ instanceId: "port-object", pinName: "P" }],
+    });
+    document.netlist = {
+      name: "Child",
+      formalParameters: [],
+      terminals: [
+        {
+          id: "terminal-vout",
+          name: "Vout",
+          netId: "net-vout",
+          direction: "output",
+          interfaceInstanceId: "port-object",
+        },
+      ],
+    };
+
+    expect(SchematicDocumentSchema.safeParse(document).success).toBe(false);
+    delete document.instances[0]!.schematicReference;
+    expect(SchematicDocumentSchema.safeParse(document).success).toBe(true);
+    document.annotations.push({
+      id: "label-port",
+      kind: "instance-label",
+      binding: {
+        kind: "instance-schematic-name",
+        instanceId: "port-object",
+      },
+      anchor: { kind: "free", position: { x: 0, y: 0 } },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    });
+    expect(SchematicDocumentSchema.safeParse(document).success).toBe(false);
+    document.annotations[0]!.binding = {
+      kind: "cell-terminal-name",
+      terminalId: "terminal-vout",
+    };
+    expect(SchematicDocumentSchema.safeParse(document).success).toBe(true);
+  });
+
   it("rejects a persisted page point that is not aligned to its Document grid", () => {
     const document = createEmptyProject("project-grid", "Grid").documents[0]!;
     document.drafting!.objects.push({

--- a/packages/model/src/schema/annotations.ts
+++ b/packages/model/src/schema/annotations.ts
@@ -37,7 +37,18 @@ export const AnnotationKindSchema = z.enum([
  */
 export const AnnotationTextBindingSchema = z.discriminatedUnion("kind", [
   z.strictObject({
-    kind: z.literal("instance-reference"),
+    /** The emitted SPICE/Spectre designator, never the internal object ID. */
+    kind: z.literal("instance-designator"),
+    instanceId: StableIdSchema,
+  }),
+  z.strictObject({
+    /** The user-owned RichText alias shown only on this schematic. */
+    kind: z.literal("instance-schematic-name"),
+    instanceId: StableIdSchema,
+  }),
+  z.strictObject({
+    /** The binding target's human-readable master/Cell/model name. */
+    kind: z.literal("instance-master-name"),
     instanceId: StableIdSchema,
   }),
   z.strictObject({

--- a/packages/model/src/schema/annotations.ts
+++ b/packages/model/src/schema/annotations.ts
@@ -37,12 +37,12 @@ export const AnnotationKindSchema = z.enum([
  */
 export const AnnotationTextBindingSchema = z.discriminatedUnion("kind", [
   z.strictObject({
-    /** The schematic-facing instance reference, never the internal object ID. */
+    /** Optional, read-only emitted network designator; never an object ID. */
     kind: z.literal("instance-designator"),
     instanceId: StableIdSchema,
   }),
   z.strictObject({
-    /** The user-owned RichText alias shown only on this schematic. */
+    /** The default user-owned RichText schematic label. */
     kind: z.literal("instance-schematic-name"),
     instanceId: StableIdSchema,
   }),

--- a/packages/model/src/schema/annotations.ts
+++ b/packages/model/src/schema/annotations.ts
@@ -37,7 +37,7 @@ export const AnnotationKindSchema = z.enum([
  */
 export const AnnotationTextBindingSchema = z.discriminatedUnion("kind", [
   z.strictObject({
-    /** The emitted SPICE/Spectre designator, never the internal object ID. */
+    /** The schematic-facing instance reference, never the internal object ID. */
     kind: z.literal("instance-designator"),
     instanceId: StableIdSchema,
   }),

--- a/packages/model/src/schema/annotations.ts
+++ b/packages/model/src/schema/annotations.ts
@@ -78,6 +78,8 @@ export const AnnotationSchema = z
     // marker authoring; all semantic annotation producers write `binding`.
     content: RichTextDocumentSchema.optional(),
     binding: AnnotationTextBindingSchema.optional(),
+    /** Same-text RichText formatting for an editable semantic name binding. */
+    formatOverride: RichTextDocumentSchema.optional(),
     anchor: VisualAnchorSchema,
     netId: StableIdSchema.optional(),
     alignment: z.enum(["start", "middle", "end"]),
@@ -94,6 +96,18 @@ export const AnnotationSchema = z
         path: ["binding"],
         message:
           "Annotations require exactly one literal content or text binding",
+      });
+    }
+    if (
+      annotation.formatOverride &&
+      annotation.binding?.kind !== "net-name" &&
+      annotation.binding?.kind !== "cell-terminal-name"
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["formatOverride"],
+        message:
+          "RichText format overrides require an editable Net or Cell-terminal name binding",
       });
     }
     if (annotation.markerKind && annotation.kind !== "route-marker") {

--- a/packages/model/src/schema/common.ts
+++ b/packages/model/src/schema/common.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-export const CURRENT_PROJECT_SCHEMA_VERSION = 15;
+export const CURRENT_PROJECT_SCHEMA_VERSION = 16;
 
 export const StableIdSchema = z.string().min(1).max(256);
 /** A persisted Document page point before its Document-grid relation is known. */

--- a/packages/model/src/schema/common.ts
+++ b/packages/model/src/schema/common.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-export const CURRENT_PROJECT_SCHEMA_VERSION = 16;
+export const CURRENT_PROJECT_SCHEMA_VERSION = 17;
 
 export const StableIdSchema = z.string().min(1).max(256);
 /** A persisted Document page point before its Document-grid relation is known. */

--- a/packages/model/src/schema/common.ts
+++ b/packages/model/src/schema/common.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-export const CURRENT_PROJECT_SCHEMA_VERSION = 17;
+export const CURRENT_PROJECT_SCHEMA_VERSION = 18;
 
 export const StableIdSchema = z.string().min(1).max(256);
 /** A persisted Document page point before its Document-grid relation is known. */

--- a/packages/model/src/schema/document.ts
+++ b/packages/model/src/schema/document.ts
@@ -11,6 +11,8 @@ import { NetSchema, NoConnectSchema } from "./connectivity.js";
 import { JunctionSchema, RouteBranchSchema } from "./routing.js";
 import { AnnotationSchema, VisualAnchorSchema } from "./annotations.js";
 import { DraftingLayerSchema } from "./drafting.js";
+import { flattenRichText } from "../rich-text.js";
+import { semanticTextDocument } from "../semantic-text.js";
 import {
   LayoutConstraintSchema,
   LayoutGroupSchema,
@@ -438,6 +440,34 @@ export const SchematicDocumentSchema = SchematicDocumentBaseSchema.superRefine(
           message:
             "A formal Cell Port projects only its Cell terminal name annotation",
           path: ["annotations", annotationIndex, "binding"],
+        });
+      }
+      if (!annotation.formatOverride || !binding) continue;
+      const semanticContent =
+        binding.kind === "cell-terminal-name"
+          ? semanticTextDocument(
+              document.netlist?.terminals.find(
+                (terminal) => terminal.id === binding.terminalId,
+              )?.name ?? "",
+              "formal-port",
+            )
+          : binding.kind === "net-name"
+            ? semanticTextDocument(
+                document.nets.find((net) => net.id === binding.netId)?.name ??
+                  "",
+                annotation.kind === "power-label" ? "power-label" : "net-label",
+              )
+            : null;
+      if (
+        semanticContent &&
+        flattenRichText(annotation.formatOverride) !==
+          flattenRichText(semanticContent)
+      ) {
+        context.addIssue({
+          code: "custom",
+          message:
+            "A bound RichText format override must preserve the semantic name text",
+          path: ["annotations", annotationIndex, "formatOverride"],
         });
       }
     }

--- a/packages/model/src/schema/document.ts
+++ b/packages/model/src/schema/document.ts
@@ -394,6 +394,19 @@ export const SchematicDocumentSchema = SchematicDocumentBaseSchema.superRefine(
       }
       netlistReferences.add(reference);
     }
+    const schematicReferences = new Set<string>();
+    for (const [instanceIndex, instance] of document.instances.entries()) {
+      const reference = instance.schematicReference?.toLowerCase();
+      if (!reference) continue;
+      if (schematicReferences.has(reference)) {
+        context.addIssue({
+          code: "custom",
+          message: `Duplicate schematic instance reference: ${instance.schematicReference}`,
+          path: ["instances", instanceIndex, "schematicReference"],
+        });
+      }
+      schematicReferences.add(reference);
+    }
     for (const [instanceIndex, instance] of document.instances.entries()) {
       const binding = instance.mosBulkBinding;
       if (!binding) continue;

--- a/packages/model/src/schema/document.ts
+++ b/packages/model/src/schema/document.ts
@@ -395,7 +395,23 @@ export const SchematicDocumentSchema = SchematicDocumentBaseSchema.superRefine(
       netlistReferences.add(reference);
     }
     const schematicReferences = new Set<string>();
+    const formalPortInstanceIds = new Set(
+      (document.netlist?.terminals ?? []).map(
+        (terminal) => terminal.interfaceInstanceId,
+      ),
+    );
     for (const [instanceIndex, instance] of document.instances.entries()) {
+      if (
+        formalPortInstanceIds.has(instance.id) &&
+        instance.schematicReference !== undefined
+      ) {
+        context.addIssue({
+          code: "custom",
+          message:
+            "A formal Cell Port is identified by its Cell terminal name, not a schematic reference",
+          path: ["instances", instanceIndex, "schematicReference"],
+        });
+      }
       const reference = instance.schematicReference?.toLowerCase();
       if (!reference) continue;
       if (schematicReferences.has(reference)) {
@@ -406,6 +422,24 @@ export const SchematicDocumentSchema = SchematicDocumentBaseSchema.superRefine(
         });
       }
       schematicReferences.add(reference);
+    }
+    for (const [
+      annotationIndex,
+      annotation,
+    ] of document.annotations.entries()) {
+      const binding = annotation.binding;
+      if (
+        (binding?.kind === "instance-designator" ||
+          binding?.kind === "instance-schematic-name") &&
+        formalPortInstanceIds.has(binding.instanceId)
+      ) {
+        context.addIssue({
+          code: "custom",
+          message:
+            "A formal Cell Port projects only its Cell terminal name annotation",
+          path: ["annotations", annotationIndex, "binding"],
+        });
+      }
     }
     for (const [instanceIndex, instance] of document.instances.entries()) {
       const binding = instance.mosBulkBinding;

--- a/packages/model/src/schema/instance.ts
+++ b/packages/model/src/schema/instance.ts
@@ -105,16 +105,16 @@ export const InstanceSchema = z
     mosBulkBinding: MosBulkBindingSchema.optional(),
     placement: PlacementSchema.nullable(),
     /**
-     * The schematic-facing instance reference. This is intentionally separate
-     * from the optional emitted SPICE/Spectre designator so non-emitting
-     * presentation objects, including Ports, still have a stable reference.
+     * Internal, stable schematic reference used for lifecycle and as an
+     * initial label fallback. It is intentionally separate from the optional
+     * emitted SPICE/Spectre designator and is never an object identity.
      */
     schematicReference: NetlistIdentifierSchema.optional(),
     netlist: InstanceNetlistDataSchema.optional(),
     /**
-     * User-owned schematic alias. Unlike `netlist.reference`, this RichText
-     * source is presentation-only: it may be repeated, formatted, and changed
-     * without modifying the electrical/export identity.
+     * User-owned RichText schematic label. This is the default visible label;
+     * it may be repeated, formatted, and changed without modifying the
+     * electrical/export identity.
      */
     schematicName: RichTextDocumentSchema.optional(),
   })

--- a/packages/model/src/schema/instance.ts
+++ b/packages/model/src/schema/instance.ts
@@ -104,6 +104,12 @@ export const InstanceSchema = z
     // Explicit SPICE/user B connections need no parallel metadata.
     mosBulkBinding: MosBulkBindingSchema.optional(),
     placement: PlacementSchema.nullable(),
+    /**
+     * The schematic-facing instance reference. This is intentionally separate
+     * from the optional emitted SPICE/Spectre designator so non-emitting
+     * presentation objects, including Ports, still have a stable reference.
+     */
+    schematicReference: NetlistIdentifierSchema.optional(),
     netlist: InstanceNetlistDataSchema.optional(),
     /**
      * User-owned schematic alias. Unlike `netlist.reference`, this RichText

--- a/packages/project-protocol/src/persistence.test.ts
+++ b/packages/project-protocol/src/persistence.test.ts
@@ -19,9 +19,7 @@ class MemoryStorage implements ProjectStorage {
 
   async readText(path: string): Promise<string> {
     const content = this.files.get(path);
-    if (content === undefined) {
-      throw new Error(`Missing file: ${path}`);
-    }
+    if (content === undefined) throw new Error(`Missing file: ${path}`);
     return content;
   }
 
@@ -70,65 +68,68 @@ describe("Project persistence", () => {
     }
   });
 
-  it("upgrades the previous schema while preserving netlist parameters", () => {
-    const project = createEmptyProject("project-test", "Test Project");
-    const source = {
-      ...JSON.parse(serializeProject(project)),
-      schemaVersion: 14,
-    };
-    delete source.externalSubcircuitDefinitions;
-    delete source.documents[0].netlist.formalParameters;
-    source.documents[0].instances.push({
-      id: "R1",
-      symbolId: "resistor",
-      placement: null,
-      properties: { value: "20k" },
-    });
-    source.documents[0].annotations.push({
-      id: "plain-v13-value",
-      kind: "instance-value",
-      content: { runs: [{ kind: "text", value: "20u/1u" }] },
-      anchor: { kind: "free", position: { x: 0, y: 0 } },
-      alignment: "start",
-      rotation: 0,
-      locked: false,
-    });
-    const parsed = parseProjectWithMetadata(JSON.stringify(source));
-
-    expect(parsed).toMatchObject({
-      sourceSchemaVersion: 14,
-      migrated: true,
-      project: {
-        schemaVersion: 15,
-        structureRevision: 0,
-        externalSubcircuitDefinitions: [],
-        documents: [
-          {
-            netlist: { formalParameters: [] },
-            instances: [
-              {
-                id: "R1",
-                netlist: { reference: "R1", parameters: { value: "20k" } },
-              },
-            ],
-          },
-        ],
-      },
-    });
-    expect(parsed.project.documents[0]!.instances[0]).not.toHaveProperty(
-      "properties",
+  it("upgrades legacy reference labels to their visible schema-16 sources", () => {
+    const source = JSON.parse(
+      serializeProject(createEmptyProject("project-test", "Test Project")),
     );
+    source.schemaVersion = 15;
+    source.documents[0].instances.push(
+      {
+        id: "R-object",
+        symbolId: "resistor",
+        placement: null,
+        netlist: { reference: "R7", parameters: {} },
+      },
+      {
+        id: "M-object",
+        symbolId: "nmos",
+        placement: null,
+        netlist: { reference: "M3", parameters: {} },
+        schematicName: { runs: [{ kind: "text", value: "Input pair" }] },
+      },
+    );
+    source.documents[0].annotations.push(
+      {
+        id: "reference-R",
+        kind: "instance-label",
+        binding: { kind: "instance-reference", instanceId: "R-object" },
+        anchor: { kind: "free", position: { x: 0, y: 0 } },
+        alignment: "start",
+        rotation: 0,
+        locked: false,
+      },
+      {
+        id: "reference-M",
+        kind: "instance-label",
+        binding: { kind: "instance-reference", instanceId: "M-object" },
+        anchor: { kind: "free", position: { x: 20, y: 0 } },
+        alignment: "start",
+        rotation: 0,
+        locked: false,
+      },
+    );
+
+    const migrated = parseProjectWithMetadata(JSON.stringify(source));
+    expect(migrated).toMatchObject({
+      sourceSchemaVersion: 15,
+      migrated: true,
+      project: { schemaVersion: 16 },
+    });
+    expect(
+      migrated.project.documents[0]!.annotations.map(
+        (annotation) => annotation.binding,
+      ),
+    ).toEqual([
+      { kind: "instance-designator", instanceId: "R-object" },
+      { kind: "instance-schematic-name", instanceId: "M-object" },
+    ]);
   });
 
   it("lets an upgraded previous Project author and persist current content", () => {
-    const source = {
-      ...JSON.parse(
-        serializeProject(createEmptyProject("project-test", "Test Project")),
-      ),
-      schemaVersion: 14,
-    };
-    delete source.externalSubcircuitDefinitions;
-    delete source.documents[0].netlist.formalParameters;
+    const source = JSON.parse(
+      serializeProject(createEmptyProject("project-test", "Test Project")),
+    );
+    source.schemaVersion = 15;
     const project = parseProject(JSON.stringify(source));
     project.documents[0]!.annotations.push({
       id: "value-fraction",
@@ -149,147 +150,19 @@ describe("Project persistence", () => {
     });
 
     const reopened = parseProject(serializeProject(project));
-    expect(reopened.schemaVersion).toBe(15);
+    expect(reopened.schemaVersion).toBe(16);
     expect(
       reopened.documents[0]!.annotations[0]?.content!.runs[0],
-    ).toMatchObject({
-      kind: "fraction",
-      numerator: { runs: [{ value: "10um" }] },
-      denominator: { runs: [{ value: "150nm" }] },
-    });
-  });
-
-  it("rejects conflicting legacy electrical values instead of choosing one", () => {
-    const source = JSON.parse(
-      serializeProject(createEmptyProject("project-conflict", "Conflict")),
-    );
-    source.schemaVersion = 14;
-    delete source.externalSubcircuitDefinitions;
-    delete source.documents[0].netlist.formalParameters;
-    source.documents[0].instances.push({
-      id: "R1",
-      symbolId: "resistor",
-      placement: null,
-      properties: { value: "10k" },
-      netlist: { reference: "R1", parameters: { value: "20k" } },
-    });
-
-    expect(() => parseProject(JSON.stringify(source))).toThrow(
-      /conflicts with netlist.parameters.value/,
-    );
-  });
-
-  it("groups consistent external imports and preserves a conflicting one as unresolved", () => {
-    const source = JSON.parse(
-      serializeProject(createEmptyProject("project-external", "External")),
-    );
-    source.schemaVersion = 14;
-    delete source.externalSubcircuitDefinitions;
-    delete source.documents[0].netlist.formalParameters;
-    const imported = (id: string, pinName: string) => ({
-      id,
-      symbolId: "generic-block-2",
-      placement: null,
-      netlist: {
-        reference: id,
-        parameters: {},
-        terminals: [{ sourcePosition: 0, pinName }],
-        binding: { kind: "external-subcircuit", name: "OPA" },
-      },
-    });
-    source.documents[0].instances.push(
-      imported("X1", "IN"),
-      imported("X2", "INPUT"),
-    );
-
-    const migrated = parseProject(JSON.stringify(source));
-    expect(migrated.externalSubcircuitDefinitions).toEqual([
-      {
-        id: "external-subcircuit-opa",
-        name: "OPA",
-        terminals: [
-          {
-            id: "external-terminal-external-subcircuit-opa-1",
-            name: "IN",
-            direction: "passive",
-          },
-        ],
-        formalParameters: [],
-        interfaceStatus: "declared",
-      },
-    ]);
-    expect(
-      migrated.documents[0]!.instances.map(
-        (instance) => instance.netlist!.binding,
-      ),
-    ).toEqual([
-      { kind: "external-subcircuit", definitionId: "external-subcircuit-opa" },
-      { kind: "unresolved-subcircuit", name: "OPA" },
-    ]);
+    ).toMatchObject({ kind: "fraction" });
   });
 
   it("rejects schemas outside the rolling current-and-previous window", () => {
     const project = createEmptyProject("project-test", "Test Project");
     expect(() =>
       parseProject(JSON.stringify({ ...project, schemaVersion: 99 })),
-    ).toThrow(/must be 14 or 15/);
+    ).toThrow(/must be 15 or 16/);
     expect(() =>
-      parseProject(JSON.stringify({ ...project, schemaVersion: 12 })),
-    ).toThrow(/must be 14 or 15/);
-  });
-
-  it("preserves previous-schema formal terminal identity without adding visual intent", () => {
-    const source = JSON.parse(
-      serializeProject(createEmptyProject("project-port", "Port migration")),
-    );
-    source.schemaVersion = 14;
-    delete source.externalSubcircuitDefinitions;
-    delete source.documents[0].netlist.formalParameters;
-    source.documents[0].nets.push({
-      id: "net-input",
-      name: "VIN",
-      scope: "local",
-      terminals: [],
-    });
-    source.documents[0].instances.push({
-      id: "P1",
-      symbolId: "port",
-      placement: null,
-    });
-    source.documents[0].netlist.terminals.push({
-      id: "terminal-input",
-      name: "VIN",
-      netId: "net-input",
-      direction: "input",
-      interfaceInstanceId: "P1",
-    });
-    source.documents[0].nets[0].terminals.push({
-      instanceId: "P1",
-      pinName: "P",
-    });
-
-    const migrated = parseProjectWithMetadata(JSON.stringify(source));
-    const document = migrated.project.documents[0]!;
-    const terminal = document.netlist!.terminals[0]!;
-    const marker = document.instances.find(
-      (instance) => instance.id === terminal.interfaceInstanceId,
-    );
-
-    expect(migrated).toMatchObject({
-      sourceSchemaVersion: 14,
-      migrated: true,
-    });
-    expect(terminal).toMatchObject({
-      name: "VIN",
-      netId: "net-input",
-      direction: "input",
-    });
-    expect(terminal.id).toBe("terminal-input");
-    expect(marker).toMatchObject({
-      id: "P1",
-      symbolId: "port",
-      placement: null,
-    });
-    expect(document.presentation.cellSymbol).toBeUndefined();
+      parseProject(JSON.stringify({ ...project, schemaVersion: 14 })),
+    ).toThrow(/must be 15 or 16/);
   });
 });

--- a/packages/project-protocol/src/persistence.test.ts
+++ b/packages/project-protocol/src/persistence.test.ts
@@ -68,11 +68,11 @@ describe("Project persistence", () => {
     }
   });
 
-  it("upgrades legacy reference labels to their visible schema-16 sources", () => {
+  it("upgrades schema-16 Instances with schematic references", () => {
     const source = JSON.parse(
       serializeProject(createEmptyProject("project-test", "Test Project")),
     );
-    source.schemaVersion = 15;
+    source.schemaVersion = 16;
     source.documents[0].instances.push(
       {
         id: "R-object",
@@ -92,7 +92,7 @@ describe("Project persistence", () => {
       {
         id: "reference-R",
         kind: "instance-label",
-        binding: { kind: "instance-reference", instanceId: "R-object" },
+        binding: { kind: "instance-designator", instanceId: "R-object" },
         anchor: { kind: "free", position: { x: 0, y: 0 } },
         alignment: "start",
         rotation: 0,
@@ -101,7 +101,10 @@ describe("Project persistence", () => {
       {
         id: "reference-M",
         kind: "instance-label",
-        binding: { kind: "instance-reference", instanceId: "M-object" },
+        binding: {
+          kind: "instance-schematic-name",
+          instanceId: "M-object",
+        },
         anchor: { kind: "free", position: { x: 20, y: 0 } },
         alignment: "start",
         rotation: 0,
@@ -111,9 +114,9 @@ describe("Project persistence", () => {
 
     const migrated = parseProjectWithMetadata(JSON.stringify(source));
     expect(migrated).toMatchObject({
-      sourceSchemaVersion: 15,
+      sourceSchemaVersion: 16,
       migrated: true,
-      project: { schemaVersion: 16 },
+      project: { schemaVersion: 17 },
     });
     expect(
       migrated.project.documents[0]!.annotations.map(
@@ -123,13 +126,17 @@ describe("Project persistence", () => {
       { kind: "instance-designator", instanceId: "R-object" },
       { kind: "instance-schematic-name", instanceId: "M-object" },
     ]);
+    expect(migrated.project.documents[0]!.instances).toMatchObject([
+      { id: "R-object", schematicReference: "R7" },
+      { id: "M-object", schematicReference: "M3" },
+    ]);
   });
 
   it("lets an upgraded previous Project author and persist current content", () => {
     const source = JSON.parse(
       serializeProject(createEmptyProject("project-test", "Test Project")),
     );
-    source.schemaVersion = 15;
+    source.schemaVersion = 16;
     const project = parseProject(JSON.stringify(source));
     project.documents[0]!.annotations.push({
       id: "value-fraction",
@@ -150,7 +157,7 @@ describe("Project persistence", () => {
     });
 
     const reopened = parseProject(serializeProject(project));
-    expect(reopened.schemaVersion).toBe(16);
+    expect(reopened.schemaVersion).toBe(17);
     expect(
       reopened.documents[0]!.annotations[0]?.content!.runs[0],
     ).toMatchObject({ kind: "fraction" });
@@ -160,9 +167,9 @@ describe("Project persistence", () => {
     const project = createEmptyProject("project-test", "Test Project");
     expect(() =>
       parseProject(JSON.stringify({ ...project, schemaVersion: 99 })),
-    ).toThrow(/must be 15 or 16/);
+    ).toThrow(/must be 16 or 17/);
     expect(() =>
       parseProject(JSON.stringify({ ...project, schemaVersion: 14 })),
-    ).toThrow(/must be 15 or 16/);
+    ).toThrow(/must be 16 or 17/);
   });
 });

--- a/packages/project-protocol/src/persistence.test.ts
+++ b/packages/project-protocol/src/persistence.test.ts
@@ -68,42 +68,70 @@ describe("Project persistence", () => {
     }
   });
 
-  it("upgrades schema-16 Instances with schematic references", () => {
+  it("upgrades schema-17 default labels and formal Ports to their schema-18 identities", () => {
     const source = JSON.parse(
       serializeProject(createEmptyProject("project-test", "Test Project")),
     );
-    source.schemaVersion = 16;
-    source.documents[0].instances.push(
-      {
-        id: "R-object",
-        symbolId: "resistor",
-        placement: null,
-        netlist: { reference: "R7", parameters: {} },
-      },
-      {
-        id: "M-object",
-        symbolId: "nmos",
-        placement: null,
-        netlist: { reference: "M3", parameters: {} },
-        schematicName: { runs: [{ kind: "text", value: "Input pair" }] },
-      },
-    );
+    source.schemaVersion = 17;
+    source.documents[0].instances.push({
+      id: "P-object",
+      symbolId: "port",
+      schematicReference: "P1",
+      placement: null,
+    });
+    source.documents[0].instances.push({
+      id: "opaque-resistor-id",
+      symbolId: "resistor",
+      schematicReference: "R7",
+      placement: null,
+      netlist: { reference: "R7", parameters: {} },
+    });
+    source.documents[0].netlist = {
+      name: "Child",
+      terminals: [
+        {
+          id: "terminal-vout",
+          name: "Vout",
+          netId: "net-vout",
+          direction: "output",
+          interfaceInstanceId: "P-object",
+        },
+      ],
+      formalParameters: [],
+    };
+    source.documents[0].nets.push({
+      id: "net-vout",
+      scope: "local",
+      terminals: [{ instanceId: "P-object", pinName: "P" }],
+    });
     source.documents[0].annotations.push(
       {
-        id: "reference-R",
+        id: "reference-P",
         kind: "instance-label",
-        binding: { kind: "instance-designator", instanceId: "R-object" },
+        binding: { kind: "instance-designator", instanceId: "P-object" },
         anchor: { kind: "free", position: { x: 0, y: 0 } },
         alignment: "start",
         rotation: 0,
         locked: false,
       },
       {
-        id: "reference-M",
+        id: "reference-R7",
         kind: "instance-label",
         binding: {
-          kind: "instance-schematic-name",
-          instanceId: "M-object",
+          kind: "instance-designator",
+          instanceId: "opaque-resistor-id",
+        },
+        anchor: { kind: "free", position: { x: 40, y: 0 } },
+        alignment: "start",
+        rotation: 0,
+        locked: false,
+      },
+      {
+        id: "terminal-name",
+        kind: "instance-label",
+        binding: {
+          kind: "cell-terminal-name",
+          terminalId: "terminal-vout",
         },
         anchor: { kind: "free", position: { x: 20, y: 0 } },
         alignment: "start",
@@ -114,29 +142,31 @@ describe("Project persistence", () => {
 
     const migrated = parseProjectWithMetadata(JSON.stringify(source));
     expect(migrated).toMatchObject({
-      sourceSchemaVersion: 16,
+      sourceSchemaVersion: 17,
       migrated: true,
-      project: { schemaVersion: 17 },
+      project: { schemaVersion: 18 },
     });
     expect(
       migrated.project.documents[0]!.annotations.map(
         (annotation) => annotation.binding,
       ),
     ).toEqual([
-      { kind: "instance-designator", instanceId: "R-object" },
-      { kind: "instance-schematic-name", instanceId: "M-object" },
+      { kind: "cell-terminal-name", terminalId: "terminal-vout" },
+      { kind: "instance-schematic-name", instanceId: "opaque-resistor-id" },
     ]);
-    expect(migrated.project.documents[0]!.instances).toMatchObject([
-      { id: "R-object", schematicReference: "R7" },
-      { id: "M-object", schematicReference: "M3" },
-    ]);
+    expect(migrated.project.documents[0]!.instances[0]).toMatchObject({
+      id: "P-object",
+    });
+    expect(migrated.project.documents[0]!.instances[0]).not.toHaveProperty(
+      "schematicReference",
+    );
   });
 
   it("lets an upgraded previous Project author and persist current content", () => {
     const source = JSON.parse(
       serializeProject(createEmptyProject("project-test", "Test Project")),
     );
-    source.schemaVersion = 16;
+    source.schemaVersion = 17;
     const project = parseProject(JSON.stringify(source));
     project.documents[0]!.annotations.push({
       id: "value-fraction",
@@ -157,7 +187,7 @@ describe("Project persistence", () => {
     });
 
     const reopened = parseProject(serializeProject(project));
-    expect(reopened.schemaVersion).toBe(17);
+    expect(reopened.schemaVersion).toBe(18);
     expect(
       reopened.documents[0]!.annotations[0]?.content!.runs[0],
     ).toMatchObject({ kind: "fraction" });
@@ -167,9 +197,9 @@ describe("Project persistence", () => {
     const project = createEmptyProject("project-test", "Test Project");
     expect(() =>
       parseProject(JSON.stringify({ ...project, schemaVersion: 99 })),
-    ).toThrow(/must be 16 or 17/);
+    ).toThrow(/must be 17 or 18/);
     expect(() =>
-      parseProject(JSON.stringify({ ...project, schemaVersion: 14 })),
-    ).toThrow(/must be 16 or 17/);
+      parseProject(JSON.stringify({ ...project, schemaVersion: 16 })),
+    ).toThrow(/must be 17 or 18/);
   });
 });

--- a/packages/project-protocol/src/protocol.test.ts
+++ b/packages/project-protocol/src/protocol.test.ts
@@ -16,21 +16,21 @@ describe("Project protocol boundary", () => {
     });
   });
 
-  it("keeps the direct schema-14 to schema-15 upgrade", () => {
+  it("keeps the direct schema-15 to schema-16 upgrade", () => {
     const current = JSON.parse(
       serializeProject(createEmptyProject("protocol-project", "Protocol")),
     ) as Record<string, unknown>;
     const result = tryParseProjectWithMetadata(
       JSON.stringify({
         ...current,
-        schemaVersion: 14,
+        schemaVersion: 15,
       }),
     );
     expect(result).toMatchObject({
       ok: true,
-      sourceSchemaVersion: 14,
+      sourceSchemaVersion: 15,
       migrated: true,
-      project: { schemaVersion: 15, structureRevision: 0 },
+      project: { schemaVersion: 16, structureRevision: 0 },
     });
   });
 

--- a/packages/project-protocol/src/protocol.test.ts
+++ b/packages/project-protocol/src/protocol.test.ts
@@ -16,21 +16,21 @@ describe("Project protocol boundary", () => {
     });
   });
 
-  it("keeps the direct schema-15 to schema-16 upgrade", () => {
+  it("keeps the direct schema-16 to schema-17 upgrade", () => {
     const current = JSON.parse(
       serializeProject(createEmptyProject("protocol-project", "Protocol")),
     ) as Record<string, unknown>;
     const result = tryParseProjectWithMetadata(
       JSON.stringify({
         ...current,
-        schemaVersion: 15,
+        schemaVersion: 16,
       }),
     );
     expect(result).toMatchObject({
       ok: true,
-      sourceSchemaVersion: 15,
+      sourceSchemaVersion: 16,
       migrated: true,
-      project: { schemaVersion: 16, structureRevision: 0 },
+      project: { schemaVersion: 17, structureRevision: 0 },
     });
   });
 

--- a/packages/project-protocol/src/protocol.test.ts
+++ b/packages/project-protocol/src/protocol.test.ts
@@ -16,21 +16,21 @@ describe("Project protocol boundary", () => {
     });
   });
 
-  it("keeps the direct schema-16 to schema-17 upgrade", () => {
+  it("keeps the direct schema-17 to schema-18 upgrade", () => {
     const current = JSON.parse(
       serializeProject(createEmptyProject("protocol-project", "Protocol")),
     ) as Record<string, unknown>;
     const result = tryParseProjectWithMetadata(
       JSON.stringify({
         ...current,
-        schemaVersion: 16,
+        schemaVersion: 17,
       }),
     );
     expect(result).toMatchObject({
       ok: true,
-      sourceSchemaVersion: 16,
+      sourceSchemaVersion: 17,
       migrated: true,
-      project: { schemaVersion: 17, structureRevision: 0 },
+      project: { schemaVersion: 18, structureRevision: 0 },
     });
   });
 

--- a/packages/project-protocol/src/transforms/project.ts
+++ b/packages/project-protocol/src/transforms/project.ts
@@ -13,58 +13,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function schematicReferencePrefix(instance: Record<string, unknown>): string {
-  switch (instance.symbolId) {
-    case "resistor":
-      return "R";
-    case "capacitor":
-      return "C";
-    case "inductor":
-      return "L";
-    case "diode":
-      return "D";
-    case "nmos":
-    case "pmos":
-      return "M";
-    case "npn":
-    case "pnp":
-      return "Q";
-    case "voltage-source":
-      return "V";
-    case "current-source":
-      return "I";
-    case "port":
-    case "port-filled":
-      return "P";
-    case "ground":
-      return "GND";
-    case "vdd-port":
-      return "VDD";
-    default: {
-      const netlist = isRecord(instance.netlist) ? instance.netlist : null;
-      const binding =
-        netlist && isRecord(netlist.binding) ? netlist.binding : null;
-      return binding?.kind === "subcircuit" ||
-        binding?.kind === "external-subcircuit" ||
-        binding?.kind === "unresolved-subcircuit"
-        ? "X"
-        : "X";
-    }
-  }
-}
-
-function nextSchematicReference(prefix: string, used: Set<string>): string {
-  let suffix = 1;
-  while (used.has(`${prefix}${suffix}`.toLowerCase())) suffix += 1;
-  const reference = `${prefix}${suffix}`;
-  used.add(reference.toLowerCase());
-  return reference;
-}
-
 /**
- * The rolling migration adds an explicitly schematic-facing reference to
- * every Instance. Emitting instances preserve their netlist designator;
- * non-emitting objects receive a deterministic presentation reference.
+ * The rolling migration makes RichText schematic labels the default instance
+ * projection. Formal Cell Ports instead project only their terminal name.
  */
 export function upgradePreviousProject(
   raw: Record<string, unknown>,
@@ -76,31 +27,83 @@ export function upgradePreviousProject(
     const instances = Array.isArray(rawDocument.instances)
       ? rawDocument.instances
       : [];
-    const usedSchematicReferences = new Set<string>();
+    const netlist = isRecord(rawDocument.netlist) ? rawDocument.netlist : null;
+    const terminals =
+      netlist && Array.isArray(netlist.terminals) ? netlist.terminals : [];
+    const terminalIdByFormalPortInstance = new Map(
+      terminals.flatMap((terminal) =>
+        isRecord(terminal) &&
+        typeof terminal.interfaceInstanceId === "string" &&
+        typeof terminal.id === "string"
+          ? [[terminal.interfaceInstanceId, terminal.id] as const]
+          : [],
+      ),
+    );
     for (const rawInstance of instances) {
       if (!isRecord(rawInstance) || typeof rawInstance.id !== "string")
         continue;
-      const netlist = isRecord(rawInstance.netlist)
-        ? rawInstance.netlist
-        : null;
-      const emittedReference =
-        netlist && typeof netlist.reference === "string"
-          ? netlist.reference.trim()
-          : "";
-      const isPort =
-        rawInstance.symbolId === "port" ||
-        rawInstance.symbolId === "port-filled";
-      rawInstance.schematicReference =
-        emittedReference && !isPort
-          ? emittedReference
-          : nextSchematicReference(
-              schematicReferencePrefix(rawInstance),
-              usedSchematicReferences,
-            );
-      usedSchematicReferences.add(
-        (rawInstance.schematicReference as string).toLowerCase(),
-      );
+      if (terminalIdByFormalPortInstance.has(rawInstance.id)) {
+        delete rawInstance.schematicReference;
+      }
     }
+    const annotations = Array.isArray(rawDocument.annotations)
+      ? rawDocument.annotations
+      : [];
+    const terminalIdsWithDesignator = new Set(
+      annotations.flatMap((annotation) => {
+        const binding =
+          isRecord(annotation) && isRecord(annotation.binding)
+            ? annotation.binding
+            : null;
+        return binding?.kind === "instance-designator" &&
+          typeof binding.instanceId === "string" &&
+          terminalIdByFormalPortInstance.has(binding.instanceId)
+          ? [terminalIdByFormalPortInstance.get(binding.instanceId)!]
+          : [];
+      }),
+    );
+    const convertedTerminalIds = new Set<string>();
+    rawDocument.annotations = annotations.flatMap((annotation) => {
+      if (!isRecord(annotation) || !isRecord(annotation.binding)) {
+        return [annotation];
+      }
+      const binding = annotation.binding;
+      if (
+        binding.kind === "instance-designator" &&
+        typeof binding.instanceId === "string"
+      ) {
+        const terminalId = terminalIdByFormalPortInstance.get(
+          binding.instanceId,
+        );
+        if (!terminalId) {
+          return [
+            {
+              ...annotation,
+              binding: {
+                kind: "instance-schematic-name",
+                instanceId: binding.instanceId,
+              },
+            },
+          ];
+        }
+        if (convertedTerminalIds.has(terminalId)) return [];
+        convertedTerminalIds.add(terminalId);
+        return [
+          {
+            ...annotation,
+            binding: { kind: "cell-terminal-name", terminalId },
+          },
+        ];
+      }
+      if (
+        binding.kind === "cell-terminal-name" &&
+        typeof binding.terminalId === "string" &&
+        terminalIdsWithDesignator.has(binding.terminalId)
+      ) {
+        return [];
+      }
+      return [annotation];
+    });
   }
   project.schemaVersion = CURRENT_PROJECT_SCHEMA_VERSION;
   return project;

--- a/packages/project-protocol/src/transforms/project.ts
+++ b/packages/project-protocol/src/transforms/project.ts
@@ -13,230 +13,49 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function terminalMapping(value: unknown): unknown[] {
-  return Array.isArray(value) ? structuredClone(value) : [];
-}
-
-function parameterValues(
-  properties: unknown,
-  existing: Record<string, unknown>,
-  path: readonly (string | number)[],
-): Record<string, unknown> {
-  if (!isRecord(properties)) return existing;
-  const parameters = { ...existing };
-  for (const [key, value] of Object.entries(properties)) {
-    if (value === "" || value === undefined) continue;
-    if (!["value", "w", "l", "m", "dc"].includes(key)) {
-      throw new ProjectMigrationError(
-        [...path, key],
-        `Schema-14 legacy property ${key} has no schema-15 netlist authority`,
-      );
-    }
-    const normalized = String(value);
-    if (parameters[key] !== undefined && parameters[key] !== normalized) {
-      throw new ProjectMigrationError(
-        [...path, key],
-        `Schema-14 legacy property ${key} conflicts with netlist.parameters.${key}`,
-      );
-    }
-    parameters[key] = normalized;
-  }
-  return parameters;
-}
-
-/** The rolling migration: schema 14 gains stable external-terminal identities. */
+/**
+ * The rolling migration: schema 15 separates the formerly ambiguous
+ * `instance-reference` projection into an electrical designator or a
+ * presentation-only schematic alias. The selected kind preserves the visible
+ * v15 text exactly; no legacy binding reaches the schema-16 runtime model.
+ */
 export function upgradePreviousProject(
   raw: Record<string, unknown>,
 ): Record<string, unknown> {
   const project = structuredClone(raw);
-  const definitions = new Map<
-    string,
-    {
-      id: string;
-      name: string;
-      terminals: unknown[];
-      formalParameters: unknown[];
-    }
-  >();
   const documents = Array.isArray(project.documents) ? project.documents : [];
-  for (const [documentIndex, rawDocument] of documents.entries()) {
+  for (const rawDocument of documents) {
     if (!isRecord(rawDocument)) continue;
-    const document = rawDocument;
-    if (isRecord(document.netlist)) {
-      document.netlist.formalParameters ??= [];
-    }
-    const instances = Array.isArray(document.instances)
-      ? document.instances
+    const instances = Array.isArray(rawDocument.instances)
+      ? rawDocument.instances
       : [];
-    for (const [instanceIndex, rawInstance] of instances.entries()) {
-      if (!isRecord(rawInstance)) continue;
-      const instance = rawInstance;
-      const oldNetlist = isRecord(instance.netlist)
-        ? instance.netlist
-        : undefined;
-      const oldProperties = instance.properties;
-      const oldTerminals = terminalMapping(oldNetlist?.terminals);
-      let provenance = isRecord(instance.importProvenance)
-        ? { ...instance.importProvenance }
-        : undefined;
-      const provenanceAttributes = provenance?.attributes;
-      if (provenance && isRecord(provenanceAttributes)) {
-        const registryId = provenanceAttributes["symbol.mapping.registry"];
-        if (typeof registryId === "string") {
-          provenance.symbolMappingRegistryId = registryId;
-        }
-        delete provenance.attributes;
-      }
-      if (oldTerminals.length > 0) {
-        const binding = oldNetlist?.binding;
-        const bindingKind = isRecord(binding) ? binding.kind : undefined;
-        const importedName =
-          isRecord(binding) && typeof binding.name === "string"
-            ? binding.name
-            : typeof instance.id === "string"
-              ? instance.id
-              : `instance-${instanceIndex}`;
-        provenance ??= {
-          kind:
-            bindingKind === "primitive" ||
-            bindingKind === "model" ||
-            bindingKind === "subcircuit"
-              ? bindingKind
-              : "opaque",
-          name: importedName,
-          sourceTarget: `schema-13:instance:${importedName}`,
-        };
-        provenance.terminalMapping = oldTerminals;
-      }
-      if (provenance) instance.importProvenance = provenance;
-      if (oldNetlist) {
-        const { terminals: _terminals, ...nextNetlist } = oldNetlist;
-        nextNetlist.parameters = parameterValues(
-          oldProperties,
-          isRecord(nextNetlist.parameters) ? nextNetlist.parameters : {},
-          [
-            "documents",
-            documentIndex,
-            "instances",
-            instanceIndex,
-            "properties",
-          ],
-        );
-        if (isRecord(nextNetlist.binding)) {
-          const binding = nextNetlist.binding;
-          if (binding.kind === "subcircuit") delete binding.name;
-          if (binding.kind === "external-subcircuit") {
-            const name = binding.name;
-            if (typeof name !== "string") {
-              throw new ProjectMigrationError(
-                [
-                  "documents",
-                  documentIndex,
-                  "instances",
-                  instanceIndex,
-                  "netlist",
-                  "binding",
-                ],
-                "Schema-13 external subcircuit binding has no name",
-              );
-            }
-            const key = name.toLowerCase();
-            const terminals = oldTerminals;
-            const existing = definitions.get(key);
-            if (
-              existing &&
-              JSON.stringify(existing.terminals) !== JSON.stringify(terminals)
-            ) {
-              // The Project remains loadable, but this imported target cannot
-              // honestly claim one resolved external interface. Preserve its
-              // source name as an explicit analyzer-blocking unresolved state.
-              nextNetlist.binding = {
-                kind: "unresolved-subcircuit",
-                name,
-              };
-              instance.netlist = nextNetlist;
-              delete instance.properties;
-              continue;
-            }
-            const definition = existing ?? {
-              id: `external-subcircuit-${key.replaceAll(/[^a-z0-9_-]/gu, "-")}`,
-              name,
-              terminals: terminals.map((terminal) => ({
-                name: isRecord(terminal) ? terminal.pinName : "",
-              })),
-              formalParameters: [],
-            };
-            definitions.set(key, definition);
-            nextNetlist.binding = {
-              kind: "external-subcircuit",
-              definitionId: definition.id,
-            };
-          }
-        }
-        instance.netlist = nextNetlist;
-      } else if (oldProperties !== undefined) {
-        const parameters = parameterValues(oldProperties, {}, [
-          "documents",
-          documentIndex,
-          "instances",
-          instanceIndex,
-          "properties",
-        ]);
-        if (Object.keys(parameters).length > 0) {
-          if (typeof instance.id !== "string" || instance.id.length === 0) {
-            throw new ProjectMigrationError(
-              ["documents", documentIndex, "instances", instanceIndex, "id"],
-              "Schema-13 legacy properties require a stable instance ID for reference migration",
-            );
-          }
-          instance.netlist = { reference: instance.id, parameters };
-        }
-      }
-      delete instance.properties;
+    const instanceById = new Map<string, Record<string, unknown>>();
+    for (const rawInstance of instances) {
+      if (!isRecord(rawInstance) || typeof rawInstance.id !== "string")
+        continue;
+      instanceById.set(rawInstance.id, rawInstance);
+    }
+    const annotations = Array.isArray(rawDocument.annotations)
+      ? rawDocument.annotations
+      : [];
+    for (const rawAnnotation of annotations) {
+      if (!isRecord(rawAnnotation) || !isRecord(rawAnnotation.binding))
+        continue;
+      const binding = rawAnnotation.binding;
+      if (binding.kind !== "instance-reference") continue;
+      const instance =
+        typeof binding.instanceId === "string"
+          ? instanceById.get(binding.instanceId)
+          : undefined;
+      rawAnnotation.binding = {
+        kind:
+          instance && instance.schematicName !== undefined
+            ? "instance-schematic-name"
+            : "instance-designator",
+        instanceId: binding.instanceId,
+      };
     }
   }
-  const existingDefinitions = Array.isArray(
-    project.externalSubcircuitDefinitions,
-  )
-    ? project.externalSubcircuitDefinitions
-    : [...definitions.values()];
   project.schemaVersion = CURRENT_PROJECT_SCHEMA_VERSION;
-  project.externalSubcircuitDefinitions = existingDefinitions.map(
-    (rawDefinition, definitionIndex) => {
-      if (!isRecord(rawDefinition)) return rawDefinition;
-      const definitionId =
-        typeof rawDefinition.id === "string"
-          ? rawDefinition.id
-          : `external-subcircuit-${definitionIndex + 1}`;
-      const terminals = Array.isArray(rawDefinition.terminals)
-        ? rawDefinition.terminals
-        : [];
-      return {
-        ...rawDefinition,
-        id: definitionId,
-        terminals: terminals.map((rawTerminal, terminalIndex) => {
-          const terminal = isRecord(rawTerminal) ? rawTerminal : {};
-          return {
-            ...terminal,
-            id:
-              typeof terminal.id === "string"
-                ? terminal.id
-                : `external-terminal-${definitionId}-${terminalIndex + 1}`,
-            direction:
-              terminal.direction === "input" ||
-              terminal.direction === "output" ||
-              terminal.direction === "inout" ||
-              terminal.direction === "passive"
-                ? terminal.direction
-                : "passive",
-          };
-        }),
-        interfaceStatus:
-          rawDefinition.interfaceStatus === "inferred-positional"
-            ? "inferred-positional"
-            : "declared",
-      };
-    },
-  );
   return project;
 }

--- a/packages/project-protocol/src/transforms/project.ts
+++ b/packages/project-protocol/src/transforms/project.ts
@@ -13,11 +13,58 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function schematicReferencePrefix(instance: Record<string, unknown>): string {
+  switch (instance.symbolId) {
+    case "resistor":
+      return "R";
+    case "capacitor":
+      return "C";
+    case "inductor":
+      return "L";
+    case "diode":
+      return "D";
+    case "nmos":
+    case "pmos":
+      return "M";
+    case "npn":
+    case "pnp":
+      return "Q";
+    case "voltage-source":
+      return "V";
+    case "current-source":
+      return "I";
+    case "port":
+    case "port-filled":
+      return "P";
+    case "ground":
+      return "GND";
+    case "vdd-port":
+      return "VDD";
+    default: {
+      const netlist = isRecord(instance.netlist) ? instance.netlist : null;
+      const binding =
+        netlist && isRecord(netlist.binding) ? netlist.binding : null;
+      return binding?.kind === "subcircuit" ||
+        binding?.kind === "external-subcircuit" ||
+        binding?.kind === "unresolved-subcircuit"
+        ? "X"
+        : "X";
+    }
+  }
+}
+
+function nextSchematicReference(prefix: string, used: Set<string>): string {
+  let suffix = 1;
+  while (used.has(`${prefix}${suffix}`.toLowerCase())) suffix += 1;
+  const reference = `${prefix}${suffix}`;
+  used.add(reference.toLowerCase());
+  return reference;
+}
+
 /**
- * The rolling migration: schema 15 separates the formerly ambiguous
- * `instance-reference` projection into an electrical designator or a
- * presentation-only schematic alias. The selected kind preserves the visible
- * v15 text exactly; no legacy binding reaches the schema-16 runtime model.
+ * The rolling migration adds an explicitly schematic-facing reference to
+ * every Instance. Emitting instances preserve their netlist designator;
+ * non-emitting objects receive a deterministic presentation reference.
  */
 export function upgradePreviousProject(
   raw: Record<string, unknown>,
@@ -29,31 +76,30 @@ export function upgradePreviousProject(
     const instances = Array.isArray(rawDocument.instances)
       ? rawDocument.instances
       : [];
-    const instanceById = new Map<string, Record<string, unknown>>();
+    const usedSchematicReferences = new Set<string>();
     for (const rawInstance of instances) {
       if (!isRecord(rawInstance) || typeof rawInstance.id !== "string")
         continue;
-      instanceById.set(rawInstance.id, rawInstance);
-    }
-    const annotations = Array.isArray(rawDocument.annotations)
-      ? rawDocument.annotations
-      : [];
-    for (const rawAnnotation of annotations) {
-      if (!isRecord(rawAnnotation) || !isRecord(rawAnnotation.binding))
-        continue;
-      const binding = rawAnnotation.binding;
-      if (binding.kind !== "instance-reference") continue;
-      const instance =
-        typeof binding.instanceId === "string"
-          ? instanceById.get(binding.instanceId)
-          : undefined;
-      rawAnnotation.binding = {
-        kind:
-          instance && instance.schematicName !== undefined
-            ? "instance-schematic-name"
-            : "instance-designator",
-        instanceId: binding.instanceId,
-      };
+      const netlist = isRecord(rawInstance.netlist)
+        ? rawInstance.netlist
+        : null;
+      const emittedReference =
+        netlist && typeof netlist.reference === "string"
+          ? netlist.reference.trim()
+          : "";
+      const isPort =
+        rawInstance.symbolId === "port" ||
+        rawInstance.symbolId === "port-filled";
+      rawInstance.schematicReference =
+        emittedReference && !isPort
+          ? emittedReference
+          : nextSchematicReference(
+              schematicReferencePrefix(rawInstance),
+              usedSchematicReferences,
+            );
+      usedSchematicReferences.add(
+        (rawInstance.schematicReference as string).toLowerCase(),
+      );
     }
   }
   project.schemaVersion = CURRENT_PROJECT_SCHEMA_VERSION;

--- a/packages/project-protocol/src/version.ts
+++ b/packages/project-protocol/src/version.ts
@@ -2,4 +2,4 @@
  * The rolling compatibility window is deliberately explicit. Advancing the
  * current schema replaces this adapter instead of extending a migration chain.
  */
-export const PREVIOUS_PROJECT_SCHEMA_VERSION = 15;
+export const PREVIOUS_PROJECT_SCHEMA_VERSION = 16;

--- a/packages/project-protocol/src/version.ts
+++ b/packages/project-protocol/src/version.ts
@@ -2,4 +2,4 @@
  * The rolling compatibility window is deliberately explicit. Advancing the
  * current schema replaces this adapter instead of extending a migration chain.
  */
-export const PREVIOUS_PROJECT_SCHEMA_VERSION = 14;
+export const PREVIOUS_PROJECT_SCHEMA_VERSION = 15;

--- a/packages/project-protocol/src/version.ts
+++ b/packages/project-protocol/src/version.ts
@@ -2,4 +2,4 @@
  * The rolling compatibility window is deliberately explicit. Advancing the
  * current schema replaces this adapter instead of extending a migration chain.
  */
-export const PREVIOUS_PROJECT_SCHEMA_VERSION = 16;
+export const PREVIOUS_PROJECT_SCHEMA_VERSION = 17;

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -15,6 +15,7 @@ import {
   resolveEndpointPoint,
   resolveDocumentRoutingGeometry,
   resolveAnnotationPresentation,
+  isSchematicAnnotationVisible,
   resolveAnnotationText,
   resolveSchematicStyleProfile,
   resolveRouteAttachment,
@@ -450,6 +451,7 @@ function deriveBounds(
     });
   }
   for (const annotation of document.annotations) {
+    if (!isSchematicAnnotationVisible(document, annotation)) continue;
     const presentation = resolveAnnotationPresentation(
       document,
       resolver,
@@ -645,7 +647,7 @@ export function buildSvgScene(
     })
     .join("");
   const annotations = [...document.annotations]
-    .filter((annotation) => annotation.visible !== false)
+    .filter((annotation) => isSchematicAnnotationVisible(document, annotation))
     .sort((left, right) => left.id.localeCompare(right.id, "en"))
     .map((annotation) => {
       const content = resolveAnnotationText(document, annotation);

--- a/packages/spice/src/compiler.test.ts
+++ b/packages/spice/src/compiler.test.ts
@@ -213,6 +213,11 @@ Q2 collector base emitter QPREF
     );
     expect(
       document.instances
+        .filter((instance) => interfaceInstanceIds.has(instance.id))
+        .every((instance) => instance.schematicReference === undefined),
+    ).toBe(true);
+    expect(
+      document.instances
         .filter((instance) => !interfaceInstanceIds.has(instance.id))
         .every(
           (instance) =>

--- a/packages/spice/src/importer.ts
+++ b/packages/spice/src/importer.ts
@@ -360,7 +360,6 @@ function importDocument(
     instances.push({
       id: interfaceInstanceId,
       symbolId: "port",
-      schematicReference: `P${index + 1}`,
       placement: null,
     });
     const net = nets.find((candidate) => candidate.id === port.netId);
@@ -423,12 +422,19 @@ function bindImportedChildDocuments(documents: readonly SchematicDocument[]): {
   const boundDocuments: SchematicDocument[] = documents.map((document) => ({
     ...document,
     instances: document.instances.map((instance) => {
+      const isFormalPort = document.netlist?.terminals.some(
+        (terminal) => terminal.interfaceInstanceId === instance.id,
+      );
       const referencedInstance = {
         ...instance,
-        schematicReference:
-          instance.schematicReference ??
-          instance.netlist?.reference ??
-          instance.id,
+        ...(isFormalPort
+          ? {}
+          : {
+              schematicReference:
+                instance.schematicReference ??
+                instance.netlist?.reference ??
+                instance.id,
+            }),
       };
       const isImportedChild = instance.importProvenance?.kind === "subcircuit";
       const isImportedExternal =

--- a/packages/spice/src/importer.ts
+++ b/packages/spice/src/importer.ts
@@ -360,6 +360,7 @@ function importDocument(
     instances.push({
       id: interfaceInstanceId,
       symbolId: "port",
+      schematicReference: `P${index + 1}`,
       placement: null,
     });
     const net = nets.find((candidate) => candidate.id === port.netId);
@@ -422,11 +423,18 @@ function bindImportedChildDocuments(documents: readonly SchematicDocument[]): {
   const boundDocuments: SchematicDocument[] = documents.map((document) => ({
     ...document,
     instances: document.instances.map((instance) => {
+      const referencedInstance = {
+        ...instance,
+        schematicReference:
+          instance.schematicReference ??
+          instance.netlist?.reference ??
+          instance.id,
+      };
       const isImportedChild = instance.importProvenance?.kind === "subcircuit";
       const isImportedExternal =
         instance.netlist?.binding?.kind === "external-subcircuit";
       if (!isImportedChild && !isImportedExternal) {
-        return instance;
+        return referencedInstance;
       }
       const childDocumentId = isImportedChild
         ? documentIdByCellName.get(
@@ -462,7 +470,7 @@ function bindImportedChildDocuments(documents: readonly SchematicDocument[]): {
           })()
         : undefined;
       return {
-        ...instance,
+        ...referencedInstance,
         ...(externalDefinition
           ? { symbolId: externalSubcircuitSymbolId(externalDefinition.id) }
           : {}),

--- a/plan/2026-08-21-formal-port-richtext-label/plan.md
+++ b/plan/2026-08-21-formal-port-richtext-label/plan.md
@@ -1,0 +1,101 @@
+---
+status: completed
+experience: none
+---
+
+# Unified Port Naming and RichText Presentation
+
+## Goal
+
+Separate Port geometry, Net/Cell-terminal semantic naming, and annotation
+presentation. Allow explicit free Net Ports and formal Cell Pins in child
+documents, keep semantic renames electrically authoritative, and persist
+RichText only as a same-text annotation formatting override.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/schematic-instance-lifecycle-ux
+?? .pnpm-store/
+?? .worktrees/
+```
+
+The tracked worktree is clean. The untracked local dependency/worktree paths
+are out of scope and remain untouched.
+
+- `packages/model/`, `packages/edit-engine/`, `packages/derived/`
+- `apps/editor/src/`
+- affected tests, documentation, validation-contract bounds, and `plan/log.md`
+
+Shared: Net and Cell-terminal identity, hierarchy caller pin reconciliation,
+netlist export, Port insertion intent, annotation bindings, and Project
+persistence. The current branch's uncommitted `CellTerminal.schematicLabel`
+experiment is owned by this target and will be replaced rather than committed.
+Branch verification also exposed a canonical JSON formatting drift committed
+by the immediately preceding target in
+`fixtures/projects/phase-5-dense-analog/project.icproj.json`; this target owns
+only the deterministic reserialization needed to restore the existing corpus
+gate.
+
+## Work
+
+1. Keep semantic names in `Net.name` and `CellTerminal.name`; permit bound
+   `net-name`/`cell-terminal-name` annotations to retain a RichText formatting
+   override only when its normalized text matches the semantic source.
+2. Route canvas text commits by intent: character changes rename the Net or
+   Cell terminal through their existing electrical planners, while format-only
+   changes update only the annotation.
+3. Make Port insertion role explicit. A free Net Port binds its visible text to
+   the connected Net; a formal Cell Pin additionally creates a CellTerminal.
+   Remove document-position inference and Port `P#` reference display.
+4. Define deterministic create/attach naming defaults without imposing global
+   equality between terminal and Net names, then update Properties terminology,
+   contracts, docs, and focused unit/browser tests.
+
+## Validation
+
+- `pnpm test:local <affected test paths>`
+- `pnpm test:e2e:local <affected specs> --grep <pattern>`
+- `pnpm test:impact -- --base origin/main`
+- `git diff --check`
+- `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: Port labels are Net/terminal semantic projections; RichText
+  overrides cannot create aliases; free/formal roles are explicit; semantic
+  renames preserve Net/interface/caller invariants; formatting changes do not.
+- Primary checks: model annotation/document schema, derived annotation text,
+  edit-engine name planners, Port insertion, and free/formal Port browser flows.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): unify port naming and rich text
+```
+
+## Outcome
+
+Implemented one Port protocol across free Net Ports and formal Cell Pins.
+Insertion now carries an explicit role and deterministic semantic name;
+object-anchored annotations project `Net.name` or `CellTerminal.name`; canvas
+character edits rename that semantic owner; and formatting-only edits persist
+a schema-validated, same-text `Annotation.formatOverride`. Properties exposes
+the correct semantic owner, hierarchy terminal renames remain atomic across
+callers, and Port labels remain tied to Placement Tray lifecycle without a
+visible `P#` identity.
+
+Validation passed:
+
+- focused unit contracts: 6 files / 72 tests;
+- complete hierarchy browser specification: 9 tests;
+- repaired gate regressions: 2 files / 18 tests;
+- `pnpm test:impact -- --base origin/main`;
+- `pnpm verify:branch`: static contracts, 162 unit files / 975 tests, all
+  workspace builds, and production preview smoke;
+- `git diff --check` and final worktree audit.

--- a/plan/2026-08-21-imported-reference-default-display/plan.md
+++ b/plan/2026-08-21-imported-reference-default-display/plan.md
@@ -1,0 +1,77 @@
+---
+status: completed
+experience: none
+---
+
+# Imported Reference Default Display
+
+## Goal
+
+Make every imported instance's existing reference visible by default when it is
+placed from the Placement Tray, regardless of whether it is placed singly,
+dragged, or placed through Place all.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/schematic-instance-lifecycle-ux
+?? .pnpm-store/
+?? .worktrees/
+```
+
+The tracked worktree is clean. The untracked local dependency/worktree paths
+are outside this target and will remain untouched.
+
+- `apps/editor/src/features/instance-display/`
+- `apps/editor/src/features/component-insert/`
+- `apps/editor/src/app/App.tsx`
+- focused editor tests and `plan/log.md`
+
+Shared: imported SPICE instances retain their electrical `netlist.reference`
+and schema-17 schematic reference; this target creates only their missing
+visual Reference projections on placement.
+
+## Work
+
+1. Add one display helper that derives only missing default Reference/formal
+   Port labels for a placed retained instance, preserving existing user labels.
+2. Use it for single Placement Tray placement, drag/drop, and Place all.
+3. Add regression coverage for imported-style references across the shared
+   default-label and placement paths.
+
+## Validation
+
+- `pnpm test:local <affected editor tests>`
+- `pnpm test:e2e:local <affected spec> --grep <pattern>` where practical
+- `pnpm test:impact -- --base origin/main`
+- `git diff --check`
+- `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: a retained instance with a reference receives one visible default
+  Reference projection on placement; existing labels remain authoritative.
+- Primary checks: default display, retained-placement, App tray, and browser
+  import-placement contracts.
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): show imported references on placement
+```
+
+## Outcome
+
+Added one placement-time helper that creates only missing default Reference and
+formal-Port labels. Single Tray placement, canvas drag/drop, and Place all now
+use it, so imported instance references become visible on the first placement
+without replacing existing user-owned label projections.
+
+Validation passed: focused editor unit contracts (3 files / 18 tests), the
+SPICE import then Place all browser regression (1 test), typecheck, format,
+test-impact, and diff checks.

--- a/plan/2026-08-21-instance-display-authoring/plan.md
+++ b/plan/2026-08-21-instance-display-authoring/plan.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: completed
 experience: none
 ---
 
@@ -89,4 +89,16 @@ feat(editor): unify instance display authoring
 
 ## Outcome
 
-To be completed with actual changed areas, validation, and commit evidence.
+The editor now uses one category-aware display factory: ordinary devices show a
+designator/value on request, internal Cells and external calls show their
+designator plus Cell/master presentation, and formal Ports show their formal
+terminal name only. Component insertion now persists a user-entered reference,
+Properties separates Netlist Reference from optional Schematic Alias, and the
+Instance Table exposes internal ID, reference, alias and resolved master in
+separate columns.
+
+Validation passed: focused unit contracts (7 files / 25 tests), focused browser
+flows (4 tests), `pnpm typecheck`, `pnpm format:check`, `pnpm docs:check`,
+`pnpm test:impact -- --base origin/main`, and `git diff --check`.
+Implementation committed as `0da8da3c` (`feat(editor): unify instance display
+authoring`).

--- a/plan/2026-08-21-instance-display-authoring/plan.md
+++ b/plan/2026-08-21-instance-display-authoring/plan.md
@@ -1,0 +1,92 @@
+---
+status: active
+experience: none
+---
+
+# Unified Instance Display and Reference Authoring
+
+## Goal
+
+Give every editor-created or imported placed Instance one consistent display
+policy, expose its electrical designator separately from its schematic alias,
+and ensure manually requested designators actually reach `Instance.netlist`.
+This target owns display creation and authoring only; returning/deleting and
+bulk placement remain later lifecycle targets.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/schematic-instance-lifecycle-ux
+?? .pnpm-store/
+?? .worktrees/
+```
+
+The untracked directories are local dependency/worktree infrastructure and do
+not overlap this target. Schema 16 is committed as `d70c84bc` and is a shared,
+read-only dependency for this target.
+
+Owned paths:
+
+- `apps/editor/src/features/instance-display/`
+- component insertion, import placement handoff, Properties, Instance Table,
+  and focused editor tests
+- narrowly necessary derived/edit-engine display tests
+- this plan and `plan/log.md`
+
+Read-only shared dependencies:
+
+- Schema 16 annotation bindings and migration
+- typed `set_instance_reference` and `set_instance_schematic_name` edits
+- external-definition and internal-Cell creation planners
+- structural netlist exporter/importer
+
+## Work
+
+1. Add one editor-owned display factory for designator, value, master, and
+   formal-terminal label creation. It must be reused by manual primitive,
+   internal Cell, external-subcircuit, formal-port, and imported-instance
+   placement flows.
+2. Make the Properties sheet expose electrical Netlist Reference separately
+   from presentation-only Schematic Name. Formal Port and non-emitting marker
+   views must not expose a fake reference.
+3. Repair the component-insert request path so an explicit reference supplied
+   by the user initializes the new Instance netlist record and passes normal
+   reference-policy validation.
+4. Update the Instance Table to present ID, Reference, Alias and Master as
+   distinct columns/values and retain batch renumbering as the electrical
+   operation.
+5. Add focused contracts proving aliases never alter export facts and default
+   labels never project internal IDs.
+
+## Validation
+
+- focused editor display, component insertion, Properties, Instance Table,
+  netlist-authoring and browser interaction tests
+- `pnpm typecheck`
+- `pnpm format:check`
+- `pnpm test:impact -- --base origin/main`
+- `git diff --check`
+- `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: category-specific default labels, explicit reference authoring,
+  formal-port label semantics, table identity separation, and no-export effect
+  from aliases.
+- Primary checks: instance-display unit tests, component-placement tests,
+  editor Properties/Table tests, and focused browser insertion/import flows.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): unify instance display authoring
+```
+
+## Outcome
+
+To be completed with actual changed areas, validation, and commit evidence.

--- a/plan/2026-08-21-instance-lifecycle-engine/plan.md
+++ b/plan/2026-08-21-instance-lifecycle-engine/plan.md
@@ -1,0 +1,85 @@
+---
+status: completed
+experience: none
+---
+
+# Instance Placement Lifecycle Engine
+
+## Goal
+
+Make the retained-unplaced / placed / deleted Instance lifecycle explicit and
+safe at the edit-engine boundary. Add `unplace_instance`; consolidate route
+endpoint replacement and destructive cleanup so NoConnect no longer blocks a
+connected-instance delete.
+
+## State and Ownership
+
+Start state: branch `codex/schematic-instance-lifecycle-ux` contains completed
+Schema 16 and display-authoring targets. The only untracked paths remain local
+`.pnpm-store/` and `.worktrees/` infrastructure and will not be changed.
+
+Owned paths:
+
+- `packages/edit-engine/src/{edit-schema,transaction,instance-lifecycle}*`
+- selection deletion adapter and focused unit tests
+- protocol-category consumer and generated MCP resource schema required by the
+  shared edit union
+- current edit/model documentation, this plan and `plan/log.md`
+
+Shared read-only dependencies: Schema 16, Route/Junction geometry, NoConnect
+invariants, DocumentHistory, hierarchy formal-port wrappers, and editor
+selection UI.
+
+## Work
+
+1. Add `unplace_instance` to the single typed edit union; it changes only a
+   placed Instance to `placement: null` and preserves electrical facts.
+2. Move connected-instance route detachment into an edit-engine lifecycle
+   planner. It replaces routed terminal endpoints with Junctions at resolved
+   pin positions before unplace/delete.
+3. Implement delete composition that detaches routes, removes terminal
+   memberships, removes NoConnects and instance-anchored annotations, then
+   performs strict `remove_instance`.
+4. Make the editor selection deletion flow consume the shared planner, without
+   changing formal-port hierarchy protection. Keep the protocol consumer's
+   edit category and generated schema synchronized; this is contract hygiene,
+   not new Agent behavior.
+
+## Validation
+
+- focused edit-schema, transaction/lifecycle and selection-deletion tests
+- `pnpm typecheck`, `pnpm format:check`, `pnpm test:impact -- --base origin/main`
+- `git diff --check` and `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: unplace preserves netlist/electrical membership; delete clears
+  NoConnect and annotations; routed pins become stable Junction endpoints;
+  all lifecycle edits remain atomic.
+- Primary checks: edit-engine transaction/lifecycle tests and editor selection
+  deletion tests.
+
+## Commit Intent
+
+```text
+feat(edit-engine): add instance placement lifecycle
+```
+
+## Outcome
+
+Implemented `unplace_instance` and the shared lifecycle planner. Returning an
+Instance to the tray now detaches routed terminals to resolved Junctions while
+retaining net membership, NoConnects, annotations, binding, and parameters.
+Deletion reuses the same detachment and then clears terminal membership,
+NoConnects, instance-owned annotations, and unlocked layout references before
+strict removal. The editor selection adapter now delegates to this engine
+planner; the retired Agent surface parses but does not advertise or execute the
+new browser-only lifecycle edit.
+
+Validation passed: focused lifecycle/transaction/protocol/selection/Agent
+tests (5 files, 56 tests), `pnpm typecheck`, `pnpm format:check`,
+`pnpm docs:check`, `pnpm mcp:resources:check`,
+`pnpm test:impact -- --base origin/main`, and `git diff --check`. Test-impact
+reported one harmless warning while scanning the intentionally untouched local
+`.pnpm-store/` directory. Commit evidence follows this plan update.

--- a/plan/2026-08-21-placement-tray-ui/plan.md
+++ b/plan/2026-08-21-placement-tray-ui/plan.md
@@ -77,6 +77,7 @@ uniform.
 
 Validation passed: focused placement/interaction/connectivity/lifecycle unit
 tests (4 files, 24 tests), focused Placement Tray browser regression, workspace
-typecheck, format, docs, test-impact, and diff checks. Test-impact reported one
-harmless warning while scanning the intentionally untouched local
+typecheck, format, docs, test-impact, diff checks, and complete
+`pnpm verify:branch` (static contracts, workspace unit suite, build, and
+production smoke). Test-impact reported one harmless warning while scanning the intentionally untouched local
 `.pnpm-store/` directory. Commit evidence follows this plan update.

--- a/plan/2026-08-21-placement-tray-ui/plan.md
+++ b/plan/2026-08-21-placement-tray-ui/plan.md
@@ -1,0 +1,82 @@
+---
+status: completed
+experience: none
+---
+
+# Placement Tray UI
+
+## Goal
+
+Turn retained, unplaced Instances into a clear editor workflow: legible tray
+entries, explicit return-to-tray versus permanent delete, individual placement
+entry, and deterministic place-all / return-all actions. This target consumes
+the completed lifecycle engine; it does not add a second lifecycle protocol.
+
+## State and Ownership
+
+Start state: `codex/schematic-instance-lifecycle-ux` at `c2295d6e`, with only
+untracked local `.pnpm-store/` and `.worktrees/` infrastructure. Those paths
+are unrelated and will remain untouched.
+
+Owned paths:
+
+- placement-tray pure planner and tests
+- `apps/editor/src/app/App.tsx` tray, selection action, and bulk transactions
+- focused browser/unit contracts and current interaction/user documentation
+- this plan and `plan/log.md`
+
+Shared read-only dependencies: schema-16 identity bindings, edit-engine
+`unplace_instance` and lifecycle planners, formal-Port hierarchy protection,
+canvas viewbox, and existing selection deletion adapter.
+
+## Work
+
+1. Add a small deterministic editor placement planner for bulk layout within
+   the current canvas view. It emits only ordinary `place_instance` edits and
+   avoids duplicating engine semantics.
+2. Replace the bare unplaced button list with a Placement Tray that shows the
+   semantic display identity, supports one-item drag/drop and keyboard/click
+   placement entry, and exposes Place all.
+3. Add a selected-instance **Return to tray** action and **Return all** action;
+   both use the shared unplacement planner. Keep Delete permanent and visibly
+   distinct, preserving existing formal-Port safeguards.
+4. Add targeted tests and document the three-state lifecycle and bulk-layout
+   policy.
+
+## Validation
+
+- placement planner / transaction / selection focused unit tests
+- focused browser coverage for tray actions
+- `pnpm typecheck`, `pnpm format:check`, `pnpm docs:check`, and
+  `pnpm test:impact -- --base origin/main`
+- `git diff --check` and `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: bulk placement is deterministic and emits only placement edits;
+  Return retains electrical facts; permanent Delete remains separate; formal
+  Cell Ports retain existing hierarchy protection.
+- Primary checks: tray planner unit tests and editor browser interaction.
+
+## Commit Intent
+
+```text
+feat(editor): add placement tray controls
+```
+
+## Outcome
+
+Added the Placement Tray as the retained-unplaced lifecycle surface. Tray rows
+now expose semantic identity plus drag and cursor-placement entry; `Place all`
+emits deterministic ordinary placement edits. Selected non-Port Instances can
+return to the tray, while `Return all` deliberately excludes formal Cell Ports
+and permanent Delete remains unchanged. The existing component-placement state
+now also handles a retained Instance so orientation and Esc behavior stay
+uniform.
+
+Validation passed: focused placement/interaction/connectivity/lifecycle unit
+tests (4 files, 24 tests), focused Placement Tray browser regression, workspace
+typecheck, format, docs, test-impact, and diff checks. Test-impact reported one
+harmless warning while scanning the intentionally untouched local
+`.pnpm-store/` directory. Commit evidence follows this plan update.

--- a/plan/2026-08-21-port-display-and-tray-annotation-visibility/plan.md
+++ b/plan/2026-08-21-port-display-and-tray-annotation-visibility/plan.md
@@ -1,0 +1,93 @@
+---
+status: completed
+experience: none
+---
+
+# Schematic Label Authority, Port Display, and Tray Annotation Visibility
+
+## Goal
+
+Make RichText `schematicName` the single default user-visible instance label
+authority (with a non-ID fallback to the internal schematic/netlist
+reference), while hiding instance-owned visual annotations in the Placement
+Tray and making a formal Cell Port's terminal name its only visible
+identifier.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/schematic-instance-lifecycle-ux
+?? .pnpm-store/
+?? .worktrees/
+```
+
+The tracked worktree is clean. The untracked local dependency/worktree paths
+are out of scope and remain untouched.
+
+- `packages/derived/`, `packages/render-svg/`, `apps/editor/src/`
+- `packages/model/`, `packages/project-protocol/`, `packages/edit-engine/`
+- affected fixtures, tests, documentation, and `plan/log.md`
+
+Shared: Project schema compatibility, annotation bindings, and the Cell
+terminal interface contract. `Instance.id` remains the sole lifecycle identity.
+
+## Work
+
+1. Correct generic instance-label bindings so default labels resolve through
+   `schematicName`, fall back only to `schematicReference` or
+   `netlist.reference`, and materialize RichText `schematicName` when edited.
+   Keep `instance-designator` as an optional, read-only network identifier;
+   remove the duplicate user-facing schematic-reference/alias inputs.
+2. Add one shared presentation predicate so instance-owned annotations render
+   and accept hits only while their instance is placed.
+3. Change formal Cell Port presentation to render only `CellTerminal.name` in
+   the Reference slot; prevent formal Ports from owning or accepting a
+   schematic reference.
+4. Advance the Project schema and migrate schema-17 default designator
+   projections to schematic-name projections, while converting formal Port
+   projections to terminal-name-only and removing their redundant
+   `schematicReference` data.
+5. Update creators, importer, fixtures, documents, and focused lifecycle,
+   render, migration, and browser tests.
+
+## Validation
+
+- `pnpm test:local <affected test paths>`
+- `pnpm test:e2e:local <affected specs> --grep <pattern>`
+- `pnpm test:impact -- --base origin/main`
+- `git diff --check`
+- `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: `Instance.id` is never visible; generic default labels are
+  RichText `schematicName` with a schematic/netlist-only fallback; retained
+  instances leave no visible/clickable object labels; re-placement restores
+  retained labels; formal Cell Ports display only their terminal name and
+  cannot carry a schematic reference.
+- Primary checks: derived/render presentation, edit-engine schema and
+  transaction, project migration, editor display, and browser lifecycle tests.
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): restore rich schematic label authority
+```
+
+## Outcome
+
+Completed schema-18 display correction: ordinary default labels now bind to
+RichText `schematicName` with a non-ID schematic/netlist fallback; the netlist
+designator is optional and read-only. Formal Ports retain terminal-name-only
+presentation and tray-retained annotations are hidden and non-interactive until
+re-placement. The rolling v17 migration preserves ordinary label geometry while
+rebinding it and converts formal Port projections to terminal names.
+
+Validated with focused unit contracts (9 files / 78 tests), focused Playwright
+flows (5 tests), workspace typecheck, Prettier, Markdown-link validation,
+test-impact, and `git diff --check`.

--- a/plan/2026-08-21-schema16-instance-identity/plan.md
+++ b/plan/2026-08-21-schema16-instance-identity/plan.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: completed
 experience: none
 ---
 
@@ -90,4 +90,15 @@ feat(protocol): separate instance display identities
 
 ## Outcome
 
-To be completed with actual changed areas, validation, and commit evidence.
+Schema 16 now separates electrical designators, schematic aliases and master
+labels, and no current writer or renderer may use `instance-reference` or an
+internal Instance ID as a visible fallback. The rolling reader accepts schema
+15 only as input, mapping each legacy reference label to the source that
+preserves its old rendered text. Canonical fixtures, browser recovery, bundled
+examples, specs and ADR 0030 now use schema 16.
+
+Validation passed: focused model/project-protocol/derived/editor contracts
+(12 files / 102 tests), `pnpm typecheck`, `pnpm docs:check`,
+`pnpm format:check`, `pnpm test:impact -- --base origin/main`, and
+`git diff --check`. Implementation committed as `d70c84bc`
+(`feat(protocol): separate instance display identities`).

--- a/plan/2026-08-21-schema16-instance-identity/plan.md
+++ b/plan/2026-08-21-schema16-instance-identity/plan.md
@@ -1,0 +1,93 @@
+---
+status: active
+experience: none
+---
+
+# Schema 16 Instance Identity Protocol
+
+## Goal
+
+Establish one unambiguous persisted/display protocol for schematic instances:
+internal object IDs, emitted netlist designators, optional schematic aliases,
+external/internal master names, and formal Cell terminal names are separate
+concepts. Advance Project schema 15 to schema 16 with one direct reader
+migration and no mixed runtime binding semantics.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+?? .pnpm-store/
+?? .worktrees/
+```
+
+The two untracked paths are local dependency/worktree infrastructure. They are
+unrelated to the protocol target and will remain untouched. The target starts
+from `main` commit `84f33c57` on branch `codex/schematic-instance-lifecycle-ux`.
+
+Owned paths:
+
+- `packages/model/src/schema/{common,annotations}.ts` and focused model tests
+- `packages/project-protocol/src/` migration, load, corpus, and tests
+- `packages/derived/src/annotation-text*`
+- consumers of the retired annotation binding in `apps/editor/src/`
+- current protocol documentation, a new ADR, this plan, and `plan/log.md`
+
+Read-only shared dependencies:
+
+- typed instance netlist authority from ADR 0027
+- rolling N-1 reader contract from ADR 0023
+- structural import/export semantics in `packages/spice` and `packages/netlist`
+- annotation anchors and edit-union contract in `packages/edit-engine`
+
+## Work
+
+1. Add Schema 16 bindings: `instance-designator`, `instance-schematic-name`,
+   and `instance-master-name`; retain `instance-value` and
+   `cell-terminal-name`. Remove `instance-reference` from the current model.
+2. Make derived text projections strict: no user-visible text binding may
+   fall back to `Instance.id`. Designator resolves only from
+   `Instance.netlist.reference`; formal ports resolve only from the formal
+   terminal name.
+3. Advance the current Project schema to 16 and replace the rolling reader
+   adapter with a direct v15-to-v16 migration. The adapter maps legacy
+   reference bindings deterministically to the binding that preserves their
+   visible projection, then validates the sole v16 runtime shape.
+4. Migrate every in-repository creator, clipboard path, editor binding check,
+   fixture, and test to the new binding names; no current writer may emit the
+   retired kind.
+5. Record the protocol decision and update current specifications,
+   compatibility guide, version drift contracts, and corpus evidence.
+
+## Validation
+
+- focused model, project-protocol, derived annotation, editor clipboard/text
+  and relevant component-placement tests
+- `pnpm test:impact -- --base origin/main`
+- `pnpm typecheck`
+- `pnpm docs:check`
+- `git diff --check`
+- `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: schema-16 parse/save, v15 direct migration, strict identity text
+  projection, clipboard rebinding, and rejection of retired annotation kinds.
+- Primary checks: model schema/version tests, project-protocol load/persistence
+  tests, `packages/derived/src/annotation-text.test.ts`, and focused editor
+  behavior tests.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(protocol): separate instance display identities
+```
+
+## Outcome
+
+To be completed with actual changed areas, validation, and commit evidence.

--- a/plan/2026-08-21-schematic-lifecycle-mainline-gate/plan.md
+++ b/plan/2026-08-21-schematic-lifecycle-mainline-gate/plan.md
@@ -1,0 +1,91 @@
+---
+status: completed
+experience: none
+---
+
+# Schematic Lifecycle Mainline Gate
+
+## Goal
+
+Close the canonical `pnpm ci:check` failures discovered while delivering the
+schema-18 schematic lifecycle branch, without weakening accepted behavior or
+expanding product scope.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/schematic-instance-lifecycle-ux
+?? .pnpm-store/
+?? .worktrees/
+```
+
+The tracked worktree is clean at `92bb97e7`. The untracked dependency and
+worktree directories are local infrastructure, remain out of scope, and will
+not be staged.
+
+Owned paths:
+
+- failing editor E2E specifications for explicit Port insertion, editable
+  bound RichText, current schema persistence, Copy, and deletion behavior;
+- editor/model/edit-engine implementation only where a focused reproduction
+  proves a real regression;
+- this plan and `plan/log.md`.
+
+Read-only shared dependencies include schema 18, annotation bindings,
+selection/clipboard semantics, connectivity cleanup, and the explicit
+free/formal Port insertion protocol.
+
+## Work
+
+1. Update obsolete Port, bound-text, and schema-version browser assertions to
+   the accepted schema-18 protocol.
+2. Reproduce Copy and connected-deletion failures independently; repair the
+   smallest implementation contract if they are real regressions, otherwise
+   update only stale expectations.
+3. Run every previously failing test focused, then the complete canonical
+   mainline gate from a frozen dependency state.
+
+## Validation
+
+- focused `pnpm test:e2e:local` runs for all 14 reported failures;
+- `pnpm test:impact -- --base origin/main`;
+- `pnpm install --frozen-lockfile` and `pnpm ci:check`;
+- `git diff --check` and final status audit.
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: explicit Port insertion, schema-18 persistence, editable
+  Net/terminal-bound RichText, repeated Copy placement, and safe connected
+  deletion.
+- Implementation tests will be added only for any confirmed product defect.
+
+## Commit Intent
+
+Commit as:
+
+```text
+test(editor): align lifecycle mainline gate
+```
+
+## Outcome
+
+Closed all 14 canonical-gate failures. Copy was a real product regression:
+paste incremented `netlist.reference` but retained the source
+`schematicReference`, so schema validation rejected every copied instance.
+Clipboard paste now allocates a bounded, unique schematic reference and keeps
+the common schematic/netlist reference pair synchronized. The remaining
+failures were stale browser contracts for explicit Port insertion, editable
+Net-bound RichText, connected deletion, and schema-18 persistence.
+
+Validation passed:
+
+- Clipboard unit contract: 1 file / 8 tests;
+- all 14 originally failing browser cases in focused runs;
+- `pnpm test:impact -- --base origin/main`, typecheck, formatting and diff
+  checks;
+- canonical `pnpm install --frozen-lockfile` plus `pnpm ci:check`: static
+  contracts, 162 unit files / 975 tests, all workspace builds, release and MCP
+  smoke checks, and 167/167 browser tests.

--- a/plan/2026-08-21-schematic-reference-and-port-lifecycle/plan.md
+++ b/plan/2026-08-21-schematic-reference-and-port-lifecycle/plan.md
@@ -1,0 +1,83 @@
+---
+status: completed
+experience: none
+---
+
+# Schematic Reference and Port Lifecycle
+
+## Goal
+
+Unify every Instance, including ordinary and formal Ports, under one visible
+schematic-reference and placement lifecycle without fabricating a netlist
+reference for non-emitting Ports.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/schematic-instance-lifecycle-ux
+?? .pnpm-store/
+?? .worktrees/
+```
+
+The tracked worktree is clean. The two untracked paths are local dependency and
+worktree infrastructure, owned outside this target, and will remain untouched.
+
+- `packages/model/`, `packages/project-protocol/`, `packages/edit-engine/`
+- `packages/derived/`, `apps/editor/src/`
+- affected tests, documentation, `plan/log.md`
+
+Shared: the root Project schema and one-version migration boundary; typed
+annotation bindings; netlist export must continue to use only
+`Instance.netlist.reference`.
+
+## Work
+
+1. Advance the Project schema and add a stable schematic-reference authority
+   for every Instance, distinct from the optional emitting netlist reference.
+2. Migrate schema-16 Projects deterministically, preserve export semantics, and
+   bind visible Reference labels to the schematic reference.
+3. Make normal and formal Ports show their reference by default while retaining
+   the formal terminal name as separate interface text.
+4. Remove the UI-only formal-Port return exclusion, make placement locking
+   symmetric, and update focused lifecycle, display, migration, and UI tests.
+5. Update normative documentation and record factual validation.
+
+## Validation
+
+- `pnpm test:local <affected test paths>`
+- focused `pnpm test:e2e:local <spec> --grep <pattern>` where practical
+- `pnpm test:impact -- --base origin/main`
+- `git diff --check`
+- `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: schematic and netlist references are independent; Ports share
+  placement lifecycle; visible reference labels resolve the schematic source.
+- Primary checks: model, project-protocol, derived, edit-engine, editor unit,
+  and affected browser lifecycle tests.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(protocol): unify schematic references and port lifecycle
+```
+
+## Outcome
+
+Implemented Project schema 17 with an independent `Instance.schematicReference`
+that is populated by current writers and the direct schema-16 migration. The
+visible Reference annotation now resolves that authority, while netlist export
+continues to use only `Instance.netlist.reference`. Formal Cell Ports now show
+both their `P#` reference and terminal name, and share the ordinary Placement
+Tray return/re-place lifecycle without losing terminal or net facts.
+
+Validation passed: focused unit contracts (17 files / 172 tests), the focused
+formal-Port browser lifecycle (1 test), targeted regression tests (2 files /
+14 tests), format, documentation links, test-impact, diff checks, complete
+workspace unit-test execution, workspace build, and production preview smoke.

--- a/plan/log.md
+++ b/plan/log.md
@@ -3787,3 +3787,14 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   execution, workspace build, and production preview smoke passed.
 - Commit status: committed on `codex/schematic-instance-lifecycle-ux` as
   the current branch HEAD.
+
+## 2026-08-21 - Imported Reference default display
+
+- Changed areas: made Tray placement, canvas drag/drop, and Place all
+  materialize only missing default Reference projections; retained imported
+  netlist references are now visibly rendered when first placed.
+- Validation: focused editor contracts (3 files / 18 tests), SPICE
+  import-and-place browser regression (1 test), typecheck, format,
+  test-impact, and diff checks passed.
+- Commit status: committed on `codex/schematic-instance-lifecycle-ux` as
+  the current branch HEAD.

--- a/plan/log.md
+++ b/plan/log.md
@@ -3798,3 +3798,17 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   test-impact, and diff checks passed.
 - Commit status: committed on `codex/schematic-instance-lifecycle-ux` as
   the current branch HEAD.
+
+## 2026-08-21 - Rich schematic label authority and formal Port presentation
+
+- Changed areas: corrected schema-18 default instance labels to bind RichText
+  `schematicName` rather than the emitted designator; retained a
+  schematic/netlist-only fallback with no internal-ID display; made the
+  designator optional/read-only; reduced Properties to one Schematic label
+  entry; and tightened formal Cell Ports to their terminal-name-only
+  projection. The v17 reader migration preserves ordinary label placement while
+  rebinding it and removes redundant formal-Port projections.
+- Validation: focused unit contracts (9 files / 78 tests), focused Playwright
+  lifecycle/import/property flows (5 tests), workspace typecheck, Prettier,
+  Markdown-link validation, test-impact, and diff checks passed.
+- Commit status: ready to commit on `codex/schematic-instance-lifecycle-ux`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -3812,3 +3812,18 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   lifecycle/import/property flows (5 tests), workspace typecheck, Prettier,
   Markdown-link validation, test-impact, and diff checks passed.
 - Commit status: ready to commit on `codex/schematic-instance-lifecycle-ux`.
+
+## 2026-08-21 - Unified Port naming and RichText presentation
+
+- Changed areas: added explicit Free Net Port versus Formal Cell Pin insertion;
+  bound their visible text to `Net.name` or `CellTerminal.name`; introduced a
+  same-text-only RichText annotation override; routed character edits through
+  Net/hierarchy rename transactions; exposed role-correct Properties; and
+  documented the protocol in ADR 0033. Also restored canonical formatting of
+  one fixture exposed by branch verification.
+- Validation: focused unit contracts (6 files / 72 tests), complete hierarchy
+  browser specification (9 tests), repaired gate regressions (2 files / 18
+  tests), typecheck, docs, test-impact and diff checks, plus complete
+  `pnpm verify:branch` (162 unit files / 975 tests, workspace build, production
+  preview smoke) passed.
+- Commit status: ready to commit on `codex/schematic-instance-lifecycle-ux`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -3770,5 +3770,6 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   Return all, and a clear permanent-delete distinction.
 - Validation: focused tray/interaction/connectivity/lifecycle contracts (4
   files / 24 tests), focused browser tray flow, typecheck, format, docs,
-  test-impact, and diff checks passed.
-- Commit status: pending commit on `codex/schematic-instance-lifecycle-ux`.
+  test-impact, diff checks, and complete `pnpm verify:branch` passed.
+- Commit status: committed on `codex/schematic-instance-lifecycle-ux` as
+  `13ba3a26`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -3773,3 +3773,17 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   test-impact, diff checks, and complete `pnpm verify:branch` passed.
 - Commit status: committed on `codex/schematic-instance-lifecycle-ux` as
   `13ba3a26`.
+
+## 2026-08-21 - Schematic reference and unified Port lifecycle
+
+- Changed areas: advanced canonical Projects to schema 17; separated the
+  visible `Instance.schematicReference` from emitted netlist references;
+  migrated schema 16 deterministically; made References visible by default;
+  and made formal Cell Ports returnable and re-placeable without changing
+  their interface semantics.
+- Validation: focused unit contracts (17 files / 172 tests), targeted
+  regression tests (2 files / 14 tests), formal-Port browser lifecycle (1
+  test), format, docs, test-impact, diff checks, complete workspace unit-test
+  execution, workspace build, and production preview smoke passed.
+- Commit status: committed on `codex/schematic-instance-lifecycle-ux` as
+  the current branch HEAD.

--- a/plan/log.md
+++ b/plan/log.md
@@ -3728,3 +3728,14 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   release and production smoke checks, and 162 browser E2E tests.
 - Commit status: merged to `origin/main` through PR #134 as `51075420` after
   all GitHub Actions checks passed; local `main` is synchronized.
+
+## 2026-08-21 - Schema 16 instance identity protocol
+
+- Changed areas: advanced canonical Projects to schema 16; split ambiguous
+  instance labels into designator, schematic-name and master-name bindings;
+  replaced the rolling reader with a direct schema-15 migration; synchronized
+  recovery, fixtures, bundled examples, documentation, and ADR 0030.
+- Validation: focused model/project-protocol/derived/editor contracts (12 files
+  / 102 tests), typecheck, format, docs, test-impact, and diff checks passed.
+- Commit status: committed on `codex/schematic-instance-lifecycle-ux` as
+  `d70c84bc`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -3750,3 +3750,14 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   flows (4 tests), typecheck, format, docs, test-impact, and diff checks passed.
 - Commit status: committed on `codex/schematic-instance-lifecycle-ux` as
   `0da8da3c`.
+
+## 2026-08-21 - Instance placement lifecycle engine
+
+- Changed areas: added explicit retained-unplaced transaction semantics and a
+  shared lifecycle planner; selection deletion now clears route endpoints,
+  memberships, NoConnects, labels, and unlocked layout references safely
+  before strict instance removal.
+- Validation: focused lifecycle/transaction/protocol/selection/Agent contracts
+  (5 files / 56 tests), typecheck, format, docs, MCP-resource freshness,
+  test-impact, and diff checks passed.
+- Commit status: pending commit on `codex/schematic-instance-lifecycle-ux`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -3739,3 +3739,14 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   / 102 tests), typecheck, format, docs, test-impact, and diff checks passed.
 - Commit status: committed on `codex/schematic-instance-lifecycle-ux` as
   `d70c84bc`.
+
+## 2026-08-21 - Unified instance display authoring
+
+- Changed areas: introduced a shared editor display factory; made manual
+  device, Cell, external-call and formal-Port labels category-correct; persisted
+  insertion references; separated Reference and Alias in Properties; and added
+  explicit ID/Reference/Alias/Master columns to Instance Table.
+- Validation: focused unit contracts (7 files / 25 tests), focused Playwright
+  flows (4 tests), typecheck, format, docs, test-impact, and diff checks passed.
+- Commit status: committed on `codex/schematic-instance-lifecycle-ux` as
+  `0da8da3c`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -3760,4 +3760,15 @@ Keep reusable lessons in `docs/experience/`, not in this log.
 - Validation: focused lifecycle/transaction/protocol/selection/Agent contracts
   (5 files / 56 tests), typecheck, format, docs, MCP-resource freshness,
   test-impact, and diff checks passed.
+- Commit status: committed on `codex/schematic-instance-lifecycle-ux` as
+  `c2295d6e`.
+
+## 2026-08-21 - Placement Tray controls
+
+- Changed areas: replaced the bare unplaced list with a semantic Placement
+  Tray; added single cursor placement, deterministic Place all, Return to tray,
+  Return all, and a clear permanent-delete distinction.
+- Validation: focused tray/interaction/connectivity/lifecycle contracts (4
+  files / 24 tests), focused browser tray flow, typecheck, format, docs,
+  test-impact, and diff checks passed.
 - Commit status: pending commit on `codex/schematic-instance-lifecycle-ux`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -3827,3 +3827,15 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   `pnpm verify:branch` (162 unit files / 975 tests, workspace build, production
   preview smoke) passed.
 - Commit status: ready to commit on `codex/schematic-instance-lifecycle-ux`.
+
+## 2026-08-21 - Schematic lifecycle mainline gate closure
+
+- Changed areas: fixed Clipboard paste to allocate a unique
+  `schematicReference` alongside each fresh netlist designator; aligned Port,
+  Net RichText, connected-deletion, and Project persistence browser contracts
+  with the accepted schema-18 behavior.
+- Validation: Clipboard unit tests (1 file / 8 tests), all 14 originally
+  failing browser cases, typecheck, test-impact and diff checks, and canonical
+  `pnpm ci:check` passed with 162 unit files / 975 tests, all workspace builds,
+  release/MCP smoke checks, and 167 browser tests.
+- Commit status: ready to commit on `codex/schematic-instance-lifecycle-ux`.


### PR DESCRIPTION
Summary: completes explicit placement lifecycle and Placement Tray controls; separates schematic labels from netlist designators; adds external-subcircuit authoring; unifies free Net Port and formal Cell Pin semantic naming with same-text RichText formatting; fixes copied schematic reference allocation. Validation: pnpm install --frozen-lockfile and pnpm ci:check passed locally with 975 unit tests and 167 browser tests.