### PR TITLE
fix(editor): keep the publish draft when the dialog closes

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -550,6 +550,56 @@ test("a signed-in member publishes directly, bylined by the account", async ({
   ]);
 });
 
+test("a mistaken click beside the publish form keeps what was written", async ({
+  page,
+}) => {
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      json: {
+        user: {
+          id: "u1",
+          displayName: "Token Zhang",
+          email: "owner@example.com",
+          provider: "github",
+          isAdmin: true,
+        },
+      },
+    }),
+  );
+
+  await page.goto("/editor");
+  await page.getByTestId("publish-gallery-button").click();
+  const dialog = page.getByTestId("publish-gallery-dialog");
+  await expect(dialog).toBeVisible();
+
+  await dialog.getByLabel("Circuit name").fill("Folded Cascode");
+  await dialog
+    .getByLabel("Description")
+    .fill("Gain boosted, 1.2 V supply, trimmed offset.");
+  await dialog.getByLabel("Add tag").fill("Cascode");
+  await dialog.getByLabel("Add tag").press("Enter");
+  await expect(dialog.getByTestId("publish-tag-cascode")).toBeVisible();
+
+  // A stray press on the backdrop beside a form being written in is a miss,
+  // not a decision to throw the writing away.
+  const viewport = page.viewportSize()!;
+  await page.mouse.click(8, viewport.height - 8);
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByLabel("Circuit name")).toHaveValue("Folded Cascode");
+
+  // Cancelling is a decision, and it still closes — but reopening comes back
+  // to the draft rather than to an empty form.
+  await dialog.getByRole("button", { name: "Cancel" }).click();
+  await expect(dialog).toHaveCount(0);
+  await page.getByTestId("publish-gallery-button").click();
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByLabel("Circuit name")).toHaveValue("Folded Cascode");
+  await expect(dialog.getByLabel("Description")).toHaveValue(
+    "Gain boosted, 1.2 V supply, trimmed offset.",
+  );
+  await expect(dialog.getByTestId("publish-tag-cascode")).toBeVisible();
+});
+
 test("an ordinary user sees blocking quality gates on an empty project", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -229,7 +229,10 @@ import { NetlistPreflightDialog } from "../features/netlist-export/netlist-prefl
 import { parseProject } from "@icm/project-protocol";
 import { DocumentSettingsSection } from "../features/editor-shell/document-settings-section";
 import { derivedFingerWidth } from "../features/properties/finger-width";
-import { PublishGalleryDialog } from "../features/editor-shell/publish-gallery-dialog";
+import {
+  PublishGalleryDialog,
+  type PublishGalleryDraft,
+} from "../features/editor-shell/publish-gallery-dialog";
 import {
   publishProjectToGallery,
   updateGalleryEntry,
@@ -854,6 +857,10 @@ export function App({
   const [selectedRouteSegmentIndex, setSelectedRouteSegmentIndex] = useState<
     number | null
   >(null);
+  /** Survives the dialog closing, so a mistaken dismissal loses nothing. */
+  const [publishDraft, setPublishDraft] = useState<PublishGalleryDraft | null>(
+    null,
+  );
   /**
    * The corner shape is a standing authoring preference, not per-wire state:
    * picking the wire tool again reset it, so a chosen diagonal had to be
@@ -8005,6 +8012,8 @@ export function App({
       />
       {publishGalleryOpen ? (
         <PublishGalleryDialog
+          draft={publishDraft}
+          onDraftChange={setPublishDraft}
           defaultName={project.name}
           session={publishSession}
           gateReport={publishGates}
@@ -8035,6 +8044,7 @@ export function App({
           }
           onPublished={({ name, updated }) => {
             setPublishGalleryOpen(false);
+            setPublishDraft(null);
             setStatus(
               updated
                 ? `Updated "${name}" in the gallery`

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.test.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.test.tsx
@@ -47,6 +47,30 @@ describe("PublishGalleryDialog", () => {
     expect(markup).not.toMatch(/disabled=""[^>]*>Publish</u);
   });
 
+  it("reopens on the draft it was closed with", () => {
+    // Closing the dialog unmounts it, so a mistaken dismissal used to throw
+    // away everything typed. The draft is held outside and handed back.
+    const markup = renderToStaticMarkup(
+      createElement(PublishGalleryDialog, {
+        defaultName: "Ring Oscillator",
+        session: { displayName: "Visitor", isAdmin: false, role: "user" },
+        gateReport: { ok: true, failures: [] },
+        draft: {
+          name: "Ring Oscillator v2",
+          description: "Five stages, skewed for duty cycle.",
+          tags: ["oscillator", "cmos"],
+        },
+        publish: () => Promise.resolve({ status: "unauthorized" as const }),
+        onPublished: () => undefined,
+        onClose: () => undefined,
+      }),
+    );
+    expect(markup).toContain('value="Ring Oscillator v2"');
+    expect(markup).toContain("Five stages, skewed for duty cycle.");
+    expect(markup).toContain("oscillator");
+    expect(markup).toContain("cmos");
+  });
+
   it("never asks for the byline: the account supplies it", () => {
     const markup = renderToStaticMarkup(
       createElement(PublishGalleryDialog, {

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
@@ -36,6 +36,19 @@ export interface PublishGalleryDialogProps {
    * Rendered only alongside an update target. */
   onShowHistory?: (() => void) | undefined;
   onClose: () => void;
+  /**
+   * What was typed last time the dialog was open. The dialog unmounts on
+   * close, so without somewhere outside it to keep them, a mistaken click on
+   * the backdrop threw away everything the person had written.
+   */
+  draft?: PublishGalleryDraft | null;
+  onDraftChange?: ((draft: PublishGalleryDraft) => void) | undefined;
+}
+
+export interface PublishGalleryDraft {
+  name: string;
+  description: string;
+  tags: readonly string[];
 }
 
 /**
@@ -57,6 +70,8 @@ export function PublishGalleryDialog({
   onPublished,
   onShowHistory,
   onClose,
+  draft = null,
+  onDraftChange,
 }: PublishGalleryDialogProps) {
   const privileged = session?.isAdmin === true || session?.role === "moderator";
   const ordinary = session !== null && !privileged;
@@ -67,9 +82,9 @@ export function PublishGalleryDialog({
     canUpdate ? "update" : "new",
   );
   const updating = canUpdate && mode === "update";
-  const [name, setName] = useState(defaultName);
-  const [description, setDescription] = useState("");
-  const [tags, setTags] = useState<string[]>([]);
+  const [name, setName] = useState(draft?.name ?? defaultName);
+  const [description, setDescription] = useState(draft?.description ?? "");
+  const [tags, setTags] = useState<string[]>([...(draft?.tags ?? [])]);
   const [tagDraft, setTagDraft] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -92,6 +107,18 @@ export function PublishGalleryDialog({
       previous.length > 0 ? previous : [...updateDefaults.tags],
     );
   }, [canUpdate, updateDefaults, defaultsApplied]);
+
+  // Report the draft outward on every keystroke, so it survives whichever way
+  // the dialog closes — backdrop, Escape, or Cancel.
+  useEffect(() => {
+    onDraftChange?.({ name, description, tags });
+  }, [name, description, tags, onDraftChange]);
+
+  const hasDraft =
+    description.trim().length > 0 ||
+    tags.length > 0 ||
+    tagDraft.trim().length > 0 ||
+    name.trim() !== defaultName.trim();
 
   function addTag(raw: string): void {
     const tag = raw.replace(/\s+/gu, " ").trim().toLowerCase();
@@ -121,7 +148,11 @@ export function PublishGalleryDialog({
     <div
       className="insert-dialog-backdrop"
       onPointerDown={(event) => {
-        if (event.target === event.currentTarget && !busy) onClose();
+        // A stray click beside a form someone has been writing in is far more
+        // likely a miss than a decision to abandon it. Cancel and Escape are
+        // still there, and both now keep the draft.
+        if (event.target !== event.currentTarget || busy || hasDraft) return;
+        onClose();
       }}
     >
       <section


### PR DESCRIPTION
A stray press beside the publish form dismissed it, and because the dialog unmounts on close, everything written was gone — reopening gave back an empty form.

Two changes, because there were two faults:

**The draft now lives outside the dialog.** It survives whichever way the dialog closes — backdrop, Escape, or Cancel — and reopening comes back to what was written. A completed publish clears it.

**The backdrop stops dismissing a form that has something in it.** A stray click beside a form someone has been writing in is far more likely a miss than a decision to abandon it, and Cancel is right there for the decision. An untouched form still closes on a backdrop click, so nothing gets harder to dismiss than it was.

## Validation

- unit: 1206 passed, including a new case that renders the dialog with a draft and asserts the name, description, and tags all come back
- Playwright: 217 passed. A new spec fills in the form, clicks the far corner of the backdrop, and asserts the dialog is still open with its text intact; then cancels, reopens, and asserts every field is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)