### PR TITLE
feat(edit-engine): place another marker for an existing Cell Pin name

### DIFF
--- a/apps/editor/e2e/hierarchy.spec.ts
+++ b/apps/editor/e2e/hierarchy.spec.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "@playwright/test";
 
-import { clickCommand, emulateDownloadOnlyBrowser } from "./editor-fixtures.js";
+import {
+  clickCommand,
+  clickDrawTool,
+  downloadBytes,
+  emulateDownloadOnlyBrowser,
+} from "./editor-fixtures.js";
 
 test.beforeEach(async ({ page }) => {
   await emulateDownloadOnlyBrowser(page);
@@ -575,4 +580,41 @@ test("places an existing Cell and blocks deleting its shared definition", async 
     manager.getByRole("button", { name: "Delete" }).last(),
   ).toBeDisabled();
   await expect(page.getByTestId("document-count")).toHaveText("2");
+});
+
+test("places a second Port for a Cell terminal that already exists", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+
+  // First Cell Pin takes the free ordinal name and names its Net with it.
+  await page.getByTestId("shapes-chip-cell-pin").click();
+  await canvas.click({ position: { x: 240, y: 200 } });
+  await page.keyboard.press("Escape");
+
+  // A second Cell Pin whose pin lands on that same named Net resolves its own
+  // formal name to P1, which previously aborted placement outright.
+  await page.getByTestId("shapes-chip-cell-pin").click();
+  await canvas.click({ position: { x: 240, y: 200 } });
+  await expect(page.getByTestId("status")).toContainText(
+    "marker for Cell port P1",
+  );
+  await page.keyboard.press("Escape");
+
+  const saved = JSON.parse(
+    (await downloadBytes(page, "File", "Save Project")).toString("utf8"),
+  ) as {
+    documents: Array<{
+      netlist?: {
+        terminals: Array<{ name: string; interfaceInstanceIds: string[] }>;
+      };
+    }>;
+  };
+  const terminals = saved.documents[0]!.netlist!.terminals;
+  // One formal terminal, two markers: the Cell interface a parent resolves
+  // against stays single-valued.
+  expect(terminals).toHaveLength(1);
+  expect(terminals[0]!.name).toBe("P1");
+  expect(terminals[0]!.interfaceInstanceIds).toHaveLength(2);
 });

--- a/apps/editor/src/features/component-insert/use-component-placement.ts
+++ b/apps/editor/src/features/component-insert/use-component-placement.ts
@@ -10,6 +10,7 @@ import {
   planEnsureNamedNet,
   createHierarchyInstance,
   createExternalSubcircuitInstance,
+  planAttachCellPortMarker,
   planCreateCellPort,
   planPlaceExternalSubcircuitInstance,
   planPlaceCellInstance,
@@ -505,14 +506,12 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       placementRequest.portName?.trim() ||
       connectedNet?.name?.trim() ||
       nextFreeCellTerminalName(options.document);
-    if (
-      options.document.netlist?.terminals.some(
-        (terminal) => terminal.name === formalName,
-      )
-    ) {
-      options.setStatus(`Cell port ${formalName} already exists`);
-      return;
-    }
+    // Repeating an interface name places another marker for the terminal that
+    // already owns it rather than a second terminal, so the same pin can be
+    // drawn wherever it is needed on the sheet.
+    const existingTerminal = options.document.netlist?.terminals.find(
+      (terminal) => terminal.name.toLowerCase() === formalName.toLowerCase(),
+    );
     const baseNetId = `net-cell-port-${id.toLowerCase()}`;
     let netId = contact.netId ?? baseNetId;
     let netSuffix = 2;
@@ -541,10 +540,12 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
                 pinName: "P",
               },
               newNetId: netId,
-              newNetName: formalName,
+              // An additional marker carries no name of its own: it is merged
+              // into the terminal's Net, which already holds the name.
+              ...(existingTerminal ? {} : { newNetName: formalName }),
             },
           ]),
