### PR TITLE
feat(editor): feed paging, author filter, and the admin recycle bin

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -96,6 +96,149 @@ test("masonry places the top row left-to-right in distinct columns", async ({
   expect(wallHeight).toBeGreaterThan(100);
 });
 
+test("the feed pages through the cursor as the sentinel comes into view", async ({
+  page,
+}) => {
+  const listRequests: string[] = [];
+  await page.route("**/api/gallery**", (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname !== "/api/gallery") return route.fallback();
+    listRequests.push(url.search);
+    const second = url.searchParams.get("cursor") === "c1";
+    const ids = second ? ["p2-a", "p2-b"] : ["p1-a", "p1-b", "p1-c"];
+    return route.fulfill({
+      json: {
+        entries: ids.map((id) => ({
+          id,
+          name: `Circuit ${id}`,
+          author: "tz",
+          description: "",
+          createdAt: "2026-08-22T10:00:00.000Z",
+          schemaVersion: 21,
+        })),
+        nextCursor: second ? null : "c1",
+      },
+    });
+  });
+  await page.route("**/api/gallery/*/preview.svg", (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"><rect width="10" height="6" fill="#fff"/></svg>',
+    }),
+  );
+
+  await page.goto("/");
+  await expect(page.getByTestId("gallery-tile-p1-a")).toBeVisible();
+  // The short first page leaves the sentinel visible, so page two loads
+  // without any user scrolling and the cursor chain ends. (StrictMode
+  // double-mounts the initial effect in dev, so the plain request may
+  // fire twice; the cursor page must load exactly once.)
+  await expect(page.getByTestId("gallery-tile-p2-b")).toBeVisible();
+  expect(listRequests.filter((query) => query === "?cursor=c1")).toHaveLength(
+    1,
+  );
+  expect(
+    listRequests.every((query) => query === "" || query === "?cursor=c1"),
+  ).toBe(true);
+});
+
+test("clicking a byline filters the wall to that author, clearable", async ({
+  page,
+}) => {
+  await page.route("**/api/gallery**", (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname !== "/api/gallery") return route.fallback();
+    const alice = url.searchParams.get("author") === "alice";
+    const entries = [
+      {
+        id: "f-alice",
+        name: "Alice's OTA",
+        author: "alice",
+        description: "",
+        createdAt: "2026-08-22T10:00:00.000Z",
+        schemaVersion: 21,
+      },
+      ...(alice
+        ? []
+        : [
+            {
+              id: "f-bob",
+              name: "Bob's Mixer",
+              author: "bob",
+              description: "",
+              createdAt: "2026-08-22T09:00:00.000Z",
+              schemaVersion: 21,
+            },
+          ]),
+    ];
+    return route.fulfill({ json: { entries, nextCursor: null } });
+  });
+  await page.route("**/api/gallery/*/preview.svg", (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"><rect width="10" height="6" fill="#fff"/></svg>',
+    }),
+  );
+
+  await page.goto("/");
+  await expect(page.getByTestId("gallery-tile-f-bob")).toBeVisible();
+  await page.getByTestId("gallery-author-f-alice").click();
+  await expect(page.getByTestId("gallery-filter")).toContainText(
+    "Circuits by alice",
+  );
+  await expect(page.getByTestId("gallery-tile-f-bob")).toHaveCount(0);
+  await expect(page).toHaveURL(/\?author=alice$/);
+  await page.getByTestId("gallery-filter-clear").click();
+  await expect(page.getByTestId("gallery-tile-f-bob")).toBeVisible();
+  await expect(page).not.toHaveURL(/author=/);
+});
+
+test("the admin recycle bin restores a recycled entry", async ({ page }) => {
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      json: {
+        user: {
+          id: "u1",
+          displayName: "Token Zhang",
+          email: "owner@example.com",
+          provider: "github",
+          role: "user",
+          isAdmin: true,
+        },
+      },
+    }),
+  );
+  await page.route("**/api/gallery/review", (route) =>
+    route.fulfill({ json: { entries: [] } }),
+  );
+  let restored = 0;
+  await page.route("**/api/gallery/recycled", (route) =>
+    route.fulfill({
+      json: {
+        entries: restored
+          ? []
+          : [
+              {
+                id: "bin-1",
+                name: "Old Sketch",
+                recycledAt: "2026-08-22T08:00:00.000Z",
+              },
+            ],
+      },
+    }),
+  );
+  await page.route("**/api/gallery/bin-1/restore", (route) => {
+    restored += 1;
+    return route.fulfill({ json: { id: "bin-1", status: "public" } });
+  });
+
+  await page.goto("/review");
+  await expect(page.getByTestId("bin-card-bin-1")).toBeVisible();
+  await page.getByTestId("bin-restore-bin-1").click();
+  await expect(page.getByTestId("bin-empty")).toBeVisible();
+  expect(restored).toBe(1);
+});
+
 test("falls back to bundled tiles when the gallery is empty or unreachable", async ({
   page,
 }) => {

--- a/apps/editor/src/components/gallery-feed.test.tsx
+++ b/apps/editor/src/components/gallery-feed.test.tsx
@@ -13,8 +13,8 @@ function fetchReturning(payload: unknown, ok = true): typeof fetch {
 }
 
 describe("loadGalleryFeed", () => {
-  it("returns ready entries from the worker", async () => {
-    const state = await loadGalleryFeed(
+  it("returns a page of entries with its cursor", async () => {
+    const page = await loadGalleryFeed(
       fetchReturning({
         entries: [
           {
@@ -26,24 +26,35 @@ describe("loadGalleryFeed", () => {
             schemaVersion: 21,
           },
         ],
+        nextCursor: "2026-08-21T00:00:00.000Z|g1",
       }),
     );
-    expect(state).toMatchObject({ status: "ready" });
-    if (state.status === "ready") {
-      expect(state.entries.map((entry) => entry.id)).toEqual(["g1"]);
-    }
+    expect(page?.entries.map((entry) => entry.id)).toEqual(["g1"]);
+    expect(page?.nextCursor).toBe("2026-08-21T00:00:00.000Z|g1");
   });
 
-  it("degrades to unavailable on errors and non-OK responses", async () => {
-    expect(await loadGalleryFeed(fetchReturning({}, false))).toEqual({
-      status: "unavailable",
-    });
+  it("builds the query only from the options that are set", async () => {
+    const urls: string[] = [];
+    const capturing = (async (input: RequestInfo | URL) => {
+      urls.push(String(input));
+      return new Response(JSON.stringify({ entries: [] }), { status: 200 });
+    }) as typeof fetch;
+    await loadGalleryFeed(capturing);
+    await loadGalleryFeed(capturing, { author: "alice" });
+    await loadGalleryFeed(capturing, { author: "alice", cursor: "c|1" });
+    expect(urls).toEqual([
+      "/api/gallery",
+      "/api/gallery?author=alice",
+      "/api/gallery?author=alice&cursor=c%7C1",
+    ]);
+  });
+
+  it("degrades to null on errors and non-OK responses", async () => {
+    expect(await loadGalleryFeed(fetchReturning({}, false))).toBeNull();
     const throwing = (async () => {
       throw new Error("offline");
     }) as unknown as typeof fetch;
-    expect(await loadGalleryFeed(throwing)).toEqual({
-      status: "unavailable",
-    });
+    expect(await loadGalleryFeed(throwing)).toBeNull();
   });
 });
 

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { renderDocumentSvg } from "@icm/render-svg";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
@@ -16,10 +16,16 @@ export interface GalleryFeedEntry {
   schemaVersion: number;
 }
 
-export type GalleryFeedState =
-  | { status: "loading" }
-  | { status: "ready"; entries: GalleryFeedEntry[] }
-  | { status: "unavailable" };
+export interface GalleryFeedPage {
+  entries: GalleryFeedEntry[];
+  nextCursor: string | null;
+}
+
+export interface GalleryFeedState {
+  status: "loading" | "ready" | "unavailable";
+  entries: GalleryFeedEntry[];
+  nextCursor: string | null;
+}
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
@@ -49,20 +55,32 @@ function bundledTiles() {
   });
 }
 
+/** One feed page; the plain first request stays exactly `/api/gallery`. */
 export async function loadGalleryFeed(
   fetchLike: typeof fetch = fetch,
-): Promise<GalleryFeedState> {
+  options: { cursor?: string | null; author?: string | null } = {},
+): Promise<GalleryFeedPage | null> {
+  const params = new URLSearchParams();
+  if (options.author) params.set("author", options.author);
+  if (options.cursor) params.set("cursor", options.cursor);
+  const query = params.toString();
   try {
-    const response = await fetchLike("/api/gallery", {
-      credentials: "same-origin",
-    });
-    if (!response.ok) return { status: "unavailable" };
+    const response = await fetchLike(
+      `/api/gallery${query ? `?${query}` : ""}`,
+      { credentials: "same-origin" },
+    );
+    if (!response.ok) return null;
     const payload = (await response.json()) as {
       entries?: GalleryFeedEntry[];
+      nextCursor?: unknown;
     };
-    return { status: "ready", entries: payload.entries ?? [] };
+    return {
+      entries: payload.entries ?? [],
+      nextCursor:
+        typeof payload.nextCursor === "string" ? payload.nextCursor : null,
+    };
   } catch {
-    return { status: "unavailable" };
+    return null;
   }
 }
 
@@ -73,24 +91,92 @@ export async function loadGalleryFeed(
  * worker), so the landing page is never blank.
  */
 export function GalleryFeed() {
-  const [state, setState] = useState<GalleryFeedState>({ status: "loading" });
+  const [author, setAuthor] = useState<string | null>(() =>
+    typeof window === "undefined"
+      ? null
+      : new URLSearchParams(window.location.search).get("author"),
+  );
+  const [state, setState] = useState<GalleryFeedState>({
+    status: "loading",
+    entries: [],
+    nextCursor: null,
+  });
+  const loadingMoreRef = useRef(false);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    void loadGalleryFeed().then((next) => {
-      if (!cancelled) setState(next);
+    setState({ status: "loading", entries: [], nextCursor: null });
+    void loadGalleryFeed(fetch, { author }).then((page) => {
+      if (cancelled) return;
+      setState(
+        page
+          ? { status: "ready", ...page }
+          : { status: "unavailable", entries: [], nextCursor: null },
+      );
     });
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [author]);
 
-  const entries = state.status === "ready" ? state.entries : [];
+  // Infinite scroll: while a cursor remains, the sentinel below the wall
+  // appends the next page whenever it scrolls into view.
+  const nextCursor = state.nextCursor;
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel || nextCursor === null) return;
+    if (typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver((observed) => {
+      if (!observed.some((entry) => entry.isIntersecting)) return;
+      if (loadingMoreRef.current) return;
+      loadingMoreRef.current = true;
+      void loadGalleryFeed(fetch, { author, cursor: nextCursor }).then(
+        (page) => {
+          loadingMoreRef.current = false;
+          if (!page) return;
+          setState((previous) =>
+            previous.status === "ready"
+              ? {
+                  status: "ready",
+                  entries: [...previous.entries, ...page.entries],
+                  nextCursor: page.nextCursor,
+                }
+              : previous,
+          );
+        },
+      );
+    });
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [nextCursor, author]);
+
+  function selectAuthor(next: string | null): void {
+    setAuthor(next);
+    const url = new URL(window.location.href);
+    if (next) url.searchParams.set("author", next);
+    else url.searchParams.delete("author");
+    window.history.replaceState(null, "", url.pathname + url.search);
+  }
+
+  const entries = state.entries;
 
   return (
     <main className="gallery-shell" data-testid="gallery-feed">
       <GalleryChrome subtitle="Community gallery" />
 
+      {author ? (
+        <div className="gallery-filter" data-testid="gallery-filter">
+          <span>Circuits by {author}</span>
+          <button
+            type="button"
+            data-testid="gallery-filter-clear"
+            onClick={() => selectAuthor(null)}
+          >
+            Show everyone
+          </button>
+        </div>
+      ) : null}
       {state.status === "loading" ? (
         <p className="gallery-status" data-testid="gallery-loading">
           Loading gallery…
@@ -118,7 +204,24 @@ export function GalleryFeed() {
                     <span className="gallery-tile-copy">
                       <span className="gallery-tile-name">{entry.name}</span>
                       <span className="gallery-tile-meta">
-                        {entry.author ? `${entry.author} · ` : ""}
+                        {entry.author ? (
+                          <>
+                            <button
+                              type="button"
+                              className="gallery-tile-author"
+                              data-testid={`gallery-author-${entry.id}`}
+                              title={`Show circuits by ${entry.author}`}
+                              onClick={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                selectAuthor(entry.author);
+                              }}
+                            >
+                              {entry.author}
+                            </button>
+                            {" · "}
+                          </>
+                        ) : null}
                         {savedAtLabel(entry.createdAt)}
                       </span>
                       {entry.description ? (
@@ -130,7 +233,7 @@ export function GalleryFeed() {
                   </a>
                 ),
               })),
-              ...(entries.length === 0
+              ...(entries.length === 0 && author === null
                 ? bundledTiles().map((tile) => ({
                     key: `bundled-${tile.id}`,
                     node: (
@@ -159,8 +262,19 @@ export function GalleryFeed() {
                 : []),
             ]}
           />
+          {entries.length === 0 && author !== null ? (
+            <p className="gallery-status" data-testid="gallery-filter-empty">
+              No public circuits by {author} yet.
+            </p>
+          ) : null}
         </section>
       )}
+      <div
+        ref={sentinelRef}
+        className="gallery-sentinel"
+        data-testid="gallery-sentinel"
+        aria-hidden="true"
+      />
       <footer className="gallery-footnote">
         Browse freely; open any circuit and edit your own copy. Publishing joins
         in a later release with sign-in.

--- a/apps/editor/src/components/review-queue.tsx
+++ b/apps/editor/src/components/review-queue.tsx
@@ -156,6 +156,115 @@ function ReviewCard({
   );
 }
 
+interface RecycledEntry {
+  id: string;
+  name: string;
+  recycledAt?: string | null;
+}
+
+/**
+ * In-feed admin recycle bin (G4): the post-approval takedown surface.
+ * Restore returns an entry to the public wall; Delete forever is the
+ * only hard deletion and asks for confirmation first.
+ */
+function RecycleBin() {
+  const [entries, setEntries] = useState<RecycledEntry[] | null>(null);
+
+  async function refresh(): Promise<void> {
+    try {
+      const response = await fetch("/api/gallery/recycled", {
+        credentials: "same-origin",
+      });
+      if (!response.ok) {
+        setEntries([]);
+        return;
+      }
+      const payload = (await response.json()) as {
+        entries?: RecycledEntry[];
+      };
+      setEntries(payload.entries ?? []);
+    } catch {
+      setEntries([]);
+    }
+  }
+
+  useEffect(() => {
+    void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- load once
+  }, []);
+
+  async function act(id: string, kind: "restore" | "delete"): Promise<void> {
+    if (
+      kind === "delete" &&
+      !window.confirm("Delete this entry forever? This cannot be undone.")
+    ) {
+      return;
+    }
+    try {
+      await fetch(
+        kind === "restore"
+          ? `/api/gallery/${id}/restore`
+          : `/api/gallery/${id}`,
+        {
+          method: kind === "restore" ? "POST" : "DELETE",
+          credentials: "same-origin",
+        },
+      );
+    } catch {
+      // The refresh below shows the true state either way.
+    }
+    void refresh();
+  }
+
+  if (entries === null) return null;
+  return (
+    <section className="review-bin" data-testid="review-bin">
+      <h2>Recycle bin</h2>
+      {entries.length === 0 ? (
+        <p className="gallery-status" data-testid="bin-empty">
+          The bin is empty.
+        </p>
+      ) : (
+        <div className="mine-list">
+          {entries.map((entry) => (
+            <article
+              key={entry.id}
+              className="mine-card"
+              data-testid={`bin-card-${entry.id}`}
+            >
+              <div className="mine-card-copy">
+                <h2>{entry.name}</h2>
+                {entry.recycledAt ? (
+                  <p className="review-card-meta">
+                    Recycled {new Date(entry.recycledAt).toLocaleString()}
+                  </p>
+                ) : null}
+              </div>
+              <div className="review-card-actions">
+                <button
+                  type="button"
+                  data-testid={`bin-delete-${entry.id}`}
+                  onClick={() => void act(entry.id, "delete")}
+                >
+                  Delete forever
+                </button>
+                <button
+                  type="button"
+                  className="review-approve"
+                  data-testid={`bin-restore-${entry.id}`}
+                  onClick={() => void act(entry.id, "restore")}
+                >
+                  Restore
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
 export function ReviewQueue() {
   const [state, setState] = useState<QueueState>({ status: "loading" });
   const [email, setEmail] = useState("");
@@ -242,6 +351,7 @@ export function ReviewQueue() {
             ))}
           </section>
         )}
+        {state.user.isAdmin ? <RecycleBin /> : null}
       </div>
     </main>
   );

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -5539,6 +5539,54 @@ html.light .analytics-map-land path {
   margin-top: 4px;
 }
 
+.gallery-filter {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 22px 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.gallery-filter button {
+  padding: 4px 10px;
+  border: 1px solid var(--icm-border);
+  border-radius: 999px;
+  color: var(--icm-text-muted);
+  background: var(--icm-surface);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.gallery-filter button:hover {
+  background: var(--icm-surface-hover);
+}
+
+.gallery-tile-author {
+  padding: 0;
+  border: none;
+  color: inherit;
+  background: none;
+  font: inherit;
+  text-decoration: underline dotted;
+  cursor: pointer;
+}
+
+.gallery-sentinel {
+  height: 1px;
+}
+
+.review-bin {
+  margin-top: 30px;
+  border-top: 1px solid var(--icm-border);
+  padding-top: 10px;
+}
+
+.review-bin h2 {
+  margin: 8px 0 0;
+  font-size: 17px;
+}
+
 .publish-gallery-mode {
   display: flex;
   flex-direction: column;

--- a/docs/roadmap/community-gallery-platform.md
+++ b/docs/roadmap/community-gallery-platform.md
@@ -118,7 +118,10 @@ anonymous writes are impossible at the API, not just the UI.
 
 - Masonry (shipped 2026-08-22: JS greedy shortest-column layout keeping
   each circuit's natural aspect ratio, left-to-right reading order,
-  balanced bottoms); still open: infinite scroll, per-author filtering,
-  in-feed admin recycle-bin view, and seeded starter content curation.
+  balanced bottoms). Infinite scroll (sentinel over the keyset cursor),
+  per-author filtering (clickable bylines, URL-carried, clearable chip),
+  and the in-feed admin recycle bin (restore / delete-forever on
+  /review) shipped 2026-08-22; still open: seeded starter content
+  curation.
 
 Each phase closes by updating this file's status line for that phase.

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -23,7 +23,8 @@ restrictive content-security-policy.
 ## Public surface
 
 - `GET /api/gallery` — newest-first `public` entries
-  (`{entries, nextCursor}`; keyset cursor; limit clamps at 60). Recycled
+  (`{entries, nextCursor}`; keyset cursor; limit clamps at 60; optional
+  `author` filters to that exact byline before pagination). Recycled
   entries never appear.
 - `GET /api/gallery/<id>` — one public entry with its canonical
   `projectText`.

--- a/plan/2026-08-22-gallery-feed-g4/plan.md
+++ b/plan/2026-08-22-gallery-feed-g4/plan.md
@@ -1,0 +1,90 @@
+---
+status: completed
+experience: none
+---
+
+# Gallery Feed G4 Remainder: Infinite Scroll, Author Filter, Admin Bin
+
+## Goal
+
+Finish the three open G4 items. The feed pages through the existing
+keyset cursor with an IntersectionObserver sentinel (masonry grows in
+place); clicking a tile's author filters the wall to that author (server
+filter + URL `?author=` + a clearable chip); and `/review` gains the
+in-feed admin recycle-bin view (restore, delete-forever with
+confirmation) so takedown management stops requiring curl.
+
+## State and Ownership
+
+Stacked on `claude/gallery-owner-editing` (PR #176) as
+`claude/gallery-feed-g4`; merges cleanly over it.
+
+Owned paths:
+
+- `worker/gallery.ts` (+ test): author filter on the list op/route
+- `apps/editor/src/components/gallery-feed.tsx` (paging state, sentinel,
+  author chip and buttons)
+- `apps/editor/src/components/review-queue.tsx` (admin bin section)
+- `apps/editor/src/styles.css`, `apps/editor/e2e/gallery.spec.ts`
+- `docs/specs/community-gallery.md`, roadmap, plan files
+
+Shared dependencies: the list contract gains an optional `author` query
+parameter (absent = unchanged behavior; every existing mock and consumer
+keeps working because the client only appends parameters when set).
+
+## Design
+
+- List: `GET /api/gallery?limit&cursor&author` — `author` filters to the
+  exact byline before keyset pagination; the DO op takes the same field.
+- Feed state keeps `entries + nextCursor + author`; a sentinel div below
+  the wall observes viewport intersection and appends the next page
+  while a cursor remains (guarded against double-fires). Switching the
+  author filter restarts from the first page and rewrites the URL query
+  (`history.replaceState`); the initial filter reads from the URL.
+- Tile bylines become buttons (stopping the tile link) that set the
+  filter; an active filter renders a chip with a clear control.
+- `/review` (admin only) appends a "Recycle bin" section listing
+  `GET /api/gallery/recycled` with per-entry Restore and Delete forever
+  (native confirm) wired to the existing admin routes.
+
+## Validation
+
+- `vitest`: worker list author-filter test
+- `playwright`: gallery spec — sentinel auto-loads page two; author
+  click filters the request and the chip clears; admin bin restores a
+  mocked entry
+- repository typecheck, prettier,
+  `node scripts/check-test-impact.mjs --base origin/main`
+- `git diff --check` and `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: the plain list request is byte-compatible with before; the
+  cursor pages the filtered set; the bin acts only behind admin review
+  authority
+- Primary checks: `worker/gallery.test.ts`,
+  `apps/editor/e2e/gallery.spec.ts`
+
+## Commit Intent
+
+Committed on `claude/gallery-feed-g4` under the user's standing
+commit-push-merge direction as:
+
+```text
+feat(editor): feed paging, author filter, and the admin recycle bin
+```
+
+## Outcome
+
+Delivered. The list contract gained an optional exact-byline `author`
+filter ahead of the unchanged keyset pagination (the plain request stays
+byte-compatible); the feed keeps entries+cursor state, appends pages as
+an IntersectionObserver sentinel enters the viewport (double-fire
+guarded), and filters by author from clickable tile bylines with a
+URL-carried, clearable chip (bundled fallback suppressed while
+filtering). `/review` gained the admin recycle bin: restore and
+confirm-guarded delete-forever over the existing admin routes.
+Validation: worker gallery 14 (filtered paging), feed/component units 28,
+gallery Playwright 16/16 (sentinel paging, author filter round-trip,
+bin restore), repository typecheck, prettier, test-impact, diff checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4638,3 +4638,15 @@ Keep reusable lessons in `docs/experience/`, not in this log.
 - Validation: worker gallery 13, unit sweep 472, gallery Playwright
   13/13, typecheck, prettier, test-impact, diff checks.
 - Commit status: completed on `claude/gallery-owner-editing`.
+
+## 2026-08-22 — Gallery feed G4 remainder
+
+- Target: `plan/2026-08-22-gallery-feed-g4/plan.md` (completed).
+- Change: list gains an `author` filter before keyset paging; the feed
+  pages via an IntersectionObserver sentinel and filters by clickable
+  bylines (URL-carried, clearable); `/review` gains the admin recycle
+  bin (restore, confirm-guarded delete-forever).
+- Validation: worker gallery 14, component units 28, gallery Playwright
+  16/16, typecheck, prettier, test-impact, diff checks.
+- Commit status: completed on `claude/gallery-feed-g4` (stacked on
+  `claude/gallery-owner-editing`).

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -526,6 +526,53 @@ function wiredProjectText(name = "Wired"): string {
   return serializeProject(project);
 }
 
+describe("gallery list author filter and paging (phase G4)", () => {
+  it("filters by exact byline and pages the filtered set", async () => {
+    const env = environment(ADMIN_TOKEN);
+    for (const [name, author] of [
+      ["A1", "alice"],
+      ["B1", "bob"],
+      ["A2", "alice"],
+      ["A3", "alice"],
+    ] as const) {
+      await route(
+        env,
+        submissionRequest({ name, author, projectText: projectText(name) }),
+      );
+    }
+
+    const filtered = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery?author=alice&limit=2`),
+    );
+    const first = (await filtered.json()) as {
+      entries: { name: string; author: string }[];
+      nextCursor: string | null;
+    };
+    expect(first.entries.every((entry) => entry.author === "alice")).toBe(true);
+    expect(first.entries).toHaveLength(2);
+    expect(first.nextCursor).not.toBeNull();
+
+    const second = await route(
+      env,
+      new Request(
+        `${ORIGIN}/api/gallery?author=alice&limit=2&cursor=${encodeURIComponent(first.nextCursor!)}`,
+      ),
+    );
+    const rest = (await second.json()) as {
+      entries: { name: string }[];
+      nextCursor: string | null;
+    };
+    expect(rest.entries).toHaveLength(1);
+    expect(rest.nextCursor).toBeNull();
+
+    const unfiltered = await route(env, new Request(`${ORIGIN}/api/gallery`));
+    expect(
+      ((await unfiltered.json()) as { entries: unknown[] }).entries,
+    ).toHaveLength(4);
+  });
+});
+
 describe("gallery owner editing (phase G3 completion)", () => {
   it("owner updates re-enter review and clear the previous rejection", async () => {
     const { authDurable, env } = reviewHarness();

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -239,23 +239,28 @@ export class GalleryDO {
       GALLERY_MAX_LIST_LIMIT,
     );
     const cursor = typeof body.cursor === "string" ? body.cursor : null;
-    const rows = cursor
-      ? this.sql
-          .exec<EntryRow>(
-            `SELECT * FROM gallery_entries WHERE status = 'public'
-             AND (created_at || '|' || id) < ?
-             ORDER BY created_at DESC, id DESC LIMIT ?`,
-            cursor,
-            limit + 1,
-          )
-          .toArray()
-      : this.sql
-          .exec<EntryRow>(
-            `SELECT * FROM gallery_entries WHERE status = 'public'
-             ORDER BY created_at DESC, id DESC LIMIT ?`,
-            limit + 1,
-          )
-          .toArray();
+    const author =
+      typeof body.author === "string" && body.author.length > 0
+        ? body.author
+        : null;
+    const conditions = ["status = 'public'"];
+    const bindings: (string | number)[] = [];
+    if (author) {
+      conditions.push("author = ?");
+      bindings.push(author);
+    }
+    if (cursor) {
+      conditions.push("(created_at || '|' || id) < ?");
+      bindings.push(cursor);
+    }
+    const rows = this.sql
+      .exec<EntryRow>(
+        `SELECT * FROM gallery_entries WHERE ${conditions.join(" AND ")}
+         ORDER BY created_at DESC, id DESC LIMIT ?`,
+        ...bindings,
+        limit + 1,
+      )
+      .toArray();
     const page = rows.slice(0, limit);
     const nextCursor =
       rows.length > limit && page.length > 0
@@ -742,6 +747,7 @@ export async function routeGalleryRequest(
     const { payload } = await callGallery(env, "list", {
       limit: url.searchParams.get("limit"),
       cursor: url.searchParams.get("cursor"),
+      author: url.searchParams.get("author"),
     });
     return Response.json(payload, {
       headers: { "cache-control": "no-store" },


### PR DESCRIPTION
Finishes the three open G4 items.

- **Infinite scroll**: the feed keeps entries+cursor state and appends the next keyset page whenever an IntersectionObserver sentinel below the wall enters the viewport (double-fire guarded); masonry grows in place.
- **Author filter**: the list op/route gains an optional exact-byline `author` parameter ahead of unchanged pagination (the plain request stays byte-compatible); tile bylines become clickable, the active filter renders a URL-carried (`?author=`) clearable chip, and the bundled fallback stays suppressed while filtering.
- **Admin recycle bin**: `/review` (admin only) lists recycled entries with Restore and confirm-guarded Delete-forever over the existing admin routes — takedown management without curl.

Tests: worker gallery 14 (filtered paging both pages), feed/component units 28 (query building, page mapping), gallery Playwright 16/16 (sentinel paging with request accounting, author filter round-trip incl. URL, bin restore). Spec + roadmap updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)