### PR TITLE
fix(editor): stop the canvas text editor clipping a wrapped label

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3735,3 +3735,28 @@ test("resizes a plain Power Rail from its end handle", async ({ page }) => {
   expect(rightOf(after)).toBeGreaterThan(rightOf(before));
   expect(new Set(after.map((point) => point.y)).size).toBe(1);
 });
+
+test("keeps a long right-aligned Port label readable while editing", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await page.getByTestId("shapes-chip-port").click();
+  await canvas.click({ position: { x: 400, y: 250 } });
+  await page.keyboard.press("Escape");
+
+  await page.getByTestId("annotation-hit-instance-label-P1").dblclick();
+  const editable = page.locator(".rich-text-editable");
+  await expect(editable).toBeVisible();
+  await editable.click();
+  await page.keyboard.type("VinputDifferentialPositive");
+
+  // The overlay is a foreignObject, so anything past its frame is clipped
+  // away silently rather than scrolled to.
+  const overflow = await editable.evaluate((element) => ({
+    hidden: element.scrollHeight - element.clientHeight,
+    scrollable: getComputedStyle(element).overflowY,
+  }));
+  expect(overflow.hidden).toBeLessThanOrEqual(0);
+  expect(overflow.scrollable).toBe("auto");
+});

--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.test.ts
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.test.ts
@@ -10,7 +10,7 @@ describe("canvas text editor frame", () => {
         { x: 0, y: 0, width: 960, height: 640 },
         1,
       ),
-    ).toEqual({ x: 94, y: 116, width: 420, height: 76 });
+    ).toEqual({ x: 94, y: 83.5824, width: 420, height: 108.4176 });
   });
 
   it("grows with text scale before reaching the viewport boundary", () => {
@@ -21,9 +21,9 @@ describe("canvas text editor frame", () => {
     );
 
     expect(frame.x).toBe(94);
-    expect(frame.y).toBeCloseTo(83.5824);
+    expect(frame.y).toBeCloseTo(238);
     expect(frame.width).toBe(420);
-    expect(frame.height).toBeCloseTo(108.4176);
+    expect(frame.height).toBeCloseTo(217.2528);
   });
 
   it("clamps the frame to all four viewport edges", () => {
@@ -33,7 +33,7 @@ describe("canvas text editor frame", () => {
         { x: 0, y: 0, width: 960, height: 640 },
         1,
       ),
-    ).toEqual({ x: 8, y: 18, width: 420, height: 76 });
+    ).toEqual({ x: 8, y: 18, width: 420, height: 108.4176 });
 
     expect(
       resolveCanvasTextEditorFrame(
@@ -41,7 +41,7 @@ describe("canvas text editor frame", () => {
         { x: 0, y: 0, width: 960, height: 640 },
         1,
       ),
-    ).toEqual({ x: 532, y: 536, width: 420, height: 86 });
+    ).toEqual({ x: 532, y: 513.5824, width: 420, height: 108.4176 });
   });
 
   it("fits oversized content inside a translated viewport", () => {
@@ -52,5 +52,19 @@ describe("canvas text editor frame", () => {
         1,
       ),
     ).toEqual({ x: 28, y: 38, width: 944, height: 624 });
+  });
+
+  it("budgets several wrapped lines so a long name is not clipped away", () => {
+    // The frame is sized from the committed bounds, before any longer name is
+    // typed, and the overlay is a foreignObject that clips silently. One
+    // line's worth of height left a wrapped name unreadable.
+    const oneLine = 15.116 * 1.2;
+    const frame = resolveCanvasTextEditorFrame(
+      { x: 100, y: 200, width: 200, height: 30 },
+      { x: 0, y: 0, width: 960, height: 640 },
+      1,
+    );
+
+    expect(frame.height).toBeGreaterThan(54 + oneLine * 2);
   });
 });

