### PR TITLE
fix(connectivity): preserve transformed direct contacts

### DIFF
--- a/docs/adr/0041-physical-cut-and-endpoint-readiness.md
+++ b/docs/adr/0041-physical-cut-and-endpoint-readiness.md
@@ -28,6 +28,12 @@ Evidence edits.
 - `cut_connection` always partitions the affected Base Net by explicit Routes
   and confirmed coincident endpoint contacts. Logical name, global, import, or
   explicit-equivalence Evidence never suppresses the physical split.
+- A confirmed coincident endpoint contact is a derived zero-length physical
+  connection, not a persisted object. If a completed move/rotate/mirror
+  transaction separates it, the Edit Engine expands the lost contact into one
+  ordinary Route unless another physical path still connects the endpoints.
+  New coincidence remains explicit `connect_endpoints` intent; raw geometry
+  cannot create or merge Base Nets.
 - The component containing the deleted Route's `from` endpoint (or `to` if the
   former was an orphan Junction removed by the cut) retains the original
   Base-Net ID and non-owner Evidence. Other components receive deterministic

--- a/docs/specs/connectivity-and-routing.md
+++ b/docs/specs/connectivity-and-routing.md
@@ -25,6 +25,15 @@ Route transaction.
 
 - Starting and ending a wire on terminals or explicit Junctions creates or
   joins real Net membership through one atomic Edit Engine transaction.
+- Exact visible endpoint coincidence is a derived zero-length physical contact
+  only for endpoints already in the same Base Net. New contact intent is still
+  authored explicitly by the snap/placement planner through
+  `connect_endpoints`; raw coordinate overlap never merges or creates a Net.
+- If a move, rotation, or mirror separates a confirmed direct contact, the
+  transaction materializes one ordinary manual Route after all transforms have
+  reached their final positions. Jointly transformed endpoints remain a
+  route-free direct contact, and an existing alternate physical path prevents
+  duplicate Route creation.
 - A Route-segment tap splits geometry at an explicit Junction. A mere crossing
   remains disconnected.
 - Moving a connected Instance stretches the attached Route while preserving

--- a/packages/derived/src/contact.test.ts
+++ b/packages/derived/src/contact.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   contactRequiresJunctionDot,
+  deriveDirectContactDelta,
   deriveDocumentContactEvidence,
 } from "./contact.js";
 
@@ -366,5 +367,33 @@ describe("contactRequiresJunctionDot", () => {
       [{ id: "M1", symbolId: "pmos", position: { x: 0, y: 0 }, pins: ["G"] }],
     );
     expect(dotAt(document, { x: -20, y: 0 })).toBe(true);
+  });
+});
+
+describe("deriveDirectContactDelta", () => {
+  it("identifies endpoint pairs rather than treating page position as identity", () => {
+    const before = documentWith(
+      [],
+      [
+        { id: "M1", symbolId: "nmos", position: { x: 0, y: 0 }, pins: ["G"] },
+        { id: "M2", symbolId: "nmos", position: { x: 0, y: 0 }, pins: ["G"] },
+      ],
+    );
+    const movedTogether = structuredClone(before);
+    for (const instance of movedTogether.instances) {
+      instance.placement!.position.x += 20;
+    }
+    const retained = deriveDirectContactDelta(before, movedTogether, resolver);
+    const gatePairId = "terminal:M1:G|terminal:M2:G";
+    expect(retained.retained.map((pair) => pair.id)).toContain(gatePairId);
+    expect(retained.gained).toEqual([]);
+    expect(retained.lost).toEqual([]);
+
+    const movedApart = structuredClone(before);
+    movedApart.instances.find(
+      (instance) => instance.id === "M1",
+    )!.placement!.position.x += 20;
+    const lost = deriveDirectContactDelta(before, movedApart, resolver);
+    expect(lost.lost.map((pair) => pair.id)).toContain(gatePairId);
   });
 });

