### PR TITLE
fix(validation): retire the stale gate review check

### DIFF
--- a/config/validation-gates.json
+++ b/config/validation-gates.json
@@ -65,7 +65,6 @@
       "config/validation-gates.json",
       "docs/testing/**",
       "scripts/gate-*.mjs",
-      "scripts/check-gate-review.mjs",
       "scripts/check-test-impact.mjs",
       "scripts/lib/test-impact*.mjs",
       "scripts/lib/validation-gates*.mjs"
@@ -78,13 +77,6 @@
       "when": "docs-only",
       "description": "Validate links for documentation-only changes.",
       "command": ["pnpm", "docs:check"]
-    },
-    {
-      "id": "gate-review",
-      "stage": "preflight",
-      "when": "non-doc",
-      "description": "Require the target plan to review early, affected, and final gates.",
-      "command": ["pnpm", "gate:review:check", "--", "--base", "{base}"]
     },
     {
       "id": "static-contracts",
@@ -183,7 +175,7 @@
   ],
   "fullFallback": {
     "gateContractGroups": ["gateContract"],
-    "preflightGate": "gate-review",
+    "preflightGate": "static-contracts",
     "affectedGate": "branch-verification",
     "finalGate": "full-delivery"
   }

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -43,37 +43,34 @@ advisory phase, the plan does not skip `pnpm gate:full` or any required GitHub
 check; it makes the expected validation surface visible before those checks
 consume minutes.
 
-`gate:preflight` verifies the plan's Gate Review and runs cheap structural
-contracts. `gate:affected` runs the catalog's bounded unit, focused browser,
-release, or branch checks. Review the printed reasons before execution; update
-the target plan if the real diff materially changes the selection.
+`gate:preflight` runs cheap static contracts and cross-checks the commit's test
+impact declaration. `gate:affected` runs the catalog's bounded unit, focused
+browser, release, or branch checks. Review the printed reasons before
+execution; revisit the chosen validation surface if the real diff materially
+changes the selection.
 
 ## Change discipline
 
-Every target that changes implementation code must add `## Test Impact` to its
-target plan before the implementation is completed:
+Every commit that changes implementation code must carry one test-impact
+trailer:
 
-```md
-## Test Impact
-
-- Decision: tests-updated
-- Contracts: persisted grid normalization; project import
-- Primary checks: packages/model/src/coordinate-domain.test.ts
+```text
+Test-Impact: tests-updated
 ```
 
-For behavior-neutral work, use `no-test-change` and state the evidence:
+For behavior-neutral work, use `no-test-change` and state the evidence on the
+same line:
 
-```md
-## Test Impact
-
-- Decision: no-test-change
-- Reason: formatting-only change; no emitted code or behavior changed
+```text
+Test-Impact: no-test-change — formatting-only change; no emitted code or behavior changed
 ```
 
 `pnpm test:impact -- --base <base-ref>` checks the changed range. It accepts a
 test update with `tests-updated`, or a testless implementation change with an
 explicit evidence-based `no-test-change` decision. It deliberately does not
-force meaningless test-file edits.
+force meaningless test-file edits. The trailer lives with the diff in Git; a
+local untracked plan may still be used as scratch work, but it is not a gate
+input.
 
 ## Removing or simplifying a test
 

--- a/scripts/lib/validation-gates.test.mjs
+++ b/scripts/lib/validation-gates.test.mjs
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -10,12 +12,24 @@ import {
 } from "./validation-gates.mjs";
 
 const catalog = await loadGateCatalog();
+const rootPackage = JSON.parse(
+  await readFile(new URL("../../package.json", import.meta.url), "utf8"),
+);
 
 function ids(paths) {
   return planValidation(paths, catalog).gates.map((gate) => gate.id);
 }
 
 describe("validation gate planning", () => {
+  it("references only declared pnpm scripts", () => {
+    const missing = catalog.gates
+      .filter((gate) => gate.command[0] === "pnpm")
+      .map((gate) => gate.command[1])
+      .filter((script) => !Object.hasOwn(rootPackage.scripts, script));
+
+    expect(missing).toEqual([]);
+  });
+
   it("matches repository globs without treating a single star as a slash", () => {
     expect(
       globPattern("apps/**/src/**").test("apps/editor/src/app/App.tsx"),
@@ -41,7 +55,6 @@ describe("validation gate planning", () => {
         "apps/editor/src/features/component-insert/placement-connectivity.ts",
       ]),
     ).toEqual([
-      "gate-review",
       "static-contracts",
       "test-impact",
       "workspace-unit",
@@ -52,7 +65,8 @@ describe("validation gate planning", () => {
 
   it("expands shared protocol changes to hierarchy and persistence", () => {
     const selected = ids(["packages/project-protocol/src/persistence.ts"]);
-    expect(selected).toContain("gate-review");
+    expect(selected).toContain("static-contracts");
+    expect(selected).toContain("test-impact");
     expect(selected).toContain("workspace-unit");
     expect(selected).toContain("hierarchy-browser");
     expect(selected).toContain("project-file-browser");
@@ -71,27 +85,21 @@ describe("validation gate planning", () => {
     );
     expect(plan.gates.map((gate) => gate.id)).toContain("branch-verification");
     expect(plan.gates.map((gate) => gate.id)).toContain("full-delivery");
-    expect(plan.gates.map((gate) => gate.id)).toContain("gate-review");
+    expect(plan.gates.map((gate) => gate.id)).toContain("static-contracts");
   });
 
-  it("requires a review for documentation that defines the gate contract", () => {
+  it("runs static contracts for documentation that defines the gate contract", () => {
     const plan = planValidation(["docs/testing/README.md"], catalog);
     expect(plan.docsOnly).toBe(true);
     expect(plan.requiresFull).toBe(true);
-    expect(plan.gates.map((gate) => gate.id)).toContain("gate-review");
-  });
-
-  it("treats the Gate Review checker itself as gate policy", () => {
-    const plan = planValidation(["scripts/check-gate-review.mjs"], catalog);
-    expect(plan.requiresFull).toBe(true);
-    expect(plan.gates.map((gate) => gate.id)).toContain("branch-verification");
+    expect(plan.gates.map((gate) => gate.id)).toContain("static-contracts");
   });
 
   it("forces a full fallback for an unclassified implementation path", () => {
     const plan = planValidation(["tooling/new-runner.toml"], catalog);
     expect(plan.unknownPaths).toEqual(["tooling/new-runner.toml"]);
     expect(plan.requiresFull).toBe(true);
-    expect(plan.gates.map((gate) => gate.id)).toContain("gate-review");
+    expect(plan.gates.map((gate) => gate.id)).toContain("static-contracts");
     expect(plan.gates.map((gate) => gate.id)).toContain("branch-verification");
   });
 


### PR DESCRIPTION
## Summary
- complete the retired Gate Review cleanup
- keep preflight running static contracts and test-impact checks
- validate every catalog pnpm gate references a declared root script
- align testing documentation with commit-based Test-Impact trailers

## Validation
- pnpm test:local scripts/lib/validation-gates.test.mjs
- pnpm ci:static
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- git diff --check