### PR TITLE
feat(editor): rename the circuit from the canvas

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -369,7 +369,8 @@ test("a gallery tile opens its circuit in the editor", async ({ page }) => {
   await expect(page.getByTestId("status")).toContainText(
     `Opened gallery circuit: ${ENTRY.name}`,
   );
-  await expect(page.locator(".app-brand-copy p")).toContainText(ENTRY.name);
+  // The circuit name is an editable field now, so it is read as a value.
+  await expect(page.getByTestId("project-name-input")).toHaveValue(ENTRY.name);
 
   // The brand mark is the single way back; a second toolbar link said the
   // same thing twice.

--- a/apps/editor/e2e/project-file.spec.ts
+++ b/apps/editor/e2e/project-file.spec.ts
@@ -279,3 +279,21 @@ test("offers a download from the replacement guard", async ({ page }) => {
   await expect(dialog).toBeHidden();
   await expect(page.getByTestId("revision")).toHaveText("1");
 });
+
+test("the circuit name drives publish and the saved file name", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const name = page.getByTestId("project-name-input");
+  await expect(name).toHaveValue("New Circuit");
+
+  await name.fill("Bandgap Reference");
+  await name.press("Enter");
+  await expect(page.getByTestId("status")).toContainText("Renamed circuit");
+
+  // One name: the header, the publish dialog, and the saved file all read it.
+  await expect(name).toHaveValue("Bandgap Reference");
+  const bytes = await downloadBytes(page, "File", "Save Project");
+  const saved = JSON.parse(bytes.toString("utf8")) as { name?: string };
+  expect(saved.name).toBe("Bandgap Reference");
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -667,6 +667,7 @@ export function App({
   const [cellManagerOpen, setCellManagerOpen] = useState(false);
   const [netlistPreflightOpen, setNetlistPreflightOpen] = useState(false);
   const [documentSettingsOpen, setDocumentSettingsOpen] = useState(false);
+  const [projectNameDraft, setProjectNameDraft] = useState<string | null>(null);
   const [publishGalleryOpen, setPublishGalleryOpen] = useState(false);
   const [versionHistoryOpen, setVersionHistoryOpen] = useState(false);
   const [publishSession, setPublishSession] = useState<SessionUser | null>(
@@ -2427,6 +2428,19 @@ export function App({
           ),
         )
       : undefined;
+  function commitProjectName(): void {
+    const next = (projectNameDraft ?? "").trim();
+    setProjectNameDraft(null);
+    if (!next || next === project.name) return;
+    if (
+      commitStructure("rename-project", [
+        { kind: "rename_project", name: next },
+      ])
+    ) {
+      setStatus(`Renamed circuit to ${next}`);
+    }
+  }
+
   function renameSelectedNetPort(name: string): void {
     if (!selectedPortNet || !selectedInstance || selectedFormalTerminal) return;
     name = name.trim();
@@ -7221,7 +7235,24 @@ export function App({
             </a>
             <div className="app-brand-copy">
               <p title={`${project.name} / ${document.name}`}>
-                {project.name} /{" "}
+                {/* The circuit's name is what a published entry and a saved
+                    file are called, so it is edited where it is read. */}
+                <input
+                  className="app-project-name"
+                  aria-label="Circuit name"
+                  data-testid="project-name-input"
+                  value={projectNameDraft ?? project.name}
+                  size={Math.max((projectNameDraft ?? project.name).length, 6)}
+                  onChange={(event) =>
+                    setProjectNameDraft(event.currentTarget.value)
+                  }
+                  onBlur={() => commitProjectName()}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") event.currentTarget.blur();
+                    if (event.key === "Escape") setProjectNameDraft(null);
+                  }}
+                />{" "}
+                /{" "}
                 <span data-testid="active-document-name">{document.name}</span>
               </p>
             </div>

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -6192,3 +6192,25 @@ html.light .analytics-map-land path {
   z-index: 20;
   min-width: 11rem;
 }
+
+/* The circuit name is edited where it is read, so the field carries no chrome
+   until it is hovered or focused. */
+.app-project-name {
+  min-width: 4rem;
+  max-width: 14rem;
+  padding: 0 0.15rem;
+  border: 1px solid transparent;
+  border-radius: var(--icm-radius-sm);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+}
+
+.app-project-name:hover {
+  border-color: var(--icm-border);
+}
+
+.app-project-name:focus {
+  border-color: var(--icm-accent);
+  outline: 0;
+}

--- a/packages/edit-engine/src/project-transaction.ts
+++ b/packages/edit-engine/src/project-transaction.ts
@@ -32,6 +32,10 @@ export const ProjectStructureEditSchema = z.discriminatedUnion("kind", [
     documentId: z.string().min(1),
   }),
   z.strictObject({
+    kind: z.literal("rename_project"),
+    name: z.string().min(1).max(128),
+  }),
+  z.strictObject({
     kind: z.literal("rename_document"),
     documentId: z.string().min(1),
     name: z.string().min(1).max(128),
@@ -246,6 +250,15 @@ export function executeProjectTransaction(
       continue;
     }
 
+    if (edit.kind === "rename_project") {
+      // The Project's name is what a published circuit and a saved file are
+      // called, so it is renamed through the same transaction path as
+      // everything else rather than by rewriting the Project object.
+      if (candidate.name === edit.name) continue;
+      candidate.name = edit.name;
+      structuralChange = true;
+      continue;
+    }
     if (edit.kind === "rename_document") {
       const document = candidate.documents.find(
         (item) => item.id === edit.documentId,

--- a/plan/2026-08-22-circuit-name-is-editable/plan.md
+++ b/plan/2026-08-22-circuit-name-is-editable/plan.md
@@ -1,0 +1,76 @@
+---
+status: completed
+experience: none
+---
+
+# The circuit name is editable where it is read
+
+## Goal
+
+Let the circuit be renamed from the canvas, and keep one name behind the
+header, the publish dialog, and the saved file.
+
+## What was already true
+
+Publishing (`defaultName={project.name}`), export
+(`safeExportBaseName(project.name)`), and the saved file
+(`projectFileBaseName`) all already derive from the Project's name. The only
+missing half was being able to change it: the header rendered `New Circuit`
+as static text.
+
+## Work
+
+1. Add a `rename_project` structure edit so the name changes through the same
+   transaction path as everything else, rather than by rewriting the Project
+   object and discarding its history. It counts as a structural change, or
+   the transaction would report that it made none.
+2. Render the name as a borderless field in the header: Enter commits, Escape
+   reverts, blur commits.
+
+## Also verified, not changed
+
+Two reported defects did not reproduce and are recorded rather than "fixed":
+
+- A deleted label **can** be restored from its Display checkbox, for both an
+  instance reference and a Port label. `referenceLabelVisibilityEdits` already
+  recreates a missing label when the box is ticked; probed both cases from
+  delete through restore.
+
+## Validation
+
+- Full unit suite (1191 passed), full Playwright suite (211 passed)
+- New Playwright case renames the circuit and asserts the saved Project file
+  carries the new name
+- `node scripts/visual-golden.mjs --check` clean
+- `tsc -p tsconfig.check.json`, Prettier, `git diff --check`
+
+## Gate Review
+
+- Decision: affected
+- Early gates: typecheck, Prettier
+- Affected gates: edit-engine project-transaction tests, the project-file and
+  gallery Playwright specs
+- Final gates: golden check, remote GitHub Actions
+- Platform risks: this adds a Project-structure edit kind, so the schema and
+  its transaction path were exercised rather than assumed.
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: the Project rename edit, and that one name drives publish and the
+  saved file.
+- Primary checks: `apps/editor/e2e/project-file.spec.ts`,
+  `apps/editor/e2e/gallery.spec.ts`
+
+One gallery case read the circuit name from the header's text. The name is a
+field now, so it reads the value instead.
+
+## Commit Intent
+
+```text
+feat(editor): rename the circuit from the canvas
+```
+
+## Outcome
+
+The header carries an editable circuit name, and the saved file follows it.

--- a/plan/log.md
+++ b/plan/log.md
@@ -5085,3 +5085,24 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   golden check clean, markdown link check clean.
 - Commit status: completed on `claude/any-angle-routes`; mainline merge gated
   on the remote required checks.
+
+## 2026-08-22 - The circuit name is editable where it is read
+
+- Publishing, export, and the saved file already derived from the Project's
+  name; the missing half was being able to change it, since the header
+  rendered it as static text.
+- Added a `rename_project` structure edit so the name changes through the same
+  transaction path as everything else rather than by rewriting the Project
+  object and discarding its history. It has to count as a structural change,
+  or the transaction reports that it made none.
+- The header now carries a borderless field: Enter commits, Escape reverts,
+  blur commits.
+- Verified rather than changed: a deleted label can be restored from its
+  Display checkbox for both an instance reference and a Port label —
+  `referenceLabelVisibilityEdits` already recreates a missing label. Probed
+  both cases from delete through restore.
+- Validation: full unit suite (1191), full Playwright suite (211 passed) with
+  a new case that renames the circuit and asserts the saved Project file
+  carries the new name, visual golden check clean.
+- Commit status: completed on `claude/label-restore-and-name`; mainline merge
+  gated on the remote required checks.


### PR DESCRIPTION
## One name, now editable

Publishing (`defaultName={project.name}`), export (`safeExportBaseName`), and the saved file (`projectFileBaseName`) **already** derived from the Project's name. The missing half was being able to change it — the header rendered `New Circuit` as static text.

- A **`rename_project`** structure edit changes it through the same transaction path as everything else, rather than by rewriting the Project object and discarding its history. It has to count as a *structural change*, or the transaction reports it made none.
- The header carries a borderless field: **Enter** commits, **Escape** reverts, blur commits.

## Verified, not "fixed"

A reported defect that **did not reproduce**, recorded honestly rather than papered over:

- A **deleted label can be restored** from its Display checkbox — for both an instance reference *and* a Port label. `referenceLabelVisibilityEdits` already recreates a missing label when the box is ticked; I probed both cases from delete through restore.

## Validation

- Full unit suite: **1191 passed**
- Full Playwright suite: **211 passed**, including a new case that renames the circuit and asserts the **saved Project file** carries the new name
- `visual-golden.mjs --check` clean
- Typecheck, Prettier, `git diff --check`, test-impact gate

One gallery case read the circuit name from the header's *text*; it is a field now, so it reads the value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)