### PR TITLE
feat(editor): name the + / − input swap and unify the brand

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -64,6 +64,7 @@ import {
   endpointKey,
   findHierarchyPath,
   findHierarchyPaths,
+  hasDifferentialInputs,
   isMosBulkTerminal,
   isSchematicAnnotationVisible,
   isVisibleEndpoint,
@@ -932,6 +933,11 @@ export function App({
     selectedIds.length === 1
       ? document.instances.find((instance) => instance.id === selectedId)
       : undefined;
+  const selectedInstanceHasDifferentialInputs = (() => {
+    if (!selectedInstance) return false;
+    const resolved = resolver.resolve(selectedInstance.symbolId);
+    return resolved ? hasDifferentialInputs(resolved) : false;
+  })();
   const selectedHierarchyCell = selectedInstance
     ? project.documents.find(
         (candidate) =>
@@ -8544,6 +8550,17 @@ export function App({
                         >
                           Mirror top/bottom
                         </button>
+                        {selectedInstanceHasDifferentialInputs ? (
+                          <button
+                            type="button"
+                            data-testid="swap-differential-inputs"
+                            aria-label="Swap the + and - inputs"
+                            title="Swap + / - inputs (Ctrl+R)"
+                            onClick={() => mirrorSelected("top-bottom")}
+                          >
+                            Swap + / − inputs
+                          </button>
+                        ) : null}
                         <button
                           type="button"
                           aria-label="Return component to Placement Tray"

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -89,19 +89,21 @@ export function GalleryFeed() {
   return (
     <main className="gallery-shell" data-testid="gallery-feed">
       <header className="gallery-chrome">
-        <a
-          className="gallery-brand"
-          href="/editor"
-          aria-label="Open the editor"
-          title="Open the editor"
-          data-testid="gallery-editor-link"
-        >
-          <span className="app-brand-mark" aria-hidden="true" />
-          <div>
+        <div className="app-brand">
+          <a
+            className="gallery-home-link"
+            href="/editor"
+            aria-label="Open the editor"
+            title="Open the editor"
+            data-testid="gallery-editor-link"
+          >
+            <span className="app-brand-mark" aria-hidden="true" />
             <h1>Analog Canvas</h1>
-            <p>Community circuit gallery</p>
+          </a>
+          <div className="app-brand-copy">
+            <p>Community gallery</p>
           </div>
-        </a>
+        </div>
         <nav className="gallery-actions">
           <AccountMenu />
           <a

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -216,8 +216,13 @@ body {
   gap: var(--icm-space-2);
   flex: 0 1 auto;
   min-width: 0;
-  max-width: min(16rem, 36vw);
   padding: 0;
+}
+
+/* Only the editor's menubar competes for horizontal space, so the brand
+   truncates there and renders in full on the gallery. */
+.app-chrome-main .app-brand {
+  max-width: min(16rem, 36vw);
   overflow: hidden;
 }
 
@@ -5278,24 +5283,6 @@ html.light .analytics-map-land path {
   position: sticky;
   top: 0;
   z-index: 2;
-}
-
-.gallery-brand {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.gallery-brand h1 {
-  margin: 0;
-  font-size: 17px;
-  line-height: 1.2;
-}
-
-.gallery-brand p {
-  margin: 0;
-  font-size: 12px;
-  color: var(--icm-text-muted);
 }
 
 .gallery-actions {

--- a/packages/derived/src/instance-label-placement.test.ts
+++ b/packages/derived/src/instance-label-placement.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   defaultInstanceLabelPlacement,
+  hasDifferentialInputs,
   isBjtSymbol,
   isMosSymbol,
 } from "./instance-label-placement.js";
@@ -184,5 +185,20 @@ describe("instance label placement", () => {
     expect(value.alignment).toBe("end");
     expect(value.position.x).toBe(reference.position.x);
     expect(value.position.y - reference.position.y).toBe(30);
+  });
+});
+
+describe("differential input detection", () => {
+  it("recognizes the polarity-marked pairs and nothing else", () => {
+    for (const symbolId of ["opamp", "comparator"]) {
+      const resolved = resolver.resolve(symbolId);
+      expect(resolved).toBeDefined();
+      expect(hasDifferentialInputs(resolved!)).toBe(true);
+    }
+    for (const symbolId of ["resistor", "nmos", "voltage-amplifier"]) {
+      const resolved = resolver.resolve(symbolId);
+      expect(resolved).toBeDefined();
+      expect(hasDifferentialInputs(resolved!)).toBe(false);
+    }
   });
 });

--- a/packages/derived/src/instance-label-placement.ts
+++ b/packages/derived/src/instance-label-placement.ts
@@ -50,6 +50,17 @@ export function isBjtSymbol(resolved: ResolvedSymbol): boolean {
   return roles.has("base") && roles.has("collector") && roles.has("emitter");
 }
 
+/**
+ * True when the Symbol draws a polarity-marked differential input pair, so a
+ * caller can offer "swap + / −" as a named action. The swap itself is the
+ * ordinary top/bottom reflection: the marks are artwork, and the terminals
+ * move with them, so the electrical fact and the drawing stay in agreement.
+ */
+export function hasDifferentialInputs(resolved: ResolvedSymbol): boolean {
+  const roles = new Set(resolved.definition.pins.map((pin) => pin.role));
+  return roles.has("non-inverting-input") && roles.has("inverting-input");
+}
+
 function transformedBounds(
   localBounds: Rect,
   instance: SchematicDocument["instances"][number],

--- a/plan/2026-08-22-differential-input-swap/plan.md
+++ b/plan/2026-08-22-differential-input-swap/plan.md
@@ -1,0 +1,88 @@
+---
+status: completed
+experience: none
+---
+
+# Named + / − input swap and one brand across both views
+
+## Goal
+
+1. The op amp and comparator need an explicit way to reverse their `+` and `−`
+   inputs. The capability already exists (a top/bottom reflection moves the
+   marks and their terminals together) but nothing names it, so it is not
+   discoverable.
+2. The editor and the gallery drew the same brand two different ways — a
+   different heading size, a different subtitle treatment, and a click target
+   that existed on one side only. They should read as one product in two
+   views.
+
+## State and Ownership
+
+Start state: clean worktree on `main`. Branch
+`claude/differential-input-swap`.
+
+Owned paths:
+
+- `packages/derived/src/instance-label-placement.ts` and its test
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/components/gallery-feed.tsx`
+- `apps/editor/src/styles.css`
+- `plan/2026-08-22-differential-input-swap/plan.md`, `plan/log.md`
+
+## Work
+
+1. Add `hasDifferentialInputs(resolved)` to the derived projections: true when
+   a Symbol carries both a `non-inverting-input` and an `inverting-input` pin.
+   It is role-driven, so any future differential Symbol gets the action for
+   free.
+2. Offer "Swap + / − inputs" in the instance properties for those Symbols. It
+   issues the same top/bottom reflection as `Ctrl+R`, so the marks and the
+   terminals stay in agreement — no presentation-only polarity lie.
+3. Give the gallery the editor's brand markup and classes, so one rule set
+   styles both: mark plus "Analog Canvas" wordmark as the link to the other
+   view, subtitle underneath (project/document in the editor, "Community
+   gallery" in the gallery). Scope the editor's truncation to the editor
+   chrome, which is the only place the brand competes for width.
+
+## Validation
+
+- repository typecheck, prettier
+- `packages/derived/src/instance-label-placement.test.ts`
+- full unit suite; full Playwright suite
+- the swap exercised on a placed op amp in a running editor, and both brands
+  compared side by side
+
+## Gate Review
+
+- Decision: affected — one derived projection plus editor presentation.
+- Early gates: prettier, the derived unit test.
+- Affected gates: full unit suite, gallery and editor browser specs.
+- Final gates: `pnpm ci:check` cannot run locally (pnpm absent); delegated to
+  the remote required checks.
+- Platform risks: none; no generated artifact or persisted contract changes.
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: differential-input detection by pin role; brand presentation
+  shared by both views.
+- Primary checks: `packages/derived/src/instance-label-placement.test.ts`
+
+## Commit Intent
+
+```text
+feat(editor): name the + / - input swap and unify the brand
+```
+
+## Outcome
+
+The op amp and comparator now carry a "Swap + / − inputs" action in their
+properties; pressing it reflects the instance top-to-bottom, which moves the
+polarity marks and their terminals together (verified live: the `+` mark
+crossed to the top while the triangle kept pointing right). The gallery brand
+now uses the editor's markup, typography, and hover treatment, links to the
+editor, and shows "Community gallery" as its subtitle; the editor's brand
+links to the gallery and shows the project and document.
+
+Validation: typecheck, 180 unit files / 1133 tests, 187 Playwright tests,
+prettier, and diff checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4444,3 +4444,18 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   squareness, and panel resizing all exercised in a running editor.
 - Commit status: completed on `claude/publish-label-clarity`; mainline merge
   gated on the remote required checks.
+
+## 2026-08-22 - Named differential input swap and one shared brand
+
+- Changed areas: new role-driven `hasDifferentialInputs` projection in
+  `@icm/derived`; instance properties offer "Swap + / − inputs" for op amps
+  and comparators, issuing the existing top/bottom reflection so marks and
+  terminals move together; the gallery brand adopts the editor's markup,
+  classes, and typography, links to the editor, and the editor's brand
+  truncation is scoped to the editor chrome so the gallery shows the full
+  wordmark.
+- Validation: typecheck, full unit suite (180 files / 1133 tests), full
+  Playwright suite (187 passed), prettier, diff checks; the swap and both
+  brands verified in the running app.
+- Commit status: completed on `claude/differential-input-swap`; mainline
+  merge gated on the remote required checks.


### PR DESCRIPTION
Two review items.

## 1. A named way to reverse `+` and `−`

Reversing an op amp's or comparator's inputs was already possible — a top/bottom reflection moves the polarity marks *and their terminals* together — but nothing named it, so it wasn't discoverable.

Instance properties now offer **"Swap + / − inputs"** for any Symbol carrying both a `non-inverting-input` and an `inverting-input` pin. The detection is a new role-driven projection (`hasDifferentialInputs` in `@icm/derived`) rather than a hard-coded symbol list, so a future differential Symbol gets the action for free.

The action issues the same reflection as `Ctrl+R`. That matters: the polarity marks are artwork and the terminals move with them, so the drawing and the electrical fact never disagree. A presentation-only "flip the glyphs" toggle would have made the symbol lie about which terminal is inverting.

Verified live: the `+` mark crosses to the top while the triangle keeps pointing right.

## 2. One brand across both views

The gallery drew the same brand differently from the editor — another heading size, another subtitle treatment, and a click target on one side only. Both now share the editor's markup, classes, and typography:

| | Editor | Gallery |
|---|---|---|
| link target | `/` (gallery) | `/editor` |
| wordmark | "Analog Canvas" | "Analog Canvas" |
| subtitle | project / document | "Community gallery" |

The truncation the editor needs (its menubar competes for width) is now scoped to the editor chrome, so the gallery shows the full wordmark instead of "Analog Ca…".

## Test plan

- [x] `tsc -p tsconfig.check.json` clean
- [x] Full unit suite: **180 files / 1133 tests** (new coverage for the role-driven detection)
- [x] Full Playwright suite: **187 passed**
- [x] prettier, markdown links, `git diff --check`, test-impact
- [x] Swap exercised on a placed op amp; both brands compared side by side in the running app
- [ ] Remote required checks green — pnpm is unavailable locally, so `pnpm ci:check` is delegated to CI

Still open from the same review: the differential-output op amp (an output `+`/`−` pair that flips independently of the inputs) needs a new Symbol, since a variant cannot rename or move pins. `set_instance_symbol` already exists, so the plan is a reviewed differential Symbol plus an output-swapped sibling reached from a properties action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)