### PR TITLE
feat(editor): shared gallery chrome and owner entry editing

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -388,6 +388,110 @@ test("a reviewer approves a pending submission from the review queue", async ({
   expect(decisions).toEqual(["approve"]);
 });
 
+test("/mine wears the site chrome and links every entry back to the editor", async ({
+  page,
+}) => {
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      json: {
+        user: {
+          id: "u7",
+          displayName: "Maker",
+          email: "maker@example.com",
+          provider: "email",
+          role: "user",
+          isAdmin: false,
+        },
+      },
+    }),
+  );
+  await page.route("**/api/gallery/mine", (route) =>
+    route.fulfill({
+      json: {
+        entries: [
+          {
+            id: "mine-1",
+            name: "Rejected Filter",
+            createdAt: "2026-08-22T09:00:00.000Z",
+            status: "rejected",
+            rejectReason: "Label the ports",
+          },
+          {
+            id: "mine-2",
+            name: "Live Amp",
+            createdAt: "2026-08-22T08:00:00.000Z",
+            status: "public",
+            rejectReason: null,
+          },
+        ],
+      },
+    }),
+  );
+  await page.route("**/api/gallery/*/preview.svg", (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"><rect width="10" height="6" fill="#fff"/></svg>',
+    }),
+  );
+
+  await page.goto("/mine");
+  // The standard chrome is present, not a bare paragraph.
+  await expect(page.getByTestId("gallery-editor-link")).toBeVisible();
+  await expect(page.getByTestId("gallery-new-circuit")).toBeVisible();
+  await expect(page.getByTestId("mine-reason-mine-1")).toContainText(
+    "Label the ports",
+  );
+  await expect(page.getByTestId("mine-edit-mine-2")).toHaveAttribute(
+    "href",
+    "/g/mine-2",
+  );
+  await expect(page.getByTestId("mine-status-mine-2")).toHaveText("Published");
+});
+
+test("an opened gallery entry offers updating in place", async ({ page }) => {
+  await mockGallery(page, [ENTRY]);
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      json: {
+        user: {
+          id: "u1",
+          displayName: "Token Zhang",
+          email: "owner@example.com",
+          provider: "github",
+          role: "user",
+          isAdmin: true,
+        },
+      },
+    }),
+  );
+  const updates: { method: string; body: { name: string } }[] = [];
+  await page.route(`**/api/gallery/${ENTRY.id}`, (route) => {
+    if (route.request().method() !== "PUT") return route.fallback();
+    updates.push({
+      method: route.request().method(),
+      body: route.request().postDataJSON() as { name: string },
+    });
+    return route.fulfill({ json: { id: ENTRY.id, status: "public" } });
+  });
+
+  await page.goto(`/g/${ENTRY.id}`);
+  await expect(page.getByTestId("status")).toContainText(
+    `Opened gallery circuit: ${ENTRY.name}`,
+  );
+  await page.getByTestId("publish-gallery-button").click();
+  const dialog = page.getByTestId("publish-gallery-dialog");
+  await expect(dialog).toBeVisible();
+  await expect(page.getByTestId("publish-mode")).toBeVisible();
+  await expect(dialog.getByText("updates the entry in place")).toBeVisible();
+
+  await dialog.getByRole("button", { name: "Update entry" }).click();
+  await expect(page.getByTestId("status")).toContainText(
+    `Updated "${ENTRY.name}" in the gallery`,
+  );
+  expect(updates).toHaveLength(1);
+  expect(updates[0]!.body.name).toBe(ENTRY.name);
+});
+
 test("bundled starter tiles open their example in the editor", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -219,7 +219,10 @@ import { NetlistPreflightDialog } from "../features/netlist-export/netlist-prefl
 import { parseProject } from "@icm/project-protocol";
 import { StyleDialog } from "../features/editor-shell/style-dialog";
 import { PublishGalleryDialog } from "../features/editor-shell/publish-gallery-dialog";
-import { publishProjectToGallery } from "../features/editor-shell/gallery-publish";
+import {
+  publishProjectToGallery,
+  updateGalleryEntry,
+} from "../features/editor-shell/gallery-publish";
 import { fetchSessionUser, type SessionUser } from "../components/account";
 import {
   evaluateSubmissionGates,
@@ -647,6 +650,10 @@ export function App({
   const [publishSession, setPublishSession] = useState<SessionUser | null>(
     null,
   );
+  const [galleryEntryContext, setGalleryEntryContext] = useState<{
+    id: string;
+    ownerUserId: string | null;
+  } | null>(null);
   const [publishGates, setPublishGates] = useState<SubmissionGateReport | null>(
     null,
   );
@@ -1892,6 +1899,7 @@ export function App({
           }
           const payload = (await response.json()) as {
             entry?: { name?: string };
+            ownerUserId?: string | null;
             projectText?: string;
           };
           if (!payload.projectText) {
@@ -1900,6 +1908,10 @@ export function App({
           }
           const galleryProject = parseProject(payload.projectText);
           replaceActiveProject(galleryProject);
+          setGalleryEntryContext({
+            id: initialGalleryEntryId,
+            ownerUserId: payload.ownerUserId ?? null,
+          });
           setStatus(
             `Opened gallery circuit: ${payload.entry?.name ?? galleryProject.name}`,
           );
@@ -7673,13 +7685,33 @@ export function App({
           defaultName={project.name}
           session={publishSession}
           gateReport={publishGates}
+          updateTarget={
+            galleryEntryContext &&
+            publishSession &&
+            (publishSession.isAdmin ||
+              publishSession.role === "moderator" ||
+              (galleryEntryContext.ownerUserId !== null &&
+                publishSession.id === galleryEntryContext.ownerUserId))
+              ? { id: galleryEntryContext.id }
+              : null
+          }
           publish={(fields) => publishProjectToGallery(project, fields)}
-          onPublished={({ name, pending }) => {
+          publishUpdate={
+            galleryEntryContext
+              ? (fields) =>
+                  updateGalleryEntry(galleryEntryContext.id, project, fields)
+              : undefined
+          }
+          onPublished={({ name, pending, updated }) => {
             setPublishGalleryOpen(false);
             setStatus(
-              pending
-                ? `Submitted "${name}" for review`
-                : `Published "${name}" to the gallery`,
+              updated
+                ? pending
+                  ? `Submitted the update to "${name}" for review`
+                  : `Updated "${name}" in the gallery`
+                : pending
+                  ? `Submitted "${name}" for review`
+                  : `Published "${name}" to the gallery`,
             );
           }}
           onClose={() => setPublishGalleryOpen(false)}

--- a/apps/editor/src/components/gallery-chrome.tsx
+++ b/apps/editor/src/components/gallery-chrome.tsx
@@ -1,0 +1,50 @@
+import { AccountMenu } from "./account";
+
+/**
+ * The one gallery site header, shared by the feed and every gallery
+ * subpage (/mine, /review) in all their states, so no page ever renders
+ * as a bare paragraph without navigation. Markup mirrors the feed's
+ * original header exactly (test ids included).
+ */
+export function GalleryChrome({
+  subtitle,
+  showGalleryLink = false,
+}: {
+  subtitle: string;
+  showGalleryLink?: boolean;
+}) {
+  return (
+    <header className="gallery-chrome">
+      <div className="app-brand">
+        <a
+          className="gallery-home-link"
+          href="/editor"
+          aria-label="Open the editor"
+          title="Open the editor"
+          data-testid="gallery-editor-link"
+        >
+          <span className="app-brand-mark" aria-hidden="true" />
+          <h1>Analog Canvas</h1>
+        </a>
+        <div className="app-brand-copy">
+          <p>{subtitle}</p>
+        </div>
+      </div>
+      <nav className="gallery-actions">
+        {showGalleryLink ? (
+          <a className="account-link" href="/" data-testid="chrome-gallery">
+            Gallery
+          </a>
+        ) : null}
+        <AccountMenu />
+        <a
+          className="gallery-open-editor"
+          href="/editor"
+          data-testid="gallery-new-circuit"
+        >
+          New Circuit
+        </a>
+      </nav>
+    </header>
+  );
+}

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -4,7 +4,7 @@ import { renderDocumentSvg } from "@icm/render-svg";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 
 import { libraryProjectExamples } from "../examples/library-examples";
-import { AccountMenu } from "./account";
+import { GalleryChrome } from "./gallery-chrome";
 import { Masonry } from "./masonry";
 
 export interface GalleryFeedEntry {
@@ -89,33 +89,7 @@ export function GalleryFeed() {
 
   return (
     <main className="gallery-shell" data-testid="gallery-feed">
-      <header className="gallery-chrome">
-        <div className="app-brand">
-          <a
-            className="gallery-home-link"
-            href="/editor"
-            aria-label="Open the editor"
-            title="Open the editor"
-            data-testid="gallery-editor-link"
-          >
-            <span className="app-brand-mark" aria-hidden="true" />
-            <h1>Analog Canvas</h1>
-          </a>
-          <div className="app-brand-copy">
-            <p>Community gallery</p>
-          </div>
-        </div>
-        <nav className="gallery-actions">
-          <AccountMenu />
-          <a
-            className="gallery-open-editor"
-            href="/editor"
-            data-testid="gallery-new-circuit"
-          >
-            New Circuit
-          </a>
-        </nav>
-      </header>
+      <GalleryChrome subtitle="Community gallery" />
 
       {state.status === "loading" ? (
         <p className="gallery-status" data-testid="gallery-loading">

--- a/apps/editor/src/components/my-submissions.tsx
+++ b/apps/editor/src/components/my-submissions.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 
 import { fetchSessionUser } from "./account";
+import { GalleryChrome } from "./gallery-chrome";
 
 /**
  * "My submissions" (roadmap phase G3): a signed-in user's gallery entries
  * with their review status; a rejection shows the reviewer's optional
- * reason so resubmission is informed, not a guessing game.
+ * reason, and every entry opens back into the editor for another round
+ * (an owner update re-enters review server-side).
  */
 
 export interface MineEntry {
@@ -58,74 +60,80 @@ export function MySubmissions() {
     };
   }, []);
 
-  if (state.status === "loading") {
-    return <p className="gallery-status">Loading your submissions…</p>;
-  }
-  if (state.status === "signed-out") {
-    return (
-      <main className="review-shell" data-testid="mine-signed-out">
-        <p className="gallery-status">
-          Sign in on the <a href="/">gallery page</a> to see your submissions.
-        </p>
-      </main>
-    );
-  }
-
   return (
-    <main className="review-shell" data-testid="mine-list">
-      <header className="gallery-chrome">
-        <div className="gallery-brand">
-          <span className="app-brand-mark" aria-hidden="true" />
-          <div>
-            <h1>My submissions</h1>
-            <p>Status of everything you sent to the gallery</p>
-          </div>
-        </div>
-        <nav className="gallery-actions">
-          <a className="gallery-open-editor" href="/">
-            Back to the gallery
-          </a>
-        </nav>
-      </header>
-      {state.entries.length === 0 ? (
-        <p className="gallery-status">
-          Nothing yet — open the <a href="/editor">editor</a> and use File →
-          Publish to Gallery.
-        </p>
-      ) : (
-        <section className="mine-list">
-          {state.entries.map((entry) => (
-            <article
-              key={entry.id}
-              className="mine-card"
-              data-testid={`mine-card-${entry.id}`}
-            >
-              <div className="mine-card-copy">
-                <h2>{entry.name}</h2>
-                <p className="review-card-meta">
-                  {new Date(entry.createdAt).toLocaleString()}
-                </p>
-              </div>
-              <div className="mine-card-status">
-                <span
-                  className={`mine-status mine-status-${entry.status}`}
-                  data-testid={`mine-status-${entry.id}`}
+    <main className="review-shell" data-testid="mine-page">
+      <GalleryChrome subtitle="My submissions" showGalleryLink />
+      <div className="page-body">
+        {state.status === "loading" ? (
+          <p className="gallery-status">Loading your submissions…</p>
+        ) : state.status === "signed-out" ? (
+          <p className="gallery-status" data-testid="mine-signed-out">
+            Sign in (top right) to see your submissions.
+          </p>
+        ) : state.entries.length === 0 ? (
+          <p className="gallery-status">
+            Nothing yet — open the <a href="/editor">editor</a> and use the
+            Publish button.
+          </p>
+        ) : (
+          <section className="mine-list" data-testid="mine-list">
+            {state.entries.map((entry) => (
+              <article
+                key={entry.id}
+                className="mine-card"
+                data-testid={`mine-card-${entry.id}`}
+              >
+                <a
+                  className="mine-card-preview"
+                  href={`/g/${entry.id}`}
+                  title="Open in the editor"
                 >
-                  {STATUS_LABELS[entry.status] ?? entry.status}
-                </span>
-                {entry.status === "rejected" && entry.rejectReason ? (
-                  <p
-                    className="mine-reason"
-                    data-testid={`mine-reason-${entry.id}`}
-                  >
-                    Reason: {entry.rejectReason}
+                  <img
+                    src={`/api/gallery/${entry.id}/preview.svg`}
+                    alt={`Preview of ${entry.name}`}
+                    loading="lazy"
+                  />
+                </a>
+                <div className="mine-card-copy">
+                  <h2>{entry.name}</h2>
+                  <p className="review-card-meta">
+                    {new Date(entry.createdAt).toLocaleString()}
                   </p>
-                ) : null}
-              </div>
-            </article>
-          ))}
-        </section>
-      )}
+                  <a
+                    className="account-link mine-card-edit"
+                    href={`/g/${entry.id}`}
+                    data-testid={`mine-edit-${entry.id}`}
+                  >
+                    Open in editor
+                  </a>
+                </div>
+                <div className="mine-card-status">
+                  <span
+                    className={`mine-status mine-status-${entry.status}`}
+                    data-testid={`mine-status-${entry.id}`}
+                  >
+                    {STATUS_LABELS[entry.status] ?? entry.status}
+                  </span>
+                  {entry.status === "rejected" && entry.rejectReason ? (
+                    <p
+                      className="mine-reason"
+                      data-testid={`mine-reason-${entry.id}`}
+                    >
+                      Reason: {entry.rejectReason}
+                    </p>
+                  ) : null}
+                  {entry.status === "rejected" ? (
+                    <p className="mine-reason">
+                      Edit it in the editor and publish again — the update
+                      re-enters review.
+                    </p>
+                  ) : null}
+                </div>
+              </article>
+            ))}
+          </section>
+        )}
+      </div>
     </main>
   );
 }

--- a/apps/editor/src/components/review-queue.tsx
+++ b/apps/editor/src/components/review-queue.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { fetchSessionUser, type SessionUser } from "./account";
+import { GalleryChrome } from "./gallery-chrome";
 
 /**
  * Review queue (roadmap phase G3): the super-admin and appointed
@@ -170,83 +171,78 @@ export function ReviewQueue() {
     };
   }, []);
 
-  if (state.status === "loading") {
-    return <p className="gallery-status">Loading review queue…</p>;
-  }
-  if (state.status === "denied") {
+  if (state.status !== "ready") {
     return (
-      <main className="review-shell" data-testid="review-denied">
-        <p className="gallery-status">
-          The review queue is for the gallery owner and appointed moderators.{" "}
-          <a href="/">Back to the gallery</a>
-        </p>
+      <main
+        className="review-shell"
+        data-testid={
+          state.status === "denied" ? "review-denied" : "review-page"
+        }
+      >
+        <GalleryChrome subtitle="Review queue" showGalleryLink />
+        <div className="page-body">
+          <p className="gallery-status">
+            {state.status === "loading"
+              ? "Loading review queue…"
+              : "The review queue is for the gallery owner and appointed moderators."}
+          </p>
+        </div>
       </main>
     );
   }
 
   return (
     <main className="review-shell" data-testid="review-queue">
-      <header className="gallery-chrome">
-        <div className="gallery-brand">
-          <span className="app-brand-mark" aria-hidden="true" />
-          <div>
-            <h1>Review queue</h1>
-            <p>Pending community submissions</p>
-          </div>
-        </div>
-        <nav className="gallery-actions">
-          <a className="gallery-open-editor" href="/">
-            Back to the gallery
-          </a>
-        </nav>
-      </header>
-      {state.user.isAdmin ? (
-        <form
-          className="review-appoint"
-          data-testid="review-appoint"
-          onSubmit={(event) => {
-            event.preventDefault();
-            if (!email.trim()) return;
-            void appointModerator(email.trim(), "moderator").then(setNotice);
-          }}
-        >
-          <input
-            type="email"
-            aria-label="Moderator email"
-            placeholder="Appoint a moderator by email"
-            value={email}
-            onChange={(event) => setEmail(event.currentTarget.value)}
-          />
-          <button type="submit">Appoint</button>
-          {notice ? <span className="account-notice">{notice}</span> : null}
-        </form>
-      ) : null}
-      {state.entries.length === 0 ? (
-        <p className="gallery-status" data-testid="review-empty">
-          Nothing waiting for review.
-        </p>
-      ) : (
-        <section className="review-list">
-          {state.entries.map((entry) => (
-            <ReviewCard
-              key={entry.id}
-              entry={entry}
-              onDecided={(id) =>
-                setState((previous) =>
-                  previous.status === "ready"
-                    ? {
-                        ...previous,
-                        entries: previous.entries.filter(
-                          (candidate) => candidate.id !== id,
-                        ),
-                      }
-                    : previous,
-                )
-              }
+      <GalleryChrome subtitle="Review queue" showGalleryLink />
+      <div className="page-body">
+        {state.user.isAdmin ? (
+          <form
+            className="review-appoint"
+            data-testid="review-appoint"
+            onSubmit={(event) => {
+              event.preventDefault();
+              if (!email.trim()) return;
+              void appointModerator(email.trim(), "moderator").then(setNotice);
+            }}
+          >
+            <input
+              type="email"
+              aria-label="Moderator email"
+              placeholder="Appoint a moderator by email"
+              value={email}
+              onChange={(event) => setEmail(event.currentTarget.value)}
             />
-          ))}
-        </section>
-      )}
+            <button type="submit">Appoint</button>
+            {notice ? <span className="account-notice">{notice}</span> : null}
+          </form>
+        ) : null}
+        {state.entries.length === 0 ? (
+          <p className="gallery-status" data-testid="review-empty">
+            Nothing waiting for review.
+          </p>
+        ) : (
+          <section className="review-list">
+            {state.entries.map((entry) => (
+              <ReviewCard
+                key={entry.id}
+                entry={entry}
+                onDecided={(id) =>
+                  setState((previous) =>
+                    previous.status === "ready"
+                      ? {
+                          ...previous,
+                          entries: previous.entries.filter(
+                            (candidate) => candidate.id !== id,
+                          ),
+                        }
+                      : previous,
+                  )
+                }
+              />
+            ))}
+          </section>
+        )}
+      </div>
     </main>
   );
 }

--- a/apps/editor/src/features/editor-shell/gallery-publish.ts
+++ b/apps/editor/src/features/editor-shell/gallery-publish.ts
@@ -35,20 +35,22 @@ export type GalleryPublishOutcome =
   | { status: "rejected"; message: string }
   | { status: "unreachable"; message: string };
 
-export async function publishProjectToGallery(
+async function sendGalleryProject(
+  url: string,
+  method: "POST" | "PUT",
   project: CircuitProject,
   fields: GalleryPublishFields,
-  fetchLike: typeof fetch = fetch,
+  fetchLike: typeof fetch,
 ): Promise<GalleryPublishOutcome> {
   const headers: Record<string, string> = {
     "content-type": "application/json",
   };
-  // Without a passphrase the admin session cookie authenticates instead.
+  // Without a passphrase the session cookie authenticates instead.
   if (fields.token) headers.authorization = `Bearer ${fields.token}`;
   let response: Response;
   try {
-    response = await fetchLike("/api/gallery/submissions", {
-      method: "POST",
+    response = await fetchLike(url, {
+      method,
       credentials: "same-origin",
       headers,
       body: JSON.stringify({
@@ -64,7 +66,7 @@ export async function publishProjectToGallery(
       message: error instanceof Error ? error.message : String(error),
     };
   }
-  if (response.status === 201) {
+  if (response.status === 201 || response.status === 200) {
     const payload = (await response.json().catch(() => null)) as {
       id?: unknown;
       status?: unknown;
@@ -95,6 +97,36 @@ export async function publishProjectToGallery(
   };
 }
 
+export function publishProjectToGallery(
+  project: CircuitProject,
+  fields: GalleryPublishFields,
+  fetchLike: typeof fetch = fetch,
+): Promise<GalleryPublishOutcome> {
+  return sendGalleryProject(
+    "/api/gallery/submissions",
+    "POST",
+    project,
+    fields,
+    fetchLike,
+  );
+}
+
+/** Owner/reviewer update of an existing entry (phase G3 completion). */
+export function updateGalleryEntry(
+  entryId: string,
+  project: CircuitProject,
+  fields: GalleryPublishFields,
+  fetchLike: typeof fetch = fetch,
+): Promise<GalleryPublishOutcome> {
+  return sendGalleryProject(
+    `/api/gallery/${entryId}`,
+    "PUT",
+    project,
+    fields,
+    fetchLike,
+  );
+}
+
 /** One human-readable line per outcome, shown in the dialog or status bar. */
 export function describePublishOutcome(outcome: GalleryPublishOutcome): string {
   switch (outcome.status) {
@@ -115,7 +147,9 @@ export function describePublishOutcome(outcome: GalleryPublishOutcome): string {
         ? "Check the fields: a name is required; author and description have length caps"
         : outcome.message === "invalid-project"
           ? "The Project failed strict validation on the server"
-          : `The gallery rejected the submission (${outcome.message})`;
+          : outcome.message === "forbidden"
+            ? "Only the entry's owner or a reviewer can update it"
+            : `The gallery rejected the submission (${outcome.message})`;
     case "unreachable":
       return `Could not reach the gallery: ${outcome.message}`;
   }

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
@@ -20,11 +20,18 @@ export interface PublishGalleryDialogProps {
   session?: PublishSessionUser | null;
   /** Quality-gate evaluation of the live Project (phase G3). */
   gateReport?: SubmissionGateReport | null;
+  /** Present when the open circuit came from a gallery entry the signed-in
+   * user may update (owner, admin, or moderator). */
+  updateTarget?: { id: string } | null;
   publish: (fields: GalleryPublishFields) => Promise<GalleryPublishOutcome>;
+  publishUpdate?:
+    | ((fields: GalleryPublishFields) => Promise<GalleryPublishOutcome>)
+    | undefined;
   onPublished: (outcome: {
     id: string;
     name: string;
     pending: boolean;
+    updated: boolean;
   }) => void;
   onClose: () => void;
 }
@@ -41,7 +48,9 @@ export function PublishGalleryDialog({
   defaultName,
   session = null,
   gateReport = null,
+  updateTarget = null,
   publish,
+  publishUpdate,
   onPublished,
   onClose,
 }: PublishGalleryDialogProps) {
@@ -49,6 +58,11 @@ export function PublishGalleryDialog({
   const ordinary = session !== null && !privileged;
   const anonymous = session === null;
   const gatesBlock = ordinary && gateReport !== null && !gateReport.ok;
+  const canUpdate = updateTarget !== null && publishUpdate !== undefined;
+  const [mode, setMode] = useState<"update" | "new">(
+    canUpdate ? "update" : "new",
+  );
+  const updating = canUpdate && mode === "update";
   const [name, setName] = useState(defaultName);
   const [author, setAuthor] = useState(
     () => rememberedPublishAuthor() || session?.displayName || "",
@@ -67,10 +81,18 @@ export function PublishGalleryDialog({
     }
   }, [sessionDisplayName]);
 
+  // The update permission also arrives with the session; default to
+  // updating the opened entry unless the user already chose a mode.
+  const [modeTouched, setModeTouched] = useState(false);
+  useEffect(() => {
+    if (canUpdate && !modeTouched) setMode("update");
+  }, [canUpdate, modeTouched]);
+
   async function submit(): Promise<void> {
     setBusy(true);
     setError(null);
-    const outcome = await publish({
+    const send = updating ? (publishUpdate ?? publish) : publish;
+    const outcome = await send({
       name,
       author,
       description,
@@ -83,6 +105,7 @@ export function PublishGalleryDialog({
         id: outcome.id,
         name: name.trim(),
         pending: outcome.status === "pending-review",
+        updated: updating,
       });
       return;
     }
@@ -109,6 +132,34 @@ export function PublishGalleryDialog({
           <p>Share this circuit on the public wall</p>
           <h2 id="publish-gallery-title">Publish to Gallery</h2>
         </header>
+        {canUpdate ? (
+          <div className="publish-gallery-mode" data-testid="publish-mode">
+            <label>
+              <input
+                type="radio"
+                name="publish-mode"
+                checked={mode === "update"}
+                onChange={() => {
+                  setMode("update");
+                  setModeTouched(true);
+                }}
+              />
+              Update the opened gallery entry
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="publish-mode"
+                checked={mode === "new"}
+                onChange={() => {
+                  setMode("new");
+                  setModeTouched(true);
+                }}
+              />
+              Publish as a new entry
+            </label>
+          </div>
+        ) : null}
         <div className="publish-gallery-fields">
           <label>
             Circuit name
@@ -186,9 +237,13 @@ export function PublishGalleryDialog({
         ) : null}
         <p className="publish-gallery-note">
           {privileged
-            ? `Signed in as ${session?.displayName} — this publishes directly.`
+            ? updating
+              ? `Signed in as ${session?.displayName} — this updates the entry in place.`
+              : `Signed in as ${session?.displayName} — this publishes directly.`
             : ordinary
-              ? `Signed in as ${session?.displayName} — your circuit enters the review queue and appears once a reviewer approves it.`
+              ? updating
+                ? `Signed in as ${session?.displayName} — your update replaces the entry and re-enters review.`
+                : `Signed in as ${session?.displayName} — your circuit enters the review queue and appears once a reviewer approves it.`
               : "Publishing is owner-approved for now: it needs the gallery owner's passphrase, or sign in on the gallery page to submit for review."}
         </p>
         {error ? (
@@ -211,7 +266,15 @@ export function PublishGalleryDialog({
             }
             onClick={() => void submit()}
           >
-            {busy ? "Publishing…" : ordinary ? "Submit for review" : "Publish"}
+            {busy
+              ? "Publishing…"
+              : updating
+                ? ordinary
+                  ? "Submit update for review"
+                  : "Update entry"
+                : ordinary
+                  ? "Submit for review"
+                  : "Publish"}
           </button>
         </div>
       </section>

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -5508,13 +5508,53 @@ html.light .analytics-map-land path {
   cursor: pointer;
 }
 
+.page-body {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 6px 22px 40px;
+}
+
 .review-list,
 .mine-list {
   display: flex;
   flex-direction: column;
   gap: 14px;
-  max-width: 56rem;
-  padding: 18px 22px 40px;
+  padding: 12px 0 0;
+}
+
+.mine-card-preview img {
+  display: block;
+  width: 150px;
+  height: 100px;
+  object-fit: contain;
+  border: 1px solid var(--icm-border);
+  border-radius: 8px;
+  background: #fff;
+}
+
+.mine-card-edit {
+  align-self: flex-start;
+  margin-top: 4px;
+}
+
+.publish-gallery-mode {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border: 1px solid var(--icm-accent);
+  border-radius: 8px;
+  background: var(--icm-accent-soft);
+  font-size: 0.85rem;
+}
+
+.publish-gallery-mode label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
 }
 
 .review-card,
@@ -5593,6 +5633,14 @@ html.light .analytics-map-land path {
 .mine-card {
   align-items: center;
   justify-content: space-between;
+}
+
+.mine-card .mine-card-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .mine-card-status {

--- a/docs/roadmap/community-gallery-platform.md
+++ b/docs/roadmap/community-gallery-platform.md
@@ -104,8 +104,10 @@ one shared evaluator in the worker and previewed live in the publish
 dialog, then wait in `pending` (publicly invisible) until the
 super-admin or an appointed moderator (`/review`, in-app appointment by
 email) approves or rejects with an optional reason surfaced at `/mine`.
-Remaining in this phase: owner editing/withdrawal of published entries
-re-entering review.
+Owner editing shipped 2026-08-22: every entry stays editable by its
+owner (updates re-enter review; a rejection becomes an informed
+resubmission) and by reviewers in place; withdrawal remains a recorded
+refinement.
 
 Acceptance: an ordinary submission is invisible publicly until approved;
 rejection stores and surfaces its optional reason; two ordinary accounts

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -90,8 +90,21 @@ their detail and preview answer only to reviewers or the owning session.
 
 The editor surfaces the queue at `/review` (approve, reject with reason,
 admin-only moderator appointment) and the submitter's view at `/mine`
-(status chips plus the rejection reason). Owner editing and withdrawal
-of published entries (re-entering review) is a recorded follow-up.
+(status chips, rejection reason, owner-visible preview, open-in-editor).
+Every gallery page state wears the shared site chrome.
+
+## Owner editing (Phase G3 completion)
+
+`PUT /api/gallery/<id>` (same-origin) updates an entry's content and
+metadata with the submission field rules. Authority: the bearer and
+admin/moderator sessions may update any entry, keeping its current
+status; an ordinary session must own the entry (403 otherwise) and
+passes the quality gates (422), after which the entry re-enters review
+as `pending` with the previous decision cleared — a rejection becomes an
+informed resubmission. The Project is re-serialized canonically and the
+preview re-rendered; 200 answers `{id, status}`. The detail response
+carries `ownerUserId` so the editor offers "update the opened entry"
+exactly to owners and reviewers.
 
 Entries persist a nullable owner column stamped from the submitting
 session.

--- a/plan/2026-08-22-gallery-owner-editing/plan.md
+++ b/plan/2026-08-22-gallery-owner-editing/plan.md
@@ -1,0 +1,113 @@
+---
+status: completed
+experience: none
+---
+
+# Gallery Chrome Everywhere and Owner Editing (G3 completion)
+
+## Goal
+
+Three owner-reported gaps. (1) `/mine` and `/review` lose the site
+header entirely in their loading/signed-out/denied states and render a
+bare paragraph touching the viewport edge; every state of both pages
+gets the standard gallery chrome (brand, account menu, New Circuit) via
+one shared component, with centered, padded content. (2) Published
+content must stay editable: every entry remains updatable by its owner
+(and by admin/moderators for any entry) — open it from `/mine` or its
+tile, edit, and the publish dialog offers "update this entry"; an
+ordinary owner's update re-enters review (this also turns a rejection
+into an informed resubmission), admin updates keep the current status.
+This closes the G3 follow-up recorded in the roadmap.
+
+## State and Ownership
+
+Branched from `origin/main` (post PR #173) as
+`claude/gallery-owner-editing`.
+
+Owned paths:
+
+- `apps/editor/src/components/gallery-chrome.tsx` (new shared header)
+- `apps/editor/src/components/gallery-feed.tsx`, `review-queue.tsx`,
+  `my-submissions.tsx` (chrome + layout + open/edit links + previews)
+- `worker/gallery.ts` (+ test): `replace-entry` op, `PUT
+/api/gallery/<id>`, `ownerUserId` in the detail response
+- `apps/editor/src/features/editor-shell/gallery-publish.ts(.test.ts)`
+  (`updateGalleryEntry`) and `publish-gallery-dialog.tsx(.test.tsx)`
+  (update mode)
+- `apps/editor/src/app/App.tsx` (gallery-entry context, update wiring),
+  `styles.css`, `apps/editor/e2e/gallery.spec.ts`
+- `docs/specs/community-gallery.md`, roadmap, plan files
+
+Shared dependencies: feed header markup contracts (test ids preserved
+verbatim inside the shared component).
+
+## Design
+
+- `PUT /api/gallery/<id>` (same-origin): 401 without any authority; the
+  bearer and admin/moderator sessions may update any entry keeping its
+  current status; an ordinary session must own the entry (403 otherwise)
+  and passes the quality gates (422), after which the entry re-enters
+  review as `pending` with reviewer fields cleared. Fields and caps
+  match submissions; the Project is re-serialized canonically and the
+  preview re-rendered. 200 `{id, status}`.
+- The public/owner detail response gains `ownerUserId` so the editor can
+  decide whether to offer updating.
+- App remembers which gallery entry the session opened (`/g/<id>` boot);
+  when the publish dialog opens and the signed-in user may update it
+  (owner, admin, or moderator), the dialog defaults to "Update this
+  gallery entry" with a switch back to "Publish as new".
+- `/mine` cards gain the owner-visible preview thumbnail and an "Open in
+  editor" link (`/g/<id>` already serves owners their pending/rejected
+  entries).
+
+## Validation
+
+- `vitest`: worker gallery update tests (owner re-entry, admin
+  keep-status, 403 stranger, gates), publish client update mapping,
+  dialog update-mode markup
+- `playwright`: gallery spec — `/mine` shows chrome, thumbnails, reason,
+  and the editor offers and posts an update for an opened entry
+- repository typecheck, prettier,
+  `node scripts/check-test-impact.mjs --base origin/main`
+- `git diff --check` and `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: every page state carries the standard chrome; an entry is
+  updatable exactly by its owner and reviewers; ordinary updates
+  re-enter review with the rejection reason cleared; gates guard
+  ordinary updates like submissions
+- Primary checks: `worker/gallery.test.ts`,
+  `apps/editor/e2e/gallery.spec.ts`
+
+## Commit Intent
+
+Committed on `claude/gallery-owner-editing` under the user's standing
+commit-push-merge direction as:
+
+```text
+feat(editor): shared gallery chrome and owner entry editing
+```
+
+## Outcome
+
+Delivered. Every gallery page state (feed, /mine, /review — loading,
+signed-out, denied, ready) now wears the one shared `GalleryChrome`
+(brand, account menu, New Circuit, Gallery link on subpages) with
+centered padded content, ending the bare edge-touching paragraphs.
+`PUT /api/gallery/<id>` lets the bearer and admin/moderator sessions
+update any entry in place (status kept) and lets an ordinary owner
+update their own — through the quality gates, re-entering review with
+the previous decision cleared, which turns a rejection into an informed
+resubmission. The detail response names the owner; the editor remembers
+which entry it opened and the publish dialog defaults to "Update the
+opened gallery entry" (switchable to publish-as-new) with role-aware
+labels; `/mine` cards gained owner-visible preview thumbnails,
+open-in-editor links, and resubmission guidance under rejections.
+
+Validation: worker gallery suite 13 (owner re-entry walk-through,
+stranger 403, anonymous 401, admin keep-status, gate 422, ownerUserId in
+detail), editor+worker unit sweep 472, gallery Playwright 13/13 (new:
+/mine chrome with thumbnails and links; opened-entry update posting the
+PUT), repository typecheck, prettier, test-impact, diff checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4625,3 +4625,16 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   CLK/A and both drafting cases.
 - Commit status: completed on `claude/semantic-text-subscripts`; mainline
   merge gated on the remote required checks.
+
+## 2026-08-22 — Gallery chrome everywhere and owner editing
+
+- Target: `plan/2026-08-22-gallery-owner-editing/plan.md` (completed).
+- Change: shared `GalleryChrome` on every state of the feed, `/mine`,
+  and `/review` (no more bare edge-touching paragraphs); `PUT
+/api/gallery/<id>` — reviewers update any entry in place, ordinary
+  owners update through the gates and re-enter review with the previous
+  decision cleared; publish dialog gains an update-vs-new mode; `/mine`
+  cards show previews, open-in-editor links, and resubmission guidance.
+- Validation: worker gallery 13, unit sweep 472, gallery Playwright
+  13/13, typecheck, prettier, test-impact, diff checks.
+- Commit status: completed on `claude/gallery-owner-editing`.

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -249,96 +249,6 @@ describe("gallery submissions", () => {
 });
 
 describe("gallery review queue with quality gates (phase G3)", () => {
-  function reviewHarness() {
-    const authDurable = new AuthDO(sqliteState(), {
-      RESEND_API_KEY: "rk",
-      ADMIN_EMAILS: "owner@example.com",
-    } as AuthEnv);
-    const env: GalleryEnv = {
-      ...environment(ADMIN_TOKEN),
-      AUTH: {
-        getByName: () => ({
-          fetch: (input: Request | string, init?: RequestInit) =>
-            authDurable.fetch(
-              typeof input === "string" ? new Request(input, init) : input,
-            ),
-        }),
-      },
-    };
-    return { authDurable, env };
-  }
-
-  async function signIn(authDurable: AuthDO, email: string): Promise<string> {
-    const sent: string[] = [];
-    authDurable.fetchLike = (async (
-      input: RequestInfo | URL,
-      init?: RequestInit,
-    ) => {
-      void input;
-      sent.push((JSON.parse(String(init?.body)) as { text: string }).text);
-      return Response.json({ id: "email-1" });
-    }) as typeof fetch;
-    await authDurable.fetch(
-      new Request(`${ORIGIN}/api/auth/email/start`, {
-        method: "POST",
-        headers: { Origin: ORIGIN, "content-type": "application/json" },
-        body: JSON.stringify({ email }),
-      }),
-    );
-    const link = sent[0]!.match(/https?:\/\/\S+/u)![0];
-    const callback = await authDurable.fetch(new Request(link));
-    return callback.headers
-      .getSetCookie()
-      .find((cookie) => cookie.startsWith("icm_session="))!
-      .split(";")[0]!;
-  }
-
-  function wiredProjectText(name = "Wired"): string {
-    const project = createEmptyProject("g3", name);
-    const document = project.documents[0]!;
-    document.instances = [
-      {
-        id: "R1",
-        symbolId: "resistor",
-        placement: {
-          position: { x: 0, y: 0 },
-          rotation: 0,
-          mirror: "none",
-        },
-        netlist: { reference: "R1", parameters: {} },
-      },
-      {
-        id: "R2",
-        symbolId: "resistor",
-        placement: {
-          position: { x: 200, y: 0 },
-          rotation: 0,
-          mirror: "none",
-        },
-        netlist: { reference: "R2", parameters: {} },
-      },
-    ];
-    document.nets = [
-      {
-        id: "n1",
-        scope: "local",
-        terminals: [
-          { instanceId: "R1", pinName: "1" },
-          { instanceId: "R2", pinName: "1" },
-        ],
-      },
-      {
-        id: "n2",
-        scope: "local",
-        terminals: [
-          { instanceId: "R1", pinName: "2" },
-          { instanceId: "R2", pinName: "2" },
-        ],
-      },
-    ];
-    return serializeProject(project);
-  }
-
   it("walks submit → pending (invisible) → approve → public", async () => {
     const { authDurable, env } = reviewHarness();
     const userCookie = await signIn(authDurable, "maker@example.com");
@@ -523,6 +433,206 @@ describe("gallery review queue with quality gates (phase G3)", () => {
     expect(((await viaAdmin.json()) as { status: string }).status).toBe(
       "public",
     );
+  });
+});
+
+function reviewHarness() {
+  const authDurable = new AuthDO(sqliteState(), {
+    RESEND_API_KEY: "rk",
+    ADMIN_EMAILS: "owner@example.com",
+  } as AuthEnv);
+  const env: GalleryEnv = {
+    ...environment(ADMIN_TOKEN),
+    AUTH: {
+      getByName: () => ({
+        fetch: (input: Request | string, init?: RequestInit) =>
+          authDurable.fetch(
+            typeof input === "string" ? new Request(input, init) : input,
+          ),
+      }),
+    },
+  };
+  return { authDurable, env };
+}
+
+async function signIn(authDurable: AuthDO, email: string): Promise<string> {
+  const sent: string[] = [];
+  authDurable.fetchLike = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => {
+    void input;
+    sent.push((JSON.parse(String(init?.body)) as { text: string }).text);
+    return Response.json({ id: "email-1" });
+  }) as typeof fetch;
+  await authDurable.fetch(
+    new Request(`${ORIGIN}/api/auth/email/start`, {
+      method: "POST",
+      headers: { Origin: ORIGIN, "content-type": "application/json" },
+      body: JSON.stringify({ email }),
+    }),
+  );
+  const link = sent[0]!.match(/https?:\/\/\S+/u)![0];
+  const callback = await authDurable.fetch(new Request(link));
+  return callback.headers
+    .getSetCookie()
+    .find((cookie) => cookie.startsWith("icm_session="))!
+    .split(";")[0]!;
+}
+
+function wiredProjectText(name = "Wired"): string {
+  const project = createEmptyProject("g3", name);
+  const document = project.documents[0]!;
+  document.instances = [
+    {
+      id: "R1",
+      symbolId: "resistor",
+      placement: {
+        position: { x: 0, y: 0 },
+        rotation: 0,
+        mirror: "none",
+      },
+      netlist: { reference: "R1", parameters: {} },
+    },
+    {
+      id: "R2",
+      symbolId: "resistor",
+      placement: {
+        position: { x: 200, y: 0 },
+        rotation: 0,
+        mirror: "none",
+      },
+      netlist: { reference: "R2", parameters: {} },
+    },
+  ];
+  document.nets = [
+    {
+      id: "n1",
+      scope: "local",
+      terminals: [
+        { instanceId: "R1", pinName: "1" },
+        { instanceId: "R2", pinName: "1" },
+      ],
+    },
+    {
+      id: "n2",
+      scope: "local",
+      terminals: [
+        { instanceId: "R1", pinName: "2" },
+        { instanceId: "R2", pinName: "2" },
+      ],
+    },
+  ];
+  return serializeProject(project);
+}
+
+describe("gallery owner editing (phase G3 completion)", () => {
+  it("owner updates re-enter review and clear the previous rejection", async () => {
+    const { authDurable, env } = reviewHarness();
+    const ownerCookie = await signIn(authDurable, "maker@example.com");
+    const adminCookie = await signIn(authDurable, "owner@example.com");
+    const strangerCookie = await signIn(authDurable, "other@example.com");
+
+    const submitted = await route(
+      env,
+      submissionRequest(
+        { name: "Edit Me", projectText: wiredProjectText("Edit Me") },
+        { token: null, cookie: ownerCookie },
+      ),
+    );
+    const { id } = (await submitted.json()) as { id: string };
+    await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/reject`, {
+        method: "POST",
+        headers: {
+          Origin: ORIGIN,
+          Cookie: adminCookie,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ reason: "Wrong polarity" }),
+      }),
+    );
+
+    function updateRequest(cookie: string | null, token = false): Request {
+      const headers = new Headers({
+        "content-type": "application/json",
+        Origin: ORIGIN,
+      });
+      if (cookie) headers.set("Cookie", cookie);
+      if (token) headers.set("Authorization", `Bearer ${ADMIN_TOKEN}`);
+      return new Request(`${ORIGIN}/api/gallery/${id}`, {
+        method: "PUT",
+        headers,
+        body: JSON.stringify({
+          name: "Edit Me v2",
+          author: "maker",
+          projectText: wiredProjectText("Edit Me v2"),
+        }),
+      });
+    }
+
+    const stranger = await route(env, updateRequest(strangerCookie));
+    expect(stranger.status).toBe(403);
+    const anonymous = await route(env, updateRequest(null));
+    expect(anonymous.status).toBe(401);
+
+    const updated = await route(env, updateRequest(ownerCookie));
+    expect(updated.status).toBe(200);
+    expect(((await updated.json()) as { status: string }).status).toBe(
+      "pending",
+    );
+
+    const mine = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/mine`, {
+        headers: { Cookie: ownerCookie },
+      }),
+    );
+    const entries = (await mine.json()) as {
+      entries: { name: string; status: string; rejectReason: string | null }[];
+    };
+    expect(entries.entries).toMatchObject([
+      { name: "Edit Me v2", status: "pending", rejectReason: null },
+    ]);
+
+    // Approve, then an admin edit keeps the entry public.
+    await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/approve`, {
+        method: "POST",
+        headers: { Origin: ORIGIN, Cookie: adminCookie },
+      }),
+    );
+    const adminEdit = await route(env, updateRequest(adminCookie));
+    expect(((await adminEdit.json()) as { status: string }).status).toBe(
+      "public",
+    );
+
+    // An empty replacement fails the gates for the ordinary owner.
+    const gated = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}`, {
+        method: "PUT",
+        headers: {
+          Origin: ORIGIN,
+          Cookie: ownerCookie,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ name: "Empty", projectText: projectText() }),
+      }),
+    );
+    expect(gated.status).toBe(422);
+
+    // The detail response names the owner so the editor can offer updates.
+    const detail = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}`, {
+        headers: { Cookie: ownerCookie },
+      }),
+    );
+    const payload = (await detail.json()) as { ownerUserId: string | null };
+    expect(typeof payload.ownerUserId).toBe("string");
   });
 });
 

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -178,6 +178,8 @@ export class GalleryDO {
         return this.allIds();
       case "update-entry":
         return this.updateEntry(body);
+      case "replace-entry":
+        return this.replaceEntry(body);
       default:
         return Response.json({ error: "Unknown operation" }, { status: 404 });
     }
@@ -319,6 +321,33 @@ export class GalleryDO {
       id: row.id,
       status: approve ? "public" : "rejected",
     });
+  }
+
+  /** Owner/reviewer edit (phase G3): new content, possibly new status. */
+  private replaceEntry(body: Record<string, unknown>): Response {
+    const row = this.sql
+      .exec<EntryRow>(
+        "SELECT * FROM gallery_entries WHERE id = ?",
+        String(body.id),
+      )
+      .toArray()[0];
+    if (!row) return Response.json({ error: "not-found" }, { status: 404 });
+    this.sql.exec(
+      `UPDATE gallery_entries
+       SET name = ?, author = ?, description = ?, project_text = ?,
+           svg_text = ?, schema_version = ?, status = ?,
+           reject_reason = NULL, reviewed_at = NULL, reviewed_by = NULL
+       WHERE id = ?`,
+      String(body.name),
+      String(body.author),
+      String(body.description),
+      String(body.projectText),
+      String(body.svgText),
+      Number(body.schemaVersion),
+      String(body.status),
+      row.id,
+    );
+    return Response.json({ id: row.id, status: String(body.status) });
   }
 
   private mine(ownerUserId: string): Response {
@@ -574,6 +603,99 @@ async function handleSubmission(
   );
 }
 
+/**
+ * Owner/reviewer entry update (phase G3 completion). The bearer and
+ * admin/moderator sessions may update any entry, keeping its current
+ * status; an ordinary session must own the entry and passes the quality
+ * gates, after which the entry re-enters review as `pending` with the
+ * previous decision cleared — a rejection therefore becomes an informed
+ * resubmission.
+ */
+async function handleEntryUpdate(
+  request: Request,
+  env: GalleryEnv,
+  id: string,
+): Promise<Response> {
+  if (!sameOrigin(request)) {
+    return Response.json({ error: "forbidden" }, { status: 403 });
+  }
+  const existing = await callGallery<{
+    status?: string;
+    ownerUserId?: string | null;
+  }>(env, "any-entry", { id });
+  if (existing.status !== 200) {
+    return Response.json({ error: "not-found" }, { status: 404 });
+  }
+  const bearer = bearerIsAdmin(request, env);
+  const user = await sessionUserOf(request, env);
+  const privileged =
+    bearer || user?.isAdmin === true || user?.role === "moderator";
+  if (!bearer && !user) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+  const owner =
+    user !== null &&
+    existing.payload.ownerUserId != null &&
+    existing.payload.ownerUserId === user.id;
+  if (!privileged && !owner) {
+    return Response.json({ error: "forbidden" }, { status: 403 });
+  }
+  const body = (await request.json().catch(() => null)) as {
+    name?: unknown;
+    author?: unknown;
+    description?: unknown;
+    projectText?: unknown;
+  } | null;
+  const name = fieldText(body?.name, GALLERY_MAX_NAME_LENGTH);
+  const author = fieldText(body?.author, GALLERY_MAX_AUTHOR_LENGTH);
+  const description = fieldText(
+    body?.description,
+    GALLERY_MAX_DESCRIPTION_LENGTH,
+  );
+  if (!body || !name || author === null || description === null) {
+    return Response.json({ error: "invalid-fields" }, { status: 400 });
+  }
+  if (typeof body.projectText !== "string") {
+    return Response.json({ error: "invalid-project" }, { status: 400 });
+  }
+  if (
+    new TextEncoder().encode(body.projectText).length >
+    GALLERY_MAX_PROJECT_BYTES
+  ) {
+    return Response.json({ error: "too-large" }, { status: 413 });
+  }
+  let project: CircuitProject;
+  try {
+    project = parseProject(body.projectText);
+  } catch {
+    return Response.json({ error: "invalid-project" }, { status: 400 });
+  }
+  if (!privileged) {
+    const report = evaluateSubmissionGates(project, resolver);
+    if (!report.ok) {
+      return Response.json(
+        { error: "quality-gate", failures: report.failures },
+        { status: 422 },
+      );
+    }
+  }
+  project.name = name;
+  const nextStatus = privileged
+    ? (existing.payload.status ?? "public")
+    : "pending";
+  const { status, payload } = await callGallery(env, "replace-entry", {
+    id,
+    name,
+    author,
+    description,
+    projectText: serializeProject(project),
+    svgText: renderPreview(project),
+    schemaVersion: project.schemaVersion,
+    status: nextStatus,
+  });
+  return Response.json(payload, { status });
+}
+
 async function handleReserialize(env: GalleryEnv): Promise<Response> {
   const { payload } = await callGallery<{ ids: string[] }>(env, "all-ids", {});
   let upgraded = 0;
@@ -739,10 +861,14 @@ export async function routeGalleryRequest(
       {
         entry: payload.entry,
         status: payload.status,
+        ownerUserId: payload.ownerUserId ?? null,
         projectText: payload.projectText,
       },
       { headers: { "cache-control": "no-store" } },
     );
+  }
+  if (segments.length === 1 && request.method === "PUT") {
+    return handleEntryUpdate(request, env, segments[0]!);
   }
   if (segments.length === 2 && request.method === "POST") {
     const [id, action] = segments;


### PR DESCRIPTION
Fixes the three owner-reported /mine gaps and completes G3's follow-up.

**Chrome & layout** — one shared `GalleryChrome` (brand, account menu, New Circuit, Gallery link on subpages) now wears every state of the feed, `/mine`, and `/review` (loading/signed-out/denied included), with a centered `page-body` container — no more bare paragraphs touching the viewport edge.

**Owner editing** — `PUT /api/gallery/<id>` (same-origin):
- Bearer and admin/moderator sessions update any entry in place, keeping its status.
- An ordinary session must own the entry (403 otherwise), passes the quality gates (422), and the entry re-enters review as `pending` with the previous decision cleared — a rejection becomes an informed resubmission.
- Detail responses carry `ownerUserId`; the editor remembers which entry it opened and the publish dialog defaults to "Update the opened gallery entry" (switchable to publish-as-new) with role-aware labels and notes.
- `/mine` cards gain owner-visible preview thumbnails, "Open in editor" links, and resubmission guidance under rejections.

**Tests**: worker gallery 13 (owner re-entry walk-through, stranger 403, anonymous 401, admin keep-status, gate 422, ownerUserId in detail); unit sweep 472; gallery Playwright 13/13 (new: /mine chrome + thumbnails + links; opened-entry update posting the PUT). Spec and roadmap updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)