### PR TITLE
feat(editor): add bundled differential examples

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -942,7 +942,7 @@ test("opens named full-width Project examples from the left tool rail", async ({
   const exampleList = panel.locator(".shapes-example-list");
   const examples = exampleList.locator(".shapes-example-card");
   await expect(panel).toHaveAttribute("data-open", "true");
-  await expect(examples).toHaveCount(2);
+  await expect(examples).toHaveCount(4);
   expect(
     await exampleList.evaluate(
       (element) =>
@@ -955,6 +955,19 @@ test("opens named full-width Project examples from the left tool rail", async ({
   await expect(
     panel.getByTestId("shapes-example-two-stage-op-amp"),
   ).toContainText("Two-Stage Op Amp");
+  await expect(
+    panel.getByTestId("shapes-example-current-mirror-loaded-differential-pair"),
+  ).toContainText("Current-Mirror-Loaded Differential Pair");
+  await expect(
+    panel.getByTestId("shapes-example-fully-differential-two-stage-op-amp"),
+  ).toContainText("Fully Differential Two-Stage Op Amp");
+
+  await examplesToggle.click();
+  await expect(panel).toHaveAttribute("data-open", "false");
+  await expect(examplesToggle).toHaveAttribute("aria-expanded", "false");
+
+  await examplesToggle.click();
+  await expect(panel).toHaveAttribute("data-open", "true");
 
   await panel.getByTestId("shapes-example-common-source-amplifier").click();
   await expect(page.getByTestId("status")).toHaveText(

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -502,6 +502,7 @@ export function App({
     closeAbout,
     closeSearch,
     showLeftPanel,
+    toggleExamplesPanel: toggleExamplesPanelFromShell,
     toggleLibraryPanel,
   } = useEditorPanels({
     initialCompact: compactLayoutMatches(COMPACT_LAYOUT_MEDIA_QUERY),
@@ -1792,6 +1793,11 @@ export function App({
 
   function showExamplesPanel(): void {
     showLeftPanel("examples");
+    void refreshUserExamples();
+  }
+
+  function toggleExamplesPanel(): void {
+    toggleExamplesPanelFromShell();
     void refreshUserExamples();
   }
 
@@ -7643,7 +7649,11 @@ export function App({
           <button
             type="button"
             className="tool-rail-button examples-toggle"
-            title="Show circuit examples"
+            title={
+              leftPanelMode === "examples" && visibleLibraryPanelOpen
+                ? "Hide circuit examples"
+                : "Show circuit examples"
+            }
             aria-pressed={
               leftPanelMode === "examples" && visibleLibraryPanelOpen
             }
@@ -7652,7 +7662,7 @@ export function App({
               leftPanelMode === "examples" && visibleLibraryPanelOpen
             }
             data-testid="examples-toggle"
-            onClick={showExamplesPanel}
+            onClick={toggleExamplesPanel}
           >
             <ToolIcon name="examples" />
             <span>Examples</span>

--- a/apps/editor/src/examples/current-mirror-loaded-differential-pair.icproj.json
+++ b/apps/editor/src/examples/current-mirror-loaded-differential-pair.icproj.json
@@ -1,0 +1,1024 @@
+{
+  "documents": [
+    {
+      "annotations": [
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 550,
+              "y": 170
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 10
+            },
+            "objectId": "junction-vdd1-end"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-power-vdd1"
+          },
+          "id": "label-VDD1",
+          "kind": "power-label",
+          "locked": false,
+          "netId": "net-power-vdd1",
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 510,
+              "y": 210
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "M1"
+          },
+          "binding": {
+            "instanceId": "M1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 370,
+              "y": 210
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 10
+            },
+            "objectId": "M2"
+          },
+          "binding": {
+            "instanceId": "M2",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 390,
+              "y": 310
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "M3"
+          },
+          "binding": {
+            "instanceId": "M3",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M3",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 490,
+              "y": 310
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 10
+            },
+            "objectId": "M4"
+          },
+          "binding": {
+            "instanceId": "M4",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M4",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 450,
+              "y": 380
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "M5"
+          },
+          "binding": {
+            "instanceId": "M5",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M5",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 300,
+              "y": 300
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -40,
+              "y": 0
+            },
+            "objectId": "P1"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-contact-p1"
+          },
+          "formatOverride": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "V"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  },
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "in1"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "subscript"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-P1",
+          "kind": "net-label",
+          "locked": false,
+          "netId": "net-contact-p1",
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 560,
+              "y": 300
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 0
+            },
+            "objectId": "P2"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-contact-p2"
+          },
+          "formatOverride": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "V"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  },
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "in2"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "subscript"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-P2",
+          "kind": "net-label",
+          "locked": false,
+          "netId": "net-contact-p2",
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 550,
+              "y": 250
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 0
+            },
+            "objectId": "P3"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-ui-8"
+          },
+          "id": "instance-label-P3",
+          "kind": "net-label",
+          "locked": false,
+          "netId": "net-ui-8",
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 360,
+              "y": 370
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -40,
+              "y": 0
+            },
+            "objectId": "P4"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-contact-p4"
+          },
+          "formatOverride": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "V"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  },
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "b"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "subscript"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-P4",
+          "kind": "net-label",
+          "locked": false,
+          "netId": "net-contact-p4",
+          "rotation": 0,
+          "sizeScale": 1
+        }
+      ],
+      "constraints": [],
+      "drafting": {
+        "objects": []
+      },
+      "id": "document-main",
+      "instances": [
+        {
+          "id": "M1",
+          "netlist": {
+            "parameters": {},
+            "reference": "M1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 490,
+              "y": 200
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M1",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M2",
+          "netlist": {
+            "parameters": {},
+            "reference": "M2"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 390,
+              "y": 200
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M2",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M3",
+          "netlist": {
+            "parameters": {},
+            "reference": "M3"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 370,
+              "y": 300
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M3",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M4",
+          "netlist": {
+            "parameters": {},
+            "reference": "M4"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 510,
+              "y": 300
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M4",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M5",
+          "netlist": {
+            "parameters": {},
+            "reference": "M5"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 430,
+              "y": 370
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M5",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "P1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 340,
+              "y": 300
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "P2",
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 540,
+              "y": 300
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "P3",
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 530,
+              "y": 250
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "P4",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 400,
+              "y": 370
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "GND1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 440,
+              "y": 400
+            },
+            "rotation": 0
+          },
+          "schematicReference": "GND1",
+          "symbolId": "ground"
+        }
+      ],
+      "junctions": [
+        {
+          "id": "junction-vdd1-start",
+          "netId": "net-power-vdd1",
+          "position": {
+            "x": 370,
+            "y": 160
+          },
+          "role": "route-anchor"
+        },
+        {
+          "id": "junction-vdd1-end",
+          "netId": "net-power-vdd1",
+          "position": {
+            "x": 510,
+            "y": 160
+          },
+          "role": "route-anchor"
+        },
+        {
+          "id": "junction-ui-1",
+          "netId": "net-power-vdd1",
+          "position": {
+            "x": 380,
+            "y": 160
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-3",
+          "netId": "net-power-vdd1",
+          "position": {
+            "x": 500,
+            "y": 160
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-12",
+          "netId": "net-ui-7",
+          "position": {
+            "x": 380,
+            "y": 240
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-13",
+          "netId": "net-ui-7",
+          "position": {
+            "x": 430,
+            "y": 200
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-16",
+          "netId": "net-ui-15",
+          "position": {
+            "x": 440,
+            "y": 330
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-18",
+          "netId": "net-ui-8",
+          "position": {
+            "x": 500,
+            "y": 250
+          },
+          "role": "branch"
+        }
+      ],
+      "layoutGroups": [],
+      "name": "Main",
+      "netlist": {
+        "formalParameters": [],
+        "name": "Main",
+        "terminals": []
+      },
+      "nets": [
+        {
+          "id": "net-power-vdd1",
+          "name": "VDD",
+          "origin": {
+            "kind": "authored"
+          },
+          "powerDomain": "vdd",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "M2",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "S"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-7",
+          "origin": {
+            "kind": "authored"
+          },
+          "powerDomain": "none",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "M2",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "G"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-8",
+          "name": "Vout",
+          "origin": {
+            "kind": "authored"
+          },
+          "powerDomain": "none",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "M4",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "P3",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-15",
+          "origin": {
+            "kind": "authored"
+          },
+          "powerDomain": "none",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "M3",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "D"
+            }
+          ]
+        },
+        {
+          "id": "net-contact-p1",
+          "name": "Vin1",
+          "origin": {
+            "kind": "authored"
+          },
+          "powerDomain": "none",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "P1",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "G"
+            }
+          ]
+        },
+        {
+          "id": "net-contact-p2",
+          "name": "Vin2",
+          "origin": {
+            "kind": "authored"
+          },
+          "powerDomain": "none",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "P2",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "G"
+            }
+          ]
+        },
+        {
+          "id": "net-contact-p4",
+          "name": "Vb",
+          "origin": {
+            "kind": "authored"
+          },
+          "powerDomain": "none",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "P4",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "G"
+            }
+          ]
+        },
+        {
+          "id": "net-contact-gnd1",
+          "name": "0",
+          "origin": {
+            "kind": "authored"
+          },
+          "powerDomain": "ground",
+          "scope": "global",
+          "terminals": [
+            {
+              "instanceId": "GND1",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "S"
+            }
+          ]
+        }
+      ],
+      "noConnects": [],
+      "presentation": {
+        "compactness": "normal",
+        "grid": 10,
+        "styleProfileId": "razavi-textbook-v1"
+      },
+      "revision": 145,
+      "routes": [
+        {
+          "from": {
+            "junctionId": "junction-vdd1-start",
+            "kind": "junction"
+          },
+          "id": "route-vdd1-rail-a-1",
+          "netId": "net-power-vdd1",
+          "presentation": "power-rail",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-1",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-1",
+            "kind": "junction"
+          },
+          "id": "route-vdd1-rail-b-1-a-3",
+          "netId": "net-power-vdd1",
+          "presentation": "power-rail",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-3",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-3",
+            "kind": "junction"
+          },
+          "id": "route-vdd1-rail-b-1-b-3",
+          "netId": "net-power-vdd1",
+          "presentation": "power-rail",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-vdd1-end",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M2",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "id": "route-ui-2",
+          "netId": "net-power-vdd1",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-1",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M1",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "id": "route-ui-4",
+          "netId": "net-power-vdd1",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-3",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M2",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "id": "route-ui-7-a-12",
+          "netId": "net-ui-7",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-12",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-12",
+            "kind": "junction"
+          },
+          "id": "route-ui-7-b-12",
+          "netId": "net-ui-7",
+          "segmentModes": ["manual"],
+          "to": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "id": "route-ui-8-a-18",
+          "netId": "net-ui-8",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-18",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-18",
+            "kind": "junction"
+          },
+          "id": "route-ui-8-b-18",
+          "netId": "net-ui-8",
+          "segmentModes": ["manual"],
+          "to": {
+            "instanceId": "M1",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M2",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "id": "route-ui-9-a-13",
+          "netId": "net-ui-7",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-13",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-13",
+            "kind": "junction"
+          },
+          "id": "route-ui-9-b-13",
+          "netId": "net-ui-7",
+          "segmentModes": ["manual"],
+          "to": {
+            "instanceId": "M1",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-12",
+            "kind": "junction"
+          },
+          "id": "route-ui-14",
+          "netId": "net-ui-7",
+          "segmentModes": ["manual", "manual"],
+          "to": {
+            "junctionId": "junction-ui-13",
+            "kind": "junction"
+          },
+          "waypoints": [
+            {
+              "x": 430,
+              "y": 240
+            }
+          ]
+        },
+        {
+          "from": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "id": "route-ui-15-a-16",
+          "netId": "net-ui-15",
+          "segmentModes": ["manual", "manual"],
+          "to": {
+            "junctionId": "junction-ui-16",
+            "kind": "junction"
+          },
+          "waypoints": [
+            {
+              "x": 380,
+              "y": 330
+            }
+          ]
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-16",
+            "kind": "junction"
+          },
+          "id": "route-ui-15-b-16",
+          "netId": "net-ui-15",
+          "segmentModes": ["manual", "manual"],
+          "to": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "waypoints": [
+            {
+              "x": 500,
+              "y": 330
+            }
+          ]
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-16",
+            "kind": "junction"
+          },
+          "id": "route-ui-17",
+          "netId": "net-ui-15",
+          "segmentModes": ["manual"],
+          "to": {
+            "instanceId": "M5",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-18",
+            "kind": "junction"
+          },
+          "id": "route-ui-19",
+          "netId": "net-ui-8",
+          "segmentModes": ["manual"],
+          "to": {
+            "instanceId": "P3",
+            "kind": "terminal",
+            "pinName": "P"
+          },
+          "waypoints": []
+        }
+      ],
+      "sourceStatus": "connectivity-modified"
+    }
+  ],
+  "externalSubcircuitDefinitions": [],
+  "id": "project-main",
+  "name": "New Circuit",
+  "schemaVersion": 21,
+  "source": {
+    "dialect": "none",
+    "entry": null,
+    "files": [],
+    "sourcePolicy": "copy"
+  },
+  "structureRevision": 0,
+  "symbolLibrary": {
+    "hash": "razavi-reference-v1",
+    "id": "razavi-symbols",
+    "version": "1"
+  },
+  "topDocumentId": "document-main"
+}

