### PR TITLE
Community gallery: public feed foundation (platform phase G1)

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -39,3 +39,13 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # The gallery admin bearer lives in the GitHub secret and is synced to
+      # the Worker on every deploy; rotate by updating the GitHub secret and
+      # re-running this workflow.
+      - name: Sync gallery admin secret
+        if: ${{ secrets.GALLERY_ADMIN_TOKEN != '' }}
+        run: printf '%s' "$GALLERY_ADMIN_TOKEN" | pnpm dlx wrangler@4.120.1 secret put GALLERY_ADMIN_TOKEN
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          GALLERY_ADMIN_TOKEN: ${{ secrets.GALLERY_ADMIN_TOKEN }}

--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -41,10 +41,15 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       # The gallery admin bearer lives in the GitHub secret and is synced to
       # the Worker on every deploy; rotate by updating the GitHub secret and
-      # re-running this workflow.
+      # re-running this workflow. The guard is shell-level because the
+      # secrets context is not available in step `if` expressions.
       - name: Sync gallery admin secret
-        if: ${{ secrets.GALLERY_ADMIN_TOKEN != '' }}
-        run: printf '%s' "$GALLERY_ADMIN_TOKEN" | pnpm dlx wrangler@4.120.1 secret put GALLERY_ADMIN_TOKEN
+        run: |
+          if [ -z "$GALLERY_ADMIN_TOKEN" ]; then
+            echo "GALLERY_ADMIN_TOKEN is not configured; skipping sync"
+            exit 0
+          fi
+          printf '%s' "$GALLERY_ADMIN_TOKEN" | pnpm dlx wrangler@4.120.1 secret put GALLERY_ADMIN_TOKEN
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/apps/editor/e2e/chrome-isolation.spec.ts
+++ b/apps/editor/e2e/chrome-isolation.spec.ts
@@ -5,7 +5,7 @@ import { chooseComponent } from "./editor-fixtures.js";
 test("keeps editor chrome typography from suppressing SVG italics", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
 
   await chooseComponent(page, "resistor");
   await page
@@ -26,7 +26,7 @@ test("keeps editor chrome typography from suppressing SVG italics", async ({
 });
 
 test("dismisses Help with Escape or a backdrop pointer", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const help = page.getByRole("dialog", { name: "Help" });
 
   await page.getByRole("button", { name: "Help" }).click();
@@ -41,7 +41,7 @@ test("dismisses Help with Escape or a backdrop pointer", async ({ page }) => {
 });
 
 test("opens About with the version and repository link", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await page.getByRole("button", { name: "About" }).click();
 
   const about = page.getByRole("dialog", { name: "About" });

--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -11,7 +11,7 @@ import {
 test("blocks destructive browser refresh shortcuts and uses the stronger grid", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await expect(page.locator(".canvas-grid-dot").first()).toHaveCSS(
     "fill",
     "rgb(196, 199, 201)",
@@ -48,7 +48,7 @@ test("blocks destructive browser refresh shortcuts and uses the stronger grid", 
 test("mirrors component and copy placement previews before their commits", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "resistor");
 
   const canvas = page.getByTestId("schematic-canvas");
@@ -83,7 +83,7 @@ test("mirrors component and copy placement previews before their commits", async
 test("writes a manual netlist reference into the placed Instance", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill("resistor");
@@ -103,7 +103,7 @@ test("writes a manual netlist reference into the placed Instance", async ({
 test("returns a component to the Placement Tray and places the retained Instance again", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "resistor");
   const canvas = page.getByTestId("schematic-canvas");
   await canvas.click({ position: { x: 320, y: 220 } });
@@ -155,7 +155,7 @@ test("returns a component to the Placement Tray and places the retained Instance
 test("refreshes explicitly only after flushing and automatically restoring recovery", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "resistor");
   await page
     .getByTestId("schematic-canvas")
@@ -185,7 +185,7 @@ test("refreshes explicitly only after flushing and automatically restoring recov
 test("inserts from the master-detail dialog with keyboard and live placement preview", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await expect(page.getByTestId("canvas-empty-state")).toBeVisible();
 
   await page.keyboard.press("i");
@@ -246,7 +246,7 @@ test("inserts from the master-detail dialog with keyboard and live placement pre
 
 test("places a named power rail from I", async ({ page }) => {
   await emulateDownloadOnlyBrowser(page);
-  await page.goto("/");
+  await page.goto("/editor");
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill("vdd");
@@ -297,7 +297,7 @@ test("places the VDD power-port device as the default VDD entry", async ({
   page,
 }) => {
   await emulateDownloadOnlyBrowser(page);
-  await page.goto("/");
+  await page.goto("/editor");
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill("vdd");
@@ -364,7 +364,7 @@ test("places the VDD power-port device as the default VDD entry", async ({
 test("reopens I and starts Copy from retained selection without stacking modes", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "resistor");
   const canvas = page.getByTestId("schematic-canvas");
   await canvas.click({ position: { x: 360, y: 230 } });
@@ -392,7 +392,7 @@ test("reopens I and starts Copy from retained selection without stacking modes",
 test("publishes placement cancellation synchronously before rapid Copy", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");
   const symbols = ["nmos", "pmos", "resistor"] as const;
 
@@ -430,7 +430,7 @@ test("publishes placement cancellation synchronously before rapid Copy", async (
 test("copies a MOS whose bulk belongs to a shared supply Net", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");
 
   await chooseComponent(page, "nmos");
@@ -454,7 +454,7 @@ test("copies a MOS whose bulk belongs to a shared supply Net", async ({
 test("carries a manual Value through placement and Q property editing", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill("resistor");
@@ -550,7 +550,7 @@ test("carries a manual Value through placement and Q property editing", async ({
 test("keeps the workspace inside the viewport and exposes low-interference zoom controls", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
 
   expect(
     await page.evaluate(() => ({
@@ -581,7 +581,7 @@ test("keeps preview fixed while picking from the always-open catalog", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1100, height: 720 });
-  await page.goto("/");
+  await page.goto("/editor");
   await page.keyboard.press("i");
 
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
@@ -642,7 +642,7 @@ test("keeps preview fixed while picking from the always-open catalog", async ({
 test("places MOS parameters and orientation without a hidden-label suppressor", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await page.keyboard.press("i");
 
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
@@ -703,7 +703,7 @@ test("places MOS parameters and orientation without a hidden-label suppressor", 
 test("keeps component placement active across independent canvas commits", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill("resistor");
@@ -732,7 +732,7 @@ test("shows the complete foldable categorized Library, quick-places a device, an
   page,
 }) => {
   await page.setViewportSize({ width: 1024, height: 720 });
-  await page.goto("/");
+  await page.goto("/editor");
   const panel = page.getByTestId("shapes-library-panel");
   const canvas = page.getByTestId("schematic-canvas");
   const libraryChips = panel.locator('[data-testid^="shapes-chip-"]');
@@ -920,7 +920,7 @@ test("opens named full-width Project examples from the left tool rail", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1024, height: 720 });
-  await page.goto("/");
+  await page.goto("/editor");
 
   const libraryToggle = page.getByTestId("library-toggle");
   const examplesToggle = page.getByTestId("examples-toggle");
@@ -969,7 +969,7 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
   page,
 }) => {
   await page.setViewportSize({ width: 720, height: 720 });
-  await page.goto("/");
+  await page.goto("/editor");
 
   const chrome = page.locator(".app-chrome-main");
   const analytics = page.getByRole("link", { name: "Open visitor analytics" });
@@ -1035,7 +1035,7 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
 test("double-clicking a placed device opens Properties for editing", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill("resistor");
@@ -1064,7 +1064,7 @@ test("double-clicking a placed device opens Properties for editing", async ({
 test("Library rail folds the sidebar; Insert and title open the catalog", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const panel = page.getByTestId("shapes-library-panel");
   await expect(panel).toHaveAttribute("data-open", "true");
 
@@ -1094,7 +1094,7 @@ test("Library rail folds the sidebar; Insert and title open the catalog", async 
 test("double-clicking a catalog item applies it immediately", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByTestId("insert-component-resistor").dblclick();

--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -104,7 +104,7 @@ async function expectForeignObjectContentsContained(
 test("adds formatted drafting text and undo/redo restores it", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await expect(page.getByTestId("revision")).toHaveText("0");
 
   await clickCommand(page, "Draw", "Text");
@@ -184,7 +184,7 @@ test("adds formatted drafting text and undo/redo restores it", async ({
 test("snaps quick Text creation after a non-grid viewport zoom", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");
   await canvas.hover({ position: { x: 317, y: 243 } });
   await page.mouse.wheel(0, -120);
@@ -218,7 +218,7 @@ test("snaps quick Text creation after a non-grid viewport zoom", async ({
 test("fits drafting text with F using an integer grid camera", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Text");
   const draftInput = page.getByRole("textbox", {
     name: "Canvas text editor",
@@ -241,7 +241,7 @@ test("fits drafting text with F using an integer grid camera", async ({
 test("text floating editor closes on Escape or an outside pointer", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Text");
   await expect(page.getByTestId("canvas-text-editor")).toBeVisible();
   await page.keyboard.press("Escape");
@@ -258,7 +258,7 @@ test("text floating editor closes on Escape or an outside pointer", async ({
 test("exports a newly created construction line through the File menu", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Construction line (K)");
   await clickCreate(page, { x: 200, y: 200 }, { x: 420, y: 260 });
   await expect(page.getByTestId("revision")).toHaveText("1");
@@ -272,7 +272,7 @@ test("exports a newly created construction line through the File menu", async ({
 test("switching creation tools discards the incompatible draft session", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Arrow (A)");
   await page.getByTestId("schematic-canvas").click({
     position: { x: 220, y: 220 },
@@ -290,7 +290,7 @@ test("switching creation tools discards the incompatible draft session", async (
 test("repeating A or K preserves the current drafting session", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");
 
   await page.keyboard.press("a");
@@ -317,7 +317,7 @@ test("repeating A or K preserves the current drafting session", async ({
 test("existing text drag commits once and undoes atomically", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Text");
   await page
     .getByRole("textbox", { name: "Canvas text editor" })
@@ -348,7 +348,7 @@ test("existing text drag commits once and undoes atomically", async ({
 test("Escape cancels an existing text drag without a revision", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Text");
   await page
     .getByRole("textbox", { name: "Canvas text editor" })
@@ -370,7 +370,7 @@ test("Escape cancels an existing text drag without a revision", async ({
 test("Escape removes Smart Snap guides from a cancelled component drag", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "resistor");
   await page.getByTestId("schematic-canvas").click({
     position: { x: 300, y: 240 },
@@ -412,7 +412,7 @@ test("Escape removes Smart Snap guides from a cancelled component drag", async (
 
 // Creating a construction line commits one object.
 test("two-phase click-creates a construction line", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Construction line (K)");
   await expect(page.getByTestId("active-tool")).toHaveText("construction-line");
   await clickCreate(page, { x: 200, y: 200 }, { x: 420, y: 260 });
@@ -426,7 +426,7 @@ test("two-phase click-creates a construction line", async ({ page }) => {
 
 // Two-phase click-creating an arrow commits one object.
 test("two-phase click-creates an arrow", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Arrow (A)");
   await expect(page.getByTestId("active-tool")).toHaveText("arrow");
   await clickCreate(page, { x: 200, y: 320 }, { x: 420, y: 380 });
@@ -441,7 +441,7 @@ test("two-phase click-creates an arrow", async ({ page }) => {
 test("construction line uses stroke-based hit, not a blocking rect", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Construction line (K)");
   await clickCreate(page, { x: 200, y: 200 }, { x: 420, y: 200 });
   await expect(page.getByTestId("revision")).toHaveText("1");
@@ -464,7 +464,7 @@ test("construction line uses stroke-based hit, not a blocking rect", async ({
 
 // An unedited Apply must not add a revision.
 test("unedited Apply does not add a revision", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Text");
   const draftInput = page.getByRole("textbox", {
     name: "Canvas text editor",
@@ -486,7 +486,7 @@ test("unedited Apply does not add a revision", async ({ page }) => {
 test("drafting content and anchor survive save and reopen", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Text");
   const draftInput = page.getByRole("textbox", {
     name: "Canvas text editor",
@@ -534,7 +534,7 @@ test("drafting content and anchor survive save and reopen", async ({
 test("selected arrow rotates via R and shows selection handles", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Arrow (A)");
   await clickCreate(page, { x: 200, y: 300 }, { x: 320, y: 300 });
   await expect(page.getByTestId("revision")).toHaveText("1");
@@ -556,7 +556,7 @@ test("selected arrow rotates via R and shows selection handles", async ({
 test("R creates a selectable, styleable rectangle with four resize handles", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await page.keyboard.press("r");
   await clickCreate(page, { x: 220, y: 220 }, { x: 380, y: 320 });
   await expect(page.getByTestId("revision")).toHaveText("1");
@@ -639,7 +639,7 @@ test("R creates a selectable, styleable rectangle with four resize handles", asy
 test("E converts a rectangle into a navigable hierarchical Cell", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await page.keyboard.press("r");
   await clickCreate(page, { x: 220, y: 220 }, { x: 380, y: 320 });
 
@@ -719,7 +719,7 @@ test("E converts a rectangle into a navigable hierarchical Cell", async ({
 // Dragging an arrow endpoint handle moves just that endpoint in one
 // transaction; undo restores it.
 test("arrow endpoint handle drag moves the tip", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Arrow (A)");
   await clickCreate(page, { x: 200, y: 300 }, { x: 320, y: 300 });
   await clickSvgPolyline(page.getByTestId(/^drafting-hit-arrow-/));
@@ -734,7 +734,7 @@ test("arrow endpoint handle drag moves the tip", async ({ page }) => {
 // Double-clicking a construction line inserts a vertex; double-clicking a
 // vertex below the two-vertex floor is refused.
 test("construction line vertex insert via double-click", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Construction line (K)");
   await clickCreate(page, { x: 200, y: 200 }, { x: 420, y: 200 });
   await expect(page.getByTestId("revision")).toHaveText("1");
@@ -756,7 +756,7 @@ test("construction line vertex insert via double-click", async ({ page }) => {
 // The [ and ] shortcuts step the selected object's stroke width and commit one
 // revision each.
 test("bracket shortcuts step stroke width", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Construction line (K)");
   await clickCreate(page, { x: 200, y: 200 }, { x: 420, y: 200 });
   await page.getByTestId(/^drafting-hit-construction-/).click({ force: true });
@@ -768,7 +768,7 @@ test("bracket shortcuts step stroke width", async ({ page }) => {
 
 // Drawing style lives in Properties; it is not a second floating canvas UI.
 test("Properties changes drawing line style", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Construction line (K)");
   await clickCreate(page, { x: 200, y: 200 }, { x: 420, y: 200 });
   await page.getByTestId(/^drafting-hit-construction-/).click({ force: true });
@@ -782,7 +782,7 @@ test("Properties changes drawing line style", async ({ page }) => {
 });
 
 test("Properties renders an arrow line-style override", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Arrow (A)");
   await clickCreate(page, { x: 200, y: 200 }, { x: 420, y: 200 });
   await page.getByTestId(/^drafting-hit-arrow-/).click({ force: true });
@@ -799,7 +799,7 @@ test("Properties renders an arrow line-style override", async ({ page }) => {
 });
 
 test("arrow Properties omits the Segment selector", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Arrow (A)");
   await clickCreate(page, { x: 200, y: 200 }, { x: 420, y: 200 });
   await page.getByTestId(/^drafting-hit-arrow-/).click({ force: true });
@@ -827,7 +827,7 @@ test("arrow Properties omits the Segment selector", async ({ page }) => {
 test("drawing Properties follows selection and closes with the dock", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Arrow (A)");
   await clickCreate(page, { x: 200, y: 200 }, { x: 420, y: 200 });
   const hit = page.getByTestId(/^drafting-hit-arrow-/);
@@ -859,7 +859,7 @@ test("drawing Properties follows selection and closes with the dock", async ({
 test("drawing Properties unlocks a protected drawing and Delete overrides its lock", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Construction line (K)");
   await clickCreate(page, { x: 200, y: 200 }, { x: 420, y: 200 });
   const drawing = page.getByTestId(/^drafting-hit-construction-/);
@@ -894,7 +894,7 @@ test("drawing Properties unlocks a protected drawing and Delete overrides its lo
 test("double-click inside a rectangle writes a centered, anchored label", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await page.keyboard.press("r");
   await clickCreate(page, { x: 220, y: 220 }, { x: 380, y: 320 });
   await expect(page.getByTestId("revision")).toHaveText("1");

--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+import { createEmptyProject } from "@icm/model";
+import { serializeProject } from "@icm/project-protocol";
+
+const ENTRY = {
+  id: "g-ring",
+  name: "Ring Oscillator",
+  author: "tz",
+  description: "Three-stage loop",
+  createdAt: "2026-08-21T10:00:00.000Z",
+  schemaVersion: 21,
+};
+
+async function mockGallery(page: Page, entries: object[]): Promise<void> {
+  await page.route("**/api/gallery", (route) =>
+    route.fulfill({ json: { entries, nextCursor: null } }),
+  );
+  await page.route(`**/api/gallery/${ENTRY.id}/preview.svg`, (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10" fill="#fff"/></svg>',
+    }),
+  );
+  await page.route(`**/api/gallery/${ENTRY.id}`, (route) =>
+    route.fulfill({
+      json: {
+        entry: ENTRY,
+        projectText: serializeProject(
+          createEmptyProject("gallery-ring", ENTRY.name),
+        ),
+      },
+    }),
+  );
+}
+
+test("the site lands on the full-screen gallery feed", async ({ page }) => {
+  await mockGallery(page, [ENTRY]);
+  await page.goto("/");
+  const feed = page.getByTestId("gallery-feed");
+  await expect(feed).toBeVisible();
+
+  // Published tile plus the bundled starter tiles keep the wall non-empty.
+  await expect(page.getByTestId(`gallery-tile-${ENTRY.id}`)).toBeVisible();
+  await expect(
+    page.getByTestId("gallery-bundled-common-source-amplifier"),
+  ).toBeVisible();
+  await expect(page.getByTestId("gallery-new-circuit")).toHaveAttribute(
+    "href",
+    "/editor",
+  );
+});
+
+test("falls back to bundled tiles when the gallery is empty or unreachable", async ({
+  page,
+}) => {
+  await page.route("**/api/gallery", (route) =>
+    route.fulfill({ status: 502, json: { error: "unavailable" } }),
+  );
+  await page.goto("/");
+  await expect(
+    page.getByTestId("gallery-bundled-two-stage-op-amp"),
+  ).toBeVisible();
+});
+
+test("a gallery tile opens its circuit in the editor", async ({ page }) => {
+  await mockGallery(page, [ENTRY]);
+  await page.goto("/");
+  await page.getByTestId(`gallery-tile-${ENTRY.id}`).click();
+  await expect(page).toHaveURL(/\/g\/g-ring$/);
+  await expect(page.getByTestId("status")).toContainText(
+    `Opened gallery circuit: ${ENTRY.name}`,
+  );
+  await expect(page.locator(".app-brand-copy p")).toContainText(ENTRY.name);
+
+  // The brand mark links back to the gallery landing page.
+  await expect(
+    page.getByRole("link", { name: "Back to the gallery" }),
+  ).toHaveAttribute("href", "/");
+});
+
+test("bundled starter tiles open their example in the editor", async ({
+  page,
+}) => {
+  await mockGallery(page, []);
+  await page.goto("/");
+  await page.getByTestId("gallery-bundled-common-source-amplifier").click();
+  await expect(page).toHaveURL(/\/editor\?example=common-source-amplifier$/);
+  await expect(page.getByTestId("status")).toContainText(
+    "Opened example: Common-Source Amplifier",
+  );
+});

--- a/apps/editor/e2e/hierarchy.spec.ts
+++ b/apps/editor/e2e/hierarchy.spec.ts
@@ -56,7 +56,7 @@ async function beginPortPlacement(
 
 test("keeps direct Cell commands in one hierarchy row", async ({ page }) => {
   await page.setViewportSize({ width: 420, height: 700 });
-  await page.goto("/");
+  await page.goto("/editor");
   const toolbar = page.locator('.toolbar-row[aria-label="Document hierarchy"]');
   await expect(
     page.getByRole("button", { name: "Manage Cells…" }),
@@ -75,7 +75,7 @@ test("keeps direct Cell commands in one hierarchy row", async ({ page }) => {
 });
 
 test("creates and deletes an unreferenced reusable Cell", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await createCell(page, "ReusableStage");
 
   await expect(page.getByTestId("document-count")).toHaveText("2");
@@ -103,7 +103,7 @@ test("creates and deletes an unreferenced reusable Cell", async ({ page }) => {
 });
 
 test("manages Cell rename and lists callers", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await createCell(page, "ReusableStage");
   await page
     .getByTestId("cell-navigation")
@@ -137,7 +137,7 @@ test("manages Cell rename and lists callers", async ({ page }) => {
 });
 
 test("declares and places a Cell Port on a new local Net", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await createCell(page, "ReusableStage");
 
   const canvas = page.getByTestId("schematic-canvas");
@@ -302,7 +302,7 @@ test("declares and places a Cell Port on a new local Net", async ({ page }) => {
 test("declares a top Formal Cell Pin and exports the top interface", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await beginPortPlacement(page, {
     role: "cell-terminal",
     name: "VIN",
@@ -336,7 +336,7 @@ test("copies and independently deletes repeated Formal Cell Pin markers", async 
     window.localStorage.clear();
     window.sessionStorage.clear();
   });
-  await page.goto("/");
+  await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");
   await beginPortPlacement(page, {
     role: "cell-terminal",
@@ -392,7 +392,7 @@ test("copies and independently deletes repeated Formal Cell Pin markers", async 
 test("places a free Net Port whose rich label edits the Net name", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await beginPortPlacement(page, { role: "net-port", name: "VIN" });
   await page
     .getByTestId("schematic-canvas")
@@ -436,7 +436,7 @@ test("places a free Net Port whose rich label edits the Net name", async ({
 test("returns a formal Cell Port to the Tray without deleting its interface", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await createCell(page, "ReusableStage");
   const canvas = page.getByTestId("schematic-canvas");
   await beginPortPlacement(page, {
@@ -477,7 +477,7 @@ test("returns a formal Cell Port to the Tray without deleting its interface", as
 test("authors formal Cell parameters without entering Cell Symbol Layout", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await createCell(page, "ReusableStage");
   await beginPortPlacement(page, {
     role: "cell-terminal",
@@ -512,7 +512,7 @@ test("authors formal Cell parameters without entering Cell Symbol Layout", async
 test("deletes a wired child Cell Port through the ordinary instance path", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await createCell(page, "ReusableStage");
   const canvas = page.getByTestId("schematic-canvas");
   await beginPortPlacement(page, {
@@ -531,7 +531,7 @@ test("deletes a wired child Cell Port through the ordinary instance path", async
 test("places an existing Cell and blocks deleting its shared definition", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await createCell(page, "ReusableStage");
   await page
     .getByTestId("cell-navigation")

--- a/apps/editor/e2e/instance-table.spec.ts
+++ b/apps/editor/e2e/instance-table.spec.ts
@@ -5,7 +5,7 @@ import { chooseComponent, clickCommand } from "./editor-fixtures.js";
 test("edits compatible selected instances through the explicit Instance Table", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "nmos");
   const canvas = page.getByTestId("schematic-canvas");
   await canvas.click({ position: { x: 220, y: 180 } });

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -30,7 +30,7 @@ test.beforeEach(async ({ page }) => {
 test("opens netlist preflight and navigates its canonical finding", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 360, y: 240 });
   await clickCommand(page, "Netlist", "Run Preflight…");
   const dialog = page.getByRole("dialog", { name: "Netlist Preflight" });
@@ -47,7 +47,7 @@ test("opens netlist preflight and navigates its canonical finding", async ({
 test("previews a validated structural netlist in both export dialects", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Netlist", "Run Preflight…");
   const dialog = page.getByRole("dialog", { name: "Netlist Preflight" });
   const preview = dialog.getByTestId("netlist-preview");
@@ -271,7 +271,7 @@ async function dragBy(
 test("shows faithful symbol previews for the reviewed Razavi palette", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   const search = dialog.getByLabel("Component search");
@@ -293,7 +293,7 @@ test("shows faithful symbol previews for the reviewed Razavi palette", async ({
 });
 
 test("constructs VDD as a drawn dotless power rail", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await page.getByTestId("shapes-chip-vdd").click();
   const canvas = page.getByTestId("schematic-canvas");
 
@@ -330,7 +330,7 @@ test("constructs VDD as a drawn dotless power rail", async ({ page }) => {
 test("keeps a tapped VDD rail movable and stretchable as one supply bar", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");
   await page.getByTestId("shapes-chip-vdd").click();
   await canvas.click({ position: { x: 180, y: 120 } });
@@ -388,7 +388,7 @@ test("keeps a tapped VDD rail movable and stretchable as one supply bar", async 
 test("keeps unresolved PMOS bulk separate from a named VDD rail", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "pmos", { x: 360, y: 260 });
   await page.getByTestId("shapes-chip-vdd").click();
   const canvas = page.getByTestId("schematic-canvas");
@@ -427,7 +427,7 @@ test("keeps unresolved PMOS bulk separate from a named VDD rail", async ({
 test("cancels VDD rail placement before or after its first endpoint", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");
 
   await page.getByTestId("shapes-chip-vdd").click();
@@ -453,7 +453,7 @@ test("cancels VDD rail placement before or after its first endpoint", async ({
 test("command move follows the pointer and commits on one click", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 340, y: 220 });
   const resistor = page.getByTestId("hit-R1");
   await resistor.click();
@@ -471,7 +471,7 @@ test("command move follows the pointer and commits on one click", async ({
 });
 
 test("Port shortcut starts ordinary component placement", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");
   await page.keyboard.press("p");
   const dialog = page.getByRole("dialog", { name: "Place Net Port" });
@@ -500,7 +500,7 @@ test("Port shortcut starts ordinary component placement", async ({ page }) => {
 test("Free Net Ports merge by name and release their final Net lifecycle", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");
 
   const placeNamedPort = async (
@@ -555,7 +555,7 @@ test("Free Net Ports merge by name and release their final Net lifecycle", async
 test("Ctrl+D deselects without allowing browser bookmarking", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 340, y: 220 });
   await page.getByTestId("hit-R1").click();
   await page.keyboard.press("Control+d");
@@ -567,7 +567,7 @@ test("Ctrl+D deselects without allowing browser bookmarking", async ({
 test("Ctrl+R mirrors a selected component instead of refreshing", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "nmos", { x: 340, y: 220 });
   await page.getByTestId("hit-M1").click();
   await page.keyboard.press("Control+r");
@@ -583,7 +583,7 @@ test("Ctrl+R mirrors a selected component instead of refreshing", async ({
 test("treats hollow and filled Ports as ordinary wired components", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 460, y: 240 });
   await placeComponent(page, "port", { x: 260, y: 220 });
   await placeComponent(page, "port-filled", { x: 260, y: 300 });
@@ -638,7 +638,7 @@ test("treats hollow and filled Ports as ordinary wired components", async ({
 test("authors components and connectivity manually from an empty canvas", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await expect(page.getByTestId("cell-navigation")).toBeVisible();
   await expect(page.getByTestId("revision")).toHaveText("0");
 
@@ -680,7 +680,7 @@ test("authors components and connectivity manually from an empty canvas", async 
 test("connects one MOS Gate to Drain without false contact ambiguity", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "nmos", { x: 480, y: 260 });
   await clickCommand(page, "Draw", "Wire (W)");
   await page.getByTestId("terminal-M1-G").click();
@@ -695,7 +695,7 @@ test("connects one MOS Gate to Drain without false contact ambiguity", async ({
 test("keeps Wire input above labels and resolves a screen-tolerant route tap", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 340, y: 220 });
   await placeComponent(page, "resistor", { x: 660, y: 220 });
 
@@ -727,7 +727,7 @@ test("keeps Wire input above labels and resolves a screen-tolerant route tap", a
 test("keeps a Wire source across repeated activation and cancels it after undo", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 340, y: 220 });
   await placeComponent(page, "resistor", { x: 660, y: 220 });
 
@@ -747,7 +747,7 @@ test("keeps a Wire source across repeated activation and cancels it after undo",
 });
 
 test("deletes a wire without exposing Unroute", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 340, y: 220 });
   await placeComponent(page, "resistor", { x: 660, y: 220 });
   await clickCommand(page, "Draw", "Wire (W)");
@@ -779,7 +779,7 @@ test("deletes a wire without exposing Unroute", async ({ page }) => {
 test("adds and straightens an explicit jog on the selected wire segment", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Wire (W)");
   const canvas = page.getByTestId("schematic-canvas");
   await canvas.click({ position: { x: 300, y: 240 } });
@@ -809,7 +809,7 @@ test("adds and straightens an explicit jog on the selected wire segment", async 
 test("keeps Wire active for consecutive independent routes until Escape", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 280, y: 180 });
   await placeComponent(page, "resistor", { x: 520, y: 180 });
   await placeComponent(page, "resistor", { x: 280, y: 360 });
@@ -852,7 +852,7 @@ test("re-derives guidance after manually deleting an imported Route", async ({
       segmentModes: ["manual"],
     },
   ];
-  await page.goto("/");
+  await page.goto("/editor");
   await page.getByTestId("project-file").setInputFiles({
     name: "routing-imported-partial.icproj.json",
     mimeType: "application/json",
@@ -886,7 +886,7 @@ test("keeps remaining imported flightlines after routing one guided connection",
       end: { offset: 1, line: 1, column: 2 },
     },
   };
-  await page.goto("/");
+  await page.goto("/editor");
   await page.getByTestId("project-file").setInputFiles({
     name: "routing-flightlines.icproj.json",
     mimeType: "application/json",
@@ -928,7 +928,7 @@ test("suppresses only the highlighted imported Net guidance", async ({
       end: { offset: 1, line: 1, column: 2 },
     },
   };
-  await page.goto("/");
+  await page.goto("/editor");
   await page.getByTestId("project-file").setInputFiles({
     name: "routing-imported.icproj.json",
     mimeType: "application/json",
@@ -955,7 +955,7 @@ test("suppresses only the highlighted imported Net guidance", async ({
 test("turns an off-axis tap near a route bend into an exact junction", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "nmos", { x: 300, y: 260 });
   await placeComponent(page, "resistor", { x: 540, y: 160 });
   await placeComponent(page, "resistor", { x: 680, y: 360 });
@@ -977,7 +977,7 @@ test("turns an off-axis tap near a route bend into an exact junction", async ({
 test("keeps a selected MOS in its fixed Razavi three-terminal view", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "pmos", { x: 420, y: 260 });
   await expect(page.getByTestId("terminal-M1-B")).toHaveCount(0);
 
@@ -990,7 +990,7 @@ test("keeps a selected MOS in its fixed Razavi three-terminal view", async ({
 test("leaves unconfigured MOS bulk unresolved until an explicit dashed route connects it", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "nmos", { x: 360, y: 220 });
   await placeComponent(page, "ground", { x: 620, y: 280 });
 
@@ -1037,7 +1037,7 @@ test("leaves unconfigured MOS bulk unresolved until an explicit dashed route con
 test("places free wire bends and finishes at an arbitrary grid point", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 300, y: 200 });
   await clickCommand(page, "Draw", "Wire (W)");
   await page.getByTestId("terminal-R1-2").click();
@@ -1063,7 +1063,7 @@ test("places free wire bends and finishes at an arbitrary grid point", async ({
 });
 
 test("reuses a free wire endpoint as a later wire source", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 300, y: 200 });
   await placeComponent(page, "resistor", { x: 600, y: 300 });
   await clickCommand(page, "Draw", "Wire (W)");
@@ -1083,7 +1083,7 @@ test("reuses a free wire endpoint as a later wire source", async ({ page }) => {
 });
 
 test("moves an isolated free wire as one route", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");
   await clickCommand(page, "Draw", "Wire (W)");
   await canvas.click({ position: { x: 420, y: 220 } });
@@ -1116,7 +1116,7 @@ test("moves an isolated free wire as one route", async ({ page }) => {
 test("stretches the pointed segment of a selected attached wire", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 300, y: 220 });
   await placeComponent(page, "resistor", { x: 540, y: 220 });
   await clickCommand(page, "Draw", "Wire (W)");
@@ -1137,7 +1137,7 @@ test("stretches the pointed segment of a selected attached wire", async ({
 test("keeps a BJT base connection as an ordinary solid wire", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "npn", { x: 300, y: 220 });
   await placeComponent(page, "resistor", { x: 540, y: 220 });
   await clickCommand(page, "Draw", "Wire (W)");
@@ -1159,7 +1159,7 @@ test("keeps a BJT base connection as an ordinary solid wire", async ({
 test("keeps direct device pin corners on-grid and deletes a selected junction", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "nmos", { x: 300, y: 260 });
   await placeComponent(page, "resistor", { x: 540, y: 160 });
   await clickCommand(page, "Draw", "Wire (W)");
@@ -1204,7 +1204,7 @@ test("keeps direct device pin corners on-grid and deletes a selected junction", 
 test("connects copied multi-pin groups through a manually bent wire", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "nmos", { x: 320, y: 180 });
   await placeComponent(page, "nmos", { x: 320, y: 360 });
   await clickCommand(page, "Draw", "Wire (W)");
@@ -1247,7 +1247,7 @@ test("connects copied multi-pin groups through a manually bent wire", async ({
 test("moves a selected wire segment and deletes a connected component safely", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 320, y: 220 });
   await placeComponent(page, "resistor", { x: 520, y: 220 });
   await clickCommand(page, "Draw", "Wire (W)");
@@ -1278,7 +1278,7 @@ test("moves a selected wire segment and deletes a connected component safely", a
 });
 
 test("previews a connected Wire while its Instance moves", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 320, y: 220 });
   await placeComponent(page, "resistor", { x: 520, y: 220 });
   await clickCommand(page, "Draw", "Wire (W)");
@@ -1313,7 +1313,7 @@ test("previews a connected Wire while its Instance moves", async ({ page }) => {
 test("moves internal wiring with a selected group and copies the routed subgraph", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 320, y: 220 });
   await placeComponent(page, "resistor", { x: 520, y: 220 });
   await clickCommand(page, "Draw", "Wire (W)");
@@ -1377,7 +1377,7 @@ test("moves internal wiring with a selected group and copies the routed subgraph
 test("keeps an internal junction with the live group preview", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 320, y: 220 });
   await placeComponent(page, "resistor", { x: 520, y: 220 });
   await placeComponent(page, "resistor", { x: 420, y: 420 });
@@ -1413,7 +1413,7 @@ test("keeps an internal junction with the live group preview", async ({
 test("drags a current marker directly along and around its route", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 320, y: 220 });
   await placeComponent(page, "resistor", { x: 520, y: 220 });
   await clickCommand(page, "Draw", "Wire (W)");
@@ -1491,7 +1491,7 @@ test("drags a current marker directly along and around its route", async ({
 test("moves an unselected component in one thresholded drag", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 320, y: 220 });
   const canvas = page.getByTestId("schematic-canvas");
   const hit = page.getByTestId("hit-R1");
@@ -1526,7 +1526,7 @@ test("moves an unselected component in one thresholded drag", async ({
 test("keeps a transformed instance label at a constant distance while moving", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 320, y: 220 });
   await page.keyboard.press("Shift+r");
   await expect(page.getByTestId("revision")).toHaveText("2");
@@ -1548,7 +1548,7 @@ test("keeps a transformed instance label at a constant distance while moving", a
 test("selects an attached label without selecting its host", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 320, y: 220 });
 
   await page
@@ -1566,7 +1566,7 @@ test("selects an attached label without selecting its host", async ({
 });
 
 test("moves an explicitly selected attached label", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 320, y: 220 });
 
   // Text uses the same one-gesture threshold as a component.
@@ -1589,7 +1589,7 @@ test("moves an explicitly selected attached label", async ({ page }) => {
 });
 
 test("moves floating text after it is created", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Text");
   await page
     .getByRole("textbox", { name: "Canvas text editor" })
@@ -1612,7 +1612,7 @@ test("moves floating text after it is created", async ({ page }) => {
 test("edits instance, electrical Net, and free text with bounded label handles", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 280, y: 180 });
   await placeComponent(page, "resistor", { x: 480, y: 180 });
   await clickCommand(page, "Draw", "Wire (W)");
@@ -1699,7 +1699,7 @@ test("edits instance, electrical Net, and free text with bounded label handles",
 test("keeps literal text line breaks and overbars visible while editing", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await clickCommand(page, "Draw", "Text");
   const editor = page.getByRole("textbox", { name: "Canvas text editor" });
   await editor.fill("Vx");
@@ -1728,7 +1728,7 @@ test("keeps literal text line breaks and overbars visible while editing", async 
 test("L edits a selected route Net Label without opening Properties", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 280, y: 180 });
   await placeComponent(page, "resistor", { x: 480, y: 180 });
   await clickCommand(page, "Draw", "Wire (W)");
@@ -1789,7 +1789,7 @@ test("L edits a selected route Net Label without opening Properties", async ({
 test("Properties toggles reference label visibility for one or many components", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 280, y: 180 });
   await placeComponent(page, "resistor", { x: 480, y: 180 });
 
@@ -1863,7 +1863,7 @@ test("Properties toggles reference label visibility for one or many components",
 test("value display projects MOS W/L and passive values beside the reference", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill("nmos");
@@ -1923,7 +1923,7 @@ test("value display projects MOS W/L and passive values beside the reference", a
 test("reference and value toggles refresh content after parameter edits", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 300, y: 200 });
   await placeComponent(page, "resistor", { x: 500, y: 200 });
 
@@ -1998,7 +1998,7 @@ test("reference and value toggles refresh content after parameter edits", async 
 test("drag value annotation keeps the user offset through rotation", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 360, y: 220 });
   await page.getByTestId("hit-R1").click();
   await openSelectionShelf(page);
@@ -2042,7 +2042,7 @@ test("drag value annotation keeps the user offset through rotation", async ({
 test("property edits commit on blank click and Escape instead of vanishing", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 320, y: 200 });
   const canvas = page.getByTestId("schematic-canvas");
 
@@ -2072,7 +2072,7 @@ test("property edits commit on blank click and Escape instead of vanishing", asy
 test("canvas text editor commits on Escape and on an outside click", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 420, y: 280 });
   const rendered = page.locator('[data-object-id="instance-label-R1"]');
 
@@ -2096,7 +2096,7 @@ test("canvas text editor commits on Escape and on an outside click", async ({
 test("a dragged Net label re-anchors along its route and stays released", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 280, y: 180 });
   await placeComponent(page, "resistor", { x: 520, y: 180 });
   await clickCommand(page, "Draw", "Wire (W)");
@@ -2128,7 +2128,7 @@ test("a dragged Net label re-anchors along its route and stays released", async 
 test("selects and moves multiple instances while viewport gestures stay transient", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "nmos", { x: 330, y: 180 });
   await placeComponent(page, "nmos", { x: 560, y: 180 });
   await expect(page.getByTestId("revision")).toHaveText("2");
@@ -2181,7 +2181,7 @@ test("selects and moves multiple instances while viewport gestures stay transien
 test("R rotates a selected component instead of entering Rectangle", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "nmos", { x: 420, y: 260 });
   await expect(page.getByTestId("revision")).toHaveText("1");
 
@@ -2200,7 +2200,7 @@ test("R rotates a selected component instead of entering Rectangle", async ({
 test("C previews one copy and Escape cancels without a revision", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 360, y: 220 });
   await page.getByTestId("hit-R1").click();
 
@@ -2225,7 +2225,7 @@ test("C previews one copy and Escape cancels without a revision", async ({
 test("R rotates a copy preview before committing the copied component", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 360, y: 220 });
   await page.getByTestId("hit-R1").click();
   const canvas = page.getByTestId("schematic-canvas");
@@ -2254,7 +2254,7 @@ test("R rotates a copy preview before committing the copied component", async ({
 test("numbers placed components per device type instead of globally", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "nmos", { x: 320, y: 200 });
   await placeComponent(page, "nmos", { x: 520, y: 200 });
   await placeComponent(page, "resistor", { x: 720, y: 200 });
@@ -2270,7 +2270,7 @@ test("numbers placed components per device type instead of globally", async ({
 test("right-drag frames a region and fits the camera to it transiently", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 320, y: 200 });
 
   const canvas = page.getByTestId("schematic-canvas");
@@ -2320,7 +2320,7 @@ test("right-drag frames a region and fits the camera to it transiently", async (
 test("keeps copy placement active for repeated commits until Escape", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 320, y: 220 });
   await page.getByTestId("hit-R1").click();
   const canvas = page.getByTestId("schematic-canvas");
@@ -2346,7 +2346,7 @@ test("keeps copy placement active for repeated commits until Escape", async ({
 test("keeps the rich-text editor outside its target and shields canvas input", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 420, y: 280 });
   const label = page.getByTestId("annotation-hit-instance-label-R1");
   await label.dblclick();
@@ -2402,7 +2402,7 @@ test("deletes imported Net Labels with non-editor ids", async ({ page }) => {
     rotation: 0,
     locked: false,
   });
-  await page.goto("/");
+  await page.goto("/editor");
   await page.getByTestId("project-file").setInputFiles({
     name: "legacy-net-label.icproj.json",
     mimeType: "application/json",
@@ -2469,7 +2469,7 @@ test("deletes imported Net Labels with non-editor ids", async ({ page }) => {
 test("derives crossings and creates junctions only when a wire ends on a route", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await page.getByTestId("project-file").setInputFiles({
     name: "routing-example.icproj.json",
     mimeType: "application/json",
@@ -2524,7 +2524,7 @@ test("derives crossings and creates junctions only when a wire ends on a route",
 test("places a Ground pin onto a canonical Route and keeps real split topology", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const project = createRoutingDemoProject();
   const document = project.documents[0]!;
   const horizontalNet = document.nets.find((net) => net.id === "net-h");
@@ -2641,7 +2641,7 @@ test("connects every compatible pin crossed by one wire", async ({ page }) => {
     terminals: [{ instanceId: "GND1", pinName: "0" }],
   });
 
-  await page.goto("/");
+  await page.goto("/editor");
   await page.getByTestId("project-file").setInputFiles({
     name: "wire-through-pins.icproj.json",
     mimeType: "application/json",
@@ -2685,7 +2685,7 @@ test("connects every compatible pin crossed by one wire", async ({ page }) => {
 test("keeps rejected SPICE import diagnostics in a historical report", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await openMenu(page, "File");
   await page
     .getByTestId("spice-files")
@@ -2722,7 +2722,7 @@ test("keeps rejected SPICE import diagnostics in a historical report", async ({
 test("imports a parameterized hierarchy and re-exports its structural semantics", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await page.getByTestId("spice-files").setInputFiles({
     name: "circuit.spi",
     mimeType: "application/x-spice",
@@ -2749,7 +2749,7 @@ X2 OUT IN EXT_MASTER l=1u nf=4
 });
 
 test("shows imported instance references after Place all", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await page.getByTestId("spice-files").setInputFiles({
     name: "circuit.spi",
     mimeType: "application/x-spice",
@@ -2816,7 +2816,7 @@ test("requires warning review before exporting generated NoConnect nodes", async
     endpoint: { kind: "terminal", instanceId: "R1", pinName: "2" },
   });
 
-  await page.goto("/");
+  await page.goto("/editor");
   await page.getByTestId("project-file").setInputFiles({
     name: "warning.icproj.json",
     mimeType: "application/json",
@@ -2840,7 +2840,7 @@ test("requires warning review before exporting generated NoConnect nodes", async
 test("exports one formal visual scene as Project, SVG, PNG, and PDF", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
 
   const projectBytes = await downloadBytes(page, "File", "Save Project");
   expect(JSON.parse(projectBytes.toString("utf8")).topDocumentId).toBeTruthy();
@@ -2859,7 +2859,7 @@ test("exports one formal visual scene as Project, SVG, PNG, and PDF", async ({
 test("exports structural SPICE and Spectre netlists while exposing instance authoring", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const spice = (
     await downloadBytes(page, "File", "Export SPICE netlist")
   ).toString("utf8");
@@ -2887,7 +2887,7 @@ test("exports structural SPICE and Spectre netlists while exposing instance auth
 test("uses automatic recovery and guards shortcuts while typing", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 360, y: 220 });
   await expect(page.getByTestId("revision")).toHaveText("1");
   await expect
@@ -2913,7 +2913,7 @@ test("uses automatic recovery and guards shortcuts while typing", async ({
 test("keeps component insertion and inspection from resizing the canvas", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");
   const beforePlaceCanvas = await canvas.boundingBox();
   if (!beforePlaceCanvas) throw new Error("Canvas is not measurable");
@@ -2947,7 +2947,7 @@ test("keeps component insertion and inspection from resizing the canvas", async 
 test("retains recovery across save and project replacement", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 360, y: 220 });
   await expect(page.getByTestId("revision")).toHaveText("1");
 
@@ -2992,7 +2992,7 @@ test("retains recovery across save and project replacement", async ({
 });
 
 test("discard recovery clears the recovery slot", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 360, y: 220 });
   await expect
     .poll(() => recoveryProjectTexts(page))
@@ -3012,7 +3012,7 @@ test("discard recovery clears the recovery slot", async ({ page }) => {
 test("keeps the production command surface compact and publishes PWA metadata", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const toolbar = page.getByRole("navigation", { name: "Editor commands" });
   for (const label of ["File", "Edit", "Draw"]) {
     await expect(toolbar.locator("summary", { hasText: label })).toBeVisible();
@@ -3053,7 +3053,7 @@ test("keeps the production command surface compact and publishes PWA metadata", 
 test("clears the active canvas atomically after confirmation and restores it with Undo", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 320, y: 240 });
   await placeComponent(page, "resistor", { x: 560, y: 240 });
   await clickCommand(page, "Draw", "Wire (W)");
@@ -3172,7 +3172,7 @@ test("shows first-party visitor analytics without tracking the dashboard itself"
 test("dismisses a command menu on outside click or Escape", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const fileMenu = await openMenu(page, "File");
   await expect(fileMenu).toHaveAttribute("open", "");
 
@@ -3185,7 +3185,7 @@ test("dismisses a command menu on outside click or Escape", async ({
 });
 
 test("selecting an object does not change canvas width", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");
   const widthBefore = (await canvas.boundingBox())!.width;
 
@@ -3202,7 +3202,7 @@ test("selecting an object does not change canvas width", async ({ page }) => {
 test("opens project search with Ctrl+F and selects a matching component", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 420, y: 260 });
   await page.keyboard.press("Control+f");
   const input = page.getByTestId("project-search-input");
@@ -3218,7 +3218,7 @@ test("opens project search with Ctrl+F and selects a matching component", async 
 test("highlights the complete current-document Net from a selected route", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 380, y: 260 });
   await placeComponent(page, "resistor", { x: 600, y: 260 });
   await clickCommand(page, "Draw", "Wire (W)");
@@ -3322,7 +3322,7 @@ test("recomputes highlighted routed components after a Net Label is deleted", as
     },
   ];
 
-  await page.goto("/");
+  await page.goto("/editor");
   await page.getByTestId("project-file").setInputFiles({
     name: "label-highlight.icproj.json",
     mimeType: "application/json",
@@ -3352,7 +3352,7 @@ test("recomputes highlighted routed components after a Net Label is deleted", as
 test("marks and clears an unconnected endpoint as No Connect", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 380, y: 260 });
 
   await page.getByTestId("terminal-R1-1").click({ button: "right" });
@@ -3374,7 +3374,7 @@ test("marks and clears an unconnected endpoint as No Connect", async ({
 test("surfaces and locates current-document ERC diagnostics", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 380, y: 260 });
   await openSelectionShelf(page);
   await page
@@ -3404,7 +3404,7 @@ test("surfaces and locates current-document ERC diagnostics", async ({
 test("removes resolved live diagnostics and restores them through undo", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 380, y: 260 });
   await openSelectionShelf(page);
   await page
@@ -3431,7 +3431,7 @@ test("removes resolved live diagnostics and restores them through undo", async (
 test("filters and navigates locator-backed visual diagnostics", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 420, y: 300 });
   await placeComponent(page, "resistor", { x: 420, y: 300 });
   await openSelectionShelf(page);
@@ -3454,7 +3454,7 @@ test("filters and navigates locator-backed visual diagnostics", async ({
 test("directional marquee: window needs full coverage, crossing selects on touch", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "resistor");
   const canvas = page.getByTestId("schematic-canvas");
   await canvas.click({ position: { x: 420, y: 260 } });
@@ -3510,7 +3510,7 @@ test("directional marquee: window needs full coverage, crossing selects on touch
 test("Document style dialog scales fonts document-wide and resets", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 320, y: 220 });
   const label = page.locator('[data-kind="instance-label"]').first();
   await expect(label).toHaveAttribute("font-size", "15.116");
@@ -3539,7 +3539,7 @@ test("Document style dialog scales fonts document-wide and resets", async ({
 });
 
 test("saves, reopens, and deletes a user Library example", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 320, y: 220 });
   await expect(page.getByTestId("hit-R1")).toHaveCount(1);
 

--- a/apps/editor/e2e/project-file.spec.ts
+++ b/apps/editor/e2e/project-file.spec.ts
@@ -18,7 +18,7 @@ test.beforeEach(async ({ page }) => {
 test("downloads the canonical Project when File System Access is unavailable", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "resistor");
   await page
     .getByTestId("schematic-canvas")
@@ -50,7 +50,7 @@ test("upgrades the previous Project schema and saves it as current", async ({
   const previousVersion = CURRENT_PROJECT_SCHEMA_VERSION - 1;
   source.schemaVersion = previousVersion;
 
-  await page.goto("/");
+  await page.goto("/editor");
   await page.getByTestId("project-file").setInputFiles({
     name: `minimal-v${previousVersion}.icproj.json`,
     mimeType: "application/json",
@@ -85,7 +85,7 @@ test("reports a confirmed File System Access save", async ({ page }) => {
         }),
       });
   });
-  await page.goto("/");
+  await page.goto("/editor");
   const fileMenu = await openMenu(page, "File");
   await fileMenu.getByRole("button", { name: "Save Project" }).click();
   await expect(page.getByTestId("status")).toContainText(
@@ -111,7 +111,7 @@ test("falls back to download when the save location is denied", async ({
         throw new DOMException("location denied", "NotAllowedError");
       };
   });
-  await page.goto("/");
+  await page.goto("/editor");
   const bytes = await downloadBytes(page, "File", "Save Project");
   expect(JSON.parse(bytes.toString("utf8")).schemaVersion).toBe(
     CURRENT_PROJECT_SCHEMA_VERSION,
@@ -135,7 +135,7 @@ test("keeps the Project and recovery intact when the save stream fails", async (
         }),
       });
   });
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "resistor");
   await page
     .getByTestId("schematic-canvas")
@@ -158,7 +158,7 @@ test("keeps the Project and recovery intact when the save stream fails", async (
 test("keeps the Project unchanged when an opened file is rejected", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "resistor");
   await page
     .getByTestId("schematic-canvas")
@@ -192,7 +192,7 @@ test("protects dirty work before opening a replacement", async ({ page }) => {
       },
     });
   });
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "resistor");
   await page
     .getByTestId("schematic-canvas")
@@ -246,7 +246,7 @@ test("offers a download from the replacement guard", async ({ page }) => {
       },
     });
   });
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "resistor");
   await page
     .getByTestId("schematic-canvas")

--- a/apps/editor/e2e/recovery-dialog.spec.ts
+++ b/apps/editor/e2e/recovery-dialog.spec.ts
@@ -83,7 +83,7 @@ test.beforeEach(async ({ page }) => {
 test("startup banner opens the dialog and restore forks a working copy", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "resistor");
   await page
     .getByTestId("schematic-canvas")
@@ -114,7 +114,7 @@ test("startup banner opens the dialog and restore forks a working copy", async (
 test("a damaged latest copy restores the previous generation", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "resistor");
   await page
     .getByTestId("schematic-canvas")
@@ -178,7 +178,7 @@ test("a damaged latest copy restores the previous generation", async ({
 test("a newer-schema copy is downloadable but not restorable", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   const futureText = JSON.stringify({
     ...JSON.parse(fixtureText),
     schemaVersion: 99,
@@ -223,7 +223,7 @@ test("a newer-schema copy is downloadable but not restorable", async ({
 test("deleting one session keeps the other project's copy", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "resistor");
   await page
     .getByTestId("schematic-canvas")
@@ -261,7 +261,7 @@ test("deleting one session keeps the other project's copy", async ({
 });
 
 test("dialog closes with Escape and keeps focus labels", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "resistor");
   await page
     .getByTestId("schematic-canvas")
@@ -293,7 +293,7 @@ test("storage failure shows a persistent warning with a direct download", async 
       },
     });
   });
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "resistor");
   await page
     .getByTestId("schematic-canvas")

--- a/apps/editor/e2e/recovery-hardening.spec.ts
+++ b/apps/editor/e2e/recovery-hardening.spec.ts
@@ -47,7 +47,7 @@ test.beforeEach(async ({ page }) => {
 test("a hard renderer crash restores the latest committed Project", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeResistor(page, 360, 230);
   await expect(page.getByTestId("revision")).toHaveText("1");
   await expect
@@ -67,7 +67,7 @@ test("a hard renderer crash restores the latest committed Project", async ({
   await page.close({ runBeforeUnload: false });
   const revived = await page.context().newPage();
   await emulateDownloadOnlyBrowser(revived);
-  await revived.goto("/");
+  await revived.goto("/editor");
 
   await restoreThroughDialog(revived, "revision 2");
   await expect(revived.getByTestId("revision")).toHaveText("2");
@@ -81,12 +81,12 @@ test("simultaneous tabs keep separate working copies", async ({ context }) => {
   await emulateDownloadOnlyBrowser(pageA);
   await emulateDownloadOnlyBrowser(pageB);
 
-  await pageA.goto("/");
+  await pageA.goto("/editor");
   await placeResistor(pageA, 360, 230);
   await placeResistor(pageA, 500, 230);
   await expect(pageA.getByTestId("revision")).toHaveText("2");
 
-  await pageB.goto("/");
+  await pageB.goto("/editor");
   await chooseComponent(pageB, "nmos");
   await pageB
     .getByTestId("schematic-canvas")
@@ -183,7 +183,7 @@ test("quota-exceeded keeps the editor alive with a persistent warning", async ({
       return request;
     }) as IDBFactory["open"];
   });
-  await page.goto("/");
+  await page.goto("/editor");
   await placeResistor(page, 360, 230);
   await expect(page.getByTestId("revision")).toHaveText("1");
 
@@ -206,7 +206,7 @@ test("quota-exceeded keeps the editor alive with a persistent warning", async ({
 });
 
 test("no Project data enters Cache Storage", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await placeResistor(page, 360, 230);
   await expect(page.getByTestId("revision")).toHaveText("1");
   await expect

--- a/apps/editor/e2e/runtime-crash-safety.spec.ts
+++ b/apps/editor/e2e/runtime-crash-safety.spec.ts
@@ -12,7 +12,7 @@ test.beforeEach(async ({ page }) => {
 test("a render crash shows the recovery screen instead of a blank page", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await expect(page.getByTestId("schematic-canvas")).toBeVisible();
 
   // Arm the DEV-only render crash probe and force one more App render.
@@ -37,7 +37,7 @@ test("a render crash shows the recovery screen instead of a blank page", async (
 test("a scene build failure degrades to the last good view and recovers", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto("/editor");
   await chooseComponent(page, "resistor");
   await page
     .getByTestId("schematic-canvas")

--- a/apps/editor/e2e/web-agent-session.spec.ts
+++ b/apps/editor/e2e/web-agent-session.spec.ts
@@ -80,7 +80,7 @@ test("grants a browser Agent, edits through the live host, and shares undo", asy
     await route.abort();
   });
 
-  await page.goto("/");
+  await page.goto("/editor");
   const agentMenu = await openMenu(page, "Agent");
   await agentMenu.getByRole("button", { name: "Connect Agent" }).click();
   await page.getByTestId("agent-preset-full").click();

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -195,6 +195,7 @@ import { ExamplesPanel } from "../features/editor-shell/examples-panel";
 import { convertRectangleToHierarchy } from "../features/hierarchy/rectangle-to-cell";
 import { CellManagerDialog } from "../features/hierarchy/cell-manager-dialog";
 import { NetlistPreflightDialog } from "../features/netlist-export/netlist-preflight-dialog";
+import { parseProject } from "@icm/project-protocol";
 import { StyleDialog } from "../features/editor-shell/style-dialog";
 import {
   createUserExamplesStore,
@@ -206,6 +207,7 @@ import {
 } from "../features/selection/delete-selection";
 import {
   createLibraryExampleProject,
+  libraryProjectExamples,
   type LibraryProjectExample,
 } from "../examples/library-examples";
 import { useDocumentController } from "../document/document-controller";
@@ -437,12 +439,15 @@ export interface AppProps {
   visitStats?: { pv: number; uv: number } | null;
   /** Test/staging seam; production defaults to a human-only editor. */
   publicAgentUiEnabled?: boolean;
+  /** `/g/<id>` deep link: load this gallery entry after boot. */
+  initialGalleryEntryId?: string | null;
 }
 
 export function App({
   project: initialProject,
   visitStats,
   publicAgentUiEnabled = PUBLIC_AGENT_UI_ENABLED,
+  initialGalleryEntryId = null,
 }: AppProps) {
   const [preparedInitialProject] = useState(
     () =>
@@ -1741,6 +1746,58 @@ export function App({
     showLeftPanel("examples");
     void refreshUserExamples();
   }
+
+  // Landing-page deep links: `/g/<id>` opens a published gallery entry and
+  // `/editor?example=<id>` opens a bundled example. Both replace the fresh
+  // boot Project only; ordinary sessions never re-run these.
+  const bootTargetHandled = useRef(false);
+  useEffect(() => {
+    if (bootTargetHandled.current) return;
+    bootTargetHandled.current = true;
+    const exampleId = new URLSearchParams(window.location.search).get(
+      "example",
+    );
+    if (initialGalleryEntryId) {
+      void (async () => {
+        try {
+          const response = await fetch(
+            `/api/gallery/${initialGalleryEntryId}`,
+            { credentials: "same-origin" },
+          );
+          if (!response.ok) {
+            setStatus("This gallery entry is unavailable");
+            return;
+          }
+          const payload = (await response.json()) as {
+            entry?: { name?: string };
+            projectText?: string;
+          };
+          if (!payload.projectText) {
+            setStatus("This gallery entry is unavailable");
+            return;
+          }
+          const galleryProject = parseProject(payload.projectText);
+          replaceActiveProject(galleryProject);
+          setStatus(
+            `Opened gallery circuit: ${payload.entry?.name ?? galleryProject.name}`,
+          );
+        } catch {
+          setStatus("This gallery entry is unavailable");
+        }
+      })();
+      return;
+    }
+    if (exampleId) {
+      const exampleProject = createLibraryExampleProject(exampleId);
+      const example = libraryProjectExamples.find(
+        (candidate) => candidate.id === exampleId,
+      );
+      if (exampleProject && example) {
+        replaceActiveProject(exampleProject);
+        setStatus(`Opened example: ${example.name}`);
+      }
+    }
+  }, [initialGalleryEntryId]);
 
   async function refreshUserExamples(): Promise<void> {
     const outcome = await userExamplesStore.current.list();
@@ -6730,7 +6787,14 @@ export function App({
       <header className="app-chrome">
         <div className="app-chrome-main">
           <div className="app-brand">
-            <span className="app-brand-mark" aria-hidden="true" />
+            <a
+              className="gallery-home-link"
+              href="/"
+              aria-label="Back to the gallery"
+              title="Back to the gallery"
+            >
+              <span className="app-brand-mark" aria-hidden="true" />
+            </a>
             <div className="app-brand-copy">
               <h1 title="Interactive Circuit Maker">Circuit Maker</h1>
               <p title={`${project.name} / ${document.name}`}>

--- a/apps/editor/src/components/gallery-feed.test.tsx
+++ b/apps/editor/src/components/gallery-feed.test.tsx
@@ -1,0 +1,59 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { GalleryFeed, loadGalleryFeed } from "./gallery-feed";
+
+function fetchReturning(payload: unknown, ok = true): typeof fetch {
+  return (async () =>
+    new Response(JSON.stringify(payload), {
+      status: ok ? 200 : 502,
+      headers: { "content-type": "application/json" },
+    })) as typeof fetch;
+}
+
+describe("loadGalleryFeed", () => {
+  it("returns ready entries from the worker", async () => {
+    const state = await loadGalleryFeed(
+      fetchReturning({
+        entries: [
+          {
+            id: "g1",
+            name: "Ring",
+            author: "tz",
+            description: "",
+            createdAt: "2026-08-21T00:00:00.000Z",
+            schemaVersion: 21,
+          },
+        ],
+      }),
+    );
+    expect(state).toMatchObject({ status: "ready" });
+    if (state.status === "ready") {
+      expect(state.entries.map((entry) => entry.id)).toEqual(["g1"]);
+    }
+  });
+
+  it("degrades to unavailable on errors and non-OK responses", async () => {
+    expect(await loadGalleryFeed(fetchReturning({}, false))).toEqual({
+      status: "unavailable",
+    });
+    const throwing = (async () => {
+      throw new Error("offline");
+    }) as unknown as typeof fetch;
+    expect(await loadGalleryFeed(throwing)).toEqual({
+      status: "unavailable",
+    });
+  });
+});
+
+describe("GalleryFeed", () => {
+  it("renders the landing chrome and editor entry point", () => {
+    const markup = renderToStaticMarkup(createElement(GalleryFeed));
+    expect(markup).toContain('data-testid="gallery-feed"');
+    expect(markup).toContain("Analog Canvas");
+    expect(markup).toContain('data-testid="gallery-new-circuit"');
+    expect(markup).toContain('href="/editor"');
+    expect(markup).toContain('data-testid="gallery-loading"');
+  });
+});

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useState } from "react";
+
+import { renderDocumentSvg } from "@icm/render-svg";
+import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
+
+import { libraryProjectExamples } from "../examples/library-examples";
+
+export interface GalleryFeedEntry {
+  id: string;
+  name: string;
+  author: string;
+  description: string;
+  createdAt: string;
+  schemaVersion: number;
+}
+
+export type GalleryFeedState =
+  | { status: "loading" }
+  | { status: "ready"; entries: GalleryFeedEntry[] }
+  | { status: "unavailable" };
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+function savedAtLabel(createdAt: string): string {
+  const parsed = new Date(createdAt);
+  return Number.isNaN(parsed.getTime())
+    ? createdAt
+    : parsed.toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
+}
+
+/** Bundled examples double as never-empty starter tiles for the feed. */
+function bundledTiles() {
+  return libraryProjectExamples.map((example) => {
+    const topDocument = example.project.documents.find(
+      (document) => document.id === example.project.topDocumentId,
+    )!;
+    return {
+      id: example.id,
+      name: example.name,
+      description: example.description,
+      svg: renderDocumentSvg(topDocument, resolver),
+    };
+  });
+}
+
+export async function loadGalleryFeed(
+  fetchLike: typeof fetch = fetch,
+): Promise<GalleryFeedState> {
+  try {
+    const response = await fetchLike("/api/gallery", {
+      credentials: "same-origin",
+    });
+    if (!response.ok) return { status: "unavailable" };
+    const payload = (await response.json()) as {
+      entries?: GalleryFeedEntry[];
+    };
+    return { status: "ready", entries: payload.entries ?? [] };
+  } catch {
+    return { status: "unavailable" };
+  }
+}
+
+/**
+ * Full-screen landing feed: every tile is one published circuit that opens
+ * in the editor at `/g/<id>`. Bundled Library examples fill the wall while
+ * the community gallery is empty or unreachable (development hosts have no
+ * worker), so the landing page is never blank.
+ */
+export function GalleryFeed() {
+  const [state, setState] = useState<GalleryFeedState>({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadGalleryFeed().then((next) => {
+      if (!cancelled) setState(next);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const entries = state.status === "ready" ? state.entries : [];
+
+  return (
+    <main className="gallery-shell" data-testid="gallery-feed">
+      <header className="gallery-chrome">
+        <div className="gallery-brand">
+          <span className="app-brand-mark" aria-hidden="true" />
+          <div>
+            <h1>Analog Canvas</h1>
+            <p>Community circuit gallery</p>
+          </div>
+        </div>
+        <nav className="gallery-actions">
+          <a
+            className="gallery-open-editor"
+            href="/editor"
+            data-testid="gallery-new-circuit"
+          >
+            New Circuit
+          </a>
+        </nav>
+      </header>
+
+      {state.status === "loading" ? (
+        <p className="gallery-status" data-testid="gallery-loading">
+          Loading gallery…
+        </p>
+      ) : (
+        <section className="gallery-wall" aria-label="Published circuits">
+          {entries.map((entry) => (
+            <a
+              key={entry.id}
+              className="gallery-tile"
+              href={`/g/${entry.id}`}
+              data-testid={`gallery-tile-${entry.id}`}
+            >
+              <span className="gallery-tile-preview">
+                <img
+                  src={`/api/gallery/${entry.id}/preview.svg`}
+                  alt={`Preview of ${entry.name}`}
+                  loading="lazy"
+                />
+              </span>
+              <span className="gallery-tile-copy">
+                <span className="gallery-tile-name">{entry.name}</span>
+                <span className="gallery-tile-meta">
+                  {entry.author ? `${entry.author} · ` : ""}
+                  {savedAtLabel(entry.createdAt)}
+                </span>
+                {entry.description ? (
+                  <span className="gallery-tile-description">
+                    {entry.description}
+                  </span>
+                ) : null}
+              </span>
+            </a>
+          ))}
+          {bundledTiles().map((tile) => (
+            <a
+              key={tile.id}
+              className="gallery-tile gallery-tile-bundled"
+              href={`/editor?example=${tile.id}`}
+              data-testid={`gallery-bundled-${tile.id}`}
+            >
+              <span
+                className="gallery-tile-preview"
+                // Server-free preview: our own renderer's escaped SVG output.
+                dangerouslySetInnerHTML={{ __html: tile.svg }}
+              />
+              <span className="gallery-tile-copy">
+                <span className="gallery-tile-kicker">Built-in example</span>
+                <span className="gallery-tile-name">{tile.name}</span>
+                <span className="gallery-tile-description">
+                  {tile.description}
+                </span>
+              </span>
+            </a>
+          ))}
+        </section>
+      )}
+      <footer className="gallery-footnote">
+        Browse freely; open any circuit and edit your own copy. Publishing joins
+        in a later release with sign-in.
+      </footer>
+    </main>
+  );
+}

--- a/apps/editor/src/main.tsx
+++ b/apps/editor/src/main.tsx
@@ -19,6 +19,18 @@ const AnalyticsPage = lazy(() =>
   })),
 );
 
+const GalleryFeed = lazy(() =>
+  import("./components/gallery-feed").then((module) => ({
+    default: module.GalleryFeed,
+  })),
+);
+
+/** `/` is the gallery, `/editor` the editor, `/g/<id>` one gallery entry. */
+function galleryEntryIdOf(path: string): string | null {
+  const match = /^\/g\/([A-Za-z0-9-]{1,64})\/?$/.exec(path);
+  return match ? match[1]! : null;
+}
+
 function Root() {
   const path = window.location.pathname;
   const [stats, setStats] = useState<VisitStats | null>(null);
@@ -65,14 +77,26 @@ function Root() {
       });
   }, [path]);
 
-  return /^\/analytics\/?$/.test(path) ? (
-    <Suspense
-      fallback={<div className="analytics-loading">Loading analytics…</div>}
-    >
-      <AnalyticsPage />
-    </Suspense>
-  ) : (
-    <App visitStats={stats} />
+  if (/^\/analytics\/?$/.test(path)) {
+    return (
+      <Suspense
+        fallback={<div className="analytics-loading">Loading analytics…</div>}
+      >
+        <AnalyticsPage />
+      </Suspense>
+    );
+  }
+  if (/^\/?$/.test(path)) {
+    return (
+      <Suspense
+        fallback={<div className="analytics-loading">Loading gallery…</div>}
+      >
+        <GalleryFeed />
+      </Suspense>
+    );
+  }
+  return (
+    <App visitStats={stats} initialGalleryEntryId={galleryEntryIdOf(path)} />
   );
 }
 

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -4996,3 +4996,147 @@ html.light .analytics-map-land path {
   color: #5f6b7a;
   font-size: var(--icm-font-sm);
 }
+
+/* ---------- Community gallery landing feed ---------- */
+
+.gallery-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--icm-chrome-bg);
+  color: var(--icm-text);
+}
+
+.gallery-chrome {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--icm-space-3);
+  padding: 14px 22px;
+  border-bottom: 1px solid var(--icm-border);
+  background: var(--icm-surface);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.gallery-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.gallery-brand h1 {
+  margin: 0;
+  font-size: 17px;
+  line-height: 1.2;
+}
+
+.gallery-brand p {
+  margin: 0;
+  font-size: 12px;
+  color: var(--icm-text-muted);
+}
+
+.gallery-open-editor {
+  display: inline-block;
+  padding: 8px 16px;
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-accent);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.gallery-open-editor:hover {
+  filter: brightness(1.05);
+}
+
+.gallery-status,
+.gallery-footnote {
+  padding: 18px 22px;
+  color: var(--icm-text-muted);
+  font-size: 13px;
+}
+
+.gallery-footnote {
+  margin-top: auto;
+  border-top: 1px solid var(--icm-border);
+  background: var(--icm-surface);
+}
+
+/* Pinterest-style wall: CSS columns give a dependency-free masonry. */
+.gallery-wall {
+  columns: 5 240px;
+  column-gap: 14px;
+  padding: 18px 22px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.gallery-tile {
+  display: block;
+  break-inside: avoid;
+  margin: 0 0 14px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-md, 10px);
+  background: var(--icm-surface);
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.gallery-tile:hover {
+  border-color: var(--icm-border-hover);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 8%);
+}
+
+.gallery-tile-preview {
+  display: block;
+  background: #fff;
+  border-bottom: 1px solid var(--icm-border);
+  padding: 10px;
+}
+
+.gallery-tile-preview img,
+.gallery-tile-preview svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 320px;
+  object-fit: contain;
+}
+
+.gallery-tile-copy {
+  display: grid;
+  gap: 2px;
+  padding: 10px 12px 12px;
+}
+
+.gallery-tile-kicker {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--icm-text-muted);
+}
+
+.gallery-tile-name {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.gallery-tile-meta,
+.gallery-tile-description {
+  font-size: 12px;
+  color: var(--icm-text-muted);
+}
+
+.gallery-home-link {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+}

--- a/docs/roadmap/community-gallery-platform.md
+++ b/docs/roadmap/community-gallery-platform.md
@@ -2,12 +2,15 @@
 
 Status: `active`
 
-Owner direction (2026-08-21): the site opens as a full-screen gallery feed
-(Pinterest-style tiles of example circuits); every circuit is openable and
-editable; ordinary users may modify only their own published entries while
-the site owner is super-admin over all content; publishing requires signing
-in with Google or email, while anonymous visitors can browse and use
-everything read-only.
+Owner direction (2026-08-21, refined the same day): the site opens as a
+full-screen gallery feed (Pinterest-style tiles of example circuits); every
+circuit is openable and editable; ordinary users may modify only their own
+entries while the site owner is super-admin over all content; signing in
+works with any single credential — GitHub, Google, or plain email — and
+users can rename their own display name; publishing requires sign-in AND
+review: submissions enter a pending queue that the owner, or reviewers the
+owner appoints, approve or reject (rejection carries an optional reason);
+anonymous visitors browse and use everything read-only.
 
 This roadmap frames the cross-module outcome; each phase lands as its own
 bounded target under `plan/` with the normal delivery gate. The normative
@@ -21,7 +24,8 @@ server contract lives in
   nothing client-authored is ever stored or served as markup.
 - Public read API: list, entry, preview image. Publishing exists but is
   admin-token-gated until real sign-in lands (anonymous upload stays
-  impossible from day one, which is the end-state rule anyway).
+  impossible from day one; admin-published entries go live directly — the
+  end-state review queue for ordinary users arrives in G3).
 - Admin API (bearer `GALLERY_ADMIN_TOKEN`): recycle (soft, restorable),
   restore, hard-delete from the bin only, recycled list, and batch
   re-serialization that keeps long-lived entries inside the rolling schema
@@ -39,32 +43,45 @@ editor behavior reachable at `/editor` unchanged.
 
 ## Phase G2 — Accounts and sign-in
 
-- `AuthDO` (users, sessions): Google OAuth code flow on the worker plus
-  email magic-link sign-in behind a mail-provider credential; HttpOnly
+- `AuthDO` (users, sessions): GitHub and Google OAuth code flows on the
+  worker plus email magic-link sign-in behind a mail-provider credential —
+  any one credential signs a user in, no passwords stored; HttpOnly
   session cookie; sign-in UI on the feed and in the editor chrome.
+- Profile basics: users can rename their own display name (shown on their
+  tiles); identities from different providers stay distinct accounts in
+  G2 (linking is a later refinement).
 - Super-admin role assigned automatically to the owner's sign-in identity
   (`ADMIN_EMAILS` secret), replacing bearer-token administration in the UI.
 - External prerequisites the owner must provision (Claude cannot create
-  accounts or handle credentials): a Google OAuth client
-  (`GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` secrets), `ADMIN_EMAILS`, and
-  — for email sign-in — a transactional mail provider key; email sign-in
-  ships dark until its secret exists.
+  accounts or handle credentials): a GitHub OAuth App
+  (`GITHUB_OAUTH_CLIENT_ID`/`GITHUB_OAUTH_CLIENT_SECRET`), a Google OAuth
+  client (`GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`), `ADMIN_EMAILS`, and
+  — for email sign-in — a transactional mail provider key; each provider
+  ships dark until its secrets exist.
 
-Acceptance: sign in/out round-trips on the deployed site; the owner's
-account sees admin affordances; no credential material ever transits or is
-stored beyond the provider contract.
+Acceptance: sign in/out round-trips on the deployed site with any single
+provider; display-name edits stick; the owner's account sees admin
+affordances; no credential material ever transits or is stored beyond the
+provider contract.
 
-## Phase G3 — Ownership and editing
+## Phase G3 — Ownership, review, and editing
 
-- Publishing requires a session; entries record their owner; owners can
-  update or recycle their own entries ("modify my content"), the
-  super-admin can do so for any entry.
-- Editor gains "publish to gallery / update my tile" against the signed-in
+- Publishing requires a session; a submission enters a `pending` queue
+  instead of going live. The super-admin — or reviewers the super-admin
+  appoints (a `moderator` role) — approves it to `public` or rejects it
+  with an optional reason shown to the submitter.
+- Entries record their owner; owners can update or withdraw their own
+  entries (an update to an approved entry re-enters review), the
+  super-admin and moderators can act on any entry; the recycle bin remains
+  the post-approval takedown path.
+- Editor gains "submit to gallery / update my tile" against the signed-in
   identity; anonymous visitors keep full read-and-local-edit freedom
   without any way to write back.
 
-Acceptance: two ordinary accounts cannot touch each other's tiles; the
-admin can; anonymous writes are impossible at the API, not just the UI.
+Acceptance: an ordinary submission is invisible publicly until approved;
+rejection stores and surfaces its optional reason; two ordinary accounts
+cannot touch each other's tiles while moderators and the admin can;
+anonymous writes are impossible at the API, not just the UI.
 
 ## Phase G4 — Feed experience
 

--- a/docs/roadmap/community-gallery-platform.md
+++ b/docs/roadmap/community-gallery-platform.md
@@ -1,0 +1,74 @@
+# Community Gallery Platform
+
+Status: `active`
+
+Owner direction (2026-08-21): the site opens as a full-screen gallery feed
+(Pinterest-style tiles of example circuits); every circuit is openable and
+editable; ordinary users may modify only their own published entries while
+the site owner is super-admin over all content; publishing requires signing
+in with Google or email, while anonymous visitors can browse and use
+everything read-only.
+
+This roadmap frames the cross-module outcome; each phase lands as its own
+bounded target under `plan/` with the normal delivery gate. The normative
+server contract lives in
+[`../specs/community-gallery.md`](../specs/community-gallery.md).
+
+## Phase G1 — Public feed foundation (this phase)
+
+- `GalleryDO` (SQLite, third Durable Object) stores published entries:
+  canonical strict-schema Project text plus a server-rendered preview SVG;
+  nothing client-authored is ever stored or served as markup.
+- Public read API: list, entry, preview image. Publishing exists but is
+  admin-token-gated until real sign-in lands (anonymous upload stays
+  impossible from day one, which is the end-state rule anyway).
+- Admin API (bearer `GALLERY_ADMIN_TOKEN`): recycle (soft, restorable),
+  restore, hard-delete from the bin only, recycled list, and batch
+  re-serialization that keeps long-lived entries inside the rolling schema
+  window (previews stored independently so browsing survives an expired
+  entry).
+- The site opens at `/` as the full-screen feed; `/editor` is the editor;
+  `/g/<id>` opens one gallery entry in the editor. While the gallery is
+  empty the feed shows the bundled Library examples as tiles so the landing
+  page is never blank.
+- Entries already carry a nullable owner column so G3 needs no migration.
+
+Acceptance: feed loads from the deployed worker; a seeded entry renders as
+a tile, opens in the editor, and survives recycle/restore; all existing
+editor behavior reachable at `/editor` unchanged.
+
+## Phase G2 — Accounts and sign-in
+
+- `AuthDO` (users, sessions): Google OAuth code flow on the worker plus
+  email magic-link sign-in behind a mail-provider credential; HttpOnly
+  session cookie; sign-in UI on the feed and in the editor chrome.
+- Super-admin role assigned automatically to the owner's sign-in identity
+  (`ADMIN_EMAILS` secret), replacing bearer-token administration in the UI.
+- External prerequisites the owner must provision (Claude cannot create
+  accounts or handle credentials): a Google OAuth client
+  (`GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` secrets), `ADMIN_EMAILS`, and
+  — for email sign-in — a transactional mail provider key; email sign-in
+  ships dark until its secret exists.
+
+Acceptance: sign in/out round-trips on the deployed site; the owner's
+account sees admin affordances; no credential material ever transits or is
+stored beyond the provider contract.
+
+## Phase G3 — Ownership and editing
+
+- Publishing requires a session; entries record their owner; owners can
+  update or recycle their own entries ("modify my content"), the
+  super-admin can do so for any entry.
+- Editor gains "publish to gallery / update my tile" against the signed-in
+  identity; anonymous visitors keep full read-and-local-edit freedom
+  without any way to write back.
+
+Acceptance: two ordinary accounts cannot touch each other's tiles; the
+admin can; anonymous writes are impossible at the API, not just the UI.
+
+## Phase G4 — Feed experience
+
+- Masonry/infinite scroll, per-author filtering, in-feed admin recycle-bin
+  view, and seeded starter content curation.
+
+Each phase closes by updating this file's status line for that phase.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -23,6 +23,7 @@ against. They describe required behavior and invariants, not task history.
 | [`performance.md`](performance.md)                           |             7 | accepted                 | Representative workloads and release budgets                                 |
 | [`editor-interaction.md`](editor-interaction.md)             |             8 | accepted                 | Direct manipulation, manual authoring, gestures, and automation boundary     |
 | [`web-agent-session.md`](web-agent-session.md)               |     Web Agent | accepted                 | Browser-authoritative relay: scopes, transport, events, errors, threat       |
+| [`community-gallery.md`](community-gallery.md)               |    Gallery G1 | accepted                 | Public feed, publishing gate, admin recycle bin, retention re-serialization  |
 
 Create a specification when its owning phase begins; do not create empty files
 only to mirror this table. Start from [`spec.template.md`](spec.template.md).

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -50,7 +50,9 @@ nullable owner column so G3 ownership requires no migration.
 ## Administration
 
 Admin routes require `Authorization: Bearer <GALLERY_ADMIN_TOKEN>` (a
-Cloudflare secret; every admin route answers 401 until it is set):
+Cloudflare Worker secret, synced from the GitHub Actions secret of the same
+name on every Cloudflare deploy; every admin route answers 401 until it is
+set, and rotation is one GitHub-secret update plus a deploy run):
 
 - `POST /api/gallery/<id>/recycle` — soft delete into the restorable bin;
   the entry disappears from every public surface.

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -68,8 +68,11 @@ set, and rotation is one GitHub-secret update plus a deploy run):
 
 ## Retention and privacy
 
-Entries are public content; the recycle bin is the moderation mechanism
-(publish-first by owner decision). Submitter identity is a salted hash of
+Entries are public content; in the shipped G1 surface only the admin can
+publish and the recycle bin is the takedown mechanism. The decided end
+state (roadmap G3) is review-then-publish: ordinary submissions wait in a
+pending queue for the owner or appointed moderators, and a rejection may
+carry an optional reason. Submitter identity is a salted hash of
 the connecting IP used only for the daily quota; no account data exists in
 Phase G1. Sign-in, per-user ownership, and owner-scoped editing arrive in
 Phases G2–G3 as recorded in the roadmap.

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -1,0 +1,73 @@
+# Community Gallery
+
+Status: `accepted` (Phase G1 surface)
+
+Primary owners: `worker/gallery.ts`, `apps/editor` landing feed
+
+Roadmap: [community gallery platform](../roadmap/community-gallery-platform.md)
+(G1 public feed foundation → G2 sign-in → G3 ownership → G4 feed
+experience). This specification describes the currently shipped surface and
+names the clauses later phases replace.
+
+## Trust boundary
+
+The only accepted input is Project JSON that passes the strict protocol
+boundary (`parseProject`; the rolling previous-version upgrade applies).
+Everything stored and served — canonical Project text and the preview SVG —
+is derived server-side from that validated model. Client-supplied markup is
+never stored, echoed, or served. Previews are rendered by `@icm/render-svg`
+from the entry's top document and served as `image/svg+xml` with a
+restrictive content-security-policy.
+
+## Public surface
+
+- `GET /api/gallery` — newest-first `public` entries
+  (`{entries, nextCursor}`; keyset cursor; limit clamps at 60). Recycled
+  entries never appear.
+- `GET /api/gallery/<id>` — one public entry with its canonical
+  `projectText`.
+- `GET /api/gallery/<id>/preview.svg` — the server-rendered preview.
+- `/` serves the full-screen feed; each tile links to `/g/<id>`, which the
+  editor opens through the ordinary protocol boundary. `/editor` is the
+  plain editor; `/editor?example=<id>` opens a bundled example. While the
+  gallery is empty or unreachable the feed shows the bundled Library
+  examples, so the landing page is never blank.
+
+## Publishing
+
+`POST /api/gallery/submissions` (same-origin) publishes immediately with:
+trimmed `name` (required, ≤120), optional `author` (≤40) and `description`
+(≤300), `projectText` ≤2 MiB. The Worker validates, stamps the canonical
+serialization, renders the preview, and stores the entry as `public`.
+Submissions count against a per-submitter (hashed IP) limit of 10 per UTC
+day.
+
+Phase G1 gate: publishing additionally requires the admin bearer until
+Phase G2 sign-in replaces it with session identity — anonymous upload is
+impossible from day one, which is also the end state. Entries persist a
+nullable owner column so G3 ownership requires no migration.
+
+## Administration
+
+Admin routes require `Authorization: Bearer <GALLERY_ADMIN_TOKEN>` (a
+Cloudflare secret; every admin route answers 401 until it is set):
+
+- `POST /api/gallery/<id>/recycle` — soft delete into the restorable bin;
+  the entry disappears from every public surface.
+- `POST /api/gallery/<id>/restore` — back to `public`.
+- `DELETE /api/gallery/<id>` — permanent, and only for entries already in
+  the bin (`409` otherwise).
+- `GET /api/gallery/recycled` — the bin.
+- `POST /api/gallery/maintenance/reserialize` — re-parse and re-serialize
+  every stored entry through the current protocol and refresh its preview;
+  run once per schema advance while the rolling window still reads the old
+  version. Failures are reported per entry and never destroy the record;
+  the independently stored preview keeps expired entries browsable.
+
+## Retention and privacy
+
+Entries are public content; the recycle bin is the moderation mechanism
+(publish-first by owner decision). Submitter identity is a salted hash of
+the connecting IP used only for the daily quota; no account data exists in
+Phase G1. Sign-in, per-user ownership, and owner-scoped editing arrive in
+Phases G2–G3 as recorded in the roadmap.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "pnpm": ">=11.16.0"
   },
   "dependencies": {
-    "@icm/agent-adapter": "workspace:*"
+    "@icm/agent-adapter": "workspace:*",
+    "@icm/model": "workspace:*",
+    "@icm/project-protocol": "workspace:*",
+    "@icm/render-svg": "workspace:*",
+    "@icm/symbols": "workspace:*"
   },
   "scripts": {
     "build": "pnpm -r --if-present build",

--- a/plan/2026-08-21-community-gallery/plan.md
+++ b/plan/2026-08-21-community-gallery/plan.md
@@ -1,0 +1,129 @@
+---
+status: completed
+experience: none
+---
+
+# Gallery Platform Phase G1: Public Feed Foundation
+
+## Goal
+
+First phase of the community-gallery platform direction
+(`docs/roadmap/community-gallery-platform.md`): the site opens at `/` as a
+full-screen Pinterest-style feed of published example circuits; `/editor`
+is the ordinary editor and `/g/<id>` opens one entry in it. A third
+SQLite Durable Object stores entries (canonical strict-schema Project text
+plus a server-rendered preview SVG — no client markup is ever stored or
+served); publishing is admin-token-gated until Phase G2 sign-in lands, so
+anonymous upload is impossible from day one; the admin has a restorable
+recycle bin, bin-only hard delete, and batch re-serialization that keeps
+long-lived entries inside the rolling schema window. While the gallery is
+empty, the feed shows the bundled Library examples as tiles so the landing
+page is never blank. Entries already persist a nullable owner column so
+Phase G3 ownership needs no migration.
+
+## State and Ownership
+
+Branched from `origin/main` as `claude/community-gallery`; worktree clean
+at target start. Another session owns palette/VDD/recent-panel work in a
+separate worktree per the user's direction — this target does not touch
+those areas; `App.tsx`/e2e merge conflicts, if any, are resolved at
+delivery.
+
+Owned paths:
+
+- `worker/gallery.ts` (new) and `worker/gallery.test.ts`
+  (node:sqlite-backed storage fake), `worker/index.ts`, `wrangler.jsonc`
+  (GALLERY binding, migration v3)
+- `apps/editor/src/main.tsx` (route split), new
+  `apps/editor/src/components/gallery-feed.tsx` (+ test),
+  `apps/editor/src/app/App.tsx` (gallery-entry boot load, back-to-gallery
+  chrome), `apps/editor/src/styles.css`
+- `apps/editor/e2e/gallery.spec.ts` (new, route-mocked) and the mechanical
+  `goto("/")` -> `goto("/editor")` sweep across existing specs
+- `docs/specs/community-gallery.md` (new) and the specs README row;
+  `docs/roadmap/community-gallery-platform.md` (new roadmap)
+- `plan/2026-08-21-community-gallery/plan.md`, `plan/log.md`
+
+Shared dependencies: project-protocol and render-svg consumed inside the
+Worker (already in the deploy build closure), the Cloudflare deploy
+workflow, the `/` landing contract for every existing Playwright spec
+(deliberately moved to `/editor`), and the new `GALLERY_ADMIN_TOKEN`
+secret (admin and publish routes answer 401 until it is set).
+
+## Work
+
+1. `GalleryDO` tables (`gallery_entries` with nullable `owner_user_id`,
+   `gallery_submissions` day counters) and internal fetch protocol;
+   `routeGalleryRequest` with public list/entry/preview, admin-gated
+   publish (G1), recycle/restore/bin-delete/recycled-list, and
+   `maintenance/reserialize`.
+2. Route split in `main.tsx` (feed at `/`, editor at `/editor`, entry at
+   `/g/<id>`, analytics untouched); full-screen feed component with
+   column-masonry tiles, bundled-example fallback tiles, and a New
+   Circuit entry point; App boot loads a gallery entry by id and links
+   back to the gallery.
+3. Contract spec + roadmap; Playwright: new gallery spec plus the landing
+   sweep; worker suite on a real in-memory SQLite.
+
+## Validation
+
+- focused `vitest`: `worker/gallery.test.ts`, gallery feed component test
+- `playwright`: new `gallery.spec.ts` plus full existing suites after the
+  `/editor` sweep (drafting, manual-editor, component-insert, hierarchy)
+- repository typecheck, prettier, markdown links
+- `node scripts/check-test-impact.mjs --base origin/main`
+- `git diff --check` and `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: submissions are strict-schema-validated, canonically
+  re-serialized, size- and rate-limited, admin-gated in G1, and published
+  immediately; the public list exposes only `public` entries; previews are
+  server-rendered and served as images; recycle is restorable and hard
+  delete is bin-only; re-serialization upgrades entries inside the rolling
+  window and reports failures without destroying records; `/` renders the
+  feed with bundled fallback tiles, `/editor` keeps every existing editor
+  behavior, `/g/<id>` opens a gallery entry
+- Primary checks: `worker/gallery.test.ts`,
+  `apps/editor/e2e/gallery.spec.ts`, existing Playwright suites at
+  `/editor`
+
+## Commit Intent
+
+Committed on `claude/community-gallery` under the user's standing
+commit-push-merge direction as:
+
+```text
+feat(gallery): public feed foundation (platform phase G1)
+```
+
+## Outcome
+
+Phase G1 delivered. `GalleryDO` (third SQLite Durable Object, wrangler
+migration v3) stores published entries as canonical strict-schema Project
+text plus a server-rendered preview SVG with a nullable owner column ready
+for G3; `routeGalleryRequest` serves the public list/entry/preview surface,
+admin-gated publishing (401 for anyone without the bearer while G2 sign-in
+is pending — anonymous upload impossible from day one), the restorable
+recycle bin with bin-only hard delete, per-hashed-IP daily quotas, and
+batch re-serialization that keeps entries inside the rolling schema window.
+The site now lands on `/` as a full-screen masonry feed (tiles link to
+`/g/<id>`, which the editor opens through the protocol boundary; bundled
+Library examples render as starter tiles whenever the gallery is empty or
+unreachable, so the landing page is never blank), `/editor` keeps the
+entire existing editor (every Playwright spec moved its landing there), and
+the brand mark links back to the gallery. Root workspace dependencies for
+the Worker (`@icm/model`, `project-protocol`, `render-svg`, `symbols`) were
+added with hand-maintained lockfile link entries (no local pnpm). The
+normative contract is `docs/specs/community-gallery.md` and the phased
+platform direction (G2 sign-in, G3 ownership, G4 feed experience) is
+`docs/roadmap/community-gallery-platform.md`. Validation: worker suite on
+real in-memory SQLite (8 contracts: publish/canonicalize/preview,
+previous-schema upgrade, publish gate, field/origin/size rejection, rate
+limiting, recycle lifecycle, re-serialization), feed component tests, the
+new gallery Playwright spec (4 scenarios), the COMPLETE Playwright suite
+(179 passed) on the new routing, repository typecheck, prettier, markdown
+links, test-impact, and diff checks all green; feed and tile-to-editor
+flow verified live. Deploy note: set the `GALLERY_ADMIN_TOKEN` secret to
+enable publishing/administration.

--- a/plan/2026-08-21-community-gallery/plan.md
+++ b/plan/2026-08-21-community-gallery/plan.md
@@ -125,5 +125,9 @@ limiting, recycle lifecycle, re-serialization), feed component tests, the
 new gallery Playwright spec (4 scenarios), the COMPLETE Playwright suite
 (179 passed) on the new routing, repository typecheck, prettier, markdown
 links, test-impact, and diff checks all green; feed and tile-to-editor
-flow verified live. Deploy note: set the `GALLERY_ADMIN_TOKEN` secret to
-enable publishing/administration.
+flow verified live. Administration was enabled at the user's request: a
+generated `GALLERY_ADMIN_TOKEN` now lives in the repository's GitHub
+secrets, the Cloudflare deploy workflow syncs it to the Worker on every
+deploy (rotation = update the GitHub secret and re-run the deploy), and a
+copy for the user sits outside the repository in
+`~/analog-canvas-gallery-admin-token.txt`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4134,3 +4134,20 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   test-impact, diff checks.
 - Commit status: completed on `claude/example-promotion`; mainline merge
   gated on the remote required checks.
+
+## 2026-08-21 - Community gallery phase G1 (public feed foundation)
+
+- Changed areas: new `GalleryDO` + `/api/gallery*` Worker surface
+  (publish-first storage with admin recycle bin, bin-only hard delete,
+  hashed-IP quotas, rolling-window re-serialization, server-rendered
+  previews); site lands on a full-screen gallery feed at `/` with the
+  editor at `/editor` and entry deep links at `/g/<id>`; bundled examples
+  double as starter tiles; new community-gallery spec and platform roadmap
+  (G1-G4); root workspace deps for the Worker with hand-maintained
+  lockfile links.
+- Validation: worker suite on in-memory SQLite (8 contracts), feed
+  component tests, new gallery Playwright spec, complete Playwright suite
+  (179 passed) after the `/editor` landing sweep, typecheck, prettier,
+  markdown links, test-impact, diff checks.
+- Commit status: completed on `claude/community-gallery`; mainline merge
+  gated on the remote required checks.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,18 @@ importers:
       "@icm/agent-adapter":
         specifier: workspace:*
         version: link:packages/agent-adapter
+      "@icm/model":
+        specifier: workspace:*
+        version: link:packages/model
+      "@icm/project-protocol":
+        specifier: workspace:*
+        version: link:packages/project-protocol
+      "@icm/render-svg":
+        specifier: workspace:*
+        version: link:packages/render-svg
+      "@icm/symbols":
+        specifier: workspace:*
+        version: link:packages/symbols
     devDependencies:
       "@playwright/test":
         specifier: 1.62.1

--- a/scripts/editor-production-smoke.mjs
+++ b/scripts/editor-production-smoke.mjs
@@ -48,7 +48,15 @@ async function main() {
       if (message.type() === "error") consoleErrors.push(message.text());
     });
     page.on("pageerror", (error) => consoleErrors.push(error.message));
+    // The production build serves two surfaces: the gallery feed at the
+    // root and the full editor at /editor. Both must mount.
     await page.goto(url, { waitUntil: "networkidle" });
+    await page.waitForSelector('[data-testid="gallery-feed"]', {
+      timeout: 10_000,
+    });
+    await page.goto(new URL("editor", url).href, {
+      waitUntil: "networkidle",
+    });
     await page.waitForSelector('[data-testid="schematic-canvas"]', {
       timeout: 10_000,
     });

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -1,0 +1,393 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+
+import { createEmptyProject, CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
+import { serializeProject } from "@icm/project-protocol";
+
+import {
+  GALLERY_DAILY_SUBMISSION_LIMIT,
+  GALLERY_MAX_PROJECT_BYTES,
+  GalleryDO,
+  routeGalleryRequest,
+  type GalleryEnv,
+} from "./gallery";
+
+function sqliteState() {
+  const db = new DatabaseSync(":memory:");
+  return {
+    storage: {
+      sql: {
+        exec<T>(query: string, ...bindings: unknown[]) {
+          const statement = db.prepare(query);
+          if (/^\s*(select|with|pragma)/iu.test(query)) {
+            const rows = statement.all(
+              ...(bindings as (string | number | null)[]),
+            ) as T[];
+            return {
+              toArray: () => rows,
+              one: () => {
+                if (rows.length !== 1) throw new Error("expected one row");
+                return rows[0]!;
+              },
+            };
+          }
+          statement.run(...(bindings as (string | number | null)[]));
+          return {
+            toArray: () => [] as T[],
+            one: () => {
+              throw new Error("no rows");
+            },
+          };
+        },
+      },
+      transactionSync<T>(callback: () => T): T {
+        return callback();
+      },
+    },
+  };
+}
+
+function environment(adminToken?: string): GalleryEnv {
+  const durable = new GalleryDO(sqliteState());
+  return {
+    GALLERY: {
+      getByName: () => ({
+        fetch: (input: string, init?: RequestInit) =>
+          durable.fetch(new Request(input, init)),
+      }),
+    },
+    ...(adminToken ? { GALLERY_ADMIN_TOKEN: adminToken } : {}),
+  };
+}
+
+const ORIGIN = "https://gallery.test";
+const ADMIN_TOKEN = "secret-token";
+
+function submissionRequest(
+  body: unknown,
+  overrides: {
+    ip?: string;
+    origin?: string | null;
+    token?: string | null;
+  } = {},
+): Request {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (overrides.origin !== null) {
+    headers.set("Origin", overrides.origin ?? ORIGIN);
+  }
+  if (overrides.token !== null) {
+    headers.set("Authorization", `Bearer ${overrides.token ?? ADMIN_TOKEN}`);
+  }
+  headers.set("CF-Connecting-IP", overrides.ip ?? "203.0.113.7");
+  return new Request(`${ORIGIN}/api/gallery/submissions`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+function projectText(name = "Fixture"): string {
+  return serializeProject(createEmptyProject("gallery-fixture", name));
+}
+
+function previousVersionText(): string {
+  const raw = JSON.parse(projectText()) as { schemaVersion: number };
+  raw.schemaVersion = CURRENT_PROJECT_SCHEMA_VERSION - 1;
+  return JSON.stringify(raw);
+}
+
+async function route(env: GalleryEnv, request: Request) {
+  const response = await routeGalleryRequest(request, env);
+  if (!response) throw new Error("gallery route did not match");
+  return response;
+}
+
+function adminHeaders(token: string): HeadersInit {
+  return { Authorization: `Bearer ${token}` };
+}
+
+async function submitOne(
+  env: GalleryEnv,
+  name: string,
+  overrides: { ip?: string; text?: string } = {},
+): Promise<string> {
+  const response = await route(
+    env,
+    submissionRequest(
+      {
+        name,
+        author: "tz",
+        description: "d",
+        projectText: overrides.text ?? projectText(name),
+      },
+      { ip: overrides.ip ?? "203.0.113.7" },
+    ),
+  );
+  expect(response.status).toBe(201);
+  const payload = (await response.json()) as { id: string };
+  return payload.id;
+}
+
+describe("gallery submissions", () => {
+  it("publishes immediately with canonical text and a server preview", async () => {
+    const env = environment(ADMIN_TOKEN);
+    const id = await submitOne(env, "Ring Oscillator");
+
+    const list = await route(env, new Request(`${ORIGIN}/api/gallery`));
+    const listed = (await list.json()) as {
+      entries: { id: string; name: string; schemaVersion: number }[];
+    };
+    expect(listed.entries.map((entry) => entry.id)).toEqual([id]);
+    expect(listed.entries[0]).toMatchObject({
+      name: "Ring Oscillator",
+      schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION,
+    });
+
+    const detail = await route(env, new Request(`${ORIGIN}/api/gallery/${id}`));
+    const payload = (await detail.json()) as { projectText: string };
+    expect(JSON.parse(payload.projectText)).toMatchObject({
+      schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION,
+      name: "Ring Oscillator",
+    });
+
+    const preview = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/preview.svg`),
+    );
+    expect(preview.headers.get("content-type")).toBe("image/svg+xml");
+    expect(await preview.text()).toContain("<svg");
+  });
+
+  it("upgrades a previous-schema submission through the protocol", async () => {
+    const env = environment(ADMIN_TOKEN);
+    const id = await submitOne(env, "Old Schema", {
+      text: previousVersionText(),
+    });
+    const detail = await route(env, new Request(`${ORIGIN}/api/gallery/${id}`));
+    const payload = (await detail.json()) as { projectText: string };
+    expect(JSON.parse(payload.projectText).schemaVersion).toBe(
+      CURRENT_PROJECT_SCHEMA_VERSION,
+    );
+  });
+
+  it("refuses publishing without the admin bearer while sign-in is pending", async () => {
+    const env = environment(ADMIN_TOKEN);
+    const anonymous = await route(
+      env,
+      submissionRequest(
+        { name: "X", projectText: projectText() },
+        { token: null },
+      ),
+    );
+    expect(anonymous.status).toBe(401);
+    const wrongToken = await route(
+      env,
+      submissionRequest(
+        { name: "X", projectText: projectText() },
+        { token: "wrong" },
+      ),
+    );
+    expect(wrongToken.status).toBe(401);
+  });
+
+  it("rejects invalid fields, foreign origins, oversized and invalid projects", async () => {
+    const env = environment(ADMIN_TOKEN);
+    const noName = await route(
+      env,
+      submissionRequest({ name: "  ", projectText: projectText() }),
+    );
+    expect(noName.status).toBe(400);
+
+    const foreign = await route(
+      env,
+      submissionRequest(
+        { name: "X", projectText: projectText() },
+        { origin: "https://evil.example" },
+      ),
+    );
+    expect(foreign.status).toBe(403);
+
+    const oversized = await route(
+      env,
+      submissionRequest({
+        name: "X",
+        projectText: "x".repeat(GALLERY_MAX_PROJECT_BYTES + 1),
+      }),
+    );
+    expect(oversized.status).toBe(413);
+
+    const invalid = await route(
+      env,
+      submissionRequest({ name: "X", projectText: '{"schemaVersion":99}' }),
+    );
+    expect(invalid.status).toBe(400);
+  });
+
+  it("rate-limits one submitter per day without touching others", async () => {
+    const env = environment(ADMIN_TOKEN);
+    for (let index = 0; index < GALLERY_DAILY_SUBMISSION_LIMIT; index += 1) {
+      await submitOne(env, `Entry ${index}`);
+    }
+    const overflow = await route(
+      env,
+      submissionRequest({ name: "One more", projectText: projectText() }),
+    );
+    expect(overflow.status).toBe(429);
+
+    const other = await route(
+      env,
+      submissionRequest(
+        { name: "Other submitter", projectText: projectText() },
+        { ip: "198.51.100.2" },
+      ),
+    );
+    expect(other.status).toBe(201);
+  });
+});
+
+describe("gallery administration", () => {
+  it("requires the bearer secret for every admin operation", async () => {
+    const env = environment(ADMIN_TOKEN);
+    const id = await submitOne(env, "Guarded");
+
+    const anonymous = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/recycle`, { method: "POST" }),
+    );
+    expect(anonymous.status).toBe(401);
+
+    const noTokenConfigured = environment();
+    const impossible = await route(
+      noTokenConfigured,
+      new Request(`${ORIGIN}/api/gallery/some-id/recycle`, {
+        method: "POST",
+        headers: adminHeaders("anything"),
+      }),
+    );
+    expect(impossible.status).toBe(401);
+  });
+
+  it("recycles, hides, restores, and only hard-deletes from the bin", async () => {
+    const token = ADMIN_TOKEN;
+    const env = environment(token);
+    const id = await submitOne(env, "Lifecycle");
+
+    const earlyDelete = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}`, {
+        method: "DELETE",
+        headers: adminHeaders(token),
+      }),
+    );
+    expect(earlyDelete.status).toBe(409);
+
+    const recycle = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/recycle`, {
+        method: "POST",
+        headers: adminHeaders(token),
+      }),
+    );
+    expect(recycle.status).toBe(200);
+
+    const list = await route(env, new Request(`${ORIGIN}/api/gallery`));
+    expect(((await list.json()) as { entries: unknown[] }).entries).toEqual([]);
+    const hidden = await route(env, new Request(`${ORIGIN}/api/gallery/${id}`));
+    expect(hidden.status).toBe(404);
+
+    const bin = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/recycled`, {
+        headers: adminHeaders(token),
+      }),
+    );
+    const binned = (await bin.json()) as { entries: { id: string }[] };
+    expect(binned.entries.map((entry) => entry.id)).toEqual([id]);
+
+    const restore = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/restore`, {
+        method: "POST",
+        headers: adminHeaders(token),
+      }),
+    );
+    expect(restore.status).toBe(200);
+    const back = await route(env, new Request(`${ORIGIN}/api/gallery`));
+    expect(
+      ((await back.json()) as { entries: { id: string }[] }).entries,
+    ).toHaveLength(1);
+
+    await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/recycle`, {
+        method: "POST",
+        headers: adminHeaders(token),
+      }),
+    );
+    const remove = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}`, {
+        method: "DELETE",
+        headers: adminHeaders(token),
+      }),
+    );
+    expect(remove.status).toBe(200);
+    const gone = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/recycled`, {
+        headers: adminHeaders(token),
+      }),
+    );
+    expect(((await gone.json()) as { entries: unknown[] }).entries).toEqual([]);
+  });
+
+  it("re-serializes stored entries back into the rolling window", async () => {
+    const token = ADMIN_TOKEN;
+    const env = environment(token);
+    const id = await submitOne(env, "Aging Entry");
+
+    // Age the stored record to the previous schema version through the
+    // internal update operation, simulating a record left behind by time.
+    await env.GALLERY.getByName("gallery").fetch(
+      "https://gallery/update-entry",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          id,
+          projectText: previousVersionText(),
+          schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION - 1,
+          svgText: "<svg/>",
+        }),
+      },
+    );
+
+    const maintenance = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/maintenance/reserialize`, {
+        method: "POST",
+        headers: adminHeaders(token),
+      }),
+    );
+    const report = (await maintenance.json()) as {
+      upgraded: number;
+      failed: unknown[];
+    };
+    expect(report).toMatchObject({ upgraded: 1, failed: [] });
+
+    const detail = await route(env, new Request(`${ORIGIN}/api/gallery/${id}`));
+    const payload = (await detail.json()) as {
+      entry: { schemaVersion: number };
+      projectText: string;
+    };
+    expect(payload.entry.schemaVersion).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
+    expect(JSON.parse(payload.projectText).schemaVersion).toBe(
+      CURRENT_PROJECT_SCHEMA_VERSION,
+    );
+    const preview = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/preview.svg`),
+    );
+    expect(await preview.text()).toContain("<svg");
+  });
+});

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -1,0 +1,591 @@
+// Community example gallery: publish-first with an admin recycle bin.
+//
+// Trust boundary: the only accepted input is Project JSON that passes the
+// strict protocol boundary (`parseProject`, rolling-window upgrade applied).
+// Everything served back — canonical Project text and the preview SVG — is
+// derived server-side from that validated model; no client-supplied markup
+// is ever stored or echoed. Entries publish immediately; the admin (bearer
+// `GALLERY_ADMIN_TOKEN`, a Cloudflare secret) can recycle (soft, restorable),
+// hard-delete from the bin only, and batch re-serialize every entry to keep
+// long-lived records inside the rolling schema window. Previews are stored
+// independently so browsing survives an entry the current window can no
+// longer open.
+
+import { parseProject, serializeProject } from "@icm/project-protocol";
+import { renderDocumentSvg } from "@icm/render-svg";
+import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
+import type { CircuitProject } from "@icm/model";
+
+export const GALLERY_MAX_PROJECT_BYTES = 2 * 1024 * 1024;
+export const GALLERY_MAX_NAME_LENGTH = 120;
+export const GALLERY_MAX_AUTHOR_LENGTH = 40;
+export const GALLERY_MAX_DESCRIPTION_LENGTH = 300;
+export const GALLERY_DAILY_SUBMISSION_LIMIT = 10;
+export const GALLERY_DEFAULT_LIST_LIMIT = 30;
+export const GALLERY_MAX_LIST_LIMIT = 60;
+
+type SqlResult<T> = {
+  toArray(): T[];
+  one(): T;
+};
+
+type SqlStorage = {
+  exec<T>(query: string, ...bindings: unknown[]): SqlResult<T>;
+};
+
+type DurableObjectStateLike = {
+  storage: {
+    sql: SqlStorage;
+    transactionSync<T>(callback: () => T): T;
+  };
+};
+
+export type GalleryNamespaceLike = {
+  getByName(name: string): {
+    fetch(input: string, init?: RequestInit): Promise<Response>;
+  };
+};
+
+export type GalleryEnv = {
+  GALLERY: GalleryNamespaceLike;
+  GALLERY_ADMIN_TOKEN?: string;
+};
+
+export interface GalleryEntrySummary {
+  id: string;
+  name: string;
+  author: string;
+  description: string;
+  createdAt: string;
+  schemaVersion: number;
+}
+
+interface EntryRow {
+  id: string;
+  name: string;
+  author: string;
+  description: string;
+  created_at: string;
+  schema_version: number;
+  status: string;
+  recycled_at: string | null;
+  owner_user_id: string | null;
+  project_text: string;
+  svg_text: string;
+}
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+function summaryOf(row: EntryRow): GalleryEntrySummary {
+  return {
+    id: row.id,
+    name: row.name,
+    author: row.author,
+    description: row.description,
+    createdAt: row.created_at,
+    schemaVersion: row.schema_version,
+  };
+}
+
+/** Storage-only Durable Object; policy lives in `routeGalleryRequest`. */
+export class GalleryDO {
+  private readonly sql: SqlStorage;
+
+  constructor(private readonly state: DurableObjectStateLike) {
+    this.sql = state.storage.sql;
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS gallery_entries (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        author TEXT NOT NULL,
+        description TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        schema_version INTEGER NOT NULL,
+        status TEXT NOT NULL,
+        recycled_at TEXT,
+        owner_user_id TEXT,
+        project_text TEXT NOT NULL,
+        svg_text TEXT NOT NULL
+      ) WITHOUT ROWID
+    `);
+    this.sql.exec(`
+      CREATE INDEX IF NOT EXISTS idx_gallery_entries_status_created
+      ON gallery_entries(status, created_at)
+    `);
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS gallery_submissions (
+        day TEXT NOT NULL,
+        submitter_hash TEXT NOT NULL,
+        count INTEGER NOT NULL,
+        PRIMARY KEY (day, submitter_hash)
+      ) WITHOUT ROWID
+    `);
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const operation = new URL(request.url).pathname.slice(1);
+    const body =
+      request.method === "POST"
+        ? ((await request.json()) as Record<string, unknown>)
+        : {};
+    switch (operation) {
+      case "submit":
+        return this.submit(body);
+      case "list":
+        return this.list(body);
+      case "entry":
+        return this.entry(String(body.id), "public");
+      case "any-entry":
+        return this.entry(String(body.id), null);
+      case "set-status":
+        return this.setStatus(
+          String(body.id),
+          String(body.status),
+          String(body.at),
+        );
+      case "delete":
+        return this.delete(String(body.id));
+      case "recycled":
+        return this.recycled();
+      case "all-ids":
+        return this.allIds();
+      case "update-entry":
+        return this.updateEntry(body);
+      default:
+        return Response.json({ error: "Unknown operation" }, { status: 404 });
+    }
+  }
+
+  private submit(body: Record<string, unknown>): Response {
+    const entry = body.entry as EntryRow;
+    const day = String(body.day);
+    const submitterHash = String(body.submitterHash);
+    const outcome = this.state.storage.transactionSync(() => {
+      const used =
+        this.sql
+          .exec<{
+            count: number;
+          }>(
+            "SELECT count FROM gallery_submissions WHERE day = ? AND submitter_hash = ?",
+            day,
+            submitterHash,
+          )
+          .toArray()[0]?.count ?? 0;
+      if (used >= GALLERY_DAILY_SUBMISSION_LIMIT) {
+        return { status: "rate-limited" as const };
+      }
+      this.sql.exec(
+        `INSERT INTO gallery_submissions(day, submitter_hash, count) VALUES (?, ?, 1)
+         ON CONFLICT(day, submitter_hash) DO UPDATE SET count = count + 1`,
+        day,
+        submitterHash,
+      );
+      this.sql.exec(
+        `INSERT INTO gallery_entries(
+          id, name, author, description, created_at, schema_version,
+          status, recycled_at, owner_user_id, project_text, svg_text
+        ) VALUES (?, ?, ?, ?, ?, ?, 'public', NULL, NULL, ?, ?)`,
+        entry.id,
+        entry.name,
+        entry.author,
+        entry.description,
+        entry.created_at,
+        entry.schema_version,
+        entry.project_text,
+        entry.svg_text,
+      );
+      return { status: "stored" as const };
+    });
+    if (outcome.status === "rate-limited") {
+      return Response.json({ error: "rate-limited" }, { status: 429 });
+    }
+    return Response.json({ id: entry.id });
+  }
+
+  private list(body: Record<string, unknown>): Response {
+    const limit = Math.min(
+      Math.max(Number(body.limit) || GALLERY_DEFAULT_LIST_LIMIT, 1),
+      GALLERY_MAX_LIST_LIMIT,
+    );
+    const cursor = typeof body.cursor === "string" ? body.cursor : null;
+    const rows = cursor
+      ? this.sql
+          .exec<EntryRow>(
+            `SELECT * FROM gallery_entries WHERE status = 'public'
+             AND (created_at || '|' || id) < ?
+             ORDER BY created_at DESC, id DESC LIMIT ?`,
+            cursor,
+            limit + 1,
+          )
+          .toArray()
+      : this.sql
+          .exec<EntryRow>(
+            `SELECT * FROM gallery_entries WHERE status = 'public'
+             ORDER BY created_at DESC, id DESC LIMIT ?`,
+            limit + 1,
+          )
+          .toArray();
+    const page = rows.slice(0, limit);
+    const nextCursor =
+      rows.length > limit && page.length > 0
+        ? `${page.at(-1)!.created_at}|${page.at(-1)!.id}`
+        : null;
+    return Response.json({ entries: page.map(summaryOf), nextCursor });
+  }
+
+  private entry(id: string, requiredStatus: string | null): Response {
+    const row = this.sql
+      .exec<EntryRow>("SELECT * FROM gallery_entries WHERE id = ?", id)
+      .toArray()[0];
+    if (!row || (requiredStatus !== null && row.status !== requiredStatus)) {
+      return Response.json({ error: "not-found" }, { status: 404 });
+    }
+    return Response.json({
+      entry: summaryOf(row),
+      status: row.status,
+      projectText: row.project_text,
+      svgText: row.svg_text,
+    });
+  }
+
+  private setStatus(id: string, status: string, at: string): Response {
+    const row = this.sql
+      .exec<EntryRow>("SELECT * FROM gallery_entries WHERE id = ?", id)
+      .toArray()[0];
+    if (!row) return Response.json({ error: "not-found" }, { status: 404 });
+    this.sql.exec(
+      "UPDATE gallery_entries SET status = ?, recycled_at = ? WHERE id = ?",
+      status,
+      status === "recycled" ? at : null,
+      id,
+    );
+    return Response.json({ id, status });
+  }
+
+  private delete(id: string): Response {
+    const row = this.sql
+      .exec<EntryRow>("SELECT * FROM gallery_entries WHERE id = ?", id)
+      .toArray()[0];
+    if (!row) return Response.json({ error: "not-found" }, { status: 404 });
+    if (row.status !== "recycled") {
+      return Response.json({ error: "not-recycled" }, { status: 409 });
+    }
+    this.sql.exec("DELETE FROM gallery_entries WHERE id = ?", id);
+    return Response.json({ id, deleted: true });
+  }
+
+  private recycled(): Response {
+    const rows = this.sql
+      .exec<EntryRow>(
+        `SELECT * FROM gallery_entries WHERE status = 'recycled'
+         ORDER BY recycled_at DESC, id DESC`,
+      )
+      .toArray();
+    return Response.json({
+      entries: rows.map((row) => ({
+        ...summaryOf(row),
+        recycledAt: row.recycled_at,
+      })),
+    });
+  }
+
+  private allIds(): Response {
+    const rows = this.sql
+      .exec<{ id: string }>("SELECT id FROM gallery_entries ORDER BY id")
+      .toArray();
+    return Response.json({ ids: rows.map((row) => row.id) });
+  }
+
+  private updateEntry(body: Record<string, unknown>): Response {
+    const row = this.sql
+      .exec<EntryRow>(
+        "SELECT * FROM gallery_entries WHERE id = ?",
+        String(body.id),
+      )
+      .toArray()[0];
+    if (!row) return Response.json({ error: "not-found" }, { status: 404 });
+    this.sql.exec(
+      "UPDATE gallery_entries SET project_text = ?, schema_version = ?, svg_text = ? WHERE id = ?",
+      String(body.projectText),
+      Number(body.schemaVersion),
+      String(body.svgText),
+      String(body.id),
+    );
+    return Response.json({ id: row.id });
+  }
+}
+
+function galleryStub(env: GalleryEnv) {
+  return env.GALLERY.getByName("gallery");
+}
+
+async function callGallery<T>(
+  env: GalleryEnv,
+  operation: string,
+  body: Record<string, unknown>,
+): Promise<{ status: number; payload: T }> {
+  const response = await galleryStub(env).fetch(
+    `https://gallery/${operation}`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+  return { status: response.status, payload: (await response.json()) as T };
+}
+
+function sameOrigin(request: Request): boolean {
+  const expected = new URL(request.url).origin;
+  const origin = request.headers.get("Origin");
+  const fetchSite = request.headers.get("Sec-Fetch-Site");
+  if (origin && origin !== expected) return false;
+  if (fetchSite && !["same-origin", "same-site", "none"].includes(fetchSite)) {
+    return false;
+  }
+  return true;
+}
+
+function isAdmin(request: Request, env: GalleryEnv): boolean {
+  if (!env.GALLERY_ADMIN_TOKEN) return false;
+  return (
+    request.headers.get("Authorization") === `Bearer ${env.GALLERY_ADMIN_TOKEN}`
+  );
+}
+
+async function submitterHash(request: Request): Promise<string> {
+  const ip =
+    request.headers.get("CF-Connecting-IP") ??
+    request.headers.get("X-Forwarded-For") ??
+    "unknown";
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`gallery:${ip}`),
+  );
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function fieldText(value: unknown, maxLength: number): string | null {
+  if (value === undefined || value === null) return "";
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length <= maxLength ? trimmed : null;
+}
+
+function renderPreview(project: CircuitProject): string {
+  const topDocument = project.documents.find(
+    (document) => document.id === project.topDocumentId,
+  )!;
+  return renderDocumentSvg(topDocument, resolver);
+}
+
+async function handleSubmission(
+  request: Request,
+  env: GalleryEnv,
+): Promise<Response> {
+  if (!sameOrigin(request)) {
+    return Response.json({ error: "forbidden" }, { status: 403 });
+  }
+  // Phase G1: publishing requires the admin bearer until Phase G2 sign-in
+  // replaces it with session identity. Anonymous upload therefore stays
+  // impossible from day one — which is also the end-state rule.
+  if (!isAdmin(request, env)) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+  const body = (await request.json().catch(() => null)) as {
+    name?: unknown;
+    author?: unknown;
+    description?: unknown;
+    projectText?: unknown;
+  } | null;
+  const name = fieldText(body?.name, GALLERY_MAX_NAME_LENGTH);
+  const author = fieldText(body?.author, GALLERY_MAX_AUTHOR_LENGTH);
+  const description = fieldText(
+    body?.description,
+    GALLERY_MAX_DESCRIPTION_LENGTH,
+  );
+  if (!body || !name || author === null || description === null) {
+    return Response.json({ error: "invalid-fields" }, { status: 400 });
+  }
+  if (typeof body.projectText !== "string") {
+    return Response.json({ error: "invalid-project" }, { status: 400 });
+  }
+  if (
+    new TextEncoder().encode(body.projectText).length >
+    GALLERY_MAX_PROJECT_BYTES
+  ) {
+    return Response.json({ error: "too-large" }, { status: 413 });
+  }
+  let project: CircuitProject;
+  try {
+    project = parseProject(body.projectText);
+  } catch {
+    return Response.json({ error: "invalid-project" }, { status: 400 });
+  }
+  project.name = name;
+  const now = new Date();
+  const { status, payload } = await callGallery<{ id?: string }>(
+    env,
+    "submit",
+    {
+      day: now.toISOString().slice(0, 10),
+      submitterHash: await submitterHash(request),
+      entry: {
+        id: crypto.randomUUID(),
+        name,
+        author,
+        description,
+        created_at: now.toISOString(),
+        schema_version: project.schemaVersion,
+        project_text: serializeProject(project),
+        svg_text: renderPreview(project),
+      },
+    },
+  );
+  if (status === 429) {
+    return Response.json({ error: "rate-limited" }, { status: 429 });
+  }
+  return Response.json({ id: payload.id }, { status: 201 });
+}
+
+async function handleReserialize(env: GalleryEnv): Promise<Response> {
+  const { payload } = await callGallery<{ ids: string[] }>(env, "all-ids", {});
+  let upgraded = 0;
+  const failed: { id: string; message: string }[] = [];
+  for (const id of payload.ids) {
+    const detail = await callGallery<{ projectText?: string }>(
+      env,
+      "any-entry",
+      { id },
+    );
+    if (!detail.payload.projectText) continue;
+    try {
+      const project = parseProject(detail.payload.projectText);
+      await callGallery(env, "update-entry", {
+        id,
+        projectText: serializeProject(project),
+        schemaVersion: project.schemaVersion,
+        svgText: renderPreview(project),
+      });
+      upgraded += 1;
+    } catch (error) {
+      failed.push({
+        id,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return Response.json({ upgraded, failed });
+}
+
+/**
+ * All `/api/gallery*` routing. Returns null for unrelated paths so the
+ * worker entry keeps its ordinary dispatch.
+ */
+export async function routeGalleryRequest(
+  request: Request,
+  env: GalleryEnv,
+): Promise<Response | null> {
+  const url = new URL(request.url);
+  if (!url.pathname.startsWith("/api/gallery")) return null;
+  const segments = url.pathname.split("/").filter(Boolean).slice(2);
+
+  if (segments.length === 0 && request.method === "GET") {
+    const { payload } = await callGallery(env, "list", {
+      limit: url.searchParams.get("limit"),
+      cursor: url.searchParams.get("cursor"),
+    });
+    return Response.json(payload, {
+      headers: { "cache-control": "no-store" },
+    });
+  }
+  if (
+    segments.length === 1 &&
+    segments[0] === "submissions" &&
+    request.method === "POST"
+  ) {
+    return handleSubmission(request, env);
+  }
+  if (
+    segments.length === 1 &&
+    segments[0] === "recycled" &&
+    request.method === "GET"
+  ) {
+    if (!isAdmin(request, env)) {
+      return Response.json({ error: "unauthorized" }, { status: 401 });
+    }
+    const { payload } = await callGallery(env, "recycled", {});
+    return Response.json(payload, {
+      headers: { "cache-control": "no-store" },
+    });
+  }
+  if (
+    segments.length === 2 &&
+    segments[0] === "maintenance" &&
+    segments[1] === "reserialize" &&
+    request.method === "POST"
+  ) {
+    if (!isAdmin(request, env)) {
+      return Response.json({ error: "unauthorized" }, { status: 401 });
+    }
+    return handleReserialize(env);
+  }
+  if (segments.length === 2 && segments[1] === "preview.svg") {
+    const { status, payload } = await callGallery<{ svgText?: string }>(
+      env,
+      "entry",
+      { id: segments[0] },
+    );
+    if (status !== 200 || !payload.svgText) {
+      return Response.json({ error: "not-found" }, { status: 404 });
+    }
+    return new Response(payload.svgText, {
+      headers: {
+        "content-type": "image/svg+xml",
+        "cache-control": "public, max-age=300",
+        "content-security-policy":
+          "default-src 'none'; style-src 'unsafe-inline'",
+      },
+    });
+  }
+  if (segments.length === 1 && request.method === "GET") {
+    const { status, payload } = await callGallery<{
+      entry?: GalleryEntrySummary;
+      projectText?: string;
+    }>(env, "entry", { id: segments[0] });
+    if (status !== 200) {
+      return Response.json({ error: "not-found" }, { status: 404 });
+    }
+    return Response.json(
+      { entry: payload.entry, projectText: payload.projectText },
+      { headers: { "cache-control": "no-store" } },
+    );
+  }
+  if (segments.length === 2 && request.method === "POST") {
+    const [id, action] = segments;
+    if (action !== "recycle" && action !== "restore") {
+      return Response.json({ error: "not-found" }, { status: 404 });
+    }
+    if (!isAdmin(request, env)) {
+      return Response.json({ error: "unauthorized" }, { status: 401 });
+    }
+    const { status, payload } = await callGallery(env, "set-status", {
+      id,
+      status: action === "recycle" ? "recycled" : "public",
+      at: new Date().toISOString(),
+    });
+    return Response.json(payload, { status });
+  }
+  if (segments.length === 1 && request.method === "DELETE") {
+    if (!isAdmin(request, env)) {
+      return Response.json({ error: "unauthorized" }, { status: 401 });
+    }
+    const { status, payload } = await callGallery(env, "delete", {
+      id: segments[0],
+    });
+    return Response.json(payload, { status });
+  }
+  return Response.json({ error: "not-found" }, { status: 404 });
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -13,9 +13,11 @@ import {
   routeAgentSessionRequest,
   type AgentSessionNamespaceLike,
 } from "./agent-session";
+import { routeGalleryRequest, type GalleryNamespaceLike } from "./gallery";
 
 export { AnalyticsDO } from "./analytics";
 export { AgentSessionDO } from "./agent-session";
+export { GalleryDO } from "./gallery";
 
 type Env = {
   ANALYTICS: DurableObjectNamespaceLike;
@@ -23,6 +25,8 @@ type Env = {
   ANALYTICS_KEY: string | undefined;
   AGENT_SESSION: AgentSessionNamespaceLike;
   AGENT_ALLOWED_ORIGIN?: string;
+  GALLERY: GalleryNamespaceLike;
+  GALLERY_ADMIN_TOKEN?: string;
 };
 
 type RequestCf = {
@@ -84,6 +88,9 @@ export default {
 
     const agentResponse = await routeAgentSessionRequest(request, env);
     if (agentResponse) return agentResponse;
+
+    const galleryResponse = await routeGalleryRequest(request, env);
+    if (galleryResponse) return galleryResponse;
 
     if (url.pathname === "/api/track" && request.method === "POST") {
       return trackPageView(request, env);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -25,6 +25,10 @@
         "name": "AGENT_SESSION",
         "class_name": "AgentSessionDO",
       },
+      {
+        "name": "GALLERY",
+        "class_name": "GalleryDO",
+      },
     ],
   },
   "migrations": [
@@ -35,6 +39,10 @@
     {
       "tag": "v2",
       "new_sqlite_classes": ["AgentSessionDO"],
+    },
+    {
+      "tag": "v3",
+      "new_sqlite_classes": ["GalleryDO"],
     },
   ],
   "observability": {


### PR DESCRIPTION
## Summary

Phase G1 of the gallery platform direction (`docs/roadmap/community-gallery-platform.md`): **the site now opens as a full-screen Pinterest-style gallery feed**.

- **Worker**: third SQLite Durable Object (`GalleryDO`, wrangler migration v3) storing published circuits as canonical strict-schema Project text plus **server-rendered** preview SVGs (no client markup is ever stored or served). Public surface: list / entry / `preview.svg`. Publish-first moderation per the owner's decision: admin **recycle bin** (soft, restorable), **bin-only hard delete**, hashed-IP daily quotas, and `maintenance/reserialize` to keep long-lived entries inside the rolling schema window (previews stored independently so browsing survives expired entries). Publishing is admin-token-gated until Phase G2 sign-in — anonymous upload impossible from day one. Entries already carry a nullable owner column so G3 needs no migration.
- **Frontend**: `/` renders the masonry feed (tiles open at `/g/<id>` through the ordinary protocol boundary; bundled Library examples double as starter tiles so the wall is never blank); `/editor` keeps the entire existing editor (every Playwright spec moved its landing there — 176 call sites); the brand mark links back to the gallery; `/editor?example=<id>` opens a bundled example.
- **Docs**: normative contract `docs/specs/community-gallery.md` (+ specs table row) and the phased platform roadmap (G2 sign-in via Google/email, G3 per-user ownership with super-admin, G4 feed experience).
- Root gains workspace deps (`@icm/model`, `project-protocol`, `render-svg`, `symbols`) for the Worker bundle, with matching hand-maintained lockfile link entries.

**Deploy note**: set the `GALLERY_ADMIN_TOKEN` secret (`wrangler secret put GALLERY_ADMIN_TOKEN`) to enable publishing/administration; all admin routes answer 401 until then.

Target plan: `plan/2026-08-21-community-gallery/`.

## Validation

- Worker suite on real in-memory SQLite (8 contracts: publish/canonicalize/preview, previous-schema upgrade on submit, publish gate, field/origin/size rejection, rate limiting, recycle lifecycle incl. bin-only delete, re-serialization).
- Feed component tests; new `gallery.spec.ts` (4 scenarios: landing feed, bundled fallback, tile→editor, example tile→editor).
- **Complete Playwright suite: 179/179** on the new routing; typecheck, prettier, markdown links, test-impact, diff checks green; feed and tile-to-editor flow verified live in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)