### PR TITLE
refactor(editor): unify public command dispatch

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -192,7 +192,6 @@ import {
   powerConnectionForSymbol,
   proposePlacementContact,
   proposedStandalonePowerConnection,
-  proposedSupplyPortRename,
 } from "../features/component-insert/placement-connectivity";
 import {
   componentParameters,
@@ -296,6 +295,7 @@ import {
   resolveEditorShortcut,
   stepBoundedScale,
 } from "../interaction/editor-shortcuts";
+import { createEditorCommandRouter } from "../commands/editor-command";
 import { EditorHelpDialog } from "../components/editor-help-dialog";
 import { ReplaceGuardDialog } from "../components/replace-guard-dialog";
 import { RecentRecoveryDialog } from "../components/recent-recovery-dialog";
@@ -1219,6 +1219,7 @@ export function App({
     beginDraftingTextEditing,
     beginNetLabelEditing,
     commitInstancePropertyDraft,
+    commitElectricalMarkerName,
     commitNetLabelEditing,
     commitPendingNetLabelDraft,
     commitTextEditing,
@@ -1344,6 +1345,11 @@ export function App({
         object?.kind === "rectangle"
       );
     });
+  const hasMirrorableSelection = selectedIds.some((id) =>
+    document.instances.some(
+      (instance) => instance.id === id && instance.placement !== null,
+    ),
+  );
   const hasInspectableSelection = Boolean(
     selectedIds.length > 0 ||
     selectedRoute ||
@@ -1992,6 +1998,34 @@ export function App({
     });
   }
 
+  function closeProperties(): void {
+    exitCellSymbolLayout();
+    setSelectionOpen(false);
+    setImportReviewOpen(false);
+  }
+
+  function selectAllObjects(): void {
+    replaceSelection({
+      instanceIds: document.instances
+        .filter((instance) => instance.placement)
+        .map((instance) => instance.id),
+      routeIds: document.routes.map((route) => route.id),
+      junctionIds: document.junctions.map((junction) => junction.id),
+      annotationIds: document.annotations.map((annotation) => annotation.id),
+      draftingIds: (document.drafting?.objects ?? []).map(
+        (object) => object.id,
+      ),
+    });
+    setSelectedEndpoint(null);
+  }
+
+  function clearEditorSelection(): void {
+    resetSelection();
+    setSelectedEndpoint(null);
+    setSelectedRouteSegmentIndex(null);
+    setStatus("Selection cleared");
+  }
+
   function inspectInstance(instanceId: string): void {
     setSelectedEndpoint(null);
     updateInstanceSelection(instanceId, false);
@@ -2241,7 +2275,10 @@ export function App({
       setStatus("Create another Cell before placing a hierarchical Instance");
       return;
     }
-    startInsertFromHook(cellInsertLaunch());
+    editorCommands.execute({
+      id: "insert.start",
+      launch: cellInsertLaunch(),
+    });
     setStatus("Choose a Cell, then place it on the canvas");
   }
 
@@ -2558,52 +2595,6 @@ export function App({
     }
   }
 
-  function renameSelectedNetPort(name: string): void {
-    if (!selectedPortNet || !selectedInstance || selectedFormalTerminal) return;
-    name = name.trim();
-    if (!name || name === selectedPortLogicalName) return;
-    if (selectedSupplyMarker) {
-      // Naming a supply detaches it onto a rail of its own rather than
-      // renaming the shared one under every other marker using it.
-      const plan = proposedSupplyPortRename(
-        document,
-        selectedSupplyMarker,
-        name,
-      );
-      if (plan.rejected) {
-        setStatus(plan.rejected);
-        return;
-      }
-      if (transact(plan.edits).ok) setStatus(`Supply named ${name}`);
-      return;
-    }
-    const plan = planEnsureNamedNet(document, {
-      candidateNetId: selectedPortNet.id,
-      name,
-      evidenceId:
-        document.connectivityEvidence.find(
-          (evidence) =>
-            evidence.kind === "name-claim" &&
-            evidence.owner.kind === "free-port" &&
-            evidence.owner.instanceId === selectedInstance!.id,
-        )?.id ??
-        deriveStableId(
-          "connectivity-evidence",
-          document.id,
-          "free-port",
-          selectedPortNet.id,
-          selectedInstance!.id,
-        ),
-      owner: { kind: "free-port", instanceId: selectedInstance!.id },
-    });
-    if (!plan.ok) {
-      setStatus(plan.message);
-      return;
-    }
-    if (plan.edits.length === 0 || transact([...plan.edits]).ok) {
-      setStatus(`Renamed Net Port to ${plan.name}`);
-    }
-  }
   function renameSelectedFormalPort(name: string): void {
     if (!selectedFormalTerminal) return;
     name = name.trim();
@@ -4992,6 +4983,90 @@ export function App({
       );
     }
   }
+
+  const editorCommands = createEditorCommandRouter({
+    getContext: () => ({
+      interactionMode: getCurrentInteractionState().kind,
+      activeTool: tool,
+      hasDeletableSelection:
+        hasVisualSelection(visualSelection) || selectedEndpoint !== null,
+      hasMoveSelection: hasVisualSelection(visualSelection),
+      hasRotatableSelection,
+      hasMirrorableSelection,
+      hasInspectableSelection,
+      propertiesOpen: selectionOpen,
+      canUndo,
+      canRedo,
+      helpOpen,
+      canvasDragActive: canvasDragSessionRef.current !== null,
+      hasClearableDraftingSelection:
+        selectedDrafting?.kind === "arrow" ||
+        selectedDrafting?.kind === "construction-line" ||
+        selectedDrafting?.kind === "rectangle",
+    }),
+    operations: {
+      closeHelp,
+      cancelCanvasDrag: () => {
+        canvasDragSessionRef.current?.cancel();
+        setStatus("Cancelled canvas drag");
+      },
+      cancelInteraction: (interactionMode) => {
+        cancelAllTransientInteraction();
+        setStatus(
+          interactionMode === "copy-placement"
+            ? "Copy placement cancelled"
+            : interactionMode === "placing-vdd-rail"
+              ? "Power Rail cancelled"
+              : interactionMode === "placing-component"
+                ? "Component placement cancelled"
+                : interactionMode === "drawing"
+                  ? "Drawing cancelled"
+                  : "Cancelled active tool",
+        );
+      },
+      clearDraftingSelection: () => {
+        replaceSelectionKind("drafting", []);
+        setStatus("Cleared drawing selection");
+      },
+      cancelPassive: () => {
+        setBoxPreview(null);
+        paintSnapGuides([]);
+        setStatus("Cancelled");
+      },
+      undo: () => {
+        transact([{ kind: "undo" }]);
+      },
+      redo: () => {
+        transact([{ kind: "redo" }]);
+      },
+      selectAll: selectAllObjects,
+      clearSelection: clearEditorSelection,
+      deleteSelection: deleteCurrentSelection,
+      beginCopy: beginCopyPlacementFromSelection,
+      beginMove: beginKeyboardSelectionMoveFromSelection,
+      rotatePlacement: rotatePendingComponentFromHook,
+      rotateCopy: rotatePendingCopy,
+      rotateSelection: rotateSelected,
+      mirrorPlacement: mirrorPendingComponentFromHook,
+      mirrorCopy: mirrorPendingCopy,
+      mirrorSelection: mirrorSelected,
+      startInsert: startInsertFromHook,
+      openInsert: () => startInsertFromHook(fullInsertLaunch()),
+      placeFreeNetPort: () => {
+        const request = quickPlaceRequest(
+          document.presentation.styleProfileId,
+          "port",
+        );
+        if (request) startInsertFromHook({ kind: "quick", request });
+      },
+      activateTool,
+      addText: addPlainText,
+      openProperties,
+      closeProperties,
+      fitView,
+      report: setStatus,
+    },
+  });
 
   function download(
     bytes: BlobPart,
@@ -7433,10 +7508,13 @@ export function App({
         hasRoutedMarkerSelection: Boolean(
           selectedAnnotation && isRoutedMarker(selectedAnnotation),
         ),
-        hasRotatableSelection,
+        canRotate: editorCommands.state({ id: "transform.rotate" }).enabled,
+        canMirror: editorCommands.state({
+          id: "transform.mirror",
+          direction: "left-right",
+        }).enabled,
         hasDraftingSelection: Boolean(selectedDrafting),
         hasInspectableSelection,
-        hasMoveSelection: hasVisualSelection(visualSelection),
         hasRouteSelection: Boolean(selectedRoute),
         hasHighlightableNet: selectedHighlightNetId !== null,
         wireReadyToFinish: Boolean(wireSource && wirePreviewPoint),
@@ -7445,12 +7523,6 @@ export function App({
             tool === "construction-line" ||
             tool === "rectangle") &&
           draftingSource !== null,
-        helpOpen,
-        canvasDragActive: canvasDragSessionRef.current !== null,
-        hasClearableDraftingSelection:
-          selectedDrafting?.kind === "arrow" ||
-          selectedDrafting?.kind === "construction-line" ||
-          selectedDrafting?.kind === "rectangle",
         hasRemovableWireWaypoint: Boolean(
           wireSource && wireDraftSteps.length > 0,
         ),
@@ -7461,32 +7533,19 @@ export function App({
       if (!shortcut) return;
 
       const escapeIntent =
-        shortcut.kind === "close-help" ||
-        shortcut.kind === "cancel-canvas-drag" ||
-        shortcut.kind === "cancel-interaction" ||
-        shortcut.kind === "clear-drafting-selection" ||
-        shortcut.kind === "cancel-passive";
+        shortcut.kind === "run-command" &&
+        shortcut.command.id === "editor.cancel";
       if (!escapeIntent) event.preventDefault();
 
       switch (shortcut.kind) {
+        case "run-command":
+          editorCommands.execute(shortcut.command);
+          return;
         case "block-browser-refresh":
           setStatus("Refresh blocked to protect the current circuit");
           return;
         case "block-browser-bookmark":
           setStatus("Browser bookmark shortcut blocked while editing");
-          return;
-        case "undo":
-        case "redo":
-          transact([{ kind: shortcut.kind }]);
-          return;
-        case "copy":
-          beginCopyPlacementFromSelection();
-          return;
-        case "begin-selection-move":
-          beginKeyboardSelectionMoveFromSelection();
-          return;
-        case "move-selection-required":
-          setStatus("Select objects before moving them");
           return;
         case "save":
           void saveProjectFile();
@@ -7494,76 +7553,8 @@ export function App({
         case "open":
           projectInputRef.current?.click();
           return;
-        case "select-all":
-          replaceSelection({
-            instanceIds: document.instances
-              .filter((instance) => instance.placement)
-              .map((instance) => instance.id),
-            routeIds: document.routes.map((route) => route.id),
-            junctionIds: document.junctions.map((junction) => junction.id),
-            annotationIds: document.annotations.map(
-              (annotation) => annotation.id,
-            ),
-            draftingIds: (document.drafting?.objects ?? []).map(
-              (object) => object.id,
-            ),
-          });
-          setSelectedEndpoint(null);
-          return;
-        case "clear-selection":
-          resetSelection();
-          setSelectedEndpoint(null);
-          setSelectedRouteSegmentIndex(null);
-          setStatus("Selection cleared");
-          return;
         case "reverse-current-marker":
           reverseSelectedCurrentArrow();
-          return;
-        case "open-component-insert":
-          startInsertFromHook(fullInsertLaunch());
-          return;
-        case "place-port": {
-          const request = quickPlaceRequest(
-            document.presentation.styleProfileId,
-            "port",
-          );
-          if (request) startInsertFromHook({ kind: "quick", request });
-          return;
-        }
-        case "rotate-placement":
-          rotatePendingComponentFromHook(shortcut.deltaDegrees);
-          return;
-        case "rotate-copy-placement":
-          rotatePendingCopy(shortcut.deltaDegrees);
-          return;
-        case "mirror-placement":
-          mirrorPendingComponentFromHook(shortcut.direction);
-          return;
-        case "mirror-copy-placement":
-          mirrorPendingCopy(shortcut.direction);
-          return;
-        case "rotate":
-          rotateSelected(shortcut.deltaDegrees);
-          return;
-        case "mirror":
-          mirrorSelected(shortcut.direction);
-          return;
-        case "activate-tool":
-          activateTool(shortcut.tool);
-          return;
-        case "add-text":
-          addPlainText();
-          return;
-        case "open-properties":
-          openProperties();
-          return;
-        case "close-properties":
-          exitCellSymbolLayout();
-          setSelectionOpen(false);
-          setImportReviewOpen(false);
-          return;
-        case "property-selection-required":
-          setStatus("Select an object before opening Properties");
           return;
         case "edit-net-label":
           beginNetLabelEditing();
@@ -7584,9 +7575,6 @@ export function App({
           setStatus(
             "Select a rectangle or hierarchical block before entering a Cell",
           );
-          return;
-        case "fit-view":
-          fitView();
           return;
         case "step-drafting-style": {
           if (!selectedDrafting) return;
@@ -7620,38 +7608,6 @@ export function App({
         case "finish-drafting":
           finishDraftingCreate();
           return;
-        case "close-help":
-          closeHelp();
-          return;
-        case "cancel-canvas-drag":
-          canvasDragSessionRef.current?.cancel();
-          setStatus("Cancelled canvas drag");
-          return;
-        case "cancel-interaction": {
-          const cancelledKind = getCurrentInteractionState().kind;
-          cancelAllTransientInteraction();
-          setStatus(
-            cancelledKind === "copy-placement"
-              ? "Copy placement cancelled"
-              : cancelledKind === "placing-vdd-rail"
-                ? "Power Rail cancelled"
-                : cancelledKind === "placing-component"
-                  ? "Component placement cancelled"
-                  : cancelledKind === "drawing"
-                    ? "Drawing cancelled"
-                    : "Cancelled active tool",
-          );
-          return;
-        }
-        case "clear-drafting-selection":
-          replaceSelectionKind("drafting", []);
-          setStatus("Cleared drawing selection");
-          return;
-        case "cancel-passive":
-          setBoxPreview(null);
-          paintSnapGuides([]);
-          setStatus("Cancelled");
-          return;
         case "remove-wire-waypoint":
           setWireDraftSteps(wireDraftSteps.slice(0, -1));
           setStatus("Removed last authored wire step");
@@ -7660,9 +7616,6 @@ export function App({
           setStatus(
             `${shortcut.command} is unavailable while an active tool owns the canvas · Esc cancels`,
           );
-          return;
-        case "delete-selection":
-          deleteCurrentSelection();
           return;
       }
     }
@@ -7930,21 +7883,31 @@ export function App({
                   </button>
                   <button
                     type="button"
-                    onClick={() => transact([{ kind: "undo" }])}
-                    disabled={!canUndo}
+                    onClick={() =>
+                      editorCommands.execute({ id: "history.undo" })
+                    }
+                    disabled={
+                      !editorCommands.state({ id: "history.undo" }).enabled
+                    }
                   >
                     Undo
                   </button>
                   <button
                     type="button"
-                    onClick={() => transact([{ kind: "redo" }])}
-                    disabled={!canRedo}
+                    onClick={() =>
+                      editorCommands.execute({ id: "history.redo" })
+                    }
+                    disabled={
+                      !editorCommands.state({ id: "history.redo" }).enabled
+                    }
                   >
                     Redo
                   </button>
                   <button
                     type="button"
-                    onClick={deleteCurrentSelection}
+                    onClick={() =>
+                      editorCommands.execute({ id: "selection.delete" })
+                    }
                     disabled={
                       !hasVisualSelection(visualSelection) && !selectedEndpoint
                     }
@@ -7983,23 +7946,47 @@ export function App({
                   </button>
                   <button
                     type="button"
-                    onClick={() => rotateSelected()}
-                    disabled={selectedIds.length === 0}
+                    onClick={() =>
+                      editorCommands.execute({ id: "transform.rotate" })
+                    }
+                    disabled={
+                      !editorCommands.state({ id: "transform.rotate" }).enabled
+                    }
                   >
                     <ToolIcon name="rotate" />
                     Rotate
                   </button>
                   <button
                     type="button"
-                    onClick={() => mirrorSelected("left-right")}
-                    disabled={selectedIds.length === 0}
+                    onClick={() =>
+                      editorCommands.execute({
+                        id: "transform.mirror",
+                        direction: "left-right",
+                      })
+                    }
+                    disabled={
+                      !editorCommands.state({
+                        id: "transform.mirror",
+                        direction: "left-right",
+                      }).enabled
+                    }
                   >
                     Mirror left/right (Shift+R)
                   </button>
                   <button
                     type="button"
-                    onClick={() => mirrorSelected("top-bottom")}
-                    disabled={selectedIds.length === 0}
+                    onClick={() =>
+                      editorCommands.execute({
+                        id: "transform.mirror",
+                        direction: "top-bottom",
+                      })
+                    }
+                    disabled={
+                      !editorCommands.state({
+                        id: "transform.mirror",
+                        direction: "top-bottom",
+                      }).enabled
+                    }
                   >
                     Mirror top/bottom (Ctrl+R)
                   </button>
@@ -8159,7 +8146,12 @@ export function App({
             className="draw-tool"
             data-testid="draw-tool-insert"
             title="Insert component (I)"
-            onClick={() => startInsertFromHook(fullInsertLaunch())}
+            onClick={() =>
+              editorCommands.execute({
+                id: "insert.start",
+                launch: fullInsertLaunch(),
+              })
+            }
           >
             <ToolIcon name="insert" />
             <span>Insert</span>
@@ -8170,7 +8162,9 @@ export function App({
             data-testid="draw-tool-wire"
             aria-pressed={tool === "wire"}
             title="Wire (W)"
-            onClick={() => activateTool("wire")}
+            onClick={() =>
+              editorCommands.execute({ id: "tool.activate", tool: "wire" })
+            }
           >
             <ToolIcon name="wire" />
             <span>Wire</span>
@@ -8181,7 +8175,7 @@ export function App({
             data-testid="draw-tool-text"
             aria-label="Text"
             title="Text (T)"
-            onClick={addPlainText}
+            onClick={() => editorCommands.execute({ id: "drafting.add-text" })}
           >
             <ToolIcon name="text" />
             <span>Text</span>
@@ -8193,7 +8187,9 @@ export function App({
             data-testid="draw-tool-arrow"
             aria-pressed={tool === "arrow"}
             title="Arrow (A)"
-            onClick={() => activateTool("arrow")}
+            onClick={() =>
+              editorCommands.execute({ id: "tool.activate", tool: "arrow" })
+            }
           >
             <ToolIcon name="arrow" />
             <span>Arrow</span>
@@ -8204,7 +8200,12 @@ export function App({
             data-testid="draw-tool-line"
             aria-pressed={tool === "construction-line"}
             title="Construction line (K)"
-            onClick={() => activateTool("construction-line")}
+            onClick={() =>
+              editorCommands.execute({
+                id: "tool.activate",
+                tool: "construction-line",
+              })
+            }
           >
             <ToolIcon name="line" />
             <span>Line</span>
@@ -8215,7 +8216,12 @@ export function App({
             data-testid="draw-tool-rectangle"
             aria-pressed={tool === "rectangle"}
             title="Rectangle (R)"
-            onClick={() => activateTool("rectangle")}
+            onClick={() =>
+              editorCommands.execute({
+                id: "tool.activate",
+                tool: "rectangle",
+              })
+            }
           >
             <ToolIcon name="rectangle" />
             <span>Rect</span>
@@ -8417,7 +8423,12 @@ export function App({
         externalDefinitions={externalSubcircuitInsertCandidates}
         scope={insertScope}
         initialSelectionId={insertInitialSelectionId}
-        onApply={(request) => startInsertFromHook({ kind: "quick", request })}
+        onApply={(request) =>
+          editorCommands.execute({
+            id: "insert.start",
+            launch: { kind: "quick", request },
+          })
+        }
         onCancel={cancelComponentInsertFromHook}
       />
       {pendingCellReset ? (
@@ -8675,7 +8686,9 @@ export function App({
           <ShapesPanel
             styleProfileId={document.presentation.styleProfileId}
             open={visibleLibraryPanelOpen}
-            onStartInsert={startInsertFromHook}
+            onStartInsert={(launch) =>
+              editorCommands.execute({ id: "insert.start", launch })
+            }
           />
         ) : (
           <ExamplesPanel
@@ -9093,7 +9106,10 @@ export function App({
                               }
                               defaultValue={selectedPortLogicalName ?? ""}
                               onBlur={(event) =>
-                                renameSelectedNetPort(event.currentTarget.value)
+                                commitElectricalMarkerName(
+                                  selectedInstance.id,
+                                  event.currentTarget.value,
+                                )
                               }
                             />
                           </dd>
@@ -9494,7 +9510,9 @@ export function App({
                           className="property-placement-icon-button"
                           aria-label={`Rotate component clockwise 90 degrees; current rotation ${instancePropertyDraft.rotation} degrees; shortcut R`}
                           title={`Rotate 90° clockwise · current ${instancePropertyDraft.rotation}° (R)`}
-                          onClick={() => rotateSelected()}
+                          onClick={() =>
+                            editorCommands.execute({ id: "transform.rotate" })
+                          }
                         >
                           <ToolIcon name="rotate" />
                         </button>
@@ -9503,7 +9521,12 @@ export function App({
                           className="property-placement-icon-button"
                           aria-label="Mirror component left to right, Shift+R"
                           title="Mirror left/right (Shift+R)"
-                          onClick={() => mirrorSelected("left-right")}
+                          onClick={() =>
+                            editorCommands.execute({
+                              id: "transform.mirror",
+                              direction: "left-right",
+                            })
+                          }
                         >
                           <ToolIcon name="mirror-horizontal" />
                         </button>
@@ -9512,7 +9535,12 @@ export function App({
                           className="property-placement-icon-button"
                           aria-label="Mirror component top to bottom, Ctrl+R"
                           title="Mirror top/bottom (Ctrl+R)"
-                          onClick={() => mirrorSelected("top-bottom")}
+                          onClick={() =>
+                            editorCommands.execute({
+                              id: "transform.mirror",
+                              direction: "top-bottom",
+                            })
+                          }
                         >
                           <ToolIcon name="mirror-vertical" />
                         </button>
@@ -9857,7 +9885,9 @@ export function App({
                         <button
                           type="button"
                           disabled={selectedDrafting.locked}
-                          onClick={() => rotateSelected()}
+                          onClick={() =>
+                            editorCommands.execute({ id: "transform.rotate" })
+                          }
                         >
                           <ToolIcon name="rotate" />
                           Rotate
@@ -11674,7 +11704,7 @@ export function App({
             type="button"
             aria-label="Fit view"
             title="Fit view (Home)"
-            onClick={fitView}
+            onClick={() => editorCommands.execute({ id: "view.fit" })}
           >
             <ToolIcon name="fit" />
           </button>

--- a/apps/editor/src/commands/editor-command.test.ts
+++ b/apps/editor/src/commands/editor-command.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { EditorTool } from "../interaction/interaction-state";
+import {
+  createEditorCommandRouter,
+  type EditorCommandContext,
+  type EditorCommandOperations,
+} from "./editor-command";
+
+function fixture(overrides: Partial<EditorCommandContext> = {}) {
+  const context: EditorCommandContext = {
+    interactionMode: "idle",
+    activeTool: "pointer",
+    hasDeletableSelection: true,
+    hasMoveSelection: true,
+    hasRotatableSelection: true,
+    hasMirrorableSelection: true,
+    hasInspectableSelection: true,
+    propertiesOpen: false,
+    canUndo: true,
+    canRedo: true,
+    helpOpen: false,
+    canvasDragActive: false,
+    hasClearableDraftingSelection: false,
+    ...overrides,
+  };
+  const operations: EditorCommandOperations = {
+    closeHelp: vi.fn(),
+    cancelCanvasDrag: vi.fn(),
+    cancelInteraction: vi.fn(),
+    clearDraftingSelection: vi.fn(),
+    cancelPassive: vi.fn(),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    selectAll: vi.fn(),
+    clearSelection: vi.fn(),
+    deleteSelection: vi.fn(),
+    beginCopy: vi.fn(),
+    beginMove: vi.fn(),
+    rotatePlacement: vi.fn(),
+    rotateCopy: vi.fn(),
+    rotateSelection: vi.fn(),
+    mirrorPlacement: vi.fn(),
+    mirrorCopy: vi.fn(),
+    mirrorSelection: vi.fn(),
+    startInsert: vi.fn(),
+    openInsert: vi.fn(),
+    placeFreeNetPort: vi.fn(),
+    activateTool: vi.fn<(tool: EditorTool) => void>(),
+    addText: vi.fn(),
+    openProperties: vi.fn(),
+    closeProperties: vi.fn(),
+    fitView: vi.fn(),
+    report: vi.fn(),
+  };
+  return {
+    context,
+    operations,
+    router: createEditorCommandRouter({
+      getContext: () => context,
+      operations,
+    }),
+  };
+}
+
+describe("editor command router", () => {
+  it("keeps the established Escape priority in one command", () => {
+    const help = fixture({
+      helpOpen: true,
+      canvasDragActive: true,
+      interactionMode: "wire",
+      hasClearableDraftingSelection: true,
+    });
+    help.router.execute({ id: "editor.cancel" });
+    expect(help.operations.closeHelp).toHaveBeenCalledOnce();
+    expect(help.operations.cancelCanvasDrag).not.toHaveBeenCalled();
+
+    const interaction = fixture({ interactionMode: "placing-vdd-rail" });
+    interaction.router.execute({ id: "editor.cancel" });
+    expect(interaction.operations.cancelInteraction).toHaveBeenCalledWith(
+      "placing-vdd-rail",
+    );
+  });
+
+  it("routes one Rotate command to the active domain", () => {
+    const selected = fixture();
+    selected.router.execute({ id: "transform.rotate" });
+    expect(selected.operations.rotateSelection).toHaveBeenCalledWith(90);
+
+    const placement = fixture({ interactionMode: "placing-component" });
+    placement.router.execute({ id: "transform.rotate", deltaDegrees: -90 });
+    expect(placement.operations.rotatePlacement).toHaveBeenCalledWith(-90);
+
+    const copy = fixture({ interactionMode: "copy-placement" });
+    copy.router.execute({ id: "transform.rotate" });
+    expect(copy.operations.rotateCopy).toHaveBeenCalledWith(90);
+  });
+
+  it("keeps Power Rail specialized and rejects generic transforms", () => {
+    const { router, operations } = fixture({
+      interactionMode: "placing-vdd-rail",
+    });
+    expect(router.state({ id: "transform.rotate" }).enabled).toBe(false);
+    expect(router.execute({ id: "transform.rotate" })).toMatchObject({
+      status: "rejected",
+    });
+    expect(operations.rotateSelection).not.toHaveBeenCalled();
+    expect(operations.report).toHaveBeenCalledWith(
+      "Rotate is unavailable for the current interaction",
+    );
+  });
+
+  it("does not claim drafting mirroring when only rotation is implemented", () => {
+    const { router, operations } = fixture({
+      hasRotatableSelection: true,
+      hasMirrorableSelection: false,
+    });
+    expect(
+      router.state({
+        id: "transform.mirror",
+        direction: "left-right",
+      }).enabled,
+    ).toBe(false);
+    router.execute({ id: "transform.mirror", direction: "left-right" });
+    expect(operations.mirrorSelection).not.toHaveBeenCalled();
+  });
+
+  it("delegates insertion without flattening its specialized request", () => {
+    const { router, operations } = fixture();
+    const launch = { kind: "picker", scope: "cells" } as const;
+    router.execute({ id: "insert.start", launch });
+    expect(operations.startInsert).toHaveBeenCalledWith(launch);
+  });
+
+  it("publishes one active state for tool buttons and shortcuts", () => {
+    const { router, operations } = fixture({ activeTool: "wire" });
+    expect(router.state({ id: "tool.activate", tool: "wire" })).toEqual({
+      enabled: true,
+      active: true,
+    });
+    router.execute({ id: "tool.activate", tool: "arrow" });
+    expect(operations.activateTool).toHaveBeenCalledWith("arrow");
+  });
+
+  it("preserves silent shortcut no-ops while publishing disabled menu state", () => {
+    const { router, operations } = fixture({
+      canUndo: false,
+      canRedo: false,
+      hasDeletableSelection: false,
+    });
+
+    expect(router.state({ id: "history.undo" }).enabled).toBe(false);
+    expect(router.execute({ id: "history.undo" }).status).toBe("rejected");
+    expect(router.execute({ id: "history.redo" }).status).toBe("rejected");
+    expect(router.execute({ id: "selection.delete" }).status).toBe("rejected");
+    expect(operations.report).not.toHaveBeenCalled();
+  });
+});

--- a/apps/editor/src/commands/editor-command.ts
+++ b/apps/editor/src/commands/editor-command.ts
@@ -1,0 +1,298 @@
+import type { InsertLaunch } from "../features/component-insert/insert-launch";
+import type {
+  EditorTool,
+  InteractionMode,
+} from "../interaction/interaction-state";
+import type { ScreenFlip } from "../interaction/shortcut-orientation";
+
+export type EditorCommandRequest =
+  | { id: "editor.cancel" }
+  | { id: "history.undo" }
+  | { id: "history.redo" }
+  | { id: "selection.select-all" }
+  | { id: "selection.clear" }
+  | { id: "selection.delete" }
+  | { id: "selection.copy" }
+  | { id: "selection.move" }
+  | { id: "transform.rotate"; deltaDegrees?: 90 | -90 }
+  | { id: "transform.mirror"; direction: ScreenFlip }
+  | { id: "insert.start"; launch: InsertLaunch }
+  | { id: "insert.open" }
+  | { id: "insert.free-net-port" }
+  | { id: "tool.activate"; tool: EditorTool }
+  | { id: "drafting.add-text" }
+  | { id: "properties.open" }
+  | { id: "properties.close" }
+  | { id: "view.fit" };
+
+export interface EditorCommandState {
+  enabled: boolean;
+  active: boolean;
+  reason?: string;
+}
+
+export interface EditorCommandResult {
+  status: "executed" | "rejected";
+  message?: string;
+}
+
+export interface EditorCommandContext {
+  interactionMode: InteractionMode;
+  activeTool: EditorTool;
+  hasDeletableSelection: boolean;
+  hasMoveSelection: boolean;
+  hasRotatableSelection: boolean;
+  hasMirrorableSelection: boolean;
+  hasInspectableSelection: boolean;
+  propertiesOpen: boolean;
+  canUndo: boolean;
+  canRedo: boolean;
+  helpOpen: boolean;
+  canvasDragActive: boolean;
+  hasClearableDraftingSelection: boolean;
+}
+
+export interface EditorCommandOperations {
+  closeHelp(): void;
+  cancelCanvasDrag(): void;
+  cancelInteraction(interactionMode: InteractionMode): void;
+  clearDraftingSelection(): void;
+  cancelPassive(): void;
+  undo(): void;
+  redo(): void;
+  selectAll(): void;
+  clearSelection(): void;
+  deleteSelection(): void;
+  beginCopy(): void;
+  beginMove(): void;
+  rotatePlacement(deltaDegrees: 90 | -90): void;
+  rotateCopy(deltaDegrees: 90 | -90): void;
+  rotateSelection(deltaDegrees: 90 | -90): void;
+  mirrorPlacement(direction: ScreenFlip): void;
+  mirrorCopy(direction: ScreenFlip): void;
+  mirrorSelection(direction: ScreenFlip): void;
+  startInsert(launch: InsertLaunch): void;
+  openInsert(): void;
+  placeFreeNetPort(): void;
+  activateTool(tool: EditorTool): void;
+  addText(): void;
+  openProperties(): void;
+  closeProperties(): void;
+  fitView(): void;
+  report(message: string): void;
+}
+
+export interface EditorCommandRouter {
+  state(request: EditorCommandRequest): EditorCommandState;
+  execute(request: EditorCommandRequest): EditorCommandResult;
+}
+
+type EditorCommandRouterOptions = {
+  getContext(): EditorCommandContext;
+  operations: EditorCommandOperations;
+};
+
+function enabled(active = false): EditorCommandState {
+  return { enabled: true, active };
+}
+
+function disabled(reason: string): EditorCommandState {
+  return { enabled: false, active: false, reason };
+}
+
+/**
+ * Thin editor-local command plane. It owns cross-surface availability and
+ * interaction arbitration, then delegates to the existing domain owners. It
+ * deliberately knows nothing about Project JSON, Engine edits, geometry, or
+ * electrical topology.
+ */
+export function createEditorCommandRouter(
+  options: EditorCommandRouterOptions,
+): EditorCommandRouter {
+  const state = (request: EditorCommandRequest): EditorCommandState => {
+    const context = options.getContext();
+    switch (request.id) {
+      case "editor.cancel":
+        return enabled(
+          context.helpOpen ||
+            context.canvasDragActive ||
+            context.interactionMode !== "idle" ||
+            context.hasClearableDraftingSelection,
+        );
+      case "history.undo":
+        return context.canUndo ? enabled() : disabled("Nothing to undo");
+      case "history.redo":
+        return context.canRedo ? enabled() : disabled("Nothing to redo");
+      case "selection.select-all":
+      case "selection.clear":
+        return enabled();
+      case "selection.delete":
+        return context.hasDeletableSelection
+          ? enabled()
+          : disabled("Select an object before deleting it");
+      case "selection.copy":
+        if (
+          context.interactionMode !== "idle" &&
+          context.interactionMode !== "copy-placement"
+        ) {
+          return disabled("Finish or cancel the active tool before copying");
+        }
+        return enabled(context.interactionMode === "copy-placement");
+      case "selection.move":
+        if (
+          context.interactionMode !== "idle" &&
+          context.interactionMode !== "moving-selection"
+        ) {
+          return disabled("Finish or cancel the active tool before moving");
+        }
+        return context.hasMoveSelection ||
+          context.interactionMode === "moving-selection"
+          ? enabled(context.interactionMode === "moving-selection")
+          : disabled("Select objects before moving them");
+      case "transform.rotate":
+        if (
+          context.interactionMode === "placing-component" ||
+          context.interactionMode === "copy-placement"
+        ) {
+          return enabled(true);
+        }
+        return context.interactionMode === "idle" &&
+          context.hasRotatableSelection
+          ? enabled()
+          : disabled("Rotate is unavailable for the current interaction");
+      case "transform.mirror":
+        if (
+          context.interactionMode === "placing-component" ||
+          context.interactionMode === "copy-placement"
+        ) {
+          return enabled(true);
+        }
+        return context.interactionMode === "idle" &&
+          context.hasMirrorableSelection
+          ? enabled()
+          : disabled("Mirror is unavailable for the current selection");
+      case "insert.start":
+      case "insert.open":
+      case "insert.free-net-port":
+        return enabled(
+          context.interactionMode === "placing-component" ||
+            context.interactionMode === "placing-vdd-rail",
+        );
+      case "tool.activate":
+        return enabled(context.activeTool === request.tool);
+      case "drafting.add-text":
+      case "view.fit":
+        return enabled();
+      case "properties.open":
+        return context.hasInspectableSelection
+          ? enabled(context.propertiesOpen)
+          : disabled("Select an object before opening Properties");
+      case "properties.close":
+        return enabled(context.propertiesOpen);
+    }
+  };
+
+  const execute = (request: EditorCommandRequest): EditorCommandResult => {
+    const availability = state(request);
+    if (!availability.enabled) {
+      const message = availability.reason ?? "Command is unavailable";
+      // Undo, redo, and Delete historically no-op when invoked from a
+      // shortcut with nothing to act on. Menus still consume the disabled
+      // state, but the shared command must not add a new status-bar side
+      // effect merely because routing was unified.
+      if (
+        request.id !== "history.undo" &&
+        request.id !== "history.redo" &&
+        request.id !== "selection.delete"
+      ) {
+        options.operations.report(message);
+      }
+      return { status: "rejected", message };
+    }
+
+    const context = options.getContext();
+    switch (request.id) {
+      case "editor.cancel":
+        if (context.helpOpen) {
+          options.operations.closeHelp();
+        } else if (context.canvasDragActive) {
+          options.operations.cancelCanvasDrag();
+        } else if (context.interactionMode !== "idle") {
+          options.operations.cancelInteraction(context.interactionMode);
+        } else if (context.hasClearableDraftingSelection) {
+          options.operations.clearDraftingSelection();
+        } else {
+          options.operations.cancelPassive();
+        }
+        break;
+      case "history.undo":
+        options.operations.undo();
+        break;
+      case "history.redo":
+        options.operations.redo();
+        break;
+      case "selection.select-all":
+        options.operations.selectAll();
+        break;
+      case "selection.clear":
+        options.operations.clearSelection();
+        break;
+      case "selection.delete":
+        options.operations.deleteSelection();
+        break;
+      case "selection.copy":
+        options.operations.beginCopy();
+        break;
+      case "selection.move":
+        options.operations.beginMove();
+        break;
+      case "transform.rotate": {
+        const deltaDegrees = request.deltaDegrees ?? 90;
+        if (context.interactionMode === "placing-component") {
+          options.operations.rotatePlacement(deltaDegrees);
+        } else if (context.interactionMode === "copy-placement") {
+          options.operations.rotateCopy(deltaDegrees);
+        } else {
+          options.operations.rotateSelection(deltaDegrees);
+        }
+        break;
+      }
+      case "transform.mirror":
+        if (context.interactionMode === "placing-component") {
+          options.operations.mirrorPlacement(request.direction);
+        } else if (context.interactionMode === "copy-placement") {
+          options.operations.mirrorCopy(request.direction);
+        } else {
+          options.operations.mirrorSelection(request.direction);
+        }
+        break;
+      case "insert.start":
+        options.operations.startInsert(request.launch);
+        break;
+      case "insert.open":
+        options.operations.openInsert();
+        break;
+      case "insert.free-net-port":
+        options.operations.placeFreeNetPort();
+        break;
+      case "tool.activate":
+        options.operations.activateTool(request.tool);
+        break;
+      case "drafting.add-text":
+        options.operations.addText();
+        break;
+      case "properties.open":
+        options.operations.openProperties();
+        break;
+      case "properties.close":
+        options.operations.closeProperties();
+        break;
+      case "view.fit":
+        options.operations.fitView();
+        break;
+    }
+    return { status: "executed" };
+  };
+
+  return { state, execute };
+}

--- a/apps/editor/src/features/properties/electrical-marker-name.test.ts
+++ b/apps/editor/src/features/properties/electrical-marker-name.test.ts
@@ -1,0 +1,98 @@
+import { createEmptyDocument } from "@icm/model";
+import { describe, expect, it } from "vitest";
+
+import { planElectricalMarkerName } from "./electrical-marker-name";
+
+function documentWithMarker(symbolId: "port" | "vdd-port") {
+  const document = createEmptyDocument("main", "Main");
+  document.instances.push({
+    id: "P1",
+    symbolId,
+    placement: {
+      position: { x: 100, y: 100 },
+      rotation: 0,
+      mirror: "none",
+    },
+  });
+  document.nets.push({
+    id: "net-p1",
+    scope: symbolId === "vdd-port" ? "global" : "local",
+    powerDomain: symbolId === "vdd-port" ? "vdd" : "none",
+    terminals: [{ instanceId: "P1", pinName: "P" }],
+  });
+  document.connectivityEvidence.push({
+    id: "claim-p1",
+    kind: "name-claim",
+    netId: "net-p1",
+    name: symbolId === "vdd-port" ? "VDD" : "P1",
+    scope: symbolId === "vdd-port" ? "global" : "local",
+    ...(symbolId === "vdd-port" ? { powerDomain: "vdd" as const } : {}),
+    owner:
+      symbolId === "vdd-port"
+        ? { kind: "power-marker" as const, objectId: "P1" }
+        : { kind: "free-port" as const, instanceId: "P1" },
+  });
+  return document;
+}
+
+describe("electrical marker name planning", () => {
+  it("keeps supply markers on the specialized detach-and-rejoin planner", () => {
+    const plan = planElectricalMarkerName(
+      documentWithMarker("vdd-port"),
+      "P1",
+      "  AVDD  ",
+    );
+
+    expect(plan).toMatchObject({
+      status: "ready",
+      message: "Supply named AVDD",
+    });
+    expect(
+      plan.status === "ready" &&
+        plan.edits.some((edit) => edit.kind === "disconnect_endpoint"),
+    ).toBe(true);
+  });
+
+  it("keeps Free Net Ports on the same-name logical Net planner", () => {
+    const plan = planElectricalMarkerName(
+      documentWithMarker("port"),
+      "P1",
+      "  CLK  ",
+    );
+
+    expect(plan).toMatchObject({
+      status: "ready",
+      message: "Renamed Net Port to CLK",
+    });
+    expect(
+      plan.status === "ready" &&
+        plan.edits.some((edit) => edit.kind === "disconnect_endpoint"),
+    ).toBe(false);
+    expect(
+      plan.status === "ready" &&
+        plan.edits.some((edit) => edit.kind === "upsert_connectivity_evidence"),
+    ).toBe(true);
+  });
+
+  it("does not send formal Cell pins through free-marker naming", () => {
+    const document = documentWithMarker("port");
+    document.netlist = {
+      name: "Main",
+      terminals: [
+        {
+          id: "formal-in",
+          name: "IN",
+          netId: "net-p1",
+          interfaceInstanceIds: ["P1"],
+          direction: "input",
+        },
+      ],
+      formalParameters: [],
+    };
+
+    expect(planElectricalMarkerName(document, "P1", "VIN")).toEqual({
+      status: "rejected",
+      message: "Formal Cell Pins use Cell naming",
+    });
+  });
+});

--- a/apps/editor/src/features/properties/electrical-marker-name.ts
+++ b/apps/editor/src/features/properties/electrical-marker-name.ts
@@ -1,0 +1,90 @@
+import { planEnsureNamedNet, type SchematicEdit } from "@icm/edit-engine";
+import { deriveStableId, type SchematicDocument } from "@icm/model";
+import { resolveDocumentLogicalNets } from "@icm/derived";
+
+import { proposedSupplyPortRename } from "../component-insert/placement-connectivity";
+
+export type ElectricalMarkerNamePlan =
+  | { status: "noop" }
+  | { status: "rejected"; message: string }
+  | { status: "ready"; edits: readonly SchematicEdit[]; message: string };
+
+/**
+ * Properties-domain name planning for electrical markers. Free Net Ports and
+ * supply markers share one field in the inspector but deliberately keep their
+ * different electrical planners.
+ */
+export function planElectricalMarkerName(
+  document: SchematicDocument,
+  instanceId: string,
+  rawName: string,
+): ElectricalMarkerNamePlan {
+  const instance = document.instances.find(
+    (candidate) => candidate.id === instanceId,
+  );
+  if (!instance) {
+    return { status: "rejected", message: "Electrical marker is unavailable" };
+  }
+  if (
+    document.netlist?.terminals.some((terminal) =>
+      terminal.interfaceInstanceIds.includes(instanceId),
+    )
+  ) {
+    return { status: "rejected", message: "Formal Cell Pins use Cell naming" };
+  }
+  if (
+    instance.symbolId !== "port" &&
+    instance.symbolId !== "port-filled" &&
+    instance.symbolId !== "vdd-port"
+  ) {
+    return {
+      status: "rejected",
+      message: "Instance is not an electrical marker",
+    };
+  }
+  const net = document.nets.find((candidate) =>
+    candidate.terminals.some((terminal) => terminal.instanceId === instanceId),
+  );
+  if (!net) {
+    return { status: "rejected", message: "Electrical marker has no Net" };
+  }
+  const name = rawName.trim();
+  const currentName = resolveDocumentLogicalNets(document).byBaseNetId.get(
+    net.id,
+  )?.name;
+  if (!name || name === currentName) return { status: "noop" };
+
+  if (instance.symbolId === "vdd-port") {
+    const plan = proposedSupplyPortRename(document, instance, name);
+    return plan.rejected
+      ? { status: "rejected", message: plan.rejected }
+      : { status: "ready", edits: plan.edits, message: `Supply named ${name}` };
+  }
+
+  const plan = planEnsureNamedNet(document, {
+    candidateNetId: net.id,
+    name,
+    evidenceId:
+      document.connectivityEvidence.find(
+        (evidence) =>
+          evidence.kind === "name-claim" &&
+          evidence.owner.kind === "free-port" &&
+          evidence.owner.instanceId === instanceId,
+      )?.id ??
+      deriveStableId(
+        "connectivity-evidence",
+        document.id,
+        "free-port",
+        net.id,
+        instanceId,
+      ),
+    owner: { kind: "free-port", instanceId },
+  });
+  return plan.ok
+    ? {
+        status: "ready",
+        edits: plan.edits,
+        message: `Renamed Net Port to ${plan.name}`,
+      }
+    : { status: "rejected", message: plan.message };
+}

--- a/apps/editor/src/features/properties/use-properties-editor.ts
+++ b/apps/editor/src/features/properties/use-properties-editor.ts
@@ -32,6 +32,7 @@ import {
   updateTextEditingSession,
 } from "../text-editing/text-editing";
 import type { TextEditingSession } from "../text-editing/text-editing";
+import { planElectricalMarkerName } from "./electrical-marker-name";
 
 export interface InstancePropertyDraft {
   instanceId: string | null;
@@ -182,6 +183,19 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
   const parametersForInstance = (instance: Instance) =>
     options.componentParametersForInstance?.(instance) ??
     componentParameters(instance.symbolId);
+
+  const commitElectricalMarkerName = (
+    instanceId: string,
+    name: string,
+  ): void => {
+    const plan = planElectricalMarkerName(options.document, instanceId, name);
+    if (plan.status === "noop") return;
+    if (plan.status === "rejected") {
+      options.setStatus(plan.message);
+      return;
+    }
+    if (options.transact([...plan.edits]).ok) options.setStatus(plan.message);
+  };
 
   const draftForInstance = (instance: Instance): InstancePropertyDraft => ({
     instanceId: instance.id,
@@ -823,6 +837,7 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     beginDraftingTextEditing,
     beginNetLabelEditing,
     commitInstancePropertyDraft,
+    commitElectricalMarkerName,
     commitNetLabelEditing,
     commitPendingNetLabelDraft,
     commitTextEditing,

--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -10,17 +10,14 @@ const baseContext: EditorShortcutContext = {
   isTyping: false,
   interactionMode: "idle",
   hasRoutedMarkerSelection: false,
-  hasRotatableSelection: false,
+  canRotate: false,
+  canMirror: false,
   hasDraftingSelection: false,
   hasInspectableSelection: false,
-  hasMoveSelection: false,
   hasRouteSelection: false,
   hasHighlightableNet: false,
   wireReadyToFinish: false,
   draftingReadyToFinish: false,
-  helpOpen: false,
-  canvasDragActive: false,
-  hasClearableDraftingSelection: false,
   hasRemovableWireWaypoint: false,
   propertiesOpen: false,
   hasHierarchyEnterSelection: false,
@@ -52,14 +49,20 @@ function resolve(
   });
 }
 
+const command = (value: object) => ({ kind: "run-command", command: value });
+
 describe("editor shortcut contract", () => {
   it("maps history and file chord shortcuts without stealing copy/paste chords", () => {
-    expect(resolve("u")).toEqual({ kind: "undo" });
-    expect(resolve("u", {}, { shiftKey: true })).toEqual({ kind: "redo" });
-    expect(resolve("z", {}, { ctrlKey: true })).toEqual({ kind: "undo" });
-    expect(resolve("z", {}, { ctrlKey: true, shiftKey: true })).toEqual({
-      kind: "redo",
-    });
+    expect(resolve("u")).toEqual(command({ id: "history.undo" }));
+    expect(resolve("u", {}, { shiftKey: true })).toEqual(
+      command({ id: "history.redo" }),
+    );
+    expect(resolve("z", {}, { ctrlKey: true })).toEqual(
+      command({ id: "history.undo" }),
+    );
+    expect(resolve("z", {}, { ctrlKey: true, shiftKey: true })).toEqual(
+      command({ id: "history.redo" }),
+    );
     expect(resolve("s", {}, { ctrlKey: true })).toEqual({ kind: "save" });
     expect(resolve("s", {}, { metaKey: true })).toBeNull();
     expect(resolve("c", {}, { ctrlKey: true })).toBeNull();
@@ -79,18 +82,22 @@ describe("editor shortcut contract", () => {
     expect(resolve("F5", { isTyping: true })).toEqual({
       kind: "block-browser-refresh",
     });
+    expect(resolve("r", { canMirror: true }, { ctrlKey: true })).toEqual(
+      command({ id: "transform.mirror", direction: "top-bottom" }),
+    );
     expect(
-      resolve("r", { hasRotatableSelection: true }, { ctrlKey: true }),
-    ).toEqual({ kind: "mirror", direction: "top-bottom" });
-    expect(
-      resolve("r", { interactionMode: "placing-component" }, { ctrlKey: true }),
-    ).toEqual({ kind: "mirror-placement", direction: "top-bottom" });
+      resolve(
+        "r",
+        { interactionMode: "placing-component", canMirror: true },
+        { ctrlKey: true },
+      ),
+    ).toEqual(command({ id: "transform.mirror", direction: "top-bottom" }));
   });
 
   it("maps Ctrl+D to idle deselection while always blocking browser bookmarking", () => {
-    expect(resolve("d", {}, { ctrlKey: true })).toEqual({
-      kind: "clear-selection",
-    });
+    expect(resolve("d", {}, { ctrlKey: true })).toEqual(
+      command({ id: "selection.clear" }),
+    );
     expect(
       resolve("d", { interactionMode: "wire" }, { ctrlKey: true }),
     ).toEqual({
@@ -102,64 +109,56 @@ describe("editor shortcut contract", () => {
   });
 
   it("resolves R rotation and the two agreed mirror shortcuts", () => {
-    expect(resolve("r")).toEqual({
-      kind: "activate-tool",
-      tool: "rectangle",
-    });
-    expect(resolve("r", { hasRotatableSelection: true })).toEqual({
-      kind: "rotate",
-      deltaDegrees: 90,
-    });
-    expect(
-      resolve("r", { hasRotatableSelection: true }, { shiftKey: true }),
-    ).toEqual({
-      kind: "mirror",
-      direction: "left-right",
-    });
-    expect(
-      resolve("v", { hasRotatableSelection: true }, { shiftKey: true }),
-    ).toBeNull();
+    expect(resolve("r")).toEqual(
+      command({ id: "tool.activate", tool: "rectangle" }),
+    );
+    expect(resolve("r", { canRotate: true })).toEqual(
+      command({ id: "transform.rotate", deltaDegrees: 90 }),
+    );
+    expect(resolve("r", { canMirror: true }, { shiftKey: true })).toEqual(
+      command({ id: "transform.mirror", direction: "left-right" }),
+    );
+    expect(resolve("v", { canRotate: true }, { shiftKey: true })).toBeNull();
   });
 
   it("opens insertion with I and gives placement rotation priority", () => {
-    expect(resolve("i")).toEqual({ kind: "open-component-insert" });
+    expect(resolve("i")).toEqual(command({ id: "insert.open" }));
     expect(
       resolve("r", {
         interactionMode: "placing-component",
-        hasRotatableSelection: true,
+        canRotate: true,
       }),
-    ).toEqual({ kind: "rotate-placement", deltaDegrees: 90 });
-    expect(resolve("r", { interactionMode: "copy-placement" })).toEqual({
-      kind: "rotate-copy-placement",
-      deltaDegrees: 90,
-    });
+    ).toEqual(command({ id: "transform.rotate", deltaDegrees: 90 }));
+    expect(resolve("r", { interactionMode: "copy-placement" })).toEqual(
+      command({ id: "transform.rotate", deltaDegrees: 90 }),
+    );
     expect(
       resolve(
         "r",
         { interactionMode: "placing-component" },
         { shiftKey: true },
       ),
-    ).toEqual({ kind: "mirror-placement", direction: "left-right" });
+    ).toEqual(command({ id: "transform.mirror", direction: "left-right" }));
     expect(
       resolve("r", { interactionMode: "copy-placement" }, { shiftKey: true }),
-    ).toEqual({ kind: "mirror-copy-placement", direction: "left-right" });
+    ).toEqual(command({ id: "transform.mirror", direction: "left-right" }));
     expect(
       resolve("v", { interactionMode: "copy-placement" }, { shiftKey: true }),
     ).toBeNull();
   });
 
   it("maps creation, fit, and marker commands", () => {
-    expect(resolve("w")).toEqual({ kind: "activate-tool", tool: "wire" });
-    expect(resolve("a")).toEqual({ kind: "activate-tool", tool: "arrow" });
-    expect(resolve("k")).toEqual({
-      kind: "activate-tool",
-      tool: "construction-line",
-    });
-    expect(resolve("p")).toEqual({ kind: "place-port" });
-    expect(resolve("m")).toEqual({ kind: "move-selection-required" });
-    expect(resolve("m", { hasMoveSelection: true })).toEqual({
-      kind: "begin-selection-move",
-    });
+    expect(resolve("w")).toEqual(
+      command({ id: "tool.activate", tool: "wire" }),
+    );
+    expect(resolve("a")).toEqual(
+      command({ id: "tool.activate", tool: "arrow" }),
+    );
+    expect(resolve("k")).toEqual(
+      command({ id: "tool.activate", tool: "construction-line" }),
+    );
+    expect(resolve("p")).toEqual(command({ id: "insert.free-net-port" }));
+    expect(resolve("m")).toEqual(command({ id: "selection.move" }));
     expect(resolve("l")).toEqual({ kind: "net-label-selection-required" });
     expect(resolve("l", { hasRouteSelection: true })).toEqual({
       kind: "edit-net-label",
@@ -174,21 +173,21 @@ describe("editor shortcut contract", () => {
     expect(resolve("h", { hasHighlightableNet: true })).toEqual({
       kind: "toggle-net-highlight",
     });
-    expect(resolve("q")).toEqual({ kind: "property-selection-required" });
-    expect(resolve("q", { hasInspectableSelection: true })).toEqual({
-      kind: "open-properties",
-    });
+    expect(resolve("q")).toEqual(command({ id: "properties.open" }));
+    expect(resolve("q", { hasInspectableSelection: true })).toEqual(
+      command({ id: "properties.open" }),
+    );
     expect(
       resolve("q", { propertiesOpen: true, hasInspectableSelection: true }),
-    ).toEqual({ kind: "close-properties" });
-    expect(resolve("q", { propertiesOpen: true })).toEqual({
-      kind: "close-properties",
-    });
+    ).toEqual(command({ id: "properties.close" }));
+    expect(resolve("q", { propertiesOpen: true })).toEqual(
+      command({ id: "properties.close" }),
+    );
     expect(resolve("g")).toBeNull();
-    expect(resolve("t")).toEqual({ kind: "add-text" });
-    expect(resolve("f")).toEqual({ kind: "fit-view" });
+    expect(resolve("t")).toEqual(command({ id: "drafting.add-text" }));
+    expect(resolve("f")).toEqual(command({ id: "view.fit" }));
     expect(resolve("f", {}, { shiftKey: true })).toBeNull();
-    expect(resolve("Home")).toEqual({ kind: "fit-view" });
+    expect(resolve("Home")).toEqual(command({ id: "view.fit" }));
     expect(resolve("x", { hasRoutedMarkerSelection: true })).toEqual({
       kind: "reverse-current-marker",
     });
@@ -217,9 +216,9 @@ describe("editor shortcut contract", () => {
   });
 
   it("gives Ctrl+A selection precedence over the plain Arrow shortcut", () => {
-    expect(resolve("a", {}, { ctrlKey: true })).toEqual({
-      kind: "select-all",
-    });
+    expect(resolve("a", {}, { ctrlKey: true })).toEqual(
+      command({ id: "selection.select-all" }),
+    );
   });
 
   it("resolves style steps only for a drafting selection", () => {
@@ -252,35 +251,18 @@ describe("editor shortcut contract", () => {
     });
   });
 
-  it("encodes contextual Escape priority in one place", () => {
-    expect(
-      resolve("Escape", {
-        helpOpen: true,
-        canvasDragActive: true,
-        interactionMode: "wire",
-        hasClearableDraftingSelection: true,
-      }),
-    ).toEqual({ kind: "close-help" });
-    expect(
-      resolve("Escape", {
-        canvasDragActive: true,
-        interactionMode: "wire",
-      }),
-    ).toEqual({ kind: "cancel-canvas-drag" });
-    expect(resolve("Escape", { interactionMode: "wire" })).toEqual({
-      kind: "cancel-interaction",
-    });
-    expect(resolve("Escape", { hasClearableDraftingSelection: true })).toEqual({
-      kind: "clear-drafting-selection",
-    });
-    expect(resolve("Escape")).toEqual({ kind: "cancel-passive" });
+  it("maps Escape to the one contextual cancel command", () => {
+    expect(resolve("Escape", { interactionMode: "wire" })).toEqual(
+      command({ id: "editor.cancel" }),
+    );
+    expect(resolve("Escape")).toEqual(command({ id: "editor.cancel" }));
   });
 
   it("removes a pending wire bend before deleting selection", () => {
     expect(resolve("Delete", { hasRemovableWireWaypoint: true })).toEqual({
       kind: "remove-wire-waypoint",
     });
-    expect(resolve("Backspace")).toEqual({ kind: "delete-selection" });
+    expect(resolve("Backspace")).toEqual(command({ id: "selection.delete" }));
   });
 
   it("arbitrates competing commands while one interaction owns the canvas", () => {
@@ -289,16 +271,16 @@ describe("editor shortcut contract", () => {
       kind: "blocked-interaction-command",
       command: "Copy",
     });
-    expect(resolve("c", { interactionMode: "copy-placement" })).toEqual({
-      kind: "copy",
-    });
+    expect(resolve("c", { interactionMode: "copy-placement" })).toEqual(
+      command({ id: "selection.copy" }),
+    );
     expect(resolve("m", active)).toEqual({
       kind: "blocked-interaction-command",
       command: "Move",
     });
-    expect(resolve("m", { interactionMode: "moving-selection" })).toEqual({
-      kind: "begin-selection-move",
-    });
+    expect(resolve("m", { interactionMode: "moving-selection" })).toEqual(
+      command({ id: "selection.move" }),
+    );
     expect(resolve("q", active)).toEqual({
       kind: "blocked-interaction-command",
       command: "Properties",
@@ -316,28 +298,27 @@ describe("editor shortcut contract", () => {
         interactionMode: "wire",
         hasInspectableSelection: true,
       }),
-    ).toEqual({ kind: "delete-selection" });
-    expect(resolve("i", active)).toEqual({ kind: "open-component-insert" });
-    expect(resolve("w", active)).toEqual({
-      kind: "activate-tool",
-      tool: "wire",
-    });
-    expect(resolve("f", active)).toEqual({ kind: "fit-view" });
+    ).toEqual(command({ id: "selection.delete" }));
+    expect(resolve("i", active)).toEqual(command({ id: "insert.open" }));
+    expect(resolve("w", active)).toEqual(
+      command({ id: "tool.activate", tool: "wire" }),
+    );
+    expect(resolve("f", active)).toEqual(command({ id: "view.fit" }));
   });
 
   it("does not rotate a stale selection underneath another active tool", () => {
     expect(
       resolve("r", {
         interactionMode: "drawing",
-        hasRotatableSelection: true,
+        canRotate: false,
       }),
-    ).toEqual({ kind: "activate-tool", tool: "rectangle" });
+    ).toEqual(command({ id: "tool.activate", tool: "rectangle" }));
     expect(
       resolve("r", {
         interactionMode: "placing-component",
-        hasRotatableSelection: true,
+        canRotate: true,
       }),
-    ).toEqual({ kind: "rotate-placement", deltaDegrees: 90 });
+    ).toEqual(command({ id: "transform.rotate", deltaDegrees: 90 }));
   });
 
   it("suppresses every global shortcut while typing", () => {

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -1,5 +1,5 @@
-import type { EditorTool, InteractionMode } from "./interaction-state";
-import type { ScreenFlip } from "./shortcut-orientation";
+import type { InteractionMode } from "./interaction-state";
+import type { EditorCommandRequest } from "../commands/editor-command";
 
 export interface EditorShortcutKey {
   key: string;
@@ -13,17 +13,14 @@ export interface EditorShortcutContext {
   isTyping: boolean;
   interactionMode: InteractionMode;
   hasRoutedMarkerSelection: boolean;
-  hasRotatableSelection: boolean;
+  canRotate: boolean;
+  canMirror: boolean;
   hasDraftingSelection: boolean;
   hasInspectableSelection: boolean;
-  hasMoveSelection: boolean;
   hasRouteSelection: boolean;
   hasHighlightableNet: boolean;
   wireReadyToFinish: boolean;
   draftingReadyToFinish: boolean;
-  helpOpen: boolean;
-  canvasDragActive: boolean;
-  hasClearableDraftingSelection: boolean;
   hasRemovableWireWaypoint: boolean;
   propertiesOpen: boolean;
   hasHierarchyEnterSelection: boolean;
@@ -31,33 +28,17 @@ export interface EditorShortcutContext {
 }
 
 export type EditorShortcutIntent =
+  | { kind: "run-command"; command: EditorCommandRequest }
   | { kind: "block-browser-refresh" }
   | { kind: "block-browser-bookmark" }
-  | { kind: "undo" | "redo" }
-  | { kind: "copy" | "save" | "open" | "select-all" | "clear-selection" }
-  | { kind: "begin-selection-move" | "move-selection-required" }
+  | { kind: "save" | "open" }
   | { kind: "reverse-current-marker" }
-  | { kind: "open-component-insert" }
-  | { kind: "place-port" }
-  | { kind: "rotate-placement"; deltaDegrees: 90 | -90 }
-  | { kind: "rotate-copy-placement"; deltaDegrees: 90 | -90 }
-  | { kind: "mirror-placement"; direction: ScreenFlip }
-  | { kind: "mirror-copy-placement"; direction: ScreenFlip }
-  | { kind: "rotate"; deltaDegrees: 90 | -90 }
-  | { kind: "activate-tool"; tool: EditorTool }
-  | { kind: "add-text" }
-  | {
-      kind:
-        "open-properties" | "close-properties" | "property-selection-required";
-    }
   | { kind: "edit-net-label" | "net-label-selection-required" }
   | { kind: "toggle-net-highlight" }
   | {
       kind:
         "enter-hierarchy" | "return-to-parent" | "hierarchy-selection-required";
     }
-  | { kind: "mirror"; direction: ScreenFlip }
-  | { kind: "fit-view" }
   | {
       kind: "step-drafting-style";
       target: "stroke" | "arrow-head";
@@ -65,15 +46,7 @@ export type EditorShortcutIntent =
     }
   | { kind: "finish-wire" | "finish-drafting" }
   | { kind: "toggle-wire-options" }
-  | {
-      kind:
-        | "close-help"
-        | "cancel-canvas-drag"
-        | "cancel-interaction"
-        | "clear-drafting-selection"
-        | "cancel-passive";
-    }
-  | { kind: "remove-wire-waypoint" | "delete-selection" }
+  | { kind: "remove-wire-waypoint" }
   | { kind: "blocked-interaction-command"; command: string };
 
 export function stepBoundedScale<T extends number>(
@@ -103,25 +76,20 @@ export function resolveEditorShortcut(
   if (event.key === "F5") return { kind: "block-browser-refresh" };
   if (commandModifier && key === "r") {
     if (context.isTyping) return { kind: "block-browser-refresh" };
-    if (
-      context.interactionMode === "placing-component" ||
-      context.interactionMode === "copy-placement"
-    ) {
-      return context.interactionMode === "placing-component"
-        ? { kind: "mirror-placement", direction: "top-bottom" }
-        : { kind: "mirror-copy-placement", direction: "top-bottom" };
-    }
+    if (context.canMirror)
+      return {
+        kind: "run-command",
+        command: { id: "transform.mirror", direction: "top-bottom" },
+      };
     if (context.interactionMode !== "idle") {
       return { kind: "block-browser-refresh" };
     }
-    return context.hasRotatableSelection
-      ? { kind: "mirror", direction: "top-bottom" }
-      : { kind: "block-browser-refresh" };
+    return { kind: "block-browser-refresh" };
   }
   if (commandModifier && key === "d") {
     if (context.isTyping) return { kind: "block-browser-bookmark" };
     return context.interactionMode === "idle"
-      ? { kind: "clear-selection" }
+      ? { kind: "run-command", command: { id: "selection.clear" } }
       : { kind: "block-browser-bookmark" };
   }
 
@@ -131,23 +99,25 @@ export function resolveEditorShortcut(
   const interactionActive = context.interactionMode !== "idle";
 
   if (plain && key === "u") {
-    return { kind: event.shiftKey ? "redo" : "undo" };
+    return {
+      kind: "run-command",
+      command: { id: event.shiftKey ? "history.redo" : "history.undo" },
+    };
   }
   if (event.ctrlKey && key === "z") {
-    return { kind: event.shiftKey ? "redo" : "undo" };
+    return {
+      kind: "run-command",
+      command: { id: event.shiftKey ? "history.redo" : "history.undo" },
+    };
   }
-  if (event.ctrlKey && key === "y") return { kind: "redo" };
+  if (event.ctrlKey && key === "y") {
+    return { kind: "run-command", command: { id: "history.redo" } };
+  }
   if (event.ctrlKey && key === "s") return { kind: "save" };
   if (event.ctrlKey && key === "o") return { kind: "open" };
 
   if (event.key === "Escape") {
-    if (context.helpOpen) return { kind: "close-help" };
-    if (context.canvasDragActive) return { kind: "cancel-canvas-drag" };
-    if (interactionActive) return { kind: "cancel-interaction" };
-    if (context.hasClearableDraftingSelection) {
-      return { kind: "clear-drafting-selection" };
-    }
-    return { kind: "cancel-passive" };
+    return { kind: "run-command", command: { id: "editor.cancel" } };
   }
 
   if (interactionActive) {
@@ -156,23 +126,34 @@ export function resolveEditorShortcut(
     }
     if (plain && key === "c") {
       return context.interactionMode === "copy-placement"
-        ? { kind: "copy" }
+        ? { kind: "run-command", command: { id: "selection.copy" } }
         : { kind: "blocked-interaction-command", command: "Copy" };
     }
     if (plain && key === "m") {
       return context.interactionMode === "moving-selection"
-        ? { kind: "begin-selection-move" }
+        ? { kind: "run-command", command: { id: "selection.move" } }
         : { kind: "blocked-interaction-command", command: "Move" };
     }
-    if (plain && key === "i") return { kind: "open-component-insert" };
+    if (plain && key === "i") {
+      return { kind: "run-command", command: { id: "insert.open" } };
+    }
     if (plain && key === "w") {
-      return { kind: "activate-tool", tool: "wire" };
+      return {
+        kind: "run-command",
+        command: { id: "tool.activate", tool: "wire" },
+      };
     }
     if (plain && key === "a") {
-      return { kind: "activate-tool", tool: "arrow" };
+      return {
+        kind: "run-command",
+        command: { id: "tool.activate", tool: "arrow" },
+      };
     }
     if (plain && key === "k") {
-      return { kind: "activate-tool", tool: "construction-line" };
+      return {
+        kind: "run-command",
+        command: { id: "tool.activate", tool: "construction-line" },
+      };
     }
     if (
       plain &&
@@ -181,23 +162,36 @@ export function resolveEditorShortcut(
       (context.interactionMode === "placing-component" ||
         context.interactionMode === "copy-placement")
     ) {
-      return context.interactionMode === "placing-component"
-        ? { kind: "mirror-placement", direction: "left-right" }
-        : { kind: "mirror-copy-placement", direction: "left-right" };
+      return {
+        kind: "run-command",
+        command: { id: "transform.mirror", direction: "left-right" },
+      };
     }
     if (plain && key === "r") {
       if (context.interactionMode === "placing-component") {
-        return { kind: "rotate-placement", deltaDegrees: 90 };
+        return {
+          kind: "run-command",
+          command: { id: "transform.rotate", deltaDegrees: 90 },
+        };
       }
       if (context.interactionMode === "copy-placement") {
-        return { kind: "rotate-copy-placement", deltaDegrees: 90 };
+        return {
+          kind: "run-command",
+          command: { id: "transform.rotate", deltaDegrees: 90 },
+        };
       }
-      if (!event.shiftKey) return { kind: "activate-tool", tool: "rectangle" };
+      if (!event.shiftKey)
+        return {
+          kind: "run-command",
+          command: { id: "tool.activate", tool: "rectangle" },
+        };
     }
     if (plain && key === "f" && !event.shiftKey) {
-      return { kind: "fit-view" };
+      return { kind: "run-command", command: { id: "view.fit" } };
     }
-    if (plain && key === "home") return { kind: "fit-view" };
+    if (plain && key === "home") {
+      return { kind: "run-command", command: { id: "view.fit" } };
+    }
     if (event.key === "Enter" && context.wireReadyToFinish) {
       return { kind: "finish-wire" };
     }
@@ -215,7 +209,7 @@ export function resolveEditorShortcut(
       context.interactionMode === "wire" &&
       context.hasInspectableSelection
     ) {
-      return { kind: "delete-selection" };
+      return { kind: "run-command", command: { id: "selection.delete" } };
     }
     const blockedCommands: Record<string, string> = {
       c: "Copy",
@@ -236,7 +230,9 @@ export function resolveEditorShortcut(
     return command ? { kind: "blocked-interaction-command", command } : null;
   }
 
-  if (event.ctrlKey && key === "a") return { kind: "select-all" };
+  if (event.ctrlKey && key === "a") {
+    return { kind: "run-command", command: { id: "selection.select-all" } };
+  }
 
   if (plain && key === "e") {
     if (event.shiftKey) {
@@ -250,36 +246,51 @@ export function resolveEditorShortcut(
   if (plain && key === "x" && context.hasRoutedMarkerSelection) {
     return { kind: "reverse-current-marker" };
   }
-  if (plain && key === "c") return { kind: "copy" };
-  if (plain && key === "m") {
-    return context.hasMoveSelection
-      ? { kind: "begin-selection-move" }
-      : { kind: "move-selection-required" };
+  if (plain && key === "c") {
+    return { kind: "run-command", command: { id: "selection.copy" } };
   }
-  if (plain && key === "i") return { kind: "open-component-insert" };
-  if (plain && key === "p") return { kind: "place-port" };
+  if (plain && key === "m") {
+    return { kind: "run-command", command: { id: "selection.move" } };
+  }
+  if (plain && key === "i") {
+    return { kind: "run-command", command: { id: "insert.open" } };
+  }
+  if (plain && key === "p") {
+    return { kind: "run-command", command: { id: "insert.free-net-port" } };
+  }
   if (plain && key === "r") {
-    if (context.interactionMode === "placing-component") {
-      return {
-        kind: "rotate-placement",
-        deltaDegrees: 90,
-      };
-    }
     if (event.shiftKey) {
-      return context.hasRotatableSelection
-        ? { kind: "mirror", direction: "left-right" }
+      return context.canMirror
+        ? {
+            kind: "run-command",
+            command: { id: "transform.mirror", direction: "left-right" },
+          }
         : null;
     }
-    return context.hasRotatableSelection
-      ? { kind: "rotate", deltaDegrees: 90 }
-      : { kind: "activate-tool", tool: "rectangle" };
+    return context.canRotate
+      ? {
+          kind: "run-command",
+          command: { id: "transform.rotate", deltaDegrees: 90 },
+        }
+      : {
+          kind: "run-command",
+          command: { id: "tool.activate", tool: "rectangle" },
+        };
   }
   if (plain && key === "w") {
-    return { kind: "activate-tool", tool: "wire" };
+    return {
+      kind: "run-command",
+      command: { id: "tool.activate", tool: "wire" },
+    };
   }
-  if (plain && key === "t") return { kind: "add-text" };
+  if (plain && key === "t") {
+    return { kind: "run-command", command: { id: "drafting.add-text" } };
+  }
   if (plain && key === "a") {
-    return { kind: "activate-tool", tool: "arrow" };
+    return {
+      kind: "run-command",
+      command: { id: "tool.activate", tool: "arrow" },
+    };
   }
   if (plain && key === "l" && context.interactionMode !== "wire") {
     return context.hasRouteSelection
@@ -290,16 +301,25 @@ export function resolveEditorShortcut(
     return { kind: "toggle-net-highlight" };
   }
   if (plain && key === "k") {
-    return { kind: "activate-tool", tool: "construction-line" };
+    return {
+      kind: "run-command",
+      command: { id: "tool.activate", tool: "construction-line" },
+    };
   }
   if (plain && key === "q") {
-    if (context.propertiesOpen) return { kind: "close-properties" };
-    return context.hasInspectableSelection
-      ? { kind: "open-properties" }
-      : { kind: "property-selection-required" };
+    return {
+      kind: "run-command",
+      command: {
+        id: context.propertiesOpen ? "properties.close" : "properties.open",
+      },
+    };
   }
-  if (plain && key === "f" && !event.shiftKey) return { kind: "fit-view" };
-  if (plain && key === "home") return { kind: "fit-view" };
+  if (plain && key === "f" && !event.shiftKey) {
+    return { kind: "run-command", command: { id: "view.fit" } };
+  }
+  if (plain && key === "home") {
+    return { kind: "run-command", command: { id: "view.fit" } };
+  }
   if (
     plain &&
     (event.key === "[" || event.key === "]") &&
@@ -320,7 +340,7 @@ export function resolveEditorShortcut(
   if (event.key === "Delete" || event.key === "Backspace") {
     return context.hasRemovableWireWaypoint
       ? { kind: "remove-wire-waypoint" }
-      : { kind: "delete-selection" };
+      : { kind: "run-command", command: { id: "selection.delete" } };
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- add a thin editor-local command router for shared shortcut, menu, toolbar, Library, and Properties actions
- preserve specialized Insert, Power Rail, selection, drafting, and Engine owners behind that router
- move Free Net Port and supply-marker name orchestration into the Properties domain without changing same-name Net semantics
- keep the existing UI layout, labels, shortcuts, and visual styling unchanged

## Validation
- pnpm install --frozen-lockfile`n- pnpm ci:check (1291 unit tests, 228 browser tests, build/release/golden/performance checks)
- pnpm gate:affected -- --base origin/main (1291 unit tests, 104 manual-editor browser tests)
- pnpm test:impact -- --base origin/main`n
## Infrastructure note
pnpm gate:preflight -- --base origin/main cannot complete on the current base because config/validation-gates.json references the absent gate:review:check script. Its other gates were run directly and passed.