### PR TITLE
fix(editor): move a marquee selection that contains no Instance

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3760,3 +3760,55 @@ test("keeps a long right-aligned Port label readable while editing", async ({
   expect(overflow.hidden).toBeLessThanOrEqual(0);
   expect(overflow.scrollable).toBe("auto");
 });
+
+test("drags a marquee selection that holds no instance", async ({ page }) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+
+  await clickDrawTool(page, "wire");
+  await canvas.click({ position: { x: 200, y: 200 } });
+  await canvas.dblclick({ position: { x: 340, y: 200 } });
+  await canvas.click({ position: { x: 200, y: 260 } });
+  await canvas.dblclick({ position: { x: 340, y: 260 } });
+  await page.keyboard.press("Escape");
+
+  const readAll = () =>
+    page
+      .locator('[data-testid^="route-hit-"]')
+      .evaluateAll((elements) =>
+        elements.map((element) =>
+          Array.from((element as unknown as SVGPolylineElement).points).map(
+            (point) => ({ x: point.x, y: point.y }),
+          ),
+        ),
+      );
+  const before = await readAll();
+  expect(before).toHaveLength(2);
+
+  const bounds = (await canvas.boundingBox())!;
+  await page.mouse.move(bounds.x + 150, bounds.y + 150);
+  await page.mouse.down();
+  await page.mouse.move(bounds.x + 500, bounds.y + 330, { steps: 12 });
+  await page.mouse.up();
+  await expect(page.getByTestId("status")).toContainText("Selected");
+
+  // A marquee can hold only Routes and Junctions. Grabbing one of them used
+  // to drag it out of its own selection and leave the rest behind.
+  const grab = (await page
+    .locator('[data-testid^="route-hit-"]')
+    .first()
+    .boundingBox())!;
+  const x = grab.x + grab.width / 2;
+  const y = grab.y + grab.height / 2;
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  await page.mouse.move(x, y + 60, { steps: 10 });
+  await page.mouse.up();
+
+  const after = await readAll();
+  const shifts = after.map(
+    (points, index) => points[0]!.y - before[index]![0]!.y,
+  );
+  expect(shifts[0]).toBeGreaterThan(0);
+  expect(shifts[1]).toBe(shifts[0]);
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -1819,13 +1819,17 @@ export function App({
     kind: "instance" | "instance-label" | "annotation" | "route" | "junction",
     id: string,
   ): boolean {
+    // Any multi-object selection is composite, counted across every kind. The
+    // previous rule also required at least one Instance, so a marquee holding
+    // only Routes, Junctions, or Annotations was never treated as a group and
+    // dragging it moved just the grabbed object.
     const hasCompositeSelection =
-      selectedIds.length > 0 &&
-      (selectedIds.length > 1 ||
-        visualSelection.routeIds.length > 0 ||
-        visualSelection.junctionIds.length > 0 ||
-        visualSelection.annotationIds.length > 0 ||
-        visualSelection.draftingIds.length > 0);
+      selectedIds.length +
+        visualSelection.routeIds.length +
+        visualSelection.junctionIds.length +
+        visualSelection.annotationIds.length +
+        visualSelection.draftingIds.length >
+      1;
     if (!hasCompositeSelection) return false;
     if (kind === "instance" || kind === "instance-label") {
       return selectedIds.includes(id);
@@ -4145,6 +4149,19 @@ export function App({
       const primaryInstanceId = selectedIds.at(-1);
       if (primaryInstanceId) {
         beginMoveFromSelection(event, primaryInstanceId, hitTarget);
+        return;
+      }
+      // A marquee can hold only Routes, Junctions, and Annotations. Without an
+      // Instance to anchor the move, the press used to fall through to the
+      // single-object branches below and drag just the grabbed object out of
+      // its own selection.
+      const movePlan = planSelectionMove(document, visualSelection);
+      if (movePlan.previewObjectIds.length > 0) {
+        beginVisualSelectionMoveFromSelection(
+          event,
+          visualSelection,
+          hitTarget,
+        );
         return;
       }
     }

--- a/plan/2026-08-22-marquee-drag-without-instance/plan.md
+++ b/plan/2026-08-22-marquee-drag-without-instance/plan.md
@@ -1,0 +1,89 @@
+---
+status: completed
+experience: none
+---
+
+# Dragging a marquee selection that holds no Instance
+
+## Goal
+
+Make a marquee selection move as one group however it was composed. Dragging
+a selection of only Routes, Junctions, or Annotations moved just the grabbed
+object and left the rest behind.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## claude/marquee-drag
+```
+
+Branched from `origin/main` after PR #184 merged.
+
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/e2e/manual-editor.spec.ts`
+
+## The defect
+
+Reproduced before fixing: two standalone wires, marquee across both (status
+"Selected 6 objects", both Routes marked `selected`), then drag one. Only the
+grabbed Route moved — `dy 70` against `dy 0` — and the status read "Moved
+loose route …", a single-object move.
+
+`compositeSelectionOwnsHit` required `selectedIds.length > 0`, and
+`selectedIds` holds only Instances. A marquee with no Instance therefore never
+counted as a composite selection, so the press fell through to the
+single-object branches: a Route dragged alone, and a Junction only re-selected
+itself, which reads as the drag doing nothing at all.
+
+That is what made it intermittent — the group move worked whenever the
+selection happened to include an Instance.
+
+## Work
+
+1. Count a composite selection across every kind (Instances, Routes,
+   Junctions, Annotations, drafting objects) rather than requiring an
+   Instance.
+2. When the composite selection owns the hit but has no Instance to anchor
+   the move, fall back to `beginVisualSelectionMoveFromSelection`, guarded by
+   `planSelectionMove` exactly as the existing route-tap path does.
+
+## Validation
+
+- `git diff --check`
+- `git status --short --branch`
+- Full unit suite (1172 passed), full Playwright suite (204 passed)
+- The new e2e case was re-run with the fix stashed and fails without it
+  (`Expected 70, Received 0`)
+- `tsc -p tsconfig.check.json`
+
+## Gate Review
+
+- Decision: affected
+- Early gates: typecheck, Prettier on changed files
+- Affected gates: the manual-editor Playwright spec that owns selection and
+  movement
+- Final gates: remote GitHub Actions on the PR
+- Platform risks: `compositeSelectionOwnsHit` gates every canvas press, so the
+  full browser suite was run rather than the selection specs alone
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: a multi-object selection moves as one group regardless of which
+  kinds it contains.
+- Primary checks: `apps/editor/e2e/manual-editor.spec.ts`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(editor): move a marquee selection that contains no Instance
+```
+
+## Outcome
+
+Both wires now move together and the edit commits as one group revision
+instead of a single-route move.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4781,3 +4781,25 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   diff checks.
 - Commit status: completed on `claude/text-editor-clipping`; mainline merge
   gated on the remote required checks.
+
+## 2026-08-22 - Dragging a marquee selection that holds no Instance
+
+- Reproduced the reported intermittent "marquee then drag does nothing": two
+  standalone wires, marquee across both (status "Selected 6 objects", both
+  Routes marked `selected`), drag one — only the grabbed Route moved (dy 70
+  against dy 0) and the status read "Moved loose route", a single-object move.
+- Cause: `compositeSelectionOwnsHit` required `selectedIds.length > 0`, and
+  `selectedIds` holds only Instances, so a marquee with no Instance never
+  counted as composite and the press fell through to the single-object
+  branches. A Junction hit only re-selected itself, which reads as the drag
+  doing nothing. That is what made it intermittent — it worked whenever the
+  selection happened to include an Instance.
+- Fix: count a composite selection across every kind, and when it owns the hit
+  without an Instance to anchor the move, fall back to
+  `beginVisualSelectionMoveFromSelection` guarded by `planSelectionMove`, the
+  same pattern the existing route-tap path uses.
+- Validation: full unit suite (1172), full Playwright suite (204 passed), the
+  new e2e case re-run against a stashed fix to prove it fails without it
+  (Expected 70, Received 0); typecheck, prettier, diff checks.
+- Commit status: completed on `claude/marquee-drag`; mainline merge gated on
+  the remote required checks.


### PR DESCRIPTION
Fixes the reported intermittent "marquee-select several things, then drag the group — sometimes it doesn't work".

## Reproduced first

Two standalone wires, marquee across both — status `Selected 6 objects`, both routes carry the `selected` class. Then drag one:

- only the grabbed route moved: `dy 70` vs `dy 0`
- status read `Moved loose route route-ui-4` — a **single-object** move

## Cause

`compositeSelectionOwnsHit` required `selectedIds.length > 0`, and `selectedIds` holds **only Instances**. A marquee containing no Instance therefore never counted as a composite selection, so the press fell through to the single-object branches below it:

- a **Route** hit dragged that route alone, out of its own selection
- a **Junction** hit only re-selected itself — which reads as the drag doing nothing at all

That is exactly what made it intermittent: the group move worked whenever the selection happened to include an Instance.

## Fix

1. Count a composite selection across **every** kind (Instances, Routes, Junctions, Annotations, drafting objects) rather than requiring an Instance.
2. When the composite selection owns the hit but has no Instance to anchor the move, fall back to `beginVisualSelectionMoveFromSelection`, guarded by `planSelectionMove` — the same pattern the existing route-tap path already uses.

After: both wires move together and the edit commits as one group revision.

## Validation

- Full unit suite: **1172 passed**
- Full Playwright suite: **204 passed** — run in full rather than just the selection specs, because `compositeSelectionOwnsHit` gates every canvas press
- The new e2e case was re-run with the fix stashed and **fails** without it (`Expected: 70, Received: 0`)
- Typecheck, Prettier, `git diff --check`, test-impact gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)