--- a/packages/derived/src/contact.ts
+++ b/packages/derived/src/contact.ts
@@ -44,8 +44,77 @@ export interface DocumentContactEvidence {
   byEndpointKey: ReadonlyMap<string, CoincidentContact>;
 }
 
+/**
+ * One pairwise projection of a confirmed same-Net {@link CoincidentContact}.
+ * It is the transform-time input used to detect when a previously confirmed
+ * direct contact has been separated. New contact intent remains an explicit
+ * authoring operation.
+ */
+export interface DirectContactPair {
+  id: string;
+  netId: string;
+  point: Point;
+  endpoints: readonly [RouteEndpoint, RouteEndpoint];
+}
+
+export interface DirectContactDelta {
+  gained: readonly DirectContactPair[];
+  lost: readonly DirectContactPair[];
+  retained: readonly DirectContactPair[];
+}
+
 function pointKey(point: Point): string {
   return `${point.x},${point.y}`;
+}
+
+function directContactPairs(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+): DirectContactPair[] {
+  const pairs: DirectContactPair[] = [];
+  for (const contact of deriveDocumentContactEvidence(document, resolver)
+    .contacts) {
+    for (let leftIndex = 0; leftIndex < contact.endpoints.length; leftIndex++) {
+      for (
+        let rightIndex = leftIndex + 1;
+        rightIndex < contact.endpoints.length;
+        rightIndex++
+      ) {
+        const left = contact.endpoints[leftIndex]!;
+        const right = contact.endpoints[rightIndex]!;
+        pairs.push({
+          id: [endpointKey(left), endpointKey(right)]
+            .sort((a, b) => a.localeCompare(b, "en"))
+            .join("|"),
+          netId: contact.netId,
+          point: { ...contact.point },
+          endpoints: [left, right],
+        });
+      }
+    }
+  }
+  return pairs.sort((left, right) => left.id.localeCompare(right.id, "en"));
+}
+
+/**
+ * Compare confirmed direct contacts across one projected edit. Pair identity
+ * is endpoint-based, so two endpoints translated together are retained even
+ * though their page coordinate changes.
+ */
+export function deriveDirectContactDelta(
+  before: SchematicDocument,
+  after: SchematicDocument,
+  resolver: SymbolResolver,
+): DirectContactDelta {
+  const beforePairs = directContactPairs(before, resolver);
+  const afterPairs = directContactPairs(after, resolver);
+  const beforeById = new Map(beforePairs.map((pair) => [pair.id, pair]));
+  const afterById = new Map(afterPairs.map((pair) => [pair.id, pair]));
+  return {
+    gained: afterPairs.filter((pair) => !beforeById.has(pair.id)),
+    lost: beforePairs.filter((pair) => !afterById.has(pair.id)),
+    retained: afterPairs.filter((pair) => beforeById.has(pair.id)),
+  };
 }
 
 function directionKey(direction: Point): string {

--- a/packages/edit-engine/src/direct-contact-lifecycle.test.ts
+++ b/packages/edit-engine/src/direct-contact-lifecycle.test.ts
@@ -1,0 +1,380 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { endpointKey, resolveRouteGeometry } from "@icm/derived";
+import type { RouteEndpoint, SchematicDocument } from "@icm/model";
+import { parseProject } from "@icm/project-protocol";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { executeTransaction } from "./transaction.js";
+import { DocumentHistory } from "./history.js";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+const context = { symbolResolver: resolver };
+const terminal = (instanceId: string): RouteEndpoint => ({
+  kind: "terminal",
+  instanceId,
+  pinName: "P",
+});
+
+function fixture(): SchematicDocument {
+  const document = parseProject(
+    readFileSync(
+      resolve(
+        process.cwd(),
+        "fixtures/projects/phase-3-routing/project.icproj.json",
+      ),
+      "utf8",
+    ),
+  ).documents[0]!;
+  document.instances = document.instances.filter((instance) =>
+    ["A", "B"].includes(instance.id),
+  );
+  document.nets = [
+    {
+      id: "net-contact",
+      scope: "local",
+      powerDomain: "none",
+      terminals: [
+        { instanceId: "A", pinName: "P" },
+        { instanceId: "B", pinName: "P" },
+      ],
+    },
+  ];
+  document.connectivityEvidence = [];
+  document.instances.find((instance) => instance.id === "B")!.placement = {
+    position: { x: 160, y: 300 },
+    rotation: 0,
+    mirror: "x",
+  };
+  return document;
+}
+
+function transaction(
+  document: SchematicDocument,
+  edits: unknown[],
+  suffix = "edit",
+) {
+  return {
+    transactionId: `direct-contact-${suffix}-${document.revision}`,
+    documentId: document.id,
+    expectedRevision: document.revision,
+    actor: { kind: "human" as const, id: "direct-contact-test" },
+    edits,
+  };
+}
+
+describe("direct-contact transform lifecycle", () => {
+  it("materializes an ordinary Route when one endpoint moves away", () => {
+    const document = fixture();
+    const result = executeTransaction(
+      document,
+      transaction(document, [
+        {
+          kind: "move_instance",
+          instanceId: "A",
+          position: { x: 100, y: 300 },
+        },
+      ]),
+      context,
+    );
+
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.document.routes).toHaveLength(1);
+    const route = result.document.routes[0]!;
+    expect(new Set([endpointKey(route.from), endpointKey(route.to)])).toEqual(
+      new Set([endpointKey(terminal("A")), endpointKey(terminal("B"))]),
+    );
+    expect(route.netId).toBe("net-contact");
+    expect(
+      resolveRouteGeometry(result.document, resolver, route)?.centerline,
+    ).toEqual(
+      expect.arrayContaining([
+        { x: 110, y: 300 },
+        { x: 150, y: 300 },
+      ]),
+    );
+  });
+
+  it("keeps a jointly moved direct contact route-free", () => {
+    const document = fixture();
+    const result = executeTransaction(
+      document,
+      transaction(document, [
+        {
+          kind: "move_instance",
+          instanceId: "A",
+          position: { x: 180, y: 320 },
+        },
+        {
+          kind: "move_instance",
+          instanceId: "B",
+          position: { x: 200, y: 320 },
+        },
+      ]),
+      context,
+    );
+
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.document.routes).toEqual([]);
+  });
+
+  it.each([
+    {
+      label: "rotation",
+      edit: { kind: "rotate_instance", instanceId: "A", rotation: 90 },
+    },
+    {
+      label: "mirror",
+      edit: { kind: "mirror_instance", instanceId: "A", mirror: "x" },
+    },
+  ])("materializes a Route after $label separates the pins", ({ edit }) => {
+    const document = fixture();
+    const result = executeTransaction(
+      document,
+      transaction(document, [edit], edit.kind),
+      context,
+    );
+
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.document.routes).toHaveLength(1);
+    expect(result.document.routes[0]).toMatchObject({ netId: "net-contact" });
+  });
+
+  it("does not add a duplicate Route when another physical path remains", () => {
+    const document = fixture();
+    document.junctions.push({
+      id: "J1",
+      netId: "net-contact",
+      position: { x: 300, y: 300 },
+      role: "route-anchor",
+    });
+    document.routes.push(
+      {
+        id: "route-a-j1",
+        netId: "net-contact",
+        from: terminal("A"),
+        to: { kind: "junction", junctionId: "J1" },
+        waypoints: [],
+        segmentModes: ["manual"],
+      },
+      {
+        id: "route-b-j1",
+        netId: "net-contact",
+        from: terminal("B"),
+        to: { kind: "junction", junctionId: "J1" },
+        waypoints: [],
+        segmentModes: ["manual"],
+      },
+    );
+
+    const result = executeTransaction(
+      document,
+      transaction(
+        document,
+        [
+          {
+            kind: "move_instance",
+            instanceId: "A",
+            position: { x: 100, y: 300 },
+          },
+        ],
+        "alternate-path",
+      ),
+      context,
+    );
+
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.document.routes.map((route) => route.id).sort()).toEqual([
+      "route-a-j1",
+      "route-b-j1",
+    ]);
+  });
+
+  it("splits the Base Net when the materialized Route is deleted", () => {
+    const document = fixture();
+    const moved = executeTransaction(
+      document,
+      transaction(
+        document,
+        [
+          {
+            kind: "move_instance",
+            instanceId: "A",
+            position: { x: 100, y: 300 },
+          },
+        ],
+        "move-before-cut",
+      ),
+      context,
+    );
+    if (!moved.ok) throw new Error(moved.error.message);
+    const routeId = moved.document.routes[0]!.id;
+
+    const cut = executeTransaction(
+      moved.document,
+      transaction(moved.document, [{ kind: "cut_connection", routeId }], "cut"),
+      context,
+    );
+    if (!cut.ok) throw new Error(cut.error.message);
+    const owner = (instanceId: string) =>
+      cut.document.nets.find((net) =>
+        net.terminals.some((terminal) => terminal.instanceId === instanceId),
+      )?.id;
+    expect(cut.document.routes).toEqual([]);
+    expect(owner("A")).toBeTruthy();
+    expect(owner("B")).toBeTruthy();
+    expect(owner("A")).not.toBe(owner("B"));
+  });
+
+  it("preserves a direct-contact component when another Route is cut", () => {
+    const document = fixture();
+    document.junctions.push({
+      id: "J1",
+      netId: "net-contact",
+      position: { x: 300, y: 300 },
+      role: "route-anchor",
+    });
+    document.routes.push({
+      id: "route-a-j1",
+      netId: "net-contact",
+      from: terminal("A"),
+      to: { kind: "junction", junctionId: "J1" },
+      waypoints: [],
+      segmentModes: ["manual"],
+    });
+
+    const cut = executeTransaction(
+      document,
+      transaction(
+        document,
+        [{ kind: "cut_connection", routeId: "route-a-j1" }],
+        "direct-contact-cut",
+      ),
+      context,
+    );
+    if (!cut.ok) throw new Error(cut.error.message);
+    const aOwner = cut.document.nets.find((net) =>
+      net.terminals.some((candidate) => candidate.instanceId === "A"),
+    )?.id;
+    const bOwner = cut.document.nets.find((net) =>
+      net.terminals.some((candidate) => candidate.instanceId === "B"),
+    )?.id;
+    expect(aOwner).toBe(bOwner);
+  });
+
+  it("does not infer a new Net from raw geometric coincidence", () => {
+    const document = fixture();
+    document.nets = [];
+    document.instances.find((instance) => instance.id === "B")!.placement = {
+      position: { x: 460, y: 300 },
+      rotation: 0,
+      mirror: "x",
+    };
+    const result = executeTransaction(
+      document,
+      transaction(
+        document,
+        [
+          {
+            kind: "move_instance",
+            instanceId: "B",
+            position: { x: 160, y: 300 },
+          },
+        ],
+        "gain",
+      ),
+      context,
+    );
+
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.document.nets).toEqual([]);
+    expect(result.document.routes).toEqual([]);
+  });
+
+  it("does not merge different Base Nets from raw geometric coincidence", () => {
+    const document = fixture();
+    document.instances.find((instance) => instance.id === "B")!.placement = {
+      position: { x: 460, y: 300 },
+      rotation: 0,
+      mirror: "x",
+    };
+    document.nets = [
+      {
+        id: "net-a",
+        scope: "local",
+        powerDomain: "none",
+        terminals: [{ instanceId: "A", pinName: "P" }],
+      },
+      {
+        id: "net-b",
+        scope: "local",
+        powerDomain: "none",
+        terminals: [{ instanceId: "B", pinName: "P" }],
+      },
+    ];
+    const result = executeTransaction(
+      document,
+      transaction(
+        document,
+        [
+          {
+            kind: "move_instance",
+            instanceId: "B",
+            position: { x: 160, y: 300 },
+          },
+        ],
+        "conflict",
+      ),
+      context,
+    );
+
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.document.nets).toHaveLength(2);
+    expect(result.document.nets.map((net) => net.id).sort()).toEqual([
+      "net-a",
+      "net-b",
+    ]);
+  });
+
+  it("restores both zero-length contact and materialized Route with history", () => {
+    const document = fixture();
+    const history = new DocumentHistory(document, context);
+    const moved = history.transact(
+      transaction(
+        document,
+        [
+          {
+            kind: "move_instance",
+            instanceId: "A",
+            position: { x: 100, y: 300 },
+          },
+        ],
+        "history-move",
+      ),
+    );
+    if (!moved.ok) throw new Error(moved.error.message);
+    expect(history.document.routes).toHaveLength(1);
+
+    const undo = history.transact(
+      transaction(history.document, [{ kind: "undo" }], "undo"),
+    );
+    if (!undo.ok) throw new Error(undo.error.message);
+    expect(history.document.routes).toEqual([]);
+    expect(
+      history.document.instances.find((instance) => instance.id === "A")
+        ?.placement?.position,
+    ).toEqual({ x: 140, y: 300 });
+
+    const redo = history.transact(
+      transaction(history.document, [{ kind: "redo" }], "redo"),
+    );
+    if (!redo.ok) throw new Error(redo.error.message);
+    expect(history.document.routes).toHaveLength(1);
+    expect(
+      history.document.instances.find((instance) => instance.id === "A")
+        ?.placement?.position,
+    ).toEqual({ x: 100, y: 300 });
+  });
+});

