### PR TITLE
chore: follow the repository move to cascode-ai/analog-canvas

### DIFF
--- a/apps/editor/e2e/chrome-isolation.spec.ts
+++ b/apps/editor/e2e/chrome-isolation.spec.ts
@@ -53,11 +53,11 @@ test("carries the version and repository link inside Help", async ({
   await expect(about).toContainText("About Analog Canvas");
   await expect(about).toContainText("Version 0.1.0");
   const repositoryLink = about.getByRole("link", {
-    name: "https://github.com/chenzc24/Analog-Canvas",
+    name: "https://github.com/cascode-ai/analog-canvas",
   });
   await expect(repositoryLink).toHaveAttribute(
     "href",
-    "https://github.com/chenzc24/Analog-Canvas",
+    "https://github.com/cascode-ai/analog-canvas",
   );
   await expect(repositoryLink).toHaveAttribute("target", "_blank");
   await page.keyboard.press("Escape");

--- a/apps/editor/src/components/editor-help-dialog.test.tsx
+++ b/apps/editor/src/components/editor-help-dialog.test.tsx
@@ -15,7 +15,7 @@ describe("EditorHelpDialog", () => {
     expect(markup).toContain("About Analog Canvas");
     expect(markup).toContain("Version <strong>0.1.0</strong>");
     expect(markup).toContain(
-      'href="https://github.com/chenzc24/Analog-Canvas"',
+      'href="https://github.com/cascode-ai/analog-canvas"',
     );
     expect(markup).toContain('target="_blank"');
     expect(markup).toContain('rel="noreferrer"');

--- a/apps/editor/src/components/editor-help-dialog.tsx
+++ b/apps/editor/src/components/editor-help-dialog.tsx
@@ -2,7 +2,7 @@ import type { RefObject } from "react";
 
 import editorPackage from "../../package.json";
 
-const REPOSITORY_URL = "https://github.com/chenzc24/Analog-Canvas";
+const REPOSITORY_URL = "https://github.com/cascode-ai/analog-canvas";
 
 export interface EditorHelpDialogProps {
   closeButtonRef: RefObject<HTMLButtonElement | null>;

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -115,7 +115,7 @@ Source: GitHub Actions** once. The included `Deploy GitHub Pages` workflow
 then publishes every push to `main` at:
 
 ```text
-https://chenzc24.github.io/Analog-Canvas/
+https://cascode-ai.github.io/analog-canvas/
 ```
 
 It also supports a manual run from the Actions tab. The workflow builds with

--- a/plan/2026-08-23-repository-move/plan.md
+++ b/plan/2026-08-23-repository-move/plan.md
@@ -1,0 +1,61 @@
+---
+status: completed
+experience: none
+---
+
+# Follow the repository to its new home
+
+## Goal
+
+Point the checkout and the product's own links at
+`cascode-ai/analog-canvas`, so neither depends on GitHub's rename redirect.
+
+## What the move did and did not require
+
+No re-clone. GitHub redirects the old path, which is why pushes kept working
+while printing "This repository moved". Updating the remote URL is enough, and
+because a worktree shares its git directory, one update covers the primary
+checkout too.
+
+What does need changing is every place the old URL is written down: a redirect
+is a courtesy, not an address to publish.
+
+## Work
+
+1. `git remote set-url origin https://github.com/cascode-ai/analog-canvas.git`
+   (configuration, not a tracked change).
+2. Update the repository link the editor shows in Help, its two tests, and the
+   GitHub Pages URL in the getting-started guide.
+
+## Validation
+
+- `git fetch` succeeds with no redirect notice; `gh repo view` resolves to
+  `cascode-ai/analog-canvas`; push access confirmed with `--dry-run`
+- `tsc -p tsconfig.check.json`, Prettier, markdown link check
+- Component tests (14) and `chrome-isolation.spec.ts` (3) pass
+
+## Gate Review
+
+- Decision: affected
+- Early gates: typecheck, Prettier, markdown links
+- Affected gates: the component tests and the Playwright spec that assert the
+  repository link
+- Final gates: remote GitHub Actions
+- Platform risks: none; no behavior changes.
+
+## Test Impact
+
+- Decision: tests-updated
+- Contracts: the repository URL the product publishes.
+- Primary checks: `apps/editor/src/components/editor-help-dialog.test.tsx`,
+  `apps/editor/e2e/chrome-isolation.spec.ts`
+
+## Commit Intent
+
+```text
+chore: follow the repository move to cascode-ai/analog-canvas
+```
+
+## Outcome
+
+The editor links to the new repository and the guide names the new Pages URL.

--- a/plan/log.md
+++ b/plan/log.md
@@ -5120,3 +5120,20 @@ Keep reusable lessons in `docs/experience/`, not in this log.
   typecheck, prettier, diff checks.
 - Commit status: completed on `claude/cleanup`; mainline merge gated on the
   remote required checks.
+
+## 2026-08-23 - Follow the repository move to cascode-ai/analog-canvas
+
+- The repository moved to `cascode-ai/analog-canvas`. No re-clone was needed:
+  GitHub redirects the old path, which is why pushes kept working while
+  printing "This repository moved". Updating the remote URL is enough, and a
+  worktree shares its git directory, so one update covered the primary
+  checkout too.
+- What did need changing is every place the old URL was written down — a
+  redirect is a courtesy, not an address to publish: the repository link the
+  editor shows in Help, its two tests, and the GitHub Pages URL in the
+  getting-started guide.
+- Validation: `git fetch` with no redirect notice, `gh repo view` resolving to
+  the new path, push access confirmed with `--dry-run`, typecheck, prettier,
+  markdown links, component tests (14) and `chrome-isolation.spec.ts` (3).
+- Commit status: completed on `claude/repo-move`; mainline merge gated on the
+  remote required checks.


### PR DESCRIPTION
## No re-clone needed

GitHub **redirects** the old path — that is why pushes kept working while printing `This repository moved`. Updating the remote URL covers it, and since a worktree shares its git directory, one update covered the primary checkout too:

```
origin  https://github.com/cascode-ai/analog-canvas.git
```

Verified: `git fetch` with no redirect notice, `gh repo view` resolving to `cascode-ai/analog-canvas`, and push access confirmed with `--dry-run`.

## What did need changing

Every place the old URL is **written down** — a redirect is a courtesy, not an address to publish:

- the repository link the editor shows in **Help** (user-facing)
- its two tests
- the **GitHub Pages** URL in the getting-started guide

## Validation

- Typecheck, Prettier, markdown link check
- Component tests: **14 passed**
- `chrome-isolation.spec.ts`: **3 passed** (asserts the repository link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)