### PR TITLE
docs(worker): record why the Worker keeps its old script name

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,5 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/cloudflare/workers-sdk/main/packages/wrangler/config-schema.json",
+  // Deliberately not renamed to match the product. A Worker's Durable Object
+  // namespaces are keyed to this script name, so renaming it would create
+  // empty ones and strand the published gallery, accounts, and analytics in
+  // the old script. The public identity is the custom domain below.
   "name": "interactive-circuit-maker",
   "main": "./worker/index.ts",
   "compatibility_date": "2026-08-11",


### PR DESCRIPTION
The script is still named `interactive-circuit-maker` while the product and its domain are `analog-canvas`. That mismatch invites a well-meaning rename — so the reason not to is now written where the rename would happen.

## Why not rename

A Worker's **Durable Object namespaces are keyed to the script name**. Renaming creates *empty* namespaces and strands the existing state in the old script:

| Durable Object | What it holds today |
| --- | --- |
| `GalleryDO` | **13 published circuits** |
| `AuthDO` | accounts |
| `AnalyticsDO` | 661 views / 65 visitors |
| `AgentSessionDO` | agent sessions |

The public identity is the custom domain `analog-canvas.tokenzhang.com`, which is already correct. The script name is an account-internal identifier no user ever sees.

Renaming is still possible, but it is a **data migration** (export each DO's state, deploy under the new name, import, then move the route) — not a config edit.

## Validation

Comment-only change; the config still parses and is unchanged otherwise:

```
name = interactive-circuit-maker
route = analog-canvas.tokenzhang.com
DO classes = AnalyticsDO, AgentSessionDO, GalleryDO, AuthDO
```

Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)