### PR TITLE
fix(editor): show the placement ghost without waiting for a pointer move

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -433,6 +433,23 @@ test("Escape closes the Insert dialog even when focus is outside it", async ({
   await expect(dialog).toHaveCount(0);
 });
 
+test("Copy shows its ghost under the cursor without waiting for a move", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await chooseComponent(page, "resistor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.click({ position: { x: 360, y: 230 } });
+  await page.keyboard.press("Escape");
+  await page.getByTestId("hit-R1").click();
+
+  // The pointer is over the canvas and stays there: the ghost has to appear
+  // from the remembered position rather than from the next pointer move.
+  await canvas.hover({ position: { x: 500, y: 300 } });
+  await page.keyboard.press("c");
+  await expect(page.getByTestId("copy-placement-preview")).toBeVisible();
+});
+
 test("publishes placement cancellation synchronously before rapid Copy", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -798,6 +798,27 @@ export function App({
   } | null>(null);
   const routeCounter = useRef(0);
   const canvasDragSessionRef = useRef<CanvasDragSession | null>(null);
+  /**
+   * Last pointer position seen on the canvas, in document coordinates. A
+   * placement that starts from the keyboard has no pointer event of its own,
+   * so it seeds its preview from here instead of waiting for the next move.
+   */
+  const lastCanvasPointRef = useRef<Point | null>(null);
+
+  /** Show a placement ghost under the cursor without waiting for a move. */
+  function seedComponentPreviewFromPointer(): void {
+    const point = lastCanvasPointRef.current;
+    if (point) setComponentPreviewPoint(point);
+  }
+
+  function seedCopyPreviewFromPointer(): void {
+    const point = lastCanvasPointRef.current;
+    if (!point) return;
+    setCopyPreviewPoint({
+      x: snapCoordinate(point.x, document.presentation.grid),
+      y: snapCoordinate(point.y, document.presentation.grid),
+    });
+  }
   const suppressInstanceClick = useRef(false);
   const projectInputRef = useRef<HTMLInputElement>(null);
   const selectionShelfRef = useRef<HTMLButtonElement>(null);
@@ -1567,7 +1588,10 @@ export function App({
     clearTransientCanvasState,
     paintSnapGuides,
     beginVddRailInteraction,
-    beginComponentPlacement,
+    beginComponentPlacement: (request) => {
+      beginComponentPlacement(request);
+      seedComponentPreviewFromPointer();
+    },
     rotateComponentPlacement,
     mirrorComponentPlacement,
     componentPlacementRotation,
@@ -1636,7 +1660,10 @@ export function App({
     cancelInteraction,
     cancelCanvasDrag: () => canvasDragSessionRef.current?.cancel(),
     paintSnapGuides,
-    beginCopyPlacementInteraction,
+    beginCopyPlacementInteraction: (clipboard, anchor) => {
+      beginCopyPlacementInteraction(clipboard, anchor);
+      seedCopyPreviewFromPointer();
+    },
     setCopyPreviewPoint,
     nextUniqueSuffix: () => {
       uniqueSuffixCounter.current += 1;
@@ -6159,6 +6186,7 @@ export function App({
       event.clientY,
       event.currentTarget,
     );
+    lastCanvasPointRef.current = point;
     if (vddRailMode) {
       const snapped = {
         x: snapCoordinate(point.x, document.presentation.grid),

--- a/plan/2026-08-22-seed-placement-preview/plan.md
+++ b/plan/2026-08-22-seed-placement-preview/plan.md
@@ -1,0 +1,62 @@
+---
+status: completed
+experience: none
+---
+
+# Placement ghosts appear under the cursor immediately
+
+## Goal
+
+Pressing `C` sometimes started a copy with nothing following the pointer. The
+preview point was only ever set from the canvas `pointermove` handler, so a
+placement started from the keyboard stayed invisible until the pointer moved
+— and the pointer is usually already sitting still over the canvas at that
+moment.
+
+## State and Ownership
+
+Start state: clean worktree on `main`. Branch `claude/seed-placement-preview`.
+
+Owned paths:
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/e2e/component-insert.spec.ts`
+- `plan/2026-08-22-seed-placement-preview/plan.md`, `plan/log.md`
+
+## Work
+
+1. Remember the last pointer position seen on the canvas, in document
+   coordinates.
+2. Seed the ghost from it when a copy or component placement begins, so the
+   preview is on screen before the next move. Component placement gets the
+   same treatment because it has the same gap.
+
+## Validation
+
+- repository typecheck, prettier
+- the new browser test, run with the fix stashed to prove it fails without it
+- editor unit tests; full Playwright suite
+
+## Gate Review
+
+- Decision: affected — editor interaction state only.
+- Early gates: prettier, the focused browser test.
+- Affected gates: the component-insert browser spec.
+- Final gates: `pnpm ci:check` cannot run locally (pnpm absent); delegated to
+  the remote required checks.
+- Platform risks: none.
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: a copy started from the keyboard shows its ghost at the cursor
+  without a pointer move.
+- Primary checks: `apps/editor/e2e/component-insert.spec.ts` — "Copy shows its
+  ghost under the cursor without waiting for a move"
+
+## Outcome
+
+Reproduced first: after `C` the status bar announced the placement while
+`copy-placement-preview` was absent, and it only appeared once the pointer
+moved. With the seeded point the ghost is present immediately. The new test
+was verified to fail with the fix stashed. Full Playwright suite: 189 passed.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4581,3 +4581,15 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   (419), full Playwright suite (188 passed), prettier, diff checks.
 - Commit status: completed on `claude/fix-copy-mode-flake`; mainline merge
   gated on the remote required checks.
+
+## 2026-08-22 - Placement ghosts seeded from the last pointer position
+
+- Changed areas: the canvas remembers its last pointer position, and both the
+  copy and component placement paths seed their preview from it, so a
+  placement started from the keyboard shows its ghost at the cursor instead of
+  waiting for the next pointer move.
+- Validation: typecheck, editor unit tests (419), full Playwright suite (189
+  passed), the new test re-run with the fix stashed to prove it fails without
+  it, prettier, diff checks; reproduced and re-verified in a running editor.
+- Commit status: completed on `claude/seed-placement-preview`; mainline merge
+  gated on the remote required checks.


### PR DESCRIPTION
Pressing `C` sometimes started a copy with **nothing following the pointer**.

## Cause

The preview point was only ever set from the canvas `pointermove` handler. A placement started from the keyboard therefore stayed invisible until the pointer moved — and at that moment the pointer is usually already sitting still over the canvas, so nothing appeared at all.

Reproduced before touching anything: after `C` the status bar announced `Place copy of 1 components …` while `copy-placement-preview` was absent from the DOM, and it appeared only after a hover.

## Fix

The canvas remembers its last pointer position in document coordinates, and both the copy and the component placement paths seed their ghost from it when the placement begins. Component placement had the same gap, so it gets the same treatment.

## Test plan

- [x] `tsc -p tsconfig.check.json` clean
- [x] Editor unit tests: 419 passed
- [x] Full Playwright suite: **189 passed**
- [x] New test verified to **fail with the fix stashed**
- [x] prettier, markdown links, `git diff --check`, test-impact
- [ ] Remote required checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)