### PR TITLE
feat(editor): true masonry gallery feed

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -53,6 +53,49 @@ test("the site lands on the full-screen gallery feed", async ({ page }) => {
   );
 });
 
+test("masonry places the top row left-to-right in distinct columns", async ({
+  page,
+}) => {
+  const entries = ["m-a", "m-b", "m-c"].map((id, index) => ({
+    id,
+    name: `Circuit ${id}`,
+    author: "tz",
+    description: index === 0 ? "taller card" : "",
+    createdAt: "2026-08-22T10:00:00.000Z",
+    schemaVersion: 21,
+  }));
+  await page.route("**/api/gallery", (route) =>
+    route.fulfill({ json: { entries, nextCursor: null } }),
+  );
+  await page.route("**/api/gallery/*/preview.svg", (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"><rect width="10" height="6" fill="#fff"/></svg>',
+    }),
+  );
+
+  await page.goto("/");
+  await expect(page.getByTestId("gallery-tile-m-c")).toBeVisible();
+  const positions = await page.locator(".masonry-item").evaluateAll((items) =>
+    items.map((item) => {
+      const match = /translate\(([-\d.]+)px, ([-\d.]+)px\)/u.exec(
+        (item as HTMLElement).style.transform,
+      );
+      return { x: Number(match?.[1]), y: Number(match?.[2]) };
+    }),
+  );
+  expect(positions).toHaveLength(3);
+  // All three fit the top row: same y, strictly increasing x (reading
+  // order), and the container has a measured height.
+  expect(positions.every((position) => position.y === 0)).toBe(true);
+  expect(positions[1]!.x).toBeGreaterThan(positions[0]!.x);
+  expect(positions[2]!.x).toBeGreaterThan(positions[1]!.x);
+  const wallHeight = await page
+    .locator(".masonry")
+    .evaluate((wall) => Number.parseFloat((wall as HTMLElement).style.height));
+  expect(wallHeight).toBeGreaterThan(100);
+});
+
 test("falls back to bundled tiles when the gallery is empty or unreachable", async ({
   page,
 }) => {

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -5,6 +5,7 @@ import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 
 import { libraryProjectExamples } from "../examples/library-examples";
 import { AccountMenu } from "./account";
+import { Masonry } from "./masonry";
 
 export interface GalleryFeedEntry {
   id: string;
@@ -121,60 +122,69 @@ export function GalleryFeed() {
           Loading gallery…
         </p>
       ) : (
-        <section className="gallery-wall" aria-label="Published circuits">
-          {entries.map((entry) => (
-            <a
-              key={entry.id}
-              className="gallery-tile"
-              href={`/g/${entry.id}`}
-              data-testid={`gallery-tile-${entry.id}`}
-            >
-              <span className="gallery-tile-preview">
-                <img
-                  src={`/api/gallery/${entry.id}/preview.svg`}
-                  alt={`Preview of ${entry.name}`}
-                  loading="lazy"
-                />
-              </span>
-              <span className="gallery-tile-copy">
-                <span className="gallery-tile-name">{entry.name}</span>
-                <span className="gallery-tile-meta">
-                  {entry.author ? `${entry.author} · ` : ""}
-                  {savedAtLabel(entry.createdAt)}
-                </span>
-                {entry.description ? (
-                  <span className="gallery-tile-description">
-                    {entry.description}
-                  </span>
-                ) : null}
-              </span>
-            </a>
-          ))}
-          {entries.length === 0
-            ? bundledTiles().map((tile) => (
-                <a
-                  key={tile.id}
-                  className="gallery-tile gallery-tile-bundled"
-                  href={`/editor?example=${tile.id}`}
-                  data-testid={`gallery-bundled-${tile.id}`}
-                >
-                  <span
-                    className="gallery-tile-preview"
-                    // Server-free preview: our own renderer's escaped SVG output.
-                    dangerouslySetInnerHTML={{ __html: tile.svg }}
-                  />
-                  <span className="gallery-tile-copy">
-                    <span className="gallery-tile-kicker">
-                      Built-in example
+        <section className="gallery-wall">
+          <Masonry
+            aria-label="Published circuits"
+            items={[
+              ...entries.map((entry) => ({
+                key: entry.id,
+                node: (
+                  <a
+                    className="gallery-tile"
+                    href={`/g/${entry.id}`}
+                    data-testid={`gallery-tile-${entry.id}`}
+                  >
+                    <span className="gallery-tile-preview">
+                      <img
+                        src={`/api/gallery/${entry.id}/preview.svg`}
+                        alt={`Preview of ${entry.name}`}
+                        loading="lazy"
+                      />
                     </span>
-                    <span className="gallery-tile-name">{tile.name}</span>
-                    <span className="gallery-tile-description">
-                      {tile.description}
+                    <span className="gallery-tile-copy">
+                      <span className="gallery-tile-name">{entry.name}</span>
+                      <span className="gallery-tile-meta">
+                        {entry.author ? `${entry.author} · ` : ""}
+                        {savedAtLabel(entry.createdAt)}
+                      </span>
+                      {entry.description ? (
+                        <span className="gallery-tile-description">
+                          {entry.description}
+                        </span>
+                      ) : null}
                     </span>
-                  </span>
-                </a>
-              ))
-            : null}
+                  </a>
+                ),
+              })),
+              ...(entries.length === 0
+                ? bundledTiles().map((tile) => ({
+                    key: `bundled-${tile.id}`,
+                    node: (
+                      <a
+                        className="gallery-tile gallery-tile-bundled"
+                        href={`/editor?example=${tile.id}`}
+                        data-testid={`gallery-bundled-${tile.id}`}
+                      >
+                        <span
+                          className="gallery-tile-preview"
+                          // Server-free preview: our own renderer's escaped SVG output.
+                          dangerouslySetInnerHTML={{ __html: tile.svg }}
+                        />
+                        <span className="gallery-tile-copy">
+                          <span className="gallery-tile-kicker">
+                            Built-in example
+                          </span>
+                          <span className="gallery-tile-name">{tile.name}</span>
+                          <span className="gallery-tile-description">
+                            {tile.description}
+                          </span>
+                        </span>
+                      </a>
+                    ),
+                  }))
+                : []),
+            ]}
+          />
         </section>
       )}
       <footer className="gallery-footnote">

--- a/apps/editor/src/components/masonry.test.ts
+++ b/apps/editor/src/components/masonry.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { masonryColumnCount, shortestColumn } from "./masonry";
+
+describe("masonryColumnCount", () => {
+  it("fits as many min-width columns as the container allows", () => {
+    // 1236px container, 250px min columns, 14px gaps → 4 columns.
+    expect(masonryColumnCount(1236, 250, 14)).toBe(4);
+    expect(masonryColumnCount(514, 250, 14)).toBe(2);
+    expect(masonryColumnCount(500, 250, 14)).toBe(1);
+  });
+
+  it("never drops below one column", () => {
+    expect(masonryColumnCount(120, 250, 14)).toBe(1);
+    expect(masonryColumnCount(0, 250, 14)).toBe(1);
+  });
+});
+
+describe("shortestColumn", () => {
+  it("targets the shortest column", () => {
+    expect(shortestColumn([300, 120, 260])).toBe(1);
+  });
+
+  it("prefers the leftmost column on (near-)ties for reading order", () => {
+    expect(shortestColumn([0, 0, 0])).toBe(0);
+    expect(shortestColumn([200, 200.2, 199.8])).toBe(0);
+  });
+
+  it("fills an empty row left to right before stacking", () => {
+    const heights = [0, 0, 0];
+    const placed: number[] = [];
+    for (const tileHeight of [120, 180, 150, 90]) {
+      const column = shortestColumn(heights);
+      placed.push(column);
+      heights[column]! += tileHeight + 14;
+    }
+    // Three tiles fill the top row in order; the fourth lands under the
+    // shortest (the first, 120-tall) column.
+    expect(placed).toEqual([0, 1, 2, 0]);
+  });
+});

--- a/apps/editor/src/components/masonry.tsx
+++ b/apps/editor/src/components/masonry.tsx
@@ -1,0 +1,94 @@
+import { useLayoutEffect, useRef, type ReactNode } from "react";
+
+/**
+ * True masonry (Pinterest-style) layout: equal-width columns derived from
+ * the container, every item keeping its natural height, each item placed
+ * greedily into the currently shortest column so rows read left-to-right
+ * and column bottoms stay balanced. The layout is imperative (widths,
+ * transforms, and the container height are written straight to the DOM),
+ * so image loads and window resizes re-run it through one ResizeObserver
+ * without React re-renders; the first pass runs before paint.
+ */
+
+export function masonryColumnCount(
+  containerWidth: number,
+  minColumnWidth: number,
+  gap: number,
+): number {
+  return Math.max(
+    1,
+    Math.floor((containerWidth + gap) / (minColumnWidth + gap)),
+  );
+}
+
+/** Index of the shortest column; the leftmost wins ties (reading order). */
+export function shortestColumn(heights: readonly number[]): number {
+  let column = 0;
+  for (let index = 1; index < heights.length; index += 1) {
+    if (heights[index]! < heights[column]! - 0.5) column = index;
+  }
+  return column;
+}
+
+export interface MasonryItem {
+  key: string;
+  node: ReactNode;
+}
+
+export interface MasonryProps {
+  items: readonly MasonryItem[];
+  minColumnWidth?: number;
+  gap?: number;
+  "aria-label"?: string;
+}
+
+export function Masonry({
+  items,
+  minColumnWidth = 250,
+  gap = 14,
+  "aria-label": ariaLabel,
+}: MasonryProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container || typeof ResizeObserver === "undefined") return;
+    const relayout = () => {
+      const tiles = [...container.children].filter(
+        (child): child is HTMLElement => child instanceof HTMLElement,
+      );
+      const width = container.clientWidth;
+      if (width <= 0) return;
+      const count = masonryColumnCount(width, minColumnWidth, gap);
+      const columnWidth = (width - gap * (count - 1)) / count;
+      const heights = new Array<number>(count).fill(0);
+      for (const tile of tiles) {
+        tile.style.width = `${columnWidth}px`;
+        const height = tile.offsetHeight;
+        const column = shortestColumn(heights);
+        tile.style.transform = `translate(${column * (columnWidth + gap)}px, ${heights[column]}px)`;
+        heights[column] = heights[column]! + height + gap;
+      }
+      container.style.height = `${Math.max(0, Math.max(...heights) - gap)}px`;
+    };
+    const observer = new ResizeObserver(relayout);
+    observer.observe(container);
+    for (const child of container.children) observer.observe(child);
+    relayout();
+    return () => observer.disconnect();
+  }, [items, minColumnWidth, gap]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="masonry"
+      {...(ariaLabel === undefined ? {} : { "aria-label": ariaLabel })}
+    >
+      {items.map((item) => (
+        <div key={item.key} className="masonry-item">
+          {item.node}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -5682,17 +5682,27 @@ html.light .analytics-map-land path {
 
 /* Pinterest-style wall: CSS columns give a dependency-free masonry. */
 .gallery-wall {
-  columns: 5 240px;
-  column-gap: 14px;
   padding: 18px 22px;
   width: 100%;
   box-sizing: border-box;
 }
 
+/* True masonry: the component measures tiles and writes width/transform;
+   items are absolutely positioned inside a relative container whose
+   height is set to the tallest column. */
+.masonry {
+  position: relative;
+  width: 100%;
+}
+
+.masonry-item {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
 .gallery-tile {
   display: block;
-  break-inside: avoid;
-  margin: 0 0 14px;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-md, 10px);
   background: var(--icm-surface);
@@ -5721,7 +5731,7 @@ html.light .analytics-map-land path {
   display: block;
   width: 100%;
   height: auto;
-  max-height: 320px;
+  max-height: 380px;
   object-fit: contain;
 }
 

--- a/docs/roadmap/community-gallery-platform.md
+++ b/docs/roadmap/community-gallery-platform.md
@@ -112,9 +112,11 @@ rejection stores and surfaces its optional reason; two ordinary accounts
 cannot touch each other's tiles while moderators and the admin can;
 anonymous writes are impossible at the API, not just the UI.
 
-## Phase G4 — Feed experience
+## Phase G4 — Feed experience (masonry live)
 
-- Masonry/infinite scroll, per-author filtering, in-feed admin recycle-bin
-  view, and seeded starter content curation.
+- Masonry (shipped 2026-08-22: JS greedy shortest-column layout keeping
+  each circuit's natural aspect ratio, left-to-right reading order,
+  balanced bottoms); still open: infinite scroll, per-author filtering,
+  in-feed admin recycle-bin view, and seeded starter content curation.
 
 Each phase closes by updating this file's status line for that phase.

--- a/plan/2026-08-22-gallery-masonry/plan.md
+++ b/plan/2026-08-22-gallery-masonry/plan.md
@@ -1,0 +1,86 @@
+---
+status: completed
+experience: none
+---
+
+# Gallery Masonry Feed (G4, first slice)
+
+## Goal
+
+Replace the CSS multi-column wall (vertical fill order, ragged bottoms)
+with a true Pinterest-style masonry the owner chose from rendered
+comparisons: fixed-width columns computed from the container, every tile
+keeping its circuit's natural aspect ratio, each tile greedily placed
+into the currently shortest column (horizontal reading order, balanced
+bottoms), relaid out on container resize and image load.
+
+## State and Ownership
+
+Branched from `origin/main` (post PR #164) as `claude/gallery-masonry`.
+
+Owned paths:
+
+- `apps/editor/src/components/masonry.tsx` (+ test) — reusable layout
+  component with pure `masonryColumnCount`/`shortestColumn` helpers
+- `apps/editor/src/components/gallery-feed.tsx` (tiles through Masonry)
+- `apps/editor/src/styles.css` (absolute-tile rules, preview cap)
+- `apps/editor/e2e/gallery.spec.ts` (top-row placement scenario)
+- `docs/roadmap/community-gallery-platform.md` (G4 slice recorded)
+- `plan/2026-08-22-gallery-masonry/plan.md`, `plan/log.md`
+
+Shared dependencies: none — feed markup contracts (test ids, hrefs)
+unchanged; tiles gain a positioning wrapper only.
+
+## Design
+
+Imperative layout, no React state: a `useLayoutEffect` measures the
+container, derives `columnCount = max(1, floor((w+gap)/(min+gap)))` and
+the equal column width, sets each wrapper's width, reads its height, and
+assigns `translate(x, y)` into the shortest column (leftmost on ties, so
+rows read left to right); container height becomes the tallest column. A
+single `ResizeObserver` over the container and every wrapper re-runs the
+layout when the window resizes or an image finishes loading; values
+stabilize, so the observer settles. First layout runs before paint (no
+overlap flash). Preview images keep natural ratio (cap 380px).
+
+## Validation
+
+- `vitest`: masonry helper tests (column count, greedy leftmost-shortest)
+- `playwright`: gallery spec — three community tiles land on one top row
+  in distinct columns; existing feed scenarios unchanged
+- repository typecheck, prettier,
+  `node scripts/check-test-impact.mjs --base origin/main`
+- `git diff --check` and `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: tiles keep natural aspect ratios in equal-width columns;
+  placement is greedy shortest-column with horizontal reading order;
+  layout follows container size and image loads
+- Primary checks: `apps/editor/src/components/masonry.test.ts`,
+  `apps/editor/e2e/gallery.spec.ts`
+
+## Commit Intent
+
+Committed on `claude/gallery-masonry` under the user's standing
+commit-push-merge direction as:
+
+```text
+feat(editor): true masonry gallery feed
+```
+
+## Outcome
+
+Delivered: the feed lays out through the reusable `Masonry` component —
+equal-width columns from the container width, natural tile heights
+(preview cap raised to 380px), greedy shortest-column placement with
+leftmost tie-breaks so rows read left-to-right and bottoms balance, one
+ResizeObserver re-running the imperative layout on resize and image
+load, first pass before paint. Tile markup, test ids, and the
+bundled-fallback contract are unchanged; the owner chose this option
+from side-by-side renderings built with the seven live gallery entries.
+Validation: masonry helper tests (component suite 13), gallery
+Playwright 11/11 (new scenario asserts a left-to-right top row in
+distinct columns and a measured container height), repository
+typecheck, prettier, test-impact, diff checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4475,6 +4475,7 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   verified in the running editor.
 - Commit status: completed on `claude/differential-output-opamp`; mainline
   merge gated on the remote required checks.
+
 ## 2026-08-22 - Unified copy placement transforms
 
 - Target: `plan/2026-08-22-unified-copy-transform/plan.md` (completed).
@@ -4535,7 +4536,6 @@ Keep reusable lessons in `docs/experience/`, not in this log.
 - Commit status: committed locally as `bd5bc67e`; mainline delivery proceeds
   through the canonical local and remote gates.
 
-
 ## 2026-08-22 - Publish button spells out its destination
 
 - Changed areas: the menubar publish control reads "Publish to Gallery"
@@ -4593,3 +4593,15 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   it, prettier, diff checks; reproduced and re-verified in a running editor.
 - Commit status: completed on `claude/seed-placement-preview`; mainline merge
   gated on the remote required checks.
+
+## 2026-08-22 — Gallery masonry feed (G4 first slice)
+
+- Target: `plan/2026-08-22-gallery-masonry/plan.md` (completed).
+- Change: replaced the CSS multi-column wall with a true masonry
+  component (equal-width columns, natural tile heights, greedy
+  shortest-column placement with left-to-right reading order, one
+  ResizeObserver relayout on resize/image load); owner picked it from
+  side-by-side renderings of the live entries.
+- Validation: component suite 13, gallery Playwright 11/11 (new
+  placement scenario), typecheck, prettier, test-impact, diff checks.
+- Commit status: completed on `claude/gallery-masonry`.


### PR DESCRIPTION
G4 first slice, chosen by the owner from side-by-side renderings of the seven live gallery entries: a true Pinterest-style masonry replaces the CSS multi-column wall.

- Reusable `Masonry` component: equal-width columns computed from the container, tiles keep their circuit's natural aspect ratio (preview cap 380px), greedy shortest-column placement with leftmost tie-breaks — rows read left-to-right, bottoms balance.
- Imperative layout (width/transform/container-height written to the DOM), one ResizeObserver re-runs it on container resize and image load; first pass before paint, no overlap flash, no React re-renders.
- Feed markup contracts unchanged (tile test ids, hrefs, bundled-fallback rule); tiles gained only a positioning wrapper.
- Tests: pure helpers (column count, greedy leftmost-shortest, row-fill order); new Playwright scenario asserts a left-to-right top row in distinct columns and a measured container height — gallery spec 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)