### PR TITLE
feat(gallery): keep the wall scrolling, in a fresh order each time round

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -784,6 +784,10 @@ test("stars the circuits that extract and counts thumbs on every card", async ({
   await expect(page.getByTestId(`gallery-tile-${sketch.id}`)).toBeVisible();
 
   const thumb = page.getByTestId(`gallery-like-${extractable.id}`);
+  // The mark is drawn, not typed: an emoji is a different picture on every
+  // platform and brings its own colour onto a wall of circuit drawings.
+  await expect(thumb.locator("svg")).toHaveCount(1);
+  await expect(thumb).not.toContainText("👍");
   await expect(thumb).toContainText("2");
   await expect(thumb).toHaveAttribute("aria-pressed", "false");
 

--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -15,8 +15,14 @@ const ENTRY = {
   schemaVersion: 21,
 };
 
+/**
+ * The feed asks for `/api/gallery?seed=…`, so a mock has to match on the path
+ * rather than on a glob that assumes no query.
+ */
+const galleryListUrl = (url: URL): boolean => url.pathname === "/api/gallery";
+
 async function mockGallery(page: Page, entries: object[]): Promise<void> {
-  await page.route("**/api/gallery", (route) =>
+  await page.route(galleryListUrl, (route) =>
     route.fulfill({ json: { entries, nextCursor: null } }),
   );
   await page.route(`**/api/gallery/${ENTRY.id}/preview.svg`, (route) =>
@@ -66,7 +72,7 @@ test("masonry places the top row left-to-right in distinct columns", async ({
     createdAt: "2026-08-22T10:00:00.000Z",
     schemaVersion: 21,
   }));
-  await page.route("**/api/gallery", (route) =>
+  await page.route(galleryListUrl, (route) =>
     route.fulfill({ json: { entries, nextCursor: null } }),
   );
   await page.route("**/api/gallery/*/preview.svg", (route) =>
@@ -119,6 +125,7 @@ test("the feed pages through the cursor as the sentinel comes into view", async 
           schemaVersion: 21,
         })),
         nextCursor: second ? null : "c1",
+        total: 5,
       },
     });
   });
@@ -136,12 +143,19 @@ test("the feed pages through the cursor as the sentinel comes into view", async 
   // double-mounts the initial effect in dev, so the plain request may
   // fire twice; the cursor page must load exactly once.)
   await expect(page.getByTestId("gallery-tile-p2-b")).toBeVisible();
-  expect(listRequests.filter((query) => query === "?cursor=c1")).toHaveLength(
-    1,
+  const cursors = listRequests.map((query) =>
+    new URLSearchParams(query).get("cursor"),
   );
-  expect(
-    listRequests.every((query) => query === "" || query === "?cursor=c1"),
-  ).toBe(true);
+  expect(cursors.filter((cursor) => cursor === "c1")).toHaveLength(1);
+  expect(cursors.every((cursor) => cursor === null || cursor === "c1")).toBe(
+    true,
+  );
+  // Every request carries this visit's shuffle, so its pages are one order.
+  const seeds = new Set(
+    listRequests.map((query) => new URLSearchParams(query).get("seed")),
+  );
+  expect(seeds.size).toBe(1);
+  expect([...seeds][0]).toMatch(/^[0-9a-f]{16}$/u);
 });
 
 test("the feed scrolls inside its shell despite the locked app root", async ({
@@ -156,7 +170,7 @@ test("the feed scrolls inside its shell despite the locked app root", async ({
     createdAt: "2026-08-22T10:00:00.000Z",
     schemaVersion: 21,
   }));
-  await page.route("**/api/gallery", (route) =>
+  await page.route(galleryListUrl, (route) =>
     route.fulfill({ json: { entries, nextCursor: null } }),
   );
   await page.route("**/api/gallery/*/preview.svg", (route) =>
@@ -351,7 +365,7 @@ test("the admin recycle bin restores a recycled entry", async ({ page }) => {
 test("falls back to bundled tiles when the gallery is empty or unreachable", async ({
   page,
 }) => {
-  await page.route("**/api/gallery", (route) =>
+  await page.route(galleryListUrl, (route) =>
     route.fulfill({ status: 502, json: { error: "unavailable" } }),
   );
   await page.goto("/");
@@ -460,7 +474,7 @@ test("a signed-in owner renames the display name and signs out", async ({
 test("a signed-out visitor is asked to sign in, not for a passphrase", async ({
   page,
 }) => {
-  await page.route("**/api/gallery", (route) =>
+  await page.route(galleryListUrl, (route) =>
     route.fulfill({ json: { entries: [], nextCursor: null } }),
   );
 
@@ -673,6 +687,59 @@ test("Check and Save shelves the circuit and the shelf reopens it", async ({
   await expect(page.getByTestId("status")).toContainText("Opened");
 });
 
+test("keeps the wall scrolling past its last circuit, in a new order", async ({
+  page,
+}) => {
+  // Big enough that coming back around lands the repeat off-screen.
+  const wall = Array.from({ length: 10 }, (_, index) => ({
+    ...ENTRY,
+    id: `g-${index}`,
+    name: `Circuit ${index}`,
+  }));
+  const seeds: string[] = [];
+  await page.route("**/api/gallery?*", (route) => {
+    const url = new URL(route.request().url());
+    const seed = url.searchParams.get("seed") ?? "";
+    const offset = Number(url.searchParams.get("cursor") ?? "0");
+    if (!seeds.includes(seed)) seeds.push(seed);
+    // Each seed orders the wall its own way; three at a time.
+    const ordered = [...wall].sort((left, right) =>
+      `${seed}${left.id}`.localeCompare(`${seed}${right.id}`),
+    );
+    const slice = ordered.slice(offset, offset + 3);
+    return route.fulfill({
+      json: {
+        entries: slice,
+        nextCursor:
+          offset + slice.length < ordered.length
+            ? String(offset + slice.length)
+            : null,
+        total: ordered.length,
+      },
+    });
+  });
+  await page.route("**/preview.svg", (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"></svg>',
+    }),
+  );
+
+  await page.goto("/");
+  const tiles = page.locator('[data-testid^="gallery-tile-"]');
+  await expect(tiles.first()).toBeVisible();
+
+  // The wall keeps filling as long as the bottom stays in view, and past the
+  // sixth circuit it comes back around under a different shuffle rather than
+  // stopping — which is the whole point of a wall smaller than the scroll.
+  for (let scroll = 0; scroll < 6; scroll += 1) {
+    await page.mouse.wheel(0, 4000);
+    await page.waitForTimeout(250);
+  }
+  expect(await tiles.count()).toBeGreaterThan(wall.length);
+  expect(seeds.length).toBeGreaterThan(1);
+});
+
 test("stars the circuits that extract and counts thumbs on every card", async ({
   page,
 }) => {
@@ -690,7 +757,7 @@ test("stars the circuits that extract and counts thumbs on every card", async ({
     likes: 0,
     likedByViewer: false,
   };
-  await page.route("**/api/gallery", (route) =>
+  await page.route(galleryListUrl, (route) =>
     route.fulfill({
       json: { entries: [extractable, sketch], nextCursor: null },
     }),

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -28,12 +28,43 @@ export interface GalleryFeedEntry {
 export interface GalleryFeedPage {
   entries: GalleryFeedEntry[];
   nextCursor: string | null;
+  /** How many circuits this round covers; 0 means there is nothing to loop. */
+  total: number;
 }
 
 export interface GalleryFeedState {
   status: "loading" | "ready" | "unavailable";
   entries: GalleryFeedEntry[];
   nextCursor: string | null;
+  /** The shuffle this round is ordered by. */
+  seed: string;
+  /** Which pass over the wall these entries came from, counting from 0. */
+  round: number;
+  /** Circuits in the round; 0 means there is nothing to come back to. */
+  total: number;
+}
+
+/**
+ * A fresh shuffle. The wall is browsed rather than read newest-first, so each
+ * visit gets its own order, and each pass over it gets another one — which is
+ * what keeps scrolling worthwhile once the wall is smaller than the scroll.
+ */
+/**
+ * How many circuits a round needs before the feed comes back around.
+ *
+ * Repeating is only invisible when the repeat lands well off-screen. A wall of
+ * two circuits looped would stack the same two down the page, which reads as
+ * a fault rather than as more to look at, so a small wall simply ends. Roughly
+ * a screenful of tiles is the point where a second pass reads as more feed.
+ */
+const ENDLESS_MIN_ROUND = 8;
+
+function newFeedSeed(): string {
+  const bytes = new Uint8Array(8);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
 }
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
@@ -71,6 +102,8 @@ export async function loadGalleryFeed(
     cursor?: string | null;
     author?: string | null;
     tags?: readonly string[];
+    /** Asks for a shuffled round instead of newest-first. */
+    seed?: string | null;
   } = {},
 ): Promise<GalleryFeedPage | null> {
   const params = new URLSearchParams();
@@ -79,6 +112,7 @@ export async function loadGalleryFeed(
     params.set("tags", options.tags.join(","));
   }
   if (options.cursor) params.set("cursor", options.cursor);
+  if (options.seed) params.set("seed", options.seed);
   const query = params.toString();
   try {
     const response = await fetchLike(
@@ -89,11 +123,14 @@ export async function loadGalleryFeed(
     const payload = (await response.json()) as {
       entries?: GalleryFeedEntry[];
       nextCursor?: unknown;
+      total?: unknown;
     };
+    const entries = payload.entries ?? [];
     return {
-      entries: payload.entries ?? [],
+      entries,
       nextCursor:
         typeof payload.nextCursor === "string" ? payload.nextCursor : null,
+      total: typeof payload.total === "number" ? payload.total : entries.length,
     };
   } catch {
     return null;
@@ -143,11 +180,21 @@ export function GalleryFeed() {
       cancelled = true;
     };
   }, []);
-  const [state, setState] = useState<GalleryFeedState>({
+  /**
+   * The shuffle a reload starts from. Held here rather than made inside the
+   * effect so that running the effect twice — as StrictMode does — reloads
+   * the same order instead of throwing the first one away. Rounds advance
+   * `state.seed`, which deliberately does not feed back into the reload.
+   */
+  const [reloadSeed, setReloadSeed] = useState(newFeedSeed);
+  const [state, setState] = useState<GalleryFeedState>(() => ({
     status: "loading",
     entries: [],
     nextCursor: null,
-  });
+    seed: reloadSeed,
+    round: 0,
+    total: 0,
+  }));
   const loadingMoreRef = useRef(false);
 
   /**
@@ -193,44 +240,72 @@ export function GalleryFeed() {
 
   useEffect(() => {
     let cancelled = false;
-    setState({ status: "loading", entries: [], nextCursor: null });
-    void loadGalleryFeed(fetch, { author, tags: selectedTags }).then((page) => {
-      if (cancelled) return;
-      setState(
-        page
-          ? { status: "ready", ...page }
-          : { status: "unavailable", entries: [], nextCursor: null },
-      );
+    const seed = reloadSeed;
+    setState({
+      status: "loading",
+      entries: [],
+      nextCursor: null,
+      seed,
+      round: 0,
+      total: 0,
     });
+    void loadGalleryFeed(fetch, { author, tags: selectedTags, seed }).then(
+      (page) => {
+        if (cancelled) return;
+        setState(
+          page
+            ? { status: "ready", seed, round: 0, ...page }
+            : {
+                status: "unavailable",
+                entries: [],
+                nextCursor: null,
+                seed,
+                round: 0,
+                total: 0,
+              },
+        );
+      },
+    );
     return () => {
       cancelled = true;
     };
-  }, [author, selectedTags]);
+  }, [author, selectedTags, reloadSeed]);
 
-  // Infinite scroll: while a cursor remains, the sentinel below the wall
-  // appends the next page whenever it scrolls into view.
-  const nextCursor = state.nextCursor;
+  // Endless scroll: the sentinel below the wall appends the next page as it
+  // comes into view, and when a round runs out it starts another one under a
+  // fresh shuffle rather than stopping. The wall is smaller than the scroll,
+  // so ending at the last upload would end the browsing too; coming back
+  // around in a different order is the point. A wall too small for a repeat
+  // to land off-screen ends instead — see ENDLESS_MIN_ROUND.
+  const { nextCursor, seed, round, total } = state;
+  const exhausted = nextCursor === null;
   useEffect(() => {
     const sentinel = sentinelRef.current;
-    if (!sentinel || nextCursor === null) return;
+    if (!sentinel) return;
+    if (exhausted && total < ENDLESS_MIN_ROUND) return;
     if (typeof IntersectionObserver === "undefined") return;
     const observer = new IntersectionObserver((observed) => {
       if (!observed.some((entry) => entry.isIntersecting)) return;
       if (loadingMoreRef.current) return;
       loadingMoreRef.current = true;
+      const nextRoundSeed = exhausted ? newFeedSeed() : seed;
       void loadGalleryFeed(fetch, {
         author,
         tags: selectedTags,
-        cursor: nextCursor,
+        seed: nextRoundSeed,
+        cursor: exhausted ? null : nextCursor,
       }).then((page) => {
         loadingMoreRef.current = false;
         if (!page) return;
         setState((previous) =>
           previous.status === "ready"
             ? {
-                status: "ready",
+                ...previous,
                 entries: [...previous.entries, ...page.entries],
                 nextCursor: page.nextCursor,
+                seed: nextRoundSeed,
+                round: exhausted ? previous.round + 1 : previous.round,
+                total: page.total,
               }
             : previous,
         );
@@ -238,7 +313,7 @@ export function GalleryFeed() {
     });
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [nextCursor, author, selectedTags]);
+  }, [nextCursor, exhausted, seed, round, total, author, selectedTags]);
 
   function syncQuery(nextAuthor: string | null, nextTags: string[]): void {
     const url = new URL(window.location.href);
@@ -250,11 +325,13 @@ export function GalleryFeed() {
   }
 
   function selectAuthor(next: string | null): void {
+    setReloadSeed(newFeedSeed());
     setAuthor(next);
     syncQuery(next, selectedTags);
   }
 
   function toggleTag(tag: string): void {
+    setReloadSeed(newFeedSeed());
     setSelectedTags((previous) => {
       const next = previous.includes(tag)
         ? previous.filter((candidate) => candidate !== tag)
@@ -324,8 +401,11 @@ export function GalleryFeed() {
           <Masonry
             aria-label="Published circuits"
             items={[
-              ...entries.map((entry) => ({
-                key: entry.id,
+              // A circuit can come round again in a later shuffle, so the key
+              // is its place in the feed rather than its id. Entries are only
+              // ever appended, so the index is stable.
+              ...entries.map((entry, feedIndex) => ({
+                key: `${feedIndex}-${entry.id}`,
                 node: (
                   <a
                     className="gallery-tile"

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -69,6 +69,33 @@ function newFeedSeed(): string {
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
+/**
+ * The like mark, drawn rather than typed.
+ *
+ * An emoji is a different picture on every platform and carries its own
+ * colour, which on a wall of circuit drawings reads as a sticker. This is one
+ * path that inherits the button's colour: outlined until the circuit is
+ * liked, filled once it is, so the state is legible without reading a count.
+ */
+function HeartIcon({ filled }: { filled: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="14"
+      height="14"
+      aria-hidden="true"
+      focusable="false"
+      fill={filled ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeWidth={filled ? 0 : 2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 20.5 4.2 13a4.8 4.8 0 0 1 6.8-6.8l1 1 1-1A4.8 4.8 0 0 1 19.8 13Z" />
+    </svg>
+  );
+}
+
 function savedAtLabel(createdAt: string): string {
   const parsed = new Date(createdAt);
   return Number.isNaN(parsed.getTime())
@@ -461,8 +488,13 @@ export function GalleryFeed() {
                           aria-pressed={entry.likedByViewer === true}
                           title={
                             entry.likedByViewer
-                              ? "Take back your thumbs up"
-                              : "Thumbs up this circuit"
+                              ? "Remove your like"
+                              : "Like this circuit"
+                          }
+                          aria-label={
+                            entry.likedByViewer
+                              ? `Remove your like from ${entry.name}`
+                              : `Like ${entry.name}`
                           }
                           onClick={(event) => {
                             event.preventDefault();
@@ -470,7 +502,7 @@ export function GalleryFeed() {
                             void toggleLike(entry.id);
                           }}
                         >
-                          <span aria-hidden="true">👍</span>
+                          <HeartIcon filled={entry.likedByViewer === true} />
                           {entry.likes ?? 0}
                         </button>
                       </span>

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -6390,8 +6390,27 @@ html.light .analytics-map-land path {
 }
 
 .gallery-tile-like[aria-pressed="true"] {
-  color: var(--icm-accent);
+  color: #e0245e;
   font-weight: 600;
+}
+
+.gallery-tile-like svg {
+  display: block;
+  transition: transform 120ms ease;
+}
+
+.gallery-tile-like:active svg {
+  transform: scale(1.25);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gallery-tile-like svg {
+    transition: none;
+  }
+
+  .gallery-tile-like:active svg {
+    transform: none;
+  }
 }
 
 /* The wordmark is the editor's half of the two-way gallery/editor switch, so

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -237,6 +237,98 @@ async function submitOne(
   return payload.id;
 }
 
+describe("endless shuffled feed", () => {
+  async function seededPage(
+    env: Harness,
+    seed: string,
+    cursor?: string,
+  ): Promise<{ ids: string[]; nextCursor: string | null; total: number }> {
+    const params = new URLSearchParams({ seed, limit: "3" });
+    if (cursor) params.set("cursor", cursor);
+    const response = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery?${params.toString()}`),
+    );
+    const payload = (await response.json()) as {
+      entries: { id: string }[];
+      nextCursor: string | null;
+      total: number;
+    };
+    return {
+      ids: payload.entries.map((entry) => entry.id),
+      nextCursor: payload.nextCursor,
+      total: payload.total,
+    };
+  }
+
+  async function wallOf(env: Harness, count: number): Promise<string[]> {
+    const cookie = await adminOf(env);
+    const ids: string[] = [];
+    for (let index = 0; index < count; index += 1) {
+      ids.push(await submitOne(env, `Circuit ${index}`, { cookie }));
+    }
+    return ids;
+  }
+
+  it("pages one shuffle without repeating or skipping a circuit", async () => {
+    const env = environment();
+    const wall = await wallOf(env, 7);
+
+    const first = await seededPage(env, "seed-a");
+    expect(first.total).toBe(7);
+    const second = await seededPage(env, "seed-a", first.nextCursor!);
+    const third = await seededPage(env, "seed-a", second.nextCursor!);
+    expect(third.nextCursor).toBeNull();
+
+    const seen = [...first.ids, ...second.ids, ...third.ids];
+    expect(seen).toHaveLength(7);
+    expect(new Set(seen).size).toBe(7);
+    expect([...seen].sort()).toEqual([...wall].sort());
+  });
+
+  it("gives the same order to the same seed and a different one to another", async () => {
+    const env = environment();
+    await wallOf(env, 7);
+    const again = await seededPage(env, "seed-a");
+    const same = await seededPage(env, "seed-a");
+    expect(same.ids).toEqual(again.ids);
+
+    // Some seed orders the wall differently; the feed would be pointless if
+    // every visit saw the same column.
+    const orders = await Promise.all(
+      ["s1", "s2", "s3", "s4", "s5"].map((seed) => seededPage(env, seed)),
+    );
+    expect(orders.some((order) => order.ids.join() !== again.ids.join())).toBe(
+      true,
+    );
+  });
+
+  it("reports an exhausted round apart from an empty wall", async () => {
+    const env = environment();
+    // Nothing published: no next page and nothing to come back to, which is
+    // what tells the feed to stop rather than loop forever.
+    const empty = await seededPage(env, "seed-a");
+    expect(empty).toMatchObject({ ids: [], nextCursor: null, total: 0 });
+
+    await wallOf(env, 2);
+    const full = await seededPage(env, "seed-a");
+    expect(full.nextCursor).toBeNull();
+    expect(full.total).toBe(2);
+  });
+
+  it("keeps newest-first when no seed is asked for", async () => {
+    const env = environment();
+    await wallOf(env, 3);
+    const plain = await route(env, new Request(`${ORIGIN}/api/gallery`));
+    const payload = (await plain.json()) as { entries: { name: string }[] };
+    expect(payload.entries.map((entry) => entry.name)).toEqual([
+      "Circuit 2",
+      "Circuit 1",
+      "Circuit 0",
+    ]);
+  });
+});
+
 describe("stars and thumbs", () => {
   function likeRequest(id: string, cookie?: string): Request {
     const headers = new Headers({ Origin: ORIGIN });

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -175,6 +175,26 @@ interface EntryRow {
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
+/**
+ * A stable shuffle key for one circuit in one round of the feed.
+ *
+ * The wall is browsed, not read newest-first, so a visit gets its own order
+ * rather than everyone seeing the same column of the most recent uploads.
+ * The order has to be stable across pages of that visit — otherwise scrolling
+ * would repeat and skip entries — so it is a hash of the round's seed and the
+ * entry id rather than anything random per query. FNV-1a is enough: this
+ * spreads a list, it does not defend anything.
+ */
+function shuffleRank(seed: string, id: string): number {
+  let hash = 0x811c9dc5;
+  const input = `${seed}:${id}`;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash;
+}
+
 function summaryOf(
   row: EntryRow & { likes?: number; liked_by_viewer?: number },
 ): GalleryEntrySummary {
@@ -480,6 +500,74 @@ export class GalleryDO {
     return Response.json({ id: entry.id });
   }
 
+  /**
+   * One page of a shuffled round.
+   *
+   * The matching ids are ranked by the round's shuffle key and the page is
+   * the slice at `offset`, so paging is an index into a fixed order rather
+   * than a comparison against a moving column. The whole id list is
+   * materialized, which is right while the wall is a wall: it is a list of
+   * ids, and the alternative is a hash function SQLite does not have.
+   *
+   * `total` travels with the page so the caller can tell an exhausted round
+   * from an empty wall — one is a reason to start the next round, the other
+   * is a reason to stop.
+   */
+  private shuffledList(options: {
+    seed: string;
+    offset: number;
+    limit: number;
+    viewerId: string;
+    where: string;
+    bindings: (string | number)[];
+  }): Response {
+    const ranked = this.sql
+      .exec<{
+        id: string;
+      }>(
+        `SELECT id FROM gallery_entries e WHERE ${options.where}`,
+        ...options.bindings,
+      )
+      .toArray()
+      .map((row) => ({ id: row.id, rank: shuffleRank(options.seed, row.id) }))
+      .sort(
+        (left, right) =>
+          left.rank - right.rank || left.id.localeCompare(right.id, "en"),
+      );
+
+    const page = ranked.slice(options.offset, options.offset + options.limit);
+    if (page.length === 0) {
+      return Response.json({
+        entries: [],
+        nextCursor: null,
+        total: ranked.length,
+      });
+    }
+    const placeholders = page.map(() => "?").join(", ");
+    const rows = this.sql
+      .exec<EntryRow & { likes: number; liked_by_viewer: number }>(
+        `SELECT e.*,
+           (SELECT COUNT(*) FROM gallery_likes WHERE entry_id = e.id) AS likes,
+           (SELECT COUNT(*) FROM gallery_likes
+             WHERE entry_id = e.id AND user_id = ?) AS liked_by_viewer
+         FROM gallery_entries e WHERE e.id IN (${placeholders})`,
+        options.viewerId,
+        ...page.map((item) => item.id),
+      )
+      .toArray();
+    const byId = new Map(rows.map((row) => [row.id, row]));
+    const entries = page
+      .map((item) => byId.get(item.id))
+      .filter((row): row is (typeof rows)[number] => row !== undefined)
+      .map(summaryOf);
+    const nextOffset = options.offset + page.length;
+    return Response.json({
+      entries,
+      nextCursor: nextOffset < ranked.length ? String(nextOffset) : null,
+      total: ranked.length,
+    });
+  }
+
   private list(body: Record<string, unknown>): Response {
     const limit = Math.min(
       Math.max(Number(body.limit) || GALLERY_DEFAULT_LIST_LIMIT, 1),
@@ -501,12 +589,23 @@ export class GalleryDO {
       conditions.push(`(${tags.map(() => "tags LIKE ?").join(" OR ")})`);
       for (const tag of tags) bindings.push(`%,${tag},%`);
     }
+    // The viewer id leads the bindings because its sub-select comes first.
+    const viewerId = typeof body.viewerId === "string" ? body.viewerId : "";
+    const seed = typeof body.seed === "string" ? body.seed.slice(0, 64) : "";
+    if (seed) {
+      return this.shuffledList({
+        seed,
+        offset: Math.max(0, Number(cursor) || 0),
+        limit,
+        viewerId,
+        where: conditions.join(" AND "),
+        bindings,
+      });
+    }
     if (cursor) {
       conditions.push("(created_at || '|' || id) < ?");
       bindings.push(cursor);
     }
-    // The viewer id leads the bindings because its sub-select comes first.
-    const viewerId = typeof body.viewerId === "string" ? body.viewerId : "";
     const rows = this.sql
       .exec<EntryRow & { likes: number; liked_by_viewer: number }>(
         `SELECT e.*,
@@ -1324,6 +1423,10 @@ export async function routeGalleryRequest(
     const viewer = await sessionUserOf(request, env);
     const { payload } = await callGallery(env, "list", {
       viewerId: viewer?.id ?? "",
+      // A seed asks for a shuffled round instead of newest-first. The caller
+      // owns it, so a visit keeps one order while it scrolls and a new visit
+      // gets a different one.
+      seed: url.searchParams.get("seed") ?? "",
       limit: url.searchParams.get("limit"),
       cursor: url.searchParams.get("cursor"),
       author: url.searchParams.get("author"),


### PR DESCRIPTION
The wall was read newest-first and ended at the oldest upload, so browsing ended with it. It is a wall, not a changelog.

## A shuffle per visit, and another each time round

A visit gets its own order, and when it reaches the end it comes back around under a different shuffle instead of stopping.

The order is `hash(seed, id)`, not a random ordering per query — a random one would repeat and skip entries as you scrolled, because each page would be drawn from a different order. Paging is an index into that fixed order, so one visit's pages are one order and the next visit's are another.

The seed lives in state rather than inside the loading effect. Making it in the effect meant running the effect twice threw the first order away; the paging spec caught this because StrictMode double-mounts in dev.

## A small wall stops

Repeating is only invisible when the repeat lands well off-screen. Two circuits looped would stack the same two down the page, which reads as a fault rather than as more to look at — the first draft did exactly that and a spec found five copies of one circuit. Below roughly a screenful, the wall ends.

## The like mark is drawn, not typed

👍 is a different picture on every platform and brings its own colour, which on a wall of black-and-white circuit drawings reads as a sticker stuck to the card. It is now one SVG path inheriting the button's colour — outlined until liked, filled once it is — with a small pop on press that `prefers-reduced-motion` turns off.

## Validation

- unit: 1260 passed. Four new worker cases: paging one shuffle covers every circuit exactly once and ends; the same seed gives the same order while other seeds differ; an exhausted round is reported apart from an empty wall; and no seed still means newest-first.
- Playwright: 227 passed, including a new spec that scrolls a ten-circuit wall past its end and asserts more tiles than circuits, under more than one seed.
- Six existing gallery mocks matched `**/api/gallery` and no longer matched once the feed carried a seed; they now match on the path.

Two pre-existing local failures in `worker/gallery.test.ts` come from this machine having no pnpm (stale package `dist/`); they fail identically on unmodified `main`, whose CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)