### PR TITLE
feat(worker): owner withdrawal and owner-visible version history

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -719,6 +719,90 @@ test("/mine wears the site chrome and links every entry back to the editor", asy
   await expect(page.getByTestId("mine-status-mine-2")).toHaveText("Published");
 });
 
+test("/mine offers owner withdrawal, restore, and version history", async ({
+  page,
+}) => {
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      json: {
+        user: {
+          id: "u7",
+          displayName: "Maker",
+          email: "maker@example.com",
+          provider: "email",
+          role: "user",
+          isAdmin: false,
+        },
+      },
+    }),
+  );
+  let withdrawn = false;
+  await page.route("**/api/gallery/mine", (route) =>
+    route.fulfill({
+      json: {
+        entries: [
+          {
+            id: "mine-2",
+            name: "Live Amp",
+            createdAt: "2026-08-22T08:00:00.000Z",
+            status: withdrawn ? "recycled" : "public",
+            rejectReason: null,
+          },
+        ],
+      },
+    }),
+  );
+  await page.route("**/api/gallery/mine-2/recycle", (route) => {
+    withdrawn = true;
+    return route.fulfill({ json: { id: "mine-2" } });
+  });
+  await page.route("**/api/gallery/mine-2/restore", (route) => {
+    withdrawn = false;
+    return route.fulfill({ json: { id: "mine-2" } });
+  });
+  await page.route("**/api/gallery/mine-2/versions", (route) =>
+    route.fulfill({
+      json: {
+        versions: [
+          {
+            versionId: "v-1",
+            versionNo: 1,
+            name: "Live Amp v1",
+            author: "Maker",
+            tags: [],
+            createdAt: "2026-08-21T08:00:00.000Z",
+          },
+        ],
+      },
+    }),
+  );
+  const svg = {
+    contentType: "image/svg+xml",
+    body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"><rect width="10" height="6" fill="#fff"/></svg>',
+  };
+  await page.route("**/api/gallery/*/preview.svg", (route) =>
+    route.fulfill(svg),
+  );
+  await page.route("**/api/gallery/*/versions/*/preview.svg", (route) =>
+    route.fulfill(svg),
+  );
+
+  await page.goto("/mine");
+  // Withdrawal asks for a second, explicit click.
+  await page.getByTestId("mine-withdraw-mine-2").click();
+  await page.getByTestId("mine-withdraw-confirm-mine-2").click();
+  await expect(page.getByTestId("mine-status-mine-2")).toHaveText("Withdrawn");
+  await expect(page.getByTestId("mine-notice")).toContainText("Withdrew");
+  // Restore (the worker re-enters review for ordinary owners; the mock
+  // simply flips the entry back).
+  await page.getByTestId("mine-restore-mine-2").click();
+  await expect(page.getByTestId("mine-status-mine-2")).toHaveText("Published");
+  // The version history dialog lists the snapshot with its preview.
+  await page.getByTestId("mine-history-mine-2").click();
+  await expect(page.getByTestId("version-history-dialog")).toBeVisible();
+  await expect(page.getByTestId("version-1")).toContainText("Live Amp v1");
+});
+
 test("an opened gallery entry offers updating in place", async ({ page }) => {
   await mockGallery(page, [ENTRY]);
   await page.route("**/api/auth/me", (route) =>

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -224,7 +224,7 @@ import {
   publishProjectToGallery,
   updateGalleryEntry,
 } from "../features/editor-shell/gallery-publish";
-import { VersionHistoryDialog } from "../features/editor-shell/version-history-dialog";
+import { VersionHistoryDialog } from "../components/version-history-dialog";
 import { fetchSessionUser, type SessionUser } from "../components/account";
 import {
   evaluateSubmissionGates,

--- a/apps/editor/src/components/my-submissions.tsx
+++ b/apps/editor/src/components/my-submissions.tsx
@@ -1,13 +1,16 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { fetchSessionUser } from "./account";
 import { GalleryChrome } from "./gallery-chrome";
+import { VersionHistoryDialog } from "./version-history-dialog";
 
 /**
  * "My submissions" (roadmap phase G3): a signed-in user's gallery entries
  * with their review status; a rejection shows the reviewer's optional
  * reason, and every entry opens back into the editor for another round
- * (an owner update re-enters review server-side).
+ * (an owner update re-enters review server-side). Owners can withdraw an
+ * entry from the gallery, bring it back (through review for ordinary
+ * accounts), and browse its version history.
  */
 
 export interface MineEntry {
@@ -40,15 +43,40 @@ export async function loadMySubmissions(
   }
 }
 
+/** Owner lifecycle action; the worker checks ownership per entry. */
+export async function setMyEntryRecycled(
+  id: string,
+  action: "recycle" | "restore",
+  fetchLike: typeof fetch = fetch,
+): Promise<boolean> {
+  try {
+    const response = await fetchLike(`/api/gallery/${id}/${action}`, {
+      method: "POST",
+      credentials: "same-origin",
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
 const STATUS_LABELS: Record<string, string> = {
   public: "Published",
   pending: "Waiting for review",
   rejected: "Rejected",
-  recycled: "Removed",
+  recycled: "Withdrawn",
 };
 
 export function MySubmissions() {
   const [state, setState] = useState<MineState>({ status: "loading" });
+  const [confirming, setConfirming] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [historyFor, setHistoryFor] = useState<MineEntry | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setState(await loadMySubmissions());
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -60,10 +88,38 @@ export function MySubmissions() {
     };
   }, []);
 
+  async function act(
+    entry: MineEntry,
+    action: "recycle" | "restore",
+  ): Promise<void> {
+    setBusy(entry.id);
+    setNotice(null);
+    const ok = await setMyEntryRecycled(entry.id, action);
+    setBusy(null);
+    setConfirming(null);
+    if (!ok) {
+      setNotice(
+        `Could not ${action === "recycle" ? "withdraw" : "restore"} "${entry.name}".`,
+      );
+      return;
+    }
+    setNotice(
+      action === "recycle"
+        ? `Withdrew "${entry.name}" from the gallery.`
+        : `"${entry.name}" is on its way back — it re-enters review first.`,
+    );
+    await reload();
+  }
+
   return (
     <main className="review-shell" data-testid="mine-page">
       <GalleryChrome subtitle="My submissions" showGalleryLink />
       <div className="page-body">
+        {notice ? (
+          <p className="gallery-status" data-testid="mine-notice">
+            {notice}
+          </p>
+        ) : null}
         {state.status === "loading" ? (
           <p className="gallery-status">Loading your submissions…</p>
         ) : state.status === "signed-out" ? (
@@ -99,13 +155,62 @@ export function MySubmissions() {
                   <p className="review-card-meta">
                     {new Date(entry.createdAt).toLocaleString()}
                   </p>
-                  <a
-                    className="account-link mine-card-edit"
-                    href={`/g/${entry.id}`}
-                    data-testid={`mine-edit-${entry.id}`}
-                  >
-                    Open in editor
-                  </a>
+                  <div className="mine-card-actions">
+                    <a
+                      className="account-link mine-card-edit"
+                      href={`/g/${entry.id}`}
+                      data-testid={`mine-edit-${entry.id}`}
+                    >
+                      Open in editor
+                    </a>
+                    <button
+                      type="button"
+                      className="account-link mine-card-history"
+                      data-testid={`mine-history-${entry.id}`}
+                      onClick={() => setHistoryFor(entry)}
+                    >
+                      Version history
+                    </button>
+                    {entry.status === "recycled" ? (
+                      <button
+                        type="button"
+                        className="account-link mine-card-restore"
+                        data-testid={`mine-restore-${entry.id}`}
+                        disabled={busy === entry.id}
+                        onClick={() => void act(entry, "restore")}
+                      >
+                        Restore (re-enters review)
+                      </button>
+                    ) : confirming === entry.id ? (
+                      <>
+                        <button
+                          type="button"
+                          className="mine-withdraw mine-withdraw-confirm"
+                          data-testid={`mine-withdraw-confirm-${entry.id}`}
+                          disabled={busy === entry.id}
+                          onClick={() => void act(entry, "recycle")}
+                        >
+                          Really withdraw
+                        </button>
+                        <button
+                          type="button"
+                          className="account-link"
+                          onClick={() => setConfirming(null)}
+                        >
+                          Keep it
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        type="button"
+                        className="mine-withdraw"
+                        data-testid={`mine-withdraw-${entry.id}`}
+                        onClick={() => setConfirming(entry.id)}
+                      >
+                        Withdraw
+                      </button>
+                    )}
+                  </div>
                 </div>
                 <div className="mine-card-status">
                   <span
@@ -128,12 +233,32 @@ export function MySubmissions() {
                       re-enters review.
                     </p>
                   ) : null}
+                  {entry.status === "recycled" ? (
+                    <p className="mine-reason">
+                      Not shown in the gallery. Restore sends it back through
+                      review.
+                    </p>
+                  ) : null}
                 </div>
               </article>
             ))}
           </section>
         )}
       </div>
+      {historyFor ? (
+        <VersionHistoryDialog
+          entryId={historyFor.id}
+          entryName={historyFor.name}
+          onRestored={() => {
+            setHistoryFor(null);
+            setNotice(
+              `Restored an earlier version of "${historyFor.name}" — it re-enters review unless you are a reviewer.`,
+            );
+            void reload();
+          }}
+          onClose={() => setHistoryFor(null)}
+        />
+      ) : null}
     </main>
   );
 }

--- a/apps/editor/src/components/version-history-dialog.tsx
+++ b/apps/editor/src/components/version-history-dialog.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 
 /**
- * Version history of one gallery entry (reviewer surface): every update
- * snapshotted the previous state; Restore adopts a version after
- * snapshotting the current one, so restores are themselves reversible.
+ * Version history of one gallery entry, for reviewers and the entry's
+ * owner: every update snapshotted the previous state; Restore adopts a
+ * version after snapshotting the current one, so restores are themselves
+ * reversible. An ordinary owner's restore re-enters review server-side.
  */
 
 export interface GalleryEntryVersion {

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
@@ -39,7 +39,8 @@ export interface PublishGalleryDialogProps {
     pending: boolean;
     updated: boolean;
   }) => void;
-  /** Reviewer-only: open the entry's version history instead. */
+  /** Reviewers and the entry's owner: open the version history instead.
+   * Rendered only alongside an update target. */
   onShowHistory?: (() => void) | undefined;
   onClose: () => void;
 }
@@ -195,7 +196,7 @@ export function PublishGalleryDialog({
               />
               Publish as a new entry
             </label>
-            {privileged && onShowHistory ? (
+            {onShowHistory ? (
               <button
                 type="button"
                 className="publish-gallery-history-link"

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -5563,6 +5563,46 @@ html.light .analytics-map-land path {
   margin-top: 4px;
 }
 
+.mine-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.mine-card-actions .account-link {
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+}
+
+.mine-withdraw {
+  padding: 3px 10px;
+  border: 1px solid color-mix(in srgb, #c0392b 45%, var(--icm-border));
+  border-radius: 999px;
+  color: #c0392b;
+  background: var(--icm-surface);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.mine-withdraw:hover {
+  background: color-mix(in srgb, #c0392b 8%, var(--icm-surface));
+}
+
+.mine-withdraw-confirm {
+  color: #fff;
+  background: #c0392b;
+  border-color: #c0392b;
+}
+
+.mine-withdraw-confirm:hover {
+  background: #a93226;
+}
+
 .gallery-filter {
   display: flex;
   align-items: center;

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -120,6 +120,15 @@ exactly to owners and reviewers.
 Entries persist a nullable owner column stamped from the submitting
 session.
 
+Owner withdrawal: `POST /api/gallery/<id>/recycle` (same-origin) also
+accepts the owning session — the entry moves to `recycled` and leaves
+every public surface, exactly like an admin recycle. The owner brings it
+back with `POST /api/gallery/<id>/restore`; because the pre-withdrawal
+status is not recorded (and may have been `pending`), an ordinary
+owner's restore re-enters review as `pending`, while an admin restore
+still goes straight to `public`. `/mine` surfaces both actions (a
+two-step Withdraw and a Restore on withdrawn entries).
+
 ## Version history
 
 Every content-replacing update (`PUT`, and Restore itself) first
@@ -127,16 +136,20 @@ snapshots the entry's previous state — name, author, description, tags,
 canonical project text, preview — into `gallery_entry_versions`,
 numbered per entry and capped at the newest 20 (older pruned).
 Maintenance re-serialization does not snapshot (content-equivalent).
-Reviewer authority (bearer, admin, or moderator):
+Authority: reviewers (bearer, admin, or moderator) and the entry's
+owning session:
 
 - `GET /api/gallery/<id>/versions` — versions, newest first.
 - `GET /api/gallery/<id>/versions/<versionId>/preview.svg`.
 - `POST /api/gallery/<id>/versions/<versionId>/restore` — snapshots the
-  current state, then adopts the version's content and metadata (entry
-  status unchanged), so restores are themselves reversible.
+  current state, then adopts the version's content and metadata, so
+  restores are themselves reversible. A reviewer's restore keeps the
+  entry status; an ordinary owner's restore is an owner edit and
+  re-enters review as `pending`.
 
 The editor surfaces this as "Version history…" inside the publish
-dialog's update mode for reviewer sessions.
+dialog's update mode (reviewers and owners) and as a per-entry
+"Version history" action on `/mine`.
 
 ## Accounts and sessions (Phase G2, dark-shipped)
 
@@ -185,8 +198,10 @@ signed-in super-admin session. With neither configured every admin route
 answers 401:
 
 - `POST /api/gallery/<id>/recycle` — soft delete into the restorable bin;
-  the entry disappears from every public surface.
-- `POST /api/gallery/<id>/restore` — back to `public`.
+  the entry disappears from every public surface. (Also open to the
+  owning session as withdrawal — see Owner editing.)
+- `POST /api/gallery/<id>/restore` — back to `public` (an ordinary
+  owner's restore re-enters review instead).
 - `DELETE /api/gallery/<id>` — permanent, and only for entries already in
   the bin (`409` otherwise).
 - `GET /api/gallery/recycled` — the bin.

--- a/plan/2026-08-22-owner-withdraw-history/plan.md
+++ b/plan/2026-08-22-owner-withdraw-history/plan.md
@@ -1,0 +1,62 @@
+# Owner withdrawal and owner-visible version history
+
+- status: complete
+- experience: The gallery's lifecycle surfaces were reviewer-only:
+  ordinary authors could not take their own entry off the wall, and
+  could not see the version snapshots their own updates create. The
+  owner asked for both: 普通用户可撤回自己的作品，普通作者可查看自己的
+  版本历史。
+
+## Goal
+
+An entry's owner manages its lifecycle without reviewer powers:
+withdraw it from the gallery (soft, restorable), bring it back (through
+review, since the pre-withdrawal status is not recorded), and browse or
+restore its version history (a restore is an owner edit and re-enters
+review).
+
+## Changes
+
+- `worker/gallery.ts`
+  - New `entryManager(request, env, id)` helper: `{found, reviewer,
+owner}` for one entry's management surfaces.
+  - `POST /:id/recycle|restore`: same-origin; admin keeps full
+    authority; the owning session may withdraw and restore its own
+    entry. Owner restore targets `pending` (admin restore stays
+    `public`). Unknown entries answer 404 before the authority check.
+  - Versions routes (list, version preview, restore): now reviewer OR
+    owner. Restore passes `pending: !reviewer`; the `restore-version`
+    op sets `status='pending', reject_reason=NULL` inside the same
+    transaction when asked.
+- `apps/editor/src/components/my-submissions.tsx` — per-entry actions:
+  two-step Withdraw, Restore (labelled as re-entering review), Version
+  history dialog; notices and reload after each action; `recycled`
+  status labelled "Withdrawn" with an explanation.
+- `apps/editor/src/components/version-history-dialog.tsx` — moved from
+  `features/editor-shell/` so `/mine` (components layer) can reuse it;
+  App import updated.
+- `apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx` —
+  the "Version history…" link now renders for anyone with an update
+  target (owners included), not only privileged sessions.
+- `apps/editor/src/styles.css` — mine-card action row and withdraw
+  button styles.
+- `docs/specs/community-gallery.md` — owner withdrawal contract,
+  version-history authority, admin-route notes.
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: entry lifecycle authority (owner withdrawal/restore with
+  review re-entry; owner-visible version history; stranger/anonymous
+  denial), unchanged admin curation.
+- Primary checks: `node_modules/.bin/vitest run worker/gallery.test.ts`
+  (two new owner-lifecycle tests; the bearer-guard test now expects 404
+  for an unknown entry since ownership is resolved first);
+  `node_modules/.bin/playwright test apps/editor/e2e/gallery.spec.ts
+--grep "owner withdrawal"` (new `/mine` actions spec).
+
+## Validation
+
+- Worker vitest: 19 passed. Editor e2e (mine + history specs): 3
+  passed. `tsc --noEmit -p tsconfig.check.json` clean. Prettier on
+  touched files; `git diff --check`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -4913,3 +4913,16 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   failures updated, then green), typecheck, prettier, diff checks.
 - Commit status: completed on `claude/port-defaults`; mainline merge gated on
   the remote required checks.
+
+## 2026-08-22 — Owner withdrawal and owner-visible version history
+
+- Plan: `plan/2026-08-22-owner-withdraw-history/plan.md` (complete)
+- The owning session can now withdraw its entry (`POST /:id/recycle`),
+  bring it back through review (`/restore` → `pending` for ordinary
+  owners, `public` for admins), and read/restore its version history
+  (restore re-enters review via the new `pending` flag on the
+  `restore-version` op). `/mine` gained two-step Withdraw, Restore, and
+  a Version history dialog (moved to `components/` for reuse); the
+  publish dialog's history link now shows for owners too. Spec updated.
+  Worker vitest 19 passed; e2e mine/history specs 3 passed; typecheck
+  clean.

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -1007,6 +1007,8 @@ describe("gallery administration", () => {
     );
     expect(anonymous.status).toBe(401);
 
+    // Without a configured bearer the caller is an ordinary visitor; the
+    // ownership check runs first, so an unknown entry reads as not-found.
     const noTokenConfigured = environment();
     const impossible = await route(
       noTokenConfigured,
@@ -1015,7 +1017,7 @@ describe("gallery administration", () => {
         headers: adminHeaders("anything"),
       }),
     );
-    expect(impossible.status).toBe(401);
+    expect(impossible.status).toBe(404);
   });
 
   it("recycles, hides, restores, and only hard-deletes from the bin", async () => {
@@ -1140,5 +1142,186 @@ describe("gallery administration", () => {
       new Request(`${ORIGIN}/api/gallery/${id}/preview.svg`),
     );
     expect(await preview.text()).toContain("<svg");
+  });
+});
+
+describe("gallery owner lifecycle (withdrawal and history)", () => {
+  async function submitApproved(
+    env: GalleryEnv,
+    ownerCookie: string,
+    adminCookie: string,
+    name: string,
+  ): Promise<string> {
+    const submitted = await route(
+      env,
+      submissionRequest(
+        { name, projectText: wiredProjectText(name) },
+        { token: null, cookie: ownerCookie },
+      ),
+    );
+    expect(submitted.status).toBe(201);
+    const { id } = (await submitted.json()) as { id: string };
+    const approved = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/approve`, {
+        method: "POST",
+        headers: { Origin: ORIGIN, Cookie: adminCookie },
+      }),
+    );
+    expect(approved.status).toBe(200);
+    return id;
+  }
+
+  function lifecycle(
+    id: string,
+    action: "recycle" | "restore",
+    cookie: string | null,
+  ): Request {
+    const headers = new Headers({ Origin: ORIGIN });
+    if (cookie) headers.set("Cookie", cookie);
+    return new Request(`${ORIGIN}/api/gallery/${id}/${action}`, {
+      method: "POST",
+      headers,
+    });
+  }
+
+  async function mineStatus(
+    env: GalleryEnv,
+    cookie: string,
+    id: string,
+  ): Promise<string | undefined> {
+    const mine = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/mine`, {
+        headers: { Cookie: cookie },
+      }),
+    );
+    const payload = (await mine.json()) as {
+      entries: { id: string; status: string }[];
+    };
+    return payload.entries.find((entry) => entry.id === id)?.status;
+  }
+
+  it("owners withdraw and restore their own entries; strangers cannot", async () => {
+    const { authDurable, env } = reviewHarness();
+    const ownerCookie = await signIn(authDurable, "maker@example.com");
+    const adminCookie = await signIn(authDurable, "owner@example.com");
+    const strangerCookie = await signIn(authDurable, "other@example.com");
+    const id = await submitApproved(env, ownerCookie, adminCookie, "Mine");
+
+    expect(
+      (await route(env, lifecycle(id, "recycle", strangerCookie))).status,
+    ).toBe(401);
+    expect((await route(env, lifecycle(id, "recycle", null))).status).toBe(401);
+
+    // Owner withdraws: gone from the public wall, "recycled" in /mine.
+    expect(
+      (await route(env, lifecycle(id, "recycle", ownerCookie))).status,
+    ).toBe(200);
+    const list = await route(env, new Request(`${ORIGIN}/api/gallery`));
+    const wall = (await list.json()) as { entries: { id: string }[] };
+    expect(wall.entries.some((entry) => entry.id === id)).toBe(false);
+    expect(await mineStatus(env, ownerCookie, id)).toBe("recycled");
+
+    // The owner's restore re-enters review; the admin's goes straight back.
+    expect(
+      (await route(env, lifecycle(id, "restore", ownerCookie))).status,
+    ).toBe(200);
+    expect(await mineStatus(env, ownerCookie, id)).toBe("pending");
+    expect(
+      (await route(env, lifecycle(id, "recycle", adminCookie))).status,
+    ).toBe(200);
+    expect(
+      (await route(env, lifecycle(id, "restore", adminCookie))).status,
+    ).toBe(200);
+    expect(await mineStatus(env, ownerCookie, id)).toBe("public");
+
+    const missing = await route(
+      env,
+      lifecycle("does-not-exist", "recycle", ownerCookie),
+    );
+    expect(missing.status).toBe(404);
+  });
+
+  it("owners browse their version history; restores re-enter review", async () => {
+    const { authDurable, env } = reviewHarness();
+    const ownerCookie = await signIn(authDurable, "maker@example.com");
+    const adminCookie = await signIn(authDurable, "owner@example.com");
+    const strangerCookie = await signIn(authDurable, "other@example.com");
+    const id = await submitApproved(env, ownerCookie, adminCookie, "Hist v1");
+
+    // Owner update snapshots v1 and re-enters review.
+    const updated = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}`, {
+        method: "PUT",
+        headers: {
+          Origin: ORIGIN,
+          Cookie: ownerCookie,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "Hist v2",
+          author: "maker",
+          projectText: wiredProjectText("Hist v2"),
+        }),
+      }),
+    );
+    expect(updated.status).toBe(200);
+
+    function versionsRequest(cookie: string | null): Request {
+      const headers = new Headers();
+      if (cookie) headers.set("Cookie", cookie);
+      return new Request(`${ORIGIN}/api/gallery/${id}/versions`, { headers });
+    }
+    expect((await route(env, versionsRequest(strangerCookie))).status).toBe(
+      401,
+    );
+    expect((await route(env, versionsRequest(null))).status).toBe(401);
+    const listed = await route(env, versionsRequest(ownerCookie));
+    expect(listed.status).toBe(200);
+    const { versions } = (await listed.json()) as {
+      versions: { versionId: string; name: string }[];
+    };
+    expect(versions).toHaveLength(1);
+    expect(versions[0]!.name).toBe("Hist v1");
+
+    const previewPath = `${ORIGIN}/api/gallery/${id}/versions/${versions[0]!.versionId}/preview.svg`;
+    const strangerPreview = await route(
+      env,
+      new Request(previewPath, { headers: { Cookie: strangerCookie } }),
+    );
+    expect(strangerPreview.status).toBe(404);
+    const ownerPreview = await route(
+      env,
+      new Request(previewPath, { headers: { Cookie: ownerCookie } }),
+    );
+    expect(await ownerPreview.text()).toContain("<svg");
+
+    // Approve v2, then the owner's restore of v1 demotes it to pending.
+    await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/approve`, {
+        method: "POST",
+        headers: { Origin: ORIGIN, Cookie: adminCookie },
+      }),
+    );
+    const restore = await route(
+      env,
+      new Request(
+        `${ORIGIN}/api/gallery/${id}/versions/${versions[0]!.versionId}/restore`,
+        { method: "POST", headers: { Origin: ORIGIN, Cookie: ownerCookie } },
+      ),
+    );
+    expect(restore.status).toBe(200);
+    expect(await mineStatus(env, ownerCookie, id)).toBe("pending");
+    const detail = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}`, {
+        headers: { Cookie: ownerCookie },
+      }),
+    );
+    const payload = (await detail.json()) as { entry: { name: string } };
+    expect(payload.entry.name).toBe("Hist v1");
   });
 });

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -572,6 +572,14 @@ export class GalleryDO {
         version.tags ?? "",
         entry.id,
       );
+      // An owner-initiated restore re-enters review like any owner edit.
+      if (body.pending === true) {
+        this.sql.exec(
+          `UPDATE gallery_entries
+           SET status = 'pending', reject_reason = NULL WHERE id = ?`,
+          entry.id,
+        );
+      }
     });
     return Response.json({ id: entry.id, restored: true });
   }
@@ -729,6 +737,32 @@ async function canReview(request: Request, env: GalleryEnv): Promise<boolean> {
   if (bearerIsAdmin(request, env)) return true;
   const user = await sessionUserOf(request, env);
   return user?.isAdmin === true || user?.role === "moderator";
+}
+
+/**
+ * Who may manage one entry's lifecycle surfaces (withdrawal, version
+ * history): a reviewer, or the signed-in owner of that entry.
+ */
+async function entryManager(
+  request: Request,
+  env: GalleryEnv,
+  id: string,
+): Promise<{ found: boolean; reviewer: boolean; owner: boolean }> {
+  const existing = await callGallery<{ ownerUserId?: string | null }>(
+    env,
+    "any-entry",
+    { id },
+  );
+  if (existing.status !== 200) {
+    return { found: false, reviewer: false, owner: false };
+  }
+  const reviewer = await canReview(request, env);
+  const user = await sessionUserOf(request, env);
+  const owner =
+    user !== null &&
+    existing.payload.ownerUserId != null &&
+    existing.payload.ownerUserId === user.id;
+  return { found: true, reviewer, owner };
 }
 
 async function submitterHash(request: Request): Promise<string> {
@@ -1071,7 +1105,11 @@ export async function routeGalleryRequest(
     segments[1] === "versions" &&
     request.method === "GET"
   ) {
-    if (!(await canReview(request, env))) {
+    const access = await entryManager(request, env, segments[0]!);
+    if (!access.found) {
+      return Response.json({ error: "not-found" }, { status: 404 });
+    }
+    if (!access.reviewer && !access.owner) {
       return Response.json({ error: "unauthorized" }, { status: 401 });
     }
     const { status, payload } = await callGallery(env, "versions", {
@@ -1088,7 +1126,8 @@ export async function routeGalleryRequest(
     segments[3] === "preview.svg" &&
     request.method === "GET"
   ) {
-    if (!(await canReview(request, env))) {
+    const access = await entryManager(request, env, segments[0]!);
+    if (!access.found || (!access.reviewer && !access.owner)) {
       return Response.json({ error: "not-found" }, { status: 404 });
     }
     const { status, payload } = await callGallery<{ svgText?: string }>(
@@ -1117,13 +1156,19 @@ export async function routeGalleryRequest(
     if (!sameOrigin(request)) {
       return Response.json({ error: "forbidden" }, { status: 403 });
     }
-    if (!(await canReview(request, env))) {
+    const access = await entryManager(request, env, segments[0]!);
+    if (!access.found) {
+      return Response.json({ error: "not-found" }, { status: 404 });
+    }
+    if (!access.reviewer && !access.owner) {
       return Response.json({ error: "unauthorized" }, { status: 401 });
     }
     const { status, payload } = await callGallery(env, "restore-version", {
       entryId: segments[0],
       versionId: segments[2],
       at: new Date().toISOString(),
+      // An ordinary owner's restore is an owner edit: back through review.
+      pending: !access.reviewer,
     });
     return Response.json(payload, { status });
   }
@@ -1220,12 +1265,26 @@ export async function routeGalleryRequest(
     if (action !== "recycle" && action !== "restore") {
       return Response.json({ error: "not-found" }, { status: 404 });
     }
-    if (!(await isAdmin(request, env))) {
-      return Response.json({ error: "unauthorized" }, { status: 401 });
+    if (!sameOrigin(request)) {
+      return Response.json({ error: "forbidden" }, { status: 403 });
+    }
+    // Admins curate anything; an owner may withdraw their own entry and
+    // bring it back — but an ordinary owner's restore re-enters review
+    // (the pre-withdrawal status is not recorded, and it may have been
+    // pending).
+    const admin = await isAdmin(request, env);
+    if (!admin) {
+      const access = await entryManager(request, env, id!);
+      if (!access.found) {
+        return Response.json({ error: "not-found" }, { status: 404 });
+      }
+      if (!access.owner) {
+        return Response.json({ error: "unauthorized" }, { status: 401 });
+      }
     }
     const { status, payload } = await callGallery(env, "set-status", {
       id,
-      status: action === "recycle" ? "recycled" : "public",
+      status: action === "recycle" ? "recycled" : admin ? "public" : "pending",
       at: new Date().toISOString(),
     });
     return Response.json(payload, { status });


### PR DESCRIPTION
## Summary
- **Owner withdrawal**: `POST /api/gallery/:id/recycle` now also accepts the owning session — the entry leaves every public surface (same soft state as an admin recycle). `/restore` brings it back: straight to `public` for admins, **through review (`pending`)** for ordinary owners, since the pre-withdrawal status is not recorded and may have been pending.
- **Owner-visible version history**: the versions list, version previews, and restore now answer to the entry's owner as well as reviewers; an ordinary owner's restore re-enters review (new `pending` flag on the `restore-version` op, applied in the same transaction).
- **/mine**: per-entry actions — two-step Withdraw, Restore (labelled as re-entering review), and a Version history dialog (moved to `components/` for reuse); notices and reload after each action; `recycled` shows as "Withdrawn".
- Publish dialog's "Version history…" link now renders for anyone with an update target (owners included).
- Spec updated (owner editing, version history, admin routes). The bearer-guard test now expects 404 for an unknown entry because ownership resolves first (still a refusal, no information leak).

## Test plan
- `vitest run worker/gallery.test.ts` — 19 passed (2 new owner-lifecycle tests)
- `playwright test apps/editor/e2e/gallery.spec.ts --grep 'owner withdrawal|history|chrome'` — 3 passed
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)