### PR TITLE
feat(edit-engine): flip a multi-part selection as one rigid body

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -4037,6 +4037,49 @@ test("swaps a comparator's + and - without turning the body over", async ({
   expect(after.transform).not.toContain("scale");
 });
 
+test("flips a marquee selection as one body, not three parts in place", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+
+  await placeComponent(page, "resistor", { x: 220, y: 240 });
+  await placeComponent(page, "capacitor", { x: 340, y: 240 });
+  await placeComponent(page, "diode", { x: 460, y: 240 });
+
+  const order = async () =>
+    page
+      .locator('[data-layer="symbols"] [data-object-id]')
+      .evaluateAll((elements) =>
+        elements
+          .map((element) => {
+            const box = (element as SVGGraphicsElement).getBBox();
+            return {
+              id: element.getAttribute("data-object-id") ?? "",
+              x: box.x + box.width / 2,
+            };
+          })
+          .sort((left, right) => left.x - right.x)
+          .map((item) => item.id),
+      );
+
+  const before = await order();
+  expect(before).toHaveLength(3);
+
+  const bounds = (await canvas.boundingBox())!;
+  await page.mouse.move(bounds.x + 160, bounds.y + 180);
+  await page.mouse.down();
+  await page.mouse.move(bounds.x + 540, bounds.y + 310, { steps: 12 });
+  await page.mouse.up();
+  await expect(page.getByTestId("status")).toContainText("Selected");
+
+  await page.keyboard.press("Shift+R");
+  // Flipping left to right reverses the row. Flipping each part about its own
+  // centre would have left the order exactly as it was.
+  await expect(page.getByTestId("status")).toContainText("as one group");
+  expect(await order()).toEqual([...before].reverse());
+});
+
 test("drags a marquee selection that holds no instance", async ({ page }) => {
   await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -19,6 +19,7 @@ import {
   createRouteWireAnchor,
   proposeEndpointRouteAttachment,
   proposeGroupMoveEdits,
+  proposeGroupReflectionEdits,
   proposeGroupRotationEdits,
   proposeLooseRouteTranslation,
   proposePowerRailEndpointResize,
@@ -4868,12 +4869,17 @@ export function App({
     }
   }
 
-  function rotateSelected(deltaDegrees: 90 | -90 = 90): void {
-    const placedSelection = selectedIds.filter((id) =>
+  /** Selected Instances that are actually on the sheet, in selection order. */
+  function placedSelectionIds(): string[] {
+    return selectedIds.filter((id) =>
       document.instances.some(
         (candidate) => candidate.id === id && candidate.placement,
       ),
     );
+  }
+
+  function rotateSelected(deltaDegrees: 90 | -90 = 90): void {
+    const placedSelection = placedSelectionIds();
     // Several parts turn as one body about a shared pivot. Spinning each one
     // about its own origin leaves the arrangement exactly where it was, which
     // is not what turning a selection means. A lone part has no arrangement to
@@ -4923,10 +4929,38 @@ export function App({
       },
     );
     const edits = [...instanceEdits, ...draftingEdits];
-    if (edits.length > 0) transact(edits);
+    if (edits.length === 0 || !transact(edits).ok) return;
+    // Name which turn happened. "Committed revision 5" cannot tell someone
+    // whether the arrangement turned or only the symbols did.
+    setStatus(
+      groupRotation
+        ? `Turned ${placedSelection.length} parts as one group`
+        : "Turned the selection in place",
+    );
   }
 
   function mirrorSelected(direction: ScreenFlip = "left-right"): void {
+    // Several parts flip as one body about the selection's own axis. Flipping
+    // each about its own centre leaves the arrangement exactly where it was —
+    // a row of three flipped one at a time is still the same row — which is
+    // the same fault rotation had.
+    const placedSelection = placedSelectionIds();
+    if (placedSelection.length > 1) {
+      const plan = proposeGroupReflectionEdits(
+        document,
+        resolver,
+        placedSelection,
+        direction,
+      );
+      if (plan.edits.length > 0 && transact(plan.edits).ok) {
+        setStatus(
+          `Flipped ${placedSelection.length} parts as one group, ${
+            direction === "left-right" ? "left to right" : "top to bottom"
+          }`,
+        );
+      }
+      return;
+    }
     const edits = selectedIds.flatMap((id): SchematicEdit[] => {
       const instance = document.instances.find(
         (candidate) => candidate.id === id,
@@ -4950,7 +4984,13 @@ export function App({
             ]),
       ];
     });
-    if (edits.length > 0) transact(edits);
+    if (edits.length > 0 && transact(edits).ok) {
+      setStatus(
+        `Flipped the selection ${
+          direction === "left-right" ? "left to right" : "top to bottom"
+        }`,
+      );
+    }
   }
 
   function download(

--- a/apps/editor/src/interaction/shortcut-orientation.ts
+++ b/apps/editor/src/interaction/shortcut-orientation.ts
@@ -1,7 +1,12 @@
-import type { Orientation, Rotation } from "@icm/model";
+import {
+  reflectOrientation,
+  type Orientation,
+  type Rotation,
+  type ScreenFlip,
+} from "@icm/model";
 
-/** The visible direction of a reflection in document coordinates. */
-export type ScreenFlip = "left-right" | "top-bottom";
+export { reflectOrientation };
+export type { ScreenFlip };
 
 /**
  * A canvas-local orientation command. It is deliberately not a model edit:
@@ -11,23 +16,6 @@ export type ScreenFlip = "left-right" | "top-bottom";
 export type PlacementOrientationOperation =
   | { kind: "rotate"; deltaDegrees: 90 | -90 }
   | { kind: "reflect"; direction: ScreenFlip };
-
-/**
- * Compose a screen-space reflection with the canonical orientation transform
- * (`rotate(mirror(local))`). The persisted representation deliberately has one
- * mirror bit: its four rotations form the other reflection direction without
- * needing another schema or edit kind.
- */
-export function reflectOrientation(
-  orientation: Orientation,
-  direction: ScreenFlip,
-): Orientation {
-  const baseRotation = direction === "left-right" ? 0 : 180;
-  return {
-    rotation: ((baseRotation - orientation.rotation + 360) % 360) as Rotation,
-    mirror: orientation.mirror === "none" ? "x" : "none",
-  };
-}
 
 export function applyOrientationOperations(
   orientation: Orientation,

--- a/packages/edit-engine/src/route-operations.ts
+++ b/packages/edit-engine/src/route-operations.ts
@@ -1,4 +1,10 @@
-import type { Point, SchematicDocument } from "@icm/model";
+import {
+  reflectOrientation,
+  type Orientation,
+  type Point,
+  type SchematicDocument,
+  type ScreenFlip,
+} from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 
 import {
@@ -888,6 +894,7 @@ export interface InstanceRotationProposal {
   instanceId: string;
   position: Point;
   rotation: 0 | 90 | 180 | 270;
+  mirror: "none" | "x";
 }
 
 export interface GroupRotationProposal {
@@ -930,6 +937,49 @@ export function proposeGroupRotation(
   instanceIds: readonly string[],
   deltaDegrees: 90 | -90,
 ): GroupRotationProposal {
+  return proposeRigidBodyMove(document, resolver, instanceIds, (pivot) => ({
+    point: (point) => turn(point, pivot, deltaDegrees),
+    placement: (placement) => ({
+      rotation: ((((placement.rotation + deltaDegrees) % 360) + 360) % 360) as
+        0 | 90 | 180 | 270,
+      mirror: placement.mirror,
+    }),
+  }));
+}
+
+/**
+ * Reflect a selection as one rigid body.
+ *
+ * Reflecting each part about its own centre leaves the arrangement exactly
+ * where it was, the same way rotating each part in place did — a row of three
+ * flipped one at a time is still the same row. Here the arrangement reflects
+ * about the selection's own axis and every part reflects with it, so a signal
+ * path that ran left to right runs right to left.
+ */
+export function proposeGroupReflection(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  instanceIds: readonly string[],
+  direction: ScreenFlip,
+): GroupRotationProposal {
+  const axis = direction === "left-right" ? "x" : "y";
+  return proposeRigidBodyMove(document, resolver, instanceIds, (pivot) => ({
+    point: (point) => ({ ...point, [axis]: 2 * pivot[axis] - point[axis] }),
+    placement: (placement) => reflectOrientation(placement, direction),
+  }));
+}
+
+interface RigidBodyTransform {
+  point: (point: Point) => Point;
+  placement: (placement: Orientation) => Orientation;
+}
+
+function proposeRigidBodyMove(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  instanceIds: readonly string[],
+  transformFor: (pivot: Point) => RigidBodyTransform,
+): GroupRotationProposal {
   const selected = new Set(instanceIds);
   const placed = document.instances.filter(
     (instance) => selected.has(instance.id) && instance.placement,
@@ -954,14 +1004,16 @@ export function proposeGroupRotation(
     y: snap((Math.min(...ys) + Math.max(...ys)) / 2),
   };
 
+  const transform = transformFor(pivot);
   const instances = placed
     .map((instance): InstanceRotationProposal => {
       const placement = instance.placement!;
+      const oriented = transform.placement(placement);
       return {
         instanceId: instance.id,
-        position: turn(placement.position, pivot, deltaDegrees),
-        rotation: ((((placement.rotation + deltaDegrees) % 360) + 360) %
-          360) as 0 | 90 | 180 | 270,
+        position: transform.point(placement.position),
+        rotation: oriented.rotation,
+        mirror: oriented.mirror,
       };
     })
     .sort((left, right) =>
@@ -996,9 +1048,7 @@ export function proposeGroupRotation(
       // turns rather than being stretched between two moved ends.
       proposals.set(route.id, {
         routeId: route.id,
-        waypoints: route.waypoints.map((point) =>
-          turn(point, pivot, deltaDegrees),
-        ),
+        waypoints: route.waypoints.map((point) => transform.point(point)),
         segmentModes: [...route.segmentModes],
       });
       continue;
@@ -1016,7 +1066,7 @@ export function proposeGroupRotation(
         modes,
         "from",
         from,
-        turn(from, pivot, deltaDegrees),
+        transform.point(from),
       );
     }
     if (toTurns) {
@@ -1027,7 +1077,7 @@ export function proposeGroupRotation(
         modes,
         "to",
         to,
-        turn(to, pivot, deltaDegrees),
+        transform.point(to),
       );
     }
     proposals.set(route.id, normalizeProposal(route.id, points, modes));
@@ -1048,7 +1098,7 @@ export function proposeGroupRotation(
       .filter((junction) => turningJunctionIds.has(junction.id))
       .map((junction) => ({
         junctionId: junction.id,
-        position: turn(junction.position, pivot, deltaDegrees),
+        position: transform.point(junction.position),
       }))
       .sort((left, right) =>
         left.junctionId.localeCompare(right.junctionId, "en"),
@@ -1068,7 +1118,7 @@ export function proposeGroupRotation(
           annotationId: annotation.id,
           anchor: {
             kind: "free" as const,
-            position: turn(anchor.position, pivot, deltaDegrees),
+            position: transform.point(anchor.position),
           },
         };
       })

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -12,7 +12,9 @@ import {
 } from "./route-geometry-edit.js";
 import {
   proposeGroupMove,
+  proposeGroupReflection,
   proposeGroupRotation,
+  type GroupRotationProposal,
   proposeJunctionGroupTranslation,
   proposeWireSegmentDrag,
   type JunctionMoveProposal,
@@ -23,6 +25,7 @@ import type {
   RouteEndpoint,
   RoutePresentation,
   SchematicDocument,
+  ScreenFlip,
 } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 
@@ -220,34 +223,63 @@ export function proposeGroupMoveEdits(
  * place and orbits the shared pivot, and the plan supplies every affected
  * Route so geometry does not depend on transaction edit order.
  */
+/** Typed edits that reflect a selection as one rigid body. */
+export function proposeGroupReflectionEdits(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  instanceIds: readonly string[],
+  direction: ScreenFlip,
+): GroupMoveEditProposal {
+  return rigidBodyEdits(
+    document,
+    proposeGroupReflection(document, resolver, instanceIds, direction),
+  );
+}
+
 export function proposeGroupRotationEdits(
   document: SchematicDocument,
   resolver: SymbolResolver,
   instanceIds: readonly string[],
   deltaDegrees: 90 | -90,
 ): GroupMoveEditProposal {
-  const proposal = proposeGroupRotation(
+  return rigidBodyEdits(
     document,
-    resolver,
-    instanceIds,
-    deltaDegrees,
+    proposeGroupRotation(document, resolver, instanceIds, deltaDegrees),
   );
+}
+
+/**
+ * Typed edits for a rigid-body move of a selection.
+ *
+ * Orientation and position travel together — a part both turns or flips and
+ * carries to its new place — and the plan supplies every affected Route so
+ * geometry does not depend on transaction edit order.
+ */
+function rigidBodyEdits(
+  document: SchematicDocument,
+  proposal: GroupRotationProposal,
+): GroupMoveEditProposal {
   return {
     preview: {
       routes: proposal.routes,
       junctions: proposal.junctions,
     },
     edits: [
-      ...proposal.instances.flatMap((turn): SchematicEdit[] => [
+      ...proposal.instances.flatMap((moved): SchematicEdit[] => [
+        {
+          kind: "mirror_instance",
+          instanceId: moved.instanceId,
+          mirror: moved.mirror,
+        },
         {
           kind: "rotate_instance",
-          instanceId: turn.instanceId,
-          rotation: turn.rotation,
+          instanceId: moved.instanceId,
+          rotation: moved.rotation,
         },
         {
           kind: "move_instance",
-          instanceId: turn.instanceId,
-          position: turn.position,
+          instanceId: moved.instanceId,
+          position: moved.position,
         },
       ]),
       ...proposal.junctions.map((move): SchematicEdit => ({

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -16,6 +16,7 @@ import { isOrthogonal } from "./route-geometry-edit.js";
 import { proposeWireSegmentDrag } from "./route-operations.js";
 import {
   proposeGroupMoveEdits,
+  proposeGroupReflectionEdits,
   proposeGroupRotationEdits,
   proposeEndpointRouteAttachment,
   proposeLooseRouteTranslation,
@@ -872,6 +873,65 @@ describe("routing Edit Engine", () => {
     expect(placement("B").position).toEqual({ x: 300, y: 460 });
     expect(placement("A").rotation).toBe(90);
     expect(placement("B").rotation).toBe(90);
+  });
+
+  it("flips a multi-part selection as one body about its own axis", () => {
+    const document = documentFixture();
+    // A and B sit side by side on y=300. Flipping left to right has to
+    // exchange them, not leave each where it was wearing a mirror bit.
+    const plan = proposeGroupReflectionEdits(
+      document,
+      resolver,
+      ["A", "B"],
+      "left-right",
+    );
+    const applied = executeTransaction(
+      document,
+      transaction(document.id, document.revision, plan.edits),
+      context,
+    );
+    expect(applied.ok).toBe(true);
+    if (!applied.ok) return;
+    const placement = (id: string) =>
+      applied.document.instances.find((instance) => instance.id === id)!
+        .placement!;
+    expect(placement("A").position).toEqual({ x: 460, y: 300 });
+    expect(placement("B").position).toEqual({ x: 140, y: 300 });
+    // Across the other axis they do not move: the flip is about one axis.
+    expect(placement("A").position.y).toBe(300);
+  });
+
+  it("flips a quarter each way back to where it started", () => {
+    const document = documentFixture();
+    const ids = ["A", "B", "C"];
+    let current = document;
+    for (const pass of [0, 1]) {
+      const applied = executeTransaction(
+        current,
+        transaction(
+          current.id,
+          current.revision,
+          proposeGroupReflectionEdits(current, resolver, ids, "top-bottom")
+            .edits,
+        ),
+        context,
+      );
+      expect(applied.ok).toBe(true);
+      if (!applied.ok) return;
+      current = applied.document;
+      expect(pass).toBeLessThan(2);
+    }
+    for (const id of ids) {
+      const original = document.instances.find(
+        (instance) => instance.id === id,
+      )!.placement!;
+      const restored = current.instances.find(
+        (instance) => instance.id === id,
+      )!.placement!;
+      expect(restored.position).toEqual(original.position);
+      expect(restored.rotation).toBe(original.rotation);
+      expect(restored.mirror).toBe(original.mirror);
+    }
   });
 
   it("leaves a lone part turning in place", () => {

--- a/packages/model/src/index.ts
+++ b/packages/model/src/index.ts
@@ -4,6 +4,7 @@ export * from "./factories.js";
 export * from "./geometry.js";
 export * from "./ids.js";
 export * from "./net-name.js";
+export * from "./orientation-reflect.js";
 export * from "./rich-text.js";
 export * from "./semantic-text.js";
 export * from "./schema.js";

--- a/packages/model/src/orientation-reflect.ts
+++ b/packages/model/src/orientation-reflect.ts
@@ -1,0 +1,26 @@
+import type { Orientation, Rotation } from "./schema.js";
+
+/** The visible direction of a reflection in document coordinates. */
+export type ScreenFlip = "left-right" | "top-bottom";
+
+/**
+ * Compose a screen-space reflection with the canonical orientation transform
+ * (`rotate(mirror(local))`). The persisted representation deliberately has one
+ * mirror bit: its four rotations form the other reflection direction without
+ * needing another schema or edit kind.
+ *
+ * This lives beside the Orientation it transforms because both the editor's
+ * placement preview and the edit engine's group reflection need it, and they
+ * have to agree — a part reflected one way while the arrangement reflects the
+ * other would come apart.
+ */
+export function reflectOrientation(
+  orientation: Orientation,
+  direction: ScreenFlip,
+): Orientation {
+  const baseRotation = direction === "left-right" ? 0 : 180;
+  return {
+    rotation: ((baseRotation - orientation.rotation + 360) % 360) as Rotation,
+    mirror: orientation.mirror === "none" ? "x" : "none",
+  };
+}

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -319,13 +319,22 @@ describe("endless shuffled feed", () => {
   it("keeps newest-first when no seed is asked for", async () => {
     const env = environment();
     await wallOf(env, 3);
-    const plain = await route(env, new Request(`${ORIGIN}/api/gallery`));
-    const payload = (await plain.json()) as { entries: { name: string }[] };
-    expect(payload.entries.map((entry) => entry.name)).toEqual([
-      "Circuit 2",
-      "Circuit 1",
-      "Circuit 0",
-    ]);
+    const read = async () => {
+      const plain = await route(env, new Request(`${ORIGIN}/api/gallery`));
+      return (await plain.json()) as {
+        entries: { id: string; createdAt: string }[];
+      };
+    };
+    const payload = await read();
+    expect(payload.entries).toHaveLength(3);
+    // Newest-first, and the same every time. Entries submitted inside one
+    // millisecond share a timestamp and fall back to comparing ids, so the
+    // contract is the ordering and its stability, not a fixed sequence.
+    const stamps = payload.entries.map((entry) => entry.createdAt);
+    expect([...stamps].sort().reverse()).toEqual(stamps);
+    expect((await read()).entries.map((entry) => entry.id)).toEqual(
+      payload.entries.map((entry) => entry.id),
+    );
   });
 });
 


### PR DESCRIPTION
Rotation learned to turn a selection as one body. **Reflection did not** — it still flipped each part about its own centre, which leaves the arrangement exactly where it was. A row of three flipped one at a time is still the same row, in the same order, which is what "flipping in place" looks like.

Flipping now reflects the arrangement about the selection's own axis and every part reflects with it, so a signal path that ran left to right runs right to left.

## One plan, two ways to move

Rotation and reflection are the same rigid-body plan differing only in how a point and an orientation transform, so they are now literally that: `proposeRigidBodyMove` parameterized by a transform. Reflection inherits everything rotation already settled — routes wholly inside the selection travelling with the body, a route that leaves it stretching, junctions and free annotations following, every affected route supplied so geometry does not depend on edit order.

`reflectOrientation` moved to `@icm/model`, beside the `Orientation` it transforms. The editor's placement preview and the engine's group reflection both need it and have to agree — a part reflected one way while the arrangement reflects the other would come apart. The editor keeps its import path.

## Both actions now say what they did

`Committed revision 5` could not tell anyone whether the arrangement moved or only the symbols did — which is precisely the question. The status line now reads `Turned 3 parts as one group` or `Turned the selection in place`, and likewise for flips.

## On rotation

I could not reproduce rotation spinning in place. Probes across four layouts — a row, a column, an L, and a tight cluster — all rotate rigidly, the deployed bundle carries the paired `rotate_instance`/`move_instance` edits that only the group path emits, and the service worker is network-first over content-hashed assets so a stale bundle is not being served. The new status line is deliberately part of this change: if it still spins, it will now say which path ran.

## Validation

- unit: 1279 passed. New cases flip two parts side by side and assert they exchange places, and flip twice to assert position, rotation, and mirror all return exactly.
- Playwright: 228 passed, including a new spec that marquees three parts, presses `Shift+R`, and asserts the row's left-to-right order is reversed — which flipping each part in place would not do.
- One of my own worker tests was fragile: three submissions inside one millisecond share a timestamp and fell back to comparing random ids. It now asserts the actual contract — newest-first and stable — instead of a sequence it could not control.

Two pre-existing local failures in `worker/gallery.test.ts` come from this machine having no pnpm (stale package `dist/`); they fail identically on unmodified `main`, whose CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)