### PR TITLE
feat(worker): gallery review queue with submission quality gates

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -257,6 +257,93 @@ test("an admin session publishes without the passphrase row", async ({
   expect(posted).toEqual([{ authorization: null, author: "Token Zhang" }]);
 });
 
+test("an ordinary user sees blocking quality gates on an empty project", async ({
+  page,
+}) => {
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      json: {
+        user: {
+          id: "u9",
+          displayName: "Visitor",
+          email: "visitor@example.com",
+          provider: "email",
+          role: "user",
+          isAdmin: false,
+        },
+      },
+    }),
+  );
+
+  await page.goto("/editor");
+  await clickCommand(page, "File", "Publish to Gallery…");
+  const dialog = page.getByTestId("publish-gallery-dialog");
+  await expect(dialog).toBeVisible();
+
+  // The empty canvas fails the content gate, evaluated locally.
+  const gates = page.getByTestId("publish-gallery-gates");
+  await expect(gates).toBeVisible();
+  await expect(gates).toContainText("Fix these before submitting");
+  await expect(gates).toContainText("Too little content");
+  await expect(dialog.getByLabel("Owner passphrase")).toHaveCount(0);
+  await expect(
+    dialog.getByRole("button", { name: "Submit for review" }),
+  ).toBeDisabled();
+});
+
+test("a reviewer approves a pending submission from the review queue", async ({
+  page,
+}) => {
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      json: {
+        user: {
+          id: "u1",
+          displayName: "Token Zhang",
+          email: "owner@example.com",
+          provider: "github",
+          role: "user",
+          isAdmin: true,
+        },
+      },
+    }),
+  );
+  await page.route("**/api/gallery/review", (route) =>
+    route.fulfill({
+      json: {
+        entries: [
+          {
+            id: "p-1",
+            name: "Pending Filter",
+            author: "maker",
+            description: "Second-order RC",
+            createdAt: "2026-08-22T09:00:00.000Z",
+          },
+        ],
+      },
+    }),
+  );
+  await page.route("**/api/gallery/p-1/preview.svg", (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10" fill="#fff"/></svg>',
+    }),
+  );
+  const decisions: string[] = [];
+  await page.route("**/api/gallery/p-1/approve", (route) => {
+    decisions.push("approve");
+    return route.fulfill({ json: { id: "p-1", status: "public" } });
+  });
+
+  await page.goto("/review");
+  const card = page.getByTestId("review-card-p-1");
+  await expect(card).toBeVisible();
+  await expect(card).toContainText("Pending Filter");
+  await card.getByTestId("review-approve-p-1").click();
+  await expect(page.getByTestId("review-empty")).toBeVisible();
+  expect(decisions).toEqual(["approve"]);
+});
+
 test("bundled starter tiles open their example in the editor", async ({
   page,
 }) => {

--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -277,7 +277,7 @@ test("an ordinary user sees blocking quality gates on an empty project", async (
   );
 
   await page.goto("/editor");
-  await clickCommand(page, "File", "Publish to Gallery…");
+  await page.getByTestId("publish-gallery-button").click();
   const dialog = page.getByTestId("publish-gallery-dialog");
   await expect(dialog).toBeVisible();
 

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -120,6 +120,7 @@ import {
   externalSubcircuitSymbolId,
   findUnsupportedProjectSymbolIds,
   hierarchicalSymbolId,
+  InMemorySymbolResolver,
   resolvePdkSymbolMapping,
   reviewedSky130MosModelSuggestions,
 } from "@icm/symbols";
@@ -210,6 +211,10 @@ import { StyleDialog } from "../features/editor-shell/style-dialog";
 import { PublishGalleryDialog } from "../features/editor-shell/publish-gallery-dialog";
 import { publishProjectToGallery } from "../features/editor-shell/gallery-publish";
 import { fetchSessionUser, type SessionUser } from "../components/account";
+import {
+  evaluateSubmissionGates,
+  type SubmissionGateReport,
+} from "@icm/derived";
 import {
   createUserExamplesStore,
   type UserExampleSummary,
@@ -622,15 +627,26 @@ export function App({
   const [publishSession, setPublishSession] = useState<SessionUser | null>(
     null,
   );
+  const [publishGates, setPublishGates] = useState<SubmissionGateReport | null>(
+    null,
+  );
   useEffect(() => {
     if (!publishGalleryOpen) return;
     let cancelled = false;
     void fetchSessionUser().then((user) => {
       if (!cancelled) setPublishSession(user);
     });
+    // The same evaluator the worker enforces, run live on the open Project.
+    setPublishGates(
+      evaluateSubmissionGates(
+        project,
+        new InMemorySymbolResolver(builtInSymbols),
+      ),
+    );
     return () => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- evaluated once per dialog open
   }, [publishGalleryOpen]);
   const userExamplesStore = useRef(createUserExamplesStore());
   const [userExamples, setUserExamples] = useState<UserExampleSummary[]>([]);
@@ -7551,10 +7567,15 @@ export function App({
         <PublishGalleryDialog
           defaultName={project.name}
           session={publishSession}
+          gateReport={publishGates}
           publish={(fields) => publishProjectToGallery(project, fields)}
-          onPublished={({ name }) => {
+          onPublished={({ name, pending }) => {
             setPublishGalleryOpen(false);
-            setStatus(`Published "${name}" to the gallery`);
+            setStatus(
+              pending
+                ? `Submitted "${name}" for review`
+                : `Published "${name}" to the gallery`,
+            );
           }}
           onClose={() => setPublishGalleryOpen(false)}
         />

--- a/apps/editor/src/components/account.test.tsx
+++ b/apps/editor/src/components/account.test.tsx
@@ -49,6 +49,7 @@ describe("AccountMenuView", () => {
         displayName: "Token Zhang",
         email: "owner@example.com",
         provider: "github",
+        role: "user",
         isAdmin: true,
       },
     });

--- a/apps/editor/src/components/account.tsx
+++ b/apps/editor/src/components/account.tsx
@@ -12,6 +12,8 @@ export interface SessionUser {
   displayName: string;
   email: string | null;
   provider: string;
+  /** "user" or "moderator" (appointed by the super-admin). */
+  role: string;
   isAdmin: boolean;
 }
 
@@ -178,7 +180,23 @@ export function AccountMenuView({
           <span className="account-owner-badge" data-testid="account-owner">
             Owner
           </span>
+        ) : user.role === "moderator" ? (
+          <span className="account-owner-badge" data-testid="account-mod">
+            Reviewer
+          </span>
         ) : null}
+        {user.isAdmin || user.role === "moderator" ? (
+          <a
+            className="account-link"
+            href="/review"
+            data-testid="account-review-link"
+          >
+            Review
+          </a>
+        ) : null}
+        <a className="account-link" href="/mine" data-testid="account-mine">
+          My submissions
+        </a>
         <button
           type="button"
           className="account-signout"

--- a/apps/editor/src/components/my-submissions.tsx
+++ b/apps/editor/src/components/my-submissions.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from "react";
+
+import { fetchSessionUser } from "./account";
+
+/**
+ * "My submissions" (roadmap phase G3): a signed-in user's gallery entries
+ * with their review status; a rejection shows the reviewer's optional
+ * reason so resubmission is informed, not a guessing game.
+ */
+
+export interface MineEntry {
+  id: string;
+  name: string;
+  createdAt: string;
+  status: string;
+  rejectReason: string | null;
+}
+
+type MineState =
+  | { status: "loading" }
+  | { status: "signed-out" }
+  | { status: "ready"; entries: MineEntry[] };
+
+export async function loadMySubmissions(
+  fetchLike: typeof fetch = fetch,
+): Promise<MineState> {
+  const user = await fetchSessionUser(fetchLike);
+  if (!user) return { status: "signed-out" };
+  try {
+    const response = await fetchLike("/api/gallery/mine", {
+      credentials: "same-origin",
+    });
+    if (!response.ok) return { status: "signed-out" };
+    const payload = (await response.json()) as { entries?: MineEntry[] };
+    return { status: "ready", entries: payload.entries ?? [] };
+  } catch {
+    return { status: "signed-out" };
+  }
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  public: "Published",
+  pending: "Waiting for review",
+  rejected: "Rejected",
+  recycled: "Removed",
+};
+
+export function MySubmissions() {
+  const [state, setState] = useState<MineState>({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadMySubmissions().then((next) => {
+      if (!cancelled) setState(next);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (state.status === "loading") {
+    return <p className="gallery-status">Loading your submissions…</p>;
+  }
+  if (state.status === "signed-out") {
+    return (
+      <main className="review-shell" data-testid="mine-signed-out">
+        <p className="gallery-status">
+          Sign in on the <a href="/">gallery page</a> to see your submissions.
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="review-shell" data-testid="mine-list">
+      <header className="gallery-chrome">
+        <div className="gallery-brand">
+          <span className="app-brand-mark" aria-hidden="true" />
+          <div>
+            <h1>My submissions</h1>
+            <p>Status of everything you sent to the gallery</p>
+          </div>
+        </div>
+        <nav className="gallery-actions">
+          <a className="gallery-open-editor" href="/">
+            Back to the gallery
+          </a>
+        </nav>
+      </header>
+      {state.entries.length === 0 ? (
+        <p className="gallery-status">
+          Nothing yet — open the <a href="/editor">editor</a> and use File →
+          Publish to Gallery.
+        </p>
+      ) : (
+        <section className="mine-list">
+          {state.entries.map((entry) => (
+            <article
+              key={entry.id}
+              className="mine-card"
+              data-testid={`mine-card-${entry.id}`}
+            >
+              <div className="mine-card-copy">
+                <h2>{entry.name}</h2>
+                <p className="review-card-meta">
+                  {new Date(entry.createdAt).toLocaleString()}
+                </p>
+              </div>
+              <div className="mine-card-status">
+                <span
+                  className={`mine-status mine-status-${entry.status}`}
+                  data-testid={`mine-status-${entry.id}`}
+                >
+                  {STATUS_LABELS[entry.status] ?? entry.status}
+                </span>
+                {entry.status === "rejected" && entry.rejectReason ? (
+                  <p
+                    className="mine-reason"
+                    data-testid={`mine-reason-${entry.id}`}
+                  >
+                    Reason: {entry.rejectReason}
+                  </p>
+                ) : null}
+              </div>
+            </article>
+          ))}
+        </section>
+      )}
+    </main>
+  );
+}

--- a/apps/editor/src/components/review-queue.tsx
+++ b/apps/editor/src/components/review-queue.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useState } from "react";
+
+import { fetchSessionUser, type SessionUser } from "./account";
+
+/**
+ * Review queue (roadmap phase G3): the super-admin and appointed
+ * moderators approve pending community submissions into the public feed
+ * or reject them with an optional reason the submitter sees. The admin
+ * additionally appoints moderators by email from this page.
+ */
+
+export interface PendingEntry {
+  id: string;
+  name: string;
+  author: string;
+  description: string;
+  createdAt: string;
+}
+
+type QueueState =
+  | { status: "loading" }
+  | { status: "denied" }
+  | { status: "ready"; user: SessionUser; entries: PendingEntry[] };
+
+export async function loadReviewQueue(
+  fetchLike: typeof fetch = fetch,
+): Promise<QueueState> {
+  const user = await fetchSessionUser(fetchLike);
+  if (!user || (!user.isAdmin && user.role !== "moderator")) {
+    return { status: "denied" };
+  }
+  try {
+    const response = await fetchLike("/api/gallery/review", {
+      credentials: "same-origin",
+    });
+    if (!response.ok) return { status: "denied" };
+    const payload = (await response.json()) as { entries?: PendingEntry[] };
+    return { status: "ready", user, entries: payload.entries ?? [] };
+  } catch {
+    return { status: "denied" };
+  }
+}
+
+async function decide(
+  id: string,
+  decision: "approve" | "reject",
+  reason: string,
+  fetchLike: typeof fetch = fetch,
+): Promise<boolean> {
+  try {
+    const response = await fetchLike(`/api/gallery/${id}/${decision}`, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(decision === "reject" ? { reason } : {}),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function appointModerator(
+  email: string,
+  role: "moderator" | "user",
+  fetchLike: typeof fetch = fetch,
+): Promise<string> {
+  try {
+    const response = await fetchLike("/api/auth/users/role", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, role }),
+    });
+    if (response.ok) {
+      return role === "moderator"
+        ? `${email} can now review submissions.`
+        : `${email} is an ordinary user again.`;
+    }
+    if (response.status === 404) {
+      return "No account with that email has signed in yet.";
+    }
+    return "Could not change the role.";
+  } catch {
+    return "Could not change the role.";
+  }
+}
+
+function ReviewCard({
+  entry,
+  onDecided,
+}: {
+  entry: PendingEntry;
+  onDecided: (id: string) => void;
+}) {
+  const [reason, setReason] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  async function act(decision: "approve" | "reject"): Promise<void> {
+    setBusy(true);
+    const ok = await decide(entry.id, decision, reason.trim());
+    setBusy(false);
+    if (ok) onDecided(entry.id);
+  }
+
+  return (
+    <article className="review-card" data-testid={`review-card-${entry.id}`}>
+      <a
+        className="review-card-preview"
+        href={`/g/${entry.id}`}
+        title="Open in the editor"
+      >
+        <img
+          src={`/api/gallery/${entry.id}/preview.svg`}
+          alt={`Preview of ${entry.name}`}
+          loading="lazy"
+        />
+      </a>
+      <div className="review-card-copy">
+        <h2>{entry.name}</h2>
+        <p className="review-card-meta">
+          {entry.author ? `${entry.author} · ` : ""}
+          {new Date(entry.createdAt).toLocaleString()}
+        </p>
+        {entry.description ? <p>{entry.description}</p> : null}
+        <input
+          aria-label="Rejection reason"
+          data-testid={`review-reason-${entry.id}`}
+          placeholder="Optional rejection reason"
+          value={reason}
+          maxLength={300}
+          onChange={(event) => setReason(event.currentTarget.value)}
+        />
+        <div className="review-card-actions">
+          <button
+            type="button"
+            data-testid={`review-reject-${entry.id}`}
+            disabled={busy}
+            onClick={() => void act("reject")}
+          >
+            Reject
+          </button>
+          <button
+            type="button"
+            className="review-approve"
+            data-testid={`review-approve-${entry.id}`}
+            disabled={busy}
+            onClick={() => void act("approve")}
+          >
+            Approve
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export function ReviewQueue() {
+  const [state, setState] = useState<QueueState>({ status: "loading" });
+  const [email, setEmail] = useState("");
+  const [notice, setNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadReviewQueue().then((next) => {
+      if (!cancelled) setState(next);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (state.status === "loading") {
+    return <p className="gallery-status">Loading review queue…</p>;
+  }
+  if (state.status === "denied") {
+    return (
+      <main className="review-shell" data-testid="review-denied">
+        <p className="gallery-status">
+          The review queue is for the gallery owner and appointed moderators.{" "}
+          <a href="/">Back to the gallery</a>
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="review-shell" data-testid="review-queue">
+      <header className="gallery-chrome">
+        <div className="gallery-brand">
+          <span className="app-brand-mark" aria-hidden="true" />
+          <div>
+            <h1>Review queue</h1>
+            <p>Pending community submissions</p>
+          </div>
+        </div>
+        <nav className="gallery-actions">
+          <a className="gallery-open-editor" href="/">
+            Back to the gallery
+          </a>
+        </nav>
+      </header>
+      {state.user.isAdmin ? (
+        <form
+          className="review-appoint"
+          data-testid="review-appoint"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (!email.trim()) return;
+            void appointModerator(email.trim(), "moderator").then(setNotice);
+          }}
+        >
+          <input
+            type="email"
+            aria-label="Moderator email"
+            placeholder="Appoint a moderator by email"
+            value={email}
+            onChange={(event) => setEmail(event.currentTarget.value)}
+          />
+          <button type="submit">Appoint</button>
+          {notice ? <span className="account-notice">{notice}</span> : null}
+        </form>
+      ) : null}
+      {state.entries.length === 0 ? (
+        <p className="gallery-status" data-testid="review-empty">
+          Nothing waiting for review.
+        </p>
+      ) : (
+        <section className="review-list">
+          {state.entries.map((entry) => (
+            <ReviewCard
+              key={entry.id}
+              entry={entry}
+              onDecided={(id) =>
+                setState((previous) =>
+                  previous.status === "ready"
+                    ? {
+                        ...previous,
+                        entries: previous.entries.filter(
+                          (candidate) => candidate.id !== id,
+                        ),
+                      }
+                    : previous,
+                )
+              }
+            />
+          ))}
+        </section>
+      )}
+    </main>
+  );
+}

--- a/apps/editor/src/features/editor-shell/gallery-publish.ts
+++ b/apps/editor/src/features/editor-shell/gallery-publish.ts
@@ -1,3 +1,4 @@
+import type { SubmissionGateFailure } from "@icm/derived";
 import type { CircuitProject } from "@icm/model";
 import { serializeProject } from "@icm/project-protocol";
 
@@ -20,10 +21,14 @@ export interface GalleryPublishFields {
 export interface PublishSessionUser {
   displayName: string;
   isAdmin: boolean;
+  /** "user" or "moderator"; moderators publish directly (phase G3). */
+  role?: string;
 }
 
 export type GalleryPublishOutcome =
   | { status: "published"; id: string }
+  | { status: "pending-review"; id: string }
+  | { status: "gate-failed"; failures: readonly SubmissionGateFailure[] }
   | { status: "unauthorized" }
   | { status: "too-large" }
   | { status: "rate-limited" }
@@ -62,11 +67,18 @@ export async function publishProjectToGallery(
   if (response.status === 201) {
     const payload = (await response.json().catch(() => null)) as {
       id?: unknown;
+      status?: unknown;
     } | null;
-    return {
-      status: "published",
-      id: typeof payload?.id === "string" ? payload.id : "",
-    };
+    const id = typeof payload?.id === "string" ? payload.id : "";
+    return payload?.status === "pending"
+      ? { status: "pending-review", id }
+      : { status: "published", id };
+  }
+  if (response.status === 422) {
+    const payload = (await response.json().catch(() => null)) as {
+      failures?: SubmissionGateFailure[];
+    } | null;
+    return { status: "gate-failed", failures: payload?.failures ?? [] };
   }
   if (response.status === 401) return { status: "unauthorized" };
   if (response.status === 413) return { status: "too-large" };
@@ -88,6 +100,10 @@ export function describePublishOutcome(outcome: GalleryPublishOutcome): string {
   switch (outcome.status) {
     case "published":
       return "Published to the gallery";
+    case "pending-review":
+      return "Submitted — your circuit is waiting for review";
+    case "gate-failed":
+      return "The submission did not pass the quality gates";
     case "unauthorized":
       return "The passphrase was not accepted, so it was forgotten — ask the gallery owner for the current one";
     case "too-large":

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.test.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.test.tsx
@@ -47,17 +47,74 @@ describe("PublishGalleryDialog", () => {
     expect(markup).toContain('value="Token Zhang"');
   });
 
-  it("keeps the passphrase row for an ordinary signed-in user", () => {
+  it("offers submit-for-review, not a passphrase, to an ordinary user", () => {
     const markup = renderToStaticMarkup(
       createElement(PublishGalleryDialog, {
         defaultName: "Ring Oscillator",
-        session: { displayName: "Visitor", isAdmin: false },
+        session: { displayName: "Visitor", isAdmin: false, role: "user" },
+        gateReport: { ok: true, failures: [] },
         publish: () => Promise.resolve({ status: "unauthorized" as const }),
         onPublished: () => undefined,
         onClose: () => undefined,
       }),
     );
-    expect(markup).toContain("Owner passphrase");
-    expect(markup).toMatch(/disabled=""[^>]*>Publish</u);
+    expect(markup).not.toContain("Owner passphrase");
+    expect(markup).toContain("Submit for review");
+    expect(markup).toContain("review queue");
+    expect(markup).not.toMatch(/disabled=""[^>]*>Submit for review</u);
+  });
+
+  it("blocks an ordinary user on gate failures and lists them", () => {
+    const markup = renderToStaticMarkup(
+      createElement(PublishGalleryDialog, {
+        defaultName: "Ring Oscillator",
+        session: { displayName: "Visitor", isAdmin: false, role: "user" },
+        gateReport: {
+          ok: false,
+          failures: [
+            {
+              code: "floating-endpoints",
+              message:
+                "Floating endpoints: wire each pin, name its net, or mark it NoConnect",
+              count: 2,
+              examples: ["M1.g", "R2.2"],
+            },
+          ],
+        },
+        publish: () => Promise.resolve({ status: "unauthorized" as const }),
+        onPublished: () => undefined,
+        onClose: () => undefined,
+      }),
+    );
+    expect(markup).toContain("publish-gallery-gates-blocking");
+    expect(markup).toContain("Fix these before submitting:");
+    expect(markup).toContain("M1.g, R2.2");
+    expect(markup).toMatch(/disabled=""[^>]*>Submit for review</u);
+  });
+
+  it("shows the same failures as informational for a moderator", () => {
+    const markup = renderToStaticMarkup(
+      createElement(PublishGalleryDialog, {
+        defaultName: "Ring Oscillator",
+        session: { displayName: "Rev", isAdmin: false, role: "moderator" },
+        gateReport: {
+          ok: false,
+          failures: [
+            {
+              code: "empty-project",
+              message: "Too little content",
+              count: 1,
+              examples: [],
+            },
+          ],
+        },
+        publish: () => Promise.resolve({ status: "unauthorized" as const }),
+        onPublished: () => undefined,
+        onClose: () => undefined,
+      }),
+    );
+    expect(markup).not.toContain("publish-gallery-gates-blocking");
+    expect(markup).toContain("informational for your role");
+    expect(markup).not.toMatch(/disabled=""[^>]*>Publish</u);
   });
 });

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 
+import type { SubmissionGateReport } from "@icm/derived";
+
 import {
   describePublishOutcome,
   forgetOnUnauthorized,
@@ -14,28 +16,39 @@ import {
 
 export interface PublishGalleryDialogProps {
   defaultName: string;
-  /** The signed-in user, if any; an admin session publishes cookie-side. */
+  /** The signed-in user, if any; admins and moderators publish directly. */
   session?: PublishSessionUser | null;
+  /** Quality-gate evaluation of the live Project (phase G3). */
+  gateReport?: SubmissionGateReport | null;
   publish: (fields: GalleryPublishFields) => Promise<GalleryPublishOutcome>;
-  onPublished: (outcome: { id: string; name: string }) => void;
+  onPublished: (outcome: {
+    id: string;
+    name: string;
+    pending: boolean;
+  }) => void;
   onClose: () => void;
 }
 
 /**
- * File > "Publish to Gallery…". A signed-in super-admin (G2) publishes
- * directly on the session — no passphrase row. Anyone else needs the
- * gallery owner's passphrase (remembered for the browser session,
+ * File > "Publish to Gallery…". Admin and moderator sessions publish
+ * directly; an ordinary signed-in user submits into the review queue and
+ * must pass the quality gates (listed live, blocking). Without a session
+ * the owner-passphrase path remains (remembered per browser session,
  * forgotten on a 401). The author byline prefills from the account's
  * display name, else from the last successful publish.
  */
 export function PublishGalleryDialog({
   defaultName,
   session = null,
+  gateReport = null,
   publish,
   onPublished,
   onClose,
 }: PublishGalleryDialogProps) {
-  const admin = session?.isAdmin === true;
+  const privileged = session?.isAdmin === true || session?.role === "moderator";
+  const ordinary = session !== null && !privileged;
+  const anonymous = session === null;
+  const gatesBlock = ordinary && gateReport !== null && !gateReport.ok;
   const [name, setName] = useState(defaultName);
   const [author, setAuthor] = useState(
     () => rememberedPublishAuthor() || session?.displayName || "",
@@ -61,12 +74,16 @@ export function PublishGalleryDialog({
       name,
       author,
       description,
-      token: admin ? "" : token,
+      token: anonymous ? token : "",
     });
-    if (outcome.status === "published") {
-      if (!admin) rememberPublishToken(token);
+    if (outcome.status === "published" || outcome.status === "pending-review") {
+      if (anonymous) rememberPublishToken(token);
       rememberPublishAuthor(author);
-      onPublished({ id: outcome.id, name: name.trim() });
+      onPublished({
+        id: outcome.id,
+        name: name.trim(),
+        pending: outcome.status === "pending-review",
+      });
       return;
     }
     if (forgetOnUnauthorized(outcome)) setToken("");
@@ -128,7 +145,7 @@ export function PublishGalleryDialog({
               onChange={(event) => setDescription(event.currentTarget.value)}
             />
           </label>
-          {admin ? null : (
+          {anonymous ? (
             <label>
               Owner passphrase
               <input
@@ -138,12 +155,41 @@ export function PublishGalleryDialog({
                 onChange={(event) => setToken(event.currentTarget.value)}
               />
             </label>
-          )}
+          ) : null}
         </div>
+        {gateReport && gateReport.failures.length > 0 ? (
+          <div
+            className={
+              gatesBlock
+                ? "publish-gallery-gates publish-gallery-gates-blocking"
+                : "publish-gallery-gates"
+            }
+            data-testid="publish-gallery-gates"
+          >
+            <p>
+              {gatesBlock
+                ? "Fix these before submitting:"
+                : "Quality checks (informational for your role):"}
+            </p>
+            <ul>
+              {gateReport.failures.map((failure) => (
+                <li key={failure.code}>
+                  {failure.message}
+                  {failure.count > 1 ? ` (${failure.count})` : ""}
+                  {failure.examples.length > 0
+                    ? ` — ${failure.examples.join(", ")}`
+                    : ""}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
         <p className="publish-gallery-note">
-          {admin
-            ? `Signed in as ${session?.displayName} — this publishes directly as the gallery owner.`
-            : "Publishing is owner-approved for now: it needs the gallery owner's passphrase. Community sign-in with review is on the roadmap — until then, send your circuit file to the owner."}
+          {privileged
+            ? `Signed in as ${session?.displayName} — this publishes directly.`
+            : ordinary
+              ? `Signed in as ${session?.displayName} — your circuit enters the review queue and appears once a reviewer approves it.`
+              : "Publishing is owner-approved for now: it needs the gallery owner's passphrase, or sign in on the gallery page to submit for review."}
         </p>
         {error ? (
           <p role="alert" className="publish-gallery-error">
@@ -158,11 +204,14 @@ export function PublishGalleryDialog({
             type="button"
             className="publish-gallery-primary"
             disabled={
-              busy || name.trim() === "" || (!admin && token.trim() === "")
+              busy ||
+              name.trim() === "" ||
+              (anonymous && token.trim() === "") ||
+              gatesBlock
             }
             onClick={() => void submit()}
           >
-            {busy ? "Publishing…" : "Publish"}
+            {busy ? "Publishing…" : ordinary ? "Submit for review" : "Publish"}
           </button>
         </div>
       </section>

--- a/apps/editor/src/main.tsx
+++ b/apps/editor/src/main.tsx
@@ -25,6 +25,18 @@ const GalleryFeed = lazy(() =>
   })),
 );
 
+const ReviewQueue = lazy(() =>
+  import("./components/review-queue").then((module) => ({
+    default: module.ReviewQueue,
+  })),
+);
+
+const MySubmissions = lazy(() =>
+  import("./components/my-submissions").then((module) => ({
+    default: module.MySubmissions,
+  })),
+);
+
 /** `/` is the gallery, `/editor` the editor, `/g/<id>` one gallery entry. */
 function galleryEntryIdOf(path: string): string | null {
   const match = /^\/g\/([A-Za-z0-9-]{1,64})\/?$/.exec(path);
@@ -92,6 +104,24 @@ function Root() {
         fallback={<div className="analytics-loading">Loading gallery…</div>}
       >
         <GalleryFeed />
+      </Suspense>
+    );
+  }
+  if (/^\/review\/?$/.test(path)) {
+    return (
+      <Suspense
+        fallback={<div className="analytics-loading">Loading review…</div>}
+      >
+        <ReviewQueue />
+      </Suspense>
+    );
+  }
+  if (/^\/mine\/?$/.test(path)) {
+    return (
+      <Suspense
+        fallback={<div className="analytics-loading">Loading submissions…</div>}
+      >
+        <MySubmissions />
       </Suspense>
     );
   }

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -5356,6 +5356,198 @@ html.light .analytics-map-land path {
   font-size: 12px;
 }
 
+.account-link {
+  padding: 6px 10px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  color: var(--icm-text);
+  background: var(--icm-surface);
+  font-size: 13px;
+  text-decoration: none;
+}
+
+.account-link:hover {
+  background: var(--icm-surface-hover);
+}
+
+.review-shell {
+  min-height: 100vh;
+  background: var(--icm-surface);
+}
+
+.review-appoint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 22px 0;
+}
+
+.review-appoint input {
+  box-sizing: border-box;
+  width: 20rem;
+  padding: 7px 10px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  font: inherit;
+  font-size: 13px;
+}
+
+.review-appoint button {
+  padding: 7px 12px;
+  border: 1px solid var(--icm-accent);
+  border-radius: var(--icm-radius-sm);
+  color: #fff;
+  background: var(--icm-accent);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.review-list,
+.mine-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  max-width: 56rem;
+  padding: 18px 22px 40px;
+}
+
+.review-card,
+.mine-card {
+  display: flex;
+  gap: 16px;
+  padding: 14px;
+  border: 1px solid var(--icm-border);
+  border-radius: 12px;
+  background: var(--icm-surface);
+}
+
+.review-card-preview img {
+  display: block;
+  width: 220px;
+  height: 150px;
+  object-fit: contain;
+  border: 1px solid var(--icm-border);
+  border-radius: 8px;
+  background: #fff;
+}
+
+.review-card-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.review-card-copy h2,
+.mine-card-copy h2 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.review-card-meta {
+  margin: 0;
+  color: var(--icm-text-muted);
+  font-size: 12px;
+}
+
+.review-card-copy input {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 7px 10px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  font: inherit;
+  font-size: 13px;
+}
+
+.review-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.review-card-actions button {
+  padding: 6px 14px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  color: var(--icm-text);
+  background: var(--icm-surface);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.review-card-actions .review-approve {
+  border-color: var(--icm-accent);
+  color: #fff;
+  background: var(--icm-accent);
+}
+
+.mine-card {
+  align-items: center;
+  justify-content: space-between;
+}
+
+.mine-card-status {
+  text-align: right;
+}
+
+.mine-status {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: var(--icm-surface-muted);
+  color: var(--icm-text-muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.mine-status-public {
+  background: var(--icm-accent-soft);
+  color: var(--icm-accent);
+}
+
+.mine-status-rejected {
+  background: rgb(180 35 24 / 10%);
+  color: var(--icm-danger, #b42318);
+}
+
+.mine-reason {
+  margin: 6px 0 0;
+  max-width: 24rem;
+  color: var(--icm-text-muted);
+  font-size: 12px;
+}
+
+.publish-gallery-gates {
+  padding: 10px 12px;
+  border: 1px solid var(--icm-border);
+  border-radius: 8px;
+  background: var(--icm-surface-muted);
+  font-size: 0.8rem;
+}
+
+.publish-gallery-gates p {
+  margin: 0 0 4px;
+  font-weight: 600;
+}
+
+.publish-gallery-gates ul {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.publish-gallery-gates-blocking {
+  border-color: var(--icm-danger, #b42318);
+  background: rgb(180 35 24 / 6%);
+}
+
+.publish-gallery-gates-blocking p {
+  color: var(--icm-danger, #b42318);
+}
+
 .gallery-open-editor {
   display: inline-block;
   padding: 8px 16px;

--- a/docs/roadmap/community-gallery-platform.md
+++ b/docs/roadmap/community-gallery-platform.md
@@ -83,7 +83,7 @@ provider; display-name edits stick; the owner's account sees admin
 affordances; no credential material ever transits or is stored beyond the
 provider contract.
 
-## Phase G3 — Ownership, review, and editing
+## Phase G3 — Ownership, review, and editing (queue + gates live)
 
 - Publishing requires a session; a submission enters a `pending` queue
   instead of going live. The super-admin — or reviewers the super-admin
@@ -96,6 +96,16 @@ provider contract.
 - Editor gains "submit to gallery / update my tile" against the signed-in
   identity; anonymous visitors keep full read-and-local-edit freedom
   without any way to write back.
+
+Shipped 2026-08-22: ordinary signed-in submissions pass deterministic
+quality gates (owner policy: no ERC errors; no floating endpoints —
+wire, name the net, or NoConnect; no near-empty projects) enforced by
+one shared evaluator in the worker and previewed live in the publish
+dialog, then wait in `pending` (publicly invisible) until the
+super-admin or an appointed moderator (`/review`, in-app appointment by
+email) approves or rejects with an optional reason surfaced at `/mine`.
+Remaining in this phase: owner editing/withdrawal of published entries
+re-entering review.
 
 Acceptance: an ordinary submission is invisible publicly until approved;
 rejection stores and surfaces its optional reason; two ordinary accounts

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -43,11 +43,58 @@ serialization, renders the preview, and stores the entry as `public`.
 Submissions count against a per-submitter (hashed IP) limit of 10 per UTC
 day.
 
-Phase G1 gate: publishing additionally requires admin authority —
-the bearer, or (since G2) a signed-in super-admin session — until Phase
-G3 opens a review queue for ordinary signed-in users. Anonymous upload is
-impossible from day one, which is also the end state. Entries persist a
-nullable owner column so G3 ownership requires no migration.
+Publishing authority (since G3): the bearer and admin/moderator sessions
+publish directly as `public`; an ordinary signed-in session submits into
+the review queue as `pending` after passing the quality gates below;
+anonymous upload stays impossible — the day-one rule. A successful
+submission answers 201 `{id, status}`.
+
+## Submission quality gates (Phase G3)
+
+`evaluateSubmissionGates` in `@icm/derived` is the single evaluator; the
+worker enforces it (422 `{error: "quality-gate", failures}`) and the
+publish dialog runs the same function live, so the API can never accept
+what the UI refuses. Gates apply only to ordinary users — the bearer and
+admin/moderator sessions bypass them (failures still shown as
+informational in the dialog). Failure codes:
+
+- `erc-errors` — any ERC diagnostic with `severity: "error"`.
+- `floating-endpoints` — `ERC_UNCONNECTED_PIN`, `ERC_BULK_UNRESOLVED`,
+  and `ERC_FLOATING_GATE`, except a floating gate whose single-member
+  net carries a name (a deliberate port/rail). The sanctioned escapes
+  are therefore: wire the pin, name its net, or mark it NoConnect.
+- `empty-project` — fewer than 2 instances AND no substantial drawing
+  (3+ drafting objects including a text); pure block diagrams pass.
+
+Failures carry `message`, `count`, and up to five example labels.
+
+## Review queue (Phase G3)
+
+Statuses: `public | pending | rejected | recycled`. Pending and rejected
+entries never appear on any public surface (list, detail, preview);
+their detail and preview answer only to reviewers or the owning session.
+
+- `GET /api/gallery/review` — pending entries, oldest first (reviewers:
+  bearer, admin, or moderator session).
+- `POST /api/gallery/<id>/approve` — pending → `public` (reviewers).
+- `POST /api/gallery/<id>/reject` — pending → `rejected` with an
+  optional trimmed reason (≤300) stored alongside reviewer id and
+  timestamp (reviewers). Reviewing a decided entry answers 409.
+- `GET /api/gallery/mine` — the calling session's entries with `status`
+  and `rejectReason`.
+- Moderators: `users.role` (`user`/`moderator`); the super-admin
+  appoints by email via `POST /api/auth/users/role` `{email, role}`,
+  which applies to every account carrying that verified email.
+  Moderators hold exactly review authority; the recycle bin and
+  maintenance stay admin-only.
+
+The editor surfaces the queue at `/review` (approve, reject with reason,
+admin-only moderator appointment) and the submitter's view at `/mine`
+(status chips plus the rejection reason). Owner editing and withdrawal
+of published entries (re-entering review) is a recorded follow-up.
+
+Entries persist a nullable owner column stamped from the submitting
+session.
 
 ## Accounts and sessions (Phase G2, dark-shipped)
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@icm/agent-adapter": "workspace:*",
+    "@icm/derived": "workspace:*",
     "@icm/model": "workspace:*",
     "@icm/project-protocol": "workspace:*",
     "@icm/render-svg": "workspace:*",

--- a/packages/derived/src/index.ts
+++ b/packages/derived/src/index.ts
@@ -27,5 +27,6 @@ export * from "./route-attachment.js";
 export * from "./rich-text-layout.js";
 export * from "./style-profile.js";
 export * from "./segment-geometry.js";
+export * from "./submission-gates.js";
 export * from "./topology-hash.js";
 export * from "./visual.js";

--- a/packages/derived/src/submission-gates.test.ts
+++ b/packages/derived/src/submission-gates.test.ts
@@ -1,0 +1,229 @@
+import { createEmptyProject, type CircuitProject } from "@icm/model";
+import { InMemorySymbolResolver } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { evaluateSubmissionGates } from "./submission-gates.js";
+
+const dual = {
+  schemaVersion: 1 as const,
+  id: "dual",
+  name: "Dual",
+  viewBox: { x: -20, y: -20, width: 40, height: 40 },
+  pins: [
+    {
+      name: "L",
+      role: "passive",
+      at: { x: -20, y: 0 },
+      direction: "west" as const,
+      presentation: { visibility: "visible" as const },
+    },
+    {
+      name: "R",
+      role: "passive",
+      at: { x: 20, y: 0 },
+      direction: "east" as const,
+      presentation: { visibility: "visible" as const },
+    },
+  ],
+  primitives: [
+    { kind: "line" as const, from: { x: -10, y: 0 }, to: { x: 10, y: 0 } },
+  ],
+  variants: [],
+};
+
+const mos = {
+  ...dual,
+  id: "mos",
+  name: "MOS",
+  pins: [
+    {
+      name: "G",
+      role: "gate",
+      at: { x: -20, y: 0 },
+      direction: "west" as const,
+      presentation: { visibility: "visible" as const },
+    },
+    {
+      name: "D",
+      role: "drain",
+      at: { x: 0, y: -20 },
+      direction: "north" as const,
+      presentation: { visibility: "visible" as const },
+    },
+    {
+      name: "S",
+      role: "source",
+      at: { x: 0, y: 20 },
+      direction: "south" as const,
+      presentation: { visibility: "visible" as const },
+    },
+  ],
+  variants: [],
+};
+
+const resolver = new InMemorySymbolResolver([dual, mos]);
+
+function project(): CircuitProject {
+  return createEmptyProject("gates", "Gates", "doc");
+}
+
+function dualInstance(id: string, reference?: string) {
+  return {
+    id,
+    symbolId: "dual",
+    placement: {
+      position: { x: 0, y: 0 },
+      rotation: 0 as const,
+      mirror: "none" as const,
+    },
+    ...(reference ? { netlist: { reference, parameters: {} } } : {}),
+  };
+}
+
+function gates(target: CircuitProject) {
+  return evaluateSubmissionGates(target, resolver);
+}
+
+function failureCodes(target: CircuitProject): string[] {
+  return gates(target).failures.map((failure) => failure.code);
+}
+
+describe("evaluateSubmissionGates", () => {
+  it("passes a clean, fully wired two-instance schematic", () => {
+    const target = project();
+    const document = target.documents[0]!;
+    document.instances = [dualInstance("I1", "R1"), dualInstance("I2", "R2")];
+    document.nets = [
+      {
+        id: "n1",
+        scope: "local",
+        terminals: [
+          { instanceId: "I1", pinName: "L" },
+          { instanceId: "I2", pinName: "L" },
+        ],
+      },
+      {
+        id: "n2",
+        scope: "local",
+        terminals: [
+          { instanceId: "I1", pinName: "R" },
+          { instanceId: "I2", pinName: "R" },
+        ],
+      },
+    ];
+    expect(gates(target)).toEqual({ ok: true, failures: [] });
+  });
+
+  it("blocks floating pins with terminal examples, released by NoConnect", () => {
+    const target = project();
+    const document = target.documents[0]!;
+    document.instances = [dualInstance("I1", "R1"), dualInstance("I2", "R2")];
+    document.nets = [
+      {
+        id: "n1",
+        scope: "local",
+        terminals: [
+          { instanceId: "I1", pinName: "L" },
+          { instanceId: "I2", pinName: "L" },
+        ],
+      },
+    ];
+    const report = gates(target);
+    expect(report.ok).toBe(false);
+    const floating = report.failures.find(
+      (failure) => failure.code === "floating-endpoints",
+    );
+    expect(floating?.count).toBe(2);
+    expect(floating?.examples).toContain("I1.R");
+
+    document.noConnects = [
+      {
+        id: "nc1",
+        endpoint: { kind: "terminal", instanceId: "I1", pinName: "R" },
+      },
+      {
+        id: "nc2",
+        endpoint: { kind: "terminal", instanceId: "I2", pinName: "R" },
+      },
+    ];
+    expect(gates(target).ok).toBe(true);
+  });
+
+  it("blocks an unnamed single-ended gate but accepts a named one", () => {
+    const target = project();
+    const document = target.documents[0]!;
+    document.instances = [
+      { ...dualInstance("M1", "M1"), symbolId: "mos" },
+      { ...dualInstance("M2", "M2"), symbolId: "mos" },
+    ];
+    document.nets = [
+      {
+        id: "channel",
+        scope: "local",
+        terminals: [
+          { instanceId: "M1", pinName: "D" },
+          { instanceId: "M1", pinName: "S" },
+          { instanceId: "M2", pinName: "G" },
+          { instanceId: "M2", pinName: "D" },
+          { instanceId: "M2", pinName: "S" },
+        ],
+      },
+      {
+        id: "gate-net",
+        scope: "local",
+        terminals: [{ instanceId: "M1", pinName: "G" }],
+      },
+    ];
+    expect(failureCodes(target)).toEqual(["floating-endpoints"]);
+
+    document.nets[1]!.name = "CLK";
+    expect(gates(target).ok).toBe(true);
+  });
+
+  it("reports ERC errors such as duplicate instance names", () => {
+    const target = project();
+    const document = target.documents[0]!;
+    document.instances = [dualInstance("I1", "X1"), dualInstance("I2", "X1")];
+    document.nets = [
+      {
+        id: "n1",
+        scope: "local",
+        terminals: [
+          { instanceId: "I1", pinName: "L" },
+          { instanceId: "I2", pinName: "L" },
+        ],
+      },
+      {
+        id: "n2",
+        scope: "local",
+        terminals: [
+          { instanceId: "I1", pinName: "R" },
+          { instanceId: "I2", pinName: "R" },
+        ],
+      },
+    ];
+    const report = gates(target);
+    expect(report.ok).toBe(false);
+    expect(report.failures.map((failure) => failure.code)).toEqual([
+      "erc-errors",
+    ]);
+    expect(report.failures[0]?.examples[0]).toContain(
+      "ERC_DUPLICATE_INSTANCE_NAME",
+    );
+  });
+
+  it("blocks near-empty projects but accepts a substantial block diagram", () => {
+    const empty = project();
+    expect(failureCodes(empty)).toEqual(["empty-project"]);
+
+    const diagram = project();
+    diagram.documents[0]!.drafting = {
+      objects: [
+        { kind: "text" },
+        { kind: "rectangle" },
+        { kind: "arrow" },
+      ] as never,
+    } as never;
+    expect(gates(diagram).ok).toBe(true);
+  });
+});

--- a/packages/derived/src/submission-gates.ts
+++ b/packages/derived/src/submission-gates.ts
@@ -1,0 +1,142 @@
+import type { CircuitProject } from "@icm/model";
+import type { SymbolResolver } from "@icm/symbols";
+
+import { buildProjectConnectivityIndex } from "./connectivity-index.js";
+import { runErcChecks } from "./diagnostics/erc.js";
+
+/**
+ * Gallery submission quality gates (roadmap phase G3). One deterministic
+ * evaluator runs in the publish dialog (live feedback) and in the worker
+ * (authoritative enforcement), so the API can never accept what the UI
+ * would refuse. Policy set by the owner:
+ *
+ * - no ERC errors;
+ * - no floating endpoints — every visible pin is wired into a net with
+ *   other members, sits on a NAMED single-member net (a deliberate
+ *   port/rail), or carries an explicit NoConnect (the ERC engine already
+ *   honors NoConnect and hidden/implicit pins);
+ * - no near-empty submissions — at least 2 instances, or a drawing with
+ *   at least 3 drafting objects including a text (pure block diagrams
+ *   stay submittable).
+ */
+
+export type SubmissionGateCode =
+  "erc-errors" | "floating-endpoints" | "empty-project";
+
+export interface SubmissionGateFailure {
+  code: SubmissionGateCode;
+  message: string;
+  count: number;
+  /** Up to five human-readable example labels ("M1.g", "ERC_…"). */
+  examples: readonly string[];
+}
+
+export interface SubmissionGateReport {
+  ok: boolean;
+  failures: readonly SubmissionGateFailure[];
+}
+
+const FLOATING_CODES = new Set([
+  "ERC_UNCONNECTED_PIN",
+  "ERC_FLOATING_GATE",
+  "ERC_BULK_UNRESOLVED",
+]);
+
+const EXAMPLE_LIMIT = 5;
+
+function netIsNamed(
+  project: CircuitProject,
+  documentId: string,
+  netId: string,
+): boolean {
+  const document = project.documents.find(
+    (candidate) => candidate.id === documentId,
+  );
+  const net = document?.nets.find((candidate) => candidate.id === netId);
+  return typeof net?.name === "string" && net.name.length > 0;
+}
+
+function terminalLabel(parameters: Record<string, unknown>): string {
+  const instanceId = parameters.instanceId;
+  const pinName = parameters.pinName;
+  return typeof instanceId === "string" && typeof pinName === "string"
+    ? `${instanceId}.${pinName}`
+    : "(terminal)";
+}
+
+export function evaluateSubmissionGates(
+  project: CircuitProject,
+  resolver: SymbolResolver,
+): SubmissionGateReport {
+  const failures: SubmissionGateFailure[] = [];
+  const diagnostics = runErcChecks(
+    project,
+    buildProjectConnectivityIndex(project, resolver),
+    resolver,
+  );
+
+  const errors = diagnostics.filter(
+    (diagnostic) => diagnostic.severity === "error",
+  );
+  if (errors.length > 0) {
+    failures.push({
+      code: "erc-errors",
+      message: "The schematic has electrical rule errors",
+      count: errors.length,
+      examples: errors
+        .slice(0, EXAMPLE_LIMIT)
+        .map(
+          (diagnostic) => `${diagnostic.code}: ${diagnostic.primary.objectId}`,
+        ),
+    });
+  }
+
+  const floating = diagnostics.filter((diagnostic) => {
+    if (!FLOATING_CODES.has(diagnostic.code)) return false;
+    // A gate wired onto a single-member net that carries a NAME is a
+    // deliberate port/rail declaration and passes ("unwired but named").
+    if (diagnostic.code === "ERC_FLOATING_GATE") {
+      const netId = diagnostic.parameters.netId;
+      if (
+        typeof netId === "string" &&
+        netIsNamed(project, diagnostic.primary.documentId, netId)
+      ) {
+        return false;
+      }
+    }
+    return true;
+  });
+  if (floating.length > 0) {
+    failures.push({
+      code: "floating-endpoints",
+      message:
+        "Floating endpoints: wire each pin, name its net, or mark it NoConnect",
+      count: floating.length,
+      examples: floating
+        .slice(0, EXAMPLE_LIMIT)
+        .map((diagnostic) => terminalLabel(diagnostic.parameters)),
+    });
+  }
+
+  const instanceCount = project.documents.reduce(
+    (total, document) => total + document.instances.length,
+    0,
+  );
+  const draftingObjects = project.documents.flatMap(
+    (document) => document.drafting?.objects ?? [],
+  );
+  const drawingSubstantial =
+    draftingObjects.length >= 3 &&
+    draftingObjects.some((object) => object.kind === "text");
+  if (instanceCount < 2 && !drawingSubstantial) {
+    failures.push({
+      code: "empty-project",
+      message:
+        "Too little content: place at least 2 components, or a drawing with 3+ objects including text",
+      count: 1,
+      examples: [],
+    });
+  }
+
+  return { ok: failures.length === 0, failures };
+}

--- a/plan/2026-08-22-gallery-review-g3/plan.md
+++ b/plan/2026-08-22-gallery-review-g3/plan.md
@@ -1,0 +1,136 @@
+---
+status: completed
+experience: none
+---
+
+# Gallery Phase G3: Review Queue with Submission Quality Gates
+
+## Goal
+
+Open publishing to ordinary signed-in users behind two mechanisms the
+owner specified: deterministic quality gates (no ERC errors; no floating
+endpoints — every visible pin is wired, in a named net, or explicitly
+NoConnect; no empty submissions) and a review queue (gated submissions
+enter `pending`, invisible publicly, until the super-admin or an
+appointed moderator approves them or rejects them with an optional
+reason the submitter sees). Admin/moderator submissions keep publishing
+directly. Gates run twice from one shared evaluator: authoritatively in
+the worker (API cannot bypass) and live in the publish dialog (problems
+listed before submitting).
+
+## State and Ownership
+
+Branched from `origin/main` (post PR #162) as `claude/gallery-review-g3`.
+
+Owned paths:
+
+- `packages/derived/src/submission-gates.ts` (+ test) and the package
+  index export
+- `worker/gallery.ts` (+ test): pending/rejected statuses, owner stamp,
+  gate enforcement, review/mine routes, moderator-aware preview access
+- `worker/auth.ts` (+ test): `users.role` column, appoint-moderator
+  route, role in the session payload
+- `apps/editor/src/features/editor-shell/gallery-publish.ts(.test.ts)`
+  and `publish-gallery-dialog.tsx(.test.tsx)`: pending/gate outcomes,
+  pre-submit gate list, submit-for-review variant
+- `apps/editor/src/components/review-queue.tsx`,
+  `my-submissions.tsx` (+ tests), `gallery-feed.tsx` (links),
+  `account.tsx` (role field)
+- `apps/editor/src/main.tsx` (`/review`, `/mine` routes),
+  `apps/editor/src/app/App.tsx` (gate report + session plumbing),
+  `styles.css`, `apps/editor/e2e/gallery.spec.ts`
+- `docs/specs/community-gallery.md`, `docs/roadmap/…`, plan files
+
+Shared dependencies: the ERC engine and connectivity index in
+`@icm/derived` (consumed, not modified); the existing submissions
+contract (extended: 201 gains `status`, 422 `quality-gate` added).
+
+## Design
+
+- `evaluateSubmissionGates(project, resolver)` → `{ok, failures[]}` with
+  codes `erc-errors` (any `severity: "error"` ERC diagnostic),
+  `floating-endpoints` (`ERC_UNCONNECTED_PIN`, `ERC_BULK_UNRESOLVED`,
+  and `ERC_FLOATING_GATE` except when its single-member net carries a
+  name — the "named port" escape), and `empty-project` (fewer than 2
+  instances AND fewer than 3 drafting objects with at least one text —
+  pure block diagrams stay submittable). Failures carry counts and up to
+  5 example labels.
+- Worker submission flow: anonymous → 401 (unchanged); bearer or
+  admin/moderator session → gates skipped, `public` (unchanged
+  behavior); ordinary session → gates (422 `{error:"quality-gate",
+failures}`) → stored `pending` with `owner_user_id`. 201 returns
+  `{id, status}`.
+- Gallery schema (guarded ALTERs): `reject_reason`, `reviewed_at`,
+  `reviewed_by`. Statuses: `public | pending | rejected | recycled`.
+- Review routes (admin or moderator session; bearer also accepted):
+  `GET /api/gallery/review` (pending, oldest first),
+  `POST /api/gallery/<id>/approve`, `POST /api/gallery/<id>/reject`
+  (optional reason ≤300). `GET /api/gallery/mine` (session) lists the
+  caller's entries with status and reason. Preview route serves
+  non-public entries only to reviewers or the owner.
+- Auth: `users.role` (`user`/`moderator`, guarded ALTER), role included
+  in the session user, `POST /api/auth/users/role` (admin session) sets
+  the role for every account with a given email.
+- Editor: dialog gains a gate panel (blocking for ordinary users,
+  informational otherwise) and "Submit for review" copy; `/review` page
+  (queue cards with preview, approve, reject-with-reason, and an
+  admin-only appoint-moderator form); `/mine` page (status chips +
+  rejection reason); feed header links per session.
+- Deferred to a follow-up (recorded in the roadmap): owner editing and
+  withdrawal of published entries re-entering review.
+
+## Validation
+
+- `vitest`: submission-gates, worker gallery review flow (pending
+  invisibility, approve/reject + reason, gate 422, admin bypass,
+  ownership), auth role tests, editor client/dialog/component tests
+- `playwright`: gallery spec — ordinary-user dialog shows blocking gate
+  failures; admin review page approves a mocked pending entry
+- repository typecheck, prettier,
+  `node scripts/check-test-impact.mjs --base origin/main`
+- `git diff --check` and `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: gates run identically client- and server-side and only for
+  ordinary users; pending entries are invisible on every public surface;
+  approve/reject transitions with the stored reason surface to the
+  owner; moderators gain exactly review authority
+- Primary checks: `packages/derived/src/submission-gates.test.ts`,
+  `worker/gallery.test.ts`, `apps/editor/e2e/gallery.spec.ts`
+
+## Commit Intent
+
+Committed on `claude/gallery-review-g3` under the user's standing
+commit-push-merge direction as:
+
+```text
+feat(worker): gallery review queue with submission quality gates
+```
+
+## Outcome
+
+Delivered. `evaluateSubmissionGates` (@icm/derived) encodes the owner's
+policy — zero ERC errors; zero floating endpoints with the wire/named-
+net/NoConnect escapes; no near-empty projects (block diagrams pass) —
+and runs identically in the worker (422 with structured failures) and
+live in the publish dialog (blocking list for ordinary users,
+informational for admin/moderator/bearer). Ordinary signed-in
+submissions enter `pending` (invisible on every public surface,
+preview/detail readable only by reviewers and the owner) until approved
+to `public` or rejected with an optional stored reason; deciding twice
+answers 409. Moderators are appointed in-app by email (`users.role` +
+`POST /api/auth/users/role`), hold exactly review authority, and the
+`/review` page (queue cards, approve/reject with reason, admin-only
+appointment form) plus `/mine` (status chips, rejection reason) surface
+the flow; the feed account menu links both. The root workspace gained
+`@icm/derived` so the worker can import the evaluator. Spec and roadmap
+updated; owner editing/withdrawal recorded as the phase's follow-up.
+
+Validation: submission-gates 5, worker suites 47 (review walk-through,
+reason surfacing, gate 422 with bearer/admin bypass, moderator
+appointment), editor unit sweep 31 (editor-shell + components), full
+unit run 460 green, gallery Playwright 10/10 (new: local blocking gates
+on an empty project; review-queue approve), repository typecheck,
+prettier, test-impact, diff checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4396,3 +4396,19 @@ Keep reusable lessons in `docs/experience/`, not in this log.
 - Validation: worker suites, typecheck, prettier, test-impact; production
   GitHub sign-in verified after deploy.
 - Commit status: completed on `claude/auth-fetch-binding`.
+
+## 2026-08-22 — Gallery phase G3: review queue with quality gates
+
+- Target: `plan/2026-08-22-gallery-review-g3/plan.md` (completed).
+- Change: shared `evaluateSubmissionGates` (@icm/derived) — zero ERC
+  errors, zero floating endpoints (wire / named net / NoConnect), no
+  near-empty projects — enforced in the worker (422) and previewed
+  blocking in the publish dialog; ordinary signed-in submissions enter
+  `pending` until a reviewer approves or rejects with a stored optional
+  reason; in-app moderator appointment by email; `/review` and `/mine`
+  pages; feed account links; root workspace gained `@icm/derived`.
+- Validation: gates 5, worker 47, editor units 31, full unit sweep 1132,
+  gallery Playwright 10/10, typecheck, prettier, test-impact, diff
+  checks.
+- Commit status: completed on `claude/gallery-review-g3`; mainline merge
+  gated on the remote required checks.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
       "@icm/agent-adapter":
         specifier: workspace:*
         version: link:packages/agent-adapter
+      "@icm/derived":
+        specifier: workspace:*
+        version: link:packages/derived
       "@icm/model":
         specifier: workspace:*
         version: link:packages/model

--- a/worker/auth.test.ts
+++ b/worker/auth.test.ts
@@ -418,6 +418,54 @@ describe("Google OAuth", () => {
   });
 });
 
+describe("moderator appointment", () => {
+  it("lets only the admin set a role, applied across the email's accounts", async () => {
+    const auth = harness({
+      RESEND_API_KEY: "rk",
+      ADMIN_EMAILS: "owner@example.com",
+    });
+    const adminCookie = await emailSignIn(auth, "owner@example.com");
+    const reviewerCookie = await emailSignIn(auth, "reviewer@example.com");
+    expect((await me(auth, reviewerCookie))?.role).toBe("user");
+
+    const denied = await auth.call("/api/auth/users/role", {
+      method: "POST",
+      cookie: reviewerCookie,
+      body: JSON.stringify({
+        email: "reviewer@example.com",
+        role: "moderator",
+      }),
+    });
+    expect(denied.status).toBe(401);
+
+    const appointed = await auth.call("/api/auth/users/role", {
+      method: "POST",
+      cookie: adminCookie,
+      body: JSON.stringify({
+        email: "Reviewer@Example.com",
+        role: "moderator",
+      }),
+    });
+    expect(appointed.status).toBe(200);
+    expect((await me(auth, reviewerCookie))?.role).toBe("moderator");
+
+    const unknown = await auth.call("/api/auth/users/role", {
+      method: "POST",
+      cookie: adminCookie,
+      body: JSON.stringify({ email: "ghost@example.com", role: "moderator" }),
+    });
+    expect(unknown.status).toBe(404);
+
+    const revoked = await auth.call("/api/auth/users/role", {
+      method: "POST",
+      cookie: adminCookie,
+      body: JSON.stringify({ email: "reviewer@example.com", role: "user" }),
+    });
+    expect(revoked.status).toBe(200);
+    expect((await me(auth, reviewerCookie))?.role).toBe("user");
+  });
+});
+
 describe("sessionUserOf (module seam for the gallery)", () => {
   it("resolves the signed-in user through the binding and null otherwise", async () => {
     const auth = harness({ RESEND_API_KEY: "rk", ADMIN_EMAILS: "b@e.co" });

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -56,6 +56,8 @@ export interface SessionUser {
   displayName: string;
   email: string | null;
   provider: string;
+  /** "user" or "moderator" (appointed by the super-admin). */
+  role: string;
   isAdmin: boolean;
 }
 
@@ -65,6 +67,7 @@ interface UserRow {
   provider_id: string;
   email: string | null;
   display_name: string;
+  role: string;
   created_at: string;
 }
 
@@ -196,10 +199,19 @@ export class AuthDO {
         provider_id TEXT NOT NULL,
         email TEXT,
         display_name TEXT NOT NULL,
+        role TEXT NOT NULL DEFAULT 'user',
         created_at TEXT NOT NULL,
         UNIQUE (provider, provider_id)
       ) WITHOUT ROWID
     `);
+    try {
+      // Additive upgrade for databases created before roles existed.
+      this.sql.exec(
+        "ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'user'",
+      );
+    } catch {
+      // Column already present.
+    }
     this.sql.exec(`
       CREATE TABLE IF NOT EXISTS sessions (
         token_hash TEXT PRIMARY KEY,
@@ -266,6 +278,9 @@ export class AuthDO {
     if (route === "profile" && method === "POST") {
       return this.renameProfile(request);
     }
+    if (route === "users/role" && method === "POST") {
+      return this.setRole(request);
+    }
     return Response.json({ error: "not-found" }, { status: 404 });
   }
 
@@ -299,6 +314,7 @@ export class AuthDO {
       displayName: row.display_name,
       email: row.email,
       provider: row.provider,
+      role: row.role ?? "user",
       isAdmin:
         row.email !== null &&
         adminEmails(this.env).includes(row.email.toLowerCase()),
@@ -355,15 +371,17 @@ export class AuthDO {
       email,
       display_name:
         defaultDisplayName.trim().slice(0, AUTH_DISPLAY_NAME_MAX) || "Someone",
+      role: "user",
       created_at: this.now().toISOString(),
     };
     this.sql.exec(
-      "INSERT INTO users(id, provider, provider_id, email, display_name, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+      "INSERT INTO users(id, provider, provider_id, email, display_name, role, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
       row.id,
       row.provider,
       row.provider_id,
       row.email,
       row.display_name,
+      row.role,
       row.created_at,
     );
     return row;
@@ -721,6 +739,42 @@ export class AuthDO {
       user.id,
     );
     return noStoreJson({ user: { ...user, displayName } });
+  }
+
+  /**
+   * Super-admin appoints (or revokes) moderators by email; the role
+   * applies to every account carrying that verified email, so it covers
+   * a person's GitHub, Google, and email identities at once.
+   */
+  private async setRole(request: Request): Promise<Response> {
+    if (!sameOrigin(request)) {
+      return Response.json({ error: "forbidden" }, { status: 403 });
+    }
+    const caller = await this.sessionUser(request);
+    if (!caller?.isAdmin) {
+      return Response.json({ error: "unauthorized" }, { status: 401 });
+    }
+    const body = (await request.json().catch(() => null)) as {
+      email?: unknown;
+      role?: unknown;
+    } | null;
+    const email = normalizedEmail(body?.email);
+    const role = body?.role;
+    if (!email || (role !== "user" && role !== "moderator")) {
+      return Response.json({ error: "invalid-fields" }, { status: 400 });
+    }
+    const targets = this.sql
+      .exec<UserRow>("SELECT * FROM users WHERE lower(email) = ?", email)
+      .toArray();
+    if (targets.length === 0) {
+      return Response.json({ error: "no-such-user" }, { status: 404 });
+    }
+    this.sql.exec(
+      "UPDATE users SET role = ? WHERE lower(email) = ?",
+      role,
+      email,
+    );
+    return noStoreJson({ updated: targets.length, role });
   }
 }
 

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -248,6 +248,284 @@ describe("gallery submissions", () => {
   });
 });
 
+describe("gallery review queue with quality gates (phase G3)", () => {
+  function reviewHarness() {
+    const authDurable = new AuthDO(sqliteState(), {
+      RESEND_API_KEY: "rk",
+      ADMIN_EMAILS: "owner@example.com",
+    } as AuthEnv);
+    const env: GalleryEnv = {
+      ...environment(ADMIN_TOKEN),
+      AUTH: {
+        getByName: () => ({
+          fetch: (input: Request | string, init?: RequestInit) =>
+            authDurable.fetch(
+              typeof input === "string" ? new Request(input, init) : input,
+            ),
+        }),
+      },
+    };
+    return { authDurable, env };
+  }
+
+  async function signIn(authDurable: AuthDO, email: string): Promise<string> {
+    const sent: string[] = [];
+    authDurable.fetchLike = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      void input;
+      sent.push((JSON.parse(String(init?.body)) as { text: string }).text);
+      return Response.json({ id: "email-1" });
+    }) as typeof fetch;
+    await authDurable.fetch(
+      new Request(`${ORIGIN}/api/auth/email/start`, {
+        method: "POST",
+        headers: { Origin: ORIGIN, "content-type": "application/json" },
+        body: JSON.stringify({ email }),
+      }),
+    );
+    const link = sent[0]!.match(/https?:\/\/\S+/u)![0];
+    const callback = await authDurable.fetch(new Request(link));
+    return callback.headers
+      .getSetCookie()
+      .find((cookie) => cookie.startsWith("icm_session="))!
+      .split(";")[0]!;
+  }
+
+  function wiredProjectText(name = "Wired"): string {
+    const project = createEmptyProject("g3", name);
+    const document = project.documents[0]!;
+    document.instances = [
+      {
+        id: "R1",
+        symbolId: "resistor",
+        placement: {
+          position: { x: 0, y: 0 },
+          rotation: 0,
+          mirror: "none",
+        },
+        netlist: { reference: "R1", parameters: {} },
+      },
+      {
+        id: "R2",
+        symbolId: "resistor",
+        placement: {
+          position: { x: 200, y: 0 },
+          rotation: 0,
+          mirror: "none",
+        },
+        netlist: { reference: "R2", parameters: {} },
+      },
+    ];
+    document.nets = [
+      {
+        id: "n1",
+        scope: "local",
+        terminals: [
+          { instanceId: "R1", pinName: "1" },
+          { instanceId: "R2", pinName: "1" },
+        ],
+      },
+      {
+        id: "n2",
+        scope: "local",
+        terminals: [
+          { instanceId: "R1", pinName: "2" },
+          { instanceId: "R2", pinName: "2" },
+        ],
+      },
+    ];
+    return serializeProject(project);
+  }
+
+  it("walks submit → pending (invisible) → approve → public", async () => {
+    const { authDurable, env } = reviewHarness();
+    const userCookie = await signIn(authDurable, "maker@example.com");
+    const adminCookie = await signIn(authDurable, "owner@example.com");
+
+    const submitted = await route(
+      env,
+      submissionRequest(
+        { name: "Queued", projectText: wiredProjectText("Queued") },
+        { token: null, cookie: userCookie },
+      ),
+    );
+    expect(submitted.status).toBe(201);
+    const { id, status } = (await submitted.json()) as {
+      id: string;
+      status: string;
+    };
+    expect(status).toBe("pending");
+
+    // Invisible on every public surface.
+    const list = await route(env, new Request(`${ORIGIN}/api/gallery`));
+    expect(((await list.json()) as { entries: unknown[] }).entries).toEqual([]);
+    const anonymousDetail = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}`),
+    );
+    expect(anonymousDetail.status).toBe(404);
+    const anonymousPreview = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/preview.svg`),
+    );
+    expect(anonymousPreview.status).toBe(404);
+
+    // The owner and reviewers can see it; the queue lists it.
+    const ownerPreview = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/preview.svg`, {
+        headers: { Cookie: userCookie },
+      }),
+    );
+    expect(ownerPreview.status).toBe(200);
+    const queue = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/review`, {
+        headers: { Cookie: adminCookie },
+      }),
+    );
+    const queued = (await queue.json()) as { entries: { id: string }[] };
+    expect(queued.entries.map((entry) => entry.id)).toEqual([id]);
+    const deniedQueue = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/review`, {
+        headers: { Cookie: userCookie },
+      }),
+    );
+    expect(deniedQueue.status).toBe(401);
+
+    const approved = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/approve`, {
+        method: "POST",
+        headers: { Origin: ORIGIN, Cookie: adminCookie },
+      }),
+    );
+    expect(approved.status).toBe(200);
+    const publicList = await route(env, new Request(`${ORIGIN}/api/gallery`));
+    expect(
+      ((await publicList.json()) as { entries: { id: string }[] }).entries.map(
+        (entry) => entry.id,
+      ),
+    ).toEqual([id]);
+  });
+
+  it("rejects with a stored reason the owner sees; moderators can review", async () => {
+    const { authDurable, env } = reviewHarness();
+    const userCookie = await signIn(authDurable, "maker@example.com");
+    const modCookie = await signIn(authDurable, "reviewer@example.com");
+    const adminCookie = await signIn(authDurable, "owner@example.com");
+    await authDurable.fetch(
+      new Request(`${ORIGIN}/api/auth/users/role`, {
+        method: "POST",
+        headers: {
+          Origin: ORIGIN,
+          Cookie: adminCookie,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          email: "reviewer@example.com",
+          role: "moderator",
+        }),
+      }),
+    );
+
+    const submitted = await route(
+      env,
+      submissionRequest(
+        { name: "Refused", projectText: wiredProjectText("Refused") },
+        { token: null, cookie: userCookie },
+      ),
+    );
+    const { id } = (await submitted.json()) as { id: string };
+
+    const rejected = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/reject`, {
+        method: "POST",
+        headers: {
+          Origin: ORIGIN,
+          Cookie: modCookie,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ reason: "Needs net labels" }),
+      }),
+    );
+    expect(rejected.status).toBe(200);
+
+    const mine = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/mine`, {
+        headers: { Cookie: userCookie },
+      }),
+    );
+    const entries = (await mine.json()) as {
+      entries: { id: string; status: string; rejectReason: string | null }[];
+    };
+    expect(entries.entries).toMatchObject([
+      { id, status: "rejected", rejectReason: "Needs net labels" },
+    ]);
+
+    // A decided entry cannot be re-reviewed.
+    const again = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/approve`, {
+        method: "POST",
+        headers: { Origin: ORIGIN, Cookie: modCookie },
+      }),
+    );
+    expect(again.status).toBe(409);
+  });
+
+  it("blocks gate failures for ordinary users and bypasses them for admins", async () => {
+    const { authDurable, env } = reviewHarness();
+    const userCookie = await signIn(authDurable, "maker@example.com");
+
+    const gated = await route(
+      env,
+      submissionRequest(
+        { name: "Empty", projectText: projectText("Empty") },
+        { token: null, cookie: userCookie },
+      ),
+    );
+    expect(gated.status).toBe(422);
+    const payload = (await gated.json()) as {
+      error: string;
+      failures: { code: string }[];
+    };
+    expect(payload.error).toBe("quality-gate");
+    expect(payload.failures.map((failure) => failure.code)).toContain(
+      "empty-project",
+    );
+
+    // The bearer (owner) publishes the same empty project directly.
+    const viaBearer = await route(
+      env,
+      submissionRequest({ name: "Empty", projectText: projectText("Empty") }),
+    );
+    expect(viaBearer.status).toBe(201);
+    expect(((await viaBearer.json()) as { status: string }).status).toBe(
+      "public",
+    );
+
+    // A moderator submission also publishes directly.
+    const adminCookie = await signIn(authDurable, "owner@example.com");
+    const viaAdmin = await route(
+      env,
+      submissionRequest(
+        { name: "Admin Empty", projectText: projectText("Admin Empty") },
+        { token: null, cookie: adminCookie },
+      ),
+    );
+    expect(viaAdmin.status).toBe(201);
+    expect(((await viaAdmin.json()) as { status: string }).status).toBe(
+      "public",
+    );
+  });
+});
+
 describe("gallery admin sessions (phase G2)", () => {
   async function sessionCookieFor(
     authDurable: AuthDO,
@@ -308,6 +586,9 @@ describe("gallery admin sessions (phase G2)", () => {
     );
     expect(viaSession.status).toBe(201);
 
+    // An ordinary session is no longer refused outright (phase G3): it
+    // goes through the quality gates instead — the empty fixture fails
+    // them — and never publishes directly.
     const ordinaryCookie = await sessionCookieFor(
       authDurable,
       "visitor@example.com",
@@ -315,11 +596,11 @@ describe("gallery admin sessions (phase G2)", () => {
     const viaOrdinary = await route(
       env,
       submissionRequest(
-        { name: "Blocked", projectText: projectText() },
+        { name: "Gated", projectText: projectText() },
         { token: null, cookie: ordinaryCookie },
       ),
     );
-    expect(viaOrdinary.status).toBe(401);
+    expect(viaOrdinary.status).toBe(422);
 
     const recycledList = await route(
       env,

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -11,6 +11,7 @@
 // independently so browsing survives an entry the current window can no
 // longer open.
 
+import { evaluateSubmissionGates } from "@icm/derived";
 import { parseProject, serializeProject } from "@icm/project-protocol";
 import { renderDocumentSvg } from "@icm/render-svg";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
@@ -75,6 +76,9 @@ interface EntryRow {
   status: string;
   recycled_at: string | null;
   owner_user_id: string | null;
+  reject_reason: string | null;
+  reviewed_at: string | null;
+  reviewed_by: string | null;
   project_text: string;
   svg_text: string;
 }
@@ -125,6 +129,18 @@ export class GalleryDO {
         PRIMARY KEY (day, submitter_hash)
       ) WITHOUT ROWID
     `);
+    // Additive review-queue columns (phase G3) for pre-existing databases.
+    for (const alteration of [
+      "ALTER TABLE gallery_entries ADD COLUMN reject_reason TEXT",
+      "ALTER TABLE gallery_entries ADD COLUMN reviewed_at TEXT",
+      "ALTER TABLE gallery_entries ADD COLUMN reviewed_by TEXT",
+    ]) {
+      try {
+        this.sql.exec(alteration);
+      } catch {
+        // Column already present.
+      }
+    }
   }
 
   async fetch(request: Request): Promise<Response> {
@@ -152,6 +168,12 @@ export class GalleryDO {
         return this.delete(String(body.id));
       case "recycled":
         return this.recycled();
+      case "pending":
+        return this.pending();
+      case "review":
+        return this.review(body);
+      case "mine":
+        return this.mine(String(body.ownerUserId));
       case "all-ids":
         return this.allIds();
       case "update-entry":
@@ -189,13 +211,15 @@ export class GalleryDO {
         `INSERT INTO gallery_entries(
           id, name, author, description, created_at, schema_version,
           status, recycled_at, owner_user_id, project_text, svg_text
-        ) VALUES (?, ?, ?, ?, ?, ?, 'public', NULL, NULL, ?, ?)`,
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)`,
         entry.id,
         entry.name,
         entry.author,
         entry.description,
         entry.created_at,
         entry.schema_version,
+        entry.status === "pending" ? "pending" : "public",
+        entry.owner_user_id ?? null,
         entry.project_text,
         entry.svg_text,
       );
@@ -248,8 +272,69 @@ export class GalleryDO {
     return Response.json({
       entry: summaryOf(row),
       status: row.status,
+      ownerUserId: row.owner_user_id,
       projectText: row.project_text,
       svgText: row.svg_text,
+    });
+  }
+
+  private pending(): Response {
+    const rows = this.sql
+      .exec<EntryRow>(
+        `SELECT * FROM gallery_entries WHERE status = 'pending'
+         ORDER BY created_at ASC, id ASC`,
+      )
+      .toArray();
+    return Response.json({
+      entries: rows.map((row) => ({
+        ...summaryOf(row),
+        ownerUserId: row.owner_user_id,
+      })),
+    });
+  }
+
+  private review(body: Record<string, unknown>): Response {
+    const row = this.sql
+      .exec<EntryRow>(
+        "SELECT * FROM gallery_entries WHERE id = ?",
+        String(body.id),
+      )
+      .toArray()[0];
+    if (!row) return Response.json({ error: "not-found" }, { status: 404 });
+    if (row.status !== "pending") {
+      return Response.json({ error: "not-pending" }, { status: 409 });
+    }
+    const approve = body.decision === "approve";
+    this.sql.exec(
+      `UPDATE gallery_entries
+       SET status = ?, reject_reason = ?, reviewed_at = ?, reviewed_by = ?
+       WHERE id = ?`,
+      approve ? "public" : "rejected",
+      approve ? null : ((body.reason as string | null) ?? null),
+      String(body.at),
+      String(body.reviewerId),
+      row.id,
+    );
+    return Response.json({
+      id: row.id,
+      status: approve ? "public" : "rejected",
+    });
+  }
+
+  private mine(ownerUserId: string): Response {
+    const rows = this.sql
+      .exec<EntryRow>(
+        `SELECT * FROM gallery_entries WHERE owner_user_id = ?
+         ORDER BY created_at DESC, id DESC`,
+        ownerUserId,
+      )
+      .toArray();
+    return Response.json({
+      entries: rows.map((row) => ({
+        ...summaryOf(row),
+        status: row.status,
+        rejectReason: row.reject_reason,
+      })),
     });
   }
 
@@ -351,15 +436,25 @@ function sameOrigin(request: Request): boolean {
   return true;
 }
 
-async function isAdmin(request: Request, env: GalleryEnv): Promise<boolean> {
-  if (
+function bearerIsAdmin(request: Request, env: GalleryEnv): boolean {
+  return Boolean(
     env.GALLERY_ADMIN_TOKEN &&
-    request.headers.get("Authorization") === `Bearer ${env.GALLERY_ADMIN_TOKEN}`
-  ) {
-    return true;
-  }
+    request.headers.get("Authorization") ===
+      `Bearer ${env.GALLERY_ADMIN_TOKEN}`,
+  );
+}
+
+async function isAdmin(request: Request, env: GalleryEnv): Promise<boolean> {
+  if (bearerIsAdmin(request, env)) return true;
   const user = await sessionUserOf(request, env);
   return user?.isAdmin === true;
+}
+
+/** Review authority (phase G3): the bearer, an admin, or a moderator. */
+async function canReview(request: Request, env: GalleryEnv): Promise<boolean> {
+  if (bearerIsAdmin(request, env)) return true;
+  const user = await sessionUserOf(request, env);
+  return user?.isAdmin === true || user?.role === "moderator";
 }
 
 async function submitterHash(request: Request): Promise<string> {
@@ -397,10 +492,15 @@ async function handleSubmission(
   if (!sameOrigin(request)) {
     return Response.json({ error: "forbidden" }, { status: 403 });
   }
-  // Phase G1: publishing requires the admin bearer until Phase G2 sign-in
-  // replaces it with session identity. Anonymous upload therefore stays
-  // impossible from day one — which is also the end-state rule.
-  if (!(await isAdmin(request, env))) {
+  // Phase G3: the bearer and admin/moderator sessions publish directly;
+  // ordinary signed-in users pass the quality gates and enter the review
+  // queue as `pending`. Anonymous upload stays impossible — the original
+  // day-one rule.
+  const bearer = bearerIsAdmin(request, env);
+  const user = await sessionUserOf(request, env);
+  const privileged =
+    bearer || user?.isAdmin === true || user?.role === "moderator";
+  if (!bearer && !user) {
     return Response.json({ error: "unauthorized" }, { status: 401 });
   }
   const body = (await request.json().catch(() => null)) as {
@@ -433,8 +533,18 @@ async function handleSubmission(
   } catch {
     return Response.json({ error: "invalid-project" }, { status: 400 });
   }
+  if (!privileged) {
+    const report = evaluateSubmissionGates(project, resolver);
+    if (!report.ok) {
+      return Response.json(
+        { error: "quality-gate", failures: report.failures },
+        { status: 422 },
+      );
+    }
+  }
   project.name = name;
   const now = new Date();
+  const entryStatus = privileged ? "public" : "pending";
   const { status, payload } = await callGallery<{ id?: string }>(
     env,
     "submit",
@@ -448,6 +558,8 @@ async function handleSubmission(
         description,
         created_at: now.toISOString(),
         schema_version: project.schemaVersion,
+        status: entryStatus,
+        owner_user_id: user?.id ?? null,
         project_text: serializeProject(project),
         svg_text: renderPreview(project),
       },
@@ -456,7 +568,10 @@ async function handleSubmission(
   if (status === 429) {
     return Response.json({ error: "rate-limited" }, { status: 429 });
   }
-  return Response.json({ id: payload.id }, { status: 201 });
+  return Response.json(
+    { id: payload.id, status: entryStatus },
+    { status: 201 },
+  );
 }
 
 async function handleReserialize(env: GalleryEnv): Promise<Response> {
@@ -541,19 +656,61 @@ export async function routeGalleryRequest(
     }
     return handleReserialize(env);
   }
+  if (
+    segments.length === 1 &&
+    segments[0] === "review" &&
+    request.method === "GET"
+  ) {
+    if (!(await canReview(request, env))) {
+      return Response.json({ error: "unauthorized" }, { status: 401 });
+    }
+    const { payload } = await callGallery(env, "pending", {});
+    return Response.json(payload, { headers: { "cache-control": "no-store" } });
+  }
+  if (
+    segments.length === 1 &&
+    segments[0] === "mine" &&
+    request.method === "GET"
+  ) {
+    const user = await sessionUserOf(request, env);
+    if (!user) {
+      return Response.json({ error: "unauthorized" }, { status: 401 });
+    }
+    const { payload } = await callGallery(env, "mine", {
+      ownerUserId: user.id,
+    });
+    return Response.json(payload, { headers: { "cache-control": "no-store" } });
+  }
   if (segments.length === 2 && segments[1] === "preview.svg") {
-    const { status, payload } = await callGallery<{ svgText?: string }>(
-      env,
-      "entry",
-      { id: segments[0] },
-    );
+    const { status, payload } = await callGallery<{
+      status?: string;
+      ownerUserId?: string | null;
+      svgText?: string;
+    }>(env, "any-entry", { id: segments[0] });
     if (status !== 200 || !payload.svgText) {
+      return Response.json({ error: "not-found" }, { status: 404 });
+    }
+    if (payload.status === "public") {
+      return new Response(payload.svgText, {
+        headers: {
+          "content-type": "image/svg+xml",
+          "cache-control": "public, max-age=300",
+          "content-security-policy":
+            "default-src 'none'; style-src 'unsafe-inline'",
+        },
+      });
+    }
+    const allowed =
+      (await canReview(request, env)) ||
+      (payload.ownerUserId != null &&
+        (await sessionUserOf(request, env))?.id === payload.ownerUserId);
+    if (!allowed) {
       return Response.json({ error: "not-found" }, { status: 404 });
     }
     return new Response(payload.svgText, {
       headers: {
         "content-type": "image/svg+xml",
-        "cache-control": "public, max-age=300",
+        "cache-control": "no-store",
         "content-security-policy":
           "default-src 'none'; style-src 'unsafe-inline'",
       },
@@ -562,18 +719,54 @@ export async function routeGalleryRequest(
   if (segments.length === 1 && request.method === "GET") {
     const { status, payload } = await callGallery<{
       entry?: GalleryEntrySummary;
+      status?: string;
+      ownerUserId?: string | null;
       projectText?: string;
-    }>(env, "entry", { id: segments[0] });
+    }>(env, "any-entry", { id: segments[0] });
     if (status !== 200) {
       return Response.json({ error: "not-found" }, { status: 404 });
     }
+    if (payload.status !== "public") {
+      const allowed =
+        (await canReview(request, env)) ||
+        (payload.ownerUserId != null &&
+          (await sessionUserOf(request, env))?.id === payload.ownerUserId);
+      if (!allowed) {
+        return Response.json({ error: "not-found" }, { status: 404 });
+      }
+    }
     return Response.json(
-      { entry: payload.entry, projectText: payload.projectText },
+      {
+        entry: payload.entry,
+        status: payload.status,
+        projectText: payload.projectText,
+      },
       { headers: { "cache-control": "no-store" } },
     );
   }
   if (segments.length === 2 && request.method === "POST") {
     const [id, action] = segments;
+    if (action === "approve" || action === "reject") {
+      if (!(await canReview(request, env))) {
+        return Response.json({ error: "unauthorized" }, { status: 401 });
+      }
+      const body =
+        action === "reject"
+          ? ((await request.json().catch(() => null)) as {
+              reason?: unknown;
+            } | null)
+          : null;
+      const reason = fieldText(body?.reason, GALLERY_MAX_DESCRIPTION_LENGTH);
+      const reviewer = await sessionUserOf(request, env);
+      const { status, payload } = await callGallery(env, "review", {
+        id,
+        decision: action,
+        reason: action === "reject" && reason ? reason : null,
+        at: new Date().toISOString(),
+        reviewerId: reviewer?.id ?? "bearer",
+      });
+      return Response.json(payload, { status });
+    }
     if (action !== "recycle" && action !== "restore") {
       return Response.json({ error: "not-found" }, { status: 404 });
     }


### PR DESCRIPTION
Phase G3: opens publishing to ordinary signed-in users behind the owner's quality bar and a review queue.

**Quality gates** — one shared evaluator, `evaluateSubmissionGates` in `@icm/derived`, runs authoritatively in the worker (422 with structured failures) and live in the publish dialog (blocking list for ordinary users, informational for admin/moderator/bearer):
- `erc-errors`: any ERC error diagnostic.
- `floating-endpoints`: unconnected pins, unresolved bulks, floating gates — with the sanctioned escapes: wire the pin, name its net (a single-ended NAMED net is a deliberate port/rail), or mark it NoConnect.
- `empty-project`: fewer than 2 instances and no substantial drawing (block diagrams with 3+ objects incl. text pass).

**Review queue** — ordinary submissions enter `pending` (invisible on every public surface; preview/detail readable only by reviewers and the owner) until approved to `public` or rejected with an optional stored reason (409 on double-decide). Admin/moderator/bearer publish directly, unchanged.
- Moderators: `users.role`, appointed in-app by email (`POST /api/auth/users/role`, applies across that email's provider identities); exactly review authority — bin/maintenance stay admin-only.
- `/review`: queue cards with preview, approve, reject-with-reason, admin-only appointment form. `/mine`: the submitter's statuses and rejection reasons. Feed account menu links both.
- Guarded additive schema upgrades (gallery review columns, users.role); root workspace gains `@icm/derived` for the worker import.

**Docs**: normative gate + queue contract in `docs/specs/community-gallery.md`; roadmap G3 marked live (owner edit/withdraw recorded as the follow-up).

**Tests**: gates evaluator 5; worker 47 (queue walk-through, reason surfacing, gate 422 with bypasses, moderator appointment, pending invisibility); editor units 31; full unit sweep 1132; gallery Playwright 10/10 (new: locally-evaluated blocking gates on an empty project; review-queue approve). Adapted to the concurrently-merged chrome refactor (#163 publish button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)