### PR TITLE
fix(editor): make the middle-click wire corner cycle respond to every press

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -215,6 +215,13 @@ async function onlyRouteId(page: Page): Promise<string> {
   return testId.replace(/^route-hit-/u, "");
 }
 
+async function lastRouteId(page: Page): Promise<string> {
+  const routes = page.locator('[data-testid^="route-hit-"]');
+  const testId = await routes.last().getAttribute("data-testid");
+  if (!testId) throw new Error("Route has no test id");
+  return testId.replace(/^route-hit-/u, "");
+}
+
 async function instanceLabelVector(
   page: Page,
   instanceId: string,
@@ -3692,7 +3699,6 @@ test("middle-click steers which way the wire corner turns", async ({
   await clickDrawTool(page, "wire");
   await canvas.click({ position: { x: 200, y: 200 } });
   await canvas.click({ button: "middle", position: { x: 260, y: 240 } });
-  await canvas.click({ button: "middle", position: { x: 260, y: 240 } });
   await expect(page.getByTestId("status")).toContainText("vertical first");
   await canvas.dblclick({ position: { x: 360, y: 300 } });
 
@@ -3850,6 +3856,56 @@ test("draws a wire at an angle the 45-degree grid cannot reach", async ({
   const dx = Math.abs(points[1]!.x - points[0]!.x);
   const dy = Math.abs(points[1]!.y - points[0]!.y);
   // Neither axis-aligned nor 45 degrees: the leg reaches the endpoint direct.
+  expect(dx).toBeGreaterThan(0);
+  expect(dy).toBeGreaterThan(0);
+  expect(dx).not.toBe(dy);
+});
+
+test("cycles the corner from a middle press that drifts under the hand", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await clickDrawTool(page, "wire");
+  await canvas.click({ position: { x: 200, y: 200 } });
+
+  // Clicking a scroll wheel drags the hand a few pixels. That is a click, not
+  // a pan, so the cycle still has to advance.
+  const box = (await canvas.boundingBox())!;
+  await page.mouse.move(box.x + 260, box.y + 240);
+  await page.mouse.down({ button: "middle" });
+  await page.mouse.move(box.x + 266, box.y + 245);
+  await page.mouse.up({ button: "middle" });
+
+  await expect(page.getByTestId("status")).toContainText("vertical first");
+});
+
+test("keeps the chosen corner shape when the wire tool is picked again", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await clickDrawTool(page, "wire");
+  await canvas.click({ position: { x: 200, y: 200 } });
+  for (let step = 0; step < 4; step += 1) {
+    await canvas.click({ button: "middle", position: { x: 260, y: 240 } });
+  }
+  await expect(page.getByTestId("status")).toContainText("any angle");
+  await canvas.dblclick({ position: { x: 430, y: 260 } });
+
+  // Leaving the tool and coming back used to silently drop the choice, so a
+  // diagonal had to be re-selected for every wire.
+  await page.keyboard.press("Escape");
+  await clickDrawTool(page, "wire");
+  await canvas.click({ position: { x: 200, y: 340 } });
+  await canvas.dblclick({ position: { x: 430, y: 400 } });
+
+  const ids = await page.locator('[data-testid^="route-hit-"]').count();
+  expect(ids).toBe(2);
+  const points = await readRoutePoints(page, await lastRouteId(page));
+  expect(points).toHaveLength(2);
+  const dx = Math.abs(points[1]!.x - points[0]!.x);
+  const dy = Math.abs(points[1]!.y - points[0]!.y);
   expect(dx).toBeGreaterThan(0);
   expect(dy).toBeGreaterThan(0);
   expect(dx).not.toBe(dy);

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -45,6 +45,8 @@ import {
   type ConnectivityIntent,
   type SchematicEdit,
   type WireSource,
+  type WireRoutingMode,
+  type WireCornerOrder,
 } from "@icm/edit-engine";
 import { createFormalExportSource, safeExportBaseName } from "@icm/exporters";
 import {
@@ -394,6 +396,13 @@ const LIBRARY_WIDTH_STORAGE_KEY = "icm.library-panel-width.v1";
 const REFRESH_RESTORE_STORAGE_KEY = "icm.restore-after-refresh.v1";
 const COMPACT_LAYOUT_MEDIA_QUERY = "(max-width: 860px)";
 const DRAG_START_DISTANCE_PX = 4;
+/**
+ * Middle-press slop before a pan begins. A scroll wheel is stiff enough that
+ * clicking it drags the hand several pixels, and the ordinary 4px threshold
+ * turned those clicks into pans — so the corner cycle they were meant to
+ * trigger did nothing and the middle button felt unresponsive.
+ */
+const PAN_START_DISTANCE_PX = 10;
 const SNAP_CAPTURE_RADIUS_PX = 7;
 
 /** Persisted Junctions are grid points, including on ±45° Route segments. */
@@ -840,6 +849,15 @@ export function App({
   const [selectedRouteSegmentIndex, setSelectedRouteSegmentIndex] = useState<
     number | null
   >(null);
+  /**
+   * The corner shape is a standing authoring preference, not per-wire state:
+   * picking the wire tool again reset it, so a chosen diagonal had to be
+   * re-selected for every single wire.
+   */
+  const lastWireShapeRef = useRef<{
+    routingMode: WireRoutingMode;
+    cornerOrder: WireCornerOrder;
+  }>({ routingMode: "orthogonal", cornerOrder: "auto" });
   const [selectedEndpoint, setSelectedEndpoint] = useState<WireSource | null>(
     null,
   );
@@ -4069,17 +4087,48 @@ export function App({
    * click used to reach only the diagonal, so the two orthogonal elbows were
    * unreachable without the Corner menu.
    */
+  // Re-arm the remembered corner shape on a fresh wire. Activating the wire
+  // tool builds a clean state, which dropped the choice; this restores it
+  // without touching a wire already in progress.
+  useEffect(() => {
+    if (tool !== "wire" || wireSource !== null || wireDraftSteps.length > 0)
+      return;
+    const remembered = lastWireShapeRef.current;
+    if (remembered.routingMode !== wireRoutingMode)
+      setWireRoutingMode(remembered.routingMode);
+    if (remembered.cornerOrder !== wireCornerOrder)
+      setWireCornerOrder(remembered.cornerOrder);
+  }, [
+    tool,
+    wireSource,
+    wireDraftSteps.length,
+    wireRoutingMode,
+    wireCornerOrder,
+    setWireRoutingMode,
+    setWireCornerOrder,
+  ]);
+
   function cycleWireCornerShape(): void {
+    // "auto" is where every wire starts, so it has to be a named stop on the
+    // cycle: leaving it out made findIndex return -1 and the first press land
+    // on entry 0. That press was also invisible, because a first leg drawn by
+    // "auto" already runs horizontal — hence vertical first comes next, so
+    // every press visibly redraws the preview.
     const shapes = [
       {
         routingMode: "orthogonal" as const,
-        cornerOrder: "horizontal-first" as const,
-        label: "horizontal first",
+        cornerOrder: "auto" as const,
+        label: "auto",
       },
       {
         routingMode: "orthogonal" as const,
         cornerOrder: "vertical-first" as const,
         label: "vertical first",
+      },
+      {
+        routingMode: "orthogonal" as const,
+        cornerOrder: "horizontal-first" as const,
+        label: "horizontal first",
       },
       {
         routingMode: "octilinear" as const,
@@ -4098,6 +4147,7 @@ export function App({
         shape.cornerOrder === wireCornerOrder,
     );
     const next = shapes[(index + 1) % shapes.length]!;
+    lastWireShapeRef.current = next;
     if (next.routingMode !== wireRoutingMode)
       setWireRoutingMode(next.routingMode);
     setWireCornerOrder(next.cornerOrder);
@@ -6371,7 +6421,11 @@ export function App({
         Math.hypot(
           event.clientX - panPreview.clientStart.x,
           event.clientY - panPreview.clientStart.y,
-        ) >= DRAG_START_DISTANCE_PX;
+        ) >= PAN_START_DISTANCE_PX;
+      // A middle press stays a click until it travels far enough to be a pan.
+      // Panning on sub-threshold jitter nudged the canvas under an ordinary
+      // click, so the press is ignored until the gesture commits to a drag.
+      if (!moved && !panPreview.dragged) return;
       if (moved && !panPreview.dragged)
         setPanPreview({ ...panPreview, dragged: true });
       setViewBox({


### PR DESCRIPTION
Arbitrary-angle wiring shipped in ADR 0039 and the engine does produce it — a `free` draft compiles `(0,0) → (130,47)` as one straight ~19.9° leg. It was unreachable in practice because three faults stacked on the control that selects it.

**A middle press was read as a pan.** Clicking a scroll wheel drags the hand several pixels, past the 4px drag threshold, so the press panned instead of cycling and nothing happened. Measured: the cycle fired at 3px of drift and silently died at 5px. Pan now needs 10px, and sub-threshold jitter no longer nudges the canvas under an ordinary click.

**The first press was always invisible.** `auto` is the shape every wire starts in and it was missing from the cycle, so `findIndex` returned `-1` and the first press merely landed on entry 0. That entry was `horizontal-first` — and a first leg drawn by `auto` already runs horizontal, so the press changed nothing you could see. `auto` is now a named stop and `vertical first` follows it, so every press visibly redraws the preview.

**The choice did not survive the tool.** Activating the wire tool rebuilds a clean interaction state, which dropped the corner shape — a diagonal had to be re-selected for every single wire. It is a standing authoring preference and is now re-armed on a fresh wire, without touching a wire already in progress.

## Validation

- unit: 1179 passed (the 15 failures in `worker/gallery.test.ts` are an unrelated in-flight refactor sitting uncommitted in the worktree; that file is green on `main` and is not part of this branch)
- Playwright, wire-corner and pan specs: 5 passed, including two new regressions — a middle press that drifts under the hand, and any-angle surviving a tool switch
- the existing `middle-click steers which way the wire corner turns` spec now needs one press where it previously needed two, matching what its own comment already claimed

🤖 Generated with [Claude Code](https://claude.com/claude-code)