### PR TITLE
fix(schematic): align SKY130 MOS, VDD export, and junction dots

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -2977,6 +2977,7 @@ test("selects a reviewed SKY130 MOS through the existing Model field", async ({
   ]);
   expect(saved.documents[0].instances[0]).toMatchObject({
     id: "M1",
+    symbolId: "nmos",
     schematicReference: "M1",
     netlist: {
       reference: "X1",

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -683,6 +683,29 @@ test("connects one MOS Gate to Drain without false contact ambiguity", async ({
   ).toHaveCount(0);
 });
 
+test("keeps three collinear MOS Gates connected without a junction dot", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "nmos", { x: 420, y: 260 });
+  await placeComponent(page, "nmos", { x: 560, y: 260 });
+  await placeComponent(page, "nmos", { x: 700, y: 260 });
+
+  await clickDrawTool(page, "wire");
+  await page.getByTestId("terminal-M1-G").click();
+  await page.getByTestId("terminal-M2-G").click();
+  await expect(page.getByTestId("status")).toContainText("Committed route");
+
+  await clickDrawTool(page, "wire");
+  await page.getByTestId("terminal-M2-G").click();
+  await page.getByTestId("terminal-M3-G").click();
+  await expect(page.getByTestId("status")).toContainText("Committed route");
+  await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(2);
+  await expect(
+    page.locator('[data-layer="junctions"] [data-node-kind="contact"]'),
+  ).toHaveCount(0);
+});
+
 test("keeps Wire input above labels and resolves a screen-tolerant route tap", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -124,6 +124,7 @@ import {
   hierarchicalSymbolId,
   InMemorySymbolResolver,
   resolvePdkSymbolMapping,
+  resolvePdkSymbolMappingForTerminalOrder,
   reviewedSky130MosModelSuggestions,
 } from "@icm/symbols";
 import {
@@ -1031,20 +1032,12 @@ export function App({
         )
       : undefined;
   const selectedExternalMosMapping = selectedExternalSubcircuit
-    ? (() => {
-        const mapping = resolvePdkSymbolMapping(
+    ? selectedExternalSubcircuit.presentation
+      ? undefined
+      : resolvePdkSymbolMappingForTerminalOrder(
           selectedExternalSubcircuit.name,
-          selectedExternalSubcircuit.terminals.length,
-        );
-        return mapping &&
-          selectedExternalSubcircuit.terminals.every(
-            (terminal, index) =>
-              terminal.name.toLowerCase() ===
-              mapping.pinNames[index]?.toLowerCase(),
-          )
-          ? mapping
-          : undefined;
-      })()
+          selectedExternalSubcircuit.terminals.map((terminal) => terminal.name),
+        )
     : undefined;
   const selectedPropertyDevice =
     selectedDevice ??
@@ -1590,8 +1583,14 @@ export function App({
   const externalSubcircuitInsertCandidates = useMemo(
     () =>
       project.externalSubcircuitDefinitions.flatMap((definition) => {
+        const mapping = definition.presentation
+          ? undefined
+          : resolvePdkSymbolMappingForTerminalOrder(
+              definition.name,
+              definition.terminals.map((terminal) => terminal.name),
+            );
         const symbol = resolver.resolve(
-          externalSubcircuitSymbolId(definition.id),
+          mapping?.symbolId ?? externalSubcircuitSymbolId(definition.id),
         )?.definition;
         return symbol
           ? [

--- a/docs/specs/connectivity-and-routing.md
+++ b/docs/specs/connectivity-and-routing.md
@@ -96,10 +96,11 @@ movement, stretch, and the `RouteEditPlan` preview/commit boundary belong to
 For explicit same-Net endpoints at the same page coordinate, contact evidence
 records terminals/Junctions, independently authored Route arms, and incident
 directions. Route waypoints are not implicit contacts. A visible dot represents
-authored branch topology, not line intersection: Route arms count by distinct
-incident direction, so same-Net arms that overlap collinearly paint as one
-conductor and never justify a dot, while coincident terminals keep per-pin
-counting.
+authored branch topology, not line intersection: Route arms and terminal stems
+count by distinct visible direction, so collinear incidents paint as one
+conductor and do not justify a dot. Three distinct visible directions require a
+dot; three or more coincident terminals also require one even when some stems
+overlap.
 
 ## Transaction invariants
 

--- a/docs/specs/netlist-export.md
+++ b/docs/specs/netlist-export.md
@@ -160,12 +160,13 @@ hint/example/help, and display role). Required export fields are derived from
 `parameters`; there is no separate `requiredParameters` registry.
 
 Pin order names canonical Symbol pins. Hidden or implicit pins remain present.
-Canonical MOS ordering is D/G/S/B. Ground is a Net marker that verifies an
-explicit global Net and emits no instance line. A VDD Port or named power Rail
-is ordinary Net presentation, never a VDD symbol instance; only an explicitly
-global Net is emitted through the dialect's global declaration. Decorative
-symbols never have a device definition. An unsupported electrical Symbol blocks
-export.
+Canonical MOS ordering is D/G/S/B. Ground is a Net marker that verifies the
+explicit global Net `0` and emits no instance line. A VDD Port is a non-emitting
+marker for an explicitly named `powerDomain: vdd` Net, which may be local or
+global under the named-power policy. A named power Rail has no Instance. Only
+an explicitly global Net is emitted through the dialect's global declaration.
+Decorative symbols never have a device definition. An unsupported electrical
+Symbol blocks export.
 
 Independent source syntax is accepted only after its source specification is
 represented structurally. A display string is not a source specification.

--- a/packages/derived/src/contact.test.ts
+++ b/packages/derived/src/contact.test.ts
@@ -24,6 +24,7 @@ function documentWith(
     symbolId: string;
     position: { x: number; y: number };
     rotation?: 0 | 90 | 180 | 270;
+    mirror?: "none" | "x";
     pins: string[];
   }> = [],
 ): SchematicDocument {
@@ -45,7 +46,7 @@ function documentWith(
       placement: {
         position: instance.position,
         rotation: instance.rotation ?? 0,
-        mirror: "none",
+        mirror: instance.mirror ?? "none",
       },
     });
     for (const pinName of instance.pins) {
@@ -117,7 +118,7 @@ describe("contactRequiresJunctionDot", () => {
     expect(dotAt(document, { x: 0, y: 0 })).toBe(true);
   });
 
-  it("dots a pin tapped by a straight-through conductor", () => {
+  it("dots a perpendicular pin tapped by a straight-through conductor", () => {
     // Resistor pin 1 sits at (0,0): body at (0,20), pin 1 local (0,-20).
     const document = documentWith(
       [
@@ -142,6 +143,157 @@ describe("contactRequiresJunctionDot", () => {
       ],
     );
     expect(dotAt(document, { x: 0, y: 0 })).toBe(true);
+  });
+
+  it("keeps three collinear MOS Gates dotless at the middle terminal", () => {
+    const document = documentWith(
+      [
+        {
+          id: "left",
+          from: { instanceId: "M3", pinName: "G" },
+          to: { instanceId: "M2", pinName: "G" },
+        },
+        {
+          id: "right",
+          from: { instanceId: "M2", pinName: "G" },
+          to: { instanceId: "M1", pinName: "G" },
+        },
+      ],
+      [
+        { id: "M3", symbolId: "nmos", position: { x: 0, y: 0 }, pins: ["G"] },
+        { id: "M2", symbolId: "nmos", position: { x: 60, y: 0 }, pins: ["G"] },
+        { id: "M1", symbolId: "nmos", position: { x: 120, y: 0 }, pins: ["G"] },
+      ],
+    );
+    // Gate pins resolve at x = instance.x - 20. The M2 stem and right-hand
+    // Route share one direction, leaving only the two visible line directions.
+    expect(dotAt(document, { x: 40, y: 0 })).toBe(false);
+  });
+
+  it("keeps a single right-angle Route from a terminal dotless", () => {
+    const document = documentWith(
+      [
+        {
+          id: "turn",
+          from: { x: -20, y: 60 },
+          to: { instanceId: "M1", pinName: "G" },
+        },
+      ],
+      [{ id: "M1", symbolId: "pmos", position: { x: 0, y: 0 }, pins: ["G"] }],
+    );
+    expect(dotAt(document, { x: -20, y: 0 })).toBe(false);
+  });
+
+  it("uses rotated terminal directions when classifying collinear Gates", () => {
+    const document = documentWith(
+      [
+        {
+          id: "top",
+          from: { instanceId: "M3", pinName: "G" },
+          to: { instanceId: "M2", pinName: "G" },
+        },
+        {
+          id: "bottom",
+          from: { instanceId: "M2", pinName: "G" },
+          to: { instanceId: "M1", pinName: "G" },
+        },
+      ],
+      [
+        {
+          id: "M3",
+          symbolId: "nmos",
+          position: { x: 0, y: 0 },
+          rotation: 90,
+          pins: ["G"],
+        },
+        {
+          id: "M2",
+          symbolId: "nmos",
+          position: { x: 0, y: 60 },
+          rotation: 90,
+          pins: ["G"],
+        },
+        {
+          id: "M1",
+          symbolId: "nmos",
+          position: { x: 0, y: 120 },
+          rotation: 90,
+          pins: ["G"],
+        },
+      ],
+    );
+    expect(dotAt(document, { x: 0, y: 40 })).toBe(false);
+  });
+
+  it("uses mirrored terminal directions when classifying collinear Gates", () => {
+    const document = documentWith(
+      [
+        {
+          id: "left",
+          from: { instanceId: "M3", pinName: "G" },
+          to: { instanceId: "M2", pinName: "G" },
+        },
+        {
+          id: "right",
+          from: { instanceId: "M2", pinName: "G" },
+          to: { instanceId: "M1", pinName: "G" },
+        },
+      ],
+      [
+        {
+          id: "M3",
+          symbolId: "nmos",
+          position: { x: 0, y: 0 },
+          mirror: "x",
+          pins: ["G"],
+        },
+        {
+          id: "M2",
+          symbolId: "nmos",
+          position: { x: 60, y: 0 },
+          mirror: "x",
+          pins: ["G"],
+        },
+        {
+          id: "M1",
+          symbolId: "nmos",
+          position: { x: 120, y: 0 },
+          mirror: "x",
+          pins: ["G"],
+        },
+      ],
+    );
+    expect(dotAt(document, { x: 80, y: 0 })).toBe(false);
+  });
+
+  it("dots a true three-direction branch containing 45-degree arms", () => {
+    const document = documentWith([
+      { id: "northwest", from: { x: -40, y: -40 }, to: { x: 0, y: 0 } },
+      { id: "southeast", from: { x: 0, y: 0 }, to: { x: 40, y: 40 } },
+      { id: "east", from: { x: 0, y: 0 }, to: { x: 60, y: 0 } },
+    ]);
+    expect(dotAt(document, { x: 0, y: 0 })).toBe(true);
+  });
+
+  it("keeps two coincident pins dotless but dots three coincident pins", () => {
+    const twoPins = documentWith(
+      [],
+      [
+        { id: "M1", symbolId: "nmos", position: { x: 0, y: 0 }, pins: ["G"] },
+        { id: "M2", symbolId: "nmos", position: { x: 0, y: 0 }, pins: ["G"] },
+      ],
+    );
+    expect(dotAt(twoPins, { x: -20, y: 0 })).toBe(false);
+
+    const threePins = documentWith(
+      [],
+      [
+        { id: "M1", symbolId: "nmos", position: { x: 0, y: 0 }, pins: ["G"] },
+        { id: "M2", symbolId: "nmos", position: { x: 0, y: 0 }, pins: ["G"] },
+        { id: "M3", symbolId: "nmos", position: { x: 0, y: 0 }, pins: ["G"] },
+      ],
+    );
+    expect(dotAt(threePins, { x: -20, y: 0 })).toBe(true);
   });
 
   it("never dots collinear overlapping arms ending on one pin", () => {
@@ -197,7 +349,7 @@ describe("contactRequiresJunctionDot", () => {
     expect(dotAt(document, { x: 0, y: 0 })).toBe(true);
   });
 
-  it("keeps a corner-into-pin tap dotted", () => {
+  it("dots a pin contact with three distinct visible directions", () => {
     const document = documentWith(
       [
         {

--- a/packages/derived/src/contact.ts
+++ b/packages/derived/src/contact.ts
@@ -35,8 +35,7 @@ export interface CoincidentContact {
   point: Point;
   endpoints: readonly RouteEndpoint[];
   incidents: readonly ContactIncident[];
-  /** Number of independently authored Route ends incident on this node. */
-  routeArmCount: number;
+  /** Distinct visible directions across both Route arms and terminal stems. */
   branchDirections: readonly Point[];
 }
 
@@ -176,8 +175,6 @@ function netContacts(
         point: { ...point },
         endpoints,
         incidents,
-        routeArmCount: incidents.filter((incident) => incident.kind === "route")
-          .length,
         branchDirections: [...directions.values()],
       };
     })
@@ -193,16 +190,12 @@ function netContacts(
 /**
  * Whether a confirmed same-Net contact needs a visible junction dot.
  *
- * A dot communicates a branch, not mere electrical continuity. Two incident
- * arms form either a straight join or a corner and remain dotless. A terminal
- * on a Route middle/bend contributes the Route arms on both sides and therefore
- * becomes a three-way branch. Three coincident pins also require a dot even if
- * two symbol stems happen to share the same geometric direction.
- *
- * Route arms count by DISTINCT direction: two same-Net arms arriving from the
- * same side lie on top of each other and paint as one conductor, so they can
- * never justify a dot the visible drawing cannot explain (the spec's "a
- * visible dot represents authored branch topology").
+ * A dot communicates a visible branch, not the number of model objects at a
+ * contact. Route arms and terminal stems that leave in the same direction
+ * paint as one conductor. A straight join, a corner, and a terminal stem that
+ * is collinear with a through-wire therefore remain dotless. Three distinct
+ * visible directions require a dot. Three coincident terminals also require a
+ * dot even when some symbol stems overlap geometrically.
  */
 export function contactRequiresJunctionDot(
   contact: CoincidentContact,
@@ -210,12 +203,7 @@ export function contactRequiresJunctionDot(
   const terminalCount = contact.endpoints.filter(
     (endpoint) => endpoint.kind === "terminal",
   ).length;
-  const distinctRouteDirections = new Set(
-    contact.incidents
-      .filter((incident) => incident.kind === "route")
-      .map((incident) => directionKey(incident.direction)),
-  ).size;
-  return terminalCount + distinctRouteDirections >= 3;
+  return terminalCount >= 3 || contact.branchDirections.length >= 3;
 }
 
 export function deriveDocumentContactEvidence(

--- a/packages/derived/src/routing-guidance.test.ts
+++ b/packages/derived/src/routing-guidance.test.ts
@@ -130,4 +130,49 @@ describe("routing guidance", () => {
       ).map((guide) => guide.netId),
     ).toEqual(["net-imported"]);
   });
+
+  it("routes an imported explicit MOS body through the canonical auxiliary B anchor", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.instances.push(
+      {
+        id: "XM1",
+        symbolId: "nmos",
+        placement: {
+          position: { x: 0, y: 0 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        id: "P1",
+        symbolId: "port",
+        placement: {
+          position: { x: 100, y: 0 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+    );
+    document.nets.push({
+      id: "net-imported-body",
+      scope: "local",
+      terminals: [
+        { instanceId: "XM1", pinName: "B" },
+        { instanceId: "P1", pinName: "P" },
+      ],
+      origin: { kind: "spice-import", sourceNetIds: ["source-body"] },
+    });
+
+    const guides = deriveImportedRoutingGuidance(
+      document,
+      new InMemorySymbolResolver(builtInSymbols),
+    );
+
+    expect(guides).toHaveLength(1);
+    expect([guides[0]!.from, guides[0]!.to]).toContainEqual({
+      kind: "terminal",
+      instanceId: "XM1",
+      pinName: "B",
+    });
+  });
 });

--- a/packages/edit-engine/src/hierarchy-planner.test.ts
+++ b/packages/edit-engine/src/hierarchy-planner.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { createEmptyDocument, createEmptyProject } from "@icm/model";
 
 import {
+  createExternalSubcircuitInstance,
   createHierarchyInstance,
   planAttachCellPortMarker,
   planCreateCellPort,
@@ -294,6 +295,7 @@ describe("reviewed external MOS model targets", () => {
       terminals: [{ name: "D" }, { name: "G" }, { name: "S" }, { name: "B" }],
     });
     expect(instance).toMatchObject({
+      symbolId: "nmos",
       schematicReference: "M1",
       netlist: {
         reference: "X1",
@@ -313,6 +315,41 @@ describe("reviewed external MOS model targets", () => {
       kind: "terminal",
       instanceId: "M1",
       pinName: "B",
+    });
+  });
+
+  it("places a reviewed external master with canonical MOS artwork", () => {
+    const project = projectWithNmos();
+    const result = executeProjectTransaction(project, {
+      transactionId: "create-sky130-definition",
+      projectId: project.id,
+      expectedStructureRevision: project.structureRevision,
+      actor: { kind: "human", id: "test" },
+      edits: planSetMosModelTarget(
+        project,
+        project.topDocumentId,
+        "M1",
+        "sky130_fd_pr__nfet_01v8",
+      ),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(
+      createExternalSubcircuitInstance(
+        "X2",
+        result.project.externalSubcircuitDefinitions[0]!,
+        {
+          position: { x: 100, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+      ),
+    ).toMatchObject({
+      symbolId: "nmos",
+      netlist: {
+        binding: { kind: "external-subcircuit" },
+      },
     });
   });
 

--- a/packages/edit-engine/src/hierarchy-planner.ts
+++ b/packages/edit-engine/src/hierarchy-planner.ts
@@ -17,6 +17,7 @@ import {
   externalSubcircuitSymbolId,
   hierarchicalSymbolId,
   resolvePdkSymbolMapping,
+  resolvePdkSymbolMappingForTerminalOrder,
 } from "@icm/symbols";
 
 import type { ProjectStructureEdit } from "./project-transaction.js";
@@ -117,20 +118,12 @@ function matchingExternalMosDefinition(
   const definition = project.externalSubcircuitDefinitions.find(
     (candidate) => candidate.id === definitionId,
   );
-  if (!definition) return undefined;
-  const mapping = resolvePdkSymbolMapping(
+  if (!definition || definition.presentation) return undefined;
+  const mapping = resolvePdkSymbolMappingForTerminalOrder(
     definition.name,
-    definition.terminals.length,
+    definition.terminals.map((terminal) => terminal.name),
   );
-  if (
-    !mapping ||
-    !definition.terminals.every(
-      (terminal, index) =>
-        terminal.name.toLowerCase() === mapping.pinNames[index]?.toLowerCase(),
-    )
-  ) {
-    return undefined;
-  }
+  if (!mapping) return undefined;
   return { definition, mapping };
 }
 
@@ -193,24 +186,18 @@ export function planSetMosModelTarget(
         formalParameters: [],
         interfaceStatus: "declared" as const,
       } satisfies ExternalSubcircuitDefinition);
-    const verified = resolvePdkSymbolMapping(
-      definition.name,
-      definition.terminals.length,
-    );
-    if (
-      !verified ||
-      verified.symbolId !== sourceMosSymbolId ||
-      !definition.terminals.every(
-        (terminal, index) =>
-          terminal.name.toLowerCase() ===
-          verified.pinNames[index]?.toLowerCase(),
-      )
-    ) {
+    const verified = definition.presentation
+      ? undefined
+      : resolvePdkSymbolMappingForTerminalOrder(
+          definition.name,
+          definition.terminals.map((terminal) => terminal.name),
+        );
+    if (!verified || verified.symbolId !== sourceMosSymbolId) {
       throw new Error(
         `Existing external definition ${definition.name} does not declare D, G, S, B in reviewed order`,
       );
     }
-    const symbolId = externalSubcircuitSymbolId(definition.id);
+    const symbolId = verified.symbolId;
     const reference =
       instance.netlist.binding?.kind === "external-subcircuit"
         ? instance.netlist.reference
@@ -311,9 +298,15 @@ export function createExternalSubcircuitInstance(
   placement: NonNullable<SchematicDocument["instances"][number]["placement"]>,
   reference = id,
 ): SchematicDocument["instances"][number] {
+  const mapping = definition.presentation
+    ? undefined
+    : resolvePdkSymbolMappingForTerminalOrder(
+        definition.name,
+        definition.terminals.map((terminal) => terminal.name),
+      );
   return {
     id,
-    symbolId: externalSubcircuitSymbolId(definition.id),
+    symbolId: mapping?.symbolId ?? externalSubcircuitSymbolId(definition.id),
     schematicReference: reference,
     placement,
     netlist: {

--- a/packages/edit-engine/src/project-transaction.test.ts
+++ b/packages/edit-engine/src/project-transaction.test.ts
@@ -5,7 +5,7 @@ import {
   createEmptyProject,
   flattenRichText,
 } from "@icm/model";
-import { hierarchicalSymbolId } from "@icm/symbols";
+import { externalSubcircuitSymbolId, hierarchicalSymbolId } from "@icm/symbols";
 
 import {
   planRenameCell,
@@ -688,5 +688,71 @@ describe("Project structural transaction", () => {
         ],
       },
     });
+  });
+
+  it("preserves a canonical MOS caller while its reviewed external definition stays compatible", () => {
+    const project = createEmptyProject("project", "Project");
+    const definition = {
+      id: "sky130-nfet",
+      name: "sky130_fd_pr__nfet_01v8",
+      terminals: ["D", "G", "S", "B"].map((name, index) => ({
+        id: `terminal-${index}`,
+        name,
+        direction: "passive" as const,
+      })),
+      formalParameters: [],
+      interfaceStatus: "declared" as const,
+    };
+    project.externalSubcircuitDefinitions.push(definition);
+    project.documents[0]!.instances.push({
+      id: "X1",
+      symbolId: "nmos",
+      placement: null,
+      netlist: {
+        reference: "X1",
+        binding: {
+          kind: "external-subcircuit",
+          definitionId: definition.id,
+        },
+        parameters: {},
+      },
+    });
+
+    const compatible = executeProjectTransaction(project, {
+      transactionId: "refresh-reviewed-external",
+      projectId: project.id,
+      expectedStructureRevision: project.structureRevision,
+      actor: { kind: "human", id: "test" },
+      edits: [{ kind: "upsert_external_subcircuit_definition", definition }],
+    });
+    expect(compatible.ok).toBe(true);
+    if (!compatible.ok) return;
+    expect(compatible.project.documents[0]!.instances[0]!.symbolId).toBe(
+      "nmos",
+    );
+
+    const incompatibleDefinition = {
+      ...definition,
+      terminals: definition.terminals.map((terminal, index) =>
+        index === 0 ? { ...terminal, name: "DRAIN" } : terminal,
+      ),
+    };
+    const incompatible = executeProjectTransaction(compatible.project, {
+      transactionId: "break-reviewed-external-order",
+      projectId: project.id,
+      expectedStructureRevision: compatible.project.structureRevision,
+      actor: { kind: "human", id: "test" },
+      edits: [
+        {
+          kind: "upsert_external_subcircuit_definition",
+          definition: incompatibleDefinition,
+        },
+      ],
+    });
+    expect(incompatible.ok).toBe(true);
+    if (!incompatible.ok) return;
+    expect(incompatible.project.documents[0]!.instances[0]!.symbolId).toBe(
+      externalSubcircuitSymbolId(definition.id),
+    );
   });
 });

--- a/packages/edit-engine/src/project-transaction.ts
+++ b/packages/edit-engine/src/project-transaction.ts
@@ -10,6 +10,7 @@ import {
   createProjectSymbolResolver,
   externalSubcircuitSymbolId,
   hierarchicalSymbolId,
+  resolvePdkSymbolMappingForTerminalOrder,
 } from "@icm/symbols";
 import { z } from "zod";
 
@@ -308,18 +309,29 @@ export function executeProjectTransaction(
           edit.definition,
         );
       }
+      const reviewedMapping = edit.definition.presentation
+        ? undefined
+        : resolvePdkSymbolMappingForTerminalOrder(
+            edit.definition.name,
+            edit.definition.terminals.map((terminal) => terminal.name),
+          );
+      const externalSymbolId = externalSubcircuitSymbolId(edit.definition.id);
       for (const document of candidate.documents) {
         let changed = false;
         for (const instance of document.instances) {
           const binding = instance.netlist?.binding;
           if (
             binding?.kind !== "external-subcircuit" ||
-            binding.definitionId !== edit.definition.id ||
-            instance.symbolId === externalSubcircuitSymbolId(edit.definition.id)
+            binding.definitionId !== edit.definition.id
           ) {
             continue;
           }
-          instance.symbolId = externalSubcircuitSymbolId(edit.definition.id);
+          const symbolId =
+            reviewedMapping?.symbolId === instance.symbolId
+              ? instance.symbolId
+              : externalSymbolId;
+          if (instance.symbolId === symbolId) continue;
+          instance.symbolId = symbolId;
           changed = true;
         }
         if (changed) {

--- a/packages/model/src/schema/routing.ts
+++ b/packages/model/src/schema/routing.ts
@@ -51,6 +51,7 @@ export const JunctionSchema = z.strictObject({
   id: StableIdSchema,
   netId: StableIdSchema,
   position: PointSchema,
-  // Omitted role preserves older Project behavior as a branch dot.
+  // Omitted role preserves the legacy branch-anchor topology. Visible dots are
+  // derived from contact directions rather than guaranteed by this role.
   role: JunctionRoleSchema.optional(),
 });

--- a/packages/netlist/src/current-contract.test.ts
+++ b/packages/netlist/src/current-contract.test.ts
@@ -464,4 +464,60 @@ describe("current formal cell interface", () => {
       { pinName: "A", netName: "NET_A" },
     ]);
   });
+
+  it("exports a canonical MOS symbol as an ordered external SKY130 X call", () => {
+    const project = createEmptyProject("project", "Project");
+    const document = project.documents[0]!;
+    project.externalSubcircuitDefinitions.push({
+      id: "sky130-nfet",
+      name: "sky130_fd_pr__nfet_01v8",
+      terminals: ["D", "G", "S", "B"].map((name, index) => ({
+        id: `terminal-${index}`,
+        name,
+        direction: "passive",
+      })),
+      formalParameters: [],
+      interfaceStatus: "declared",
+    });
+    document.instances.push({
+      id: "XM1",
+      symbolId: "nmos",
+      placement: null,
+      netlist: {
+        reference: "XM1",
+        binding: {
+          kind: "external-subcircuit",
+          definitionId: "sky130-nfet",
+        },
+        parameters: { l: "150n", w: "2u", nf: "4" },
+      },
+    });
+    for (const [pinName, netName] of [
+      ["D", "DRAIN"],
+      ["G", "GATE"],
+      ["S", "SOURCE"],
+      ["B", "BODY"],
+    ] as const) {
+      document.nets.push({
+        id: `net-${pinName.toLowerCase()}`,
+        name: netName,
+        scope: "local",
+        terminals: [{ instanceId: "XM1", pinName }],
+      });
+    }
+
+    const result = analyzeDesignNetlist(project);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.ir?.cells[0]!.instances[0]).toMatchObject({
+      reference: "XM1",
+      target: "sky130_fd_pr__nfet_01v8",
+      nodes: [
+        { pinName: "D", netName: "DRAIN" },
+        { pinName: "G", netName: "GATE" },
+        { pinName: "S", netName: "SOURCE" },
+        { pinName: "B", netName: "BODY" },
+      ],
+    });
+  });
 });

--- a/packages/netlist/src/current-contract.test.ts
+++ b/packages/netlist/src/current-contract.test.ts
@@ -269,6 +269,60 @@ describe("current formal cell interface", () => {
     expect(result.ir?.globals).toEqual(["0"]);
   });
 
+  it("exports a local named VDD Port Net without inventing a marker record", () => {
+    const project = createEmptyProject("project", "Project");
+    const document = project.documents[0]!;
+    document.instances.push({
+      id: "VDD1",
+      symbolId: "vdd-port",
+      placement: null,
+    });
+    document.nets.push({
+      id: "net-vdd",
+      name: "VDD",
+      scope: "local",
+      powerDomain: "vdd",
+      terminals: [{ instanceId: "VDD1", pinName: "P" }],
+    });
+
+    const result = analyzeDesignNetlist(project);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.ir?.cells[0]?.instances).toEqual([]);
+    expect(result.ir?.cells[0]?.nets).toContainEqual({
+      id: "net-vdd",
+      name: "VDD",
+      scope: "local",
+    });
+    expect(result.ir?.globals).toEqual([]);
+  });
+
+  it("rejects a VDD Port attached to a named non-VDD Net", () => {
+    const project = createEmptyProject("project", "Project");
+    const document = project.documents[0]!;
+    document.instances.push({
+      id: "VDD1",
+      symbolId: "vdd-port",
+      placement: null,
+    });
+    document.nets.push({
+      id: "net-signal",
+      name: "SIGNAL",
+      scope: "local",
+      terminals: [{ instanceId: "VDD1", pinName: "P" }],
+    });
+
+    const result = analyzeDesignNetlist(project);
+
+    expect(result.ir).toBeNull();
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "INVALID_NET_MARKER",
+        objectIds: ["VDD1", "net-signal"],
+      }),
+    );
+  });
+
   it("emits a resolved shared external interface without inventing an empty Cell", () => {
     const project = createEmptyProject("project", "Project");
     const document = project.documents[0]!;

--- a/packages/netlist/src/extract.ts
+++ b/packages/netlist/src/extract.ts
@@ -599,20 +599,34 @@ function extractDeviceInstance(
     const markerNet = context.netByTerminal.get(
       `${instance.id}\u0000${definition.pinOrder[0]}`,
     );
-    if (!markerNet || markerNet.scope !== "global" || !markerNet.name) {
+    if (!markerNet || !markerNet.name) {
       diagnostic(
         diagnostics,
         document.id,
         "INVALID_NET_MARKER",
-        `Net marker ${instance.id} must connect to an explicitly named global Net`,
+        `Net marker ${instance.id} must connect to an explicitly named Net`,
         [instance.id],
       );
-    } else if (instance.symbolId === "ground" && markerNet.name !== "0") {
+    } else if (
+      instance.symbolId === "ground" &&
+      (markerNet.scope !== "global" || markerNet.name !== "0")
+    ) {
       diagnostic(
         diagnostics,
         document.id,
         "GROUND_NAME_MISMATCH",
-        `Ground marker must connect to global Net 0, not ${markerNet.name}`,
+        `Ground marker must connect to global Net 0, not ${markerNet.scope} Net ${markerNet.name}`,
+        [instance.id, markerNet.id],
+      );
+    } else if (
+      instance.symbolId === "vdd-port" &&
+      markerNet.powerDomain !== "vdd"
+    ) {
+      diagnostic(
+        diagnostics,
+        document.id,
+        "INVALID_NET_MARKER",
+        `VDD Port ${instance.id} must connect to an explicitly classified VDD Net`,
         [instance.id, markerNet.id],
       );
     }

--- a/packages/spice/src/compiler.test.ts
+++ b/packages/spice/src/compiler.test.ts
@@ -255,6 +255,15 @@ Q2 collector base emitter QPREF
             instance.netlist?.binding?.kind === "external-subcircuit",
         ),
     ).toBe(true);
+    expect(
+      document.instances
+        .filter((instance) => !interfaceInstanceIds.has(instance.id))
+        .map((instance) => instance.symbolId)
+        .filter(
+          (symbolId, index, symbols) => symbols.indexOf(symbolId) === index,
+        )
+        .sort(),
+    ).toEqual(["nmos", "pmos"]);
     expect(document.instances[0]!.importProvenance).toMatchObject({
       kind: "opaque",
       name: "sky130_fd_pr__nfet_01v8",
@@ -273,6 +282,9 @@ Q2 collector base emitter QPREF
       binding: expect.objectContaining({ kind: "external-subcircuit" }),
       parameters: { l: "1.0", w: "96", nf: "12" },
     });
+    expect(document.instances[0]).toMatchObject({
+      symbolId: "nmos",
+    });
     const resolved = createProjectSymbolResolver(
       imported.project!,
       builtInSymbols,
@@ -282,9 +294,13 @@ Q2 collector base emitter QPREF
       definition: {
         pins: nmos?.pins,
         primitives: nmos?.primitives,
-        variants: [],
-        hierarchicalBlock: true,
+        defaultVariantId: "textbook-3terminal",
+        variants: nmos?.variants,
       },
+      variant: expect.objectContaining({
+        id: "textbook-3terminal",
+        hiddenPinNames: ["B"],
+      }),
     });
     expect(
       document.nets

--- a/packages/spice/src/importer.ts
+++ b/packages/spice/src/importer.ts
@@ -112,9 +112,11 @@ function symbolFor(
       symbolMappings,
     );
     return {
-      symbolId: externalSubcircuitSymbolId(
-        externalDefinitionId(instance.target.masterName),
-      ),
+      symbolId:
+        mapping?.symbolId ??
+        externalSubcircuitSymbolId(
+          externalDefinitionId(instance.target.masterName),
+        ),
       ...(mapping?.pinNames ? { pinNames: mapping.pinNames } : {}),
       ...(mapping?.registryId ? { registryId: mapping.registryId } : {}),
     };
@@ -480,9 +482,6 @@ function bindImportedChildDocuments(documents: readonly SchematicDocument[]): {
         : undefined;
       return {
         ...referencedInstance,
-        ...(externalDefinition
-          ? { symbolId: externalSubcircuitSymbolId(externalDefinition.id) }
-          : {}),
         importProvenance: {
           ...instance.importProvenance,
           status: childDocumentId

--- a/packages/symbols/src/hierarchical-block.test.ts
+++ b/packages/symbols/src/hierarchical-block.test.ts
@@ -198,7 +198,7 @@ describe("external PDK symbol presentation", () => {
     ["sky130_fd_pr__nfet_01v8", "nmos"],
     ["sky130_fd_pr__pfet_01v8", "pmos"],
   ])(
-    "uses four-terminal %s MOS artwork without changing external identity",
+    "retains canonical %s MOS presentation for existing external identity",
     (name, baseId) => {
       const symbol = createProjectHierarchicalSymbols(
         projectWithExternal(name),
@@ -215,9 +215,9 @@ describe("external PDK symbol presentation", () => {
         hierarchicalBlock: true,
         pins: base?.pins,
         primitives: base?.primitives,
-        variants: [],
+        defaultVariantId: "textbook-3terminal",
+        variants: base?.variants,
       });
-      expect(symbol).not.toHaveProperty("defaultVariantId");
       expect(symbol?.pins.map((pin) => pin.name)).toEqual(["D", "G", "S", "B"]);
     },
   );

--- a/packages/symbols/src/hierarchical-block.ts
+++ b/packages/symbols/src/hierarchical-block.ts
@@ -2,7 +2,7 @@ import { deriveStableId } from "@icm/model";
 import type { CircuitProject, SchematicDocument } from "@icm/model";
 
 import { createHierarchicalBlockGeometry } from "./hierarchical-block-geometry.js";
-import { resolvePdkSymbolMapping } from "./pdk-registry.js";
+import { resolvePdkSymbolMappingForTerminalOrder } from "./pdk-registry.js";
 import { SymbolDefinitionSchema } from "./schema.js";
 import type { SymbolDefinition } from "./schema.js";
 
@@ -65,38 +65,21 @@ export function createProjectHierarchicalSymbols(
     (definition) => {
       const mapping = definition.presentation
         ? undefined
-        : resolvePdkSymbolMapping(definition.name, definition.terminals.length);
+        : resolvePdkSymbolMappingForTerminalOrder(
+            definition.name,
+            definition.terminals.map((terminal) => terminal.name),
+          );
       const mappedDefinition = mapping
         ? baseDefinitions.find((candidate) => candidate.id === mapping.symbolId)
         : undefined;
-      const orderedTerminalNames = definition.terminals.map((terminal) =>
-        terminal.name.toLowerCase(),
-      );
-      const orderedMappedPins = mapping?.pinNames.map((name) =>
-        name.toLowerCase(),
-      );
-      if (
-        mappedDefinition &&
-        orderedMappedPins &&
-        orderedTerminalNames.every(
-          (name, index) => name === orderedMappedPins[index],
-        )
-      ) {
-        const {
-          id: _baseId,
-          name: _baseName,
-          defaultVariantId: _defaultVariantId,
-          variants: _variants,
-          decorative: _decorative,
-          ...artwork
-        } = mappedDefinition;
+      if (mappedDefinition) {
+        const { id: _baseId, name: _baseName, ...artwork } = mappedDefinition;
         return [
           SymbolDefinitionSchema.parse({
             ...artwork,
             id: externalSubcircuitSymbolId(definition.id),
             name: definition.name,
             hierarchicalBlock: true,
-            variants: [],
           }),
         ];
       }

--- a/packages/symbols/src/pdk-registry.test.ts
+++ b/packages/symbols/src/pdk-registry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   resolvePdkSymbolMapping,
+  resolvePdkSymbolMappingForTerminalOrder,
   reviewedSky130MosModelSuggestions,
 } from "./pdk-registry.js";
 
@@ -37,6 +38,25 @@ describe("PDK symbol mapping registry", () => {
     ).toBeUndefined();
     expect(
       resolvePdkSymbolMapping("sky130_fd_pr__nfet_01v8", 3),
+    ).toBeUndefined();
+  });
+
+  it("accepts only the reviewed ordered external terminal interface", () => {
+    expect(
+      resolvePdkSymbolMappingForTerminalOrder("sky130_fd_pr__nfet_01v8", [
+        "D",
+        "G",
+        "S",
+        "B",
+      ]),
+    ).toMatchObject({ symbolId: "nmos" });
+    expect(
+      resolvePdkSymbolMappingForTerminalOrder("sky130_fd_pr__nfet_01v8", [
+        "G",
+        "D",
+        "S",
+        "B",
+      ]),
     ).toBeUndefined();
   });
 

--- a/packages/symbols/src/pdk-registry.ts
+++ b/packages/symbols/src/pdk-registry.ts
@@ -89,3 +89,22 @@ export function resolvePdkSymbolMapping(
       }
     : undefined;
 }
+
+export function resolvePdkSymbolMappingForTerminalOrder(
+  modelName: string,
+  terminalNames: readonly string[],
+  exactOverrides: readonly PdkSymbolMappingOverride[] = [],
+): PdkSymbolMapping | undefined {
+  const mapping = resolvePdkSymbolMapping(
+    modelName,
+    terminalNames.length,
+    exactOverrides,
+  );
+  return mapping &&
+    terminalNames.every(
+      (name, index) =>
+        name.toLowerCase() === mapping.pinNames[index]?.toLowerCase(),
+    )
+    ? mapping
+    : undefined;
+}

--- a/plan/2026-08-22-junction-visible-directions/plan.md
+++ b/plan/2026-08-22-junction-visible-directions/plan.md
@@ -1,0 +1,91 @@
+---
+status: completed
+experience: none
+---
+
+# Derive Junction Dots from Visible Directions
+
+## Goal
+
+Make a visible Junction dot represent a real visual branch: collinear Route
+arms and a collinear terminal stem form one conductor direction, while true
+three-direction branches and three-or-more coincident terminals remain dotted.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/junction-visible-directions...origin/main
+```
+
+The dedicated worktree is clean and starts at `origin/main@1634ed2c`. The root
+worktree and its unrelated user/worker state are outside this target.
+
+- `packages/derived/src/contact.ts`
+- `packages/derived/src/contact.test.ts`
+- `apps/editor/e2e/manual-editor.spec.ts`
+- `docs/specs/connectivity-and-routing.md`
+- `packages/model/src/schema/routing.ts` (comment-only contract clarification)
+- `plan/2026-08-22-junction-visible-directions/plan.md`
+- `plan/log.md`
+
+Shared dependencies: resolved terminal directions, resolved Route geometry,
+SVG Junction rendering, and the accepted connectivity/routing specification.
+The Edit Engine, persisted Route/Junction shapes, Net membership, and symbol
+geometry are read-only and must not change.
+
+## Work
+
+1. Classify visible branches from distinct directions across both Route and
+   terminal incidents, retaining the explicit three-terminal override.
+2. Replace the incorrect straight-through-pin expectation and add exact MOS,
+   perpendicular tap, corner, rotation/mirroring, and 45-degree coverage.
+3. Add one browser regression proving three collinear MOS Gates render without
+   a contact dot, then align the accepted specification and schema comment.
+
+## Validation
+
+- `pnpm test:local packages/derived/src/contact.test.ts`
+- `pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts --grep "collinear MOS Gates"`
+- `pnpm gate:preflight -- --base origin/main`
+- `pnpm gate:affected -- --base origin/main`
+- `pnpm test:impact -- --base origin/main`
+- `git diff --check`
+- `git status --short --branch`
+
+## Gate Review
+
+- Decision: affected
+- Early gates: `gate:review:check`, `ci:static`, and `test:impact`
+- Affected gates: derived unit tests; model comment conservatively selects
+  hierarchy and project-file browser checks
+- Final gates: branch delivery requires `pnpm ci:check` and remote required
+  checks before any later merge to `main`; this target stops at a review branch
+- Platform risks: SVG/browser regression and transformed pin directions;
+  no generated artifact or release path is owned
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: visible dot classification, collinear terminal continuity, true
+  branch display, transformed pin direction, and octilinear direction handling
+- Primary checks: `packages/derived/src/contact.test.ts` and the focused
+  `apps/editor/e2e/manual-editor.spec.ts` scenario
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(connectivity): derive junction dots from visible directions
+```
+
+## Outcome
+
+Junction dots now derive from distinct visible directions across Route arms and
+terminal stems, with a separate three-terminal override. The obsolete raw
+Route-arm count was removed, the accepted specification and Junction role
+comment now distinguish topology anchors from visual dots, and unit/browser
+regressions cover the reported three-MOS case plus transforms and 45-degree
+branches. Focused tests, preflight, build, and all affected gates passed.

--- a/plan/2026-08-22-sky130-canonical-mos-mapping/plan.md
+++ b/plan/2026-08-22-sky130-canonical-mos-mapping/plan.md
@@ -1,0 +1,124 @@
+---
+status: completed
+experience: none
+---
+
+# Reuse canonical MOS symbols for reviewed SKY130 external calls
+
+## Goal
+
+Map reviewed SKY130 four-node external calls onto the existing canonical
+`nmos`/`pmos` symbols, while retaining their external-subcircuit binding,
+ordered D/G/S/B connectivity, X reference, master name, parameters, and
+round-trip netlist behavior. Confirm that the existing explicit-B auxiliary
+anchor and imported routing-guidance path supplies the expected Bulk flightline
+without changing the MOS electrical protocol.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/sky130-canonical-mos-mapping
+```
+
+The dedicated worktree is clean. Root-level untracked `.worktrees/` and
+`.pnpm-store/` belong to workspace infrastructure and are outside this
+worktree and target.
+
+- `packages/spice/src/importer.ts`
+- `packages/spice/src/compiler.test.ts`
+- `packages/edit-engine/src/hierarchy-planner.ts`
+- `packages/edit-engine/src/hierarchy-planner.test.ts`
+- `packages/edit-engine/src/project-transaction.ts`
+- `packages/edit-engine/src/project-transaction.test.ts`
+- `packages/symbols/src/pdk-registry.ts`
+- `packages/symbols/src/pdk-registry.test.ts`
+- `packages/symbols/src/hierarchical-block.ts`
+- `packages/symbols/src/hierarchical-block.test.ts`
+- `packages/derived/src/routing-guidance.test.ts`
+- `packages/netlist/src/current-contract.test.ts`
+- `apps/editor/src/app/App.tsx`
+- `apps/editor/e2e/manual-editor.spec.ts`
+- this target plan and `plan/log.md`
+
+Shared dependencies are the accepted external-definition binding contract,
+canonical MOS D/G/S/B symbol/device contracts, and derived Bulk visibility and
+routing guidance. The model schema, device descriptors, MOS symbol assets,
+generated artifacts, and netlist extractor are read-only for this target.
+
+## Work
+
+1. Preserve the reviewed PDK mapping's canonical MOS `symbolId` through both
+   SPICE import passes while keeping the external definition binding.
+2. Keep canonical `nmos`/`pmos` symbols when switching Model targets and when
+   upserting compatible external definitions; retain generic external symbols
+   for unknown or incompatible definitions.
+3. Keep the existing Insert workflow but use canonical MOS artwork and
+   placement for reviewed external masters; retain the generic external path
+   for other definitions.
+4. Remove the special four-terminal SKY130 artwork expectation and prove the
+   canonical three-terminal presentation, explicit B endpoint guidance, and
+   external X-call export contract with focused tests.
+
+## Validation
+
+- `pnpm test:local packages/spice/src/compiler.test.ts packages/edit-engine/src/hierarchy-planner.test.ts packages/edit-engine/src/project-transaction.test.ts packages/symbols/src/pdk-registry.test.ts packages/symbols/src/hierarchical-block.test.ts packages/derived/src/routing-guidance.test.ts packages/netlist/src/current-contract.test.ts`
+- `pnpm gate:preflight -- --base origin/main`
+- `pnpm gate:affected -- --base origin/main`
+- `pnpm test:impact -- --base origin/main`
+- `git diff --check`
+- `git status --short --branch`
+
+## Gate Review
+
+- Decision: affected
+- Early gates: `gate-review`, `ci:static`, and `test:impact`
+- Affected gates: workspace unit tests and hierarchy browser coverage
+- Final gates: `pnpm ci:check` before any mainline delivery; this branch target
+  will first complete focused and affected validation
+- Platform risks: external-definition changes cross importer, editor planning,
+  symbol resolution, and hierarchy browser behavior; no generated or release
+  artifact is intentionally changed
+
+The advisory path plan selected workspace unit tests plus
+`apps/editor/e2e/hierarchy.spec.ts`; no full fallback was required.
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: reviewed SKY130 X calls reuse canonical MOS presentation and
+  explicit Bulk guidance while preserving D/G/S/B external netlist order
+- Primary checks: `packages/spice/src/compiler.test.ts`,
+  `packages/edit-engine/src/hierarchy-planner.test.ts`,
+  `packages/edit-engine/src/project-transaction.test.ts`, and
+  `packages/derived/src/routing-guidance.test.ts`, with direct external export
+  protection in `packages/netlist/src/current-contract.test.ts` and the
+  existing Model-field browser workflow in `apps/editor/e2e/manual-editor.spec.ts`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(schematic): reuse canonical MOS for SKY130 calls
+```
+
+## Outcome
+
+Reviewed SKY130 external calls now keep canonical `nmos`/`pmos` symbols across
+SPICE import, the existing Model field, compatible definition updates, and the
+unchanged Insert workflow. Their external definition, X reference, raw
+parameters, and ordered D/G/S/B node contract remain authoritative for export.
+Unknown, incompatible, or explicitly presented external definitions retain the
+generic external-symbol path. The pre-existing auxiliary B endpoint and
+imported routing-guidance implementation required no production change; a new
+test demonstrates that explicit imported B membership produces its flightline.
+
+Validation passed: focused tests (64), preflight static/type/test-impact gates,
+affected workspace units (183 files / 1171 tests), hierarchy Playwright (12),
+manual-editor Playwright (93), the focused SKY130 Model-field browser case,
+workspace build, production preview smoke, `pnpm verify:branch`, and
+`git diff --check`. The first affected run reached the browser suites before a
+clean worktree build had created package `dist` files; building the workspace
+resolved that environment prerequisite, and the complete affected rerun passed.

--- a/plan/2026-08-22-stack-sky130-vdd-junction-mainline/plan.md
+++ b/plan/2026-08-22-stack-sky130-vdd-junction-mainline/plan.md
@@ -1,0 +1,93 @@
+---
+status: completed
+experience: none
+---
+
+# Stack SKY130, VDD Export, and Junction Direction Work
+
+## Goal
+
+Deliver the completed canonical SKY130 MOS mapping, local named VDD Port
+export correction, and visible-direction Junction-dot correction as one linear
+review stack on the latest remote `main`, preserving each accepted contract and
+passing the canonical mainline gate before merge.
+
+## State and Ownership
+
+The integration worktree was clean. Remote `main` advanced from the original
+feature base `f6fe3d01` to `dff17f82`, so the SKY130/VDD stack was rebased first.
+Its only conflict was additive `plan/log.md` history; both sides were retained.
+
+Owned integration surface:
+
+- the three existing feature commits and their plans
+- overlap resolution in `apps/editor/e2e/manual-editor.spec.ts` and
+  `plan/log.md`
+- this integration plan and `plan/log.md`
+
+All functional files remain owned by their completed feature plans. No protocol
+or behavior expansion is authorized during stacking. Latest-main editor fixes,
+the existing D/G/S/B MOS electrical contract, VDD/Ground marker semantics, and
+persisted connectivity topology are shared dependencies.
+
+## Work
+
+1. Rebase the SKY130/VDD stack onto the latest `origin/main`.
+2. Stack `codex/junction-visible-directions` above it, resolving only genuine
+   additive overlap and preserving both sets of tests and factual logs.
+3. Review the combined diff for semantic consistency and unnecessary protocol
+   additions.
+4. Run focused union checks, advisory affected gates, and the canonical clean
+   `pnpm install --frozen-lockfile` plus `pnpm ci:check` mainline gate.
+5. Push the rebased review branch, open one PR, wait for required checks, and
+   merge it to `main` only after green status.
+
+## Validation
+
+- `pnpm gate:plan -- --base origin/main`
+- focused netlist, SKY130 mapping, contact, and junction browser contracts
+- `pnpm gate:preflight -- --base origin/main`
+- `pnpm gate:affected -- --base origin/main`
+- `pnpm test:impact -- --base origin/main`
+- `pnpm install --frozen-lockfile`
+- `pnpm ci:check`
+- corresponding GitHub Actions required checks
+- `git diff --check`
+- `git status --short --branch`
+
+## Gate Review
+
+- Decision: full
+- Early gates: gate review, static contracts, and test-impact for the complete
+  three-commit diff
+- Affected gates: workspace units plus hierarchy/project/manual-editor browser
+  contracts selected across netlist, importer, symbol, edit-engine, model, and
+  derived-contact boundaries
+- Final gates: canonical local `ci:check` from frozen dependencies and remote
+  required checks are mandatory before merging to `main`
+- Platform risks: browser junction rendering and production editor smoke;
+  no release artifact or persisted-schema migration is introduced
+
+## Test Impact
+
+- Decision: tests-updated
+- Existing feature tests protect canonical SKY130 presentation with D/G/S/B
+  binding, legal local VDD marker export, Ground node `0`, and visible Junction
+  classification across route/terminal directions and transforms.
+- The integration adds no duplicate test layer; it validates the union.
+
+## Commit Intent
+
+Keep the three functional commits separate and add only an integration-record
+commit if required after conflict resolution and delivery logging.
+
+## Outcome
+
+Rebased the SKY130/VDD commits onto `origin/main@dff17f82` and stacked the
+Junction visible-direction commit above them. Both Git conflicts were additive
+`plan/log.md` tails; every mainline and feature record was retained, while all
+functional code and tests merged without manual protocol changes. Focused
+contracts passed 78/78 units and 1/1 browser test; affected gates passed 1185
+units, 12 hierarchy, 8 project-file, and 98 manual-editor browser tests. The
+canonical frozen-install `ci:check` passed static contracts, build, goldens,
+production/release/MCP smoke, 1185 units, and 205 browser tests.

--- a/plan/2026-08-22-vdd-port-local-net-export/plan.md
+++ b/plan/2026-08-22-vdd-port-local-net-export/plan.md
@@ -1,0 +1,91 @@
+---
+status: completed
+experience: none
+---
+
+# Permit local named VDD Port Nets in netlist export
+
+## Goal
+
+Align design-netlist validation with the accepted named-power policy: a VDD
+Port connected to an explicitly named `powerDomain: vdd` Net may be local or
+global and emits no device record, while Ground continues to require the
+explicit global node `0`.
+
+## State and Ownership
+
+Start state from `git status --short --branch`:
+
+```text
+## codex/sky130-canonical-mos-mapping...origin/codex/sky130-canonical-mos-mapping
+```
+
+The dedicated worktree is clean after the completed SKY130 canonical-MOS
+commit. This is a separate export-contract correction found during localhost
+acceptance testing.
+
+- `packages/netlist/src/extract.ts`
+- `packages/netlist/src/current-contract.test.ts`
+- `docs/specs/netlist-export.md`
+- this target plan and `plan/log.md`
+
+Shared dependencies are ADR 0036's local named VDD policy, the `vdd-port` and
+`ground` device descriptors, and the persisted `Net.name`, `scope`, and
+`powerDomain` facts. Editor authoring and model schemas are read-only.
+
+## Work
+
+1. Separate Ground validation from VDD Port validation instead of imposing the
+   Ground global-Net rule on every net marker.
+2. Require VDD Port to reference an explicitly named VDD-domain Net, without
+   restricting that Net to global scope.
+3. Add direct export tests for legal local VDD, legal Ground, and invalid VDD
+   classification while retaining non-emitting marker behavior.
+4. Correct the deterministic netlist specification to match current VDD Port
+   authoring semantics.
+
+## Validation
+
+- `pnpm test:local packages/netlist/src/current-contract.test.ts`
+- `pnpm gate:preflight -- --base 3be59366`
+- `pnpm gate:affected -- --base 3be59366`
+- `pnpm test:impact -- --base 3be59366`
+- `git diff --check`
+- `git status --short --branch`
+
+## Gate Review
+
+- Decision: affected
+- Early gates: gate-review, static contracts, and test-impact
+- Affected gates: workspace unit tests selected by the netlist extractor and
+  its current-contract suite
+- Final gates: `pnpm ci:check` remains required before mainline delivery
+- Platform risks: none beyond shared SPICE/Spectre extraction behavior; no
+  generated or browser artifact changes
+
+The advisory path plan selected workspace unit coverage and no full fallback.
+The base is the preceding completed SKY130 commit so this stacked target's
+validation selection is isolated from the already-validated first target.
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: local named VDD Port Nets export without a marker instance;
+  Ground remains global node `0`; a VDD Port cannot bless a non-VDD Net
+- Primary checks: `packages/netlist/src/current-contract.test.ts`
+
+## Commit Intent
+
+Commit as:
+
+```text
+fix(netlist): allow local named VDD ports
+```
+
+## Outcome
+
+Separated shared net-marker validation from marker-specific electrical rules.
+VDD Port now accepts an explicitly named local or global VDD-domain Net and
+remains non-emitting; Ground still requires the explicit global Net `0`.
+Focused coverage passed 17/17, and the affected workspace unit sweep passed
+1173/1173 after static, type, documentation, and test-impact preflight checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4814,3 +4814,15 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   hierarchy Playwright (12), manual-editor Playwright (93), branch verification,
   workspace build, production smoke, test-impact, and diff checks.
 - Commit status: completed on `codex/sky130-canonical-mos-mapping`.
+
+## 2026-08-22 - Local named VDD Port netlist export
+
+- Target: `plan/2026-08-22-vdd-port-local-net-export/plan.md` (completed).
+- Changed areas: net-marker extraction now applies the global-Net requirement
+  only to Ground; a VDD Port accepts an explicitly named local or global
+  `powerDomain: vdd` Net, emits no marker record, and rejects named non-VDD
+  Nets. The deterministic export specification now records the same policy.
+- Validation: focused netlist contract (17), preflight static/type/docs and
+  test-impact checks, affected workspace units (1173), and diff checks.
+- Commit status: completed on `codex/sky130-canonical-mos-mapping` as a stacked
+  fix after the canonical SKY130 MOS commit.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4844,3 +4844,19 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   Playwright (12), project-file Playwright (8), and workspace build passed.
 - Commit status: completed on `codex/junction-visible-directions`; mainline
   delivery remains gated on the canonical local and remote checks.
+
+## 2026-08-22 - Stacked SKY130, VDD export, and Junction mainline delivery
+
+- Target: `plan/2026-08-22-stack-sky130-vdd-junction-mainline/plan.md`
+  (completed).
+- Changed areas: rebased the canonical SKY130 MOS and local named VDD export
+  commits onto `origin/main@dff17f82`, then stacked the Junction
+  visible-direction commit. Only additive plan-log conflicts required manual
+  resolution; no new model, binding, routing, or persistence protocol was
+  introduced during integration.
+- Validation: focused union units (78) and Junction browser case (1), preflight,
+  affected units (1185), hierarchy (12), project-file (8), manual-editor (98),
+  frozen dependency install, and canonical `ci:check` including build, release
+  smoke, and all 205 browser tests.
+- Commit status: stacked review branch prepared for required remote checks and
+  one PR merge to `main`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4803,3 +4803,14 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   (Expected 70, Received 0); typecheck, prettier, diff checks.
 - Commit status: completed on `claude/marquee-drag`; mainline merge gated on
   the remote required checks.
+## 2026-08-22 - Canonical MOS presentation for SKY130 calls
+
+- Target: `plan/2026-08-22-sky130-canonical-mos-mapping/plan.md` (completed).
+- Changed areas: reviewed SKY130 external calls now reuse canonical
+  `nmos`/`pmos` symbols through import, Model-field switching, definition
+  synchronization, and Insert, while preserving external X binding and ordered
+  D/G/S/B export; incompatible external definitions keep the generic block.
+- Validation: focused contracts (64), preflight, affected units (1171),
+  hierarchy Playwright (12), manual-editor Playwright (93), branch verification,
+  workspace build, production smoke, test-impact, and diff checks.
+- Commit status: completed on `codex/sky130-canonical-mos-mapping`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4803,6 +4803,7 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   (Expected 70, Received 0); typecheck, prettier, diff checks.
 - Commit status: completed on `claude/marquee-drag`; mainline merge gated on
   the remote required checks.
+
 ## 2026-08-22 - Canonical MOS presentation for SKY130 calls
 
 - Target: `plan/2026-08-22-sky130-canonical-mos-mapping/plan.md` (completed).
@@ -4826,3 +4827,20 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   test-impact checks, affected workspace units (1173), and diff checks.
 - Commit status: completed on `codex/sky130-canonical-mos-mapping` as a stacked
   fix after the canonical SKY130 MOS commit.
+
+## 2026-08-22 - Junction dots follow visible conductor directions
+
+- Changed areas: contact evidence now classifies a visible Junction dot from
+  distinct Route-arm and terminal-stem directions instead of adding terminal
+  objects to Route direction counts; three-or-more coincident terminals remain
+  an explicit dot rule. Removed the unused raw Route-arm count and aligned the
+  connectivity specification and Junction-role comment.
+- Protected cases: three collinear MOS Gates stay electrically connected but
+  dotless at the middle Gate; true perpendicular taps, three-way and 45-degree
+  branches remain dotted; right-angle terminal exits, rotation, and mirroring
+  use the same direction protocol.
+- Validation: focused derived tests (12), focused Playwright regression (1),
+  preflight/static/typecheck, full affected unit suite (1177), hierarchy
+  Playwright (12), project-file Playwright (8), and workspace build passed.
+- Commit status: completed on `codex/junction-visible-directions`; mainline
+  delivery remains gated on the canonical local and remote checks.


### PR DESCRIPTION
## Summary
- reuse canonical NMOS/PMOS presentation for reviewed SKY130 external-subcircuit calls while retaining D/G/S/B binding and X export
- allow named local VDD-domain Nets to pass non-emitting VDD Port export validation while Ground remains global node 0
- derive visible junction dots from distinct Route-arm and terminal-stem directions
- stack all three commits on the latest main without adding a new persistence or binding protocol

## Validation
- focused union: 78 unit tests and 1 browser regression
- affected gates: 1185 units, hierarchy 12, project-file 8, manual-editor 98
- canonical frozen-install pnpm ci:check: static/build/goldens/release smoke, 1185 units, 205 browser tests