### PR TITLE
feat(editor): examples panel reads the community gallery

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -726,6 +726,33 @@ test("an opened gallery entry offers updating in place", async ({ page }) => {
   expect(updates[0]!.body.name).toBe(ENTRY.name);
 });
 
+test("the Examples panel lists the gallery and opens an entry", async ({
+  page,
+}) => {
+  await mockGallery(page, [ENTRY]);
+  await page.route("**/api/gallery?limit=60", (route) =>
+    route.fulfill({ json: { entries: [ENTRY], nextCursor: null } }),
+  );
+
+  await page.goto("/editor");
+  await page.getByTestId("examples-toggle").click();
+  const panel = page.getByTestId("examples-panel");
+  await expect(panel).toHaveAttribute("data-open", "true");
+  const card = panel.getByTestId(`gallery-example-${ENTRY.id}`);
+  await expect(card).toBeVisible();
+  await expect(card).toContainText(ENTRY.name);
+  await expect(card).toContainText(ENTRY.author);
+  // The panel replaced the bundled list with the shared gallery source.
+  await expect(
+    panel.getByTestId("shapes-example-common-source-amplifier"),
+  ).toHaveCount(0);
+
+  await card.click();
+  await expect(page.getByTestId("status")).toContainText(
+    `Opened gallery circuit: ${ENTRY.name}`,
+  );
+});
+
 test("bundled starter tiles open their example in the editor", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -554,6 +554,34 @@ export function App({
   const visibleLibraryPanelOpen = compactLayout
     ? compactLibraryPanelOpen
     : libraryPanelOpen;
+  useEffect(() => {
+    if (!visibleLibraryPanelOpen) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetch("/api/gallery?limit=60", {
+          credentials: "same-origin",
+        });
+        if (!response.ok) return;
+        const payload = (await response.json()) as {
+          entries?: {
+            id: string;
+            name: string;
+            author: string;
+            description: string;
+          }[];
+        };
+        if (!cancelled && payload.entries && payload.entries.length > 0) {
+          setGalleryExamples(payload.entries);
+        }
+      } catch {
+        // Unreachable worker (offline dev): the bundled list stands in.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [visibleLibraryPanelOpen]);
 
   const refreshRestoreAttemptedRef = useRef(false);
   // Formal-file lifecycle of the current working copy, orthogonal to recovery
@@ -657,6 +685,17 @@ export function App({
     description: string;
     tags: readonly string[];
   } | null>(null);
+  // The Examples panel reads the same community gallery as the landing
+  // feed; null means unreachable, so the bundled list stands in.
+  const [galleryExamples, setGalleryExamples] = useState<
+    | readonly {
+        id: string;
+        name: string;
+        author: string;
+        description: string;
+      }[]
+    | null
+  >(null);
   const [publishGates, setPublishGates] = useState<SubmissionGateReport | null>(
     null,
   );
@@ -1881,6 +1920,49 @@ export function App({
 
   // Landing-page deep links: `/g/<id>` opens a published gallery entry and
   // `/editor?example=<id>` opens a bundled example. Both replace the fresh
+  // Open one gallery entry into the live editor: the same path serves the
+  // `/g/<id>` boot and the Examples panel, and it remembers the entry so
+  // the publish dialog can offer updating it.
+  async function openGalleryEntryById(entryId: string): Promise<void> {
+    try {
+      const response = await fetch(`/api/gallery/${entryId}`, {
+        credentials: "same-origin",
+      });
+      if (!response.ok) {
+        setStatus("This gallery entry is unavailable");
+        return;
+      }
+      const payload = (await response.json()) as {
+        entry?: {
+          name?: string;
+          author?: string;
+          description?: string;
+          tags?: string[];
+        };
+        ownerUserId?: string | null;
+        projectText?: string;
+      };
+      if (!payload.projectText) {
+        setStatus("This gallery entry is unavailable");
+        return;
+      }
+      const galleryProject = parseProject(payload.projectText);
+      replaceActiveProject(galleryProject);
+      setGalleryEntryContext({
+        id: entryId,
+        ownerUserId: payload.ownerUserId ?? null,
+        author: payload.entry?.author ?? "",
+        description: payload.entry?.description ?? "",
+        tags: payload.entry?.tags ?? [],
+      });
+      setStatus(
+        `Opened gallery circuit: ${payload.entry?.name ?? galleryProject.name}`,
+      );
+    } catch {
+      setStatus("This gallery entry is unavailable");
+    }
+  }
+
   // boot Project only; ordinary sessions never re-run these.
   const bootTargetHandled = useRef(false);
   useEffect(() => {
@@ -1890,46 +1972,7 @@ export function App({
       "example",
     );
     if (initialGalleryEntryId) {
-      void (async () => {
-        try {
-          const response = await fetch(
-            `/api/gallery/${initialGalleryEntryId}`,
-            { credentials: "same-origin" },
-          );
-          if (!response.ok) {
-            setStatus("This gallery entry is unavailable");
-            return;
-          }
-          const payload = (await response.json()) as {
-            entry?: {
-              name?: string;
-              author?: string;
-              description?: string;
-              tags?: string[];
-            };
-            ownerUserId?: string | null;
-            projectText?: string;
-          };
-          if (!payload.projectText) {
-            setStatus("This gallery entry is unavailable");
-            return;
-          }
-          const galleryProject = parseProject(payload.projectText);
-          replaceActiveProject(galleryProject);
-          setGalleryEntryContext({
-            id: initialGalleryEntryId,
-            ownerUserId: payload.ownerUserId ?? null,
-            author: payload.entry?.author ?? "",
-            description: payload.entry?.description ?? "",
-            tags: payload.entry?.tags ?? [],
-          });
-          setStatus(
-            `Opened gallery circuit: ${payload.entry?.name ?? galleryProject.name}`,
-          );
-        } catch {
-          setStatus("This gallery entry is unavailable");
-        }
-      })();
+      void openGalleryEntryById(initialGalleryEntryId);
       return;
     }
     if (exampleId) {
@@ -7873,6 +7916,8 @@ export function App({
         ) : (
           <ExamplesPanel
             open={visibleLibraryPanelOpen}
+            galleryExamples={galleryExamples}
+            onOpenGalleryExample={(id) => void openGalleryEntryById(id)}
             onOpenExample={openLibraryExample}
             userExamples={userExamples}
             onOpenUserExample={(id) => void openUserExample(id)}

--- a/apps/editor/src/features/editor-shell/examples-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/examples-panel.test.ts
@@ -26,6 +26,40 @@ describe("ExamplesPanel", () => {
   });
 });
 
+describe("gallery-backed library", () => {
+  it("lists the community gallery when available and falls back bundled", () => {
+    const gallery = renderToStaticMarkup(
+      createElement(ExamplesPanel, {
+        open: true,
+        galleryExamples: [
+          {
+            id: "g-1",
+            name: "StrongArm Comparator",
+            author: "Zhishuai Zhang",
+            description: "Clocked comparator",
+          },
+        ],
+        onOpenGalleryExample: () => undefined,
+        onOpenExample: () => undefined,
+      }),
+    );
+    expect(gallery).toContain('data-testid="gallery-example-g-1"');
+    expect(gallery).toContain("StrongArm Comparator");
+    expect(gallery).toContain("Zhishuai Zhang");
+    expect(gallery).not.toContain('data-testid="shapes-example-');
+
+    const fallback = renderToStaticMarkup(
+      createElement(ExamplesPanel, {
+        open: true,
+        galleryExamples: null,
+        onOpenExample: () => undefined,
+      }),
+    );
+    expect(fallback).toContain('data-testid="shapes-example-');
+    expect(fallback).not.toContain('data-testid="gallery-example-');
+  });
+});
+
 describe("user examples section", () => {
   it("renders saved snapshots with open, export, and delete actions", () => {
     const markup = renderToStaticMarkup(

--- a/apps/editor/src/features/editor-shell/examples-panel.tsx
+++ b/apps/editor/src/features/editor-shell/examples-panel.tsx
@@ -4,8 +4,21 @@ import {
 } from "../../examples/library-examples";
 import type { UserExampleSummary } from "../../document/user-examples-store";
 
+export interface GalleryExampleSummary {
+  id: string;
+  name: string;
+  author: string;
+  description: string;
+}
+
 export interface ExamplesPanelProps {
   open: boolean;
+  /**
+   * The community gallery — the same source as the landing feed. Null or
+   * empty falls back to the bundled starter examples (offline dev).
+   */
+  galleryExamples?: readonly GalleryExampleSummary[] | null;
+  onOpenGalleryExample?(id: string): void;
   onOpenExample(example: LibraryProjectExample): void;
   /** User-saved snapshots, newest first; empty hides the section body. */
   userExamples?: readonly UserExampleSummary[];
@@ -28,12 +41,15 @@ function savedAtLabel(savedAt: string): string {
 
 export function ExamplesPanel({
   open,
+  galleryExamples = null,
+  onOpenGalleryExample,
   onOpenExample,
   userExamples = [],
   onOpenUserExample,
   onExportUserExample,
   onDeleteUserExample,
 }: ExamplesPanelProps) {
+  const showGallery = galleryExamples !== null && galleryExamples.length > 0;
   return (
     <aside
       id="examples-panel"
@@ -48,25 +64,49 @@ export function ExamplesPanel({
     >
       <div className="shapes-panel-body">
         <div className="shapes-example-list">
-          {libraryProjectExamples.map((example) => (
-            <button
-              key={example.id}
-              type="button"
-              className="shapes-example-card"
-              data-testid={`shapes-example-${example.id}`}
-              aria-label={`Open example ${example.name}`}
-              title={`Open ${example.name}`}
-              onClick={() => onOpenExample(example)}
-            >
-              <span className="shapes-example-copy">
-                <span className="shapes-example-kicker">Example</span>
-                <span className="shapes-example-name">{example.name}</span>
-                <span className="shapes-example-description">
-                  {example.description}
-                </span>
-              </span>
-            </button>
-          ))}
+          {showGallery
+            ? galleryExamples.map((example) => (
+                <button
+                  key={example.id}
+                  type="button"
+                  className="shapes-example-card"
+                  data-testid={`gallery-example-${example.id}`}
+                  aria-label={`Open gallery circuit ${example.name}`}
+                  title={`Open ${example.name}`}
+                  onClick={() => onOpenGalleryExample?.(example.id)}
+                >
+                  <span className="shapes-example-copy">
+                    <span className="shapes-example-kicker">
+                      {example.author || "Gallery"}
+                    </span>
+                    <span className="shapes-example-name">{example.name}</span>
+                    {example.description ? (
+                      <span className="shapes-example-description">
+                        {example.description}
+                      </span>
+                    ) : null}
+                  </span>
+                </button>
+              ))
+            : libraryProjectExamples.map((example) => (
+                <button
+                  key={example.id}
+                  type="button"
+                  className="shapes-example-card"
+                  data-testid={`shapes-example-${example.id}`}
+                  aria-label={`Open example ${example.name}`}
+                  title={`Open ${example.name}`}
+                  onClick={() => onOpenExample(example)}
+                >
+                  <span className="shapes-example-copy">
+                    <span className="shapes-example-kicker">Example</span>
+                    <span className="shapes-example-name">{example.name}</span>
+                    <span className="shapes-example-description">
+                      {example.description}
+                    </span>
+                  </span>
+                </button>
+              ))}
         </div>
         {userExamples.length > 0 ? (
           <div

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -34,9 +34,11 @@ restrictive content-security-policy.
 - `GET /api/gallery/<id>/preview.svg` — the server-rendered preview.
 - `/` serves the full-screen feed; each tile links to `/g/<id>`, which the
   editor opens through the ordinary protocol boundary. `/editor` is the
-  plain editor; `/editor?example=<id>` opens a bundled example. While the
-  gallery is empty or unreachable the feed shows the bundled Library
-  examples, so the landing page is never blank.
+  plain editor; `/editor?example=<id>` opens a bundled example. The
+  editor's Examples panel reads the same gallery list and opens entries
+  through the same path as `/g/<id>`. While the gallery is empty or
+  unreachable, the feed and the panel both fall back to the bundled
+  Library examples, so neither surface is ever blank.
 
 ## Publishing
 

--- a/plan/2026-08-22-examples-from-gallery/plan.md
+++ b/plan/2026-08-22-examples-from-gallery/plan.md
@@ -1,0 +1,91 @@
+---
+status: completed
+experience: none
+---
+
+# Examples Panel Reads the Community Gallery
+
+## Goal
+
+Owner request: the editor's Examples side panel must show exactly what
+the gallery shows — one source of truth. The panel now lists the
+community gallery (same list endpoint as the landing feed, author as the
+kicker) and opens entries through the same path as `/g/<id>` (which also
+arms the publish dialog's update mode); the bundled starter examples
+remain only as the offline/dev fallback when the worker is unreachable.
+Separately (data, not code): the two bundled examples that never made it
+into the production gallery were seeded with tags, and the two existing
+seeds were retagged, so all four starters now live in the gallery
+itself.
+
+## State and Ownership
+
+Branched from `origin/main` (post PR #179) as
+`claude/examples-from-gallery`.
+
+Owned paths:
+
+- `apps/editor/src/features/editor-shell/examples-panel.tsx` (+ test)
+- `apps/editor/src/app/App.tsx` (shared `openGalleryEntryById`, panel
+  data load on open)
+- `apps/editor/e2e/gallery.spec.ts`
+- `docs/specs/community-gallery.md`, plan files
+
+Shared dependencies: the gallery list/detail contracts (consumed as-is);
+the bundled examples module stays untouched as the fallback and seed
+source.
+
+## Design
+
+- App extracts the `/g/<id>` boot into `openGalleryEntryById` (fetch →
+  strict parse → replace → remember entry context → status) and reuses
+  it for panel clicks, so panel-opened entries are update-offerable too.
+- Opening the panel fetches `/api/gallery?limit=60`; a non-empty result
+  renders gallery cards (`gallery-example-<id>`, author kicker); null or
+  empty keeps the bundled cards exactly as before (test ids unchanged),
+  so offline development and every existing spec keep working.
+
+## Validation
+
+- `vitest`: panel renders gallery cards when provided and falls back to
+  the bundled list otherwise
+- `playwright`: with a mocked gallery, the Examples panel lists the
+  community entries and opens one into the editor
+- repository typecheck, prettier,
+  `node scripts/check-test-impact.mjs --base origin/main`
+- `git diff --check` and `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: the panel and the feed read the same list; panel opens use
+  the same entry path as `/g/<id>`; the bundled list appears exactly
+  when the gallery is unreachable or empty
+- Primary checks:
+  `apps/editor/src/features/editor-shell/examples-panel.test.ts`,
+  `apps/editor/e2e/gallery.spec.ts`
+
+## Commit Intent
+
+Committed on `claude/examples-from-gallery` under the user's standing
+commit-push-merge direction as:
+
+```text
+feat(editor): examples panel reads the community gallery
+```
+
+## Outcome
+
+Delivered. `openGalleryEntryById` is the one entry-opening path (boot
+and panel; panel-opened entries arm the publish dialog's update mode);
+opening the Examples panel fetches the same gallery list as the feed and
+renders the community entries with author kickers, falling back to the
+bundled starters exactly when the worker is unreachable or the gallery
+is empty — offline dev and every pre-existing panel spec unchanged.
+Production data: the two never-seeded bundled examples were published
+(with tags) and the two original seeds retagged, so all four starters
+live in the gallery (12 public entries at the time).
+Validation: editor-shell units 26 (gallery/fallback markup), gallery
+Playwright 18/18 (panel lists gallery, opens an entry, bundled testids
+absent), existing examples e2e 2/2 untouched, repository typecheck,
+prettier, test-impact, diff checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4663,3 +4663,15 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   17/17, typecheck, prettier, test-impact, diff checks.
 - Commit status: completed on `claude/gallery-tags` (stacked on
   `claude/gallery-feed-g4`).
+
+## 2026-08-22 — Examples panel reads the community gallery
+
+- Target: `plan/2026-08-22-examples-from-gallery/plan.md` (completed).
+- Change: the Examples panel lists the same gallery as the landing feed
+  and opens entries through the shared `/g/<id>` path (arming publish
+  update mode); bundled starters remain the offline/empty fallback.
+  Production data: the two missing bundled examples seeded with tags and
+  the two original seeds retagged — all four starters now in the gallery.
+- Validation: editor-shell units 26, gallery Playwright 18/18, existing
+  examples e2e 2/2, typecheck, prettier, test-impact, diff checks.
+- Commit status: completed on `claude/examples-from-gallery`.


### PR DESCRIPTION
Owner request: the editor's Examples panel must show exactly what the gallery shows — one source of truth.

- `openGalleryEntryById` is now the single entry-opening path (the `/g/<id>` boot and the panel share it), so panel-opened entries also arm the publish dialog's update mode.
- Opening the panel fetches the same `/api/gallery` list as the landing feed and renders the community entries with author kickers; the bundled starters remain exactly as before as the offline/empty fallback (test ids unchanged — every pre-existing panel spec passes untouched).
- Production data (done directly, no code): the two bundled examples that never made it into the gallery were seeded with tags, and the two original seeds retagged — all four starters now live in the gallery (12 public entries).

Tests: editor-shell units 26 (gallery/fallback markup), gallery Playwright 18/18 (panel lists the gallery, opens an entry, bundled ids absent), existing examples e2e 2/2. Spec updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)