### PR TITLE
Directional window/crossing marquee selection and native text-selection fix

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -1829,13 +1829,14 @@ test("Properties toggles reference label visibility for one or many components",
     page.getByTestId("annotation-hit-instance-label-R1"),
   ).toHaveCount(1);
 
-  // Marquee both components and toggle the whole group.
+  // Marquee both components and toggle the whole group. The left-to-right
+  // window requires FULL coverage, so sweep well past both symbol bodies.
   const canvas = page.getByTestId("schematic-canvas");
   const box = await canvas.boundingBox();
   if (!box) throw new Error("Canvas is not measurable");
-  await page.mouse.move(box.x + 200, box.y + 80);
+  await page.mouse.move(box.x + 120, box.y + 40);
   await page.mouse.down();
-  await page.mouse.move(box.x + 620, box.y + 320, { steps: 6 });
+  await page.mouse.move(box.x + 700, box.y + 340, { steps: 6 });
   await page.mouse.up();
   const groupToggle = page.getByRole("checkbox", {
     name: "Reference",
@@ -3448,4 +3449,60 @@ test("filters and navigates locator-backed visual diagnostics", async ({
   await expect(page.getByTestId("status")).toContainText(
     "VISUAL VISUAL_SYMBOL_OVERLAP",
   );
+});
+
+test("directional marquee: window needs full coverage, crossing selects on touch", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await chooseComponent(page, "resistor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.click({ position: { x: 420, y: 260 } });
+  await page.keyboard.press("Escape");
+  const hit = page.getByTestId("hit-R1");
+  const bounds = await hit.boundingBox();
+  if (!bounds) throw new Error("Placed resistor is not measurable");
+
+  // Left-to-right window covering only the upper half: nothing is selected.
+  const partial = {
+    left: bounds.x - 20,
+    top: bounds.y - 20,
+    right: bounds.x + bounds.width + 20,
+    middle: bounds.y + bounds.height / 2,
+  };
+  await page.mouse.move(partial.left, partial.top);
+  await page.mouse.down();
+  await page.mouse.move(partial.right, partial.middle, { steps: 4 });
+  await expect(page.getByTestId("selection-box")).toHaveClass(
+    "selection-box selection-box--window",
+  );
+  await page.mouse.up();
+  await expect(page.getByTestId("status")).toContainText("Selection cleared");
+
+  // The same rectangle dragged right-to-left is a crossing and selects R1.
+  await page.mouse.move(partial.right, partial.top);
+  await page.mouse.down();
+  await page.mouse.move(partial.left, partial.middle, { steps: 4 });
+  await expect(page.getByTestId("selection-box")).toHaveClass(
+    "selection-box selection-box--crossing",
+  );
+  await page.mouse.up();
+  await expect(page.getByTestId("status")).toContainText(/Selected \d+ object/);
+
+  // A left-to-right window swallowing the whole symbol selects it too.
+  await page.mouse.move(bounds.x - 30, bounds.y - 30);
+  await page.mouse.down();
+  await page.mouse.move(
+    bounds.x + bounds.width + 30,
+    bounds.y + bounds.height + 30,
+    { steps: 4 },
+  );
+  await page.mouse.up();
+  await expect(page.getByTestId("status")).toContainText(/Selected \d+ object/);
+
+  // Marquee sweeps are gestures: they must never start a native browser text
+  // selection over the SVG labels (the old distant-label highlight bug).
+  expect(
+    await page.evaluate(() => window.getSelection()?.toString() ?? ""),
+  ).toBe("");
 });

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -145,11 +145,7 @@ import {
   closestPointOnSegment,
   normalizedBearing,
   normalizedRect,
-  pointInRect,
   polylineBounds,
-  rectangleBoundaryIntersectsRect,
-  rectsIntersect,
-  segmentIntersectsRect,
   serializePolylinePoints,
 } from "../canvas/canvas-geometry";
 import { CanvasTextEditorOverlay } from "../features/text-editing/canvas-text-editor-overlay";
@@ -230,6 +226,10 @@ import {
   rectangleInteriorAt,
   rectangleLabelFor,
 } from "../features/drafting/rectangle-label";
+import {
+  marqueeMode,
+  marqueeSelection,
+} from "../features/selection/marquee-selection";
 import {
   draftingPathData,
   quadraticMidpoint,
@@ -5923,84 +5923,28 @@ export function App({
     const clicked =
       rect.width <= document.presentation.grid &&
       rect.height <= document.presentation.grid;
-    const ids = clicked
-      ? []
-      : [
-          ...new Set(
-            document.instances
-              .filter((instance) => {
-                const bounds = instanceHitBox(instance, resolver);
-                return bounds !== null && rectsIntersect(bounds, rect);
-              })
-              .map((instance) => instance.id),
-          ),
-        ];
-    const supplemental = clicked
-      ? EMPTY_SUPPLEMENTAL_SELECTION
-      : {
-          routeIds: routeGeometryRecords
-            .filter(({ geometry }) =>
-              geometry.centerline
-                .slice(0, -1)
-                .some((from, index) =>
-                  segmentIntersectsRect(
-                    from,
-                    geometry.centerline[index + 1]!,
-                    rect,
-                  ),
-                ),
-            )
-            .map(({ route }) => route.id),
-          junctionIds: document.junctions
-            .filter((junction) => pointInRect(junction.position, rect))
-            .map((junction) => junction.id),
-          annotationIds: document.annotations
-            .filter(
-              (annotation) =>
-                isSchematicAnnotationVisible(document, annotation) &&
-                rectsIntersect(
-                  annotationHitBox(
-                    document,
-                    annotation,
-                    annotationAnchor(
-                      document,
-                      resolver,
-                      annotation,
-                      routeGeometryRecords,
-                      styleProfile,
-                    ),
-                    routeGeometryRecords,
-                    styleProfile,
-                  ),
-                  rect,
-                ),
-            )
-            .map((annotation) => annotation.id),
-          draftingIds: (document.drafting?.objects ?? [])
-            .filter((object) => {
-              const geometry = resolveDraftingObjectGeometry(
-                document,
-                resolver,
-                object,
-              );
-              return geometry.kind === "rectangle"
-                ? rectangleBoundaryIntersectsRect(geometry.corners, rect)
-                : rectsIntersect(geometry.bounds, rect);
-            })
-            .map((object) => object.id),
-        };
-    replaceSelection({
-      instanceIds: ids,
-      ...supplemental,
-    });
+    // Classic directional marquee: a left-to-right drag is a window (full
+    // containment required), a right-to-left drag is a crossing (any overlap
+    // selects). Geometry alone decides membership.
+    const selection = clicked
+      ? { instanceIds: [], ...EMPTY_SUPPLEMENTAL_SELECTION }
+      : marqueeSelection(
+          document,
+          resolver,
+          routeGeometryRecords,
+          styleProfile,
+          rect,
+          marqueeMode(boxPreview.start, boxPreview.end),
+        );
+    replaceSelection(selection);
     setSelectedEndpoint(null);
     setBoxPreview(null);
     const count =
-      ids.length +
-      supplemental.routeIds.length +
-      supplemental.junctionIds.length +
-      supplemental.annotationIds.length +
-      supplemental.draftingIds.length;
+      selection.instanceIds.length +
+      selection.routeIds.length +
+      selection.junctionIds.length +
+      selection.annotationIds.length +
+      selection.draftingIds.length;
     setStatus(count > 0 ? `Selected ${count} objects` : "Selection cleared");
   }
 
@@ -10103,7 +10047,12 @@ export function App({
                     boxPreview.intent === "zoom" ? "zoom-box" : "selection-box"
                   }
                   className={
-                    boxPreview.intent === "zoom" ? "zoom-box" : "selection-box"
+                    boxPreview.intent === "zoom"
+                      ? "zoom-box"
+                      : `selection-box selection-box--${marqueeMode(
+                          boxPreview.start,
+                          boxPreview.end,
+                        )}`
                   }
                   {...normalizedRect(boxPreview.start, boxPreview.end)}
                 />

--- a/apps/editor/src/canvas/canvas-geometry.test.ts
+++ b/apps/editor/src/canvas/canvas-geometry.test.ts
@@ -7,6 +7,8 @@ import {
   normalizedRect,
   pointInRect,
   polylineBounds,
+  polylineInRect,
+  rectContainsRect,
   rectangleBoundaryIntersectsRect,
   rectsIntersect,
   rotatePointByDegrees,
@@ -103,5 +105,54 @@ describe("canvas geometry primitives", () => {
       width: 1,
       height: 1,
     });
+  });
+});
+
+describe("rectContainsRect", () => {
+  const outer = { x: 0, y: 0, width: 100, height: 50 };
+
+  it("accepts full containment, boundary inclusive", () => {
+    expect(
+      rectContainsRect(outer, { x: 10, y: 10, width: 20, height: 20 }),
+    ).toBe(true);
+    expect(
+      rectContainsRect(outer, { x: 0, y: 0, width: 100, height: 50 }),
+    ).toBe(true);
+  });
+
+  it("rejects partial overlap and disjoint rectangles", () => {
+    expect(
+      rectContainsRect(outer, { x: 90, y: 10, width: 20, height: 10 }),
+    ).toBe(false);
+    expect(
+      rectContainsRect(outer, { x: 200, y: 0, width: 10, height: 10 }),
+    ).toBe(false);
+  });
+});
+
+describe("polylineInRect", () => {
+  const rect = { x: 0, y: 0, width: 100, height: 50 };
+
+  it("requires every vertex inside", () => {
+    expect(
+      polylineInRect(
+        [
+          { x: 10, y: 10 },
+          { x: 90, y: 10 },
+          { x: 90, y: 40 },
+        ],
+        rect,
+      ),
+    ).toBe(true);
+    expect(
+      polylineInRect(
+        [
+          { x: 10, y: 10 },
+          { x: 120, y: 10 },
+        ],
+        rect,
+      ),
+    ).toBe(false);
+    expect(polylineInRect([], rect)).toBe(false);
   });
 });

--- a/apps/editor/src/canvas/canvas-geometry.ts
+++ b/apps/editor/src/canvas/canvas-geometry.ts
@@ -81,6 +81,22 @@ export function pointInRect(point: Point, rect: Rect): boolean {
   );
 }
 
+/** True when `inner` lies entirely inside `outer` (boundary inclusive). */
+export function rectContainsRect(outer: Rect, inner: Rect): boolean {
+  return (
+    inner.x >= outer.x &&
+    inner.y >= outer.y &&
+    inner.x + inner.width <= outer.x + outer.width &&
+    inner.y + inner.height <= outer.y + outer.height
+  );
+}
+
+/** True when every vertex — and therefore, for an axis-aligned rectangle,
+ * every segment of the polyline — lies inside the rectangle. */
+export function polylineInRect(points: readonly Point[], rect: Rect): boolean {
+  return points.length > 0 && points.every((point) => pointInRect(point, rect));
+}
+
 export function segmentIntersectsRect(
   from: Point,
   to: Point,

--- a/apps/editor/src/features/selection/marquee-selection.test.ts
+++ b/apps/editor/src/features/selection/marquee-selection.test.ts
@@ -1,0 +1,219 @@
+import { createEmptyDocument } from "@icm/model";
+import type { Rect, SchematicDocument } from "@icm/model";
+import {
+  resolveRouteGeometry,
+  resolveSchematicStyleProfile,
+} from "@icm/derived";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import {
+  annotationAnchor,
+  annotationHitBox,
+  defaultInstanceLabel,
+  instanceHitBox,
+  type RouteGeometryRecord,
+} from "../wiring/route-interaction-geometry";
+import { marqueeMode, marqueeSelection } from "./marquee-selection";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+const styleProfile = resolveSchematicStyleProfile("razavi-textbook-v1");
+
+function grow(rect: Rect, margin: number): Rect {
+  return {
+    x: rect.x - margin,
+    y: rect.y - margin,
+    width: rect.width + margin * 2,
+    height: rect.height + margin * 2,
+  };
+}
+
+function fixture(): {
+  document: SchematicDocument;
+  records: RouteGeometryRecord[];
+  instanceBounds: Rect;
+  labelBounds: Rect;
+} {
+  const document = createEmptyDocument("marquee", "Marquee");
+  document.nets.push({ id: "net-1", scope: "local", terminals: [] });
+  document.junctions.push(
+    {
+      id: "j1",
+      netId: "net-1",
+      position: { x: 0, y: 0 },
+      role: "route-anchor",
+    },
+    {
+      id: "j2",
+      netId: "net-1",
+      position: { x: 100, y: 0 },
+      role: "route-anchor",
+    },
+  );
+  document.routes.push({
+    id: "route-1",
+    netId: "net-1",
+    from: { kind: "junction", junctionId: "j1" },
+    to: { kind: "junction", junctionId: "j2" },
+    waypoints: [],
+    segmentModes: ["manual"],
+  });
+  document.instances.push({
+    id: "M1",
+    symbolId: "nmos",
+    placement: { position: { x: 300, y: 200 }, rotation: 0, mirror: "none" },
+  });
+  const label = defaultInstanceLabel(
+    document,
+    document.instances[0]!,
+    resolver,
+    styleProfile,
+  );
+  if (!label) throw new Error("Fixture label must resolve");
+  document.annotations.push(label);
+  document.drafting = {
+    objects: [
+      {
+        id: "box-1",
+        kind: "rectangle",
+        locked: false,
+        zIndex: 0,
+        anchor: { kind: "free", position: { x: 500, y: 100 } },
+        center: { x: 500, y: 100 },
+        width: 80,
+        height: 40,
+        rotation: 0,
+        lineStyle: "solid",
+      },
+    ],
+  };
+  const geometry = resolveRouteGeometry(
+    document,
+    resolver,
+    document.routes[0]!,
+  );
+  if (!geometry) throw new Error("Fixture route must resolve");
+  const records = [{ route: document.routes[0]!, geometry }];
+  const instanceBounds = instanceHitBox(document.instances[0]!, resolver);
+  if (!instanceBounds) throw new Error("Fixture instance must resolve");
+  const labelBounds = annotationHitBox(
+    document,
+    label,
+    annotationAnchor(document, resolver, label, records, styleProfile),
+    records,
+    styleProfile,
+  );
+  return { document, records, instanceBounds, labelBounds };
+}
+
+function select(rect: Rect, mode: "window" | "crossing") {
+  const { document, records } = fixtureCache;
+  return marqueeSelection(
+    document,
+    resolver,
+    records,
+    styleProfile,
+    rect,
+    mode,
+  );
+}
+
+const fixtureCache = fixture();
+
+describe("marqueeMode", () => {
+  it("maps left-to-right to window and right-to-left to crossing", () => {
+    expect(marqueeMode({ x: 0, y: 0 }, { x: 50, y: 30 })).toBe("window");
+    expect(marqueeMode({ x: 0, y: 0 }, { x: 0, y: 30 })).toBe("window");
+    expect(marqueeMode({ x: 50, y: 0 }, { x: 0, y: 30 })).toBe("crossing");
+  });
+});
+
+describe("marquee window selection (left-to-right)", () => {
+  it("selects an instance only when its bounds are fully contained", () => {
+    const { instanceBounds } = fixtureCache;
+    expect(select(grow(instanceBounds, 4), "window").instanceIds).toEqual([
+      "M1",
+    ]);
+    const partial = {
+      ...grow(instanceBounds, 4),
+      width: instanceBounds.width / 2,
+    };
+    expect(select(partial, "window").instanceIds).toEqual([]);
+  });
+
+  it("selects a route only when the whole centerline is inside", () => {
+    expect(
+      select({ x: -10, y: -10, width: 120, height: 20 }, "window").routeIds,
+    ).toEqual(["route-1"]);
+    expect(
+      select({ x: 40, y: -10, width: 120, height: 20 }, "window").routeIds,
+    ).toEqual([]);
+  });
+
+  it("selects an annotation only when fully contained", () => {
+    const { labelBounds } = fixtureCache;
+    expect(select(grow(labelBounds, 4), "window").annotationIds).toEqual([
+      fixtureCache.document.annotations[0]!.id,
+    ]);
+    const partial = { ...grow(labelBounds, 4), width: labelBounds.width / 2 };
+    expect(select(partial, "window").annotationIds).toEqual([]);
+  });
+
+  it("selects an outline rectangle only when all corners are inside", () => {
+    expect(
+      select({ x: 450, y: 70, width: 100, height: 60 }, "window").draftingIds,
+    ).toEqual(["box-1"]);
+    // Partially covering or sitting wholly inside the box selects nothing.
+    expect(
+      select({ x: 450, y: 70, width: 60, height: 60 }, "window").draftingIds,
+    ).toEqual([]);
+    expect(
+      select({ x: 480, y: 90, width: 30, height: 15 }, "window").draftingIds,
+    ).toEqual([]);
+  });
+});
+
+describe("marquee crossing selection (right-to-left)", () => {
+  it("selects an instance on any overlap", () => {
+    const { instanceBounds } = fixtureCache;
+    const partial = {
+      ...grow(instanceBounds, 4),
+      width: instanceBounds.width / 2,
+    };
+    expect(select(partial, "crossing").instanceIds).toEqual(["M1"]);
+  });
+
+  it("selects a route touched by the rectangle", () => {
+    expect(
+      select({ x: 40, y: -10, width: 20, height: 20 }, "crossing").routeIds,
+    ).toEqual(["route-1"]);
+  });
+
+  it("selects an outline rectangle only through its boundary", () => {
+    expect(
+      select({ x: 450, y: 70, width: 60, height: 60 }, "crossing").draftingIds,
+    ).toEqual(["box-1"]);
+    // A crossing wholly inside the empty box still selects only contents.
+    expect(
+      select({ x: 480, y: 90, width: 30, height: 15 }, "crossing").draftingIds,
+    ).toEqual([]);
+  });
+
+  it("keeps junction membership identical in both modes", () => {
+    const around = { x: -5, y: -5, width: 10, height: 10 };
+    expect(select(around, "crossing").junctionIds).toEqual(["j1"]);
+    expect(select(around, "window").junctionIds).toEqual(["j1"]);
+  });
+
+  it("never selects distant objects in either mode", () => {
+    const empty = { x: 1000, y: 1000, width: 200, height: 200 };
+    for (const mode of ["window", "crossing"] as const) {
+      const selection = select(empty, mode);
+      expect(selection.instanceIds).toEqual([]);
+      expect(selection.routeIds).toEqual([]);
+      expect(selection.junctionIds).toEqual([]);
+      expect(selection.annotationIds).toEqual([]);
+      expect(selection.draftingIds).toEqual([]);
+    }
+  });
+});

--- a/apps/editor/src/features/selection/marquee-selection.ts
+++ b/apps/editor/src/features/selection/marquee-selection.ts
@@ -1,0 +1,127 @@
+import {
+  isSchematicAnnotationVisible,
+  resolveDraftingObjectGeometry,
+} from "@icm/derived";
+import type { SchematicStyleProfile } from "@icm/derived";
+import type { Point, Rect, SchematicDocument } from "@icm/model";
+import type { SymbolResolver } from "@icm/symbols";
+
+import {
+  pointInRect,
+  polylineInRect,
+  rectContainsRect,
+  rectangleBoundaryIntersectsRect,
+  rectsIntersect,
+  segmentIntersectsRect,
+} from "../../canvas/canvas-geometry";
+import {
+  annotationAnchor,
+  annotationHitBox,
+  instanceHitBox,
+  type RouteGeometryRecord,
+} from "../wiring/route-interaction-geometry";
+
+/**
+ * Classic drafting-tool marquee semantics: dragging left-to-right is a
+ * `window` (an object is selected only when fully contained), dragging
+ * right-to-left is a `crossing` (touching the rectangle is enough).
+ */
+export type MarqueeMode = "window" | "crossing";
+
+export function marqueeMode(start: Point, end: Point): MarqueeMode {
+  return end.x < start.x ? "crossing" : "window";
+}
+
+export interface MarqueeSelectionSet {
+  instanceIds: string[];
+  routeIds: string[];
+  junctionIds: string[];
+  annotationIds: string[];
+  draftingIds: string[];
+}
+
+/**
+ * The complete marquee selection for one normalized rectangle. Only geometry
+ * decides membership: a junction is its point in both modes; every other
+ * object needs full containment under `window` and any overlap under
+ * `crossing`. Route membership tests the actual centerline, never a bounding
+ * box, so a distant bend cannot join the selection.
+ */
+export function marqueeSelection(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  routeGeometryRecords: readonly RouteGeometryRecord[],
+  styleProfile: SchematicStyleProfile,
+  rect: Rect,
+  mode: MarqueeMode,
+): MarqueeSelectionSet {
+  const window = mode === "window";
+  const boxSelected = (bounds: Rect): boolean =>
+    window ? rectContainsRect(rect, bounds) : rectsIntersect(bounds, rect);
+
+  return {
+    instanceIds: document.instances
+      .filter((instance) => {
+        const bounds = instanceHitBox(instance, resolver);
+        return bounds !== null && boxSelected(bounds);
+      })
+      .map((instance) => instance.id),
+    routeIds: routeGeometryRecords
+      .filter(({ geometry }) =>
+        window
+          ? polylineInRect(geometry.centerline, rect)
+          : geometry.centerline
+              .slice(0, -1)
+              .some((from, index) =>
+                segmentIntersectsRect(
+                  from,
+                  geometry.centerline[index + 1]!,
+                  rect,
+                ),
+              ),
+      )
+      .map(({ route }) => route.id),
+    junctionIds: document.junctions
+      .filter((junction) => pointInRect(junction.position, rect))
+      .map((junction) => junction.id),
+    annotationIds: document.annotations
+      .filter(
+        (annotation) =>
+          isSchematicAnnotationVisible(document, annotation) &&
+          boxSelected(
+            annotationHitBox(
+              document,
+              annotation,
+              annotationAnchor(
+                document,
+                resolver,
+                annotation,
+                routeGeometryRecords,
+                styleProfile,
+              ),
+              routeGeometryRecords,
+              styleProfile,
+            ),
+          ),
+      )
+      .map((annotation) => annotation.id),
+    draftingIds: (document.drafting?.objects ?? [])
+      .filter((object) => {
+        const geometry = resolveDraftingObjectGeometry(
+          document,
+          resolver,
+          object,
+        );
+        if (geometry.kind === "rectangle") {
+          // An outline rectangle is its border: a window must swallow all
+          // four corners; a crossing must actually touch the boundary, so a
+          // marquee wholly inside an empty box selects its contents only.
+          return window
+            ? geometry.corners.every((corner) => pointInRect(corner, rect))
+            : rectangleBoundaryIntersectsRect(geometry.corners, rect);
+        }
+        return boxSelected(geometry.bounds);
+      })
+      .map((object) => object.id),
+  };
+}

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -24,6 +24,8 @@
   --icm-accent-tint: #e7f3fc;
   --icm-error: #eb5757;
   --icm-warning: #9a6700;
+  --icm-marquee-crossing: #3fa34d;
+  --icm-marquee-crossing-soft: rgb(63 163 77 / 10%);
   --icm-grid-dot: #c4c7c9;
 
   /* Spacing: 4px base */
@@ -1916,6 +1918,19 @@ body {
   background: #fff;
   box-shadow: none;
   touch-action: none;
+  /* Canvas drags are gestures, never reading flows: without this, a marquee
+     sweep starts a NATIVE browser text selection across the SVG labels in
+     DOM order, highlighting text far outside the dragged rectangle. */
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* The inline text editor is the one place canvas text is really edited;
+   restore selection inside it so caret and range editing keep working. */
+.canvas-text-editor-overlay,
+.canvas-text-editor-overlay * {
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 /* The interactive scene reuses the formal renderer body without its exported
@@ -2083,6 +2098,18 @@ body {
   stroke-dasharray: 5 4;
   pointer-events: none;
   vector-effect: non-scaling-stroke;
+}
+
+/* Directional marquee affordance: a left-to-right window (solid blue) selects
+   only what it fully contains; a right-to-left crossing (dashed green) selects
+   anything it touches — the classic drafting-tool pairing. */
+.selection-box--window {
+  stroke-dasharray: none;
+}
+
+.selection-box--crossing {
+  fill: var(--icm-marquee-crossing-soft);
+  stroke: var(--icm-marquee-crossing);
 }
 
 /* Right-drag camera frame: hints navigation, not selection. */

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -210,6 +210,16 @@ fallback, not a second progressive planner for a group gesture. Marquee Route
 selection tests actual polyline segments against the rectangle, rather than
 selecting a distant bend solely because its bounding box overlaps the gesture.
 
+The marquee is directional, following the classic drafting-tool pairing. A
+left-to-right drag is a window: an object joins the selection only when its
+geometry is fully contained (an outline rectangle needs all four corners; a
+Route needs its whole centerline). A right-to-left drag is a crossing: any
+geometric overlap selects, which preserves the previous behavior. A Junction
+is its point in both directions. The live preview distinguishes the modes
+(solid window, dashed crossing). Membership is decided by document geometry
+alone: the canvas suppresses native browser text selection, so a drag can
+never highlight or select labels outside the dragged rectangle.
+
 ## No-reroute movement boundary
 
 The editor's finite direct-manipulation vocabulary is transient only:

--- a/plan/2026-08-21-marquee-window-crossing/plan.md
+++ b/plan/2026-08-21-marquee-window-crossing/plan.md
@@ -1,0 +1,120 @@
+---
+status: completed
+experience: none
+---
+
+# Directional Marquee Selection and Native Text-Selection Fix
+
+## Goal
+
+Fix the reported "distant labels get selected by a marquee" bug and introduce
+the classic directional marquee scheme. Diagnosis (reproduced in the running
+editor): the editor's own marquee math never selected the distant labels —
+dragging across the canvas starts a NATIVE browser text selection over the SVG
+`<text>` labels (`.schematic-canvas` is `user-select: auto`), which highlights
+labels in DOM order regardless of geometry (`window.getSelection()` held
+"X1\nX2\nX3\nX4\nX5" after an empty-area drag). Fix: suppress native selection
+on the canvas while keeping the rich-text editing overlay selectable.
+
+New behavior (AutoCAD window/crossing): dragging left-to-right selects only
+objects FULLY contained in the marquee (window, solid border); dragging
+right-to-left selects anything partially covered (crossing, dashed border —
+today's semantics). Junction points behave identically in both modes.
+
+## State and Ownership
+
+`git status --short --branch`: clean on `claude/marquee-window-crossing`,
+branched from `claude/block-diagram-authoring` after its origin/main
+merge-update (PR #142 pending its CI-then-merge chain). No overlap with other
+sessions' active work.
+
+Owned paths:
+
+- `apps/editor/src/features/selection/marquee-selection.ts` (new) and test —
+  the extracted pure marquee-set computation with a window/crossing mode
+- `apps/editor/src/canvas/canvas-geometry.ts` and `canvas-geometry.test.ts`
+  (containment helpers)
+- `apps/editor/src/app/App.tsx` (finishCanvasGesture calls the module; box
+  preview carries the mode class)
+- `apps/editor/src/styles.css` (canvas `user-select: none`, overlay text
+  restore, window/crossing marquee styles)
+- `apps/editor/e2e/manual-editor.spec.ts` (window/crossing + no-native-text
+  scenarios; audit existing marquee drags in `drafting.spec.ts` /
+  `hierarchy.spec.ts` for direction assumptions)
+- `docs/specs/editor-interaction.md` (marquee direction + native-selection
+  clause in the movement/marquee section)
+- `plan/2026-08-21-marquee-window-crossing/plan.md`, `plan/log.md`
+
+Shared dependencies: the editor-interaction spec's marquee clauses (updated
+deliberately here), selection replace semantics, and existing e2e marquee
+gestures whose drag directions now carry meaning.
+
+## Work
+
+1. CSS: `.schematic-canvas { user-select: none; }` plus explicit
+   `user-select: text` for the canvas text-editing overlay's editable and
+   input surfaces.
+2. Extract the box-selection filters from `finishCanvasGesture` into a pure
+   `marqueeSelection(document, resolver, routeGeometryRecords, styleProfile,
+   rect, mode)`; add `rectContainsRect` / polyline containment helpers to
+   canvas-geometry. Window mode: instances/annotations/drafting bounds fully
+   contained, routes with every centerline vertex inside, drafting rectangles
+   with all four corners inside. Crossing mode keeps today's predicates.
+3. Mode = `end.x < start.x ? "crossing" : "window"`; the live preview box
+   shows solid border for window and dashed for crossing.
+4. Update the editor-interaction spec marquee clauses; adjust existing e2e
+   drags whose expectations depend on the old always-crossing semantics; add
+   window/crossing and no-native-text-selection scenarios.
+
+## Validation
+
+- focused `vitest`: `apps/editor/src/features/selection`,
+  `apps/editor/src/canvas/canvas-geometry.test.ts`
+- `playwright` (local server reuse): `apps/editor/e2e/manual-editor.spec.ts`,
+  `apps/editor/e2e/drafting.spec.ts`, `apps/editor/e2e/hierarchy.spec.ts`
+- repository typecheck; `node scripts/check-markdown-links.mjs`
+- `node scripts/check-test-impact.mjs --base <branch-base>`
+- `git diff --check` and `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: marquee window mode selects only fully-contained objects;
+  crossing mode preserves partial-overlap selection; junctions identical in
+  both modes; canvas drags never produce a native browser text selection;
+  existing marquee-dependent flows keep their meaning under the direction
+  they drag
+- Primary checks:
+  `apps/editor/src/features/selection/marquee-selection.test.ts`,
+  `apps/editor/src/canvas/canvas-geometry.test.ts`,
+  `apps/editor/e2e/manual-editor.spec.ts`
+
+## Commit Intent
+
+Committed on `claude/marquee-window-crossing` under the user's standing
+commit-push-merge direction as:
+
+```text
+feat(editor): directional window/crossing marquee selection
+```
+
+## Outcome
+
+Root cause confirmed and fixed: the "distant labels" were the browser's own
+text selection, not editor state — `.schematic-canvas` now suppresses native
+selection (`user-select: none`) with an explicit restore inside the
+canvas text-editor overlay, and marquee sweeps leave `window.getSelection()`
+empty (asserted in e2e). The box-selection filters moved into a pure
+`features/selection/marquee-selection` module with the directional scheme:
+left-to-right window (full containment: instance/annotation/drafting bounds,
+whole route centerline, all four outline-rectangle corners), right-to-left
+crossing (previous overlap semantics), junctions identical in both; the live
+preview renders solid (window) vs dashed green (crossing). The
+editor-interaction spec's marquee clauses were extended accordingly. One
+existing browser test relied on partial coverage under a left-to-right drag;
+its gesture now sweeps fully (trace-verified that the window correctly
+excluded a body 10 units outside the rectangle while its label was inside).
+Validation: 19 new unit tests (marquee module + geometry helpers) within
+64 passing across selection/canvas/wiring, full manual-editor (88), drafting
+(27+), and hierarchy suites green, repository typecheck, prettier, markdown
+links, test-impact, and diff checks clean.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4035,3 +4035,17 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   inspected in the running editor.
 - Commit status: completed on `claude/block-diagram-authoring` at the
   user's direction; mainline merge gated on the remote required checks.
+
+## 2026-08-21 - Directional marquee and native text-selection fix
+
+- Changed areas: canvas suppresses native browser text selection (the cause
+  of "distant labels" highlighting during drags) with an overlay restore;
+  box-selection extracted to a pure marquee-selection module implementing
+  left-to-right window (full containment) vs right-to-left crossing (overlap)
+  with distinct live-preview styling; editor-interaction spec updated; one
+  browser test's marquee gesture widened for window semantics.
+- Validation: 19 new unit tests (64 across selection/canvas/wiring), full
+  manual-editor/drafting/hierarchy Playwright suites, typecheck, prettier,
+  markdown links, test-impact, and diff checks passed.
+- Commit status: completed on `claude/marquee-window-crossing`; mainline
+  merge gated on the remote required checks.


### PR DESCRIPTION
## Summary

- **Bug fix (the "distant labels get selected" report):** a marquee drag was starting a NATIVE browser text selection over the SVG labels — DOM order, geometry-independent — because the canvas allowed `user-select`. The canvas now suppresses native selection (restored inside the inline text editor), and an e2e asserts `window.getSelection()` stays empty after sweeps. The editor's own marquee math was never at fault.
- **Classic directional marquee:** left-to-right = **window** (only fully contained objects: instance/annotation/drafting bounds, the whole route centerline, all four outline-rectangle corners), right-to-left = **crossing** (anything touched — previous semantics). Junction points behave identically in both modes. The live preview draws solid (window) vs dashed green (crossing). Box selection is extracted into a pure `features/selection/marquee-selection` module with unit coverage.
- `docs/specs/editor-interaction.md` marquee clauses updated; one existing browser test widened its sweep (it had relied on 10-units-partial coverage under a left-to-right drag — trace-verified).

Target plan: `plan/2026-08-21-marquee-window-crossing/`.

## Validation

- 19 new unit tests; selection/canvas/wiring suites 64 green.
- Full `manual-editor.spec.ts` (88), `drafting.spec.ts`, and `hierarchy.spec.ts` Playwright suites green, including the new directional-marquee scenario.
- Repository typecheck, prettier, markdown links, test-impact, and diff checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)