### PR TITLE
feat(editor): steer the wire corner with a middle-click cycle

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3668,3 +3668,40 @@ test("saves, reopens, and deletes a user Library example", async ({ page }) => {
   );
   await expect(section).toHaveCount(0);
 });
+
+test("middle-click steers which way the wire corner turns", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await clickDrawTool(page, "wire");
+
+  const drawCorner = async (
+    start: { x: number; y: number },
+    end: typeof start,
+  ) => {
+    await canvas.click({ position: start });
+    await canvas.dblclick({ position: end });
+  };
+
+  // Default corner carries the horizontal leg first.
+  await drawCorner({ x: 200, y: 200 }, { x: 360, y: 300 });
+  const horizontal = await readRoutePoints(page, await onlyRouteId(page));
+  expect(horizontal).toHaveLength(3);
+  expect(horizontal[1]!.y).toBe(horizontal[0]!.y);
+
+  await clickCommand(page, "Edit", "Undo");
+  await expect(page.locator('[data-testid^="route-hit-"]')).toHaveCount(0);
+
+  // One middle-click flips the corner onto the other axis.
+  await clickDrawTool(page, "wire");
+  await canvas.click({ position: { x: 200, y: 200 } });
+  await canvas.click({ button: "middle", position: { x: 260, y: 240 } });
+  await canvas.click({ button: "middle", position: { x: 260, y: 240 } });
+  await expect(page.getByTestId("status")).toContainText("vertical first");
+  await canvas.dblclick({ position: { x: 360, y: 300 } });
+
+  const vertical = await readRoutePoints(page, await onlyRouteId(page));
+  expect(vertical).toHaveLength(3);
+  expect(vertical[1]!.x).toBe(vertical[0]!.x);
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -3951,6 +3951,41 @@ export function App({
     };
   }
 
+  /**
+   * One middle-click steps the corner through the shapes a wire actually
+   * turns with: horizontal-first, vertical-first, then the 45° diagonal. The
+   * click used to reach only the diagonal, so the two orthogonal elbows were
+   * unreachable without the Corner menu.
+   */
+  function cycleWireCornerShape(): void {
+    const shapes = [
+      {
+        routingMode: "orthogonal" as const,
+        cornerOrder: "horizontal-first" as const,
+        label: "horizontal first",
+      },
+      {
+        routingMode: "orthogonal" as const,
+        cornerOrder: "vertical-first" as const,
+        label: "vertical first",
+      },
+      {
+        routingMode: "octilinear" as const,
+        cornerOrder: "diagonal-first" as const,
+        label: "45° diagonal",
+      },
+    ];
+    const index = shapes.findIndex(
+      (shape) =>
+        shape.routingMode === wireRoutingMode &&
+        shape.cornerOrder === wireCornerOrder,
+    );
+    const next = shapes[(index + 1) % shapes.length]!;
+    if (next.routingMode !== wireRoutingMode) toggleWireRoutingMode();
+    setWireCornerOrder(next.cornerOrder);
+    setStatus(`Wire corner: ${next.label}`);
+  }
+
   function applyWireCanvasPoint(
     rawPoint: Point,
     svg: SVGSVGElement,
@@ -6283,10 +6318,7 @@ export function App({
     if (panPreview?.pointerId === event.pointerId) {
       event.currentTarget.releasePointerCapture(event.pointerId);
       if (!panPreview.dragged && getCurrentInteractionState().kind === "wire") {
-        toggleWireRoutingMode();
-        setStatus(
-          `Wire mode: ${wireRoutingMode === "orthogonal" ? "45° octilinear" : "orthogonal"}`,
-        );
+        cycleWireCornerShape();
       }
       setPanPreview(null);
       return;
@@ -10779,6 +10811,8 @@ export function App({
                   }
                 >
                   <option value="auto">Auto</option>
+                  <option value="horizontal-first">Horizontal first</option>
+                  <option value="vertical-first">Vertical first</option>
                   <option value="diagonal-first">Diagonal first</option>
                   <option value="orthogonal-first">Orthogonal first</option>
                 </select>

--- a/apps/editor/src/features/wiring/use-wire-interaction.ts
+++ b/apps/editor/src/features/wiring/use-wire-interaction.ts
@@ -21,6 +21,7 @@ import {
   type ConnectivityIntent,
   type ConnectivityProposal,
   type WireSource,
+  type WireCornerOrder,
 } from "@icm/edit-engine";
 import {
   derivePowerRailComponent,
@@ -96,7 +97,7 @@ export interface UseWireInteractionOptions {
   wireWaypoints: readonly Point[];
   wireDraftSteps: readonly WireDraftStep[];
   wireRoutingMode: "orthogonal" | "octilinear";
-  wireCornerOrder: "auto" | "diagonal-first" | "orthogonal-first";
+  wireCornerOrder: WireCornerOrder;
   nextRoutingSuffix: () => number;
   transact: (
     edits: SchematicEdit[],

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -39,7 +39,18 @@ export interface ManualWirePath {
 
 /** A transient command constraint, never a second persisted Route type. */
 export type WireRoutingMode = "orthogonal" | "octilinear";
-export type WireCornerOrder = "auto" | "diagonal-first" | "orthogonal-first";
+/**
+ * Which leg of a corner is drawn first. `diagonal-first`/`orthogonal-first`
+ * order an octilinear corner; `horizontal-first`/`vertical-first` order an
+ * orthogonal one. `auto` keeps the incoming segment's direction, which is the
+ * behavior every existing draft relies on.
+ */
+export type WireCornerOrder =
+  | "auto"
+  | "diagonal-first"
+  | "orthogonal-first"
+  | "horizontal-first"
+  | "vertical-first";
 
 /** One authored click. The compiler may insert an unpersisted elbow. */
 export interface WireDraftStep {
@@ -630,19 +641,26 @@ function appendOrthogonal(
   modes: SegmentMode[],
   target: Point,
   mode: SegmentMode,
+  cornerOrder: WireCornerOrder = "auto",
 ): void {
   const last = points.at(-1)!;
   if (samePoint(last, target)) return;
   if (last.x !== target.x && last.y !== target.y) {
     const previous = points.at(-2);
+    // An explicit axis wins; otherwise the corner carries the incoming
+    // segment's direction through before it turns.
+    const horizontalFirst =
+      cornerOrder === "horizontal-first"
+        ? true
+        : cornerOrder === "vertical-first"
+          ? false
+          : previous
+            ? previous.y === last.y
+            : true;
     append(
       points,
       modes,
-      previous
-        ? previous.y === last.y
-          ? { x: target.x, y: last.y }
-          : { x: last.x, y: target.y }
-        : { x: target.x, y: last.y },
+      horizontalFirst ? { x: target.x, y: last.y } : { x: last.x, y: target.y },
       mode,
     );
   }
@@ -705,7 +723,13 @@ export function compileWireDraft(
   const modes: SegmentMode[] = [];
   const appendStep = (step: WireDraftStep) => {
     if (step.routingMode === "orthogonal") {
-      appendOrthogonal(points, modes, step.point, "manual");
+      appendOrthogonal(
+        points,
+        modes,
+        step.point,
+        "manual",
+        step.cornerOrder ?? "auto",
+      );
     } else {
       appendOctilinear(
         points,

--- a/packages/edit-engine/src/wire-path.test.ts
+++ b/packages/edit-engine/src/wire-path.test.ts
@@ -86,3 +86,43 @@ describe("buildManualWirePath", () => {
     ]);
   });
 });
+
+describe("orthogonal corner order", () => {
+  const from = { point: { x: 0, y: 0 } };
+  const to = { point: { x: 100, y: 60 } };
+
+  it("turns horizontally first by default", () => {
+    expect(compileWireDraft(from, to).points).toEqual([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 60 },
+    ]);
+  });
+
+  it("turns vertically first when the corner is flipped", () => {
+    expect(
+      compileWireDraft(from, to, [], "orthogonal", "vertical-first").points,
+    ).toEqual([
+      { x: 0, y: 0 },
+      { x: 0, y: 60 },
+      { x: 100, y: 60 },
+    ]);
+  });
+
+  it("keeps the flip explicit against the incoming direction", () => {
+    // Auto would carry the incoming vertical leg through; horizontal-first
+    // must win over that inherited direction.
+    const steps = [
+      { point: { x: 0, y: 40 }, routingMode: "orthogonal" as const },
+    ];
+    expect(
+      compileWireDraft(from, to, steps, "orthogonal", "horizontal-first")
+        .points,
+    ).toEqual([
+      { x: 0, y: 0 },
+      { x: 0, y: 40 },
+      { x: 100, y: 40 },
+      { x: 100, y: 60 },
+    ]);
+  });
+});

--- a/plan/2026-08-22-wire-corner-steering/plan.md
+++ b/plan/2026-08-22-wire-corner-steering/plan.md
@@ -1,0 +1,106 @@
+---
+status: completed
+experience: none
+---
+
+# Steering the wire corner from the drafting gesture
+
+## Goal
+
+Let a middle-click choose which way a wire corner turns while drafting,
+instead of only reaching the 45° mode. An orthogonal elbow can now be pinned
+to horizontal-first or vertical-first rather than always inheriting the
+incoming segment's direction.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## claude/wire-drafting-iteration
+```
+
+Branched from `origin/main` after PRs #175 and #177 merged.
+
+- `packages/edit-engine/src/routing-planner.ts`
+- `packages/edit-engine/src/wire-path.test.ts`
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/src/features/wiring/use-wire-interaction.ts`
+- `apps/editor/e2e/manual-editor.spec.ts`
+
+- Shared: `WireCornerOrder`, a transient command constraint that never enters
+  the persisted model.
+
+## Work
+
+1. Extend `WireCornerOrder` with `horizontal-first` and `vertical-first` and
+   teach `appendOrthogonal` to honor them, keeping `auto` (carry the incoming
+   direction through the corner) as the default every existing draft uses.
+2. Thread the step's corner order through `compileWireDraft`'s orthogonal
+   branch, which previously dropped it.
+3. Replace the middle-click "toggle routing mode" action with one cycle over
+   the corner shapes a wire actually turns with: horizontal-first →
+   vertical-first → 45° diagonal.
+4. Offer the two new orders in the Corner menu.
+
+## What was already there
+
+Double-click to finish a wire already worked: the canvas `onDoubleClick`
+calls `applyWireCanvasPoint(..., finish=true)` while the pointer-down path
+ignores `event.detail !== 1`. Confirmed in a running editor — the status reads
+"Committed route … Wire remains active". No change was needed, and it had no
+coverage, so the new spec exercises it as part of the corner assertions.
+
+## Not done: free-angle segments
+
+Arbitrary-angle wire segments are deliberately out of scope here.
+`validateRoute` rejects any Route that is not octilinear, so free angles are a
+change to an enforced geometry invariant rather than a drafting option, and
+they would touch ERC, extraction, and every golden. That needs a spec/ADR
+decision before implementation.
+
+## Validation
+
+- `git diff --check`
+- `git status --short --branch`
+- `vitest run` full unit suite (1169 passed)
+- Full Playwright suite (199 passed), including a new spec that draws the same
+  corner twice and asserts the bend point moves from the horizontal leg to the
+  vertical one
+- `tsc -p tsconfig.check.json`
+
+## Gate Review
+
+- Decision: affected
+- Early gates: typecheck, Prettier on changed files
+- Affected gates: edit-engine wire-path unit tests, the manual-editor
+  Playwright spec that owns wire drafting
+- Final gates: remote GitHub Actions on the PR
+- Platform risks: none; `WireCornerOrder` is transient and no persisted
+  geometry rule changed
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: orthogonal corner order, including explicit axis over the
+  inherited incoming direction; the middle-click cycle.
+- Primary checks: `packages/edit-engine/src/wire-path.test.ts`,
+  `apps/editor/e2e/manual-editor.spec.ts`
+
+All new cases. The previous corner rule was implicit in `appendOrthogonal`
+and had no direct assertion.
+
+## Commit Intent
+
+Commit as:
+
+```text
+feat(editor): steer the wire corner with a middle-click cycle
+```
+
+## Outcome
+
+Middle-click now steps horizontal-first → vertical-first → 45° diagonal, so
+both orthogonal elbows are reachable without opening the Corner menu; the
+click previously reached only the diagonal. Double-click-to-finish already
+worked and is now covered.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4693,3 +4693,22 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   typecheck, prettier, diff checks.
 - Commit status: completed on `claude/duplicate-pin-names`; mainline merge
   gated on the remote required checks.
+
+## 2026-08-22 - Steering the wire corner from the drafting gesture
+
+- Changed areas: `WireCornerOrder` gained `horizontal-first`/`vertical-first`,
+  `appendOrthogonal` honors them over the inherited incoming direction, and
+  `compileWireDraft` now threads a step's corner order through its orthogonal
+  branch (it was previously dropped). Middle-click while drafting cycles the
+  corner shape — horizontal-first, vertical-first, 45° diagonal — replacing a
+  binding that only reached the diagonal.
+- Already worked, now covered: double-click finishes a wire while single click
+  continues it (`onDoubleClick` → `applyWireCanvasPoint(finish=true)`;
+  pointer-down ignores `detail !== 1`). Confirmed in a running editor.
+- Deliberately not done: free-angle segments. `validateRoute` rejects any
+  non-octilinear Route, so arbitrary angles change an enforced geometry
+  invariant rather than a drafting option and need a spec/ADR decision.
+- Validation: full unit suite (1169), full Playwright suite (199 passed)
+  including a new corner-geometry spec, typecheck, prettier, diff checks.
+- Commit status: completed on `claude/wire-drafting-iteration`; mainline merge
+  gated on the remote required checks.


### PR DESCRIPTION
## What changed

An orthogonal elbow always inherited the incoming segment's direction, so you couldn't choose which way a corner turned while drafting.

- `WireCornerOrder` gains `horizontal-first` and `vertical-first`; `appendOrthogonal` honors them over the inherited direction (`auto` keeps today's behavior).
- `compileWireDraft` now threads a step's corner order through its **orthogonal** branch — it was previously dropped, so only octilinear steps could carry one.
- **Middle-click during a draft cycles the corner shape**: horizontal-first → vertical-first → 45° diagonal. It previously toggled only into the diagonal mode, leaving both orthogonal elbows reachable only from the Corner menu.
- The Corner menu lists the two new orders.

## Already worked

**Double-click to finish a wire** already worked — `onDoubleClick` calls `applyWireCanvasPoint(..., finish=true)` while the pointer-down path ignores `event.detail !== 1`. Verified in a running editor (status: "Committed route … Wire remains active"). It had no coverage, so the new spec exercises it.

## Deliberately not included: free-angle segments

`validateRoute` rejects any Route that is not octilinear. Arbitrary-angle wires are therefore a change to an **enforced geometry invariant**, not a drafting option — they'd touch ERC, netlist extraction, and every golden. That needs a spec/ADR decision first, so it is called out rather than half-done here.

## Validation

- Full unit suite: **1169 passed**
- Full Playwright suite: **199 passed**, including a new spec that draws the same corner twice and asserts the bend point moves from the horizontal leg to the vertical one
- Typecheck, Prettier, `git diff --check`, test-impact gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)