### PR TITLE
Show bundled tiles only while the gallery is empty

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -41,11 +41,12 @@ test("the site lands on the full-screen gallery feed", async ({ page }) => {
   const feed = page.getByTestId("gallery-feed");
   await expect(feed).toBeVisible();
 
-  // Published tile plus the bundled starter tiles keep the wall non-empty.
+  // With community entries present the wall shows them alone: the bundled
+  // starter tiles exist only while the gallery is empty.
   await expect(page.getByTestId(`gallery-tile-${ENTRY.id}`)).toBeVisible();
   await expect(
     page.getByTestId("gallery-bundled-common-source-amplifier"),
-  ).toBeVisible();
+  ).toHaveCount(0);
   await expect(page.getByTestId("gallery-new-circuit")).toHaveAttribute(
     "href",
     "/editor",

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -140,27 +140,31 @@ export function GalleryFeed() {
               </span>
             </a>
           ))}
-          {bundledTiles().map((tile) => (
-            <a
-              key={tile.id}
-              className="gallery-tile gallery-tile-bundled"
-              href={`/editor?example=${tile.id}`}
-              data-testid={`gallery-bundled-${tile.id}`}
-            >
-              <span
-                className="gallery-tile-preview"
-                // Server-free preview: our own renderer's escaped SVG output.
-                dangerouslySetInnerHTML={{ __html: tile.svg }}
-              />
-              <span className="gallery-tile-copy">
-                <span className="gallery-tile-kicker">Built-in example</span>
-                <span className="gallery-tile-name">{tile.name}</span>
-                <span className="gallery-tile-description">
-                  {tile.description}
-                </span>
-              </span>
-            </a>
-          ))}
+          {entries.length === 0
+            ? bundledTiles().map((tile) => (
+                <a
+                  key={tile.id}
+                  className="gallery-tile gallery-tile-bundled"
+                  href={`/editor?example=${tile.id}`}
+                  data-testid={`gallery-bundled-${tile.id}`}
+                >
+                  <span
+                    className="gallery-tile-preview"
+                    // Server-free preview: our own renderer's escaped SVG output.
+                    dangerouslySetInnerHTML={{ __html: tile.svg }}
+                  />
+                  <span className="gallery-tile-copy">
+                    <span className="gallery-tile-kicker">
+                      Built-in example
+                    </span>
+                    <span className="gallery-tile-name">{tile.name}</span>
+                    <span className="gallery-tile-description">
+                      {tile.description}
+                    </span>
+                  </span>
+                </a>
+              ))
+            : null}
         </section>
       )}
       <footer className="gallery-footnote">

--- a/plan/2026-08-22-gallery-bundled-fallback/plan.md
+++ b/plan/2026-08-22-gallery-bundled-fallback/plan.md
@@ -1,0 +1,69 @@
+---
+status: completed
+experience: none
+---
+
+# Bundled Tiles Only When the Gallery Is Empty
+
+## Goal
+
+The feed rendered the bundled Library examples unconditionally, so once the
+community gallery gained its first real entries (the seeded pair happens to
+be the same two circuits), the wall showed duplicates. The documented G1
+contract already says bundled tiles appear "while the gallery is empty";
+align the implementation: bundled starter tiles render only when the
+feed has zero community entries (empty result or unreachable worker), and
+disappear as soon as real content exists.
+
+## State and Ownership
+
+Branched from `origin/main` (post PR #150) as
+`claude/gallery-bundled-fallback`; worktree clean.
+
+Owned paths:
+
+- `apps/editor/src/components/gallery-feed.tsx`
+- `apps/editor/e2e/gallery.spec.ts`
+- `plan/2026-08-22-gallery-bundled-fallback/plan.md`, `plan/log.md`
+
+Shared dependencies: none beyond the feed markup its own spec exercises.
+
+## Work
+
+1. Gate the bundled-tile block on the community entry list being empty.
+2. Flip the populated-feed e2e expectation (bundled tiles absent when
+   community entries exist); the empty/unreachable scenarios keep proving
+   the fallback.
+
+## Validation
+
+- `playwright`: `apps/editor/e2e/gallery.spec.ts`
+- feed component unit test, repository typecheck, prettier
+- `node scripts/check-test-impact.mjs --base origin/main`
+- `git diff --check` and `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: bundled starter tiles render exactly when the gallery has no
+  community entries; a populated feed shows community tiles only
+- Primary checks: `apps/editor/e2e/gallery.spec.ts`
+
+## Commit Intent
+
+Committed on `claude/gallery-bundled-fallback` under the user's standing
+commit-push-merge direction as:
+
+```text
+fix(gallery): show bundled tiles only while the gallery is empty
+```
+
+## Outcome
+
+Delivered: the bundled starter tiles now render only when the feed has zero
+community entries (empty result or unreachable worker) and vanish as soon
+as real content exists, matching the documented G1 contract and removing
+the duplicate wall the first seeded entries exposed. Gallery Playwright
+spec updated (populated feed shows community tiles alone; empty and
+unreachable scenarios still prove the fallback) — 4/4 green with feed unit
+tests, typecheck, prettier, test-impact, and diff checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4151,3 +4151,13 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   markdown links, test-impact, diff checks.
 - Commit status: completed on `claude/community-gallery`; mainline merge
   gated on the remote required checks.
+
+## 2026-08-22 - Bundled tiles only while the gallery is empty
+
+- Changed areas: gallery feed gates its bundled starter tiles on the
+  community list being empty, removing the duplicated wall after the first
+  real entries; populated-feed e2e expectation flipped.
+- Validation: gallery Playwright spec (4 passed), feed unit tests,
+  typecheck, prettier, test-impact, diff checks.
+- Commit status: completed on `claude/gallery-bundled-fallback`; mainline
+  merge gated on the remote required checks.


### PR DESCRIPTION
## Summary

The feed rendered the bundled starter tiles unconditionally, so the first seeded community entries (the same two circuits) duplicated the wall. Per the documented G1 contract ("while the gallery is empty"), the bundled tiles now render only when the feed has zero community entries — empty result or unreachable worker — and disappear once real content exists.

Target plan: `plan/2026-08-22-gallery-bundled-fallback/`.

## Validation

- `gallery.spec.ts` 4/4: populated feed shows community tiles alone; empty and unreachable scenarios still prove the fallback; tile→editor flows unchanged.
- Feed unit tests, repository typecheck, prettier, test-impact, diff checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)