-      ...(contact.netId && !connectedNet?.name
+      ...(contact.netId && !connectedNet?.name && !existingTerminal
         ? [
             {
               kind: "set_net_name" as const,
@@ -554,32 +555,37 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
           ]
         : []),
     ];
+    const annotation = annotations[0] ? { ...annotations[0] } : undefined;
     const committed = options.transactProject(
       "place-cell-port",
-      planCreateCellPort(options.project, options.document.id, {
-        instance,
-        connectionEdits,
-        terminal: {
-          id: `terminal-${id.toLowerCase()}`,
-          name: formalName,
-          netId,
-          direction: placementRequest.direction,
-          interfaceInstanceIds: [id],
-        },
-        ...(annotations[0]
-          ? {
-              annotation: {
-                ...annotations[0],
-              },
-            }
-          : {}),
-      }),
+      existingTerminal
+        ? planAttachCellPortMarker(options.project, options.document.id, {
+            instance,
+            connectionEdits,
+            terminalId: existingTerminal.id,
+            markerNetId: netId,
+            ...(annotation ? { annotation } : {}),
+          })
+        : planCreateCellPort(options.project, options.document.id, {
+            instance,
+            connectionEdits,
+            terminal: {
+              id: `terminal-${id.toLowerCase()}`,
+              name: formalName,
+              netId,
+              direction: placementRequest.direction,
+              interfaceInstanceIds: [id],
+            },
+            ...(annotation ? { annotation } : {}),
+          }),
     );
     if (!committed) return;
     options.selectOnly("instance", [id]);
     options.setComponentPreviewPoint(position);
     options.setStatus(
-      `Added Cell port ${formalName} · click to place another · Esc exits`,
+      existingTerminal
+        ? `Added another marker for Cell port ${formalName} · click to place another · Esc exits`
+        : `Added Cell port ${formalName} · click to place another · Esc exits`,
     );
   };
 

--- a/packages/edit-engine/src/hierarchy-planner.test.ts
+++ b/packages/edit-engine/src/hierarchy-planner.test.ts
@@ -4,6 +4,7 @@ import { createEmptyDocument, createEmptyProject } from "@icm/model";
 
 import {
   createHierarchyInstance,
+  planAttachCellPortMarker,
   planCreateCellPort,
   planPlaceCellInstance,
   planReorderCellTerminal,
@@ -124,6 +125,85 @@ describe("hierarchy domain planners", () => {
         ],
       },
     });
