### PR TITLE
feat(editor): in-editor publish to gallery

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -4,6 +4,8 @@ import type { Page } from "@playwright/test";
 import { createEmptyProject } from "@icm/model";
 import { serializeProject } from "@icm/project-protocol";
 
+import { clickCommand } from "./editor-fixtures.js";
+
 const ENTRY = {
   id: "g-ring",
   name: "Ring Oscillator",
@@ -85,6 +87,55 @@ test("a gallery tile opens its circuit in the editor", async ({ page }) => {
   await expect(backLink).toBeVisible();
   await backLink.click();
   await expect(page.getByTestId("gallery-feed")).toBeVisible();
+});
+
+test("File > Publish to Gallery posts the live Project with the passphrase", async ({
+  page,
+}) => {
+  const posted: { authorization: string | null; body: string }[] = [];
+  await page.route("**/api/gallery", (route) => {
+    if (route.request().method() !== "POST") {
+      return route.fulfill({ json: { entries: [], nextCursor: null } });
+    }
+    posted.push({
+      authorization: route.request().headers()["authorization"] ?? null,
+      body: route.request().postData() ?? "",
+    });
+    return route.fulfill({ status: 201, json: { id: "entry-99" } });
+  });
+
+  await page.goto("/editor");
+  await clickCommand(page, "File", "Publish to Gallery…");
+  const dialog = page.getByTestId("publish-gallery-dialog");
+  await expect(dialog).toBeVisible();
+
+  await dialog.getByLabel("Circuit name").fill("Publish Demo");
+  await dialog.getByLabel("Author").fill("Vivian");
+  const publish = dialog.getByRole("button", { name: "Publish" });
+  await expect(publish).toBeDisabled();
+  await dialog.getByLabel("Owner passphrase").fill("secret-token");
+  await publish.click();
+
+  await expect(page.getByTestId("status")).toHaveText(
+    'Published "Publish Demo" to the gallery',
+  );
+  expect(posted).toHaveLength(1);
+  const request = posted[0]!;
+  expect(request.authorization).toBe("Bearer secret-token");
+  const body = JSON.parse(request.body) as {
+    name: string;
+    author: string;
+    projectText: string;
+  };
+  expect(body.name).toBe("Publish Demo");
+  expect(body.author).toBe("Vivian");
+  expect(JSON.parse(body.projectText).schemaVersion).toBe(ENTRY.schemaVersion);
+
+  // The passphrase is remembered for the session and offered on reopen.
+  await clickCommand(page, "File", "Publish to Gallery…");
+  await expect(
+    page.getByTestId("publish-gallery-dialog").getByLabel("Owner passphrase"),
+  ).toHaveValue("secret-token");
 });
 
 test("bundled starter tiles open their example in the editor", async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -198,6 +198,8 @@ import { CellManagerDialog } from "../features/hierarchy/cell-manager-dialog";
 import { NetlistPreflightDialog } from "../features/netlist-export/netlist-preflight-dialog";
 import { parseProject } from "@icm/project-protocol";
 import { StyleDialog } from "../features/editor-shell/style-dialog";
+import { PublishGalleryDialog } from "../features/editor-shell/publish-gallery-dialog";
+import { publishProjectToGallery } from "../features/editor-shell/gallery-publish";
 import {
   createUserExamplesStore,
   type UserExampleSummary,
@@ -604,6 +606,7 @@ export function App({
   const [cellManagerOpen, setCellManagerOpen] = useState(false);
   const [netlistPreflightOpen, setNetlistPreflightOpen] = useState(false);
   const [styleDialogOpen, setStyleDialogOpen] = useState(false);
+  const [publishGalleryOpen, setPublishGalleryOpen] = useState(false);
   const userExamplesStore = useRef(createUserExamplesStore());
   const [userExamples, setUserExamples] = useState<UserExampleSummary[]>([]);
   const [instanceTableOpen, setInstanceTableOpen] = useState(false);
@@ -6863,6 +6866,14 @@ export function App({
                   >
                     Save as Example
                   </button>
+                  <button
+                    type="button"
+                    aria-haspopup="dialog"
+                    aria-expanded={publishGalleryOpen}
+                    onClick={() => setPublishGalleryOpen(true)}
+                  >
+                    Publish to Gallery…
+                  </button>
                   <span className="command-group-label">Export</span>
                   <button
                     type="button"
@@ -7418,6 +7429,17 @@ export function App({
             }
           }}
           onClose={() => setStyleDialogOpen(false)}
+        />
+      ) : null}
+      {publishGalleryOpen ? (
+        <PublishGalleryDialog
+          defaultName={project.name}
+          publish={(fields) => publishProjectToGallery(project, fields)}
+          onPublished={({ name }) => {
+            setPublishGalleryOpen(false);
+            setStatus(`Published "${name}" to the gallery`);
+          }}
+          onClose={() => setPublishGalleryOpen(false)}
         />
       ) : null}
       {publicAgentUiEnabled ? (

--- a/apps/editor/src/features/editor-shell/gallery-publish.test.ts
+++ b/apps/editor/src/features/editor-shell/gallery-publish.test.ts
@@ -1,0 +1,114 @@
+import { createEmptyProject } from "@icm/model";
+import { describe, expect, it } from "vitest";
+
+import {
+  describePublishOutcome,
+  forgetOnUnauthorized,
+  publishProjectToGallery,
+  rememberedPublishToken,
+  rememberPublishToken,
+} from "./gallery-publish";
+
+const project = createEmptyProject("p1", "Ring Oscillator");
+
+function fetchReturning(
+  status: number,
+  payload: unknown,
+  seen: { url?: string; init?: RequestInit | undefined } = {},
+): typeof fetch {
+  return (async (url: RequestInfo | URL, init?: RequestInit) => {
+    seen.url = String(url);
+    seen.init = init;
+    return new Response(JSON.stringify(payload), { status });
+  }) as typeof fetch;
+}
+
+function memoryStorage(): Pick<
+  Storage,
+  "getItem" | "setItem" | "removeItem"
+> & { map: Map<string, string> } {
+  const map = new Map<string, string>();
+  return {
+    map,
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => void map.set(key, value),
+    removeItem: (key) => void map.delete(key),
+  };
+}
+
+describe("publishProjectToGallery", () => {
+  it("posts the serialized Project with the bearer passphrase", async () => {
+    const seen: { url?: string; init?: RequestInit | undefined } = {};
+    const outcome = await publishProjectToGallery(
+      project,
+      {
+        name: "  Ring Oscillator  ",
+        author: "Vivian",
+        description: "Five stages",
+        token: "secret-token",
+      },
+      fetchReturning(201, { id: "entry-1" }, seen),
+    );
+    expect(outcome).toEqual({ status: "published", id: "entry-1" });
+    expect(seen.url).toBe("/api/gallery");
+    expect((seen.init?.headers as Record<string, string>).authorization).toBe(
+      "Bearer secret-token",
+    );
+    const body = JSON.parse(String(seen.init?.body)) as {
+      name: string;
+      author: string;
+      description: string;
+      projectText: string;
+    };
+    expect(body.name).toBe("Ring Oscillator");
+    expect(body.author).toBe("Vivian");
+    expect(body.description).toBe("Five stages");
+    expect(JSON.parse(body.projectText).schemaVersion).toBe(
+      project.schemaVersion,
+    );
+  });
+
+  it("maps every documented rejection to a typed outcome", async () => {
+    const cases: [number, unknown, string][] = [
+      [401, { error: "unauthorized" }, "unauthorized"],
+      [413, { error: "too-large" }, "too-large"],
+      [429, { error: "rate-limited" }, "rate-limited"],
+      [400, { error: "invalid-fields" }, "rejected"],
+    ];
+    for (const [status, payload, expected] of cases) {
+      const outcome = await publishProjectToGallery(
+        project,
+        { name: "N", author: "", description: "", token: "t" },
+        fetchReturning(status, payload),
+      );
+      expect(outcome.status).toBe(expected);
+      expect(describePublishOutcome(outcome)).not.toHaveLength(0);
+    }
+  });
+
+  it("reports a thrown fetch as unreachable", async () => {
+    const outcome = await publishProjectToGallery(
+      project,
+      { name: "N", author: "", description: "", token: "t" },
+      (() => Promise.reject(new Error("offline"))) as typeof fetch,
+    );
+    expect(outcome).toEqual({ status: "unreachable", message: "offline" });
+  });
+});
+
+describe("publish passphrase session memory", () => {
+  it("round-trips the passphrase and forgets it on a 401", () => {
+    const storage = memoryStorage();
+    rememberPublishToken("secret-token", storage);
+    expect(rememberedPublishToken(storage)).toBe("secret-token");
+    expect(forgetOnUnauthorized({ status: "rate-limited" }, storage)).toBe(
+      false,
+    );
+    expect(rememberedPublishToken(storage)).toBe("secret-token");
+    expect(forgetOnUnauthorized({ status: "unauthorized" }, storage)).toBe(
+      true,
+    );
+    expect(rememberedPublishToken(storage)).toBe("");
+    expect(storage.map.size).toBe(0);
+  });
+});

--- a/apps/editor/src/features/editor-shell/gallery-publish.ts
+++ b/apps/editor/src/features/editor-shell/gallery-publish.ts
@@ -1,0 +1,143 @@
+import type { CircuitProject } from "@icm/model";
+import { serializeProject } from "@icm/project-protocol";
+
+/**
+ * Client for the documented gallery submissions endpoint
+ * (docs/specs/community-gallery.md). Phase G1 gates publishing behind the
+ * owner's admin passphrase; the same call path later carries the signed-in
+ * session instead. The fetch seam keeps the mapping testable offline.
+ */
+
+export interface GalleryPublishFields {
+  name: string;
+  author: string;
+  description: string;
+  token: string;
+}
+
+export type GalleryPublishOutcome =
+  | { status: "published"; id: string }
+  | { status: "unauthorized" }
+  | { status: "too-large" }
+  | { status: "rate-limited" }
+  | { status: "rejected"; message: string }
+  | { status: "unreachable"; message: string };
+
+export async function publishProjectToGallery(
+  project: CircuitProject,
+  fields: GalleryPublishFields,
+  fetchLike: typeof fetch = fetch,
+): Promise<GalleryPublishOutcome> {
+  let response: Response;
+  try {
+    response = await fetchLike("/api/gallery", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${fields.token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        name: fields.name.trim(),
+        author: fields.author.trim(),
+        description: fields.description.trim(),
+        projectText: serializeProject(project),
+      }),
+    });
+  } catch (error) {
+    return {
+      status: "unreachable",
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+  if (response.status === 201) {
+    const payload = (await response.json().catch(() => null)) as {
+      id?: unknown;
+    } | null;
+    return {
+      status: "published",
+      id: typeof payload?.id === "string" ? payload.id : "",
+    };
+  }
+  if (response.status === 401) return { status: "unauthorized" };
+  if (response.status === 413) return { status: "too-large" };
+  if (response.status === 429) return { status: "rate-limited" };
+  const payload = (await response.json().catch(() => null)) as {
+    error?: unknown;
+  } | null;
+  return {
+    status: "rejected",
+    message:
+      typeof payload?.error === "string"
+        ? payload.error
+        : `HTTP ${response.status}`,
+  };
+}
+
+/** One human-readable line per outcome, shown in the dialog or status bar. */
+export function describePublishOutcome(outcome: GalleryPublishOutcome): string {
+  switch (outcome.status) {
+    case "published":
+      return "Published to the gallery";
+    case "unauthorized":
+      return "The passphrase was not accepted, so it was forgotten — ask the gallery owner for the current one";
+    case "too-large":
+      return "This Project exceeds the gallery's 2 MB limit";
+    case "rate-limited":
+      return "Daily publish limit reached — try again tomorrow";
+    case "rejected":
+      return outcome.message === "invalid-fields"
+        ? "Check the fields: a name is required; author and description have length caps"
+        : outcome.message === "invalid-project"
+          ? "The Project failed strict validation on the server"
+          : `The gallery rejected the submission (${outcome.message})`;
+    case "unreachable":
+      return `Could not reach the gallery: ${outcome.message}`;
+  }
+}
+
+const TOKEN_STORAGE_KEY = "icm.gallery-publish-token.v1";
+
+type TokenStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+function sessionStorageOrNull(): TokenStorage | null {
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+/** The passphrase remembered for this browser session, if any. */
+export function rememberedPublishToken(
+  storage: TokenStorage | null = sessionStorageOrNull(),
+): string {
+  try {
+    return storage?.getItem(TOKEN_STORAGE_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+/** A 401 forgets the remembered passphrase; reports whether it did. */
+export function forgetOnUnauthorized(
+  outcome: GalleryPublishOutcome,
+  storage: TokenStorage | null = sessionStorageOrNull(),
+): boolean {
+  if (outcome.status !== "unauthorized") return false;
+  rememberPublishToken("", storage);
+  return true;
+}
+
+/** Remember (non-empty) or forget (empty) the passphrase for this session. */
+export function rememberPublishToken(
+  token: string,
+  storage: TokenStorage | null = sessionStorageOrNull(),
+): void {
+  try {
+    if (token) storage?.setItem(TOKEN_STORAGE_KEY, token);
+    else storage?.removeItem(TOKEN_STORAGE_KEY);
+  } catch {
+    // Session storage may be unavailable (private mode); publishing still
+    // works, the passphrase is just not remembered.
+  }
+}

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.test.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.test.tsx
@@ -1,0 +1,25 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { PublishGalleryDialog } from "./publish-gallery-dialog";
+
+describe("PublishGalleryDialog", () => {
+  it("prefills the Project name and gates Publish on the passphrase", () => {
+    const markup = renderToStaticMarkup(
+      createElement(PublishGalleryDialog, {
+        defaultName: "Ring Oscillator",
+        publish: () => Promise.resolve({ status: "unauthorized" as const }),
+        onPublished: () => undefined,
+        onClose: () => undefined,
+      }),
+    );
+    expect(markup).toContain('data-testid="publish-gallery-dialog"');
+    expect(markup).toContain('value="Ring Oscillator"');
+    expect(markup).toContain('aria-label="Owner passphrase"');
+    expect(markup).toContain('type="password"');
+    // Empty passphrase (no session memory in this render) disables Publish.
+    expect(markup).toMatch(/disabled=""[^>]*>Publish</u);
+    expect(markup).toContain("owner&#x27;s passphrase");
+  });
+});

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
@@ -1,0 +1,136 @@
+import { useState } from "react";
+
+import {
+  describePublishOutcome,
+  forgetOnUnauthorized,
+  rememberedPublishToken,
+  rememberPublishToken,
+  type GalleryPublishFields,
+  type GalleryPublishOutcome,
+} from "./gallery-publish";
+
+export interface PublishGalleryDialogProps {
+  defaultName: string;
+  publish: (fields: GalleryPublishFields) => Promise<GalleryPublishOutcome>;
+  onPublished: (outcome: { id: string; name: string }) => void;
+  onClose: () => void;
+}
+
+/**
+ * File > "Publish to Gallery…". Phase G1: the submissions endpoint accepts
+ * only the gallery owner's passphrase (remembered for the browser session,
+ * forgotten on a 401); visitors see the sign-in-pending note instead of a
+ * dead end. G3 swaps the passphrase row for the signed-in identity.
+ */
+export function PublishGalleryDialog({
+  defaultName,
+  publish,
+  onPublished,
+  onClose,
+}: PublishGalleryDialogProps) {
+  const [name, setName] = useState(defaultName);
+  const [author, setAuthor] = useState("");
+  const [description, setDescription] = useState("");
+  const [token, setToken] = useState(() => rememberedPublishToken());
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(): Promise<void> {
+    setBusy(true);
+    setError(null);
+    const outcome = await publish({ name, author, description, token });
+    if (outcome.status === "published") {
+      rememberPublishToken(token);
+      onPublished({ id: outcome.id, name: name.trim() });
+      return;
+    }
+    if (forgetOnUnauthorized(outcome)) setToken("");
+    setBusy(false);
+    setError(describePublishOutcome(outcome));
+  }
+
+  return (
+    <div
+      className="insert-dialog-backdrop"
+      onPointerDown={(event) => {
+        if (event.target === event.currentTarget && !busy) onClose();
+      }}
+    >
+      <section
+        className="insert-component-dialog publish-gallery-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="publish-gallery-title"
+        data-testid="publish-gallery-dialog"
+      >
+        <header className="insert-dialog-header">
+          <div>
+            <p>Share this circuit on the public wall</p>
+            <h2 id="publish-gallery-title">Publish to Gallery</h2>
+          </div>
+        </header>
+        <div className="insert-dialog-body">
+          <section className="insert-control-column">
+            <label>
+              Circuit name
+              <input
+                aria-label="Circuit name"
+                value={name}
+                maxLength={120}
+                onChange={(event) => setName(event.currentTarget.value)}
+              />
+            </label>
+            <label>
+              Author (optional)
+              <input
+                aria-label="Author"
+                value={author}
+                maxLength={40}
+                onChange={(event) => setAuthor(event.currentTarget.value)}
+              />
+            </label>
+            <label>
+              Description (optional)
+              <textarea
+                aria-label="Description"
+                value={description}
+                maxLength={300}
+                rows={3}
+                onChange={(event) => setDescription(event.currentTarget.value)}
+              />
+            </label>
+            <label>
+              Owner passphrase
+              <input
+                aria-label="Owner passphrase"
+                type="password"
+                value={token}
+                onChange={(event) => setToken(event.currentTarget.value)}
+              />
+            </label>
+            <p className="publish-gallery-note">
+              Publishing is owner-approved for now: it needs the gallery
+              owner&apos;s passphrase. Community sign-in with review is on the
+              roadmap — until then, send your circuit file to the owner.
+            </p>
+            {error ? (
+              <p role="alert" className="publish-gallery-error">
+                {error}
+              </p>
+            ) : null}
+            <button
+              type="button"
+              disabled={busy || name.trim() === "" || token.trim() === ""}
+              onClick={() => void submit()}
+            >
+              {busy ? "Publishing…" : "Publish"}
+            </button>
+            <button type="button" disabled={busy} onClick={onClose}>
+              Cancel
+            </button>
+          </section>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -3648,6 +3648,24 @@ body {
   scrollbar-width: thin;
 }
 
+.publish-gallery-dialog .insert-control-column {
+  border-right: none;
+}
+
+.publish-gallery-note {
+  margin: 0;
+  color: var(--icm-text-muted, #667085);
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.publish-gallery-error {
+  margin: 0;
+  color: var(--icm-danger, #b42318);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
 .netlist-preview {
   min-height: 10rem;
   margin: 0;

--- a/docs/roadmap/community-gallery-platform.md
+++ b/docs/roadmap/community-gallery-platform.md
@@ -25,7 +25,11 @@ server contract lives in
 - Public read API: list, entry, preview image. Publishing exists but is
   admin-token-gated until real sign-in lands (anonymous upload stays
   impossible from day one; admin-published entries go live directly — the
-  end-state review queue for ordinary users arrives in G3).
+  end-state review queue for ordinary users arrives in G3). The editor's
+  File > "Publish to Gallery…" dialog is the in-app publishing surface:
+  it posts the live Project with the owner passphrase (remembered per
+  browser session, forgotten on a 401) and later switches to signed-in
+  identity without moving the entry point.
 - Admin API (bearer `GALLERY_ADMIN_TOKEN`): recycle (soft, restorable),
   restore, hard-delete from the bin only, recycled list, and batch
   re-serialization that keeps long-lived entries inside the rolling schema

--- a/plan/2026-08-22-gallery-publish-dialog/plan.md
+++ b/plan/2026-08-22-gallery-publish-dialog/plan.md
@@ -1,0 +1,91 @@
+---
+status: completed
+experience: none
+---
+
+# In-Editor "Publish to Gallery" (Admin-Gated Bridge)
+
+## Goal
+
+Answer "how do I contribute to the gallery?" with a real in-app path
+today. Until G2 sign-in ships, publishing stays admin-token-gated, but the
+only flow was raw curl. Add File > "Publish to Gallery…": a dialog with
+name (prefilled from the Project), optional author and description, and
+the admin passphrase (session-remembered, cleared on a 401); it serializes
+the live Project and posts it through the existing submissions endpoint,
+mapping every outcome (published / wrong passphrase / daily limit /
+too large / invalid) to a clear message. The same entry point later
+switches to signed-in identity in G3 — visitors without the passphrase
+see exactly the sign-in-pending story the footer already tells.
+
+## State and Ownership
+
+Branched from `claude/gallery-back-button` (PR #152 in its merge chain);
+stacked so the File-menu region merges cleanly.
+
+Owned paths:
+
+- `apps/editor/src/features/editor-shell/gallery-publish.ts` (+ test) —
+  pure publish client with an injectable fetch seam
+- `apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx`
+  (+ test)
+- `apps/editor/src/app/App.tsx` (File-menu action + dialog wiring)
+- `apps/editor/e2e/gallery.spec.ts` (route-mocked publish scenario)
+- `plan/2026-08-22-gallery-publish-dialog/plan.md`, `plan/log.md`
+
+Shared dependencies: the submissions contract from
+`docs/specs/community-gallery.md` (consumed as-is), the insert-dialog
+styling, and the project-protocol serializer.
+
+## Work
+
+1. `publishProjectToGallery(project, fields, fetchLike)`: canonical
+   serialization, bearer header, outcome mapping for 201/401/413/429/400.
+2. Dialog: prefilled name, optional author/description, passphrase field
+   (session-remembered), busy/error states, publish-notice copy.
+3. App: File-menu button, success status plus passphrase retention,
+   401 clears the stored passphrase.
+4. Tests: client outcome mapping, dialog markup, one route-mocked
+   Playwright scenario asserting the posted body and bearer header.
+
+## Validation
+
+- focused `vitest`: gallery-publish client and dialog tests
+- `playwright`: `apps/editor/e2e/gallery.spec.ts`
+- repository typecheck, prettier
+- `node scripts/check-test-impact.mjs --base origin/main`
+- `git diff --check` and `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: the editor publishes the live Project through the documented
+  submissions endpoint with the admin bearer; every rejection surfaces a
+  specific message and a 401 forgets the stored passphrase; the dialog
+  never publishes without a passphrase
+- Primary checks:
+  `apps/editor/src/features/editor-shell/gallery-publish.test.ts`,
+  `apps/editor/e2e/gallery.spec.ts`
+
+## Commit Intent
+
+Committed on `claude/gallery-publish` under the user's standing
+commit-push-merge direction as:
+
+```text
+feat(editor): in-editor publish to gallery
+```
+
+## Outcome
+
+Delivered: File > "Publish to Gallery…" opens a dialog prefilled with the
+Project name plus optional author/description and the owner passphrase;
+publishing serializes the live Project canonically and posts it to
+`/api/gallery` with the bearer, mapping 201/401/413/429/400 and network
+failure to specific messages. The passphrase is remembered for the browser
+session and forgotten on a 401. Roadmap G1 records the dialog as the
+in-app publishing surface that G3 later switches to signed-in identity.
+Validation: publish client + dialog unit tests (5), gallery Playwright
+spec 5/5 (new scenario asserts the posted body, bearer header, and
+session-remembered passphrase), repository typecheck, prettier,
+test-impact, diff checks green.

--- a/plan/log.md
+++ b/plan/log.md
@@ -3883,6 +3883,7 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   `pnpm ci:check` passed with 162 unit files / 975 tests, all workspace builds,
   release/MCP smoke checks, and 167 browser tests.
 - Commit status: ready to commit on `codex/schematic-instance-lifecycle-ux`.
+
 ## 2026-08-21 - Free Net Port lifecycle
 
 - Changed areas: reused the deterministic named-Net planner for Free Port
@@ -4065,7 +4066,7 @@ Keep reusable lessons in `docs/experience/`, not in this log.
 ## 2026-08-21 - Visual golden refresh and release-gate wiring
 
 - Changed areas: regenerated the stale `fixtures/visual-golden/
-  {phase-3-crossing,phase-5-dense-analog}.svg` from current `main`
+{phase-3-crossing,phase-5-dense-analog}.svg` from current `main`
   (d8a813a8) after tracing every delta to accepted merged changes —
   9a552d32 removed the legacy ports layer and in-symbol instance labels and
   replaced the phase-5 input project; later bound-display/rich-text,
@@ -4076,7 +4077,7 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   gate catalog's release group.
 - Validation: fresh renders diffed element-by-element against both stale
   goldens with per-delta commit attribution; `node scripts/visual-golden.mjs
-  --check` passes post-regeneration; prettier, markdown-link, test-impact,
+--check` passes post-regeneration; prettier, markdown-link, test-impact,
   and diff checks passed. pnpm is unavailable on this machine, so the
   canonical mainline gate is delegated to the remote required checks.
 - Commit status: completed on `claude/peaceful-poitras-f8ccde`; mainline
@@ -4194,4 +4195,19 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   App/component unit suites (18), typecheck, prettier, test-impact, diff
   checks.
 - Commit status: completed on `claude/gallery-back-button`; mainline merge
+  gated on the remote required checks.
+
+## 2026-08-22 — In-editor Publish to Gallery (admin-gated bridge)
+
+- Target: `plan/2026-08-22-gallery-publish-dialog/plan.md` (completed).
+- Change: File > "Publish to Gallery…" dialog publishes the live Project
+  through the documented submissions endpoint with the owner passphrase
+  (session-remembered, forgotten on 401); outcome-specific messages for
+  201/401/413/429/400/network. Roadmap G1 notes the in-app surface.
+- Files: `features/editor-shell/gallery-publish.ts(.test.ts)`,
+  `publish-gallery-dialog.tsx(.test.tsx)`, `App.tsx`, `styles.css`,
+  `e2e/gallery.spec.ts`, roadmap.
+- Validation: 5 unit tests, gallery Playwright spec 5/5, typecheck,
+  prettier, test-impact, diff checks.
+- Commit status: completed on `claude/gallery-publish`; mainline merge
   gated on the remote required checks.


### PR DESCRIPTION
Answers "how do I contribute to the gallery?" with a real in-app path. File > "Publish to Gallery…" opens a dialog (name prefilled from the Project, optional author/description, owner passphrase) and posts the live, canonically serialized Project through the documented submissions endpoint with the bearer header.

- Passphrase is remembered for the browser session and forgotten on a 401.
- Every documented outcome (201/401/413/429/400, network failure) maps to a specific message.
- Phase G1 gate unchanged: the endpoint still requires the owner bearer; G3 swaps this same entry point to signed-in identity.
- Tests: publish client + dialog unit tests, new route-mocked Playwright scenario asserting the posted body, bearer header, and session-remembered passphrase (gallery spec 5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)