### PR TITLE
User-saved library examples

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3537,3 +3537,29 @@ test("Document style dialog scales fonts document-wide and resets", async ({
   await dialog.getByRole("button", { name: "Close", exact: true }).click();
   await expect(dialog).toHaveCount(0);
 });
+
+test("saves, reopens, and deletes a user Library example", async ({ page }) => {
+  await page.goto("/");
+  await placeComponent(page, "resistor", { x: 320, y: 220 });
+  await expect(page.getByTestId("hit-R1")).toHaveCount(1);
+
+  await clickCommand(page, "File", "Save as Example");
+  await expect(page.getByTestId("status")).toContainText("to My examples");
+  const panel = page.getByTestId("examples-panel");
+  await expect(panel).toHaveAttribute("data-open", "true");
+  const section = page.getByTestId("user-examples-section");
+  await expect(section).toBeVisible();
+  const card = section.locator('[data-testid^="user-example-"]');
+  await expect(card).toHaveCount(1);
+
+  // Opening the snapshot replaces the live Project with the saved circuit.
+  await card.getByRole("button", { name: /Open my example/ }).click();
+  await expect(page.getByTestId("status")).toContainText("Opened my example");
+  await expect(page.getByTestId("hit-R1")).toHaveCount(1);
+
+  await card.getByRole("button", { name: /Delete my example/ }).click();
+  await expect(page.getByTestId("status")).toContainText(
+    "Deleted saved example",
+  );
+  await expect(section).toHaveCount(0);
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -197,6 +197,10 @@ import { CellManagerDialog } from "../features/hierarchy/cell-manager-dialog";
 import { NetlistPreflightDialog } from "../features/netlist-export/netlist-preflight-dialog";
 import { StyleDialog } from "../features/editor-shell/style-dialog";
 import {
+  createUserExamplesStore,
+  type UserExampleSummary,
+} from "../document/user-examples-store";
+import {
   proposeConnectedInstanceDeletion,
   proposeVisualSelectionDeletion,
 } from "../features/selection/delete-selection";
@@ -596,6 +600,8 @@ export function App({
   const [cellManagerOpen, setCellManagerOpen] = useState(false);
   const [netlistPreflightOpen, setNetlistPreflightOpen] = useState(false);
   const [styleDialogOpen, setStyleDialogOpen] = useState(false);
+  const userExamplesStore = useRef(createUserExamplesStore());
+  const [userExamples, setUserExamples] = useState<UserExampleSummary[]>([]);
   const [instanceTableOpen, setInstanceTableOpen] = useState(false);
   const [agentFileCandidate, setAgentFileCandidate] =
     useState<AgentFileCandidateSummary | null>(null);
@@ -1733,6 +1739,75 @@ export function App({
 
   function showExamplesPanel(): void {
     showLeftPanel("examples");
+    void refreshUserExamples();
+  }
+
+  async function refreshUserExamples(): Promise<void> {
+    const outcome = await userExamplesStore.current.list();
+    if (outcome.status === "ready") setUserExamples(outcome.examples);
+  }
+
+  async function saveCurrentProjectAsExample(): Promise<void> {
+    const outcome = await userExamplesStore.current.save(project, {
+      id: crypto.randomUUID(),
+      name: project.name,
+      savedAt: new Date().toISOString(),
+    });
+    if (outcome.status === "stored") {
+      await refreshUserExamples();
+      setStatus(`Saved "${outcome.record.name}" to My examples`);
+      showExamplesPanel();
+      return;
+    }
+    setStatus(
+      outcome.status === "rejected-too-large"
+        ? "Cannot save example: the Project snapshot is too large"
+        : `Cannot save example: ${outcome.message}`,
+    );
+  }
+
+  async function openUserExample(id: string): Promise<void> {
+    const outcome = await userExamplesStore.current.read(id);
+    if (outcome.status !== "ready") {
+      setStatus(
+        outcome.status === "missing"
+          ? "This saved example no longer exists"
+          : `Cannot open saved example: ${
+              outcome.status === "invalid" ? outcome.message : outcome.message
+            }`,
+      );
+      void refreshUserExamples();
+      return;
+    }
+    void guardDirtyReplacement(`Open ${outcome.record.name} example`, () => {
+      replaceActiveProject(outcome.project);
+      setStatus(`Opened my example: ${outcome.record.name}`);
+    });
+  }
+
+  async function exportUserExample(id: string): Promise<void> {
+    const outcome = await userExamplesStore.current.read(id);
+    if (outcome.status !== "ready") {
+      setStatus("Cannot export: this saved example is unavailable");
+      return;
+    }
+    download(
+      outcome.record.projectText,
+      "application/json",
+      "icproj.json",
+      outcome.record.name,
+    );
+    setStatus(`Exported my example: ${outcome.record.name}`);
+  }
+
+  async function deleteUserExample(id: string): Promise<void> {
+    const outcome = await userExamplesStore.current.remove(id);
+    setStatus(
+      outcome.status === "deleted"
+        ? "Deleted saved example"
+        : `Cannot delete saved example: ${outcome.message}`,
+    );
+    await refreshUserExamples();
   }
 
   function resetInteractionState(): void {
@@ -4301,11 +4376,12 @@ export function App({
     bytes: BlobPart,
     mediaType: string,
     extension: string,
+    baseName = project.name,
   ): void {
     const url = URL.createObjectURL(new Blob([bytes], { type: mediaType }));
     const anchor = window.document.createElement("a");
     anchor.href = url;
-    anchor.download = `${safeExportBaseName(project.name)}.${extension}`;
+    anchor.download = `${safeExportBaseName(baseName)}.${extension}`;
     anchor.click();
     window.setTimeout(() => URL.revokeObjectURL(url), 0);
   }
@@ -6712,6 +6788,12 @@ export function App({
                       }
                     />
                   </label>
+                  <button
+                    type="button"
+                    onClick={() => void saveCurrentProjectAsExample()}
+                  >
+                    Save as Example
+                  </button>
                   <span className="command-group-label">Export</span>
                   <button
                     type="button"
@@ -7440,6 +7522,10 @@ export function App({
           <ExamplesPanel
             open={visibleLibraryPanelOpen}
             onOpenExample={openLibraryExample}
+            userExamples={userExamples}
+            onOpenUserExample={(id) => void openUserExample(id)}
+            onExportUserExample={(id) => void exportUserExample(id)}
+            onDeleteUserExample={(id) => void deleteUserExample(id)}
           />
         )}
         <aside

--- a/apps/editor/src/document/user-examples-store.test.ts
+++ b/apps/editor/src/document/user-examples-store.test.ts
@@ -1,0 +1,147 @@
+import { IDBFactory } from "fake-indexeddb";
+import { createEmptyProject, CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
+import { serializeProject } from "@icm/project-protocol";
+import { describe, expect, it } from "vitest";
+
+import {
+  createUserExamplesStore,
+  USER_EXAMPLE_MAX_RECORD_BYTES,
+} from "./user-examples-store";
+
+function storeWithFreshDatabase() {
+  return createUserExamplesStore({ idbFactory: new IDBFactory() });
+}
+
+const identity = (id: string, savedAt: string) => ({
+  id,
+  name: `Example ${id}`,
+  savedAt,
+});
+
+describe("user examples store", () => {
+  it("round-trips a saved snapshot through list and read", async () => {
+    const store = storeWithFreshDatabase();
+    const project = createEmptyProject("example-project", "My Inverter");
+
+    const saved = await store.save(
+      project,
+      identity("ex-1", "2026-08-21T10:00:00.000Z"),
+    );
+    expect(saved.status).toBe("stored");
+
+    const listed = await store.list();
+    expect(listed).toMatchObject({
+      status: "ready",
+      examples: [
+        {
+          id: "ex-1",
+          name: "Example ex-1",
+          savedAt: "2026-08-21T10:00:00.000Z",
+          schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION,
+        },
+      ],
+    });
+
+    const read = await store.read("ex-1");
+    expect(read.status).toBe("ready");
+    if (read.status === "ready") {
+      expect(read.project).toEqual(project);
+      expect(read.record.projectText).toBe(serializeProject(project));
+    }
+  });
+
+  it("lists newest first and deletes exactly one record", async () => {
+    const store = storeWithFreshDatabase();
+    const project = createEmptyProject("example-project", "P");
+    await store.save(project, identity("older", "2026-08-20T10:00:00.000Z"));
+    await store.save(project, identity("newer", "2026-08-21T10:00:00.000Z"));
+
+    const listed = await store.list();
+    if (listed.status !== "ready") throw new Error("expected ready");
+    expect(listed.examples.map((example) => example.id)).toEqual([
+      "newer",
+      "older",
+    ]);
+
+    expect(await store.remove("older")).toEqual({ status: "deleted" });
+    const after = await store.list();
+    if (after.status !== "ready") throw new Error("expected ready");
+    expect(after.examples.map((example) => example.id)).toEqual(["newer"]);
+    expect(await store.read("older")).toEqual({ status: "missing" });
+  });
+
+  it("upgrades a previous-schema snapshot through the protocol on read", async () => {
+    const factory = new IDBFactory();
+    const store = createUserExamplesStore({ idbFactory: factory });
+    const project = createEmptyProject("example-project", "P");
+    await store.save(project, identity("ex-prev", "2026-08-21T10:00:00.000Z"));
+
+    // Age the stored snapshot to the previous schema version in place.
+    const database = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = factory.open("analog-canvas-user-examples", 1);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    await new Promise<void>((resolve, reject) => {
+      const transaction = database.transaction("user-examples-v1", "readwrite");
+      const objectStore = transaction.objectStore("user-examples-v1");
+      const get = objectStore.get("ex-prev");
+      get.onsuccess = () => {
+        const record = get.result as { projectText: string };
+        const raw = JSON.parse(record.projectText) as {
+          schemaVersion: number;
+        };
+        raw.schemaVersion = CURRENT_PROJECT_SCHEMA_VERSION - 1;
+        record.projectText = JSON.stringify(raw);
+        const put = objectStore.put(record, "ex-prev");
+        put.onsuccess = () => resolve();
+        put.onerror = () => reject(put.error);
+      };
+      get.onerror = () => reject(get.error);
+    });
+    database.close();
+
+    const read = await store.read("ex-prev");
+    expect(read.status).toBe("ready");
+    if (read.status === "ready") {
+      expect(read.project.schemaVersion).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
+    }
+  });
+
+  it("rejects an oversized snapshot without writing", async () => {
+    const store = storeWithFreshDatabase();
+    const project = createEmptyProject("example-project", "P");
+    project.documents[0]!.name = "x".repeat(USER_EXAMPLE_MAX_RECORD_BYTES);
+    const saved = await store.save(
+      project,
+      identity("huge", "2026-08-21T10:00:00.000Z"),
+    );
+    expect(saved.status).toBe("rejected-too-large");
+    const listed = await store.list();
+    if (listed.status !== "ready") throw new Error("expected ready");
+    expect(listed.examples).toEqual([]);
+  });
+
+  it("reports storage-unavailable instead of throwing without IndexedDB", async () => {
+    const store = createUserExamplesStore({
+      idbFactory: undefined as unknown as IDBFactory,
+    });
+    const original = globalThis.indexedDB;
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: undefined,
+    });
+    try {
+      const listed = await store.list();
+      expect(listed).toMatchObject({
+        status: "failed",
+        failure: "storage-unavailable",
+      });
+    } finally {
+      Object.defineProperty(globalThis, "indexedDB", {
+        configurable: true,
+        value: original,
+      });
+    }
+  });
+});

--- a/apps/editor/src/document/user-examples-store.ts
+++ b/apps/editor/src/document/user-examples-store.ts
@@ -1,0 +1,273 @@
+// Origin-local, non-authoritative store for user-saved Library examples.
+//
+// A user example is a convenience snapshot: canonical serialized Project
+// text plus a display name. It is not Project persistence — the downloaded
+// `.icproj.json` remains the authoritative file — and this store owns its
+// own IndexedDB database only: it never reads, writes, or deletes recovery
+// records or any other database.
+
+import type { CircuitProject } from "@icm/model";
+import {
+  parseProject,
+  ProjectFormatError,
+  serializeProject,
+} from "@icm/project-protocol";
+
+export const USER_EXAMPLES_DATABASE_NAME = "analog-canvas-user-examples";
+export const USER_EXAMPLES_STORE_NAME = "user-examples-v1";
+export const USER_EXAMPLES_DATABASE_VERSION = 1;
+
+/** One snapshot stays well under any realistic browser quota slice. */
+export const USER_EXAMPLE_MAX_RECORD_BYTES = 8 * 1024 * 1024;
+
+export type UserExampleStorageFailure =
+  "quota-exceeded" | "storage-unavailable" | "storage-failed";
+
+export interface UserExampleRecord {
+  id: string;
+  name: string;
+  savedAt: string;
+  schemaVersion: number;
+  projectText: string;
+}
+
+export interface UserExampleSummary {
+  id: string;
+  name: string;
+  savedAt: string;
+  schemaVersion: number;
+}
+
+export type UserExampleSaveOutcome =
+  | { status: "stored"; record: UserExampleRecord }
+  | { status: "rejected-too-large"; byteLength: number }
+  | { status: "failed"; failure: UserExampleStorageFailure; message: string };
+
+export type UserExampleListOutcome =
+  | { status: "ready"; examples: UserExampleSummary[] }
+  | { status: "failed"; failure: UserExampleStorageFailure; message: string };
+
+export type UserExampleReadOutcome =
+  | { status: "ready"; record: UserExampleRecord; project: CircuitProject }
+  | { status: "missing" }
+  | { status: "invalid"; message: string }
+  | { status: "failed"; failure: UserExampleStorageFailure; message: string };
+
+export type UserExampleDeleteOutcome =
+  | { status: "deleted" }
+  | { status: "failed"; failure: UserExampleStorageFailure; message: string };
+
+export interface UserExamplesStoreSeams {
+  /** Injectable IndexedDB factory for deterministic tests. */
+  readonly idbFactory?: IDBFactory;
+}
+
+export interface UserExamplesStore {
+  list(): Promise<UserExampleListOutcome>;
+  save(
+    project: CircuitProject,
+    identity: { id: string; name: string; savedAt: string },
+  ): Promise<UserExampleSaveOutcome>;
+  read(id: string): Promise<UserExampleReadOutcome>;
+  remove(id: string): Promise<UserExampleDeleteOutcome>;
+  close(): void;
+}
+
+/** Thrown when the runtime exposes no IndexedDB at all (SSR, hard denial). */
+class UserExamplesStorageUnavailableError extends Error {
+  constructor() {
+    super("IndexedDB is unavailable in this browsing context");
+    this.name = "UserExamplesStorageUnavailableError";
+  }
+}
+
+function classifyStorageFailure(error: unknown): UserExampleStorageFailure {
+  if (error instanceof UserExamplesStorageUnavailableError) {
+    return "storage-unavailable";
+  }
+  const name = error instanceof Error ? error.name : "";
+  if (name === "QuotaExceededError") return "quota-exceeded";
+  if (
+    name === "NotFoundError" ||
+    name === "InvalidStateError" ||
+    name === "SecurityError" ||
+    name === "VersionError"
+  ) {
+    return "storage-unavailable";
+  }
+  return "storage-failed";
+}
+
+function failureMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("IDB request"));
+  });
+}
+
+function decodeRecord(value: unknown): UserExampleRecord | null {
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.id !== "string" ||
+    typeof record.name !== "string" ||
+    typeof record.savedAt !== "string" ||
+    typeof record.schemaVersion !== "number" ||
+    typeof record.projectText !== "string"
+  ) {
+    return null;
+  }
+  return {
+    id: record.id,
+    name: record.name,
+    savedAt: record.savedAt,
+    schemaVersion: record.schemaVersion,
+    projectText: record.projectText,
+  };
+}
+
+export function createUserExamplesStore(
+  seams: UserExamplesStoreSeams = {},
+): UserExamplesStore {
+  let database: IDBDatabase | null = null;
+
+  async function openDatabase(): Promise<IDBDatabase> {
+    if (database) return database;
+    const factory = seams.idbFactory ?? globalThis.indexedDB ?? null;
+    if (!factory) throw new UserExamplesStorageUnavailableError();
+    const request = factory.open(
+      USER_EXAMPLES_DATABASE_NAME,
+      USER_EXAMPLES_DATABASE_VERSION,
+    );
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(USER_EXAMPLES_STORE_NAME)) {
+        db.createObjectStore(USER_EXAMPLES_STORE_NAME);
+      }
+    };
+    database = await requestToPromise(request as IDBRequest<IDBDatabase>);
+    return database;
+  }
+
+  async function withStore<T>(
+    mode: IDBTransactionMode,
+    body: (store: IDBObjectStore) => Promise<T>,
+  ): Promise<T> {
+    const db = await openDatabase();
+    const transaction = db.transaction(USER_EXAMPLES_STORE_NAME, mode);
+    return body(transaction.objectStore(USER_EXAMPLES_STORE_NAME));
+  }
+
+  return {
+    async list() {
+      try {
+        const values = await withStore("readonly", (store) =>
+          requestToPromise(store.getAll()),
+        );
+        const examples = values
+          .map(decodeRecord)
+          .filter((record): record is UserExampleRecord => record !== null)
+          .map(({ projectText: _text, ...summary }) => summary)
+          .sort((left, right) => right.savedAt.localeCompare(left.savedAt));
+        return { status: "ready" as const, examples };
+      } catch (error) {
+        return {
+          status: "failed" as const,
+          failure: classifyStorageFailure(error),
+          message: failureMessage(error),
+        };
+      }
+    },
+
+    async save(project, identity) {
+      const projectText = serializeProject(project);
+      const record: UserExampleRecord = {
+        id: identity.id,
+        name: identity.name,
+        savedAt: identity.savedAt,
+        schemaVersion: project.schemaVersion,
+        projectText,
+      };
+      const byteLength = new TextEncoder().encode(projectText).length;
+      if (byteLength > USER_EXAMPLE_MAX_RECORD_BYTES) {
+        return { status: "rejected-too-large" as const, byteLength };
+      }
+      try {
+        await withStore("readwrite", (store) =>
+          requestToPromise(store.put(record, record.id)),
+        );
+        return { status: "stored" as const, record };
+      } catch (error) {
+        return {
+          status: "failed" as const,
+          failure: classifyStorageFailure(error),
+          message: failureMessage(error),
+        };
+      }
+    },
+
+    async read(id) {
+      try {
+        const value = await withStore("readonly", (store) =>
+          requestToPromise(store.get(id)),
+        );
+        if (value === undefined) return { status: "missing" as const };
+        const record = decodeRecord(value);
+        if (!record) {
+          return {
+            status: "invalid" as const,
+            message: "Stored example is not decodable",
+          };
+        }
+        try {
+          // The ordinary protocol boundary revalidates and, within the
+          // rolling window, upgrades the snapshot before it can replace a
+          // live Project.
+          return {
+            status: "ready" as const,
+            record,
+            project: parseProject(record.projectText),
+          };
+        } catch (error) {
+          return {
+            status: "invalid" as const,
+            message:
+              error instanceof ProjectFormatError
+                ? (error.diagnostics[0]?.message ?? error.message)
+                : failureMessage(error),
+          };
+        }
+      } catch (error) {
+        return {
+          status: "failed" as const,
+          failure: classifyStorageFailure(error),
+          message: failureMessage(error),
+        };
+      }
+    },
+
+    async remove(id) {
+      try {
+        await withStore("readwrite", (store) =>
+          requestToPromise(store.delete(id)),
+        );
+        return { status: "deleted" as const };
+      } catch (error) {
+        return {
+          status: "failed" as const,
+          failure: classifyStorageFailure(error),
+          message: failureMessage(error),
+        };
+      }
+    },
+
+    close() {
+      database?.close();
+      database = null;
+    },
+  };
+}

--- a/apps/editor/src/features/editor-shell/examples-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/examples-panel.test.ts
@@ -25,3 +25,39 @@ describe("ExamplesPanel", () => {
     }
   });
 });
