### PR TITLE
fix(editor): resize a Power Rail from its ends and keep it straight

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3705,3 +3705,33 @@ test("middle-click steers which way the wire corner turns", async ({
   expect(vertical).toHaveLength(3);
   expect(vertical[1]!.x).toBe(vertical[0]!.x);
 });
+
+test("resizes a plain Power Rail from its end handle", async ({ page }) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await page.getByTestId("shapes-chip-vdd").click();
+  await canvas.click({ position: { x: 180, y: 120 } });
+  await canvas.click({ position: { x: 520, y: 120 } });
+  await page.keyboard.press("Escape");
+
+  const before = await readRoutePoints(page, "route-vdd1-rail");
+  await clickRoute(page, "route-vdd1-rail");
+
+  // The end handle sits under the Junction's endpoint circle. The canvas
+  // capture layer used to claim the press there and translate the whole rail,
+  // which left a rail's length uneditable.
+  await dragBy(page.getByTestId("junction-junction-vdd1-end"), {
+    x: 100,
+    y: 0,
+  });
+  await expect(page.getByTestId("status")).toContainText("Resized Power Rail");
+
+  const after = await readRoutePoints(page, "route-vdd1-rail");
+  const leftOf = (points: typeof before) =>
+    Math.min(...points.map((point) => point.x));
+  const rightOf = (points: typeof before) =>
+    Math.max(...points.map((point) => point.x));
+  expect(leftOf(after)).toBe(leftOf(before));
+  expect(rightOf(after)).toBeGreaterThan(rightOf(before));
+  expect(new Set(after.map((point) => point.y)).size).toBe(1);
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -4069,9 +4069,15 @@ export function App({
       // a selected hierarchy instance cannot start an ordinary move first.
       return;
     }
-    if ((event.target as Element).closest(".draft-handle, .route-handle")) {
-      return;
-    }
+    // Handles outrank the scene they sit on, the same way layout grips do.
+    // Testing only event.target missed a handle drawn under another hit
+    // surface — a Power Rail end handle sits beneath its Junction's endpoint
+    // circle — so this capture layer claimed the press and the rail moved
+    // instead of resizing. Rank the whole stack at the point instead.
+    const handleAtPoint = event.currentTarget.ownerDocument
+      .elementsFromPoint(event.clientX, event.clientY)
+      .some((element) => element.closest(".draft-handle, .route-handle"));
+    if (handleAtPoint) return;
     const hit = resolveCanvasHitAtPoint(
       event.currentTarget.ownerDocument,
       { x: event.clientX, y: event.clientY },

--- a/packages/edit-engine/src/transaction-routing.ts
+++ b/packages/edit-engine/src/transaction-routing.ts
@@ -6,6 +6,7 @@ import type {
   SchematicDocument,
 } from "@icm/model";
 import {
+  derivePowerRailComponent,
   endpointBelongsToNet,
   endpointKey,
   netEndpoints,
@@ -238,6 +239,26 @@ export function validateRoute(
     )
   ) {
     return `Power rail ${route.id} must be straight and axis-aligned`;
+  }
+  if (route.presentation === "power-rail") {
+    // A rail is one straight conductor, so the whole connected run has to be
+    // collinear — not merely each stored Route. Without this, extending a
+    // rail perpendicular to itself produced a bent rail out of two
+    // individually straight halves.
+    const component = derivePowerRailComponent(document, route.id);
+    const positions = (component?.junctionIds ?? []).flatMap((junctionId) => {
+      const junction = document.junctions.find(
+        (candidate) => candidate.id === junctionId,
+      );
+      return junction ? [junction.position] : [];
+    });
+    if (
+      positions.length > 2 &&
+      !positions.every((position) => position.y === positions[0]!.y) &&
+      !positions.every((position) => position.x === positions[0]!.x)
+    ) {
+      return `Power rail ${route.id} must stay one straight run without a bend`;
+    }
   }
   for (const [endpoint, point, adjacent, mode] of [
     [

--- a/packages/edit-engine/src/transaction.test.ts
+++ b/packages/edit-engine/src/transaction.test.ts
@@ -422,6 +422,97 @@ describe("Edit Transaction envelope", () => {
     expect(JSON.stringify(document)).toBe(before);
   });
 
+  it("rejects a second rail Route that would bend the run", () => {
+    const empty = createEmptyDocument("document-main", "Main");
+    const railed = executeTransaction(
+      empty,
+      {
+        ...transaction(),
+        edits: [
+          {
+            kind: "add_power_rail",
+            netId: "net-vdd",
+            routeId: "rail-vdd",
+            startJunctionId: "junction-start",
+            endJunctionId: "junction-end",
+            labelId: "label-vdd",
+            netName: "VDD",
+            scope: "local",
+            powerDomain: "vdd",
+            start: { x: 10, y: 10 },
+            end: { x: 100, y: 10 },
+          },
+        ],
+      },
+      { symbolResolver: resolver },
+    );
+    expect(railed.ok).toBe(true);
+    const straight = railed.document;
+
+    const bendEdits = [
+      {
+        kind: "add_junction" as const,
+        junctionId: "junction-bend",
+        netId: "net-vdd",
+        position: { x: 100, y: 90 },
+        role: "route-anchor" as const,
+      },
+      {
+        kind: "set_route_points" as const,
+        routeId: "rail-vdd-branch",
+        netId: "net-vdd",
+        from: { kind: "junction" as const, junctionId: "junction-end" },
+        to: { kind: "junction" as const, junctionId: "junction-bend" },
+        waypoints: [],
+        segmentModes: ["manual" as const],
+        presentation: "power-rail" as const,
+      },
+    ];
+
+    // A rail is one straight conductor. Hanging a perpendicular rail Route off
+    // its end would leave two individually straight halves with a bend.
+    const bent = executeTransaction(
+      straight,
+      {
+        ...transaction(),
+        expectedRevision: straight.revision,
+        edits: bendEdits,
+      },
+      { symbolResolver: resolver },
+    );
+    console.log(
+      "BENT",
+      JSON.stringify({ ok: bent.ok, rejection: (bent as any).rejection }).slice(
+        0,
+        300,
+      ),
+    );
+    expect(bent).toMatchObject({ ok: false, applied: false });
+
+    // The same branch drawn collinearly extends the rail instead.
+    const extended = executeTransaction(
+      straight,
+      {
+        ...transaction(),
+        expectedRevision: straight.revision,
+        edits: [
+          { ...bendEdits[0]!, position: { x: 200, y: 10 } },
+          bendEdits[1]!,
+        ],
+      },
+      { symbolResolver: resolver },
+    );
+    console.log(
+      "EXT",
+      JSON.stringify(
+        Object.fromEntries(
+          Object.entries(extended).filter(([k]) => k !== "document"),
+        ),
+      ).slice(0, 600),
+    );
+    expect(extended.ok).toBe(true);
+  });
+
   it("rejects a power rail whose generated IDs collide with an existing object", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.instances.push({

--- a/plan/2026-08-22-power-rail-straight-and-resizable/plan.md
+++ b/plan/2026-08-22-power-rail-straight-and-resizable/plan.md
@@ -1,0 +1,109 @@
+---
+status: completed
+experience: none
+---
+
+# A Power Rail stays straight and resizes from its ends
+
+## Goal
+
+Make a Power Rail behave as the one thing it can be: a single straight
+conductor whose length is editable. Dragging an end must lengthen the rail
+rather than translate it, and no edit may leave a rail bent.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## claude/power-rail-straight
+```
+
+Branched from `origin/main` after PR #181 merged.
+
+- `apps/editor/src/app/App.tsx`
+- `packages/edit-engine/src/transaction-routing.ts`
+- `packages/edit-engine/src/transaction.test.ts`
+- `apps/editor/e2e/manual-editor.spec.ts`
+
+- Shared: `validateRoute`, the routing invariant every transaction is checked
+  against.
+
+## The resize defect
+
+Reproduced before fixing: placing a rail and dragging its end junction moved
+the whole rail (both ends `+100`) and reported "Moved Power Rail".
+
+The rail's `power-rail-handle-…-end` circle is drawn _under_ the junction's
+`endpoint-hit` circle. `handleCanvasHitPointerDown` runs on
+`onPointerDownCapture` and skipped handles by testing only `event.target`,
+which is the topmost element — the endpoint circle — so the guard missed, the
+capture layer claimed the press with `stopPropagation`, and the endpoint
+circle's own resize branch never ran.
+
+The existing e2e case passed only because it connects a wire first, which
+stops the junction being a free wiring endpoint and removes the covering
+circle. That is why the bug survived: the test drove a state real usage does
+not start from.
+
+Fix: rank the whole element stack at the point, not just `event.target`.
+
+## The straightness invariant
+
+`add_power_rail` already required one axis-aligned segment, and
+`validateRoute` already required each stored rail Route to be straight. Both
+are per-Route, and `proposeWireCommit` gives any wire drawn from a rail
+endpoint `presentation: "power-rail"`, so a perpendicular branch produced a
+bent rail out of two individually straight halves.
+
+`validateRoute` now also requires the whole connected rail run to be
+collinear. Extending a rail along its own axis still succeeds.
+
+## Historical data
+
+The rule is enforced through `validateRoute`, which the transaction layer
+already grandfathers for pre-existing errors on unchanged geometry: an
+already-bent Project still opens, but any edit touching that rail must leave
+it straight. Nothing is silently straightened.
+
+## Validation
+
+- `git diff --check`
+- `git status --short --branch`
+- Full unit suite (1170 passed); the new transaction case was re-run with the
+  invariant stashed to confirm it fails without it
+- Full Playwright suite (200 passed), including a new case that resizes a
+  plain rail and asserts the fixed end stays put
+- `tsc -p tsconfig.check.json`
+
+## Gate Review
+
+- Decision: affected
+- Early gates: typecheck, Prettier on changed files
+- Affected gates: edit-engine transaction tests, the manual-editor Playwright
+  spec that owns rail interaction
+- Final gates: remote GitHub Actions on the PR
+- Platform risks: the capture-layer change affects every canvas press, so the
+  full browser suite was run rather than the rail specs alone
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: a rail end handle resizes rather than translates; a rail run
+  stays collinear.
+- Primary checks: `packages/edit-engine/src/transaction.test.ts`,
+  `apps/editor/e2e/manual-editor.spec.ts`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): resize a Power Rail from its ends and keep it straight
+```
+
+## Outcome
+
+Dragging a rail end now reports "Resized Power Rail" and moves only that end.
+A perpendicular rail branch is rejected; a collinear one still extends the
+rail.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4712,3 +4712,28 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   including a new corner-geometry spec, typecheck, prettier, diff checks.
 - Commit status: completed on `claude/wire-drafting-iteration`; mainline merge
   gated on the remote required checks.
+
+## 2026-08-22 - A Power Rail stays straight and resizes from its ends
+
+- Fixed the reported "rail length cannot be changed": the rail's end handle is
+  drawn under the Junction's `endpoint-hit` circle, and the capture-phase
+  `handleCanvasHitPointerDown` skipped handles by testing only `event.target`
+  — the topmost element — so it claimed the press and translated the rail.
+  It now ranks the whole element stack at the point. Reproduced first (both
+  ends moved +100, status "Moved Power Rail"), fixed, re-verified.
+- The existing rail-resize e2e passed throughout because it connects a wire
+  first, which removes the covering endpoint circle; real usage never starts
+  from that state.
+- Added the missing invariant: `validateRoute` now requires a whole connected
+  rail run to be collinear, not just each stored Route. A wire drawn from a
+  rail endpoint inherits `presentation: "power-rail"`, so a perpendicular
+  branch previously produced a bent rail from two straight halves. Collinear
+  extension still succeeds.
+- Historical data is not silently straightened: the transaction layer
+  grandfathers pre-existing route errors on unchanged geometry, so a bent
+  Project still opens but any edit touching that rail must leave it straight.
+- Validation: full unit suite (1170) with the new case re-run against a
+  stashed invariant to prove it fails without it, full Playwright suite (200
+  passed), typecheck, prettier, diff checks.
+- Commit status: completed on `claude/power-rail-straight`; mainline merge
+  gated on the remote required checks.


### PR DESCRIPTION
Two Power Rail defects, both reported by the owner: the rail's length couldn't be changed, and a rail could end up bent.

## 1. The rail could not be resized

**Reproduced first:** placing a rail and dragging its end junction moved the *whole* rail (both ends `+100`) and reported `Moved Power Rail`.

The rail's `power-rail-handle-…-end` circle is drawn **under** the junction's `endpoint-hit` circle. `handleCanvasHitPointerDown` runs on `onPointerDownCapture` and skipped handles by testing only `event.target` — which is the topmost element, the endpoint circle — so the guard missed, the capture layer claimed the press with `stopPropagation`, and the endpoint circle's own resize branch never ran.

Fix: rank the whole element stack at the point rather than just `event.target`.

Now: `Resized Power Rail`, with the far end staying put.

### Why the existing test didn't catch it

`manual-editor.spec.ts` already had a passing rail-resize assertion — but it connects a wire to the rail first, which stops the junction being a free wiring endpoint and removes the covering circle. It drove a state real usage never starts from. The new spec resizes a **plain** rail.

## 2. A rail could be bent

`add_power_rail` required one axis-aligned segment and `validateRoute` required each stored rail Route to be straight — both **per-Route**. But `proposeWireCommit` gives any wire drawn from a rail endpoint `presentation: "power-rail"`, so a perpendicular branch produced a bent rail out of two individually straight halves.

`validateRoute` now requires the whole connected rail run to be **collinear**. Extending a rail along its own axis still succeeds — the new unit test asserts both directions.

## Historical data

Not silently straightened. The rule rides on `validateRoute`, which the transaction layer already grandfathers for pre-existing errors on unchanged geometry: an already-bent Project still opens, but any edit touching that rail must leave it straight.

## Validation

- Full unit suite: **1170 passed**. The new transaction case was re-run with the invariant stashed to confirm it **fails** without it (and that the collinear case still passes).
- Full Playwright suite: **200 passed** — run in full rather than just the rail specs, because the capture-layer change affects every canvas press.
- Typecheck, Prettier, `git diff --check`, test-impact gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)