### PR TITLE
fix(editor): dismiss the Insert dialog on Escape regardless of focus

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -388,6 +388,11 @@ test("reopens I and starts Copy from retained selection without stacking modes",
     page.getByRole("dialog", { name: "Insert Component" }),
   ).toBeVisible();
   await page.keyboard.press("Escape");
+  // Closing the dialog is a state update, so a keystroke sent in the same tick
+  // still lands in its search field. Wait for it to leave before typing.
+  await expect(
+    page.getByRole("dialog", { name: "Insert Component" }),
+  ).toHaveCount(0);
   await page.keyboard.press("c");
   await page.keyboard.press("c");
   await canvas.hover({ position: { x: 560, y: 330 } });
@@ -399,6 +404,33 @@ test("reopens I and starts Copy from retained selection without stacking modes",
   await expect(
     page.getByRole("dialog", { name: "Insert Component" }),
   ).toBeVisible();
+});
+
+test("Escape closes the Insert dialog even when focus is outside it", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const dialog = page.getByRole("dialog", { name: "Insert Component" });
+
+  await page.keyboard.press("i");
+  await expect(dialog).toBeVisible();
+  // The dialog claims focus a frame after it opens, so an Escape pressed in
+  // that gap is delivered elsewhere. Reproduce that deterministically by
+  // moving focus out, then dismiss: the dialog must not stay stuck open.
+  await page.evaluate(() => {
+    (
+      document.querySelector(
+        '[data-testid="draw-tool-wire"]',
+      ) as HTMLElement | null
+    )?.focus();
+  });
+  await page.keyboard.press("Escape");
+  await expect(dialog).toHaveCount(0);
+
+  await page.keyboard.press("i");
+  await expect(dialog).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(dialog).toHaveCount(0);
 });
 
 test("publishes placement cancellation synchronously before rapid Copy", async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -6665,6 +6665,14 @@ export function App({
         closeSearch();
         return;
       }
+      if (event.key === "Escape" && insertDialogOpen) {
+        // The dialog focuses its search field a frame after it opens, so an
+        // Escape pressed in that gap never reaches its own handler. Cancel it
+        // from the window instead of leaving the dialog stuck open.
+        event.preventDefault();
+        cancelComponentInsertFromHook();
+        return;
+      }
       if (event.key === "Escape" && dismissOpenCommandMenus()) {
         event.preventDefault();
         return;

--- a/plan/2026-08-22-insert-dialog-escape/plan.md
+++ b/plan/2026-08-22-insert-dialog-escape/plan.md
@@ -1,0 +1,66 @@
+---
+status: completed
+experience: none
+---
+
+# Escape dismisses the Insert dialog regardless of focus
+
+## Goal
+
+`component-insert.spec.ts:376` failed in four separate full-suite runs this
+session and passed on every isolated re-run, so it was being treated as a
+timing flake. It is not: it exposes a real dismissal gap.
+
+## State and Ownership
+
+Start state: clean worktree on `main`. Branch `claude/fix-copy-mode-flake`.
+
+Owned paths:
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `plan/2026-08-22-insert-dialog-escape/plan.md`, `plan/log.md`
+
+## Work
+
+The Insert dialog focuses its search field inside a `requestAnimationFrame`,
+and its Escape handler lives on the dialog form. An Escape delivered in that
+gap therefore reaches the window instead, where no case covered the dialog, so
+the dialog stayed open and its backdrop swallowed every later pointer action —
+which is exactly what the spec's `canvas.hover` timeout reported.
+
+1. Handle Escape for the open Insert dialog at the window level, beside the
+   existing search-dialog case.
+2. Replace the spec's incidental coverage with a deterministic test: open the
+   dialog, move focus outside it, press Escape, and require the dialog to go.
+
+## Validation
+
+- repository typecheck, prettier
+- the changed spec file run three times end to end
+- the new test run with the fix reverted, to prove it fails without it
+- full unit suite; full Playwright suite
+
+## Gate Review
+
+- Decision: affected — one editor shell key handler.
+- Early gates: prettier, the focused browser test.
+- Affected gates: the component-insert browser spec.
+- Final gates: `pnpm ci:check` cannot run locally (pnpm absent); delegated to
+  the remote required checks.
+- Platform risks: none.
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: Escape dismisses the Insert dialog no matter which element holds
+  focus.
+- Primary checks: `apps/editor/e2e/component-insert.spec.ts` — "Escape closes
+  the Insert dialog even when focus is outside it"
+
+## Outcome
+
+Before the fix the spec file failed two runs out of three; after it, three
+runs out of three passed, and the full browser suite is green at 188. The new
+test was verified to fail with the fix stashed, so it protects the behavior
+rather than the timing.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4565,3 +4565,19 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   and button geometry measured in both views.
 - Commit status: completed on `claude/gallery-header-band`; mainline merge
   gated on the remote required checks.
+
+## 2026-08-22 - Insert dialog dismissal gap behind a recurring "flake"
+
+- Changed areas: Escape now dismisses an open Insert dialog from the window
+  handler. The dialog focuses its search field a frame after opening and its
+  own Escape handler sits on the dialog form, so an Escape pressed in that gap
+  left the dialog open with its backdrop swallowing later pointer actions —
+  the cause of the `component-insert.spec.ts:376` failures that had looked
+  like a timing flake all session. The spec's incidental coverage is replaced
+  by a deterministic test that moves focus out of the dialog before pressing
+  Escape.
+- Validation: typecheck, the spec file three times end to end, the new test
+  re-run with the fix stashed to prove it fails without it, editor unit tests
+  (419), full Playwright suite (188 passed), prettier, diff checks.
+- Commit status: completed on `claude/fix-copy-mode-flake`; mainline merge
+  gated on the remote required checks.


### PR DESCRIPTION
`component-insert.spec.ts:376` failed in **four separate full-suite runs** this session and passed on every isolated re-run, so it was being written off as a timing flake. It wasn't — it was reporting a real dismissal gap.

## What was actually happening

The Insert dialog focuses its search field inside a `requestAnimationFrame`, and its Escape handler lives on the dialog form. An Escape delivered in that one-frame gap reaches the **window** instead, where no case covered the dialog. So the dialog stayed open, and its backdrop swallowed every later pointer action:

```
Error: locator.hover: Test timeout of 30000ms exceeded.
  - <p>Select a component to preview it.</p> from
    <div class="insert-dialog-backdrop"> subtree intercepts pointer events
```

That is a user-facing rough edge, not a test artifact: press `I` and `Escape` in quick succession and the dialog can stick.

## Fix

Handle Escape for the open Insert dialog at the window level, beside the existing search-dialog case.

## Evidence

| | before fix | after fix |
|---|---|---|
| spec file, 3 consecutive runs | 2 failed | 3 passed |
| full browser suite | 186/187 | **188/188** |

The spec's incidental coverage is replaced by a deterministic test — open the dialog, move focus outside it, press Escape — and I verified it **fails with the fix stashed**, so it protects the behavior rather than the timing.

## Test plan

- [x] `tsc -p tsconfig.check.json` clean
- [x] Editor unit tests: 419 passed
- [x] Full Playwright suite: **188 passed**
- [x] New test verified to fail without the fix
- [x] prettier, markdown links, `git diff --check`, test-impact
- [ ] Remote required checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)