### PR TITLE
fix(editor): let a wire land anywhere along a conductor

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -392,6 +392,7 @@ import {
   isRoutedMarker,
   looseRouteAnchorIds,
   NET_LABEL_MAX_NORMAL_OFFSET,
+  routeTapPoint,
 } from "../features/wiring/route-interaction-geometry";
 import { reflectOrientation } from "../interaction/shortcut-orientation";
 import type { ScreenFlip } from "../interaction/shortcut-orientation";
@@ -427,28 +428,6 @@ const PAN_START_DISTANCE_PX = 10;
 const SNAP_CAPTURE_RADIUS_PX = 7;
 
 /** Persisted Junctions are grid points, including on ±45° Route segments. */
-function snapPointOnRouteGrid(
-  pointer: Point,
-  from: Point,
-  to: Point,
-  grid: number,
-): Point {
-  const projected = closestPointOnSegment(pointer, from, to);
-  if (from.y === to.y) {
-    return { x: snapCoordinate(projected.x, grid), y: from.y };
-  }
-  if (from.x === to.x) {
-    return { x: from.x, y: snapCoordinate(projected.y, grid) };
-  }
-  // Octilinear diagonal: choosing one grid coordinate determines the other.
-  // Endpoints already satisfy the grid invariant, so the paired coordinate
-  // remains integral and on-grid too.
-  const slope = Math.sign(to.y - from.y) * Math.sign(to.x - from.x);
-  const minX = Math.min(from.x, to.x);
-  const maxX = Math.max(from.x, to.x);
-  const x = clamp(snapCoordinate(projected.x, grid), minX, maxX);
-  return { x, y: from.y + slope * (x - from.x) };
-}
 
 type DragPreview = InstanceMovePreview;
 