--- a/packages/edit-engine/src/transaction-direct-contact.ts
+++ b/packages/edit-engine/src/transaction-direct-contact.ts
@@ -1,0 +1,134 @@
+import { deriveStableId } from "@icm/model";
+import type { RouteEndpoint, SchematicDocument } from "@icm/model";
+import {
+  deriveDirectContactDelta,
+  endpointKey,
+  isMosBulkTerminal,
+  resolveEndpointPoint,
+} from "@icm/derived";
+import type { SymbolResolver } from "@icm/symbols";
+
+import { buildManualWirePath } from "./routing-planner.js";
+import {
+  endpointOwnerNetId,
+  netEndpointGroups,
+} from "./transaction-routing.js";
+
+export interface DirectContactReconciliation {
+  geometryChanged: boolean;
+  changedRouteIds: readonly string[];
+}
+
+function endpointsSharePhysicalComponent(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  netId: string,
+  endpoints: readonly [RouteEndpoint, RouteEndpoint],
+): boolean {
+  const [leftKey, rightKey] = endpoints.map(endpointKey);
+  return netEndpointGroups(document, netId, resolver).some(
+    (group) => group.includes(leftKey!) && group.includes(rightKey!),
+  );
+}
+
+function uniqueDerivedId(
+  document: SchematicDocument,
+  transactionId: string,
+  pairId: string,
+): string {
+  const occupied = new Set([
+    ...document.instances.map((instance) => instance.id),
+    ...document.nets.map((net) => net.id),
+    ...document.routes.map((route) => route.id),
+    ...document.junctions.map((junction) => junction.id),
+    ...document.annotations.map((annotation) => annotation.id),
+    ...document.noConnects.map((noConnect) => noConnect.id),
+    ...document.connectivityEvidence.map((evidence) => evidence.id),
+    ...document.layoutGroups.map((group) => group.id),
+    ...document.constraints.map((constraint) => constraint.id),
+    ...(document.drafting?.objects.map((object) => object.id) ?? []),
+    ...(document.netlist?.terminals.map((terminal) => terminal.id) ?? []),
+  ]);
+  let attempt = 0;
+  while (true) {
+    const id = deriveStableId(
+      "route",
+      document.id,
+      "direct-contact",
+      transactionId,
+      pairId,
+      String(attempt),
+    );
+    if (!occupied.has(id)) return id;
+    attempt += 1;
+  }
+}
+
+/**
+ * Reconcile zero-length endpoint contacts once, after all transform edits have
+ * reached their final projected positions.
+ *
+ * This mutates only ordinary Route geometry. It never creates or merges Base
+ * Nets: new direct-contact intent remains an explicit authoring action.
+ */
+export function reconcileTransformDirectContacts(
+  before: SchematicDocument,
+  draft: SchematicDocument,
+  resolver: SymbolResolver,
+  transactionId: string,
+  changedObjectIds: Set<string>,
+): DirectContactReconciliation {
+  const delta = deriveDirectContactDelta(before, draft, resolver);
+  let geometryChanged = false;
+  const changedRouteIds: string[] = [];
+
+  for (const pair of delta.lost) {
+    const [left, right] = pair.endpoints;
+    const leftOwner = endpointOwnerNetId(draft, left);
+    const rightOwner = endpointOwnerNetId(draft, right);
+    if (!leftOwner || leftOwner !== rightOwner) continue;
+    if (
+      endpointsSharePhysicalComponent(
+        draft,
+        resolver,
+        leftOwner,
+        pair.endpoints,
+      )
+    ) {
+      continue;
+    }
+    const leftPoint = resolveEndpointPoint(draft, resolver, left);
+    const rightPoint = resolveEndpointPoint(draft, resolver, right);
+    if (
+      !leftPoint ||
+      !rightPoint ||
+      (leftPoint.x === rightPoint.x && leftPoint.y === rightPoint.y)
+    ) {
+      continue;
+    }
+    const geometry = buildManualWirePath(
+      { point: leftPoint },
+      { point: rightPoint },
+    );
+    const routeId = uniqueDerivedId(draft, transactionId, pair.id);
+    draft.routes.push({
+      id: routeId,
+      netId: leftOwner,
+      from: structuredClone(left),
+      to: structuredClone(right),
+      waypoints: geometry.waypoints,
+      segmentModes: geometry.segmentModes,
+      ...([left, right].some((endpoint) => isMosBulkTerminal(draft, endpoint))
+        ? { presentation: "bulk-dashed" as const }
+        : {}),
+    });
+    changedObjectIds.add(routeId);
+    changedRouteIds.push(routeId);
+    geometryChanged = true;
+  }
+
+  return {
+    geometryChanged,
+    changedRouteIds,
+  };
+}

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -58,6 +58,7 @@ import {
   refreshInstanceValueAnnotation,
   translateObjectAnchoredAnnotation,
 } from "./transaction-instance-annotations.js";