+
+describe("user examples section", () => {
+  it("renders saved snapshots with open, export, and delete actions", () => {
+    const markup = renderToStaticMarkup(
+      createElement(ExamplesPanel, {
+        open: true,
+        onOpenExample: () => undefined,
+        userExamples: [
+          {
+            id: "ex-1",
+            name: "My Inverter",
+            savedAt: "2026-08-21T10:00:00.000Z",
+            schemaVersion: 21,
+          },
+        ],
+      }),
+    );
+    expect(markup).toContain('data-testid="user-examples-section"');
+    expect(markup).toContain("My examples");
+    expect(markup).toContain('data-testid="user-example-ex-1"');
+    expect(markup).toContain('aria-label="Open my example My Inverter"');
+    expect(markup).toContain('aria-label="Export my example My Inverter"');
+    expect(markup).toContain('aria-label="Delete my example My Inverter"');
+  });
+
+  it("hides the section entirely without saved snapshots", () => {
+    const markup = renderToStaticMarkup(
+      createElement(ExamplesPanel, {
+        open: true,
+        onOpenExample: () => undefined,
+        userExamples: [],
+      }),
+    );
+    expect(markup).not.toContain('data-testid="user-examples-section"');
+  });
+});

--- a/apps/editor/src/features/editor-shell/examples-panel.tsx
+++ b/apps/editor/src/features/editor-shell/examples-panel.tsx
@@ -2,13 +2,38 @@ import {
   libraryProjectExamples,
   type LibraryProjectExample,
 } from "../../examples/library-examples";
