### PR TITLE
feat(editor): circuit tags with a multi-select feed filter

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -193,6 +193,79 @@ test("clicking a byline filters the wall to that author, clearable", async ({
   await expect(page).not.toHaveURL(/author=/);
 });
 
+test("the tag menu multi-selects and tile tags join the selection", async ({
+  page,
+}) => {
+  const listQueries: string[] = [];
+  await page.route("**/api/gallery**", (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname === "/api/gallery/tags") {
+      return route.fulfill({
+        json: {
+          tags: [
+            { tag: "amplifier", count: 3 },
+            { tag: "adc", count: 2 },
+            { tag: "pll", count: 1 },
+          ],
+        },
+      });
+    }
+    if (url.pathname !== "/api/gallery") return route.fallback();
+    listQueries.push(url.searchParams.get("tags") ?? "");
+    const selected = (url.searchParams.get("tags") ?? "")
+      .split(",")
+      .filter(Boolean);
+    const all = [
+      { id: "t-amp", tags: ["amplifier"] },
+      { id: "t-adc", tags: ["adc", "amplifier"] },
+      { id: "t-pll", tags: ["pll"] },
+    ];
+    const entries = all
+      .filter(
+        (entry) =>
+          selected.length === 0 ||
+          entry.tags.some((tag) => selected.includes(tag)),
+      )
+      .map((entry) => ({
+        id: entry.id,
+        name: `Circuit ${entry.id}`,
+        author: "tz",
+        description: "",
+        createdAt: "2026-08-22T10:00:00.000Z",
+        schemaVersion: 21,
+        tags: entry.tags,
+      }));
+    return route.fulfill({ json: { entries, nextCursor: null } });
+  });
+  await page.route("**/api/gallery/*/preview.svg", (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"><rect width="10" height="6" fill="#fff"/></svg>',
+    }),
+  );
+
+  await page.goto("/");
+  await expect(page.getByTestId("gallery-tile-t-pll")).toBeVisible();
+
+  // Multi-select two tags: OR union, URL carried.
+  await page.getByTestId("gallery-tag-option-amplifier").click();
+  await expect(page.getByTestId("gallery-tile-t-pll")).toHaveCount(0);
+  await page.getByTestId("gallery-tag-option-adc").click();
+  await expect(page).toHaveURL(/tags=amplifier%2Cadc|tags=amplifier,adc/);
+  await expect(page.getByTestId("gallery-tile-t-amp")).toBeVisible();
+  expect(listQueries).toContain("amplifier,adc");
+
+  // Clearing restores the full wall; a tile tag chip re-enters selection.
+  await page.getByTestId("gallery-tags-clear").click();
+  await expect(page.getByTestId("gallery-tile-t-pll")).toBeVisible();
+  await page.getByTestId("gallery-tile-tag-t-pll-pll").click();
+  await expect(page.getByTestId("gallery-tile-t-amp")).toHaveCount(0);
+  await expect(page.getByTestId("gallery-tag-option-pll")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+});
+
 test("the admin recycle bin restores a recycled entry", async ({ page }) => {
   await page.route("**/api/auth/me", (route) =>
     route.fulfill({
@@ -417,12 +490,20 @@ test("an admin session publishes without the passphrase row", async ({
       },
     }),
   );
-  const posted: { authorization: string | null; author: string }[] = [];
+  const posted: {
+    authorization: string | null;
+    author: string;
+    tags: string[];
+  }[] = [];
   await page.route("**/api/gallery/submissions", (route) => {
-    const body = route.request().postDataJSON() as { author: string };
+    const body = route.request().postDataJSON() as {
+      author: string;
+      tags: string[];
+    };
     posted.push({
       authorization: route.request().headers()["authorization"] ?? null,
       author: body.author,
+      tags: body.tags,
     });
     return route.fulfill({ status: 201, json: { id: "entry-77" } });
   });
@@ -437,11 +518,21 @@ test("an admin session publishes without the passphrase row", async ({
   await expect(dialog.getByLabel("Author")).toHaveValue("Token Zhang");
 
   await dialog.getByLabel("Circuit name").fill("Session Publish");
+  await dialog.getByTestId("publish-preset-amplifier").click();
+  await dialog.getByLabel("Add tag").fill("Latch");
+  await dialog.getByLabel("Add tag").press("Enter");
+  await expect(dialog.getByTestId("publish-tag-latch")).toBeVisible();
   await dialog.getByRole("button", { name: "Publish" }).click();
   await expect(page.getByTestId("status")).toHaveText(
     'Published "Session Publish" to the gallery',
   );
-  expect(posted).toEqual([{ authorization: null, author: "Token Zhang" }]);
+  expect(posted).toEqual([
+    {
+      authorization: null,
+      author: "Token Zhang",
+      tags: ["amplifier", "latch"],
+    },
+  ]);
 });
 
 test("an ordinary user sees blocking quality gates on an empty project", async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -653,6 +653,9 @@ export function App({
   const [galleryEntryContext, setGalleryEntryContext] = useState<{
     id: string;
     ownerUserId: string | null;
+    author: string;
+    description: string;
+    tags: readonly string[];
   } | null>(null);
   const [publishGates, setPublishGates] = useState<SubmissionGateReport | null>(
     null,
@@ -1898,7 +1901,12 @@ export function App({
             return;
           }
           const payload = (await response.json()) as {
-            entry?: { name?: string };
+            entry?: {
+              name?: string;
+              author?: string;
+              description?: string;
+              tags?: string[];
+            };
             ownerUserId?: string | null;
             projectText?: string;
           };
@@ -1911,6 +1919,9 @@ export function App({
           setGalleryEntryContext({
             id: initialGalleryEntryId,
             ownerUserId: payload.ownerUserId ?? null,
+            author: payload.entry?.author ?? "",
+            description: payload.entry?.description ?? "",
+            tags: payload.entry?.tags ?? [],
           });
           setStatus(
             `Opened gallery circuit: ${payload.entry?.name ?? galleryProject.name}`,
@@ -7693,6 +7704,15 @@ export function App({
               (galleryEntryContext.ownerUserId !== null &&
                 publishSession.id === galleryEntryContext.ownerUserId))
               ? { id: galleryEntryContext.id }
+              : null
+          }
+          updateDefaults={
+            galleryEntryContext
+              ? {
+                  author: galleryEntryContext.author,
+                  description: galleryEntryContext.description,
+                  tags: galleryEntryContext.tags,
+                }
               : null
           }
           publish={(fields) => publishProjectToGallery(project, fields)}

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -14,6 +14,7 @@ export interface GalleryFeedEntry {
   description: string;
   createdAt: string;
   schemaVersion: number;
+  tags?: string[];
 }
 
 export interface GalleryFeedPage {
@@ -58,10 +59,17 @@ function bundledTiles() {
 /** One feed page; the plain first request stays exactly `/api/gallery`. */
 export async function loadGalleryFeed(
   fetchLike: typeof fetch = fetch,
-  options: { cursor?: string | null; author?: string | null } = {},
+  options: {
+    cursor?: string | null;
+    author?: string | null;
+    tags?: readonly string[];
+  } = {},
 ): Promise<GalleryFeedPage | null> {
   const params = new URLSearchParams();
   if (options.author) params.set("author", options.author);
+  if (options.tags && options.tags.length > 0) {
+    params.set("tags", options.tags.join(","));
+  }
   if (options.cursor) params.set("cursor", options.cursor);
   const query = params.toString();
   try {
@@ -96,6 +104,37 @@ export function GalleryFeed() {
       ? null
       : new URLSearchParams(window.location.search).get("author"),
   );
+  const [selectedTags, setSelectedTags] = useState<string[]>(() =>
+    typeof window === "undefined"
+      ? []
+      : (new URLSearchParams(window.location.search).get("tags") ?? "")
+          .split(",")
+          .filter((tag) => tag.length > 0),
+  );
+  const [tagOptions, setTagOptions] = useState<
+    { tag: string; count: number }[]
+  >([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetch("/api/gallery/tags", {
+          credentials: "same-origin",
+        });
+        if (!response.ok) return;
+        const payload = (await response.json()) as {
+          tags?: { tag: string; count: number }[];
+        };
+        if (!cancelled) setTagOptions(payload.tags ?? []);
+      } catch {
+        // No menu without the worker; the wall itself still works.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   const [state, setState] = useState<GalleryFeedState>({
     status: "loading",
     entries: [],
@@ -107,7 +146,7 @@ export function GalleryFeed() {
   useEffect(() => {
     let cancelled = false;
     setState({ status: "loading", entries: [], nextCursor: null });
-    void loadGalleryFeed(fetch, { author }).then((page) => {
+    void loadGalleryFeed(fetch, { author, tags: selectedTags }).then((page) => {
       if (cancelled) return;
       setState(
         page
@@ -118,7 +157,7 @@ export function GalleryFeed() {
     return () => {
       cancelled = true;
     };
-  }, [author]);
+  }, [author, selectedTags]);
 
   // Infinite scroll: while a cursor remains, the sentinel below the wall
   // appends the next page whenever it scrolls into view.
@@ -131,32 +170,50 @@ export function GalleryFeed() {
       if (!observed.some((entry) => entry.isIntersecting)) return;
       if (loadingMoreRef.current) return;
       loadingMoreRef.current = true;
-      void loadGalleryFeed(fetch, { author, cursor: nextCursor }).then(
-        (page) => {
-          loadingMoreRef.current = false;
-          if (!page) return;
-          setState((previous) =>
-            previous.status === "ready"
-              ? {
-                  status: "ready",
-                  entries: [...previous.entries, ...page.entries],
-                  nextCursor: page.nextCursor,
-                }
-              : previous,
-          );
-        },
-      );
+      void loadGalleryFeed(fetch, {
+        author,
+        tags: selectedTags,
+        cursor: nextCursor,
+      }).then((page) => {
+        loadingMoreRef.current = false;
+        if (!page) return;
+        setState((previous) =>
+          previous.status === "ready"
+            ? {
+                status: "ready",
+                entries: [...previous.entries, ...page.entries],
+                nextCursor: page.nextCursor,
+              }
+            : previous,
+        );
+      });
     });
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [nextCursor, author]);
+  }, [nextCursor, author, selectedTags]);
+
+  function syncQuery(nextAuthor: string | null, nextTags: string[]): void {
+    const url = new URL(window.location.href);
+    if (nextAuthor) url.searchParams.set("author", nextAuthor);
+    else url.searchParams.delete("author");
+    if (nextTags.length > 0) url.searchParams.set("tags", nextTags.join(","));
+    else url.searchParams.delete("tags");
+    window.history.replaceState(null, "", url.pathname + url.search);
+  }
 
   function selectAuthor(next: string | null): void {
     setAuthor(next);
-    const url = new URL(window.location.href);
-    if (next) url.searchParams.set("author", next);
-    else url.searchParams.delete("author");
-    window.history.replaceState(null, "", url.pathname + url.search);
+    syncQuery(next, selectedTags);
+  }
+
+  function toggleTag(tag: string): void {
+    setSelectedTags((previous) => {
+      const next = previous.includes(tag)
+        ? previous.filter((candidate) => candidate !== tag)
+        : [...previous, tag];
+      syncQuery(author, next);
+      return next;
+    });
   }
 
   const entries = state.entries;
@@ -165,6 +222,39 @@ export function GalleryFeed() {
     <main className="gallery-shell" data-testid="gallery-feed">
       <GalleryChrome subtitle="Community gallery" />
 
+      {tagOptions.length > 0 ? (
+        <div className="gallery-tag-bar" data-testid="gallery-tag-bar">
+          {tagOptions.map(({ tag, count }) => (
+            <button
+              key={tag}
+              type="button"
+              className={
+                selectedTags.includes(tag)
+                  ? "gallery-tag-option gallery-tag-selected"
+                  : "gallery-tag-option"
+              }
+              data-testid={`gallery-tag-option-${tag.replace(/\s/gu, "-")}`}
+              aria-pressed={selectedTags.includes(tag)}
+              onClick={() => toggleTag(tag)}
+            >
+              {tag} <span>{count}</span>
+            </button>
+          ))}
+          {selectedTags.length > 0 ? (
+            <button
+              type="button"
+              className="gallery-tag-option gallery-tag-clear"
+              data-testid="gallery-tags-clear"
+              onClick={() => {
+                setSelectedTags([]);
+                syncQuery(author, []);
+              }}
+            >
+              Clear tags
+            </button>
+          ) : null}
+        </div>
+      ) : null}
       {author ? (
         <div className="gallery-filter" data-testid="gallery-filter">
           <span>Circuits by {author}</span>
@@ -227,6 +317,26 @@ export function GalleryFeed() {
                       {entry.description ? (
                         <span className="gallery-tile-description">
                           {entry.description}
+                        </span>
+                      ) : null}
+                      {entry.tags && entry.tags.length > 0 ? (
+                        <span className="gallery-tile-tags">
+                          {entry.tags.map((tag) => (
+                            <button
+                              key={tag}
+                              type="button"
+                              className="gallery-tile-tag"
+                              data-testid={`gallery-tile-tag-${entry.id}-${tag.replace(/\s/gu, "-")}`}
+                              title={`Filter by ${tag}`}
+                              onClick={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                if (!selectedTags.includes(tag)) toggleTag(tag);
+                              }}
+                            >
+                              {tag}
+                            </button>
+                          ))}
                         </span>
                       ) : null}
                     </span>

--- a/apps/editor/src/features/editor-shell/gallery-publish.test.ts
+++ b/apps/editor/src/features/editor-shell/gallery-publish.test.ts
@@ -47,6 +47,7 @@ describe("publishProjectToGallery", () => {
         name: "  Ring Oscillator  ",
         author: "Vivian",
         description: "Five stages",
+        tags: ["Amplifier", "OTA"],
         token: "secret-token",
       },
       fetchReturning(201, { id: "entry-1" }, seen),
@@ -80,7 +81,7 @@ describe("publishProjectToGallery", () => {
     for (const [status, payload, expected] of cases) {
       const outcome = await publishProjectToGallery(
         project,
-        { name: "N", author: "", description: "", token: "t" },
+        { name: "N", author: "", description: "", tags: [], token: "t" },
         fetchReturning(status, payload),
       );
       expect(outcome.status).toBe(expected);
@@ -92,7 +93,7 @@ describe("publishProjectToGallery", () => {
     const seen: { url?: string; init?: RequestInit | undefined } = {};
     const outcome = await publishProjectToGallery(
       project,
-      { name: "N", author: "", description: "", token: "" },
+      { name: "N", author: "", description: "", tags: [], token: "" },
       fetchReturning(201, { id: "entry-2" }, seen),
     );
     expect(outcome.status).toBe("published");
@@ -104,7 +105,7 @@ describe("publishProjectToGallery", () => {
   it("reports a thrown fetch as unreachable", async () => {
     const outcome = await publishProjectToGallery(
       project,
-      { name: "N", author: "", description: "", token: "t" },
+      { name: "N", author: "", description: "", tags: [], token: "t" },
       (() => Promise.reject(new Error("offline"))) as typeof fetch,
     );
     expect(outcome).toEqual({ status: "unreachable", message: "offline" });

--- a/apps/editor/src/features/editor-shell/gallery-publish.ts
+++ b/apps/editor/src/features/editor-shell/gallery-publish.ts
@@ -13,6 +13,8 @@ export interface GalleryPublishFields {
   name: string;
   author: string;
   description: string;
+  /** Category tags ("amplifier", "adc", …); the server normalizes. */
+  tags: readonly string[];
   /** Owner passphrase; empty when an admin session authenticates instead. */
   token: string;
 }
@@ -57,6 +59,7 @@ async function sendGalleryProject(
         name: fields.name.trim(),
         author: fields.author.trim(),
         description: fields.description.trim(),
+        tags: fields.tags,
         projectText: serializeProject(project),
       }),
     });

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
@@ -23,6 +23,12 @@ export interface PublishGalleryDialogProps {
   /** Present when the open circuit came from a gallery entry the signed-in
    * user may update (owner, admin, or moderator). */
   updateTarget?: { id: string } | null;
+  /** The opened entry's stored fields, prefilled once in update mode. */
+  updateDefaults?: {
+    author: string;
+    description: string;
+    tags: readonly string[];
+  } | null;
   publish: (fields: GalleryPublishFields) => Promise<GalleryPublishOutcome>;
   publishUpdate?:
     | ((fields: GalleryPublishFields) => Promise<GalleryPublishOutcome>)
@@ -49,6 +55,7 @@ export function PublishGalleryDialog({
   session = null,
   gateReport = null,
   updateTarget = null,
+  updateDefaults = null,
   publish,
   publishUpdate,
   onPublished,
@@ -68,6 +75,8 @@ export function PublishGalleryDialog({
     () => rememberedPublishAuthor() || session?.displayName || "",
   );
   const [description, setDescription] = useState("");
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagDraft, setTagDraft] = useState("");
   const [token, setToken] = useState(() => rememberedPublishToken());
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -88,6 +97,30 @@ export function PublishGalleryDialog({
     if (canUpdate && !modeTouched) setMode("update");
   }, [canUpdate, modeTouched]);
 
+  // In update mode, prefill the entry's stored fields exactly once so
+  // "edit the tags any time" is open → adjust → save.
+  const [defaultsApplied, setDefaultsApplied] = useState(false);
+  useEffect(() => {
+    if (!canUpdate || !updateDefaults || defaultsApplied) return;
+    setDefaultsApplied(true);
+    setAuthor((previous) => previous || updateDefaults.author);
+    setDescription((previous) => previous || updateDefaults.description);
+    setTags((previous) =>
+      previous.length > 0 ? previous : [...updateDefaults.tags],
+    );
+  }, [canUpdate, updateDefaults, defaultsApplied]);
+
+  function addTag(raw: string): void {
+    const tag = raw.replace(/\s+/gu, " ").trim().toLowerCase();
+    if (!tag) return;
+    setTags((previous) =>
+      previous.includes(tag) || previous.length >= 5
+        ? previous
+        : [...previous, tag],
+    );
+    setTagDraft("");
+  }
+
   async function submit(): Promise<void> {
     setBusy(true);
     setError(null);
@@ -96,6 +129,7 @@ export function PublishGalleryDialog({
       name,
       author,
       description,
+      tags,
       token: anonymous ? token : "",
     });
     if (outcome.status === "published" || outcome.status === "pending-review") {
@@ -196,6 +230,68 @@ export function PublishGalleryDialog({
               onChange={(event) => setDescription(event.currentTarget.value)}
             />
           </label>
+          <div className="publish-gallery-tags" data-testid="publish-tags">
+            <span className="publish-gallery-tags-label">
+              Tags <span className="publish-gallery-optional">up to 5</span>
+            </span>
+            {tags.length > 0 ? (
+              <div className="publish-gallery-tag-chips">
+                {tags.map((tag) => (
+                  <button
+                    key={tag}
+                    type="button"
+                    className="publish-gallery-tag"
+                    data-testid={`publish-tag-${tag}`}
+                    title="Remove tag"
+                    onClick={() =>
+                      setTags((previous) =>
+                        previous.filter((candidate) => candidate !== tag),
+                      )
+                    }
+                  >
+                    {tag} ×
+                  </button>
+                ))}
+              </div>
+            ) : null}
+            <input
+              aria-label="Add tag"
+              placeholder="Type a tag and press Enter"
+              value={tagDraft}
+              maxLength={24}
+              onChange={(event) => setTagDraft(event.currentTarget.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === ",") {
+                  event.preventDefault();
+                  addTag(tagDraft);
+                }
+              }}
+              onBlur={() => addTag(tagDraft)}
+            />
+            <div className="publish-gallery-tag-presets">
+              {[
+                "amplifier",
+                "comparator",
+                "adc",
+                "dac",
+                "pll",
+                "oscillator",
+                "filter",
+                "current mirror",
+              ]
+                .filter((preset) => !tags.includes(preset))
+                .map((preset) => (
+                  <button
+                    key={preset}
+                    type="button"
+                    data-testid={`publish-preset-${preset.replace(/\s/gu, "-")}`}
+                    onClick={() => addTag(preset)}
+                  >
+                    + {preset}
+                  </button>
+                ))}
+            </div>
+          </div>
           {anonymous ? (
             <label>
               Owner passphrase

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -5562,6 +5562,115 @@ html.light .analytics-map-land path {
   background: var(--icm-surface-hover);
 }
 
+.gallery-tag-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px 22px 0;
+}
+
+.gallery-tag-option {
+  padding: 5px 12px;
+  border: 1px solid var(--icm-border);
+  border-radius: 999px;
+  color: var(--icm-text);
+  background: var(--icm-surface);
+  font-size: 12.5px;
+  cursor: pointer;
+}
+
+.gallery-tag-option span {
+  color: var(--icm-text-muted);
+  font-size: 11px;
+}
+
+.gallery-tag-option:hover {
+  background: var(--icm-surface-hover);
+}
+
+.gallery-tag-selected {
+  border-color: var(--icm-accent);
+  color: var(--icm-accent);
+  background: var(--icm-accent-soft);
+  font-weight: 600;
+}
+
+.gallery-tag-clear {
+  color: var(--icm-text-muted);
+}
+
+.gallery-tile-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 6px;
+}
+
+.gallery-tile-tag {
+  padding: 2px 8px;
+  border: 1px solid var(--icm-border);
+  border-radius: 999px;
+  color: var(--icm-text-muted);
+  background: var(--icm-surface-muted);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.gallery-tile-tag:hover {
+  border-color: var(--icm-accent);
+  color: var(--icm-accent);
+}
+
+.publish-gallery-tags {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.publish-gallery-tags input {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--icm-border);
+  border-radius: 8px;
+  font: inherit;
+  font-size: 0.9rem;
+}
+
+.publish-gallery-tag-chips,
+.publish-gallery-tag-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.publish-gallery-tag {
+  padding: 3px 10px;
+  border: 1px solid var(--icm-accent);
+  border-radius: 999px;
+  color: var(--icm-accent);
+  background: var(--icm-accent-soft);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.publish-gallery-tag-presets button {
+  padding: 3px 10px;
+  border: 1px solid var(--icm-border);
+  border-radius: 999px;
+  color: var(--icm-text-muted);
+  background: var(--icm-surface);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.publish-gallery-tag-presets button:hover {
+  color: var(--icm-accent);
+  border-color: var(--icm-accent);
+}
+
 .gallery-tile-author {
   padding: 0;
   border: none;

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -24,8 +24,11 @@ restrictive content-security-policy.
 
 - `GET /api/gallery` — newest-first `public` entries
   (`{entries, nextCursor}`; keyset cursor; limit clamps at 60; optional
-  `author` filters to that exact byline before pagination). Recycled
+  `author` filters to that exact byline and optional `tags=a,b` to
+  entries carrying ANY listed tag, both ahead of pagination). Recycled
   entries never appear.
+- `GET /api/gallery/tags` — distinct public tags with counts, most
+  frequent first (feeds the multi-select menu).
 - `GET /api/gallery/<id>` — one public entry with its canonical
   `projectText`.
 - `GET /api/gallery/<id>/preview.svg` — the server-rendered preview.
@@ -38,8 +41,10 @@ restrictive content-security-policy.
 ## Publishing
 
 `POST /api/gallery/submissions` (same-origin) publishes immediately with:
-trimmed `name` (required, ≤120), optional `author` (≤40) and `description`
-(≤300), `projectText` ≤2 MiB. The Worker validates, stamps the canonical
+trimmed `name` (required, ≤120), optional `author` (≤40), `description`
+(≤300), and `tags` (array; normalized lowercase `[a-z0-9 +/-]`, ≤24
+chars each, at most 5, deduplicated — `sanitizeGalleryTags` is the one
+normalization for writes and filters), `projectText` ≤2 MiB. The Worker validates, stamps the canonical
 serialization, renders the preview, and stores the entry as `public`.
 Submissions count against a per-submitter (hashed IP) limit of 10 per UTC
 day.
@@ -97,7 +102,8 @@ Every gallery page state wears the shared site chrome.
 ## Owner editing (Phase G3 completion)
 
 `PUT /api/gallery/<id>` (same-origin) updates an entry's content and
-metadata with the submission field rules. Authority: the bearer and
+metadata (tags included — they stay editable any time) with the
+submission field rules. Authority: the bearer and
 admin/moderator sessions may update any entry, keeping its current
 status; an ordinary session must own the entry (403 otherwise) and
 passes the quality gates (422), after which the entry re-enters review

--- a/plan/2026-08-22-gallery-tags/plan.md
+++ b/plan/2026-08-22-gallery-tags/plan.md
@@ -1,0 +1,94 @@
+---
+status: completed
+experience: none
+---
+
+# Gallery Circuit Tags
+
+## Goal
+
+Owner request: every circuit can carry category tags (amplifier,
+comparator, ADC, PLL, …). Submitters set tags when publishing and can
+change them any time through the existing owner-update path; the feed
+gains a multi-select tag menu that narrows the wall to circuits carrying
+ANY selected tag (URL-carried, combinable with the author filter), and
+tile tags are clickable shortcuts into that selection.
+
+## State and Ownership
+
+Stacked on `claude/gallery-feed-g4` (PR #178) as `claude/gallery-tags`.
+
+Owned paths:
+
+- `worker/gallery.ts` (+ test): `tags` column (guarded ALTER),
+  `sanitizeGalleryTags`, tags through submit/replace/list/summary, the
+  `GET /api/gallery/tags` aggregate
+- `apps/editor/src/features/editor-shell/gallery-publish.ts(.test.ts)`
+  and `publish-gallery-dialog.tsx(.test.tsx)`: tags field, editor chips
+  with presets, update-mode prefill of author/description/tags
+- `apps/editor/src/components/gallery-feed.tsx` (multi-select tag bar,
+  tile tag chips), `apps/editor/src/app/App.tsx` (entry context fields),
+  `styles.css`, `apps/editor/e2e/gallery.spec.ts`
+- `docs/specs/community-gallery.md`, plan files
+
+Shared dependencies: submissions/update/list contracts gain optional
+`tags`; absent tags keep every existing request and mock byte-identical.
+
+## Design
+
+- Normalization (`sanitizeGalleryTags`): trim, lowercase, collapse inner
+  whitespace, keep `[a-z0-9 +/-]`, ≤24 chars each, deduplicate, at most 5. Stored comma-wrapped (`,amp,adc,`) so the list filter is a keyset-
+  compatible `tags LIKE '%,t,%'` OR-union, ANDed with author/cursor.
+- `GET /api/gallery?tags=a,b` filters to entries carrying any selected
+  tag; `GET /api/gallery/tags` returns `{tags: [{tag, count}]}` over
+  public entries, most frequent first.
+- Publish dialog: a chip editor (type + Enter/comma, preset shortcuts,
+  cap 5); in update mode the entry's current author, description, and
+  tags prefill once so "edit tags any time" is one open-edit-save loop.
+- Feed: a toggleable multi-select chip bar under the chrome (from the
+  aggregate), selections carried in `?tags=`, tiles render their tags as
+  chips that add to the selection.
+
+## Validation
+
+- `vitest`: sanitize rules; worker tags round-trip (submit → filtered
+  list OR-semantics → aggregate → update rewrites tags)
+- `playwright`: publish posts chosen tags; feed multi-select narrows the
+  request and tiles' tag chips join the selection
+- repository typecheck, prettier,
+  `node scripts/check-test-impact.mjs --base origin/main`
+- `git diff --check` and `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: tags normalize identically everywhere; absent tags change
+  nothing; the multi-select is an OR-union ANDed with other filters;
+  owner updates rewrite tags
+- Primary checks: `worker/gallery.test.ts`,
+  `apps/editor/e2e/gallery.spec.ts`
+
+## Commit Intent
+
+Committed on `claude/gallery-tags` under the user's standing
+commit-push-merge direction as:
+
+```text
+feat(editor): circuit tags with a multi-select feed filter
+```
+
+## Outcome
+
+Delivered. Tags flow through one normalization (`sanitizeGalleryTags`)
+into submissions, owner/reviewer updates (editable any time), summaries,
+the comma-wrapped LIKE filter (`?tags=a,b`, OR-union ANDed with
+author/cursor), and the `GET /api/gallery/tags` aggregate. The publish
+dialog gained a chip editor with preset shortcuts (cap 5, Enter/comma,
+removable chips) that prefills the opened entry's author, description,
+and tags once in update mode; the feed gained the multi-select tag menu
+with counts (URL-carried, clearable) and tile tag chips that join the
+selection. Validation: worker gallery 15 (normalize/filter/aggregate/
+update round-trip), editor-shell+components units 54, gallery Playwright
+17/17 (publish posts chosen tags; menu multi-select narrows requests and
+URL; tile chips join selection), repository typecheck, prettier,
+test-impact, diff checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4650,3 +4650,16 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   16/16, typecheck, prettier, test-impact, diff checks.
 - Commit status: completed on `claude/gallery-feed-g4` (stacked on
   `claude/gallery-owner-editing`).
+
+## 2026-08-22 — Gallery circuit tags
+
+- Target: `plan/2026-08-22-gallery-tags/plan.md` (completed).
+- Change: one tag normalization through submit/update/list/aggregate;
+  `?tags=a,b` OR-union filter; `GET /api/gallery/tags` counts; publish
+  dialog chip editor with presets and update-mode prefill (tags editable
+  any time via the owner-update path); feed multi-select tag menu with
+  clickable tile chips.
+- Validation: worker gallery 15, editor units 54, gallery Playwright
+  17/17, typecheck, prettier, test-impact, diff checks.
+- Commit status: completed on `claude/gallery-tags` (stacked on
+  `claude/gallery-feed-g4`).

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -526,6 +526,88 @@ function wiredProjectText(name = "Wired"): string {
   return serializeProject(project);
 }
 
+describe("gallery circuit tags", () => {
+  it("normalizes tags on write, filters as an OR-union, and aggregates", async () => {
+    const env = environment(ADMIN_TOKEN);
+    const submitTagged = (name: string, tags: unknown) =>
+      route(
+        env,
+        submissionRequest({ name, tags, projectText: projectText(name) }),
+      );
+    await submitTagged("Amp A", ["  Amplifier ", "OTA", "amplifier"]);
+    await submitTagged("Comp B", ["comparator"]);
+    await submitTagged("Mixed C", ["ADC", "amplifier "]);
+    await submitTagged("Plain D", "not-an-array");
+
+    const list = await route(env, new Request(`${ORIGIN}/api/gallery`));
+    const all = (await list.json()) as {
+      entries: { name: string; tags: string[] }[];
+    };
+    expect(all.entries.find((entry) => entry.name === "Amp A")?.tags).toEqual([
+      "amplifier",
+      "ota",
+    ]);
+    expect(all.entries.find((entry) => entry.name === "Plain D")?.tags).toEqual(
+      [],
+    );
+
+    const union = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery?tags=comparator,adc`),
+    );
+    const filtered = (await union.json()) as { entries: { name: string }[] };
+    expect(filtered.entries.map((entry) => entry.name).sort()).toEqual([
+      "Comp B",
+      "Mixed C",
+    ]);
+
+    const aggregate = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/tags`),
+    );
+    const counts = (await aggregate.json()) as {
+      tags: { tag: string; count: number }[];
+    };
+    expect(counts.tags[0]).toEqual({ tag: "amplifier", count: 2 });
+
+    // The bearer update path rewrites tags ("editable any time").
+    const target = all.entries.find((entry) => entry.name === "Comp B")!;
+    const detail = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery?limit=60`),
+    );
+    void detail;
+    const id = (
+      (await (
+        await route(env, new Request(`${ORIGIN}/api/gallery`))
+      ).json()) as {
+        entries: { id: string; name: string }[];
+      }
+    ).entries.find((entry) => entry.name === "Comp B")!.id;
+    const updated = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}`, {
+        method: "PUT",
+        headers: {
+          Origin: ORIGIN,
+          Authorization: `Bearer ${ADMIN_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          name: target.name,
+          tags: ["latch", "comparator"],
+          projectText: projectText(target.name),
+        }),
+      }),
+    );
+    expect(updated.status).toBe(200);
+    const after = (await (
+      await route(env, new Request(`${ORIGIN}/api/gallery/${id}`))
+    ).json()) as { entry: { tags: string[] } };
+    expect(after.entry.tags).toEqual(["latch", "comparator"]);
+  });
+});
+
 describe("gallery list author filter and paging (phase G4)", () => {
   it("filters by exact byline and pages the filtered set", async () => {
     const env = environment(ADMIN_TOKEN);

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -24,6 +24,8 @@ export const GALLERY_MAX_NAME_LENGTH = 120;
 export const GALLERY_MAX_AUTHOR_LENGTH = 40;
 export const GALLERY_MAX_DESCRIPTION_LENGTH = 300;
 export const GALLERY_DAILY_SUBMISSION_LIMIT = 10;
+export const GALLERY_MAX_TAGS = 5;
+export const GALLERY_MAX_TAG_LENGTH = 24;
 export const GALLERY_DEFAULT_LIST_LIMIT = 30;
 export const GALLERY_MAX_LIST_LIMIT = 60;
 
@@ -64,6 +66,41 @@ export interface GalleryEntrySummary {
   description: string;
   createdAt: string;
   schemaVersion: number;
+  tags: string[];
+}
+
+/**
+ * One tag normalization for every write and filter: trimmed, lowercased,
+ * inner whitespace collapsed, `[a-z0-9 +/-]` only, capped in length and
+ * count, deduplicated.
+ */
+export function sanitizeGalleryTags(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const tags: string[] = [];
+  for (const raw of value) {
+    if (typeof raw !== "string") continue;
+    const tag = raw
+      .toLowerCase()
+      .replace(/\s+/gu, " ")
+      .trim()
+      .replace(/[^a-z0-9 +/-]/gu, "")
+      .slice(0, GALLERY_MAX_TAG_LENGTH)
+      .trim();
+    if (tag.length === 0 || tags.includes(tag)) continue;
+    tags.push(tag);
+    if (tags.length === GALLERY_MAX_TAGS) break;
+  }
+  return tags;
+}
+
+/** Storage form: `,a,b,` so `LIKE '%,a,%'` matches exactly one tag. */
+function wrapTags(tags: string[]): string {
+  return tags.length === 0 ? "" : `,${tags.join(",")},`;
+}
+
+function unwrapTags(stored: string | null): string[] {
+  if (!stored) return [];
+  return stored.split(",").filter((tag) => tag.length > 0);
 }
 
 interface EntryRow {
@@ -76,6 +113,7 @@ interface EntryRow {
   status: string;
   recycled_at: string | null;
   owner_user_id: string | null;
+  tags: string | null;
   reject_reason: string | null;
   reviewed_at: string | null;
   reviewed_by: string | null;
@@ -93,6 +131,7 @@ function summaryOf(row: EntryRow): GalleryEntrySummary {
     description: row.description,
     createdAt: row.created_at,
     schemaVersion: row.schema_version,
+    tags: unwrapTags(row.tags),
   };
 }
 
@@ -134,6 +173,7 @@ export class GalleryDO {
       "ALTER TABLE gallery_entries ADD COLUMN reject_reason TEXT",
       "ALTER TABLE gallery_entries ADD COLUMN reviewed_at TEXT",
       "ALTER TABLE gallery_entries ADD COLUMN reviewed_by TEXT",
+      "ALTER TABLE gallery_entries ADD COLUMN tags TEXT NOT NULL DEFAULT ''",
     ]) {
       try {
         this.sql.exec(alteration);
@@ -176,6 +216,8 @@ export class GalleryDO {
         return this.mine(String(body.ownerUserId));
       case "all-ids":
         return this.allIds();
+      case "tags":
+        return this.tagCounts();
       case "update-entry":
         return this.updateEntry(body);
       case "replace-entry":
@@ -212,8 +254,8 @@ export class GalleryDO {
       this.sql.exec(
         `INSERT INTO gallery_entries(
           id, name, author, description, created_at, schema_version,
-          status, recycled_at, owner_user_id, project_text, svg_text
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)`,
+          status, recycled_at, owner_user_id, tags, project_text, svg_text
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)`,
         entry.id,
         entry.name,
         entry.author,
@@ -222,6 +264,7 @@ export class GalleryDO {
         entry.schema_version,
         entry.status === "pending" ? "pending" : "public",
         entry.owner_user_id ?? null,
+        entry.tags ?? "",
         entry.project_text,
         entry.svg_text,
       );
@@ -248,6 +291,11 @@ export class GalleryDO {
     if (author) {
       conditions.push("author = ?");
       bindings.push(author);
+    }
+    const tags = sanitizeGalleryTags(body.tags);
+    if (tags.length > 0) {
+      conditions.push(`(${tags.map(() => "tags LIKE ?").join(" OR ")})`);
+      for (const tag of tags) bindings.push(`%,${tag},%`);
     }
     if (cursor) {
       conditions.push("(created_at || '|' || id) < ?");
@@ -340,7 +388,7 @@ export class GalleryDO {
     this.sql.exec(
       `UPDATE gallery_entries
        SET name = ?, author = ?, description = ?, project_text = ?,
-           svg_text = ?, schema_version = ?, status = ?,
+           svg_text = ?, schema_version = ?, status = ?, tags = ?,
            reject_reason = NULL, reviewed_at = NULL, reviewed_by = NULL
        WHERE id = ?`,
       String(body.name),
@@ -350,6 +398,7 @@ export class GalleryDO {
       String(body.svgText),
       Number(body.schemaVersion),
       String(body.status),
+      typeof body.tags === "string" ? body.tags : "",
       row.id,
     );
     return Response.json({ id: row.id, status: String(body.status) });
@@ -411,6 +460,25 @@ export class GalleryDO {
         recycledAt: row.recycled_at,
       })),
     });
+  }
+
+  /** Distinct public tags with counts, most frequent first (G4 menu). */
+  private tagCounts(): Response {
+    const rows = this.sql
+      .exec<{ tags: string | null }>(
+        "SELECT tags FROM gallery_entries WHERE status = 'public'",
+      )
+      .toArray();
+    const counts = new Map<string, number>();
+    for (const row of rows) {
+      for (const tag of unwrapTags(row.tags)) {
+        counts.set(tag, (counts.get(tag) ?? 0) + 1);
+      }
+    }
+    const tags = [...counts.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0], "en"))
+      .map(([tag, count]) => ({ tag, count }));
+    return Response.json({ tags });
   }
 
   private allIds(): Response {
@@ -541,6 +609,7 @@ async function handleSubmission(
     name?: unknown;
     author?: unknown;
     description?: unknown;
+    tags?: unknown;
     projectText?: unknown;
   } | null;
   const name = fieldText(body?.name, GALLERY_MAX_NAME_LENGTH);
@@ -594,6 +663,7 @@ async function handleSubmission(
         schema_version: project.schemaVersion,
         status: entryStatus,
         owner_user_id: user?.id ?? null,
+        tags: wrapTags(sanitizeGalleryTags(body.tags)),
         project_text: serializeProject(project),
         svg_text: renderPreview(project),
       },
@@ -649,6 +719,7 @@ async function handleEntryUpdate(
     name?: unknown;
     author?: unknown;
     description?: unknown;
+    tags?: unknown;
     projectText?: unknown;
   } | null;
   const name = fieldText(body?.name, GALLERY_MAX_NAME_LENGTH);
@@ -697,6 +768,7 @@ async function handleEntryUpdate(
     svgText: renderPreview(project),
     schemaVersion: project.schemaVersion,
     status: nextStatus,
+    tags: wrapTags(sanitizeGalleryTags(body.tags)),
   });
   return Response.json(payload, { status });
 }
@@ -748,6 +820,9 @@ export async function routeGalleryRequest(
       limit: url.searchParams.get("limit"),
       cursor: url.searchParams.get("cursor"),
       author: url.searchParams.get("author"),
+      tags: (url.searchParams.get("tags") ?? "")
+        .split(",")
+        .filter((tag) => tag.length > 0),
     });
     return Response.json(payload, {
       headers: { "cache-control": "no-store" },
@@ -783,6 +858,14 @@ export async function routeGalleryRequest(
       return Response.json({ error: "unauthorized" }, { status: 401 });
     }
     return handleReserialize(env);
+  }
+  if (
+    segments.length === 1 &&
+    segments[0] === "tags" &&
+    request.method === "GET"
+  ) {
+    const { payload } = await callGallery(env, "tags", {});
+    return Response.json(payload, { headers: { "cache-control": "no-store" } });
   }
   if (
     segments.length === 1 &&


### PR DESCRIPTION
Owner request: every circuit carries category tags (amplifier, comparator, ADC, PLL, …), editable any time, with a multi-select gallery filter.

- **One normalization** (`sanitizeGalleryTags`: lowercase, `[a-z0-9 +/-]`, ≤24 chars, ≤5, deduplicated) flows through submissions, owner/reviewer updates (`PUT` rewrites tags — the "edit any time" path), summaries, the list filter, and the aggregate. Stored comma-wrapped so `?tags=a,b` is a keyset-compatible OR-union `LIKE` filter ANDed with author/cursor.
- `GET /api/gallery/tags` — distinct public tags with counts (feeds the menu).
- **Publish dialog**: chip editor (type + Enter/comma, removable chips, preset shortcuts, cap 5); in update mode the opened entry's author, description, and tags prefill once, so retagging is open → adjust → save.
- **Feed**: multi-select tag chip bar with counts under the chrome (URL-carried `?tags=`, clearable), and tile tag chips that join the selection.

Tests: worker gallery 15 (normalize / OR-filter / aggregate / update round-trip), editor units 89 across shell+components+worker sweep, gallery Playwright 17/17 (publish posts the chosen tags; menu multi-select narrows requests and URL; tile chips join the selection). Spec updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)