### PR TITLE
feat(worker): gallery entry version history with restore

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -765,6 +765,76 @@ test("an opened gallery entry offers updating in place", async ({ page }) => {
   expect(updates[0]!.body.name).toBe(ENTRY.name);
 });
 
+test("a reviewer browses version history and restores a version", async ({
+  page,
+}) => {
+  await mockGallery(page, [ENTRY]);
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      json: {
+        user: {
+          id: "u1",
+          displayName: "Token Zhang",
+          email: "owner@example.com",
+          provider: "github",
+          role: "user",
+          isAdmin: true,
+        },
+      },
+    }),
+  );
+  await page.route(`**/api/gallery/${ENTRY.id}/versions`, (route) =>
+    route.fulfill({
+      json: {
+        versions: [
+          {
+            versionId: "v-2",
+            versionNo: 2,
+            name: "Ring Oscillator (older)",
+            author: "tz",
+            tags: ["oscillator"],
+            createdAt: "2026-08-22T10:00:00.000Z",
+          },
+        ],
+      },
+    }),
+  );
+  await page.route(
+    `**/api/gallery/${ENTRY.id}/versions/v-2/preview.svg`,
+    (route) =>
+      route.fulfill({
+        contentType: "image/svg+xml",
+        body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"><rect width="10" height="6" fill="#fff"/></svg>',
+      }),
+  );
+  let restores = 0;
+  await page.route(
+    `**/api/gallery/${ENTRY.id}/versions/v-2/restore`,
+    (route) => {
+      restores += 1;
+      return route.fulfill({ json: { id: ENTRY.id, restored: true } });
+    },
+  );
+
+  await page.goto(`/g/${ENTRY.id}`);
+  await expect(page.getByTestId("status")).toContainText(
+    `Opened gallery circuit: ${ENTRY.name}`,
+  );
+  await page.getByTestId("publish-gallery-button").click();
+  await page.getByTestId("publish-history").click();
+
+  const history = page.getByTestId("version-history-dialog");
+  await expect(history).toBeVisible();
+  await expect(page.getByTestId("version-2")).toContainText(
+    "Ring Oscillator (older)",
+  );
+  await page.getByTestId("version-restore-2").click();
+  await expect(page.getByTestId("status")).toContainText(
+    `Opened gallery circuit: ${ENTRY.name}`,
+  );
+  expect(restores).toBe(1);
+});
+
 test("replacing the project retires the stale update offer", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -224,6 +224,7 @@ import {
   publishProjectToGallery,
   updateGalleryEntry,
 } from "../features/editor-shell/gallery-publish";
+import { VersionHistoryDialog } from "../features/editor-shell/version-history-dialog";
 import { fetchSessionUser, type SessionUser } from "../components/account";
 import {
   evaluateSubmissionGates,
@@ -676,6 +677,7 @@ export function App({
   const [netlistPreflightOpen, setNetlistPreflightOpen] = useState(false);
   const [styleDialogOpen, setStyleDialogOpen] = useState(false);
   const [publishGalleryOpen, setPublishGalleryOpen] = useState(false);
+  const [versionHistoryOpen, setVersionHistoryOpen] = useState(false);
   const [publishSession, setPublishSession] = useState<SessionUser | null>(
     null,
   );
@@ -7846,7 +7848,27 @@ export function App({
                   : `Published "${name}" to the gallery`,
             );
           }}
+          onShowHistory={
+            galleryEntryContext
+              ? () => {
+                  setPublishGalleryOpen(false);
+                  setVersionHistoryOpen(true);
+                }
+              : undefined
+          }
           onClose={() => setPublishGalleryOpen(false)}
+        />
+      ) : null}
+      {versionHistoryOpen && galleryEntryContext ? (
+        <VersionHistoryDialog
+          entryId={galleryEntryContext.id}
+          entryName={galleryEntryContext.name}
+          onRestored={() => {
+            setVersionHistoryOpen(false);
+            setStatus("Version restored — reloading the entry");
+            void openGalleryEntryById(galleryEntryContext.id);
+          }}
+          onClose={() => setVersionHistoryOpen(false)}
         />
       ) : null}
       {publicAgentUiEnabled ? (

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
@@ -39,6 +39,8 @@ export interface PublishGalleryDialogProps {
     pending: boolean;
     updated: boolean;
   }) => void;
+  /** Reviewer-only: open the entry's version history instead. */
+  onShowHistory?: (() => void) | undefined;
   onClose: () => void;
 }
 
@@ -59,6 +61,7 @@ export function PublishGalleryDialog({
   publish,
   publishUpdate,
   onPublished,
+  onShowHistory,
   onClose,
 }: PublishGalleryDialogProps) {
   const privileged = session?.isAdmin === true || session?.role === "moderator";
@@ -192,6 +195,16 @@ export function PublishGalleryDialog({
               />
               Publish as a new entry
             </label>
+            {privileged && onShowHistory ? (
+              <button
+                type="button"
+                className="publish-gallery-history-link"
+                data-testid="publish-history"
+                onClick={onShowHistory}
+              >
+                Version history…
+              </button>
+            ) : null}
           </div>
         ) : null}
         <div className="publish-gallery-fields">

--- a/apps/editor/src/features/editor-shell/version-history-dialog.tsx
+++ b/apps/editor/src/features/editor-shell/version-history-dialog.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Version history of one gallery entry (reviewer surface): every update
+ * snapshotted the previous state; Restore adopts a version after
+ * snapshotting the current one, so restores are themselves reversible.
+ */
+
+export interface GalleryEntryVersion {
+  versionId: string;
+  versionNo: number;
+  name: string;
+  author: string;
+  tags: string[];
+  createdAt: string;
+}
+
+export async function loadEntryVersions(
+  entryId: string,
+  fetchLike: typeof fetch = fetch,
+): Promise<GalleryEntryVersion[] | null> {
+  try {
+    const response = await fetchLike(`/api/gallery/${entryId}/versions`, {
+      credentials: "same-origin",
+    });
+    if (!response.ok) return null;
+    const payload = (await response.json()) as {
+      versions?: GalleryEntryVersion[];
+    };
+    return payload.versions ?? [];
+  } catch {
+    return null;
+  }
+}
+
+async function restoreVersion(
+  entryId: string,
+  versionId: string,
+  fetchLike: typeof fetch = fetch,
+): Promise<boolean> {
+  try {
+    const response = await fetchLike(
+      `/api/gallery/${entryId}/versions/${versionId}/restore`,
+      { method: "POST", credentials: "same-origin" },
+    );
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+export interface VersionHistoryDialogProps {
+  entryId: string;
+  entryName: string;
+  onRestored(): void;
+  onClose(): void;
+}
+
+export function VersionHistoryDialog({
+  entryId,
+  entryName,
+  onRestored,
+  onClose,
+}: VersionHistoryDialogProps) {
+  const [versions, setVersions] = useState<GalleryEntryVersion[] | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadEntryVersions(entryId).then((loaded) => {
+      if (!cancelled) setVersions(loaded ?? []);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [entryId]);
+
+  async function restore(versionId: string): Promise<void> {
+    setBusy(true);
+    setError(null);
+    const ok = await restoreVersion(entryId, versionId);
+    setBusy(false);
+    if (ok) onRestored();
+    else setError("Could not restore this version.");
+  }
+
+  return (
+    <div
+      className="insert-dialog-backdrop"
+      onPointerDown={(event) => {
+        if (event.target === event.currentTarget && !busy) onClose();
+      }}
+    >
+      <section
+        className="publish-gallery-dialog version-history-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="version-history-title"
+        data-testid="version-history-dialog"
+      >
+        <header className="publish-gallery-header">
+          <p>Every update keeps the previous state</p>
+          <h2 id="version-history-title">Version history — {entryName}</h2>
+        </header>
+        {versions === null ? (
+          <p className="publish-gallery-note">Loading history…</p>
+        ) : versions.length === 0 ? (
+          <p className="publish-gallery-note" data-testid="version-empty">
+            No earlier versions yet — history starts with the first update.
+          </p>
+        ) : (
+          <div className="version-list">
+            {versions.map((version) => (
+              <article
+                key={version.versionId}
+                className="version-row"
+                data-testid={`version-${version.versionNo}`}
+              >
+                <img
+                  src={`/api/gallery/${entryId}/versions/${version.versionId}/preview.svg`}
+                  alt={`Version ${version.versionNo} preview`}
+                  loading="lazy"
+                />
+                <div className="version-copy">
+                  <b>
+                    v{version.versionNo} · {version.name}
+                  </b>
+                  <small>
+                    {version.author ? `${version.author} · ` : ""}
+                    {new Date(version.createdAt).toLocaleString()}
+                    {version.tags.length > 0
+                      ? ` · ${version.tags.join(", ")}`
+                      : ""}
+                  </small>
+                </div>
+                <button
+                  type="button"
+                  className="publish-gallery-primary"
+                  data-testid={`version-restore-${version.versionNo}`}
+                  disabled={busy}
+                  onClick={() => void restore(version.versionId)}
+                >
+                  Restore
+                </button>
+              </article>
+            ))}
+          </div>
+        )}
+        {error ? (
+          <p role="alert" className="publish-gallery-error">
+            {error}
+          </p>
+        ) : null}
+        <div className="publish-gallery-actions">
+          <button type="button" disabled={busy} onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -5645,6 +5645,73 @@ html.light .analytics-map-land path {
   color: var(--icm-accent);
 }
 
+.publish-gallery-history-link {
+  align-self: flex-start;
+  padding: 0;
+  border: none;
+  color: var(--icm-accent);
+  background: none;
+  font-size: 0.78rem;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.version-history-dialog {
+  width: min(36rem, 100%);
+}
+
+.version-list {
+  display: flex;
+  max-height: 22rem;
+  flex-direction: column;
+  gap: 10px;
+  overflow-y: auto;
+}
+
+.version-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px;
+  border: 1px solid var(--icm-border);
+  border-radius: 10px;
+}
+
+.version-row img {
+  width: 110px;
+  height: 74px;
+  object-fit: contain;
+  border: 1px solid var(--icm-border);
+  border-radius: 6px;
+  background: #fff;
+}
+
+.version-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.version-copy b {
+  font-size: 0.9rem;
+}
+
+.version-copy small {
+  color: var(--icm-text-muted);
+}
+
+.version-row .publish-gallery-primary {
+  padding: 0.4rem 0.9rem;
+  border: 1px solid var(--icm-accent);
+  border-radius: 8px;
+  color: #fff;
+  background: var(--icm-accent);
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
 .publish-gallery-tags {
   display: flex;
   flex-direction: column;

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -118,6 +118,24 @@ exactly to owners and reviewers.
 Entries persist a nullable owner column stamped from the submitting
 session.
 
+## Version history
+
+Every content-replacing update (`PUT`, and Restore itself) first
+snapshots the entry's previous state — name, author, description, tags,
+canonical project text, preview — into `gallery_entry_versions`,
+numbered per entry and capped at the newest 20 (older pruned).
+Maintenance re-serialization does not snapshot (content-equivalent).
+Reviewer authority (bearer, admin, or moderator):
+
+- `GET /api/gallery/<id>/versions` — versions, newest first.
+- `GET /api/gallery/<id>/versions/<versionId>/preview.svg`.
+- `POST /api/gallery/<id>/versions/<versionId>/restore` — snapshots the
+  current state, then adopts the version's content and metadata (entry
+  status unchanged), so restores are themselves reversible.
+
+The editor surfaces this as "Version history…" inside the publish
+dialog's update mode for reviewer sessions.
+
 ## Accounts and sessions (Phase G2, dark-shipped)
 
 `AuthDO` (one SQLite Durable Object singleton) owns users and sessions

--- a/plan/2026-08-22-gallery-version-history/plan.md
+++ b/plan/2026-08-22-gallery-version-history/plan.md
@@ -1,0 +1,99 @@
+---
+status: completed
+experience: none
+---
+
+# Gallery Version History
+
+## Goal
+
+Owner-approved after a real overwrite loss: every content-replacing
+update of a gallery entry first snapshots the previous state (project
+text, preview, name, author, description, tags) into a per-entry
+version history (capped at 20, oldest pruned). Reviewers browse an
+entry's history from the publish dialog's update mode and can Restore
+any version — restoring snapshots the current state first, so restores
+are themselves reversible.
+
+## State and Ownership
+
+Branched from `origin/main` (post PR #187) as
+`claude/gallery-version-history`.
+
+Owned paths:
+
+- `worker/gallery.ts` (+ test): `gallery_entry_versions` table,
+  snapshot inside `replace-entry`, `versions`/`version`/
+  `restore-version` ops, reviewer routes (list, version preview,
+  restore)
+- `apps/editor/src/features/editor-shell/version-history-dialog.tsx`
+  (+ test) and `publish-gallery-dialog.tsx` (history link in update
+  mode)
+- `apps/editor/src/app/App.tsx` (dialog wiring), `styles.css`,
+  `apps/editor/e2e/gallery.spec.ts`
+- `docs/specs/community-gallery.md`, plan files
+
+Shared dependencies: the update/restore semantics reuse the entry
+replacement op; entry contracts otherwise unchanged.
+
+## Design
+
+- Table `gallery_entry_versions(id, entry_id, version_no, name, author,
+description, tags, schema_version, project_text, svg_text,
+created_at)`; created guarded like other additive schema.
+- `replace-entry` snapshots the pre-update row in the same transaction,
+  assigns the next version number, prunes beyond 20 per entry.
+  Maintenance re-serialization (`update-entry`) does NOT snapshot —
+  content-equivalent canonicalization would only spam versions.
+- Routes (reviewer authority — bearer, admin, or moderator):
+  `GET /api/gallery/<id>/versions` (newest first),
+  `GET /api/gallery/<id>/versions/<versionId>/preview.svg`,
+  `POST /api/gallery/<id>/versions/<versionId>/restore` — restore
+  replaces entry content/metadata from the version (status kept) via
+  the same snapshotting op.
+- UI: the publish dialog's update mode (reviewer session) links
+  "Version history…"; the dialog lists versions with preview
+  thumbnails, timestamps, and per-version Restore.
+
+## Validation
+
+- `vitest`: worker — update snapshots, list order, restore round-trip
+  (including the pre-restore snapshot), 20-cap prune, 401 without
+  reviewer authority; dialog markup test
+- `playwright`: reviewer opens an entry, reaches Version history from
+  the publish dialog, restores a mocked version
+- repository typecheck, prettier,
+  `node scripts/check-test-impact.mjs --base origin/main`
+- `git diff --check` and `git status --short --branch`
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: every replace snapshots first; restores are snapshots too;
+  history is reviewer-only and capped at 20
+- Primary checks: `worker/gallery.test.ts`,
+  `apps/editor/e2e/gallery.spec.ts`
+
+## Commit Intent
+
+Committed on `claude/gallery-version-history` under the user's standing
+commit-push-merge direction as:
+
+```text
+feat(worker): gallery entry version history with restore
+```
+
+## Outcome
+
+Delivered. `replace-entry` (updates and restores alike) snapshots the
+previous state transactionally into `gallery_entry_versions` (per-entry
+numbering, newest-20 cap with pruning); reviewer routes list versions,
+serve their stored previews, and restore — restore snapshots current
+first, so it is reversible. The publish dialog's update mode links
+"Version history…" (reviewer sessions) to a dialog with thumbnails,
+timestamps, and per-version Restore; a restore reloads the entry into
+the editor. Spec updated. Validation: worker gallery 17 (snapshot on
+update, list order, reversible restore round-trip, 20-cap prune,
+anonymous 401), editor-shell+worker units 78, gallery Playwright 21/21
+(history reached from the dialog, restore posted and entry reloaded),
+repository typecheck, prettier, test-impact, diff checks.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4871,3 +4871,14 @@ Keep reusable lessons in `docs/experience/`, not in this log.
 - Validation: gallery Playwright 20/20, dialog units 26, typecheck,
   prettier, test-impact, diff checks.
 - Commit status: completed on `claude/update-mode-guard`.
+
+## 2026-08-22 — Gallery entry version history with restore
+
+- Target: `plan/2026-08-22-gallery-version-history/plan.md` (completed).
+- Change: every entry update (and restore) first snapshots the previous
+  state (newest-20 cap); reviewer routes list/preview/restore versions;
+  the publish dialog's update mode links a Version history dialog with
+  per-version Restore that reloads the entry.
+- Validation: worker gallery 17, units 78, gallery Playwright 21/21,
+  typecheck, prettier, test-impact, diff checks.
+- Commit status: completed on `claude/gallery-version-history`.

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -526,6 +526,125 @@ function wiredProjectText(name = "Wired"): string {
   return serializeProject(project);
 }
 
+describe("gallery version history", () => {
+  it("snapshots on every update, lists, restores (reversibly), and guards", async () => {
+    const env = environment(ADMIN_TOKEN);
+    const id = await submitOne(env, "Versioned v1");
+
+    function updateRequest(name: string): Request {
+      return new Request(`${ORIGIN}/api/gallery/${id}`, {
+        method: "PUT",
+        headers: {
+          Origin: ORIGIN,
+          Authorization: `Bearer ${ADMIN_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          name,
+          author: "tz",
+          projectText: projectText(name),
+        }),
+      });
+    }
+    await route(env, updateRequest("Versioned v2"));
+    await route(env, updateRequest("Versioned v3"));
+
+    // Anonymous callers see nothing.
+    const denied = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/versions`),
+    );
+    expect(denied.status).toBe(401);
+
+    const listed = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/versions`, {
+        headers: adminHeaders(ADMIN_TOKEN),
+      }),
+    );
+    const { versions } = (await listed.json()) as {
+      versions: { versionId: string; versionNo: number; name: string }[];
+    };
+    expect(versions.map((version) => version.name)).toEqual([
+      "Versioned v2",
+      "Versioned v1",
+    ]);
+
+    const versionPreview = await route(
+      env,
+      new Request(
+        `${ORIGIN}/api/gallery/${id}/versions/${versions[1]!.versionId}/preview.svg`,
+        { headers: adminHeaders(ADMIN_TOKEN) },
+      ),
+    );
+    expect(versionPreview.headers.get("content-type")).toBe("image/svg+xml");
+
+    // Restore v1: current v3 is snapshotted first, entry becomes v1.
+    const restored = await route(
+      env,
+      new Request(
+        `${ORIGIN}/api/gallery/${id}/versions/${versions[1]!.versionId}/restore`,
+        {
+          method: "POST",
+          headers: { Origin: ORIGIN, ...adminHeaders(ADMIN_TOKEN) },
+        },
+      ),
+    );
+    expect(restored.status).toBe(200);
+    const detail = (await (
+      await route(env, new Request(`${ORIGIN}/api/gallery/${id}`))
+    ).json()) as { entry: { name: string } };
+    expect(detail.entry.name).toBe("Versioned v1");
+
+    const afterRestore = (await (
+      await route(
+        env,
+        new Request(`${ORIGIN}/api/gallery/${id}/versions`, {
+          headers: adminHeaders(ADMIN_TOKEN),
+        }),
+      )
+    ).json()) as { versions: { name: string }[] };
+    expect(afterRestore.versions.map((version) => version.name)).toEqual([
+      "Versioned v3",
+      "Versioned v2",
+      "Versioned v1",
+    ]);
+  });
+
+  it("prunes history beyond the per-entry cap", async () => {
+    const env = environment(ADMIN_TOKEN);
+    const id = await submitOne(env, "Cap 0");
+    for (let index = 1; index <= 24; index += 1) {
+      await route(
+        env,
+        new Request(`${ORIGIN}/api/gallery/${id}`, {
+          method: "PUT",
+          headers: {
+            Origin: ORIGIN,
+            Authorization: `Bearer ${ADMIN_TOKEN}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            name: `Cap ${index}`,
+            projectText: projectText(`Cap ${index}`),
+          }),
+        }),
+      );
+    }
+    const listed = (await (
+      await route(
+        env,
+        new Request(`${ORIGIN}/api/gallery/${id}/versions`, {
+          headers: adminHeaders(ADMIN_TOKEN),
+        }),
+      )
+    ).json()) as { versions: { versionNo: number }[] };
+    expect(listed.versions).toHaveLength(20);
+    expect(listed.versions[0]!.versionNo).toBe(24);
+    expect(listed.versions.at(-1)!.versionNo).toBe(5);
+  });
+});
+
 describe("gallery circuit tags", () => {
   it("normalizes tags on write, filters as an OR-union, and aggregates", async () => {
     const env = environment(ADMIN_TOKEN);

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -26,6 +26,7 @@ export const GALLERY_MAX_DESCRIPTION_LENGTH = 300;
 export const GALLERY_DAILY_SUBMISSION_LIMIT = 10;
 export const GALLERY_MAX_TAGS = 5;
 export const GALLERY_MAX_TAG_LENGTH = 24;
+export const GALLERY_MAX_VERSIONS_PER_ENTRY = 20;
 export const GALLERY_DEFAULT_LIST_LIMIT = 30;
 export const GALLERY_MAX_LIST_LIMIT = 60;
 
@@ -168,6 +169,25 @@ export class GalleryDO {
         PRIMARY KEY (day, submitter_hash)
       ) WITHOUT ROWID
     `);
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS gallery_entry_versions (
+        id TEXT PRIMARY KEY,
+        entry_id TEXT NOT NULL,
+        version_no INTEGER NOT NULL,
+        name TEXT NOT NULL,
+        author TEXT NOT NULL,
+        description TEXT NOT NULL,
+        tags TEXT NOT NULL DEFAULT '',
+        schema_version INTEGER NOT NULL,
+        project_text TEXT NOT NULL,
+        svg_text TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      ) WITHOUT ROWID
+    `);
+    this.sql.exec(`
+      CREATE INDEX IF NOT EXISTS idx_gallery_entry_versions_entry
+      ON gallery_entry_versions(entry_id, version_no)
+    `);
     // Additive review-queue columns (phase G3) for pre-existing databases.
     for (const alteration of [
       "ALTER TABLE gallery_entries ADD COLUMN reject_reason TEXT",
@@ -222,6 +242,12 @@ export class GalleryDO {
         return this.updateEntry(body);
       case "replace-entry":
         return this.replaceEntry(body);
+      case "versions":
+        return this.versions(String(body.entryId));
+      case "version":
+        return this.version(String(body.entryId), String(body.versionId));
+      case "restore-version":
+        return this.restoreVersion(body);
       default:
         return Response.json({ error: "Unknown operation" }, { status: 404 });
     }
@@ -377,6 +403,40 @@ export class GalleryDO {
   }
 
   /** Owner/reviewer edit (phase G3): new content, possibly new status. */
+  /** Version-history snapshot of the entry's current state (pre-write). */
+  private snapshotEntry(row: EntryRow, at: string): void {
+    const lastVersion =
+      this.sql
+        .exec<{ v: number | null }>(
+          "SELECT MAX(version_no) AS v FROM gallery_entry_versions WHERE entry_id = ?",
+          row.id,
+        )
+        .toArray()[0]?.v ?? 0;
+    this.sql.exec(
+      `INSERT INTO gallery_entry_versions(
+        id, entry_id, version_no, name, author, description, tags,
+        schema_version, project_text, svg_text, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      crypto.randomUUID(),
+      row.id,
+      lastVersion + 1,
+      row.name,
+      row.author,
+      row.description,
+      row.tags ?? "",
+      row.schema_version,
+      row.project_text,
+      row.svg_text,
+      at,
+    );
+    this.sql.exec(
+      `DELETE FROM gallery_entry_versions
+       WHERE entry_id = ? AND version_no <= ?`,
+      row.id,
+      lastVersion + 1 - GALLERY_MAX_VERSIONS_PER_ENTRY,
+    );
+  }
+
   private replaceEntry(body: Record<string, unknown>): Response {
     const row = this.sql
       .exec<EntryRow>(
@@ -385,23 +445,130 @@ export class GalleryDO {
       )
       .toArray()[0];
     if (!row) return Response.json({ error: "not-found" }, { status: 404 });
-    this.sql.exec(
-      `UPDATE gallery_entries
-       SET name = ?, author = ?, description = ?, project_text = ?,
-           svg_text = ?, schema_version = ?, status = ?, tags = ?,
-           reject_reason = NULL, reviewed_at = NULL, reviewed_by = NULL
-       WHERE id = ?`,
-      String(body.name),
-      String(body.author),
-      String(body.description),
-      String(body.projectText),
-      String(body.svgText),
-      Number(body.schemaVersion),
-      String(body.status),
-      typeof body.tags === "string" ? body.tags : "",
-      row.id,
-    );
+    this.state.storage.transactionSync(() => {
+      this.snapshotEntry(row, String(body.at ?? row.created_at));
+      this.sql.exec(
+        `UPDATE gallery_entries
+         SET name = ?, author = ?, description = ?, project_text = ?,
+             svg_text = ?, schema_version = ?, status = ?, tags = ?,
+             reject_reason = NULL, reviewed_at = NULL, reviewed_by = NULL
+         WHERE id = ?`,
+        String(body.name),
+        String(body.author),
+        String(body.description),
+        String(body.projectText),
+        String(body.svgText),
+        Number(body.schemaVersion),
+        String(body.status),
+        typeof body.tags === "string" ? body.tags : "",
+        row.id,
+      );
+    });
     return Response.json({ id: row.id, status: String(body.status) });
+  }
+
+  private versions(entryId: string): Response {
+    const rows = this.sql
+      .exec<{
+        id: string;
+        version_no: number;
+        name: string;
+        author: string;
+        tags: string | null;
+        created_at: string;
+      }>(
+        `SELECT id, version_no, name, author, tags, created_at
+         FROM gallery_entry_versions WHERE entry_id = ?
+         ORDER BY version_no DESC`,
+        entryId,
+      )
+      .toArray();
+    return Response.json({
+      versions: rows.map((row) => ({
+        versionId: row.id,
+        versionNo: row.version_no,
+        name: row.name,
+        author: row.author,
+        tags: unwrapTags(row.tags),
+        createdAt: row.created_at,
+      })),
+    });
+  }
+
+  private version(entryId: string, versionId: string): Response {
+    const row = this.sql
+      .exec<{
+        id: string;
+        name: string;
+        author: string;
+        description: string;
+        tags: string | null;
+        schema_version: number;
+        project_text: string;
+        svg_text: string;
+      }>(
+        `SELECT * FROM gallery_entry_versions
+         WHERE entry_id = ? AND id = ?`,
+        entryId,
+        versionId,
+      )
+      .toArray()[0];
+    if (!row) return Response.json({ error: "not-found" }, { status: 404 });
+    return Response.json({
+      name: row.name,
+      author: row.author,
+      description: row.description,
+      tags: unwrapTags(row.tags),
+      schemaVersion: row.schema_version,
+      projectText: row.project_text,
+      svgText: row.svg_text,
+    });
+  }
+
+  /** Restore = snapshot the current state, then adopt the version. */
+  private restoreVersion(body: Record<string, unknown>): Response {
+    const entry = this.sql
+      .exec<EntryRow>(
+        "SELECT * FROM gallery_entries WHERE id = ?",
+        String(body.entryId),
+      )
+      .toArray()[0];
+    const version = this.sql
+      .exec<{
+        name: string;
+        author: string;
+        description: string;
+        tags: string | null;
+        schema_version: number;
+        project_text: string;
+        svg_text: string;
+      }>(
+        "SELECT * FROM gallery_entry_versions WHERE entry_id = ? AND id = ?",
+        String(body.entryId),
+        String(body.versionId),
+      )
+      .toArray()[0];
+    if (!entry || !version) {
+      return Response.json({ error: "not-found" }, { status: 404 });
+    }
+    this.state.storage.transactionSync(() => {
+      this.snapshotEntry(entry, String(body.at));
+      this.sql.exec(
+        `UPDATE gallery_entries
+         SET name = ?, author = ?, description = ?, project_text = ?,
+             svg_text = ?, schema_version = ?, tags = ?
+         WHERE id = ?`,
+        version.name,
+        version.author,
+        version.description,
+        version.project_text,
+        version.svg_text,
+        version.schema_version,
+        version.tags ?? "",
+        entry.id,
+      );
+    });
+    return Response.json({ id: entry.id, restored: true });
   }
 
   private mine(ownerUserId: string): Response {
@@ -761,6 +928,7 @@ async function handleEntryUpdate(
     : "pending";
   const { status, payload } = await callGallery(env, "replace-entry", {
     id,
+    at: new Date().toISOString(),
     name,
     author,
     description,
@@ -891,6 +1059,67 @@ export async function routeGalleryRequest(
       ownerUserId: user.id,
     });
     return Response.json(payload, { headers: { "cache-control": "no-store" } });
+  }
+  if (
+    segments.length === 2 &&
+    segments[1] === "versions" &&
+    request.method === "GET"
+  ) {
+    if (!(await canReview(request, env))) {
+      return Response.json({ error: "unauthorized" }, { status: 401 });
+    }
+    const { status, payload } = await callGallery(env, "versions", {
+      entryId: segments[0],
+    });
+    return Response.json(payload, {
+      status,
+      headers: { "cache-control": "no-store" },
+    });
+  }
+  if (
+    segments.length === 4 &&
+    segments[1] === "versions" &&
+    segments[3] === "preview.svg" &&
+    request.method === "GET"
+  ) {
+    if (!(await canReview(request, env))) {
+      return Response.json({ error: "not-found" }, { status: 404 });
+    }
+    const { status, payload } = await callGallery<{ svgText?: string }>(
+      env,
+      "version",
+      { entryId: segments[0], versionId: segments[2] },
+    );
+    if (status !== 200 || !payload.svgText) {
+      return Response.json({ error: "not-found" }, { status: 404 });
+    }
+    return new Response(payload.svgText, {
+      headers: {
+        "content-type": "image/svg+xml",
+        "cache-control": "no-store",
+        "content-security-policy":
+          "default-src 'none'; style-src 'unsafe-inline'",
+      },
+    });
+  }
+  if (
+    segments.length === 4 &&
+    segments[1] === "versions" &&
+    segments[3] === "restore" &&
+    request.method === "POST"
+  ) {
+    if (!sameOrigin(request)) {
+      return Response.json({ error: "forbidden" }, { status: 403 });
+    }
+    if (!(await canReview(request, env))) {
+      return Response.json({ error: "unauthorized" }, { status: 401 });
+    }
+    const { status, payload } = await callGallery(env, "restore-version", {
+      entryId: segments[0],
+      versionId: segments[2],
+      at: new Date().toISOString(),
+    });
+    return Response.json(payload, { status });
   }
   if (segments.length === 2 && segments[1] === "preview.svg") {
     const { status, payload } = await callGallery<{


### PR DESCRIPTION
Owner-approved after a real overwrite loss (an entry was silently replaced): the gallery gains **Version history**.

- Every content-replacing update — `PUT`, and Restore itself — first snapshots the entry's previous state (name, author, description, tags, canonical project text, preview) into `gallery_entry_versions`, numbered per entry and capped at the newest 20 (older pruned, snapshot+write in one transaction). Maintenance re-serialization does not snapshot (content-equivalent).
- Reviewer routes (bearer/admin/moderator): `GET /:id/versions`, `GET /:id/versions/:vid/preview.svg`, `POST /:id/versions/:vid/restore` — restore snapshots the current state first, so restores are themselves reversible; entry status is kept.
- Editor: the publish dialog's update mode (reviewer sessions) links "Version history…" — a dialog with per-version thumbnails, timestamps, tags, and Restore; restoring reloads the entry into the editor.

Tests: worker gallery 17 (snapshot on update, newest-first list, reversible restore round-trip, 20-cap prune, anonymous 401), editor-shell+worker units 78, gallery Playwright 21/21 (history reached from the dialog, restore posted, entry reloaded). Spec updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)