### PR TITLE
fix(editor): keep Power Rails when importing a circuit

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -1757,7 +1757,8 @@ test("keeps literal text line breaks and overbars visible while editing", async 
   await editor.press("ControlOrMeta+A");
   await page.getByRole("button", { name: "Overbar" }).click();
   await editor.press("End");
-  await editor.press("Enter");
+  // Enter finishes the text everywhere; a deliberate modifier asks for a line.
+  await editor.press("Shift+Enter");
   await editor.type("bias");
   await page.getByRole("button", { name: "Apply text changes" }).click();
   await expect(

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -131,6 +131,7 @@ import {
   clipboardPlacementAnchor,
   clipboardPreviewDocument,
   copySelection,
+  copyWholeDocument,
 } from "../features/clipboard/clipboard";
 import type { SchematicClipboard } from "../features/clipboard/clipboard";
 import { startCanvasDragSession } from "../canvas/canvas-drag-session";
@@ -3305,10 +3306,7 @@ export function App({
       (candidate) => candidate.id === imported.topDocumentId,
     );
     if (!importedDocument || imported.documents.length > 1) return false;
-    const clipboard = copySelection(
-      importedDocument,
-      importedDocument.instances.map((instance) => instance.id),
-    );
+    const clipboard = copyWholeDocument(importedDocument);
     const anchor = clipboard ? clipboardPlacementAnchor(clipboard) : null;
     if (!clipboard || !anchor) return false;
     cancelAllTransientInteraction();

--- a/apps/editor/src/features/clipboard/clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard.test.ts
@@ -14,6 +14,7 @@ import {
   clipboardPreviewDocument,
   copyPlacementOrientationEdits,
   copySelection,
+  copyWholeDocument,
   proposePaste,
 } from "./clipboard";
 
@@ -602,5 +603,52 @@ describe("schematic clipboard", () => {
       origin: "supply-default",
       netId: "net-global-0",
     });
+  });
+});
+
+describe("copyWholeDocument", () => {
+  it("keeps a Power Rail that no device is wired to yet", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.nets.push({
+      id: "net-vdd",
+      name: "VDD",
+      scope: "local",
+      powerDomain: "vdd",
+      terminals: [],
+      origin: { kind: "authored" },
+    });
+    document.junctions.push(
+      {
+        id: "junction-vdd-start",
+        netId: "net-vdd",
+        position: { x: 10, y: 10 },
+        role: "route-anchor",
+      },
+      {
+        id: "junction-vdd-end",
+        netId: "net-vdd",
+        position: { x: 110, y: 10 },
+        role: "route-anchor",
+      },
+    );
+    document.routes.push({
+      id: "rail-vdd",
+      netId: "net-vdd",
+      from: { kind: "junction", junctionId: "junction-vdd-start" },
+      to: { kind: "junction", junctionId: "junction-vdd-end" },
+      waypoints: [],
+      segmentModes: ["manual"],
+      presentation: "power-rail",
+    });
+
+    // A selection copy keeps only Nets whose every terminal is selected, so a
+    // rail with no device on it yet is not part of any selection.
+    expect(copySelection(document, [])).toBeNull();
+
+    const whole = copyWholeDocument(document);
+    expect(whole?.routes).toHaveLength(1);
+    expect(whole?.routes[0]?.presentation).toBe("power-rail");
+    expect(whole?.junctions).toHaveLength(2);
+    expect(whole?.nets.map((net) => net.name)).toEqual(["VDD"]);
   });
 });

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -271,6 +271,33 @@ export function clipboardPreviewDocument(
   );
 }
 
