### PR TITLE
feat(edit-engine): allow any-angle Route geometry

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3843,3 +3843,28 @@ test("double-click ends the wire even when it lands on another wire", async ({
   await page.mouse.move(500, 500);
   await expect(page.getByTestId("status")).toContainText("Wire finished");
 });
+
+test("draws a wire at an angle the 45-degree grid cannot reach", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await clickDrawTool(page, "wire");
+
+  await canvas.click({ position: { x: 200, y: 200 } });
+  // Middle-click cycles the corner shape and ends on any angle.
+  for (let step = 0; step < 4; step += 1) {
+    await canvas.click({ button: "middle", position: { x: 260, y: 240 } });
+  }
+  await expect(page.getByTestId("status")).toContainText("any angle");
+  await canvas.dblclick({ position: { x: 430, y: 260 } });
+
+  const points = await readRoutePoints(page, await onlyRouteId(page));
+  expect(points).toHaveLength(2);
+  const dx = Math.abs(points[1]!.x - points[0]!.x);
+  const dy = Math.abs(points[1]!.y - points[0]!.y);
+  // Neither axis-aligned nor 45 degrees: the leg reaches the endpoint direct.
+  expect(dx).toBeGreaterThan(0);
+  expect(dy).toBeGreaterThan(0);
+  expect(dx).not.toBe(dy);
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -4070,6 +4070,11 @@ export function App({
         cornerOrder: "diagonal-first" as const,
         label: "45° diagonal",
       },
+      {
+        routingMode: "free" as const,
+        cornerOrder: "auto" as const,
+        label: "any angle",
+      },
     ];
     const index = shapes.findIndex(
       (shape) =>
@@ -4077,7 +4082,8 @@ export function App({
         shape.cornerOrder === wireCornerOrder,
     );
     const next = shapes[(index + 1) % shapes.length]!;
-    if (next.routingMode !== wireRoutingMode) toggleWireRoutingMode();
+    if (next.routingMode !== wireRoutingMode)
+      setWireRoutingMode(next.routingMode);
     setWireCornerOrder(next.cornerOrder);
     setStatus(`Wire corner: ${next.label}`);
   }
@@ -10939,6 +10945,7 @@ export function App({
                 >
                   <option value="orthogonal">Orthogonal</option>
                   <option value="octilinear">45° octilinear</option>
+                  <option value="free">Any angle</option>
                 </select>
               </label>
               <label>

--- a/apps/editor/src/features/wiring/use-wire-interaction.ts
+++ b/apps/editor/src/features/wiring/use-wire-interaction.ts
@@ -22,6 +22,7 @@ import {
   type ConnectivityProposal,
   type WireSource,
   type WireCornerOrder,
+  type WireRoutingMode,
 } from "@icm/edit-engine";
 import {
   derivePowerRailComponent,
@@ -96,7 +97,7 @@ export interface UseWireInteractionOptions {
   wireSourceRevision: number | null;
   wireWaypoints: readonly Point[];
   wireDraftSteps: readonly WireDraftStep[];
-  wireRoutingMode: "orthogonal" | "octilinear";
+  wireRoutingMode: WireRoutingMode;
   wireCornerOrder: WireCornerOrder;
   nextRoutingSuffix: () => number;
   transact: (

--- a/docs/adr/0028-octilinear-route-geometry-protocol.md
+++ b/docs/adr/0028-octilinear-route-geometry-protocol.md
@@ -1,6 +1,6 @@
 # 0028 - One Route Geometry Protocol with Octilinear Authoring
 
-Status: `accepted`
+Status: `accepted` (authoring clause superseded by [ADR 0039](0039-any-angle-route-authoring.md))
 
 Date: `2026-08-20`
 
@@ -42,7 +42,8 @@ horizontal-only. Crossings remain disconnected absent an explicit Junction.
 
 ### Negative or limiting
 
-- Arbitrary-angle authoring is intentionally not exposed yet.
+- Arbitrary-angle authoring is intentionally not exposed yet. ADR 0039 later
+  granted the explicitly approved arbitrary-angle policy this anticipated.
 - Existing route editing must infer its allowed geometry from the Route rather
   than silently rerouting a diagonal path as orthogonal.
 

--- a/docs/adr/0039-any-angle-route-authoring.md
+++ b/docs/adr/0039-any-angle-route-authoring.md
@@ -1,0 +1,78 @@
+# 0039 - Any-Angle Route Authoring
+
+Status: `accepted`
+
+Date: `2026-08-22`
+
+Owners: `derived geometry, edit engine, editor, Agent API`
+
+## Context
+
+[ADR 0028](0028-octilinear-route-geometry-protocol.md) established one Route
+geometry protocol and made segment heading geometry rather than topology. It
+recorded that the derived segment-geometry kernel "is generic enough for a
+future explicitly approved arbitrary-angle policy", and listed
+"arbitrary-angle authoring is intentionally not exposed yet" as its one
+limiting consequence.
+
+The repository owner has now asked for arbitrary-angle wires, stating that the
+octilinear restriction is too limiting and that write validation should not
+enforce it. This ADR is that explicit approval.
+
+## Decision
+
+Segment heading is not a validity rule. Write validation accepts any Route
+whose segments are non-zero; `orthogonal`, `octilinear`, and the new `free`
+mode remain transient authoring policies chosen per command, exactly as ADR
+0028 framed them.
+
+`WireRoutingMode` gains `free`, which compiles an authored click to the
+straight line that reaches it. The middle-click corner cycle ends on it, so
+any angle is reachable without opening the Wire options.
+
+Direct manipulation follows: a segment drag and an endpoint move reject only
+degenerate geometry. The tidying elbow that an endpoint move inserts stays
+limited to legs that were already octilinear, so a diagonal is stretched
+rather than given a corner.
+
+Unchanged: `power-rail` remains one straight axis-aligned run, a Crossing is
+still not a Junction, and `@icm/agent-routing` keeps the stricter octilinear
+contract ADR 0008 gives that Agent-side helper — it snaps and validates what
+an Agent supplies and is not the model's invariant.
+
+## Consequences
+
+### Positive
+
+- A wire can land at whatever angle reaches its endpoint.
+- The geometry kernel needed no change: projection, containment,
+  intersection, collinearity, and unit direction were already angle-agnostic,
+  so crossing detection, hit testing, and rendering follow for free.
+
+### Negative or limiting
+
+- Orthogonal drawings remain the default, so a document's look is now a
+  function of authoring discipline rather than of validation.
+- A free-angle Route cannot be expressed through the Agent RouteGraph helper
+  until ADR 0008's contract is revisited.
+
+## Compatibility and migration
+
+The persisted Route shape is unchanged and every existing document stays
+valid: this widens what validation accepts and never rewrites geometry. No
+Project-version advancement is required.
+
+## Validation
+
+- transaction acceptance of an arbitrary-angle ordinary Route, and continued
+  rejection of a degenerate one;
+- continued rejection of a non-straight `power-rail`;
+- wire compilation for `free`, and the middle-click corner cycle reaching it.
+
+## Related documents
+
+- [ADR 0028](0028-octilinear-route-geometry-protocol.md) — superseded on its
+  authoring clause only
+- [ADR 0008](0008-agent-local-route-tree-expander.md)
+- [connectivity and routing spec](../specs/connectivity-and-routing.md)
+- [editor interaction spec](../specs/editor-interaction.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -79,6 +79,8 @@ The repeated formal-Port marker and schema-20 decision is
 [`0037-repeated-formal-port-markers.md`](0037-repeated-formal-port-markers.md).
 The document style-overrides and schema-21 decision is
 [`0038-document-style-overrides.md`](0038-document-style-overrides.md).
+The arbitrary-angle Route authoring decision is
+[`0039-any-angle-route-authoring.md`](0039-any-angle-route-authoring.md).
 
 Use [`adr.template.md`](adr.template.md) for new decisions.
 

--- a/docs/specs/agent-api.md
+++ b/docs/specs/agent-api.md
@@ -76,7 +76,8 @@ The wire API itself remains raw and strict: a directly submitted ambiguous
 `set_net_name` edit is rejected by the Edit Engine.
 
 `wireIntent` has the same Route planner as interactive Wire. Its optional
-`routingMode` is `orthogonal` (default) or `octilinear`; an optional
+`routingMode` is `orthogonal` (default), `octilinear`, or `free` (ADR 0039);
+an optional
 `cornerOrder` selects the deterministic diagonal/orthogonal pair used when an
 exact 45-degree leg cannot reach the target. It never creates a diagonal-only
 edit or a second Route model.

--- a/docs/specs/edit-engine.md
+++ b/docs/specs/edit-engine.md
@@ -215,7 +215,8 @@ Phase 8 topology operations have these preconditions:
   transaction. GUI movement planners always author those Route edits; Routes
   protected by locked geometry reject the move.
 - `move_instance` stretches unprotected connected Routes under their existing
-  geometry constraint (orthogonal or octilinear; ADR 0009 and ADR 0028). A
+  geometry constraint (orthogonal, octilinear, or free; ADR 0009, ADR 0028, and
+  ADR 0039). A
   Route with a locked/trunk adjacent segment is
   skipped; if the caller does not re-point it in the same transaction, the
   post-loop validation rejects with `INVALID_RESULT` naming the Route. The

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -127,7 +127,8 @@ last rendered React closure, so consecutive native events such as `Escape -> C`
 observe the first transition even when React batches the next render.
 
 Wire defaults to orthogonal. While Wire is active, a middle-button click
-switches only the unresolved leg between orthogonal and 45-degree octilinear;
+switches only the unresolved leg between orthogonal, 45-degree octilinear, and
+any angle (ADR 0039);
 a middle-button drag pans as usual. F3 opens Wire options including corner
 order. Existing authored legs are immutable under mode switches; Backspace
 removes the latest authored step rather than an automatically compiled elbow.

--- a/packages/edit-engine/src/route-operations.ts
+++ b/packages/edit-engine/src/route-operations.ts
@@ -5,13 +5,13 @@ import {
   deriveInternalGroupSelection as deriveRoutingInternalGroupSelection,
   derivePowerRailComponent,
   isSegmentAllowed,
+  polylineSatisfiesConstraint,
   resolveDocumentRoutingGeometry,
   resolveEndpointPoint,
   resolveRouteGeometry,
   type ResolvedDocumentRoutingGeometry,
 } from "@icm/derived";
 import {
-  isOctilinear,
   moveRouteSegment,
   normalizeRouteGeometry,
   type RouteEditPath,
@@ -110,15 +110,22 @@ function routeEditPathFromGeometry(
   };
 }
 
+/** Every stored step must advance; heading itself is unconstrained. */
+function isSegmentGeometryUsable(points: readonly Point[]): boolean {
+  return polylineSatisfiesConstraint(points, "any-angle");
+}
+
 function normalizeProposal(
   routeId: string,
   points: readonly Point[],
   modes: readonly SegmentMode[],
 ): RouteStretchProposal {
   const normalized = normalizeRouteGeometry(points, modes);
-  if (!isOctilinear(normalized.points)) {
+  // Any heading is legal geometry (ADR 0039); only a degenerate segment is
+  // not, and normalizeRouteGeometry already removes zero-length steps.
+  if (!isSegmentGeometryUsable(normalized.points)) {
     throw new Error(
-      `Wire segment drag would make route ${routeId} non-octilinear`,
+      `Wire segment drag would leave route ${routeId} degenerate`,
     );
   }
   return {
@@ -175,6 +182,8 @@ function stretchRouteEndpoint(
     return;
   }
 
+  // A leg that was already free-angle keeps its heading; the tidying elbow is
+  // for orthogonal drawings and would otherwise put a corner into a diagonal.
   if (isSegmentAllowed(movedPoint, neighbor, "octilinear")) return;
 
   const dx = neighbor.x - movedPoint.x;
@@ -333,12 +342,9 @@ export function proposeWireSegmentDrag(
   const toPoint = selectedPolyline.points[segmentIndex + 1]!;
   const horizontal = fromPoint.y === toPoint.y;
   const vertical = fromPoint.x === toPoint.x;
-  const diagonal =
-    !horizontal &&
-    !vertical &&
-    Math.abs(toPoint.x - fromPoint.x) === Math.abs(toPoint.y - fromPoint.y);
-  if (!horizontal && !vertical && !diagonal) {
-    throw new Error(`Route ${routeId} segment is not octilinear`);
+  const diagonal = !horizontal && !vertical;
+  if (horizontal && vertical) {
+    throw new Error(`Route ${routeId} segment is degenerate`);
   }
 
   const lastPointIndex = selectedPolyline.points.length - 1;

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -38,7 +38,7 @@ export interface ManualWirePath {
 }
 
 /** A transient command constraint, never a second persisted Route type. */
-export type WireRoutingMode = "orthogonal" | "octilinear";
+export type WireRoutingMode = "orthogonal" | "octilinear" | "free";
 /**
  * Which leg of a corner is drawn first. `diagonal-first`/`orthogonal-first`
  * order an octilinear corner; `horizontal-first`/`vertical-first` order an
@@ -722,6 +722,12 @@ export function compileWireDraft(
   const points: Point[] = [{ ...from.point }];
   const modes: SegmentMode[] = [];
   const appendStep = (step: WireDraftStep) => {
+    // A free leg is the straight line to the click: no elbow is inserted, so
+    // the wire lands at whatever angle reaches the endpoint.
+    if (step.routingMode === "free") {
+      append(points, modes, step.point, "manual");
+      return;
+    }
     if (step.routingMode === "orthogonal") {
       appendOrthogonal(
         points,

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -1765,7 +1765,7 @@ describe("routing Edit Engine", () => {
     ).toEqual(document.routes[1]);
   });
 
-  it("rejects diagonal, context-free, and locked route mutations atomically", () => {
+  it("accepts an arbitrary-angle route and still needs its context", () => {
     const document = documentFixture();
     const diagonal = transaction(document.id, 0, [
       {
@@ -1778,10 +1778,9 @@ describe("routing Edit Engine", () => {
         segmentModes: ["manual"],
       },
     ]);
+    // ADR 0039: segment heading is geometry, not a rule about legal Routes.
     expect(executeTransaction(document, diagonal, context)).toMatchObject({
-      ok: false,
-      error: { code: "EDIT_PRECONDITION" },
-      document,
+      ok: true,
     });
     expect(executeTransaction(document, diagonal)).toMatchObject({
       ok: false,

--- a/packages/edit-engine/src/transaction-routing.ts
+++ b/packages/edit-engine/src/transaction-routing.ts
@@ -8,6 +8,7 @@ import type {
 import {
   derivePowerRailComponent,
   endpointBelongsToNet,
+  polylineSatisfiesConstraint,
   endpointKey,
   netEndpoints,
   pointOnSegment as pointOnGenericSegment,
@@ -16,7 +17,6 @@ import {
 import type { SymbolResolver } from "@icm/symbols";
 
 import type { SchematicEdit } from "./edit-schema.js";
-import { isOctilinear } from "./route-geometry-edit.js";
 import { resolveRouteEditPath } from "./route-operations.js";
 
 export function pointOnSegment(point: Point, from: Point, to: Point): boolean {
@@ -216,8 +216,12 @@ export function validateRoute(
   }
   const polyline = resolveRouteEditPath(document, resolver, route);
   if (!polyline) return `Route ${route.id} has an unresolved endpoint`;
-  if (!isOctilinear(polyline.points)) {
-    return `Route ${route.id} must contain only non-zero octilinear segments`;
+  // Segment heading is geometry, not topology (ADR 0028), and ADR 0039 grants
+  // the arbitrary-angle policy that ADR 0028 anticipated. Validation therefore
+  // rejects only degenerate geometry; which headings a command may author is
+  // the edit engine's transient policy, not a rule about legal Routes.
+  if (!polylineSatisfiesConstraint(polyline.points, "any-angle")) {
+    return `Route ${route.id} must contain only non-zero segments`;
   }
   if (
     route.presentation === "power-rail" &&

--- a/packages/edit-engine/src/wire-path.test.ts
+++ b/packages/edit-engine/src/wire-path.test.ts
@@ -126,3 +126,39 @@ describe("orthogonal corner order", () => {
     ]);
   });
 });
+
+describe("free-angle authoring", () => {
+  it("draws the straight line that reaches the click", () => {
+    // ADR 0039: no elbow is inserted, so the wire lands at whatever angle
+    // reaches the endpoint.
+    expect(
+      compileWireDraft(
+        { point: { x: 0, y: 0 } },
+        { point: { x: 130, y: 40 } },
+        [],
+        "free",
+      ).points,
+    ).toEqual([
+      { x: 0, y: 0 },
+      { x: 130, y: 40 },
+    ]);
+  });
+
+  it("keeps a free leg free while earlier legs stay as authored", () => {
+    const steps = [
+      { point: { x: 60, y: 0 }, routingMode: "orthogonal" as const },
+    ];
+    expect(
+      compileWireDraft(
+        { point: { x: 0, y: 0 } },
+        { point: { x: 130, y: 40 } },
+        steps,
+        "free",
+      ).points,
+    ).toEqual([
+      { x: 0, y: 0 },
+      { x: 60, y: 0 },
+      { x: 130, y: 40 },
+    ]);
+  });
+});

--- a/plan/2026-08-22-any-angle-route-authoring/plan.md
+++ b/plan/2026-08-22-any-angle-route-authoring/plan.md
@@ -1,0 +1,85 @@
+---
+status: completed
+experience: none
+---
+
+# Any-angle Route authoring
+
+## Goal
+
+Stop rejecting a Route for its heading. Wire authoring gains a free-angle mode
+so a segment may land at whatever angle reaches its endpoint, and the
+transaction layer validates only that a segment is non-degenerate.
+
+## Owner decision
+
+The owner asked for arbitrary-angle wires and stated that the octilinear check
+should not exist. ADR 0028 anticipated exactly this: it records that the
+derived geometry kernel "is generic enough for a future explicitly approved
+arbitrary-angle policy" and lists "arbitrary-angle authoring is intentionally
+not exposed yet" as its one limiting consequence. This target is that
+approval, so it ships with ADR 0039 rather than changing behavior silently.
+
+## Why the blast radius is small
+
+`segment-geometry.ts` states that it "deliberately does not encode an
+authoring policy", already exposes `any-angle`, and builds projection,
+containment, intersection, collinearity, and unit direction on cross products
+and `hypot`. Crossing detection, hit testing, label placement, and rendering
+were therefore already angle-agnostic; only the edit engine's authoring gates
+assumed octilinear.
+
+## Work
+
+1. `validateRoute` checks `any-angle`, so only zero-length segments fail.
+2. Segment drag and endpoint move reject only degenerate geometry. The tidying
+   elbow an endpoint move inserts stays limited to legs that were already
+   octilinear, so a diagonal is stretched rather than given a corner.
+3. `WireRoutingMode` gains `free`, compiling an authored click to the straight
+   line that reaches it, and it ends the middle-click corner cycle.
+4. Record ADR 0039, mark ADR 0028's authoring clause superseded, and update
+   the edit-engine, editor-interaction, and agent-api specs plus the ADR index.
+
+Unchanged by design: `power-rail` stays one straight axis-aligned run, and
+`@icm/agent-routing` keeps the stricter octilinear contract ADR 0008 gives that
+Agent-side helper.
+
+## Validation
+
+- Full unit suite (1189 passed), full Playwright suite (209 passed)
+- New Playwright case draws a leg that is neither axis-aligned nor 45 degrees
+- `node scripts/visual-golden.mjs --check` and `check-markdown-links.mjs` clean
+- `tsc -p tsconfig.check.json`, Prettier, `git diff --check`
+
+## Gate Review
+
+- Decision: full
+- Early gates: typecheck, Prettier, markdown links
+- Affected gates: edit-engine routing and wire-path tests, the manual-editor
+  Playwright spec
+- Final gates: golden check, remote GitHub Actions
+- Platform risks: this changes an accepted ADR's contract and the normative
+  specs, so the documentation gates matter as much as the behavior tests.
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: legal persisted Route geometry and the wire authoring modes.
+- Primary checks: `packages/edit-engine/src/{routing,wire-path}.test.ts`,
+  `apps/editor/e2e/manual-editor.spec.ts`
+
+One routing case asserted that a diagonal Route is rejected. That is the
+contract this target changes, so it now asserts acceptance while keeping the
+context-required and locked-segment halves intact.
+
+## Commit Intent
+
+```text
+feat(edit-engine): allow any-angle Route geometry
+```
+
+## Outcome
+
+Write validation rejects only degenerate geometry. `free` joins the wire
+routing modes and ends the middle-click corner cycle, so any angle is reachable
+without opening the Wire options.

--- a/plan/log.md
+++ b/plan/log.md
@@ -5060,3 +5060,28 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   canvas carries both `Vshared` and `Vbias`.
 - Commit status: completed on `claude/port-rename-and-labels`; mainline merge
   gated on the remote required checks.
+
+## 2026-08-22 - Any-angle Route authoring
+
+- The owner asked for arbitrary-angle wires and said the octilinear check
+  should not exist. ADR 0028 had anticipated exactly this: it records that the
+  geometry kernel "is generic enough for a future explicitly approved
+  arbitrary-angle policy" and that such authoring was "intentionally not
+  exposed yet". ADR 0039 is that approval; ADR 0028's authoring clause is
+  marked superseded and the three specs plus the ADR index follow.
+- Write validation now rejects only degenerate geometry. `free` joins the wire
+  routing modes, compiling an authored click to the straight line that reaches
+  it, and ends the middle-click corner cycle.
+- Direct manipulation follows: segment drag and endpoint move reject only
+  degenerate geometry, and the tidying elbow stays limited to legs that were
+  already octilinear so a diagonal is stretched rather than given a corner.
+- Unchanged by design: `power-rail` stays one straight axis-aligned run, and
+  `@icm/agent-routing` keeps the stricter octilinear contract ADR 0008 gives
+  that Agent-side helper.
+- The geometry kernel needed no change — projection, containment,
+  intersection, collinearity, and unit direction were already angle-agnostic.
+- Validation: full unit suite (1189), full Playwright suite (209 passed) with a
+  new case drawing a leg that is neither axis-aligned nor 45 degrees, visual
+  golden check clean, markdown link check clean.
+- Commit status: completed on `claude/any-angle-routes`; mainline merge gated
+  on the remote required checks.


### PR DESCRIPTION
Implements the owner's decision that wires should not be restricted to eight headings.

## This was anticipated, not overridden

**ADR 0028** made segment heading *geometry, not topology*, and recorded:

> the kernel itself is generic enough for a future explicitly approved arbitrary-angle policy

listing "arbitrary-angle authoring is intentionally not exposed yet" as its one limiting consequence. **ADR 0039** grants that approval; ADR 0028's authoring clause is marked superseded, and the edit-engine, editor-interaction, and agent-api specs plus the ADR index follow.

## What changed

- **Validation** accepts any Route whose segments are non-zero. `orthogonal`, `octilinear`, and the new `free` mode stay *transient authoring policies chosen per command* — exactly how ADR 0028 framed them.
- **`free`** compiles an authored click to the straight line that reaches it, and **ends the middle-click corner cycle**, so any angle is reachable without opening the Wire options.
- **Direct manipulation follows**: segment drag and endpoint move reject only degenerate geometry. The tidying elbow an endpoint move inserts stays limited to legs that were *already* octilinear, so a diagonal is stretched rather than given a corner.

## The kernel needed no change

`segment-geometry.ts` already says it "deliberately does not encode an authoring policy", already exposes `any-angle`, and builds projection, containment, intersection, collinearity, and unit direction on cross products and `hypot`. Crossing detection, hit testing, label placement, and rendering were **already angle-agnostic**.

## Unchanged by design

- `power-rail` remains one straight axis-aligned run.
- A Crossing is still not a Junction.
- `@icm/agent-routing` keeps the stricter octilinear contract ADR 0008 gives that Agent-side helper — it snaps and validates what an Agent supplies; it is not the model's invariant.

## Validation

- Full unit suite: **1189 passed**
- Full Playwright suite: **209 passed**, including a new case that draws a leg which is neither axis-aligned nor 45°
- `visual-golden.mjs --check` and `check-markdown-links.mjs` clean
- Typecheck, Prettier, `git diff --check`, test-impact gate

One routing case asserted a diagonal Route is **rejected** — that is the contract this changes, so it now asserts acceptance while keeping its context-required and locked-segment halves intact.

Existing documents stay valid: this widens what validation accepts and never rewrites geometry, so no Project-version advancement is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)