### PR TITLE
Fix direct-contact and MOS bulk supply lifecycles

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -27,6 +27,7 @@ import {
   proposeWireCommitThroughContacts,
   proposeWireSegmentMove,
   planEnsureNamedNet,
+  planDirectEndpointConnection,
   planCreateCell,
   planDeleteCell,
   planRenameCell,
@@ -4810,7 +4811,20 @@ export function App({
           );
           if (instance?.placement) instance.placement.position = move.position;
         }
-        const contactEdits: SchematicEdit[] =
+        const directContactPlan =
+          movingElectrical?.kind === "endpoint" &&
+          targetElectrical?.kind === "endpoint"
+            ? planDirectEndpointConnection(projected, {
+                from: movingElectrical.endpoint,
+                to: targetElectrical.endpoint,
+                newNetId: `net-ui-${nextRoutingSuffix()}`,
+              })
+            : null;
+        if (directContactPlan && !directContactPlan.ok) {
+          setStatus(directContactPlan.message);
+          return;
+        }
+        const contactEdits: readonly SchematicEdit[] =
           movingElectrical?.kind === "endpoint" &&
           targetElectrical?.kind === "route"
             ? proposeEndpointRouteAttachment(
@@ -4824,16 +4838,7 @@ export function App({
               ).edits
             : movingElectrical?.kind === "endpoint" &&
                 targetElectrical?.kind === "endpoint"
-              ? [
-                  {
-                    kind: "connect_endpoints" as const,
-                    from: movingElectrical.endpoint,
-                    to: targetElectrical.endpoint,
-                    ...(!movingElectrical.netId && !targetElectrical.netId
-                      ? { newNetId: `net-ui-${nextRoutingSuffix()}` }
-                      : {}),
-                  },
-                ]
+              ? (directContactPlan?.edits ?? [])
               : [];
         const result = transactConnectivity(
           targetElectrical?.kind === "route"

--- a/apps/editor/src/features/component-insert/placement-connectivity.ts
+++ b/apps/editor/src/features/component-insert/placement-connectivity.ts
@@ -1,4 +1,5 @@
 import {
+  planDirectEndpointConnection,
   planEnsurePowerNet,
   proposeEndpointRouteAttachment,
   type SchematicEdit,
@@ -180,12 +181,20 @@ export function proposePlacementContact(
                 : "pin"
             }`;
       const createsNet = target.endpoint.netId === null;
-      edits.push({
-        kind: "connect_endpoints",
+      const directContact = planDirectEndpointConnection(document, {
         from: source.endpoint,
         to: target.endpoint.endpoint,
-        ...(createsNet ? { newNetId } : {}),
+        newNetId,
       });
+      if (!directContact.ok) {
+        return {
+          edits: [],
+          matched: false,
+          ambiguous: false,
+          rejected: directContact.message,
+        };
+      }
+      edits.push(...directContact.edits);
       if (power && createsNet) powerNetId = newNetId;
       else if (power && target.endpoint.netId) {
         powerNetId = target.endpoint.netId;

--- a/apps/editor/src/features/netlist-export/check-and-save.test.ts
+++ b/apps/editor/src/features/netlist-export/check-and-save.test.ts
@@ -12,18 +12,41 @@ function documentWith(options: {
   document.nets = options.nets.map((net) => ({
     id: net.id,
     scope: "local" as const,
-    terminals: [],
+    terminals: options.instances.flatMap((instance) =>
+      instance.bound && net.id === "n-gnd"
+        ? [{ instanceId: instance.id, pinName: "B" }]
+        : [],
+    ),
     ...(net.powerDomain ? { powerDomain: net.powerDomain } : {}),
   }));
+  document.connectivityEvidence = options.nets.flatMap((net) =>
+    net.powerDomain
+      ? [
+          {
+            id: `claim-${net.id}`,
+            kind: "name-claim" as const,
+            netId: net.id,
+            name:
+              net.id === "n-gnd"
+                ? "0"
+                : net.id === "n-vdd"
+                  ? "VDD"
+                  : net.powerDomain === "ground"
+                    ? "AGND"
+                    : "AVDD",
+            scope: "global" as const,
+            powerDomain: net.powerDomain,
+            owner: { kind: "explicit-net-property" as const },
+          },
+        ]
+      : [],
+  );
   document.instances = options.instances.map((instance) => ({
     id: instance.id,
     symbolId: instance.symbolId,
     reference: instance.id,
     parameters: {},
     placement: { position: { x: 0, y: 0 }, rotation: 0, mirror: "none" },
-    ...(instance.bound
-      ? { mosBulkBinding: { netId: "n-gnd", origin: "explicit" as const } }
-      : {}),
   })) as unknown as typeof document.instances;
   if (options.defaults) document.mosBulkDefaults = options.defaults;
   return document;

--- a/apps/editor/src/features/netlist-export/check-and-save.ts
+++ b/apps/editor/src/features/netlist-export/check-and-save.ts
@@ -1,4 +1,8 @@
 import type { SchematicEdit } from "@icm/edit-engine";
+import {
+  resolveDocumentLogicalNets,
+  resolveMosBulkConnection,
+} from "@icm/derived";
 import type { SchematicDocument } from "@icm/model";
 
 /**
@@ -25,7 +29,9 @@ function soleNetOfDomain(
   document: SchematicDocument,
   domain: "vdd" | "ground",
 ): string | null {
-  const matches = document.nets.filter((net) => net.powerDomain === domain);
+  const matches = resolveDocumentLogicalNets(document).groups.filter(
+    (net) => net.powerDomain === domain,
+  );
   return matches.length === 1 ? matches[0]!.id : null;
 }
 
@@ -37,8 +43,25 @@ function unboundCount(
     (instance) =>
       instance.symbolId === symbolId &&
       instance.placement !== null &&
-      !instance.mosBulkBinding,
+      resolveMosBulkConnection(document, instance)?.status === "unresolved",
   ).length;
+}
+
+function pendingDefaultCount(
+  document: SchematicDocument,
+  symbolId: "nmos" | "pmos",
+): number {
+  return document.instances.filter((instance) => {
+    if (instance.symbolId !== symbolId || instance.placement === null)
+      return false;
+    const resolution = resolveMosBulkConnection(document, instance);
+    return Boolean(
+      resolution &&
+      !resolution.materialized &&
+      (resolution.status === "cell-default" ||
+        resolution.status === "supply-default"),
+    );
+  }).length;
 }
 
 export function planCheckBulkDefaults(
@@ -69,10 +92,8 @@ export function planCheckBulkDefaults(
   // a default already named before this check ran.
   const reconcilable =
     edits.length > 0 ||
-    (document.mosBulkDefaults?.nmosNetId != null &&
-      unboundCount(document, "nmos") > 0) ||
-    (document.mosBulkDefaults?.pmosNetId != null &&
-      unboundCount(document, "pmos") > 0);
+    pendingDefaultCount(document, "nmos") > 0 ||
+    pendingDefaultCount(document, "pmos") > 0;
   if (reconcilable) edits.push({ kind: "reconcile_mos_bulk" });
   return { edits, ambiguous };
 }

--- a/apps/editor/src/snap/engine.test.ts
+++ b/apps/editor/src/snap/engine.test.ts
@@ -272,6 +272,43 @@ describe("unified Snap Engine", () => {
     });
   });
 
+  it("offers exact endpoint snap across Base Nets for the contact planner", () => {
+    const result = resolveTranslationSnap({
+      rawDelta: { x: 9, y: 10 },
+      movingAnchors: [
+        {
+          id: "moving-pin",
+          point: { x: 0, y: 0 },
+          kind: "pin",
+          electrical: {
+            kind: "endpoint",
+            endpoint: { kind: "terminal", instanceId: "A", pinName: "P" },
+            netId: "net-a",
+          },
+        },
+      ],
+      targetAnchors: [
+        {
+          id: "target-pin",
+          point: { x: 10, y: 10 },
+          kind: "pin",
+          electrical: {
+            kind: "endpoint",
+            endpoint: { kind: "terminal", instanceId: "B", pinName: "P" },
+            netId: "net-b",
+          },
+        },
+      ],
+      primaryAnchorId: "moving-pin",
+      grid: 10,
+      tolerance: 3,
+      profile: SNAP_PROFILES.instanceMove,
+    });
+
+    expect(result.delta).toEqual({ x: 10, y: 10 });
+    expect(result.electricalMatch?.target.id).toBe("target-pin");
+  });
+
   it("prefers an explicit endpoint over its coincident Route projection", () => {
     const moving = {
       id: "moving-pin",

--- a/apps/editor/src/snap/engine.ts
+++ b/apps/editor/src/snap/engine.ts
@@ -173,11 +173,11 @@ function compatibleElectrical(left: SnapAnchor, right: SnapAnchor): boolean {
   ) {
     return false;
   }
-  return !(
-    left.electrical.netId &&
-    right.electrical.netId &&
-    left.electrical.netId !== right.electrical.netId
-  );
+  // Different Base Nets are still eligible for an exact visual snap. The
+  // high-level direct-contact planner decides whether they may be merged and
+  // atomically rejects incompatible names or power domains; snap geometry
+  // must not make that decision from raw Net IDs.
+  return true;
 }
 
 function compatibleAxisKinds(moving: SnapAnchor, target: SnapAnchor): boolean {

--- a/packages/derived/src/diagnostics/erc.test.ts
+++ b/packages/derived/src/diagnostics/erc.test.ts
@@ -311,6 +311,29 @@ describe("ERC engine", () => {
     expect(roleRun(project)).toEqual([]);
   });
 
+  it("does not treat MOS bulk pins alone as an external body reference", () => {
+    const project = emptyProject();
+    const document = project.documents[0]!;
+    document.instances = [
+      roleInstance("three-terminal"),
+      { ...roleInstance("three-terminal"), id: "M2" },
+    ];
+    document.nets.push({
+      id: "net-bulk-only",
+      scope: "local",
+      terminals: [
+        { instanceId: "M1", pinName: "B" },
+        { instanceId: "M2", pinName: "B" },
+      ],
+    });
+
+    expect(
+      roleRun(project).filter(
+        (diagnostic) => diagnostic.code === "ERC_BULK_UNRESOLVED",
+      ),
+    ).toHaveLength(2);
+  });
+
   it("flags two instances sharing a normalized netlist reference", () => {
     const project = emptyProject();
     project.documents[0]!.instances = [

--- a/packages/derived/src/diagnostics/erc.ts
+++ b/packages/derived/src/diagnostics/erc.ts
@@ -392,11 +392,14 @@ export function runErcChecks(
 
         if (role === "bulk") {
           const resolution = resolveMosBulkConnection(document, instance);
+          const bulkAssessment = endpointConnectivity.assessMosBulk(
+            instance.id,
+          );
           const configuredDefault =
             resolution?.status === "cell-default" ||
             resolution?.status === "supply-default";
           if (
-            !assessment.electricallySatisfied &&
+            !bulkAssessment.electricallySatisfied &&
             !configuredDefault &&
             pin.presentation.visibility !== "implicit"
           ) {

--- a/packages/derived/src/endpoint-connectivity.ts
+++ b/packages/derived/src/endpoint-connectivity.ts
@@ -4,6 +4,7 @@ import type { SymbolResolver } from "@icm/symbols";
 import type { DocumentConnectivityIndex } from "./connectivity-index.js";
 import { endpointKey } from "./endpoint.js";
 import { resolveDocumentLogicalNets } from "./logical-net.js";
+import { resolveMosBulkConnection } from "./mos-bulk.js";
 
 export type EndpointMembership = "unbound" | "singleton" | "peer-connected";
 
@@ -32,6 +33,7 @@ export interface EndpointConnectivityAssessment {
 
 export interface EndpointConnectivityClassifier {
   assess(endpoint: RouteEndpoint): EndpointConnectivityAssessment;
+  assessMosBulk(instanceId: string): EndpointConnectivityAssessment;
 }
 
 function sameEndpoint(left: RouteEndpoint, right: RouteEndpoint): boolean {
@@ -48,67 +50,124 @@ export function createEndpointConnectivityClassifier(
     document.noConnects.map((record) => endpointKey(record.endpoint)),
   );
 
+  const assess = (endpoint: RouteEndpoint): EndpointConnectivityAssessment => {
+    const key = endpointKey(endpoint);
+    const baseNetId = index?.endpointToBaseNetId.get(key) ?? null;
+    const record = baseNetId
+      ? index?.logicalNetByBaseNetId.get(baseNetId)
+      : undefined;
+    const peers = (record?.logicalEndpoints ?? []).filter(
+      (candidate) => !sameEndpoint(candidate, endpoint),
+    );
+    const membership: EndpointMembership = !baseNetId
+      ? "unbound"
+      : peers.length > 0
+        ? "peer-connected"
+        : "singleton";
+    const logicalGroup = baseNetId
+      ? logicalResolution.byBaseNetId.get(baseNetId)
+      : undefined;
+    const formalBoundary = Boolean(
+      logicalGroup &&
+      document.netlist?.terminals.some((terminal) =>
+        logicalGroup.baseNetIds.includes(terminal.netId),
+      ),
+    );
+    const globalSupply = Boolean(
+      logicalGroup?.scope === "global" &&
+      (logicalGroup.powerDomain === "vdd" ||
+        logicalGroup.powerDomain === "ground"),
+    );
+    let implicit = false;
+    if (endpoint.kind === "terminal") {
+      const instance = document.instances.find(
+        (candidate) => candidate.id === endpoint.instanceId,
+      );
+      const resolved = instance
+        ? resolver.resolve(instance.symbolId, instance.symbolVariantId)
+        : undefined;
+      implicit = Boolean(
+        resolved?.definition.pins.find((pin) => pin.name === endpoint.pinName)
+          ?.presentation.visibility === "implicit",
+      );
+    }
+    const intent: EndpointConnectivityIntent = {
+      explicitNoConnect: noConnectKeys.has(key),
+      implicit,
+      formalBoundary,
+      globalSupply,
+    };
+    return {
+      endpoint,
+      baseNetId,
+      logicalNetId: record?.netId ?? null,
+      membership,
+      peerEndpoints: peers,
+      intent,
+      electricallySatisfied:
+        membership === "peer-connected" ||
+        intent.explicitNoConnect ||
+        intent.implicit ||
+        intent.formalBoundary ||
+        intent.globalSupply,
+    };
+  };
+
   return {
-    assess(endpoint): EndpointConnectivityAssessment {
-      const key = endpointKey(endpoint);
-      const baseNetId = index?.endpointToBaseNetId.get(key) ?? null;
-      const record = baseNetId
-        ? index?.logicalNetByBaseNetId.get(baseNetId)
-        : undefined;
-      const peers = (record?.logicalEndpoints ?? []).filter(
-        (candidate) => !sameEndpoint(candidate, endpoint),
-      );
-      const membership: EndpointMembership = !baseNetId
-        ? "unbound"
-        : peers.length > 0
-          ? "peer-connected"
-          : "singleton";
-      const logicalGroup = baseNetId
-        ? logicalResolution.byBaseNetId.get(baseNetId)
-        : undefined;
-      const formalBoundary = Boolean(
-        logicalGroup &&
-        document.netlist?.terminals.some((terminal) =>
-          logicalGroup.baseNetIds.includes(terminal.netId),
-        ),
-      );
-      const globalSupply = Boolean(
-        logicalGroup?.scope === "global" &&
-        (logicalGroup.powerDomain === "vdd" ||
-          logicalGroup.powerDomain === "ground"),
-      );
-      let implicit = false;
-      if (endpoint.kind === "terminal") {
-        const instance = document.instances.find(
-          (candidate) => candidate.id === endpoint.instanceId,
-        );
-        const resolved = instance
-          ? resolver.resolve(instance.symbolId, instance.symbolVariantId)
-          : undefined;
-        implicit = Boolean(
-          resolved?.definition.pins.find((pin) => pin.name === endpoint.pinName)
-            ?.presentation.visibility === "implicit",
-        );
-      }
-      const intent: EndpointConnectivityIntent = {
-        explicitNoConnect: noConnectKeys.has(key),
-        implicit,
-        formalBoundary,
-        globalSupply,
+    assess,
+    assessMosBulk(instanceId): EndpointConnectivityAssessment {
+      const endpoint = {
+        kind: "terminal" as const,
+        instanceId,
+        pinName: "B",
       };
+      const assessment = assess(endpoint);
+      const instance = document.instances.find(
+        (candidate) => candidate.id === instanceId,
+      );
+      const resolution = instance
+        ? resolveMosBulkConnection(document, instance)
+        : undefined;
+      const configuredDefault =
+        resolution?.status === "cell-default" ||
+        resolution?.status === "supply-default";
+      const externalPeers = assessment.peerEndpoints.filter((candidate) => {
+        if (candidate.kind !== "terminal") return true;
+        const peerInstance = document.instances.find(
+          (item) => item.id === candidate.instanceId,
+        );
+        const peerResolved = peerInstance
+          ? resolver.resolve(
+              peerInstance.symbolId,
+              peerInstance.symbolVariantId,
+            )
+          : undefined;
+        return (
+          peerResolved?.definition.pins
+            .find((pin) => pin.name === candidate.pinName)
+            ?.role.toLowerCase() !== "bulk"
+        );
+      });
+      const sourceBacked = Boolean(
+        assessment.baseNetId &&
+        logicalResolution.byBaseNetId.get(assessment.baseNetId)?.sourceNetIds
+          .length,
+      );
       return {
-        endpoint,
-        baseNetId,
-        logicalNetId: record?.netId ?? null,
-        membership,
-        peerEndpoints: peers,
-        intent,
+        ...assessment,
+        peerEndpoints: externalPeers,
+        membership: !assessment.baseNetId
+          ? "unbound"
+          : externalPeers.length > 0
+            ? "peer-connected"
+            : "singleton",
         electricallySatisfied:
-          membership === "peer-connected" ||
-          intent.explicitNoConnect ||
-          intent.implicit ||
-          intent.formalBoundary ||
-          intent.globalSupply,
+          configuredDefault ||
+          sourceBacked ||
+          externalPeers.length > 0 ||
+          assessment.intent.explicitNoConnect ||
+          assessment.intent.formalBoundary ||
+          assessment.intent.globalSupply,
       };
     },
   };

--- a/packages/edit-engine/src/direct-contact-planner.test.ts
+++ b/packages/edit-engine/src/direct-contact-planner.test.ts
@@ -1,0 +1,113 @@
+import { createEmptyDocument } from "@icm/model";
+import { describe, expect, it } from "vitest";
+
+import { planDirectEndpointConnection } from "./direct-contact-planner.js";
+
+const endpoint = (instanceId: string) => ({
+  kind: "terminal" as const,
+  instanceId,
+  pinName: "P",
+});
+
+function fixture() {
+  const document = createEmptyDocument("main", "Main");
+  document.instances.push(
+    { id: "A", symbolId: "port", placement: null },
+    { id: "B", symbolId: "port", placement: null },
+  );
+  return document;
+}
+
+describe("direct endpoint connection planner", () => {
+  it("creates a Base Net when both endpoints are unbound", () => {
+    expect(
+      planDirectEndpointConnection(fixture(), {
+        from: endpoint("A"),
+        to: endpoint("B"),
+        newNetId: "net-contact",
+      }),
+    ).toMatchObject({
+      ok: true,
+      netId: "net-contact",
+      edits: [{ kind: "connect_endpoints", newNetId: "net-contact" }],
+    });
+  });
+
+  it("merges two compatible Base Nets before confirming contact", () => {
+    const document = fixture();
+    document.nets.push(
+      {
+        id: "net-a",
+        scope: "local",
+        terminals: [{ instanceId: "A", pinName: "P" }],
+      },
+      {
+        id: "net-b",
+        scope: "local",
+        terminals: [{ instanceId: "B", pinName: "P" }],
+      },
+    );
+
+    expect(
+      planDirectEndpointConnection(document, {
+        from: endpoint("A"),
+        to: endpoint("B"),
+        newNetId: "unused",
+      }),
+    ).toMatchObject({
+      ok: true,
+      netId: "net-a",
+      edits: [
+        { kind: "merge_nets", targetNetId: "net-a", sourceNetId: "net-b" },
+        { kind: "connect_endpoints" },
+      ],
+    });
+  });
+
+  it("rejects direct contact between differently named Nets", () => {
+    const document = fixture();
+    document.nets.push(
+      {
+        id: "net-a",
+        scope: "local",
+        terminals: [{ instanceId: "A", pinName: "P" }],
+      },
+      {
+        id: "net-b",
+        scope: "local",
+        terminals: [{ instanceId: "B", pinName: "P" }],
+      },
+    );
+    document.connectivityEvidence.push(
+      {
+        id: "claim-a",
+        kind: "name-claim",
+        netId: "net-a",
+        name: "AVDD",
+        scope: "global",
+        powerDomain: "vdd",
+        owner: { kind: "explicit-net-property" },
+      },
+      {
+        id: "claim-b",
+        kind: "name-claim",
+        netId: "net-b",
+        name: "DVDD",
+        scope: "global",
+        powerDomain: "vdd",
+        owner: { kind: "explicit-net-property" },
+      },
+    );
+
+    expect(
+      planDirectEndpointConnection(document, {
+        from: endpoint("A"),
+        to: endpoint("B"),
+        newNetId: "unused",
+      }),
+    ).toMatchObject({
+      ok: false,
+      relatedNetIds: ["net-a", "net-b"],
+    });
+  });
+});

--- a/packages/edit-engine/src/direct-contact-planner.ts
+++ b/packages/edit-engine/src/direct-contact-planner.ts
@@ -1,0 +1,123 @@
+import { foldNetName } from "@icm/model";
+import type { RouteEndpoint, SchematicDocument } from "@icm/model";
+import { resolveDocumentLogicalNets } from "@icm/derived";
+
+import type { SchematicEdit } from "./edit-schema.js";
+import { endpointOwnerNetId } from "./transaction-routing.js";
+
+export type DirectEndpointConnectionPlan =
+  | {
+      ok: true;
+      netId: string;
+      edits: readonly SchematicEdit[];
+    }
+  | {
+      ok: false;
+      message: string;
+      relatedNetIds: readonly string[];
+    };
+
+export interface DirectEndpointConnectionRequest {
+  from: RouteEndpoint;
+  to: RouteEndpoint;
+  newNetId: string;
+}
+
+/**
+ * Plan one explicit zero-length electrical contact. The strict transaction
+ * primitive still refuses cross-Net connection; this authoring layer emits an
+ * equally explicit merge first when the two authored Nets are compatible.
+ */
+export function planDirectEndpointConnection(
+  document: SchematicDocument,
+  request: DirectEndpointConnectionRequest,
+): DirectEndpointConnectionPlan {
+  const fromNetId = endpointOwnerNetId(document, request.from);
+  const toNetId = endpointOwnerNetId(document, request.to);
+  if (!fromNetId && !toNetId) {
+    return {
+      ok: true,
+      netId: request.newNetId,
+      edits: [
+        {
+          kind: "connect_endpoints",
+          from: request.from,
+          to: request.to,
+          newNetId: request.newNetId,
+        },
+      ],
+    };
+  }
+
+  const netId = fromNetId ?? toNetId!;
+  if (!fromNetId || !toNetId || fromNetId === toNetId) {
+    return {
+      ok: true,
+      netId,
+      edits: [
+        { kind: "connect_endpoints", from: request.from, to: request.to },
+      ],
+    };
+  }
+
+  const logical = resolveDocumentLogicalNets(document);
+  const fromLogical = logical.byBaseNetId.get(fromNetId);
+  const toLogical = logical.byBaseNetId.get(toNetId);
+  const relatedNetIds = [fromNetId, toNetId].sort((left, right) =>
+    left.localeCompare(right, "en"),
+  );
+  if (
+    fromLogical?.name &&
+    toLogical?.name &&
+    foldNetName(fromLogical.name) !== foldNetName(toLogical.name)
+  ) {
+    return {
+      ok: false,
+      message: `Cannot directly connect named Nets ${fromLogical.name} and ${toLogical.name}`,
+      relatedNetIds,
+    };
+  }
+  if (
+    fromLogical?.powerDomain === "conflict" ||
+    toLogical?.powerDomain === "conflict" ||
+    (fromLogical?.powerDomain !== "none" &&
+      toLogical?.powerDomain !== "none" &&
+      fromLogical?.powerDomain !== toLogical?.powerDomain)
+  ) {
+    return {
+      ok: false,
+      message: "Cannot directly connect Nets with incompatible power domains",
+      relatedNetIds,
+    };
+  }
+  if (
+    fromLogical?.name &&
+    toLogical?.name &&
+    fromLogical.scope &&
+    toLogical.scope &&
+    fromLogical.scope !== toLogical.scope
+  ) {
+    return {
+      ok: false,
+      message: "Cannot directly connect named Nets with incompatible scopes",
+      relatedNetIds,
+    };
+  }
+
+  const fromHasSemantics = Boolean(
+    fromLogical?.evidenceIds.length || fromLogical?.sourceNetIds.length,
+  );
+  const toHasSemantics = Boolean(
+    toLogical?.evidenceIds.length || toLogical?.sourceNetIds.length,
+  );
+  const targetNetId = !fromHasSemantics && toHasSemantics ? toNetId : fromNetId;
+  const sourceNetId = targetNetId === fromNetId ? toNetId : fromNetId;
+  return {
+    ok: true,
+    netId: targetNetId,
+    edits: [
+      { kind: "merge_nets", targetNetId, sourceNetId },
+      { kind: "connect_endpoints", from: request.from, to: request.to },
+    ],
+  };
+}

--- a/packages/edit-engine/src/index.ts
+++ b/packages/edit-engine/src/index.ts
@@ -4,6 +4,7 @@ export * from "./route-operations.js";
 export * from "./routing-planner.js";
 export * from "./power-net-planner.js";
 export * from "./named-net-planner.js";
+export * from "./direct-contact-planner.js";
 export * from "./reference-planner.js";
 export * from "./reference-batch-planner.js";
 export * from "./batch-property-planner.js";

--- a/packages/edit-engine/src/transaction.test.ts
+++ b/packages/edit-engine/src/transaction.test.ts
@@ -1240,6 +1240,171 @@ describe("Edit Transaction envelope", () => {
     });
   });
 
+  it("revokes a materialized PMOS default when the last VDD claim is deleted", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.instances.push(
+      { id: "M1", symbolId: "pmos", placement: null },
+      { id: "VDD1", symbolId: "vdd-port", placement: null },
+    );
+    document.nets.push({
+      id: "net-power-vdd1",
+      scope: "local",
+      terminals: [
+        { instanceId: "M1", pinName: "B" },
+        { instanceId: "VDD1", pinName: "P" },
+      ],
+    });
+    document.connectivityEvidence.push({
+      id: "claim-vdd-1",
+      kind: "name-claim",
+      netId: "net-power-vdd1",
+      name: "VDD",
+      owner: { kind: "power-marker", objectId: "VDD1" },
+      scope: "global",
+      powerDomain: "vdd",
+    });
+    document.mosBulkDefaults = { pmosNetId: "net-power-vdd1" };
+    document.instances[0]!.mosBulkBinding = {
+      origin: "cell-default",
+      netId: "net-power-vdd1",
+    };
+
+    const removed = executeTransaction(
+      document,
+      {
+        ...transaction(),
+        edits: [
+          {
+            kind: "disconnect_endpoint",
+            endpoint: { kind: "terminal", instanceId: "VDD1", pinName: "P" },
+          },
+          { kind: "remove_instance", instanceId: "VDD1" },
+        ],
+      },
+      { symbolResolver: resolver },
+    );
+
+    expect(removed.ok).toBe(true);
+    if (!removed.ok) return;
+    expect(removed.document.mosBulkDefaults).toBeUndefined();
+    expect(removed.document.instances[0]?.mosBulkBinding).toBeUndefined();
+    expect(removed.document.nets).toEqual([]);
+  });
+
+  it("keeps an explicit custom PMOS body default without a power marker", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.instances.push({
+      id: "M1",
+      symbolId: "pmos",
+      placement: null,
+      mosBulkBinding: { origin: "cell-default", netId: "net-body" },
+    });
+    document.nets.push({
+      id: "net-body",
+      scope: "local",
+      terminals: [{ instanceId: "M1", pinName: "B" }],
+    });
+    document.mosBulkDefaults = { pmosNetId: "net-body" };
+
+    const edited = executeTransaction(
+      document,
+      { ...transaction(), edits: [{ kind: "noop", reason: "unrelated edit" }] },
+      { symbolResolver: resolver },
+    );
+
+    expect(edited.ok).toBe(true);
+    if (!edited.ok) return;
+    expect(edited.document.mosBulkDefaults).toEqual({ pmosNetId: "net-body" });
+    expect(edited.document.instances[0]?.mosBulkBinding).toEqual({
+      origin: "cell-default",
+      netId: "net-body",
+    });
+  });
+
+  it("migrates a PMOS default to another marker of the same supply", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.instances.push(
+      {
+        id: "M1",
+        symbolId: "pmos",
+        placement: null,
+        mosBulkBinding: { origin: "cell-default", netId: "net-vdd-1" },
+      },
+      { id: "VDD1", symbolId: "vdd-port", placement: null },
+      { id: "VDD2", symbolId: "vdd-port", placement: null },
+    );
+    document.nets.push(
+      {
+        id: "net-vdd-1",
+        scope: "local",
+        terminals: [
+          { instanceId: "M1", pinName: "B" },
+          { instanceId: "VDD1", pinName: "P" },
+        ],
+      },
+      {
+        id: "net-vdd-2",
+        scope: "local",
+        terminals: [{ instanceId: "VDD2", pinName: "P" }],
+      },
+    );
+    document.connectivityEvidence.push(
+      {
+        id: "claim-vdd-1",
+        kind: "name-claim",
+        netId: "net-vdd-1",
+        name: "VDD",
+        owner: { kind: "power-marker", objectId: "VDD1" },
+        scope: "global",
+        powerDomain: "vdd",
+      },
+      {
+        id: "claim-vdd-2",
+        kind: "name-claim",
+        netId: "net-vdd-2",
+        name: "VDD",
+        owner: { kind: "power-marker", objectId: "VDD2" },
+        scope: "global",
+        powerDomain: "vdd",
+      },
+    );
+    document.mosBulkDefaults = { pmosNetId: "net-vdd-1" };
+
+    const removed = executeTransaction(
+      document,
+      {
+        ...transaction(),
+        edits: [
+          {
+            kind: "disconnect_endpoint",
+            endpoint: { kind: "terminal", instanceId: "VDD1", pinName: "P" },
+          },
+          { kind: "remove_instance", instanceId: "VDD1" },
+        ],
+      },
+      { symbolResolver: resolver },
+    );
+
+    expect(removed.ok).toBe(true);
+    if (!removed.ok) return;
+    expect(removed.document.mosBulkDefaults).toEqual({
+      pmosNetId: "net-vdd-2",
+    });
+    expect(
+      removed.document.instances.find((instance) => instance.id === "M1")
+        ?.mosBulkBinding,
+    ).toEqual({
+      origin: "cell-default",
+      netId: "net-vdd-2",
+    });
+    expect(
+      removed.document.nets.find((net) => net.id === "net-vdd-2")?.terminals,
+    ).toContainEqual({
+      instanceId: "M1",
+      pinName: "B",
+    });
+  });
+
   it("removes only evidence owned by a deleted Net Label", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.nets.push({ id: "net-a", scope: "local", terminals: [] });

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -10,6 +10,7 @@ import {
   NoConnectSchema,
   SchematicDocumentSchema,
   deriveStableId,
+  foldNetName,
 } from "@icm/model";
 import { createReferenceIndex, referenceIssuesForInstance } from "@icm/devices";
 import type {
@@ -349,6 +350,110 @@ function pruneUnreachableLocalNet(
   }
   draft.nets = draft.nets.filter((candidate) => candidate.id !== netId);
   changedObjectIds.add(netId);
+}
+
+/**
+ * A Cell bulk default may deliberately point at an ordinary custom body-bias
+ * Net, so a default is not invalid merely because it is not a power Net.
+ * However, when the default was a reviewed supply before this transaction and
+ * the transaction removes its final supply claim, retaining the materialized
+ * B terminals turns deleted presentation into stale electrical truth.
+ *
+ * Compare the transaction boundary rather than guessing from the final shape:
+ * explicit custom defaults remain untouched, while a last VDD/Ground marker
+ * deletion revokes only the bindings that were materialized from that default.
+ */
+function revokeInvalidatedSupplyBulkDefaults(
+  before: SchematicDocument,
+  draft: SchematicDocument,
+  changedObjectIds: Set<string>,
+): boolean {
+  const beforeLogical = resolveDocumentLogicalNets(before);
+  const afterLogical = resolveDocumentLogicalNets(draft);
+  let changed = false;
+
+  for (const [kind, field, expectedDomain] of [
+    ["nmos", "nmosNetId", "ground"],
+    ["pmos", "pmosNetId", "vdd"],
+  ] as const) {
+    const beforeDefaultId = before.mosBulkDefaults?.[field];
+    const afterDefaultId = draft.mosBulkDefaults?.[field];
+    if (!beforeDefaultId || !afterDefaultId) continue;
+    const beforeGroup = beforeLogical.byBaseNetId.get(beforeDefaultId);
+    const wasSupply = beforeGroup?.powerDomain === expectedDomain;
+    const remainsSupply =
+      afterLogical.byBaseNetId.get(afterDefaultId)?.powerDomain ===
+      expectedDomain;
+    if (!wasSupply || remainsSupply) continue;
+
+    const replacementGroups = afterLogical.groups.filter(
+      (group) =>
+        group.powerDomain === expectedDomain &&
+        beforeGroup?.name &&
+        group.name &&
+        foldNetName(group.name) === foldNetName(beforeGroup.name),
+    );
+    const replacementNetId =
+      replacementGroups.length === 1 ? replacementGroups[0]!.id : undefined;
+
+    const affectedNetIds = new Set<string>();
+    for (const instance of draft.instances) {
+      if (
+        instance.symbolId !== kind ||
+        instance.mosBulkBinding?.origin !== "cell-default" ||
+        instance.mosBulkBinding.netId !== afterDefaultId
+      ) {
+        continue;
+      }
+      const net = draft.nets.find(
+        (candidate) => candidate.id === afterDefaultId,
+      );
+      if (net && replacementNetId !== afterDefaultId) {
+        net.terminals = net.terminals.filter(
+          (terminal) =>
+            terminal.instanceId !== instance.id || terminal.pinName !== "B",
+        );
+        affectedNetIds.add(net.id);
+        changedObjectIds.add(net.id);
+      }
+      if (replacementNetId) {
+        const replacement = draft.nets.find(
+          (candidate) => candidate.id === replacementNetId,
+        );
+        if (
+          replacement &&
+          !replacement.terminals.some(
+            (terminal) =>
+              terminal.instanceId === instance.id && terminal.pinName === "B",
+          )
+        ) {
+          replacement.terminals.push({ instanceId: instance.id, pinName: "B" });
+          changedObjectIds.add(replacement.id);
+        }
+        instance.mosBulkBinding.netId = replacementNetId;
+      } else {
+        delete instance.mosBulkBinding;
+      }
+      changedObjectIds.add(instance.id);
+    }
+
+    if (replacementNetId) draft.mosBulkDefaults![field] = replacementNetId;
+    else delete draft.mosBulkDefaults![field];
+    changedObjectIds.add(draft.id);
+    changed = true;
+    for (const netId of affectedNetIds) {
+      pruneUnreachableLocalNet(draft, netId, changedObjectIds);
+    }
+  }
+
+  if (
+    draft.mosBulkDefaults &&
+    !draft.mosBulkDefaults.nmosNetId &&
+    !draft.mosBulkDefaults.pmosNetId
+  ) {
+    delete draft.mosBulkDefaults;
+  }
+  return changed;
 }
 
 export function executeTransaction(
@@ -3160,6 +3265,13 @@ export function executeTransaction(
       changedRouteIds.add(routeId);
     }
   }
+
+  const invalidatedBulkDefault = revokeInvalidatedSupplyBulkDefaults(
+    document,
+    draft,
+    changedObjectIds,
+  );
+  connectivityChanged ||= invalidatedBulkDefault;
 
   const introducedNetContractIssue = validateLogicalNetContract(draft).find(
     (issue) =>


### PR DESCRIPTION
## Summary
- revoke or migrate materialized MOS bulk defaults when the final matching VDD/Ground claim disappears
- require an external non-B reference for Bulk ERC and resolve Check and Save supplies through Logical Nets
- plan compatible pin-to-pin contact as explicit merge_nets followed by strict connect_endpoints
- retain atomic rejection for conflicting names, scopes, and power domains

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- pnpm install --frozen-lockfile
- pnpm ci:check (1310 unit tests, 228 browser tests)