### PR TITLE
feat(model): one annotation text house style with italic supply subscripts

### DIFF
--- a/packages/model/src/semantic-text.test.ts
+++ b/packages/model/src/semantic-text.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { flattenRichText } from "./rich-text.js";
-import { semanticTextDocument } from "./semantic-text.js";
+import {
+  defaultDraftTextDocument,
+  semanticTextDocument,
+} from "./semantic-text.js";
 
 describe("semantic formal-Port text", () => {
   it("derives a Razavi voltage base and subscript from the electrical name", () => {
@@ -35,7 +38,7 @@ describe("semantic formal-Port text", () => {
     });
   });
 
-  it("uses a Razavi mathematical base for non-voltage Port and Net names", () => {
+  it("splits every Port and Net name into a symbol and its subscript", () => {
     const port = semanticTextDocument("CLK", "formal-port");
     const net = semanticTextDocument("NET1", "net-label");
 
@@ -48,15 +51,97 @@ describe("semantic formal-Port text", () => {
             {
               kind: "span",
               style: "bold",
-              children: [{ kind: "text", value: "CLK" }],
+              children: [{ kind: "text", value: "C" }],
+            },
+          ],
+        },
+        {
+          kind: "span",
+          style: "subscript",
+          children: [
+            {
+              kind: "span",
+              style: "bold",
+              children: [{ kind: "text", value: "LK" }],
             },
           ],
         },
       ],
     });
     expect(net).toMatchObject({
-      runs: [{ kind: "span", style: "italic", children: [{ kind: "span" }] }],
+      runs: [
+        { kind: "span", style: "italic" },
+        { kind: "span", style: "subscript" },
+      ],
     });
     expect(flattenRichText(net)).toBe("NET1");
+  });
+});
+
+describe("house text style", () => {
+  it("keeps a supply subscript italic while ordinary subscripts stay upright", () => {
+    const supply = semanticTextDocument("VDD", "net-label");
+    const signal = semanticTextDocument("Vin", "net-label");
+
+    expect(flattenRichText(supply)).toBe("VDD");
+    // Scripts render upright by default, so the supply exception is carried
+    // as a nested italic span inside the subscript.
+    expect(supply.runs[1]).toMatchObject({
+      kind: "span",
+      style: "subscript",
+      children: [{ kind: "span", style: "italic" }],
+    });
+    expect(signal.runs[1]).toMatchObject({
+      kind: "span",
+      style: "subscript",
+      children: [{ kind: "span", style: "bold" }],
+    });
+  });
+
+  it("capitalizes the leading symbol and subscripts the remainder", () => {
+    const content = semanticTextDocument("vout", "net-label");
+
+    expect(flattenRichText(content)).toBe("Vout");
+    expect(content.runs[0]).toMatchObject({
+      style: "italic",
+      children: [{ children: [{ value: "V" }] }],
+    });
+    expect(content.runs[1]).toMatchObject({
+      style: "subscript",
+      children: [{ children: [{ value: "out" }] }],
+    });
+  });
+
+  it("keeps a trailing polarity sign outside the subscript", () => {
+    const content = semanticTextDocument("Vout+", "formal-port");
+
+    expect(flattenRichText(content)).toBe("Vout+");
+    expect(content.runs).toHaveLength(3);
+    expect(content.runs[2]).toEqual({ kind: "text", value: "+" });
+  });
+
+  it("leaves a single-character name as a bare italic symbol", () => {
+    const content = semanticTextDocument("A", "net-label");
+
+    expect(content.runs).toHaveLength(1);
+    expect(flattenRichText(content)).toBe("A");
+  });
+});
+
+describe("drafting text", () => {
+  it("subscripts an identifier typed into a text box", () => {
+    const content = defaultDraftTextDocument("vbias");
+
+    expect(flattenRichText(content)).toBe("Vbias");
+    expect(content.runs).toHaveLength(2);
+    expect(content.runs[1]).toMatchObject({ style: "subscript" });
+  });
+
+  it("keeps a multi-word note as prose instead of one long subscript", () => {
+    const content = defaultDraftTextDocument("design note");
+
+    expect(flattenRichText(content)).toBe("Design note");
+    expect(content.runs).toHaveLength(1);
+    expect(content.runs[0]).toMatchObject({ style: "italic" });
   });
 });

--- a/packages/model/src/semantic-text.ts
+++ b/packages/model/src/semantic-text.ts
@@ -25,8 +25,43 @@ function mathBase(value: string): RichTextRun {
   return span([span([{ kind: "text", value }], "bold")], "italic");
 }
 
