### PR TITLE
fix(connectivity): unify wire cut and endpoint readiness

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -862,7 +862,7 @@ test("keeps Wire active for consecutive independent routes until Escape", async 
   await expect(page.getByTestId("active-tool")).toHaveText("pointer");
 });
 
-test("re-derives guidance after manually deleting an imported Route", async ({
+test("physically cuts an imported Route and retires detached source guidance", async ({
   page,
 }) => {
   const project = createRoutingDemoProject();
@@ -902,9 +902,9 @@ test("re-derives guidance after manually deleting an imported Route", async ({
   );
 
   await expect(page.getByTestId("source-status")).toHaveText(
-    "geometry-only-changed",
+    "connectivity-modified",
   );
-  await expect(page.getByTestId("flightline")).toHaveCount(3);
+  await expect(page.getByTestId("flightline")).toHaveCount(1);
 });
 
 test("keeps remaining imported flightlines after routing one guided connection", async ({
@@ -2875,9 +2875,15 @@ X2 OUT IN EXT_MASTER l=1u nf=4
   await expect(page.getByTestId("status")).toContainText(
     "Imported 2 Documents",
   );
-  const spice = (
-    await downloadBytes(page, "File", "Export SPICE netlist")
-  ).toString("utf8");
+  await clickCommand(page, "File", "Export SPICE netlist");
+  const report = page.getByRole("dialog", { name: "Check Report" });
+  await expect(report.getByLabel("Electrical findings")).toBeVisible();
+  const downloadPromise = page.waitForEvent("download");
+  await report.getByRole("button", { name: "Download SPICE netlist" }).click();
+  const stream = await (await downloadPromise).createReadStream();
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk));
+  const spice = Buffer.concat(chunks).toString("utf8");
   expect(spice).toContain(".subckt leaf A B params: scale=1");
   expect(spice).toContain("X1 IN OUT leaf scale=2");
   expect(spice).toContain("X2 OUT IN EXT_MASTER l=1u nf=4");

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -933,6 +933,7 @@ export function App({
   const [highlightedNetOrigin, setHighlightedNetOrigin] = useState<{
     documentId: string;
     netId: string;
+    hierarchyPath: readonly HierarchyFrame[];
     endpoint?: RouteEndpoint;
   } | null>(null);
   const routeCounter = useRef(0);
@@ -1059,6 +1060,7 @@ export function App({
             highlightedNetOrigin.documentId,
             highlightedNetOrigin.netId,
             highlightedNetOrigin.endpoint,
+            highlightedNetOrigin.hierarchyPath,
           )
         : undefined,
     [highlightedNetOrigin, projectConnectivityIndex],
@@ -1066,14 +1068,30 @@ export function App({
   const highlightedNet = useMemo(
     () =>
       highlightedTrace?.highlights.find(
-        (highlight) => highlight.documentId === document.id,
+        (highlight) =>
+          highlight.documentId === document.id &&
+          highlight.hierarchyPath.length === documentStack.length &&
+          highlight.hierarchyPath.every(
+            (frame, index) =>
+              frame.parentDocumentId ===
+                documentStack[index]?.parentDocumentId &&
+              frame.instanceId === documentStack[index]?.instanceId &&
+              frame.childDocumentId === documentStack[index]?.childDocumentId,
+          ),
       ),
-    [document.id, highlightedTrace],
+    [document.id, documentStack, highlightedTrace],
   );
   const highlightedNetId = highlightedNet?.netId ?? null;
   const liveDiagnosticSnapshot = useMemo(
     () => diagnoseProjectSnapshot(project, resolver, projectConnectivityIndex),
     [project, projectConnectivityIndex, resolver],
+  );
+  const electricalDiagnostics = useMemo(
+    () =>
+      liveDiagnosticSnapshot.diagnostics.filter(
+        (diagnostic) => diagnostic.domain === "erc",
+      ),
+    [liveDiagnosticSnapshot],
   );
   const searchResults = useMemo(
     () =>
@@ -1427,6 +1445,13 @@ export function App({
   const selectedHighlightIsActive = Boolean(
     selectedHighlightNetId &&
     highlightedNetOrigin?.documentId === document.id &&
+    highlightedNetOrigin.hierarchyPath.length === documentStack.length &&
+    highlightedNetOrigin.hierarchyPath.every(
+      (frame, index) =>
+        frame.parentDocumentId === documentStack[index]?.parentDocumentId &&
+        frame.instanceId === documentStack[index]?.instanceId &&
+        frame.childDocumentId === documentStack[index]?.childDocumentId,
+    ) &&
     highlightedNetOrigin.netId === selectedHighlightNetId &&
     (!highlightedNetOrigin.endpoint ||
       (selectedHighlightEndpoint &&
@@ -2864,6 +2889,7 @@ export function App({
       setHighlightedNetOrigin({
         documentId: opened.id,
         netId: locator.objectId,
+        hierarchyPath: locator.hierarchyPath,
       });
       const route = opened.routes.find(
         (item) => item.netId === locator.objectId,
@@ -6547,7 +6573,11 @@ export function App({
       setStatus("Resolve the Check Report findings before export");
       return;
     }
-    if (netlistAnalysis.diagnostics.length > 0 && !warningsReviewed) {
+    if (
+      (netlistAnalysis.diagnostics.length > 0 ||
+        electricalDiagnostics.length > 0) &&
+      !warningsReviewed
+    ) {
       setNetlistPreflightOpen(true);
       setStatus("Review the Check Report warnings before export");
       return;
@@ -7605,10 +7635,18 @@ export function App({
     netId: string,
     documentId = document.id,
     endpoint?: RouteEndpoint,
+    hierarchyPath: readonly HierarchyFrame[] = documentId === document.id
+      ? documentStack
+      : (findHierarchyPath(
+          projectConnectivityIndex,
+          project.topDocumentId,
+          documentId,
+        ) ?? []),
   ): void {
     setHighlightedNetOrigin({
       documentId,
       netId,
+      hierarchyPath,
       ...(endpoint ? { endpoint } : {}),
     });
     setStatus(`Highlighted Net ${netId}`);
@@ -7636,7 +7674,7 @@ export function App({
     navigateToLocator(
       {
         documentId: hop.to.documentId,
-        hierarchyPath: [],
+        hierarchyPath: hop.to.hierarchyPath,
         kind: "net",
         objectId: hop.to.netId,
       },
@@ -8429,8 +8467,10 @@ export function App({
       <NetlistPreflightDialog
         open={netlistPreflightOpen}
         result={netlistAnalysis}
+        electricalDiagnostics={electricalDiagnostics}
         onClose={() => setNetlistPreflightOpen(false)}
         onNavigate={navigateToNetlistDiagnostic}
+        onNavigateElectrical={jumpToProjectDiagnostic}
         onExport={(format) => exportDesignNetlist(format, true)}
       />
       {publishGalleryOpen ? (

--- a/apps/editor/src/document/document-controller.test.ts
+++ b/apps/editor/src/document/document-controller.test.ts
@@ -106,6 +106,71 @@ describe("EditorDocumentController", () => {
     expect(codes()).not.toContain("ERC_UNCONNECTED_PIN");
   });
 
+  it("re-derives endpoint readiness when Wire Delete is undone and redone", () => {
+    const controller = new EditorDocumentController(hierarchicalProject());
+    controller.transact([
+      {
+        kind: "add_instance",
+        instance: {
+          id: "P1",
+          symbolId: "port",
+          placement: {
+            position: { x: 0, y: 0 },
+            rotation: 0,
+            mirror: "none",
+          },
+        },
+      },
+      {
+        kind: "add_instance",
+        instance: {
+          id: "P2",
+          symbolId: "port",
+          placement: {
+            position: { x: 100, y: 0 },
+            rotation: 0,
+            mirror: "none",
+          },
+        },
+      },
+      {
+        kind: "connect_endpoints",
+        from: { kind: "terminal", instanceId: "P1", pinName: "P" },
+        to: { kind: "terminal", instanceId: "P2", pinName: "P" },
+        newNetId: "net-ports",
+      },
+      {
+        kind: "set_route_points",
+        routeId: "wire-ports",
+        netId: "net-ports",
+        from: { kind: "terminal", instanceId: "P1", pinName: "P" },
+        to: { kind: "terminal", instanceId: "P2", pinName: "P" },
+        waypoints: [],
+        segmentModes: ["manual"],
+      },
+    ]);
+    const unconnectedCount = () =>
+      diagnoseProjectSnapshot(
+        controller.project,
+        controller.resolver,
+      ).diagnostics.filter(
+        (diagnostic) => diagnostic.code === "ERC_UNCONNECTED_PIN",
+      ).length;
+
+    expect(unconnectedCount()).toBe(0);
+    const cut = controller.transact([
+      { kind: "cut_connection", routeId: "wire-ports" },
+    ]);
+    expect(cut.ok).toBe(true);
+    expect(unconnectedCount()).toBe(2);
+
+    controller.transact([{ kind: "undo" }]);
+    expect(unconnectedCount()).toBe(0);
+
+    controller.transact([{ kind: "redo" }]);
+    expect(unconnectedCount()).toBe(2);
+  });
+
   it("rejects missing documents without changing the active history", () => {
     const controller = new EditorDocumentController(hierarchicalProject());
     const activeId = controller.activeDocumentId;

--- a/apps/editor/src/features/netlist-export/netlist-preflight-dialog.test.tsx
+++ b/apps/editor/src/features/netlist-export/netlist-preflight-dialog.test.tsx
@@ -1,0 +1,48 @@
+import type { Diagnostic } from "@icm/derived";
+import type { DesignNetlistAnalysisResult } from "@icm/netlist";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { NetlistPreflightDialog } from "./netlist-preflight-dialog";
+
+describe("NetlistPreflightDialog", () => {
+  it("shows current electrical readiness separately from structural analysis", () => {
+    const result: DesignNetlistAnalysisResult = {
+      ir: null,
+      diagnostics: [],
+    };
+    const electrical: Diagnostic = {
+      id: "erc:unconnected:main:M1:D",
+      domain: "erc",
+      code: "ERC_UNCONNECTED_PIN",
+      severity: "warning",
+      confidence: "high",
+      gateEligible: false,
+      message: "Pin M1.D is the only endpoint on its Net",
+      primary: {
+        documentId: "main",
+        hierarchyPath: [],
+        kind: "terminal",
+        objectId: "M1:D",
+      },
+      related: [],
+      parameters: { instanceId: "M1", pinName: "D" },
+    };
+
+    const markup = renderToStaticMarkup(
+      <NetlistPreflightDialog
+        open
+        result={result}
+        electricalDiagnostics={[electrical]}
+        onClose={() => undefined}
+        onNavigate={() => undefined}
+        onNavigateElectrical={() => undefined}
+        onExport={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Electrical readiness (1)");
+    expect(markup).toContain("ERC_UNCONNECTED_PIN");
+    expect(markup).toContain("same current-revision connectivity assessment");
+  });
+});

--- a/apps/editor/src/features/netlist-export/netlist-preflight-dialog.tsx
+++ b/apps/editor/src/features/netlist-export/netlist-preflight-dialog.tsx
@@ -1,4 +1,5 @@
 import { printDesignNetlist } from "@icm/netlist";
+import type { Diagnostic } from "@icm/derived";
 import type {
   DesignNetlistAnalysisResult,
   NetlistDiagnostic,
@@ -6,18 +7,22 @@ import type {
 } from "@icm/netlist";
 import { useMemo, useState } from "react";
 
-/** Presentation-only consumer of the canonical design-netlist analysis. */
+/** Presentation-only composition of structural analysis and current ERC. */
 export function NetlistPreflightDialog({
   open,
   result,
+  electricalDiagnostics,
   onClose,
   onNavigate,
+  onNavigateElectrical,
   onExport,
 }: {
   open: boolean;
   result: DesignNetlistAnalysisResult;
+  electricalDiagnostics: readonly Diagnostic[];
   onClose(): void;
   onNavigate(diagnostic: NetlistDiagnostic): void;
+  onNavigateElectrical(diagnostic: Diagnostic): void;
   onExport(format: NetlistFormat): void;
 }) {
   const [format, setFormat] = useState<NetlistFormat>("spice");
@@ -78,7 +83,11 @@ export function NetlistPreflightDialog({
         <div className="insert-dialog-body">
           {result.ir ? (
             <section className="insert-control-column">
-              <h3>Ready to export</h3>
+              <h3>
+                {electricalDiagnostics.length > 0
+                  ? "Structure ready; review electrical findings"
+                  : "Ready to export"}
+              </h3>
               <p>
                 {result.ir.cells.length} internal Cell
                 {result.ir.cells.length === 1 ? "" : "s"};{" "}
@@ -138,6 +147,33 @@ export function NetlistPreflightDialog({
                         {group.message}
                         {group.count > 1 ? ` (×${group.count})` : ""}
                       </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+          {electricalDiagnostics.length > 0 ? (
+            <section
+              className="insert-control-column"
+              aria-label="Electrical findings"
+            >
+              <h3>Electrical readiness ({electricalDiagnostics.length})</h3>
+              <p>
+                These findings use the same current-revision connectivity
+                assessment as ERC and the Gallery gate. Saving remains a
+                separate action and is allowed for unfinished work.
+              </p>
+              <ul className="preflight-findings">
+                {electricalDiagnostics.map((diagnostic) => (
+                  <li key={diagnostic.id}>
+                    <button
+                      type="button"
+                      data-severity={diagnostic.severity}
+                      onClick={() => onNavigateElectrical(diagnostic)}
+                    >
+                      <strong>{diagnostic.code}</strong>
+                      <span>{diagnostic.message}</span>
                     </button>
                   </li>
                 ))}

--- a/apps/editor/src/features/selection/selection-inspector-details.test.tsx
+++ b/apps/editor/src/features/selection/selection-inspector-details.test.tsx
@@ -143,6 +143,7 @@ describe("selection inspector details", () => {
     const trace: HierarchyNetTrace = {
       primary: {
         documentId: "document-top",
+        hierarchyPath: [],
         netId: "net-top",
         visibleEndpoints: [],
         routes: [],
@@ -153,6 +154,7 @@ describe("selection inspector details", () => {
       highlights: [
         {
           documentId: "document-top",
+          hierarchyPath: [],
           netId: "net-top",
           visibleEndpoints: [],
           routes: [],
@@ -162,6 +164,13 @@ describe("selection inspector details", () => {
         },
         {
           documentId: "document-child",
+          hierarchyPath: [
+            {
+              parentDocumentId: "document-top",
+              instanceId: "XBIAS",
+              childDocumentId: "document-child",
+            },
+          ],
           netId: "net-child",
           visibleEndpoints: [],
           routes: [],
@@ -173,8 +182,22 @@ describe("selection inspector details", () => {
       hops: [
         {
           direction: "down",
-          from: { documentId: "document-top", netId: "net-top" },
-          to: { documentId: "document-child", netId: "net-child" },
+          from: {
+            documentId: "document-top",
+            netId: "net-top",
+            hierarchyPath: [],
+          },
+          to: {
+            documentId: "document-child",
+            netId: "net-child",
+            hierarchyPath: [
+              {
+                parentDocumentId: "document-top",
+                instanceId: "XBIAS",
+                childDocumentId: "document-child",
+              },
+            ],
+          },
           frame: {
             parentDocumentId: "document-top",
             instanceId: "XBIAS",
@@ -206,6 +229,7 @@ describe("selection inspector details", () => {
     const trace: HierarchyNetTrace = {
       primary: {
         documentId: "document-top",
+        hierarchyPath: [],
         netId: "net-vdd-top",
         visibleEndpoints: [],
         routes: [],
@@ -217,8 +241,16 @@ describe("selection inspector details", () => {
       hops: [
         {
           direction: "global",
-          from: { documentId: "document-top", netId: "net-vdd-top" },
-          to: { documentId: "document-child", netId: "net-vdd-child" },
+          from: {
+            documentId: "document-top",
+            netId: "net-vdd-top",
+            hierarchyPath: [],
+          },
+          to: {
+            documentId: "document-child",
+            netId: "net-vdd-child",
+            hierarchyPath: [],
+          },
           foldedName: "vdd",
         },
       ],

--- a/docs/adr/0041-physical-cut-and-endpoint-readiness.md
+++ b/docs/adr/0041-physical-cut-and-endpoint-readiness.md
@@ -1,0 +1,112 @@
+# 0041 - Physical cut and endpoint readiness
+
+Status: `accepted`
+
+Date: `2026-08-23`
+
+Owners: `packages/edit-engine`, `packages/derived`, `packages/netlist`,
+`packages/agent-adapter`, `apps/editor`
+
+## Context
+
+The current model correctly separates physical Base Nets from derived Logical
+Nets, but two remaining shortcuts contradicted that boundary. `cut_connection`
+could preserve one Base Net when it was imported, global, or already had more
+than one routed component. ERC then treated membership in any Base Net as proof
+that an ordinary pin was connected. Consequently deleting a Wire could leave
+real logical connectivity behind, while an isolated singleton pin could pass
+ERC, Gallery, or a structural Check Report.
+
+Hierarchy tracing also addressed a Net by Document alone. Two instances such
+as X1 and X2 that reuse one child definition could therefore be traversed as if
+they were the same occurrence. Finally, the derived Logical-Net representative
+was described as stable although it can change after split, merge, pruning, or
+Evidence edits.
+
+## Decision
+
+- `cut_connection` always partitions the affected Base Net by explicit Routes
+  and confirmed coincident endpoint contacts. Logical name, global, import, or
+  explicit-equivalence Evidence never suppresses the physical split.
+- The component containing the deleted Route's `from` endpoint (or `to` if the
+  former was an orphan Junction removed by the cut) retains the original
+  Base-Net ID and non-owner Evidence. Other components receive deterministic
+  new IDs. Owner-addressed Evidence follows its surviving marker, Port, or
+  annotation; it is not copied blindly.
+- Route-anchored annotations are an explicit deletion closure. Planners remove
+  them first through typed edits; raw Route deletion rejects while a live
+  anchor remains.
+- One pure derived endpoint assessment separates membership (`unbound`,
+  `singleton`, `peer-connected`) from accepted intent (explicit NoConnect,
+  implicit pin, formal boundary, global supply). ERC, Gallery gates, and the
+  editor Check Report/export review consume this assessment. Check and Save
+  deliberately remains a non-judgmental persistence action and cannot block or
+  mislabel unfinished drawings. The assessment is not persisted.
+- Cross-Cell Net references include `HierarchyFrame[]`. Down traversal appends
+  the concrete instance frame and up traversal may pop only that same caller.
+- A derived Logical-Net ID is a deterministic, revision-scoped Base-Net
+  representative, not persistent identity. Agent Snapshot clients refresh all
+  Net IDs after any revision change.
+
+This supersedes only ADR 0035's clauses that require a normal cut to retain
+imported membership. `remove_route_geometry` remains the explicit
+presentation-only operation and imported routing guidance remains derived.
+
+## Alternatives considered
+
+### Preserve imported/global membership and repair only ERC
+
+- Benefits: smaller Edit Engine change.
+- Costs: Wire Delete would still not mean electrical disconnect and export
+  could retain a connection the user removed.
+- Reason not selected: it preserves the Base/Logical-Net layer violation.
+
+### Add a persisted endpoint lifecycle or readiness object
+
+- Benefits: consumers could read a stored status directly.
+- Costs: creates another electrical protocol, stale derived state, migrations,
+  and synchronization requirements.
+- Reason not selected: readiness is completely derivable from current model
+  facts and explicit intent.
+
+## Consequences
+
+### Positive
+
+- Wire Delete has one electrical meaning in authored, imported, global, and
+  partially routed circuits.
+- ERC, Gallery, and Check Report no longer disagree about singleton pins;
+  Check and Save remains independent of those judgments.
+- Reused Cell definitions no longer cross-connect X1 and X2 traces.
+- No new Project schema, Net object, or Lifecycle Manager is introduced.
+
+### Negative or limiting
+
+- Deleting an imported Wire intentionally marks source connectivity modified;
+  re-import guidance cannot silently restore the cut component.
+- Route-attached annotations are removed with their Route instead of being
+  retained at a fallback position.
+- Snapshot consumers cannot cache derived Net representatives across edits.
+
+## Compatibility and migration
+
+The Project schema and rolling reader are unchanged. Existing projects are
+reinterpreted only when a new cut is committed or readiness is derived. Agent
+API version remains 2.0; generated schema descriptions clarify the existing
+revision fence rather than adding a field.
+
+## Validation
+
+- Delete/undo/redo tests for ordinary, imported, global, partial, named, and
+  direct-contact Nets.
+- Endpoint assessment and ERC tests for every membership and accepted intent.
+- Gallery and Check Report tests proving the same current-revision result.
+- X1/X2 repeated-child hierarchy trace and navigation tests.
+- Agent Snapshot schema/documentation checks for revision-scoped Net IDs.
+
+## Related documents
+
+- [ADR 0035](0035-imported-net-routing-guidance.md)
+- [ADR 0040](0040-connectivity-evidence.md)
+- [Connectivity and routing](../specs/connectivity-and-routing.md)
+- [Agent Circuit API](../specs/agent-api.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -82,6 +82,10 @@ The document style-overrides and schema-21 decision is
 The owner-addressable Connectivity Evidence layer and schema-22 rolling
 migration decision is
 [`0040-connectivity-evidence.md`](0040-connectivity-evidence.md).
+The physical Wire-cut, derived endpoint-readiness, occurrence-aware trace, and
+revision-scoped Logical-Net representative decision—partially superseding ADR
+0035—is
+[`0041-physical-cut-and-endpoint-readiness.md`](0041-physical-cut-and-endpoint-readiness.md).
 The arbitrary-angle Route authoring decision is
 [`0039-any-angle-route-authoring.md`](0039-any-angle-route-authoring.md).
 

--- a/docs/specs/agent-api.md
+++ b/docs/specs/agent-api.md
@@ -76,6 +76,15 @@ name, scope, power-role, or Evidence mutation. A future reviewed marker action
 may author the same owner-addressed Net Marker operation as the GUI without
 adding a second Net-renaming protocol.
 
+Every Snapshot `net.id` and every `netId` reference to it is a deterministic
+Logical-Net representative scoped to that Snapshot Document revision. It is
+not a persistent identity: split, merge, pruning, or Evidence edits may change
+the representative even when some circuit intent remains recognizable. After
+any commit, stale-revision result, or uncertain transport outcome, discard all
+previous Snapshot Net IDs and request a fresh Snapshot. Persisted Base-Net IDs
+remain valid only while their objects survive the edit lifecycle and are not
+exposed as an alternate Agent naming protocol.
+
 `wireIntent` has the same Route planner as interactive Wire. Its optional
 `routingMode` is `orthogonal` (default), `octilinear`, or `free` (ADR 0039);
 an optional

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -81,9 +81,9 @@ informational in the dialog). Failure codes:
 
 - `erc-errors` — any ERC diagnostic with `severity: "error"`.
 - `floating-endpoints` — `ERC_UNCONNECTED_PIN`, `ERC_BULK_UNRESOLVED`,
-  and `ERC_FLOATING_GATE`, except a floating gate whose single-member
-  net carries a name (a deliberate port/rail). The sanctioned escapes
-  are therefore: wire the pin, name its net, or mark it NoConnect.
+  and `ERC_FLOATING_GATE`. A name on a singleton local Net is not electrical
+  connectivity. The sanctioned cases are a real peer connection, a formal
+  boundary, a reviewed global supply, an implicit pin, or explicit NoConnect.
 - `empty-project` — fewer than 2 instances AND no substantial drawing
   (3+ drafting objects including a text); pure block diagrams pass.
 

--- a/docs/specs/connectivity-and-routing.md
+++ b/docs/specs/connectivity-and-routing.md
@@ -29,7 +29,12 @@ Route transaction.
   remains disconnected.
 - Moving a connected Instance stretches the attached Route while preserving
   endpoint identity.
-- Deleting geometry does not silently invent an alternate connection.
+- `remove_route_geometry` removes presentation geometry only. The ordinary
+  Wire Delete command uses `cut_connection`: it always recomputes physical
+  Base-Net components and never lets imported, global, or name Evidence hide a
+  real disconnection.
+- A Route-anchored label or marker is part of the Route deletion closure and is
+  removed through its typed annotation edit before the Route is cut.
 - `NoConnect` and Net membership are mutually exclusive.
 - Snap, selection, highlight, clipboard, undo, Agent Snapshot, and formal render
   consume the same resolved endpoint geometry.
@@ -74,8 +79,10 @@ A guide is transient presentation, never a Route, Junction, or electrical
 contact. A guide click starts the ordinary Wire interaction. Label, geometry,
 or transform edits cannot dismiss guidance; the current graph simply yields a
 new result. `remove_route_geometry` retains Net membership and therefore
-re-exposes unresolved imported components. A normal connection cut may split
-an authored local Net but must retain imported membership. The editor may show
+re-exposes unresolved imported components. A normal connection cut splits all
+physical components, including imported and global Base Nets; only the primary
+component retains source/equivalence Evidence, while owner-addressed markers
+follow their surviving component. The editor may show
 focused, all, or hidden imported guides; Net highlight suppresses only the
 highlighted Net's guides. Unplaced endpoints remain in the Placement Tray and
 do not receive invented page coordinates.

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -78,9 +78,14 @@ The **File** menu exports SVG, PNG, and PDF containing only formal schematic
 layers. PNG uses 3x raster scale. PDF contains that same high-resolution raster
 on a page matching the SVG viewBox.
 
-For an electrical design netlist, choose **Netlist / Check Report** first, or press **Check and Save** in the toolbar to check the circuit and keep a copy on your account's shelf.
-The dialog reports every blocking electrical fact and, when valid, previews
-the deterministic structural SPICE or Spectre text. Use either the dialog's
+For an electrical design netlist, choose **Netlist / Check Report**. **Check and
+Save** is separate: it settles available MOS-body defaults and keeps a copy on
+your account's shelf without judging whether an abbreviated or unfinished
+drawing can be emitted as a netlist.
+The dialog reports structural netlist findings and current-revision ERC
+readiness separately; the ERC section is the same evidence used by Gallery.
+When a structural IR is available, it previews the deterministic SPICE or
+Spectre text. Use either the dialog's
 download button or **File / SPICE netlist** and **File / Spectre netlist** to
 download it. These files contain structure only: they do not add PDK includes,
 models, corners, stimuli, analyses, or simulator options.

--- a/packages/agent-adapter/src/schema.ts
+++ b/packages/agent-adapter/src/schema.ts
@@ -348,6 +348,10 @@ const SnapshotPrimitiveSchema = z.union([
   z.boolean(),
 ]);
 
+const AgentSnapshotLogicalNetIdSchema = StableIdSchema.describe(
+  "Resolved Logical-Net representative valid only for this Snapshot Document revision; refresh after any committed edit",
+);
+
 export const AgentSnapshotPinSchema = z.strictObject({
   name: z.string().min(1),
   role: z.string().min(1).nullable(),
@@ -355,7 +359,7 @@ export const AgentSnapshotPinSchema = z.strictObject({
   visibility: z.enum(["visible", "implicit", "conditional", "unknown"]),
   localPosition: SymbolLocalPointSchema.nullable(),
   pagePosition: PointSchema.nullable(),
-  netId: StableIdSchema.nullable(),
+  netId: AgentSnapshotLogicalNetIdSchema.nullable(),
 });
 
 const AgentNetlistFactsSchema = z.strictObject({
@@ -424,7 +428,7 @@ export const AgentSnapshotInstanceSchema = z.strictObject({
 });
 
 export const AgentSnapshotNetSchema = z.strictObject({
-  id: StableIdSchema,
+  id: AgentSnapshotLogicalNetIdSchema,
   name: z.string().min(1).nullable(),
   scope: z.enum(["local", "global"]),
   powerDomain: NetPowerDomainSchema,
@@ -440,7 +444,7 @@ export const AgentSnapshotNetSchema = z.strictObject({
 
 export const AgentSnapshotRouteSchema = z.strictObject({
   id: StableIdSchema,
-  netId: StableIdSchema,
+  netId: AgentSnapshotLogicalNetIdSchema,
   from: RouteEndpointSchema,
   to: RouteEndpointSchema,
   waypoints: z.array(PointSchema),
@@ -451,7 +455,7 @@ export const AgentSnapshotRouteSchema = z.strictObject({
 
 export const AgentSnapshotJunctionSchema = z.strictObject({
   id: StableIdSchema,
-  netId: StableIdSchema,
+  netId: AgentSnapshotLogicalNetIdSchema,
   position: PointSchema,
   role: JunctionRoleSchema.optional(),
 });

--- a/packages/derived/src/connectivity-index.ts
+++ b/packages/derived/src/connectivity-index.ts
@@ -105,6 +105,7 @@ export interface ProjectObjectIndex {
 
 export interface ProjectConnectivityIndex {
   projectId: string;
+  topDocumentId: string;
   documents: ReadonlyMap<string, DocumentConnectivityIndex>;
   hierarchy: HierarchyConnectivityIndex;
   globalNets: ReadonlyMap<string, GlobalNetGroup>;
@@ -500,6 +501,7 @@ export function buildProjectConnectivityIndex(
   }
   return {
     projectId: project.id,
+    topDocumentId: project.topDocumentId,
     documents,
     hierarchy: buildHierarchyIndex(project, resolver),
     globalNets: buildGlobalNetIndex(project),

--- a/packages/derived/src/diagnostics/diagnostic.test.ts
+++ b/packages/derived/src/diagnostics/diagnostic.test.ts
@@ -161,16 +161,31 @@ describe("diagnostic aggregation", () => {
 
     const resolved = structuredClone(unresolved);
     resolved.documents[0]!.revision = 4;
+    resolved.documents[0]!.instances.push({
+      id: "I2",
+      symbolId: "dual",
+      placement: {
+        position: { x: 100, y: 0 },
+        rotation: 0,
+        mirror: "none",
+      },
+    });
     resolved.documents[0]!.nets = [
       {
         id: "net-left",
         scope: "local",
-        terminals: [{ instanceId: "I1", pinName: "L" }],
+        terminals: [
+          { instanceId: "I1", pinName: "L" },
+          { instanceId: "I2", pinName: "L" },
+        ],
       },
       {
         id: "net-right",
         scope: "local",
-        terminals: [{ instanceId: "I1", pinName: "R" }],
+        terminals: [
+          { instanceId: "I1", pinName: "R" },
+          { instanceId: "I2", pinName: "R" },
+        ],
       },
     ];
     const after = diagnoseProjectSnapshot(resolved, resolver);

--- a/packages/derived/src/diagnostics/erc.test.ts
+++ b/packages/derived/src/diagnostics/erc.test.ts
@@ -340,13 +340,16 @@ describe("ERC engine", () => {
 
   it("treats equal local names as one logical Net without physically merging", () => {
     const project = emptyProject();
-    project.documents[0]!.instances = [instance("I1")];
+    project.documents[0]!.instances = [instance("I1"), instance("I2")];
     project.documents[0]!.nets = [
       {
         id: "net-a",
         name: "out",
         scope: "local",
-        terminals: [{ instanceId: "I1", pinName: "L" }],
+        terminals: [
+          { instanceId: "I1", pinName: "L" },
+          { instanceId: "I2", pinName: "L" },
+        ],
       },
       {
         id: "net-b",
@@ -411,13 +414,16 @@ describe("ERC engine", () => {
     // The schema invariant (WP-R7) rejects this at parse/Edit-Engine time; ERC
     // repeats the check defensively. Construct the invalid state via a cast.
     const project = emptyProject();
-    project.documents[0]!.instances = [instance("I1")];
+    project.documents[0]!.instances = [instance("I1"), instance("I2")];
     project.documents[0]!.nets = [
       {
         id: "net-1",
         name: "sig",
         scope: "local",
-        terminals: [{ instanceId: "I1", pinName: "L" }],
+        terminals: [
+          { instanceId: "I1", pinName: "L" },
+          { instanceId: "I2", pinName: "L" },
+        ],
       },
     ];
     project.documents[0]!.noConnects = [

--- a/packages/derived/src/diagnostics/erc.ts
+++ b/packages/derived/src/diagnostics/erc.ts
@@ -1,10 +1,8 @@
 import type { CircuitProject } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 
-import type {
-  DocumentConnectivityIndex,
-  ProjectConnectivityIndex,
-} from "../connectivity-index.js";
+import type { ProjectConnectivityIndex } from "../connectivity-index.js";
+import { createEndpointConnectivityClassifier } from "../endpoint-connectivity.js";
 import {
   resolveDocumentLogicalNets,
   validateLogicalNetContract,
@@ -48,22 +46,6 @@ function terminalLocator(
   };
 }
 
-function endpointHasOnlyInternalMembership(
-  index: DocumentConnectivityIndex | undefined,
-  netId: string,
-  instanceId: string,
-  pinName: string,
-): boolean {
-  const net = index?.logicalNetByBaseNetId.get(netId);
-  return Boolean(
-    net &&
-    net.logicalEndpoints.length === 1 &&
-    net.logicalEndpoints[0]?.kind === "terminal" &&
-    net.logicalEndpoints[0]?.instanceId === instanceId &&
-    net.logicalEndpoints[0]?.pinName === pinName,
-  );
-}
-
 export function runErcChecks(
   project: CircuitProject,
   index: ProjectConnectivityIndex,
@@ -76,12 +58,11 @@ export function runErcChecks(
 
   for (const document of documents) {
     const docIndex = index.documents.get(document.id);
-    const endpointToNet =
-      docIndex?.endpointToBaseNetId ?? new Map<string, string>();
-    const noConnectEndpoints = new Set(
-      document.noConnects.map((noConnect) => noConnectKey(noConnect.endpoint)),
+    const endpointConnectivity = createEndpointConnectivityClassifier(
+      document,
+      docIndex,
+      resolver,
     );
-
     const logicalNets = resolveDocumentLogicalNets(document);
     for (const net of logicalNets.groups) {
       if (net.powerDomain !== "conflict") continue;
@@ -336,8 +317,13 @@ export function runErcChecks(
 
     // ERC_NO_CONNECT_CONFLICT
     for (const noConnect of document.noConnects) {
-      const owner = endpointToNet.get(noConnectKey(noConnect.endpoint));
-      if (!owner) continue;
+      const assessment = endpointConnectivity.assess(noConnect.endpoint);
+      const conflictsWithConnection =
+        assessment.membership === "peer-connected" ||
+        assessment.intent.formalBoundary ||
+        assessment.intent.globalSupply;
+      if (!conflictsWithConnection) continue;
+      const owner = assessment.baseNetId;
       diagnostics.push({
         id: `erc:no-connect-conflict:${document.id}:${noConnect.id}`,
         domain: "erc",
@@ -345,13 +331,16 @@ export function runErcChecks(
         severity: "error",
         confidence: "high",
         gateEligible: true,
-        message: `NoConnect ${noConnect.id} is also connected to net ${owner}`,
+        message: `NoConnect ${noConnect.id} is also electrically connected${owner ? ` to net ${owner}` : ""}`,
         primary: {
           ...directObjectLocator(document.id, "no-connect", noConnect.id),
           endpoint: noConnect.endpoint,
         },
-        related: [directObjectLocator(document.id, "net", owner)],
-        parameters: { netId: owner, noConnectId: noConnect.id },
+        related: owner ? [directObjectLocator(document.id, "net", owner)] : [],
+        parameters: {
+          ...(owner ? { netId: owner } : {}),
+          noConnectId: noConnect.id,
+        },
       });
     }
 
@@ -371,22 +360,12 @@ export function runErcChecks(
           instanceId: instance.id,
           pinName: pin.name,
         };
-        const key = noConnectKey(endpoint);
-        const netId = endpointToNet.get(key);
-        const explicitlyNoConnect = noConnectEndpoints.has(key);
+        const assessment = endpointConnectivity.assess(endpoint);
+        const netId = assessment.baseNetId ?? undefined;
         const role = pin.role.toLowerCase();
 
         if (role === "gate") {
-          if (
-            !explicitlyNoConnect &&
-            (!netId ||
-              endpointHasOnlyInternalMembership(
-                docIndex,
-                netId,
-                instance.id,
-                pin.name,
-              ))
-          ) {
+          if (!assessment.electricallySatisfied) {
             diagnostics.push({
               id: `erc:floating-gate:${document.id}:${instance.id}:${pin.name}`,
               domain: "erc",
@@ -413,10 +392,12 @@ export function runErcChecks(
 
         if (role === "bulk") {
           const resolution = resolveMosBulkConnection(document, instance);
+          const configuredDefault =
+            resolution?.status === "cell-default" ||
+            resolution?.status === "supply-default";
           if (
-            !explicitlyNoConnect &&
-            !netId &&
-            (!resolution || resolution.status === "unresolved") &&
+            !assessment.electricallySatisfied &&
+            !configuredDefault &&
             pin.presentation.visibility !== "implicit"
           ) {
             diagnostics.push({
@@ -426,13 +407,16 @@ export function runErcChecks(
               severity: "warning",
               confidence: "high",
               gateEligible: false,
-              message: `Bulk ${instance.id}.${pin.name} has no explicit or configured cell-default connection`,
+              message: netId
+                ? `Bulk ${instance.id}.${pin.name} is the only endpoint on net ${netId}`
+                : `Bulk ${instance.id}.${pin.name} has no explicit or configured cell-default connection`,
               primary: terminalLocator(document.id, instance.id, pin.name),
               related: [],
               parameters: {
                 instanceId: instance.id,
                 pinName: pin.name,
                 hidden: hidden.has(pin.name),
+                ...(netId ? { netId } : {}),
               },
             });
           }
@@ -443,8 +427,7 @@ export function runErcChecks(
         // visible non-role-specialized pin must have a Net or a NoConnect;
         // passive-pin tolerance is deferred).
         if (hidden.has(pin.name)) continue;
-        if (pin.presentation.visibility === "implicit") continue;
-        if (netId || explicitlyNoConnect) continue;
+        if (assessment.electricallySatisfied) continue;
         diagnostics.push({
           id: `erc:unconnected-pin:${document.id}:${instance.id}:${pin.name}`,
           domain: "erc",
@@ -452,10 +435,18 @@ export function runErcChecks(
           severity: "warning",
           confidence: "high",
           gateEligible: false,
-          message: `Pin ${instance.id}.${pin.name} is not connected and has no NoConnect`,
+          message: netId
+            ? `Pin ${instance.id}.${pin.name} is the only endpoint on net ${netId}`
+            : `Pin ${instance.id}.${pin.name} is not connected and has no NoConnect`,
           primary: terminalLocator(document.id, instance.id, pin.name),
-          related: [],
-          parameters: { instanceId: instance.id, pinName: pin.name },
+          related: netId
+            ? [directObjectLocator(document.id, "net", netId)]
+            : [],
+          parameters: {
+            instanceId: instance.id,
+            pinName: pin.name,
+            ...(netId ? { netId } : {}),
+          },
         });
       }
     }

--- a/packages/derived/src/endpoint-connectivity.test.ts
+++ b/packages/derived/src/endpoint-connectivity.test.ts
@@ -1,0 +1,168 @@
+import { createEmptyProject } from "@icm/model";
+import { InMemorySymbolResolver } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { buildProjectConnectivityIndex } from "./connectivity-index.js";
+import { createEndpointConnectivityClassifier } from "./endpoint-connectivity.js";
+
+const symbol = {
+  schemaVersion: 1 as const,
+  id: "assessment-symbol",
+  name: "Assessment symbol",
+  viewBox: { x: -20, y: -20, width: 40, height: 40 },
+  pins: [
+    {
+      name: "L",
+      role: "passive",
+      at: { x: -20, y: 0 },
+      direction: "west" as const,
+      presentation: { visibility: "visible" as const },
+    },
+    {
+      name: "R",
+      role: "passive",
+      at: { x: 20, y: 0 },
+      direction: "east" as const,
+      presentation: { visibility: "visible" as const },
+    },
+    {
+      name: "I",
+      role: "passive",
+      at: { x: 0, y: 20 },
+      direction: "south" as const,
+      presentation: { visibility: "implicit" as const },
+    },
+  ],
+  primitives: [],
+  variants: [],
+};
+
+const resolver = new InMemorySymbolResolver([symbol]);
+const endpoint = (instanceId: string, pinName: string) => ({
+  kind: "terminal" as const,
+  instanceId,
+  pinName,
+});
+
+function fixture() {
+  const project = createEmptyProject("assessment", "Assessment", "main");
+  const document = project.documents[0]!;
+  document.instances.push(
+    ...["A", "B"].map((id) => ({
+      id,
+      symbolId: symbol.id,
+      placement: null,
+    })),
+  );
+  return { project, document };
+}
+
+function classifierFor(project: ReturnType<typeof fixture>["project"]) {
+  const index = buildProjectConnectivityIndex(project, resolver);
+  const document = project.documents[0]!;
+  return createEndpointConnectivityClassifier(
+    document,
+    index.documents.get(document.id),
+    resolver,
+  );
+}
+
+describe("endpoint connectivity assessment", () => {
+  it("distinguishes unbound, singleton, and peer-connected membership", () => {
+    const { project, document } = fixture();
+    document.nets.push(
+      {
+        id: "single",
+        scope: "local",
+        terminals: [{ instanceId: "A", pinName: "L" }],
+      },
+      {
+        id: "peer",
+        scope: "local",
+        terminals: [
+          { instanceId: "A", pinName: "R" },
+          { instanceId: "B", pinName: "L" },
+        ],
+      },
+    );
+    const classifier = classifierFor(project);
+
+    expect(classifier.assess(endpoint("B", "R"))).toMatchObject({
+      membership: "unbound",
+      electricallySatisfied: false,
+    });
+    expect(classifier.assess(endpoint("A", "L"))).toMatchObject({
+      membership: "singleton",
+      electricallySatisfied: false,
+    });
+    expect(classifier.assess(endpoint("A", "R"))).toMatchObject({
+      membership: "peer-connected",
+      electricallySatisfied: true,
+      peerEndpoints: [endpoint("B", "L")],
+    });
+  });
+
+  it("keeps explicit intents separate from physical membership", () => {
+    const { project, document } = fixture();
+    document.noConnects.push({
+      id: "nc-b-r",
+      endpoint: endpoint("B", "R"),
+    });
+    document.nets.push(
+      {
+        id: "formal",
+        scope: "local",
+        terminals: [{ instanceId: "A", pinName: "L" }],
+      },
+      {
+        id: "supply",
+        scope: "local",
+        terminals: [{ instanceId: "A", pinName: "R" }],
+      },
+    );
+    document.netlist = {
+      name: "assessment",
+      formalParameters: [],
+      terminals: [
+        {
+          id: "formal-l",
+          name: "L",
+          netId: "formal",
+          direction: "passive",
+          interfaceInstanceIds: ["A"],
+        },
+      ],
+    };
+    document.connectivityEvidence.push({
+      id: "claim-vdd",
+      kind: "name-claim",
+      netId: "supply",
+      name: "VDD",
+      owner: { kind: "explicit-net-property" },
+      scope: "global",
+      powerDomain: "vdd",
+    });
+    const classifier = classifierFor(project);
+
+    expect(classifier.assess(endpoint("B", "R"))).toMatchObject({
+      membership: "unbound",
+      intent: { explicitNoConnect: true },
+      electricallySatisfied: true,
+    });
+    expect(classifier.assess(endpoint("A", "I"))).toMatchObject({
+      membership: "unbound",
+      intent: { implicit: true },
+      electricallySatisfied: true,
+    });
+    expect(classifier.assess(endpoint("A", "L"))).toMatchObject({
+      membership: "singleton",
+      intent: { formalBoundary: true },
+      electricallySatisfied: true,
+    });
+    expect(classifier.assess(endpoint("A", "R"))).toMatchObject({
+      membership: "singleton",
+      intent: { globalSupply: true },
+      electricallySatisfied: true,
+    });
+  });
+});

--- a/packages/derived/src/endpoint-connectivity.ts
+++ b/packages/derived/src/endpoint-connectivity.ts
@@ -1,0 +1,115 @@
+import type { RouteEndpoint, SchematicDocument } from "@icm/model";
+import type { SymbolResolver } from "@icm/symbols";
+
+import type { DocumentConnectivityIndex } from "./connectivity-index.js";
+import { endpointKey } from "./endpoint.js";
+import { resolveDocumentLogicalNets } from "./logical-net.js";
+
+export type EndpointMembership = "unbound" | "singleton" | "peer-connected";
+
+export interface EndpointConnectivityIntent {
+  explicitNoConnect: boolean;
+  implicit: boolean;
+  formalBoundary: boolean;
+  globalSupply: boolean;
+}
+
+/**
+ * One pure, revision-local answer to two deliberately separate questions:
+ * what electrical peers does this endpoint have, and which explicit design
+ * intents make an otherwise peerless endpoint acceptable? This is derived
+ * from the canonical Base/Logical-Net model and is never persisted.
+ */
+export interface EndpointConnectivityAssessment {
+  endpoint: RouteEndpoint;
+  baseNetId: string | null;
+  logicalNetId: string | null;
+  membership: EndpointMembership;
+  peerEndpoints: readonly RouteEndpoint[];
+  intent: EndpointConnectivityIntent;
+  electricallySatisfied: boolean;
+}
+
+export interface EndpointConnectivityClassifier {
+  assess(endpoint: RouteEndpoint): EndpointConnectivityAssessment;
+}
+
+function sameEndpoint(left: RouteEndpoint, right: RouteEndpoint): boolean {
+  return endpointKey(left) === endpointKey(right);
+}
+
+export function createEndpointConnectivityClassifier(
+  document: SchematicDocument,
+  index: DocumentConnectivityIndex | undefined,
+  resolver: SymbolResolver,
+): EndpointConnectivityClassifier {
+  const logicalResolution = resolveDocumentLogicalNets(document);
+  const noConnectKeys = new Set(
+    document.noConnects.map((record) => endpointKey(record.endpoint)),
+  );
+
+  return {
+    assess(endpoint): EndpointConnectivityAssessment {
+      const key = endpointKey(endpoint);
+      const baseNetId = index?.endpointToBaseNetId.get(key) ?? null;
+      const record = baseNetId
+        ? index?.logicalNetByBaseNetId.get(baseNetId)
+        : undefined;
+      const peers = (record?.logicalEndpoints ?? []).filter(
+        (candidate) => !sameEndpoint(candidate, endpoint),
+      );
+      const membership: EndpointMembership = !baseNetId
+        ? "unbound"
+        : peers.length > 0
+          ? "peer-connected"
+          : "singleton";
+      const logicalGroup = baseNetId
+        ? logicalResolution.byBaseNetId.get(baseNetId)
+        : undefined;
+      const formalBoundary = Boolean(
+        logicalGroup &&
+        document.netlist?.terminals.some((terminal) =>
+          logicalGroup.baseNetIds.includes(terminal.netId),
+        ),
+      );
+      const globalSupply = Boolean(
+        logicalGroup?.scope === "global" &&
+        (logicalGroup.powerDomain === "vdd" ||
+          logicalGroup.powerDomain === "ground"),
+      );
+      let implicit = false;
+      if (endpoint.kind === "terminal") {
+        const instance = document.instances.find(
+          (candidate) => candidate.id === endpoint.instanceId,
+        );
+        const resolved = instance
+          ? resolver.resolve(instance.symbolId, instance.symbolVariantId)
+          : undefined;
+        implicit = Boolean(
+          resolved?.definition.pins.find((pin) => pin.name === endpoint.pinName)
+            ?.presentation.visibility === "implicit",
+        );
+      }
+      const intent: EndpointConnectivityIntent = {
+        explicitNoConnect: noConnectKeys.has(key),
+        implicit,
+        formalBoundary,
+        globalSupply,
+      };
+      return {
+        endpoint,
+        baseNetId,
+        logicalNetId: record?.netId ?? null,
+        membership,
+        peerEndpoints: peers,
+        intent,
+        electricallySatisfied:
+          membership === "peer-connected" ||
+          intent.explicitNoConnect ||
+          intent.implicit ||
+          intent.formalBoundary ||
+          intent.globalSupply,
+      };
+    },
+  };
+}

--- a/packages/derived/src/index.ts
+++ b/packages/derived/src/index.ts
@@ -10,6 +10,7 @@ export * from "./diagnostics/diagnostic.js";
 export * from "./diagnostics/erc.js";
 export * from "./drafting-geometry.js";
 export * from "./endpoint.js";
+export * from "./endpoint-connectivity.js";
 export * from "./hierarchy-navigation.js";
 export * from "./instance-label-placement.js";
 export * from "./instance-value.js";

--- a/packages/derived/src/logical-net.ts
+++ b/packages/derived/src/logical-net.ts
@@ -6,7 +6,11 @@ export type LogicalNetConflictCode =
 export type LogicalNetPowerDomain = "none" | "vdd" | "ground" | "conflict";
 
 export interface ResolvedLogicalNet {
-  /** Stable canonical Base-Net ID; derived groups are never persisted. */
+  /**
+   * Deterministic representative Base-Net ID for this Document revision.
+   * Split, merge, pruning, or Evidence edits may change or remove it; derived
+   * Logical-Net groups and their representatives are never persisted.
+   */
   id: string;
   baseNetIds: readonly string[];
   name?: string;

--- a/packages/derived/src/net-highlight.test.ts
+++ b/packages/derived/src/net-highlight.test.ts
@@ -82,8 +82,16 @@ describe("Net highlight", () => {
     ]);
     expect(trace?.hops).toContainEqual({
       direction: "global",
-      from: { documentId: "top", netId: "net-vdd-top" },
-      to: { documentId: "child", netId: "net-vdd-child" },
+      from: {
+        documentId: "top",
+        netId: "net-vdd-top",
+        hierarchyPath: [],
+      },
+      to: {
+        documentId: "child",
+        netId: "net-vdd-child",
+        hierarchyPath: [],
+      },
       foldedName: "vdd",
     });
   });
@@ -167,9 +175,107 @@ describe("Net highlight", () => {
     expect(trace?.hops).toContainEqual(
       expect.objectContaining({
         direction: "down",
-        from: { documentId: "top", netId: "net-a" },
-        to: { documentId: "child", netId: "child-net" },
+        from: { documentId: "top", netId: "net-a", hierarchyPath: [] },
+        to: {
+          documentId: "child",
+          netId: "child-net",
+          hierarchyPath: [
+            {
+              parentDocumentId: "top",
+              instanceId: "X1",
+              childDocumentId: "child",
+            },
+          ],
+        },
       }),
     );
+  });
+
+  it("keeps repeated child Cell occurrences distinct when tracing upward", () => {
+    const project = createEmptyProject("project", "Project", "top");
+    const top = project.documents[0]!;
+    top.instances.push(
+      ...["X1", "X2"].map((id) => ({
+        id,
+        symbolId: "single",
+        placement: null,
+        netlist: {
+          reference: id,
+          parameters: {},
+          binding: {
+            kind: "subcircuit" as const,
+            childDocumentId: "child",
+          },
+        },
+      })),
+    );
+    top.nets.push(
+      {
+        id: "parent-a",
+        scope: "local",
+        terminals: [{ instanceId: "X1", pinName: "P" }],
+      },
+      {
+        id: "parent-b",
+        scope: "local",
+        terminals: [{ instanceId: "X2", pinName: "P" }],
+      },
+    );
+    const child = createEmptyDocument("child", "Child");
+    child.instances.push({ id: "P1", symbolId: "port", placement: null });
+    child.nets.push({
+      id: "child-net",
+      scope: "local",
+      terminals: [{ instanceId: "P1", pinName: "P" }],
+    });
+    child.netlist = {
+      name: "child",
+      formalParameters: [],
+      terminals: [
+        {
+          id: "terminal-p",
+          name: "P",
+          netId: "child-net",
+          direction: "passive",
+          interfaceInstanceIds: ["P1"],
+        },
+      ],
+    };
+    project.documents.push(child);
+
+    const index = buildProjectConnectivityIndex(
+      project,
+      new InMemorySymbolResolver([...builtInSymbols, single]),
+    );
+    const x1Path = [
+      {
+        parentDocumentId: "top",
+        instanceId: "X1",
+        childDocumentId: "child",
+      },
+    ];
+    const trace = traceHierarchyNet(
+      index,
+      "child",
+      "child-net",
+      undefined,
+      x1Path,
+    );
+
+    expect(
+      trace?.highlights.map((highlight) => ({
+        documentId: highlight.documentId,
+        netId: highlight.netId,
+        path: highlight.hierarchyPath.map((frame) => frame.instanceId),
+      })),
+    ).toEqual([
+      { documentId: "child", netId: "child-net", path: ["X1"] },
+      { documentId: "top", netId: "parent-a", path: [] },
+    ]);
+    expect(
+      trace?.hops.some(
+        (hop) => hop.direction !== "global" && hop.frame.instanceId === "X2",
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/derived/src/net-highlight.ts
+++ b/packages/derived/src/net-highlight.ts
@@ -5,6 +5,8 @@ import type {
 } from "./connectivity-index.js";
 import type { RoutingGuide } from "./routing-guidance.js";
 import { endpointKey } from "./endpoint.js";
+import { findHierarchyPaths } from "./hierarchy-navigation.js";
+import type { HierarchyFrame } from "./object-locator.js";
 
 /**
  * Net highlight and cross-cell trace (ADR 0013 index / roadmap WP-R6 core).
@@ -14,6 +16,7 @@ import { endpointKey } from "./endpoint.js";
 
 export interface NetHighlight {
   documentId: string;
+  hierarchyPath: readonly HierarchyFrame[];
   netId: string;
   visibleEndpoints: readonly EndpointRef[];
   routes: readonly string[];
@@ -39,6 +42,7 @@ export interface NetTrace {
 export interface HierarchyNetRef {
   documentId: string;
   netId: string;
+  hierarchyPath: readonly HierarchyFrame[];
 }
 
 export interface HierarchyNetTraceHop {
@@ -63,11 +67,28 @@ export interface HierarchyNetTrace {
   hops: readonly (HierarchyNetTraceHop | GlobalNetTraceHop)[];
 }
 
+function hierarchyPathKey(path: readonly HierarchyFrame[]): string {
+  return path
+    .map(
+      (frame) =>
+        `${frame.parentDocumentId}/${frame.instanceId}/${frame.childDocumentId}`,
+    )
+    .join(">");
+}
+
+function sameHierarchyPath(
+  left: readonly HierarchyFrame[],
+  right: readonly HierarchyFrame[],
+): boolean {
+  return hierarchyPathKey(left) === hierarchyPathKey(right);
+}
+
 export function computeNetHighlight(
   index: ProjectConnectivityIndex,
   documentId: string,
   netId: string,
   origin?: EndpointRef,
+  hierarchyPath: readonly HierarchyFrame[] = [],
 ): NetHighlight | undefined {
   const documentIndex = index.documents.get(documentId);
   const record =
@@ -87,6 +108,7 @@ export function computeNetHighlight(
   const visibleEndpointKeys = new Set(visibleEndpoints.map(endpointKey));
   return {
     documentId,
+    hierarchyPath,
     netId,
     visibleEndpoints,
     routes: component?.routes ?? record.routes,
@@ -161,28 +183,53 @@ export function traceHierarchyNet(
   documentId: string,
   netId: string,
   origin?: EndpointRef,
+  hierarchyPath: readonly HierarchyFrame[] = [],
 ): HierarchyNetTrace | undefined {
-  const primary = computeNetHighlight(index, documentId, netId, origin);
+  const primary = computeNetHighlight(
+    index,
+    documentId,
+    netId,
+    origin,
+    hierarchyPath,
+  );
   if (!primary) return undefined;
   const canonicalRef = (ref: HierarchyNetRef): HierarchyNetRef => ({
     documentId: ref.documentId,
+    hierarchyPath: ref.hierarchyPath,
     netId:
       index.documents.get(ref.documentId)?.logicalNetByBaseNetId.get(ref.netId)
         ?.netId ?? ref.netId,
   });
-  const queue: HierarchyNetRef[] = [canonicalRef({ documentId, netId })];
+  const queue: HierarchyNetRef[] = [
+    canonicalRef({ documentId, netId, hierarchyPath }),
+  ];
   const visited = new Set<string>();
   const highlights: NetHighlight[] = [];
   const hops: Array<HierarchyNetTraceHop | GlobalNetTraceHop> = [];
 
   while (queue.length > 0) {
     const current = queue.shift()!;
-    const key = `${current.documentId}\u0000${current.netId}`;
+    const pathKey = hierarchyPathKey(current.hierarchyPath);
+    const key = `${pathKey}\u0000${current.documentId}\u0000${current.netId}`;
     if (visited.has(key)) continue;
     const highlight =
-      current.documentId === documentId && current.netId === netId
-        ? computeNetHighlight(index, current.documentId, current.netId, origin)
-        : computeNetHighlight(index, current.documentId, current.netId);
+      current.documentId === documentId &&
+      current.netId === primary.netId &&
+      sameHierarchyPath(current.hierarchyPath, hierarchyPath)
+        ? computeNetHighlight(
+            index,
+            current.documentId,
+            current.netId,
+            origin,
+            current.hierarchyPath,
+          )
+        : computeNetHighlight(
+            index,
+            current.documentId,
+            current.netId,
+            undefined,
+            current.hierarchyPath,
+          );
     if (!highlight) continue;
     visited.add(key);
     highlights.push(highlight);
@@ -208,11 +255,28 @@ export function traceHierarchyNet(
         const to = canonicalRef({
           documentId: edge.childDocumentId,
           netId: edge.childNetId,
+          hierarchyPath: [
+            ...current.hierarchyPath,
+            {
+              parentDocumentId: edge.parentDocumentId,
+              instanceId: edge.instanceId,
+              childDocumentId: edge.childDocumentId,
+            },
+          ],
         });
         hops.push({ direction: "down", from: current, to, frame });
         queue.push(to);
       }
       if (edge.childDocumentId === current.documentId) {
+        const caller = current.hierarchyPath.at(-1);
+        if (
+          !caller ||
+          caller.parentDocumentId !== edge.parentDocumentId ||
+          caller.instanceId !== edge.instanceId ||
+          caller.childDocumentId !== edge.childDocumentId
+        ) {
+          continue;
+        }
         if (!currentRecord?.baseNetIds.includes(edge.childNetId)) continue;
         const parentNetId = index.documents
           .get(edge.parentDocumentId)
@@ -228,6 +292,7 @@ export function traceHierarchyNet(
         const to = canonicalRef({
           documentId: edge.parentDocumentId,
           netId: parentNetId,
+          hierarchyPath: current.hierarchyPath.slice(0, -1),
         });
         hops.push({ direction: "up", from: current, to, frame });
         queue.push(to);
@@ -244,27 +309,40 @@ export function traceHierarchyNet(
       ),
     );
     if (globalRecord && group) {
-      for (const to of group.nets) {
-        if (
-          to.documentId === current.documentId &&
-          to.netId === current.netId
-        ) {
-          continue;
+      for (const target of group.nets) {
+        const targetPaths =
+          target.documentId === index.topDocumentId
+            ? [[]]
+            : (findHierarchyPaths(
+                index,
+                index.topDocumentId,
+                target.documentId,
+              ) ?? [[]]);
+        for (const targetPath of targetPaths) {
+          const to = canonicalRef({ ...target, hierarchyPath: targetPath });
+          const samePath = sameHierarchyPath(targetPath, current.hierarchyPath);
+          if (
+            to.documentId === current.documentId &&
+            to.netId === current.netId &&
+            samePath
+          ) {
+            continue;
+          }
+          hops.push({
+            direction: "global",
+            from: current,
+            to,
+            foldedName: group.foldedName,
+          });
+          queue.push(to);
         }
-        hops.push({
-          direction: "global",
-          from: current,
-          to,
-          foldedName: group.foldedName,
-        });
-        queue.push(canonicalRef(to));
       }
     }
   }
 
   highlights.sort((left, right) =>
-    `${left.documentId}\u0000${left.netId}`.localeCompare(
-      `${right.documentId}\u0000${right.netId}`,
+    `${left.documentId}\u0000${left.hierarchyPath.map((frame) => frame.instanceId).join("/")}\u0000${left.netId}`.localeCompare(
+      `${right.documentId}\u0000${right.hierarchyPath.map((frame) => frame.instanceId).join("/")}\u0000${right.netId}`,
       "en",
     ),
   );
@@ -277,8 +355,8 @@ export function traceHierarchyNet(
       right.direction === "global"
         ? right.foldedName
         : `${right.frame.instanceId}\u0000${right.frame.parentPinName}`;
-    return `${left.direction}\u0000${left.from.documentId}\u0000${left.from.netId}\u0000${leftSuffix}`.localeCompare(
-      `${right.direction}\u0000${right.from.documentId}\u0000${right.from.netId}\u0000${rightSuffix}`,
+    return `${left.direction}\u0000${left.from.hierarchyPath.map((frame) => frame.instanceId).join("/")}\u0000${left.from.documentId}\u0000${left.from.netId}\u0000${leftSuffix}`.localeCompare(
+      `${right.direction}\u0000${right.from.hierarchyPath.map((frame) => frame.instanceId).join("/")}\u0000${right.from.documentId}\u0000${right.from.netId}\u0000${rightSuffix}`,
       "en",
     );
   });

--- a/packages/derived/src/submission-gates.test.ts
+++ b/packages/derived/src/submission-gates.test.ts
@@ -149,7 +149,7 @@ describe("evaluateSubmissionGates", () => {
     expect(gates(target).ok).toBe(true);
   });
 
-  it("blocks an unnamed single-ended gate but accepts a named one", () => {
+  it("keeps a named singleton gate floating until it has a sanctioned boundary", () => {
     const target = project();
     const document = target.documents[0]!;
     document.instances = [
@@ -184,7 +184,7 @@ describe("evaluateSubmissionGates", () => {
       scope: "local",
       owner: { kind: "explicit-net-property" },
     });
-    expect(gates(target).ok).toBe(true);
+    expect(failureCodes(target)).toEqual(["floating-endpoints"]);
   });
 
   it("reports ERC errors such as duplicate instance names", () => {

--- a/packages/derived/src/submission-gates.ts
+++ b/packages/derived/src/submission-gates.ts
@@ -3,7 +3,6 @@ import type { SymbolResolver } from "@icm/symbols";
 
 import { buildProjectConnectivityIndex } from "./connectivity-index.js";
 import { runErcChecks } from "./diagnostics/erc.js";
-import { resolveDocumentLogicalNets } from "./logical-net.js";
 
 /**
  * Gallery submission quality gates (roadmap phase G3). One deterministic
@@ -13,9 +12,8 @@ import { resolveDocumentLogicalNets } from "./logical-net.js";
  *
  * - no ERC errors;
  * - no floating endpoints — every visible pin is wired into a net with
- *   other members, sits on a NAMED single-member net (a deliberate
- *   port/rail), or carries an explicit NoConnect (the ERC engine already
- *   honors NoConnect and hidden/implicit pins);
+ *   other members or carries a sanctioned intent (formal boundary, global
+ *   supply, implicit pin, or explicit NoConnect) already classified by ERC;
  * - no near-empty submissions — at least 2 instances, or a drawing with
  *   at least 3 drafting objects including a text (pure block diagrams
  *   stay submittable).
@@ -44,20 +42,6 @@ const FLOATING_CODES = new Set([
 ]);
 
 const EXAMPLE_LIMIT = 5;
-
-function netIsNamed(
-  project: CircuitProject,
-  documentId: string,
-  netId: string,
-): boolean {
-  const document = project.documents.find(
-    (candidate) => candidate.id === documentId,
-  );
-  const net = document
-    ? resolveDocumentLogicalNets(document).byBaseNetId.get(netId)
-    : undefined;
-  return typeof net?.name === "string" && net.name.length > 0;
-}
 
 function terminalLabel(parameters: Record<string, unknown>): string {
   const instanceId = parameters.instanceId;
@@ -94,26 +78,14 @@ export function evaluateSubmissionGates(
     });
   }
 
-  const floating = diagnostics.filter((diagnostic) => {
-    if (!FLOATING_CODES.has(diagnostic.code)) return false;
-    // A gate wired onto a single-member net that carries a NAME is a
-    // deliberate port/rail declaration and passes ("unwired but named").
-    if (diagnostic.code === "ERC_FLOATING_GATE") {
-      const netId = diagnostic.parameters.netId;
-      if (
-        typeof netId === "string" &&
-        netIsNamed(project, diagnostic.primary.documentId, netId)
-      ) {
-        return false;
-      }
-    }
-    return true;
-  });
+  const floating = diagnostics.filter((diagnostic) =>
+    FLOATING_CODES.has(diagnostic.code),
+  );
   if (floating.length > 0) {
     failures.push({
       code: "floating-endpoints",
       message:
-        "Floating endpoints: wire each pin, name its net, or mark it NoConnect",
+        "Floating endpoints: wire each pin, declare a formal/global boundary, or mark it NoConnect",
       count: floating.length,
       examples: floating
         .slice(0, EXAMPLE_LIMIT)

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -596,6 +596,13 @@ export function proposeVisualRouteDeletion(
   const sortedJunctionIds = [...junctionsToRemove].sort((a, b) =>
     a.localeCompare(b, "en"),
   );
+  const removedRouteAnnotationIds = document.annotations
+    .filter(
+      (annotation) =>
+        annotation.anchor.kind === "route" &&
+        routesToRemove.has(annotation.anchor.routeId),
+    )
+    .map((annotation) => annotation.id);
   const removedPowerLabelIds = document.annotations
     .filter(
       (annotation) =>
@@ -609,8 +616,10 @@ export function proposeVisualRouteDeletion(
             route.netId === annotation.netId,
         ),
     )
-    .map((annotation) => annotation.id)
-    .sort((a, b) => a.localeCompare(b, "en"));
+    .map((annotation) => annotation.id);
+  const removedAnnotationIds = [
+    ...new Set([...removedRouteAnnotationIds, ...removedPowerLabelIds]),
+  ].sort((a, b) => a.localeCompare(b, "en"));
   // `cut_connection` removes a junction that becomes orphaned. Only a selected
   // junction already detached before this transaction needs an explicit edit;
   // otherwise a second remove would reject the transaction.
@@ -656,9 +665,9 @@ export function proposeVisualRouteDeletion(
   return {
     routeIds: sortedRouteIds,
     junctionIds: sortedJunctionIds,
-    annotationIds: removedPowerLabelIds,
+    annotationIds: removedAnnotationIds,
     edits: [
-      ...removedPowerLabelIds.map((annotationId): SchematicEdit => ({
+      ...removedAnnotationIds.map((annotationId): SchematicEdit => ({
         kind: "remove_schematic_annotation",
         annotationId,
       })),

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -438,14 +438,45 @@ describe("routing Edit Engine", () => {
       rotation: 0,
       locked: false,
     });
+    document.annotations.push({
+      id: "label-on-vdd-route",
+      kind: "net-label",
+      netId: "VDD",
+      content: { runs: [{ kind: "text", value: "VDD" }] },
+      anchor: {
+        kind: "route",
+        routeId: "vdd-rail",
+        segmentIndex: 0,
+        t: 0.5,
+        normalOffset: 10,
+        direction: "forward",
+        orientation: "horizontal",
+        fallbackPosition: { x: 50, y: 10 },
+      },
+      alignment: "middle",
+      rotation: 0,
+      locked: false,
+    });
+
+    const rawCut = executeTransaction(
+      document,
+      transaction(document.id, 0, [
+        { kind: "cut_connection", routeId: "vdd-rail" },
+      ]),
+      context,
+    );
+    expect(rawCut).toMatchObject({
+      ok: false,
+      error: { code: "EDIT_PRECONDITION" },
+    });
 
     const proposal = proposeVisualRouteDeletion(document, ["vdd-rail"], []);
-    expect(proposal.annotationIds).toEqual(["label-VDD"]);
+    expect(proposal.annotationIds).toEqual(["label-on-vdd-route", "label-VDD"]);
     expect(
       proposal.edits.filter(
         (edit) => edit.kind === "remove_schematic_annotation",
       ),
-    ).toHaveLength(1);
+    ).toHaveLength(2);
     const deleted = executeTransaction(
       document,
       transaction(document.id, 0, proposal.edits),
@@ -2223,8 +2254,14 @@ describe("routing Edit Engine", () => {
     );
   });
 
-  it("deletes routed geometry while preserving a partially routed imported Net", () => {
+  it("physically splits a partially routed imported Net and keeps source Evidence on the primary component", () => {
     const document = documentFixture();
+    document.connectivityEvidence.push({
+      id: "source-net-h",
+      kind: "spice-source",
+      netId: "net-h",
+      sourceNetId: "source-horizontal",
+    });
     document.routes = [
       {
         id: "route-partial",
@@ -2244,20 +2281,33 @@ describe("routing Edit Engine", () => {
       context,
     );
 
-    const beforeNet = structuredClone(
-      document.nets.find((net) => net.id === "net-h"),
-    );
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.document.routes).toEqual([]);
-    expect(result.document.nets.find((net) => net.id === "net-h")).toEqual(
-      beforeNet,
+    expect(
+      result.document.nets.find((net) => net.id === "net-h")?.terminals,
+    ).toEqual([{ instanceId: "A", pinName: "P" }]);
+    expect(
+      result.document.nets
+        .filter((net) =>
+          net.terminals.some((terminal) =>
+            ["A", "B", "E"].includes(terminal.instanceId),
+          ),
+        )
+        .map((net) => net.terminals.map((terminal) => terminal.instanceId)),
+    ).toEqual([["A"], ["B"], ["E"]]);
+    expect(
+      result.document.connectivityEvidence.filter(
+        (evidence) => evidence.kind === "spice-source",
+      ),
+    ).toEqual(
+      expect.arrayContaining([expect.objectContaining({ netId: "net-h" })]),
     );
-    expect(deriveFlightlines(result.document, resolver)).toHaveLength(3);
-    expect(result.document.sourceStatus).toBe("geometry-only-changed");
+    expect(deriveFlightlines(result.document, resolver)).toHaveLength(1);
+    expect(result.document.sourceStatus).toBe("connectivity-modified");
   });
 
-  it("deletes global-Net route geometry without partitioning the Net", () => {
+  it("physically splits a global-Net Route instead of hiding the cut behind global Evidence", () => {
     const document = documentFixture();
     const net = document.nets.find((candidate) => candidate.id === "net-v")!;
     net.scope = "global";
@@ -2266,7 +2316,6 @@ describe("routing Edit Engine", () => {
         evidence.scope = "global";
       }
     }
-    const beforeNet = structuredClone(net);
     document.routes = [
       {
         id: "route-global",
@@ -2290,8 +2339,14 @@ describe("routing Edit Engine", () => {
     if (!result.ok) return;
     expect(result.document.routes).toEqual([]);
     expect(
-      result.document.nets.find((candidate) => candidate.id === "net-v"),
-    ).toEqual(beforeNet);
-    expect(result.document.sourceStatus).toBe("geometry-only-changed");
+      result.document.nets.find((candidate) => candidate.id === "net-v")
+        ?.terminals,
+    ).toEqual([{ instanceId: "C", pinName: "P" }]);
+    expect(
+      result.document.nets.find((candidate) =>
+        candidate.terminals.some((terminal) => terminal.instanceId === "D"),
+      ),
+    ).toMatchObject({ scope: "local", terminals: [{ instanceId: "D" }] });
+    expect(result.document.sourceStatus).toBe("connectivity-modified");
   });
 });

--- a/packages/edit-engine/src/transaction-routing.ts
+++ b/packages/edit-engine/src/transaction-routing.ts
@@ -7,6 +7,7 @@ import type {
 } from "@icm/model";
 import {
   derivePowerRailComponent,
+  deriveDocumentContactEvidence,
   endpointBelongsToNet,
   polylineSatisfiesConstraint,
   endpointKey,
@@ -55,6 +56,7 @@ export function endpointOwnerNetId(
 export function netEndpointGroups(
   document: SchematicDocument,
   netId: string,
+  resolver?: SymbolResolver,
 ): string[][] {
   const net = document.nets.find((candidate) => candidate.id === netId);
   if (!net) return [];
@@ -81,6 +83,19 @@ export function netEndpointGroups(
     (candidate) => candidate.netId === netId,
   )) {
     union(endpointKey(route.from), endpointKey(route.to));
+  }
+  // A pin or Junction placed directly on another explicit same-Net endpoint
+  // is a real electrical contact even when no Route object exists between the
+  // coincident endpoints. Preserve that contact when a different Route is cut.
+  // Name claims and other Logical-Net Evidence are intentionally excluded:
+  // they express logical equivalence, not one physical Base-Net component.
+  if (resolver) {
+    for (const contact of deriveDocumentContactEvidence(document, resolver)
+      .contacts) {
+      if (contact.netId !== netId || contact.endpoints.length < 2) continue;
+      const [first, ...rest] = contact.endpoints.map(endpointKey);
+      for (const key of rest) union(first!, key);
+    }
   }
   const grouped = new Map<string, string[]>();
   for (const key of keys) {

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -2086,6 +2086,19 @@ export function executeTransaction(
             `Route contains a locked segment: ${route.id}`,
           );
         }
+        const anchoredAnnotation = draft.annotations.find(
+          (annotation) =>
+            annotation.anchor.kind === "route" &&
+            annotation.anchor.routeId === route.id,
+        );
+        if (anchoredAnnotation) {
+          return rejectAt(
+            "EDIT_PRECONDITION",
+            `Remove Route annotation ${anchoredAnnotation.id} before deleting Route ${route.id}`,
+            [],
+            [anchoredAnnotation.id, route.id],
+          );
+        }
         const ownerNetIds = removeConnectivityEvidenceOwnedBy(
           draft,
           new Set([route.id]),
@@ -2116,6 +2129,19 @@ export function executeTransaction(
             `Route contains a locked segment: ${route.id}`,
           );
         }
+        const anchoredAnnotation = draft.annotations.find(
+          (annotation) =>
+            annotation.anchor.kind === "route" &&
+            annotation.anchor.routeId === route.id,
+        );
+        if (anchoredAnnotation) {
+          return rejectAt(
+            "EDIT_PRECONDITION",
+            `Remove Route annotation ${anchoredAnnotation.id} before cutting Route ${route.id}`,
+            [],
+            [anchoredAnnotation.id, route.id],
+          );
+        }
         const net = draft.nets.find(
           (candidate) => candidate.id === route.netId,
         );
@@ -2125,14 +2151,6 @@ export function executeTransaction(
             `Route Net does not exist: ${route.netId}`,
           );
         }
-        const beforeGroups = netEndpointGroups(draft, net.id);
-        const logicalNetBeforeCut = resolveDocumentLogicalNets(
-          draft,
-        ).byBaseNetId.get(net.id);
-        const preserveLogicalNet =
-          beforeGroups.length > 1 ||
-          (logicalNetBeforeCut?.sourceNetIds.length ?? 0) > 0;
-
         const candidateOrphanJunctionIds = new Set(
           [route.from, route.to].flatMap((endpoint) =>
             endpoint.kind === "junction" ? [endpoint.junctionId] : [],
@@ -2178,7 +2196,7 @@ export function executeTransaction(
           changedObjectIds.add(junctionId);
         }
 
-        const groups = netEndpointGroups(draft, net.id);
+        const groups = netEndpointGroups(draft, net.id, context.symbolResolver);
         if (groups.length === 0) {
           for (const netId of new Set([net.id, ...ownerNetIds])) {
             pruneUnreachableLocalNet(draft, netId, changedObjectIds);
@@ -2194,11 +2212,19 @@ export function executeTransaction(
           connectivityChanged = true;
           break;
         }
-        if (
-          groups.length > 1 &&
-          !preserveLogicalNet &&
-          logicalNetBeforeCut?.scope !== "global"
-        ) {
+        if (groups.length > 1) {
+          // The component containing the authored Route's `from` endpoint (or
+          // `to` when `from` was an orphan Junction removed by this cut)
+          // retains the original Base-Net identity and non-owner Evidence.
+          // Every detached component receives a new Base Net; logical/global/
+          // imported Evidence is never allowed to suppress physical splitting.
+          const primaryIndex = [route.from, route.to]
+            .map((endpoint) => endpointKey(endpoint))
+            .map((key) => groups.findIndex((group) => group.includes(key)))
+            .find((index) => index >= 0);
+          if (primaryIndex !== undefined && primaryIndex > 0) {
+            groups.unshift(...groups.splice(primaryIndex, 1));
+          }
           const netIdByEndpoint = new Map<string, string>();
           const splitNetIds = groups
             .slice(1)


### PR DESCRIPTION
## Summary
- make every wire deletion split physical Base-Net connectivity and close route-owned annotation lifecycle
- derive one endpoint connectivity assessment for ERC, Gallery readiness, Check Report, and export review
- preserve hierarchy occurrence paths during Net tracing and document Logical-Net IDs as revision-scoped representatives

## Validation
- pnpm gate:affected -- --base origin/main
- pnpm test:impact -- --base origin/main
- pnpm ci:static
- pnpm install --frozen-lockfile && pnpm ci:check
- 1259 unit tests and 225 Playwright tests passed

gate:preflight selected a missing gate:review:check package script on current main; all remaining selected checks were run explicitly and passed.