### PR TITLE
style(editor): put both headers on one chrome band

### DIFF
--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -5285,17 +5285,42 @@ html.light .analytics-map-land path {
   color: var(--icm-text);
 }
 
+/* Both views wear the same chrome band: one header height, one control
+   height, and a brand block that spans the same band as the buttons so the
+   two sides of the row read as equal. */
 .gallery-chrome {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--icm-space-3);
-  padding: 14px 22px;
+  height: var(--icm-menubar-h);
+  min-height: var(--icm-menubar-h);
+  padding: 0 var(--icm-space-3);
   border-bottom: 1px solid var(--icm-border);
   background: var(--icm-surface);
   position: sticky;
   top: 0;
   z-index: 2;
+}
+
+.gallery-chrome .app-brand,
+.app-chrome-main .app-brand,
+.gallery-actions,
+.account-menu {
+  min-height: var(--icm-control-h);
+}
+
+.gallery-actions .account-owner-badge,
+.gallery-actions .account-link,
+.gallery-actions .account-name,
+.gallery-actions .account-signout,
+.gallery-actions .account-signin summary,
+.gallery-open-editor {
+  display: inline-flex;
+  align-items: center;
+  height: var(--icm-control-h);
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 .gallery-actions {
@@ -5629,8 +5654,7 @@ html.light .analytics-map-land path {
 }
 
 .gallery-open-editor {
-  display: inline-block;
-  padding: 8px 16px;
+  padding: 0 16px;
   border-radius: var(--icm-radius-sm);
   background: var(--icm-accent);
   color: #fff;

--- a/plan/2026-08-22-shared-chrome-band/plan.md
+++ b/plan/2026-08-22-shared-chrome-band/plan.md
@@ -1,0 +1,79 @@
+---
+status: completed
+experience: none
+---
+
+# One chrome band across the editor and the gallery
+
+## Goal
+
+The two headers were different heights, and inside each one the left and right
+sides sat in different bands:
+
+| | editor | gallery |
+| --- | --- | --- |
+| header | 44px | 62.5px |
+| brand block | 22px | 22px |
+| button block | 28px | 33.5px |
+
+The gallery header also mixed control heights among itself — the owner badge,
+the account buttons, and the primary action each carried their own padding.
+
+## State and Ownership
+
+Start state: clean worktree on `main`. Branch `claude/gallery-header-band`.
+
+Owned paths:
+
+- `apps/editor/src/styles.css`
+- `plan/2026-08-22-shared-chrome-band/plan.md`, `plan/log.md`
+
+## Work
+
+1. Give the gallery header the editor's `--icm-menubar-h` height and matching
+   horizontal padding, so both headers are one band tall.
+2. Put every gallery header control on `--icm-control-h` with centred content,
+   including the owner badge, the account links and buttons, the sign-in
+   summary, and the primary "New Circuit" action.
+3. Give the brand block in both views a `--icm-control-h` minimum, so the left
+   and right sides of each header span the same band.
+
+## Validation
+
+- repository typecheck, prettier
+- full unit suite; full Playwright suite
+- header, brand, and button geometry measured in both views
+
+## Gate Review
+
+- Decision: affected — presentation only, no behavior change.
+- Early gates: prettier, unit suite.
+- Affected gates: the browser specs that measure editor chrome geometry.
+- Final gates: `pnpm ci:check` cannot run locally (pnpm absent); delegated to
+  the remote required checks.
+- Platform risks: none.
+
+## Test Impact
+
+- Decision: no-test-change
+- Reason: no assertion pins the header or control heights; the browser specs
+  locate chrome by role and test id, and the narrow-breakpoint spec that does
+  measure geometry only asserts the right-hand chrome stays inside the
+  viewport, which this change preserves (verified by a full suite run).
+
+## Commit Intent
+
+```text
+style(editor): put both headers on one chrome band
+```
+
+## Outcome
+
+Both headers are now 44px tall with every group — brand, menubar, and buttons
+— spanning the same 28px band. Measured after the change: editor brand,
+menubar, and actions all 28px at y 8–36; gallery brand, actions, and primary
+button all 28px at y 7.5–35.5.
+
+Validation: typecheck, 182 unit files / 1148 tests, full Playwright suite (186
+passed; the recurring `component-insert.spec.ts:376` timing flake passed on
+its isolated re-run), prettier, and diff checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4551,3 +4551,17 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   geometry measured in both views.
 - Commit status: completed on `claude/publish-full-label`; mainline merge
   gated on the remote required checks.
+
+## 2026-08-22 - One chrome band across both views
+
+- Changed areas: the gallery header adopts the editor's menubar height and
+  padding; every gallery header control (owner badge, account links and
+  buttons, sign-in summary, primary action) sits on the shared control
+  height; the brand block in both views spans that same band, so each
+  header's two sides are equal and the two headers match each other.
+- Validation: typecheck, full unit suite (182 files / 1148 tests), full
+  Playwright suite (186 passed; the recurring component-insert:376 timing
+  flake passed on its isolated re-run), prettier, diff checks; header, brand,
+  and button geometry measured in both views.
+- Commit status: completed on `claude/gallery-header-band`; mainline merge
+  gated on the remote required checks.


### PR DESCRIPTION
The editor and gallery headers were different heights, and inside each one the two sides sat in different bands.

## Measured before

| | editor | gallery |
|---|---|---|
| header | 44px | **62.5px** |
| brand block | 22px | 22px |
| button block | 28px | **33.5px** |

The gallery header also mixed heights among its own controls — the owner badge (21px), the account buttons (29.5px), the sign-in summary and primary action (33.5px) each carried their own padding, which is visible as a ragged row.

## What changed

1. The gallery header takes the editor's `--icm-menubar-h` height and horizontal padding, so both headers are one band tall.
2. Every control in the gallery header sits on `--icm-control-h` with centred content: owner badge, account links and buttons, sign-in summary, and the primary "New Circuit" action.
3. The brand block in **both** views takes that same height as its minimum, so each header's left and right sides span one band.

## Measured after

| | editor | gallery |
|---|---|---|
| header | 44px | 44px |
| brand block | 28px (y 8–36) | 28px (y 7.5–35.5) |
| menubar | 28px (y 8–36) | — |
| button block | 28px (y 8–36) | 28px (y 7.5–35.5) |

## Test plan

- [x] `tsc -p tsconfig.check.json` clean
- [x] Full unit suite: **182 files / 1148 tests**
- [x] Full Playwright suite: **186 passed** — the recurring `component-insert.spec.ts:376` timing flake failed in the parallel run and passed on its isolated re-run, as it has all session
- [x] prettier, markdown links, `git diff --check`, test-impact
- [x] Header, brand, and button geometry measured in both views
- [ ] Remote required checks green

Presentation only: no assertion pins these heights, and the narrow-breakpoint spec that does measure chrome geometry still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)