--- a/apps/editor/src/examples/fully-differential-two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/fully-differential-two-stage-op-amp.icproj.json
@@ -1,0 +1,2011 @@
+{
+  "documents": [
+    {
+      "annotations": [
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 590,
+              "y": 180
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 10
+            },
+            "objectId": "junction-vdd1-end"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-power-vdd1"
+          },
+          "id": "label-VDD1",
+          "kind": "power-label",
+          "locked": false,
+          "netId": "net-power-vdd1",
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 260,
+              "y": 220
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 10
+            },
+            "objectId": "M1"
+          },
+          "binding": {
+            "instanceId": "M1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 350,
+              "y": 210
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 0
+            },
+            "objectId": "M2"
+          },
+          "binding": {
+            "instanceId": "M2",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 470,
+              "y": 210
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 0
+            },
+            "objectId": "M3"
+          },
+          "binding": {
+            "instanceId": "M3",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M3",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 570,
+              "y": 220
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "M4"
+          },
+          "binding": {
+            "instanceId": "M4",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M4",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 230,
+              "y": 380
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -30,
+              "y": 30
+            },
+            "objectId": "M5"
+          },
+          "binding": {
+            "instanceId": "M5",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M5",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 310,
+              "y": 380
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -30,
+              "y": 30
+            },
+            "objectId": "M6"
+          },
+          "binding": {
+            "instanceId": "M6",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M6",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 500,
+              "y": 380
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 30
+            },
+            "objectId": "M7"
+          },
+          "binding": {
+            "instanceId": "M7",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M5-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 570,
+              "y": 380
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 0,
+              "y": 30
+            },
+            "objectId": "M8"
+          },
+          "binding": {
+            "instanceId": "M8",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M6-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 190,
+              "y": 350
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -40,
+              "y": 0
+            },
+            "objectId": "P1"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-ui-34"
+          },
+          "formatOverride": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "V"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "in"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "subscript"
+              },
+              {
+                "children": [
+                  {
+                    "kind": "text",
+                    "value": "+"
+                  }
+                ],
+                "kind": "span",
+                "style": "superscript"
+              }
+            ]
+          },
+          "id": "instance-label-P1",
+          "kind": "net-label",
+          "locked": false,
+          "netId": "net-ui-34",
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 610,
+              "y": 340
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": -10
+            },
+            "objectId": "P2"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-ui-35"
+          },
+          "formatOverride": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "V"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  },
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "in"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "subscript"
+                  },
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "-"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "superscript"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-P2",
+          "kind": "net-label",
+          "locked": false,
+          "netId": "net-ui-35",
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 380,
+              "y": 330
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 0,
+              "y": -10
+            },
+            "objectId": "C1"
+          },
+          "binding": {
+            "instanceId": "C1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-C1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 430,
+              "y": 330
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": -10
+            },
+            "objectId": "C2"
+          },
+          "binding": {
+            "instanceId": "C2",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-C2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 370,
+              "y": 240
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 0,
+              "y": -10
+            },
+            "objectId": "P3"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-port-p3"
+          },
+          "formatOverride": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "V"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  },
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "out1"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "subscript"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-P3",
+          "kind": "net-label",
+          "locked": false,
+          "netId": "net-port-p3",
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 430,
+              "y": 240
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -30,
+              "y": -10
+            },
+            "objectId": "P4"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-port-p4"
+          },
+          "formatOverride": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "V"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  },
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "out2"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "subscript"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-P4",
+          "kind": "net-label",
+          "locked": false,
+          "netId": "net-port-p4",
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 430,
+              "y": 440
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "I1"
+          },
+          "binding": {
+            "instanceId": "I1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-I1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 290,
+              "y": 460
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "I2"
+          },
+          "binding": {
+            "instanceId": "I2",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-I2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        }
+      ],
+      "constraints": [],
+      "drafting": {
+        "objects": []
+      },
+      "id": "document-main",
+      "instances": [
+        {
+          "id": "M1",
+          "netlist": {
+            "parameters": {},
+            "reference": "M1"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 280,
+              "y": 210
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M1",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M2",
+          "netlist": {
+            "parameters": {},
+            "reference": "M2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 340,
+              "y": 210
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M2",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M3",
+          "netlist": {
+            "parameters": {},
+            "reference": "M3"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 490,
+              "y": 210
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M3",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M4",
+          "netlist": {
+            "parameters": {},
+            "reference": "M4"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 550,
+              "y": 210
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M4",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M5",
+          "netlist": {
+            "parameters": {},
+            "reference": "M5"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 260,
+              "y": 350
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M5",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M6",
+          "netlist": {
+            "parameters": {},
+            "reference": "M6"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 340,
+              "y": 350
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M6",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M7",
+          "netlist": {
+            "parameters": {},
+            "reference": "M7"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 490,
+              "y": 350
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M7",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M8",
+          "netlist": {
+            "parameters": {},
+            "reference": "M8"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 570,
+              "y": 350
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M8",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "P1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 230,
+              "y": 350
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "P2",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 600,
+              "y": 350
+            },
+            "rotation": 180
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "C1",
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "C1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 380,
+              "y": 340
+            },
+            "rotation": 0
+          },
+          "schematicReference": "C1",
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "C2",
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "C2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 450,
+              "y": 340
+            },
+            "rotation": 0
+          },
+          "schematicReference": "C2",
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "GND3",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 380,
+              "y": 370
+            },
+            "rotation": 0
+          },
+          "schematicReference": "GND3",
+          "symbolId": "ground"
+        },
+        {
+          "id": "GND4",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 450,
+              "y": 370
+            },
+            "rotation": 0
+          },
+          "schematicReference": "GND4",
+          "symbolId": "ground"
+        },
+        {
+          "id": "P3",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 370,
+              "y": 250
+            },
+            "rotation": 180
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "P4",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 460,
+              "y": 250
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "I1",
+          "netlist": {
+            "binding": {
+              "deviceClass": "current-source",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "I1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 410,
+              "y": 430
+            },
+            "rotation": 0
+          },
+          "schematicName": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "I"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "SS1"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "subscript"
+              }
+            ]
+          },
+          "schematicReference": "I1",
+          "symbolId": "current-source"
+        },
+        {
+          "id": "I2",
+          "netlist": {
+            "binding": {
+              "deviceClass": "current-source",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "I2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 270,
+              "y": 450
+            },
+            "rotation": 0
+          },
+          "schematicName": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "I"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  },
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "SS"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "subscript"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "2"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "subscript"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "schematicReference": "I2",
+          "symbolId": "current-source"
+        },
+        {
+          "id": "GND1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 270,
+              "y": 480
+            },
+            "rotation": 0
+          },
+          "schematicReference": "GND1",
+          "symbolId": "ground"
+        },
+        {
+          "id": "GND2",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 410,
+              "y": 460
+            },
+            "rotation": 0
+          },
+          "schematicReference": "GND2",
+          "symbolId": "ground"
+        }
+      ],
+      "junctions": [
+        {
+          "id": "junction-vdd1-start",
+          "netId": "net-power-vdd1",
+          "position": {
+            "x": 250,
+            "y": 170
+          },
+          "role": "route-anchor"
+        },
+        {
+          "id": "junction-vdd1-end",
+          "netId": "net-power-vdd1",
+          "position": {
+            "x": 580,
+            "y": 170
+          },
+          "role": "route-anchor"
+        },
+        {
+          "id": "junction-ui-20",
+          "netId": "net-power-vdd1",
+          "position": {
+            "x": 270,
+            "y": 170
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-22",
+          "netId": "net-power-vdd1",
+          "position": {
+            "x": 350,
+            "y": 170
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-24",
+          "netId": "net-power-vdd1",
+          "position": {
+            "x": 480,
+            "y": 170
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-26",
+          "netId": "net-power-vdd1",
+          "position": {
+            "x": 560,
+            "y": 170
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-36",
+          "netId": "net-port-p3",
+          "position": {
+            "x": 350,
+            "y": 320
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-38",
+          "netId": "net-port-p4",
+          "position": {
+            "x": 480,
+            "y": 320
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-40",
+          "netId": "net-ui-28",
+          "position": {
+            "x": 310,
+            "y": 210
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-41",
+          "netId": "net-ui-28",
+          "position": {
+            "x": 270,
+            "y": 240
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-43",
+          "netId": "net-ui-29",
+          "position": {
+            "x": 520,
+            "y": 210
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-44",
+          "netId": "net-ui-29",
+          "position": {
+            "x": 560,
+            "y": 240
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-50",
+          "netId": "net-port-p3",
+          "position": {
+            "x": 350,
+            "y": 250
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-52",
+          "netId": "net-port-p4",
+          "position": {
+            "x": 480,
+            "y": 250
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-58",
+          "netId": "net-contact-gnd1",
+          "position": {
+            "x": 410,
+            "y": 390
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-60",
+          "netId": "net-contact-gnd1",
+          "position": {
+            "x": 270,
+            "y": 410
+          },
+          "role": "branch"
+        }
+      ],
+      "layoutGroups": [],
+      "name": "Main",
+      "netlist": {
+        "formalParameters": [],
+        "name": "Main",
+        "terminals": []
+      },
+      "nets": [
+        {
+          "id": "net-contact-gnd1",
+          "name": "0",
+          "origin": {
+            "kind": "authored"
+          },
+          "powerDomain": "ground",
+          "scope": "global",
+          "terminals": [
+            {
+              "instanceId": "M5",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M6",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "GND3",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "C1",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "GND4",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "C2",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "I2",
+              "pinName": "+"
+            },
+            {
+              "instanceId": "M7",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "I1",
+              "pinName": "+"
+            },
+            {
+              "instanceId": "M8",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "GND1",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "GND2",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "I1",
+              "pinName": "-"
+            },
+            {
+              "instanceId": "I2",
+              "pinName": "-"
+            }
+          ]
+        },
+        {
+          "id": "net-power-vdd1",
+          "name": "VDD",
+          "origin": {
+            "kind": "authored"
+          },
+          "powerDomain": "vdd",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "M1",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "S"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-28",
+          "origin": {
+            "kind": "authored"
+          },
+          "powerDomain": "none",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "M1",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M8",
+              "pinName": "D"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-29",
+          "origin": {
+            "kind": "authored"
+          },
+          "powerDomain": "none",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "M3",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "D"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-34",
+          "name": "Vin+",
+          "origin": {
+            "kind": "authored"
+          },
+          "powerDomain": "none",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "M6",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "P1",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-35",
+          "name": "Vin-",
+          "origin": {
+            "kind": "authored"
+          },
+          "powerDomain": "none",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "M7",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M8",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "P2",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-port-p3",
+          "name": "Vout1",
+          "origin": {
+            "kind": "authored"
+          },
+          "powerDomain": "none",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "P3",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M6",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "C1",
+              "pinName": "1"
+            }
+          ]
+        },
+        {
+          "id": "net-port-p4",
+          "name": "Vout2",
+          "origin": {
+            "kind": "authored"
+          },
+          "powerDomain": "none",
+          "scope": "local",
+          "terminals": [
+            {
+              "instanceId": "P4",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M7",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "C2",
+              "pinName": "1"
+            }
+          ]
+        }
+      ],
+      "noConnects": [],
+      "presentation": {
+        "compactness": "normal",
+        "grid": 10,
+        "styleProfileId": "razavi-textbook-v1"
+      },
+      "revision": 302,
+      "routes": [
+        {
+          "from": {
+            "junctionId": "junction-vdd1-start",
+            "kind": "junction"
+          },
+          "id": "route-vdd1-rail-a-20",
+          "netId": "net-power-vdd1",
+          "presentation": "power-rail",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-20",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-20",
+            "kind": "junction"
+          },
+          "id": "route-vdd1-rail-b-20-a-22",
+          "netId": "net-power-vdd1",
+          "presentation": "power-rail",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-22",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-22",
+            "kind": "junction"
+          },
+          "id": "route-vdd1-rail-b-20-b-22-a-24",
+          "netId": "net-power-vdd1",
+          "presentation": "power-rail",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-24",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-24",
+            "kind": "junction"
+          },
+          "id": "route-vdd1-rail-b-20-b-22-b-24-a-26",
+          "netId": "net-power-vdd1",
+          "presentation": "power-rail",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-26",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-26",
+            "kind": "junction"
+          },
+          "id": "route-vdd1-rail-b-20-b-22-b-24-b-26",
+          "netId": "net-power-vdd1",
+          "presentation": "power-rail",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-vdd1-end",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M1",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "id": "route-ui-21",
+          "netId": "net-power-vdd1",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-20",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M2",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "id": "route-ui-23",
+          "netId": "net-power-vdd1",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-22",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "id": "route-ui-25",
+          "netId": "net-power-vdd1",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-24",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "id": "route-ui-27",
+          "netId": "net-power-vdd1",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-26",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M1",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "id": "route-ui-28-a-40",
+          "netId": "net-ui-28",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-40",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-40",
+            "kind": "junction"
+          },
+          "id": "route-ui-28-b-40",
+          "netId": "net-ui-28",
+          "segmentModes": ["manual"],
+          "to": {
+            "instanceId": "M2",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "id": "route-ui-29-a-43",
+          "netId": "net-ui-29",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-43",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-43",
+            "kind": "junction"
+          },
+          "id": "route-ui-29-b-43",
+          "netId": "net-ui-29",
+          "segmentModes": ["manual"],
+          "to": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M2",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "id": "route-ui-30-a-36-a-50",
+          "netId": "net-port-p3",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-50",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-50",
+            "kind": "junction"
+          },
+          "id": "route-ui-30-a-36-b-50",
+          "netId": "net-port-p3",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-36",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-36",
+            "kind": "junction"
+          },
+          "id": "route-ui-30-b-36",
+          "netId": "net-port-p3",
+          "segmentModes": ["manual"],
+          "to": {
+            "instanceId": "M6",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "id": "route-ui-31-a-38-a-52",
+          "netId": "net-port-p4",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-52",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-52",
+            "kind": "junction"
+          },
+          "id": "route-ui-31-a-38-b-52",
+          "netId": "net-port-p4",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-38",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-38",
+            "kind": "junction"
+          },
+          "id": "route-ui-31-b-38",
+          "netId": "net-port-p4",
+          "segmentModes": ["manual"],
+          "to": {
+            "instanceId": "M7",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M1",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "id": "route-ui-32-a-41",
+          "netId": "net-ui-28",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-41",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-41",
+            "kind": "junction"
+          },
+          "id": "route-ui-32-b-41",
+          "netId": "net-ui-28",
+          "segmentModes": ["manual", "manual", "manual", "manual", "manual"],
+          "to": {
+            "instanceId": "M8",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "waypoints": [
+            {
+              "x": 270,
+              "y": 270
+            },
+            {
+              "x": 400,
+              "y": 270
+            },
+            {
+              "x": 430,
+              "y": 300
+            },
+            {
+              "x": 560,
+              "y": 300
+            }
+          ]
+        },
+        {
+          "from": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "id": "route-ui-33-a-44",
+          "netId": "net-ui-29",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-44",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-44",
+            "kind": "junction"
+          },
+          "id": "route-ui-33-b-44",
+          "netId": "net-ui-29",
+          "segmentModes": ["manual", "manual", "manual", "manual", "manual"],
+          "to": {
+            "instanceId": "M5",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "waypoints": [
+            {
+              "x": 560,
+              "y": 270
+            },
+            {
+              "x": 430,
+              "y": 270
+            },
+            {
+              "x": 400,
+              "y": 300
+            },
+            {
+              "x": 270,
+              "y": 300
+            }
+          ]
+        },
+        {
+          "from": {
+            "instanceId": "M6",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "id": "route-ui-34",
+          "netId": "net-ui-34",
+          "segmentModes": ["manual"],
+          "to": {
+            "instanceId": "M5",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M7",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "id": "route-ui-35",
+          "netId": "net-ui-35",
+          "segmentModes": ["manual"],
+          "to": {
+            "instanceId": "M8",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-36",
+            "kind": "junction"
+          },
+          "id": "route-ui-37",
+          "netId": "net-port-p3",
+          "segmentModes": ["manual"],
+          "to": {
+            "instanceId": "C1",
+            "kind": "terminal",
+            "pinName": "1"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "C2",
+            "kind": "terminal",
+            "pinName": "1"
+          },
+          "id": "route-ui-39",
+          "netId": "net-port-p4",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-38",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-40",
+            "kind": "junction"
+          },
+          "id": "route-ui-42",
+          "netId": "net-ui-28",
+          "segmentModes": ["manual", "manual"],
+          "to": {
+            "junctionId": "junction-ui-41",
+            "kind": "junction"
+          },
+          "waypoints": [
+            {
+              "x": 310,
+              "y": 240
+            }
+          ]
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-43",
+            "kind": "junction"
+          },
+          "id": "route-ui-45",
+          "netId": "net-ui-29",
+          "segmentModes": ["manual", "manual"],
+          "to": {
+            "junctionId": "junction-ui-44",
+            "kind": "junction"
+          },
+          "waypoints": [
+            {
+              "x": 520,
+              "y": 240
+            }
+          ]
+        },
+        {
+          "from": {
+            "instanceId": "P3",
+            "kind": "terminal",
+            "pinName": "P"
+          },
+          "id": "route-ui-51",
+          "netId": "net-port-p3",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-50",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "P4",
+            "kind": "terminal",
+            "pinName": "P"
+          },
+          "id": "route-ui-53",
+          "netId": "net-port-p4",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-52",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M5",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "id": "route-ui-56-a-60",
+          "netId": "net-contact-gnd1",
+          "segmentModes": ["manual"],
+          "to": {
+            "junctionId": "junction-ui-60",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-60",
+            "kind": "junction"
+          },
+          "id": "route-ui-56-b-60",
+          "netId": "net-contact-gnd1",
+          "segmentModes": ["manual"],
+          "to": {
+            "instanceId": "I2",
+            "kind": "terminal",
+            "pinName": "+"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M6",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "id": "route-ui-57-a-58",
+          "netId": "net-contact-gnd1",
+          "segmentModes": ["manual", "manual"],
+          "to": {
+            "junctionId": "junction-ui-58",
+            "kind": "junction"
+          },
+          "waypoints": [
+            {
+              "x": 350,
+              "y": 390
+            }
+          ]
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-58",
+            "kind": "junction"
+          },
+          "id": "route-ui-57-b-58",
+          "netId": "net-contact-gnd1",
+          "segmentModes": ["manual", "manual"],
+          "to": {
+            "instanceId": "M7",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "waypoints": [
+            {
+              "x": 480,
+              "y": 390
+            }
+          ]
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-58",
+            "kind": "junction"
+          },
+          "id": "route-ui-59",
+          "netId": "net-contact-gnd1",
+          "segmentModes": ["manual"],
+          "to": {
+            "instanceId": "I1",
+            "kind": "terminal",
+            "pinName": "+"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-60",
+            "kind": "junction"
+          },
+          "id": "route-ui-61",
+          "netId": "net-contact-gnd1",
+          "segmentModes": ["manual", "manual"],
+          "to": {
+            "instanceId": "M8",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "waypoints": [
+            {
+              "x": 560,
+              "y": 410
+            }
+          ]
+        }
+      ],
+      "sourceStatus": "connectivity-modified"
+    }
+  ],
+  "externalSubcircuitDefinitions": [],
+  "id": "project-main",
+  "name": "New Circuit",
+  "schemaVersion": 21,
+  "source": {
+    "dialect": "none",
+    "entry": null,
+    "files": [],
+    "sourcePolicy": "copy"
+  },
+  "structureRevision": 0,
+  "symbolLibrary": {
+    "hash": "razavi-reference-v1",
+    "id": "razavi-symbols",
+    "version": "1"
+  },
+  "topDocumentId": "document-main"
+}

--- a/apps/editor/src/examples/library-examples.test.ts
+++ b/apps/editor/src/examples/library-examples.test.ts
@@ -9,11 +9,15 @@ import {
 
 describe("bundled Library Project examples", () => {
   it("ships canonical, schema-current, openable Projects", () => {
-    // The curated pair stays; promoted examples may extend the set (see
-    // scripts/promote-example.mjs), so the contract is per-example, not a
+    // Bundled examples can grow, so the contract is per-example rather than a
     // frozen count or single-document shape.
     expect(libraryProjectExamples.map((example) => example.id)).toEqual(
-      expect.arrayContaining(["common-source-amplifier", "two-stage-op-amp"]),
+      expect.arrayContaining([
+        "common-source-amplifier",
+        "two-stage-op-amp",
+        "current-mirror-loaded-differential-pair",
+        "fully-differential-two-stage-op-amp",
+      ]),
     );
     expect(
       new Set(libraryProjectExamples.map((example) => example.id)).size,

--- a/apps/editor/src/examples/library-examples.ts
+++ b/apps/editor/src/examples/library-examples.ts
@@ -2,6 +2,8 @@ import type { CircuitProject } from "@icm/model";
 import { parseProject } from "@icm/project-protocol";
 
 import commonSourceAmplifier from "./common-source-amplifier.icproj.json";
+import currentMirrorLoadedDifferentialPair from "./current-mirror-loaded-differential-pair.icproj.json";
+import fullyDifferentialTwoStageOpAmp from "./fully-differential-two-stage-op-amp.icproj.json";
 import twoStageOpAmp from "./two-stage-op-amp.icproj.json";
 
 export interface LibraryProjectExample {
@@ -32,6 +34,18 @@ export const libraryProjectExamples: readonly LibraryProjectExample[] = [
     name: "Two-Stage Op Amp",
     description: "Miller-compensated amplifier",
     project: bundledProject(twoStageOpAmp),
+  },
+  {
+    id: "current-mirror-loaded-differential-pair",
+    name: "Current-Mirror-Loaded Differential Pair",
+    description: "NMOS differential pair with PMOS active load",
+    project: bundledProject(currentMirrorLoadedDifferentialPair),
+  },
+  {
+    id: "fully-differential-two-stage-op-amp",
+    name: "Fully Differential Two-Stage Op Amp",
+    description: "Differential CMOS amplifier with capacitive loads",
+    project: bundledProject(fullyDifferentialTwoStageOpAmp),
   },
 ];
 

--- a/apps/editor/src/features/editor-shell/use-editor-panels.ts
+++ b/apps/editor/src/features/editor-shell/use-editor-panels.ts
@@ -103,6 +103,26 @@ export function useEditorPanels(options: UseEditorPanelsOptions) {
     });
   };
 
+  const toggleExamplesPanel = (): void => {
+    if (leftPanelMode !== "examples") {
+      showLeftPanel("examples");
+      return;
+    }
+    if (compactLayout) {
+      setCompactLibraryPanelOpen((current) => {
+        const next = !current;
+        if (next) setSelectionOpen(false);
+        return next;
+      });
+      return;
+    }
+    setLibraryPanelOpen((current) => {
+      const next = !current;
+      persistLibraryOpen(next);
+      return next;
+    });
+  };
+
   const closeHelp = (): void => {
     setHelpOpen(false);
     requestAnimationFrame(() => options.helpButtonRef.current?.focus());
@@ -147,6 +167,7 @@ export function useEditorPanels(options: UseEditorPanelsOptions) {
     setSearchQuery,
     setSelectionOpen,
     showLeftPanel,
+    toggleExamplesPanel,
     toggleLibraryPanel,
   };
 }

--- a/plan/2026-08-22-examples-toggle-and-circuits/plan.md
+++ b/plan/2026-08-22-examples-toggle-and-circuits/plan.md
@@ -1,0 +1,93 @@
+---
+status: completed
+experience: none
+---
+
+# Examples toggle and bundled circuit additions
+
+## Goal
+
+Make a second click on the left-rail Examples control collapse its panel, matching the Library control, and publish the two user-supplied Project files as named bundled Examples.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main [ahead 3, behind 9]
+?? .pnpm-store/
+?? .worktrees/
+```
+
+The untracked dependency cache and worktree container are unrelated and will be left untouched. This target owns only the Examples-panel state, bundled Example assets/metadata, and their focused tests.
+
+- `apps/editor/src/features/editor-shell/use-editor-panels.ts`
+- `apps/editor/src/examples/library-examples.ts`
+- `apps/editor/src/examples/library-examples.test.ts`
+- `apps/editor/src/examples/*.icproj.json` for the two curated Projects
+- `apps/editor/e2e/component-insert.spec.ts`
+- `plan/2026-08-22-examples-toggle-and-circuits/plan.md`
+- `plan/log.md`
+
+- Read-only: `apps/editor/src/app/App.tsx`, `apps/editor/src/features/editor-shell/examples-panel.tsx`, supplied files in `E:/Downloads/`.
+- Shared: Project parsing/schema migration through `@icm/project-protocol`; the left-panel mode contract in `useEditorPanels`.
+
+## Work
+
+1. Add a mode-aware Examples toggle that collapses an open Examples panel and otherwise opens it, preserving the established Library behavior.
+2. Bundle the two supplied Project files with concise topology-based names and list them in the Example registry.
+3. Extend focused unit and browser coverage for the new toggle and named cards.
+
+## Validation
+
+- `pnpm test:local apps/editor/src/examples/library-examples.test.ts`
+- `pnpm test:e2e:local apps/editor/e2e/component-insert.spec.ts --grep "opens named full-width Project examples"`
+- `pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts`
+- `pnpm test:impact -- --base main`
+- `pnpm gate:preflight -- --base main`
+- `pnpm gate:affected -- --base main`
+- `git diff --check`
+- `git status --short --branch`
+
+## Gate Review
+
+- Decision: affected
+- Early gates: `pnpm gate:review:check -- --base main`, `pnpm ci:static`, and `pnpm test:impact -- --base main`.
+- Affected gates: focused registry unit test plus `component-insert` and full `manual-editor` browser coverage; then `pnpm gate:affected -- --base main`.
+- Final gates: `pnpm ci:check` and remote required checks before any merge to `main`.
+- Platform risks: browser panel state must match desktop and compact behavior; source Project assets must parse to the current schema.
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: an active Examples toggle collapses the left panel; each built-in card has a unique ID, a non-empty name, and opens as a current-schema Project.
+- Primary checks: `apps/editor/src/examples/library-examples.test.ts`; `apps/editor/e2e/component-insert.spec.ts`; `apps/editor/e2e/manual-editor.spec.ts`.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): add bundled differential examples
+```
+
+## Outcome
+
+Examples now mirror Library's toggle semantics: a repeated click folds the
+active Examples panel and a later click opens it again. Added the supplied
+current-mirror-loaded differential pair and fully differential two-stage op
+amp as schema-current bundled Projects with named cards.
+
+Validation passed:
+
+- `pnpm test:local apps/editor/src/examples/library-examples.test.ts`
+- focused `component-insert` Example test
+- `pnpm gate:preflight -- --base main`
+- `pnpm gate:affected -- --base main` (1108 unit tests, 22 component-insert
+  browser tests, and 91 manual-editor browser tests)
+- `git diff --check`
+
+The first standalone manual-editor run was interrupted by an orphaned
+Playwright process from an earlier invocation; after stopping only those
+verified test processes, the canonical affected gate reran the suite cleanly.
+Commit status: committed locally on `codex/examples-toggle-and-circuits`.

--- a/plan/2026-08-22-merge-examples-main/plan.md
+++ b/plan/2026-08-22-merge-examples-main/plan.md
@@ -1,0 +1,71 @@
+---
+status: active
+experience: none
+---
+
+# Deliver Examples toggle and bundled circuits to main
+
+## Goal
+
+Rebase `codex/examples-toggle-and-circuits` onto current `origin/main`, complete the canonical mainline checks, and merge the reviewed branch into remote `main`.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/examples-toggle-and-circuits...origin/codex/examples-toggle-and-circuits
+?? .pnpm-store/
+?? .worktrees/
+```
+
+The untracked local dependency cache and linked-worktree directory are unrelated and will remain untouched. This delivery target owns the branch integration and its records; the implementation files are already committed in `65250cf5`.
+
+- `plan/2026-08-22-merge-examples-main/plan.md`
+- `plan/log.md`
+
+- Read-only: committed Examples implementation in `65250cf5`, `origin/main`, and GitHub Actions results.
+- Shared: remote `main`, branch protection, package lockfile and mainline CI commands.
+
+## Work
+
+1. Rebase the reviewed Example change onto current `origin/main`, resolving only conflicts attributable to this branch.
+2. Run the canonical fresh-install and CI check required for mainline delivery.
+3. Push the rebased review branch, open a pull request, wait for required checks, and merge it through GitHub.
+
+## Validation
+
+- `pnpm install --frozen-lockfile`
+- `pnpm ci:check`
+- GitHub Actions required checks on the review pull request
+- `git diff --check`
+- `git status --short --branch`
+
+## Gate Review
+
+- Decision: full
+- Early gates: fresh frozen dependency install before the canonical CI check.
+- Affected gates: already completed for `65250cf5`; rebase conflicts would require rerunning the relevant affected gate.
+- Final gates: `pnpm ci:check`, remote required checks, and GitHub merge.
+- Platform risks: rebase may duplicate or conflict with upstream changes; remote branch protection is authoritative.
+
+## Test Impact
+
+- Decision: no-test-change
+- Reason: this delivery target only rebases previously tested implementation and
+  resolves a plan-log conflict; it introduces no behavioral source change.
+- Existing protection: `apps/editor/src/examples/library-examples.test.ts` and
+  `apps/editor/e2e/component-insert.spec.ts` were updated and passed for the
+  implementation target.
+
+## Commit Intent
+
+Commit as:
+
+```text
+docs(plan): record examples mainline delivery
+```
+
+## Outcome
+
+Update after merge with the rebased commit, CI and remote-check status, and merge commit or PR reference.

--- a/plan/2026-08-22-merge-examples-main/plan.md
+++ b/plan/2026-08-22-merge-examples-main/plan.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: completed
 experience: none
 ---
 
@@ -68,4 +68,8 @@ docs(plan): record examples mainline delivery
 
 ## Outcome
 
-Update after merge with the rebased commit, CI and remote-check status, and merge commit or PR reference.
+Rebased the Examples feature as `9463fd87` on `d24a5ee2` (`origin/main`),
+resolving only the concurrent `plan/log.md` entries. `pnpm gate:preflight --
+--base origin/main`, `pnpm install --frozen-lockfile`, and `pnpm ci:check`
+passed locally; Playwright recorded a passed run with no failed tests. The
+rebased review branch is ready to push for required GitHub checks and merge.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4363,3 +4363,13 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   #159 before close-out.
 - Commit status: delivered to `codex/sky130-logic-vdd-cap-stack`; PR #159 open
   for review, superseding closed draft PR #141.
+
+## 2026-08-22 — Examples toggle and bundled circuit additions
+
+- Target: `plan/2026-08-22-examples-toggle-and-circuits/plan.md` (completed).
+- Change: Examples now collapses when its active rail button is clicked again;
+  added bundled Current-Mirror-Loaded Differential Pair and Fully Differential
+  Two-Stage Op Amp Project cards.
+- Validation: focused unit/browser checks, preflight, and affected gate
+  (1108 unit tests; 22 component-insert and 91 manual-editor browser tests).
+- Commit status: committed locally on `codex/examples-toggle-and-circuits`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4373,3 +4373,14 @@ Keep reusable lessons in `docs/experience/`, not in this log.
 - Validation: focused unit/browser checks, preflight, and affected gate
   (1108 unit tests; 22 component-insert and 91 manual-editor browser tests).
 - Commit status: committed locally on `codex/examples-toggle-and-circuits`.
+
+## 2026-08-22 — Examples mainline delivery
+
+- Target: `plan/2026-08-22-merge-examples-main/plan.md` (completed).
+- Change: rebased the completed Examples feature on current `origin/main`,
+  retaining concurrent plan-log entries without changing product behavior.
+- Validation: preflight against `origin/main`, frozen dependency install, and
+  canonical `pnpm ci:check`; the full Playwright run recorded `passed` with no
+  failed tests.
+- Commit status: rebased review branch is ready for required GitHub checks and
+  merge to remote `main`.


### PR DESCRIPTION
## Summary
- make the Examples rail button toggle its panel like Library
- add current-mirror-loaded differential-pair and fully differential two-stage op-amp projects
- record mainline delivery validation

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm install --frozen-lockfile
- pnpm ci:check