### PR TITLE
feat(edit-engine): turn a multi-part selection as one rigid body

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3762,6 +3762,55 @@ test("keeps a long right-aligned Port label readable while editing", async ({
   expect(overflow.scrollable).toBe("auto");
 });
 
+test("turns a marquee selection as one body, not three parts in place", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+
+  await placeComponent(page, "resistor", { x: 220, y: 240 });
+  await placeComponent(page, "capacitor", { x: 340, y: 240 });
+  await placeComponent(page, "resistor", { x: 460, y: 240 });
+
+  const centres = async () =>
+    page
+      .locator('[data-layer="symbols"] [data-object-id]')
+      .evaluateAll((elements) =>
+        elements
+          .map((element) => {
+            const box = (element as SVGGraphicsElement).getBBox();
+            return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+          })
+          .sort((left, right) => left.x - right.x || left.y - right.y),
+      );
+
+  const before = await centres();
+  expect(before).toHaveLength(3);
+  // The three sit in a row, so the row's width dwarfs its height.
+  const spreadX = before[2]!.x - before[0]!.x;
+  expect(spreadX).toBeGreaterThan(100);
+
+  const bounds = (await canvas.boundingBox())!;
+  await page.mouse.move(bounds.x + 160, bounds.y + 180);
+  await page.mouse.down();
+  await page.mouse.move(bounds.x + 540, bounds.y + 310, { steps: 12 });
+  await page.mouse.up();
+  await expect(page.getByTestId("status")).toContainText("Selected");
+
+  await page.keyboard.press("r");
+
+  // A quarter turn stands the row up: the arrangement itself rotates rather
+  // than each symbol spinning where it stands.
+  const after = await centres();
+  expect(after).toHaveLength(3);
+  const afterSpreadX = after[2]!.x - after[0]!.x;
+  const afterSpreadY =
+    Math.max(...after.map((point) => point.y)) -
+    Math.min(...after.map((point) => point.y));
+  expect(afterSpreadX).toBeLessThan(20);
+  expect(afterSpreadY).toBeGreaterThan(100);
+});
+
 test("drags a marquee selection that holds no instance", async ({ page }) => {
   await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -19,6 +19,7 @@ import {
   createRouteWireAnchor,
   proposeEndpointRouteAttachment,
   proposeGroupMoveEdits,
+  proposeGroupRotationEdits,
   proposeLooseRouteTranslation,
   proposePowerRailEndpointResize,
   proposePowerRailTranslation,
@@ -4787,21 +4788,41 @@ export function App({
   }
 
   function rotateSelected(deltaDegrees: 90 | -90 = 90): void {
-    const instanceEdits = selectedIds.flatMap((id): SchematicEdit[] => {
-      const instance = document.instances.find(
-        (candidate) => candidate.id === id,
-      );
-      if (!instance?.placement) return [];
-      const next =
-        (((instance.placement.rotation + deltaDegrees) % 360) + 360) % 360;
-      return [
-        {
-          kind: "rotate_instance",
-          instanceId: instance.id,
-          rotation: next as 0 | 90 | 180 | 270,
-        },
-      ];
-    });
+    const placedSelection = selectedIds.filter((id) =>
+      document.instances.some(
+        (candidate) => candidate.id === id && candidate.placement,
+      ),
+    );
+    // Several parts turn as one body about a shared pivot. Spinning each one
+    // about its own origin leaves the arrangement exactly where it was, which
+    // is not what turning a selection means. A lone part has no arrangement to
+    // preserve, so it keeps the simpler in-place turn.
+    const groupRotation =
+      placedSelection.length > 1
+        ? proposeGroupRotationEdits(
+            document,
+            resolver,
+            placedSelection,
+            deltaDegrees,
+          )
+        : null;
+    const instanceEdits = groupRotation
+      ? groupRotation.edits
+      : selectedIds.flatMap((id): SchematicEdit[] => {
+          const instance = document.instances.find(
+            (candidate) => candidate.id === id,
+          );
+          if (!instance?.placement) return [];
+          const next =
+            (((instance.placement.rotation + deltaDegrees) % 360) + 360) % 360;
+          return [
+            {
+              kind: "rotate_instance",
+              instanceId: instance.id,
+              rotation: next as 0 | 90 | 180 | 270,
+            },
+          ];
+        });
     // Drafting rotation: R now also rotates a selected drafting object. An arrow
     // pivots about its resolved center; a construction line pivots about the
     // center of its bounds. Purely geometric — never changes electrical Nets.

--- a/packages/edit-engine/src/route-operations.ts
+++ b/packages/edit-engine/src/route-operations.ts
@@ -732,3 +732,197 @@ export function proposeGroupMove(
     internalRouteIds,
   };
 }
+
+export interface InstanceRotationProposal {
+  instanceId: string;
+  position: Point;
+  rotation: 0 | 90 | 180 | 270;
+}
+
+export interface GroupRotationProposal {
+  instances: InstanceRotationProposal[];
+  routes: RouteStretchProposal[];
+  junctions: JunctionMoveProposal[];
+  annotations: AnnotationMoveProposal[];
+  pivot: Point;
+}
+
+/** Screen-space quarter turn: +90 turns clockwise, as SVG rotate() does. */
+function turn(point: Point, pivot: Point, deltaDegrees: 90 | -90): Point {
+  const dx = point.x - pivot.x;
+  const dy = point.y - pivot.y;
+  return deltaDegrees === 90
+    ? { x: pivot.x - dy, y: pivot.y + dx }
+    : { x: pivot.x + dy, y: pivot.y - dx };
+}
+
+/**
+ * Turn a selection as one rigid body.
+ *
+ * Rotating each Instance about its own origin leaves the group's layout
+ * untouched, which is not what selecting several parts and turning them
+ * means. Here every member orbits one shared pivot and turns by the same
+ * angle, so the arrangement itself rotates.
+ *
+ * The pivot is the centre of the selected Instances' bounding box snapped to
+ * the grid, which keeps on-grid geometry exactly on-grid through the turn.
+ *
+ * A rigid turn also fixes where each pin lands: an Instance and its pins
+ * rotate together, so a terminal endpoint's new position is simply its old
+ * position orbited about the pivot. Routes wholly inside the selection turn
+ * with it; a Route that leaves the selection keeps its outside endpoint and
+ * stretches, exactly as a group translation does.
+ */
+export function proposeGroupRotation(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  instanceIds: readonly string[],
+  deltaDegrees: 90 | -90,
+): GroupRotationProposal {
+  const selected = new Set(instanceIds);
+  const placed = document.instances.filter(
+    (instance) => selected.has(instance.id) && instance.placement,
+  );
+  if (placed.length === 0) {
+    return {
+      instances: [],
+      routes: [],
+      junctions: [],
+      annotations: [],
+      pivot: { x: 0, y: 0 },
+    };
+  }
+
+  const grid = document.presentation.grid;
+  const xs = placed.map((instance) => instance.placement!.position.x);
+  const ys = placed.map((instance) => instance.placement!.position.y);
+  const snap = (value: number): number =>
+    grid > 0 ? Math.round(value / grid) * grid : value;
+  const pivot = {
+    x: snap((Math.min(...xs) + Math.max(...xs)) / 2),
+    y: snap((Math.min(...ys) + Math.max(...ys)) / 2),
+  };
+
+  const instances = placed
+    .map((instance): InstanceRotationProposal => {
+      const placement = instance.placement!;
+      return {
+        instanceId: instance.id,
+        position: turn(placement.position, pivot, deltaDegrees),
+        rotation: ((((placement.rotation + deltaDegrees) % 360) + 360) %
+          360) as 0 | 90 | 180 | 270,
+      };
+    })
+    .sort((left, right) =>
+      left.instanceId.localeCompare(right.instanceId, "en"),
+    );
+
+  const internalSelection = deriveRoutingInternalGroupSelection(document, [
+    ...selected,
+  ]);
+  const internalNetIds = new Set(internalSelection.netIds);
+  const turningJunctionIds = new Set(internalSelection.junctionIds);
+  const routingGeometry = resolveDocumentRoutingGeometry(document, resolver);
+
+  const turns = (
+    endpoint: SchematicDocument["routes"][number]["from"],
+  ): boolean =>
+    (endpoint.kind === "terminal" && selected.has(endpoint.instanceId)) ||
+    (endpoint.kind === "junction" &&
+      turningJunctionIds.has(endpoint.junctionId));
+
+  const proposals = new Map<string, RouteStretchProposal>();
+  for (const route of document.routes) {
+    const fromTurns = turns(route.from);
+    const toTurns = turns(route.to);
+    if (!fromTurns && !toTurns) continue;
+
+    if (fromTurns && toTurns) {
+      if (route.segmentModes.includes("locked")) {
+        throw new Error(`Route ${route.id} contains a locked segment`);
+      }
+      // Wholly inside: the Route is part of the body, so its own geometry
+      // turns rather than being stretched between two moved ends.
+      proposals.set(route.id, {
+        routeId: route.id,
+        waypoints: route.waypoints.map((point) =>
+          turn(point, pivot, deltaDegrees),
+        ),
+        segmentModes: [...route.segmentModes],
+      });
+      continue;
+    }
+
+    const original = routeEditPathFromGeometry(routingGeometry, route.id);
+    if (!original) throw new Error(`Route ${route.id} has unresolved geometry`);
+    const points = original.points.map((point) => ({ ...point }));
+    const modes = [...original.segmentModes];
+    if (fromTurns) {
+      const from = original.points[0]!;
+      stretchRouteEndpoint(
+        route.id,
+        points,
+        modes,
+        "from",
+        from,
+        turn(from, pivot, deltaDegrees),
+      );
+    }
+    if (toTurns) {
+      const to = original.points.at(-1)!;
+      stretchRouteEndpoint(
+        route.id,
+        points,
+        modes,
+        "to",
+        to,
+        turn(to, pivot, deltaDegrees),
+      );
+    }
+    proposals.set(route.id, normalizeProposal(route.id, points, modes));
+  }
+
+  const turnedObjectIds = new Set<string>([
+    ...internalNetIds,
+    ...internalSelection.routeIds,
+    ...turningJunctionIds,
+  ]);
+  return {
+    instances,
+    pivot,
+    routes: [...proposals.values()].sort((left, right) =>
+      left.routeId.localeCompare(right.routeId, "en"),
+    ),
+    junctions: document.junctions
+      .filter((junction) => turningJunctionIds.has(junction.id))
+      .map((junction) => ({
+        junctionId: junction.id,
+        position: turn(junction.position, pivot, deltaDegrees),
+      }))
+      .sort((left, right) =>
+        left.junctionId.localeCompare(right.junctionId, "en"),
+      ),
+    annotations: document.annotations
+      .filter(
+        (annotation) =>
+          annotation.anchor.kind === "free" &&
+          turnedObjectIds.has(annotation.netId ?? ""),
+      )
+      .map((annotation) => {
+        const anchor = annotation.anchor;
+        if (anchor.kind !== "free") {
+          throw new Error("Free annotation filter lost anchor narrowing");
+        }
+        return {
+          annotationId: annotation.id,
+          anchor: {
+            kind: "free" as const,
+            position: turn(anchor.position, pivot, deltaDegrees),
+          },
+        };
+      })
+      .sort((left, right) =>
+        left.annotationId.localeCompare(right.annotationId, "en"),
+      ),
+  };
+}

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -12,6 +12,7 @@ import {
 } from "./route-geometry-edit.js";
 import {
   proposeGroupMove,
+  proposeGroupRotation,
   proposeJunctionGroupTranslation,
   proposeWireSegmentDrag,
   type JunctionMoveProposal,
@@ -194,6 +195,65 @@ export function proposeGroupMoveEdits(
       // Route prevents move_instance from progressively re-stretching an
       // internal wire once per selected Instance, which otherwise makes a
       // group translation depend on transaction edit order.
+      ...routeEdits(document, proposal.routes),
+      ...proposal.annotations.flatMap((move): SchematicEdit[] => {
+        const annotation = document.annotations.find(
+          (candidate) => candidate.id === move.annotationId,
+        );
+        return annotation
+          ? [
+              {
+                kind: "upsert_schematic_annotation",
+                annotation: { ...annotation, anchor: move.anchor },
+              },
+            ]
+          : [];
+      }),
+    ],
+  };
+}
+
+/**
+ * Typed edits that turn a selection as one rigid body.
+ *
+ * Instance rotation and translation travel together: a member both spins in
+ * place and orbits the shared pivot, and the plan supplies every affected
+ * Route so geometry does not depend on transaction edit order.
+ */
+export function proposeGroupRotationEdits(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  instanceIds: readonly string[],
+  deltaDegrees: 90 | -90,
+): GroupMoveEditProposal {
+  const proposal = proposeGroupRotation(
+    document,
+    resolver,
+    instanceIds,
+    deltaDegrees,
+  );
+  return {
+    preview: {
+      routes: proposal.routes,
+      junctions: proposal.junctions,
+    },
+    edits: [
+      ...proposal.instances.flatMap((turn): SchematicEdit[] => [
+        {
+          kind: "rotate_instance",
+          instanceId: turn.instanceId,
+          rotation: turn.rotation,
+        },
+        {
+          kind: "move_instance",
+          instanceId: turn.instanceId,
+          position: turn.position,
+        },
+      ]),
+      ...proposal.junctions.map((move): SchematicEdit => ({
+        kind: "move_junction",
+        ...move,
+      })),
       ...routeEdits(document, proposal.routes),
       ...proposal.annotations.flatMap((move): SchematicEdit[] => {
         const annotation = document.annotations.find(

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -15,6 +15,7 @@ import { executeTransaction } from "./transaction.js";
 import { isOrthogonal } from "./route-geometry-edit.js";
 import {
   proposeGroupMoveEdits,
+  proposeGroupRotationEdits,
   proposeEndpointRouteAttachment,
   proposeLooseRouteTranslation,
   proposePowerRailEndpointResize,
@@ -689,6 +690,89 @@ describe("routing Edit Engine", () => {
       context,
     );
     expect(moved.ok).toBe(true);
+  });
+
+  it("turns a multi-part selection as one body about a shared pivot", () => {
+    const document = documentFixture();
+    // A and B sit side by side on y=300; a quarter turn about their shared
+    // centre has to stand them up, not merely spin each symbol where it is.
+    const plan = proposeGroupRotationEdits(document, resolver, ["A", "B"], 90);
+    const applied = executeTransaction(
+      document,
+      transaction(document.id, document.revision, plan.edits),
+      context,
+    );
+    expect(applied.ok).toBe(true);
+    if (!applied.ok) return;
+
+    const placement = (id: string) =>
+      applied.document.instances.find((instance) => instance.id === id)!
+        .placement!;
+    expect(placement("A").position).toEqual({ x: 300, y: 140 });
+    expect(placement("B").position).toEqual({ x: 300, y: 460 });
+    expect(placement("A").rotation).toBe(90);
+    expect(placement("B").rotation).toBe(90);
+  });
+
+  it("leaves a lone part turning in place", () => {
+    const document = documentFixture();
+    const before = document.instances.find((instance) => instance.id === "A")!
+      .placement!.position;
+    const plan = proposeGroupRotationEdits(document, resolver, ["A"], 90);
+    const applied = executeTransaction(
+      document,
+      transaction(document.id, document.revision, plan.edits),
+      context,
+    );
+    expect(applied.ok).toBe(true);
+    if (!applied.ok) return;
+    const after = applied.document.instances.find(
+      (instance) => instance.id === "A",
+    )!.placement!;
+    expect(after.position).toEqual(before);
+    expect(after.rotation).toBe(90);
+  });
+
+  it("turns a quarter each way back to where it started", () => {
+    const document = documentFixture();
+    const forward = executeTransaction(
+      document,
+      transaction(
+        document.id,
+        document.revision,
+        proposeGroupRotationEdits(document, resolver, ["A", "B", "C"], 90)
+          .edits,
+      ),
+      context,
+    );
+    expect(forward.ok).toBe(true);
+    if (!forward.ok) return;
+    const back = executeTransaction(
+      forward.document,
+      transaction(
+        forward.document.id,
+        forward.document.revision,
+        proposeGroupRotationEdits(
+          forward.document,
+          resolver,
+          ["A", "B", "C"],
+          -90,
+        ).edits,
+      ),
+      context,
+    );
+    expect(back.ok).toBe(true);
+    if (!back.ok) return;
+    for (const id of ["A", "B", "C"]) {
+      const original = document.instances.find(
+        (instance) => instance.id === id,
+      )!.placement!;
+      const restored = back.document.instances.find(
+        (instance) => instance.id === id,
+      )!.placement!;
+      expect(restored.position).toEqual(original.position);
+      expect(restored.rotation).toBe(original.rotation);
+    }
   });
 
   it("authors group Route geometry when a group move also moves a Junction", () => {


### PR DESCRIPTION
Rotating a selection changed each Instance's own `rotation` and nothing else, so three parts picked out with a marquee spun where they stood and the arrangement they formed was left exactly as it was.

`proposeGroupRotation` plans the turn about one shared pivot — the centre of the selected Instances' bounding box, snapped to the grid so on-grid geometry stays on-grid through a quarter turn. Every member orbits that pivot and spins by the same angle.

That also settles where each pin lands. A part and its pins turn together, so a terminal endpoint's new position is simply its old position orbited about the pivot — no separate pin bookkeeping. Routes wholly inside the selection turn with it rather than being stretched between two moved ends; a Route that leaves the selection keeps its outside endpoint and stretches, exactly as a group translation already does. The plan supplies every affected Route, so the result does not depend on transaction edit order.

A lone part has no arrangement to preserve and keeps the simpler in-place turn, so single-symbol rotation is untouched.

## Validation

- unit: 1199 passed, including three new cases — a row of two standing up about their shared centre `(300,300)`, a lone part holding its position, and a +90/−90 round trip restoring every position and rotation exactly
- Playwright: a new spec places three parts in a row, marquees them, presses `R`, and measures the result — the row's horizontal spread collapses below 20 and its vertical spread exceeds 100. Under the old behaviour the spread was unchanged, so the assertion is load-bearing.

## Note on scope

Drafting objects (arrows, construction lines) still pivot about their own centres rather than orbiting a mixed selection's pivot. Left alone deliberately — it needs a translation path those objects do not have yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)