+/**
+ * Supply designators keep an italic subscript; every other subscript is
+ * upright. The renderer draws scripts upright by default and treats a nested
+ * italic span as a deliberate override, so this is expressed in the document
+ * rather than in the renderer.
+ */
+const POWER_RAIL_SUBSCRIPTS = new Set(["dd", "ss", "cc", "ee", "bb"]);
+
+function isPowerRailSubscript(value: string): boolean {
+  return POWER_RAIL_SUBSCRIPTS.has(value.trim().toLowerCase());
+}
+
 function mathSubscript(value: string): RichTextRun {
-  return span([span([{ kind: "text", value }], "bold")], "subscript");
+  const bold = span([{ kind: "text", value }], "bold");
+  return span(
+    [isPowerRailSubscript(value) ? span([bold], "italic") : bold],
+    "subscript",
+  );
+}
+
+/**
+ * House style for an authored identifier: the leading character is the
+ * capitalized symbol and everything after it defaults to its subscript. Both
+ * halves stay editable afterwards.
+ *
+ * Whitespace marks prose rather than an identifier — a drafting note must not
+ * be swallowed into one long subscript — so a multi-word value keeps its
+ * capitalized first letter and stays a single upright-size run.
+ */
+function symbolRuns(value: string): RichTextRun[] {
+  const capitalized = value.slice(0, 1).toUpperCase() + value.slice(1);
+  if (/\s/u.test(capitalized)) return [mathBase(capitalized)];
+  const head = capitalized.slice(0, 1);
+  const tail = capitalized.slice(1);
+  return tail.length > 0
+    ? [mathBase(head), mathSubscript(tail)]
+    : [mathBase(head)];
 }
 
 /** Construct the initial Razavi-style RichText for a free drafting label. */
@@ -44,7 +79,7 @@ export function defaultDraftTextDocument(value: string): RichTextDocument {
     };
   }
 
-  return { runs: [mathBase(value)] };
+  return { runs: symbolRuns(value) };
 }
 
 /** Construct current-authoring RichText for a conventional semantic label. */
@@ -67,29 +102,15 @@ export function semanticTextDocument(
   }
   if (/[\\{}^]/u.test(value)) return { runs: [{ kind: "text", value }] };
 
-  if (kind === "default-instance" || kind === "instance-label") {
-    const match = /^([A-Za-z]+)(.+)$/u.exec(value);
-    return match
-      ? { runs: [mathBase(match[1]!), mathSubscript(match[2]!)] }
-      : { runs: [mathBase(value)] };
-  }
-
-  const conventional = /^([VI])(.+?)([+-])?$/u.exec(value);
-  if (!conventional) {
-    // Net and Cell-Port names are the principal signal identifiers in a
-    // Razavi schematic. They remain mathematical labels even when their
-    // electrical spelling is not V*/I* (for example CLK or generated NET1).
-    return kind === "net-label" || kind === "formal-port"
-      ? { runs: [mathBase(value)] }
-      : { runs: [{ kind: "text", value }] };
-  }
+  // Every authored label follows one rule: capitalized leading symbol, the
+  // rest as its subscript. A trailing polarity sign stays outside the
+  // subscript because it qualifies the whole identifier.
+  const signed = /^(.+?)([+-])$/u.exec(value);
+  if (!signed) return { runs: symbolRuns(value) };
   return {
     runs: [
-      mathBase(conventional[1]!),
-      mathSubscript(conventional[2]!),
-      ...(conventional[3]
-        ? [{ kind: "text" as const, value: conventional[3] }]
-        : []),
+      ...symbolRuns(signed[1]!),
+      { kind: "text" as const, value: signed[2]! },
     ],
   };
 }

