### PR TITLE
fix(editor): retire the stale gallery update offer

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -753,6 +753,8 @@ test("an opened gallery entry offers updating in place", async ({ page }) => {
   const dialog = page.getByTestId("publish-gallery-dialog");
   await expect(dialog).toBeVisible();
   await expect(page.getByTestId("publish-mode")).toBeVisible();
+  // The update option names exactly what it will replace.
+  await expect(page.getByTestId("publish-mode")).toContainText(ENTRY.name);
   await expect(dialog.getByText("updates the entry in place")).toBeVisible();
 
   await dialog.getByRole("button", { name: "Update entry" }).click();
@@ -761,6 +763,63 @@ test("an opened gallery entry offers updating in place", async ({ page }) => {
   );
   expect(updates).toHaveLength(1);
   expect(updates[0]!.body.name).toBe(ENTRY.name);
+});
+
+test("replacing the project retires the stale update offer", async ({
+  page,
+}) => {
+  await mockGallery(page, [ENTRY]);
+  await page.route("**/api/gallery?limit=60", (route) =>
+    // The panel sees an empty gallery, so it offers the bundled examples
+    // — opening one replaces the Project with a non-gallery one.
+    route.fulfill({ json: { entries: [], nextCursor: null } }),
+  );
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      json: {
+        user: {
+          id: "u1",
+          displayName: "Token Zhang",
+          email: "owner@example.com",
+          provider: "github",
+          role: "user",
+          isAdmin: true,
+        },
+      },
+    }),
+  );
+
+  await page.goto(`/g/${ENTRY.id}`);
+  await expect(page.getByTestId("status")).toContainText(
+    `Opened gallery circuit: ${ENTRY.name}`,
+  );
+
+  // Sanity: while the entry is the active Project, updating is offered.
+  await page.getByTestId("publish-gallery-button").click();
+  await expect(page.getByTestId("publish-mode")).toBeVisible();
+  await page
+    .getByTestId("publish-gallery-dialog")
+    .getByRole("button", { name: "Cancel" })
+    .click();
+
+  // Import a different Project over it: the gallery entry is no longer
+  // active, so publishing must NOT offer updating it any more.
+  await page.getByTestId("project-file").setInputFiles({
+    name: "fresh.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(
+      serializeProject(createEmptyProject("fresh-project", "Fresh Start")),
+    ),
+  });
+  await expect(page.getByTestId("status")).toContainText(
+    "Opened fresh.icproj.json",
+  );
+
+  await page.getByTestId("publish-gallery-button").click();
+  const dialog = page.getByTestId("publish-gallery-dialog");
+  await expect(dialog).toBeVisible();
+  await expect(page.getByTestId("publish-mode")).toHaveCount(0);
+  await expect(dialog.getByRole("button", { name: "Publish" })).toBeVisible();
 });
 
 test("the Examples panel lists the gallery and opens an entry", async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -681,11 +681,24 @@ export function App({
   );
   const [galleryEntryContext, setGalleryEntryContext] = useState<{
     id: string;
+    name: string;
+    /** The opened Project's id: the context is only valid while that
+     * exact Project is still the active one. */
+    projectId: string;
     ownerUserId: string | null;
     author: string;
     description: string;
     tags: readonly string[];
   } | null>(null);
+  // The moment any OTHER Project replaces the opened gallery entry (new
+  // circuit, bundled example, import, …), the update offer must vanish —
+  // otherwise a later publish silently overwrites the stale entry.
+  const activeProjectId = project.id;
+  useEffect(() => {
+    setGalleryEntryContext((previous) =>
+      previous && previous.projectId !== activeProjectId ? null : previous,
+    );
+  }, [activeProjectId]);
   // The Examples panel reads the same community gallery as the landing
   // feed; null means unreachable, so the bundled list stands in.
   const [galleryExamples, setGalleryExamples] = useState<
@@ -1953,6 +1966,8 @@ export function App({
       replaceActiveProject(galleryProject);
       setGalleryEntryContext({
         id: entryId,
+        name: payload.entry?.name ?? galleryProject.name,
+        projectId: galleryProject.id,
         ownerUserId: payload.ownerUserId ?? null,
         author: payload.entry?.author ?? "",
         description: payload.entry?.description ?? "",
@@ -7800,7 +7815,7 @@ export function App({
               publishSession.role === "moderator" ||
               (galleryEntryContext.ownerUserId !== null &&
                 publishSession.id === galleryEntryContext.ownerUserId))
-              ? { id: galleryEntryContext.id }
+              ? { id: galleryEntryContext.id, name: galleryEntryContext.name }
               : null
           }
           updateDefaults={

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
@@ -22,7 +22,7 @@ export interface PublishGalleryDialogProps {
   gateReport?: SubmissionGateReport | null;
   /** Present when the open circuit came from a gallery entry the signed-in
    * user may update (owner, admin, or moderator). */
-  updateTarget?: { id: string } | null;
+  updateTarget?: { id: string; name: string } | null;
   /** The opened entry's stored fields, prefilled once in update mode. */
   updateDefaults?: {
     author: string;
@@ -178,7 +178,7 @@ export function PublishGalleryDialog({
                   setModeTouched(true);
                 }}
               />
-              Update the opened gallery entry
+              Update “{updateTarget?.name}” (replaces that entry)
             </label>
             <label>
               <input

--- a/plan/2026-08-22-update-mode-guard/plan.md
+++ b/plan/2026-08-22-update-mode-guard/plan.md
@@ -1,0 +1,63 @@
+---
+status: completed
+experience: none
+---
+
+# Hotfix: Retire the Stale Update Offer on Project Replacement
+
+## Goal
+
+User-reported data loss: with a gallery entry still "opened" from
+earlier, publishing a NEW circuit silently defaulted to "update the
+opened entry" and overwrote it in place (an Inverter replaced StrongArm
+Comparator v2). Two fixes: the gallery-entry context now records the
+opened Project's id and is cleared the moment any other Project becomes
+active (new circuit, import, example open, …), so the update offer can
+never target something the user is no longer editing; and the update
+option names exactly what it replaces ("Update “<entry name>” (replaces
+that entry)").
+
+## State and Ownership
+
+Branched from `origin/main` (post PR #182) as
+`claude/update-mode-guard`.
+
+Owned paths: `apps/editor/src/app/App.tsx`,
+`apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx`,
+`apps/editor/e2e/gallery.spec.ts`,
+`plan/2026-08-22-update-mode-guard/plan.md`, `plan/log.md`.
+
+## Validation
+
+- `playwright`: gallery spec — the update offer is present while the
+  entry is active, disappears after importing a different Project, and
+  the option label carries the target entry's name
+- dialog unit suite, repository typecheck, prettier,
+  `node scripts/check-test-impact.mjs --base origin/main`
+- `git diff --check` and `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: the update offer exists only while the opened entry is the
+  active Project, and always names its target
+- Primary checks: `apps/editor/e2e/gallery.spec.ts`
+
+## Commit Intent
+
+Committed on `claude/update-mode-guard` under the user's standing
+commit-push-merge direction as:
+
+```text
+fix(editor): retire the stale gallery update offer
+```
+
+## Outcome
+
+Delivered: the context carries the opened Project id and an effect
+clears it whenever another Project becomes active; the update radio
+names its target. Gallery Playwright 20/20 (new scenario: offer present
+→ import another Project → offer gone), dialog units 26, typecheck,
+prettier, test-impact, diff checks green. The overwritten entry's
+content is unrecoverable server-side; the user can republish it from a
+local copy.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4860,3 +4860,14 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   smoke, and all 205 browser tests.
 - Commit status: stacked review branch prepared for required remote checks and
   one PR merge to `main`.
+
+## 2026-08-22 — Hotfix: retire the stale gallery update offer
+
+- Target: `plan/2026-08-22-update-mode-guard/plan.md` (completed).
+- Change: the opened-entry context records its Project id and clears
+  the moment any other Project becomes active, so publishing can no
+  longer silently overwrite a stale entry (user-reported data loss);
+  the update option now names exactly what it replaces.
+- Validation: gallery Playwright 20/20, dialog units 26, typecheck,
+  prettier, test-impact, diff checks.
+- Commit status: completed on `claude/update-mode-guard`.


### PR DESCRIPTION
User-reported data loss: with a gallery entry still "opened" from earlier in the session, publishing a NEW circuit silently defaulted to "update the opened entry" and overwrote it in place (an Inverter replaced StrongArm Comparator v2).

- The gallery-entry context now records the opened Project's id, and an effect clears the context the moment any OTHER Project becomes active (new circuit, import, example open, …) — the update offer can never target something the user is no longer editing.
- The update option names exactly what it replaces: `Update "<entry name>" (replaces that entry)`.

Tests: gallery Playwright 20/20 — new scenario proves the offer is present while the entry is active, then disappears after importing a different Project; the update-in-place scenario now also asserts the target name in the option label. Dialog units 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)