+/**
+ * Copy a whole Document as one fragment.
+ *
+ * `copySelection` is driven by the instances a user picked, so it keeps only
+ * Nets every terminal of which is inside that selection. Importing a circuit
+ * is a different question — everything drawn belongs — and a Net with no
+ * instance terminals at all, such as a Power Rail that has been drawn but not
+ * yet wired to a device, would otherwise be dropped along with its rail
+ * geometry and label.
+ */
+export function copyWholeDocument(
+  document: SchematicDocument,
+): SchematicClipboard | null {
+  if (document.instances.length === 0 && document.routes.length === 0) {
+    return null;
+  }
+  return structuredClone({
+    instances: document.instances,
+    nets: document.nets,
+    boundaryNets: [],
+    routes: document.routes,
+    junctions: document.junctions,
+    annotations: document.annotations,
+    noConnects: document.noConnects,
+  });
+}
+
 export function copySelection(
   document: SchematicDocument,
   instanceIds: readonly string[],

--- a/apps/editor/src/features/editor-shell/examples-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/examples-panel.test.ts
@@ -61,7 +61,7 @@ describe("gallery-backed library", () => {
 });
 
 describe("user examples section", () => {
-  it("previews each circuit and lets the reader choose the column count", () => {
+  it("previews each circuit rather than only naming it", () => {
     const markup = renderToStaticMarkup(
       createElement(ExamplesPanel, {
         open: true,
@@ -73,8 +73,9 @@ describe("user examples section", () => {
     // want to borrow from, so every card carries the circuit itself.
     expect(markup).toContain('class="shapes-example-preview"');
     expect(markup).toContain("<svg");
-    expect(markup).toContain('data-testid="gallery-column-slider"');
-    expect(markup).toContain('aria-label="Gallery columns"');
+    // Columns follow the panel's dragged width rather than a second control
+    // for the same thing.
+    expect(markup).not.toContain('data-testid="gallery-column-slider"');
   });
 
   it("keeps the gallery as the only place circuits are stored", () => {

--- a/apps/editor/src/features/editor-shell/examples-panel.tsx
+++ b/apps/editor/src/features/editor-shell/examples-panel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 
 import { renderDocumentSvg } from "@icm/render-svg";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
@@ -26,21 +26,7 @@ export interface ExamplesPanelProps {
   onOpenExample(example: LibraryProjectExample): void;
 }
 
-const COLUMN_STORAGE_KEY = "icm.gallery-panel-columns.v1";
-const MIN_COLUMNS = 1;
-const MAX_COLUMNS = 4;
-
 const resolver = new InMemorySymbolResolver(builtInSymbols);
-
-function initialColumns(): number {
-  if (typeof window === "undefined") return 1;
-  const stored = Number(window.localStorage.getItem(COLUMN_STORAGE_KEY));
-  return Number.isFinite(stored) &&
-    stored >= MIN_COLUMNS &&
-    stored <= MAX_COLUMNS
-    ? stored
-    : 1;
-}
 
 /**
  * The circuit gallery, docked beside the canvas. Every card carries a preview
@@ -53,7 +39,6 @@ export function ExamplesPanel({
   onOpenGalleryExample,
   onOpenExample,
 }: ExamplesPanelProps) {
-  const [columns, setColumns] = useState(initialColumns);
   const showGallery = galleryExamples !== null && galleryExamples.length > 0;
 
   // Bundled circuits render from the same renderer the feed uses; the work is
@@ -71,15 +56,6 @@ export function ExamplesPanel({
     [],
   );
 
-  const changeColumns = (next: number): void => {
-    setColumns(next);
-    try {
-      window.localStorage.setItem(COLUMN_STORAGE_KEY, String(next));
-    } catch {
-      // Column count stays usable when browser storage is unavailable.
-    }
-  };
-
   return (
     <aside
       id="examples-panel"
@@ -93,27 +69,10 @@ export function ExamplesPanel({
       data-open={open ? "true" : "false"}
     >
       <div className="shapes-panel-body">
-        <label className="gallery-column-control">
-          <span>Columns</span>
-          <input
-            type="range"
-            min={MIN_COLUMNS}
-            max={MAX_COLUMNS}
-            step={1}
-            value={columns}
-            aria-label="Gallery columns"
-            data-testid="gallery-column-slider"
-            onChange={(event) =>
-              changeColumns(Number(event.currentTarget.value))
-            }
-          />
-          <output>{columns}</output>
-        </label>
-        <div
-          className="shapes-example-list"
-          data-columns={columns}
-          style={{ "--icm-gallery-columns": columns } as React.CSSProperties}
-        >
+        {/* Columns follow the panel's dragged width, the same way the Library
+            tiles do; a separate control for the same thing is one knob too
+            many. */}
+        <div className="shapes-example-list">
           {showGallery
             ? galleryExamples.map((example) => (
                 <button

--- a/apps/editor/src/features/text-editing/rich-text-editor.tsx
+++ b/apps/editor/src/features/text-editing/rich-text-editor.tsx
@@ -490,12 +490,11 @@ export function RichTextEditor({
           onKeyDown={(event) => {
             if (event.key === "Escape") {
               event.preventDefault();
-              // Escape saves the session, matching click-away and Ctrl+Enter.
+              // Escape saves the session, matching click-away and Enter.
               onCommit();
-            } else if (event.key === "Enter" && event.ctrlKey) {
-              event.preventDefault();
-              onCommit();
-            } else if (event.key === "Enter" && multiline) {
+            } else if (event.key === "Enter" && event.shiftKey && multiline) {
+              // Enter finishes the text everywhere; a deliberate modifier is
+              // what asks for another line.
               event.preventDefault();
               insertLineBreak();
             } else if (event.key === "Enter") {

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -6137,25 +6137,11 @@ html.light .analytics-map-land path {
 
 /* The gallery panel shows circuits, not just their names, and the reader
    chooses how many fit per row. */
-.gallery-column-control {
-  display: flex;
-  gap: var(--icm-space-2);
-  align-items: center;
-  padding: var(--icm-space-2);
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-xs);
-}
-
-.gallery-column-control input[type="range"] {
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
-.shapes-example-list[data-columns] {
+.shapes-example-list {
   display: grid;
-  grid-template-columns: repeat(var(--icm-gallery-columns, 1), minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   gap: var(--icm-space-2);
-  padding: 0 var(--icm-space-2) var(--icm-space-2);
+  padding: var(--icm-space-2);
 }
 
 .shapes-example-preview {

--- a/packages/derived/src/instance-label-placement.ts
+++ b/packages/derived/src/instance-label-placement.ts
@@ -174,6 +174,34 @@ export function inferInstanceLabelSide(
   return displacement.y > 0 ? "bottom" : "top";
 }
 
+/**
+ * Side opposite the Symbol's own connection point, so a label constrained to
+ * a horizontal side never lands on top of the wire leaving the Port.
+ */
+function horizontalSideAwayFromPin(
+  instance: SchematicDocument["instances"][number],
+  resolved: ResolvedSymbol,
+): InstanceLabelSide {
+  const pin = resolved.definition.pins[0];
+  if (!pin || !instance.placement) return "left";
+  const localBounds = visibleSymbolInkBounds(resolved);
+  const localCenter = {
+    x: localBounds.x + localBounds.width / 2,
+    y: localBounds.y + localBounds.height / 2,
+  };
+  const pinWorld = transformPoint(
+    pin.at,
+    instance.placement.position,
+    instance.placement,
+  );
+  const centerWorld = transformPoint(
+    localCenter,
+    instance.placement.position,
+    instance.placement,
+  );
+  return pinWorld.x > centerWorld.x ? "left" : "right";
+}
+
 function transformedSide(
   side: InstanceLabelSide,
   instance: SchematicDocument["instances"][number],
@@ -211,11 +239,21 @@ export function placeUprightInstanceLabel(
   grid: number,
   sizeScale = 1,
   rowOffset = 0,
+  /**
+   * Keep the label beside the symbol through every quarter turn. Upright text
+   * above or below a rotated Port reads as the label having flipped over, so
+   * such a Symbol swaps between left and right instead.
+   */
+  horizontalSidesOnly = false,
 ): InstanceLabelPlacement | null {
   if (!instance.placement) return null;
   const localBounds = visibleSymbolInkBounds(resolved);
   const worldBounds = transformedBounds(localBounds, instance);
-  const worldSide = transformedSide(localSide, instance);
+  const rotatedSide = transformedSide(localSide, instance);
+  const worldSide =
+    horizontalSidesOnly && (rotatedSide === "top" || rotatedSide === "bottom")
+      ? horizontalSideAwayFromPin(instance, resolved)
+      : rotatedSide;
   if (!worldBounds || !worldSide) return null;
   const semanticPosition = transformPoint(
     localAnchor,
@@ -306,6 +344,7 @@ export function defaultInstanceLabelPlacement(
       grid,
       1,
       rowOffset,
+      true,
     );
   }
 

--- a/plan/2026-08-22-import-fidelity-and-text-keys/plan.md
+++ b/plan/2026-08-22-import-fidelity-and-text-keys/plan.md
@@ -1,0 +1,85 @@
+---
+status: completed
+experience: none
+---
+
+# Imports keep their Power Rails, and Enter finishes text
+
+## Goal
+
+Stop losing a Power Rail when a circuit is inserted from the gallery, keep a
+Port's label beside the symbol through every rotation, and make Enter finish
+text everywhere.
+
+## The import defect
+
+Reported: inserting a circuit from the gallery lost its VDD line. Traced by
+probing the copy itself rather than the UI.
+
+`copySelection` is driven by the instances a user picked, so
+`deriveInternalGroupSelection` keeps only Nets whose every terminal is inside
+that selection — and it requires at least one terminal. A Net with **no**
+instance terminals, such as a Power Rail drawn but not yet wired to a device,
+therefore never qualified, and its rail routes, junctions, and label were
+dropped.
+
+Bundled examples hid this: their rails are wired to transistors, so the Net
+had terminals and survived. A published circuit whose rail is not yet wired
+did not.
+
+`copyWholeDocument` is the honest primitive for importing a circuit —
+everything drawn belongs — and `beginProjectImportPlacement` now uses it.
+
+## Work
+
+1. Add `copyWholeDocument` and import through it.
+2. Constrain a Port's label to a horizontal side: upright text above or below
+   a rotated Port reads as the label having flipped over. It now swaps between
+   left and right and never sits above or below.
+3. Enter finishes text in every canvas editor; Shift+Enter starts a line.
+4. Drop the gallery column slider: columns follow the panel's dragged width,
+   the same way the Library tiles do.
+
+## Measured, not changed
+
+- A rectangle label is already centred: its text box centre and the
+  rectangle's centre both measure 400 in the same probe.
+- Schematic and drafting text already share one family
+  (`"DejaVu Sans", Arial, …`) at one size. The visual difference is weight and
+  slope, which is the intended split: box text upright, device and Port names
+  italic, subscripts upright.
+
+## Validation
+
+- Full unit suite (1189 passed), full Playwright suite (208 passed)
+- New clipboard case proves the defect and the fix: a rail with no device on
+  it is absent from `copySelection` and present in `copyWholeDocument`
+- `tsc -p tsconfig.check.json`, Prettier, `git diff --check`
+
+## Gate Review
+
+- Decision: affected
+- Early gates: typecheck, Prettier
+- Affected gates: clipboard and derived unit tests, the manual-editor and
+  component-insert Playwright specs
+- Final gates: remote GitHub Actions
+- Platform risks: none
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: what an import carries, where a Port label sits, and what Enter
+  does in a canvas text editor.
+- Primary checks: `apps/editor/src/features/clipboard/clipboard.test.ts`,
+  `apps/editor/e2e/manual-editor.spec.ts`
+
+## Commit Intent
+
+```text
+fix(editor): keep Power Rails when importing a circuit
+```
+
+## Outcome
+
+An imported circuit arrives whole, a Port label never sits above or below its
+symbol, and Enter finishes text with Shift+Enter starting a line.

--- a/plan/log.md
+++ b/plan/log.md
@@ -5017,3 +5017,29 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   the toggle states verified live.
 - Commit status: completed on `claude/gallery-consolidation`; mainline merge
   gated on the remote required checks.
+
+## 2026-08-22 - Imports keep their Power Rails, and Enter finishes text
+
+- Reported: inserting a circuit from the gallery lost its VDD line. Traced by
+  probing the copy rather than the UI. `copySelection` is instance-driven, so
+  it keeps only Nets whose every terminal is inside the selection and requires
+  at least one terminal; a Net with no instance terminals — a Power Rail drawn
+  but not yet wired to a device — never qualified, and its routes, junctions,
+  and label were dropped. Bundled examples hid this because their rails are
+  wired to transistors.
+- `copyWholeDocument` is the honest primitive for importing a circuit, and the
+  import path now uses it. A new clipboard case proves both halves: the rail is
+  absent from `copySelection` and present in `copyWholeDocument`.
+- A Port's label is now constrained to a horizontal side, so it swaps between
+  left and right and never sits above or below a rotated Port.
+- Enter finishes text in every canvas editor; Shift+Enter starts a line.
+- The gallery column slider is gone: columns follow the panel's dragged width,
+  the same way the Library tiles do.
+- Measured rather than changed: a rectangle label is already centred (text box
+  centre and rectangle centre both 400), and schematic and drafting text already
+  share one family at one size — the visual difference is weight and slope,
+  which is the intended split.
+- Validation: full unit suite (1189), full Playwright suite (208 passed),
+  typecheck, prettier, diff checks.
+- Commit status: completed on `claude/instance-behavior`; mainline merge gated
+  on the remote required checks.


### PR DESCRIPTION
## The VDD line vanished on import

Traced by probing the **copy itself** rather than the UI.

`copySelection` is driven by the instances a user picked, so `deriveInternalGroupSelection` keeps only Nets whose *every* terminal is inside that selection — and it requires **at least one terminal**. A Net with **no** instance terminals — a Power Rail drawn but not yet wired to a device — therefore never qualified, and its rail routes, junctions, and label were dropped with it.

Bundled examples hid this: their rails *are* wired to transistors, so the Net had terminals and survived. A published circuit whose rail isn't wired yet did not.

**Fix:** `copyWholeDocument` — the honest primitive for importing a circuit, since everything drawn belongs. The import path now uses it.

A new clipboard case proves both halves: a rail with no device on it is **absent** from `copySelection` and **present** in `copyWholeDocument`.

## Also

- **Port labels** stay on a horizontal side. Upright text above or below a rotated Port reads as the label having flipped over; it now swaps between left and right and never sits above or below.
- **Enter finishes text** in every canvas editor; **Shift+Enter** starts a line.
- The gallery **column slider is gone** — columns follow the panel's dragged width, like the Library tiles.

## Measured, not changed

- A **rectangle label is already centred**: the text box centre and the rectangle centre both measure `400` in one probe.
- Schematic and drafting text **already share one family** (`"DejaVu Sans", Arial, …`) at one size. The visual difference is weight and slope — the intended split: box text upright, device and Port names italic, subscripts upright.

## Validation

- Full unit suite: **1189 passed**
- Full Playwright suite: **208 passed**
- Typecheck, Prettier, `git diff --check`, test-impact gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)