### PR TITLE
fix(symbols): swap an amplifier's + and - without turning its body over

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Unit tests are co-located `*.test.ts(x)` beside implementations under one root `
 
 ### Generated artifacts
 
-Never hand-edit `*.generated.ts` files, `packages/symbols/assets/razavi-v1/*`, `fixtures/agent-api/*`, golden fixtures, or PWA icons — each generator has a paired `:check` drift gate enforced in `ci:static` / release verification. Regeneration order when symbol data changes: `symbols:razavi-{mos,peripherals,inductor,opamp,common}` (assets) → `symbols:razavi` (TS catalog) → `agent-kit:catalog` → `pnpm build` → `mcp:resources` / `agent-api:artifacts` / `pwa:icons`. Golden outputs: `visual:golden`, `export:golden`.
+Never hand-edit `*.generated.ts` files, `packages/symbols/assets/razavi-v1/*`, `fixtures/agent-api/*`, golden fixtures, or PWA icons — each generator has a paired `:check` drift gate enforced in `ci:static` / release verification. Regeneration order when symbol data changes: `symbols:razavi-{mos,peripherals,inductor,opamp,common}` (assets) → `symbols:swap-inputs` (siblings derived from those assets) → `symbols:razavi` (TS catalog) → `agent-kit:catalog` → `pnpm build` → `mcp:resources` / `agent-api:artifacts` / `pwa:icons`. Golden outputs: `visual:golden`, `export:golden`.
 
 ## Required workflow (AGENTS.md)
 

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3879,6 +3879,45 @@ test("keeps the junction dot while a wire at a tap is dragged", async ({
   await expect(dots).toHaveCount(1);
 });
 
+test("swaps a comparator's + and - without turning the body over", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await placeComponent(page, "comparator", { x: 400, y: 300 });
+  await canvas.click({ position: { x: 400, y: 300 } });
+  await openSelectionShelf(page);
+
+  const body = page.locator('[data-layer="symbols"] [data-object-id]').first();
+  const readBody = () =>
+    body.evaluate((element) => ({
+      transform: element.getAttribute("transform") ?? "",
+      paths: Array.from(element.querySelectorAll("path")).map(
+        (path) => path.getAttribute("d") ?? "",
+      ),
+      // The + is the only vertical stroke among the polarity marks.
+      plusMarkY: Array.from(element.querySelectorAll("line"))
+        .filter((line) => line.getAttribute("x1") === line.getAttribute("x2"))
+        .map((line) => Number(line.getAttribute("y1"))),
+    }));
+
+  const before = await readBody();
+  expect(before.plusMarkY).toHaveLength(1);
+  expect(before.plusMarkY[0]!).toBeGreaterThan(0);
+
+  await page.getByTestId("swap-differential-inputs").click();
+
+  const after = await readBody();
+  // The + crossed to the other input.
+  expect(after.plusMarkY[0]!).toBe(-before.plusMarkY[0]!);
+  // Everything that is not a polarity mark held still. A reflection would
+  // have turned the triangle and the transfer-characteristic glyph over with
+  // the marks, and hung a scale() on the body.
+  expect(after.paths).toEqual(before.paths);
+  expect(after.transform).toBe(before.transform);
+  expect(after.transform).not.toContain("scale");
+});
+
 test("drags a marquee selection that holds no instance", async ({ page }) => {
   await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -218,6 +218,10 @@ import {
   differentialOutputSibling,
   planDifferentialOutputSwap,
 } from "../features/editor-shell/differential-output-swap";
+import {
+  differentialInputSibling,
+  planDifferentialInputSwap,
+} from "../features/editor-shell/differential-input-swap";
 import { ExamplesPanel } from "../features/editor-shell/examples-panel";
 import { convertRectangleToHierarchy } from "../features/hierarchy/rectangle-to-cell";
 import { CellManagerDialog } from "../features/hierarchy/cell-manager-dialog";
@@ -9022,13 +9026,23 @@ export function App({
                               Swap + / − outputs
                             </button>
                           ) : null}
-                          {selectedInstanceHasDifferentialInputs ? (
+                          {selectedInstanceHasDifferentialInputs &&
+                          differentialInputSibling(
+                            selectedInstance.symbolId,
+                          ) ? (
                             <button
                               type="button"
                               data-testid="swap-differential-inputs"
                               aria-label="Swap the + and - inputs"
                               title="Swap + / - inputs (Ctrl+R)"
-                              onClick={() => mirrorSelected("top-bottom")}
+                              onClick={() =>
+                                transact(
+                                  planDifferentialInputSwap(
+                                    selectedInstance.id,
+                                    selectedInstance.symbolId,
+                                  ),
+                                )
+                              }
                             >
                               Swap + / − inputs
                             </button>

--- a/apps/editor/src/features/editor-shell/differential-input-swap.test.ts
+++ b/apps/editor/src/features/editor-shell/differential-input-swap.test.ts
@@ -1,0 +1,81 @@
+import { builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import {
+  differentialInputSibling,
+  planDifferentialInputSwap,
+} from "./differential-input-swap";
+
+describe("differential input swap", () => {
+  it("pairs every marked amplifier with its swapped sibling, both ways", () => {
+    expect(differentialInputSibling("comparator")).toBe(
+      "comparator-inputs-swapped",
+    );
+    expect(differentialInputSibling("comparator-inputs-swapped")).toBe(
+      "comparator",
+    );
+    expect(differentialInputSibling("opamp-differential-crossed")).toBe(
+      "opamp-differential-crossed-inputs-swapped",
+    );
+    expect(differentialInputSibling("resistor")).toBeUndefined();
+  });
+
+  it("names one Symbol exchange, leaving placement alone", () => {
+    expect(planDifferentialInputSwap("X1", "opamp")).toEqual([
+      {
+        kind: "set_instance_symbol",
+        instanceId: "X1",
+        symbolId: "opamp-inputs-swapped",
+      },
+    ]);
+    expect(planDifferentialInputSwap("X1", "resistor")).toEqual([]);
+  });
+
+  it("covers every Symbol the swap action is offered on", () => {
+    // The button appears for any Symbol with a marked differential pair. One
+    // without a sibling would show a control that does nothing.
+    const marked = builtInSymbols.filter((symbol) => {
+      const roles = new Set(symbol.pins.map((pin) => pin.role));
+      return roles.has("non-inverting-input") && roles.has("inverting-input");
+    });
+    expect(marked.length).toBeGreaterThan(0);
+    for (const symbol of marked) {
+      expect(differentialInputSibling(symbol.id)).toBeDefined();
+    }
+  });
+
+  it("swaps the marks and the input pins, and nothing else", () => {
+    const byId = new Map(builtInSymbols.map((symbol) => [symbol.id, symbol]));
+    for (const id of ["comparator", "opamp-differential"]) {
+      const source = byId.get(id)!;
+      const swapped = byId.get(differentialInputSibling(id)!)!;
+
+      const inputs = (symbol: typeof source) =>
+        symbol.pins
+          .filter((pin) => pin.role.endsWith("inverting-input"))
+          .map((pin) => `${pin.name}@${pin.at.y}`)
+          .sort();
+      // Same names, opposite sides.
+      expect(inputs(swapped)).toEqual(
+        source.pins
+          .filter((pin) => pin.role.endsWith("inverting-input"))
+          .map((pin) => `${pin.name}@${-pin.at.y}`)
+          .sort(),
+      );
+      // Outputs hold still: swapping inputs is not a reflection.
+      const outputs = (symbol: typeof source) =>
+        symbol.pins
+          .filter((pin) => pin.role === "output")
+          .map((pin) => `${pin.name}@${pin.at.x},${pin.at.y}`);
+      expect(outputs(swapped)).toEqual(outputs(source));
+      // Exactly the three polarity strokes move; the body and, for the
+      // comparator, its transfer-characteristic glyph are untouched.
+      const changed = source.primitives.filter(
+        (primitive, index) =>
+          JSON.stringify(primitive) !==
+          JSON.stringify(swapped.primitives[index]),
+      );
+      expect(changed).toHaveLength(3);
+    }
+  });
+});

--- a/apps/editor/src/features/editor-shell/differential-input-swap.ts
+++ b/apps/editor/src/features/editor-shell/differential-input-swap.ts
@@ -1,0 +1,44 @@
+import type { SchematicEdit } from "@icm/edit-engine";
+
+/**
+ * Every polarity-marked amplifier ships beside an input-swapped sibling that
+ * differs only in where its two marks sit and which input pin each one names.
+ * Swapping inputs exchanges the two Symbols.
+ *
+ * Reflecting the Instance top to bottom would be shorter, and it is what this
+ * used to do, but a reflection cannot tell the marks apart from the rest of
+ * the drawing: it turns a comparator's transfer-characteristic glyph upside
+ * down, exchanges a differential amplifier's outputs along with its inputs,
+ * and flips the reference designator with the body. The exchange touches
+ * exactly what the action names, and the pin names are identical on both
+ * sides, so every attached Net survives it.
+ */
+const INPUT_SWAP_SUFFIX = "-inputs-swapped";
+const INPUT_SWAP_SOURCES = [
+  "opamp",
+  "comparator",
+  "opamp-differential",
+  "opamp-differential-crossed",
+] as const;
+
+export function differentialInputSibling(symbolId: string): string | undefined {
+  if (symbolId.endsWith(INPUT_SWAP_SUFFIX)) {
+    const source = symbolId.slice(0, -INPUT_SWAP_SUFFIX.length);
+    return INPUT_SWAP_SOURCES.some((candidate) => candidate === source)
+      ? source
+      : undefined;
+  }
+  return INPUT_SWAP_SOURCES.some((candidate) => candidate === symbolId)
+    ? `${symbolId}${INPUT_SWAP_SUFFIX}`
+    : undefined;
+}
+
+export function planDifferentialInputSwap(
+  instanceId: string,
+  symbolId: string,
+): SchematicEdit[] {
+  const sibling = differentialInputSibling(symbolId);
+  return sibling
+    ? [{ kind: "set_instance_symbol", instanceId, symbolId: sibling }]
+    : [];
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "symbols:razavi-inductor:check": "node scripts/generate-razavi-inductor-asset.mjs --check",
     "symbols:razavi-opamp": "node scripts/generate-razavi-opamp-asset.mjs",
     "symbols:razavi-opamp:check": "node scripts/generate-razavi-opamp-asset.mjs --check",
+    "symbols:swap-inputs": "node scripts/generate-input-swapped-amplifiers.mjs",
+    "symbols:swap-inputs:check": "node scripts/generate-input-swapped-amplifiers.mjs --check",
     "symbols:razavi-logic": "node scripts/generate-razavi-logic-gate-assets.mjs",
     "symbols:razavi-logic:check": "node scripts/generate-razavi-logic-gate-assets.mjs --check",
     "symbols:razavi-common": "node scripts/generate-razavi-common-assets.mjs",

--- a/packages/symbols/assets/razavi-v1/catalog.json
+++ b/packages/symbols/assets/razavi-v1/catalog.json
@@ -100,6 +100,33 @@
       }
     },
     {
+      "symbolId": "comparator-inputs-swapped",
+      "name": "Comparator (swapped inputs)",
+      "category": "analog-block",
+      "reviewStatus": "reviewed",
+      "pinOrder": ["IN+", "IN-", "OUT"],
+      "palette": false,
+      "automaticMappings": [],
+      "manualOnlyReason": "Textbook comparator block; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
+      "assetPath": "comparator-inputs-swapped.symbol.json",
+      "assetHash": "2347fb5e02a6b024ec9b758d51a80766e8665ad269616200575777a5fec9fce8",
+      "visualAuthority": {
+        "kind": "razavi-reference-v1",
+        "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
+        "referencePaths": [
+          "fixtures/visual-reference/razavi-reference-v1/opamp-vector-source.json",
+          "fixtures/visual-reference/razavi-reference-v1/opamp-reference.png"
+        ],
+        "calibrationPath": "fixtures/visual-reference/razavi-reference-v1/opamp-geometry.json"
+      },
+      "generation": {
+        "kind": "derived-input-swap",
+        "sourceSymbolId": "comparator",
+        "converterPath": "scripts/generate-input-swapped-amplifiers.mjs",
+        "converterVersion": 1
+      }
+    },
+    {
       "symbolId": "current-source",
       "name": "Independent Current Source",
       "category": "source",
@@ -421,6 +448,33 @@
       }
     },
     {
+      "symbolId": "opamp-inputs-swapped",
+      "name": "Operational Amplifier (swapped inputs)",
+      "category": "analog-block",
+      "reviewStatus": "reviewed",
+      "pinOrder": ["IN+", "IN-", "OUT"],
+      "palette": false,
+      "automaticMappings": [],
+      "manualOnlyReason": "Three-terminal textbook op-amp; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
+      "assetPath": "opamp-inputs-swapped.symbol.json",
+      "assetHash": "7bfb9eea39ed6469f7927043577b262b2e177684b02c284d8f0e8ba9ddebbad3",
+      "visualAuthority": {
+        "kind": "razavi-reference-v1",
+        "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
+        "referencePaths": [
+          "fixtures/visual-reference/razavi-reference-v1/opamp-vector-source.json",
+          "fixtures/visual-reference/razavi-reference-v1/opamp-reference.png"
+        ],
+        "calibrationPath": "fixtures/visual-reference/razavi-reference-v1/opamp-geometry.json"
+      },
+      "generation": {
+        "kind": "derived-input-swap",
+        "sourceSymbolId": "opamp",
+        "converterPath": "scripts/generate-input-swapped-amplifiers.mjs",
+        "converterVersion": 1
+      }
+    },
+    {
       "symbolId": "opamp-differential",
       "name": "Differential Op Amp",
       "category": "analog-block",
@@ -449,6 +503,33 @@
       }
     },
     {
+      "symbolId": "opamp-differential-inputs-swapped",
+      "name": "Differential Op Amp (swapped inputs)",
+      "category": "analog-block",
+      "reviewStatus": "reviewed",
+      "pinOrder": ["IN+", "IN-", "OUT+", "OUT-"],
+      "palette": false,
+      "automaticMappings": [],
+      "manualOnlyReason": "Fully differential textbook body; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
+      "assetPath": "opamp-differential-inputs-swapped.symbol.json",
+      "assetHash": "f4cbb7f66dd9fea2ae61e1b65a871744b096113a28614aa077bfe223c0cb6a57",
+      "visualAuthority": {
+        "kind": "razavi-reference-v1",
+        "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
+        "referencePaths": [
+          "fixtures/visual-reference/razavi-reference-v1/opamp-vector-source.json",
+          "fixtures/visual-reference/razavi-reference-v1/opamp-reference.png"
+        ],
+        "calibrationPath": "fixtures/visual-reference/razavi-reference-v1/opamp-geometry.json"
+      },
+      "generation": {
+        "kind": "derived-input-swap",
+        "sourceSymbolId": "opamp-differential",
+        "converterPath": "scripts/generate-input-swapped-amplifiers.mjs",
+        "converterVersion": 1
+      }
+    },
+    {
       "symbolId": "opamp-differential-crossed",
       "name": "Differential Op Amp (crossed outputs)",
       "category": "analog-block",
@@ -474,6 +555,33 @@
         "referencePath": "fixtures/visual-reference/razavi-reference-v1/opamp-vector-source.json",
         "converterPath": "scripts/generate-razavi-opamp-asset.mjs",
         "converterVersion": 2
+      }
+    },
+    {
+      "symbolId": "opamp-differential-crossed-inputs-swapped",
+      "name": "Differential Op Amp (crossed outputs) (swapped inputs)",
+      "category": "analog-block",
+      "reviewStatus": "reviewed",
+      "pinOrder": ["IN+", "IN-", "OUT+", "OUT-"],
+      "palette": false,
+      "automaticMappings": [],
+      "manualOnlyReason": "Output-polarity sibling of opamp-differential; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
+      "assetPath": "opamp-differential-crossed-inputs-swapped.symbol.json",
+      "assetHash": "088e85038212ae9d8dfd29f8a4f91447c0d5ec52f4e510364a1f3e1da41c5d7b",
+      "visualAuthority": {
+        "kind": "razavi-reference-v1",
+        "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
+        "referencePaths": [
+          "fixtures/visual-reference/razavi-reference-v1/opamp-vector-source.json",
+          "fixtures/visual-reference/razavi-reference-v1/opamp-reference.png"
+        ],
+        "calibrationPath": "fixtures/visual-reference/razavi-reference-v1/opamp-geometry.json"
+      },
+      "generation": {
+        "kind": "derived-input-swap",
+        "sourceSymbolId": "opamp-differential-crossed",
+        "converterPath": "scripts/generate-input-swapped-amplifiers.mjs",
+        "converterVersion": 1
       }
     },
     {

--- a/packages/symbols/assets/razavi-v1/comparator-inputs-swapped.symbol.json
+++ b/packages/symbols/assets/razavi-v1/comparator-inputs-swapped.symbol.json
@@ -1,0 +1,171 @@
+{
+  "schemaVersion": 1,
+  "id": "comparator-inputs-swapped",
+  "name": "Comparator (swapped inputs)",
+  "viewBox": {
+    "x": -54,
+    "y": -28,
+    "width": 98,
+    "height": 56
+  },
+  "pins": [
+    {
+      "name": "IN+",
+      "role": "non-inverting-input",
+      "at": {
+        "x": -50,
+        "y": -10
+      },
+      "direction": "west",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 20
+      }
+    },
+    {
+      "name": "IN-",
+      "role": "inverting-input",
+      "at": {
+        "x": -50,
+        "y": 10
+      },
+      "direction": "west",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 20
+      }
+    },
+    {
+      "name": "OUT",
+      "role": "output",
+      "at": {
+        "x": 40,
+        "y": 0
+      },
+      "direction": "east",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 20
+      }
+    }
+  ],
+  "primitives": [
+    {
+      "kind": "line",
+      "from": {
+        "x": -50,
+        "y": -10
+      },
+      "to": {
+        "x": -26.952962,
+        "y": -10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -50,
+        "y": 10
+      },
+      "to": {
+        "x": -26.797909,
+        "y": 10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 23.202091,
+        "y": 0
+      },
+      "to": {
+        "x": 40,
+        "y": 0
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "path",
+      "data": "M -26.7979 -24.9983 L -26.7979 25 L 23.2021 0 Z",
+      "style": {
+        "strokeRole": "emphasis",
+        "lineCap": "butt",
+        "lineJoin": "miter",
+        "miterLimit": 4
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -18.047038,
+        "y": -8.749129
+      },
+      "to": {
+        "x": -18.047038,
+        "y": -16.249129
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -21.796167,
+        "y": -12.5
+      },
+      "to": {
+        "x": -14.296167,
+        "y": -12.5
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -21.796167,
+        "y": 12.5
+      },
+      "to": {
+        "x": -14.296167,
+        "y": 12.5
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "path",
+      "data": "M -8 7 L 0 7 L 0 -7 L 8 -7",
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      },
+      "part": "hysteresis-step"
+    }
+  ],
+  "variants": []
+}

