### PR TITLE
test(editor): pin a copied VDD label upright through both turn paths

### DIFF
--- a/apps/editor/src/features/component-insert/vdd-power-label.test.ts
+++ b/apps/editor/src/features/component-insert/vdd-power-label.test.ts
@@ -5,6 +5,11 @@ import type { Annotation } from "@icm/model";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
+import {
+  copyPlacementOrientationEdits,
+  copySelection,
+  proposePaste,
+} from "../clipboard/clipboard";
 import { proposedStandalonePowerConnection } from "./placement-connectivity";
 import { vddPowerLabelAnnotation } from "./vdd-power-label";
 
@@ -218,6 +223,185 @@ describe("vdd power label annotation", () => {
         rotation: 0,
       });
     }
+  });
+
+  it("keeps a copied VDD Port label upright through two rotations", () => {
+    let document = createEmptyDocument("main", "Main");
+    const instance = {
+      id: "VDD1",
+      symbolId: "vdd-port",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0 as const,
+        mirror: "none" as const,
+      },
+    };
+    const resolved = resolver.resolve("vdd-port");
+    if (!resolved) throw new Error("missing VDD Port Symbol");
+    document.instances.push(instance);
+    document.nets.push({
+      id: "net-vdd",
+      name: "VDD",
+      scope: "global",
+      powerDomain: "vdd",
+      terminals: [],
+    });
+    document.annotations.push(
+      vddPowerLabelAnnotation({
+        instance,
+        resolved,
+        netId: "net-vdd",
+        grid: document.presentation.grid,
+      }),
+    );
+
+    // Copy through the real clipboard path, so the pasted label carries
+    // whatever identity and offsets a person's Ctrl-C / Ctrl-V would give it.
+    const clipboard = copySelection(document, ["VDD1"]);
+    expect(clipboard).not.toBeNull();
+    const paste = proposePaste(document, clipboard!, { x: 80, y: 0 }, 1);
+    const pasted = executeTransaction(
+      document,
+      {
+        transactionId: "paste-vdd",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: paste.edits,
+      },
+      { symbolResolver: resolver },
+    );
+    if (!pasted.ok) throw new Error(JSON.stringify(pasted.diagnostics));
+    document = pasted.document;
+    const copyId = paste.instanceIds[0]!;
+
+    for (const rotation of [90, 180] as const) {
+      const result = executeTransaction(
+        document,
+        {
+          transactionId: `turn-${rotation}`,
+          documentId: document.id,
+          expectedRevision: document.revision,
+          actor: { kind: "human", id: "test" },
+          edits: [{ kind: "rotate_instance", instanceId: copyId, rotation }],
+        },
+        { symbolResolver: resolver },
+      );
+      expect(
+        result.ok,
+        result.ok ? undefined : JSON.stringify(result.diagnostics),
+      ).toBe(true);
+      if (!result.ok) return;
+      document = result.document;
+
+      const copy = document.instances.find(
+        (candidate) => candidate.id === copyId,
+      )!;
+      const label = document.annotations.find(
+        (candidate) =>
+          candidate.anchor.kind === "object" &&
+          candidate.anchor.objectId === copyId,
+      )!;
+      // Turning the symbol must never turn its name over: at 180° a rotated
+      // label reads upside down, which is exactly what a reader cannot do.
+      expect(label.rotation).toBe(0);
+      const expected = defaultVddPowerLabelPlacement(
+        copy,
+        resolved,
+        document.presentation.grid,
+      );
+      expect(expected).not.toBeNull();
+      // The drawn glyph and its stored anchor must stay the same place, or
+      // the selection box detaches from the text it is supposed to frame.
+      expect(objectAnchor(label).fallbackPosition).toEqual(expected?.position);
+      expect(label.alignment).toBe(expected?.alignment);
+    }
+  });
+
+  it("keeps a VDD Port label upright when the copy is turned before it lands", () => {
+    const document = createEmptyDocument("main", "Main");
+    const instance = {
+      id: "VDD1",
+      symbolId: "vdd-port",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0 as const,
+        mirror: "none" as const,
+      },
+    };
+    const resolved = resolver.resolve("vdd-port");
+    if (!resolved) throw new Error("missing VDD Port Symbol");
+    document.instances.push(instance);
+    document.nets.push({
+      id: "net-vdd",
+      name: "VDD",
+      scope: "global",
+      powerDomain: "vdd",
+      terminals: [],
+    });
+    document.annotations.push(
+      vddPowerLabelAnnotation({
+        instance,
+        resolved,
+        netId: "net-vdd",
+        grid: document.presentation.grid,
+      }),
+    );
+
+    const clipboard = copySelection(document, ["VDD1"]);
+    expect(clipboard).not.toBeNull();
+    const paste = proposePaste(document, clipboard!, { x: 80, y: 0 }, 1);
+    // Pressing R twice while the copy is still on the pointer commits the
+    // turns in the SAME transaction as the paste, which is the shape the
+    // editor actually submits (use-selection-interaction).
+    const orientation = copyPlacementOrientationEdits(
+      clipboard!.instances,
+      paste.instanceIds,
+      [
+        { kind: "rotate", deltaDegrees: 90 },
+        { kind: "rotate", deltaDegrees: 90 },
+      ],
+    );
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "copy-turned-twice",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: [...paste.edits, ...orientation],
+      },
+      { symbolResolver: resolver },
+    );
+    expect(
+      result.ok,
+      result.ok ? undefined : JSON.stringify(result.diagnostics),
+    ).toBe(true);
+    if (!result.ok) return;
+
+    const copyId = paste.instanceIds[0]!;
+    const copy = result.document.instances.find(
+      (candidate) => candidate.id === copyId,
+    )!;
+    expect(copy.placement?.rotation).toBe(180);
+    const label = result.document.annotations.find(
+      (candidate) =>
+        candidate.anchor.kind === "object" &&
+        candidate.anchor.objectId === copyId,
+    )!;
+    // Turning the symbol must never turn its name over: at 180 degrees a
+    // rotated label reads upside down, which is what a reader cannot do.
+    expect(label.rotation).toBe(0);
+    const expected = defaultVddPowerLabelPlacement(
+      copy,
+      resolved,
+      result.document.presentation.grid,
+    );
+    expect(expected).not.toBeNull();
+    // The drawn glyph and its stored anchor must agree, or the selection box
+    // detaches from the text it is supposed to frame.
+    expect(objectAnchor(label).fallbackPosition).toEqual(expected?.position);
+    expect(label.alignment).toBe(expected?.alignment);
   });
 
   it("does not pull a user-moved VDD Port label back to the automatic position", () => {


### PR DESCRIPTION
> 左边VDD复制一份，旋转两次后，文字框和文字位置脱离
> 现在这些元件带着 label 一起旋转的时候，总是有这种问题

## It does not reproduce on current main

I chased this three ways and the label stayed upright in all of them:

| path | result |
| --- | --- |
| paste, then turn twice | `rotation: 0`, anchor = canonical |
| **turn twice while the copy is still on the pointer** | `rotation: 0`, anchor = canonical |
| select the placed copy, press R twice (in the browser) | `rotate(0 …)` in the DOM |

The third was driven against the running editor, not a fixture. Most likely #208's rigid-rotation work already carried it.

## What is missing is the coverage

Neither copy path had any. `isCanonicalVddPowerLabel` is what keeps the glyph upright, and it is guarded by an exact id match (`power-label-${instance.id.toLowerCase()}`) plus an exact placement match — both of which a copy could plausibly break. Nothing was pinning that.

So this PR adds the two cases rather than a fix:

- both go through the **real** clipboard (`copySelection` → `proposePaste`), not a hand-built fixture;
- the second puts the turns in the **same transaction** as the paste, which is what `use-selection-interaction` actually submits when R is pressed mid-placement — a narrower fixture would have missed exactly that shape;
- each asserts **both halves** of the report: the glyph never turns over (`rotation === 0`), and the stored anchor still equals `defaultVddPowerLabelPlacement`, so the selection box cannot detach from the text it frames.

If it resurfaces, please grab the version banner — that will tell us whether it predates the fix that landed.

## Validation

- `apps/editor/src/features`: **193 passed** (2 new)
- Typecheck, Prettier

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)