### PR TITLE
feat(editor): place examples into the drawing instead of replacing it

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -759,12 +759,19 @@ test("shows the complete foldable categorized Library, quick-places a device, an
   );
   await expect(transistorChips).toHaveCount(4);
   const transistorGrid = transistorCategory.locator(".shapes-grid");
-  expect(
+  // Tiles keep a fixed square size; a wider panel fits more of them per row
+  // instead of stretching each tile.
+  const tileBox = await transistorChips.first().boundingBox();
+  if (!tileBox) throw new Error("Library tile is not measurable");
+  expect(Math.round(tileBox.width)).toBe(Math.round(tileBox.height));
+  const gridBox = await transistorGrid.boundingBox();
+  if (!gridBox) throw new Error("Library grid is not measurable");
+  const columns = (
     await transistorGrid.evaluate(
-      (element) =>
-        getComputedStyle(element).gridTemplateColumns.split(" ").length,
-    ),
-  ).toBe(4);
+      (element) => getComputedStyle(element).gridTemplateColumns,
+    )
+  ).split(" ").length;
+  expect(columns).toBe(Math.floor((gridBox.width + 4) / (tileBox.width + 4)));
   expect(
     await transistorChips.evaluateAll(
       (elements) =>
@@ -774,7 +781,7 @@ test("shows the complete foldable categorized Library, quick-places a device, an
           ),
         ).size,
     ),
