### PR TITLE
Bundled-example promotion path

### DIFF
--- a/apps/editor/src/examples/library-examples.test.ts
+++ b/apps/editor/src/examples/library-examples.test.ts
@@ -1,3 +1,4 @@
+import { CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
 import { serializeProject } from "@icm/project-protocol";
 import { describe, expect, it } from "vitest";
 
@@ -7,16 +8,27 @@ import {
 } from "./library-examples";
 
 describe("bundled Library Project examples", () => {
-  it("ships two canonical, schema-valid Projects", () => {
-    expect(libraryProjectExamples.map((example) => example.name)).toEqual([
-      "Common-Source Amplifier",
-      "Two-Stage Op Amp",
-    ]);
+  it("ships canonical, schema-current, openable Projects", () => {
+    // The curated pair stays; promoted examples may extend the set (see
+    // scripts/promote-example.mjs), so the contract is per-example, not a
+    // frozen count or single-document shape.
+    expect(libraryProjectExamples.map((example) => example.id)).toEqual(
+      expect.arrayContaining(["common-source-amplifier", "two-stage-op-amp"]),
+    );
+    expect(
+      new Set(libraryProjectExamples.map((example) => example.id)).size,
+    ).toBe(libraryProjectExamples.length);
     for (const example of libraryProjectExamples) {
+      expect(example.name.trim()).not.toBe("");
       expect(serializeProject(example.project)).toContain(
-        '"schemaVersion": 21',
+        `"schemaVersion": ${CURRENT_PROJECT_SCHEMA_VERSION}`,
       );
-      expect(example.project.documents).toHaveLength(1);
+      expect(example.project.documents.length).toBeGreaterThanOrEqual(1);
+      expect(
+        example.project.documents.some(
+          (document) => document.id === example.project.topDocumentId,
+        ),
+      ).toBe(true);
     }
   });
 

--- a/plan/2026-08-21-example-promotion/plan.md
+++ b/plan/2026-08-21-example-promotion/plan.md
@@ -1,0 +1,102 @@
+---
+status: completed
+experience: none
+---
+
+# Bundled-Example Promotion Path
+
+## Goal
+
+Answer the user's "can My examples enter the main library?" with a real
+channel. "My examples" is deliberately origin-local browser data; the main
+library is source code shipped to every visitor. Promotion therefore runs
+through the repository: a new `scripts/promote-example.mjs` takes an
+exported `.icproj.json` (from the Examples panel's Export button or File >
+Save Project), validates it through the protocol boundary, writes the
+canonical prettier-formatted asset into `apps/editor/src/examples/`, and
+registers it in `library-examples.ts` — one command from exported file to
+bundled example, after which the ordinary commit -> PR -> merge -> deploy
+flow publishes it. The bundled-examples test becomes promotion-proof
+(dynamic contracts instead of a hard-coded two-name list and a
+one-document assumption that would reject hierarchical examples).
+
+## State and Ownership
+
+Branched from `origin/main` as `claude/example-promotion`; worktree clean.
+PR #148 (insert picker) is in its own CI-merge chain; files are disjoint.
+
+Owned paths:
+
+- `scripts/promote-example.mjs` (new) and
+  `scripts/lib/example-promotion.mjs` (+ `.test.mjs`) — registration codemod
+  and identifier rules kept as testable helpers per the scripts/lib pattern
+- `apps/editor/src/examples/library-examples.test.ts` — promotion-proof
+  contracts
+- `plan/2026-08-21-example-promotion/plan.md`, `plan/log.md`
+
+Shared dependencies: the bundled-example registry consumed by the Examples
+panel and its tests (shape unchanged; only the test's rigidity changes),
+and the project-protocol boundary used as-is by the script.
+
+## Work
+
+1. `scripts/lib/example-promotion.mjs`: slug/id validation, import-line and
+   registry-entry insertion into the `library-examples.ts` source (pure
+   string codemod, duplicate-id refusal), asset file naming.
+2. `scripts/promote-example.mjs`: parse arguments (`<file> --id --name
+   --description`), validate via `parseProject` (rolling upgrade applies),
+   write prettier-formatted canonical JSON, apply the codemod, print the
+   follow-up (focused tests + ordinary delivery gate).
+3. Refactor `library-examples.test.ts`: every bundled example is
+   schema-current, uniquely identified, and openable; the two curated
+   examples remain asserted by id without freezing the total count or a
+   single-document shape.
+4. Smoke-prove the script end to end on a temporary id, run the focused
+   suites, then revert the temporary promotion (the tool lands, no junk
+   example does).
+
+## Validation
+
+- `node --test`-free: focused `vitest` for
+  `scripts/lib/example-promotion.test.mjs` and
+  `apps/editor/src/examples/library-examples.test.ts`
+- end-to-end smoke: promote a fixture copy under a temp id, rerun the
+  examples suite green with three entries, revert
+- repository typecheck, prettier, markdown links
+- `node scripts/check-test-impact.mjs --base origin/main`
+- `git diff --check` and `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: registration codemod inserts exactly one import and one entry
+  and refuses duplicates/invalid slugs; bundled examples stay schema-current
+  and uniquely identified regardless of count or document depth; curated
+  ids remain present
+- Primary checks: `scripts/lib/example-promotion.test.mjs`,
+  `apps/editor/src/examples/library-examples.test.ts`
+
+## Commit Intent
+
+Committed on `claude/example-promotion` under the user's standing
+commit-push-merge direction as:
+
+```text
+feat(scripts): add bundled-example promotion path
+```
+
+## Outcome
+
+Delivered. `scripts/promote-example.mjs` turns one exported `.icproj.json`
+into a bundled Library example in a single command: protocol validation
+(rolling upgrade applies), canonical prettier-formatted asset in
+`apps/editor/src/examples/`, and registration via a testable codemod in
+`scripts/lib/example-promotion.mjs` (kebab-slug rules, duplicate refusal,
+precise anchor errors). The bundled-example contracts are now
+promotion-proof: per-example schema-current/unique/openable assertions with
+the curated pair pinned by id, no frozen count or single-document
+assumption. Proven end to end by promoting a fixture copy under a temp id —
+examples and editor-shell suites green with three entries — then reverting
+so the tool lands without a junk example. Validation: codemod tests (4),
+refactored examples suite, typecheck, prettier, markdown links,
+test-impact, diff checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4108,3 +4108,16 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   test-impact, diff checks.
 - Commit status: completed on `claude/user-examples`; mainline merge gated
   on the remote required checks.
+
+## 2026-08-21 - Bundled-example promotion path
+
+- Changed areas: new `scripts/promote-example.mjs` plus testable
+  registration codemod in `scripts/lib/example-promotion.mjs` (exported
+  Project -> validated canonical asset + registry entry in one command);
+  bundled-example test refactored to per-example contracts so promotions
+  cannot break a frozen count or single-document assumption.
+- Validation: codemod tests, refactored examples suite, end-to-end smoke
+  promotion (then reverted), typecheck, prettier, markdown links,
+  test-impact, diff checks.
+- Commit status: completed on `claude/example-promotion`; mainline merge
+  gated on the remote required checks.

--- a/scripts/lib/example-promotion.mjs
+++ b/scripts/lib/example-promotion.mjs
@@ -1,0 +1,73 @@
+// Pure helpers behind scripts/promote-example.mjs: identifier rules and the
+// registration codemod over apps/editor/src/examples/library-examples.ts.
+// Kept side-effect free so the codemod is testable without touching files.
+
+const SLUG_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/u;
+
+export function validateExampleId(id) {
+  if (!SLUG_PATTERN.test(id)) {
+    return `Example id must be a kebab-case slug (got ${JSON.stringify(id)})`;
+  }
+  return null;
+}
+
+export function exampleAssetFileName(id) {
+  return `${id}.icproj.json`;
+}
+
+/** camelCase import binding for one kebab-case example id. */
+export function exampleImportName(id) {
+  return id.replace(/-([a-z0-9])/gu, (_, char) => char.toUpperCase());
+}
+
+function escapeStringLiteral(value) {
+  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+}
+
+/**
+ * Insert the import and registry entry for one new bundled example into the
+ * `library-examples.ts` source. Returns the rewritten source, or throws with
+ * a precise reason (duplicate id, unrecognized anchors) so the caller never
+ * writes a half-registered file.
+ */
+export function registerExampleSource(source, { id, name, description }) {
+  const idError = validateExampleId(id);
+  if (idError) throw new Error(idError);
+  if (source.includes(`id: "${id}"`)) {
+    throw new Error(`Example id ${JSON.stringify(id)} is already registered`);
+  }
+  const importName = exampleImportName(id);
+  if (new RegExp(`\\bimport ${importName}\\b`, "u").test(source)) {
+    throw new Error(
+      `Import name ${JSON.stringify(importName)} is already taken`,
+    );
+  }
+
+  const importAnchor =
+    /(import [A-Za-z0-9]+ from "\.\/[a-z0-9-]+\.icproj\.json";\n)(?![\s\S]*import [A-Za-z0-9]+ from "\.\/[a-z0-9-]+\.icproj\.json";\n)/u;
+  if (!importAnchor.test(source)) {
+    throw new Error("Could not find the bundled-example import block");
+  }
+  let next = source.replace(
+    importAnchor,
+    `$1import ${importName} from "./${exampleAssetFileName(id)}";\n`,
+  );
+
+  const registryAnchor = "];";
+  const registryClose = next.lastIndexOf(
+    registryAnchor,
+    next.indexOf("export function createLibraryExampleProject"),
+  );
+  if (registryClose < 0) {
+    throw new Error("Could not find the bundled-example registry close");
+  }
+  const entry = `  {
+    id: "${id}",
+    name: "${escapeStringLiteral(name)}",
+    description: "${escapeStringLiteral(description)}",
+    project: bundledProject(${importName}),
+  },
+`;
+  next = next.slice(0, registryClose) + entry + next.slice(registryClose);
+  return next;
+}

--- a/scripts/lib/example-promotion.test.mjs
+++ b/scripts/lib/example-promotion.test.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { describe, expect, it } from "vitest";
+
+import {
+  exampleAssetFileName,
+  exampleImportName,
+  registerExampleSource,
+  validateExampleId,
+} from "./example-promotion.mjs";
+
+const registryFixture = `import type { CircuitProject } from "@icm/model";
+import { parseProject } from "@icm/project-protocol";
+
+import commonSourceAmplifier from "./common-source-amplifier.icproj.json";
+import twoStageOpAmp from "./two-stage-op-amp.icproj.json";
+
+export const libraryProjectExamples = [
+  {
+    id: "common-source-amplifier",
+    name: "Common-Source Amplifier",
+    description: "Small-signal NMOS gain stage",
+    project: bundledProject(commonSourceAmplifier),
+  },
+  {
+    id: "two-stage-op-amp",
+    name: "Two-Stage Op Amp",
+    description: "Miller-compensated amplifier",
+    project: bundledProject(twoStageOpAmp),
+  },
+];
+
+export function createLibraryExampleProject(exampleId) {
+  return null;
+}
+`;
+
+describe("example promotion identifiers", () => {
+  it("accepts kebab-case slugs and rejects everything else", () => {
+    expect(validateExampleId("ring-oscillator-3stage")).toBeNull();
+    expect(validateExampleId("Ring")).toMatch(/kebab-case/);
+    expect(validateExampleId("a--b")).toMatch(/kebab-case/);
+    expect(validateExampleId("-lead")).toMatch(/kebab-case/);
+    expect(validateExampleId("空格 example")).toMatch(/kebab-case/);
+  });
+
+  it("derives asset and import names from the slug", () => {
+    expect(exampleAssetFileName("ring-osc")).toBe("ring-osc.icproj.json");
+    expect(exampleImportName("ring-osc-3")).toBe("ringOsc3");
+  });
+});
+
+describe("registerExampleSource", () => {
+  it("inserts exactly one import and one registry entry", () => {
+    const next = registerExampleSource(registryFixture, {
+      id: "ring-oscillator",
+      name: 'Ring "Osc"',
+      description: "Three-stage inverter loop",
+    });
+    expect(next).toContain(
+      'import ringOscillator from "./ring-oscillator.icproj.json";',
+    );
+    expect(next).toContain('id: "ring-oscillator",');
+    expect(next).toContain('name: "Ring \\"Osc\\"",');
+    expect(next).toContain("project: bundledProject(ringOscillator),");
+    // Entry lands inside the registry, before its closing bracket.
+    assert.ok(
+      next.indexOf('id: "ring-oscillator"') <
+        next.indexOf("export function createLibraryExampleProject"),
+    );
+    // The import block gains exactly one line.
+    expect(
+      next.match(/import [A-Za-z0-9]+ from "\.\/.*\.icproj\.json";/gu),
+    ).toHaveLength(3);
+  });
+
+  it("refuses duplicates and unrecognized sources", () => {
+    expect(() =>
+      registerExampleSource(registryFixture, {
+        id: "two-stage-op-amp",
+        name: "Duplicate",
+        description: "",
+      }),
+    ).toThrow(/already registered/);
+    expect(() =>
+      registerExampleSource("export const nothing = [];", {
+        id: "ring-oscillator",
+        name: "Ring",
+        description: "",
+      }),
+    ).toThrow(/import block/);
+  });
+});

--- a/scripts/promote-example.mjs
+++ b/scripts/promote-example.mjs
@@ -1,0 +1,117 @@
+// Promote one exported `.icproj.json` into the bundled Library examples.
+//
+// The Examples panel's "My examples" are origin-local browser snapshots; the
+// bundled library is repository source shipped to every visitor. This script
+// is the channel between them: it validates the exported Project through the
+// ordinary protocol boundary (rolling-window upgrades apply), writes the
+// canonical prettier-formatted asset, and registers it in
+// `library-examples.ts`. Committing the result through the normal delivery
+// gate publishes the example for everyone.
+//
+// Usage:
+//   node scripts/promote-example.mjs <exported.icproj.json> \
+//     --id <kebab-slug> --name "Display Name" --description "One line"
+//
+// Follow-up printed on success: focused example tests plus the ordinary
+// mainline delivery gate.
+
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { format } from "prettier";
+
+import {
+  exampleAssetFileName,
+  registerExampleSource,
+  validateExampleId,
+} from "./lib/example-promotion.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const examplesRoot = resolve(root, "apps/editor/src/examples");
+const registryPath = resolve(examplesRoot, "library-examples.ts");
+
+function fail(message) {
+  console.error(`promote-example: ${message}`);
+  process.exit(1);
+}
+
+function parseArguments(argv) {
+  const positional = [];
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (
+      argument === "--id" ||
+      argument === "--name" ||
+      argument === "--description"
+    ) {
+      const value = argv[index + 1];
+      if (value === undefined) fail(`${argument} requires a value`);
+      options[argument.slice(2)] = value;
+      index += 1;
+    } else if (argument.startsWith("--")) {
+      fail(`Unknown option ${argument}`);
+    } else {
+      positional.push(argument);
+    }
+  }
+  return { positional, options };
+}
+
+const { positional, options } = parseArguments(process.argv.slice(2));
+if (positional.length !== 1 || !options.id || !options.name) {
+  fail(
+    'usage: node scripts/promote-example.mjs <exported.icproj.json> --id <slug> --name "Display Name" [--description "One line"]',
+  );
+}
+const idError = validateExampleId(options.id);
+if (idError) fail(idError);
+const description = options.description ?? "";
+
+const { parseProject, serializeProject } =
+  await import("../packages/project-protocol/dist/index.js").catch(() =>
+    fail(
+      "packages/project-protocol/dist is missing — build it first (pnpm build, or tsc -p packages/project-protocol)",
+    ),
+  );
+
+const sourceText = await readFile(resolve(positional[0]), "utf8").catch(
+  (error) => fail(`Cannot read ${positional[0]}: ${error.message}`),
+);
+let project;
+try {
+  project = parseProject(sourceText);
+} catch (error) {
+  fail(`Exported Project is not loadable: ${error.message}`);
+}
+// The bundled display name comes from the registry entry; keep the persisted
+// Project name in sync so opening the example shows the same identity.
+project.name = options.name;
+
+const registrySource = await readFile(registryPath, "utf8");
+let nextRegistry;
+try {
+  nextRegistry = registerExampleSource(registrySource, {
+    id: options.id,
+    name: options.name,
+    description,
+  });
+} catch (error) {
+  fail(error.message);
+}
+
+const assetPath = resolve(examplesRoot, exampleAssetFileName(options.id));
+const assetText = await format(serializeProject(project), { parser: "json" });
+await writeFile(assetPath, assetText, "utf8");
+await writeFile(registryPath, nextRegistry, "utf8");
+
+console.log(`Promoted ${options.id} (schema ${project.schemaVersion}):`);
+console.log(
+  `  wrote apps/editor/src/examples/${exampleAssetFileName(options.id)}`,
+);
+console.log("  registered in apps/editor/src/examples/library-examples.ts");
+console.log("Verify with:");
+console.log(
+  "  pnpm test:local apps/editor/src/examples apps/editor/src/features/editor-shell",
+);
+console.log("then deliver through the ordinary mainline gate.");


### PR DESCRIPTION
## Summary

Answers "can My examples enter the main library?" with a real channel. "My examples" are origin-local browser snapshots; the bundled library is repository source shipped to every visitor — so promotion runs through the repo:

```
node scripts/promote-example.mjs <exported.icproj.json> --id <slug> --name "Display Name" --description "One line"
```

validates the exported Project through the ordinary protocol boundary (rolling-window upgrade applies), writes the canonical prettier-formatted asset into `apps/editor/src/examples/`, and registers it in `library-examples.ts` via a testable codemod (kebab-slug rules, duplicate refusal, precise anchor errors). Committing the result through the normal gate publishes the example for everyone.

The bundled-example test is now promotion-proof: per-example schema-current/unique/openable contracts with the curated pair pinned by id — no frozen "two examples" count, no single-document assumption (hierarchical examples welcome).

Target plan: `plan/2026-08-21-example-promotion/`.

## Validation

- Codemod unit tests (4) and the refactored examples suite.
- End-to-end smoke: promoted a fixture copy under a temporary id — examples + editor-shell suites green with three entries, typecheck clean — then reverted, so the tool lands without a junk example.
- Repository typecheck, prettier, markdown links, test-impact, diff checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)