--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
@@ -24,8 +24,13 @@ export function resolveCanvasTextEditorFrame(
   sizeScale: number,
 ): DerivedRect {
   const width = Math.min(Math.max(420, bounds.width + 12), viewBox.width - 16);
+  // A name longer than the box wraps, and the frame is sized before any of it
+  // is typed, so budget for a few wrapped lines instead of the one the
+  // committed bounds imply. Anything past that scrolls rather than being
+  // clipped away by the foreignObject.
+  const lineHeight = 15.116 * sizeScale * 1.2;
   const height = Math.min(
-    Math.max(76, bounds.height + 36, 54 + 15.116 * sizeScale * 1.2),
+    Math.max(76, bounds.height + 36, 54 + lineHeight * 3),
     viewBox.height - 16,
   );
   const viewportInset = 8;

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -2445,6 +2445,10 @@ body {
 .rich-text-editable {
   box-sizing: border-box;
   max-width: 100%;
+  /* The overlay is a foreignObject, which clips silently. Text that still
+     overflows the frame must stay reachable by scrolling. */
+  max-height: 100%;
+  overflow-y: auto;
   min-height: 1.35rem;
   padding: 0.1rem 0.25rem;
   border: 1px solid var(--icm-accent);

--- a/plan/2026-08-22-text-editor-clipping/plan.md
+++ b/plan/2026-08-22-text-editor-clipping/plan.md
@@ -1,0 +1,88 @@
+---
+status: completed
+experience: none
+---
+
+# The canvas text editor stops clipping long labels
+
+## Goal
+
+Make everything typed into the canvas text editor visible. A label longer
+than one line was cut off with no way to reach the rest.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## claude/text-editor-clipping
+```
+
+Branched from `origin/main` after PR #183 merged.
+
+- `apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx`
+- `apps/editor/src/features/text-editing/canvas-text-editor-overlay.test.ts`
+- `apps/editor/src/styles.css`
+- `apps/editor/e2e/manual-editor.spec.ts`
+
+## The defect
+
+Measured on a Port's right-aligned label before fixing: typing a longer name
+gave `scrollHeight 40` against `clientHeight 36`, with `overflow: visible`.
+The overlay is a `foreignObject`, which clips its content silently, so the
+wrapped line was neither visible nor scrollable — it simply vanished.
+
+The cause is that `resolveCanvasTextEditorFrame` sizes the frame from the
+_committed_ bounds, before the longer name exists, and its height floor
+(`54 + oneLine`) budgets a single line.
+
+## Work
+
+1. Budget three wrapped lines in the height floor instead of one.
+2. Give `.rich-text-editable` `max-height: 100%` and `overflow-y: auto`, so
+   anything past the frame scrolls rather than being clipped away.
+
+## Validation
+
+- `git diff --check`
+- `git status --short --branch`
+- Measured after fixing: `scrollHeight === clientHeight` for a 3-, 26-, and
+  33-character name; a 400-character extreme now scrolls instead of clipping
+- Full unit suite (1172 passed), full Playwright suite (203 passed)
+- The new e2e case was re-run with the fix stashed and fails without it
+- `tsc -p tsconfig.check.json`
+
+## Gate Review
+
+- Decision: affected
+- Early gates: typecheck, Prettier on changed files
+- Affected gates: the text-editing unit tests and the manual-editor
+  Playwright spec that owns canvas text editing
+- Final gates: remote GitHub Actions on the PR
+- Platform risks: none; presentation-only
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: the editor frame's height budget and the editable's overflow
+  behavior.
+- Primary checks:
+  `apps/editor/src/features/text-editing/canvas-text-editor-overlay.test.ts`,
+  `apps/editor/e2e/manual-editor.spec.ts`
+
+Four existing frame expectations encoded the one-line height and were updated
+to the new geometry; the wrap budget and the overflow behavior are new
+assertions.
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): stop the canvas text editor clipping a wrapped label
+```
+
+## Outcome
+
+A long label now fits the editor, and text beyond three lines scrolls instead
+of disappearing.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4761,3 +4761,23 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   passed), typecheck, prettier, diff checks.
 - Commit status: completed on `claude/power-rail-straight`; mainline merge
   gated on the remote required checks.
+
+## 2026-08-22 - The canvas text editor stops clipping long labels
+
+- Reproduced the reported "text box cannot show everything" on a Port's
+  right-aligned label: typing a longer name gave `scrollHeight 40` against
+  `clientHeight 36` with `overflow: visible`. The overlay is a
+  `foreignObject`, which clips silently, so the wrapped line was neither
+  visible nor scrollable.
+- Cause: `resolveCanvasTextEditorFrame` sizes the frame from the committed
+  bounds — before the longer name exists — and its height floor budgeted one
+  line. It now budgets three, and `.rich-text-editable` gained
+  `max-height: 100%` with `overflow-y: auto` so anything past the frame
+  scrolls instead of vanishing.
+- Validation: measured `scrollHeight === clientHeight` afterwards for 3-, 26-
+  and 33-character names, with a 400-character extreme scrolling; full unit
+  suite (1172), full Playwright suite (203 passed), the new e2e case re-run
+  against a stashed fix to prove it fails without it; typecheck, prettier,
+  diff checks.
+- Commit status: completed on `claude/text-editor-clipping`; mainline merge
+  gated on the remote required checks.


### PR DESCRIPTION
Fixes the reported "the text box can't show everything", which the owner narrowed to right-aligned Port labels.

## Reproduced first

Typing a longer name into a Port's right-aligned label:

| name length | scrollHeight | clientHeight | overflow |
| --- | --- | --- | --- |
| 3 | 30 | 30 | visible |
| 26 | 30 | 30 | visible |
| 33 | **40** | **36** | visible |

The overlay is a `foreignObject`, which clips its content **silently** — so the wrapped line was neither visible nor scrollable. It just vanished.

## Cause

`resolveCanvasTextEditorFrame` sizes the frame from the **committed** bounds, before any longer name is typed, and its height floor (`54 + oneLine`) budgeted a single line.

## Fix

1. Budget three wrapped lines in the height floor.
2. Give `.rich-text-editable` `max-height: 100%` and `overflow-y: auto`, so anything past the frame scrolls rather than being clipped away.

After: `scrollHeight === clientHeight` for all three cases above; a 400-character extreme now **scrolls** instead of clipping.

## Validation

- Full unit suite: **1172 passed**
- Full Playwright suite: **203 passed**
- The new e2e case was re-run with the fix stashed and **fails** without it (`Expected "auto", Received "visible"`)
- Typecheck, Prettier, `git diff --check`, test-impact gate

Four existing frame expectations encoded the one-line height and move to the new geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)