+import type { UserExampleSummary } from "../../document/user-examples-store";
 
 export interface ExamplesPanelProps {
   open: boolean;
   onOpenExample(example: LibraryProjectExample): void;
+  /** User-saved snapshots, newest first; empty hides the section body. */
+  userExamples?: readonly UserExampleSummary[];
+  onOpenUserExample?(id: string): void;
+  onExportUserExample?(id: string): void;
+  onDeleteUserExample?(id: string): void;
 }
 
-export function ExamplesPanel({ open, onOpenExample }: ExamplesPanelProps) {
+function savedAtLabel(savedAt: string): string {
+  const parsed = new Date(savedAt);
+  return Number.isNaN(parsed.getTime())
+    ? savedAt
+    : parsed.toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+}
+
+export function ExamplesPanel({
+  open,
+  onOpenExample,
+  userExamples = [],
+  onOpenUserExample,
+  onExportUserExample,
+  onDeleteUserExample,
+}: ExamplesPanelProps) {
   return (
     <aside
       id="examples-panel"
@@ -50,6 +75,55 @@ export function ExamplesPanel({ open, onOpenExample }: ExamplesPanelProps) {
             </button>
           ))}
         </div>
+        {userExamples.length > 0 ? (
+          <div
+            className="shapes-example-list user-example-list"
+            data-testid="user-examples-section"
+          >
+            <span className="shapes-category-header">My examples</span>
+            {userExamples.map((example) => (
+              <div
+                key={example.id}
+                className="shapes-example-card user-example-card"
+                data-testid={`user-example-${example.id}`}
+              >
+                <button
+                  type="button"
+                  className="user-example-open"
+                  aria-label={`Open my example ${example.name}`}
+                  title={`Open ${example.name}`}
+                  onClick={() => onOpenUserExample?.(example.id)}
+                >
+                  <span className="shapes-example-copy">
+                    <span className="shapes-example-kicker">My example</span>
+                    <span className="shapes-example-name">{example.name}</span>
+                    <span className="shapes-example-description">
+                      Saved {savedAtLabel(example.savedAt)}
+                    </span>
+                  </span>
+                </button>
+                <span className="user-example-actions">
+                  <button
+                    type="button"
+                    aria-label={`Export my example ${example.name}`}
+                    title="Download .icproj.json"
+                    onClick={() => onExportUserExample?.(example.id)}
+                  >
+                    Export
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Delete my example ${example.name}`}
+                    title="Delete this saved example"
+                    onClick={() => onDeleteUserExample?.(example.id)}
+                  >
+                    Delete
+                  </button>
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : null}
       </div>
     </aside>
   );

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -1154,6 +1154,53 @@ body {
   text-align: left;
 }
 
+/* User-saved examples: the card is a row of one open surface plus small
+   export/delete actions, sharing the bundled-example card chrome. */
+.user-example-card {
+  display: flex;
+  align-items: stretch;
+  gap: var(--icm-space-2);
+  padding: var(--icm-space-2);
+}
+
+.user-example-card .user-example-open {
+  flex: 1;
+  min-width: 0;
+  padding: var(--icm-space-1);
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.user-example-actions {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--icm-space-1);
+}
+
+.user-example-actions button {
+  padding: 2px var(--icm-space-2);
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface);
+  color: var(--icm-text-muted);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.user-example-actions button:hover {
+  border-color: var(--icm-border-hover);
+  color: var(--icm-text);
+}
+
+.user-example-list .shapes-category-header {
+  display: block;
+  margin-top: var(--icm-space-2);
+}
+
 .shapes-example-card:hover:not(:disabled) {
   border-color: var(--icm-border-hover);
   background: #fff;

--- a/docs/specs/persistence-and-recovery.md
+++ b/docs/specs/persistence-and-recovery.md
@@ -9,15 +9,19 @@ model in `packages/model` validates the normalized shape;
 `packages/project-protocol` owns parsing, rolling compatibility diagnostics,
 and canonical serialization. Persistence validates
 the complete current schema before open or save and writes atomically where the
-platform supports it. Schema 19 reads through one direct upgrade to schema 20;
+platform supports it. Schema 20 reads through one direct upgrade to schema 21;
 older and future versions are rejected. Migration runs only at ingestion, and
-serialization remains schema 20.
+serialization remains schema 21.
 
 Recovery state is a non-authoritative browser safety copy. It may restore a
 complete schema-21 Project or a schema-20 record that validates after the direct
 upgrade, associated with a recorded working-copy session.
 Corrupt, incompatible, or partial recovery data is discarded or retained as raw
-data without changing the live Project. Credentials, Agent bearer tokens,
+data without changing the live Project. User-saved Library examples are the
+same class of origin-local, non-authoritative convenience data: canonical
+serialized Project snapshots in their own IndexedDB store, re-validated
+through the ordinary protocol boundary before they may replace a live
+Project, and never a substitute for the downloaded `.icproj.json` file. Credentials, Agent bearer tokens,
 selection, viewport, overlays, and pending external approvals are never
 embedded in Project JSON or recovery records.
 

--- a/plan/2026-08-21-user-examples/plan.md
+++ b/plan/2026-08-21-user-examples/plan.md
@@ -1,0 +1,100 @@
+---
+status: completed
+experience: none
+---
+
+# User-Saved Library Examples
+
+## Goal
+
+One-click "Save as Example": snapshot the current Project into an
+origin-local, non-authoritative IndexedDB store and list it in a new
+"My examples" section of the Examples panel, with open, export
+(`.icproj.json` download), and delete per entry. Bundled examples stay the
+curated read-only set; user examples are convenience copies stored as
+canonical serialized Project text and re-validated through the ordinary
+protocol boundary on open (rolling-window upgrades apply). No shared
+contract changes.
+
+## State and Ownership
+
+Branched from `claude/document-style-overrides` (PR #146 queued: CI-then-
+merge). Worktree clean.
+
+Owned paths:
+
+- `apps/editor/src/document/user-examples-store.ts` (new) and test —
+  IndexedDB adapter mirroring the recovery store's seams/failure taxonomy,
+  scoped to its own database; never touches recovery records
+- `apps/editor/src/features/editor-shell/examples-panel.tsx` and test —
+  "My examples" section
+- `apps/editor/src/app/App.tsx` — File-menu "Save as Example", panel wiring,
+  open/export/delete handlers (open reuses the dirty-replacement guard)
+- `docs/specs/persistence-and-recovery.md` — one non-authoritative-store
+  sentence
+- `apps/editor/e2e/manual-editor.spec.ts` — one browser scenario
+- `plan/2026-08-21-user-examples/plan.md`, `plan/log.md`
+
+Shared dependencies: the project-protocol parse/serialize boundary (used
+as-is), the Examples panel markup contract, and the recovery store's
+non-authoritative persistence philosophy (reused, not modified).
+
+## Work
+
+1. `user-examples-store.ts`: `list` (id, name, savedAt, schemaVersion),
+   `save` (canonical `serializeProject` text, byte-capped), `read`
+   (re-parse through the protocol), `remove`; injectable IDB factory seam.
+2. Panel: "My examples" cards with open plus per-card Export and Delete
+   actions; bundled section unchanged.
+3. App: File menu action, list refresh on save/delete/panel open, export
+   downloads the stored text under the example's name.
+4. Spec sentence, unit tests (fake-indexeddb), panel markup test, one
+   Playwright scenario (save, reopen, delete).
+
+## Validation
+
+- focused `vitest`: `apps/editor/src/document/user-examples-store.test.ts`,
+  `apps/editor/src/features/editor-shell/examples-panel.test.ts`
+- `playwright` scenario in `manual-editor.spec.ts`
+- repository typecheck, prettier, markdown links
+- `node scripts/check-test-impact.mjs --base <branch-base>`
+- `git diff --check` and `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: user examples persist as canonical Project text in their own
+  origin-local store and never alter recovery records; open re-validates
+  through the protocol boundary; save/list/delete outcomes surface storage
+  failures instead of throwing; the panel lists bundled and user examples
+  distinctly
+- Primary checks: `apps/editor/src/document/user-examples-store.test.ts`,
+  `apps/editor/src/features/editor-shell/examples-panel.test.ts`,
+  `apps/editor/e2e/manual-editor.spec.ts`
+
+## Commit Intent
+
+Committed on `claude/user-examples` under the user's standing
+commit-push-merge direction as:
+
+```text
+feat(editor): user-saved library examples
+```
+
+## Outcome
+
+Delivered. `user-examples-store` persists canonical serialized Project
+snapshots in its own origin-local IndexedDB database (recovery-style seams
+and failure taxonomy, 8 MiB cap, decode-tolerant list, protocol re-parse on
+read so rolling-window upgrades apply); the Examples panel gains a
+"My examples" section with open, export (`.icproj.json` under the example's
+name), and delete; File > "Save as Example" snapshots the live Project and
+reveals the panel; opening a snapshot passes through the existing
+dirty-replacement guard. The persistence spec now classifies user examples
+alongside recovery as non-authoritative origin-local data (and two missed
+schema-version sentences from the schema-21 sweep were corrected).
+Validation: 5 store contracts on fake-indexeddb (round-trip, ordering,
+delete, previous-schema upgrade on read, oversize rejection, no-IndexedDB
+failure), panel markup contracts, one Playwright scenario (save, reopen,
+delete), full unit suite 173 files / 1064 tests, typecheck, prettier,
+markdown links, test-impact, and diff checks green.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4095,3 +4095,16 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   export-golden, agent-api/MCP generator checks, test-impact, diff checks.
 - Commit status: completed on `claude/document-style-overrides`; mainline
   merge gated on the remote required checks.
+
+## 2026-08-21 - User-saved Library examples
+
+- Changed areas: new origin-local `user-examples-store` (own IndexedDB
+  database, canonical Project text, protocol re-parse on read), Examples
+  panel "My examples" section with open/export/delete, File-menu
+  "Save as Example", persistence-spec classification plus two corrected
+  schema-version sentences.
+- Validation: store and panel unit contracts, one Playwright scenario, full
+  unit suite (173 files / 1064 tests), typecheck, prettier, markdown links,
+  test-impact, diff checks.
+- Commit status: completed on `claude/user-examples`; mainline merge gated
+  on the remote required checks.


### PR DESCRIPTION
## Summary

One-click **File → Save as Example**: snapshots the live Project as canonical serialized text into an origin-local IndexedDB store (`analog-canvas-user-examples`) — the same non-authoritative class as browser recovery, never a substitute for the downloaded `.icproj.json`. The Examples panel gains a **My examples** section (newest first) with per-entry **Open**, **Export** (`.icproj.json` under the example's own name), and **Delete**.

- Store mirrors the recovery adapter's seams and failure taxonomy (injectable IDB factory, quota/unavailable/failed outcomes, 8 MiB cap, decode-tolerant listing) and owns only its own database.
- Opening a snapshot re-parses through the ordinary protocol boundary — rolling-window schema upgrades apply — and passes the existing dirty-replacement guard.
- `docs/specs/persistence-and-recovery.md` classifies user examples alongside recovery (plus two schema-version sentences the schema-21 sweep missed are corrected).

Target plan: `plan/2026-08-21-user-examples/`.

## Validation

- 5 store contracts on fake-indexeddb: round-trip, newest-first ordering + single delete, previous-schema upgrade on read, oversize rejection without write, storage-unavailable without IndexedDB.
- Panel markup contracts (section renders with open/export/delete; hidden when empty).
- Playwright scenario: save → panel reveals the card → reopen → delete.
- Full unit suite 173 files / 1064 tests, typecheck, prettier, markdown links, test-impact, diff checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)