### PR TITLE
feat(gallery): star the circuits that extract, and let people thumb them

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -673,6 +673,62 @@ test("Check and Save shelves the circuit and the shelf reopens it", async ({
   await expect(page.getByTestId("status")).toContainText("Opened");
 });
 
+test("stars the circuits that extract and counts thumbs on every card", async ({
+  page,
+}) => {
+  const extractable = {
+    ...ENTRY,
+    netlistable: true,
+    likes: 2,
+    likedByViewer: false,
+  };
+  const sketch = {
+    ...ENTRY,
+    id: "g-sketch",
+    name: "Ideal Sketch",
+    netlistable: false,
+    likes: 0,
+    likedByViewer: false,
+  };
+  await page.route("**/api/gallery", (route) =>
+    route.fulfill({
+      json: { entries: [extractable, sketch], nextCursor: null },
+    }),
+  );
+  await page.route("**/api/gallery/*/preview.svg", (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"></svg>',
+    }),
+  );
+  let toggles = 0;
+  await page.route("**/api/gallery/*/like", (route) => {
+    toggles += 1;
+    return route.fulfill({ json: { likes: 3, likedByViewer: true } });
+  });
+
+  await page.goto("/");
+  // The star marks the one that extracts. The other is on the wall all the
+  // same — a schematic is allowed to be abbreviated.
+  await expect(
+    page.getByTestId(`gallery-star-${extractable.id}`),
+  ).toBeVisible();
+  await expect(page.getByTestId(`gallery-star-${sketch.id}`)).toHaveCount(0);
+  await expect(page.getByTestId(`gallery-tile-${sketch.id}`)).toBeVisible();
+
+  const thumb = page.getByTestId(`gallery-like-${extractable.id}`);
+  await expect(thumb).toContainText("2");
+  await expect(thumb).toHaveAttribute("aria-pressed", "false");
+
+  // Pressing the thumb applies what the server returned, and does not follow
+  // the card's link on the way.
+  await thumb.click();
+  await expect(thumb).toContainText("3");
+  await expect(thumb).toHaveAttribute("aria-pressed", "true");
+  expect(toggles).toBe(1);
+  expect(new URL(page.url()).pathname).toBe("/");
+});
+
 test("an ordinary user sees blocking quality gates on an empty project", async ({
   page,
 }) => {

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -15,6 +15,14 @@ export interface GalleryFeedEntry {
   createdAt: string;
   schemaVersion: number;
   tags?: string[];
+  /**
+   * Whether the circuit extracts to a design netlist. A mark of extra
+   * completeness, never a gate — a schematic is allowed to be abbreviated,
+   * and one without this is listed exactly like one with it.
+   */
+  netlistable?: boolean;
+  likes?: number;
+  likedByViewer?: boolean;
 }
 
 export interface GalleryFeedPage {
@@ -141,6 +149,46 @@ export function GalleryFeed() {
     nextCursor: null,
   });
   const loadingMoreRef = useRef(false);
+
+  /**
+   * One thumb per account, taken back by pressing again. The server owns the
+   * count; this applies what it returns rather than guessing, so two tabs
+   * cannot drift apart.
+   */
+  async function toggleLike(entryId: string): Promise<void> {
+    let response: Response;
+    try {
+      response = await fetch(`/api/gallery/${entryId}/like`, {
+        method: "POST",
+        credentials: "same-origin",
+      });
+    } catch {
+      return;
+    }
+    if (response.status === 401) {
+      window.location.href = "/api/auth/github/start";
+      return;
+    }
+    if (!response.ok) return;
+    const result = (await response.json().catch(() => null)) as {
+      likes?: number;
+      likedByViewer?: boolean;
+    } | null;
+    if (!result) return;
+    setState((previous) => ({
+      ...previous,
+      entries: previous.entries.map((entry): GalleryFeedEntry =>
+        entry.id === entryId
+          ? {
+              ...entry,
+              likes: result.likes ?? entry.likes ?? 0,
+              likedByViewer: result.likedByViewer === true,
+            }
+          : entry,
+      ),
+    }));
+  }
+
   const sentinelRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -292,7 +340,19 @@ export function GalleryFeed() {
                       />
                     </span>
                     <span className="gallery-tile-copy">
-                      <span className="gallery-tile-name">{entry.name}</span>
+                      <span className="gallery-tile-name">
+                        {entry.name}
+                        {entry.netlistable ? (
+                          <span
+                            className="gallery-tile-star"
+                            data-testid={`gallery-star-${entry.id}`}
+                            title="Extracts to a SPICE netlist"
+                            aria-label="Extracts to a SPICE netlist"
+                          >
+                            ★
+                          </span>
+                        ) : null}
+                      </span>
                       <span className="gallery-tile-meta">
                         {entry.author ? (
                           <>
@@ -313,6 +373,26 @@ export function GalleryFeed() {
                           </>
                         ) : null}
                         {savedAtLabel(entry.createdAt)}
+                        {" · "}
+                        <button
+                          type="button"
+                          className="gallery-tile-like"
+                          data-testid={`gallery-like-${entry.id}`}
+                          aria-pressed={entry.likedByViewer === true}
+                          title={
+                            entry.likedByViewer
+                              ? "Take back your thumbs up"
+                              : "Thumbs up this circuit"
+                          }
+                          onClick={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            void toggleLike(entry.id);
+                          }}
+                        >
+                          <span aria-hidden="true">👍</span>
+                          {entry.likes ?? 0}
+                        </button>
                       </span>
                       {entry.description ? (
                         <span className="gallery-tile-description">

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -6363,6 +6363,37 @@ html.light .analytics-map-land path {
   color: var(--icm-text-muted);
 }
 
+/* A star says this circuit extracts to a netlist. It marks extra
+   completeness and gates nothing, so it is a quiet accent beside the name
+   rather than a badge competing with it. */
+.gallery-tile-star {
+  margin-left: 4px;
+  color: #c98a12;
+  font-size: 12px;
+}
+
+.gallery-tile-like {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 0 4px;
+  border: 0;
+  border-radius: var(--icm-radius-sm);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.gallery-tile-like:hover {
+  background: var(--icm-surface-hover);
+}
+
+.gallery-tile-like[aria-pressed="true"] {
+  color: var(--icm-accent);
+  font-weight: 600;
+}
+
 /* The wordmark is the editor's half of the two-way gallery/editor switch, so
    the whole brand is one link that still reads as plain chrome. */
 .gallery-home-link {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@icm/agent-adapter": "workspace:*",
     "@icm/derived": "workspace:*",
     "@icm/model": "workspace:*",
+    "@icm/netlist": "workspace:*",
     "@icm/project-protocol": "workspace:*",
     "@icm/render-svg": "workspace:*",
     "@icm/symbols": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       "@icm/model":
         specifier: workspace:*
         version: link:packages/model
+      "@icm/netlist":
+        specifier: workspace:*
+        version: link:packages/netlist
       "@icm/project-protocol":
         specifier: workspace:*
         version: link:packages/project-protocol

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -237,6 +237,103 @@ async function submitOne(
   return payload.id;
 }
 
+describe("stars and thumbs", () => {
+  function likeRequest(id: string, cookie?: string): Request {
+    const headers = new Headers({ Origin: ORIGIN });
+    if (cookie) headers.set("Cookie", cookie);
+    return new Request(`${ORIGIN}/api/gallery/${id}/like`, {
+      method: "POST",
+      headers,
+    });
+  }
+
+  async function feed(env: Harness, cookie?: string) {
+    const response = await route(
+      env,
+      new Request(
+        `${ORIGIN}/api/gallery`,
+        cookie ? { headers: cookieHeaders(cookie) } : undefined,
+      ),
+    );
+    return (await response.json()) as {
+      entries: {
+        id: string;
+        netlistable: boolean;
+        likes: number;
+        likedByViewer: boolean;
+      }[];
+    };
+  }
+
+  it("records whether a circuit extracts, and publishes both alike", async () => {
+    const env = environment();
+    const cookie = await adminOf(env);
+
+    // An ideal switch has no reviewed netlist definition, so this circuit
+    // does not extract. That is a legitimate schematic, not a mistake: it is
+    // published exactly like any other and simply wears no star.
+    const sketch = createEmptyProject("sketch", "Sketch");
+    sketch.documents[0]!.instances.push({
+      id: "S1",
+      symbolId: "ideal-switch",
+      schematicReference: "S1",
+      placement: { position: { x: 0, y: 0 }, rotation: 0, mirror: "none" },
+    });
+    const sketchId = await submitOne(env, "Sketch", {
+      cookie,
+      text: serializeProject(sketch),
+    });
+    const extractableId = await submitOne(env, "Extractable", { cookie });
+
+    const listed = await feed(env);
+    const byId = new Map(listed.entries.map((entry) => [entry.id, entry]));
+    expect(byId.get(sketchId)!.netlistable).toBe(false);
+    expect(byId.get(extractableId)!.netlistable).toBe(true);
+    // Both are on the wall; the star separates them, nothing else does.
+    expect(listed.entries).toHaveLength(2);
+  });
+
+  it("counts one thumb per account and takes it back on a second press", async () => {
+    const env = environment();
+    const owner = await adminOf(env);
+    const id = await submitOne(env, "Liked", { cookie: owner });
+    const other = await makerOf(env);
+
+    const first = await route(env, likeRequest(id, other));
+    expect(await first.json()).toEqual({ likes: 1, likedByViewer: true });
+    // Pressing again is not a second thumb; it is taking the thumb back.
+    const second = await route(env, likeRequest(id, other));
+    expect(await second.json()).toEqual({ likes: 0, likedByViewer: false });
+
+    await route(env, likeRequest(id, other));
+    await route(env, likeRequest(id, owner));
+    const listed = await feed(env, other);
+    expect(listed.entries[0]!.likes).toBe(2);
+    expect(listed.entries[0]!.likedByViewer).toBe(true);
+  });
+
+  it("shows counts to a signed-out visitor without claiming they liked it", async () => {
+    const env = environment();
+    const owner = await adminOf(env);
+    const id = await submitOne(env, "Public", { cookie: owner });
+    await route(env, likeRequest(id, owner));
+
+    const anonymous = await feed(env);
+    expect(anonymous.entries[0]!.likes).toBe(1);
+    expect(anonymous.entries[0]!.likedByViewer).toBe(false);
+    // And a thumb needs an account.
+    expect((await route(env, likeRequest(id))).status).toBe(401);
+  });
+
+  it("refuses a thumb for a circuit that is not on the wall", async () => {
+    const env = environment();
+    const cookie = await adminOf(env);
+    expect((await route(env, likeRequest("nosuchid", cookie))).status).toBe(
+      404,
+    );
+  });
+});
+
 describe("circuit addresses", () => {
   it("gives a new circuit a short, readable id", async () => {
     const env = environment();

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -14,6 +14,7 @@
 // longer open.
 
 import { evaluateSubmissionGates } from "@icm/derived";
+import { analyzeDesignNetlist } from "@icm/netlist";
 import { parseProject, serializeProject } from "@icm/project-protocol";
 import { renderDocumentSvg } from "@icm/render-svg";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
@@ -106,6 +107,15 @@ export interface GalleryEntrySummary {
   createdAt: string;
   schemaVersion: number;
   tags: string[];
+  /**
+   * Whether this circuit currently extracts to a design netlist. A schematic
+   * is allowed to be abbreviated, so this is a mark of extra completeness and
+   * never a gate: circuits without it are published and browsed alike.
+   */
+  netlistable: boolean;
+  likes: number;
+  /** Whether the requesting account has liked it; false when signed out. */
+  likedByViewer: boolean;
 }
 
 /**
@@ -160,11 +170,14 @@ interface EntryRow {
   reviewed_by: string | null;
   project_text: string;
   svg_text: string;
+  netlistable: number;
 }
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
-function summaryOf(row: EntryRow): GalleryEntrySummary {
+function summaryOf(
+  row: EntryRow & { likes?: number; liked_by_viewer?: number },
+): GalleryEntrySummary {
   return {
     id: row.id,
     name: row.name,
@@ -173,6 +186,9 @@ function summaryOf(row: EntryRow): GalleryEntrySummary {
     createdAt: row.created_at,
     schemaVersion: row.schema_version,
     tags: unwrapTags(row.tags),
+    netlistable: row.netlistable === 1,
+    likes: row.likes ?? 0,
+    likedByViewer: (row.liked_by_viewer ?? 0) === 1,
   };
 }
 
@@ -202,6 +218,19 @@ export class GalleryDO {
     this.sql.exec(`
       CREATE INDEX IF NOT EXISTS idx_gallery_entries_status_created
       ON gallery_entries(status, created_at)
+    `);
+    // One thumb per account per circuit, so the primary key is the rule.
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS gallery_likes (
+        entry_id TEXT NOT NULL,
+        user_id TEXT NOT NULL,
+        liked_at TEXT NOT NULL,
+        PRIMARY KEY (entry_id, user_id)
+      ) WITHOUT ROWID
+    `);
+    this.sql.exec(`
+      CREATE INDEX IF NOT EXISTS idx_gallery_likes_entry
+      ON gallery_likes(entry_id)
     `);
     this.sql.exec(`
       CREATE TABLE IF NOT EXISTS gallery_submissions (
@@ -257,6 +286,7 @@ export class GalleryDO {
       "ALTER TABLE gallery_entries ADD COLUMN submitter_email TEXT",
       "ALTER TABLE gallery_entries ADD COLUMN submitter_provider TEXT",
       "ALTER TABLE workspace_slots ADD COLUMN seq INTEGER NOT NULL DEFAULT 0",
+      "ALTER TABLE gallery_entries ADD COLUMN netlistable INTEGER NOT NULL DEFAULT 0",
     ]) {
       try {
         this.sql.exec(alteration);
@@ -314,6 +344,12 @@ export class GalleryDO {
         return this.version(String(body.entryId), String(body.versionId));
       case "restore-version":
         return this.restoreVersion(body);
+      case "toggle-like":
+        return this.toggleLike(
+          String(body.id),
+          String(body.userId),
+          String(body.at),
+        );
       case "workspace-save":
         return this.workspaceSave(body);
       case "workspace-list":
@@ -323,6 +359,50 @@ export class GalleryDO {
       default:
         return Response.json({ error: "Unknown operation" }, { status: 404 });
     }
+  }
+
+  /**
+   * One thumb per account, and pressing it again takes it back. The entry has
+   * to exist and be public: a like is not a way to discover a withdrawn one.
+   */
+  private toggleLike(id: string, userId: string, at: string): Response {
+    const entry = this.sql
+      .exec<{ status: string }>(
+        "SELECT status FROM gallery_entries WHERE id = ?",
+        id,
+      )
+      .toArray()[0];
+    if (!entry || entry.status !== "public") {
+      return Response.json({ error: "not-found" }, { status: 404 });
+    }
+    const existing = this.sql
+      .exec<{ entry_id: string }>(
+        "SELECT entry_id FROM gallery_likes WHERE entry_id = ? AND user_id = ?",
+        id,
+        userId,
+      )
+      .toArray();
+    if (existing.length > 0) {
+      this.sql.exec(
+        "DELETE FROM gallery_likes WHERE entry_id = ? AND user_id = ?",
+        id,
+        userId,
+      );
+    } else {
+      this.sql.exec(
+        "INSERT INTO gallery_likes(entry_id, user_id, liked_at) VALUES (?, ?, ?)",
+        id,
+        userId,
+        at,
+      );
+    }
+    const likes =
+      this.sql
+        .exec<{
+          count: number;
+        }>("SELECT COUNT(*) AS count FROM gallery_likes WHERE entry_id = ?", id)
+        .toArray()[0]?.count ?? 0;
+    return Response.json({ likes, likedByViewer: existing.length === 0 });
   }
 
   /** A free id, redrawn on the vanishing chance the first one is taken. */
@@ -376,8 +456,8 @@ export class GalleryDO {
         `INSERT INTO gallery_entries(
           id, name, author, description, created_at, schema_version,
           status, recycled_at, owner_user_id, submitter_email,
-          submitter_provider, tags, project_text, svg_text
-        ) VALUES (?, ?, ?, ?, ?, ?, 'public', NULL, ?, ?, ?, ?, ?, ?)`,
+          submitter_provider, tags, project_text, svg_text, netlistable
+        ) VALUES (?, ?, ?, ?, ?, ?, 'public', NULL, ?, ?, ?, ?, ?, ?, ?)`,
         entry.id,
         entry.name,
         entry.author,
@@ -390,6 +470,7 @@ export class GalleryDO {
         entry.tags ?? "",
         entry.project_text,
         entry.svg_text,
+        entry.netlistable ?? 0,
       );
       return { status: "stored" as const };
     });
@@ -424,10 +505,17 @@ export class GalleryDO {
       conditions.push("(created_at || '|' || id) < ?");
       bindings.push(cursor);
     }
+    // The viewer id leads the bindings because its sub-select comes first.
+    const viewerId = typeof body.viewerId === "string" ? body.viewerId : "";
     const rows = this.sql
-      .exec<EntryRow>(
-        `SELECT * FROM gallery_entries WHERE ${conditions.join(" AND ")}
+      .exec<EntryRow & { likes: number; liked_by_viewer: number }>(
+        `SELECT e.*,
+           (SELECT COUNT(*) FROM gallery_likes WHERE entry_id = e.id) AS likes,
+           (SELECT COUNT(*) FROM gallery_likes
+             WHERE entry_id = e.id AND user_id = ?) AS liked_by_viewer
+         FROM gallery_entries e WHERE ${conditions.join(" AND ")}
          ORDER BY created_at DESC, id DESC LIMIT ?`,
+        viewerId,
         ...bindings,
         limit + 1,
       )
@@ -1040,6 +1128,9 @@ async function handleSubmission(
         // The id is drawn inside the Durable Object, which is the only place
         // that can tell whether one is already taken.
         id: "",
+        // Recorded, never enforced: a circuit that does not extract is
+        // published exactly the same way, it simply does not wear the star.
+        netlistable: analyzeDesignNetlist(project).ir ? 1 : 0,
         name,
         author,
         description,
@@ -1209,8 +1300,30 @@ export async function routeGalleryRequest(
   if (!url.pathname.startsWith("/api/gallery")) return null;
   const segments = url.pathname.split("/").filter(Boolean).slice(2);
 
+  if (
+    segments.length === 2 &&
+    segments[1] === "like" &&
+    request.method === "POST"
+  ) {
+    if (!sameOrigin(request)) {
+      return Response.json({ error: "forbidden" }, { status: 403 });
+    }
+    const user = await sessionUserOf(request, env);
+    if (!user) return Response.json({ error: "unauthorized" }, { status: 401 });
+    const { status, payload } = await callGallery(env, "toggle-like", {
+      id: segments[0],
+      userId: user.id,
+      at: new Date().toISOString(),
+    });
+    return Response.json(payload, { status });
+  }
+
   if (segments.length === 0 && request.method === "GET") {
+    // Signed in, the feed says which circuits this account has already
+    // thumbed; signed out it simply carries the counts.
+    const viewer = await sessionUserOf(request, env);
     const { payload } = await callGallery(env, "list", {
+      viewerId: viewer?.id ?? "",
       limit: url.searchParams.get("limit"),
       cursor: url.searchParams.get("cursor"),
       author: url.searchParams.get("author"),


### PR DESCRIPTION
Two tiers, neither of them a gate.

## The star

A circuit that extracts to a design netlist wears a star on its card. It is recorded at submission by running the same analysis the Check Report runs, and **never enforced**: a schematic is allowed to be abbreviated and idealised, so one that does not extract is published and browsed exactly like one that does. The star marks extra completeness — it does not sort, filter, or block anything.

## The thumb

Every account can thumb a circuit and press again to take it back. One row per `(entry, account)` as the primary key, so a thumb cannot be spent twice however many times the button is pressed.

- Counts are public; **whether the viewer has thumbed it** is answered only for a signed-in viewer.
- A thumb needs an account — signed out, the button sends you to sign in rather than silently doing nothing.
- The server owns the count and the client applies what it returns rather than guessing, so two tabs cannot drift apart.
- A circuit that is not on the wall cannot be thumbed: an id is not a way to discover a withdrawn entry.

## Validation

- unit: 1251 passed. Four new worker cases: a circuit with an ideal switch is stored unstarred while an extractable one is starred **and both are listed**; a thumb toggles 0→1→0 and counts across accounts; a signed-out visitor sees the count without being told they liked it, and is refused the thumb; a thumb for an unknown id is 404.
- Playwright: a new spec renders one starred and one unstarred card, asserts the unstarred one is on the wall all the same, presses the thumb, and checks the count and pressed state follow the server — without the card's link firing.

Two pre-existing local failures in `worker/gallery.test.ts` are an artifact of this machine having no pnpm (stale package `dist/`); they fail identically on unmodified `main`, whose CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)