### PR TITLE
feat(gallery): sign in to publish, straight to the wall

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -47,7 +47,7 @@ jobs:
       # GITHUB_, hence GH_OAUTH_*.
       - name: Sync worker secrets
         run: |
-          for name in GALLERY_ADMIN_TOKEN GH_OAUTH_CLIENT_ID GH_OAUTH_CLIENT_SECRET GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET RESEND_API_KEY AUTH_EMAIL_FROM ADMIN_EMAILS; do
+          for name in GH_OAUTH_CLIENT_ID GH_OAUTH_CLIENT_SECRET GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET RESEND_API_KEY AUTH_EMAIL_FROM ADMIN_EMAILS; do
             value="${!name}"
             if [ -z "$value" ]; then
               echo "$name is not configured; skipping"
@@ -58,7 +58,6 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          GALLERY_ADMIN_TOKEN: ${{ secrets.GALLERY_ADMIN_TOKEN }}
           GH_OAUTH_CLIENT_ID: ${{ secrets.GH_OAUTH_CLIENT_ID }}
           GH_OAUTH_CLIENT_SECRET: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}

--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -318,9 +318,6 @@ test("the admin recycle bin restores a recycled entry", async ({ page }) => {
       },
     }),
   );
-  await page.route("**/api/gallery/review", (route) =>
-    route.fulfill({ json: { entries: [] } }),
-  );
   let restored = 0;
   await page.route("**/api/gallery/recycled", (route) =>
     route.fulfill({
@@ -342,7 +339,7 @@ test("the admin recycle bin restores a recycled entry", async ({ page }) => {
     return route.fulfill({ json: { id: "bin-1", status: "public" } });
   });
 
-  await page.goto("/review");
+  await page.goto("/moderation");
   await expect(page.getByTestId("bin-card-bin-1")).toBeVisible();
   await page.getByTestId("bin-restore-bin-1").click();
   await expect(page.getByTestId("bin-empty")).toBeVisible();
@@ -458,59 +455,29 @@ test("a signed-in owner renames the display name and signs out", async ({
   expect(loggedOut).toBe(1);
 });
 
-test("the Publish button posts the live Project with the passphrase", async ({
+test("a signed-out visitor is asked to sign in, not for a passphrase", async ({
   page,
 }) => {
-  const posted: { authorization: string | null; body: string }[] = [];
-  // The real submissions endpoint is /api/gallery/submissions — the mock
-  // matches it exactly so a client posting anywhere else fails this test.
   await page.route("**/api/gallery", (route) =>
     route.fulfill({ json: { entries: [], nextCursor: null } }),
   );
-  await page.route("**/api/gallery/submissions", (route) => {
-    if (route.request().method() !== "POST") return route.fallback();
-    posted.push({
-      authorization: route.request().headers()["authorization"] ?? null,
-      body: route.request().postData() ?? "",
-    });
-    return route.fulfill({ status: 201, json: { id: "entry-99" } });
-  });
 
   await page.goto("/editor");
   await page.getByTestId("publish-gallery-button").click();
   const dialog = page.getByTestId("publish-gallery-dialog");
   await expect(dialog).toBeVisible();
 
-  await dialog.getByLabel("Circuit name").fill("Publish Demo");
-  await dialog.getByLabel("Author").fill("Vivian");
-  const publish = dialog.getByRole("button", { name: "Publish" });
-  await expect(publish).toBeDisabled();
-  await dialog.getByLabel("Owner passphrase").fill("secret-token");
-  await publish.click();
-
-  await expect(page.getByTestId("status")).toHaveText(
-    'Published "Publish Demo" to the gallery',
+  await expect(dialog.getByTestId("publish-signin")).toBeVisible();
+  await expect(dialog.getByTestId("publish-signin-github")).toHaveAttribute(
+    "href",
+    "/api/auth/github/start",
   );
-  expect(posted).toHaveLength(1);
-  const request = posted[0]!;
-  expect(request.authorization).toBe("Bearer secret-token");
-  const body = JSON.parse(request.body) as {
-    name: string;
-    author: string;
-    projectText: string;
-  };
-  expect(body.name).toBe("Publish Demo");
-  expect(body.author).toBe("Vivian");
-  expect(JSON.parse(body.projectText).schemaVersion).toBe(ENTRY.schemaVersion);
-
-  // The passphrase is remembered for the session and offered on reopen.
-  await page.getByTestId("publish-gallery-button").click();
-  await expect(
-    page.getByTestId("publish-gallery-dialog").getByLabel("Owner passphrase"),
-  ).toHaveValue("secret-token");
+  // The passphrase is gone: no field, and nothing to submit without a session.
+  await expect(dialog.getByLabel("Owner passphrase")).toHaveCount(0);
+  await expect(dialog.getByRole("button", { name: "Publish" })).toHaveCount(0);
 });
 
-test("an admin session publishes without the passphrase row", async ({
+test("a signed-in member publishes directly, bylined by the account", async ({
   page,
 }) => {
   await page.route("**/api/auth/me", (route) =>
@@ -528,18 +495,28 @@ test("an admin session publishes without the passphrase row", async ({
   );
   const posted: {
     authorization: string | null;
-    author: string;
+    hasAuthor: boolean;
+    name: string;
     tags: string[];
+    schemaVersion: number;
   }[] = [];
+  // The real submissions endpoint is /api/gallery/submissions — the mock
+  // matches it exactly so a client posting anywhere else fails this test.
   await page.route("**/api/gallery/submissions", (route) => {
+    if (route.request().method() !== "POST") return route.fallback();
     const body = route.request().postDataJSON() as {
-      author: string;
+      author?: string;
+      name: string;
       tags: string[];
+      projectText: string;
     };
     posted.push({
       authorization: route.request().headers()["authorization"] ?? null,
-      author: body.author,
+      hasAuthor: "author" in body,
+      name: body.name,
       tags: body.tags,
+      schemaVersion: (JSON.parse(body.projectText) as { schemaVersion: number })
+        .schemaVersion,
     });
     return route.fulfill({ status: 201, json: { id: "entry-77" } });
   });
@@ -548,10 +525,10 @@ test("an admin session publishes without the passphrase row", async ({
   await page.getByTestId("publish-gallery-button").click();
   const dialog = page.getByTestId("publish-gallery-dialog");
   await expect(dialog).toBeVisible();
-  await expect(dialog.getByText("Signed in as Token Zhang")).toBeVisible();
+  await expect(dialog.getByText("Publishing as Token Zhang")).toBeVisible();
   await expect(dialog.getByLabel("Owner passphrase")).toHaveCount(0);
-  // The account display name prefills the author byline.
-  await expect(dialog.getByLabel("Author")).toHaveValue("Token Zhang");
+  // The byline comes from the account, so there is no field to fill in.
+  await expect(dialog.getByLabel("Author")).toHaveCount(0);
 
   await dialog.getByLabel("Circuit name").fill("Session Publish");
   await dialog.getByTestId("publish-preset-amplifier").click();
@@ -565,8 +542,10 @@ test("an admin session publishes without the passphrase row", async ({
   expect(posted).toEqual([
     {
       authorization: null,
-      author: "Token Zhang",
+      hasAuthor: false,
+      name: "Session Publish",
       tags: ["amplifier", "latch"],
+      schemaVersion: ENTRY.schemaVersion,
     },
   ]);
 });
@@ -597,15 +576,14 @@ test("an ordinary user sees blocking quality gates on an empty project", async (
   // The empty canvas fails the content gate, evaluated locally.
   const gates = page.getByTestId("publish-gallery-gates");
   await expect(gates).toBeVisible();
-  await expect(gates).toContainText("Fix these before submitting");
+  await expect(gates).toContainText("Fix these before publishing");
   await expect(gates).toContainText("Too little content");
   await expect(dialog.getByLabel("Owner passphrase")).toHaveCount(0);
-  await expect(
-    dialog.getByRole("button", { name: "Submit for review" }),
-  ).toBeDisabled();
+  // The gates still hold, but the button says what actually happens next.
+  await expect(dialog.getByRole("button", { name: "Publish" })).toBeDisabled();
 });
 
-test("a reviewer approves a pending submission from the review queue", async ({
+test("the retired review queue is gone from the moderation page", async ({
   page,
 }) => {
   await page.route("**/api/auth/me", (route) =>
@@ -622,40 +600,16 @@ test("a reviewer approves a pending submission from the review queue", async ({
       },
     }),
   );
-  await page.route("**/api/gallery/review", (route) =>
-    route.fulfill({
-      json: {
-        entries: [
-          {
-            id: "p-1",
-            name: "Pending Filter",
-            author: "maker",
-            description: "Second-order RC",
-            createdAt: "2026-08-22T09:00:00.000Z",
-          },
-        ],
-      },
-    }),
+  await page.route("**/api/gallery/recycled", (route) =>
+    route.fulfill({ json: { entries: [] } }),
   );
-  await page.route("**/api/gallery/p-1/preview.svg", (route) =>
-    route.fulfill({
-      contentType: "image/svg+xml",
-      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10" fill="#fff"/></svg>',
-    }),
-  );
-  const decisions: string[] = [];
-  await page.route("**/api/gallery/p-1/approve", (route) => {
-    decisions.push("approve");
-    return route.fulfill({ json: { id: "p-1", status: "public" } });
-  });
 
-  await page.goto("/review");
-  const card = page.getByTestId("review-card-p-1");
-  await expect(card).toBeVisible();
-  await expect(card).toContainText("Pending Filter");
-  await card.getByTestId("review-approve-p-1").click();
-  await expect(page.getByTestId("review-empty")).toBeVisible();
-  expect(decisions).toEqual(["approve"]);
+  await page.goto("/moderation");
+  await expect(page.getByTestId("moderation")).toBeVisible();
+  // Curation is post-publication now: a bin to restore from, no inbox.
+  await expect(page.getByTestId("bin-empty")).toBeVisible();
+  await expect(page.getByTestId("review-empty")).toHaveCount(0);
+  await expect(page.getByText("Nothing waiting for review")).toHaveCount(0);
 });
 
 test("/mine wears the site chrome and links every entry back to the editor", async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -8017,7 +8017,6 @@ export function App({
           updateDefaults={
             galleryEntryContext
               ? {
-                  author: galleryEntryContext.author,
                   description: galleryEntryContext.description,
                   tags: galleryEntryContext.tags,
                 }
@@ -8030,16 +8029,12 @@ export function App({
                   updateGalleryEntry(galleryEntryContext.id, project, fields)
               : undefined
           }
-          onPublished={({ name, pending, updated }) => {
+          onPublished={({ name, updated }) => {
             setPublishGalleryOpen(false);
             setStatus(
               updated
-                ? pending
-                  ? `Submitted the update to "${name}" for review`
-                  : `Updated "${name}" in the gallery`
-                : pending
-                  ? `Submitted "${name}" for review`
-                  : `Published "${name}" to the gallery`,
+                ? `Updated "${name}" in the gallery`
+                : `Published "${name}" to the gallery`,
             );
           }}
           onShowHistory={

--- a/apps/editor/src/components/account.tsx
+++ b/apps/editor/src/components/account.tsx
@@ -187,7 +187,7 @@ export function AccountMenuView({
               </span>
             ) : user.role === "moderator" ? (
               <span className="account-owner-badge" data-testid="account-mod">
-                Reviewer
+                Moderator
               </span>
             ) : null}
             <span aria-hidden="true">⋯</span>
@@ -196,10 +196,10 @@ export function AccountMenuView({
             {user.isAdmin || user.role === "moderator" ? (
               <a
                 className="account-link"
-                href="/review"
-                data-testid="account-review-link"
+                href="/moderation"
+                data-testid="account-moderation-link"
               >
-                Review
+                Moderation
               </a>
             ) : null}
             <a className="account-link" href="/mine" data-testid="account-mine">

--- a/apps/editor/src/components/gallery-chrome.tsx
+++ b/apps/editor/src/components/gallery-chrome.tsx
@@ -2,7 +2,7 @@ import { AccountMenu } from "./account";
 
 /**
  * The one gallery site header, shared by the feed and every gallery
- * subpage (/mine, /review) in all their states, so no page ever renders
+ * subpage (/mine) in all their states, so no page ever renders
  * as a bare paragraph without navigation. Markup mirrors the feed's
  * original header exactly (test ids included).
  */

--- a/apps/editor/src/components/moderation.tsx
+++ b/apps/editor/src/components/moderation.tsx
@@ -4,61 +4,25 @@ import { fetchSessionUser, type SessionUser } from "./account";
 import { GalleryChrome } from "./gallery-chrome";
 
 /**
- * Review queue (roadmap phase G3): the super-admin and appointed
- * moderators approve pending community submissions into the public feed
- * or reject them with an optional reason the submitter sees. The admin
- * additionally appoints moderators by email from this page.
+ * Moderation, the post-publication surface. Publishing is direct, so there
+ * is nothing to approve in advance; what a curator needs is the ability to
+ * take an entry down afterwards, put it back, and finally delete it. The
+ * super-admin also appoints moderators by email from here.
  */
 
-export interface PendingEntry {
-  id: string;
-  name: string;
-  author: string;
-  description: string;
-  createdAt: string;
-}
-
-type QueueState =
+type ModerationState =
   | { status: "loading" }
   | { status: "denied" }
-  | { status: "ready"; user: SessionUser; entries: PendingEntry[] };
+  | { status: "ready"; user: SessionUser };
 
-export async function loadReviewQueue(
+export async function loadModerationAccess(
   fetchLike: typeof fetch = fetch,
-): Promise<QueueState> {
+): Promise<ModerationState> {
   const user = await fetchSessionUser(fetchLike);
   if (!user || (!user.isAdmin && user.role !== "moderator")) {
     return { status: "denied" };
   }
-  try {
-    const response = await fetchLike("/api/gallery/review", {
-      credentials: "same-origin",
-    });
-    if (!response.ok) return { status: "denied" };
-    const payload = (await response.json()) as { entries?: PendingEntry[] };
-    return { status: "ready", user, entries: payload.entries ?? [] };
-  } catch {
-    return { status: "denied" };
-  }
-}
-
-async function decide(
-  id: string,
-  decision: "approve" | "reject",
-  reason: string,
-  fetchLike: typeof fetch = fetch,
-): Promise<boolean> {
-  try {
-    const response = await fetchLike(`/api/gallery/${id}/${decision}`, {
-      method: "POST",
-      credentials: "same-origin",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(decision === "reject" ? { reason } : {}),
-    });
-    return response.ok;
-  } catch {
-    return false;
-  }
+  return { status: "ready", user };
 }
 
 async function appointModerator(
@@ -75,7 +39,7 @@ async function appointModerator(
     });
     if (response.ok) {
       return role === "moderator"
-        ? `${email} can now review submissions.`
+        ? `${email} can now moderate the gallery.`
         : `${email} is an ordinary user again.`;
     }
     if (response.status === 404) {
@@ -87,75 +51,6 @@ async function appointModerator(
   }
 }
 
-function ReviewCard({
-  entry,
-  onDecided,
-}: {
-  entry: PendingEntry;
-  onDecided: (id: string) => void;
-}) {
-  const [reason, setReason] = useState("");
-  const [busy, setBusy] = useState(false);
-
-  async function act(decision: "approve" | "reject"): Promise<void> {
-    setBusy(true);
-    const ok = await decide(entry.id, decision, reason.trim());
-    setBusy(false);
-    if (ok) onDecided(entry.id);
-  }
-
-  return (
-    <article className="review-card" data-testid={`review-card-${entry.id}`}>
-      <a
-        className="review-card-preview"
-        href={`/g/${entry.id}`}
-        title="Open in the editor"
-      >
-        <img
-          src={`/api/gallery/${entry.id}/preview.svg`}
-          alt={`Preview of ${entry.name}`}
-          loading="lazy"
-        />
-      </a>
-      <div className="review-card-copy">
-        <h2>{entry.name}</h2>
-        <p className="review-card-meta">
-          {entry.author ? `${entry.author} · ` : ""}
-          {new Date(entry.createdAt).toLocaleString()}
-        </p>
-        {entry.description ? <p>{entry.description}</p> : null}
-        <input
-          aria-label="Rejection reason"
-          data-testid={`review-reason-${entry.id}`}
-          placeholder="Optional rejection reason"
-          value={reason}
-          maxLength={300}
-          onChange={(event) => setReason(event.currentTarget.value)}
-        />
-        <div className="review-card-actions">
-          <button
-            type="button"
-            data-testid={`review-reject-${entry.id}`}
-            disabled={busy}
-            onClick={() => void act("reject")}
-          >
-            Reject
-          </button>
-          <button
-            type="button"
-            className="review-approve"
-            data-testid={`review-approve-${entry.id}`}
-            disabled={busy}
-            onClick={() => void act("approve")}
-          >
-            Approve
-          </button>
-        </div>
-      </div>
-    </article>
-  );
-}
-
 interface RecycledEntry {
   id: string;
   name: string;
@@ -163,9 +58,9 @@ interface RecycledEntry {
 }
 
 /**
- * In-feed admin recycle bin (G4): the post-approval takedown surface.
- * Restore returns an entry to the public wall; Delete forever is the
- * only hard deletion and asks for confirmation first.
+ * The recycle bin: the takedown surface. Restore returns an entry to the
+ * public wall; Delete forever is the only hard deletion and asks for
+ * confirmation first.
  */
 function RecycleBin() {
   const [entries, setEntries] = useState<RecycledEntry[] | null>(null);
@@ -265,14 +160,14 @@ function RecycleBin() {
   );
 }
 
-export function ReviewQueue() {
-  const [state, setState] = useState<QueueState>({ status: "loading" });
+export function Moderation() {
+  const [state, setState] = useState<ModerationState>({ status: "loading" });
   const [email, setEmail] = useState("");
   const [notice, setNotice] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    void loadReviewQueue().then((next) => {
+    void loadModerationAccess().then((next) => {
       if (!cancelled) setState(next);
     });
     return () => {
@@ -288,12 +183,12 @@ export function ReviewQueue() {
           state.status === "denied" ? "review-denied" : "review-page"
         }
       >
-        <GalleryChrome subtitle="Review queue" />
+        <GalleryChrome subtitle="Moderation" />
         <div className="page-body">
           <p className="gallery-status">
             {state.status === "loading"
-              ? "Loading review queue…"
-              : "The review queue is for the gallery owner and appointed moderators."}
+              ? "Loading moderation…"
+              : "Moderation is for the gallery owner and appointed moderators."}
           </p>
         </div>
       </main>
@@ -301,8 +196,8 @@ export function ReviewQueue() {
   }
 
   return (
-    <main className="review-shell" data-testid="review-queue">
-      <GalleryChrome subtitle="Review queue" />
+    <main className="review-shell" data-testid="moderation">
+      <GalleryChrome subtitle="Moderation" />
       <div className="page-body">
         {state.user.isAdmin ? (
           <form
@@ -325,33 +220,14 @@ export function ReviewQueue() {
             {notice ? <span className="account-notice">{notice}</span> : null}
           </form>
         ) : null}
-        {state.entries.length === 0 ? (
-          <p className="gallery-status" data-testid="review-empty">
-            Nothing waiting for review.
-          </p>
+        {state.user.isAdmin ? (
+          <RecycleBin />
         ) : (
-          <section className="review-list">
-            {state.entries.map((entry) => (
-              <ReviewCard
-                key={entry.id}
-                entry={entry}
-                onDecided={(id) =>
-                  setState((previous) =>
-                    previous.status === "ready"
-                      ? {
-                          ...previous,
-                          entries: previous.entries.filter(
-                            (candidate) => candidate.id !== id,
-                          ),
-                        }
-                      : previous,
-                  )
-                }
-              />
-            ))}
-          </section>
+          <p className="gallery-status">
+            Withdraw an entry from its page; the owner and the admin can bring
+            it back.
+          </p>
         )}
-        {state.user.isAdmin ? <RecycleBin /> : null}
       </div>
     </main>
   );

--- a/apps/editor/src/components/my-submissions.tsx
+++ b/apps/editor/src/components/my-submissions.tsx
@@ -60,9 +60,11 @@ export async function setMyEntryRecycled(
   }
 }
 
+// Publishing is direct, so nothing new is ever "pending". `rejected` is
+// kept for the handful of entries a reviewer turned down before the queue
+// was retired; their owners still need to see why.
 const STATUS_LABELS: Record<string, string> = {
   public: "Published",
-  pending: "Waiting for review",
   rejected: "Rejected",
   recycled: "Withdrawn",
 };

--- a/apps/editor/src/features/editor-shell/gallery-publish.test.ts
+++ b/apps/editor/src/features/editor-shell/gallery-publish.test.ts
@@ -3,12 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   describePublishOutcome,
-  forgetOnUnauthorized,
   publishProjectToGallery,
-  rememberedPublishAuthor,
-  rememberedPublishToken,
-  rememberPublishAuthor,
-  rememberPublishToken,
 } from "./gallery-publish";
 
 const project = createEmptyProject("p1", "Ring Oscillator");
@@ -25,47 +20,36 @@ function fetchReturning(
   }) as typeof fetch;
 }
 
-function memoryStorage(): Pick<
-  Storage,
-  "getItem" | "setItem" | "removeItem"
-> & { map: Map<string, string> } {
-  const map = new Map<string, string>();
-  return {
-    map,
-    getItem: (key) => map.get(key) ?? null,
-    setItem: (key, value) => void map.set(key, value),
-    removeItem: (key) => void map.delete(key),
-  };
-}
-
 describe("publishProjectToGallery", () => {
-  it("posts the serialized Project with the bearer passphrase", async () => {
+  it("posts the serialized Project under the session cookie alone", async () => {
     const seen: { url?: string; init?: RequestInit | undefined } = {};
     const outcome = await publishProjectToGallery(
       project,
       {
         name: "  Ring Oscillator  ",
-        author: "Vivian",
         description: "Five stages",
         tags: ["Amplifier", "OTA"],
-        token: "secret-token",
       },
       fetchReturning(201, { id: "entry-1" }, seen),
     );
     expect(outcome).toEqual({ status: "published", id: "entry-1" });
     expect(seen.url).toBe("/api/gallery/submissions");
-    expect((seen.init?.headers as Record<string, string>).authorization).toBe(
-      "Bearer secret-token",
-    );
+    expect(seen.init?.credentials).toBe("same-origin");
+
+    // No passphrase travels any more: the cookie is the whole credential.
+    const headers = seen.init?.headers as Record<string, string>;
+    expect(headers.authorization).toBeUndefined();
+
     const body = JSON.parse(String(seen.init?.body)) as {
       name: string;
-      author: string;
       description: string;
       projectText: string;
     };
     expect(body.name).toBe("Ring Oscillator");
-    expect(body.author).toBe("Vivian");
     expect(body.description).toBe("Five stages");
+    // The byline is the server's to set from the session, so the request
+    // carries no author claim at all.
+    expect(body).not.toHaveProperty("author");
     expect(JSON.parse(body.projectText).schemaVersion).toBe(
       project.schemaVersion,
     );
@@ -81,7 +65,7 @@ describe("publishProjectToGallery", () => {
     for (const [status, payload, expected] of cases) {
       const outcome = await publishProjectToGallery(
         project,
-        { name: "N", author: "", description: "", tags: [], token: "t" },
+        { name: "N", description: "", tags: [] },
         fetchReturning(status, payload),
       );
       expect(outcome.status).toBe(expected);
@@ -89,54 +73,35 @@ describe("publishProjectToGallery", () => {
     }
   });
 
-  it("omits the bearer for an empty passphrase so the session cookie signs", async () => {
-    const seen: { url?: string; init?: RequestInit | undefined } = {};
+  it("reads a 422 as the quality gates, not as a refusal", async () => {
     const outcome = await publishProjectToGallery(
       project,
-      { name: "N", author: "", description: "", tags: [], token: "" },
-      fetchReturning(201, { id: "entry-2" }, seen),
+      { name: "N", description: "", tags: [] },
+      fetchReturning(422, {
+        error: "quality-gate",
+        failures: [
+          { code: "empty-project", message: "Nothing to publish", count: 1 },
+        ],
+      }),
     );
-    expect(outcome.status).toBe("published");
-    const headers = seen.init?.headers as Record<string, string>;
-    expect(headers.authorization).toBeUndefined();
-    expect(seen.init?.credentials).toBe("same-origin");
+    expect(outcome).toMatchObject({
+      status: "gate-failed",
+      failures: [{ code: "empty-project" }],
+    });
   });
 
   it("reports a thrown fetch as unreachable", async () => {
     const outcome = await publishProjectToGallery(
       project,
-      { name: "N", author: "", description: "", tags: [], token: "t" },
+      { name: "N", description: "", tags: [] },
       (() => Promise.reject(new Error("offline"))) as typeof fetch,
     );
     expect(outcome).toEqual({ status: "unreachable", message: "offline" });
   });
-});
 
-describe("publish passphrase session memory", () => {
-  it("round-trips the passphrase and forgets it on a 401", () => {
-    const storage = memoryStorage();
-    rememberPublishToken("secret-token", storage);
-    expect(rememberedPublishToken(storage)).toBe("secret-token");
-    expect(forgetOnUnauthorized({ status: "rate-limited" }, storage)).toBe(
-      false,
+  it("points a signed-out publisher at signing in, not at a passphrase", () => {
+    expect(describePublishOutcome({ status: "unauthorized" })).toContain(
+      "sign in",
     );
-    expect(rememberedPublishToken(storage)).toBe("secret-token");
-    expect(forgetOnUnauthorized({ status: "unauthorized" }, storage)).toBe(
-      true,
-    );
-    expect(rememberedPublishToken(storage)).toBe("");
-    expect(storage.map.size).toBe(0);
-  });
-});
-
-describe("publish author memory", () => {
-  it("prefills the last-used byline and forgets a cleared one", () => {
-    const storage = memoryStorage();
-    expect(rememberedPublishAuthor(storage)).toBe("");
-    rememberPublishAuthor("  Token Zhang  ", storage);
-    expect(rememberedPublishAuthor(storage)).toBe("Token Zhang");
-    rememberPublishAuthor("   ", storage);
-    expect(rememberedPublishAuthor(storage)).toBe("");
-    expect(storage.map.size).toBe(0);
   });
 });

--- a/apps/editor/src/features/editor-shell/gallery-publish.ts
+++ b/apps/editor/src/features/editor-shell/gallery-publish.ts
@@ -4,32 +4,29 @@ import { serializeProject } from "@icm/project-protocol";
 
 /**
  * Client for the documented gallery submissions endpoint
- * (docs/specs/community-gallery.md). Phase G1 gates publishing behind the
- * owner's admin passphrase; the same call path later carries the signed-in
- * session instead. The fetch seam keeps the mapping testable offline.
+ * (docs/specs/community-gallery.md). The signed-in session is the only
+ * credential: it travels as a same-origin cookie, so nothing here handles a
+ * secret. The fetch seam keeps the mapping testable offline.
  */
 
 export interface GalleryPublishFields {
   name: string;
-  author: string;
   description: string;
   /** Category tags ("amplifier", "adc", …); the server normalizes. */
   tags: readonly string[];
-  /** Owner passphrase; empty when an admin session authenticates instead. */
-  token: string;
 }
 
-/** What the dialog needs to know about the signed-in user (phase G2). */
+/** What the dialog needs to know about the signed-in user. */
 export interface PublishSessionUser {
+  /** Also the byline: the server takes it from the account, not from us. */
   displayName: string;
   isAdmin: boolean;
-  /** "user" or "moderator"; moderators publish directly (phase G3). */
+  /** "user" or "moderator"; moderators bypass the quality gates. */
   role?: string;
 }
 
 export type GalleryPublishOutcome =
   | { status: "published"; id: string }
-  | { status: "pending-review"; id: string }
   | { status: "gate-failed"; failures: readonly SubmissionGateFailure[] }
   | { status: "unauthorized" }
   | { status: "too-large" }
@@ -44,20 +41,15 @@ async function sendGalleryProject(
   fields: GalleryPublishFields,
   fetchLike: typeof fetch,
 ): Promise<GalleryPublishOutcome> {
-  const headers: Record<string, string> = {
-    "content-type": "application/json",
-  };
-  // Without a passphrase the session cookie authenticates instead.
-  if (fields.token) headers.authorization = `Bearer ${fields.token}`;
   let response: Response;
   try {
     response = await fetchLike(url, {
       method,
+      // The session cookie is the credential; there is nothing else to send.
       credentials: "same-origin",
-      headers,
+      headers: { "content-type": "application/json" },
       body: JSON.stringify({
         name: fields.name.trim(),
-        author: fields.author.trim(),
         description: fields.description.trim(),
         tags: fields.tags,
         projectText: serializeProject(project),
@@ -72,12 +64,11 @@ async function sendGalleryProject(
   if (response.status === 201 || response.status === 200) {
     const payload = (await response.json().catch(() => null)) as {
       id?: unknown;
-      status?: unknown;
     } | null;
-    const id = typeof payload?.id === "string" ? payload.id : "";
-    return payload?.status === "pending"
-      ? { status: "pending-review", id }
-      : { status: "published", id };
+    return {
+      status: "published",
+      id: typeof payload?.id === "string" ? payload.id : "",
+    };
   }
   if (response.status === 422) {
     const payload = (await response.json().catch(() => null)) as {
@@ -114,7 +105,7 @@ export function publishProjectToGallery(
   );
 }
 
-/** Owner/reviewer update of an existing entry (phase G3 completion). */
+/** Owner or moderator update of an existing entry. */
 export function updateGalleryEntry(
   entryId: string,
   project: CircuitProject,
@@ -135,106 +126,23 @@ export function describePublishOutcome(outcome: GalleryPublishOutcome): string {
   switch (outcome.status) {
     case "published":
       return "Published to the gallery";
-    case "pending-review":
-      return "Submitted — your circuit is waiting for review";
     case "gate-failed":
       return "The submission did not pass the quality gates";
     case "unauthorized":
-      return "The passphrase was not accepted, so it was forgotten — ask the gallery owner for the current one";
+      return "Your sign-in has expired — sign in again to publish";
     case "too-large":
       return "This Project exceeds the gallery's 2 MB limit";
     case "rate-limited":
       return "Daily publish limit reached — try again tomorrow";
     case "rejected":
       return outcome.message === "invalid-fields"
-        ? "Check the fields: a name is required; author and description have length caps"
+        ? "Check the fields: a name is required, and the description has a length cap"
         : outcome.message === "invalid-project"
           ? "The Project failed strict validation on the server"
           : outcome.message === "forbidden"
-            ? "Only the entry's owner or a reviewer can update it"
+            ? "Only the entry's owner or a moderator can update it"
             : `The gallery rejected the submission (${outcome.message})`;
     case "unreachable":
       return `Could not reach the gallery: ${outcome.message}`;
-  }
-}
-
-const TOKEN_STORAGE_KEY = "icm.gallery-publish-token.v1";
-const AUTHOR_STORAGE_KEY = "icm.gallery-publish-author.v1";
-
-type TokenStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
-
-function sessionStorageOrNull(): TokenStorage | null {
-  try {
-    return window.sessionStorage;
-  } catch {
-    return null;
-  }
-}
-
-function localStorageOrNull(): TokenStorage | null {
-  try {
-    return window.localStorage;
-  } catch {
-    return null;
-  }
-}
-
-/** The author byline used last time, prefill for the next publish. */
-export function rememberedPublishAuthor(
-  storage: TokenStorage | null = localStorageOrNull(),
-): string {
-  try {
-    return storage?.getItem(AUTHOR_STORAGE_KEY) ?? "";
-  } catch {
-    return "";
-  }
-}
-
-/** Remember (non-empty) or forget (empty) the author byline. */
-export function rememberPublishAuthor(
-  author: string,
-  storage: TokenStorage | null = localStorageOrNull(),
-): void {
-  try {
-    const trimmed = author.trim();
-    if (trimmed) storage?.setItem(AUTHOR_STORAGE_KEY, trimmed);
-    else storage?.removeItem(AUTHOR_STORAGE_KEY);
-  } catch {
-    // Local storage may be unavailable; the byline is just not remembered.
-  }
-}
-
-/** The passphrase remembered for this browser session, if any. */
-export function rememberedPublishToken(
-  storage: TokenStorage | null = sessionStorageOrNull(),
-): string {
-  try {
-    return storage?.getItem(TOKEN_STORAGE_KEY) ?? "";
-  } catch {
-    return "";
-  }
-}
-
-/** A 401 forgets the remembered passphrase; reports whether it did. */
-export function forgetOnUnauthorized(
-  outcome: GalleryPublishOutcome,
-  storage: TokenStorage | null = sessionStorageOrNull(),
-): boolean {
-  if (outcome.status !== "unauthorized") return false;
-  rememberPublishToken("", storage);
-  return true;
-}
-
-/** Remember (non-empty) or forget (empty) the passphrase for this session. */
-export function rememberPublishToken(
-  token: string,
-  storage: TokenStorage | null = sessionStorageOrNull(),
-): void {
-  try {
-    if (token) storage?.setItem(TOKEN_STORAGE_KEY, token);
-    else storage?.removeItem(TOKEN_STORAGE_KEY);
-  } catch {
-    // Session storage may be unavailable (private mode); publishing still
-    // works, the passphrase is just not remembered.
   }
 }

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.test.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import { PublishGalleryDialog } from "./publish-gallery-dialog";
 
 describe("PublishGalleryDialog", () => {
-  it("prefills the Project name and gates Publish on the passphrase", () => {
+  it("asks a signed-out visitor to sign in instead of for a passphrase", () => {
     const markup = renderToStaticMarkup(
       createElement(PublishGalleryDialog, {
         defaultName: "Ring Oscillator",
@@ -15,39 +15,17 @@ describe("PublishGalleryDialog", () => {
       }),
     );
     expect(markup).toContain('data-testid="publish-gallery-dialog"');
-    expect(markup).toContain('value="Ring Oscillator"');
-    expect(markup).toContain('aria-label="Owner passphrase"');
-    expect(markup).toContain('type="password"');
-    // Empty passphrase (no session memory in this render) disables Publish.
-    expect(markup).toMatch(/disabled=""[^>]*>Publish</u);
-    expect(markup).toContain("owner&#x27;s passphrase");
-    // The modern single-column card: stacked full-width fields, a primary
-    // Publish action, and the author byline placeholder.
-    expect(markup).toContain('class="publish-gallery-fields"');
-    expect(markup).toContain('class="publish-gallery-primary"');
-    expect(markup).toContain('placeholder="Shown on your tile"');
-    expect(markup).not.toContain("insert-component-dialog");
+    expect(markup).toContain('data-testid="publish-signin"');
+    expect(markup).toContain('href="/api/auth/github/start"');
+    // The passphrase is gone entirely — no field, no copy, no password input.
+    expect(markup).not.toContain("passphrase");
+    expect(markup).not.toContain('type="password"');
+    // With no account there is nothing to fill in and nothing to submit.
+    expect(markup).not.toContain('class="publish-gallery-fields"');
+    expect(markup).not.toContain('class="publish-gallery-primary"');
   });
 
-  it("drops the passphrase row for a signed-in admin session", () => {
-    const markup = renderToStaticMarkup(
-      createElement(PublishGalleryDialog, {
-        defaultName: "Ring Oscillator",
-        session: { displayName: "Token Zhang", isAdmin: true },
-        publish: () => Promise.resolve({ status: "unauthorized" as const }),
-        onPublished: () => undefined,
-        onClose: () => undefined,
-      }),
-    );
-    expect(markup).not.toContain("Owner passphrase");
-    expect(markup).toContain("Signed in as Token Zhang");
-    // Publish is enabled without any passphrase.
-    expect(markup).not.toMatch(/disabled=""[^>]*>Publish</u);
-    // The account display name prefills the author byline.
-    expect(markup).toContain('value="Token Zhang"');
-  });
-
-  it("offers submit-for-review, not a passphrase, to an ordinary user", () => {
+  it("publishes an ordinary member's circuit straight away", () => {
     const markup = renderToStaticMarkup(
       createElement(PublishGalleryDialog, {
         defaultName: "Ring Oscillator",
@@ -58,13 +36,33 @@ describe("PublishGalleryDialog", () => {
         onClose: () => undefined,
       }),
     );
-    expect(markup).not.toContain("Owner passphrase");
-    expect(markup).toContain("Submit for review");
-    expect(markup).toContain("review queue");
-    expect(markup).not.toMatch(/disabled=""[^>]*>Submit for review</u);
+    expect(markup).toContain('value="Ring Oscillator"');
+    expect(markup).toContain('class="publish-gallery-fields"');
+    expect(markup).toContain('class="publish-gallery-primary"');
+    expect(markup).toContain("Publishing as Visitor");
+    expect(markup).toContain("goes up straight away");
+    // No queue to wait in, and no passphrase to guess.
+    expect(markup).not.toContain("review");
+    expect(markup).not.toContain("passphrase");
+    expect(markup).not.toMatch(/disabled=""[^>]*>Publish</u);
   });
 
-  it("blocks an ordinary user on gate failures and lists them", () => {
+  it("never asks for the byline: the account supplies it", () => {
+    const markup = renderToStaticMarkup(
+      createElement(PublishGalleryDialog, {
+        defaultName: "Ring Oscillator",
+        session: { displayName: "Token Zhang", isAdmin: true },
+        publish: () => Promise.resolve({ status: "unauthorized" as const }),
+        onPublished: () => undefined,
+        onClose: () => undefined,
+      }),
+    );
+    expect(markup).not.toContain('aria-label="Author"');
+    expect(markup).not.toContain("Shown on your tile");
+    expect(markup).toContain("Publishing as Token Zhang");
+  });
+
+  it("blocks an ordinary member on gate failures and lists them", () => {
     const markup = renderToStaticMarkup(
       createElement(PublishGalleryDialog, {
         defaultName: "Ring Oscillator",
@@ -87,9 +85,9 @@ describe("PublishGalleryDialog", () => {
       }),
     );
     expect(markup).toContain("publish-gallery-gates-blocking");
-    expect(markup).toContain("Fix these before submitting:");
+    expect(markup).toContain("Fix these before publishing:");
     expect(markup).toContain("M1.g, R2.2");
-    expect(markup).toMatch(/disabled=""[^>]*>Submit for review</u);
+    expect(markup).toMatch(/disabled=""[^>]*>Publish</u);
   });
 
   it("shows the same failures as informational for a moderator", () => {

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
@@ -4,11 +4,6 @@ import type { SubmissionGateReport } from "@icm/derived";
 
 import {
   describePublishOutcome,
-  forgetOnUnauthorized,
-  rememberedPublishAuthor,
-  rememberedPublishToken,
-  rememberPublishAuthor,
-  rememberPublishToken,
   type GalleryPublishFields,
   type GalleryPublishOutcome,
   type PublishSessionUser,
@@ -16,16 +11,15 @@ import {
 
 export interface PublishGalleryDialogProps {
   defaultName: string;
-  /** The signed-in user, if any; admins and moderators publish directly. */
+  /** The signed-in user; null means there is nothing to publish with yet. */
   session?: PublishSessionUser | null;
-  /** Quality-gate evaluation of the live Project (phase G3). */
+  /** Quality-gate evaluation of the live Project. */
   gateReport?: SubmissionGateReport | null;
   /** Present when the open circuit came from a gallery entry the signed-in
    * user may update (owner, admin, or moderator). */
   updateTarget?: { id: string; name: string } | null;
   /** The opened entry's stored fields, prefilled once in update mode. */
   updateDefaults?: {
-    author: string;
     description: string;
     tags: readonly string[];
   } | null;
@@ -36,22 +30,21 @@ export interface PublishGalleryDialogProps {
   onPublished: (outcome: {
     id: string;
     name: string;
-    pending: boolean;
     updated: boolean;
   }) => void;
-  /** Reviewers and the entry's owner: open the version history instead.
+  /** Moderators and the entry's owner: open the version history instead.
    * Rendered only alongside an update target. */
   onShowHistory?: (() => void) | undefined;
   onClose: () => void;
 }
 
 /**
- * File > "Publish to Gallery…". Admin and moderator sessions publish
- * directly; an ordinary signed-in user submits into the review queue and
- * must pass the quality gates (listed live, blocking). Without a session
- * the owner-passphrase path remains (remembered per browser session,
- * forgotten on a 401). The author byline prefills from the account's
- * display name, else from the last successful publish.
+ * File > "Publish to Gallery…". Signing in is the whole gate: any signed-in
+ * account publishes straight to the wall — no passphrase, no review queue.
+ * The byline is the account's display name, which the server reads from the
+ * session rather than from this form, so one account cannot publish under
+ * another's name. Ordinary members still pass the quality gates (listed
+ * live, blocking); moderators curate past them.
  */
 export function PublishGalleryDialog({
   defaultName,
@@ -67,7 +60,7 @@ export function PublishGalleryDialog({
 }: PublishGalleryDialogProps) {
   const privileged = session?.isAdmin === true || session?.role === "moderator";
   const ordinary = session !== null && !privileged;
-  const anonymous = session === null;
+  const signedOut = session === null;
   const gatesBlock = ordinary && gateReport !== null && !gateReport.ok;
   const canUpdate = updateTarget !== null && publishUpdate !== undefined;
   const [mode, setMode] = useState<"update" | "new">(
@@ -75,27 +68,14 @@ export function PublishGalleryDialog({
   );
   const updating = canUpdate && mode === "update";
   const [name, setName] = useState(defaultName);
-  const [author, setAuthor] = useState(
-    () => rememberedPublishAuthor() || session?.displayName || "",
-  );
   const [description, setDescription] = useState("");
   const [tags, setTags] = useState<string[]>([]);
   const [tagDraft, setTagDraft] = useState("");
-  const [token, setToken] = useState(() => rememberedPublishToken());
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // The session usually arrives after mount; fill the untouched author
-  // byline with the account name once it does.
-  const sessionDisplayName = session?.displayName;
-  useEffect(() => {
-    if (sessionDisplayName) {
-      setAuthor((previous) => previous || sessionDisplayName);
-    }
-  }, [sessionDisplayName]);
-
-  // The update permission also arrives with the session; default to
-  // updating the opened entry unless the user already chose a mode.
+  // The update permission arrives with the session; default to updating the
+  // opened entry unless the user already chose a mode.
   const [modeTouched, setModeTouched] = useState(false);
   useEffect(() => {
     if (canUpdate && !modeTouched) setMode("update");
@@ -107,7 +87,6 @@ export function PublishGalleryDialog({
   useEffect(() => {
     if (!canUpdate || !updateDefaults || defaultsApplied) return;
     setDefaultsApplied(true);
-    setAuthor((previous) => previous || updateDefaults.author);
     setDescription((previous) => previous || updateDefaults.description);
     setTags((previous) =>
       previous.length > 0 ? previous : [...updateDefaults.tags],
@@ -129,25 +108,11 @@ export function PublishGalleryDialog({
     setBusy(true);
     setError(null);
     const send = updating ? (publishUpdate ?? publish) : publish;
-    const outcome = await send({
-      name,
-      author,
-      description,
-      tags,
-      token: anonymous ? token : "",
-    });
-    if (outcome.status === "published" || outcome.status === "pending-review") {
-      if (anonymous) rememberPublishToken(token);
-      rememberPublishAuthor(author);
-      onPublished({
-        id: outcome.id,
-        name: name.trim(),
-        pending: outcome.status === "pending-review",
-        updated: updating,
-      });
+    const outcome = await send({ name, description, tags });
+    if (outcome.status === "published") {
+      onPublished({ id: outcome.id, name: name.trim(), updated: updating });
       return;
     }
-    if (forgetOnUnauthorized(outcome)) setToken("");
     setBusy(false);
     setError(describePublishOutcome(outcome));
   }
@@ -170,192 +135,196 @@ export function PublishGalleryDialog({
           <p>Share this circuit on the public wall</p>
           <h2 id="publish-gallery-title">Publish to Gallery</h2>
         </header>
-        {canUpdate ? (
-          <div className="publish-gallery-mode" data-testid="publish-mode">
-            <label>
-              <input
-                type="radio"
-                name="publish-mode"
-                checked={mode === "update"}
-                onChange={() => {
-                  setMode("update");
-                  setModeTouched(true);
-                }}
-              />
-              Update “{updateTarget?.name}” (replaces that entry)
-            </label>
-            <label>
-              <input
-                type="radio"
-                name="publish-mode"
-                checked={mode === "new"}
-                onChange={() => {
-                  setMode("new");
-                  setModeTouched(true);
-                }}
-              />
-              Publish as a new entry
-            </label>
-            {onShowHistory ? (
-              <button
-                type="button"
-                className="publish-gallery-history-link"
-                data-testid="publish-history"
-                onClick={onShowHistory}
+        {signedOut ? (
+          // Nothing to fill in until there is an account to publish under:
+          // the byline, the ownership, and the credential all come from it.
+          <div className="publish-gallery-signin" data-testid="publish-signin">
+            <p>
+              Publishing needs an account, so the circuit carries your name and
+              stays yours to edit or withdraw.
+            </p>
+            <div className="publish-gallery-signin-actions">
+              <a
+                href="/api/auth/github/start"
+                data-testid="publish-signin-github"
               >
-                Version history…
-              </button>
-            ) : null}
+                Continue with GitHub
+              </a>
+              <a
+                href="/api/auth/google/start"
+                data-testid="publish-signin-google"
+              >
+                Continue with Google
+              </a>
+            </div>
+            <p className="publish-gallery-signin-note">
+              Prefer email? Sign in from the account menu on the gallery page —
+              a one-time link is all it takes.
+            </p>
           </div>
-        ) : null}
-        <div className="publish-gallery-fields">
-          <label>
-            Circuit name
-            <input
-              aria-label="Circuit name"
-              value={name}
-              maxLength={120}
-              autoFocus
-              onChange={(event) => setName(event.currentTarget.value)}
-            />
-          </label>
-          <label>
-            <span>
-              Author <span className="publish-gallery-optional">optional</span>
-            </span>
-            <input
-              aria-label="Author"
-              value={author}
-              maxLength={40}
-              placeholder="Shown on your tile"
-              onChange={(event) => setAuthor(event.currentTarget.value)}
-            />
-          </label>
-          <label>
-            <span>
-              Description{" "}
-              <span className="publish-gallery-optional">optional</span>
-            </span>
-            <textarea
-              aria-label="Description"
-              value={description}
-              maxLength={300}
-              rows={3}
-              onChange={(event) => setDescription(event.currentTarget.value)}
-            />
-          </label>
-          <div className="publish-gallery-tags" data-testid="publish-tags">
-            <span className="publish-gallery-tags-label">
-              Tags <span className="publish-gallery-optional">up to 5</span>
-            </span>
-            {tags.length > 0 ? (
-              <div className="publish-gallery-tag-chips">
-                {tags.map((tag) => (
+        ) : (
+          <>
+            {canUpdate ? (
+              <div className="publish-gallery-mode" data-testid="publish-mode">
+                <label>
+                  <input
+                    type="radio"
+                    name="publish-mode"
+                    checked={mode === "update"}
+                    onChange={() => {
+                      setMode("update");
+                      setModeTouched(true);
+                    }}
+                  />
+                  Update “{updateTarget?.name}” (replaces that entry)
+                </label>
+                <label>
+                  <input
+                    type="radio"
+                    name="publish-mode"
+                    checked={mode === "new"}
+                    onChange={() => {
+                      setMode("new");
+                      setModeTouched(true);
+                    }}
+                  />
+                  Publish as a new entry
+                </label>
+                {onShowHistory ? (
                   <button
-                    key={tag}
                     type="button"
-                    className="publish-gallery-tag"
-                    data-testid={`publish-tag-${tag}`}
-                    title="Remove tag"
-                    onClick={() =>
-                      setTags((previous) =>
-                        previous.filter((candidate) => candidate !== tag),
-                      )
-                    }
+                    className="publish-gallery-history-link"
+                    data-testid="publish-history"
+                    onClick={onShowHistory}
                   >
-                    {tag} ×
+                    Version history…
                   </button>
-                ))}
+                ) : null}
               </div>
             ) : null}
-            <input
-              aria-label="Add tag"
-              placeholder="Type a tag and press Enter"
-              value={tagDraft}
-              maxLength={24}
-              onChange={(event) => setTagDraft(event.currentTarget.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter" || event.key === ",") {
-                  event.preventDefault();
-                  addTag(tagDraft);
-                }
-              }}
-              onBlur={() => addTag(tagDraft)}
-            />
-            <div className="publish-gallery-tag-presets">
-              {[
-                "amplifier",
-                "comparator",
-                "adc",
-                "dac",
-                "pll",
-                "oscillator",
-                "filter",
-                "current mirror",
-              ]
-                .filter((preset) => !tags.includes(preset))
-                .map((preset) => (
-                  <button
-                    key={preset}
-                    type="button"
-                    data-testid={`publish-preset-${preset.replace(/\s/gu, "-")}`}
-                    onClick={() => addTag(preset)}
-                  >
-                    + {preset}
-                  </button>
-                ))}
+            <div className="publish-gallery-fields">
+              <label>
+                Circuit name
+                <input
+                  aria-label="Circuit name"
+                  value={name}
+                  maxLength={120}
+                  autoFocus
+                  onChange={(event) => setName(event.currentTarget.value)}
+                />
+              </label>
+              <label>
+                <span>
+                  Description{" "}
+                  <span className="publish-gallery-optional">optional</span>
+                </span>
+                <textarea
+                  aria-label="Description"
+                  value={description}
+                  maxLength={300}
+                  rows={3}
+                  onChange={(event) =>
+                    setDescription(event.currentTarget.value)
+                  }
+                />
+              </label>
+              <div className="publish-gallery-tags" data-testid="publish-tags">
+                <span className="publish-gallery-tags-label">
+                  Tags <span className="publish-gallery-optional">up to 5</span>
+                </span>
+                {tags.length > 0 ? (
+                  <div className="publish-gallery-tag-chips">
+                    {tags.map((tag) => (
+                      <button
+                        key={tag}
+                        type="button"
+                        className="publish-gallery-tag"
+                        data-testid={`publish-tag-${tag}`}
+                        title="Remove tag"
+                        onClick={() =>
+                          setTags((previous) =>
+                            previous.filter((candidate) => candidate !== tag),
+                          )
+                        }
+                      >
+                        {tag} ×
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+                <input
+                  aria-label="Add tag"
+                  placeholder="Type a tag and press Enter"
+                  value={tagDraft}
+                  maxLength={24}
+                  onChange={(event) => setTagDraft(event.currentTarget.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === ",") {
+                      event.preventDefault();
+                      addTag(tagDraft);
+                    }
+                  }}
+                  onBlur={() => addTag(tagDraft)}
+                />
+                <div className="publish-gallery-tag-presets">
+                  {[
+                    "amplifier",
+                    "comparator",
+                    "adc",
+                    "dac",
+                    "pll",
+                    "oscillator",
+                    "filter",
+                    "current mirror",
+                  ]
+                    .filter((preset) => !tags.includes(preset))
+                    .map((preset) => (
+                      <button
+                        key={preset}
+                        type="button"
+                        data-testid={`publish-preset-${preset.replace(/\s/gu, "-")}`}
+                        onClick={() => addTag(preset)}
+                      >
+                        + {preset}
+                      </button>
+                    ))}
+                </div>
+              </div>
             </div>
-          </div>
-          {anonymous ? (
-            <label>
-              Owner passphrase
-              <input
-                aria-label="Owner passphrase"
-                type="password"
-                value={token}
-                onChange={(event) => setToken(event.currentTarget.value)}
-              />
-            </label>
-          ) : null}
-        </div>
-        {gateReport && gateReport.failures.length > 0 ? (
-          <div
-            className={
-              gatesBlock
-                ? "publish-gallery-gates publish-gallery-gates-blocking"
-                : "publish-gallery-gates"
-            }
-            data-testid="publish-gallery-gates"
-          >
-            <p>
-              {gatesBlock
-                ? "Fix these before submitting:"
-                : "Quality checks (informational for your role):"}
+            {gateReport && gateReport.failures.length > 0 ? (
+              <div
+                className={
+                  gatesBlock
+                    ? "publish-gallery-gates publish-gallery-gates-blocking"
+                    : "publish-gallery-gates"
+                }
+                data-testid="publish-gallery-gates"
+              >
+                <p>
+                  {gatesBlock
+                    ? "Fix these before publishing:"
+                    : "Quality checks (informational for your role):"}
+                </p>
+                <ul>
+                  {gateReport.failures.map((failure) => (
+                    <li key={failure.code}>
+                      {failure.message}
+                      {failure.count > 1 ? ` (${failure.count})` : ""}
+                      {failure.examples.length > 0
+                        ? ` — ${failure.examples.join(", ")}`
+                        : ""}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+            <p className="publish-gallery-note">
+              {updating
+                ? `Publishing as ${session?.displayName} — this updates the entry in place.`
+                : `Publishing as ${session?.displayName} — it goes up straight away.`}
             </p>
-            <ul>
-              {gateReport.failures.map((failure) => (
-                <li key={failure.code}>
-                  {failure.message}
-                  {failure.count > 1 ? ` (${failure.count})` : ""}
-                  {failure.examples.length > 0
-                    ? ` — ${failure.examples.join(", ")}`
-                    : ""}
-                </li>
-              ))}
-            </ul>
-          </div>
-        ) : null}
-        <p className="publish-gallery-note">
-          {privileged
-            ? updating
-              ? `Signed in as ${session?.displayName} — this updates the entry in place.`
-              : `Signed in as ${session?.displayName} — this publishes directly.`
-            : ordinary
-              ? updating
-                ? `Signed in as ${session?.displayName} — your update replaces the entry and re-enters review.`
-                : `Signed in as ${session?.displayName} — your circuit enters the review queue and appears once a reviewer approves it.`
-              : "Publishing is owner-approved for now: it needs the gallery owner's passphrase, or sign in on the gallery page to submit for review."}
-        </p>
+          </>
+        )}
         {error ? (
           <p role="alert" className="publish-gallery-error">
             {error}
@@ -363,29 +332,18 @@ export function PublishGalleryDialog({
         ) : null}
         <div className="publish-gallery-actions">
           <button type="button" disabled={busy} onClick={onClose}>
-            Cancel
+            {signedOut ? "Close" : "Cancel"}
           </button>
-          <button
-            type="button"
-            className="publish-gallery-primary"
-            disabled={
-              busy ||
-              name.trim() === "" ||
-              (anonymous && token.trim() === "") ||
-              gatesBlock
-            }
-            onClick={() => void submit()}
-          >
-            {busy
-              ? "Publishing…"
-              : updating
-                ? ordinary
-                  ? "Submit update for review"
-                  : "Update entry"
-                : ordinary
-                  ? "Submit for review"
-                  : "Publish"}
-          </button>
+          {signedOut ? null : (
+            <button
+              type="button"
+              className="publish-gallery-primary"
+              disabled={busy || name.trim() === "" || gatesBlock}
+              onClick={() => void submit()}
+            >
+              {busy ? "Publishing…" : updating ? "Update entry" : "Publish"}
+            </button>
+          )}
         </div>
       </section>
     </div>

--- a/apps/editor/src/main.tsx
+++ b/apps/editor/src/main.tsx
@@ -25,9 +25,9 @@ const GalleryFeed = lazy(() =>
   })),
 );
 
-const ReviewQueue = lazy(() =>
-  import("./components/review-queue").then((module) => ({
-    default: module.ReviewQueue,
+const Moderation = lazy(() =>
+  import("./components/moderation").then((module) => ({
+    default: module.Moderation,
   })),
 );
 
@@ -107,12 +107,12 @@ function Root() {
       </Suspense>
     );
   }
-  if (/^\/review\/?$/.test(path)) {
+  if (/^\/moderation\/?$/.test(path)) {
     return (
       <Suspense
-        fallback={<div className="analytics-loading">Loading review…</div>}
+        fallback={<div className="analytics-loading">Loading moderation…</div>}
       >
-        <ReviewQueue />
+        <Moderation />
       </Suspense>
     );
   }

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -4017,6 +4017,47 @@ body {
   line-height: 1.4;
 }
 
+/* Signed out, the dialog is a sign-in prompt rather than a form: the byline,
+   the ownership, and the credential all come from the account. */
+.publish-gallery-signin {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.publish-gallery-signin p {
+  margin: 0;
+  color: var(--icm-text-muted, #667085);
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.publish-gallery-signin-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.publish-gallery-signin-actions a {
+  flex: 1 1 12rem;
+  padding: 0.5rem 0.85rem;
+  border: 1px solid var(--icm-border, #d0d5dd);
+  border-radius: 0.5rem;
+  background: var(--icm-surface, #fff);
+  color: inherit;
+  font-size: 0.85rem;
+  text-align: center;
+  text-decoration: none;
+}
+
+.publish-gallery-signin-actions a:hover {
+  border-color: var(--icm-accent, #1570ef);
+}
+
+.publish-gallery-signin-note {
+  font-size: 0.75rem;
+}
+
 .publish-gallery-actions {
   display: flex;
   justify-content: flex-end;

--- a/docs/roadmap/community-gallery-platform.md
+++ b/docs/roadmap/community-gallery-platform.md
@@ -22,15 +22,12 @@ server contract lives in
 - `GalleryDO` (SQLite, third Durable Object) stores published entries:
   canonical strict-schema Project text plus a server-rendered preview SVG;
   nothing client-authored is ever stored or served as markup.
-- Public read API: list, entry, preview image. Publishing exists but is
-  admin-token-gated until real sign-in lands (anonymous upload stays
-  impossible from day one; admin-published entries go live directly — the
-  end-state review queue for ordinary users arrives in G3). The editor's
-  File > "Publish to Gallery…" dialog is the in-app publishing surface:
-  it posts the live Project with the owner passphrase (remembered per
-  browser session, forgotten on a 401) and later switches to signed-in
-  identity without moving the entry point.
-- Admin API (bearer `GALLERY_ADMIN_TOKEN`): recycle (soft, restorable),
+- Public read API: list, entry, preview image. Publishing shipped behind
+  an owner passphrase while real sign-in was being built; that stopgap is
+  retired — see G5. The editor's File > "Publish to Gallery…" dialog is
+  the in-app publishing surface and did not move when the credential
+  changed.
+- Admin API (a super-admin session): recycle (soft, restorable),
   restore, hard-delete from the bin only, recycled list, and batch
   re-serialization that keeps long-lived entries inside the rolling schema
   window (previews stored independently so browsing survives an expired
@@ -54,9 +51,8 @@ editor behavior reachable at `/editor` unchanged.
 - Profile basics: users rename their own display name; identities from
   different providers stay distinct accounts in G2 (linking is a later
   refinement).
-- Super-admin is computed per request from the `ADMIN_EMAILS` secret; an
-  admin session carries the same authority as the gallery bearer,
-  including in-app publishing without the pasted passphrase.
+- Super-admin is computed per request from the `ADMIN_EMAILS` secret,
+  and rotation needs no re-login.
 - Every provider ships dark until its secrets exist; the deploy workflow
   syncs whichever of the GitHub secrets are present. To light one up, the
   owner provisions (Claude cannot create accounts or handle credentials):
@@ -83,7 +79,7 @@ provider; display-name edits stick; the owner's account sees admin
 affordances; no credential material ever transits or is stored beyond the
 provider contract.
 
-## Phase G3 — Ownership, review, and editing (queue + gates live)
+## Phase G3 — Ownership, review, and editing (queue since retired in G5)
 
 - Publishing requires a session; a submission enters a `pending` queue
   instead of going live. The super-admin — or reviewers the super-admin
@@ -105,14 +101,15 @@ dialog, then wait in `pending` (publicly invisible) until the
 super-admin or an appointed moderator (`/review`, in-app appointment by
 email) approves or rejects with an optional reason surfaced at `/mine`.
 Owner editing shipped 2026-08-22: every entry stays editable by its
-owner (updates re-enter review; a rejection becomes an informed
-resubmission) and by reviewers in place; withdrawal remains a recorded
-refinement.
+owner and by moderators in place.
 
-Acceptance: an ordinary submission is invisible publicly until approved;
-rejection stores and surfaces its optional reason; two ordinary accounts
-cannot touch each other's tiles while moderators and the admin can;
-anonymous writes are impossible at the API, not just the UI.
+Superseded by G5: the review queue described above no longer exists. The
+quality gates, the ownership rules, and the moderator role all survive
+it; only the wait for approval is gone.
+
+Acceptance: two ordinary accounts cannot touch each other's tiles while
+moderators and the admin can; anonymous writes are impossible at the
+API, not just the UI.
 
 ## Phase G4 — Feed experience (masonry live)
 
@@ -120,8 +117,35 @@ anonymous writes are impossible at the API, not just the UI.
   each circuit's natural aspect ratio, left-to-right reading order,
   balanced bottoms). Infinite scroll (sentinel over the keyset cursor),
   per-author filtering (clickable bylines, URL-carried, clearable chip),
-  and the in-feed admin recycle bin (restore / delete-forever on
-  /review) shipped 2026-08-22; still open: seeded starter content
+  and the admin recycle bin (restore / delete-forever, now on
+  /moderation) shipped 2026-08-22; still open: seeded starter content
   curation.
+
+## Phase G5 — Direct publishing (live)
+
+Shipped 2026-08-23, on the repository owner's decision that a submission
+queue should not accumulate and that the passphrase should go.
+
+- The passphrase is retired. `GALLERY_ADMIN_TOKEN` is removed from the
+  worker, the deploy workflow, and the publish dialog; a session cookie
+  is the only credential on the gallery write path, and an
+  `Authorization` header buys nothing.
+- Signing in is the whole publishing gate. Every signed-in account
+  publishes straight to the wall; the quality gates still run for
+  ordinary members, instantly and with the failures listed, because they
+  are an automatic check rather than a queue.
+- The byline comes from the account, not the form: the worker reads
+  `author` from the session, so nobody publishes under another's name
+  and an update never re-attributes an entry.
+- Every entry records the submitting account's id, email, and provider.
+  The email and provider are disclosed only to a moderator or admin.
+- `pending` is retired along with `GET /api/gallery/review` and the
+  approve/reject routes. Opening the storage promotes a leftover
+  `pending` row to `public` rather than stranding it. Curation moved to
+  `/moderation`: the recycle bin plus moderator appointment.
+
+Acceptance: a signed-in member's circuit is on the wall the moment they
+publish; an anonymous submission is refused at the API; a moderator can
+still take an entry down and put it back.
 
 Each phase closes by updating this file's status line for that phase.

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -48,16 +48,27 @@ trimmed `name` (required, ≤120), optional `author` (≤40), `description`
 chars each, at most 5, deduplicated — `sanitizeGalleryTags` is the one
 normalization for writes and filters), `projectText` ≤2 MiB. The Worker validates, stamps the canonical
 serialization, renders the preview, and stores the entry as `public`.
-Ordinary and anonymous submissions count against a per-submitter (hashed
-IP) limit of 10 per UTC day; privileged submitters (the bearer and
-admin/moderator sessions) are exempt — the quota is anti-garbage
-protection, and curators are the ones cleaning up.
+Ordinary submissions count against a per-submitter (hashed IP) limit of
+10 per UTC day; admin and moderator sessions are exempt — the quota is
+anti-garbage protection, and curators are the ones cleaning up.
 
-Publishing authority (since G3): the bearer and admin/moderator sessions
-publish directly as `public`; an ordinary signed-in session submits into
-the review queue as `pending` after passing the quality gates below;
-anonymous upload stays impossible — the day-one rule. A successful
-submission answers 201 `{id, status}`.
+Publishing authority: a signed-in session is the whole gate. Every
+signed-in account publishes directly as `public`; an ordinary member
+passes the quality gates below first, and a moderator curates past them.
+Anonymous upload stays impossible — an entry has to be attributable to
+the account that published it. A successful submission answers 201
+`{id, status}` with `status` always `public`.
+
+The byline is not a request field: the Worker takes `author` from the
+session's display name, so one account cannot publish under another's
+name, and an update never re-attributes an entry.
+
+Every entry records the submitting account: `owner_user_id` plus the
+`submitter_email` and `submitter_provider` read from the session at
+submission time, so an entry stays traceable to the identity that
+published it even if the account is later renamed. These two fields are
+traceability data, not feed data — the detail route returns them only to
+a moderator or admin, never on a public surface.
 
 ## Submission quality gates (Phase G3)
 
@@ -78,55 +89,50 @@ informational in the dialog). Failure codes:
 
 Failures carry `message`, `count`, and up to five example labels.
 
-## Review queue (Phase G3)
+## Moderation
 
-Statuses: `public | pending | rejected | recycled`. Pending and rejected
-entries never appear on any public surface (list, detail, preview);
-their detail and preview answer only to reviewers or the owning session.
+Statuses: `public | rejected | recycled`. Publishing is direct, so
+nothing new ever enters a queue; curation is post-publication. A
+`rejected` or `recycled` entry never appears on a public surface (list,
+detail, preview); its detail and preview answer only to a moderator or
+the owning session.
 
-- `GET /api/gallery/review` — pending entries, oldest first (reviewers:
-  bearer, admin, or moderator session).
-- `POST /api/gallery/<id>/approve` — pending → `public` (reviewers).
-- `POST /api/gallery/<id>/reject` — pending → `rejected` with an
-  optional trimmed reason (≤300) stored alongside reviewer id and
-  timestamp (reviewers). Reviewing a decided entry answers 409.
+`pending` is retired. `rejected` remains only for the entries a reviewer
+turned down before the queue was removed, so their owners still see why;
+opening the storage promotes any leftover `pending` row to `public`
+rather than stranding it, and leaves a real rejection alone.
+
 - `GET /api/gallery/mine` — the calling session's entries with `status`
   and `rejectReason`.
 - Moderators: `users.role` (`user`/`moderator`); the super-admin
   appoints by email via `POST /api/auth/users/role` `{email, role}`,
-  which applies to every account carrying that verified email.
-  Moderators hold exactly review authority; the recycle bin and
+  which applies to every account carrying that verified email. A
+  moderator curates and bypasses the quality gates; the recycle bin and
   maintenance stay admin-only.
 
-The editor surfaces the queue at `/review` (approve, reject with reason,
+The editor surfaces moderation at `/moderation` (the recycle bin, plus
 admin-only moderator appointment) and the submitter's view at `/mine`
-(status chips, rejection reason, owner-visible preview, open-in-editor).
-Every gallery page state wears the shared site chrome.
+(status chips, owner-visible preview, open-in-editor). Every gallery
+page state wears the shared site chrome.
 
 ## Owner editing (Phase G3 completion)
 
 `PUT /api/gallery/<id>` (same-origin) updates an entry's content and
 metadata (tags included — they stay editable any time) with the
-submission field rules. Authority: the bearer and
-admin/moderator sessions may update any entry, keeping its current
-status; an ordinary session must own the entry (403 otherwise) and
-passes the quality gates (422), after which the entry re-enters review
-as `pending` with the previous decision cleared — a rejection becomes an
-informed resubmission. The Project is re-serialized canonically and the
-preview re-rendered; 200 answers `{id, status}`. The detail response
-carries `ownerUserId` so the editor offers "update the opened entry"
-exactly to owners and reviewers.
-
-Entries persist a nullable owner column stamped from the submitting
-session.
+submission field rules. Authority: an admin or moderator session may
+update any entry; an ordinary session must own the entry (403 otherwise)
+and passes the quality gates (422). Either way the entry keeps its
+byline and its current status, so editing a published circuit neither
+takes it off the wall nor re-attributes it. The Project is re-serialized
+canonically and the preview re-rendered; 200 answers `{id, status}`. The
+detail response carries `ownerUserId` so the editor offers "update the
+opened entry" exactly to owners and moderators.
 
 Owner withdrawal: `POST /api/gallery/<id>/recycle` (same-origin) also
 accepts the owning session — the entry moves to `recycled` and leaves
 every public surface, exactly like an admin recycle. The owner brings it
-back with `POST /api/gallery/<id>/restore`; because the pre-withdrawal
-status is not recorded (and may have been `pending`), an ordinary
-owner's restore re-enters review as `pending`, while an admin restore
-still goes straight to `public`. `/mine` surfaces both actions (a
+back with `POST /api/gallery/<id>/restore`, which republishes it — for
+the owner exactly as for an admin. `/mine` surfaces both actions (a
 two-step Withdraw and a Restore on withdrawn entries).
 
 ## Version history
@@ -136,19 +142,18 @@ snapshots the entry's previous state — name, author, description, tags,
 canonical project text, preview — into `gallery_entry_versions`,
 numbered per entry and capped at the newest 20 (older pruned).
 Maintenance re-serialization does not snapshot (content-equivalent).
-Authority: reviewers (bearer, admin, or moderator) and the entry's
+Authority: moderators (admin or moderator session) and the entry's
 owning session:
 
 - `GET /api/gallery/<id>/versions` — versions, newest first.
 - `GET /api/gallery/<id>/versions/<versionId>/preview.svg`.
 - `POST /api/gallery/<id>/versions/<versionId>/restore` — snapshots the
   current state, then adopts the version's content and metadata, so
-  restores are themselves reversible. A reviewer's restore keeps the
-  entry status; an ordinary owner's restore is an owner edit and
-  re-enters review as `pending`.
+  restores are themselves reversible. A restore keeps the entry's status
+  and byline.
 
 The editor surfaces this as "Version history…" inside the publish
-dialog's update mode (reviewers and owners) and as a per-entry
+dialog's update mode (moderators and owners) and as a per-entry
 "Version history" action on `/mine`.
 
 ## Accounts and sessions (Phase G2, dark-shipped)
@@ -183,25 +188,23 @@ database stores only SHA-256 hashes of session and login tokens.
 Identities from different providers are distinct accounts in G2 (linking
 is a later refinement). Super-admin is computed per request: a session
 whose email appears in the `ADMIN_EMAILS` secret (comma-separated,
-case-insensitive) has admin authority everywhere the bearer does —
-including publishing and the administration routes below — and rotation
-of `ADMIN_EMAILS` needs no re-login. Ordinary sessions cannot publish
-until the G3 review queue exists.
+case-insensitive) has admin authority — including the administration
+routes below — and rotation of `ADMIN_EMAILS` needs no re-login. The
+session cookie is the only publishing credential there is: there is no
+passphrase, bearer token, or shared secret anywhere on the gallery
+write path.
 
 ## Administration
 
-Admin routes require admin authority: `Authorization: Bearer
-<GALLERY_ADMIN_TOKEN>` (a Cloudflare Worker secret, synced from the
-GitHub Actions secret of the same name on every Cloudflare deploy;
-rotation is one GitHub-secret update plus a deploy run) or, since G2, a
-signed-in super-admin session. With neither configured every admin route
-answers 401:
+Admin routes require a signed-in super-admin session. There is no bearer
+alternative: `GALLERY_ADMIN_TOKEN` is retired, and an `Authorization`
+header buys nothing. Without such a session every admin route answers
+401:
 
 - `POST /api/gallery/<id>/recycle` — soft delete into the restorable bin;
   the entry disappears from every public surface. (Also open to the
   owning session as withdrawal — see Owner editing.)
-- `POST /api/gallery/<id>/restore` — back to `public` (an ordinary
-  owner's restore re-enters review instead).
+- `POST /api/gallery/<id>/restore` — back to `public`.
 - `DELETE /api/gallery/<id>` — permanent, and only for entries already in
   the bin (`409` otherwise).
 - `GET /api/gallery/recycled` — the bin.
@@ -213,11 +216,16 @@ answers 401:
 
 ## Retention and privacy
 
-Entries are public content; in the shipped G1 surface only the admin can
-publish and the recycle bin is the takedown mechanism. The decided end
-state (roadmap G3) is review-then-publish: ordinary submissions wait in a
-pending queue for the owner or appointed moderators, and a rejection may
-carry an optional reason. Submitter identity is a salted hash of
-the connecting IP used only for the daily quota; no account data exists in
-Phase G1. Sign-in, per-user ownership, and owner-scoped editing arrive in
-Phases G2–G3 as recorded in the roadmap.
+Entries are public content. Publishing is publish-then-moderate: a
+signed-in account puts a circuit straight on the wall, and the recycle
+bin is the takedown mechanism if it should not have gone up.
+
+Two separate notions of "who submitted" coexist, and neither is public:
+
+- the daily quota keys on a salted hash of the connecting IP, which
+  identifies nobody and is never stored against an entry;
+- an entry stores the submitting account's id, email, and provider, and
+  the API discloses the email and provider only to a moderator or admin.
+
+What a visitor sees is the byline — the account's display name — which
+the account holder controls from the account menu.

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -48,8 +48,18 @@ function sqliteState() {
   };
 }
 
-function environment(adminToken?: string): GalleryEnv {
+type Harness = GalleryEnv & { authDurable: AuthDO };
+
+/**
+ * One harness for every test: a gallery DO plus the auth DO that is now the
+ * only way to publish anything.
+ */
+function environment(): Harness {
   const durable = new GalleryDO(sqliteState());
+  const authDurable = new AuthDO(sqliteState(), {
+    RESEND_API_KEY: "rk",
+    ADMIN_EMAILS: "owner@example.com",
+  } as AuthEnv);
   return {
     GALLERY: {
       getByName: () => ({
@@ -57,28 +67,31 @@ function environment(adminToken?: string): GalleryEnv {
           durable.fetch(new Request(input, init)),
       }),
     },
-    ...(adminToken ? { GALLERY_ADMIN_TOKEN: adminToken } : {}),
+    AUTH: {
+      getByName: () => ({
+        fetch: (input: Request | string, init?: RequestInit) =>
+          authDurable.fetch(
+            typeof input === "string" ? new Request(input, init) : input,
+          ),
+      }),
+    },
+    authDurable,
   };
 }
 
 const ORIGIN = "https://gallery.test";
-const ADMIN_TOKEN = "secret-token";
 
 function submissionRequest(
   body: unknown,
   overrides: {
     ip?: string;
     origin?: string | null;
-    token?: string | null;
     cookie?: string;
   } = {},
 ): Request {
   const headers = new Headers({ "content-type": "application/json" });
   if (overrides.origin !== null) {
     headers.set("Origin", overrides.origin ?? ORIGIN);
-  }
-  if (overrides.token !== null) {
-    headers.set("Authorization", `Bearer ${overrides.token ?? ADMIN_TOKEN}`);
   }
   if (overrides.cookie) headers.set("Cookie", overrides.cookie);
   headers.set("CF-Connecting-IP", overrides.ip ?? "203.0.113.7");
@@ -105,25 +118,37 @@ async function route(env: GalleryEnv, request: Request) {
   return response;
 }
 
-function adminHeaders(token: string): HeadersInit {
-  return { Authorization: `Bearer ${token}` };
+function cookieHeaders(cookie: string): HeadersInit {
+  return { Cookie: cookie };
+}
+
+/** A curator session: exempt from the gates and the daily quota. */
+function adminOf(env: Harness): Promise<string> {
+  return signIn(env.authDurable, "owner@example.com");
+}
+
+/** An ordinary member: gated and quota-limited, but publishes directly. */
+function makerOf(env: Harness): Promise<string> {
+  return signIn(env.authDurable, "maker@example.com");
 }
 
 async function submitOne(
-  env: GalleryEnv,
+  env: Harness,
   name: string,
-  overrides: { ip?: string; text?: string } = {},
+  overrides: { ip?: string; text?: string; cookie?: string } = {},
 ): Promise<string> {
   const response = await route(
     env,
     submissionRequest(
       {
         name,
-        author: "tz",
         description: "d",
         projectText: overrides.text ?? projectText(name),
       },
-      { ip: overrides.ip ?? "203.0.113.7" },
+      {
+        ip: overrides.ip ?? "203.0.113.7",
+        cookie: overrides.cookie ?? (await adminOf(env)),
+      },
     ),
   );
   expect(response.status).toBe(201);
@@ -133,7 +158,7 @@ async function submitOne(
 
 describe("gallery submissions", () => {
   it("publishes immediately with canonical text and a server preview", async () => {
-    const env = environment(ADMIN_TOKEN);
+    const env = environment();
     const id = await submitOne(env, "Ring Oscillator");
 
     const list = await route(env, new Request(`${ORIGIN}/api/gallery`));
@@ -162,7 +187,7 @@ describe("gallery submissions", () => {
   });
 
   it("upgrades a previous-schema submission through the protocol", async () => {
-    const env = environment(ADMIN_TOKEN);
+    const env = environment();
     const id = await submitOne(env, "Old Schema", {
       text: previousVersionText(),
     });
@@ -173,31 +198,120 @@ describe("gallery submissions", () => {
     );
   });
 
-  it("refuses publishing without the admin bearer while sign-in is pending", async () => {
-    const env = environment(ADMIN_TOKEN);
+  it("refuses an anonymous submission: a session is the whole gate", async () => {
+    const env = environment();
     const anonymous = await route(
       env,
-      submissionRequest(
-        { name: "X", projectText: projectText() },
-        { token: null },
-      ),
+      submissionRequest({ name: "X", projectText: projectText() }),
     );
     expect(anonymous.status).toBe(401);
-    const wrongToken = await route(
+
+    // There is no passphrase to fall back on: a bearer header buys nothing.
+    const withBearer = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/submissions`, {
+        method: "POST",
+        headers: {
+          Origin: ORIGIN,
+          "content-type": "application/json",
+          Authorization: "Bearer secret-token",
+        },
+        body: JSON.stringify({ name: "X", projectText: projectText() }),
+      }),
+    );
+    expect(withBearer.status).toBe(401);
+  });
+
+  it("publishes an ordinary member's circuit straight to the wall", async () => {
+    const env = environment();
+    const cookie = await makerOf(env);
+    const response = await route(
       env,
       submissionRequest(
-        { name: "X", projectText: projectText() },
-        { token: "wrong" },
+        { name: "Direct", projectText: wiredProjectText("Direct") },
+        { cookie },
       ),
     );
-    expect(wrongToken.status).toBe(401);
+    expect(response.status).toBe(201);
+    const { id, status } = (await response.json()) as {
+      id: string;
+      status: string;
+    };
+    expect(status).toBe("public");
+
+    // Visible to everyone immediately: no queue, no approval step.
+    const list = await route(env, new Request(`${ORIGIN}/api/gallery`));
+    expect(
+      ((await list.json()) as { entries: { id: string }[] }).entries.map(
+        (entry) => entry.id,
+      ),
+    ).toEqual([id]);
+    expect(
+      (await route(env, new Request(`${ORIGIN}/api/gallery/${id}`))).status,
+    ).toBe(200);
+  });
+
+  it("takes the byline from the account, not from the request", async () => {
+    const env = environment();
+    const cookie = await makerOf(env);
+    const response = await route(
+      env,
+      submissionRequest(
+        {
+          name: "Claimed",
+          author: "someone-else",
+          projectText: wiredProjectText("Claimed"),
+        },
+        { cookie },
+      ),
+    );
+    const { id } = (await response.json()) as { id: string };
+    const detail = (await (
+      await route(env, new Request(`${ORIGIN}/api/gallery/${id}`))
+    ).json()) as { entry: { author: string } };
+    expect(detail.entry.author).toBe("maker");
+  });
+
+  it("records the submitting identity and shows it only to a curator", async () => {
+    const env = environment();
+    const cookie = await makerOf(env);
+    const adminCookie = await adminOf(env);
+    const response = await route(
+      env,
+      submissionRequest(
+        { name: "Traced", projectText: wiredProjectText("Traced") },
+        { cookie },
+      ),
+    );
+    const { id } = (await response.json()) as { id: string };
+
+    const asCurator = (await (
+      await route(
+        env,
+        new Request(`${ORIGIN}/api/gallery/${id}`, {
+          headers: cookieHeaders(adminCookie),
+        }),
+      )
+    ).json()) as { submitterEmail?: string; submitterProvider?: string };
+    expect(asCurator).toMatchObject({
+      submitterEmail: "maker@example.com",
+      submitterProvider: "email",
+    });
+
+    // The wall shows a byline; it does not show anybody's email address.
+    const asVisitor = (await (
+      await route(env, new Request(`${ORIGIN}/api/gallery/${id}`))
+    ).json()) as Record<string, unknown>;
+    expect(asVisitor).not.toHaveProperty("submitterEmail");
+    expect(asVisitor).not.toHaveProperty("submitterProvider");
   });
 
   it("rejects invalid fields, foreign origins, oversized and invalid projects", async () => {
-    const env = environment(ADMIN_TOKEN);
+    const env = environment();
+    const cookie = await adminOf(env);
     const noName = await route(
       env,
-      submissionRequest({ name: "  ", projectText: projectText() }),
+      submissionRequest({ name: "  ", projectText: projectText() }, { cookie }),
     );
     expect(noName.status).toBe(400);
 
@@ -205,29 +319,35 @@ describe("gallery submissions", () => {
       env,
       submissionRequest(
         { name: "X", projectText: projectText() },
-        { origin: "https://evil.example" },
+        { origin: "https://evil.example", cookie },
       ),
     );
     expect(foreign.status).toBe(403);
 
     const oversized = await route(
       env,
-      submissionRequest({
-        name: "X",
-        projectText: "x".repeat(GALLERY_MAX_PROJECT_BYTES + 1),
-      }),
+      submissionRequest(
+        {
+          name: "X",
+          projectText: "x".repeat(GALLERY_MAX_PROJECT_BYTES + 1),
+        },
+        { cookie },
+      ),
     );
     expect(oversized.status).toBe(413);
 
     const invalid = await route(
       env,
-      submissionRequest({ name: "X", projectText: '{"schemaVersion":99}' }),
+      submissionRequest(
+        { name: "X", projectText: '{"schemaVersion":99}' },
+        { cookie },
+      ),
     );
     expect(invalid.status).toBe(400);
   });
 
   it("rate-limits ordinary submitters per day; curators are exempt", async () => {
-    const env = environment(ADMIN_TOKEN);
+    const env = environment();
 
     // Ordinary submissions (limit enforced) exhaust the day, without
     // touching a different submitter.
@@ -248,7 +368,6 @@ describe("gallery submissions", () => {
               description: "",
               created_at: "2026-08-22T00:00:00.000Z",
               schema_version: 21,
-              status: "pending",
               project_text: projectText(),
               svg_text: "<svg/>",
             },
@@ -263,167 +382,28 @@ describe("gallery submissions", () => {
     expect(await submitDirect("hash-a")).toBe(429);
     expect(await submitDirect("hash-b")).toBe(200);
 
-    // The bearer (curator) is exempt: more than the limit, all accepted.
+    // A curator is exempt: more than the limit, all accepted.
+    const adminCookie = await adminOf(env);
     for (
       let index = 0;
       index < GALLERY_DAILY_SUBMISSION_LIMIT + 2;
       index += 1
     ) {
-      await submitOne(env, `Curated ${index}`);
+      await submitOne(env, `Curated ${index}`, { cookie: adminCookie });
     }
   });
 });
 
-describe("gallery review queue with quality gates (phase G3)", () => {
-  it("walks submit → pending (invisible) → approve → public", async () => {
-    const { authDurable, env } = reviewHarness();
-    const userCookie = await signIn(authDurable, "maker@example.com");
-    const adminCookie = await signIn(authDurable, "owner@example.com");
-
-    const submitted = await route(
-      env,
-      submissionRequest(
-        { name: "Queued", projectText: wiredProjectText("Queued") },
-        { token: null, cookie: userCookie },
-      ),
-    );
-    expect(submitted.status).toBe(201);
-    const { id, status } = (await submitted.json()) as {
-      id: string;
-      status: string;
-    };
-    expect(status).toBe("pending");
-
-    // Invisible on every public surface.
-    const list = await route(env, new Request(`${ORIGIN}/api/gallery`));
-    expect(((await list.json()) as { entries: unknown[] }).entries).toEqual([]);
-    const anonymousDetail = await route(
-      env,
-      new Request(`${ORIGIN}/api/gallery/${id}`),
-    );
-    expect(anonymousDetail.status).toBe(404);
-    const anonymousPreview = await route(
-      env,
-      new Request(`${ORIGIN}/api/gallery/${id}/preview.svg`),
-    );
-    expect(anonymousPreview.status).toBe(404);
-
-    // The owner and reviewers can see it; the queue lists it.
-    const ownerPreview = await route(
-      env,
-      new Request(`${ORIGIN}/api/gallery/${id}/preview.svg`, {
-        headers: { Cookie: userCookie },
-      }),
-    );
-    expect(ownerPreview.status).toBe(200);
-    const queue = await route(
-      env,
-      new Request(`${ORIGIN}/api/gallery/review`, {
-        headers: { Cookie: adminCookie },
-      }),
-    );
-    const queued = (await queue.json()) as { entries: { id: string }[] };
-    expect(queued.entries.map((entry) => entry.id)).toEqual([id]);
-    const deniedQueue = await route(
-      env,
-      new Request(`${ORIGIN}/api/gallery/review`, {
-        headers: { Cookie: userCookie },
-      }),
-    );
-    expect(deniedQueue.status).toBe(401);
-
-    const approved = await route(
-      env,
-      new Request(`${ORIGIN}/api/gallery/${id}/approve`, {
-        method: "POST",
-        headers: { Origin: ORIGIN, Cookie: adminCookie },
-      }),
-    );
-    expect(approved.status).toBe(200);
-    const publicList = await route(env, new Request(`${ORIGIN}/api/gallery`));
-    expect(
-      ((await publicList.json()) as { entries: { id: string }[] }).entries.map(
-        (entry) => entry.id,
-      ),
-    ).toEqual([id]);
-  });
-
-  it("rejects with a stored reason the owner sees; moderators can review", async () => {
-    const { authDurable, env } = reviewHarness();
-    const userCookie = await signIn(authDurable, "maker@example.com");
-    const modCookie = await signIn(authDurable, "reviewer@example.com");
-    const adminCookie = await signIn(authDurable, "owner@example.com");
-    await authDurable.fetch(
-      new Request(`${ORIGIN}/api/auth/users/role`, {
-        method: "POST",
-        headers: {
-          Origin: ORIGIN,
-          Cookie: adminCookie,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          email: "reviewer@example.com",
-          role: "moderator",
-        }),
-      }),
-    );
-
-    const submitted = await route(
-      env,
-      submissionRequest(
-        { name: "Refused", projectText: wiredProjectText("Refused") },
-        { token: null, cookie: userCookie },
-      ),
-    );
-    const { id } = (await submitted.json()) as { id: string };
-
-    const rejected = await route(
-      env,
-      new Request(`${ORIGIN}/api/gallery/${id}/reject`, {
-        method: "POST",
-        headers: {
-          Origin: ORIGIN,
-          Cookie: modCookie,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({ reason: "Needs net labels" }),
-      }),
-    );
-    expect(rejected.status).toBe(200);
-
-    const mine = await route(
-      env,
-      new Request(`${ORIGIN}/api/gallery/mine`, {
-        headers: { Cookie: userCookie },
-      }),
-    );
-    const entries = (await mine.json()) as {
-      entries: { id: string; status: string; rejectReason: string | null }[];
-    };
-    expect(entries.entries).toMatchObject([
-      { id, status: "rejected", rejectReason: "Needs net labels" },
-    ]);
-
-    // A decided entry cannot be re-reviewed.
-    const again = await route(
-      env,
-      new Request(`${ORIGIN}/api/gallery/${id}/approve`, {
-        method: "POST",
-        headers: { Origin: ORIGIN, Cookie: modCookie },
-      }),
-    );
-    expect(again.status).toBe(409);
-  });
-
-  it("blocks gate failures for ordinary users and bypasses them for admins", async () => {
-    const { authDurable, env } = reviewHarness();
-    const userCookie = await signIn(authDurable, "maker@example.com");
+describe("direct publishing (the review queue is retired)", () => {
+  it("keeps the gates blocking for a member and open for a curator", async () => {
+    const env = environment();
+    const cookie = await makerOf(env);
 
     const gated = await route(
       env,
       submissionRequest(
         { name: "Empty", projectText: projectText("Empty") },
-        { token: null, cookie: userCookie },
+        { cookie },
       ),
     );
     expect(gated.status).toBe(422);
@@ -436,23 +416,13 @@ describe("gallery review queue with quality gates (phase G3)", () => {
       "empty-project",
     );
 
-    // The bearer (owner) publishes the same empty project directly.
-    const viaBearer = await route(
-      env,
-      submissionRequest({ name: "Empty", projectText: projectText("Empty") }),
-    );
-    expect(viaBearer.status).toBe(201);
-    expect(((await viaBearer.json()) as { status: string }).status).toBe(
-      "public",
-    );
-
-    // A moderator submission also publishes directly.
-    const adminCookie = await signIn(authDurable, "owner@example.com");
+    // A curator curates: the same empty project goes straight up.
+    const adminCookie = await adminOf(env);
     const viaAdmin = await route(
       env,
       submissionRequest(
         { name: "Admin Empty", projectText: projectText("Admin Empty") },
-        { token: null, cookie: adminCookie },
+        { cookie: adminCookie },
       ),
     );
     expect(viaAdmin.status).toBe(201);
@@ -460,25 +430,80 @@ describe("gallery review queue with quality gates (phase G3)", () => {
       "public",
     );
   });
+
+  it("has no queue to read and no decision to hand down", async () => {
+    const env = environment();
+    const adminCookie = await adminOf(env);
+    const id = await submitOne(env, "Live", { cookie: adminCookie });
+
+    for (const [path, method] of [
+      [`${ORIGIN}/api/gallery/review`, "GET"],
+      [`${ORIGIN}/api/gallery/${id}/approve`, "POST"],
+      [`${ORIGIN}/api/gallery/${id}/reject`, "POST"],
+    ] as const) {
+      const response = await route(
+        env,
+        new Request(path, {
+          method,
+          headers: { Origin: ORIGIN, Cookie: adminCookie },
+        }),
+      );
+      expect(response.status).toBe(404);
+    }
+  });
+
+  it("publishes an entry stranded in the queue, keeping real rejections", () => {
+    const state = sqliteState();
+    // A database written before direct publishing: no submitter columns,
+    // one entry still waiting for a reviewer, one already turned down.
+    state.storage.sql.exec(`
+      CREATE TABLE gallery_entries (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        author TEXT NOT NULL,
+        description TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        schema_version INTEGER NOT NULL,
+        status TEXT NOT NULL,
+        recycled_at TEXT,
+        owner_user_id TEXT,
+        project_text TEXT NOT NULL,
+        svg_text TEXT NOT NULL
+      ) WITHOUT ROWID
+    `);
+    for (const [id, status] of [
+      ["waiting", "pending"],
+      ["refused", "rejected"],
+    ]) {
+      state.storage.sql.exec(
+        `INSERT INTO gallery_entries(
+           id, name, author, description, created_at, schema_version,
+           status, recycled_at, owner_user_id, project_text, svg_text
+         ) VALUES (?, ?, '', '', '2026-01-01T00:00:00.000Z', 21, ?, NULL, NULL, ?, '<svg/>')`,
+        id,
+        id,
+        status,
+        projectText(),
+      );
+    }
+
+    new GalleryDO(state);
+
+    const rows = state.storage.sql
+      .exec<{ id: string; status: string }>(
+        "SELECT id, status FROM gallery_entries ORDER BY id",
+      )
+      .toArray();
+    expect(rows).toEqual([
+      { id: "refused", status: "rejected" },
+      { id: "waiting", status: "public" },
+    ]);
+  });
 });
 
-function reviewHarness() {
-  const authDurable = new AuthDO(sqliteState(), {
-    RESEND_API_KEY: "rk",
-    ADMIN_EMAILS: "owner@example.com",
-  } as AuthEnv);
-  const env: GalleryEnv = {
-    ...environment(ADMIN_TOKEN),
-    AUTH: {
-      getByName: () => ({
-        fetch: (input: Request | string, init?: RequestInit) =>
-          authDurable.fetch(
-            typeof input === "string" ? new Request(input, init) : input,
-          ),
-      }),
-    },
-  };
-  return { authDurable, env };
+function reviewHarness(): { authDurable: AuthDO; env: Harness } {
+  const env = environment();
+  return { authDurable: env.authDurable, env };
 }
 
 async function signIn(authDurable: AuthDO, email: string): Promise<string> {
@@ -554,15 +579,16 @@ function wiredProjectText(name = "Wired"): string {
 
 describe("gallery version history", () => {
   it("snapshots on every update, lists, restores (reversibly), and guards", async () => {
-    const env = environment(ADMIN_TOKEN);
-    const id = await submitOne(env, "Versioned v1");
+    const env = environment();
+    const adminCookie = await adminOf(env);
+    const id = await submitOne(env, "Versioned v1", { cookie: adminCookie });
 
     function updateRequest(name: string): Request {
       return new Request(`${ORIGIN}/api/gallery/${id}`, {
         method: "PUT",
         headers: {
           Origin: ORIGIN,
-          Authorization: `Bearer ${ADMIN_TOKEN}`,
+          Cookie: adminCookie,
           "content-type": "application/json",
         },
         body: JSON.stringify({
@@ -585,7 +611,7 @@ describe("gallery version history", () => {
     const listed = await route(
       env,
       new Request(`${ORIGIN}/api/gallery/${id}/versions`, {
-        headers: adminHeaders(ADMIN_TOKEN),
+        headers: cookieHeaders(adminCookie),
       }),
     );
     const { versions } = (await listed.json()) as {
@@ -600,7 +626,7 @@ describe("gallery version history", () => {
       env,
       new Request(
         `${ORIGIN}/api/gallery/${id}/versions/${versions[1]!.versionId}/preview.svg`,
-        { headers: adminHeaders(ADMIN_TOKEN) },
+        { headers: cookieHeaders(adminCookie) },
       ),
     );
     expect(versionPreview.headers.get("content-type")).toBe("image/svg+xml");
@@ -612,7 +638,7 @@ describe("gallery version history", () => {
         `${ORIGIN}/api/gallery/${id}/versions/${versions[1]!.versionId}/restore`,
         {
           method: "POST",
-          headers: { Origin: ORIGIN, ...adminHeaders(ADMIN_TOKEN) },
+          headers: { Origin: ORIGIN, ...cookieHeaders(adminCookie) },
         },
       ),
     );
@@ -626,7 +652,7 @@ describe("gallery version history", () => {
       await route(
         env,
         new Request(`${ORIGIN}/api/gallery/${id}/versions`, {
-          headers: adminHeaders(ADMIN_TOKEN),
+          headers: cookieHeaders(adminCookie),
         }),
       )
     ).json()) as { versions: { name: string }[] };
@@ -638,8 +664,9 @@ describe("gallery version history", () => {
   });
 
   it("prunes history beyond the per-entry cap", async () => {
-    const env = environment(ADMIN_TOKEN);
-    const id = await submitOne(env, "Cap 0");
+    const env = environment();
+    const adminCookie = await adminOf(env);
+    const id = await submitOne(env, "Cap 0", { cookie: adminCookie });
     for (let index = 1; index <= 24; index += 1) {
       await route(
         env,
@@ -647,7 +674,7 @@ describe("gallery version history", () => {
           method: "PUT",
           headers: {
             Origin: ORIGIN,
-            Authorization: `Bearer ${ADMIN_TOKEN}`,
+            Cookie: adminCookie,
             "content-type": "application/json",
           },
           body: JSON.stringify({
@@ -661,7 +688,7 @@ describe("gallery version history", () => {
       await route(
         env,
         new Request(`${ORIGIN}/api/gallery/${id}/versions`, {
-          headers: adminHeaders(ADMIN_TOKEN),
+          headers: cookieHeaders(adminCookie),
         }),
       )
     ).json()) as { versions: { versionNo: number }[] };
@@ -673,11 +700,15 @@ describe("gallery version history", () => {
 
 describe("gallery circuit tags", () => {
   it("normalizes tags on write, filters as an OR-union, and aggregates", async () => {
-    const env = environment(ADMIN_TOKEN);
+    const env = environment();
+    const adminCookie = await adminOf(env);
     const submitTagged = (name: string, tags: unknown) =>
       route(
         env,
-        submissionRequest({ name, tags, projectText: projectText(name) }),
+        submissionRequest(
+          { name, tags, projectText: projectText(name) },
+          { cookie: adminCookie },
+        ),
       );
     await submitTagged("Amp A", ["  Amplifier ", "OTA", "amplifier"]);
     await submitTagged("Comp B", ["comparator"]);
@@ -735,7 +766,7 @@ describe("gallery circuit tags", () => {
         method: "PUT",
         headers: {
           Origin: ORIGIN,
-          Authorization: `Bearer ${ADMIN_TOKEN}`,
+          Cookie: adminCookie,
           "content-type": "application/json",
         },
         body: JSON.stringify({
@@ -755,17 +786,44 @@ describe("gallery circuit tags", () => {
 
 describe("gallery list author filter and paging (phase G4)", () => {
   it("filters by exact byline and pages the filtered set", async () => {
-    const env = environment(ADMIN_TOKEN);
-    for (const [name, author] of [
-      ["A1", "alice"],
-      ["B1", "bob"],
-      ["A2", "alice"],
-      ["A3", "alice"],
+    const env = environment();
+    // The byline follows the account, so the fixture needs two of them. Both
+    // are admins here only to skip the gates the empty fixture would fail.
+    const alice = await signIn(env.authDurable, "alice@example.com");
+    const bob = await signIn(env.authDurable, "bob@example.com");
+    await env.authDurable.fetch(
+      new Request(`${ORIGIN}/api/auth/users/role`, {
+        method: "POST",
+        headers: {
+          Origin: ORIGIN,
+          Cookie: await adminOf(env),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ email: "alice@example.com", role: "moderator" }),
+      }),
+    );
+    await env.authDurable.fetch(
+      new Request(`${ORIGIN}/api/auth/users/role`, {
+        method: "POST",
+        headers: {
+          Origin: ORIGIN,
+          Cookie: await adminOf(env),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ email: "bob@example.com", role: "moderator" }),
+      }),
+    );
+    for (const [name, cookie] of [
+      ["A1", alice],
+      ["B1", bob],
+      ["A2", alice],
+      ["A3", alice],
     ] as const) {
-      await route(
+      const response = await route(
         env,
-        submissionRequest({ name, author, projectText: projectText(name) }),
+        submissionRequest({ name, projectText: projectText(name) }, { cookie }),
       );
+      expect(response.status).toBe(201);
     }
 
     const filtered = await route(
@@ -800,47 +858,33 @@ describe("gallery list author filter and paging (phase G4)", () => {
   });
 });
 
-describe("gallery owner editing (phase G3 completion)", () => {
-  it("owner updates re-enter review and clear the previous rejection", async () => {
-    const { authDurable, env } = reviewHarness();
-    const ownerCookie = await signIn(authDurable, "maker@example.com");
-    const adminCookie = await signIn(authDurable, "owner@example.com");
-    const strangerCookie = await signIn(authDurable, "other@example.com");
+describe("gallery owner editing", () => {
+  it("keeps an owner's update on the wall and under its own byline", async () => {
+    const env = environment();
+    const ownerCookie = await makerOf(env);
+    const adminCookie = await adminOf(env);
+    const strangerCookie = await signIn(env.authDurable, "other@example.com");
 
     const submitted = await route(
       env,
       submissionRequest(
         { name: "Edit Me", projectText: wiredProjectText("Edit Me") },
-        { token: null, cookie: ownerCookie },
+        { cookie: ownerCookie },
       ),
     );
     const { id } = (await submitted.json()) as { id: string };
-    await route(
-      env,
-      new Request(`${ORIGIN}/api/gallery/${id}/reject`, {
-        method: "POST",
-        headers: {
-          Origin: ORIGIN,
-          Cookie: adminCookie,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({ reason: "Wrong polarity" }),
-      }),
-    );
 
-    function updateRequest(cookie: string | null, token = false): Request {
+    function updateRequest(cookie: string | null): Request {
       const headers = new Headers({
         "content-type": "application/json",
         Origin: ORIGIN,
       });
       if (cookie) headers.set("Cookie", cookie);
-      if (token) headers.set("Authorization", `Bearer ${ADMIN_TOKEN}`);
       return new Request(`${ORIGIN}/api/gallery/${id}`, {
         method: "PUT",
         headers,
         body: JSON.stringify({
           name: "Edit Me v2",
-          author: "maker",
           projectText: wiredProjectText("Edit Me v2"),
         }),
       });
@@ -851,39 +895,37 @@ describe("gallery owner editing (phase G3 completion)", () => {
     const anonymous = await route(env, updateRequest(null));
     expect(anonymous.status).toBe(401);
 
+    // The owner's own edit stays live rather than dropping out of the feed.
     const updated = await route(env, updateRequest(ownerCookie));
     expect(updated.status).toBe(200);
     expect(((await updated.json()) as { status: string }).status).toBe(
-      "pending",
+      "public",
     );
 
     const mine = await route(
       env,
       new Request(`${ORIGIN}/api/gallery/mine`, {
-        headers: { Cookie: ownerCookie },
+        headers: cookieHeaders(ownerCookie),
       }),
     );
     const entries = (await mine.json()) as {
-      entries: { name: string; status: string; rejectReason: string | null }[];
+      entries: { name: string; status: string }[];
     };
     expect(entries.entries).toMatchObject([
-      { name: "Edit Me v2", status: "pending", rejectReason: null },
+      { name: "Edit Me v2", status: "public" },
     ]);
 
-    // Approve, then an admin edit keeps the entry public.
-    await route(
-      env,
-      new Request(`${ORIGIN}/api/gallery/${id}/approve`, {
-        method: "POST",
-        headers: { Origin: ORIGIN, Cookie: adminCookie },
-      }),
-    );
+    // A curator's edit does not re-attribute the entry to the curator.
     const adminEdit = await route(env, updateRequest(adminCookie));
-    expect(((await adminEdit.json()) as { status: string }).status).toBe(
-      "public",
-    );
+    expect(adminEdit.status).toBe(200);
+    const detail = (await (
+      await route(env, new Request(`${ORIGIN}/api/gallery/${id}`))
+    ).json()) as { entry: { author: string }; ownerUserId: string | null };
+    expect(detail.entry.author).toBe("maker");
+    // The detail response names the owner so the editor can offer updates.
+    expect(typeof detail.ownerUserId).toBe("string");
 
-    // An empty replacement fails the gates for the ordinary owner.
+    // An empty replacement still fails the gates for the ordinary owner.
     const gated = await route(
       env,
       new Request(`${ORIGIN}/api/gallery/${id}`, {
@@ -897,139 +939,80 @@ describe("gallery owner editing (phase G3 completion)", () => {
       }),
     );
     expect(gated.status).toBe(422);
-
-    // The detail response names the owner so the editor can offer updates.
-    const detail = await route(
-      env,
-      new Request(`${ORIGIN}/api/gallery/${id}`, {
-        headers: { Cookie: ownerCookie },
-      }),
-    );
-    const payload = (await detail.json()) as { ownerUserId: string | null };
-    expect(typeof payload.ownerUserId).toBe("string");
   });
 });
 
-describe("gallery admin sessions (phase G2)", () => {
-  async function sessionCookieFor(
-    authDurable: AuthDO,
-    email: string,
-  ): Promise<string> {
-    const sent: string[] = [];
-    authDurable.fetchLike = (async (
-      input: RequestInfo | URL,
-      init?: RequestInit,
-    ) => {
-      void input;
-      sent.push((JSON.parse(String(init?.body)) as { text: string }).text);
-      return Response.json({ id: "email-1" });
-    }) as typeof fetch;
-    const start = await authDurable.fetch(
-      new Request(`${ORIGIN}/api/auth/email/start`, {
-        method: "POST",
-        headers: { Origin: ORIGIN, "content-type": "application/json" },
-        body: JSON.stringify({ email }),
-      }),
-    );
-    expect(start.status).toBe(202);
-    const link = sent[0]!.match(/https?:\/\/\S+/u)![0];
-    const callback = await authDurable.fetch(new Request(link));
-    const header = callback.headers
-      .getSetCookie()
-      .find((cookie) => cookie.startsWith("icm_session="));
-    return header!.split(";")[0]!;
-  }
+describe("gallery admin sessions", () => {
+  it("lets a curator session reach the curator-only surfaces", async () => {
+    const env = environment();
+    const adminCookie = await adminOf(env);
+    const memberCookie = await makerOf(env);
 
-  it("accepts an admin session in place of the bearer and refuses others", async () => {
-    const authDurable = new AuthDO(sqliteState(), {
-      RESEND_API_KEY: "rk",
-      ADMIN_EMAILS: "owner@example.com",
-    } as AuthEnv);
-    const env: GalleryEnv = {
-      ...environment(ADMIN_TOKEN),
-      AUTH: {
-        getByName: () => ({
-          fetch: (input: Request | string, init?: RequestInit) =>
-            authDurable.fetch(
-              typeof input === "string" ? new Request(input, init) : input,
-            ),
-        }),
-      },
-    };
-
-    const adminCookie = await sessionCookieFor(
-      authDurable,
-      "owner@example.com",
-    );
-    const viaSession = await route(
-      env,
-      submissionRequest(
-        { name: "Session Published", projectText: projectText() },
-        { token: null, cookie: adminCookie },
-      ),
-    );
-    expect(viaSession.status).toBe(201);
-
-    // An ordinary session is no longer refused outright (phase G3): it
-    // goes through the quality gates instead — the empty fixture fails
-    // them — and never publishes directly.
-    const ordinaryCookie = await sessionCookieFor(
-      authDurable,
-      "visitor@example.com",
-    );
-    const viaOrdinary = await route(
-      env,
-      submissionRequest(
-        { name: "Gated", projectText: projectText() },
-        { token: null, cookie: ordinaryCookie },
-      ),
-    );
-    expect(viaOrdinary.status).toBe(422);
-
-    const recycledList = await route(
+    const asCurator = await route(
       env,
       new Request(`${ORIGIN}/api/gallery/recycled`, {
-        headers: { Cookie: adminCookie },
+        headers: cookieHeaders(adminCookie),
       }),
     );
-    expect(recycledList.status).toBe(200);
+    expect(asCurator.status).toBe(200);
+
+    const asMember = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/recycled`, {
+        headers: cookieHeaders(memberCookie),
+      }),
+    );
+    expect(asMember.status).toBe(401);
   });
 });
 
 describe("gallery administration", () => {
-  it("requires the bearer secret for every admin operation", async () => {
-    const env = environment(ADMIN_TOKEN);
-    const id = await submitOne(env, "Guarded");
+  it("requires an admin session for every admin operation", async () => {
+    const env = environment();
+    const adminCookie = await adminOf(env);
+    const id = await submitOne(env, "Guarded", { cookie: adminCookie });
 
     const anonymous = await route(
       env,
-      new Request(`${ORIGIN}/api/gallery/${id}/recycle`, { method: "POST" }),
+      new Request(`${ORIGIN}/api/gallery/${id}/recycle`, {
+        method: "POST",
+        headers: { Origin: ORIGIN },
+      }),
     );
     expect(anonymous.status).toBe(401);
 
-    // Without a configured bearer the caller is an ordinary visitor; the
-    // ownership check runs first, so an unknown entry reads as not-found.
-    const noTokenConfigured = environment();
+    // A bearer header is not a credential any more: the caller reads as an
+    // ordinary visitor, and the ownership check turns an unknown entry into
+    // a not-found rather than an unauthorized.
     const impossible = await route(
-      noTokenConfigured,
+      env,
       new Request(`${ORIGIN}/api/gallery/some-id/recycle`, {
         method: "POST",
-        headers: adminHeaders("anything"),
+        headers: { Origin: ORIGIN, Authorization: "Bearer anything" },
       }),
     );
     expect(impossible.status).toBe(404);
+
+    const asMember = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}`, {
+        method: "DELETE",
+        headers: cookieHeaders(await makerOf(env)),
+      }),
+    );
+    expect(asMember.status).toBe(401);
   });
 
   it("recycles, hides, restores, and only hard-deletes from the bin", async () => {
-    const token = ADMIN_TOKEN;
-    const env = environment(token);
-    const id = await submitOne(env, "Lifecycle");
+    const env = environment();
+    const adminCookie = await adminOf(env);
+    const id = await submitOne(env, "Lifecycle", { cookie: adminCookie });
 
     const earlyDelete = await route(
       env,
       new Request(`${ORIGIN}/api/gallery/${id}`, {
         method: "DELETE",
-        headers: adminHeaders(token),
+        headers: cookieHeaders(adminCookie),
       }),
     );
     expect(earlyDelete.status).toBe(409);
@@ -1038,7 +1021,7 @@ describe("gallery administration", () => {
       env,
       new Request(`${ORIGIN}/api/gallery/${id}/recycle`, {
         method: "POST",
-        headers: adminHeaders(token),
+        headers: cookieHeaders(adminCookie),
       }),
     );
     expect(recycle.status).toBe(200);
@@ -1051,7 +1034,7 @@ describe("gallery administration", () => {
     const bin = await route(
       env,
       new Request(`${ORIGIN}/api/gallery/recycled`, {
-        headers: adminHeaders(token),
+        headers: cookieHeaders(adminCookie),
       }),
     );
     const binned = (await bin.json()) as { entries: { id: string }[] };
@@ -1061,7 +1044,7 @@ describe("gallery administration", () => {
       env,
       new Request(`${ORIGIN}/api/gallery/${id}/restore`, {
         method: "POST",
-        headers: adminHeaders(token),
+        headers: cookieHeaders(adminCookie),
       }),
     );
     expect(restore.status).toBe(200);
@@ -1074,30 +1057,30 @@ describe("gallery administration", () => {
       env,
       new Request(`${ORIGIN}/api/gallery/${id}/recycle`, {
         method: "POST",
-        headers: adminHeaders(token),
+        headers: cookieHeaders(adminCookie),
       }),
     );
     const remove = await route(
       env,
       new Request(`${ORIGIN}/api/gallery/${id}`, {
         method: "DELETE",
-        headers: adminHeaders(token),
+        headers: cookieHeaders(adminCookie),
       }),
     );
     expect(remove.status).toBe(200);
     const gone = await route(
       env,
       new Request(`${ORIGIN}/api/gallery/recycled`, {
-        headers: adminHeaders(token),
+        headers: cookieHeaders(adminCookie),
       }),
     );
     expect(((await gone.json()) as { entries: unknown[] }).entries).toEqual([]);
   });
 
   it("re-serializes stored entries back into the rolling window", async () => {
-    const token = ADMIN_TOKEN;
-    const env = environment(token);
-    const id = await submitOne(env, "Aging Entry");
+    const env = environment();
+    const adminCookie = await adminOf(env);
+    const id = await submitOne(env, "Aging Entry", { cookie: adminCookie });
 
     // Age the stored record to the previous schema version through the
     // internal update operation, simulating a record left behind by time.
@@ -1119,7 +1102,7 @@ describe("gallery administration", () => {
       env,
       new Request(`${ORIGIN}/api/gallery/maintenance/reserialize`, {
         method: "POST",
-        headers: adminHeaders(token),
+        headers: cookieHeaders(adminCookie),
       }),
     );
     const report = (await maintenance.json()) as {
@@ -1146,29 +1129,24 @@ describe("gallery administration", () => {
 });
 
 describe("gallery owner lifecycle (withdrawal and history)", () => {
-  async function submitApproved(
+  async function submitPublished(
     env: GalleryEnv,
     ownerCookie: string,
-    adminCookie: string,
     name: string,
   ): Promise<string> {
     const submitted = await route(
       env,
       submissionRequest(
         { name, projectText: wiredProjectText(name) },
-        { token: null, cookie: ownerCookie },
+        { cookie: ownerCookie },
       ),
     );
     expect(submitted.status).toBe(201);
-    const { id } = (await submitted.json()) as { id: string };
-    const approved = await route(
-      env,
-      new Request(`${ORIGIN}/api/gallery/${id}/approve`, {
-        method: "POST",
-        headers: { Origin: ORIGIN, Cookie: adminCookie },
-      }),
-    );
-    expect(approved.status).toBe(200);
+    const { id, status } = (await submitted.json()) as {
+      id: string;
+      status: string;
+    };
+    expect(status).toBe("public");
     return id;
   }
 
@@ -1207,7 +1185,7 @@ describe("gallery owner lifecycle (withdrawal and history)", () => {
     const ownerCookie = await signIn(authDurable, "maker@example.com");
     const adminCookie = await signIn(authDurable, "owner@example.com");
     const strangerCookie = await signIn(authDurable, "other@example.com");
-    const id = await submitApproved(env, ownerCookie, adminCookie, "Mine");
+    const id = await submitPublished(env, ownerCookie, "Mine");
 
     expect(
       (await route(env, lifecycle(id, "recycle", strangerCookie))).status,
@@ -1223,11 +1201,11 @@ describe("gallery owner lifecycle (withdrawal and history)", () => {
     expect(wall.entries.some((entry) => entry.id === id)).toBe(false);
     expect(await mineStatus(env, ownerCookie, id)).toBe("recycled");
 
-    // The owner's restore re-enters review; the admin's goes straight back.
+    // Bringing it back republishes it, for the owner as much as the admin.
     expect(
       (await route(env, lifecycle(id, "restore", ownerCookie))).status,
     ).toBe(200);
-    expect(await mineStatus(env, ownerCookie, id)).toBe("pending");
+    expect(await mineStatus(env, ownerCookie, id)).toBe("public");
     expect(
       (await route(env, lifecycle(id, "recycle", adminCookie))).status,
     ).toBe(200);
@@ -1243,14 +1221,14 @@ describe("gallery owner lifecycle (withdrawal and history)", () => {
     expect(missing.status).toBe(404);
   });
 
-  it("owners browse their version history; restores re-enter review", async () => {
+  it("owners browse their version history; a restore stays published", async () => {
     const { authDurable, env } = reviewHarness();
     const ownerCookie = await signIn(authDurable, "maker@example.com");
     const adminCookie = await signIn(authDurable, "owner@example.com");
     const strangerCookie = await signIn(authDurable, "other@example.com");
-    const id = await submitApproved(env, ownerCookie, adminCookie, "Hist v1");
+    const id = await submitPublished(env, ownerCookie, "Hist v1");
 
-    // Owner update snapshots v1 and re-enters review.
+    // The owner's update snapshots v1 and stays on the wall.
     const updated = await route(
       env,
       new Request(`${ORIGIN}/api/gallery/${id}`, {
@@ -1298,14 +1276,7 @@ describe("gallery owner lifecycle (withdrawal and history)", () => {
     );
     expect(await ownerPreview.text()).toContain("<svg");
 
-    // Approve v2, then the owner's restore of v1 demotes it to pending.
-    await route(
-      env,
-      new Request(`${ORIGIN}/api/gallery/${id}/approve`, {
-        method: "POST",
-        headers: { Origin: ORIGIN, Cookie: adminCookie },
-      }),
-    );
+    // Restoring v1 puts the old content back without taking the entry down.
     const restore = await route(
       env,
       new Request(
@@ -1314,7 +1285,7 @@ describe("gallery owner lifecycle (withdrawal and history)", () => {
       ),
     );
     expect(restore.status).toBe(200);
-    expect(await mineStatus(env, ownerCookie, id)).toBe("pending");
+    expect(await mineStatus(env, ownerCookie, id)).toBe("public");
     const detail = await route(
       env,
       new Request(`${ORIGIN}/api/gallery/${id}`, {

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -4,8 +4,10 @@
 // strict protocol boundary (`parseProject`, rolling-window upgrade applied).
 // Everything served back — canonical Project text and the preview SVG — is
 // derived server-side from that validated model; no client-supplied markup
-// is ever stored or echoed. Entries publish immediately; the admin (bearer
-// `GALLERY_ADMIN_TOKEN`, a Cloudflare secret) can recycle (soft, restorable),
+// is ever stored or echoed. Signing in is the whole publishing gate: any
+// signed-in account publishes straight to the wall, and every entry records
+// the submitting account's email and provider so it stays traceable. An
+// admin session can recycle (soft, restorable),
 // hard-delete from the bin only, and batch re-serialize every entry to keep
 // long-lived records inside the rolling schema window. Previews are stored
 // independently so browsing survives an entry the current window can no
@@ -54,8 +56,7 @@ export type GalleryNamespaceLike = {
 
 export type GalleryEnv = {
   GALLERY: GalleryNamespaceLike;
-  GALLERY_ADMIN_TOKEN?: string;
-  /** Phase G2: an admin session works wherever the bearer does. */
+  /** Sessions are the only identity: publishing requires one. */
   AUTH?: AuthNamespaceLike;
   ADMIN_EMAILS?: string;
 };
@@ -114,6 +115,8 @@ interface EntryRow {
   status: string;
   recycled_at: string | null;
   owner_user_id: string | null;
+  submitter_email: string | null;
+  submitter_provider: string | null;
   tags: string | null;
   reject_reason: string | null;
   reviewed_at: string | null;
@@ -153,6 +156,8 @@ export class GalleryDO {
         status TEXT NOT NULL,
         recycled_at TEXT,
         owner_user_id TEXT,
+        submitter_email TEXT,
+        submitter_provider TEXT,
         project_text TEXT NOT NULL,
         svg_text TEXT NOT NULL
       ) WITHOUT ROWID
@@ -188,12 +193,14 @@ export class GalleryDO {
       CREATE INDEX IF NOT EXISTS idx_gallery_entry_versions_entry
       ON gallery_entry_versions(entry_id, version_no)
     `);
-    // Additive review-queue columns (phase G3) for pre-existing databases.
+    // Additive columns for pre-existing databases.
     for (const alteration of [
       "ALTER TABLE gallery_entries ADD COLUMN reject_reason TEXT",
       "ALTER TABLE gallery_entries ADD COLUMN reviewed_at TEXT",
       "ALTER TABLE gallery_entries ADD COLUMN reviewed_by TEXT",
       "ALTER TABLE gallery_entries ADD COLUMN tags TEXT NOT NULL DEFAULT ''",
+      "ALTER TABLE gallery_entries ADD COLUMN submitter_email TEXT",
+      "ALTER TABLE gallery_entries ADD COLUMN submitter_provider TEXT",
     ]) {
       try {
         this.sql.exec(alteration);
@@ -201,6 +208,13 @@ export class GalleryDO {
         // Column already present.
       }
     }
+    // Direct publishing retired the review queue. An entry still waiting for
+    // a reviewer would otherwise be stranded — listed nowhere, approvable by
+    // nothing — so publish it, which is what its author asked for. An entry a
+    // reviewer actually rejected keeps that decision.
+    this.sql.exec(
+      "UPDATE gallery_entries SET status = 'public' WHERE status = 'pending'",
+    );
   }
 
   async fetch(request: Request): Promise<Response> {
@@ -228,10 +242,6 @@ export class GalleryDO {
         return this.delete(String(body.id));
       case "recycled":
         return this.recycled();
-      case "pending":
-        return this.pending();
-      case "review":
-        return this.review(body);
       case "mine":
         return this.mine(String(body.ownerUserId));
       case "all-ids":
@@ -258,7 +268,7 @@ export class GalleryDO {
     const day = String(body.day);
     const submitterHash = String(body.submitterHash);
     // The daily quota is anti-garbage protection for ordinary submitters;
-    // the bearer and admin/moderator sessions are exempt (they curate).
+    // admin and moderator sessions are exempt (they curate).
     const enforceLimit = body.enforceLimit !== false;
     const outcome = this.state.storage.transactionSync(() => {
       if (enforceLimit) {
@@ -285,16 +295,18 @@ export class GalleryDO {
       this.sql.exec(
         `INSERT INTO gallery_entries(
           id, name, author, description, created_at, schema_version,
-          status, recycled_at, owner_user_id, tags, project_text, svg_text
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)`,
+          status, recycled_at, owner_user_id, submitter_email,
+          submitter_provider, tags, project_text, svg_text
+        ) VALUES (?, ?, ?, ?, ?, ?, 'public', NULL, ?, ?, ?, ?, ?, ?)`,
         entry.id,
         entry.name,
         entry.author,
         entry.description,
         entry.created_at,
         entry.schema_version,
-        entry.status === "pending" ? "pending" : "public",
         entry.owner_user_id ?? null,
+        entry.submitter_email ?? null,
+        entry.submitter_provider ?? null,
         entry.tags ?? "",
         entry.project_text,
         entry.svg_text,
@@ -348,6 +360,10 @@ export class GalleryDO {
     return Response.json({ entries: page.map(summaryOf), nextCursor });
   }
 
+  /**
+   * One entry. `submitterEmail`/`submitterProvider` ride along for the
+   * caller to gate: `routeGalleryRequest` only forwards them to a curator.
+   */
   private entry(id: string, requiredStatus: string | null): Response {
     const row = this.sql
       .exec<EntryRow>("SELECT * FROM gallery_entries WHERE id = ?", id)
@@ -359,51 +375,10 @@ export class GalleryDO {
       entry: summaryOf(row),
       status: row.status,
       ownerUserId: row.owner_user_id,
+      submitterEmail: row.submitter_email,
+      submitterProvider: row.submitter_provider,
       projectText: row.project_text,
       svgText: row.svg_text,
-    });
-  }
-
-  private pending(): Response {
-    const rows = this.sql
-      .exec<EntryRow>(
-        `SELECT * FROM gallery_entries WHERE status = 'pending'
-         ORDER BY created_at ASC, id ASC`,
-      )
-      .toArray();
-    return Response.json({
-      entries: rows.map((row) => ({
-        ...summaryOf(row),
-        ownerUserId: row.owner_user_id,
-      })),
-    });
-  }
-
-  private review(body: Record<string, unknown>): Response {
-    const row = this.sql
-      .exec<EntryRow>(
-        "SELECT * FROM gallery_entries WHERE id = ?",
-        String(body.id),
-      )
-      .toArray()[0];
-    if (!row) return Response.json({ error: "not-found" }, { status: 404 });
-    if (row.status !== "pending") {
-      return Response.json({ error: "not-pending" }, { status: 409 });
-    }
-    const approve = body.decision === "approve";
-    this.sql.exec(
-      `UPDATE gallery_entries
-       SET status = ?, reject_reason = ?, reviewed_at = ?, reviewed_by = ?
-       WHERE id = ?`,
-      approve ? "public" : "rejected",
-      approve ? null : ((body.reason as string | null) ?? null),
-      String(body.at),
-      String(body.reviewerId),
-      row.id,
-    );
-    return Response.json({
-      id: row.id,
-      status: approve ? "public" : "rejected",
     });
   }
 
@@ -572,14 +547,6 @@ export class GalleryDO {
         version.tags ?? "",
         entry.id,
       );
-      // An owner-initiated restore re-enters review like any owner edit.
-      if (body.pending === true) {
-        this.sql.exec(
-          `UPDATE gallery_entries
-           SET status = 'pending', reject_reason = NULL WHERE id = ?`,
-          entry.id,
-        );
-      }
     });
     return Response.json({ id: entry.id, restored: true });
   }
@@ -718,23 +685,13 @@ function sameOrigin(request: Request): boolean {
   return true;
 }
 
-function bearerIsAdmin(request: Request, env: GalleryEnv): boolean {
-  return Boolean(
-    env.GALLERY_ADMIN_TOKEN &&
-    request.headers.get("Authorization") ===
-      `Bearer ${env.GALLERY_ADMIN_TOKEN}`,
-  );
-}
-
 async function isAdmin(request: Request, env: GalleryEnv): Promise<boolean> {
-  if (bearerIsAdmin(request, env)) return true;
   const user = await sessionUserOf(request, env);
   return user?.isAdmin === true;
 }
 
-/** Review authority (phase G3): the bearer, an admin, or a moderator. */
+/** Curation authority: an admin or an appointed moderator. */
 async function canReview(request: Request, env: GalleryEnv): Promise<boolean> {
-  if (bearerIsAdmin(request, env)) return true;
   const user = await sessionUserOf(request, env);
   return user?.isAdmin === true || user?.role === "moderator";
 }
@@ -800,31 +757,29 @@ async function handleSubmission(
   if (!sameOrigin(request)) {
     return Response.json({ error: "forbidden" }, { status: 403 });
   }
-  // Phase G3: the bearer and admin/moderator sessions publish directly;
-  // ordinary signed-in users pass the quality gates and enter the review
-  // queue as `pending`. Anonymous upload stays impossible — the original
-  // day-one rule.
-  const bearer = bearerIsAdmin(request, env);
+  // Signing in is the whole gate: every signed-in user publishes straight to
+  // the wall. Anonymous upload stays impossible, because an entry has to be
+  // attributable to the account that submitted it.
   const user = await sessionUserOf(request, env);
-  const privileged =
-    bearer || user?.isAdmin === true || user?.role === "moderator";
-  if (!bearer && !user) {
+  if (!user) {
     return Response.json({ error: "unauthorized" }, { status: 401 });
   }
+  const privileged = user.isAdmin === true || user.role === "moderator";
   const body = (await request.json().catch(() => null)) as {
     name?: unknown;
-    author?: unknown;
     description?: unknown;
     tags?: unknown;
     projectText?: unknown;
   } | null;
   const name = fieldText(body?.name, GALLERY_MAX_NAME_LENGTH);
-  const author = fieldText(body?.author, GALLERY_MAX_AUTHOR_LENGTH);
+  // The byline is the signed-in account's display name. Reading it from the
+  // request would let one account publish under another's name.
+  const author = user.displayName.slice(0, GALLERY_MAX_AUTHOR_LENGTH);
   const description = fieldText(
     body?.description,
     GALLERY_MAX_DESCRIPTION_LENGTH,
   );
-  if (!body || !name || author === null || description === null) {
+  if (!body || !name || description === null) {
     return Response.json({ error: "invalid-fields" }, { status: 400 });
   }
   if (typeof body.projectText !== "string") {
@@ -853,7 +808,6 @@ async function handleSubmission(
   }
   project.name = name;
   const now = new Date();
-  const entryStatus = privileged ? "public" : "pending";
   const { status, payload } = await callGallery<{ id?: string }>(
     env,
     "submit",
@@ -868,8 +822,11 @@ async function handleSubmission(
         description,
         created_at: now.toISOString(),
         schema_version: project.schemaVersion,
-        status: entryStatus,
-        owner_user_id: user?.id ?? null,
+        owner_user_id: user.id,
+        // Recorded per submission, so an entry stays traceable to the
+        // identity that published it even if the account later changes.
+        submitter_email: user.email,
+        submitter_provider: user.provider,
         tags: wrapTags(sanitizeGalleryTags(body.tags)),
         project_text: serializeProject(project),
         svg_text: renderPreview(project),
@@ -879,19 +836,14 @@ async function handleSubmission(
   if (status === 429) {
     return Response.json({ error: "rate-limited" }, { status: 429 });
   }
-  return Response.json(
-    { id: payload.id, status: entryStatus },
-    { status: 201 },
-  );
+  return Response.json({ id: payload.id, status: "public" }, { status: 201 });
 }
 
 /**
- * Owner/reviewer entry update (phase G3 completion). The bearer and
- * admin/moderator sessions may update any entry, keeping its current
- * status; an ordinary session must own the entry and passes the quality
- * gates, after which the entry re-enters review as `pending` with the
- * previous decision cleared — a rejection therefore becomes an informed
- * resubmission.
+ * Owner or curator entry update. A moderator may update any entry; an
+ * ordinary session must own the entry and passes the quality gates. Either
+ * way the entry keeps its byline and its current status, so editing a
+ * published circuit neither takes it off the wall nor re-attributes it.
  */
 async function handleEntryUpdate(
   request: Request,
@@ -903,18 +855,17 @@ async function handleEntryUpdate(
   }
   const existing = await callGallery<{
     status?: string;
+    entry?: { author?: string };
     ownerUserId?: string | null;
   }>(env, "any-entry", { id });
   if (existing.status !== 200) {
     return Response.json({ error: "not-found" }, { status: 404 });
   }
-  const bearer = bearerIsAdmin(request, env);
   const user = await sessionUserOf(request, env);
-  const privileged =
-    bearer || user?.isAdmin === true || user?.role === "moderator";
-  if (!bearer && !user) {
+  if (!user) {
     return Response.json({ error: "unauthorized" }, { status: 401 });
   }
+  const privileged = user.isAdmin === true || user.role === "moderator";
   const owner =
     user !== null &&
     existing.payload.ownerUserId != null &&
@@ -924,18 +875,19 @@ async function handleEntryUpdate(
   }
   const body = (await request.json().catch(() => null)) as {
     name?: unknown;
-    author?: unknown;
     description?: unknown;
     tags?: unknown;
     projectText?: unknown;
   } | null;
   const name = fieldText(body?.name, GALLERY_MAX_NAME_LENGTH);
-  const author = fieldText(body?.author, GALLERY_MAX_AUTHOR_LENGTH);
+  // An update never re-attributes the entry, not even when a moderator
+  // makes it: the byline stays the one the submitter published under.
+  const author = existing.payload.entry?.author ?? "";
   const description = fieldText(
     body?.description,
     GALLERY_MAX_DESCRIPTION_LENGTH,
   );
-  if (!body || !name || author === null || description === null) {
+  if (!body || !name || description === null) {
     return Response.json({ error: "invalid-fields" }, { status: 400 });
   }
   if (typeof body.projectText !== "string") {
@@ -963,9 +915,7 @@ async function handleEntryUpdate(
     }
   }
   project.name = name;
-  const nextStatus = privileged
-    ? (existing.payload.status ?? "public")
-    : "pending";
+  const nextStatus = existing.payload.status ?? "public";
   const { status, payload } = await callGallery(env, "replace-entry", {
     id,
     at: new Date().toISOString(),
@@ -1077,17 +1027,6 @@ export async function routeGalleryRequest(
   }
   if (
     segments.length === 1 &&
-    segments[0] === "review" &&
-    request.method === "GET"
-  ) {
-    if (!(await canReview(request, env))) {
-      return Response.json({ error: "unauthorized" }, { status: 401 });
-    }
-    const { payload } = await callGallery(env, "pending", {});
-    return Response.json(payload, { headers: { "cache-control": "no-store" } });
-  }
-  if (
-    segments.length === 1 &&
     segments[0] === "mine" &&
     request.method === "GET"
   ) {
@@ -1167,8 +1106,6 @@ export async function routeGalleryRequest(
       entryId: segments[0],
       versionId: segments[2],
       at: new Date().toISOString(),
-      // An ordinary owner's restore is an owner edit: back through review.
-      pending: !access.reviewer,
     });
     return Response.json(payload, { status });
   }
@@ -1212,14 +1149,17 @@ export async function routeGalleryRequest(
       entry?: GalleryEntrySummary;
       status?: string;
       ownerUserId?: string | null;
+      submitterEmail?: string | null;
+      submitterProvider?: string | null;
       projectText?: string;
     }>(env, "any-entry", { id: segments[0] });
     if (status !== 200) {
       return Response.json({ error: "not-found" }, { status: 404 });
     }
+    const curator = await canReview(request, env);
     if (payload.status !== "public") {
       const allowed =
-        (await canReview(request, env)) ||
+        curator ||
         (payload.ownerUserId != null &&
           (await sessionUserOf(request, env))?.id === payload.ownerUserId);
       if (!allowed) {
@@ -1231,6 +1171,14 @@ export async function routeGalleryRequest(
         entry: payload.entry,
         status: payload.status,
         ownerUserId: payload.ownerUserId ?? null,
+        // Traceability data, not feed data: a curator sees who submitted an
+        // entry, the public sees only the byline.
+        ...(curator
+          ? {
+              submitterEmail: payload.submitterEmail ?? null,
+              submitterProvider: payload.submitterProvider ?? null,
+            }
+          : {}),
         projectText: payload.projectText,
       },
       { headers: { "cache-control": "no-store" } },
@@ -1241,27 +1189,6 @@ export async function routeGalleryRequest(
   }
   if (segments.length === 2 && request.method === "POST") {
     const [id, action] = segments;
-    if (action === "approve" || action === "reject") {
-      if (!(await canReview(request, env))) {
-        return Response.json({ error: "unauthorized" }, { status: 401 });
-      }
-      const body =
-        action === "reject"
-          ? ((await request.json().catch(() => null)) as {
-              reason?: unknown;
-            } | null)
-          : null;
-      const reason = fieldText(body?.reason, GALLERY_MAX_DESCRIPTION_LENGTH);
-      const reviewer = await sessionUserOf(request, env);
-      const { status, payload } = await callGallery(env, "review", {
-        id,
-        decision: action,
-        reason: action === "reject" && reason ? reason : null,
-        at: new Date().toISOString(),
-        reviewerId: reviewer?.id ?? "bearer",
-      });
-      return Response.json(payload, { status });
-    }
     if (action !== "recycle" && action !== "restore") {
       return Response.json({ error: "not-found" }, { status: 404 });
     }
@@ -1269,9 +1196,7 @@ export async function routeGalleryRequest(
       return Response.json({ error: "forbidden" }, { status: 403 });
     }
     // Admins curate anything; an owner may withdraw their own entry and
-    // bring it back — but an ordinary owner's restore re-enters review
-    // (the pre-withdrawal status is not recorded, and it may have been
-    // pending).
+    // bring it back, which republishes it.
     const admin = await isAdmin(request, env);
     if (!admin) {
       const access = await entryManager(request, env, id!);
@@ -1284,7 +1209,7 @@ export async function routeGalleryRequest(
     }
     const { status, payload } = await callGallery(env, "set-status", {
       id,
-      status: action === "recycle" ? "recycled" : admin ? "public" : "pending",
+      status: action === "recycle" ? "recycled" : "public",
       at: new Date().toISOString(),
     });
     return Response.json(payload, { status });

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -28,7 +28,6 @@ type Env = {
   AGENT_SESSION: AgentSessionNamespaceLike;
   AGENT_ALLOWED_ORIGIN?: string;
   GALLERY: GalleryNamespaceLike;
-  GALLERY_ADMIN_TOKEN?: string;
   AUTH: AuthNamespaceLike;
   GH_OAUTH_CLIENT_ID?: string;
   GH_OAUTH_CLIENT_SECRET?: string;


### PR DESCRIPTION
> 这个 passphrase 应该写啥呀…
> 取消 passphrase 机制。所有用户只要邮箱登录之后就可以直接传。但是每个提交都要追踪邮箱或者 github 信息
> 我希望用户可以直接上传，不需要堆积审核队列
> 邮箱 / GitHub 身份，应该每个用户登录之后就自动会有，不需要额外填写了

## What publishing asked for before

| caller | result |
| --- | --- |
| anonymous | **401** |
| owner passphrase (`GALLERY_ADMIN_TOKEN`) | published |
| admin / moderator session | published |
| ordinary signed-in member | quality gates → **`pending` review queue** |

The reported error — *"The passphrase was not accepted, so it was forgotten"* — was the **401** branch. It reads as a lost password, but the caller simply was not signed in. And signing in correctly only bought a place in a queue.

## What it asks for now

**Signing in is the whole gate.** Any signed-in account publishes straight to the wall.

### The passphrase is gone

`GALLERY_ADMIN_TOKEN` is removed from the worker, `.github/workflows/cloudflare.yml`, and the dialog. A session cookie is the only credential on the gallery write path; an `Authorization` header buys nothing.

### The byline comes from the account

The worker reads `author` from the session instead of the request body, so one account cannot publish under another's name, and an update never re-attributes an entry — not even when a moderator makes it. The manual Author field is gone.

Signed out, the dialog is a **sign-in prompt** rather than a form with a disabled button — the byline, the ownership, and the credential all come from the account, so there is nothing to fill in first.

### Every submission is traceable

Each entry records the submitting account's `owner_user_id`, `submitter_email`, and `submitter_provider`, read from the session at submission time, so it stays traceable even if the account is later renamed.

These are **traceability data, not feed data**: the detail route discloses them only to a moderator or admin. The public sees the byline.

### The queue is retired

`pending`, `GET /api/gallery/review`, and the approve/reject routes are gone. Opening the storage **promotes a leftover `pending` row to `public`** rather than stranding it — listed nowhere and approvable by nothing — while leaving a real rejection alone.

Curation moved to `/moderation`, which keeps the recycle bin and moderator appointment that shared the retired page. Withdraw → restore now republishes for an owner exactly as for an admin.

### The quality gates stay

They are an instant automatic check that names what to fix, not a queue, and they are the only thing keeping a broken schematic off a public wall. A moderator still curates past them.

## Validation

- Full unit suite: **1199 passed** (worker gallery suite rewritten around sessions)
- Full Playwright suite: **214 passed**
- Typecheck, Prettier, markdown links, reference pins

A worker test caught a real bug this change introduced: `any-entry` nests `author` under `entry`, so reading it from the top level blanked the byline on every update. Fixed before it shipped.

Specs updated (`docs/specs/community-gallery.md`) and phase **G5** recorded in the roadmap.

## One thing for you to do

The Cloudflare Worker still holds the old `GALLERY_ADMIN_TOKEN` secret and GitHub still holds the Actions secret. Nothing reads either any more, but you may want to delete both.

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)