### PR TITLE
feat(editor): Check and Save, with a shelf for the last three circuits

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -4,6 +4,8 @@ import type { Page } from "@playwright/test";
 import { createEmptyProject } from "@icm/model";
 import { serializeProject } from "@icm/project-protocol";
 
+import { chooseComponent, clickCommand } from "./editor-fixtures.js";
+
 const ENTRY = {
   id: "g-ring",
   name: "Ring Oscillator",
@@ -598,6 +600,75 @@ test("a mistaken click beside the publish form keeps what was written", async ({
     "Gain boosted, 1.2 V supply, trimmed offset.",
   );
   await expect(dialog.getByTestId("publish-tag-cascode")).toBeVisible();
+});
+
+test("Check and Save shelves the circuit and the shelf reopens it", async ({
+  page,
+}) => {
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      json: {
+        user: {
+          id: "u1",
+          displayName: "Token Zhang",
+          email: "owner@example.com",
+          provider: "github",
+          isAdmin: false,
+        },
+      },
+    }),
+  );
+  const shelf: { id: string; name: string; projectText: string }[] = [];
+  await page.route("**/api/workspace/recent", (route) => {
+    if (route.request().method() === "POST") {
+      const body = route.request().postDataJSON() as {
+        name: string;
+        projectText: string;
+      };
+      // The server keeps the newest three; the client only has to send.
+      shelf.unshift({ id: `slot-${shelf.length}`, ...body });
+      return route.fulfill({
+        json: {
+          slots: shelf.slice(0, 3).map((slot) => ({
+            id: slot.id,
+            name: slot.name,
+            savedAt: "2026-08-23T00:00:00.000Z",
+            schemaVersion: ENTRY.schemaVersion,
+          })),
+        },
+      });
+    }
+    return route.fulfill({ json: { slots: [] } });
+  });
+  await page.route("**/api/workspace/recent/*", (route) => {
+    const id = new URL(route.request().url()).pathname.split("/").pop();
+    const slot = shelf.find((candidate) => candidate.id === id);
+    return slot
+      ? route.fulfill({
+          json: { name: slot.name, projectText: slot.projectText },
+        })
+      : route.fulfill({ status: 404, json: { error: "not-found" } });
+  });
+
+  await page.goto("/editor");
+  await chooseComponent(page, "nmos");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 360, y: 280 } });
+  await page.keyboard.press("Escape");
+  await page.getByTestId("check-and-save-button").click();
+
+  // A lone transistor is not a netlistable circuit, so the check reports it —
+  // and shelves it anyway. Unfinished work is the work worth keeping.
+  await expect(page.getByTestId("status")).toContainText("problems to resolve");
+  await expect(page.getByTestId("status")).toContainText("saved to your shelf");
+  expect(shelf).toHaveLength(1);
+  expect(shelf[0]!.projectText).toContain("nmos");
+
+  // And it comes back: the shelved circuit is listed under File and reopens.
+  await page.getByTestId("check-report-close").click();
+  await clickCommand(page, "File", shelf[0]!.name);
+  await expect(page.getByTestId("status")).toContainText("Opened");
 });
 
 test("an ordinary user sees blocking quality gates on an empty project", async ({

--- a/apps/editor/e2e/hierarchy.spec.ts
+++ b/apps/editor/e2e/hierarchy.spec.ts
@@ -343,8 +343,8 @@ test("declares a top Formal Cell Pin and exports the top interface", async ({
   }
   await expect(page.getByLabel("Cell Port properties")).toBeVisible();
 
-  await clickCommand(page, "Netlist", "Run Preflight…");
-  const preflight = page.getByRole("dialog", { name: "Netlist Preflight" });
+  await clickCommand(page, "Netlist", "Check Report…");
+  const preflight = page.getByRole("dialog", { name: "Check Report" });
   await expect(preflight.getByTestId("netlist-preview")).toContainText(
     ".subckt Main VIN",
   );
@@ -402,10 +402,10 @@ test("copies and independently deletes repeated Formal Cell Pin markers", async 
       .getByLabel("Cell Port properties")
       .getByLabel("Cell Port terminal name"),
   ).toHaveValue("VIN");
-  await clickCommand(page, "Netlist", "Run Preflight…");
+  await clickCommand(page, "Netlist", "Check Report…");
   await expect(
     page
-      .getByRole("dialog", { name: "Netlist Preflight" })
+      .getByRole("dialog", { name: "Check Report" })
       .getByTestId("netlist-preview"),
   ).toContainText(".subckt Main VIN");
 });
@@ -443,8 +443,8 @@ test("places a free Net Port whose rich label edits the Net name", async ({
   await page.getByTestId("hit-P1").click();
   await expect(netName).toHaveValue("VINP");
 
-  await clickCommand(page, "Netlist", "Run Preflight…");
-  const preflight = page.getByRole("dialog", { name: "Netlist Preflight" });
+  await clickCommand(page, "Netlist", "Check Report…");
+  const preflight = page.getByRole("dialog", { name: "Check Report" });
   await expect(preflight).not.toContainText("MISSING_DEVICE_DEFINITION");
   await expect(preflight.getByTestId("netlist-preview")).toContainText(
     ".subckt Main",

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -33,8 +33,8 @@ test("opens netlist preflight and navigates its canonical finding", async ({
 }) => {
   await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 360, y: 240 });
-  await clickCommand(page, "Netlist", "Run Preflight…");
-  const dialog = page.getByRole("dialog", { name: "Netlist Preflight" });
+  await clickCommand(page, "Netlist", "Check Report…");
+  const dialog = page.getByRole("dialog", { name: "Check Report" });
   await expect(dialog).toContainText("blocking issue");
   await dialog
     .getByRole("button", { name: /MISSING_PIN_NET/u })
@@ -49,8 +49,8 @@ test("previews a validated structural netlist in both export dialects", async ({
   page,
 }) => {
   await page.goto("/editor");
-  await clickCommand(page, "Netlist", "Run Preflight…");
-  const dialog = page.getByRole("dialog", { name: "Netlist Preflight" });
+  await clickCommand(page, "Netlist", "Check Report…");
+  const dialog = page.getByRole("dialog", { name: "Check Report" });
   const preview = dialog.getByTestId("netlist-preview");
   await expect(preview).toContainText(".subckt Main");
   await dialog.getByLabel("Netlist export format").selectOption("spectre");
@@ -2895,7 +2895,7 @@ test("requires warning review before exporting generated NoConnect nodes", async
     buffer: Buffer.from(JSON.stringify(project)),
   });
   await clickCommand(page, "File", "Export SPICE netlist");
-  const dialog = page.getByRole("dialog", { name: "Netlist Preflight" });
+  const dialog = page.getByRole("dialog", { name: "Check Report" });
   await expect(dialog).toContainText("GENERATED_NO_CONNECT_NODE");
   await expect(dialog.getByTestId("netlist-preview")).toContainText(
     "R1 IN NC0001 10k",

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -105,7 +105,11 @@ describe("editor shell", () => {
     expect(markup).toContain("Manage Cells…");
     expect(markup).toContain("Instance Table…");
     expect(markup).toContain("<summary>Netlist</summary>");
-    expect(markup).toContain("Run Preflight…");
+    expect(markup).toContain("Check Report…");
+    // "Preflight" named a stage of a netlist pipeline, not the question the
+    // person is asking; the toolbar carries the plain action.
+    expect(markup).not.toContain("Preflight…");
+    expect(markup).toContain('data-testid="check-and-save-button"');
     expect(markup).not.toContain("Edit Cell Interface…");
   });
 

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -310,6 +310,13 @@ import { useInteractionState } from "../interaction/interaction-state";
 import type { EditorTool } from "../interaction/interaction-state";
 import { resolveTextEditingTarget } from "../features/text-editing/text-editing";
 import { planMosBulkDefaultUpdate } from "../features/component-insert/mos-bulk-defaults";
+import { planCheckBulkDefaults } from "../features/netlist-export/check-and-save";
+import {
+  listWorkspaceShelf,
+  openWorkspaceSlot,
+  saveToWorkspaceShelf,
+  type WorkspaceSlot,
+} from "../features/editor-shell/workspace-shelf";
 import {
   defaultRazaviSymbolVariantId,
   materializeRazaviProjectBulkConnections,
@@ -725,6 +732,22 @@ export function App({
   const [publishGates, setPublishGates] = useState<SubmissionGateReport | null>(
     null,
   );
+  // Check and Save needs to know who is signed in before anyone opens the
+  // publish dialog, and the shelf it writes to is worth listing on arrival.
+  useEffect(() => {
+    let cancelled = false;
+    void fetchSessionUser().then(async (user) => {
+      if (cancelled) return;
+      setPublishSession(user);
+      if (!user) return;
+      const slots = await listWorkspaceShelf();
+      if (!cancelled) setWorkspaceSlots(slots);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   useEffect(() => {
     if (!publishGalleryOpen) return;
     let cancelled = false;
@@ -861,6 +884,10 @@ export function App({
   const [publishDraft, setPublishDraft] = useState<PublishGalleryDraft | null>(
     null,
   );
+  /** The signed-in account's last few checked circuits, newest first. */
+  const [workspaceSlots, setWorkspaceSlots] = useState<
+    readonly WorkspaceSlot[]
+  >([]);
   /**
    * The corner shape is a standing authoring preference, not per-wire state:
    * picking the wire tool again reset it, so a chosen diagonal had to be
@@ -5169,6 +5196,25 @@ export function App({
     });
   }
 
+  /** Open a shelved circuit through the same staging path a file uses. */
+  async function openShelvedCircuit(slot: WorkspaceSlot): Promise<void> {
+    const fetched = await openWorkspaceSlot(slot.id);
+    if (fetched.status !== "opened") {
+      setStatus(
+        fetched.status === "signed-out"
+          ? "Sign in again to open your shelf"
+          : fetched.status === "not-found"
+            ? "That shelved circuit is no longer there"
+            : `Could not reach your shelf (${fetched.message})`,
+      );
+      return;
+    }
+    await openProjectFile({
+      name: `${fetched.name}.icproj.json`,
+      text: () => Promise.resolve(fetched.projectText),
+    } as unknown as File);
+  }
+
   function loadVisualDemo(): void {
     const next = createVisualDemoProject();
     replaceActiveProject(next, { x: 20, y: -10, width: 430, height: 350 });
@@ -6198,18 +6244,69 @@ export function App({
     setStatus(`Exported revision ${document.revision}`);
   }
 
+  /**
+   * Check the circuit and shelve it. One button for the question people
+   * actually ask — "is this finished, and is it somewhere safe?" — instead of
+   * a menu entry named after a stage of a netlist pipeline.
+   *
+   * A failed check never withholds the save. Unfinished work is exactly the
+   * work worth keeping, and refusing to shelve it would make the button
+   * useless at the moment it matters most; the findings are reported and the
+   * copy is kept.
+   */
+  async function checkAndSave(): Promise<void> {
+    const bulkPlan = planCheckBulkDefaults(document);
+    if (bulkPlan.edits.length > 0) transact([...bulkPlan.edits]);
+    const ambiguousSides = [
+      bulkPlan.ambiguous.nmos ? "NMOS" : null,
+      bulkPlan.ambiguous.pmos ? "PMOS" : null,
+    ].filter((side): side is string => side !== null);
+
+    // Read the analysis from a fresh run: the Project has just been edited.
+    const checked = analyzeDesignNetlist(editorDocumentController.project);
+    const findings = !checked.ir
+      ? "problems to resolve"
+      : checked.diagnostics.length > 0
+        ? `${checked.diagnostics.length} warning(s)`
+        : ambiguousSides.length > 0
+          ? `${ambiguousSides.join(" and ")} bodies still need a supply chosen`
+          : null;
+    if (!checked.ir) setNetlistPreflightOpen(true);
+
+    const checkedNote = findings ? `Checked, ${findings}` : "Checked";
+    if (!publishSession) {
+      setStatus(`${checkedNote}; sign in to keep a copy on your shelf`);
+      return;
+    }
+    const outcome = await saveToWorkspaceShelf(
+      editorDocumentController.project,
+    );
+    if (outcome.status === "saved") {
+      setWorkspaceSlots(outcome.slots);
+      setStatus(`${checkedNote} — saved to your shelf`);
+      return;
+    }
+    setStatus(
+      outcome.status === "signed-out"
+        ? `${checkedNote}; sign in again to keep a copy on your shelf`
+        : outcome.status === "too-large"
+          ? `${checkedNote}; the circuit is too large for the shelf`
+          : `${checkedNote}; the shelf could not be reached (${outcome.message})`,
+    );
+  }
+
   function exportDesignNetlist(
     format: NetlistFormat,
     warningsReviewed = false,
   ): void {
     if (!netlistAnalysis.ir) {
       setNetlistPreflightOpen(true);
-      setStatus("Resolve Netlist Preflight findings before export");
+      setStatus("Resolve the Check Report findings before export");
       return;
     }
     if (netlistAnalysis.diagnostics.length > 0 && !warningsReviewed) {
       setNetlistPreflightOpen(true);
-      setStatus("Review Netlist Preflight warnings before export");
+      setStatus("Review the Check Report warnings before export");
       return;
     }
     const artifact = printDesignNetlist(format, netlistAnalysis.ir);
@@ -7365,6 +7462,22 @@ export function App({
                   <button type="button" onClick={saveProjectFile}>
                     Save Project
                   </button>
+                  {workspaceSlots.length > 0 ? (
+                    <>
+                      <span className="command-group-label">Your shelf</span>
+                      {workspaceSlots.map((slot) => (
+                        <button
+                          key={slot.id}
+                          type="button"
+                          data-testid={`shelf-slot-${slot.id}`}
+                          title={`Saved ${slot.savedAt}`}
+                          onClick={() => void openShelvedCircuit(slot)}
+                        >
+                          {slot.name}
+                        </button>
+                      ))}
+                    </>
+                  ) : null}
                   <button type="button" onClick={refreshApp}>
                     Refresh app
                   </button>
@@ -7527,14 +7640,14 @@ export function App({
                   >
                     Instance Table…
                   </button>
-                  <span className="command-group-label">Validation</span>
+                  <span className="command-group-label">Check</span>
                   <button
                     type="button"
                     aria-haspopup="dialog"
                     aria-expanded={netlistPreflightOpen}
                     onClick={() => setNetlistPreflightOpen(true)}
                   >
-                    Run Preflight…
+                    Check Report…
                   </button>
                 </div>
               </details>
@@ -7560,6 +7673,16 @@ export function App({
                   </div>
                 </details>
               ) : null}
+              <button
+                type="button"
+                className="toolbar-check-save"
+                data-testid="check-and-save-button"
+                title="Check the circuit and save it to your shelf"
+                onClick={() => void checkAndSave()}
+              >
+                <span className="toolbar-check-glyph" aria-hidden="true" />
+                Check and Save
+              </button>
               <button
                 type="button"
                 data-testid="publish-gallery-button"

--- a/apps/editor/src/features/editor-shell/workspace-shelf.test.ts
+++ b/apps/editor/src/features/editor-shell/workspace-shelf.test.ts
@@ -1,0 +1,91 @@
+import { createEmptyProject } from "@icm/model";
+import { describe, expect, it } from "vitest";
+
+import {
+  listWorkspaceShelf,
+  openWorkspaceSlot,
+  saveToWorkspaceShelf,
+} from "./workspace-shelf";
+
+const project = createEmptyProject("shelf", "Shelved Circuit");
+
+function respondWith(
+  status: number,
+  body: unknown,
+): {
+  fetchLike: typeof fetch;
+  calls: { url: string; init: RequestInit | undefined }[];
+} {
+  const calls: { url: string; init: RequestInit | undefined }[] = [];
+  const fetchLike = ((url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    return Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }) as unknown as typeof fetch;
+  return { fetchLike, calls };
+}
+
+describe("account workspace shelf client", () => {
+  it("posts the serialized project with the session cookie", async () => {
+    const { fetchLike, calls } = respondWith(200, {
+      slots: [
+        { id: "s1", name: "Shelved Circuit", savedAt: "z", schemaVersion: 1 },
+      ],
+    });
+    const outcome = await saveToWorkspaceShelf(project, fetchLike);
+    expect(outcome).toEqual({
+      status: "saved",
+      slots: [
+        { id: "s1", name: "Shelved Circuit", savedAt: "z", schemaVersion: 1 },
+      ],
+    });
+    expect(calls[0]!.url).toBe("/api/workspace/recent");
+    expect(calls[0]!.init?.credentials).toBe("same-origin");
+    const body = JSON.parse(String(calls[0]!.init?.body)) as { name: string };
+    expect(body.name).toBe("Shelved Circuit");
+  });
+
+  it("names the reason a save did not land", async () => {
+    for (const [status, expected] of [
+      [401, "signed-out"],
+      [413, "too-large"],
+      [500, "rejected"],
+    ] as const) {
+      const { fetchLike } = respondWith(status, {});
+      const outcome = await saveToWorkspaceShelf(project, fetchLike);
+      expect(outcome.status).toBe(expected);
+    }
+  });
+
+  it("treats an unreachable shelf as empty rather than as a failure", async () => {
+    const offline = (() =>
+      Promise.reject(new Error("offline"))) as unknown as typeof fetch;
+    expect(await listWorkspaceShelf(offline)).toEqual([]);
+    expect(await saveToWorkspaceShelf(project, offline)).toEqual({
+      status: "unreachable",
+      message: "offline",
+    });
+  });
+
+  it("reads one slot by id and reports a missing one", async () => {
+    const { fetchLike, calls } = respondWith(200, {
+      name: "Shelved Circuit",
+      projectText: "{}",
+    });
+    expect(await openWorkspaceSlot("s 1", fetchLike)).toEqual({
+      status: "opened",
+      name: "Shelved Circuit",
+      projectText: "{}",
+    });
+    expect(calls[0]!.url).toBe("/api/workspace/recent/s%201");
+
+    const { fetchLike: missing } = respondWith(404, {});
+    expect(await openWorkspaceSlot("gone", missing)).toEqual({
+      status: "not-found",
+    });
+  });
+});

--- a/apps/editor/src/features/editor-shell/workspace-shelf.ts
+++ b/apps/editor/src/features/editor-shell/workspace-shelf.ts
@@ -1,0 +1,124 @@
+import type { CircuitProject } from "@icm/model";
+import { serializeProject } from "@icm/project-protocol";
+
+/**
+ * The signed-in account's scratch shelf: the last few circuits it checked.
+ *
+ * This is not the Gallery and not a save. The `.icproj.json` file stays
+ * canonical, and nothing here is visible to anyone else — the shelf exists so
+ * a check does not leave the day's work living only in one browser tab. The
+ * session cookie is the whole credential, so this handles no secret, and the
+ * fetch seam keeps the mapping testable offline.
+ */
+
+/** How many circuits the shelf keeps; the server enforces the same number. */
+export const WORKSPACE_SLOT_LIMIT = 3;
+
+export interface WorkspaceSlot {
+  id: string;
+  name: string;
+  /** ISO 8601, from the server's clock rather than the browser's. */
+  savedAt: string;
+  schemaVersion: number;
+}
+
+export type WorkspaceSaveOutcome =
+  | { status: "saved"; slots: readonly WorkspaceSlot[] }
+  | { status: "signed-out" }
+  | { status: "too-large" }
+  | { status: "rejected"; message: string }
+  | { status: "unreachable"; message: string };
+
+export type WorkspaceOpenOutcome =
+  | { status: "opened"; name: string; projectText: string }
+  | { status: "signed-out" }
+  | { status: "not-found" }
+  | { status: "unreachable"; message: string };
+
+const ENDPOINT = "/api/workspace/recent";
+
+function failureFor(
+  response: Response,
+): Exclude<WorkspaceSaveOutcome, { status: "saved" }> {
+  if (response.status === 401) return { status: "signed-out" };
+  if (response.status === 413) return { status: "too-large" };
+  return {
+    status: "rejected",
+    message: `Shelf refused the circuit (${response.status})`,
+  };
+}
+
+export async function saveToWorkspaceShelf(
+  project: CircuitProject,
+  fetchLike: typeof fetch = fetch,
+): Promise<WorkspaceSaveOutcome> {
+  let response: Response;
+  try {
+    response = await fetchLike(ENDPOINT, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: project.name,
+        projectText: serializeProject(project),
+      }),
+    });
+  } catch (error) {
+    return {
+      status: "unreachable",
+      message: error instanceof Error ? error.message : "Network error",
+    };
+  }
+  if (!response.ok) return failureFor(response);
+  const payload = (await response.json().catch(() => null)) as {
+    slots?: WorkspaceSlot[];
+  } | null;
+  return { status: "saved", slots: payload?.slots ?? [] };
+}
+
+export async function listWorkspaceShelf(
+  fetchLike: typeof fetch = fetch,
+): Promise<readonly WorkspaceSlot[]> {
+  try {
+    const response = await fetchLike(ENDPOINT, {
+      credentials: "same-origin",
+    });
+    if (!response.ok) return [];
+    const payload = (await response.json().catch(() => null)) as {
+      slots?: WorkspaceSlot[];
+    } | null;
+    return payload?.slots ?? [];
+  } catch {
+    // A shelf that cannot be reached is empty, not an error worth a dialog.
+    return [];
+  }
+}
+
+export async function openWorkspaceSlot(
+  slotId: string,
+  fetchLike: typeof fetch = fetch,
+): Promise<WorkspaceOpenOutcome> {
+  let response: Response;
+  try {
+    response = await fetchLike(`${ENDPOINT}/${encodeURIComponent(slotId)}`, {
+      credentials: "same-origin",
+    });
+  } catch (error) {
+    return {
+      status: "unreachable",
+      message: error instanceof Error ? error.message : "Network error",
+    };
+  }
+  if (response.status === 401) return { status: "signed-out" };
+  if (!response.ok) return { status: "not-found" };
+  const payload = (await response.json().catch(() => null)) as {
+    name?: string;
+    projectText?: string;
+  } | null;
+  if (!payload?.projectText) return { status: "not-found" };
+  return {
+    status: "opened",
+    name: payload.name ?? "Circuit",
+    projectText: payload.projectText,
+  };
+}

--- a/apps/editor/src/features/netlist-export/check-and-save.test.ts
+++ b/apps/editor/src/features/netlist-export/check-and-save.test.ts
@@ -1,0 +1,105 @@
+import { createEmptyProject } from "@icm/model";
+import { describe, expect, it } from "vitest";
+
+import { planCheckBulkDefaults } from "./check-and-save";
+
+function documentWith(options: {
+  nets: { id: string; powerDomain?: "vdd" | "ground" }[];
+  instances: { id: string; symbolId: "nmos" | "pmos"; bound?: boolean }[];
+  defaults?: { nmosNetId?: string; pmosNetId?: string };
+}) {
+  const document = createEmptyProject("check", "Check").documents[0]!;
+  document.nets = options.nets.map((net) => ({
+    id: net.id,
+    scope: "local" as const,
+    terminals: [],
+    ...(net.powerDomain ? { powerDomain: net.powerDomain } : {}),
+  }));
+  document.instances = options.instances.map((instance) => ({
+    id: instance.id,
+    symbolId: instance.symbolId,
+    reference: instance.id,
+    parameters: {},
+    placement: { position: { x: 0, y: 0 }, rotation: 0, mirror: "none" },
+    ...(instance.bound
+      ? { mosBulkBinding: { netId: "n-gnd", origin: "explicit" as const } }
+      : {}),
+  })) as unknown as typeof document.instances;
+  if (options.defaults) document.mosBulkDefaults = options.defaults;
+  return document;
+}
+
+describe("check-time MOS bulk defaults", () => {
+  it("adopts the one ground and the one supply on the sheet", () => {
+    const plan = planCheckBulkDefaults(
+      documentWith({
+        nets: [
+          { id: "n-gnd", powerDomain: "ground" },
+          { id: "n-vdd", powerDomain: "vdd" },
+          { id: "n-sig" },
+        ],
+        instances: [
+          { id: "M1", symbolId: "nmos" },
+          { id: "M2", symbolId: "pmos" },
+        ],
+      }),
+    );
+    expect(plan.edits).toEqual([
+      { kind: "set_mos_bulk_defaults", nmosNetId: "n-gnd" },
+      { kind: "set_mos_bulk_defaults", pmosNetId: "n-vdd" },
+      { kind: "reconcile_mos_bulk" },
+    ]);
+    expect(plan.ambiguous).toEqual({ nmos: false, pmos: false });
+  });
+
+  it("refuses to choose between two supplies and says so", () => {
+    // AVDD versus VDD is a decision. A check is no better placed to guess at
+    // it than anything else, so it reports instead of picking.
+    const plan = planCheckBulkDefaults(
+      documentWith({
+        nets: [
+          { id: "n-gnd", powerDomain: "ground" },
+          { id: "n-vdd", powerDomain: "vdd" },
+          { id: "n-avdd", powerDomain: "vdd" },
+        ],
+        instances: [
+          { id: "M1", symbolId: "nmos" },
+          { id: "M2", symbolId: "pmos" },
+        ],
+      }),
+    );
+    expect(plan.ambiguous).toEqual({ nmos: false, pmos: true });
+    expect(plan.edits).toEqual([
+      { kind: "set_mos_bulk_defaults", nmosNetId: "n-gnd" },
+      { kind: "reconcile_mos_bulk" },
+    ]);
+  });
+
+  it("leaves a cell default that is already chosen alone", () => {
+    const plan = planCheckBulkDefaults(
+      documentWith({
+        nets: [
+          { id: "n-gnd", powerDomain: "ground" },
+          { id: "n-avdd", powerDomain: "ground" },
+        ],
+        instances: [{ id: "M1", symbolId: "nmos" }],
+        defaults: { nmosNetId: "n-gnd" },
+      }),
+    );
+    // Two grounds would be ambiguous, but nothing has to be chosen: the cell
+    // already named one, so the check only settles the bodies.
+    expect(plan.edits).toEqual([{ kind: "reconcile_mos_bulk" }]);
+    expect(plan.ambiguous).toEqual({ nmos: false, pmos: false });
+  });
+
+  it("plans nothing when every body is already wired", () => {
+    const plan = planCheckBulkDefaults(
+      documentWith({
+        nets: [{ id: "n-gnd", powerDomain: "ground" }],
+        instances: [{ id: "M1", symbolId: "nmos", bound: true }],
+      }),
+    );
+    expect(plan.edits).toEqual([]);
+    expect(plan.ambiguous).toEqual({ nmos: false, pmos: false });
+  });
+});

--- a/apps/editor/src/features/netlist-export/check-and-save.ts
+++ b/apps/editor/src/features/netlist-export/check-and-save.ts
@@ -1,0 +1,78 @@
+import type { SchematicEdit } from "@icm/edit-engine";
+import type { SchematicDocument } from "@icm/model";
+
+/**
+ * Bind the bodies nobody wired.
+ *
+ * An NMOS body belongs on ground and a PMOS body on the supply; leaving both
+ * unstated is the commonest reason a finished-looking schematic will not
+ * netlist. A check is the right moment to settle them, because it is the
+ * moment someone asks whether the circuit is complete.
+ *
+ * The cell defaults come first when they are already set. When they are not,
+ * a supply is adopted only if there is exactly one of that domain — one
+ * ground, or one supply rail. Two supplies is the case the bulk planners have
+ * always refused to guess at, and a check is no better placed to guess than
+ * anything else: AVDD and VDD are a decision, not a default.
+ */
+export interface BulkDefaultPlan {
+  edits: readonly SchematicEdit[];
+  /** Instances left unbound, and why, for the status line to report. */
+  ambiguous: { nmos: boolean; pmos: boolean };
+}
+
+function soleNetOfDomain(
+  document: SchematicDocument,
+  domain: "vdd" | "ground",
+): string | null {
+  const matches = document.nets.filter((net) => net.powerDomain === domain);
+  return matches.length === 1 ? matches[0]!.id : null;
+}
+
+function unboundCount(
+  document: SchematicDocument,
+  symbolId: "nmos" | "pmos",
+): number {
+  return document.instances.filter(
+    (instance) =>
+      instance.symbolId === symbolId &&
+      instance.placement !== null &&
+      !instance.mosBulkBinding,
+  ).length;
+}
+
+export function planCheckBulkDefaults(
+  document: SchematicDocument,
+): BulkDefaultPlan {
+  const edits: SchematicEdit[] = [];
+  const ambiguous = { nmos: false, pmos: false };
+
+  for (const [symbolId, domain, current] of [
+    ["nmos", "ground", document.mosBulkDefaults?.nmosNetId ?? null],
+    ["pmos", "vdd", document.mosBulkDefaults?.pmosNetId ?? null],
+  ] as const) {
+    if (unboundCount(document, symbolId) === 0) continue;
+    if (current) continue;
+    const netId = soleNetOfDomain(document, domain);
+    if (!netId) {
+      ambiguous[symbolId] = true;
+      continue;
+    }
+    edits.push(
+      symbolId === "nmos"
+        ? { kind: "set_mos_bulk_defaults", nmosNetId: netId }
+        : { kind: "set_mos_bulk_defaults", pmosNetId: netId },
+    );
+  }
+
+  // One reconcile settles every body the defaults now cover, including those
+  // a default already named before this check ran.
+  const reconcilable =
+    edits.length > 0 ||
+    (document.mosBulkDefaults?.nmosNetId != null &&
+      unboundCount(document, "nmos") > 0) ||
+    (document.mosBulkDefaults?.pmosNetId != null &&
+      unboundCount(document, "pmos") > 0);
+  if (reconcilable) edits.push({ kind: "reconcile_mos_bulk" });
+  return { edits, ambiguous };
+}

--- a/apps/editor/src/features/netlist-export/netlist-preflight-dialog.tsx
+++ b/apps/editor/src/features/netlist-export/netlist-preflight-dialog.tsx
@@ -45,7 +45,7 @@ export function NetlistPreflightDialog({
         <header className="insert-dialog-header">
           <div>
             <p>Canonical design-netlist analysis</p>
-            <h2 id="netlist-preflight-title">Netlist Preflight</h2>
+            <h2 id="netlist-preflight-title">Check Report</h2>
           </div>
         </header>
         <div className="insert-dialog-body">
@@ -118,7 +118,11 @@ export function NetlistPreflightDialog({
           ) : null}
         </div>
         <footer className="insert-dialog-actions">
-          <button type="button" onClick={onClose}>
+          <button
+            type="button"
+            data-testid="check-report-close"
+            onClick={onClose}
+          >
             Close
           </button>
         </footer>

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -456,6 +456,36 @@ body {
   white-space: nowrap;
 }
 
+/* Check and Save reads as the one forward action in the bar, so it carries a
+   green run glyph rather than another word among words. */
+.toolbar-check-save {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--icm-space-1);
+  min-height: var(--icm-control-h);
+  padding: 0 var(--icm-space-2);
+  border: 1px solid transparent;
+  border-radius: var(--icm-radius-sm);
+  background: transparent;
+  color: var(--icm-text);
+  font-size: var(--icm-font-md);
+  font-weight: 500;
+  line-height: var(--icm-line-tight);
+  white-space: nowrap;
+}
+
+.toolbar-check-save:hover:not(:disabled) {
+  background: var(--icm-surface-hover);
+}
+
+.toolbar-check-glyph {
+  width: 0;
+  height: 0;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 8px solid #1a8f4c;
+}
+
 .document-nav {
   display: flex;
   flex: 1 1 auto;

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -78,7 +78,7 @@ The **File** menu exports SVG, PNG, and PDF containing only formal schematic
 layers. PNG uses 3x raster scale. PDF contains that same high-resolution raster
 on a page matching the SVG viewBox.
 
-For an electrical design netlist, choose **Netlist / Run Preflight** first.
+For an electrical design netlist, choose **Netlist / Check Report** first, or press **Check and Save** in the toolbar to check the circuit and keep a copy on your account's shelf.
 The dialog reports every blocking electrical fact and, when valid, previews
 the deterministic structural SPICE or Spectre text. Use either the dialog's
 download button or **File / SPICE netlist** and **File / Spectre netlist** to

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -156,6 +156,135 @@ async function submitOne(
   return payload.id;
 }
 
+describe("account workspace shelf", () => {
+  function saveRequest(cookie: string, name: string): Request {
+    return new Request(`${ORIGIN}/api/workspace/recent`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Origin: ORIGIN,
+        Cookie: cookie,
+      },
+      body: JSON.stringify({ name, projectText: projectText(name) }),
+    });
+  }
+
+  it("keeps only the newest three circuits per account", async () => {
+    const env = environment();
+    const cookie = await makerOf(env);
+    for (const name of ["One", "Two", "Three", "Four"]) {
+      const saved = await route(env, saveRequest(cookie, name));
+      expect(saved.status).toBe(200);
+    }
+    const listed = await route(
+      env,
+      new Request(`${ORIGIN}/api/workspace/recent`, {
+        headers: cookieHeaders(cookie),
+      }),
+    );
+    const { slots } = (await listed.json()) as {
+      slots: { name: string; id: string }[];
+    };
+    expect(slots.map((slot) => slot.name)).toEqual(["Four", "Three", "Two"]);
+  });
+
+  it("is private to the account that saved it", async () => {
+    const env = environment();
+    const mine = await makerOf(env);
+    const saved = await route(env, saveRequest(mine, "Private"));
+    const { slots } = (await saved.json()) as { slots: { id: string }[] };
+    const slotId = slots[0]!.id;
+
+    const stranger = await adminOf(env);
+    const strangerRead = await route(
+      env,
+      new Request(`${ORIGIN}/api/workspace/recent/${slotId}`, {
+        headers: cookieHeaders(stranger),
+      }),
+    );
+    // An id is not a capability: even an admin reads only their own shelf.
+    expect(strangerRead.status).toBe(404);
+    const strangerList = await route(
+      env,
+      new Request(`${ORIGIN}/api/workspace/recent`, {
+        headers: cookieHeaders(stranger),
+      }),
+    );
+    expect((await strangerList.json()).slots).toEqual([]);
+
+    const own = await route(
+      env,
+      new Request(`${ORIGIN}/api/workspace/recent/${slotId}`, {
+        headers: cookieHeaders(mine),
+      }),
+    );
+    expect(own.status).toBe(200);
+    expect((await own.json()).projectText).toContain("Private");
+  });
+
+  it("refuses a signed-out visitor and an oversized or unparseable project", async () => {
+    const env = environment();
+    const anonymous = await route(
+      env,
+      new Request(`${ORIGIN}/api/workspace/recent`),
+    );
+    expect(anonymous.status).toBe(401);
+
+    const cookie = await makerOf(env);
+    const oversized = await route(
+      env,
+      new Request(`${ORIGIN}/api/workspace/recent`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          Origin: ORIGIN,
+          Cookie: cookie,
+        },
+        body: JSON.stringify({
+          name: "Huge",
+          projectText: "x".repeat(GALLERY_MAX_PROJECT_BYTES + 1),
+        }),
+      }),
+    );
+    expect(oversized.status).toBe(413);
+
+    const unparseable = await route(
+      env,
+      new Request(`${ORIGIN}/api/workspace/recent`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          Origin: ORIGIN,
+          Cookie: cookie,
+        },
+        body: JSON.stringify({ name: "Broken", projectText: "{" }),
+      }),
+    );
+    expect(unparseable.status).toBe(400);
+  });
+
+  it("saves whatever was checked, gates and all", async () => {
+    // The shelf is not the Gallery: nobody else sees it, so an unfinished
+    // circuit that would fail a submission gate still has to be keepable.
+    const env = environment();
+    const cookie = await makerOf(env);
+    const empty = serializeProject(createEmptyProject("blank", "Blank"));
+    const saved = await route(
+      env,
+      new Request(`${ORIGIN}/api/workspace/recent`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          Origin: ORIGIN,
+          Cookie: cookie,
+        },
+        body: JSON.stringify({ name: "Blank", projectText: empty }),
+      }),
+    );
+    expect(saved.status).toBe(200);
+  });
+});
+
 describe("gallery submissions", () => {
   it("publishes immediately with canonical text and a server preview", async () => {
     const env = environment();

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -22,6 +22,22 @@ import type { CircuitProject } from "@icm/model";
 import { sessionUserOf, type AuthNamespaceLike } from "./auth";
 
 export const GALLERY_MAX_PROJECT_BYTES = 2 * 1024 * 1024;
+/** How many circuits an account's scratch shelf keeps. */
+export const WORKSPACE_SLOT_LIMIT = 3;
+
+export interface WorkspaceSlotSummary {
+  id: string;
+  name: string;
+  savedAt: string;
+  schemaVersion: number;
+}
+
+interface WorkspaceSlotRow {
+  id: string;
+  name: string;
+  saved_at: string;
+  schema_version: number;
+}
 export const GALLERY_MAX_NAME_LENGTH = 120;
 export const GALLERY_MAX_AUTHOR_LENGTH = 40;
 export const GALLERY_MAX_DESCRIPTION_LENGTH = 300;
@@ -193,6 +209,23 @@ export class GalleryDO {
       CREATE INDEX IF NOT EXISTS idx_gallery_entry_versions_entry
       ON gallery_entry_versions(entry_id, version_no)
     `);
+    // A signed-in account's own scratch shelf: the last few circuits it
+    // checked, kept so work survives a closed tab or a different machine.
+    // Not the Gallery — nothing here is published or visible to anyone else.
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS workspace_slots (
+        id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        saved_at TEXT NOT NULL,
+        schema_version INTEGER NOT NULL,
+        project_text TEXT NOT NULL
+      ) WITHOUT ROWID
+    `);
+    this.sql.exec(`
+      CREATE INDEX IF NOT EXISTS idx_workspace_slots_user
+      ON workspace_slots(user_id, saved_at)
+    `);
     // Additive columns for pre-existing databases.
     for (const alteration of [
       "ALTER TABLE gallery_entries ADD COLUMN reject_reason TEXT",
@@ -258,6 +291,12 @@ export class GalleryDO {
         return this.version(String(body.entryId), String(body.versionId));
       case "restore-version":
         return this.restoreVersion(body);
+      case "workspace-save":
+        return this.workspaceSave(body);
+      case "workspace-list":
+        return this.workspaceList(String(body.userId));
+      case "workspace-open":
+        return this.workspaceOpen(String(body.userId), String(body.id));
       default:
         return Response.json({ error: "Unknown operation" }, { status: 404 });
     }
@@ -568,6 +607,80 @@ export class GalleryDO {
     });
   }
 
+  /**
+   * Keep the newest few slots per account and drop the rest. A shelf that
+   * grew without bound would be storage, and this is deliberately not that:
+   * the Project file stays canonical and the Gallery stays the place work is
+   * published.
+   */
+  private workspaceSave(body: Record<string, unknown>): Response {
+    const userId = String(body.userId);
+    const id = String(body.id);
+    this.sql.exec(
+      `INSERT INTO workspace_slots
+         (id, user_id, name, saved_at, schema_version, project_text)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      id,
+      userId,
+      String(body.name),
+      String(body.savedAt),
+      Number(body.schemaVersion),
+      String(body.projectText),
+    );
+    this.sql.exec(
+      `DELETE FROM workspace_slots
+       WHERE user_id = ?
+         AND id NOT IN (
+           SELECT id FROM workspace_slots WHERE user_id = ?
+           ORDER BY saved_at DESC, id DESC LIMIT ?
+         )`,
+      userId,
+      userId,
+      WORKSPACE_SLOT_LIMIT,
+    );
+    return Response.json({ id, slots: this.workspaceRows(userId) });
+  }
+
+  private workspaceRows(userId: string): WorkspaceSlotSummary[] {
+    return this.sql
+      .exec<WorkspaceSlotRow>(
+        `SELECT id, name, saved_at, schema_version FROM workspace_slots
+         WHERE user_id = ? ORDER BY saved_at DESC, id DESC LIMIT ?`,
+        userId,
+        WORKSPACE_SLOT_LIMIT,
+      )
+      .toArray()
+      .map((row) => ({
+        id: row.id,
+        name: row.name,
+        savedAt: row.saved_at,
+        schemaVersion: row.schema_version,
+      }));
+  }
+
+  private workspaceList(userId: string): Response {
+    return Response.json({ slots: this.workspaceRows(userId) });
+  }
+
+  private workspaceOpen(userId: string, id: string): Response {
+    // Scoped by account as well as id: a slot id is never a capability.
+    const row = this.sql
+      .exec<WorkspaceSlotRow & { project_text: string }>(
+        "SELECT * FROM workspace_slots WHERE id = ? AND user_id = ?",
+        id,
+        userId,
+      )
+      .toArray()[0];
+    if (!row) return Response.json({ error: "not-found" }, { status: 404 });
+    return Response.json({
+      id: row.id,
+      name: row.name,
+      savedAt: row.saved_at,
+      schemaVersion: row.schema_version,
+      projectText: row.project_text,
+    });
+  }
+
   private setStatus(id: string, status: string, at: string): Response {
     const row = this.sql
       .exec<EntryRow>("SELECT * FROM gallery_entries WHERE id = ?", id)
@@ -748,6 +861,66 @@ function renderPreview(project: CircuitProject): string {
     (document) => document.id === project.topDocumentId,
   )!;
   return renderDocumentSvg(topDocument, resolver);
+}
+
+/**
+ * An account's own scratch shelf. Unlike a submission this is never seen by
+ * anyone else, is not gated on quality, and holds only the newest few — it
+ * exists so a check does not leave work living solely in one browser tab.
+ */
+async function handleWorkspace(
+  request: Request,
+  env: GalleryEnv,
+  slotId: string | null,
+): Promise<Response> {
+  if (request.method !== "GET" && !sameOrigin(request)) {
+    return Response.json({ error: "forbidden" }, { status: 403 });
+  }
+  const user = await sessionUserOf(request, env);
+  if (!user) return Response.json({ error: "unauthorized" }, { status: 401 });
+
+  if (request.method === "GET") {
+    const { status, payload } = slotId
+      ? await callGallery(env, "workspace-open", {
+          userId: user.id,
+          id: slotId,
+        })
+      : await callGallery(env, "workspace-list", { userId: user.id });
+    return Response.json(payload, {
+      status,
+      headers: { "cache-control": "no-store" },
+    });
+  }
+
+  const body = (await request.json().catch(() => null)) as {
+    name?: unknown;
+    projectText?: unknown;
+  } | null;
+  const name = fieldText(body?.name, GALLERY_MAX_NAME_LENGTH);
+  if (!body || !name || typeof body.projectText !== "string") {
+    return Response.json({ error: "invalid-fields" }, { status: 400 });
+  }
+  if (
+    new TextEncoder().encode(body.projectText).length >
+    GALLERY_MAX_PROJECT_BYTES
+  ) {
+    return Response.json({ error: "too-large" }, { status: 413 });
+  }
+  let project: CircuitProject;
+  try {
+    project = parseProject(body.projectText);
+  } catch {
+    return Response.json({ error: "invalid-project" }, { status: 400 });
+  }
+  const { status, payload } = await callGallery(env, "workspace-save", {
+    userId: user.id,
+    id: crypto.randomUUID(),
+    name,
+    savedAt: new Date().toISOString(),
+    schemaVersion: project.schemaVersion,
+    projectText: body.projectText,
+  });
+  return Response.json(payload, { status });
 }
 
 async function handleSubmission(
@@ -970,6 +1143,19 @@ export async function routeGalleryRequest(
   env: GalleryEnv,
 ): Promise<Response | null> {
   const url = new URL(request.url);
+  if (url.pathname === "/api/workspace/recent") {
+    if (request.method === "GET" || request.method === "POST") {
+      return handleWorkspace(request, env, null);
+    }
+    return Response.json({ error: "Not found" }, { status: 404 });
+  }
+  if (url.pathname.startsWith("/api/workspace/recent/")) {
+    const slotId = url.pathname.slice("/api/workspace/recent/".length);
+    if (request.method === "GET" && slotId.length > 0) {
+      return handleWorkspace(request, env, slotId);
+    }
+    return Response.json({ error: "Not found" }, { status: 404 });
+  }
   if (!url.pathname.startsWith("/api/gallery")) return null;
   const segments = url.pathname.split("/").filter(Boolean).slice(2);
 


### PR DESCRIPTION
"Run Preflight" named a stage of a netlist pipeline rather than the question anyone was asking, and it was buried in a menu. The toolbar now carries one green-triangle button for the question itself — *is this finished, and is it somewhere safe?* The menu entry and the report it opens are called **Check Report**.

## The check settles MOS bodies first

Leaving NMOS and PMOS bodies unstated is the commonest reason a finished-looking schematic will not netlist, and a check is the moment someone asks whether the circuit is complete.

- A cell default already chosen is used as-is.
- Otherwise a supply is adopted only when **exactly one** net of that domain exists — one ground, one rail.
- Two supplies stays a decision. AVDD versus VDD is not something a check is better placed to guess at than any other planner, so it reports which side still needs choosing rather than picking.

## The shelf

The save goes to the signed-in account's own shelf: the newest three circuits, listed under **File** so they reopen through the same staging path a file uses. It is private (an id is not a capability — scoped by account, so even an admin reads only their own), ungated, and never the Gallery. The `.icproj.json` file stays canonical; nothing here is published.

**A failed check never withholds the save.** Unfinished work is exactly the work worth keeping, and refusing to shelve it would make the button useless at the moment it matters most — so the findings are reported and the copy is kept either way. Signed out, the check still runs and the status says where a copy would have gone.

## Validation

- unit: 1218 passed. New worker cases cover the three-slot cap, cross-account isolation (a stranger gets 404 on a known id and an empty list), signed-out/oversized/unparseable rejection, and that an empty project a submission gate would block is still shelvable. New editor cases cover the bulk-default planner's four outcomes and the shelf client's request shape, failure mapping, and offline behaviour.
- Playwright: 218 passed, including a new spec that places a transistor, presses Check and Save, and asserts both that the report named the problem *and* that the circuit reached the shelf — then closes the report, reopens the circuit from File, and confirms it loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)