### PR TITLE
feat(editor): order the Library by reach and name the supply entries

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -325,11 +325,11 @@ test("places the VDD power-port device as the default VDD entry", async ({
     .evaluateAll((elements) =>
       elements.map((element) => element.getAttribute("data-testid")),
     );
-  // Both VDD entries stay reachable from one search; the rail now reads
-  // "Power Rail", so it sorts first by name.
+  // Both VDD entries stay reachable from one search, and the supply Port
+  // leads its Rail rather than being separated from it by alphabetical order.
   expect(vddEntries).toEqual([
-    "insert-component-vdd",
     "insert-component-vdd-port",
+    "insert-component-vdd",
   ]);
   await dialog.getByTestId("insert-component-vdd-port").click();
   await expect(dialog.locator("svg.insert-symbol-artwork")).toBeVisible();

--- a/apps/editor/src/features/component-insert/symbol-catalog.test.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.test.ts
@@ -91,3 +91,19 @@ describe("component insertion catalog", () => {
     ).toEqual([]);
   });
 });
+
+describe("reach order inside a category", () => {
+  it("keeps the devices used together adjacent", () => {
+    const groups = componentCatalog("razavi-textbook-v1", "");
+    const ids = (category: string) =>
+      groups
+        .find((group) => group.category === category)!
+        .symbols.map((symbol) => symbol.id);
+
+    // Alphabetical order separated NMOS from PMOS with a bipolar between them,
+    // and the supply Port from its Rail.
+    expect(ids("Transistors").slice(0, 2)).toEqual(["nmos", "pmos"]);
+    const power = ids("Power and Ports");
+    expect(power.indexOf("vdd-port")).toBeLessThan(power.indexOf("vdd"));
+  });
+});

--- a/apps/editor/src/features/component-insert/symbol-catalog.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.ts
@@ -79,6 +79,24 @@ export function paletteSymbols(_styleProfileId: string): SymbolDefinition[] {
   return [vddRailPreviewSymbol, cellPinPreviewSymbol, ...razaviProductSymbols];
 }
 
+/**
+ * Reach order inside a category. Alphabetical order separated devices that are
+ * used together — NMOS from PMOS, the supply Port from its Rail — so the
+ * frequently placed pair leads and the rest keep alphabetical order after it.
+ */
+const SYMBOL_ORDER: readonly string[] = [
+  "nmos",
+  "pmos",
+  "vdd-port",
+  "vdd",
+  "ground",
+];
+
+function symbolRank(symbolId: string): number {
+  const index = SYMBOL_ORDER.indexOf(symbolId);
+  return index < 0 ? Number.POSITIVE_INFINITY : index;
+}
+
 function searchableText(symbol: SymbolDefinition): string {
   return `${symbol.name} ${symbol.id}`.toLowerCase();
 }
@@ -102,6 +120,9 @@ export function componentCatalog(
       const leftRank = recentRank.get(left.id) ?? Number.POSITIVE_INFINITY;
       const rightRank = recentRank.get(right.id) ?? Number.POSITIVE_INFINITY;
       if (leftRank !== rightRank) return leftRank - rightRank;
+      const leftOrder = symbolRank(left.id);
+      const rightOrder = symbolRank(right.id);
+      if (leftOrder !== rightOrder) return leftOrder - rightOrder;
       return left.name.localeCompare(right.name);
     });
 

--- a/apps/editor/src/features/component-insert/vdd-rail-preview-symbol.ts
+++ b/apps/editor/src/features/component-insert/vdd-rail-preview-symbol.ts
@@ -4,12 +4,17 @@ import type { SymbolDefinition } from "@icm/symbols";
  * Editor-only artwork for the virtual Power Rail Library item. This definition
  * is deliberately absent from the product Symbol Resolver: it may be rendered
  * in the picker and placement preview, but it can never become an Instance.
+ *
+ * The drawing is a long rail with taps hanging off it, not the single stem
+ * of a supply Port. The two entries do different things — one places a point,
+ * the other draws a conductor between two clicks — so they must not read as
+ * the same tool in the Library.
  */
 export const vddRailPreviewSymbol = {
   schemaVersion: 1,
   id: "vdd",
   name: "Power Rail",
-  viewBox: { x: -12, y: -2, width: 24, height: 26 },
+  viewBox: { x: -14, y: -4, width: 28, height: 26 },
   pins: [
     {
       name: "P",
@@ -21,25 +26,33 @@ export const vddRailPreviewSymbol = {
   ],
   primitives: [
     {
-      kind: "line",
-      from: { x: 0, y: 20 },
-      to: { x: 0, y: 1.5 },
-      style: {
-        strokeRole: "normal",
-        lineCap: "butt",
-        lineJoin: "miter",
-      },
-    },
-    {
       kind: "polygon",
       points: [
-        { x: -10, y: -0.88 },
-        { x: 10, y: -0.88 },
-        { x: 10, y: 2.36 },
-        { x: -10, y: 2.36 },
+        { x: -12, y: -1.6 },
+        { x: 12, y: -1.6 },
+        { x: 12, y: 1.6 },
+        { x: -12, y: 1.6 },
       ],
       fill: "foreground",
       stroke: "none",
+    },
+    {
+      kind: "line",
+      from: { x: -7, y: 1.6 },
+      to: { x: -7, y: 11 },
+      style: { strokeRole: "normal", lineCap: "butt", lineJoin: "miter" },
+    },
+    {
+      kind: "line",
+      from: { x: 0, y: 1.6 },
+      to: { x: 0, y: 20 },
+      style: { strokeRole: "normal", lineCap: "butt", lineJoin: "miter" },
+    },
+    {
+      kind: "line",
+      from: { x: 7, y: 1.6 },
+      to: { x: 7, y: 11 },
+      style: { strokeRole: "normal", lineCap: "butt", lineJoin: "miter" },
     },
   ],
   variants: [],

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -38,8 +38,8 @@ const COMPACT_LIBRARY_LABELS: Readonly<Record<string, string>> = {
   "variable-capacitor": "Var Cap",
   "variable-inductor": "Var Ind",
   "variable-resistor": "Var Res",
-  vdd: "Rail",
-  "vdd-port": "V Port",
+  vdd: "VDD Rail",
+  "vdd-port": "VDD",
   "voltage-amplifier": "V Amp",
   "voltage-source": "V Src",
 };


### PR DESCRIPTION
Three palette issues reported together.

## Ordering

Within a category the palette sorted **alphabetically**, which separated devices used together:

| category | was | now |
| --- | --- | --- |
| Transistors | NMOS, **NPN**, PMOS, PNP | **NMOS, PMOS**, NPN, PNP |
| Power and Ports | … Rail … V Port … | **VDD, VDD Rail**, … |

A small explicit order leads each category with its pair; everything else keeps alphabetical order after it.

## Names

- `V Port` → **VDD**
- `Rail` → **VDD Rail**

## The Rail icon was a copy of the supply Port's

They read as the same tool in the Library. They are not:

- **VDD** places a point that ties one node to the supply.
- **VDD Rail** draws a conductor between two clicks.

The Rail now draws a long bar with taps hanging off it, so the drawing says which one it is.

## Validation

- Full unit suite: **1193 passed**
- Full Playwright suite: **211 passed**
- Typecheck, Prettier, test-impact gate

One Playwright case asserted the old alphabetical order (`Power Rail` before `VDD Power Port`); it now asserts the supply Port leading its Rail, which is the requested behavior.

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)