### PR TITLE
feat(editor): let a design carry more than one named supply

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -191,6 +191,7 @@ import {
   powerConnectionForSymbol,
   proposePlacementContact,
   proposedStandalonePowerConnection,
+  proposedSupplyPortRename,
 } from "../features/component-insert/placement-connectivity";
 import {
   componentParameters,
@@ -2522,10 +2523,16 @@ export function App({
         terminal.interfaceInstanceIds.includes(selectedInstance.id),
       )
     : undefined;
+  // A supply marker is nameable for the same reason a Net Port is: a design
+  // routinely carries VDDH and VDDL, or VDD1 and VDD2, at once, and until
+  // this field existed every marker was stuck on the one Net named VDD.
+  const selectedSupplyMarker =
+    selectedInstance?.symbolId === "vdd-port" ? selectedInstance : undefined;
   const selectedPortNet =
     selectedInstance &&
     (selectedInstance.symbolId === "port" ||
-      selectedInstance.symbolId === "port-filled")
+      selectedInstance.symbolId === "port-filled" ||
+      selectedInstance.symbolId === "vdd-port")
       ? document.nets.find((net) =>
           net.terminals.some(
             (terminal) => terminal.instanceId === selectedInstance.id,
@@ -2554,6 +2561,21 @@ export function App({
     if (!selectedPortNet || !selectedInstance || selectedFormalTerminal) return;
     name = name.trim();
     if (!name || name === selectedPortLogicalName) return;
+    if (selectedSupplyMarker) {
+      // Naming a supply detaches it onto a rail of its own rather than
+      // renaming the shared one under every other marker using it.
+      const plan = proposedSupplyPortRename(
+        document,
+        selectedSupplyMarker,
+        name,
+      );
+      if (plan.rejected) {
+        setStatus(plan.rejected);
+        return;
+      }
+      if (transact(plan.edits).ok) setStatus(`Supply named ${name}`);
+      return;
+    }
     const plan = planEnsureNamedNet(document, {
       candidateNetId: selectedPortNet.id,
       name,
@@ -9018,11 +9040,17 @@ export function App({
                     <dl className="component-readonly-fields">
                       {selectedPortNet && !selectedFormalTerminal ? (
                         <div>
-                          <dt>Net name</dt>
+                          <dt>
+                            {selectedSupplyMarker ? "Supply" : "Net name"}
+                          </dt>
                           <dd>
                             <input
                               key={`${selectedPortNet.id}-${document.revision}-net-port-name`}
-                              aria-label="Net Port name"
+                              aria-label={
+                                selectedSupplyMarker
+                                  ? "Supply name"
+                                  : "Net Port name"
+                              }
                               defaultValue={selectedPortLogicalName ?? ""}
                               onBlur={(event) =>
                                 renameSelectedNetPort(event.currentTarget.value)

--- a/apps/editor/src/features/component-insert/placement-connectivity.test.ts
+++ b/apps/editor/src/features/component-insert/placement-connectivity.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   proposePlacementContact,
   proposedStandalonePowerConnection,
+  proposedSupplyPortRename,
 } from "./placement-connectivity";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
@@ -470,5 +471,134 @@ describe("component placement electrical contacts", () => {
         expect.objectContaining({ baseNetIds: ["net-dvdd"], name: "DVDD" }),
       ]),
     );
+  });
+});
+
+describe("naming a supply marker", () => {
+  /** Place one VDD marker and connect it, the way the canvas does. */
+  function withSupply(
+    document: ReturnType<typeof createEmptyDocument>,
+    id: string,
+    x: number,
+  ) {
+    const instance = {
+      id,
+      symbolId: "vdd-port",
+      placement: {
+        position: { x, y: 100 },
+        rotation: 0 as const,
+        mirror: "none" as const,
+      },
+    };
+    const proposal = proposedStandalonePowerConnection(
+      { ...document, instances: [...document.instances, instance] },
+      instance,
+    );
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: `place-${id}`,
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human" as const, id: "test" },
+        edits: [{ kind: "add_instance" as const, instance }, ...proposal.edits],
+      },
+      context,
+    );
+    if (!result.ok) throw new Error(JSON.stringify(result.diagnostics));
+    return result.document;
+  }
+
+  const logicalName = (
+    document: ReturnType<typeof createEmptyDocument>,
+    instanceId: string,
+  ) => {
+    const net = document.nets.find((candidate) =>
+      candidate.terminals.some(
+        (terminal) => terminal.instanceId === instanceId,
+      ),
+    );
+    return net
+      ? resolveDocumentLogicalNets(document).byBaseNetId.get(net.id)?.name
+      : undefined;
+  };
+
+  it("starts every marker on the one shared supply", () => {
+    let document = createEmptyDocument("main", "Main");
+    document = withSupply(document, "VDD1", 100);
+    document = withSupply(document, "VDD2", 300);
+    expect(logicalName(document, "VDD1")).toBe("VDD");
+    expect(logicalName(document, "VDD2")).toBe("VDD");
+  });
+
+  it("gives one marker its own rail without moving the others", () => {
+    let document = createEmptyDocument("main", "Main");
+    document = withSupply(document, "VDD1", 100);
+    document = withSupply(document, "VDD2", 300);
+
+    const instance = document.instances.find(
+      (candidate) => candidate.id === "VDD1",
+    )!;
+    const plan = proposedSupplyPortRename(document, instance, "VDDH");
+    expect(plan.rejected).toBeUndefined();
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "name-vddh",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: plan.edits,
+      },
+      context,
+    );
+    if (!result.ok) throw new Error(JSON.stringify(result.diagnostics));
+
+    // A design carries VDDH and VDDL at once; naming one must not drag the
+    // other along, and the supply it left keeps its own name.
+    expect(logicalName(result.document, "VDD1")).toBe("VDDH");
+    expect(logicalName(result.document, "VDD2")).toBe("VDD");
+  });
+
+  it("rejoins the shared supply when named back", () => {
+    let document = createEmptyDocument("main", "Main");
+    document = withSupply(document, "VDD1", 100);
+    document = withSupply(document, "VDD2", 300);
+
+    for (const name of ["VDDH", "VDD"]) {
+      const instance = document.instances.find(
+        (candidate) => candidate.id === "VDD1",
+      )!;
+      const plan = proposedSupplyPortRename(document, instance, name);
+      expect(plan.rejected).toBeUndefined();
+      const result = executeTransaction(
+        document,
+        {
+          transactionId: `name-${name}`,
+          documentId: document.id,
+          expectedRevision: document.revision,
+          actor: { kind: "human", id: "test" },
+          edits: plan.edits,
+        },
+        context,
+      );
+      if (!result.ok) throw new Error(JSON.stringify(result.diagnostics));
+      document = result.document;
+    }
+
+    // Carrying the same name is what makes two markers the same supply, so
+    // naming it back has to put them on one Net again.
+    expect(logicalName(document, "VDD1")).toBe("VDD");
+    expect(logicalName(document, "VDD2")).toBe("VDD");
+    // Same-name Base Nets stay separate rows and are merged logically, so
+    // "one supply again" is a question for the logical index, not for ids.
+    const logical = resolveDocumentLogicalNets(document);
+    const logicalIdOf = (id: string) => {
+      const net = document.nets.find((candidate) =>
+        candidate.terminals.some((terminal) => terminal.instanceId === id),
+      )!;
+      return logical.byBaseNetId.get(net.id)?.id;
+    };
+    expect(logicalIdOf("VDD1")).toBe(logicalIdOf("VDD2"));
   });
 });

--- a/apps/editor/src/features/component-insert/placement-connectivity.ts
+++ b/apps/editor/src/features/component-insert/placement-connectivity.ts
@@ -303,3 +303,104 @@ export function proposedStandalonePowerConnection(
     powerEndpoint: endpoint,
   };
 }
+
+/**
+ * Put one supply marker on a supply of its own.
+ *
+ * Every VDD marker joins the Net named VDD, which is right: two markers
+ * carrying the same name are the same supply, and renaming that Net renames
+ * the supply everywhere it is used. What was missing is the other intent —
+ * "this one is a different rail" — because a design routinely carries VDDH
+ * and VDDL, or VDD1 and VDD2, at once.
+ *
+ * So a new name detaches rather than renames: the marker leaves the shared
+ * Net, takes a Net of its own, and claims the new name there. The supply it
+ * left keeps its name and every other marker on it. Naming it back to VDD
+ * rejoins the shared Net by the same rule, because that is what the name
+ * means.
+ */
+export function proposedSupplyPortRename(
+  document: SchematicDocument,
+  instance: Instance,
+  name: string,
+): { edits: SchematicEdit[]; netId?: string; rejected?: string } {
+  const power = powerConnectionForSymbol(instance.symbolId);
+  if (!power) return { edits: [], rejected: "Not a supply marker" };
+  const requested = name.trim();
+  if (!requested) return { edits: [], rejected: "A supply needs a name" };
+
+  const endpoint: RouteEndpoint = {
+    kind: "terminal",
+    instanceId: instance.id,
+    pinName: power.pinName,
+  };
+  // A fresh Net per name, so renaming twice cannot land back on a Net the
+  // marker already left behind.
+  const candidateNetId = deriveStableId(
+    "net",
+    document.id,
+    "power",
+    instance.id,
+    requested.toLowerCase(),
+  );
+  const plan = planEnsurePowerNet(document, {
+    candidateNetId,
+    candidateState: "pending-connection",
+    domain: power.domain,
+    name: requested,
+    scope: power.scope,
+    evidenceId: deriveStableId(
+      "connectivity-evidence",
+      document.id,
+      "power-marker",
+      instance.id,
+      candidateNetId,
+    ),
+    owner: { kind: "power-marker", objectId: instance.id },
+  });
+  if (!plan.ok) return { edits: [], rejected: plan.message };
+
+  // The claim this marker used to make on its old supply has to go, or it
+  // keeps that Net named after a marker that is no longer on it.
+  const staleClaims = document.connectivityEvidence.filter(
+    (evidence) =>
+      evidence.kind === "name-claim" &&
+      evidence.owner.kind === "power-marker" &&
+      evidence.owner.objectId === instance.id,
+  );
+
+  // The marker's own label reads the Net it names. Left pointing at the Net
+  // the marker just left, it resolves to nothing and the label goes blank.
+  const boundLabels = document.annotations.filter(
+    (annotation) =>
+      annotation.binding?.kind === "net-name" &&
+      annotation.anchor.kind === "object" &&
+      annotation.anchor.objectId === instance.id,
+  );
+
+  return {
+    edits: [
+      { kind: "disconnect_endpoint", endpoint },
+      ...staleClaims.map((evidence): SchematicEdit => ({
+        kind: "remove_connectivity_evidence",
+        evidenceId: evidence.id,
+      })),
+      {
+        kind: "connect_endpoints",
+        from: endpoint,
+        to: endpoint,
+        newNetId: candidateNetId,
+      },
+      ...plan.edits,
+      ...boundLabels.map((annotation): SchematicEdit => ({
+        kind: "upsert_schematic_annotation",
+        annotation: {
+          ...annotation,
+          netId: plan.netId,
+          binding: { kind: "net-name", netId: plan.netId },
+        },
+      })),
+    ],
+    netId: plan.netId,
+  };
+}


### PR DESCRIPTION
> 这个 vdd 目前是全局绑定的，我改一个名字，另一个也跟着变了。实际上 VDD 可以有多个，比如 VDDH、VDDL、VDD1、VDD2 等，应该允许用户自己命名多个不同的 VDD

## Why every VDD moved together

Two reasons, and only the second is a bug:

1. **Sharing a Net by name is correct.** Two markers carrying the same name *are* the same supply. Renaming that Net renames the supply everywhere it is used — that is the meaning of the name, not a defect.
2. **There was no way to express the other intent.** The properties panel offered a name field for `port` and `port-filled` only, so a `vdd-port` was stuck on the one Net named VDD forever. A design that needs VDDH beside VDDL simply could not say so.

## What changed

A supply marker now has a **Supply** field, and a new name **detaches** rather than renames:

| action | result |
| --- | --- |
| place two VDD markers | both on the shared supply, both read VDD |
| name one `VDDH` | that one leaves, takes its own Net, claims VDDH — **the other still reads VDD** |
| name it back to `VDD` | rejoins the shared supply, because that is what the name means |

## Two details the detach has to get right

Both were caught by actually running it, and both are covered by tests:

- the marker's **old name-claim evidence** is removed — otherwise it keeps naming a Net it is no longer on;
- the label's **net binding is re-pointed** — otherwise it reads the Net the marker just left and the label renders **blank**. That is exactly what happened on the first run in the browser.

## Validation

- Full unit suite: **1273 passed** (3 new: the shared start, the detach, and the round trip back)
- `component-insert.spec.ts` + `manual-editor.spec.ts`: **128 passed**
- Driven in the running editor: two markers → name one VDDH → canvas reads `["VDDH", "VDD"]`, status `Supply named VDDH`
- Typecheck, Prettier

Same-name Base Nets stay separate rows and merge logically, so the round-trip test asserts logical identity rather than row identity — matching `keeps same-name Base Nets separate and emits no semantic merge` in the planner.

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)