+  });
+
+  it("adds a second marker to an existing terminal instead of a second terminal", () => {
+    const project = createEmptyProject("project", "Project");
+    const port = (id: string, x: number) => ({
+      id,
+      symbolId: "port",
+      placement: {
+        position: { x, y: 20 },
+        rotation: 0 as const,
+        mirror: "none" as const,
+      },
+    });
+    const first = executeProjectTransaction(project, {
+      transactionId: "add-port",
+      projectId: project.id,
+      expectedStructureRevision: 0,
+      actor: { kind: "human", id: "test" },
+      edits: planCreateCellPort(project, project.topDocumentId, {
+        instance: port("P1", 40),
+        connectionEdits: [
+          {
+            kind: "connect_endpoints",
+            from: { kind: "terminal", instanceId: "P1", pinName: "P" },
+            to: { kind: "terminal", instanceId: "P1", pinName: "P" },
+            newNetId: "net-in",
+            newNetName: "IN",
+          },
+        ],
+        terminal: {
+          id: "terminal-in",
+          name: "IN",
+          netId: "net-in",
+          direction: "input",
+          interfaceInstanceIds: ["P1"],
+        },
+      }),
+    });
+    expect(first.ok).toBe(true);
+
+    const second = executeProjectTransaction(first.project, {
+      transactionId: "add-second-marker",
+      projectId: project.id,
+      expectedStructureRevision: first.structureRevision,
+      actor: { kind: "human", id: "test" },
+      edits: planAttachCellPortMarker(first.project, project.topDocumentId, {
+        instance: port("P2", 200),
+        connectionEdits: [
+          {
+            kind: "connect_endpoints",
+            from: { kind: "terminal", instanceId: "P2", pinName: "P" },
+            to: { kind: "terminal", instanceId: "P2", pinName: "P" },
+            newNetId: "net-marker-p2",
+          },
+        ],
+        terminalId: "terminal-in",
+        markerNetId: "net-marker-p2",
+      }),
+    });
+
+    expect(second.ok).toBe(true);
+    const document = second.project.documents.find(
+      (candidate) => candidate.id === project.topDocumentId,
+    )!;
+    // One formal terminal, two markers: the interface a parent resolves
+    // against stays single-valued.
+    expect(document.netlist!.terminals).toHaveLength(1);
+    expect(document.netlist!.terminals[0]).toMatchObject({
+      id: "terminal-in",
+      name: "IN",
+      interfaceInstanceIds: ["P1", "P2"],
+    });
+    // Both markers share the terminal's Net.
+    expect(document.nets.filter((net) => net.name === "IN")).toHaveLength(1);
+    const net = document.nets.find((candidate) => candidate.id === "net-in")!;
+    expect(net.terminals.map((terminal) => terminal.instanceId).sort()).toEqual(
+      ["P1", "P2"],
+    );
+    expect(document.nets.some((n) => n.id === "net-marker-p2")).toBe(false);
   });
 
   it("returns no reorder transaction at an interface boundary", () => {

--- a/packages/edit-engine/src/hierarchy-planner.ts
+++ b/packages/edit-engine/src/hierarchy-planner.ts
@@ -431,6 +431,77 @@ export function planPlaceExternalSubcircuitInstance(
   ];
 }
 
+/**
+ * Place a second Port marker for a Cell terminal that already exists.
+ *
+ * Repeating an interface name is ordinary schematic practice — the same pin
+ * drawn at both ends of a large sheet — so it adds a marker to the existing
+ * terminal rather than a second terminal. The formal interface keeps one
+ * entry per name, which the parent Instance's pin-to-terminal lookup relies
+ * on, and the new marker joins that terminal's Net.
+ */
+export function planAttachCellPortMarker(
+  project: CircuitProject,
+  documentId: string,
+  input: {
+    instance: SchematicDocument["instances"][number];
+    connectionEdits: DocumentEdits;
+    terminalId: string;
+    /** Net the placed marker currently owns; merged into the terminal's Net. */
+    markerNetId: string;
+    annotation?: Annotation;
+  },
+): ProjectStructureEdit[] {
+  const document = requireDocument(project, documentId);
+  if (!document.netlist)
+    throw new Error(`Cell has no interface: ${documentId}`);
+  if (
+    input.instance.symbolId !== "port" &&
+    input.instance.symbolId !== "port-filled"
+  ) {
+    throw new Error(
+      `Cell interface marker must be a Port: ${input.instance.symbolId}`,
+    );
+  }
+  const terminal = document.netlist.terminals.find(
+    (candidate) => candidate.id === input.terminalId,
+  );
+  if (!terminal) {
+    throw new Error(`Cell terminal does not exist: ${input.terminalId}`);
+  }
+  return [
+    transactDocument(project, documentId, [
+      { kind: "add_instance", instance: input.instance },
+      ...input.connectionEdits,
+      ...(input.markerNetId === terminal.netId
+        ? []
+        : [
+            {
+              kind: "merge_nets" as const,
+              targetNetId: terminal.netId,
+              sourceNetId: input.markerNetId,
+            },
+          ]),
+      {
+        kind: "update_cell_terminal",
+        terminalId: terminal.id,
+        interfaceInstanceIds: [
+          ...terminal.interfaceInstanceIds,
+          input.instance.id,
+        ],
+      },
+      ...(input.annotation
+        ? [
+            {
+              kind: "upsert_schematic_annotation" as const,
+              annotation: input.annotation,
+            },
+          ]
+        : []),
+    ]),
+  ];
+}
+
 export function planCreateCellPort(
   project: CircuitProject,
   documentId: string,
@@ -785,7 +856,14 @@ export function planRenameCellTerminal(
       (candidate) => candidate.id !== terminalId && candidate.name === newName,
     )
   ) {
-    throw new Error(`Cell terminal name already exists: ${newName}`);
+    // Renaming onto an existing interface name is ambiguous — it reads as
+    // either "these are one pin" or a typo — and folding two formal terminals
+    // together would silently rewrite the Cell interface every parent
+    // Instance resolves against. Placing another Port named ${newName} is the
+    // unambiguous way to draw the same pin twice.
+    throw new Error(
+      `Cell terminal name already exists: ${newName}. Place another Port named ${newName} to draw the same pin again.`,
+    );
   }
 
   const terminalRename = terminal.name !== newName;

--- a/plan/2026-08-22-duplicate-cell-pin-names/plan.md
+++ b/plan/2026-08-22-duplicate-cell-pin-names/plan.md
@@ -1,0 +1,98 @@
+---
+status: completed
+experience: none
+---
+
+# Repeating a Cell Pin name places another marker
+
+## Goal
+
+Stop rejecting a Port whose name already exists. Drawing the same interface
+pin at more than one place on a sheet is ordinary practice, so a repeated name
+must place another marker for the terminal that already owns it.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## claude/duplicate-pin-names
+```
+
+Branched from `origin/main`. `.claude/` and `node_modules` are untracked local
+scaffolding for this pnpm-less machine.
+
+- `packages/edit-engine/src/hierarchy-planner.ts`
+- `packages/edit-engine/src/hierarchy-planner.test.ts`
+- `apps/editor/src/features/component-insert/use-component-placement.ts`
+- `apps/editor/e2e/hierarchy.spec.ts`
+
+- Shared: the formal Cell interface (`netlist.terminals`), which every parent
+  Instance resolves its pins against.
+
+## Work
+
+1. Add `planAttachCellPortMarker`: place the Port Instance, append it to an
+   existing terminal's `interfaceInstanceIds`, and merge the marker's Net into
+   the terminal's Net. The model already types `interfaceInstanceIds` as a
+   plural array, so no schema change is needed.
+2. Route placement through it when the resolved formal name matches an
+   existing terminal, replacing the `Cell port X already exists` abort.
+3. Suppress the marker's own Net name and the `set_net_name` edit on that
+   path — the terminal's Net already carries the name, and emitting it again
+   would trip the duplicate-Net-name gate.
+
+## Why a repeated name is not a second terminal
+
+`connectivity-index.ts` and `schema/project.ts` resolve a parent Instance's
+pin to a child terminal **by name**. Two terminals sharing a name would make
+that lookup ambiguous and silently resolve to the first match, so the fix
+keeps one terminal per name and lets a terminal own several drawn markers.
+
+Renaming a terminal onto an existing name still rejects: unlike placement, it
+is genuinely ambiguous between "these are one pin" and a typo, and folding two
+formal terminals together would rewrite the interface every parent resolves
+against. Its message now names the working alternative.
+
+## Validation
+
+- `git diff --check`
+- `git status --short --branch`
+- `vitest run packages/edit-engine apps/editor/src/features/component-insert`
+  (221 passed), full unit suite (1162 passed)
+- Playwright `hierarchy.spec.ts` (12 passed), including the new placement case
+- `tsc -p tsconfig.check.json`
+
+## Gate Review
+
+- Decision: affected
+- Early gates: typecheck, Prettier on changed files
+- Affected gates: edit-engine and component-insert unit tests, the hierarchy
+  Playwright spec that owns Cell Port placement
+- Final gates: remote GitHub Actions on the PR
+- Platform risks: none; no generated artifact, schema, or release path changed
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: a repeated formal name adds a marker to the existing terminal
+  rather than a second terminal; the Cell interface stays one entry per name.
+- Primary checks: `packages/edit-engine/src/hierarchy-planner.test.ts`,
+  `apps/editor/e2e/hierarchy.spec.ts`
+
+Both are new cases; the previous behavior was an abort with no coverage of
+what happened after it.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(edit-engine): place another marker for an existing Cell Pin name
+```
+
+## Outcome
+
+Placing a Port whose name is already taken now succeeds and reports "Added
+another marker for Cell port X". The formal interface still holds exactly one
+terminal per name, so parent pin resolution is unchanged.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4625,3 +4625,21 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   CLK/A and both drafting cases.
 - Commit status: completed on `claude/semantic-text-subscripts`; mainline
   merge gated on the remote required checks.
+
+## 2026-08-22 - Repeating a Cell Pin name places another marker
+
+- Changed areas: new `planAttachCellPortMarker` appends a Port Instance to an
+  existing terminal's `interfaceInstanceIds` and merges the marker's Net into
+  the terminal's Net; placement routes through it instead of aborting with
+  `Cell port X already exists`. The model already typed `interfaceInstanceIds`
+  as a plural array, so no schema change was needed.
+- Kept one terminal per name deliberately: `connectivity-index.ts` and
+  `schema/project.ts` resolve a parent Instance's pin to a child terminal by
+  name, so two same-named terminals would resolve ambiguously to the first
+  match. Rename-onto-an-existing-name still rejects (ambiguous between "one
+  pin" and a typo) but now names the working alternative.
+- Validation: full unit suite (1162), edit-engine + component-insert (221),
+  Playwright hierarchy spec (12 passed) including the new placement case,
+  typecheck, prettier, diff checks.
+- Commit status: completed on `claude/duplicate-pin-names`; mainline merge
+  gated on the remote required checks.


### PR DESCRIPTION
## Problem

Placing a Port whose formal name was already taken aborted outright:

> Cell port P1 already exists

Drawing the same interface pin at more than one place on a sheet is ordinary schematic practice, so this shouldn't be blocked.

## Fix

A repeated name now places **another marker for the terminal that already owns it**, rather than a second terminal.

`planAttachCellPortMarker` appends the Port Instance to that terminal's `interfaceInstanceIds` and merges the marker's Net into the terminal's Net. The model already typed `interfaceInstanceIds` as a plural array, so **no schema change was needed**.

Status now reads `Added another marker for Cell port P1 · click to place another · Esc exits`.

## Why one terminal per name is kept

`packages/derived/src/connectivity-index.ts` and `packages/model/src/schema/project.ts` resolve a parent Instance's pin to a child terminal **by name**. Two terminals sharing a name would make that lookup ambiguous and silently resolve to whichever came first — a connectivity bug, not just a cosmetic one. Keeping one terminal per name and letting a terminal own several drawn markers gets the requested behavior without touching that contract.

Renaming a terminal *onto* an existing name still rejects. Unlike placement, that case is genuinely ambiguous between "these are one pin" and a typo, and folding two formal terminals together would rewrite the interface every parent Instance resolves against. Its message now names the working alternative instead of just refusing.

## Validation

- Full unit suite: **1162 passed**
- `packages/edit-engine` + `apps/editor/src/features/component-insert`: 221 passed
- Playwright `hierarchy.spec.ts`: **12 passed**, including a new case that places two Cell Pins on one Net and asserts the saved Project holds exactly one terminal with two `interfaceInstanceIds`
- Typecheck, Prettier, `git diff --check`, test-impact gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)