### PR TITLE
fix(editor): gallery pages scroll inside their shell

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -142,6 +142,43 @@ test("the feed pages through the cursor as the sentinel comes into view", async 
   ).toBe(true);
 });
 
+test("the feed scrolls inside its shell despite the locked app root", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 520, height: 420 });
+  const entries = Array.from({ length: 8 }, (_, index) => ({
+    id: `s-${index}`,
+    name: `Circuit ${index}`,
+    author: "tz",
+    description: "",
+    createdAt: "2026-08-22T10:00:00.000Z",
+    schemaVersion: 21,
+  }));
+  await page.route("**/api/gallery", (route) =>
+    route.fulfill({ json: { entries, nextCursor: null } }),
+  );
+  await page.route("**/api/gallery/*/preview.svg", (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 8"><rect width="10" height="8" fill="#fff"/></svg>',
+    }),
+  );
+
+  await page.goto("/");
+  await expect(page.getByTestId("gallery-tile-s-0")).toBeVisible();
+  const scrolled = await page.locator(".gallery-shell").evaluate((shell) => {
+    shell.scrollTop = 9999;
+    return {
+      overflowY: getComputedStyle(shell).overflowY,
+      scrollable: shell.scrollHeight > shell.clientHeight,
+      scrollTop: shell.scrollTop,
+    };
+  });
+  expect(scrolled.overflowY).toBe("auto");
+  expect(scrolled.scrollable).toBe(true);
+  expect(scrolled.scrollTop).toBeGreaterThan(0);
+});
+
 test("clicking a byline filters the wall to that author, clearable", async ({
   page,
 }) => {

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -5291,7 +5291,11 @@ html.light .analytics-map-land path {
 /* ---------- Community gallery landing feed ---------- */
 
 .gallery-shell {
-  min-height: 100vh;
+  /* The editor locks #root/body with overflow: hidden for the canvas;
+     the gallery pages therefore scroll INSIDE their own shell — without
+     this, anything below the first viewport is unreachable. */
+  height: 100%;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   background: var(--icm-chrome-bg);
@@ -5489,7 +5493,10 @@ html.light .analytics-map-land path {
 }
 
 .review-shell {
-  min-height: 100vh;
+  /* Same scroll-inside-the-shell rule as .gallery-shell: the app root is
+     overflow: hidden, so these pages own their scrolling. */
+  height: 100%;
+  overflow-y: auto;
   background: var(--icm-surface);
 }
 

--- a/plan/2026-08-22-gallery-scroll-fix/plan.md
+++ b/plan/2026-08-22-gallery-scroll-fix/plan.md
@@ -1,0 +1,58 @@
+---
+status: completed
+experience: none
+---
+
+# Hotfix: Gallery Pages Scroll Inside Their Shell
+
+## Goal
+
+User-reported: the masonry feed cannot be scrolled. Root cause: the
+editor locks `#root`/`body` with `overflow: hidden` and a fixed height
+for the canvas, so the gallery pages had no scroll container at all —
+anything below the first viewport was unreachable (and lazy previews
+below the fold could never load). Give `.gallery-shell` and
+`.review-shell` their own scrolling (`height: 100%; overflow-y: auto`),
+which also restores lazy-image loading and sentinel paging semantics.
+
+## State and Ownership
+
+Branched from `origin/main` as `claude/gallery-scroll-fix`.
+
+Owned paths: `apps/editor/src/styles.css`,
+`apps/editor/e2e/gallery.spec.ts`,
+`plan/2026-08-22-gallery-scroll-fix/plan.md`, `plan/log.md`.
+
+## Validation
+
+- `playwright`: gallery spec — new scenario proves the shell is the
+  scroller (overflow auto, scrollHeight beyond the viewport, scrollTop
+  advances) on a small viewport with eight tiles
+- prettier, `node scripts/check-test-impact.mjs --base origin/main`
+- `git diff --check` and `git status --short --branch`
+- Production verification after deploy
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: gallery pages scroll within their shell under the locked
+  app root
+- Primary checks: `apps/editor/e2e/gallery.spec.ts`
+
+## Commit Intent
+
+Committed on `claude/gallery-scroll-fix` under the user's standing
+commit-push-merge direction as:
+
+```text
+fix(editor): gallery pages scroll inside their shell
+```
+
+## Outcome
+
+Delivered: `.gallery-shell`/`.review-shell` own their scrolling beneath
+the overflow-hidden app root; verified live in the dev editor (shell
+scrolls to its full masonry height) and pinned by the new Playwright
+scenario. During diagnosis, the apparent ResizeObserver silence was
+traced to the debugging browser's hidden document (paused rendering
+pipeline), not to product code.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4693,3 +4693,15 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   typecheck, prettier, diff checks.
 - Commit status: completed on `claude/duplicate-pin-names`; mainline merge
   gated on the remote required checks.
+
+## 2026-08-22 — Hotfix: gallery pages scroll inside their shell
+
+- Target: `plan/2026-08-22-gallery-scroll-fix/plan.md` (completed).
+- Change: the editor locks #root/body with overflow hidden, so the
+  gallery pages had no scroll container — .gallery-shell/.review-shell
+  now scroll themselves (height 100%, overflow-y auto), which also
+  revives below-the-fold lazy previews; new e2e pins the shell as the
+  scroller.
+- Validation: gallery Playwright 18/18, prettier, test-impact, diff
+  checks; production verification after deploy.
+- Commit status: completed on `claude/gallery-scroll-fix`.


### PR DESCRIPTION
User-reported: the masonry feed cannot be scrolled. Root cause: the editor locks `#root`/`body` with `overflow: hidden` and a fixed height for the canvas, so the gallery pages had no scroll container at all — anything below the first viewport was unreachable, and below-the-fold lazy previews could never load (which also starved the masonry height).

Fix: `.gallery-shell` and `.review-shell` own their scrolling (`height: 100%; overflow-y: auto`) beneath the locked app root. A new Playwright scenario pins the shell as the scroller (overflow auto, scrollHeight beyond the viewport, scrollTop advances) on a small viewport with eight tiles — gallery spec green.

(During diagnosis the apparent ResizeObserver silence turned out to be the debugging browser's hidden document pausing the rendering pipeline — not product code.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)