### PR TITLE
refactor(editor): tighten the editor chrome

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -1078,7 +1078,7 @@ test("double-clicking a placed device opens Properties for editing", async ({
   await expect(propertyValue).toBeFocused();
 });
 
-test("Library rail folds the sidebar; Insert and title open the catalog", async ({
+test("Library rail folds the sidebar; Insert opens the catalog", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -1099,10 +1099,11 @@ test("Library rail folds the sidebar; Insert and title open the catalog", async 
     page.getByRole("dialog", { name: "Insert Component" }),
   ).toHaveCount(0);
 
-  await page
-    .getByRole("button", { name: /Library/ })
-    .filter({ hasText: "Quick place" })
-    .click();
+  // No title banner competes with the footer button or the shortcut.
+  await expect(panel.getByRole("button", { name: /Quick place/ })).toHaveCount(
+    0,
+  );
+  await page.keyboard.press("i");
   await expect(
     page.getByRole("dialog", { name: "Insert Component" }),
   ).toBeVisible();

--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -4,8 +4,6 @@ import type { Page } from "@playwright/test";
 import { createEmptyProject } from "@icm/model";
 import { serializeProject } from "@icm/project-protocol";
 
-import { clickCommand } from "./editor-fixtures.js";
-
 const ENTRY = {
   id: "g-ring",
   name: "Ring Oscillator",
@@ -82,7 +80,10 @@ test("a gallery tile opens its circuit in the editor", async ({ page }) => {
   await expect(
     page.getByRole("link", { name: "Back to the gallery", exact: true }),
   ).toHaveAttribute("href", "/");
-  await expect(page.locator(".app-brand-copy h1")).toHaveText("Analog Canvas");
+  // The wordmark is part of the gallery link now, so the switch works both ways.
+  await expect(page.locator(".gallery-home-link h1")).toHaveText(
+    "Analog Canvas",
+  );
   const backLink = page.getByTestId("toolbar-gallery-link");
   await expect(backLink).toBeVisible();
   await backLink.click();
@@ -162,7 +163,7 @@ test("a signed-in owner renames the display name and signs out", async ({
   expect(loggedOut).toBe(1);
 });
 
-test("File > Publish to Gallery posts the live Project with the passphrase", async ({
+test("the Publish button posts the live Project with the passphrase", async ({
   page,
 }) => {
   const posted: { authorization: string | null; body: string }[] = [];
@@ -181,7 +182,7 @@ test("File > Publish to Gallery posts the live Project with the passphrase", asy
   });
 
   await page.goto("/editor");
-  await clickCommand(page, "File", "Publish to Gallery…");
+  await page.getByTestId("publish-gallery-button").click();
   const dialog = page.getByTestId("publish-gallery-dialog");
   await expect(dialog).toBeVisible();
 
@@ -208,7 +209,7 @@ test("File > Publish to Gallery posts the live Project with the passphrase", asy
   expect(JSON.parse(body.projectText).schemaVersion).toBe(ENTRY.schemaVersion);
 
   // The passphrase is remembered for the session and offered on reopen.
-  await clickCommand(page, "File", "Publish to Gallery…");
+  await page.getByTestId("publish-gallery-button").click();
   await expect(
     page.getByTestId("publish-gallery-dialog").getByLabel("Owner passphrase"),
   ).toHaveValue("secret-token");
@@ -241,7 +242,7 @@ test("an admin session publishes without the passphrase row", async ({
   });
 
   await page.goto("/editor");
-  await clickCommand(page, "File", "Publish to Gallery…");
+  await page.getByTestId("publish-gallery-button").click();
   const dialog = page.getByTestId("publish-gallery-dialog");
   await expect(dialog).toBeVisible();
   await expect(dialog.getByText("Signed in as Token Zhang")).toBeVisible();

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3252,7 +3252,8 @@ test("dismisses a command menu on outside click or Escape", async ({
   const fileMenu = await openMenu(page, "File");
   await expect(fileMenu).toHaveAttribute("open", "");
 
-  await page.getByRole("heading", { name: "Analog Canvas" }).click();
+  // The wordmark now navigates to the gallery, so dismiss on a neutral spot.
+  await page.locator(".app-brand-copy p").click();
   await expect(fileMenu).not.toHaveAttribute("open", "");
 
   await openMenu(page, "File");
@@ -3610,7 +3611,7 @@ test("Document style dialog scales fonts document-wide and resets", async ({
   await reset.click();
   await expect(label).toHaveAttribute("font-size", "15.116");
   await expect(reset).toBeDisabled();
-  await dialog.getByRole("button", { name: "Close", exact: true }).click();
+  await dialog.getByRole("button", { name: "Done", exact: true }).click();
   await expect(dialog).toHaveCount(0);
 });
 

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type {
+  CSSProperties,
   DragEvent,
   MouseEvent as ReactMouseEvent,
   PointerEvent as ReactPointerEvent,
@@ -309,7 +310,11 @@ import { useSelectionController } from "../features/selection/selection-controll
 import { usePropertiesEditor } from "../features/properties/use-properties-editor";
 import { InstanceTableDialog } from "../features/properties/instance-table-dialog";
 import { capacitorPlatePropertyRows } from "../features/properties/capacitor-plate-properties";
-import { useEditorPanels } from "../features/editor-shell/use-editor-panels";
+import {
+  LIBRARY_WIDTH_MAX,
+  LIBRARY_WIDTH_MIN,
+  useEditorPanels,
+} from "../features/editor-shell/use-editor-panels";
 import {
   type InstanceMovePreview,
   useSelectionInteraction,
@@ -370,6 +375,7 @@ import type { SnapAnchor, SnapGuideLine, SnapResult } from "../snap/engine";
 const DEFAULT_VIEWBOX: GridRect = { x: 0, y: 0, width: 960, height: 640 };
 const RECENT_COMPONENTS_STORAGE_KEY = "icm.recent-components.v1";
 const LIBRARY_PANEL_STORAGE_KEY = "icm.library-panel-open.v1";
+const LIBRARY_WIDTH_STORAGE_KEY = "icm.library-panel-width.v1";
 const REFRESH_RESTORE_STORAGE_KEY = "icm.restore-after-refresh.v1";
 const COMPACT_LAYOUT_MEDIA_QUERY = "(max-width: 860px)";
 const DRAG_START_DISTANCE_PX = 4;
@@ -473,9 +479,15 @@ export function App({
   const helpCloseRef = useRef<HTMLButtonElement>(null);
   const aboutButtonRef = useRef<HTMLButtonElement>(null);
   const aboutCloseRef = useRef<HTMLButtonElement>(null);
+  const libraryResizeOriginRef = useRef<{
+    pointerX: number;
+    width: number;
+  } | null>(null);
   const {
     libraryPanelOpen,
     setLibraryPanelOpen,
+    libraryWidth,
+    setLibraryWidth,
     compactLayout,
     setCompactLayout,
     compactLibraryPanelOpen,
@@ -508,6 +520,7 @@ export function App({
     initialCompact: compactLayoutMatches(COMPACT_LAYOUT_MEDIA_QUERY),
     compactMediaQuery: COMPACT_LAYOUT_MEDIA_QUERY,
     libraryStorageKey: LIBRARY_PANEL_STORAGE_KEY,
+    libraryWidthStorageKey: LIBRARY_WIDTH_STORAGE_KEY,
     helpButtonRef,
     helpCloseRef,
     aboutButtonRef,
@@ -6918,9 +6931,9 @@ export function App({
               title="Back to the gallery"
             >
               <span className="app-brand-mark" aria-hidden="true" />
+              <h1 title="Analog Canvas">Analog Canvas</h1>
             </a>
             <div className="app-brand-copy">
-              <h1 title="Analog Canvas">Analog Canvas</h1>
               <p title={`${project.name} / ${document.name}`}>
                 {project.name} /{" "}
                 <span data-testid="active-document-name">{document.name}</span>
@@ -6981,14 +6994,6 @@ export function App({
                     onClick={() => void saveCurrentProjectAsExample()}
                   >
                     Save as Example
-                  </button>
-                  <button
-                    type="button"
-                    aria-haspopup="dialog"
-                    aria-expanded={publishGalleryOpen}
-                    onClick={() => setPublishGalleryOpen(true)}
-                  >
-                    Publish to Gallery…
                   </button>
                   <span className="command-group-label">Export</span>
                   <button
@@ -7148,6 +7153,15 @@ export function App({
                 onClick={() => setSearchOpen(true)}
               >
                 Search
+              </button>
+              <button
+                type="button"
+                data-testid="publish-gallery-button"
+                aria-haspopup="dialog"
+                aria-expanded={publishGalleryOpen}
+                onClick={() => setPublishGalleryOpen(true)}
+              >
+                Publish…
               </button>
             </div>
           </nav>
@@ -7644,6 +7658,7 @@ export function App({
             ? "app-workspace"
             : "app-workspace library-collapsed"
         }
+        style={{ "--icm-shapes-width": `${libraryWidth}px` } as CSSProperties}
       >
         <aside className="tool-rail" aria-label="Tool rail">
           <button
@@ -7701,6 +7716,46 @@ export function App({
             onDeleteUserExample={(id) => void deleteUserExample(id)}
           />
         )}
+        {visibleLibraryPanelOpen ? (
+          <div
+            className="library-resize-handle"
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize the Library panel"
+            aria-valuenow={libraryWidth}
+            aria-valuemin={LIBRARY_WIDTH_MIN}
+            aria-valuemax={LIBRARY_WIDTH_MAX}
+            tabIndex={0}
+            data-testid="library-resize-handle"
+            onPointerDown={(event) => {
+              event.preventDefault();
+              event.currentTarget.setPointerCapture(event.pointerId);
+              libraryResizeOriginRef.current = {
+                pointerX: event.clientX,
+                width: libraryWidth,
+              };
+            }}
+            onPointerMove={(event) => {
+              const origin = libraryResizeOriginRef.current;
+              if (!origin) return;
+              setLibraryWidth(origin.width + (event.clientX - origin.pointerX));
+            }}
+            onPointerUp={(event) => {
+              libraryResizeOriginRef.current = null;
+              event.currentTarget.releasePointerCapture(event.pointerId);
+            }}
+            onKeyDown={(event) => {
+              const step = event.shiftKey ? 32 : 8;
+              if (event.key === "ArrowLeft") {
+                event.preventDefault();
+                setLibraryWidth(libraryWidth - step);
+              } else if (event.key === "ArrowRight") {
+                event.preventDefault();
+                setLibraryWidth(libraryWidth + step);
+              }
+            }}
+          />
+        ) : null}
         <aside
           className={selectionOpen ? "selection-dock open" : "selection-dock"}
           aria-label="Properties"

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -89,13 +89,19 @@ export function GalleryFeed() {
   return (
     <main className="gallery-shell" data-testid="gallery-feed">
       <header className="gallery-chrome">
-        <div className="gallery-brand">
+        <a
+          className="gallery-brand"
+          href="/editor"
+          aria-label="Open the editor"
+          title="Open the editor"
+          data-testid="gallery-editor-link"
+        >
           <span className="app-brand-mark" aria-hidden="true" />
           <div>
             <h1>Analog Canvas</h1>
             <p>Community circuit gallery</p>
           </div>
-        </div>
+        </a>
         <nav className="gallery-actions">
           <AccountMenu />
           <a

--- a/apps/editor/src/features/editor-shell/examples-panel.tsx
+++ b/apps/editor/src/features/editor-shell/examples-panel.tsx
@@ -46,13 +46,6 @@ export function ExamplesPanel({
       data-testid="examples-panel"
       data-open={open ? "true" : "false"}
     >
-      <header className="shapes-panel-header">
-        <div className="shapes-panel-static-title">
-          <span className="shapes-kicker">Quick place</span>
-          <span className="shapes-panel-heading">Examples</span>
-        </div>
-      </header>
-
       <div className="shapes-panel-body">
         <div className="shapes-example-list">
           {libraryProjectExamples.map((example) => (

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -154,18 +154,6 @@ export function ShapesPanel({
       data-testid="shapes-library-panel"
       data-open={open ? "true" : "false"}
     >
-      <header className="shapes-panel-header">
-        <button
-          type="button"
-          className="shapes-panel-title"
-          onClick={() => onStartInsert(fullInsertLaunch())}
-          title="Open insert dialog (I)"
-        >
-          <span className="shapes-kicker">Quick place</span>
-          <span className="shapes-panel-heading">Library</span>
-        </button>
-      </header>
-
       <div className="shapes-panel-body">
         <details className="shapes-fold" open data-testid="shapes-fold-library">
           <summary className="shapes-fold-summary">

--- a/apps/editor/src/features/editor-shell/style-dialog.tsx
+++ b/apps/editor/src/features/editor-shell/style-dialog.tsx
@@ -87,6 +87,7 @@ export function StyleDialog({ overrides, onApply, onClose }: StyleDialogProps) {
   const changeKnob = (key: keyof StyleOverrides, value: number): void => {
     onApply(normalizedStyleOverrides({ ...draft, [key]: value }));
   };
+  const untouched = normalizedStyleOverrides(draft) === null;
   return (
     <div
       className="insert-dialog-backdrop"
@@ -95,26 +96,30 @@ export function StyleDialog({ overrides, onApply, onClose }: StyleDialogProps) {
       }}
     >
       <section
-        className="insert-component-dialog style-dialog"
+        className="style-dialog"
         role="dialog"
         aria-modal="true"
         aria-labelledby="document-style-title"
         data-testid="document-style-dialog"
       >
-        <header className="insert-dialog-header">
-          <div>
-            <p>Scales over the document&apos;s style profile</p>
-            <h2 id="document-style-title">Document style</h2>
-          </div>
+        <header className="style-dialog-header">
+          <p>Scales over the document&apos;s style profile</p>
+          <h2 id="document-style-title">Document style</h2>
         </header>
-        <div className="insert-dialog-body">
-          <section className="insert-control-column">
-            {STYLE_KNOBS.map((knob) => (
-              <label key={knob.key} title={knob.description}>
-                {knob.label}
+        <div className="style-dialog-knobs">
+          {STYLE_KNOBS.map((knob) => (
+            <label key={knob.key} className="style-dialog-knob">
+              <span className="style-dialog-knob-copy">
+                <span className="style-dialog-knob-label">{knob.label}</span>
+                <span className="style-dialog-knob-description">
+                  {knob.description}
+                </span>
+              </span>
+              <span className="style-dialog-knob-control">
                 <select
                   aria-label={knob.label}
                   value={String(draft[knob.key])}
+                  data-changed={draft[knob.key] === 1 ? undefined : "true"}
                   onChange={(event) =>
                     changeKnob(knob.key, Number(event.currentTarget.value))
                   }
@@ -125,19 +130,26 @@ export function StyleDialog({ overrides, onApply, onClose }: StyleDialogProps) {
                     </option>
                   ))}
                 </select>
-              </label>
-            ))}
-            <button
-              type="button"
-              onClick={() => onApply(null)}
-              disabled={normalizedStyleOverrides(draft) === null}
-            >
-              Reset all to profile defaults
-            </button>
-            <button type="button" onClick={onClose}>
-              Close
-            </button>
-          </section>
+              </span>
+            </label>
+          ))}
+        </div>
+        <div className="style-dialog-actions">
+          <button
+            type="button"
+            className="style-dialog-reset"
+            onClick={() => onApply(null)}
+            disabled={untouched}
+          >
+            Reset all to profile defaults
+          </button>
+          <button
+            type="button"
+            className="style-dialog-primary"
+            onClick={onClose}
+          >
+            Done
+          </button>
         </div>
       </section>
     </div>

--- a/apps/editor/src/features/editor-shell/use-editor-panels.ts
+++ b/apps/editor/src/features/editor-shell/use-editor-panels.ts
@@ -1,10 +1,23 @@
 import { useEffect, useState } from "react";
 import type { MutableRefObject } from "react";
 
+export const LIBRARY_WIDTH_MIN = 180;
+export const LIBRARY_WIDTH_MAX = 520;
+export const LIBRARY_WIDTH_DEFAULT = 248;
+
+export function clampLibraryWidth(width: number): number {
+  if (!Number.isFinite(width)) return LIBRARY_WIDTH_DEFAULT;
+  return Math.min(
+    LIBRARY_WIDTH_MAX,
+    Math.max(LIBRARY_WIDTH_MIN, Math.round(width)),
+  );
+}
+
 export interface UseEditorPanelsOptions {
   initialCompact: boolean;
   compactMediaQuery: string;
   libraryStorageKey: string;
+  libraryWidthStorageKey: string;
   helpButtonRef: MutableRefObject<HTMLButtonElement | null>;
   helpCloseRef: MutableRefObject<HTMLButtonElement | null>;
   aboutButtonRef: MutableRefObject<HTMLButtonElement | null>;
@@ -19,6 +32,19 @@ export function useEditorPanels(options: UseEditorPanelsOptions) {
       return window.localStorage.getItem(options.libraryStorageKey) !== "false";
     } catch {
       return true;
+    }
+  });
+  const [libraryWidth, setLibraryWidthState] = useState(() => {
+    if (typeof window === "undefined") return LIBRARY_WIDTH_DEFAULT;
+    try {
+      const stored = window.localStorage.getItem(
+        options.libraryWidthStorageKey,
+      );
+      return stored === null
+        ? LIBRARY_WIDTH_DEFAULT
+        : clampLibraryWidth(Number(stored));
+    } catch {
+      return LIBRARY_WIDTH_DEFAULT;
     }
   });
   const [compactLayout, setCompactLayout] = useState(options.initialCompact);
@@ -69,6 +95,17 @@ export function useEditorPanels(options: UseEditorPanelsOptions) {
       window.localStorage.setItem(options.libraryStorageKey, String(open));
     } catch {
       // Library visibility stays usable when browser storage is unavailable.
+    }
+  };
+
+  /** Commit a dragged panel width, clamped to the readable range. */
+  const setLibraryWidth = (width: number): void => {
+    const next = clampLibraryWidth(width);
+    setLibraryWidthState(next);
+    try {
+      window.localStorage.setItem(options.libraryWidthStorageKey, String(next));
+    } catch {
+      // The panel stays resizable when browser storage is unavailable.
     }
   };
 
@@ -151,6 +188,7 @@ export function useEditorPanels(options: UseEditorPanelsOptions) {
     helpOpen,
     leftPanelMode,
     libraryPanelOpen,
+    libraryWidth,
     searchOpen,
     searchQuery,
     selectionOpen,
@@ -163,6 +201,7 @@ export function useEditorPanels(options: UseEditorPanelsOptions) {
     setHelpOpen,
     setLeftPanelMode,
     setLibraryPanelOpen,
+    setLibraryWidth,
     setSearchOpen,
     setSearchQuery,
     setSelectionOpen,

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -240,7 +240,7 @@ body {
   overflow: hidden;
 }
 
-.app-brand-copy h1,
+.gallery-home-link h1,
 .app-brand-copy p {
   margin: 0;
   overflow: hidden;
@@ -248,7 +248,7 @@ body {
   white-space: nowrap;
 }
 
-.app-brand-copy h1 {
+.gallery-home-link h1 {
   font-size: var(--icm-font-lg);
   font-weight: 600;
   letter-spacing: -0.01em;
@@ -834,6 +834,30 @@ body {
   grid-template-columns: var(--icm-rail-width) 0 minmax(0, 1fr) auto;
 }
 
+/* Sits on the Library's right edge, overlapping the canvas by a few pixels so
+   the grab target is comfortable without stealing layout width. */
+.library-resize-handle {
+  grid-area: canvas;
+  z-index: 2;
+  width: 9px;
+  margin-left: -5px;
+  cursor: col-resize;
+  touch-action: none;
+  background: transparent;
+}
+
+.library-resize-handle:hover,
+.library-resize-handle:focus-visible {
+  background: linear-gradient(
+    to right,
+    transparent 3px,
+    var(--icm-accent) 3px,
+    var(--icm-accent) 5px,
+    transparent 5px
+  );
+  outline: none;
+}
+
 .tool-rail {
   grid-area: tools;
   display: flex;
@@ -896,64 +920,6 @@ body {
   opacity: 0;
   border-right-color: transparent;
   pointer-events: none;
-}
-
-.shapes-panel-title {
-  display: grid;
-  gap: 2px;
-  width: 100%;
-  padding: var(--icm-space-1);
-  border: 0;
-  border-radius: var(--icm-radius-sm);
-  background: transparent;
-  box-shadow: none;
-  color: inherit;
-  text-align: left;
-  cursor: pointer;
-}
-
-.shapes-panel-title:hover {
-  background: var(--icm-surface-hover);
-}
-
-.shapes-panel-static-title {
-  display: grid;
-  gap: 2px;
-  width: 100%;
-  padding: var(--icm-space-1);
-}
-
-.shapes-panel-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--icm-space-2);
-  padding: var(--icm-space-3) var(--icm-space-3) var(--icm-space-2);
-  border-bottom: 1px solid var(--icm-border);
-}
-
-.shapes-panel-header h2,
-.shapes-panel-header p,
-.shapes-panel-heading,
-.shapes-section h3 {
-  margin: 0;
-}
-
-.shapes-kicker {
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-xs);
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  line-height: var(--icm-line-tight);
-}
-
-.shapes-panel-header h2,
-.shapes-panel-heading {
-  font-size: var(--icm-font-lg);
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  line-height: var(--icm-line-tight);
 }
 
 .shapes-panel-footer {
@@ -3648,6 +3614,125 @@ body {
   scrollbar-width: thin;
 }
 
+/* Document style knobs: one settings row per knob, sharing the publish
+   dialog's card so the two modals read as one family. */
+.style-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  width: min(30rem, 100%);
+  max-height: 100%;
+  overflow-y: auto;
+  padding: 1.5rem;
+  border: 1px solid var(--icm-border);
+  border-radius: 14px;
+  background: var(--icm-surface);
+  box-shadow: 0 24px 48px rgb(15 15 15 / 18%);
+}
+
+.style-dialog-header p {
+  margin: 0;
+  color: var(--icm-text-muted);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.style-dialog-header h2 {
+  margin: 0.3rem 0 0;
+  font-size: 1.3rem;
+}
+
+.style-dialog-knobs {
+  display: flex;
+  flex-direction: column;
+}
+
+.style-dialog-knob {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.7rem 0;
+  border-top: 1px solid var(--icm-border);
+}
+
+.style-dialog-knob:last-child {
+  border-bottom: 1px solid var(--icm-border);
+}
+
+.style-dialog-knob-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.style-dialog-knob-label {
+  color: var(--icm-text);
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.style-dialog-knob-description {
+  color: var(--icm-text-muted);
+  font-size: 0.75rem;
+  line-height: 1.35;
+}
+
+.style-dialog-knob-control select {
+  min-width: 8.5rem;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--icm-border);
+  border-radius: 8px;
+  color: var(--icm-text);
+  background: var(--icm-surface);
+  font: inherit;
+  font-size: 0.85rem;
+}
+
+.style-dialog-knob-control select[data-changed="true"] {
+  border-color: var(--icm-accent);
+  color: var(--icm-accent);
+  font-weight: 600;
+}
+
+.style-dialog-knob-control select:focus-visible {
+  border-color: var(--icm-accent);
+  outline: none;
+  box-shadow: 0 0 0 3px var(--icm-accent-soft);
+}
+
+.style-dialog-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.style-dialog-reset,
+.style-dialog-primary {
+  padding: 0.5rem 0.9rem;
+  border: 1px solid var(--icm-border);
+  border-radius: 8px;
+  background: var(--icm-surface);
+  font: inherit;
+  font-size: 0.85rem;
+}
+
+.style-dialog-reset:disabled {
+  color: var(--icm-text-disabled);
+  cursor: default;
+}
+
+.style-dialog-primary {
+  border-color: transparent;
+  color: #fff;
+  background: var(--icm-accent);
+  font-weight: 600;
+}
+
 .publish-gallery-dialog {
   display: flex;
   flex-direction: column;
@@ -4159,10 +4244,6 @@ body {
 
   .shapes-panel {
     border-top: 0;
-  }
-
-  .shapes-kicker {
-    display: none;
   }
 
   .shapes-fold-label-full {
@@ -5453,8 +5534,17 @@ html.light .analytics-map-land path {
   color: var(--icm-text-muted);
 }
 
+/* The wordmark is the editor's half of the two-way gallery/editor switch, so
+   the whole brand is one link that still reads as plain chrome. */
 .gallery-home-link {
   display: inline-flex;
   align-items: center;
+  gap: var(--icm-space-2);
+  min-width: 0;
+  color: inherit;
   text-decoration: none;
+}
+
+.gallery-home-link:hover h1 {
+  color: var(--icm-accent);
 }

--- a/plan/2026-08-22-drop-panel-title-banner/plan.md
+++ b/plan/2026-08-22-drop-panel-title-banner/plan.md
@@ -1,0 +1,106 @@
+---
+status: completed
+experience: none
+---
+
+# Editor chrome pass: panel banner, Publish, brand, resize, style dialog
+
+## Goal
+
+Five chrome complaints from a live review, delivered together because they
+share one ownership boundary (the editor shell) and one validation surface:
+
+1. The Library panel's "QUICK PLACE / Library" banner costs a header row while
+   saying nothing the chrome does not — the rail already labels the active
+   panel and the banner's only action duplicates the `Insert I` footer button.
+   The Examples panel carries the identical banner.
+2. "Publish to Gallery…" is buried in the File menu; it belongs beside Search.
+3. The brand mark switches editor → gallery but not back.
+4. The Library panel has a fixed width and cannot be dragged wider.
+5. The Document style dialog reuses the Insert dialog's two-column shell, so
+   raw selects sit against their labels beside a large empty pane.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## main...origin/main
+?? .claude/
+?? node_modules
+```
+
+Clean apart from untracked local build scaffolding. Branch
+`claude/drop-panel-title-banner` from `main` at 6882fc28.
+
+Owned paths:
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/features/editor-shell/**`
+- `apps/editor/src/components/gallery-feed.tsx`
+- `apps/editor/src/styles.css`
+- `apps/editor/e2e/{component-insert,manual-editor,gallery}.spec.ts`
+- `plan/2026-08-22-drop-panel-title-banner/plan.md`, `plan/log.md`
+
+## Work
+
+1. Remove the `<header className="shapes-panel-header">` block from both
+   panels and the rules that only served it.
+2. Move the Publish action out of the File menu into the menubar beside
+   Search, styled like Search rather than as a bespoke control.
+3. Make the whole brand (mark plus wordmark) the editor's link to the gallery,
+   and make the gallery's brand a link to the editor.
+4. Add a dragged width to the Library panel: `useEditorPanels` owns the
+   clamped, persisted value and the workspace grid reads it from an inline
+   custom property; a `col-resize` separator sits on the panel edge and also
+   answers arrow keys.
+5. Rebuild the Document style dialog on the publish dialog's card: one settings
+   row per knob (label, description, right-aligned control), a changed-value
+   accent, and a Reset/Done footer.
+
+## Validation
+
+- `git diff --check`, `git status --short --branch`
+- repository typecheck, prettier, markdown links
+- full unit suite (the shell modules and the style-dialog contract)
+- full Playwright suite: the panel, menubar, gallery, and style-dialog specs
+  all move with this change
+- every changed surface exercised in the running editor, including a real
+  drag of the new resize handle
+
+## Gate Review
+
+- Decision: affected — presentation-only editor shell change.
+- Early gates: prettier, focused unit test.
+- Affected gates: the component-insert browser spec.
+- Final gates: `pnpm ci:check` cannot run locally (pnpm absent); delegated to
+  the remote required checks.
+- Platform risks: none; no generated artifact or persisted contract changes.
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: Library/Examples panel composition and the ways the Insert
+  catalog can be opened.
+- Primary checks: `apps/editor/e2e/component-insert.spec.ts`,
+  `apps/editor/src/features/editor-shell/shapes-panel.test.ts`
+
+## Commit Intent
+
+```text
+refactor(editor): tighten the editor chrome
+```
+
+## Outcome
+
+All five landed. The Library and Examples panels start straight at their
+content; Publish sits beside Search (`data-testid="publish-gallery-button"`);
+the brand switches both ways; the Library panel drags between 180 and 520px
+and remembers its width in `icm.library-panel-width.v1`; the style dialog is a
+compact settings card.
+
+Validation: repository typecheck, full unit suite (179 files / 1121 tests),
+full Playwright suite (185, one unrelated current-marker drag flake that
+passes on its own re-run), prettier, markdown links, and diff checks. Every
+changed surface was exercised in a running editor, including a real drag of
+the new handle (248px → 368px, persisted).

--- a/plan/log.md
+++ b/plan/log.md
@@ -4396,3 +4396,20 @@ Keep reusable lessons in `docs/experience/`, not in this log.
 - Validation: worker suites, typecheck, prettier, test-impact; production
   GitHub sign-in verified after deploy.
 - Commit status: completed on `claude/auth-fetch-binding`.
+
+## 2026-08-22 - Editor chrome pass from a live review
+
+- Changed areas: both left panels lose the "QUICK PLACE" title banner (and
+  its dead CSS); Publish to Gallery moves out of the File menu to a menubar
+  button beside Search; the brand mark plus wordmark becomes a two-way
+  editor/gallery switch (the gallery's brand now links to the editor); the
+  Library panel gains a dragged, clamped, persisted width through
+  `useEditorPanels` and a keyboard-operable `col-resize` separator; the
+  Document style dialog is rebuilt on the publish dialog's card with one
+  settings row per knob and a Reset/Done footer.
+- Validation: typecheck, full unit suite (179 files / 1121 tests), full
+  Playwright suite (185; one unrelated current-marker drag flake passed on
+  re-run), prettier, markdown links, diff checks; every surface verified in
+  a running editor including a real 248→368px handle drag.
+- Commit status: completed on `claude/drop-panel-title-banner`; mainline
+  merge gated on the remote required checks.


### PR DESCRIPTION
Five chrome fixes from a live review, all in the editor shell.

## What changed

**1. Both left panels drop the "QUICK PLACE" title banner.** It cost a full header row while saying nothing the surrounding chrome doesn't: the left rail already labels and highlights the active panel, and the banner's only action (open the Insert dialog) duplicated the panel's own `Insert I` footer button. The Examples panel carried the identical banner, so both are gone along with the CSS that only served them.

**2. Publish to Gallery moves to the menubar, beside Search.** It was buried under File ▸ Publish to Gallery…; it now renders as `data-testid="publish-gallery-button"`, styled exactly like Search rather than as a bespoke control.

**3. The brand switches both ways.** Only the small brand *mark* was a link (editor → gallery), and the gallery had no way back. Now the mark plus the "Analog Canvas" wordmark form one link in the editor, and the gallery's brand links to `/editor`.

**4. The Library panel is resizable.** `useEditorPanels` owns a clamped width (180–520px) persisted in `icm.library-panel-width.v1`; the workspace grid reads it from an inline custom property; a `col-resize` separator sits on the panel's right edge and answers both pointer drags and arrow keys (Shift for a coarse step), exposed as a proper `role="separator"` with value/min/max.

**5. The Document style dialog is rebuilt.** It borrowed the Insert dialog's two-column shell, which left raw selects jammed against their labels beside a large empty pane. It is now a settings card on the publish dialog's pattern: one row per knob with its description, right-aligned controls, an accent on values that differ from the profile default, and a Reset/Done footer.

## Test plan

- [x] `tsc -p tsconfig.check.json` clean
- [x] Full unit suite: **179 files / 1121 tests**
- [x] Full Playwright suite: **185** (one unrelated current-marker drag flake, passes on its own re-run)
- [x] prettier, markdown links, `git diff --check`, test-impact
- [x] Every surface exercised in a running editor, including a real drag of the new handle (248px → 368px, persisted across reload)
- [ ] Remote required checks green — pnpm is unavailable locally, so `pnpm ci:check` is delegated to CI

Specs that asserted the old chrome moved with it: the banner click that opened the catalog, the `Close` button now named `Done`, the brand heading selector, and the menu-dismiss test that used the wordmark as a neutral click target (it navigates now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)