+import { reconcileTransformDirectContacts } from "./transaction-direct-contact.js";
 import {
   addEndpointToNet,
   endpointOwnerNetId,
@@ -3136,6 +3137,28 @@ export function executeTransaction(
       }
     }
     geometryChanged = true;
+  }
+
+  if (
+    resolver &&
+    transaction.edits.some(
+      (edit) =>
+        edit.kind === "move_instance" ||
+        edit.kind === "rotate_instance" ||
+        edit.kind === "mirror_instance",
+    )
+  ) {
+    const directContact = reconcileTransformDirectContacts(
+      document,
+      draft,
+      resolver,
+      transaction.transactionId,
+      changedObjectIds,
+    );
+    geometryChanged ||= directContact.geometryChanged;
+    for (const routeId of directContact.changedRouteIds) {
+      changedRouteIds.add(routeId);
+    }
   }
 
   const introducedNetContractIssue = validateLogicalNetContract(draft).find(


### PR DESCRIPTION
## Summary
- derive direct-contact pair deltas from the single contact-evidence authority
- expand lost same-Base-Net contacts into ordinary routes after complete move/rotate/mirror transactions
- keep raw coincidence, explicit Net creation, and cross-Net merge rules unchanged
- document the lifecycle contract and cover move, group transform, alternate path, cut, and undo/redo

## Validation
- corepack pnpm install --frozen-lockfile
- corepack pnpm ci:check (1292 unit tests; 228 browser tests; build/release/goldens/smokes passed)
- corepack pnpm test:impact -- --base origin/main

## Known baseline issue
- gate:preflight selects pnpm gate:review:check, but latest main does not define that script; all remaining selected gates were run directly.