--- a/packages/symbols/assets/razavi-v1/opamp-differential-crossed-inputs-swapped.symbol.json
+++ b/packages/symbols/assets/razavi-v1/opamp-differential-crossed-inputs-swapped.symbol.json
@@ -1,0 +1,238 @@
+{
+  "schemaVersion": 1,
+  "id": "opamp-differential-crossed-inputs-swapped",
+  "name": "Differential Op Amp (crossed outputs) (swapped inputs)",
+  "viewBox": {
+    "x": -54,
+    "y": -28,
+    "width": 98,
+    "height": 56
+  },
+  "pins": [
+    {
+      "name": "IN+",
+      "role": "non-inverting-input",
+      "at": {
+        "x": -50,
+        "y": -10
+      },
+      "direction": "west",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 20
+      }
+    },
+    {
+      "name": "IN-",
+      "role": "inverting-input",
+      "at": {
+        "x": -50,
+        "y": 10
+      },
+      "direction": "west",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 20
+      }
+    },
+    {
+      "name": "OUT+",
+      "role": "output",
+      "at": {
+        "x": 40,
+        "y": -10
+      },
+      "direction": "east",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 20
+      }
+    },
+    {
+      "name": "OUT-",
+      "role": "output",
+      "at": {
+        "x": 40,
+        "y": 10
+      },
+      "direction": "east",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 20
+      }
+    }
+  ],
+  "primitives": [
+    {
+      "kind": "line",
+      "from": {
+        "x": -50,
+        "y": -10
+      },
+      "to": {
+        "x": -26.952962,
+        "y": -10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -50,
+        "y": 10
+      },
+      "to": {
+        "x": -26.797909,
+        "y": 10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 3.2014,
+        "y": -10
+      },
+      "to": {
+        "x": 40,
+        "y": -10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 3.2014,
+        "y": 10
+      },
+      "to": {
+        "x": 40,
+        "y": 10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "path",
+      "data": "M -26.7979 -24.9983 L -26.7979 25 L 3.2014 10 L 3.2014 -10 Z",
+      "style": {
+        "strokeRole": "emphasis",
+        "lineCap": "butt",
+        "lineJoin": "miter",
+        "miterLimit": 4
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -18.047038,
+        "y": -8.749129
+      },
+      "to": {
+        "x": -18.047038,
+        "y": -16.249129
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -21.796167,
+        "y": -12.5
+      },
+      "to": {
+        "x": -14.296167,
+        "y": -12.5
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -21.796167,
+        "y": 12.5
+      },
+      "to": {
+        "x": -14.296167,
+        "y": 12.5
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 14.4512,
+        "y": -8.749129
+      },
+      "to": {
+        "x": 14.4512,
+        "y": -16.249129
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 18.2004,
+        "y": -12.5
+      },
+      "to": {
+        "x": 10.7004,
+        "y": -12.5
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 18.2004,
+        "y": 12.5
+      },
+      "to": {
+        "x": 10.7004,
+        "y": 12.5
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    }
+  ],
+  "variants": []
+}

--- a/packages/symbols/assets/razavi-v1/opamp-differential-inputs-swapped.symbol.json
+++ b/packages/symbols/assets/razavi-v1/opamp-differential-inputs-swapped.symbol.json
@@ -1,0 +1,238 @@
+{
+  "schemaVersion": 1,
+  "id": "opamp-differential-inputs-swapped",
+  "name": "Differential Op Amp (swapped inputs)",
+  "viewBox": {
+    "x": -54,
+    "y": -28,
+    "width": 98,
+    "height": 56
+  },
+  "pins": [
+    {
+      "name": "IN+",
+      "role": "non-inverting-input",
+      "at": {
+        "x": -50,
+        "y": -10
+      },
+      "direction": "west",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 20
+      }
+    },
+    {
+      "name": "IN-",
+      "role": "inverting-input",
+      "at": {
+        "x": -50,
+        "y": 10
+      },
+      "direction": "west",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 20
+      }
+    },
+    {
+      "name": "OUT+",
+      "role": "output",
+      "at": {
+        "x": 40,
+        "y": 10
+      },
+      "direction": "east",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 20
+      }
+    },
+    {
+      "name": "OUT-",
+      "role": "output",
+      "at": {
+        "x": 40,
+        "y": -10
+      },
+      "direction": "east",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 20
+      }
+    }
+  ],
+  "primitives": [
+    {
+      "kind": "line",
+      "from": {
+        "x": -50,
+        "y": -10
+      },
+      "to": {
+        "x": -26.952962,
+        "y": -10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -50,
+        "y": 10
+      },
+      "to": {
+        "x": -26.797909,
+        "y": 10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 3.2014,
+        "y": -10
+      },
+      "to": {
+        "x": 40,
+        "y": -10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 3.2014,
+        "y": 10
+      },
+      "to": {
+        "x": 40,
+        "y": 10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "path",
+      "data": "M -26.7979 -24.9983 L -26.7979 25 L 3.2014 10 L 3.2014 -10 Z",
+      "style": {
+        "strokeRole": "emphasis",
+        "lineCap": "butt",
+        "lineJoin": "miter",
+        "miterLimit": 4
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -18.047038,
+        "y": -8.749129
+      },
+      "to": {
+        "x": -18.047038,
+        "y": -16.249129
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -21.796167,
+        "y": -12.5
+      },
+      "to": {
+        "x": -14.296167,
+        "y": -12.5
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -21.796167,
+        "y": 12.5
+      },
+      "to": {
+        "x": -14.296167,
+        "y": 12.5
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 14.4512,
+        "y": 8.749129
+      },
+      "to": {
+        "x": 14.4512,
+        "y": 16.249129
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 18.2004,
+        "y": 12.5
+      },
+      "to": {
+        "x": 10.7004,
+        "y": 12.5
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 18.2004,
+        "y": -12.5
+      },
+      "to": {
+        "x": 10.7004,
+        "y": -12.5
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    }
+  ],
+  "variants": []
+}

--- a/packages/symbols/assets/razavi-v1/opamp-inputs-swapped.symbol.json
+++ b/packages/symbols/assets/razavi-v1/opamp-inputs-swapped.symbol.json
@@ -1,0 +1,161 @@
+{
+  "schemaVersion": 1,
+  "id": "opamp-inputs-swapped",
+  "name": "Operational Amplifier (swapped inputs)",
+  "viewBox": {
+    "x": -54,
+    "y": -28,
+    "width": 98,
+    "height": 56
+  },
+  "pins": [
+    {
+      "name": "IN+",
+      "role": "non-inverting-input",
+      "at": {
+        "x": -50,
+        "y": -10
+      },
+      "direction": "west",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 20
+      }
+    },
+    {
+      "name": "IN-",
+      "role": "inverting-input",
+      "at": {
+        "x": -50,
+        "y": 10
+      },
+      "direction": "west",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 20
+      }
+    },
+    {
+      "name": "OUT",
+      "role": "output",
+      "at": {
+        "x": 40,
+        "y": 0
+      },
+      "direction": "east",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 20
+      }
+    }
+  ],
+  "primitives": [
+    {
+      "kind": "line",
+      "from": {
+        "x": -50,
+        "y": -10
+      },
+      "to": {
+        "x": -26.952962,
+        "y": -10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -50,
+        "y": 10
+      },
+      "to": {
+        "x": -26.797909,
+        "y": 10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 23.202091,
+        "y": 0
+      },
+      "to": {
+        "x": 40,
+        "y": 0
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "path",
+      "data": "M -26.7979 -24.9983 L -26.7979 25 L 23.2021 0 Z",
+      "style": {
+        "strokeRole": "emphasis",
+        "lineCap": "butt",
+        "lineJoin": "miter",
+        "miterLimit": 4
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -18.047038,
+        "y": -8.749129
+      },
+      "to": {
+        "x": -18.047038,
+        "y": -16.249129
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -21.796167,
+        "y": -12.5
+      },
+      "to": {
+        "x": -14.296167,
+        "y": -12.5
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -21.796167,
+        "y": 12.5
+      },
+      "to": {
+        "x": -14.296167,
+        "y": 12.5
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    }
+  ],
+  "variants": []
+}

--- a/packages/symbols/src/builtins.test.ts
+++ b/packages/symbols/src/builtins.test.ts
@@ -43,11 +43,30 @@ const PRODUCT_IDS = [
 
 describe("Razavi-only product Symbol Library", () => {
   it("contains exactly the reviewed Razavi product symbols", () => {
-    expect(builtInSymbols).toBe(razaviProductSymbols);
-    expect(builtInSymbols.map((symbol) => symbol.id)).toEqual(PRODUCT_IDS);
+    expect(razaviProductSymbols.map((symbol) => symbol.id)).toEqual(
+      PRODUCT_IDS,
+    );
     for (const symbol of builtInSymbols) {
       expect(SymbolDefinitionSchema.parse(symbol)).toEqual(symbol);
     }
+  });
+
+  it("resolves the reviewed Symbols an action reaches but nobody browses", () => {
+    // Swapping an amplifier's inputs or outputs exchanges the Instance's
+    // Symbol for a sibling. Those siblings stay out of the Library, so the
+    // runtime library has to be wider than the Library's own list.
+    const resolvable = new Set(builtInSymbols.map((symbol) => symbol.id));
+    const browsable = new Set(razaviProductSymbols.map((symbol) => symbol.id));
+    for (const id of [
+      "comparator-inputs-swapped",
+      "opamp-inputs-swapped",
+      "opamp-differential-inputs-swapped",
+      "opamp-differential-crossed-inputs-swapped",
+    ]) {
+      expect(resolvable.has(id)).toBe(true);
+      expect(browsable.has(id)).toBe(false);
+    }
+    for (const id of browsable) expect(resolvable.has(id)).toBe(true);
   });
 
   it("does not resolve removed compatibility or generic symbols", () => {

--- a/packages/symbols/src/builtins.ts
+++ b/packages/symbols/src/builtins.ts
@@ -1,8 +1,12 @@
-import { razaviProductSymbols } from "./razavi-catalog.js";
+import { razaviLibrarySymbols } from "./razavi-catalog.js";
 
 /**
  * The sole runtime device library. The historical hand-authored and generic
  * compatibility symbols were intentionally removed; this collection contains
  * only reviewed Razavi catalog entries.
+ *
+ * Everything reviewed resolves here, browsable or not: a Symbol an action
+ * switches an Instance to must draw even though nobody picks it from the
+ * Library. The Library's own list is `razaviProductSymbols`.
  */
-export const builtInSymbols = razaviProductSymbols;
+export const builtInSymbols = razaviLibrarySymbols;

--- a/packages/symbols/src/razavi-catalog.generated.ts
+++ b/packages/symbols/src/razavi-catalog.generated.ts
@@ -128,6 +128,37 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
     },
   },
   {
+    symbolId: "comparator-inputs-swapped",
+    name: "Comparator (swapped inputs)",
+    category: "analog-block",
+    reviewStatus: "reviewed",
+    pinOrder: ["IN+", "IN-", "OUT"],
+    palette: false,
+    automaticMappings: [],
+    manualOnlyReason:
+      "Textbook comparator block; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
+    assetPath: "comparator-inputs-swapped.symbol.json",
+    assetHash:
+      "2347fb5e02a6b024ec9b758d51a80766e8665ad269616200575777a5fec9fce8",
+    visualAuthority: {
+      kind: "razavi-reference-v1",
+      referenceManifestPath:
+        "fixtures/visual-reference/razavi-reference-v1/manifest.json",
+      referencePaths: [
+        "fixtures/visual-reference/razavi-reference-v1/opamp-vector-source.json",
+        "fixtures/visual-reference/razavi-reference-v1/opamp-reference.png",
+      ],
+      calibrationPath:
+        "fixtures/visual-reference/razavi-reference-v1/opamp-geometry.json",
+    },
+    generation: {
+      kind: "derived-input-swap",
+      sourceSymbolId: "comparator",
+      converterPath: "scripts/generate-input-swapped-amplifiers.mjs",
+      converterVersion: 1,
+    },
+  },
+  {
     symbolId: "current-source",
     name: "Independent Current Source",
     category: "source",
@@ -513,6 +544,37 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
     },
   },
   {
+    symbolId: "opamp-inputs-swapped",
+    name: "Operational Amplifier (swapped inputs)",
+    category: "analog-block",
+    reviewStatus: "reviewed",
+    pinOrder: ["IN+", "IN-", "OUT"],
+    palette: false,
+    automaticMappings: [],
+    manualOnlyReason:
+      "Three-terminal textbook op-amp; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
+    assetPath: "opamp-inputs-swapped.symbol.json",
+    assetHash:
+      "7bfb9eea39ed6469f7927043577b262b2e177684b02c284d8f0e8ba9ddebbad3",
+    visualAuthority: {
+      kind: "razavi-reference-v1",
+      referenceManifestPath:
+        "fixtures/visual-reference/razavi-reference-v1/manifest.json",
+      referencePaths: [
+        "fixtures/visual-reference/razavi-reference-v1/opamp-vector-source.json",
+        "fixtures/visual-reference/razavi-reference-v1/opamp-reference.png",
+      ],
+      calibrationPath:
+        "fixtures/visual-reference/razavi-reference-v1/opamp-geometry.json",
+    },
+    generation: {
+      kind: "derived-input-swap",
+      sourceSymbolId: "opamp",
+      converterPath: "scripts/generate-input-swapped-amplifiers.mjs",
+      converterVersion: 1,
+    },
+  },
+  {
     symbolId: "opamp-differential",
     name: "Differential Op Amp",
     category: "analog-block",
@@ -547,6 +609,37 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
     },
   },
   {
+    symbolId: "opamp-differential-inputs-swapped",
+    name: "Differential Op Amp (swapped inputs)",
+    category: "analog-block",
+    reviewStatus: "reviewed",
+    pinOrder: ["IN+", "IN-", "OUT+", "OUT-"],
+    palette: false,
+    automaticMappings: [],
+    manualOnlyReason:
+      "Fully differential textbook body; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
+    assetPath: "opamp-differential-inputs-swapped.symbol.json",
+    assetHash:
+      "f4cbb7f66dd9fea2ae61e1b65a871744b096113a28614aa077bfe223c0cb6a57",
+    visualAuthority: {
+      kind: "razavi-reference-v1",
+      referenceManifestPath:
+        "fixtures/visual-reference/razavi-reference-v1/manifest.json",
+      referencePaths: [
+        "fixtures/visual-reference/razavi-reference-v1/opamp-vector-source.json",
+        "fixtures/visual-reference/razavi-reference-v1/opamp-reference.png",
+      ],
+      calibrationPath:
+        "fixtures/visual-reference/razavi-reference-v1/opamp-geometry.json",
+    },
+    generation: {
+      kind: "derived-input-swap",
+      sourceSymbolId: "opamp-differential",
+      converterPath: "scripts/generate-input-swapped-amplifiers.mjs",
+      converterVersion: 1,
+    },
+  },
+  {
     symbolId: "opamp-differential-crossed",
     name: "Differential Op Amp (crossed outputs)",
     category: "analog-block",
@@ -578,6 +671,37 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
         "fixtures/visual-reference/razavi-reference-v1/opamp-vector-source.json",
       converterPath: "scripts/generate-razavi-opamp-asset.mjs",
       converterVersion: 2,
+    },
+  },
+  {
+    symbolId: "opamp-differential-crossed-inputs-swapped",
+    name: "Differential Op Amp (crossed outputs) (swapped inputs)",
+    category: "analog-block",
+    reviewStatus: "reviewed",
+    pinOrder: ["IN+", "IN-", "OUT+", "OUT-"],
+    palette: false,
+    automaticMappings: [],
+    manualOnlyReason:
+      "Output-polarity sibling of opamp-differential; SPICE subcircuit pin and supply contracts require an explicit PDK mapping.",
+    assetPath: "opamp-differential-crossed-inputs-swapped.symbol.json",
+    assetHash:
+      "088e85038212ae9d8dfd29f8a4f91447c0d5ec52f4e510364a1f3e1da41c5d7b",
+    visualAuthority: {
+      kind: "razavi-reference-v1",
+      referenceManifestPath:
+        "fixtures/visual-reference/razavi-reference-v1/manifest.json",
+      referencePaths: [
+        "fixtures/visual-reference/razavi-reference-v1/opamp-vector-source.json",
+        "fixtures/visual-reference/razavi-reference-v1/opamp-reference.png",
+      ],
+      calibrationPath:
+        "fixtures/visual-reference/razavi-reference-v1/opamp-geometry.json",
+    },
+    generation: {
+      kind: "derived-input-swap",
+      sourceSymbolId: "opamp-differential-crossed",
+      converterPath: "scripts/generate-input-swapped-amplifiers.mjs",
+      converterVersion: 1,
     },
   },
   {
@@ -1483,6 +1607,177 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         to: {
           x: -14.296167,
           y: -12.5,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "path",
+        data: "M -8 7 L 0 7 L 0 -7 L 8 -7",
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+        part: "hysteresis-step",
+      },
+    ],
+    variants: [],
+  },
+  {
+    schemaVersion: 1,
+    id: "comparator-inputs-swapped",
+    name: "Comparator (swapped inputs)",
+    viewBox: {
+      x: -54,
+      y: -28,
+      width: 98,
+      height: 56,
+    },
+    pins: [
+      {
+        name: "IN+",
+        role: "non-inverting-input",
+        at: {
+          x: -50,
+          y: -10,
+        },
+        direction: "west",
+        presentation: {
+          visibility: "visible",
+          leadLength: 20,
+        },
+      },
+      {
+        name: "IN-",
+        role: "inverting-input",
+        at: {
+          x: -50,
+          y: 10,
+        },
+        direction: "west",
+        presentation: {
+          visibility: "visible",
+          leadLength: 20,
+        },
+      },
+      {
+        name: "OUT",
+        role: "output",
+        at: {
+          x: 40,
+          y: 0,
+        },
+        direction: "east",
+        presentation: {
+          visibility: "visible",
+          leadLength: 20,
+        },
+      },
+    ],
+    primitives: [
+      {
+        kind: "line",
+        from: {
+          x: -50,
+          y: -10,
+        },
+        to: {
+          x: -26.952962,
+          y: -10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -50,
+          y: 10,
+        },
+        to: {
+          x: -26.797909,
+          y: 10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 23.202091,
+          y: 0,
+        },
+        to: {
+          x: 40,
+          y: 0,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "path",
+        data: "M -26.7979 -24.9983 L -26.7979 25 L 23.2021 0 Z",
+        style: {
+          strokeRole: "emphasis",
+          lineCap: "butt",
+          lineJoin: "miter",
+          miterLimit: 4,
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -18.047038,
+          y: -8.749129,
+        },
+        to: {
+          x: -18.047038,
+          y: -16.249129,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -21.796167,
+          y: -12.5,
+        },
+        to: {
+          x: -14.296167,
+          y: -12.5,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -21.796167,
+          y: 12.5,
+        },
+        to: {
+          x: -14.296167,
+          y: 12.5,
         },
         style: {
           strokeRole: "normal",
@@ -3042,6 +3337,167 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
   },
   {
     schemaVersion: 1,
+    id: "opamp-inputs-swapped",
+    name: "Operational Amplifier (swapped inputs)",
+    viewBox: {
+      x: -54,
+      y: -28,
+      width: 98,
+      height: 56,
+    },
+    pins: [
+      {
+        name: "IN+",
+        role: "non-inverting-input",
+        at: {
+          x: -50,
+          y: -10,
+        },
+        direction: "west",
+        presentation: {
+          visibility: "visible",
+          leadLength: 20,
+        },
+      },
+      {
+        name: "IN-",
+        role: "inverting-input",
+        at: {
+          x: -50,
+          y: 10,
+        },
+        direction: "west",
+        presentation: {
+          visibility: "visible",
+          leadLength: 20,
+        },
+      },
+      {
+        name: "OUT",
+        role: "output",
+        at: {
+          x: 40,
+          y: 0,
+        },
+        direction: "east",
+        presentation: {
+          visibility: "visible",
+          leadLength: 20,
+        },
+      },
+    ],
+    primitives: [
+      {
+        kind: "line",
+        from: {
+          x: -50,
+          y: -10,
+        },
+        to: {
+          x: -26.952962,
+          y: -10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -50,
+          y: 10,
+        },
+        to: {
+          x: -26.797909,
+          y: 10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 23.202091,
+          y: 0,
+        },
+        to: {
+          x: 40,
+          y: 0,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "path",
+        data: "M -26.7979 -24.9983 L -26.7979 25 L 23.2021 0 Z",
+        style: {
+          strokeRole: "emphasis",
+          lineCap: "butt",
+          lineJoin: "miter",
+          miterLimit: 4,
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -18.047038,
+          y: -8.749129,
+        },
+        to: {
+          x: -18.047038,
+          y: -16.249129,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -21.796167,
+          y: -12.5,
+        },
+        to: {
+          x: -14.296167,
+          y: -12.5,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -21.796167,
+          y: 12.5,
+        },
+        to: {
+          x: -14.296167,
+          y: 12.5,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+    ],
+    variants: [],
+  },
+  {
+    schemaVersion: 1,
     id: "opamp-differential",
     name: "Differential Op Amp",
     viewBox: {
@@ -3280,6 +3736,244 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
   },
   {
     schemaVersion: 1,
+    id: "opamp-differential-inputs-swapped",
+    name: "Differential Op Amp (swapped inputs)",
+    viewBox: {
+      x: -54,
+      y: -28,
+      width: 98,
+      height: 56,
+    },
+    pins: [
+      {
+        name: "IN+",
+        role: "non-inverting-input",
+        at: {
+          x: -50,
+          y: -10,
+        },
+        direction: "west",
+        presentation: {
+          visibility: "visible",
+          leadLength: 20,
+        },
+      },
+      {
+        name: "IN-",
+        role: "inverting-input",
+        at: {
+          x: -50,
+          y: 10,
+        },
+        direction: "west",
+        presentation: {
+          visibility: "visible",
+          leadLength: 20,
+        },
+      },
+      {
+        name: "OUT+",
+        role: "output",
+        at: {
+          x: 40,
+          y: 10,
+        },
+        direction: "east",
+        presentation: {
+          visibility: "visible",
+          leadLength: 20,
+        },
+      },
+      {
+        name: "OUT-",
+        role: "output",
+        at: {
+          x: 40,
+          y: -10,
+        },
+        direction: "east",
+        presentation: {
+          visibility: "visible",
+          leadLength: 20,
+        },
+      },
+    ],
+    primitives: [
+      {
+        kind: "line",
+        from: {
+          x: -50,
+          y: -10,
+        },
+        to: {
+          x: -26.952962,
+          y: -10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -50,
+          y: 10,
+        },
+        to: {
+          x: -26.797909,
+          y: 10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 3.2014,
+          y: -10,
+        },
+        to: {
+          x: 40,
+          y: -10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 3.2014,
+          y: 10,
+        },
+        to: {
+          x: 40,
+          y: 10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "path",
+        data: "M -26.7979 -24.9983 L -26.7979 25 L 3.2014 10 L 3.2014 -10 Z",
+        style: {
+          strokeRole: "emphasis",
+          lineCap: "butt",
+          lineJoin: "miter",
+          miterLimit: 4,
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -18.047038,
+          y: -8.749129,
+        },
+        to: {
+          x: -18.047038,
+          y: -16.249129,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -21.796167,
+          y: -12.5,
+        },
+        to: {
+          x: -14.296167,
+          y: -12.5,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -21.796167,
+          y: 12.5,
+        },
+        to: {
+          x: -14.296167,
+          y: 12.5,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 14.4512,
+          y: 8.749129,
+        },
+        to: {
+          x: 14.4512,
+          y: 16.249129,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 18.2004,
+          y: 12.5,
+        },
+        to: {
+          x: 10.7004,
+          y: 12.5,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 18.2004,
+          y: -12.5,
+        },
+        to: {
+          x: 10.7004,
+          y: -12.5,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+    ],
+    variants: [],
+  },
+  {
+    schemaVersion: 1,
     id: "opamp-differential-crossed",
     name: "Differential Op Amp (crossed outputs)",
     viewBox: {
@@ -3458,6 +4152,244 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         to: {
           x: -14.296167,
           y: -12.5,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 14.4512,
+          y: -8.749129,
+        },
+        to: {
+          x: 14.4512,
+          y: -16.249129,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 18.2004,
+          y: -12.5,
+        },
+        to: {
+          x: 10.7004,
+          y: -12.5,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 18.2004,
+          y: 12.5,
+        },
+        to: {
+          x: 10.7004,
+          y: 12.5,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+    ],
+    variants: [],
+  },
+  {
+    schemaVersion: 1,
+    id: "opamp-differential-crossed-inputs-swapped",
+    name: "Differential Op Amp (crossed outputs) (swapped inputs)",
+    viewBox: {
+      x: -54,
+      y: -28,
+      width: 98,
+      height: 56,
+    },
+    pins: [
+      {
+        name: "IN+",
+        role: "non-inverting-input",
+        at: {
+          x: -50,
+          y: -10,
+        },
+        direction: "west",
+        presentation: {
+          visibility: "visible",
+          leadLength: 20,
+        },
+      },
+      {
+        name: "IN-",
+        role: "inverting-input",
+        at: {
+          x: -50,
+          y: 10,
+        },
+        direction: "west",
+        presentation: {
+          visibility: "visible",
+          leadLength: 20,
+        },
+      },
+      {
+        name: "OUT+",
+        role: "output",
+        at: {
+          x: 40,
+          y: -10,
+        },
+        direction: "east",
+        presentation: {
+          visibility: "visible",
+          leadLength: 20,
+        },
+      },
+      {
+        name: "OUT-",
+        role: "output",
+        at: {
+          x: 40,
+          y: 10,
+        },
+        direction: "east",
+        presentation: {
+          visibility: "visible",
+          leadLength: 20,
+        },
+      },
+    ],
+    primitives: [
+      {
+        kind: "line",
+        from: {
+          x: -50,
+          y: -10,
+        },
+        to: {
+          x: -26.952962,
+          y: -10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -50,
+          y: 10,
+        },
+        to: {
+          x: -26.797909,
+          y: 10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 3.2014,
+          y: -10,
+        },
+        to: {
+          x: 40,
+          y: -10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 3.2014,
+          y: 10,
+        },
+        to: {
+          x: 40,
+          y: 10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "path",
+        data: "M -26.7979 -24.9983 L -26.7979 25 L 3.2014 10 L 3.2014 -10 Z",
+        style: {
+          strokeRole: "emphasis",
+          lineCap: "butt",
+          lineJoin: "miter",
+          miterLimit: 4,
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -18.047038,
+          y: -8.749129,
+        },
+        to: {
+          x: -18.047038,
+          y: -16.249129,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -21.796167,
+          y: -12.5,
+        },
+        to: {
+          x: -14.296167,
+          y: -12.5,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -21.796167,
+          y: 12.5,
+        },
+        to: {
+          x: -14.296167,
+          y: 12.5,
         },
         style: {
           strokeRole: "normal",

--- a/packages/symbols/src/razavi-catalog.test.ts
+++ b/packages/symbols/src/razavi-catalog.test.ts
@@ -139,6 +139,7 @@ describe("Razavi symbol catalog", () => {
       ["capacitor", "reviewed", "razavi-reference-v1"],
       ["closed-switch", "reviewed", "razavi-reference-v1"],
       ["comparator", "reviewed", "razavi-reference-v1"],
+      ["comparator-inputs-swapped", "reviewed", "razavi-reference-v1"],
       ["current-source", "reviewed", "razavi-reference-v1"],
       ["diode", "reviewed", "razavi-reference-v1"],
       ["ground", "reviewed", "razavi-reference-v1"],
@@ -151,8 +152,15 @@ describe("Razavi symbol catalog", () => {
       ["nor-gate", "reviewed", "razavi-reference-v1"],
       ["npn", "reviewed", "razavi-reference-v1"],
       ["opamp", "reviewed", "razavi-reference-v1"],
+      ["opamp-inputs-swapped", "reviewed", "razavi-reference-v1"],
       ["opamp-differential", "reviewed", "razavi-reference-v1"],
+      ["opamp-differential-inputs-swapped", "reviewed", "razavi-reference-v1"],
       ["opamp-differential-crossed", "reviewed", "razavi-reference-v1"],
+      [
+        "opamp-differential-crossed-inputs-swapped",
+        "reviewed",
+        "razavi-reference-v1",
+      ],
       ["or-gate", "reviewed", "razavi-reference-v1"],
       ["pmos", "reviewed", "razavi-reference-v1"],
       ["pnp", "reviewed", "razavi-reference-v1"],
@@ -214,7 +222,7 @@ describe("Razavi symbol catalog", () => {
   });
 
   it("uses reviewed catalog objects as the sole built-in product library", () => {
-    expect(razaviCatalogSymbols).toHaveLength(32);
+    expect(razaviCatalogSymbols).toHaveLength(36);
     for (const catalogSymbol of razaviProductSymbols) {
       expect(
         builtInSymbols.find((symbol) => symbol.id === catalogSymbol.id),

--- a/packages/symbols/src/razavi-catalog.ts
+++ b/packages/symbols/src/razavi-catalog.ts
@@ -23,18 +23,32 @@ export interface RazaviSymbolCatalogEntry {
   manualOnlyReason?: string;
   assetPath: string;
   assetHash: string;
-  generation?: {
-    kind: "razavi-raster-reference" | "razavi-pdf-vector-reference";
-    referenceManifestPath: string;
-    referencePath: string;
-    converterPath: string;
-    converterVersion: number;
-    /**
-     * Uniform factor applied to the reference geometry so this Symbol shares
-     * the pin span of its sibling family. Absent means evidence-exact.
-     */
-    pinSpanScale?: number;
-  };
+  generation?:
+    | {
+        kind: "razavi-raster-reference" | "razavi-pdf-vector-reference";
+        referenceManifestPath: string;
+        referencePath: string;
+        converterPath: string;
+        converterVersion: number;
+        /**
+         * Uniform factor applied to the reference geometry so this Symbol
+         * shares the pin span of its sibling family. Absent means
+         * evidence-exact.
+         */
+        pinSpanScale?: number;
+      }
+    | {
+        /**
+         * Derived from another reviewed Symbol rather than from the reference
+         * itself, so its visual authority is that Symbol's. The converter
+         * states the one transformation it applies and its `:check` gate
+         * keeps the pair from drifting apart.
+         */
+        kind: "derived-input-swap";
+        sourceSymbolId: string;
+        converterPath: string;
+        converterVersion: number;
+      };
 }
 
 export interface RazaviSemanticPrimitiveEntry {
@@ -56,21 +70,40 @@ const entriesById = new Map(
   razaviSymbolCatalogEntries.map((entry) => [entry.symbolId, entry]),
 );
 
-export function isRazaviProductCatalogEntry(
+/**
+ * Resolvable: a reviewed, Reference-calibrated Symbol the runtime may draw.
+ *
+ * `palette` is browsability, not existence. A Symbol reached by an action
+ * rather than by picking it — the crossed-output and swapped-input siblings —
+ * has to resolve everywhere the Project can name it while staying out of a
+ * Library where it would read as a near-duplicate of its source.
+ */
+export function isRazaviLibraryCatalogEntry(
   entry: RazaviSymbolCatalogEntry,
 ): boolean {
   return (
-    entry.palette &&
     entry.reviewStatus === "reviewed" &&
     entry.visualAuthority.kind === "razavi-reference-v1"
   );
 }
 
-export const razaviProductSymbols: readonly SymbolDefinition[] =
+/** Browsable: the subset a person picks from. */
+export function isRazaviProductCatalogEntry(
+  entry: RazaviSymbolCatalogEntry,
+): boolean {
+  return entry.palette && isRazaviLibraryCatalogEntry(entry);
+}
+
+const symbolsFor = (
+  predicate: (entry: RazaviSymbolCatalogEntry) => boolean,
+): readonly SymbolDefinition[] =>
   razaviSymbolCatalogEntries
-    .filter(isRazaviProductCatalogEntry)
+    .filter(predicate)
     .map((entry) => symbolsById.get(entry.symbolId)!)
     .filter((symbol): symbol is SymbolDefinition => symbol !== undefined);
+
+export const razaviLibrarySymbols = symbolsFor(isRazaviLibraryCatalogEntry);
+export const razaviProductSymbols = symbolsFor(isRazaviProductCatalogEntry);
 
 export {
   razaviCatalogSymbols,

--- a/scripts/generate-input-swapped-amplifiers.mjs
+++ b/scripts/generate-input-swapped-amplifiers.mjs
@@ -1,0 +1,172 @@
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { format } from "prettier";
+
+/**
+ * Derive the input-swapped sibling of every polarity-marked amplifier.
+ *
+ * "Swap + / −" used to reflect the whole Instance top to bottom. That reads as
+ * a swap only on a body with nothing else to say: it turns a comparator's
+ * transfer-characteristic glyph upside down, exchanges a differential amp's
+ * outputs along with its inputs, and flips the reference designator with the
+ * artwork. What the action means is narrower — the two polarity marks trade
+ * places and the input pins follow them — so it is a Symbol exchange, the same
+ * shape `opamp-differential-crossed` already gives the output swap.
+ *
+ * Siblings are derived from the reviewed assets rather than drawn again, so
+ * they cannot drift from the bodies they mirror. Each one keeps its source's
+ * pin names, so exchanging Symbols leaves every attached Net intact, and is
+ * kept out of the palette: it is a state of its source, not a part to browse.
+ */
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const assetRoot = resolve(root, "packages/symbols/assets/razavi-v1");
+const catalogPath = resolve(assetRoot, "catalog.json");
+const check = process.argv.includes("--check");
+const normalize = (value) => `${value.replaceAll("\r\n", "\n").trimEnd()}\n`;
+const hash = (value) => createHash("sha256").update(value).digest("hex");
+
+/** Sources, in catalog order. Each must carry a marked differential pair. */
+const SOURCE_IDS = [
+  "opamp",
+  "comparator",
+  "opamp-differential",
+  "opamp-differential-crossed",
+];
+const SWAPPED_SUFFIX = "-inputs-swapped";
+const INPUT_ROLES = new Set(["non-inverting-input", "inverting-input"]);
+/** Polarity marks are the only short strokes drawn clear of the input leads. */
+const MARK_MAX_LENGTH = 8;
+const MARK_MIN_HEIGHT = 11;
+
+function fail(message) {
+  throw new Error(`Input-swapped amplifier generation: ${message}`);
+}
+
+const midpoint = (primitive) => ({
+  x: (primitive.from.x + primitive.to.x) / 2,
+  y: (primitive.from.y + primitive.to.y) / 2,
+});
+
+/**
+ * A polarity mark on the input side: a short stroke, clear of the leads at
+ * ±10, on the input half of the body. The output marks of a differential amp
+ * match the first two tests and are excluded by the third — swapping inputs
+ * must leave the outputs exactly where they are.
+ */
+function isInputMark(primitive, centerX) {
+  if (primitive.kind !== "line") return false;
+  const length = Math.hypot(
+    primitive.to.x - primitive.from.x,
+    primitive.to.y - primitive.from.y,
+  );
+  const centre = midpoint(primitive);
+  return (
+    length <= MARK_MAX_LENGTH &&
+    Math.abs(centre.y) >= MARK_MIN_HEIGHT &&
+    centre.x < centerX
+  );
+}
+
+const acrossAxis = (primitive) => ({
+  ...primitive,
+  from: { ...primitive.from, y: -primitive.from.y },
+  to: { ...primitive.to, y: -primitive.to.y },
+});
+
+function swapInputs(source) {
+  const centerX = source.viewBox.x + source.viewBox.width / 2;
+  const marks = source.primitives.filter((primitive) =>
+    isInputMark(primitive, centerX),
+  );
+  // A plus and a minus: two strokes and one, in either order. Anything else
+  // means the artwork changed shape and the rule above no longer finds it.
+  if (marks.length !== 3) {
+    fail(`${source.id} has ${marks.length} input polarity strokes, expected 3`);
+  }
+  const inputPins = source.pins.filter((pin) => INPUT_ROLES.has(pin.role));
+  if (inputPins.length !== 2) {
+    fail(`${source.id} has ${inputPins.length} input pins, expected 2`);
+  }
+  if (inputPins[0].at.y !== -inputPins[1].at.y) {
+    fail(`${source.id} input pins are not a mirrored pair`);
+  }
+  return {
+    ...source,
+    id: `${source.id}${SWAPPED_SUFFIX}`,
+    name: `${source.name} (swapped inputs)`,
+    pins: source.pins.map((pin) =>
+      INPUT_ROLES.has(pin.role)
+        ? { ...pin, at: { ...pin.at, y: -pin.at.y } }
+        : pin,
+    ),
+    primitives: source.primitives.map((primitive) =>
+      isInputMark(primitive, centerX) ? acrossAxis(primitive) : primitive,
+    ),
+  };
+}
+
+const catalog = JSON.parse(await readFile(catalogPath, "utf8"));
+const outputs = [];
+for (const sourceId of SOURCE_IDS) {
+  const sourceEntry = catalog.entries.find(
+    (candidate) => candidate.symbolId === sourceId,
+  );
+  if (!sourceEntry) fail(`missing catalog entry ${sourceId}`);
+  const assetPath = resolve(assetRoot, sourceEntry.assetPath);
+  const source = JSON.parse(await readFile(assetPath, "utf8"));
+  const swapped = swapInputs(source);
+  const swappedSource = normalize(
+    await format(JSON.stringify(swapped, null, 2), { parser: "json" }),
+  );
+  const swappedAssetPath = `${sourceId}${SWAPPED_SUFFIX}.symbol.json`;
+  outputs.push([resolve(assetRoot, swappedAssetPath), swappedSource]);
+
+  const entry = {
+    ...sourceEntry,
+    symbolId: swapped.id,
+    name: swapped.name,
+    // A swap target, not a part to browse: it would sit in the Library as a
+    // near-duplicate of the body it was derived from.
+    palette: false,
+    assetPath: swappedAssetPath,
+    assetHash: hash(swappedSource),
+    generation: {
+      kind: "derived-input-swap",
+      sourceSymbolId: sourceId,
+      converterPath: "scripts/generate-input-swapped-amplifiers.mjs",
+      converterVersion: 1,
+    },
+  };
+  const existingIndex = catalog.entries.findIndex(
+    (candidate) => candidate.symbolId === swapped.id,
+  );
+  if (existingIndex >= 0) catalog.entries[existingIndex] = entry;
+  else {
+    const sourceIndex = catalog.entries.indexOf(sourceEntry);
+    catalog.entries.splice(sourceIndex + 1, 0, entry);
+  }
+}
+outputs.push([
+  catalogPath,
+  normalize(await format(JSON.stringify(catalog, null, 2), { parser: "json" })),
+]);
+
+if (check) {
+  for (const [path, source] of outputs) {
+    if (normalize(await readFile(path, "utf8")) !== source) {
+      fail(`${relative(root, path)} is stale`);
+    }
+  }
+} else {
+  for (const [path, source] of outputs) {
+    await writeFile(path, source, "utf8");
+  }
+}
+
+console.log(
+  `${check ? "Validated" : "Generated"} ${SOURCE_IDS.length}` +
+    " input-swapped amplifier siblings",
+);


### PR DESCRIPTION
"Swap + / − inputs" reflected the whole Instance top to bottom. That reads as a swap only on a body with nothing else to say — and none of these bodies qualify:

- **The comparator carries a transfer-characteristic glyph** (`M -8 7 L 0 7 L 0 -7 L 8 -7`). The reflection turned it upside down, drawing a non-inverting comparator as an inverting one.
- **The differential amplifier had its outputs exchanged too**, because `OUT+`/`OUT-` sit at ±10 like the inputs do.
- **Every one of them had its reference designator flipped** with the artwork.

Each polarity-marked amplifier now ships beside an input-swapped sibling, and the action exchanges the two Symbols — the same shape `opamp-differential-crossed` already gives the output swap. Pin names are identical on both sides, so every attached Net survives.

Siblings are *derived* from the reviewed assets by `scripts/generate-input-swapped-amplifiers.mjs` rather than drawn again, so they cannot drift from the bodies they mirror. The derivation moves exactly the three polarity strokes and the two input pins; a diff of source against sibling shows three changed primitives and nothing else, with `OUT+`/`OUT-` and the glyph byte-identical. The converter fails loudly if a body stops yielding exactly three input-side marks, rather than silently drawing something wrong.

## `palette` was doing two jobs

The siblings belong out of the Library, where they would sit as near-duplicates of their sources — but `builtInSymbols` was the palette-filtered set, so `palette: false` also made them unresolvable, and `set_instance_symbol` would have had nothing to switch to. `palette` now means browsability alone: `builtInSymbols` is every reviewed, Reference-calibrated Symbol, and `razaviProductSymbols` stays the browsable subset the picker reads.

## Validation

- unit: 1205 passed. New cases pin the sibling pairing in both directions, assert every Symbol the button is offered on has a sibling (so the control is never a no-op), and diff source against sibling to prove only the marks and input pins move while the outputs hold still.
- Playwright: 216 passed, including a new spec that places a comparator, swaps it, and asserts the `+` crossed sides while every `path` — triangle and glyph — is unchanged and the body's transform gained no `scale`. Under the old reflection that assertion fails.
- drift gates re-run clean: `symbols:swap-inputs:check`, `symbols:razavi:check`, `symbols:razavi-opamp:check`, `agent-kit:catalog:check`, `visual:golden --check`, `export:golden --check`, markdown links, references, Prettier, typecheck.

`CLAUDE.md` records the new step in the regeneration order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)