@@ -4024,15 +4003,21 @@ export function App({
     guides: SnapGuideLine[];
   } {
     if (suppressSnap) return { point, guides: [] };
+    // A wire already under way arrives from its last authored point, so a tap
+    // on a conductor can land exactly where that run reaches it.
+    const arrival = wireSource
+      ? (wireWaypoints.at(-1) ?? wireSource.point)
+      : null;
     const routeTargets = routeGeometryRecords.flatMap(({ route, geometry }) =>
       geometry.centerline.slice(0, -1).map((from, segmentIndex) => ({
         anchor: {
           id: `wire-route:${route.id}:${segmentIndex}`,
-          point: snapPointOnRouteGrid(
+          point: routeTapPoint(
             point,
             from,
             geometry.centerline[segmentIndex + 1]!,
             document.presentation.grid,
+            arrival,
           ),
           kind: "route" as const,
         },
@@ -10290,18 +10275,6 @@ export function App({
                   return;
                 finishDraftingCreate();
                 return;
-              }
-              if (tool === "wire") {
-                console.log(
-                  "DBLWIRE",
-                  JSON.stringify({
-                    target: target.tagName,
-                    testid: (target as HTMLElement).dataset?.testid,
-                    isCanvas: target === event.currentTarget,
-                    hasSource: Boolean(wireSource),
-                    steps: wireDraftSteps.length,
-                  }),
-                );
               }
               if (tool !== "wire") return;
               // A double-click ends the wire wherever it lands. The guard

--- a/apps/editor/src/features/wiring/route-interaction-geometry.test.ts
+++ b/apps/editor/src/features/wiring/route-interaction-geometry.test.ts
@@ -10,6 +10,7 @@ import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
 import {
   annotationAnchor,
   attachmentAtPoint,
+  routeTapPoint,
   defaultInstanceLabel,
   dragNetLabelAttachmentAtPoint,
   dragRouteAttachmentAtPoint,
@@ -238,6 +239,68 @@ describe("route interaction geometry", () => {
         fallbackPosition: { x: 90, y: 140 },
       },
       alignment: "middle",
+    });
+  });
+});
+
+describe("routeTapPoint", () => {
+  const grid = 10;
+  const vertical = { from: { x: 370, y: 120 }, to: { x: 370, y: 460 } };
+  const horizontal = { from: { x: 200, y: 290 }, to: { x: 600, y: 290 } };
+
+  it("quantizes a tap that is merely aimed at a conductor", () => {
+    expect(
+      routeTapPoint({ x: 372, y: 263 }, vertical.from, vertical.to, grid),
+    ).toEqual({ x: 370, y: 260 });
+    expect(
+      routeTapPoint({ x: 417, y: 288 }, horizontal.from, horizontal.to, grid),
+    ).toEqual({ x: 420, y: 290 });
+  });
+
+  it("lands where the run arrives, so the grid cannot bend it", () => {
+    // A run arriving at y = 265 must reach the wire at 265, not be dragged to
+    // 260 and turned into an elbow. Any point along a conductor is tappable.
+    expect(
+      routeTapPoint({ x: 372, y: 264 }, vertical.from, vertical.to, grid, {
+        x: 620,
+        y: 265,
+      }),
+    ).toEqual({ x: 370, y: 265 });
+    expect(
+      routeTapPoint({ x: 417, y: 288 }, horizontal.from, horizontal.to, grid, {
+        x: 415,
+        y: 100,
+      }),
+    ).toEqual({ x: 415, y: 290 });
+  });
+
+  it("keeps the grid when the run arrives somewhere else entirely", () => {
+    // Aiming at one end of a wire while the run comes from far away is not a
+    // straight connection to preserve; the tidy grid tap is the better answer.
+    expect(
+      routeTapPoint({ x: 372, y: 263 }, vertical.from, vertical.to, grid, {
+        x: 620,
+        y: 440,
+      }),
+    ).toEqual({ x: 370, y: 260 });
+  });
+
+  it("never lands off the end of the segment it taps", () => {
+    // An arrival beyond the wire's own extent is not on that wire.
+    expect(
+      routeTapPoint({ x: 372, y: 130 }, vertical.from, vertical.to, grid, {
+        x: 620,
+        y: 90,
+      }),
+    ).toEqual({ x: 370, y: 130 });
+  });
+
+  it("keeps a diagonal tap on the segment", () => {
+    const from = { x: 0, y: 0 };
+    const to = { x: 100, y: 100 };
+    expect(routeTapPoint({ x: 44, y: 46 }, from, to, grid)).toEqual({
+      x: 50,
+      y: 50,
     });
   });
 });

--- a/apps/editor/src/features/wiring/route-interaction-geometry.ts
+++ b/apps/editor/src/features/wiring/route-interaction-geometry.ts
@@ -25,6 +25,51 @@ import type { SymbolResolver } from "@icm/symbols";
 import { clamp, closestPointOnSegment } from "../../canvas/canvas-geometry";
 import { instanceVisibleHitBox } from "../../canvas/instance-geometry";
 
+/**
+ * Where a tap on a conductor lands.
+ *
+ * The projection onto the segment is quantized to the grid so a tap that is
+ * merely aimed at a wire still lands tidily. But the grid is a tidiness
+ * preference, while landing on a conductor is an electrical act: when a run
+ * is already under way, the coordinate it arrives on wins within one grid
+ * step, so a straight connection stays straight instead of being bent into
+ * an elbow — or refused. Any point along a conductor may be tapped.
+ */
+export function routeTapPoint(
+  pointer: Point,
+  from: Point,
+  to: Point,
+  grid: number,
+  arrival?: Point | null,
+): Point {
+  const projected = closestPointOnSegment(pointer, from, to);
+  const prefers = (wanted: number, along: number, low: number, high: number) =>
+    wanted >= Math.min(low, high) &&
+    wanted <= Math.max(low, high) &&
+    Math.abs(wanted - along) <= grid;
+  const onGrid = (value: number) => Math.round(value / grid) * grid;
+  if (from.y === to.y) {
+    if (arrival && prefers(arrival.x, projected.x, from.x, to.x)) {
+      return { x: arrival.x, y: from.y };
+    }
+    return { x: onGrid(projected.x), y: from.y };
+  }
+  if (from.x === to.x) {
+    if (arrival && prefers(arrival.y, projected.y, from.y, to.y)) {
+      return { x: from.x, y: arrival.y };
+    }
+    return { x: from.x, y: onGrid(projected.y) };
+  }
+  // Octilinear diagonal: choosing one grid coordinate determines the other.
+  // Endpoints already satisfy the grid invariant, so the paired coordinate
+  // remains integral and on-grid too.
+  const slope = Math.sign(to.y - from.y) * Math.sign(to.x - from.x);
+  const minX = Math.min(from.x, to.x);
+  const maxX = Math.max(from.x, to.x);
+  const x = clamp(onGrid(projected.x), minX, maxX);
+  return { x, y: from.y + slope * (x - from.x) };
+}
+
 export interface RouteGeometryRecord {
   route: SchematicDocument["routes"][number];
   geometry: ResolvedRouteGeometry;

--- a/apps/editor/src/features/wiring/use-wire-interaction.ts
+++ b/apps/editor/src/features/wiring/use-wire-interaction.ts
@@ -44,6 +44,7 @@ import { closestPointOnSegment } from "../../canvas/canvas-geometry";
 import {
   endpointNetId,
   looseRouteAnchorIds,
+  routeTapPoint,
   type RouteGeometryRecord,
 } from "./route-interaction-geometry";
 
@@ -64,24 +65,6 @@ type TransactionResult = {
   ok: boolean;
   revision: number;
 };
-
-function snapRouteTapPoint(
-  point: Point,
-  from: Point,
-  to: Point,
-  grid: number,
-): Point {
-  const projected = closestPointOnSegment(point, from, to);
-  if (from.y === to.y)
-    return { x: snapCoordinate(projected.x, grid), y: from.y };
-  if (from.x === to.x)
-    return { x: from.x, y: snapCoordinate(projected.y, grid) };
-  const slope = Math.sign(to.y - from.y) * Math.sign(to.x - from.x);
-  const minX = Math.min(from.x, to.x);
-  const maxX = Math.max(from.x, to.x);
-  const x = Math.min(maxX, Math.max(minX, snapCoordinate(projected.x, grid)));
-  return { x, y: from.y + slope * (x - from.x) };
-}
 
 export interface UseWireInteractionOptions {
   document: SchematicDocument;
@@ -689,11 +672,14 @@ export function useWireInteraction(options: UseWireInteractionOptions) {
     }
     const segment = record.geometry.segments[tap.address.segmentIndex];
     if (!segment) return;
-    const tapPoint = snapRouteTapPoint(
+    const tapPoint = routeTapPoint(
       tap.point,
       segment.from,
       segment.to,
       options.document.presentation.grid,
+      options.wireSource
+        ? (options.wireWaypoints.at(-1) ?? options.wireSource.point)
+        : null,
     );
     const overlappingTargets = options.routeGeometryRecords.flatMap(
       (candidate) => {


### PR DESCRIPTION
> 我这里好像没办法直接连到这根竖着线的中点，按W的时候有时候出这种问题
> 正交的时候，应可以连接到线的任何地方

## What was wrong

Tapping a wire quantized the landing point to the grid, so **only grid multiples were connectable**:

```ts
if (from.x === to.x) return { x: from.x, y: snapCoordinate(projected.y, grid) };
```

A run arriving at a coordinate the grid does not carry could not reach the conductor straight — the tap was dragged to the nearest grid line, bending a straight connection into an elbow. And a near miss became a **free waypoint one grid step short of the wire**: visually almost touching, electrically nothing, with no junction dot and no warning. That is the "sometimes" in the report.

## The rule now

Landing on a conductor is an **electrical act**; the grid is a **tidiness preference**. So the grid yields, within one grid step, to the coordinate an in-progress run arrives on.

| situation | landing point |
| --- | --- |
| no run under way (starting a wire on a conductor) | grid-quantized, as before |
| run arrives at y = 265, tap aimed near there | **y = 265** — straight stays straight |
| run arrives far from where you tapped | grid-quantized, as before |
| arrival beyond the segment's own extent | grid-quantized — that point is not on this wire |

The one-grid-step bound is what keeps intent: it cannot drag your tap somewhere you did not click.

## Also

Both call sites — the canvas snap resolver in `App.tsx` and the direct press on a route in `use-wire-interaction.ts` — had grown **their own copy** of this rule, character for character. They now share `routeTapPoint` in the pure geometry module, which is also the only reason it could be unit-tested at all.

And removes a `console.log("DBLWIRE", …)` left behind in the wire double-click handler, which was firing on every double-click in wire mode.

## Validation

- Full unit suite: **1259 passed** (5 new cases on `routeTapPoint`, covering both the yielding and the not-yielding directions)
- `manual-editor.spec.ts` + `drafting.spec.ts`: **130 passed** — the wiring specs
- Typecheck, Prettier

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)