### PR TITLE
fix(editor): give a copied device its own designator, not a copy id

### DIFF
--- a/apps/editor/src/features/clipboard/clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard.test.ts
@@ -688,3 +688,84 @@ describe("copyWholeDocument", () => {
     ).toBe(true);
   });
 });
+
+describe("a copy stands on its own", () => {
+  it("gives a device without a netlist block a fresh designator", () => {
+    const document = createEmptyDocument("document-main", "Copy");
+    // An ideal switch carries a schematic reference but no netlist block, so
+    // the reference sequence never allocated it a fresh designator and the
+    // internal copy id leaked onto the canvas as "X1-copy-3".
+    document.instances.push({
+      id: "X1",
+      symbolId: "ideal-switch",
+      schematicReference: "X1",
+      placement: { position: { x: 100, y: 100 }, rotation: 0, mirror: "none" },
+    });
+
+    const clipboard = copySelection(document, ["X1"]);
+    expect(clipboard).not.toBeNull();
+    const proposal = proposePaste(document, clipboard!, { x: 80, y: 0 }, 3);
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "paste-switch",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: proposal.edits,
+      },
+      { symbolResolver: resolver },
+    );
+    if (!result.ok) throw new Error(JSON.stringify(result.diagnostics));
+
+    const copy = result.document.instances.find(
+      (instance) => instance.id === proposal.instanceIds[0],
+    )!;
+    expect(copy.schematicReference).toBe("X2");
+    expect(copy.schematicReference).not.toMatch(/copy/u);
+  });
+
+  it("does not carry a copied Port back onto the original's Net", () => {
+    const document = createEmptyDocument("document-main", "Copy");
+    document.instances.push({
+      id: "P1",
+      symbolId: "port",
+      placement: { position: { x: 100, y: 100 }, rotation: 0, mirror: "none" },
+    });
+    document.nets.push({
+      id: "net-p12",
+      scope: "local",
+      name: "P12",
+      terminals: [{ instanceId: "P1", pinName: "P" }],
+    });
+
+    const clipboard = copySelection(document, ["P1"]);
+    expect(clipboard).not.toBeNull();
+    const proposal = proposePaste(document, clipboard!, { x: 120, y: 0 }, 1);
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "paste-port",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: proposal.edits,
+      },
+      { symbolResolver: resolver },
+    );
+    if (!result.ok) throw new Error(JSON.stringify(result.diagnostics));
+
+    const copyId = proposal.instanceIds[0]!;
+    const netOf = (instanceId: string) =>
+      result.document.nets.find((net) =>
+        net.terminals.some((terminal) => terminal.instanceId === instanceId),
+      );
+    // Sharing the Net is what made renaming one Port rename its twin: the
+    // name belongs to the Net, so a copy has to bring its own.
+    expect(netOf("P1")?.id).not.toBe(netOf(copyId)?.id);
+    // The copy brings its own, unnamed Net rather than joining the source's,
+    // so naming one of them cannot rename the other.
+    expect(netOf(copyId)?.name).toBeUndefined();
+    expect(netOf("P1")?.name).toBe("P12");
+  });
+});

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -470,19 +470,21 @@ function pastedInstanceId(
 function pastedSchematicReference(
   source: Instance,
   nextNetlistReference: string | undefined,
-  nextId: string,
   sequence: number,
   reserved: Set<string>,
 ): string | undefined {
   const current = source.schematicReference;
   if (!current) return undefined;
+  // Only a freshly allocated netlist reference may be adopted verbatim.
+  // Falling back to the pasted object id was wrong for a device with no
+  // netlist block — an ideal switch, say — because that id is a copy id, so
+  // "X1" came back onto the canvas reading "X1-copy-3". Those instances now
+  // fall through to the sequence below and get an ordinary next designator.
   const synchronized =
     nextNetlistReference &&
     (current === source.netlist?.reference || current === source.id)
       ? nextNetlistReference
-      : current === source.id
-        ? nextId
-        : undefined;
+      : undefined;
   if (synchronized) {
     reserved.add(synchronized.toLowerCase());
     return synchronized;
@@ -670,7 +672,6 @@ export function proposePaste(
       const reference = pastedSchematicReference(
         instance,
         instanceReferences.get(instance.id),
-        instanceIds.get(instance.id)!,
         sequence,
         reservedSchematicReferences,
       );


### PR DESCRIPTION
> 开关复制之后会自动命名为 -copy-3，这也不对。Copy 之后的物品就应该是跟之前的没有任何关系了，可以独立地改造。可以理解为是一种 deep copy，而不是一种表层的引用 copy

## The leak

A copied ideal switch came back onto the canvas reading **`X1-copy-3`** — reproduced exactly in a test before fixing.

The reference sequence only allocates a fresh designator to instances that carry a `netlist` block:

```ts
if (!instance.netlist) return [];   // no fresh reference for this one
```

An ideal switch has none. With nothing to adopt, `pastedSchematicReference` fell back to the **pasted object id** — and object ids are deliberately allowed to look like `X1-copy-3`. An internal id is not a designator and must never reach the canvas.

That fallback is removed. Such an instance now falls through to the sequence immediately below it, which increments the trailing number the way every other copy is numbered: **X1 → X2**.

## What "a copy stands on its own" is pinned to

Two tests, both through the real clipboard (`copySelection` → `proposePaste` → `executeTransaction`):

- the copy's designator is freshly allocated and carries **no copy marker**;
- a copied Port brings its **own Net** rather than joining the source's — the name lives on the Net, so sharing one is precisely what would make renaming one Port rename its twin.

## On the Port rename report

> port 改名一个，另一个还是会跟着改名

I could not reproduce this on current main. A pasted Port gets its own Net, unnamed (`net-p12-copy-1`, `name: undefined`), and the planner already has `keeps same-name Base Nets separate and emits no semantic merge`. #217 landed recently in this area — if it still happens for you, the version banner would tell us whether your build predates it.

## Not in this PR: the switch has no netlist at all

You are right that it should. From the benchmarks you pointed at:

```
S1 net7 bn1 rst v05 SW_RLY
.model SW_RLY SW
```

A SPICE switch is `S<name> n+ n- nc+ nc- MODEL` — **four nodes and a model card**, designator prefix `S`. The drawn `ideal-switch` symbol has **two pins**. Closing that gap means adding two control pins to a symbol people have already placed in saved circuits, which is a decision about the symbol, not a mechanical fix — so I have left it out rather than change artwork unilaterally. Happy to do it on your word.

## Validation

- Full unit suite: **1262 passed** (2 new)
- Typecheck, Prettier

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)