### PR TITLE
fix(worker): exempt reviewers from the daily submission quota

### DIFF
--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -48,8 +48,10 @@ trimmed `name` (required, ≤120), optional `author` (≤40), `description`
 chars each, at most 5, deduplicated — `sanitizeGalleryTags` is the one
 normalization for writes and filters), `projectText` ≤2 MiB. The Worker validates, stamps the canonical
 serialization, renders the preview, and stores the entry as `public`.
-Submissions count against a per-submitter (hashed IP) limit of 10 per UTC
-day.
+Ordinary and anonymous submissions count against a per-submitter (hashed
+IP) limit of 10 per UTC day; privileged submitters (the bearer and
+admin/moderator sessions) are exempt — the quota is anti-garbage
+protection, and curators are the ones cleaning up.
 
 Publishing authority (since G3): the bearer and admin/moderator sessions
 publish directly as `public`; an ordinary signed-in session submits into

--- a/plan/2026-08-22-exempt-admin-quota/plan.md
+++ b/plan/2026-08-22-exempt-admin-quota/plan.md
@@ -31,9 +31,12 @@ they must never be rate-limited by their own protection.
 
 ## Test Impact
 
-tests-updated: `worker/gallery.test.ts` ("rate-limits ordinary
-submitters per day; curators are exempt") covers both the enforcement
-and the exemption.
+- Decision: tests-updated
+- Contracts: the daily submission quota applies to ordinary/anonymous
+  submissions only; privileged submissions bypass it.
+- Primary checks: `node_modules/.bin/vitest run worker/gallery.test.ts`
+  ("rate-limits ordinary submitters per day; curators are exempt"
+  covers both the enforcement and the exemption).
 
 ## Validation
 

--- a/plan/2026-08-22-exempt-admin-quota/plan.md
+++ b/plan/2026-08-22-exempt-admin-quota/plan.md
@@ -1,0 +1,42 @@
+# Exempt privileged submitters from the daily gallery quota
+
+- status: complete
+- experience: The owner hit "Daily publish limit reached — try again
+  tomorrow" on their own gallery. The 10-per-day hashed-IP quota was
+  applied to every submission path, including the bearer and
+  admin/moderator sessions, so a curation session that published or
+  updated more than ten entries in a UTC day locked itself out.
+
+## Goal
+
+The daily submission quota is anti-garbage protection for ordinary and
+anonymous submitters. Privileged submitters (bearer token, admin
+session, moderator session) publish directly and curate the gallery;
+they must never be rate-limited by their own protection.
+
+## Changes
+
+- `worker/gallery.ts`
+  - `GalleryDO.submit` reads `body.enforceLimit !== false`; the quota
+    SELECT / 429 / counter-increment run only when enforced. The entry
+    INSERT is unchanged and stays inside the same transaction.
+  - `handleSubmission` passes `enforceLimit: !privileged` (privileged =
+    bearer, admin, or moderator — the same flag that already selects
+    direct-`public` publishing and skips the quality gates).
+- `worker/gallery.test.ts` — reworked the rate-limit test: enforced
+  submissions (direct DO op) hit 429 after 10 without touching another
+  submitter hash; bearer submissions exceed the limit and all succeed.
+- `docs/specs/community-gallery.md` — quota sentence now scopes the
+  limit to ordinary/anonymous submissions and records the exemption.
+
+## Test Impact
+
+tests-updated: `worker/gallery.test.ts` ("rate-limits ordinary
+submitters per day; curators are exempt") covers both the enforcement
+and the exemption.
+
+## Validation
+
+- `node_modules/.bin/vitest run worker/gallery.test.ts` — 17 passed.
+- `node_modules/.bin/tsc --noEmit -p tsconfig.check.json` — clean.
+- Prettier on touched files; `git diff --check`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4882,3 +4882,13 @@ Keep reusable lessons in `docs/experience/`, not in this log.
 - Validation: worker gallery 17, units 78, gallery Playwright 21/21,
   typecheck, prettier, test-impact, diff checks.
 - Commit status: completed on `claude/gallery-version-history`.
+
+## 2026-08-22 — Exempt privileged submitters from the daily gallery quota
+
+- Plan: `plan/2026-08-22-exempt-admin-quota/plan.md` (complete)
+- The owner's session hit the 10-per-day hashed-IP submission quota.
+  `GalleryDO.submit` now takes `enforceLimit`; `handleSubmission` sends
+  `enforceLimit: !privileged`, so bearer/admin/moderator submissions and
+  updates are never rate-limited while ordinary and anonymous paths keep
+  the quota. Spec updated; rate-limit test reworked to cover both sides
+  (`worker/gallery.test.ts`, 17 passed). Typecheck clean.

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -226,25 +226,51 @@ describe("gallery submissions", () => {
     expect(invalid.status).toBe(400);
   });
 
-  it("rate-limits one submitter per day without touching others", async () => {
+  it("rate-limits ordinary submitters per day; curators are exempt", async () => {
     const env = environment(ADMIN_TOKEN);
-    for (let index = 0; index < GALLERY_DAILY_SUBMISSION_LIMIT; index += 1) {
-      await submitOne(env, `Entry ${index}`);
-    }
-    const overflow = await route(
-      env,
-      submissionRequest({ name: "One more", projectText: projectText() }),
-    );
-    expect(overflow.status).toBe(429);
 
-    const other = await route(
-      env,
-      submissionRequest(
-        { name: "Other submitter", projectText: projectText() },
-        { ip: "198.51.100.2" },
-      ),
-    );
-    expect(other.status).toBe(201);
+    // Ordinary submissions (limit enforced) exhaust the day, without
+    // touching a different submitter.
+    async function submitDirect(hash: string): Promise<number> {
+      const response = await env.GALLERY.getByName("gallery").fetch(
+        "https://gallery/submit",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            day: "2026-08-22",
+            submitterHash: hash,
+            enforceLimit: true,
+            entry: {
+              id: crypto.randomUUID(),
+              name: "Quota",
+              author: "",
+              description: "",
+              created_at: "2026-08-22T00:00:00.000Z",
+              schema_version: 21,
+              status: "pending",
+              project_text: projectText(),
+              svg_text: "<svg/>",
+            },
+          }),
+        },
+      );
+      return response.status;
+    }
+    for (let index = 0; index < GALLERY_DAILY_SUBMISSION_LIMIT; index += 1) {
+      expect(await submitDirect("hash-a")).toBe(200);
+    }
+    expect(await submitDirect("hash-a")).toBe(429);
+    expect(await submitDirect("hash-b")).toBe(200);
+
+    // The bearer (curator) is exempt: more than the limit, all accepted.
+    for (
+      let index = 0;
+      index < GALLERY_DAILY_SUBMISSION_LIMIT + 2;
+      index += 1
+    ) {
+      await submitOne(env, `Curated ${index}`);
+    }
   });
 });
 

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -257,26 +257,31 @@ export class GalleryDO {
     const entry = body.entry as EntryRow;
     const day = String(body.day);
     const submitterHash = String(body.submitterHash);
+    // The daily quota is anti-garbage protection for ordinary submitters;
+    // the bearer and admin/moderator sessions are exempt (they curate).
+    const enforceLimit = body.enforceLimit !== false;
     const outcome = this.state.storage.transactionSync(() => {
-      const used =
-        this.sql
-          .exec<{
-            count: number;
-          }>(
-            "SELECT count FROM gallery_submissions WHERE day = ? AND submitter_hash = ?",
-            day,
-            submitterHash,
-          )
-          .toArray()[0]?.count ?? 0;
-      if (used >= GALLERY_DAILY_SUBMISSION_LIMIT) {
-        return { status: "rate-limited" as const };
+      if (enforceLimit) {
+        const used =
+          this.sql
+            .exec<{
+              count: number;
+            }>(
+              "SELECT count FROM gallery_submissions WHERE day = ? AND submitter_hash = ?",
+              day,
+              submitterHash,
+            )
+            .toArray()[0]?.count ?? 0;
+        if (used >= GALLERY_DAILY_SUBMISSION_LIMIT) {
+          return { status: "rate-limited" as const };
+        }
+        this.sql.exec(
+          `INSERT INTO gallery_submissions(day, submitter_hash, count) VALUES (?, ?, 1)
+           ON CONFLICT(day, submitter_hash) DO UPDATE SET count = count + 1`,
+          day,
+          submitterHash,
+        );
       }
-      this.sql.exec(
-        `INSERT INTO gallery_submissions(day, submitter_hash, count) VALUES (?, ?, 1)
-         ON CONFLICT(day, submitter_hash) DO UPDATE SET count = count + 1`,
-        day,
-        submitterHash,
-      );
       this.sql.exec(
         `INSERT INTO gallery_entries(
           id, name, author, description, created_at, schema_version,
@@ -821,6 +826,7 @@ async function handleSubmission(
     {
       day: now.toISOString().slice(0, 10),
       submitterHash: await submitterHash(request),
+      enforceLimit: !privileged,
       entry: {
         id: crypto.randomUUID(),
         name,


### PR DESCRIPTION
## Summary
- The owner hit **Daily publish limit reached** on their own gallery: the 10/day hashed-IP quota applied to every submission path, including bearer and admin/moderator sessions.
- `GalleryDO.submit` now takes `enforceLimit`; `handleSubmission` passes `enforceLimit: !privileged` — the same privileged flag that already selects direct-public publishing. Curator submissions and updates are never rate-limited; ordinary and anonymous paths keep the quota.
- Spec quota sentence scoped accordingly; rate-limit test reworked to cover enforcement (10 → 429, other hash unaffected) and exemption (bearer exceeds the limit, all accepted).

## Test plan
- `vitest run worker/gallery.test.ts` — 17 passed
- `tsc --noEmit -p tsconfig.check.json` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)