### PR TITLE
feat(editor): save back to the chosen file, and say so when exporting

### DIFF
--- a/apps/editor/e2e/project-file.spec.ts
+++ b/apps/editor/e2e/project-file.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
@@ -87,7 +87,9 @@ test("reports a confirmed File System Access save", async ({ page }) => {
   });
   await page.goto("/editor");
   const fileMenu = await openMenu(page, "File");
-  await fileMenu.getByRole("button", { name: "Save Project" }).click();
+  await fileMenu
+    .getByRole("button", { name: "Save Project", exact: true })
+    .click();
   await expect(page.getByTestId("status")).toContainText(
     "Saved chosen.icproj.json (write confirmed)",
   );
@@ -99,6 +101,131 @@ test("reports a confirmed File System Access save", async ({ page }) => {
   expect(write).not.toBeNull();
   expect(JSON.parse(write!.text).schemaVersion).toBe(
     CURRENT_PROJECT_SCHEMA_VERSION,
+  );
+});
+
+/** A picker that records how often it was opened and what was written. */
+async function installCountingPicker(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const state = { opened: 0, writes: [] as string[] };
+    (window as unknown as { __fsa: typeof state }).__fsa = state;
+    (window as unknown as { showSaveFilePicker?: unknown }).showSaveFilePicker =
+      async () => {
+        state.opened += 1;
+        return {
+          name: "chosen.icproj.json",
+          createWritable: async () => ({
+            write: async (data: string) => {
+              state.writes.push(data);
+            },
+            close: async () => undefined,
+            abort: async () => undefined,
+          }),
+        };
+      };
+  });
+}
+
+function pickerState(page: Page) {
+  return page.evaluate(
+    () =>
+      (window as unknown as { __fsa: { opened: number; writes: string[] } })
+        .__fsa,
+  );
+}
+
+test("a second save writes back to the chosen file without asking again", async ({
+  page,
+}) => {
+  await installCountingPicker(page);
+  await page.goto("/editor");
+
+  const fileMenu = await openMenu(page, "File");
+  await fileMenu
+    .getByRole("button", { name: "Save Project", exact: true })
+    .click();
+  await expect(page.getByTestId("status")).toContainText("write confirmed");
+  expect((await pickerState(page)).opened).toBe(1);
+
+  await chooseComponent(page, "resistor");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 360, y: 230 } });
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("revision")).toHaveText("1");
+
+  const again = await openMenu(page, "File");
+  await again
+    .getByRole("button", { name: "Save Project", exact: true })
+    .click();
+  await expect(page.getByTestId("status")).toContainText("write confirmed");
+
+  // The point of remembering the location: no second dialog, a second write.
+  const state = await pickerState(page);
+  expect(state.opened).toBe(1);
+  expect(state.writes).toHaveLength(2);
+});
+
+test("Save Project As… asks for a location even after one is remembered", async ({
+  page,
+}) => {
+  await installCountingPicker(page);
+  await page.goto("/editor");
+
+  const fileMenu = await openMenu(page, "File");
+  await fileMenu
+    .getByRole("button", { name: "Save Project", exact: true })
+    .click();
+  await expect(page.getByTestId("status")).toContainText("write confirmed");
+
+  const again = await openMenu(page, "File");
+  await again.getByTestId("save-project-as").click();
+  await expect(page.getByTestId("status")).toContainText("write confirmed");
+  expect((await pickerState(page)).opened).toBe(2);
+});
+
+test("exporting writes the remembered Project file back too", async ({
+  page,
+}) => {
+  await installCountingPicker(page);
+  await page.goto("/editor");
+
+  const fileMenu = await openMenu(page, "File");
+  await fileMenu
+    .getByRole("button", { name: "Save Project", exact: true })
+    .click();
+  await expect(page.getByTestId("status")).toContainText("write confirmed");
+
+  await chooseComponent(page, "resistor");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 360, y: 230 } });
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("revision")).toHaveText("1");
+
+  await downloadBytes(page, "File", "Export SVG");
+  await expect(page.getByTestId("status")).toContainText(
+    "also saved chosen.icproj.json",
+  );
+  expect((await pickerState(page)).writes).toHaveLength(2);
+});
+
+test("exporting says so when the Project file is behind and cannot be written", async ({
+  page,
+}) => {
+  // Download-only browser: there is no location to write back to, so the
+  // export must say what is stale rather than open a picker nobody asked for.
+  await page.goto("/editor");
+  await chooseComponent(page, "resistor");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 360, y: 230 } });
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("revision")).toHaveText("1");
+
+  await downloadBytes(page, "File", "Export SVG");
+  await expect(page.getByTestId("status")).toContainText(
+    "the Project file still has unsaved changes",
   );
 });
 
