### PR TITLE
fix(edit-engine): stop a wire drag from burying a branch at a junction

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3811,6 +3811,74 @@ test("turns a marquee selection as one body, not three parts in place", async ({
   expect(afterSpreadY).toBeGreaterThan(100);
 });
 
+test("keeps the junction dot while a wire at a tap is dragged", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+  const dots = page.locator('[data-layer="junctions"] circle');
+
+  // A horizontal run with a tap rising from its middle: three branches at one
+  // contact, so the contact carries a dot.
+  await clickDrawTool(page, "wire");
+  await canvas.click({ position: { x: 200, y: 300 } });
+  await canvas.dblclick({ position: { x: 400, y: 300 } });
+  await canvas.click({ position: { x: 300, y: 300 } });
+  await canvas.dblclick({ position: { x: 300, y: 200 } });
+  await page.keyboard.press("Escape");
+  await expect(dots).toHaveCount(1);
+
+  const box = (await canvas.boundingBox())!;
+  const dragSegment = async (from: number, to: number) => {
+    await page.mouse.move(box.x + 250, box.y + from);
+    await page.mouse.down();
+    await page.mouse.move(box.x + 250, box.y + to, { steps: 12 });
+    await page.mouse.up();
+  };
+
+  const allRoutePoints = () =>
+    page
+      .locator('[data-layer="routes"] polyline')
+      .evaluateAll((elements) =>
+        elements.map((element) =>
+          Array.from((element as unknown as SVGPolylineElement).points).map(
+            (point) => ({ x: point.x, y: point.y }),
+          ),
+        ),
+      );
+  const tapBefore = (await allRoutePoints()).find(
+    (points) => points.length === 2 && points[0]!.x === points[1]!.x,
+  )!;
+
+  // Down: the tap cannot follow, so the junction stays put and the dragged run
+  // doglegs to reach it. The wire still follows the pointer.
+  await dragSegment(300, 380);
+  await expect(dots).toHaveCount(1);
+  const lowered = await allRoutePoints();
+  expect(lowered.some((points) => points.some((point) => point.y > 380))).toBe(
+    true,
+  );
+  // The tap is untouched, so the contact it makes is still the same contact.
+  expect(
+    lowered.some(
+      (points) =>
+        points.length === 2 &&
+        points[0]!.x === tapBefore[0]!.x &&
+        points[0]!.y === tapBefore[0]!.y &&
+        points[1]!.y === tapBefore[1]!.y,
+    ),
+  ).toBe(true);
+
+  await clickCommand(page, "Edit", "Undo");
+  await expect(dots).toHaveCount(1);
+
+  // Up past the tap's far end: carrying the junction there would turn the tap
+  // around and bury it inside the wire, so the drag holds at the last
+  // position where every branch is still its own line.
+  await dragSegment(300, 160);
+  await expect(dots).toHaveCount(1);
+});
+
 test("drags a marquee selection that holds no instance", async ({ page }) => {
   await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");

--- a/apps/editor/src/features/wiring/use-wire-interaction.ts
+++ b/apps/editor/src/features/wiring/use-wire-interaction.ts
@@ -465,16 +465,29 @@ export function useWireInteraction(options: UseWireInteractionOptions) {
         if (result.ok)
           options.setStatus(`Resized Power Rail ${record.route.id}`);
       } else {
-        const proposal = proposeWireSegmentMove(
-          options.document,
-          options.resolver,
-          record.route.id,
-          preview.segmentIndex,
-          {
-            x: snapCoordinate(point.x, options.document.presentation.grid),
-            y: snapCoordinate(point.y, options.document.presentation.grid),
-          },
-        );
+        const grid = options.document.presentation.grid;
+        const planAt = (at: Point) =>
+          proposeWireSegmentMove(
+            options.document,
+            options.resolver,
+            record.route.id,
+            preview.segmentIndex,
+            {
+              x: snapCoordinate(at.x, grid),
+              y: snapCoordinate(at.y, grid),
+            },
+          );
+        const proposal = (() => {
+          try {
+            return planAt(point);
+          } catch (error) {
+            // Land on the furthest position the drag actually planned, which
+            // is the geometry the preview was showing when the pointer went
+            // past what the wire could do.
+            if (preview.point === preview.start) throw error;
+            return planAt(preview.point);
+          }
+        })();
         const result = transactProposal(
           proposalFor("edit_route_geometry", proposal.edits, proposal.preview),
         );
@@ -612,13 +625,17 @@ export function useWireInteraction(options: UseWireInteractionOptions) {
             (candidate) => candidate.routeId === routeId,
           );
           if (!proposal) return;
+          // Remember how far the drag actually planned. Releasing past that
+          // point used to plan once more, fail, and snap the wire back to
+          // where it started, discarding everything the preview had shown.
+          preview.point = point;
           dragVisual().setPolyline([
             record.geometry.centerline[0]!,
             ...proposal.waypoints,
             record.geometry.centerline.at(-1)!,
           ]);
         } catch {
-          // Keep the last valid preview; commit reports the geometry error.
+          // Keep the last valid preview; commit lands on it instead.
         }
       },
       onFinish: ({ client, dragged }) => {

--- a/packages/edit-engine/src/route-operations.ts
+++ b/packages/edit-engine/src/route-operations.ts
@@ -94,6 +94,91 @@ function movableSegmentJunctionId(
   return junction.id;
 }
 
+/**
+ * Reject a Junction move that would leave two of its branches overlapping.
+ *
+ * A dragged segment carries its Junction anchor along, and the branches that
+ * stay behind stretch to follow. Carried far enough, one of those branches
+ * comes to leave the Junction in the direction another one already leaves in:
+ * the two draw on top of each other, the shorter disappears inside the
+ * longer, and the contact stops reading as a branch at all — which is exactly
+ * when the junction dot goes out.
+ *
+ * Throwing is the drag's stop. Both the preview and the commit already keep
+ * the last geometry that planned, so the wire simply stops following the
+ * pointer at the last position where every branch is still its own line.
+ */
+function assertJunctionBranchesStayVisible(
+  document: SchematicDocument,
+  routingGeometry: ResolvedDocumentRoutingGeometry,
+  proposal: WireSegmentDragProposal,
+  junctionIds: readonly string[],
+): void {
+  if (junctionIds.length === 0) return;
+  const movedById = new Map(
+    proposal.junctions.map((move) => [move.junctionId, move.position]),
+  );
+  const proposedById = new Map(
+    proposal.routes.map((route) => [route.routeId, route.waypoints]),
+  );
+
+  const resultingPoints = (
+    route: SchematicDocument["routes"][number],
+  ): Point[] | null => {
+    const original = routingGeometry.routes.get(route.id)?.centerline;
+    if (!original || original.length < 2) return null;
+    const endpoint = (
+      side: "from" | "to",
+      fallback: Point,
+    ): Point | undefined => {
+      const value = route[side];
+      return value.kind === "junction"
+        ? (movedById.get(value.junctionId) ?? fallback)
+        : fallback;
+    };
+    const waypoints = proposedById.get(route.id) ?? original.slice(1, -1);
+    const from = endpoint("from", original[0]!);
+    const to = endpoint("to", original[original.length - 1]!);
+    if (!from || !to) return null;
+    return [from, ...waypoints, to];
+  };
+
+  const headingKey = (from: Point, to: Point): string | null => {
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const length = Math.hypot(dx, dy);
+    if (length === 0) return null;
+    const round = (value: number) => Math.round((value / length) * 1e6) / 1e6;
+    return `${round(dx)}:${round(dy)}`;
+  };
+
+  for (const junctionId of junctionIds) {
+    const headings = new Map<string, string>();
+    for (const route of document.routes) {
+      const points = resultingPoints(route);
+      if (!points) continue;
+      for (const side of ["from", "to"] as const) {
+        const value = route[side];
+        if (value.kind !== "junction" || value.junctionId !== junctionId) {
+          continue;
+        }
+        const at = side === "from" ? points[0]! : points[points.length - 1]!;
+        const neighbor =
+          side === "from" ? points[1]! : points[points.length - 2]!;
+        const key = headingKey(at, neighbor);
+        if (!key) continue;
+        const existing = headings.get(key);
+        if (existing && existing !== route.id) {
+          throw new Error(
+            `Routes ${existing} and ${route.id} would overlap leaving junction ${junctionId}`,
+          );
+        }
+        headings.set(key, route.id);
+      }
+    }
+  }
+}
+
 function protectedMode(mode: SegmentMode | undefined): boolean {
   return mode === "locked" || mode === "trunk";
 }
@@ -381,7 +466,7 @@ export function proposeWireSegmentDrag(
       });
     }
     if (movedJunctions.size > 0) {
-      return proposeJunctionGroupTranslation(
+      const planned = proposeJunctionGroupTranslation(
         document,
         resolver,
         [...movedJunctions.entries()].map(([junctionId, position]) => ({
@@ -389,6 +474,35 @@ export function proposeWireSegmentDrag(
           position,
         })),
       );
+      const anchorIds = [leftAnchorId, rightAnchorId].filter(
+        (value): value is string => value !== null,
+      );
+      try {
+        assertJunctionBranchesStayVisible(
+          document,
+          routingGeometry,
+          planned,
+          anchorIds,
+        );
+        return planned;
+      } catch {
+        const doglegged: WireSegmentDragProposal = {
+          routes: [
+            {
+              routeId,
+              ...moveRouteSegment(selectedPolyline, segmentIndex, target),
+            },
+          ],
+          junctions: [],
+        };
+        assertJunctionBranchesStayVisible(
+          document,
+          routingGeometry,
+          doglegged,
+          anchorIds,
+        );
+        return doglegged;
+      }
     }
     return {
       routes: [
@@ -498,7 +612,7 @@ export function proposeWireSegmentDrag(
     proposals.set(route.id, normalizeProposal(route.id, points, modes));
   }
 
-  return {
+  const planned: WireSegmentDragProposal = {
     routes: [...proposals.values()].sort((leftProposal, rightProposal) =>
       leftProposal.routeId.localeCompare(rightProposal.routeId, "en"),
     ),
@@ -508,6 +622,43 @@ export function proposeWireSegmentDrag(
         leftMove.junctionId.localeCompare(rightMove.junctionId, "en"),
       ),
   };
+  // Carrying the Junction is the nicer result while it works — the tap slides
+  // and nothing bends. Once it would bury a branch, the Junction stays put and
+  // the dragged Route doglegs to reach it instead, so the pointer is still
+  // followed and the contact still reads as a branch.
+  const anchorIds = [leftAnchorId, rightAnchorId].filter(
+    (value): value is string => value !== null,
+  );
+  try {
+    assertJunctionBranchesStayVisible(
+      document,
+      routingGeometry,
+      planned,
+      anchorIds,
+    );
+    return planned;
+  } catch {
+    // The dogleg is checked too: dragged far enough past a branch, its own
+    // leg comes down that branch's line and buries it just as moving the
+    // Junction would. When neither plan keeps every branch visible the error
+    // stands, and the drag holds at the last position that did.
+    const doglegged: WireSegmentDragProposal = {
+      routes: [
+        {
+          routeId,
+          ...moveRouteSegment(selectedPolyline, segmentIndex, target),
+        },
+      ],
+      junctions: [],
+    };
+    assertJunctionBranchesStayVisible(
+      document,
+      routingGeometry,
+      doglegged,
+      anchorIds,
+    );
+    return doglegged;
+  }
 }
 
 export function proposeLocalStretch(

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it } from "vitest";
 
 import { executeTransaction } from "./transaction.js";
 import { isOrthogonal } from "./route-geometry-edit.js";
+import { proposeWireSegmentDrag } from "./route-operations.js";
 import {
   proposeGroupMoveEdits,
   proposeGroupRotationEdits,
@@ -690,6 +691,99 @@ describe("routing Edit Engine", () => {
       context,
     );
     expect(moved.ok).toBe(true);
+  });
+
+  it("never drags a Junction so far that a branch hides inside a wire", () => {
+    // A T: two arms on y=300 meeting a tap that rises to y=200.
+    const document = createEmptyDocument("tap", "Tap");
+    document.nets.push({ id: "n1", scope: "local", terminals: [] });
+    document.junctions.push({
+      id: "J",
+      netId: "n1",
+      position: { x: 300, y: 300 },
+      role: "route-anchor",
+    });
+    document.junctions.push(
+      {
+        id: "L",
+        netId: "n1",
+        position: { x: 200, y: 300 },
+        role: "route-anchor",
+      },
+      {
+        id: "R",
+        netId: "n1",
+        position: { x: 400, y: 300 },
+        role: "route-anchor",
+      },
+      {
+        id: "T",
+        netId: "n1",
+        position: { x: 300, y: 200 },
+        role: "route-anchor",
+      },
+    );
+    const wire = (id: string, from: string, to: string) => ({
+      kind: "set_route_points" as const,
+      routeId: id,
+      netId: "n1",
+      from: { kind: "junction" as const, junctionId: from },
+      to: { kind: "junction" as const, junctionId: to },
+      waypoints: [],
+      segmentModes: ["manual"],
+    });
+    const built = executeTransaction(
+      document,
+      transaction(document.id, 0, [
+        wire("left", "L", "J"),
+        wire("right", "J", "R"),
+        wire("tap", "J", "T"),
+      ]),
+      context,
+    );
+    expect(built.ok).toBe(true);
+    if (!built.ok) return;
+
+    // Carrying J up to y=250 only shortens the tap: every branch stays visible.
+    const shortened = proposeWireSegmentDrag(
+      built.document,
+      resolver,
+      "left",
+      0,
+      { x: 250, y: 250 },
+    );
+    expect(
+      shortened.junctions.find((move) => move.junctionId === "J")?.position,
+    ).toEqual({ x: 300, y: 250 });
+
+    // Downwards the tap cannot follow at all — carrying J to y=400 would leave
+    // "right" rising back out of it along the tap's own line. J holds instead
+    // and "left" doglegs down to reach it.
+    const doglegged = proposeWireSegmentDrag(
+      built.document,
+      resolver,
+      "left",
+      0,
+      { x: 250, y: 400 },
+    );
+    expect(doglegged.junctions).toEqual([]);
+    expect(
+      doglegged.routes.find((route) => route.routeId === "left")?.waypoints,
+    ).toEqual([
+      { x: 200, y: 400 },
+      { x: 300, y: 400 },
+    ]);
+
+    // Past the tap's far end neither plan keeps every branch visible: carrying
+    // J turns the tap around, and the dogleg comes down the tap's line. The
+    // drag has nowhere left to go, so it stops rather than drawing the
+    // ambiguity.
+    expect(() =>
+      proposeWireSegmentDrag(built.document, resolver, "left", 0, {
+        x: 250,
+        y: 150,
+      }),
+    ).toThrow(/overlap/u);
   });
 
   it("turns a multi-part selection as one body about a shared pivot", () => {


### PR DESCRIPTION
Dragging a wire at a tap made the junction dot disappear.

The dot was right. A dragged segment carries its Junction anchor along, and the branches left behind stretch to follow. Carried far enough, one of them comes to leave the Junction in a direction another one already leaves in — the two draw on top of each other and the shorter disappears inside the longer. Measured on a plain T (arms on `y=300`, tap rising to `y=200`), dragging the left arm up to `y=170` moved the junction there and left the tap as `(270,170)→(270,210)`, entirely inside the right arm's new stem `(270,170)→(270,320)`. Two visible directions instead of three, so no dot. Dragging *down* produced the mirror image of the same fault.

A segment drag now checks the geometry it plans, at the Junction, against every branch:

- while carrying the Junction keeps each branch on its own line it still does — sliding a tap without bending anything is the better result, and the common cases are unchanged;
- once it would not, the Junction stays put and the dragged Route doglegs to reach it, so the wire still follows the pointer;
- where neither plan keeps the branches apart, the drag holds at the last position that did rather than drawing the ambiguity.

One more fault surfaced on the way: releasing past that limit planned once more, failed, and snapped the wire back to its starting position, discarding everything the preview had been showing. The commit now lands on the furthest position the drag actually planned — so the wire ends up where the preview left it.

## Validation

- unit: 1200 passed, including a new edit-engine case that builds a T and pins all three outcomes — the Junction sliding to `y=250`, the dogleg at `y=400` with `junctions: []`, and the throw past the tap's far end
- Playwright: 215 passed, including a new spec that drags a tapped wire down and then far up and asserts the dot survives both, the wire actually moved, and the tap itself is untouched
- measured across five drag directions before and after: the dot was lost in two of them before this change and in none after

🤖 Generated with [Claude Code](https://claude.com/claude-code)