### PR TITLE
Present SKY130 external MOS devices

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -2883,6 +2883,54 @@ test("exports structural SPICE and Spectre netlists while exposing instance auth
   await expect(properties.getByText(/^Model:/u)).toHaveCount(0);
 });
 
+test("selects a reviewed SKY130 MOS through the existing Model field", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await placeComponent(page, "nmos", { x: 360, y: 220 });
+  await openSelectionShelf(page);
+  const properties = page.getByRole("complementary", { name: "Properties" });
+  const model = properties.getByLabel("Component model target");
+
+  await expect(
+    properties.locator('datalist option[value="sky130_fd_pr__nfet_01v8"]'),
+  ).toHaveCount(1);
+  await model.fill("sky130_fd_pr__nfet_01v8");
+  await model.press("Tab");
+
+  await expect(properties).toContainText("External subcircuit · X reference");
+  await expect(
+    properties.getByLabel("Component netlist reference"),
+  ).toHaveValue("X1");
+  await expect(properties.getByLabel("Component nf")).toBeVisible();
+  await expect(
+    properties.getByLabel("Component m", { exact: true }),
+  ).toHaveCount(0);
+
+  const saved = JSON.parse(
+    (await downloadBytes(page, "File", "Save Project")).toString("utf8"),
+  );
+  expect(saved.externalSubcircuitDefinitions).toEqual([
+    expect.objectContaining({
+      name: "sky130_fd_pr__nfet_01v8",
+      terminals: [
+        expect.objectContaining({ name: "D" }),
+        expect.objectContaining({ name: "G" }),
+        expect.objectContaining({ name: "S" }),
+        expect.objectContaining({ name: "B" }),
+      ],
+    }),
+  ]);
+  expect(saved.documents[0].instances[0]).toMatchObject({
+    id: "M1",
+    schematicReference: "M1",
+    netlist: {
+      reference: "X1",
+      binding: { kind: "external-subcircuit" },
+    },
+  });
+});
+
 test("uses automatic recovery and guards shortcuts while typing", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -34,6 +34,7 @@ import {
   planEditCellTerminalAnnotation,
   planSetCellTerminalPlacement,
   planUpdateCellTerminalDirection,
+  planSetMosModelTarget,
   planInstanceUnplacement,
   proposeSetCellFormalParameters,
   proposeUpsertExternalSubcircuitDefinition,
@@ -119,6 +120,8 @@ import {
   externalSubcircuitSymbolId,
   findUnsupportedProjectSymbolIds,
   hierarchicalSymbolId,
+  resolvePdkSymbolMapping,
+  reviewedSky130MosModelSuggestions,
 } from "@icm/symbols";
 import { clipboardPreviewDocument } from "../features/clipboard/clipboard";
 import type { SchematicClipboard } from "../features/clipboard/clipboard";
@@ -174,7 +177,10 @@ import {
   proposePlacementContact,
   proposedStandalonePowerConnection,
 } from "../features/component-insert/placement-connectivity";
-import { componentParameters } from "../features/component-insert/component-parameters";
+import {
+  componentParameters,
+  externalMosComponentParameters,
+} from "../features/component-insert/component-parameters";
 import {
   endpointTestId,
   instanceLabelAnnotationFor,
@@ -870,6 +876,27 @@ export function App({
           (definition) => definition.id === selectedBinding.definitionId,
         )
       : undefined;
+  const selectedExternalMosMapping = selectedExternalSubcircuit
+    ? (() => {
+        const mapping = resolvePdkSymbolMapping(
+          selectedExternalSubcircuit.name,
+          selectedExternalSubcircuit.terminals.length,
+        );
+        return mapping &&
+          selectedExternalSubcircuit.terminals.every(
+            (terminal, index) =>
+              terminal.name.toLowerCase() ===
+              mapping.pinNames[index]?.toLowerCase(),
+          )
+          ? mapping
+          : undefined;
+      })()
+    : undefined;
+  const selectedPropertyDevice =
+    selectedDevice ??
+    (selectedExternalMosMapping
+      ? deviceDescriptor(selectedExternalMosMapping.symbolId)
+      : undefined);
   const selectedCellSymbolLayout = useMemo(() => {
     if (
       !cellSymbolLayoutEnabled ||
@@ -985,6 +1012,7 @@ export function App({
     selectedRouteNetLabel: selectedRouteNetLabel ?? null,
     selectedRouteNetLabels,
     selectedInstance,
+    componentParametersForInstance: propertyParametersForInstance,
     wireSourceActive: wireSource !== null,
     netLabelEditorInputRef,
     transact,
@@ -5355,7 +5383,7 @@ export function App({
       const netlistParameters = { ...baseNetlist.parameters };
       const set: Record<string, string> = {};
       const unset: string[] = [];
-      for (const parameter of componentParameters(instance.symbolId)) {
+      for (const parameter of propertyParametersForInstance(instance)) {
         const value = (draft.parameters[parameter.key] ?? "").trim();
         const current = netlistParameters[parameter.key];
         if (value === "") {
@@ -5423,6 +5451,40 @@ export function App({
 
   function updateSelectedModelTarget(value: string): void {
     if (!selectedInstance?.netlist) return;
+    if (
+      selectedPropertyDevice?.symbolId === "nmos" ||
+      selectedPropertyDevice?.symbolId === "pmos"
+    ) {
+      try {
+        const edits = planSetMosModelTarget(
+          project,
+          document.id,
+          selectedInstance.id,
+          value,
+        );
+        if (edits.length === 0) return;
+        if (commitStructure("set-mos-model-target", edits)) {
+          const target = value.trim();
+          const mapping = target
+            ? resolvePdkSymbolMapping(target, 4)
+            : undefined;
+          setStatus(
+            mapping
+              ? `Set external X target ${target}`
+              : target
+                ? `Set model target ${target}`
+                : `Cleared model target for ${selectedInstance.id}`,
+          );
+        }
+      } catch (error) {
+        setStatus(
+          error instanceof Error
+            ? error.message
+            : "Could not set MOS model target",
+        );
+      }
+      return;
+    }
     const binding = bindingForEditedModel(selectedInstance.symbolId, value);
     const nextBinding = binding ?? null;
     const currentBinding = selectedInstance.netlist.binding ?? null;
@@ -5442,6 +5504,32 @@ export function App({
           : `Cleared model target for ${selectedInstance.id}`,
       );
     }
+  }
+
+  function propertyParametersForInstance(
+    instance: SchematicDocument["instances"][number],
+  ) {
+    const binding = instance.netlist?.binding;
+    if (binding?.kind === "external-subcircuit") {
+      const definition = project.externalSubcircuitDefinitions.find(
+        (candidate) => candidate.id === binding.definitionId,
+      );
+      const mapping = definition
+        ? resolvePdkSymbolMapping(definition.name, definition.terminals.length)
+        : undefined;
+      if (
+        definition &&
+        (mapping?.symbolId === "nmos" || mapping?.symbolId === "pmos") &&
+        definition.terminals.every(
+          (terminal, index) =>
+            terminal.name.toLowerCase() ===
+            mapping.pinNames[index]?.toLowerCase(),
+        )
+      ) {
+        return externalMosComponentParameters(mapping.symbolId);
+      }
+    }
+    return componentParameters(instance.symbolId);
   }
 
   function updateSelectedSchematicName(value: string): void {
@@ -7823,7 +7911,7 @@ export function App({
                       </div>
                       <div>
                         <dt>Device class</dt>
-                        <dd>{selectedDevice?.deviceClass ?? "none"}</dd>
+                        <dd>{selectedPropertyDevice?.deviceClass ?? "none"}</dd>
                       </div>
                       <div>
                         <dt>Cell</dt>
@@ -7839,26 +7927,27 @@ export function App({
                       <div className="property-section-heading">
                         Netlist target
                       </div>
-                      {selectedInstance.netlist.binding?.kind === "model" ? (
+                      {selectedInstance.netlist.binding?.kind === "model" ||
+                      selectedDevice?.targetPolicy === "required-model" ||
+                      selectedExternalMosMapping ? (
                         <label>
                           Model
                           <input
                             key={`${selectedInstance.id}-${document.revision}-model-target`}
                             aria-label="Component model target"
-                            defaultValue={selectedInstance.netlist.binding.name}
-                            onBlur={(event) =>
-                              updateSelectedModelTarget(
-                                event.currentTarget.value,
-                              )
+                            list={
+                              selectedPropertyDevice?.symbolId === "nmos" ||
+                              selectedPropertyDevice?.symbolId === "pmos"
+                                ? `mos-model-options-${selectedPropertyDevice.symbolId}`
+                                : undefined
                             }
-                          />
-                        </label>
-                      ) : selectedDevice?.targetPolicy === "required-model" ? (
-                        <label>
-                          Model
-                          <input
-                            key={`${selectedInstance.id}-${document.revision}-model-target`}
-                            aria-label="Component model target"
+                            defaultValue={
+                              selectedInstance.netlist.binding?.kind === "model"
+                                ? selectedInstance.netlist.binding.name
+                                : selectedExternalMosMapping
+                                  ? selectedExternalSubcircuit?.name
+                                  : ""
+                            }
                             placeholder="Model name"
                             onBlur={(event) =>
                               updateSelectedModelTarget(
@@ -7866,6 +7955,21 @@ export function App({
                               )
                             }
                           />
+                          {selectedPropertyDevice?.symbolId === "nmos" ||
+                          selectedPropertyDevice?.symbolId === "pmos" ? (
+                            <datalist
+                              id={`mos-model-options-${selectedPropertyDevice.symbolId}`}
+                            >
+                              {reviewedSky130MosModelSuggestions(
+                                selectedPropertyDevice.symbolId,
+                              ).map((model) => (
+                                <option value={model} key={model} />
+                              ))}
+                            </datalist>
+                          ) : null}
+                          {selectedExternalMosMapping ? (
+                            <small>External subcircuit · X reference</small>
+                          ) : null}
                         </label>
                       ) : selectedInstance.netlist.binding?.kind ===
                         "primitive" ? (
@@ -7899,7 +8003,7 @@ export function App({
                   <div className="property-card property-parameters-card">
                     <div className="property-section-heading">Parameters</div>
                     <div className="component-parameter-grid">
-                      {componentParameters(selectedInstance.symbolId).map(
+                      {propertyParametersForInstance(selectedInstance).map(
                         (parameter, index) => (
                           <label key={parameter.key} title={parameter.help}>
                             <span className="property-parameter-name">

--- a/apps/editor/src/features/component-insert/component-parameters.test.ts
+++ b/apps/editor/src/features/component-insert/component-parameters.test.ts
@@ -4,6 +4,7 @@ import type { Instance } from "@icm/model";
 import {
   componentParameters,
   effectiveComponentParameterValue,
+  externalMosComponentParameters,
   initialComponentParameterValues,
 } from "./component-parameters";
 import { deviceDescriptor } from "@icm/devices";
@@ -33,6 +34,15 @@ describe("component parameter catalogue", () => {
       l: "",
       m: "",
     });
+  });
+
+  it("uses W, L, and NF for a reviewed external MOS call", () => {
+    expect(
+      externalMosComponentParameters("nmos").map(({ key }) => key),
+    ).toEqual(["w", "l", "nf"]);
+    expect(externalMosComponentParameters("pmos")).toEqual(
+      externalMosComponentParameters("nmos"),
+    );
   });
 
   it("projects the descriptor's ordered field metadata without local defaults", () => {

--- a/apps/editor/src/features/component-insert/component-parameters.ts
+++ b/apps/editor/src/features/component-insert/component-parameters.ts
@@ -23,6 +23,23 @@ export function componentParameters(
   }));
 }
 
+export function externalMosComponentParameters(
+  symbolId: "nmos" | "pmos",
+): readonly ComponentParameter[] {
+  return [
+    ...componentParameters(symbolId).filter(
+      (parameter) => parameter.key !== "m",
+    ),
+    {
+      key: "nf",
+      label: "NF",
+      placeholder: "1",
+      help: "External subcircuit finger count",
+      inputMode: "decimal",
+    },
+  ];
+}
+
 export function initialComponentParameterValues(
   symbolId: string,
 ): Record<string, string> {

--- a/apps/editor/src/features/properties/additional-parameters.ts
+++ b/apps/editor/src/features/properties/additional-parameters.ts
@@ -24,18 +24,25 @@ export type AdditionalParameterPlan =
       >;
     };
 
-function knownParameterNames(symbolId: string): ReadonlySet<string> {
+function knownParameterNames(
+  symbolId: string,
+  additionalKnownNames: readonly string[] = [],
+): ReadonlySet<string> {
   return new Set(
-    (deviceDescriptor(symbolId)?.parameters ?? []).map((parameter) =>
-      parameter.name.toLowerCase(),
-    ),
+    [
+      ...(deviceDescriptor(symbolId)?.parameters ?? []).map(
+        (parameter) => parameter.name,
+      ),
+      ...additionalKnownNames,
+    ].map((name) => name.toLowerCase()),
   );
 }
 
 export function additionalParameterDrafts(
   instance: Instance,
+  additionalKnownNames: readonly string[] = [],
 ): readonly AdditionalParameterDraft[] {
-  const known = knownParameterNames(instance.symbolId);
+  const known = knownParameterNames(instance.symbolId, additionalKnownNames);
   return Object.entries(instance.netlist?.parameters ?? {})
     .filter(([name]) => !known.has(name.toLowerCase()))
     .map(([name, value], index) => ({
@@ -53,6 +60,7 @@ export function additionalParameterDrafts(
 export function planAdditionalParameterPatch(
   instance: Instance,
   drafts: readonly AdditionalParameterDraft[],
+  additionalKnownNames: readonly string[] = [],
 ): AdditionalParameterPlan {
   if (!instance.netlist) {
     return {
@@ -60,7 +68,7 @@ export function planAdditionalParameterPatch(
       message: "This component has no netlist record to receive parameters",
     };
   }
-  const known = knownParameterNames(instance.symbolId);
+  const known = knownParameterNames(instance.symbolId, additionalKnownNames);
   const desired = new Map<string, { name: string; value: string }>();
   for (const draft of drafts) {
     const name = draft.name.trim();

--- a/apps/editor/src/features/properties/use-properties-editor.ts
+++ b/apps/editor/src/features/properties/use-properties-editor.ts
@@ -19,6 +19,7 @@ import {
   componentParameters,
   effectiveComponentParameterValue,
 } from "../component-insert/component-parameters";
+import type { ComponentParameter } from "../component-insert/component-parameters";
 import {
   additionalParameterDrafts,
   planAdditionalParameterPatch,
@@ -94,6 +95,9 @@ export interface UsePropertiesEditorOptions {
   selectedRouteNetLabel: Annotation | null;
   selectedRouteNetLabels: readonly Annotation[];
   selectedInstance: Instance | undefined;
+  componentParametersForInstance?: (
+    instance: Instance,
+  ) => readonly ComponentParameter[];
   wireSourceActive: boolean;
   netLabelEditorInputRef: MutableRefObject<HTMLInputElement | null>;
   transact: (edits: SchematicEdit[]) => TransactionResult;
@@ -142,7 +146,7 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     null,
   );
   const netLabelDraftRouteRef = useRef<string | null>(null);
-  const lastSelectedInstanceIdRef = useRef<string | null>(null);
+  const lastSelectedInstanceKeyRef = useRef<string | null>(null);
   const instancePropertyDraftRef = useRef<InstancePropertyDraft>(
     EMPTY_INSTANCE_PROPERTY_DRAFT,
   );
@@ -170,10 +174,14 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     return options.transact([...gate.edits]).ok;
   };
 
+  const parametersForInstance = (instance: Instance) =>
+    options.componentParametersForInstance?.(instance) ??
+    componentParameters(instance.symbolId);
+
   const draftForInstance = (instance: Instance): InstancePropertyDraft => ({
     instanceId: instance.id,
     parameters: Object.fromEntries(
-      componentParameters(instance.symbolId).map((parameter) => [
+      parametersForInstance(instance).map((parameter) => [
         parameter.key,
         effectiveComponentParameterValue(instance, parameter),
       ]),
@@ -231,8 +239,11 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
 
   useEffect(() => {
     const instanceId = options.selectedInstance?.id ?? null;
-    if (instanceId === lastSelectedInstanceIdRef.current) return;
-    lastSelectedInstanceIdRef.current = instanceId;
+    const instanceKey = options.selectedInstance
+      ? `${options.selectedInstance.id}:${options.selectedInstance.symbolId}`
+      : null;
+    if (instanceKey === lastSelectedInstanceKeyRef.current) return;
+    lastSelectedInstanceKeyRef.current = instanceKey;
     const nextDraft = options.selectedInstance
       ? draftForInstance(options.selectedInstance)
       : EMPTY_INSTANCE_PROPERTY_DRAFT;
@@ -240,7 +251,12 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     instancePropertyBaselineRef.current = nextDraft;
     setInstancePropertyDraft(nextDraft);
     const nextAdditionalDraft = options.selectedInstance
-      ? additionalParameterDrafts(options.selectedInstance)
+      ? additionalParameterDrafts(
+          options.selectedInstance,
+          parametersForInstance(options.selectedInstance).map(
+            (parameter) => parameter.key,
+          ),
+        )
       : [];
     additionalParameterBaselineRef.current = nextAdditionalDraft;
     setAdditionalParameterDraft(nextAdditionalDraft);
@@ -303,6 +319,7 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     const plan = planAdditionalParameterPatch(
       instance,
       additionalParameterDraft,
+      parametersForInstance(instance).map((parameter) => parameter.key),
     );
     if (plan.kind === "invalid") {
       options.setStatus(plan.message);

--- a/docs/agent/knowledge/pdk-and-symbols.md
+++ b/docs/agent/knowledge/pdk-and-symbols.md
@@ -20,6 +20,12 @@ SKY130 `sky130_fd_pr__nfet_*` and `sky130_fd_pr__pfet_*` four-terminal devices
 map to product NMOS/PMOS pins `D,G,S,B`. That rule does not apply to another
 namespace or terminal count.
 
+The mapped external definition keeps its immutable external Symbol ID and `X`
+binding; only its presentation borrows the base MOS artwork. Omit the base
+symbol's default three-terminal variant so the external contract exposes the
+fourth bulk terminal. An explicit external block presentation overrides this
+automatic artwork choice.
+
 ## Safe symbol replacement
 
 Use `set_instance_symbol` with an explicit source-pin to target-pin map whenever

--- a/docs/user/spice-compatibility.md
+++ b/docs/user/spice-compatibility.md
@@ -10,6 +10,21 @@ omit includes, PDK model paths, simulator decks, corners and analyses. Unknown
 imported `X` calls remain external subcircuit calls; a display mapping never
 turns them into a primitive model call.
 
+For the reviewed four-terminal SKY130 NFET/PFET family, the editor uses the
+existing NMOS/PMOS artwork with explicit `D`, `G`, `S`, and `B` terminals while
+retaining the external definition and `X` reference. A user may place the
+ordinary NMOS/PMOS with the unchanged Insert flow, then choose
+`sky130_fd_pr__nfet_01v8` or `sky130_fd_pr__pfet_01v8` from the existing Model
+field. The edit creates or reuses the project-local external definition,
+preserves connectivity and raw values, and exposes `w`, `l`, and `nf`. It does
+not convert `m` into `nf`.
+
+This convenience is structural only. It does not install SKY130, resolve a
+local `.include`, supply foundry models or corners, or make the exported
+netlist simulatable by itself. Unreviewed masters, incompatible terminal order,
+and external definitions with explicit block presentation continue to render
+as generic blocks.
+
 Imported `.subckt` parameter defaults become editable Cell formal parameters
 and are emitted again. Required-only Cell parameters remain an authoring
 concept but cannot be exported by the released portable dialects until they

--- a/packages/edit-engine/src/hierarchy-planner.test.ts
+++ b/packages/edit-engine/src/hierarchy-planner.test.ts
@@ -7,6 +7,7 @@ import {
   planCreateCellPort,
   planPlaceCellInstance,
   planReorderCellTerminal,
+  planSetMosModelTarget,
 } from "./hierarchy-planner.js";
 import { executeProjectTransaction } from "./project-transaction.js";
 
@@ -142,5 +143,151 @@ describe("hierarchy domain planners", () => {
         -1,
       ),
     ).toEqual([]);
+  });
+});
+
+describe("reviewed external MOS model targets", () => {
+  function projectWithNmos() {
+    const project = createEmptyProject("project", "Project");
+    const document = project.documents[0]!;
+    document.instances.push({
+      id: "M1",
+      symbolId: "nmos",
+      schematicReference: "M1",
+      placement: {
+        position: { x: 0, y: 0 },
+        rotation: 0,
+        mirror: "none",
+      },
+      netlist: {
+        reference: "M1",
+        binding: { kind: "model", deviceClass: "mos", name: "generic_nmos" },
+        parameters: { w: "2u", l: "150n", m: "2" },
+      },
+    });
+    document.nets.push({
+      id: "net-drain",
+      scope: "local",
+      terminals: [{ instanceId: "M1", pinName: "D" }],
+    });
+    document.junctions.push({
+      id: "junction-drain",
+      netId: "net-drain",
+      position: { x: 0, y: -40 },
+    });
+    document.routes.push({
+      id: "route-drain",
+      netId: "net-drain",
+      from: { kind: "terminal", instanceId: "M1", pinName: "D" },
+      to: { kind: "junction", junctionId: "junction-drain" },
+      waypoints: [],
+      segmentModes: ["auto"],
+    });
+    document.noConnects.push({
+      id: "open-bulk",
+      endpoint: { kind: "terminal", instanceId: "M1", pinName: "B" },
+    });
+    return project;
+  }
+
+  it("atomically creates a SKY130 interface and changes M to an external X call", () => {
+    const project = projectWithNmos();
+    const edits = planSetMosModelTarget(
+      project,
+      project.topDocumentId,
+      "M1",
+      "sky130_fd_pr__nfet_01v8",
+    );
+    const result = executeProjectTransaction(project, {
+      transactionId: "set-sky130-model",
+      projectId: project.id,
+      expectedStructureRevision: project.structureRevision,
+      actor: { kind: "human", id: "test" },
+      edits,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const instance = result.project.documents[0]!.instances[0]!;
+    expect(result.project.externalSubcircuitDefinitions[0]).toMatchObject({
+      name: "sky130_fd_pr__nfet_01v8",
+      terminals: [{ name: "D" }, { name: "G" }, { name: "S" }, { name: "B" }],
+    });
+    expect(instance).toMatchObject({
+      schematicReference: "M1",
+      netlist: {
+        reference: "X1",
+        parameters: { w: "2u", l: "150n", m: "2" },
+        binding: { kind: "external-subcircuit" },
+      },
+    });
+    expect(result.project.documents[0]!.nets[0]!.terminals).toEqual([
+      { instanceId: "M1", pinName: "D" },
+    ]);
+    expect(result.project.documents[0]!.routes[0]!.from).toEqual({
+      kind: "terminal",
+      instanceId: "M1",
+      pinName: "D",
+    });
+    expect(result.project.documents[0]!.noConnects[0]!.endpoint).toEqual({
+      kind: "terminal",
+      instanceId: "M1",
+      pinName: "B",
+    });
+  });
+
+  it("returns a reviewed SKY130 X call to an ordinary MOS model without deleting its interface", () => {
+    const source = projectWithNmos();
+    const externalResult = executeProjectTransaction(source, {
+      transactionId: "set-sky130-model",
+      projectId: source.id,
+      expectedStructureRevision: source.structureRevision,
+      actor: { kind: "human", id: "test" },
+      edits: planSetMosModelTarget(
+        source,
+        source.topDocumentId,
+        "M1",
+        "sky130_fd_pr__nfet_01v8",
+      ),
+    });
+    expect(externalResult.ok).toBe(true);
+    if (!externalResult.ok) return;
+    const project = externalResult.project;
+    const result = executeProjectTransaction(project, {
+      transactionId: "set-generic-model",
+      projectId: project.id,
+      expectedStructureRevision: project.structureRevision,
+      actor: { kind: "human", id: "test" },
+      edits: planSetMosModelTarget(
+        project,
+        project.topDocumentId,
+        "M1",
+        "generic_nmos",
+      ),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.project.documents[0]!.instances[0]).toMatchObject({
+      symbolId: "nmos",
+      schematicReference: "M1",
+      netlist: {
+        reference: "M1",
+        binding: { kind: "model", deviceClass: "mos", name: "generic_nmos" },
+      },
+    });
+    expect(result.project.externalSubcircuitDefinitions).toHaveLength(1);
+  });
+
+  it("rejects a PFET master on an NMOS symbol", () => {
+    const project = projectWithNmos();
+    expect(() =>
+      planSetMosModelTarget(
+        project,
+        project.topDocumentId,
+        "M1",
+        "sky130_fd_pr__pfet_01v8",
+      ),
+    ).toThrow(/not compatible/u);
   });
 });

--- a/packages/edit-engine/src/hierarchy-planner.ts
+++ b/packages/edit-engine/src/hierarchy-planner.ts
@@ -6,7 +6,18 @@ import type {
   ExternalSubcircuitDefinition,
   SchematicDocument,
 } from "@icm/model";
-import { externalSubcircuitSymbolId, hierarchicalSymbolId } from "@icm/symbols";
+import { deriveStableId } from "@icm/model";
+import {
+  createReferenceIndex,
+  hierarchyReferencePolicy,
+  nextReference,
+  referencePolicyForSymbol,
+} from "@icm/devices";
+import {
+  externalSubcircuitSymbolId,
+  hierarchicalSymbolId,
+  resolvePdkSymbolMapping,
+} from "@icm/symbols";
 
 import type { ProjectStructureEdit } from "./project-transaction.js";
 
@@ -85,6 +96,186 @@ function transactDocument(
     expectedRevision: document.revision,
     edits,
   };
+}
+
+function externalDefinitionId(masterName: string): string {
+  return deriveStableId("external-subcircuit", masterName.toLowerCase());
+}
+
+function externalTerminalId(masterName: string, index: number): string {
+  return deriveStableId(
+    "external-subcircuit-terminal",
+    masterName.toLowerCase(),
+    String(index),
+  );
+}
+
+function matchingExternalMosDefinition(
+  project: CircuitProject,
+  definitionId: string,
+) {
+  const definition = project.externalSubcircuitDefinitions.find(
+    (candidate) => candidate.id === definitionId,
+  );
+  if (!definition) return undefined;
+  const mapping = resolvePdkSymbolMapping(
+    definition.name,
+    definition.terminals.length,
+  );
+  if (
+    !mapping ||
+    !definition.terminals.every(
+      (terminal, index) =>
+        terminal.name.toLowerCase() === mapping.pinNames[index]?.toLowerCase(),
+    )
+  ) {
+    return undefined;
+  }
+  return { definition, mapping };
+}
+
+/**
+ * Switches a reviewed four-terminal MOS between an ordinary model binding and
+ * a SKY130 external X-call without changing the existing D/G/S/B connectivity.
+ */
+export function planSetMosModelTarget(
+  project: CircuitProject,
+  documentId: string,
+  instanceId: string,
+  modelName: string,
+): ProjectStructureEdit[] {
+  const document = requireDocument(project, documentId);
+  const instance = document.instances.find(
+    (candidate) => candidate.id === instanceId,
+  );
+  if (!instance?.netlist) {
+    throw new Error(`Netlisted Instance does not exist: ${instanceId}`);
+  }
+  const normalizedName = modelName.trim();
+  const targetMapping = normalizedName
+    ? resolvePdkSymbolMapping(normalizedName, 4)
+    : undefined;
+  const currentExternal =
+    instance.netlist.binding?.kind === "external-subcircuit"
+      ? matchingExternalMosDefinition(
+          project,
+          instance.netlist.binding.definitionId,
+        )
+      : undefined;
+  const sourceMosSymbolId =
+    currentExternal?.mapping.symbolId ?? instance.symbolId;
+  if (sourceMosSymbolId !== "nmos" && sourceMosSymbolId !== "pmos") {
+    throw new Error(
+      "Only reviewed NMOS and PMOS targets can use the Model field",
+    );
+  }
+
+  if (targetMapping) {
+    if (targetMapping.symbolId !== sourceMosSymbolId) {
+      throw new Error(
+        `${normalizedName} is not compatible with the selected ${sourceMosSymbolId.toUpperCase()}`,
+      );
+    }
+    const sameNameDefinition = project.externalSubcircuitDefinitions.find(
+      (definition) =>
+        definition.name.toLowerCase() === normalizedName.toLowerCase(),
+    );
+    const definition =
+      sameNameDefinition ??
+      ({
+        id: externalDefinitionId(normalizedName),
+        name: normalizedName,
+        terminals: targetMapping.pinNames.map((name, index) => ({
+          id: externalTerminalId(normalizedName, index),
+          name,
+          direction: "passive" as const,
+        })),
+        formalParameters: [],
+        interfaceStatus: "declared" as const,
+      } satisfies ExternalSubcircuitDefinition);
+    const verified = resolvePdkSymbolMapping(
+      definition.name,
+      definition.terminals.length,
+    );
+    if (
+      !verified ||
+      verified.symbolId !== sourceMosSymbolId ||
+      !definition.terminals.every(
+        (terminal, index) =>
+          terminal.name.toLowerCase() ===
+          verified.pinNames[index]?.toLowerCase(),
+      )
+    ) {
+      throw new Error(
+        `Existing external definition ${definition.name} does not declare D, G, S, B in reviewed order`,
+      );
+    }
+    const symbolId = externalSubcircuitSymbolId(definition.id);
+    const reference =
+      instance.netlist.binding?.kind === "external-subcircuit"
+        ? instance.netlist.reference
+        : nextReference(
+            createReferenceIndex(document),
+            hierarchyReferencePolicy,
+          )!;
+    const documentEdits: DocumentEdits = [];
+    if (instance.symbolId !== symbolId) {
+      documentEdits.push({
+        kind: "set_instance_symbol",
+        instanceId,
+        symbolId,
+      });
+    }
+    const netlist = {
+      ...instance.netlist,
+      reference,
+      binding: {
+        kind: "external-subcircuit" as const,
+        definitionId: definition.id,
+      },
+    };
+    if (JSON.stringify(instance.netlist) !== JSON.stringify(netlist)) {
+      documentEdits.push({ kind: "set_instance_netlist", instanceId, netlist });
+    }
+    if (documentEdits.length === 0) return [];
+    return [
+      ...(sameNameDefinition
+        ? []
+        : [
+            {
+              kind: "upsert_external_subcircuit_definition" as const,
+              definition,
+            },
+          ]),
+      transactDocument(project, documentId, documentEdits),
+    ];
+  }
+
+  const symbolId = sourceMosSymbolId;
+  const reference = currentExternal
+    ? nextReference(
+        createReferenceIndex(document),
+        referencePolicyForSymbol(symbolId),
+      )!
+    : instance.netlist.reference;
+  const binding = normalizedName
+    ? ({ kind: "model", deviceClass: "mos", name: normalizedName } as const)
+    : undefined;
+  const netlist = {
+    reference,
+    parameters: { ...instance.netlist.parameters },
+    ...(binding ? { binding } : {}),
+  };
+  const documentEdits: DocumentEdits = [];
+  if (instance.symbolId !== symbolId) {
+    documentEdits.push({ kind: "set_instance_symbol", instanceId, symbolId });
+  }
+  if (JSON.stringify(instance.netlist) !== JSON.stringify(netlist)) {
+    documentEdits.push({ kind: "set_instance_netlist", instanceId, netlist });
+  }
+  return documentEdits.length > 0
+    ? [transactDocument(project, documentId, documentEdits)]
+    : [];
 }
 
 /** Build the one canonical subcircuit Instance projection of a child Cell. */

--- a/packages/spice/src/compiler.test.ts
+++ b/packages/spice/src/compiler.test.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { builtInSymbols, createProjectSymbolResolver } from "@icm/symbols";
 
 import { compileSourceBundle, compileSpiceSources } from "./compiler.js";
 import { importCompileResult } from "./importer.js";
@@ -247,6 +248,19 @@ Q2 collector base emitter QPREF
       reference: "XM1",
       binding: expect.objectContaining({ kind: "external-subcircuit" }),
       parameters: { l: "1.0", w: "96", nf: "12" },
+    });
+    const resolved = createProjectSymbolResolver(
+      imported.project!,
+      builtInSymbols,
+    ).resolve(document.instances[0]!.symbolId);
+    const nmos = builtInSymbols.find((symbol) => symbol.id === "nmos");
+    expect(resolved).toMatchObject({
+      definition: {
+        pins: nmos?.pins,
+        primitives: nmos?.primitives,
+        variants: [],
+        hierarchicalBlock: true,
+      },
     });
     expect(
       document.nets

--- a/packages/symbols/src/hierarchical-block.test.ts
+++ b/packages/symbols/src/hierarchical-block.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { createHierarchicalBlockSymbol } from "./hierarchical-block.js";
+import { createEmptyProject } from "@icm/model";
+
+import { builtInSymbols } from "./builtins.js";
+import {
+  createHierarchicalBlockSymbol,
+  createProjectHierarchicalSymbols,
+  externalSubcircuitSymbolId,
+} from "./hierarchical-block.js";
 
 describe("hierarchical block formal terminals", () => {
   it("derives pins only from the private formal cell interface", () => {
@@ -162,5 +169,78 @@ describe("hierarchical block formal terminals", () => {
     expect(
       symbol?.pins.every((pin) => pin.at.x % 10 === 0 && pin.at.y % 10 === 0),
     ).toBe(true);
+  });
+});
+
+describe("external PDK symbol presentation", () => {
+  function projectWithExternal(
+    name: string,
+    terminalNames: readonly string[] = ["D", "G", "S", "B"],
+    presentation?: { minimumBodySize: { width: number; height: number } },
+  ) {
+    const project = createEmptyProject("project", "Project");
+    project.externalSubcircuitDefinitions.push({
+      id: "external-device",
+      name,
+      terminals: terminalNames.map((terminalName, index) => ({
+        id: `external-terminal-${index}`,
+        name: terminalName,
+        direction: "passive",
+      })),
+      formalParameters: [],
+      interfaceStatus: "declared",
+      ...(presentation ? { presentation } : {}),
+    });
+    return project;
+  }
+
+  it.each([
+    ["sky130_fd_pr__nfet_01v8", "nmos"],
+    ["sky130_fd_pr__pfet_01v8", "pmos"],
+  ])(
+    "uses four-terminal %s MOS artwork without changing external identity",
+    (name, baseId) => {
+      const symbol = createProjectHierarchicalSymbols(
+        projectWithExternal(name),
+        builtInSymbols,
+      ).find(
+        (candidate) =>
+          candidate.id === externalSubcircuitSymbolId("external-device"),
+      );
+      const base = builtInSymbols.find((candidate) => candidate.id === baseId);
+
+      expect(symbol).toMatchObject({
+        id: externalSubcircuitSymbolId("external-device"),
+        name,
+        hierarchicalBlock: true,
+        pins: base?.pins,
+        primitives: base?.primitives,
+        variants: [],
+      });
+      expect(symbol).not.toHaveProperty("defaultVariantId");
+      expect(symbol?.pins.map((pin) => pin.name)).toEqual(["D", "G", "S", "B"]);
+    },
+  );
+
+  it("keeps the generic block when terminal order is incompatible", () => {
+    const symbol = createProjectHierarchicalSymbols(
+      projectWithExternal("sky130_fd_pr__nfet_01v8", ["G", "D", "S", "B"]),
+      builtInSymbols,
+    ).at(-1);
+
+    expect(symbol?.pins.map((pin) => pin.name)).toEqual(["G", "D", "S", "B"]);
+    expect(symbol?.primitives[0]).toMatchObject({ kind: "polygon" });
+  });
+
+  it("keeps an explicit block presentation authoritative", () => {
+    const symbol = createProjectHierarchicalSymbols(
+      projectWithExternal("sky130_fd_pr__nfet_01v8", ["D", "G", "S", "B"], {
+        minimumBodySize: { width: 160, height: 100 },
+      }),
+      builtInSymbols,
+    ).at(-1);
+
+    expect(symbol?.viewBox.width).toBeGreaterThanOrEqual(160);
+    expect(symbol?.primitives[0]).toMatchObject({ kind: "polygon" });
   });
 });

--- a/packages/symbols/src/hierarchical-block.ts
+++ b/packages/symbols/src/hierarchical-block.ts
@@ -2,6 +2,7 @@ import { deriveStableId } from "@icm/model";
 import type { CircuitProject, SchematicDocument } from "@icm/model";
 
 import { createHierarchicalBlockGeometry } from "./hierarchical-block-geometry.js";
+import { resolvePdkSymbolMapping } from "./pdk-registry.js";
 import { SymbolDefinitionSchema } from "./schema.js";
 import type { SymbolDefinition } from "./schema.js";
 
@@ -39,6 +40,7 @@ export function createHierarchicalBlockSymbol(
 export function createProjectHierarchicalSymbols(
   project: Pick<CircuitProject, "documents" | "topDocumentId"> &
     Partial<Pick<CircuitProject, "externalSubcircuitDefinitions">>,
+  baseDefinitions: readonly SymbolDefinition[] = [],
 ): SymbolDefinition[] {
   const referencedChildIds = new Set(
     project.documents.flatMap((document) =>
@@ -61,6 +63,43 @@ export function createProjectHierarchicalSymbols(
   });
   const external = (project.externalSubcircuitDefinitions ?? []).flatMap(
     (definition) => {
+      const mapping = definition.presentation
+        ? undefined
+        : resolvePdkSymbolMapping(definition.name, definition.terminals.length);
+      const mappedDefinition = mapping
+        ? baseDefinitions.find((candidate) => candidate.id === mapping.symbolId)
+        : undefined;
+      const orderedTerminalNames = definition.terminals.map((terminal) =>
+        terminal.name.toLowerCase(),
+      );
+      const orderedMappedPins = mapping?.pinNames.map((name) =>
+        name.toLowerCase(),
+      );
+      if (
+        mappedDefinition &&
+        orderedMappedPins &&
+        orderedTerminalNames.every(
+          (name, index) => name === orderedMappedPins[index],
+        )
+      ) {
+        const {
+          id: _baseId,
+          name: _baseName,
+          defaultVariantId: _defaultVariantId,
+          variants: _variants,
+          decorative: _decorative,
+          ...artwork
+        } = mappedDefinition;
+        return [
+          SymbolDefinitionSchema.parse({
+            ...artwork,
+            id: externalSubcircuitSymbolId(definition.id),
+            name: definition.name,
+            hierarchicalBlock: true,
+            variants: [],
+          }),
+        ];
+      }
       const positional = createHierarchicalBlockGeometry(
         definition.terminals.map((terminal) => ({
           id: terminal.id,

--- a/packages/symbols/src/pdk-registry.test.ts
+++ b/packages/symbols/src/pdk-registry.test.ts
@@ -1,8 +1,21 @@
 import { describe, expect, it } from "vitest";
 
-import { resolvePdkSymbolMapping } from "./pdk-registry.js";
+import {
+  resolvePdkSymbolMapping,
+  reviewedSky130MosModelSuggestions,
+} from "./pdk-registry.js";
 
 describe("PDK symbol mapping registry", () => {
+  it("offers one bounded reviewed target per MOS polarity", () => {
+    expect(reviewedSky130MosModelSuggestions("nmos")).toEqual([
+      "sky130_fd_pr__nfet_01v8",
+    ]);
+    expect(reviewedSky130MosModelSuggestions("pmos")).toEqual([
+      "sky130_fd_pr__pfet_01v8",
+    ]);
+    expect(reviewedSky130MosModelSuggestions("resistor")).toEqual([]);
+  });
+
   it("maps reviewed SKY130 MOS namespaces with explicit pin order", () => {
     expect(resolvePdkSymbolMapping("sky130_fd_pr__nfet_01v8", 4)).toEqual({
       symbolId: "nmos",

--- a/packages/symbols/src/pdk-registry.ts
+++ b/packages/symbols/src/pdk-registry.ts
@@ -23,6 +23,21 @@ export interface PdkSymbolMappingOverride {
   registryId: string;
 }
 
+export const reviewedSky130MosModels = {
+  nmos: "sky130_fd_pr__nfet_01v8",
+  pmos: "sky130_fd_pr__pfet_01v8",
+} as const;
+
+export function reviewedSky130MosModelSuggestions(
+  symbolId: string,
+): readonly string[] {
+  return symbolId === "nmos"
+    ? [reviewedSky130MosModels.nmos]
+    : symbolId === "pmos"
+      ? [reviewedSky130MosModels.pmos]
+      : [];
+}
+
 const pdkRules: readonly PdkMappingRule[] = [
   {
     id: "sky130-nfet-four-terminal",

--- a/packages/symbols/src/resolver.ts
+++ b/packages/symbols/src/resolver.ts
@@ -46,7 +46,7 @@ export function createProjectSymbolResolver(
 ): InMemorySymbolResolver {
   return new InMemorySymbolResolver([
     ...baseDefinitions,
-    ...createProjectHierarchicalSymbols(project),
+    ...createProjectHierarchicalSymbols(project, baseDefinitions),
   ]);
 }
 

--- a/plan/2026-08-22-sky130-external-mos-presentation/plan.md
+++ b/plan/2026-08-22-sky130-external-mos-presentation/plan.md
@@ -1,0 +1,125 @@
+---
+status: completed
+experience: none
+---
+
+# SKY130 External MOS Presentation
+
+## Goal
+
+Make reviewed four-terminal SKY130 NFET/PFET external-subcircuit calls use the
+existing Razavi NMOS/PMOS artwork, and let a user select those masters through
+the existing MOS Model field without changing the `I` / Insert Component flow
+or the emitted `X` invocation.
+
+## State and Ownership
+
+Start state from `git status --short --branch` in the independent worktree:
+
+```text
+## codex/sky130-external-mos-presentation
+```
+
+The worktree is clean and was created from `main` at `e64afa16`. Untracked
+dependency/worktree infrastructure and unrelated plan directories in the root
+checkout are outside this worktree and will remain untouched.
+
+- `packages/symbols/src/hierarchical-block.ts`
+- `packages/symbols/src/hierarchical-block.test.ts`
+- `packages/symbols/src/pdk-registry.ts`
+- `packages/symbols/src/pdk-registry.test.ts`
+- `packages/edit-engine/src/hierarchy-planner.ts`
+- focused edit-engine tests required by the binding transition
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/features/component-insert/component-parameters.ts`
+- `apps/editor/src/features/properties/additional-parameters.ts`
+- `apps/editor/src/features/properties/use-properties-editor.ts`
+- focused editor unit/E2E tests for Model authoring and import presentation
+- `packages/spice/src/compiler.test.ts`
+- `docs/user/spice-compatibility.md`
+- this plan and `plan/log.md`
+
+- Read-only: existing Razavi `nmos`/`pmos` assets and device descriptors.
+- Shared: ADR 0029 external-definition identity and `X` binding; D/G/S/B Net
+  membership; Project-level structural transactions; deterministic netlist
+  export.
+
+## Work
+
+1. Derive a reviewed SKY130 external symbol from existing NMOS/PMOS artwork
+   while retaining the external definition's stable Symbol ID and explicit
+   four-terminal interface; preserve generic block fallback.
+2. Add a bounded Project planner that creates/reuses the reviewed SKY130
+   external definition and atomically changes a compatible selected MOS
+   between ordinary model binding and SKY130 external binding without losing
+   Nets, Routes, NoConnects, raw parameters, or schematic naming.
+3. Keep the existing Model input and `I` flow, add SKY130 suggestions/status,
+   and expose `nf` for the mapped external instance without inventing model
+   files, defaults, or parameter conversion.
+4. Protect import, manual authoring, save/reopen, visual fallback, and `X`
+   export behavior with focused contracts and document the structural-only
+   boundary.
+
+## Validation
+
+- Focused symbol, edit-engine, importer/editor unit tests changed by the work.
+- Focused hierarchy and SKY130 manual-editor browser scenarios.
+- `pnpm gate:plan -- --base origin/main`
+- `pnpm gate:preflight -- --base origin/main`
+- `pnpm gate:affected -- --base origin/main`
+- `pnpm test:impact -- --base origin/main`
+- `git diff --check`
+- `git status --short --branch`
+- `pnpm install --frozen-lockfile` and `pnpm ci:check` before mainline delivery.
+
+Electrical simulation is out of scope: this target preserves reviewed
+structural invocation and connectivity but supplies no foundry model files,
+corner, simulator, analysis, or electrical acceptance claim.
+
+## Gate Review
+
+- Decision: affected
+- The advisory plan classified all expected files and did not require the full
+  fallback during development.
+- Early gates: gate-review check, static contracts, and test-impact.
+- Affected gates: workspace unit tests plus hierarchy and editor browser
+  contracts.
+- Final gates: complete `pnpm ci:check` and required GitHub checks before any
+  non-document mainline delivery.
+- Platform risks: browser Properties/placement interaction is the primary
+  platform surface; no generated Razavi asset, release-only package, binary,
+  or golden change is planned.
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: reviewed SKY130 name/count/pin matching, external stable Symbol
+  identity with MOS artwork, atomic M/X binding transition, unchanged
+  connectivity/raw parameters, generic fallback, and structural `X` export.
+- Primary checks: focused symbol/edit-engine/editor unit tests and SKY130
+  browser import/manual-selection regression coverage.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(schematic): present SKY130 external MOS devices
+```
+
+## Outcome
+
+Reviewed four-terminal SKY130 NFET/PFET external definitions now retain their
+external stable identity and `X` semantics while borrowing the existing
+Razavi MOS artwork with an explicit bulk pin. The unchanged MOS Model field
+offers one reviewed target per polarity and atomically creates/reuses the
+external definition, preserves connectivity/schematic naming/raw parameters,
+renumbers `M` to `X`, and exposes `nf`; switching back to an ordinary model is
+also atomic and leaves the reusable definition intact. Unknown, mismatched, or
+explicitly presented external definitions remain generic blocks.
+
+Validation passed: focused contracts (32 tests plus registry/planner reruns),
+the affected gate (167 files / 1018 unit tests and all selected browser suites),
+frozen install, and canonical `pnpm ci:check` including builds, release checks,
+production smoke, and 171 browser tests. No simulation or electrical claim was
+made.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4004,3 +4004,16 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   files / 995 tests, all builds and release checks, 169 browser tests) passed.
 - Commit status: completed on `codex/variable-resistor` across the feature,
   subcircuit, and final gate-closure commits.
+
+## 2026-08-22 - SKY130 external MOS presentation
+
+- Changed areas: reused explicit four-terminal Razavi NMOS/PMOS artwork for
+  reviewed SKY130 external definitions; added an atomic Model-field transition
+  between ordinary `M` model binding and external `X` binding; exposed `nf`
+  without converting retained `m`; and preserved generic-block fallback.
+- Validation: focused symbol/planner/import/editor tests, `gate:preflight`,
+  `gate:affected` (167 files / 1018 unit tests plus all selected browser
+  suites), frozen install, and canonical `pnpm ci:check` with builds, release
+  checks, production smoke, and 171 browser tests passed.
+- Commit status: ready to commit on
+  `codex/sky130-external-mos-presentation`.


### PR DESCRIPTION
## Summary
- render reviewed four-terminal SKY130 NFET/PFET external definitions with existing Razavi MOS artwork
- switch compatible MOS Model targets atomically between ordinary M models and external X calls
- preserve connectivity and raw parameters while exposing nf and retaining generic fallback

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- pnpm install --frozen-lockfile
- pnpm ci:check (167 unit files / 1018 tests; 171 browser tests)