--- a/packages/render-svg/src/schematic-text.test.ts
+++ b/packages/render-svg/src/schematic-text.test.ts
@@ -16,7 +16,20 @@ describe("Razavi schematic typography", () => {
     expect(rendered).toContain('baseline-shift="-0.28em"');
     expect(rendered).toContain('dx="0.046em"');
     expect(rendered).toContain("font-style:italic;font-weight:700");
-    expect(rendered).toContain("font-style:normal;font-weight:700");
+    // Supply designators are the one italic subscript in the house style.
+    expect(rendered).toContain(
+      '<tspan data-text-run="span" style="font-style:italic;font-weight:700">DD</tspan>',
+    );
+  });
+
+  it("draws an ordinary subscript upright", () => {
+    const rendered = renderRichTextDocument(
+      semanticTextDocument("Vin", "net-label"),
+      razaviTextbookProfile,
+    );
+    expect(rendered).toContain(
+      '<tspan data-text-run="span" style="font-style:normal;font-weight:700">in</tspan>',
+    );
   });
 
   it("uses semantic profile sizes", () => {

--- a/plan/2026-08-22-semantic-text-house-style/plan.md
+++ b/plan/2026-08-22-semantic-text-house-style/plan.md
@@ -1,0 +1,110 @@
+---
+status: completed
+experience: none
+---
+
+# Uniform annotation text house style
+
+## Goal
+
+Apply one authoring rule to every annotation label: the leading character is a
+capitalized italic symbol, the remainder defaults to its subscript, subscripts
+render upright, and supply designators (`DD`, `SS`, `CC`, `EE`, `BB`) are the
+one italic-subscript exception.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## claude/semantic-text-subscripts
+```
+
+Worktree clean at branch creation; `.claude/` and `node_modules` are untracked
+local scaffolding for this pnpm-less machine and are not owned by this target.
+
+- `packages/model/src/semantic-text.ts`
+- `packages/model/src/semantic-text.test.ts`
+- `packages/render-svg/src/schematic-text.test.ts`
+
+- Read-only: `packages/render-svg/src/rich-text.ts`,
+  `packages/derived/src/annotation-text.ts`
+- Shared: the RichText AST shape consumed by render-svg, exporters, and the
+  Agent snapshot; visual and export goldens.
+
+## Work
+
+1. Split every authored identifier into a capitalized italic base plus a
+   subscript remainder, replacing the previous `V*`/`I*`-only shorthand and
+   the role-specific `default-instance` / `instance-label` regex.
+2. Carry the supply exception in the document rather than the renderer: the
+   renderer already draws scripts upright and honors a nested italic span as a
+   deliberate override, so an italic supply subscript is expressed as
+   `subscript > italic > bold`.
+3. Keep a trailing polarity sign outside the subscript.
+4. Guard prose: a value containing whitespace keeps its capitalized first
+   letter and stays one run, so a drafting note is not swallowed into a single
+   long subscript.
+
+## Validation
+
+- `git diff --check`
+- `git status --short --branch`
+- `node_modules/.bin/vitest run packages/model packages/render-svg`
+- Full unit suite (`vitest run`): 182 files / 1155 tests passed — the rule
+  crosses model, derived, render-svg, netlist, exporters, and the editor.
+- `node scripts/visual-golden.mjs --check` and
+  `node scripts/export-golden.mjs --check`: both clean. The goldens carry
+  `Vin+` and `Vout`, which the old `V*`/`I*` rule already split the same way,
+  so the new rule is a strict superset over covered fixtures.
+- Full Playwright suite: 189 passed.
+- `node_modules/.bin/tsc -p tsconfig.check.json`
+
+Note on historical documents: bound annotations are pure projections
+(`resolveAnnotationText` re-derives instance designators, Net names, and
+Cell-terminal names through `semanticTextDocument` on read), so existing
+Projects adopt the new style without a schema migration. Persisted
+`formatOverride` content is a deliberate manual edit and is preserved by
+design, not as a compatibility concession.
+
+## Gate Review
+
+- Decision: affected
+- Early gates: `tsc -p tsconfig.check.json`, Prettier on changed files
+- Affected gates: `packages/model`, `packages/render-svg` unit tests, then the
+  full unit suite and both golden `--check` gates because text rendering feeds
+  every downstream artifact
+- Final gates: `ci:check` equivalent run locally (pnpm unavailable; each gate
+  invoked directly), plus remote GitHub Actions on the PR
+- Platform risks: none specific; no generated artifact or release path changed
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: `semanticTextDocument` and `defaultDraftTextDocument` output
+  shape; upright-by-default script rendering with an italic supply exception.
+- Primary checks: `packages/model/src/semantic-text.test.ts`,
+  `packages/render-svg/src/schematic-text.test.ts`
+
+Two existing expectations asserted the superseded behavior and were rewritten
+rather than removed: the non-voltage `CLK`/`NET1` case now asserts the
+symbol/subscript split, and the `VDD` typography case now asserts the italic
+supply subscript alongside a new upright ordinary-subscript case.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(model): one annotation text house style with italic supply subscripts
+```
+
+## Outcome
+
+`semanticTextDocument` and `defaultDraftTextDocument` now share one rule
+instead of diverging per label role. Supply subscripts stay italic through a
+nested italic span, which the renderer already treated as an intentional
+override, so no renderer change was needed. Historical documents pick the
+style up through the existing derived-projection path. Validation as recorded
+above: 1155 unit tests, 189 e2e specs, both golden gates clean, typecheck
+clean.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4475,6 +4475,7 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   verified in the running editor.
 - Commit status: completed on `claude/differential-output-opamp`; mainline
   merge gated on the remote required checks.
+
 ## 2026-08-22 - Unified copy placement transforms
 
 - Target: `plan/2026-08-22-unified-copy-transform/plan.md` (completed).
@@ -4535,7 +4536,6 @@ Keep reusable lessons in `docs/experience/`, not in this log.
 - Commit status: committed locally as `bd5bc67e`; mainline delivery proceeds
   through the canonical local and remote gates.
 
-
 ## 2026-08-22 - Publish button spells out its destination
 
 - Changed areas: the menubar publish control reads "Publish to Gallery"
@@ -4593,3 +4593,23 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   it, prettier, diff checks; reproduced and re-verified in a running editor.
 - Commit status: completed on `claude/seed-placement-preview`; mainline merge
   gated on the remote required checks.
+
+## 2026-08-22 - One annotation text house style
+
+- Changed areas: `semanticTextDocument` and `defaultDraftTextDocument` now
+  share one rule — capitalized italic leading symbol, remainder as its
+  subscript — replacing the `V*`/`I*` shorthand and the role-specific
+  instance-label regex. Subscripts stay upright except supply designators
+  (DD/SS/CC/EE/BB), carried as a nested italic span because the renderer
+  already honors that as a deliberate override. A trailing polarity sign stays
+  outside the subscript, and a value containing whitespace stays prose so a
+  drafting note is not swallowed into one long subscript.
+- Historical documents need no migration: bound annotations are pure
+  projections re-derived on read by `resolveAnnotationText`.
+- Validation: full unit suite (1155), full Playwright suite (189 passed),
+  visual and export golden `--check` both clean (goldens carry `Vin+`/`Vout`,
+  which the superseded rule split identically), typecheck, prettier, diff
+  checks; rendered output inspected per glyph for VDD/VSS/VCC/Vin/Vout/Iout/
+  CLK/A and both drafting cases.
+- Commit status: completed on `claude/semantic-text-subscripts`; mainline
+  merge gated on the remote required checks.


### PR DESCRIPTION
## What

Every authored annotation label now follows one rule instead of diverging per label role:

- The leading character is a capitalized **italic** symbol; the remainder defaults to its **subscript**.
- Subscripts render **upright** — except supply designators (`DD`, `SS`, `CC`, `EE`, `BB`), which stay **italic**.
- A trailing polarity sign (`Vout+`) stays outside the subscript.
- A value containing whitespace stays prose, so a drafting note is not swallowed into one long subscript.

This replaces the previous `V*`/`I*`-only shorthand and the separate `default-instance` / `instance-label` regex.

Rendered result per glyph:

| input | base | subscript |
| --- | --- | --- |
| `VDD` / `VSS` / `VCC` | `V` italic | `DD` **italic** |
| `Vin` / `Vout` / `Iout` | `V` / `I` italic | `in` / `out` upright |
| `CLK` | `C` italic | `LK` upright |
| `A` | `A` italic | — |
| `Vout+` | `V` italic | `out` upright, then `+` |
| `design note` | whole string italic | — (prose) |

## Notes

The supply exception is carried **in the document** as a nested italic span, not in the renderer: `rich-text.ts` already draws scripts upright and treats a nested italic span as a deliberate override, so no renderer change was needed.

Historical documents need **no migration**. Bound annotations are pure projections — `resolveAnnotationText` re-derives instance designators, Net names, and Cell-terminal names through `semanticTextDocument` on read — so existing Projects adopt the new style automatically. Persisted `formatOverride` content is a deliberate manual edit and is preserved by design.

## Validation

- Full unit suite: **1155 passed** (182 files)
- Full Playwright suite: **189 passed**
- `visual-golden.mjs --check` and `export-golden.mjs --check`: both clean. The goldens carry `Vin+` and `Vout`, which the superseded rule split identically, so the new rule is a strict superset over covered fixtures.
- `tsc -p tsconfig.check.json`, Prettier, `git diff --check`
- `check-test-impact.mjs --base origin/main`: passed

Two existing expectations asserted the superseded behavior and were rewritten rather than removed: the non-voltage `CLK`/`NET1` case now asserts the symbol/subscript split, and the `VDD` typography case now asserts the italic supply subscript alongside a new upright ordinary-subscript case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)