### PR TITLE
Keep the insert picker list always open

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -577,7 +577,7 @@ test("keeps the workspace inside the viewport and exposes low-interference zoom 
     .toBeLessThan(canvasBefore?.width ?? 0);
 });
 
-test("keeps preview fixed while the compact catalog expands and collapses", async ({
+test("keeps preview fixed while picking from the always-open catalog", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1100, height: 720 });
@@ -588,9 +588,6 @@ test("keeps preview fixed while the compact catalog expands and collapses", asyn
   const artwork = dialog.locator(".insert-symbol-artwork");
   const cancel = dialog.getByRole("button", { name: "Cancel" });
   const apply = dialog.getByRole("button", { name: "Apply" });
-  const toggle = dialog.getByRole("button", {
-    name: "Collapse component list",
-  });
 
   const measure = () =>
     dialog.evaluate((element) => {
@@ -624,11 +621,14 @@ test("keeps preview fixed while the compact catalog expands and collapses", asyn
     await options.evaluate((element) => getComputedStyle(element).overflowY),
   ).toBe("auto");
 
-  await toggle.click();
-  await expect(options).toHaveCount(0);
-  await dialog.getByRole("button", { name: "Expand component list" }).click();
-  await expect(options).toBeVisible();
+  // The catalog is permanently open: no collapse control exists, and picking
+  // an item keeps the list in place for the next pick.
+  await expect(
+    dialog.getByRole("button", { name: "Collapse component list" }),
+  ).toHaveCount(0);
   await dialog.getByTestId("insert-component-inductor").click();
+  await expect(options).toBeVisible();
+  await expect(dialog.getByTestId("insert-component-resistor")).toBeVisible();
   const after = await measure();
   expect(after.dialog.height).toBeCloseTo(before.dialog.height, 0);
   expect(after.preview.width).toBeCloseTo(before.preview.width, 0);
@@ -1089,4 +1089,18 @@ test("Library rail folds the sidebar; Insert and title open the catalog", async 
   await expect(
     page.getByRole("dialog", { name: "Insert Component" }),
   ).toBeVisible();
+});
+
+test("double-clicking a catalog item applies it immediately", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.keyboard.press("i");
+  const dialog = page.getByRole("dialog", { name: "Insert Component" });
+  await dialog.getByTestId("insert-component-resistor").dblclick();
+  await expect(dialog).toHaveCount(0);
+  await expect(page.getByTestId("status")).toContainText(
+    "Place Resistor on the canvas",
+  );
+  await page.keyboard.press("Escape");
 });

--- a/apps/editor/src/features/component-insert/insert-component-dialog.test.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.test.tsx
@@ -22,7 +22,10 @@ describe("InsertComponentDialog", () => {
     expect(markup).toContain('role="combobox"');
     expect(markup).toContain('aria-label="Component search"');
     expect(markup).toContain('aria-expanded="true"');
-    expect(markup).toContain('aria-label="Collapse component list"');
+    // The catalog is permanently open: no collapse control exists and the
+    // listbox renders without any toggle interaction.
+    expect(markup).not.toContain("Collapse component list");
+    expect(markup).not.toContain("insert-picker-toggle");
     expect(markup).toContain('role="listbox"');
     expect(markup).toContain('class="insert-symbol-artwork"');
     expect(markup).toContain('aria-label="Component w"');

--- a/apps/editor/src/features/component-insert/insert-component-dialog.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.tsx
@@ -145,7 +145,6 @@ export function InsertComponentDialog({
     [cellsOnly, cells, externalDefinitions, recentSymbolIds, styleProfileId],
   );
   const [query, setQuery] = useState("");
-  const [pickerOpen, setPickerOpen] = useState(true);
   const [selectedId, setSelectedId] = useState(
     () => initialChoices[0]?.key ?? null,
   );
@@ -253,7 +252,6 @@ export function InsertComponentDialog({
   useEffect(() => {
     if (!open) return;
     setQuery("");
-    setPickerOpen(true);
     setSelectedId(
       initialSelectionId &&
         initialChoices.some((choice) => choice.key === initialSelectionId)
@@ -300,13 +298,13 @@ export function InsertComponentDialog({
     );
     const next = (index + offset + choices.length) % choices.length;
     setSelectedId(choices[next]!.key);
-    setPickerOpen(true);
   };
 
+  // Selecting never folds the list away: the catalog stays in place so the
+  // next pick is one click, not an expand-then-click.
   const selectChoice = (key: string): void => {
     setSelectedId(key);
     setQuery("");
-    setPickerOpen(false);
   };
 
   const rotatePreview = (): void => {
@@ -425,11 +423,9 @@ export function InsertComponentDialog({
             selectOffset(-1);
           } else if (event.key === "Home") {
             event.preventDefault();
-            setPickerOpen(true);
             setSelectedId(choices[0]?.key ?? null);
           } else if (event.key === "End") {
             event.preventDefault();
-            setPickerOpen(true);
             setSelectedId(choices.at(-1)?.key ?? null);
           }
         }}
@@ -456,7 +452,7 @@ export function InsertComponentDialog({
                     role="combobox"
                     aria-label={`${pickerNoun} search`}
                     aria-autocomplete="list"
-                    aria-expanded={pickerOpen}
+                    aria-expanded={true}
                     aria-controls="insert-component-options"
                     aria-activedescendant={
                       selected
@@ -469,27 +465,11 @@ export function InsertComponentDialog({
                         ? `${selected.cellName ?? selected.symbol.name} · ${selected.symbol.id}`
                         : `Search ${pickerNoun.toLowerCase()}`
                     }
-                    onChange={(event) => {
-                      setQuery(event.currentTarget.value);
-                      setPickerOpen(true);
-                    }}
+                    onChange={(event) => setQuery(event.currentTarget.value)}
                   />
-                  <button
-                    type="button"
-                    className="insert-picker-toggle"
-                    aria-label={
-                      pickerOpen
-                        ? `Collapse ${pickerNoun.toLowerCase()} list`
-                        : `Expand ${pickerNoun.toLowerCase()} list`
-                    }
-                    aria-expanded={pickerOpen}
-                    onClick={() => setPickerOpen((current) => !current)}
-                  >
-                    {pickerOpen ? "⌃" : "⌄"}
-                  </button>
                 </div>
               </label>
-              {pickerOpen ? (
+              {
                 <div
                   id="insert-component-options"
                   className="insert-component-options"
@@ -515,6 +495,11 @@ export function InsertComponentDialog({
                               : `insert-component-${choice.symbol.id}`
                           }
                           onClick={() => selectChoice(choice.key)}
+                          onDoubleClick={() => {
+                            // The first click of the pair already committed
+                            // this selection; the second applies it.
+                            apply();
+                          }}
                         >
                           <span>{choice.cellName ?? choice.symbol.name}</span>
                           <small>
@@ -530,7 +515,7 @@ export function InsertComponentDialog({
                     </p>
                   ) : null}
                 </div>
-              ) : null}
+              }
             </section>
 
             {selectedIsVddRail ? (

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -3631,7 +3631,9 @@ body {
 }
 
 .insert-component-options {
-  max-height: 15rem;
+  /* The catalog stays permanently open; give it real height so most
+     categories are visible without scrolling. */
+  max-height: min(26rem, 48vh);
   margin-top: 0.55rem;
   overflow-y: auto;
   border: 1px solid var(--icm-border);

--- a/plan/2026-08-21-insert-picker-always-open/plan.md
+++ b/plan/2026-08-21-insert-picker-always-open/plan.md
@@ -1,0 +1,91 @@
+---
+status: completed
+experience: none
+---
+
+# Always-Open Insert Picker List
+
+## Goal
+
+User request: after pressing `I`, the component list must simply BE there —
+no dropdown to pull open, no re-expanding after each pick, and one fewer
+click wherever possible. The Insert dialog's picker list becomes permanently
+visible: the collapse toggle is removed, selecting an item no longer folds
+the list, the visible list area grows, and double-clicking an item applies
+it immediately (single click still selects for parameter/rotation tweaks
+before Apply). Keyboard flow (type to filter, arrows, Enter) is unchanged.
+
+## State and Ownership
+
+Branched from `origin/main` (PRs #142–#147 merged) as
+`claude/insert-picker-always-open`; worktree clean. A chip session holds
+`main` in a separate worktree; this target does not touch it.
+
+Owned paths:
+
+- `apps/editor/src/features/component-insert/insert-component-dialog.tsx`
+  and `insert-component-dialog.test.tsx`
+- `apps/editor/src/styles.css` (picker list height)
+- `apps/editor/e2e/component-insert.spec.ts` (collapse-dependent stability
+  test rewritten for the always-open contract; new double-click scenario)
+- `plan/2026-08-21-insert-picker-always-open/plan.md`, `plan/log.md`
+
+Shared dependencies: the Insert dialog markup consumed by the
+`chooseComponent` e2e fixture (unchanged: search, option click, Apply all
+keep working).
+
+## Work
+
+1. Remove the `pickerOpen` state and the collapse/expand toggle; render the
+   options listbox unconditionally with `aria-expanded` fixed open.
+2. `selectChoice` keeps the list visible; double-click on an option applies
+   it through the existing `apply()` path (the first click of the pair has
+   already committed the selection).
+3. Raise the bordered list's height cap so more of the catalog is visible
+   without scrolling.
+4. Update the dialog markup test, rewrite the collapse steps of the layout
+   stability e2e around the always-open contract, and add a double-click
+   placement scenario.
+
+## Validation
+
+- focused `vitest`:
+  `apps/editor/src/features/component-insert/insert-component-dialog.test.tsx`
+- `playwright`: `apps/editor/e2e/component-insert.spec.ts`
+- repository typecheck, prettier
+- `node scripts/check-test-impact.mjs --base origin/main`
+- `git diff --check` and `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: the picker list is always visible (no collapse control; it
+  survives selection); double-clicking an option applies it immediately;
+  existing search/keyboard/Apply flows unchanged
+- Primary checks:
+  `apps/editor/src/features/component-insert/insert-component-dialog.test.tsx`,
+  `apps/editor/e2e/component-insert.spec.ts`
+
+## Commit Intent
+
+Committed on `claude/insert-picker-always-open` under the user's standing
+commit-push-merge direction as:
+
+```text
+feat(editor): keep the insert picker list always open
+```
+
+## Outcome
+
+Delivered. The Insert dialog's catalog is now permanently visible: the
+`pickerOpen` state and collapse/expand toggle are gone, selecting an item
+keeps the list in place for the next pick, the bordered list's height cap
+grew to `min(26rem, 48vh)`, and double-clicking an option applies it
+immediately through the existing `apply()` path (the pair's first click
+already commits the selection, so parameters and rotation state are
+consistent). Search, arrow-key, Enter, and Apply flows are unchanged, as is
+the `chooseComponent` e2e fixture. Validation: component-insert unit suite
+(10 files / 40 tests), full component-insert Playwright suite 22/22 —
+including the rewritten always-open layout-stability scenario and a new
+double-click-places-immediately scenario — repository typecheck, prettier,
+test-impact, and diff checks green; behavior confirmed live in the editor.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4108,3 +4108,16 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   test-impact, diff checks.
 - Commit status: completed on `claude/user-examples`; mainline merge gated
   on the remote required checks.
+
+## 2026-08-21 - Always-open insert picker list
+
+- Changed areas: removed the Insert dialog's collapse toggle and picker
+  open/close state so the catalog list is permanently visible and survives
+  selection; taller list cap; double-clicking an option applies it
+  immediately; layout-stability e2e rewritten for the always-open contract
+  plus a new double-click scenario.
+- Validation: component-insert unit suite (10 files / 40 tests), full
+  component-insert Playwright suite (22 passed), typecheck, prettier,
+  test-impact, diff checks; verified live.
+- Commit status: completed on `claude/insert-picker-always-open`; mainline
+  merge gated on the remote required checks.


### PR DESCRIPTION
## Summary

User request: pressing `I` should land on the component list itself — no dropdown to pull open, one fewer click everywhere.

- The Insert dialog's catalog listbox is now permanently visible: the collapse/expand toggle and its state are removed, and **selecting an item keeps the list in place** for the next pick.
- The bordered list's height cap grew to `min(26rem, 48vh)` so most categories are visible without scrolling.
- **Double-clicking an option applies it immediately** (the pair's first click already commits the selection, so parameter/rotation state stays consistent). Search, ↑↓, Enter, and Apply flows unchanged.

Target plan: `plan/2026-08-21-insert-picker-always-open/`.

## Validation

- Component-insert unit suite 10 files / 40 tests; full `component-insert.spec.ts` Playwright suite 22/22, including the rewritten always-open layout-stability scenario and a new double-click-places-immediately scenario.
- Repository typecheck, prettier, test-impact, diff checks green; verified live in the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)