### PR TITLE
fix(editor): rename one Net Port without renaming its twin

### DIFF
--- a/apps/editor/e2e/hierarchy.spec.ts
+++ b/apps/editor/e2e/hierarchy.spec.ts
@@ -633,3 +633,41 @@ test("places a second Port for a Cell terminal that already exists", async ({
   expect(terminals[0]!.name).toBe("P1");
   expect(terminals[0]!.interfaceInstanceIds).toHaveLength(2);
 });
+
+test("renaming one Net Port leaves its same-named twin alone", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placePort(page, {
+    role: "net-port",
+    name: "Vshared",
+    position: { x: 260, y: 180 },
+  });
+  await placePort(page, {
+    role: "net-port",
+    name: "Vshared",
+    position: { x: 260, y: 320 },
+  });
+
+  const labels = page.locator(
+    '[data-testid^="annotation-hit-instance-label-"]',
+  );
+  await expect(labels).toHaveCount(2);
+
+  // Two Ports naming one node share a Net, so renaming that Net used to
+  // rename both. Renaming one Port is a statement about that Port.
+  await page.getByTestId("hit-P2").click();
+  const shelf = page.getByTestId("selection-shelf");
+  if ((await shelf.getAttribute("aria-expanded")) === "false")
+    await shelf.click();
+  const nameField = page.getByLabel("Net Port name");
+  await nameField.fill("Vbias");
+  await nameField.blur();
+
+  await expect(page.getByTestId("status")).toContainText("Renamed Net Port");
+  const texts = await page
+    .locator('[data-testid="schematic-canvas"] text')
+    .allTextContents();
+  expect(texts).toContain("Vshared");
+  expect(texts).toContain("Vbias");
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -94,6 +94,7 @@ import {
   createEmptyDocument,
   createId,
   defaultDraftTextDocument,
+  foldNetName,
   flattenRichText,
   inverseTransformPoint,
   snapGridPoint,
@@ -2427,9 +2428,89 @@ export function App({
         )
       : undefined;
   function renameSelectedNetPort(name: string): void {
-    if (!selectedPortNet || selectedFormalTerminal) return;
+    if (!selectedPortNet || !selectedInstance || selectedFormalTerminal) return;
     name = name.trim();
     if (!name || name === selectedPortNet.name) return;
+
+    // Several Net Ports naming the same node share one Net, so renaming that
+    // Net would rename all of them. Renaming one Port is a statement about
+    // that Port, so it leaves the shared node and takes the new name with it.
+    const portInstanceIds = new Set(
+      document.instances
+        .filter(
+          (instance) =>
+            instance.symbolId === "port" || instance.symbolId === "port-filled",
+        )
+        .map((instance) => instance.id),
+    );
+    const sharedWithAnotherPort =
+      selectedPortNet.terminals.filter((terminal) =>
+        portInstanceIds.has(terminal.instanceId),
+      ).length > 1;
+
+    if (sharedWithAnotherPort) {
+      const port = {
+        kind: "terminal" as const,
+        instanceId: selectedInstance.id,
+        pinName: "P",
+      };
+      const existing = document.nets.find(
+        (net) =>
+          net.id !== selectedPortNet.id &&
+          net.name !== undefined &&
+          foldNetName(net.name) === foldNetName(name),
+      );
+      const host = existing?.terminals.find(
+        (terminal) => terminal.instanceId !== selectedInstance.id,
+      );
+      const nextNetId =
+        existing?.id ??
+        `net-port-${selectedInstance.id.toLowerCase()}-${document.revision}`;
+      // The Port's label is bound to the Net it names, so it has to follow the
+      // Port to its new node or it would keep reading the old name.
+      const boundLabel = document.annotations.find(
+        (annotation) =>
+          annotation.binding?.kind === "net-name" &&
+          annotation.binding.netId === selectedPortNet.id &&
+          annotation.anchor.kind === "object" &&
+          annotation.anchor.objectId === selectedInstance.id,
+      );
+      const detached: SchematicEdit[] = [
+        { kind: "disconnect_endpoint", endpoint: port },
+        host
+          ? {
+              kind: "connect_endpoints",
+              from: port,
+              to: {
+                kind: "terminal",
+                instanceId: host.instanceId,
+                pinName: host.pinName,
+              },
+            }
+          : {
+              kind: "connect_endpoints",
+              from: port,
+              to: port,
+              newNetId: nextNetId,
+              newNetName: name,
+            },
+        ...(boundLabel
+          ? [
+              {
+                kind: "upsert_schematic_annotation" as const,
+                annotation: {
+                  ...boundLabel,
+                  netId: nextNetId,
+                  binding: { kind: "net-name" as const, netId: nextNetId },
+                },
+              },
+            ]
+          : []),
+      ];
+      if (transact(detached).ok) setStatus(`Renamed Net Port to ${name}`);
+      return;
+    }
+
     // Naming a Free Net Port joins an existing Net of that name instead of
     // leaving two same-name Nets behind, exactly as placing a named Port does.
     const plan = planEnsureNamedNet(document, {

--- a/plan/2026-08-22-port-rename-independence/plan.md
+++ b/plan/2026-08-22-port-rename-independence/plan.md
@@ -1,0 +1,62 @@
+---
+status: completed
+experience: none
+---
+
+# Renaming one Net Port leaves its same-named twin alone
+
+## Goal
+
+Make renaming a Port a statement about that Port, not about every Port sharing
+its name.
+
+## The defect
+
+Several Net Ports naming the same node share one Net — that is what a net
+label means, and placing a second Port with an existing name merges into it.
+Renaming then went through `planEnsureNamedNet`, which renames the shared Net,
+so both Ports changed at once.
+
+## Work
+
+When the Port's Net carries another Net Port, the renamed Port leaves that
+node instead: its pin is disconnected and reconnected to a Net of the new
+name, joining an existing one when the name is already taken. Its bound label
+is re-pointed at the new Net in the same transaction — otherwise the label
+keeps reading the old name, which is exactly what the first attempt did.
+
+A Port that is the only one on its Net still renames the Net in place, which
+is the ordinary net-label behavior.
+
+## Validation
+
+- Full unit suite (1189 passed), full Playwright suite (209 passed)
+- New Playwright case places two Ports named `Vshared`, renames one, and
+  asserts the canvas carries both `Vshared` and `Vbias`
+- `tsc -p tsconfig.check.json`, Prettier, `git diff --check`
+
+## Gate Review
+
+- Decision: affected
+- Early gates: typecheck, Prettier
+- Affected gates: the hierarchy Playwright spec that owns Port naming
+- Final gates: remote GitHub Actions
+- Platform risks: this edits connectivity, so the change is expressed as
+  ordinary typed edits through the edit engine rather than by rewriting Net
+  membership directly.
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: what renaming one Net Port does to the others.
+- Primary checks: `apps/editor/e2e/hierarchy.spec.ts`
+
+## Commit Intent
+
+```text
+fix(editor): rename one Net Port without renaming its twin
+```
+
+## Outcome
+
+Renaming one of two `Vshared` Ports leaves the other reading `Vshared`.

--- a/plan/log.md
+++ b/plan/log.md
@@ -5043,3 +5043,20 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   typecheck, prettier, diff checks.
 - Commit status: completed on `claude/instance-behavior`; mainline merge gated
   on the remote required checks.
+
+## 2026-08-22 - Renaming one Net Port leaves its same-named twin alone
+
+- Several Net Ports naming the same node share one Net, so renaming through
+  `planEnsureNamedNet` renamed the shared Net and both Ports changed at once.
+- When the Port's Net carries another Net Port, the renamed Port now leaves
+  that node: its pin is disconnected and reconnected to a Net of the new name,
+  joining an existing one when the name is taken. Its bound label is
+  re-pointed at the new Net in the same transaction — without that the label
+  kept reading the old name, which is what the first attempt did.
+- A Port that is alone on its Net still renames the Net in place, the ordinary
+  net-label behavior.
+- Validation: full unit suite (1189), full Playwright suite (209 passed) with
+  a new case that places two `Vshared` Ports, renames one, and asserts the
+  canvas carries both `Vshared` and `Vbias`.
+- Commit status: completed on `claude/port-rename-and-labels`; mainline merge
+  gated on the remote required checks.


### PR DESCRIPTION
Several Net Ports naming the same node **share one Net** — that is what a net label means, and placing a second Port with an existing name merges into it.

Renaming then went through `planEnsureNamedNet`, which renames that **shared Net**, so both Ports changed at once.

## Fix

When the Port's Net carries another Net Port, the renamed Port **leaves that node**: its pin is disconnected and reconnected to a Net of the new name, joining an existing one when the name is already taken.

Its bound label is re-pointed at the new Net **in the same transaction** — without that the label keeps reading the old name, which is exactly what my first attempt did (status said "Renamed", canvas still showed `Vshared` twice).

A Port that is the only one on its Net still renames the Net in place, which is the ordinary net-label behavior.

## Validation

- Full unit suite: **1189 passed**
- Full Playwright suite: **209 passed**, including a new case that places two `Vshared` Ports, renames one, and asserts the canvas carries both `Vshared` and `Vbias`
- Typecheck, Prettier, `git diff --check`, test-impact gate

Connectivity is changed through ordinary typed edits via the edit engine, not by rewriting Net membership directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)