@@ -144,7 +271,9 @@ test("keeps the Project and recovery intact when the save stream fails", async (
   await expect(page.getByTestId("revision")).toHaveText("1");
 
   const fileMenu = await openMenu(page, "File");
-  await fileMenu.getByRole("button", { name: "Save Project" }).click();
+  await fileMenu
+    .getByRole("button", { name: "Save Project", exact: true })
+    .click();
   await expect(page.getByTestId("status")).toContainText(
     "Save failed at write",
   );

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -328,9 +328,11 @@ import {
   downloadTextArtifact,
   formatProjectOpenDiagnostics,
   requestProjectDownload,
+  resaveProjectArtifact,
   saveProjectArtifact,
   stageProjectFile,
   type ProjectFileState,
+  type ProjectSaveTarget,
 } from "../document/project-file-service";
 import type { BrowserRecoveryGeneration } from "../document/browser-recovery-contract";
 import { projectFileBaseName } from "../document/project-file-service";
@@ -598,6 +600,10 @@ export function App({
   // state: a commit makes it dirty again, only a confirmed File System
   // Access close or an explicit download transitions it out of dirty.
   const [fileState, setFileState] = useState<ProjectFileState>("new");
+  // Where this working copy was last written, so Save writes back instead of
+  // asking again. A runtime capability, never persisted: it is dropped
+  // whenever the whole project is replaced, and it dies with the tab.
+  const saveTargetRef = useRef<ProjectSaveTarget | null>(null);
   const fileStateBaselineRef = useRef<{
     session: string;
     revision: number;
@@ -3187,6 +3193,10 @@ export function App({
     setDocumentStack([]);
     setViewBox(nextViewBox, nextDocument.presentation.grid);
     resetInteractionState();
+    // The incoming project has no file of its own yet; keeping the outgoing
+    // one's location would let a later Save quietly overwrite a different
+    // circuit's file.
+    saveTargetRef.current = null;
     setFileState(options.source === "opened-file" ? "opened" : "new");
     // Seed the incoming working copy immediately; the outgoing project's
     // stored records are retained under its own session.
@@ -4897,12 +4907,17 @@ export function App({
     window.setTimeout(() => URL.revokeObjectURL(url), 0);
   }
 
-  async function saveProjectFile(): Promise<void> {
+  async function saveProjectFile(options: { pickLocation?: boolean } = {}) {
     // Saving or downloading never clears the browser recovery copies. Only a
     // confirmed File System Access close reports a confirmed write; the
     // fallback download is reported as requested, not saved.
-    const outcome = await saveProjectArtifact(project);
+    const outcome = await saveProjectArtifact(
+      project,
+      {},
+      options.pickLocation ? null : saveTargetRef.current,
+    );
     if (outcome.status === "write-confirmed") {
+      saveTargetRef.current = outcome.target ?? null;
       noteRecoveryFormalFileHint({
         name: outcome.fileName,
         lastConfirmedWriteAt: outcome.at,
@@ -4937,7 +4952,40 @@ export function App({
       );
       return;
     }
+    if (outcome.status === "target-unavailable") {
+      // Only the silent path reports this; an explicit save falls back to
+      // the picker rather than reaching here.
+      setStatus("Save location is no longer available — choose one again");
+      return;
+    }
     setStatus(`Project could not be serialized: ${outcome.message}`);
+  }
+
+  /**
+   * Exporting is the strongest signal we get that a circuit matters, so it is
+   * the right moment to make sure the project file is not left behind. When a
+   * location is already granted the write happens silently; otherwise this
+   * says so rather than opening a picker nobody asked for.
+   */
+  async function reportExport(message: string): Promise<void> {
+    if (!isDirtyWork()) {
+      setStatus(message);
+      return;
+    }
+    const target = saveTargetRef.current;
+    if (target) {
+      const outcome = await resaveProjectArtifact(project, target);
+      if (outcome.status === "write-confirmed") {
+        noteRecoveryFormalFileHint({
+          name: outcome.fileName,
+          lastConfirmedWriteAt: outcome.at,
+        });
+        setFileState("write-confirmed");
+        setStatus(`${message} — also saved ${outcome.fileName}`);
+        return;
+      }
+    }
+    setStatus(`${message} — the Project file still has unsaved changes`);
   }
 
   function isDirtyWork(): boolean {
@@ -6195,7 +6243,7 @@ export function App({
       title: project.name,
     });
     download(source.svg, "image/svg+xml", "svg");
-    setStatus(`Exported revision ${document.revision}`);
+    void reportExport(`Exported revision ${document.revision}`);
   }
 
   function exportDesignNetlist(
@@ -6214,7 +6262,7 @@ export function App({
     }
     const artifact = printDesignNetlist(format, netlistAnalysis.ir);
     download(artifact.text, artifact.mediaType, artifact.extension.slice(1));
-    setStatus(
+    void reportExport(
       `Download requested: ${safeExportBaseName(project.name)}${artifact.extension}`,
     );
   }
@@ -6232,7 +6280,7 @@ export function App({
         const { pdf } = await exportFormalArtifactsInBrowser(source);
         download(pdf as BlobPart, "application/pdf", "pdf");
       }
-      setStatus(
+      await reportExport(
         `Exported ${format.toUpperCase()} revision ${document.revision}`,
       );
     } catch (error) {
@@ -7072,7 +7120,7 @@ export function App({
           setStatus("Select objects before moving them");
           return;
         case "save":
-          saveProjectFile();
+          void saveProjectFile();
           return;
         case "open":
           projectInputRef.current?.click();
@@ -7362,8 +7410,17 @@ export function App({
               <details className="command-menu" name="editor-command-menu">
                 <summary>File</summary>
                 <div className="command-popover">
-                  <button type="button" onClick={saveProjectFile}>
+                  <button type="button" onClick={() => void saveProjectFile()}>
                     Save Project
+                  </button>
+                  {/* Save writes back to the chosen file without asking
+                      again, so choosing a different one needs its own way in. */}
+                  <button
+                    type="button"
+                    data-testid="save-project-as"
+                    onClick={() => void saveProjectFile({ pickLocation: true })}
+                  >
+                    Save Project As…
                   </button>
                   <button type="button" onClick={refreshApp}>
                     Refresh app

--- a/apps/editor/src/document/project-file-service.test.ts
+++ b/apps/editor/src/document/project-file-service.test.ts
@@ -7,9 +7,11 @@ import {
   formatProjectOpenDiagnostics,
   projectFileBaseName,
   requestProjectDownload,
+  resaveProjectArtifact,
   saveProjectArtifact,
   stageProjectFile,
   type ProjectFileServiceSeams,
+  type ProjectSaveTarget,
 } from "./project-file-service";
 
 const project = createEmptyProject("project-alpha", 'Alpha/Amp "One"');
@@ -44,10 +46,13 @@ function memoryPicker(
       if (session) session.aborted = true;
     },
   };
+  const counters = { pickerCalls: 0 };
   return {
     calls,
+    counters,
     window: {
       showSaveFilePicker: async () => {
+        counters.pickerCalls += 1;
         if (options.pickerError) throw options.pickerError;
         return {
           name: options.handleName ?? "picker-name.icproj.json",
@@ -60,6 +65,43 @@ function memoryPicker(
       },
     },
   };
+}
+
+/** A location already granted (or not), standing in for a stored handle. */
+function memoryTarget(
+  options: {
+    permission?: "granted" | "denied" | "prompt";
+    grantOnRequest?: boolean;
+    createWritableError?: Error;
+  } = {},
+) {
+  const writes: string[] = [];
+  const counters = { queried: 0, requested: 0 };
+  const target: ProjectSaveTarget = {
+    fileName: "remembered.icproj.json",
+    handle: {
+      name: "remembered.icproj.json",
+      queryPermission: async () => {
+        counters.queried += 1;
+        return options.permission ?? "granted";
+      },
+      requestPermission: async () => {
+        counters.requested += 1;
+        return options.grantOnRequest ? "granted" : "denied";
+      },
+      createWritable: async () => {
+        if (options.createWritableError) throw options.createWritableError;
+        return {
+          write: async (data: string | BufferSource | Blob) => {
+            writes.push(String(data));
+          },
+          close: async () => {},
+          abort: async () => {},
+        };
+      },
+    },
+  };
+  return { target, writes, counters };
 }
 
 function downloadSeams() {
@@ -121,7 +163,7 @@ describe("saveProjectArtifact", () => {
       getWindow: () => picker.window,
       now: () => "2026-08-14T12:00:00.000Z",
     });
-    expect(outcome).toEqual({
+    expect(outcome).toMatchObject({
       status: "write-confirmed",
       fileName: "picker-name.icproj.json",
       bytes: new TextEncoder().encode(serializeProject(project)).length,
@@ -203,6 +245,109 @@ describe("saveProjectArtifact", () => {
     expect(anchors[0]?.download).toBe("Alpha-Amp -One-.icproj.json");
     expect(anchors[0]?.clicked).toBe(true);
     expect(urls).toHaveLength(0);
+  });
+});
+
+describe("saving back to a location already chosen", () => {
+  it("hands back a reusable target and writes through it without asking again", async () => {
+    const picker = memoryPicker();
+    const seams = { getWindow: () => picker.window };
+
+    const first = await saveProjectArtifact(project, seams);
+    expect(first.status).toBe("write-confirmed");
+    const target = first.status === "write-confirmed" ? first.target : null;
+    expect(target).toBeTruthy();
+    expect(picker.counters.pickerCalls).toBe(1);
+
+    const second = await saveProjectArtifact(project, seams, target);
+    expect(second).toMatchObject({
+      status: "write-confirmed",
+      fileName: "picker-name.icproj.json",
+    });
+    // The whole point: the second save wrote the file without a dialog.
+    expect(picker.counters.pickerCalls).toBe(1);
+    expect(picker.calls).toHaveLength(2);
+  });
+
+  it("re-saves silently while the grant stands", async () => {
+    const { target, writes, counters } = memoryTarget();
+    const outcome = await resaveProjectArtifact(project, target);
+    expect(outcome).toMatchObject({
+      status: "write-confirmed",
+      fileName: "remembered.icproj.json",
+    });
+    expect(writes).toEqual([serializeProject(project)]);
+    expect(counters.queried).toBe(1);
+  });
+
+  it("declines a silent re-save rather than raising a permission prompt", async () => {
+    const { target, writes, counters } = memoryTarget({
+      permission: "prompt",
+      grantOnRequest: true,
+    });
+    const outcome = await resaveProjectArtifact(project, target);
+    // Granting would have succeeded, which is exactly why the silent path
+    // must not ask: the person did not press Save.
+    expect(outcome).toEqual({ status: "target-unavailable" });
+    expect(counters.requested).toBe(0);
+    expect(writes).toEqual([]);
+  });
+
+  it("an explicit save may prompt, and writes once granted", async () => {
+    const picker = memoryPicker();
+    const { target, writes } = memoryTarget({
+      permission: "prompt",
+      grantOnRequest: true,
+    });
+    const outcome = await saveProjectArtifact(
+      project,
+      { getWindow: () => picker.window },
+      target,
+    );
+    expect(outcome.status).toBe("write-confirmed");
+    expect(writes).toHaveLength(1);
+    expect(picker.counters.pickerCalls).toBe(0);
+  });
+
+  it("falls back to the picker when the remembered location has gone", async () => {
+    const picker = memoryPicker();
+    const { target } = memoryTarget({
+      createWritableError: new Error("file removed"),
+    });
+    const outcome = await saveProjectArtifact(
+      project,
+      { getWindow: () => picker.window },
+      target,
+    );
+    // A stale target must not wedge saving.
+    expect(outcome).toMatchObject({
+      status: "write-confirmed",
+      fileName: "picker-name.icproj.json",
+    });
+    expect(picker.counters.pickerCalls).toBe(1);
+  });
+
+  it("reports a mid-write failure instead of silently retrying elsewhere", async () => {
+    const picker = memoryPicker();
+    const target: ProjectSaveTarget = {
+      fileName: "remembered.icproj.json",
+      handle: {
+        createWritable: async () => ({
+          write: async () => {
+            throw new Error("disk full");
+          },
+          close: async () => {},
+          abort: async () => {},
+        }),
+      },
+    };
+    const outcome = await saveProjectArtifact(
+      project,
+      { getWindow: () => picker.window },
+      target,
+    );
+    expect(outcome).toMatchObject({ status: "write-failed", stage: "write" });
+    expect(picker.counters.pickerCalls).toBe(0);
   });
 });
 

--- a/apps/editor/src/document/project-file-service.ts
+++ b/apps/editor/src/document/project-file-service.ts
@@ -15,8 +15,17 @@
 //   approved-symbol validation) before the caller may replace the live
 //   Project, and rejected input leaves everything unchanged.
 //
+// A confirmed save hands back a `ProjectSaveTarget` so later saves can write
+// straight to the location already chosen: asking for a location on every
+// save is what left so many projects saved exactly once. Two entry points
+// keep that honest — `saveProjectArtifact` is the explicit save and may
+// prompt or open the picker, while `resaveProjectArtifact` is silent and
+// reports `target-unavailable` rather than raising a dialog nobody asked
+// for.
+//
 // File handles are transient runtime capabilities: nothing here serializes a
-// handle into Project JSON or a recovery record.
+// handle into Project JSON or a recovery record, and a target dies with the
+// tab.
 
 import {
   serializeProject,
@@ -57,15 +66,30 @@ export type ProjectFileOpenOutcome =
     }
   | { status: "rejected"; diagnostics: ProjectFileOpenDiagnostic[] };
 
+/**
+ * A location the person already chose, so a later save can write straight
+ * back to it instead of asking again. Transient by the module contract
+ * above: it is never serialized into Project JSON or a recovery record, and
+ * it dies with the tab.
+ */
+export interface ProjectSaveTarget {
+  readonly handle: ProjectFileHandleLike;
+  readonly fileName: string;
+}
+
 export type ProjectSaveOutcome =
   | {
       status: "write-confirmed";
       fileName: string;
       bytes: number;
       at: string;
+      /** Present when the platform gave us a reusable location. */
+      target?: ProjectSaveTarget;
     }
   | { status: "download-requested"; fileName: string; bytes: number }
   | { status: "picker-cancelled" }
+  /** A silent re-save found no usable grant and declined to interrupt. */
+  | { status: "target-unavailable" }
   | { status: "permission-denied"; message: string }
   | {
       status: "write-failed";
@@ -88,11 +112,19 @@ interface ProjectWritableStreamLike {
   abort?(reason?: unknown): Promise<void>;
 }
 
-interface ProjectFileHandleLike {
+type ProjectFilePermissionState = "granted" | "denied" | "prompt";
+
+export interface ProjectFileHandleLike {
   name?: string;
   createWritable(options?: {
     keepExistingData?: boolean;
   }): Promise<ProjectWritableStreamLike>;
+  queryPermission?(descriptor?: {
+    mode?: "read" | "readwrite";
+  }): Promise<ProjectFilePermissionState>;
+  requestPermission?(descriptor?: {
+    mode?: "read" | "readwrite";
+  }): Promise<ProjectFilePermissionState>;
 }
 
 interface ProjectFileAnchorLike {
@@ -217,6 +249,7 @@ export function downloadTextArtifact(
 export async function saveProjectArtifact(
   project: CircuitProject,
   seams: ProjectFileServiceSeams = {},
+  target: ProjectSaveTarget | null = null,
 ): Promise<ProjectSaveOutcome> {
   let text: string;
   try {
@@ -226,6 +259,21 @@ export async function saveProjectArtifact(
   }
   const bytes = new TextEncoder().encode(text).length;
   const suggestedName = `${projectFileBaseName(project.name)}.icproj.json`;
+
+  // Write straight back to the location this person already chose. Asking
+  // again on every save is what left so many projects saved exactly once.
+  if (target) {
+    if (await hasWritePermission(target.handle, { mayPrompt: true })) {
+      const outcome = await writeThrough(target, text, bytes, seams);
+      // A stale target — file moved, renamed, or deleted — must not wedge
+      // saving, so only a failure to *open* the stream falls through to the
+      // picker. A failure mid-write is reported, never silently retried.
+      if (!(outcome.status === "write-failed" && outcome.stage === "open")) {
+        return outcome;
+      }
+    }
+  }
+
   const pickerWindow = seams.getWindow?.() ?? defaultWindow();
   const picker = pickerWindow?.showSaveFilePicker;
   if (typeof picker !== "function") {
@@ -264,9 +312,51 @@ export async function saveProjectArtifact(
     return { status: "permission-denied", message: errorMessage(error) };
   }
 
+  return writeThrough(
+    { handle, fileName: handle.name ?? suggestedName },
+    text,
+    bytes,
+    seams,
+  );
+}
+
+/**
+ * Write back to a location the person already chose, without interrupting
+ * them. Silent by contract: a lapsed grant reports `target-unavailable`
+ * rather than raising a permission prompt, so an automatic save triggered by
+ * some other action can never steal focus or pop a dialog nobody asked for.
+ */
+export async function resaveProjectArtifact(
+  project: CircuitProject,
+  target: ProjectSaveTarget,
+  seams: ProjectFileServiceSeams = {},
+): Promise<ProjectSaveOutcome> {
+  let text: string;
+  try {
+    text = serializeProject(project);
+  } catch (error) {
+    return { status: "serialization-failed", message: errorMessage(error) };
+  }
+  if (!(await hasWritePermission(target.handle, { mayPrompt: false }))) {
+    return { status: "target-unavailable" };
+  }
+  const bytes = new TextEncoder().encode(text).length;
+  return writeThrough(target, text, bytes, seams);
+}
+
+/**
+ * The one place a handle is turned into bytes on disk, so both the explicit
+ * save and the silent re-save report outcomes by the same rules.
+ */
+async function writeThrough(
+  target: ProjectSaveTarget,
+  text: string,
+  bytes: number,
+  seams: ProjectFileServiceSeams,
+): Promise<ProjectSaveOutcome> {
   let writable: ProjectWritableStreamLike;
   try {
-    writable = await handle.createWritable();
+    writable = await target.handle.createWritable();
   } catch (error) {
     return {
       status: "write-failed",
@@ -296,10 +386,36 @@ export async function saveProjectArtifact(
   }
   return {
     status: "write-confirmed",
-    fileName: handle.name ?? suggestedName,
+    fileName: target.fileName,
     bytes,
     at: seams.now?.() ?? new Date().toISOString(),
+    target,
   };
+}
+
+/**
+ * Whether the handle may be written right now. A browser that exposes no
+ * permission API predates the query — there the write itself is the check,
+ * so this reports true and lets `createWritable` speak.
+ */
+async function hasWritePermission(
+  handle: ProjectFileHandleLike,
+  options: { mayPrompt: boolean },
+): Promise<boolean> {
+  if (typeof handle.queryPermission !== "function") return true;
+  try {
+    if ((await handle.queryPermission({ mode: "readwrite" })) === "granted") {
+      return true;
+    }
+    if (!options.mayPrompt || typeof handle.requestPermission !== "function") {
+      return false;
+    }
+    return (
+      (await handle.requestPermission({ mode: "readwrite" })) === "granted"
+    );
+  } catch {
+    return false;
+  }
 }
 
 async function abortQuietly(


### PR DESCRIPTION
> 能不能加一个机制：只要对方点击任何一种导出按钮，系统就会自动保存一下？

Yes — but the root cause had to go first, or "auto-save on export" would have meant **a second file picker** (two dialogs for one click) or **a second download** (two files when one was asked for).

## The root cause

`saveProjectArtifact` threw away the granted handle the moment the write finished, so **every** save reopened the picker. People saved once, hit a dialog on the second save, cancelled it, and the file on disk quietly fell behind the canvas.

## What changed

A confirmed save hands back a `ProjectSaveTarget`; **Save writes straight through it**. **Save Project As…** joins the File menu, since a Save that no longer asks needs its own way to choose elsewhere.

Two entry points keep the distinction honest:

| | prompts? | picker? | on a lapsed grant |
| --- | --- | --- | --- |
| `saveProjectArtifact` (explicit Save) | yes | yes | prompts, then falls back |
| `resaveProjectArtifact` (silent) | **never** | **never** | `target-unavailable` |

The target is a runtime capability, never persisted — dropped whenever the whole project is replaced (so a later Save cannot overwrite a *different* circuit's file) and gone with the tab.

Failure handling is deliberately asymmetric: a **stale** target (file moved or deleted) falls back to the picker rather than wedging Save, but a failure **mid-write** is reported, never silently retried somewhere else.

## Exporting now catches the file up

Export is the strongest signal that a circuit matters, so that is where the project file gets caught up:

- **location already granted** → silent write, status names the file: `Exported SVG revision 3 — also saved chosen.icproj.json`
- **no location** (Safari/Firefox, or never saved) → `Exported SVG revision 3 — the Project file still has unsaved changes`

No picker is ever opened by an export.

## Validation

- Full unit suite: **1212 passed** (6 new cases on the service)
- Full Playwright suite: **221 passed** (4 new cases)
- Typecheck, Prettier

Three pre-existing e2e matchers used `getByRole("button", { name: "Save Project" })`, which Playwright matches as a **substring** — so the new "Save Project As…" sibling made them ambiguous. They now match exactly.

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)