-  ).toBe(1);
+  ).toBe(Math.ceil(4 / columns));
   expect(
     await transistorGrid.evaluate((element) => {
       const gridBounds = element.getBoundingClientRect();
@@ -969,17 +976,40 @@ test("opens named full-width Project examples from the left tool rail", async ({
   await examplesToggle.click();
   await expect(panel).toHaveAttribute("data-open", "true");
 
+  // An example joins the drawing on the placement cursor; it never replaces
+  // the canvas, so work already on it survives.
+  await chooseComponent(page, "resistor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.click({ position: { x: 200, y: 150 } });
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("hit-R1")).toBeVisible();
+
+  const placedInstances = page.locator('[data-testid^="hit-"]');
+  await expect(placedInstances).toHaveCount(1);
+
   await panel.getByTestId("shapes-example-common-source-amplifier").click();
-  await expect(page.getByTestId("status")).toHaveText(
-    "Opened example: Common-Source Amplifier",
+  await expect(page.getByTestId("status")).toContainText(
+    "Place Common-Source Amplifier on the canvas",
   );
-  await expect(page.getByTestId("hit-M2")).toBeVisible();
+  await canvas.click({ position: { x: 520, y: 320 } });
+  await expect(page.getByTestId("status")).toContainText(
+    "Copied 12 components",
+  );
+  await page.keyboard.press("Escape");
+  // The example joined the drawing: the resistor that was already there stays.
+  await expect(page.getByTestId("hit-R1")).toBeVisible();
+  const afterFirstExample = await placedInstances.count();
+  expect(afterFirstExample).toBeGreaterThan(1);
 
   await panel.getByTestId("shapes-example-two-stage-op-amp").click();
-  await expect(page.getByTestId("status")).toHaveText(
-    "Opened example: Two-Stage Op Amp",
+  await expect(page.getByTestId("status")).toContainText(
+    "Place Two-Stage Op Amp on the canvas",
   );
-  await expect(page.getByTestId("hit-X7")).toBeVisible();
+  await canvas.click({ position: { x: 640, y: 180 } });
+  await expect(page.getByTestId("status")).toContainText("Copied 7 components");
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("hit-R1")).toBeVisible();
+  expect(await placedInstances.count()).toBeGreaterThan(afterFirstExample);
 });
 
 test("keeps a usable canvas while toggling Library at the narrow breakpoint", async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -124,7 +124,11 @@ import {
   resolvePdkSymbolMapping,
   reviewedSky130MosModelSuggestions,
 } from "@icm/symbols";
-import { clipboardPreviewDocument } from "../features/clipboard/clipboard";
+import {
+  clipboardPlacementAnchor,
+  clipboardPreviewDocument,
+  copySelection,
+} from "../features/clipboard/clipboard";
 import type { SchematicClipboard } from "../features/clipboard/clipboard";
 import { startCanvasDragSession } from "../canvas/canvas-drag-session";
 import {
@@ -3210,16 +3214,43 @@ export function App({
     );
   }
 
+  /**
+   * Examples join the drawing instead of replacing it: the example's content
+   * is attached to the placement cursor like an ordinary copy, so existing
+   * work is never overwritten. A hierarchical example cannot be flattened
+   * onto one Document, so it still opens as its own Project behind the
+   * ordinary dirty guard.
+   */
   function openLibraryExample(example: LibraryProjectExample): void {
-    void guardDirtyReplacement(`Open ${example.name} example`, () => {
-      const nextProject = createLibraryExampleProject(example.id);
-      if (!nextProject) {
-        setStatus(`Example is unavailable: ${example.name}`);
-        return;
-      }
-      replaceActiveProject(nextProject);
-      setStatus(`Opened example: ${example.name}`);
-    });
+    const exampleProject = createLibraryExampleProject(example.id);
+    if (!exampleProject) {
+      setStatus(`Example is unavailable: ${example.name}`);
+      return;
+    }
+    const exampleDocument = exampleProject.documents.find(
+      (candidate) => candidate.id === exampleProject.topDocumentId,
+    );
+    if (!exampleDocument || exampleProject.documents.length > 1) {
+      void guardDirtyReplacement(`Open ${example.name} example`, () => {
+        replaceActiveProject(exampleProject);
+        setStatus(`Opened example: ${example.name}`);
+      });
+      return;
+    }
+    const clipboard = copySelection(
+      exampleDocument,
+      exampleDocument.instances.map((instance) => instance.id),
+    );
+    const anchor = clipboard ? clipboardPlacementAnchor(clipboard) : null;
+    if (!clipboard || !anchor) {
+      setStatus(`Example has nothing to place: ${example.name}`);
+      return;
+    }
+    cancelAllTransientInteraction();
+    beginCopyPlacementInteraction(clipboard, anchor);
+    setStatus(
+      `Place ${example.name} on the canvas · R rotates · Shift+R / Ctrl+R mirrors · Esc cancels`,
+    );
   }
 
   function rotatePendingCopy(delta: 90 | -90): void {
@@ -7159,9 +7190,11 @@ export function App({
                 data-testid="publish-gallery-button"
                 aria-haspopup="dialog"
                 aria-expanded={publishGalleryOpen}
+                aria-label="Publish to Gallery"
+                title="Publish to Gallery"
                 onClick={() => setPublishGalleryOpen(true)}
               >
-                Publish…
+                Publish
               </button>
             </div>
           </nav>

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -366,27 +366,57 @@ export function proposePaste(
   );
   const referenceIndex = createReferenceIndex(document);
   const reservedReferences = new Set<string>();
-  const instanceReferences = new Map(
-    clipboard.instances.flatMap((instance) =>
-      instance.netlist &&
-      referencePolicyForInstance(instance).kind === "required"
-        ? (() => {
-            const policy = referencePolicyForInstance(instance);
-            if (policy.kind === "none") return [];
-            const sourceSuffix = referenceSuffixForPolicy(
-              instance.netlist.reference,
-              policy,
-            );
-            const reference = nextReference(referenceIndex, policy, {
-              ...(sourceSuffix !== null ? { startAt: sourceSuffix + 1 } : {}),
-              reservedReferences,
-            });
-            if (!reference) return [];
-            reservedReferences.add(reference.toLowerCase());
-            return [[instance.id, reference] as const];
-          })()
-        : [],
+  const occupiedReferences = new Set(
+    document.instances.flatMap((instance) =>
+      instance.netlist ? [instance.netlist.reference.toLowerCase()] : [],
     ),
+  );
+  /**
+   * Schematic-only markers (ground, power ports) carry a netlist reference
+   * without a device reference policy, so the policy-driven allocator above
+   * cannot renumber them. Their references are still unique per Document, so
+   * pasting one has to claim the next free ordinal of its own prefix.
+   */
+  const nextMarkerReference = (current: string): string | undefined => {
+    const parsed = /^(.*?)(\d+)$/u.exec(current);
+    if (!parsed) return undefined;
+    const prefix = parsed[1]!;
+    for (
+      let suffix = Number(parsed[2]);
+      suffix < Number(parsed[2]) + 1000;
+      suffix += 1
+    ) {
+      const candidate = `${prefix}${suffix}`;
+      const folded = candidate.toLowerCase();
+      if (occupiedReferences.has(folded) || reservedReferences.has(folded)) {
+        continue;
+      }
+      return candidate;
+    }
+    return undefined;
+  };
+  const instanceReferences = new Map(
+    clipboard.instances.flatMap((instance) => {
+      if (!instance.netlist) return [];
+      const policy = referencePolicyForInstance(instance);
+      if (policy.kind === "none") {
+        const reference = nextMarkerReference(instance.netlist.reference);
+        if (!reference) return [];
+        reservedReferences.add(reference.toLowerCase());
+        return [[instance.id, reference] as const];
+      }
+      const sourceSuffix = referenceSuffixForPolicy(
+        instance.netlist.reference,
+        policy,
+      );
+      const reference = nextReference(referenceIndex, policy, {
+        ...(sourceSuffix !== null ? { startAt: sourceSuffix + 1 } : {}),
+        reservedReferences,
+      });
+      if (!reference) return [];
+      reservedReferences.add(reference.toLowerCase());
+      return [[instance.id, reference] as const];
+    }),
   );
   const instanceIds = new Map(
     clipboard.instances.map((instance) => [

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -58,6 +58,7 @@
   /* Layout columns */
   --icm-rail-width: 56px;
   --icm-shapes-width: 248px;
+  --icm-shapes-tile: 56px;
   --icm-props-collapsed: 40px;
   --icm-props-open: 280px;
   --icm-menubar-h: 44px;
@@ -1153,9 +1154,11 @@ body {
   line-height: 1;
 }
 
+/* Fixed-size tiles rather than fractional columns: dragging the panel wider
+   fits more squares per row instead of stretching each one. */
 .shapes-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fill, var(--icm-shapes-tile));
   gap: 4px;
 }
 
@@ -1270,7 +1273,8 @@ body {
   justify-items: center;
   align-content: center;
   gap: 2px;
-  min-height: 56px;
+  width: var(--icm-shapes-tile);
+  height: var(--icm-shapes-tile);
   padding: 0;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
@@ -4254,14 +4258,9 @@ body {
     display: inline;
   }
 
-  .shapes-grid {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
   .shapes-chip {
     grid-template-rows: 36px 1.15em;
     gap: 3px;
-    min-height: 64px;
     padding: 0;
     font-size: 10px;
   }

--- a/plan/2026-08-22-example-import-and-tiles/plan.md
+++ b/plan/2026-08-22-example-import-and-tiles/plan.md
@@ -1,0 +1,94 @@
+---
+status: completed
+experience: none
+---
+
+# Example import, square palette tiles, and a clear Publish label
+
+## Goal
+
+Three review items, plus the paste defect the first one exposed:
+
+1. Clicking an Example replaced the whole canvas, silently discarding work in
+   progress behind a confirm. It should join the current drawing instead.
+2. Dragging the Library wider stretched its tiles instead of fitting more of
+   them; the tiles should stay square and the row count should follow the
+   width.
+3. The menubar button read "Publish…", whose ellipsis reads as a truncated
+   label rather than "opens a dialog".
+
+## State and Ownership
+
+Start state: clean worktree on `main` (untracked local build scaffolding
+only). Branch `claude/publish-label-clarity`.
+
+Owned paths:
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/features/clipboard/clipboard.ts`
+- `apps/editor/src/styles.css`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `plan/2026-08-22-example-import-and-tiles/plan.md`, `plan/log.md`
+
+## Work
+
+1. `openLibraryExample` builds the example's content as an ordinary clipboard
+   payload and attaches it to the placement cursor, so the example is placed
+   like a copy and nothing is overwritten. A hierarchical example (more than
+   one Document) cannot be flattened onto the current Document, so it still
+   opens as its own Project behind the existing dirty guard.
+2. The palette grid becomes `repeat(auto-fill, var(--icm-shapes-tile))` with
+   square tiles, so a wider panel fits more per row.
+3. Label the Publish button "Publish", with the full action in its title and
+   accessible name.
+4. Paste allocates a free reference for schematic-only markers (ground, power
+   ports). They carry a netlist reference but no device reference policy, so
+   the policy-driven allocator skipped them and a second paste produced
+   `Duplicate netlist instance reference: PWR1`.
+
+## Validation
+
+- repository typecheck, prettier
+- full unit suite; full Playwright suite
+- example import, tile squareness, and the resize interaction exercised in a
+  running editor
+
+## Gate Review
+
+- Decision: affected — editor shell and one clipboard planner.
+- Early gates: prettier, focused unit tests.
+- Affected gates: clipboard unit tests, component-insert browser spec.
+- Final gates: `pnpm ci:check` cannot run locally (pnpm absent); delegated to
+  the remote required checks.
+- Platform risks: none; no generated artifact or persisted contract changes.
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: example placement joins the Document; Library tile geometry;
+  paste reference allocation for schematic-only markers.
+- Primary checks: `apps/editor/e2e/component-insert.spec.ts`,
+  `apps/editor/src/features/clipboard/clipboard.test.ts`
+
+## Commit Intent
+
+```text
+feat(editor): place examples into the drawing instead of replacing it
+```
+
+## Outcome
+
+Examples now attach to the placement cursor (status "Place <name> on the
+canvas"), so existing work survives; verified live by placing a resistor,
+importing an example, and confirming both remain. Palette tiles stay 56×56 and
+the row count follows the panel width (218px → 2 columns, 405px → 5). The
+Publish button reads "Publish".
+
+The paste fix came out of the second import failing document validation with
+`Duplicate netlist instance reference: PWR1`: ground and power-port markers
+carry a netlist reference but have no device reference prefix, so paste kept
+their original reference. It now claims the next free ordinal for that prefix,
+which also fixes ordinary copy/paste of those markers.
+
+Validation: typecheck, 179 unit files / 1121 tests, 185 Playwright tests,
+prettier, and diff checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4413,3 +4413,19 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   a running editor including a real 248→368px handle drag.
 - Commit status: completed on `claude/drop-panel-title-banner`; mainline
   merge gated on the remote required checks.
+
+## 2026-08-22 - Example import, square palette tiles, paste marker references
+
+- Changed areas: clicking a Library example now attaches its content to the
+  placement cursor as an ordinary clipboard payload instead of replacing the
+  Project (hierarchical examples still open as their own Project behind the
+  dirty guard); palette tiles became fixed squares in an auto-fill grid so a
+  wider panel fits more per row; the Publish button dropped its ellipsis; and
+  paste now allocates a free reference for schematic-only markers, fixing the
+  `Duplicate netlist instance reference: PWR1` rejection that a second example
+  import (or an ordinary copy of a ground/power port) triggered.
+- Validation: typecheck, full unit suite (179 files / 1121 tests), full
+  Playwright suite (185 passed), prettier, diff checks; example import, tile
+  squareness, and panel resizing all exercised in a running editor.
+- Commit status: completed on `claude/publish-label-clarity`; mainline merge
+  gated on the remote required checks.


### PR DESCRIPTION
Three review items, plus the paste defect the first one exposed.

## 1. Examples join the drawing (the destructive one)

Clicking a Library example replaced the whole Project — work in progress was discarded behind a confirm dialog. An example is now turned into an ordinary clipboard payload and attached to the placement cursor: it is placed like a copy, existing content survives, and rotate / mirror / Esc behave as usual.

A hierarchical example (more than one Document) can't be flattened onto the current Document, so it still opens as its own Project behind the existing dirty guard.

## 2. Palette tiles stay square

The grid was `repeat(4, minmax(0, 1fr))`, so dragging the Library wider stretched each tile into a rectangle. It is now `repeat(auto-fill, var(--icm-shapes-tile))` with fixed 56×56 tiles, so a wider panel fits **more tiles per row** instead. Measured live: 218px → 2 columns, 405px → 5 columns, tiles 56×56 throughout.

## 3. "Publish…" → "Publish"

The ellipsis read as a truncated label rather than "opens a dialog". The full action stays in the button's title and accessible name.

## 4. Paste allocates references for schematic-only markers

Importing a *second* example failed Document validation:

```
INVALID_RESULT: Transaction result failed Document validation — Duplicate netlist instance reference: PWR1
```

Ground and power-port markers carry a netlist reference but have no device reference prefix (`referencePrefix: null`), so `proposePaste`'s policy-driven allocator skipped them and kept the original reference. It now claims the next free ordinal of that reference's own prefix. This also fixes ordinary copy/paste of a ground or power port, which hit the same rejection.

## Test plan

- [x] `tsc -p tsconfig.check.json` clean
- [x] Full unit suite: **179 files / 1121 tests**
- [x] Full Playwright suite: **185 passed**
- [x] prettier, markdown links, `git diff --check`, test-impact
- [x] Verified live: placed a resistor, imported two examples on top of it, and confirmed the resistor and both examples coexist
- [ ] Remote required checks green — pnpm is unavailable locally, so `pnpm ci:check` is delegated to CI

The examples browser spec now asserts the join-don't-replace behavior and the tile geometry contract rather than the old fixed 4-column layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)