### PR TITLE
Converge Project and Gallery storage on schema 23

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -2741,9 +2741,14 @@ test("deletes imported Net Labels with non-editor ids", async ({ page }) => {
   const savedDocument = JSON.parse(savedWithoutLabel.toString("utf8"))
     .documents[0];
   expect(savedDocument.annotations).toHaveLength(0);
-  expect(
-    savedDocument.nets.find((net: { id: string }) => net.id === "net-h"),
-  ).toMatchObject({ name: "HORIZONTAL" });
+  expect(savedDocument.connectivityEvidence).toContainEqual(
+    expect.objectContaining({
+      kind: "name-claim",
+      netId: "net-h",
+      name: "HORIZONTAL",
+      owner: { kind: "explicit-net-property" },
+    }),
+  );
   await page.getByTestId("project-file").setInputFiles({
     name: "legacy-net-label-reopened.icproj.json",
     mimeType: "application/json",

--- a/apps/editor/src/demos/routing-demo.ts
+++ b/apps/editor/src/demos/routing-demo.ts
@@ -51,8 +51,6 @@ export function createRoutingDemoProject(): CircuitProject {
         nets: [
           {
             id: "net-h",
-            name: "HORIZONTAL",
-            scope: "local",
             terminals: ["A", "B", "E"].map((instanceId) => ({
               instanceId,
               pinName: "P",
@@ -60,8 +58,6 @@ export function createRoutingDemoProject(): CircuitProject {
           },
           {
             id: "net-v",
-            name: "VERTICAL",
-            scope: "local",
             terminals: ["C", "D"].map((instanceId) => ({
               instanceId,
               pinName: "P",

--- a/apps/editor/src/document/browser-recovery-contract.test.ts
+++ b/apps/editor/src/document/browser-recovery-contract.test.ts
@@ -198,7 +198,7 @@ describe("reviewBrowserRecoveryProject", () => {
 
     expect(review.status).toBe("valid");
     if (review.status === "valid") {
-      expect(review.project.schemaVersion).toBe(22);
+      expect(review.project.schemaVersion).toBe(23);
     }
   });
 

--- a/apps/editor/src/document/browser-recovery-store.test.ts
+++ b/apps/editor/src/document/browser-recovery-store.test.ts
@@ -533,7 +533,7 @@ describe("migrateLegacyProjectRecovery", () => {
     expect(firstSession(read).latest?.source).toBe("recovered");
   });
 
-  it("stores a schema-21 legacy slot as internally consistent schema 22", async () => {
+  it("stores a schema-21 legacy slot as internally consistent schema 23", async () => {
     const { store } = freshStore();
     const previous = JSON.parse(projectText);
     previous.schemaVersion = 21;
@@ -543,8 +543,8 @@ describe("migrateLegacyProjectRecovery", () => {
 
     expect(await migrate(storage, store)).toMatchObject({ status: "migrated" });
     const latest = firstSession(await store.readAll()).latest!;
-    expect(latest.projectSchemaVersion).toBe(22);
-    expect(JSON.parse(latest.projectText).schemaVersion).toBe(22);
+    expect(latest.projectSchemaVersion).toBe(23);
+    expect(JSON.parse(latest.projectText).schemaVersion).toBe(23);
   });
 
   it("retains an unsupported-schema legacy slot", async () => {

--- a/apps/editor/src/document/project-file-service.test.ts
+++ b/apps/editor/src/document/project-file-service.test.ts
@@ -385,12 +385,12 @@ describe("stageProjectFile", () => {
       status: "opened",
       fileName: "amp.icproj.json",
       topDocumentRevision: 0,
-      sourceSchemaVersion: 22,
+      sourceSchemaVersion: 23,
       migrated: false,
     });
   });
 
-  it("stages schema 21 as an upgraded schema-22 Project", async () => {
+  it("stages schema 21 as an upgraded schema-23 Project", async () => {
     const previous = JSON.parse(serializeProject(project));
     previous.schemaVersion = 21;
     delete previous.documents[0].connectivityEvidence;
@@ -405,7 +405,7 @@ describe("stageProjectFile", () => {
       fileName: "amp-v21.icproj.json",
       sourceSchemaVersion: 21,
       migrated: true,
-      project: { schemaVersion: 22 },
+      project: { schemaVersion: 23 },
     });
   });
 

--- a/apps/editor/src/examples/common-source-amplifier.icproj.json
+++ b/apps/editor/src/examples/common-source-amplifier.icproj.json
@@ -428,6 +428,42 @@
           "sizeScale": 1.1
         }
       ],
+      "connectivityEvidence": [
+        {
+          "id": "connectivity-evidence-1e6705e4ac6d8747",
+          "kind": "name-claim",
+          "name": "0",
+          "netId": "net-global-0",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "powerDomain": "ground",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-b6abc746278caab4",
+          "kind": "name-claim",
+          "name": "VDD",
+          "netId": "net-power-vdd7",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "powerDomain": "vdd",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-4abcbfaaa1acf7fc",
+          "kind": "name-claim",
+          "name": "VDD",
+          "netId": "net-power-vdd7",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "junction-vdd7-end"
+          },
+          "powerDomain": "vdd",
+          "scope": "global"
+        }
+      ],
       "constraints": [],
       "drafting": {
         "objects": [
@@ -873,12 +909,6 @@
       "nets": [
         {
           "id": "net-global-0",
-          "name": "0",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "ground",
-          "scope": "global",
           "terminals": [
             {
               "instanceId": "M2",
@@ -896,11 +926,6 @@
         },
         {
           "id": "net-ui-4",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "ground",
-          "scope": "global",
           "terminals": [
             {
               "instanceId": "GND5-copy-2-copy-3-copy-4",
@@ -914,11 +939,6 @@
         },
         {
           "id": "net-ui-5",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "V6",
@@ -932,11 +952,6 @@
         },
         {
           "id": "net-ui-9",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "ground",
-          "scope": "global",
           "terminals": [
             {
               "instanceId": "C1",
@@ -950,11 +965,6 @@
         },
         {
           "id": "net-split-315c27b4f6e1c409",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "ground",
-          "scope": "global",
           "terminals": [
             {
               "instanceId": "R3",
@@ -976,12 +986,6 @@
         },
         {
           "id": "net-power-vdd7",
-          "name": "VDD",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "vdd",
-          "scope": "global",
           "terminals": [
             {
               "instanceId": "VDD7",
@@ -999,11 +1003,6 @@
         },
         {
           "id": "net-split-1143160ec6fc8d88",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "C1-copy-1",
@@ -1293,7 +1292,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 21,
+  "schemaVersion": 23,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/current-mirror-loaded-differential-pair.icproj.json
+++ b/apps/editor/src/examples/current-mirror-loaded-differential-pair.icproj.json
@@ -331,6 +331,126 @@
           "sizeScale": 1
         }
       ],
+      "connectivityEvidence": [
+        {
+          "id": "connectivity-evidence-25e634a2eea84516",
+          "kind": "name-claim",
+          "name": "VDD",
+          "netId": "net-power-vdd1",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "powerDomain": "vdd",
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-43d121a9b2699894",
+          "kind": "name-claim",
+          "name": "Vout",
+          "netId": "net-ui-8",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-e49301de7c4e842c",
+          "kind": "name-claim",
+          "name": "Vin1",
+          "netId": "net-contact-p1",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-3505353a1aed4e2e",
+          "kind": "name-claim",
+          "name": "Vin2",
+          "netId": "net-contact-p2",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-0ee42d8cf01c7bbb",
+          "kind": "name-claim",
+          "name": "Vb",
+          "netId": "net-contact-p4",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-5c878c49425c1514",
+          "kind": "name-claim",
+          "name": "0",
+          "netId": "net-contact-gnd1",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "powerDomain": "ground",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-362a0827f36de02c",
+          "kind": "name-claim",
+          "name": "VDD",
+          "netId": "net-power-vdd1",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "junction-vdd1-end"
+          },
+          "powerDomain": "vdd",
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-6609436bdf68a3a6",
+          "kind": "name-claim",
+          "name": "Vin1",
+          "netId": "net-contact-p1",
+          "owner": {
+            "annotationId": "instance-label-P1",
+            "kind": "net-label"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-34bd0e453fcb04a8",
+          "kind": "name-claim",
+          "name": "Vin2",
+          "netId": "net-contact-p2",
+          "owner": {
+            "annotationId": "instance-label-P2",
+            "kind": "net-label"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-f799d25adc817336",
+          "kind": "name-claim",
+          "name": "Vout",
+          "netId": "net-ui-8",
+          "owner": {
+            "annotationId": "instance-label-P3",
+            "kind": "net-label"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-f33b12f0d8af9c38",
+          "kind": "name-claim",
+          "name": "Vb",
+          "netId": "net-contact-p4",
+          "owner": {
+            "annotationId": "instance-label-P4",
+            "kind": "net-label"
+          },
+          "scope": "local"
+        }
+      ],
       "constraints": [],
       "drafting": {
         "objects": []
@@ -584,11 +704,11 @@
         }
       ],
       "layoutGroups": [],
-      "name": "Main",
       "mosBulkDefaults": {
         "nmosNetId": "net-contact-gnd1",
         "pmosNetId": "net-power-vdd1"
       },
+      "name": "Main",
       "netlist": {
         "formalParameters": [],
         "name": "Main",
@@ -597,12 +717,6 @@
       "nets": [
         {
           "id": "net-power-vdd1",
-          "name": "VDD",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "vdd",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "M2",
@@ -624,11 +738,6 @@
         },
         {
           "id": "net-ui-7",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "M2",
@@ -650,12 +759,6 @@
         },
         {
           "id": "net-ui-8",
-          "name": "Vout",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "M4",
@@ -673,11 +776,6 @@
         },
         {
           "id": "net-ui-15",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "M3",
@@ -695,12 +793,6 @@
         },
         {
           "id": "net-contact-p1",
-          "name": "Vin1",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "P1",
@@ -714,12 +806,6 @@
         },
         {
           "id": "net-contact-p2",
-          "name": "Vin2",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "P2",
@@ -733,12 +819,6 @@
         },
         {
           "id": "net-contact-p4",
-          "name": "Vb",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "P4",
@@ -752,12 +832,6 @@
         },
         {
           "id": "net-contact-gnd1",
-          "name": "0",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "ground",
-          "scope": "global",
           "terminals": [
             {
               "instanceId": "GND1",
@@ -1051,7 +1125,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 21,
+  "schemaVersion": 23,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/fully-differential-two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/fully-differential-two-stage-op-amp.icproj.json
@@ -549,6 +549,126 @@
           "rotation": 0
         }
       ],
+      "connectivityEvidence": [
+        {
+          "id": "connectivity-evidence-5c878c49425c1514",
+          "kind": "name-claim",
+          "name": "0",
+          "netId": "net-contact-gnd1",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "powerDomain": "ground",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-25e634a2eea84516",
+          "kind": "name-claim",
+          "name": "VDD",
+          "netId": "net-power-vdd1",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "powerDomain": "vdd",
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-8a0159c1e72c6548",
+          "kind": "name-claim",
+          "name": "Vin+",
+          "netId": "net-ui-34",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-a6dbb475386fd957",
+          "kind": "name-claim",
+          "name": "Vin-",
+          "netId": "net-ui-35",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-5c4484a1dd737a3a",
+          "kind": "name-claim",
+          "name": "Vout1",
+          "netId": "net-port-p3",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-4e3ad162be9bacee",
+          "kind": "name-claim",
+          "name": "Vout2",
+          "netId": "net-port-p4",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-362a0827f36de02c",
+          "kind": "name-claim",
+          "name": "VDD",
+          "netId": "net-power-vdd1",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "junction-vdd1-end"
+          },
+          "powerDomain": "vdd",
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-e184ab56287ec08c",
+          "kind": "name-claim",
+          "name": "Vin+",
+          "netId": "net-ui-34",
+          "owner": {
+            "annotationId": "instance-label-P1",
+            "kind": "net-label"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-ebddb387d3b751e0",
+          "kind": "name-claim",
+          "name": "Vin-",
+          "netId": "net-ui-35",
+          "owner": {
+            "annotationId": "instance-label-P2",
+            "kind": "net-label"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-c18f883543023304",
+          "kind": "name-claim",
+          "name": "Vout1",
+          "netId": "net-port-p3",
+          "owner": {
+            "annotationId": "instance-label-P3",
+            "kind": "net-label"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-fb7c58dd2bee35ba",
+          "kind": "name-claim",
+          "name": "Vout2",
+          "netId": "net-port-p4",
+          "owner": {
+            "annotationId": "instance-label-P4",
+            "kind": "net-label"
+          },
+          "scope": "local"
+        }
+      ],
       "constraints": [],
       "drafting": {
         "objects": []
@@ -1145,11 +1265,11 @@
         }
       ],
       "layoutGroups": [],
-      "name": "Main",
       "mosBulkDefaults": {
         "nmosNetId": "net-contact-gnd1",
         "pmosNetId": "net-power-vdd1"
       },
+      "name": "Main",
       "netlist": {
         "formalParameters": [],
         "name": "Main",
@@ -1158,12 +1278,6 @@
       "nets": [
         {
           "id": "net-contact-gnd1",
-          "name": "0",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "ground",
-          "scope": "global",
           "terminals": [
             {
               "instanceId": "M5",
@@ -1241,12 +1355,6 @@
         },
         {
           "id": "net-power-vdd1",
-          "name": "VDD",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "vdd",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "M1",
@@ -1284,11 +1392,6 @@
         },
         {
           "id": "net-ui-28",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "M1",
@@ -1310,11 +1413,6 @@
         },
         {
           "id": "net-ui-29",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "M3",
@@ -1336,12 +1434,6 @@
         },
         {
           "id": "net-ui-34",
-          "name": "Vin+",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "M6",
@@ -1359,12 +1451,6 @@
         },
         {
           "id": "net-ui-35",
-          "name": "Vin-",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "M7",
@@ -1382,12 +1468,6 @@
         },
         {
           "id": "net-port-p3",
-          "name": "Vout1",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "P3",
@@ -1409,12 +1489,6 @@
         },
         {
           "id": "net-port-p4",
-          "name": "Vout2",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "P4",
@@ -2062,7 +2136,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 21,
+  "schemaVersion": 23,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/two-stage-op-amp.icproj.json
@@ -257,6 +257,29 @@
           "sizeScale": 1
         }
       ],
+      "connectivityEvidence": [
+        {
+          "id": "connectivity-evidence-b1565547153d949f",
+          "kind": "name-claim",
+          "name": "VDD",
+          "netId": "net-global-vdd",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-4f697832b597ca42",
+          "kind": "name-claim",
+          "name": "0",
+          "netId": "net-contact-gnd11",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "powerDomain": "ground",
+          "scope": "global"
+        }
+      ],
       "constraints": [],
       "drafting": {
         "objects": []
@@ -434,22 +457,10 @@
       "nets": [
         {
           "id": "net-global-vdd",
-          "name": "VDD",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "global",
           "terminals": []
         },
         {
           "id": "net-contact-gnd11",
-          "name": "0",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "ground",
-          "scope": "global",
           "terminals": [
             {
               "instanceId": "GND11",
@@ -463,11 +474,6 @@
         },
         {
           "id": "net-ui-1",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "X7",
@@ -485,11 +491,6 @@
         },
         {
           "id": "net-contact-p13",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "P13",
@@ -519,11 +520,6 @@
         },
         {
           "id": "net-split-f9c443f2edef6e67",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "X7",
@@ -700,7 +696,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 21,
+  "schemaVersion": 23,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/features/component-insert/use-component-placement.ts
+++ b/apps/editor/src/features/component-insert/use-component-placement.ts
@@ -242,7 +242,6 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       if (edit.kind !== "connect_endpoints" || !edit.newNetId) continue;
       projectedDocument.nets.push({
         id: edit.newNetId,
-        scope: "local",
         terminals: [edit.from, edit.to]
           .filter(
             (
@@ -656,8 +655,6 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     if (!namedNetDocument.nets.some((net) => net.id === candidateNetId)) {
       namedNetDocument.nets.push({
         id: candidateNetId,
-        scope: "local",
-        powerDomain: "none",
         terminals: [],
       });
     }

--- a/apps/editor/src/features/component-insert/vdd-rail.test.ts
+++ b/apps/editor/src/features/component-insert/vdd-rail.test.ts
@@ -146,8 +146,6 @@ describe("drawn VDD rail construction", () => {
     expect(result.document.nets).toMatchObject([
       {
         id: "net-power-vdd1",
-        scope: "local",
-        powerDomain: "none",
       },
     ]);
     expect(

--- a/docs/adr/0042-schema-23-gallery-convergence.md
+++ b/docs/adr/0042-schema-23-gallery-convergence.md
@@ -1,0 +1,90 @@
+# ADR 0042: Schema 23 and Gallery Storage Convergence
+
+Status: accepted
+
+Date: 2026-08-24
+
+Owners: `packages/model`, `packages/project-protocol`, `worker/gallery.ts`
+
+## Context
+
+ADR 0040 made Connectivity Evidence the sole logical authority but retained
+schema-21 `Net.name`, `Net.scope`, `Net.powerDomain`, and `Net.origin` fields as
+inert schema-22 projections. The public Gallery still contains both schema 21
+and schema 22 Projects, while Gallery history and private workspace slots keep
+independent Project texts. Advancing the file format before converging every
+storage surface would make some published or restored work unreadable.
+
+## Decision
+
+Schema 23 makes a persisted Base Net exactly `{ id, terminals }`. Naming,
+scope, supply role, source membership, and explicit equivalence remain in the
+single Connectivity Evidence list and resolve through the existing Logical-Net
+resolver.
+
+The convergence release temporarily accepts schemas 21, 22, and 23 and always
+returns and writes schema 23. Gallery administration exposes an authenticated
+full backup, a no-write migration report, and an atomic apply operation over
+current entries, entry history, and private workspace slots. Version restore
+and workspace save also canonicalize through the Project protocol boundary so
+old text cannot be reintroduced after migration.
+
+After online storage contains only schema 23, the temporary schema-21 hop and
+the convergence-only Base-Net projections are removed. The normal rolling
+reader then accepts schemas 22 and 23.
+
+## Alternatives considered
+
+### Stop at schema 22 before advancing
+
+- Benefits: preserves the ordinary one-version reader during every release.
+- Costs: rewrites all online data twice and keeps inert Base-Net fields longer.
+- Reason not selected: the same validated 21-to-22 transform composes safely
+  with the field-removal transform, so an intermediate stored state adds risk
+  without adding electrical evidence.
+
+### Migrate only current public entries
+
+- Benefits: smaller maintenance operation.
+- Costs: restoring history or opening a workspace can reintroduce an old
+  schema after cleanup.
+- Reason not selected: all persisted Project-bearing tables are one
+  compatibility boundary.
+
+## Consequences
+
+### Positive
+
+- Base Nets are physically and structurally topology-only.
+- Gallery data, history, workspaces, fixtures, and new saves converge on one
+  canonical format.
+- Migration is reversible from an administrator backup and cannot partially
+  apply after a validation failure.
+
+### Negative or limiting
+
+- One deployment temporarily carries a three-version ingestion bridge.
+- Schema-21 files kept offline must be opened during that bridge release or
+  upgraded separately after the bridge is removed.
+
+## Compatibility and migration
+
+The migration changes Project JSON only. It preserves IDs, terminal
+membership, Connectivity Evidence, geometry, annotations, and stored Gallery
+SVG previews. Every source record is parsed and serialized before any write;
+all writes then occur in one Durable Object transaction.
+
+## Validation
+
+- The current reader must converge every public Gallery Project to schema 23.
+- Unit tests cover the object-anchored legacy VDD label that previously failed.
+- Gallery tests cover backup, dry-run, atomic migration of all three tables,
+  canonical workspace save, and canonical history restore.
+- Online acceptance requires zero stored schema-21/schema-22 records and a
+  second dry-run with no failures.
+
+## Related documents
+
+- [ADR 0040](0040-connectivity-evidence.md)
+- [Project file format](../specs/project-file-format.md)
+- [Persistence and recovery](../specs/persistence-and-recovery.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -84,6 +84,8 @@ The physical Wire-cut, derived endpoint-readiness, occurrence-aware trace, and
 revision-scoped Logical-Net representative decision—partially superseding ADR
 0035—is
 [`0041-physical-cut-and-endpoint-readiness.md`](0041-physical-cut-and-endpoint-readiness.md).
+The schema-23 Base-Net cleanup and full Gallery storage convergence decision is
+[`0042-schema-23-gallery-convergence.md`](0042-schema-23-gallery-convergence.md).
 The arbitrary-angle Route authoring decision is
 [`0039-any-angle-route-authoring.md`](0039-any-angle-route-authoring.md).
 

--- a/docs/overall-product-plan.md
+++ b/docs/overall-product-plan.md
@@ -67,7 +67,7 @@ revision, lock, or transaction invariants.
   ordered hierarchy interface rather than another Net-label mechanism.
 - Routes describe visible geometry; they may stretch locally during movement
   without changing logical connectivity.
-- A Project is a canonical schema-22 JSON file. Browser recovery is an
+- A Project is a canonical schema-23 JSON file. Browser recovery is an
   origin-local, non-authoritative copy.
 - Visual variants may change presentation but never remove electrical terminal
   semantics. The Razavi raster manifest is the sole visual authority.

--- a/docs/specs/edit-engine.md
+++ b/docs/specs/edit-engine.md
@@ -143,7 +143,7 @@ Document revision once and is restored by one Undo. The retired Agent product
 categorizes these guarded UI lifecycle edits as unsupported.
 
 `upsert_connectivity_evidence` and `remove_connectivity_evidence` are the only
-atomic writers for the schema-22 evidence list. Upsert replaces evidence with
+atomic writers for the schema-23 evidence list. Upsert replaces evidence with
 the same ID or inserts a new record after checking the shared Document object
 namespace; final Document validation checks every Net and owner reference.
 Removing an Instance, Net Label, Junction, or Route also removes only

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -95,10 +95,10 @@ Its editor-local VDD artwork is preview-only and is not registered with the
 product Symbol Resolver. Before the first click the artwork follows the
 pointer; after the first click the preview becomes a straight horizontal or
 vertical rail, selected by the pointer's dominant axis. The second click
-  creates a Base Net with the selected global supply claim, creates two route-anchor
+creates a Base Net with the selected global supply claim, creates two route-anchor
 Junctions and one `power-rail` Route, and persists one net-name-bound RichText
-  power-label annotation. Same-name supply claims resolve to one Logical Net
-  without a physical merge. The Route is the only rail geometry: the annotation adds no
+power-label annotation. Same-name supply claims resolve to one Logical Net
+without a physical merge. The Route is the only rail geometry: the annotation adds no
 supply bar or terminal stub, and the semantic name uses the shared Razavi
 schematic-math style. It creates no VDD Instance and exits placement after the
 commit. Deleting the rail also deletes its power label and rail-only Junctions;
@@ -341,7 +341,7 @@ Open, demo load, restore, and human-approved staged import replace the entire
 Project through one replacement boundary; they are not Edit Engine
 transactions. Replacement cancels pending recovery for the outgoing Project
 and terminates its Agent session. A complete schema-21 Project may be upgraded
-at the read boundary and then enters the editor only as schema-22; migrated
+at the read boundary and then enters the editor only as schema-23; migrated
 files are marked as needing save.
 
 Selection, viewport, active tool, previews, Agent tokens, and approval UI are

--- a/docs/specs/persistence-and-recovery.md
+++ b/docs/specs/persistence-and-recovery.md
@@ -4,18 +4,18 @@ Status: `accepted`
 
 Primary owner: `packages/project-protocol` and the editor document lifecycle
 
-Portable Projects use canonical schema-22 `.icproj.json`. The current-only
+Portable Projects use canonical schema-23 `.icproj.json`. The current-only
 model in `packages/model` validates the normalized shape;
 `packages/project-protocol` owns parsing, rolling compatibility diagnostics,
 and canonical serialization. Persistence validates
 the complete current schema before open or save and writes atomically where the
-platform supports it. Schema 21 reads through one direct upgrade to schema 22;
-older and future versions are rejected. Migration runs only at ingestion, and
-serialization remains schema 22.
+platform supports it. During Gallery convergence, schemas 21 and 22 upgrade to
+23 at ingestion; serialization always writes schema 23. The schema-21 hop is a
+bounded deployment bridge and is removed after online storage convergence.
 
 Recovery state is a non-authoritative browser safety copy. It may restore a
-complete schema-22 Project or a schema-21 record that validates after the direct
-upgrade, associated with a recorded working-copy session.
+complete schema-23 Project or a schema-21/22 record that validates after the
+bounded upgrade, associated with a recorded working-copy session.
 Corrupt, incompatible, or partial recovery data is discarded or retained as raw
 data without changing the live Project. User-saved Library examples are the
 same class of origin-local, non-authoritative convenience data: canonical

--- a/docs/specs/project-file-format.md
+++ b/docs/specs/project-file-format.md
@@ -2,18 +2,19 @@
 
 Status: `accepted`
 
-Current Project schema: `22`
+Current Project schema: `23`
 
 Primary owners: `packages/model` (current shape) and
 `packages/project-protocol` (file boundary)
 
 An `.icproj.json` file is canonical JSON for one complete `CircuitProject`.
-`@icm/project-protocol` exposes `parseProject` and accepts Project schemas 21
-and 22. Schema 21 advances directly to 22 by adding deterministic Connectivity
-Evidence for existing explicit Net names, Net/power Labels, and imported Net
-source membership. Every reader returns the sole schema-22 in-memory Project
-shape; schema 20 and older and all future versions are rejected. There is no
-sequential migration registry or second in-memory Project shape.
+`@icm/project-protocol` exposes `parseProject`. During the Gallery convergence
+release it accepts schemas 21, 22, and 23, upgrades every accepted input to the
+sole schema-23 in-memory Project, and writes only schema 23. Schema 21 first
+gains deterministic Connectivity Evidence; schema 22 then drops the inert
+Base-Net name, scope, power-role, and origin projections. This temporary
+two-hop reader is removed after Gallery entries, history, and workspaces have
+all been rewritten to 23.
 
 ## Current authorities
 
@@ -64,8 +65,8 @@ sequential migration registry or second in-memory Project shape.
 ## Read and write
 
 ```text
-read text -> parse JSON -> require Project schema 21 or 22
--> direct v21-to-v22 upgrade when needed -> strict schema-22 validation -> open
+read text -> parse JSON -> require Project schema 21, 22, or 23
+-> converge to schema 23 -> strict schema-23 validation -> open
 save -> strict validation -> canonical key ordering -> atomic write
 ```
 
@@ -75,7 +76,7 @@ after explicit human approval in the editor.
 
 A migrated formal file is marked as needing save. The editor does not silently
 overwrite the source selected through the browser file input. Browser recovery
-records may be canonicalized to v22 only after a successful validated write.
+records may be canonicalized to v23 only after a successful validated write.
 
 Project entry does not repair duplicate canonical supply Nets (`0` or `VDD`).
 Duplicate folded Net names are invalid input and remain a blocking diagnostic
@@ -84,7 +85,7 @@ until the author explicitly renames or merges the Nets.
 Canonical serialization ends with one newline and is byte-stable across
 save/load/save. The current corpus is listed in
 `fixtures/projects/compatibility-corpus.json`; its accepted entries must all be
-already canonical Project schema 22. The rejected corpus names expected
+already canonical Project schema 23. The rejected corpus names expected
 validation failures.
 
 Viewport, selection, undo history, canvas overlays, Agent credentials,

--- a/docs/specs/schematic-model.md
+++ b/docs/specs/schematic-model.md
@@ -5,7 +5,7 @@ Status: `accepted`
 Primary owner: `packages/model`
 
 The Project contains Documents; each Document owns revisioned electrical,
-geometric, and presentation facts. The current model is strict schema 22 and has
+geometric, and presentation facts. The current model is strict schema 23 and has
 no compatibility shape.
 
 ## Coordinate domains
@@ -150,6 +150,6 @@ ordinary Schematic edits inside one Project structural transaction. The
 Project's `structureRevision` protects this cross-Document boundary and the
 editor records it as one undoable structural commit.
 
-Persistence writes only schema 22. `packages/project-protocol` accepts schema
-21 through the bounded direct upgrade defined by ADR 0039, then supplies the
-current model only; no compatibility shape enters `packages/model`.
+Persistence writes only schema 23. The convergence reader accepts schemas 21
+and 22 at the file boundary, then supplies the current model only; no
+compatibility shape enters runtime electrical derivation.

--- a/docs/user/project-compatibility.md
+++ b/docs/user/project-compatibility.md
@@ -1,6 +1,6 @@
 # Project File Compatibility
 
-The released Project schema version is `22`. It retains schematic-only
+The released Project schema version is `23`. It retains schematic-only
 hierarchy integrity, a Project structural revision, stable formal Cell ports,
 and definition-level Cell symbol presentation. It also has one typed Instance
 netlist authority, formal Cell parameters, and Project-local external
@@ -10,16 +10,15 @@ from its internal schematic or netlist reference until the user edits it. A
 free Port is identified by its Net name; a formal Cell Pin is identified by its
 terminal name, such as `Vout`. Their bound annotations may persist same-text
 RichText formatting but cannot store a divergent alias. A
-canonical v22 file can be opened, saved, reopened, and saved again without
+canonical v23 file can be opened, saved, reopened, and saved again without
 byte drift.
 
-Schema v21 is accepted through one direct upgrade to v22. The upgrade adds
-deterministic ownership evidence for retained Net names, labels, and imported
-source membership without changing the visible drawing. The next save writes
-v22. The
-original file is never overwritten silently. Schema v20 and older, and
-versions newer than v22, are rejected; there is no accumulating
-migration registry.
+During Gallery convergence, schemas v21 and v22 are accepted through a bounded
+upgrade to v23. The upgrade adds deterministic ownership evidence where needed
+and removes inert Base-Net projections without changing the visible drawing.
+The next save writes v23. The original file is never overwritten silently.
+Schema v20 and older, and versions newer than v23, are rejected. The temporary
+v21 hop is removed after online Gallery storage has converged.
 
 The canonical-current corpus at
 [`fixtures/projects/compatibility-corpus.json`](../../fixtures/projects/compatibility-corpus.json)
@@ -31,7 +30,7 @@ Retired fields such as first-class
 
 An incompatible Project is rejected before it can replace the current browser
 Project. Conversion, when needed, is an explicit external operation that must
-produce and validate a complete v21 candidate before a human chooses to load it.
+produce and validate a complete v23 candidate before a human chooses to load it.
 
 The editor never silently merges duplicate canonical Ground (`0`) or VDD Nets.
 Duplicate folded Net names are invalid and remain diagnostics until the author

--- a/docs/user/schematic-hierarchy.md
+++ b/docs/user/schematic-hierarchy.md
@@ -74,8 +74,8 @@ the Properties values remain the precise fallback. These are definition operatio
 not top-level drawing tools.
 
 Hierarchy presentation is saved as definition-level size and pin-placement
-intent in current Project schema 22. Schema-21 projects open through the
-bounded direct upgrade; schema-20 files are outside the supported rolling
-compatibility window. The block uses a closed polygon body and the shared
+intent in current Project schema 23. During Gallery convergence, schema-21 and
+schema-22 projects open through the bounded upgrade; schema-20 files remain
+unsupported. The block uses a closed polygon body and the shared
 Razavi rich-text renderer for pin and Cell names; it is compatible with that
 visual grammar rather than a pixel-for-pixel textbook symbol asset.

--- a/fixtures/projects/instance-value-display/project.icproj.json
+++ b/fixtures/projects/instance-value-display/project.icproj.json
@@ -1048,7 +1048,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "instance-value-display",
   "name": "Instance Value Display",
-  "schemaVersion": 22,
+  "schemaVersion": 23,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/minimal/project.icproj.json
+++ b/fixtures/projects/minimal/project.icproj.json
@@ -32,7 +32,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-minimal",
   "name": "Minimal Project",
-  "schemaVersion": 22,
+  "schemaVersion": 23,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-1-manual/project.icproj.json
+++ b/fixtures/projects/phase-1-manual/project.icproj.json
@@ -59,7 +59,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-1-manual",
   "name": "Phase 1 Manual Editor",
-  "schemaVersion": 22,
+  "schemaVersion": 23,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-3-routing/project.icproj.json
+++ b/fixtures/projects/phase-3-routing/project.icproj.json
@@ -107,8 +107,6 @@
       "nets": [
         {
           "id": "net-h",
-          "name": "HORIZONTAL",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "A",
@@ -126,8 +124,6 @@
         },
         {
           "id": "net-v",
-          "name": "VERTICAL",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "C",
@@ -154,7 +150,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-routing",
   "name": "Phase 3 Routing Demo",
-  "schemaVersion": 22,
+  "schemaVersion": 23,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-5-dense-analog/project.icproj.json
+++ b/fixtures/projects/phase-5-dense-analog/project.icproj.json
@@ -192,12 +192,6 @@
       "nets": [
         {
           "id": "net-vinp",
-          "name": "VINP",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "VINP",
@@ -211,12 +205,6 @@
         },
         {
           "id": "net-vout",
-          "name": "VOUT",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "M1",
@@ -234,11 +222,6 @@
         },
         {
           "id": "net-tail",
-          "origin": {
-            "kind": "authored"
-          },
-          "powerDomain": "none",
-          "scope": "local",
           "terminals": [
             {
               "instanceId": "M1",
@@ -376,7 +359,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-5-dense-analog",
   "name": "Current Differential Stage",
-  "schemaVersion": 22,
+  "schemaVersion": 23,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/packages/derived/src/logical-net.ts
+++ b/packages/derived/src/logical-net.ts
@@ -79,7 +79,7 @@ function unionGroups(
 }
 
 /**
- * Resolve Document-local logical identity from schema-22 evidence. Physical
+ * Resolve Document-local logical identity from schema-23 evidence. Physical
  * Base Nets remain intact; this pure result is the only name/source folding
  * implementation used by editor and netlist consumers.
  */

--- a/packages/edit-engine/src/power-net-planner.ts
+++ b/packages/edit-engine/src/power-net-planner.ts
@@ -92,8 +92,6 @@ export function planEnsurePowerNet(
   if (!candidate) {
     planningDocument.nets.push({
       id: request.candidateNetId,
-      scope: "local",
-      powerDomain: "none",
       terminals: [],
     });
   }

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -2406,7 +2406,7 @@ describe("routing Edit Engine", () => {
       result.document.nets.find((candidate) =>
         candidate.terminals.some((terminal) => terminal.instanceId === "D"),
       ),
-    ).toMatchObject({ scope: "local", terminals: [{ instanceId: "D" }] });
+    ).toMatchObject({ terminals: [{ instanceId: "D" }] });
     expect(result.document.sourceStatus).toBe("connectivity-modified");
   });
 });

--- a/packages/edit-engine/src/transaction.test.ts
+++ b/packages/edit-engine/src/transaction.test.ts
@@ -1517,8 +1517,6 @@ describe("Edit Transaction envelope", () => {
         nets: [
           {
             id: "net-ui-2",
-            scope: "local",
-            powerDomain: "none",
             terminals: [],
           },
         ],

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -1900,8 +1900,6 @@ export function executeTransaction(
           }
           draft.nets.push({
             id: edit.netId,
-            scope: "local",
-            powerDomain: "none",
             terminals: [],
           });
           changedObjectIds.add(edit.netId);
@@ -2383,8 +2381,6 @@ export function executeTransaction(
             const groupNetId = netIdByEndpoint.get(group[0]!)!;
             draft.nets.push({
               id: groupNetId,
-              scope: "local",
-              powerDomain: "none",
               terminals: terminalsFor(groupNetId),
             });
             changedObjectIds.add(groupNetId);
@@ -2469,8 +2465,6 @@ export function executeTransaction(
           netId = edit.newNetId;
           draft.nets.push({
             id: netId,
-            scope: "local",
-            powerDomain: "none",
             terminals: [],
           });
           changedObjectIds.add(netId);
@@ -2544,8 +2538,6 @@ export function executeTransaction(
         if (!existingSupplyNet) {
           draft.nets.push({
             id: edit.netId,
-            scope: "local",
-            powerDomain: "none",
             terminals: [],
           });
         }

--- a/packages/model/src/protocol-documentation.test.ts
+++ b/packages/model/src/protocol-documentation.test.ts
@@ -21,7 +21,7 @@ describe("Project protocol documentation", () => {
       ["docs/specs/persistence-and-recovery.md", `schema-${version}`],
       ["docs/specs/project-file-format.md", `Project schema: \`${version}\``],
       ["docs/specs/editor-interaction.md", `schema-${version}`],
-      ["docs/adr/0040-connectivity-evidence.md", `schema ${version}`],
+      ["docs/adr/0042-schema-23-gallery-convergence.md", `Schema ${version}`],
       [
         "docs/user/project-compatibility.md",
         `schema version is \`${version}\``,

--- a/packages/model/src/schema/common.ts
+++ b/packages/model/src/schema/common.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-export const CURRENT_PROJECT_SCHEMA_VERSION = 22;
+export const CURRENT_PROJECT_SCHEMA_VERSION = 23;
 
 export const StableIdSchema = z.string().min(1).max(256);
 /** A persisted Document page point before its Document-grid relation is known. */

--- a/packages/model/src/schema/connectivity.ts
+++ b/packages/model/src/schema/connectivity.ts
@@ -4,13 +4,14 @@ import { StableIdSchema } from "./common.js";
 import { TerminalRefSchema } from "./instance.js";
 import { SourceSpanSchema } from "./source.js";
 
+/** Logical-Net electrical role shared by derived and Agent contracts. */
 export const NetPowerDomainSchema = z.enum([
   "none",
   "vdd",
   "ground",
   "conflict",
 ]);
-/** Legacy schema-21 import lineage. Runtime connectivity never reads it. */
+/** Temporary schema-23 convergence input; removed after Gallery migration. */
 export const NetOriginSchema = z.discriminatedUnion("kind", [
   z.strictObject({ kind: z.literal("authored") }),
   z.strictObject({
@@ -18,16 +19,17 @@ export const NetOriginSchema = z.discriminatedUnion("kind", [
     sourceNetIds: z.array(StableIdSchema).min(1).max(256),
   }),
 ]);
+
 export const NetSchema = z.strictObject({
   id: StableIdSchema,
-  /** @deprecated Inert schema-21 projection; Logical Net evidence is authoritative. */
+  /** Temporary migration projection; never authoritative in schema 23. */
   name: z.string().min(1).optional(),
-  /** @deprecated Base Nets are physical; marker evidence carries logical scope. */
-  scope: z.enum(["local", "global"]),
-  /** @deprecated Base Nets have no power role; retained until schema-23 cleanup. */
+  /** Temporary migration projection; never authoritative in schema 23. */
+  scope: z.enum(["local", "global"]).optional(),
+  /** Temporary migration projection; never authoritative in schema 23. */
   powerDomain: NetPowerDomainSchema.optional(),
   terminals: z.array(TerminalRefSchema),
-  /** @deprecated Import lineage is represented by spice-source evidence. */
+  /** Temporary migration projection; never authoritative in schema 23. */
   origin: NetOriginSchema.optional(),
 });
 

--- a/packages/netlist/src/current-contract.test.ts
+++ b/packages/netlist/src/current-contract.test.ts
@@ -25,7 +25,7 @@ function analyzeDesignNetlist(project: CircuitProject) {
         netId: net.id,
         name: net.name,
         owner: { kind: "explicit-net-property" },
-        scope: net.scope,
+        scope: net.scope ?? "local",
         ...(net.powerDomain === "vdd" || net.powerDomain === "ground"
           ? { powerDomain: net.powerDomain }
           : {}),

--- a/packages/netlist/src/roundtrip.test.ts
+++ b/packages/netlist/src/roundtrip.test.ts
@@ -197,7 +197,7 @@ function structuralProject(): CircuitProject {
         netId: net.id,
         name: net.name,
         owner: { kind: "explicit-net-property" },
-        scope: net.scope,
+        scope: net.scope ?? "local",
       });
     }
   }

--- a/packages/project-protocol/src/load.ts
+++ b/packages/project-protocol/src/load.ts
@@ -12,10 +12,14 @@ import {
 } from "./diagnostics.js";
 import {
   ProjectMigrationError,
-  upgradePreviousProject,
+  upgradeSchema21To22,
+  upgradeSchema22To23,
 } from "./previous-to-current.js";
-import { repairCurrentProjectEvidence } from "./transforms/project.js";
-import { PREVIOUS_PROJECT_SCHEMA_VERSION } from "./version.js";
+import { canonicalizeSchema23Project } from "./transforms/project.js";
+import {
+  GALLERY_MIGRATION_SCHEMA_VERSION,
+  PREVIOUS_PROJECT_SCHEMA_VERSION,
+} from "./version.js";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -87,14 +91,19 @@ export function tryParseProjectWithMetadata(
   }
 
   const sourceSchemaVersion = parsed.schemaVersion as number;
-  const migrated = sourceSchemaVersion === PREVIOUS_PROJECT_SCHEMA_VERSION;
-  if (sourceSchemaVersion !== CURRENT_PROJECT_SCHEMA_VERSION && !migrated) {
+  const migrated = sourceSchemaVersion !== CURRENT_PROJECT_SCHEMA_VERSION;
+  const supported = new Set([
+    GALLERY_MIGRATION_SCHEMA_VERSION,
+    PREVIOUS_PROJECT_SCHEMA_VERSION,
+    CURRENT_PROJECT_SCHEMA_VERSION,
+  ]);
+  if (!supported.has(sourceSchemaVersion)) {
     return {
       ok: false,
       diagnostics: [
         {
           code: "UNSUPPORTED_SCHEMA_VERSION",
-          message: `Project schemaVersion must be ${PREVIOUS_PROJECT_SCHEMA_VERSION} or ${CURRENT_PROJECT_SCHEMA_VERSION}`,
+          message: `Project schemaVersion must be ${GALLERY_MIGRATION_SCHEMA_VERSION}, ${PREVIOUS_PROJECT_SCHEMA_VERSION}, or ${CURRENT_PROJECT_SCHEMA_VERSION}`,
           path: ["schemaVersion"],
         },
       ],
@@ -103,9 +112,12 @@ export function tryParseProjectWithMetadata(
 
   let current: Record<string, unknown>;
   try {
-    current = repairCurrentProjectEvidence(
-      migrated ? upgradePreviousProject(parsed) : parsed,
-    );
+    current =
+      sourceSchemaVersion === GALLERY_MIGRATION_SCHEMA_VERSION
+        ? upgradeSchema22To23(upgradeSchema21To22(parsed))
+        : sourceSchemaVersion === PREVIOUS_PROJECT_SCHEMA_VERSION
+          ? upgradeSchema22To23(parsed)
+          : canonicalizeSchema23Project(parsed);
   } catch (error) {
     if (error instanceof ProjectMigrationError) {
       return {

--- a/packages/project-protocol/src/persistence.test.ts
+++ b/packages/project-protocol/src/persistence.test.ts
@@ -164,7 +164,7 @@ describe("Project persistence", () => {
     expect(migrated).toMatchObject({
       sourceSchemaVersion: 21,
       migrated: true,
-      project: { schemaVersion: 22 },
+      project: { schemaVersion: 23 },
     });
     expect(
       migrated.project.documents[0]!.annotations.map(
@@ -250,7 +250,7 @@ describe("Project persistence", () => {
     });
 
     const reopened = parseProject(serializeProject(project));
-    expect(reopened.schemaVersion).toBe(22);
+    expect(reopened.schemaVersion).toBe(23);
     expect(
       reopened.documents[0]!.annotations[0]?.content!.runs[0],
     ).toMatchObject({ kind: "fraction" });
@@ -260,6 +260,7 @@ describe("Project persistence", () => {
     const source = JSON.parse(
       serializeProject(createEmptyProject("project-test", "Test Project")),
     );
+    source.schemaVersion = 22;
     source.documents[0].nets.push({
       id: "net-vdd",
       name: "VDD",
@@ -311,13 +312,96 @@ describe("Project persistence", () => {
     ]);
   });
 
+  it("migrates an object-anchored schema-21 VDD format override", () => {
+    const source = JSON.parse(
+      serializeProject(createEmptyProject("project-test", "Gallery VDD")),
+    );
+    source.schemaVersion = 21;
+    delete source.documents[0].connectivityEvidence;
+    source.documents[0].instances.push({
+      id: "VDD1",
+      symbolId: "vdd-port",
+      schematicReference: "VDD1",
+      placement: {
+        position: { x: 120, y: 350 },
+        rotation: 270,
+        mirror: "none",
+      },
+    });
+    source.documents[0].nets.push({
+      id: "net-power-vdd1",
+      name: "VDD",
+      scope: "global",
+      powerDomain: "vdd",
+      origin: { kind: "authored" },
+      terminals: [{ instanceId: "VDD1", pinName: "P" }],
+    });
+    source.documents[0].annotations.push({
+      id: "power-label-vdd1",
+      kind: "power-label",
+      binding: { kind: "net-name", netId: "net-power-vdd1" },
+      formatOverride: {
+        runs: [
+          {
+            kind: "span",
+            style: "italic",
+            children: [
+              {
+                kind: "span",
+                style: "bold",
+                children: [{ kind: "text", value: "V" }],
+              },
+            ],
+          },
+          {
+            kind: "span",
+            style: "subscript",
+            children: [
+              {
+                kind: "span",
+                style: "bold",
+                children: [{ kind: "text", value: "DD" }],
+              },
+            ],
+          },
+        ],
+      },
+      anchor: {
+        kind: "object",
+        objectId: "VDD1",
+        localOffset: { x: -30, y: 10 },
+        fallbackPosition: { x: 90, y: 360 },
+      },
+      netId: "net-power-vdd1",
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+      sizeScale: 1,
+    });
+
+    const migrated = parseProject(JSON.stringify(source));
+    expect(migrated.schemaVersion).toBe(23);
+    expect(migrated.documents[0]!.connectivityEvidence).toContainEqual(
+      expect.objectContaining({
+        kind: "name-claim",
+        name: "VDD",
+        powerDomain: "vdd",
+        owner: { kind: "power-marker", objectId: "VDD1" },
+      }),
+    );
+    expect(migrated.documents[0]!.nets[0]).toEqual({
+      id: "net-power-vdd1",
+      terminals: [{ instanceId: "VDD1", pinName: "P" }],
+    });
+  });
+
   it("rejects schemas outside the rolling current-and-previous window", () => {
     const project = createEmptyProject("project-test", "Test Project");
     expect(() =>
       parseProject(JSON.stringify({ ...project, schemaVersion: 99 })),
-    ).toThrow(/must be 21 or 22/);
+    ).toThrow(/must be 21, 22, or 23/);
     expect(() =>
       parseProject(JSON.stringify({ ...project, schemaVersion: 20 })),
-    ).toThrow(/must be 21 or 22/);
+    ).toThrow(/must be 21, 22, or 23/);
   });
 });

--- a/packages/project-protocol/src/previous-to-current.ts
+++ b/packages/project-protocol/src/previous-to-current.ts
@@ -1,4 +1,5 @@
 export {
   ProjectMigrationError,
-  upgradePreviousProject,
+  upgradeSchema21To22,
+  upgradeSchema22To23,
 } from "./transforms/project.js";

--- a/packages/project-protocol/src/protocol.test.ts
+++ b/packages/project-protocol/src/protocol.test.ts
@@ -16,7 +16,7 @@ describe("Project protocol boundary", () => {
     });
   });
 
-  it("keeps the direct schema-21 to schema-22 upgrade", () => {
+  it("converges schema 21 directly to schema 23", () => {
     const current = JSON.parse(
       serializeProject(createEmptyProject("protocol-project", "Protocol")),
     ) as Record<string, unknown>;
@@ -32,7 +32,7 @@ describe("Project protocol boundary", () => {
       ok: true,
       sourceSchemaVersion: 21,
       migrated: true,
-      project: { schemaVersion: 22, structureRevision: 0 },
+      project: { schemaVersion: 23, structureRevision: 0 },
     });
   });
 

--- a/packages/project-protocol/src/transforms/project.ts
+++ b/packages/project-protocol/src/transforms/project.ts
@@ -20,7 +20,7 @@ export class ProjectMigrationError extends Error {
  * while deterministic evidence is added beside them. Historical destructive
  * merge lineage cannot be reconstructed and is never fabricated here.
  */
-export function upgradePreviousProject(
+export function upgradeSchema21To22(
   raw: Record<string, unknown>,
 ): Record<string, unknown> {
   const project = structuredClone(raw);
@@ -98,6 +98,13 @@ export function upgradePreviousProject(
         const powerDomain = legacyPowerDomain(net);
         const ownerKind =
           annotation.kind === "power-label" ? "power-marker" : "net-label";
+        const markerObjectId =
+          annotation.kind === "power-label" &&
+          isRecord(annotation.anchor) &&
+          annotation.anchor.kind === "object" &&
+          typeof annotation.anchor.objectId === "string"
+            ? annotation.anchor.objectId
+            : annotation.id;
         evidence.push({
           id: evidenceId(
             documentId,
@@ -110,7 +117,7 @@ export function upgradePreviousProject(
           name,
           owner:
             ownerKind === "power-marker"
-              ? { kind: "power-marker", objectId: annotation.id }
+              ? { kind: "power-marker", objectId: markerObjectId }
               : { kind: "net-label", annotationId: annotation.id },
           scope: net.scope === "global" ? "global" : "local",
           ...(powerDomain ? { powerDomain } : {}),
@@ -119,7 +126,7 @@ export function upgradePreviousProject(
       rawDocument.connectivityEvidence = evidence;
     }
   }
-  project.schemaVersion = CURRENT_PROJECT_SCHEMA_VERSION;
+  project.schemaVersion = 22;
   return project;
 }
 
@@ -129,7 +136,7 @@ export function upgradePreviousProject(
  * load-boundary normalization merely restores information that the same file
  * already carries in its inert schema-21 Net projection.
  */
-export function repairCurrentProjectEvidence(
+export function repairSchema22ProjectEvidence(
   raw: Record<string, unknown>,
 ): Record<string, unknown> {
   const project = structuredClone(raw);
@@ -144,13 +151,13 @@ export function repairCurrentProjectEvidence(
         typeof net.id === "string" ? [[net.id, net] as const] : [],
       ),
     );
-    const powerLabelIds = new Set(
+    const powerLabelsById = new Map(
       (Array.isArray(rawDocument.annotations)
         ? rawDocument.annotations.filter(isRecord)
         : []
       ).flatMap((annotation) =>
         annotation.kind === "power-label" && typeof annotation.id === "string"
-          ? [annotation.id]
+          ? [[annotation.id, annotation] as const]
           : [],
       ),
     );
@@ -176,12 +183,59 @@ export function repairCurrentProjectEvidence(
       if (
         owner?.kind === "net-label" &&
         typeof owner.annotationId === "string" &&
-        powerLabelIds.has(owner.annotationId)
+        powerLabelsById.has(owner.annotationId)
       ) {
-        claim.owner = { kind: "power-marker", objectId: owner.annotationId };
+        const annotation = powerLabelsById.get(owner.annotationId);
+        const anchor = isRecord(annotation?.anchor) ? annotation.anchor : null;
+        claim.owner = {
+          kind: "power-marker",
+          objectId:
+            anchor?.kind === "object" && typeof anchor.objectId === "string"
+              ? anchor.objectId
+              : owner.annotationId,
+        };
+      } else if (
+        owner?.kind === "power-marker" &&
+        typeof owner.objectId === "string" &&
+        powerLabelsById.has(owner.objectId)
+      ) {
+        const annotation = powerLabelsById.get(owner.objectId);
+        const anchor = isRecord(annotation?.anchor) ? annotation.anchor : null;
+        if (anchor?.kind === "object" && typeof anchor.objectId === "string") {
+          claim.owner = { kind: "power-marker", objectId: anchor.objectId };
+        }
       }
     }
   }
+  return project;
+}
+
+/** Schema 23 makes Base Nets purely physical; Evidence owns every logical fact. */
+export function upgradeSchema22To23(
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  const project = repairSchema22ProjectEvidence(raw);
+  return canonicalizeSchema23Project(project);
+}
+
+/** Remove convergence-only projections from an already-versioned schema-23 input. */
+export function canonicalizeSchema23Project(
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  const project = structuredClone(raw);
+  if (Array.isArray(project.documents)) {
+    for (const rawDocument of project.documents) {
+      if (!isRecord(rawDocument) || !Array.isArray(rawDocument.nets)) continue;
+      for (const rawNet of rawDocument.nets) {
+        if (!isRecord(rawNet)) continue;
+        delete rawNet.name;
+        delete rawNet.scope;
+        delete rawNet.powerDomain;
+        delete rawNet.origin;
+      }
+    }
+  }
+  project.schemaVersion = CURRENT_PROJECT_SCHEMA_VERSION;
   return project;
 }
 

--- a/packages/project-protocol/src/version.ts
+++ b/packages/project-protocol/src/version.ts
@@ -2,4 +2,6 @@
  * The rolling compatibility window is deliberately explicit. Advancing the
  * current schema replaces this adapter instead of extending a migration chain.
  */
-export const PREVIOUS_PROJECT_SCHEMA_VERSION = 21;
+export const PREVIOUS_PROJECT_SCHEMA_VERSION = 22;
+/** Temporary online-convergence input. Removed after Gallery storage reaches 23. */
+export const GALLERY_MIGRATION_SCHEMA_VERSION = 21;

--- a/packages/spice/src/importer.ts
+++ b/packages/spice/src/importer.ts
@@ -336,7 +336,6 @@ function importDocument(
   );
   const nets: Net[] = cell.nets.map((net) => ({
     id: net.id,
-    scope: net.scope,
     terminals: visibleInstances
       .filter((instance) => importedInstanceById.has(instance.id))
       .flatMap((instance) =>

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -2,7 +2,7 @@ import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 
 import { createEmptyProject, CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
-import { serializeProject } from "@icm/project-protocol";
+import { parseProject, serializeProject } from "@icm/project-protocol";
 
 import {
   GALLERY_DAILY_SUBMISSION_LIMIT,
@@ -122,7 +122,7 @@ function previousVersionText(): string {
 
 function previousPowerRailVersionText(): string {
   const raw = JSON.parse(projectText("Legacy VDD")) as any;
-  raw.schemaVersion = CURRENT_PROJECT_SCHEMA_VERSION - 1;
+  raw.schemaVersion = 21;
   const document = raw.documents[0];
   delete document.connectivityEvidence;
   document.nets.push({
@@ -171,7 +171,7 @@ function previousPowerRailVersionText(): string {
 
 function brokenCurrentPowerRailText(): string {
   const raw = JSON.parse(previousPowerRailVersionText()) as any;
-  raw.schemaVersion = CURRENT_PROJECT_SCHEMA_VERSION;
+  raw.schemaVersion = 22;
   raw.documents[0].connectivityEvidence = [
     {
       id: "legacy-explicit-vdd",
@@ -1589,11 +1589,12 @@ describe("gallery administration", () => {
         headers: cookieHeaders(adminCookie),
       }),
     );
-    const report = (await maintenance.json()) as {
-      upgraded: number;
-      failed: unknown[];
-    };
-    expect(report).toMatchObject({ upgraded: 1, failed: [] });
+    expect(await maintenance.json()).toMatchObject({
+      applied: true,
+      ready: 1,
+      failures: [],
+      targetSchemaVersion: CURRENT_PROJECT_SCHEMA_VERSION,
+    });
 
     const detail = await route(env, new Request(`${ORIGIN}/api/gallery/${id}`));
     const payload = (await detail.json()) as {
@@ -1636,7 +1637,12 @@ describe("gallery administration", () => {
         headers: cookieHeaders(adminCookie),
       }),
     );
-    expect(await maintenance.json()).toMatchObject({ upgraded: 1, failed: [] });
+    expect(await maintenance.json()).toMatchObject({
+      applied: true,
+      ready: 1,
+      failures: [],
+      targetSchemaVersion: CURRENT_PROJECT_SCHEMA_VERSION,
+    });
 
     const detail = await route(env, new Request(`${ORIGIN}/api/gallery/${id}`));
     const payload = (await detail.json()) as { projectText: string };
@@ -1654,7 +1660,143 @@ describe("gallery administration", () => {
       env,
       new Request(`${ORIGIN}/api/gallery/${id}/preview.svg`),
     );
-    expect(await preview.text()).toContain('stroke-width="3.24"');
+    expect(await preview.text()).toBe("<svg/>");
+  });
+
+  it("backs up, dry-runs, and atomically converges every Project table", async () => {
+    const env = environment();
+    const adminCookie = await adminOf(env);
+    const id = await submitOne(env, "Schema convergence", {
+      cookie: adminCookie,
+    });
+    await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}`, {
+        method: "PUT",
+        headers: {
+          Origin: ORIGIN,
+          Cookie: adminCookie,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "Schema convergence v2",
+          projectText: projectText("Schema convergence v2"),
+        }),
+      }),
+    );
+    const versionId = env.gallerySql
+      .exec<{ id: string }>(
+        "SELECT id FROM gallery_entry_versions WHERE entry_id = ?",
+        id,
+      )
+      .one().id;
+    env.gallerySql.exec(
+      "UPDATE gallery_entries SET schema_version = ?, project_text = ? WHERE id = ?",
+      22,
+      previousVersionText(),
+      id,
+    );
+    env.gallerySql.exec(
+      "UPDATE gallery_entry_versions SET schema_version = ?, project_text = ? WHERE id = ?",
+      21,
+      previousPowerRailVersionText(),
+      versionId,
+    );
+    env.gallerySql.exec(
+      `INSERT INTO workspace_slots
+       (id, user_id, name, saved_at, seq, schema_version, project_text)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      "workspace-legacy",
+      "user-legacy",
+      "Legacy workspace",
+      "2026-08-24T00:00:00.000Z",
+      1,
+      21,
+      previousPowerRailVersionText(),
+    );
+
+    const backup = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/maintenance/schema-backup`, {
+        headers: cookieHeaders(adminCookie),
+      }),
+    );
+    expect(backup.status).toBe(200);
+    expect(backup.headers.get("content-disposition")).toContain("attachment");
+    const backupPayload = (await backup.json()) as any;
+    expect(backupPayload.tables.galleryEntries).toHaveLength(1);
+    expect(backupPayload.tables.galleryEntryVersions).toHaveLength(1);
+    expect(backupPayload.tables.workspaceSlots).toHaveLength(1);
+
+    const dryRun = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/maintenance/schema23`, {
+        method: "POST",
+        headers: {
+          ...cookieHeaders(adminCookie),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ apply: false }),
+      }),
+    );
+    expect(await dryRun.json()).toMatchObject({
+      applied: false,
+      ready: 3,
+      failures: [],
+      inventory: {
+        gallery_entries: { "22": 1 },
+        gallery_entry_versions: { "21": 1 },
+        workspace_slots: { "21": 1 },
+      },
+    });
+    expect(
+      env.gallerySql
+        .exec<{ schema_version: number }>(
+          "SELECT schema_version FROM gallery_entries WHERE id = ?",
+          id,
+        )
+        .one().schema_version,
+    ).toBe(22);
+
+    const applied = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/maintenance/schema23`, {
+        method: "POST",
+        headers: {
+          ...cookieHeaders(adminCookie),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ apply: true }),
+      }),
+    );
+    expect(await applied.json()).toMatchObject({
+      applied: true,
+      ready: 3,
+      failures: [],
+    });
+    for (const table of [
+      "gallery_entries",
+      "gallery_entry_versions",
+      "workspace_slots",
+    ]) {
+      const row = env.gallerySql
+        .exec<{
+          id: string;
+          schema_version: number;
+          project_text: string;
+        }>(`SELECT id, schema_version, project_text FROM ${table}`)
+        .one();
+      expect(row.schema_version).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
+      expect(parseProject(row.project_text).schemaVersion).toBe(
+        CURRENT_PROJECT_SCHEMA_VERSION,
+      );
+      const stored = JSON.parse(row.project_text) as any;
+      for (const document of stored.documents) {
+        for (const net of document.nets) {
+          expect(Object.keys(net).sort()).toEqual(["id", "terminals"]);
+        }
+      }
+    }
   });
 });
 

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -18,7 +18,10 @@ import { analyzeDesignNetlist } from "@icm/netlist";
 import { parseProject, serializeProject } from "@icm/project-protocol";
 import { renderDocumentSvg } from "@icm/render-svg";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
-import type { CircuitProject } from "@icm/model";
+import {
+  CURRENT_PROJECT_SCHEMA_VERSION,
+  type CircuitProject,
+} from "@icm/model";
 
 import { sessionUserOf, type AuthNamespaceLike } from "./auth";
 
@@ -59,6 +62,12 @@ interface WorkspaceSlotRow {
   name: string;
   saved_at: string;
   schema_version: number;
+}
+
+interface StoredProjectRow {
+  id: string;
+  schema_version: number;
+  project_text: string;
 }
 export const GALLERY_MAX_NAME_LENGTH = 120;
 export const GALLERY_MAX_AUTHOR_LENGTH = 40;
@@ -376,6 +385,10 @@ export class GalleryDO {
         return this.workspaceList(String(body.userId));
       case "workspace-open":
         return this.workspaceOpen(String(body.userId), String(body.id));
+      case "schema-backup":
+        return this.schemaBackup();
+      case "schema-converge":
+        return this.schemaConverge(body.apply === true);
       default:
         return Response.json({ error: "Unknown operation" }, { status: 404 });
     }
@@ -798,6 +811,19 @@ export class GalleryDO {
     if (!entry || !version) {
       return Response.json({ error: "not-found" }, { status: 404 });
     }
+    let restoredProject: CircuitProject;
+    try {
+      restoredProject = parseProject(version.project_text);
+    } catch (error) {
+      return Response.json(
+        {
+          error: "invalid-version-project",
+          message: error instanceof Error ? error.message : String(error),
+        },
+        { status: 409 },
+      );
+    }
+    const restoredProjectText = serializeProject(restoredProject);
     this.state.storage.transactionSync(() => {
       this.snapshotEntry(entry, String(body.at));
       this.sql.exec(
@@ -808,9 +834,9 @@ export class GalleryDO {
         version.name,
         version.author,
         version.description,
-        version.project_text,
+        restoredProjectText,
         version.svg_text,
-        version.schema_version,
+        restoredProject.schemaVersion,
         version.tags ?? "",
         entry.id,
       );
@@ -913,6 +939,127 @@ export class GalleryDO {
       savedAt: row.saved_at,
       schemaVersion: row.schema_version,
       projectText: row.project_text,
+    });
+  }
+
+  /** Full-fidelity administrator backup before an online schema migration. */
+  private schemaBackup(): Response {
+    return Response.json({
+      format: "analog-canvas-gallery-schema-backup-v1",
+      exportedAt: new Date().toISOString(),
+      targetSchemaVersion: CURRENT_PROJECT_SCHEMA_VERSION,
+      tables: {
+        galleryEntries: this.sql
+          .exec<Record<string, unknown>>("SELECT * FROM gallery_entries")
+          .toArray(),
+        galleryEntryVersions: this.sql
+          .exec<Record<string, unknown>>("SELECT * FROM gallery_entry_versions")
+          .toArray(),
+        workspaceSlots: this.sql
+          .exec<Record<string, unknown>>("SELECT * FROM workspace_slots")
+          .toArray(),
+      },
+    });
+  }
+
+  /**
+   * Validate every persisted Project before writing any of them. The apply
+   * phase is one Durable Object transaction, so a failed record cannot leave
+   * the three storage surfaces at mixed schema versions.
+   */
+  private schemaConverge(apply: boolean): Response {
+    const sources = [
+      {
+        table: "gallery_entries",
+        rows: this.sql
+          .exec<StoredProjectRow>(
+            "SELECT id, schema_version, project_text FROM gallery_entries",
+          )
+          .toArray(),
+      },
+      {
+        table: "gallery_entry_versions",
+        rows: this.sql
+          .exec<StoredProjectRow>(
+            "SELECT id, schema_version, project_text FROM gallery_entry_versions",
+          )
+          .toArray(),
+      },
+      {
+        table: "workspace_slots",
+        rows: this.sql
+          .exec<StoredProjectRow>(
+            "SELECT id, schema_version, project_text FROM workspace_slots",
+          )
+          .toArray(),
+      },
+    ] as const;
+    const inventory: Record<string, Record<string, number>> = {};
+    const updates: Array<{
+      table: (typeof sources)[number]["table"];
+      id: string;
+      projectText: string;
+    }> = [];
+    const failures: Array<{
+      table: string;
+      id: string;
+      storedSchemaVersion: number;
+      message: string;
+    }> = [];
+    for (const source of sources) {
+      const versions: Record<string, number> = {};
+      inventory[source.table] = versions;
+      for (const row of source.rows) {
+        const versionKey = String(row.schema_version);
+        versions[versionKey] = (versions[versionKey] ?? 0) + 1;
+        try {
+          const project = parseProject(row.project_text);
+          updates.push({
+            table: source.table,
+            id: row.id,
+            projectText: serializeProject(project),
+          });
+        } catch (error) {
+          failures.push({
+            table: source.table,
+            id: row.id,
+            storedSchemaVersion: row.schema_version,
+            message: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+    if (apply && failures.length > 0) {
+      return Response.json(
+        {
+          applied: false,
+          targetSchemaVersion: CURRENT_PROJECT_SCHEMA_VERSION,
+          inventory,
+          failures,
+        },
+        { status: 409 },
+      );
+    }
+    if (apply) {
+      this.state.storage.transactionSync(() => {
+        for (const update of updates) {
+          this.sql.exec(
+            `UPDATE ${update.table}
+             SET project_text = ?, schema_version = ? WHERE id = ?`,
+            update.projectText,
+            CURRENT_PROJECT_SCHEMA_VERSION,
+            update.id,
+          );
+        }
+      });
+    }
+    return Response.json({
+      applied: apply,
+      targetSchemaVersion: CURRENT_PROJECT_SCHEMA_VERSION,
+      inventory,
+      records: updates.length + failures.length,
+      ready: updates.length,
+      failures,
     });
   }
 
@@ -1153,7 +1300,7 @@ async function handleWorkspace(
     name,
     savedAt: new Date().toISOString(),
     schemaVersion: project.schemaVersion,
-    projectText: body.projectText,
+    projectText: serializeProject(project),
   });
   return Response.json(payload, { status });
 }
@@ -1345,33 +1492,10 @@ async function handleEntryUpdate(
 }
 
 async function handleReserialize(env: GalleryEnv): Promise<Response> {
-  const { payload } = await callGallery<{ ids: string[] }>(env, "all-ids", {});
-  let upgraded = 0;
-  const failed: { id: string; message: string }[] = [];
-  for (const id of payload.ids) {
-    const detail = await callGallery<{ projectText?: string }>(
-      env,
-      "any-entry",
-      { id },
-    );
-    if (!detail.payload.projectText) continue;
-    try {
-      const project = parseProject(detail.payload.projectText);
-      await callGallery(env, "update-entry", {
-        id,
-        projectText: serializeProject(project),
-        schemaVersion: project.schemaVersion,
-        svgText: renderPreview(project),
-      });
-      upgraded += 1;
-    } catch (error) {
-      failed.push({
-        id,
-        message: error instanceof Error ? error.message : String(error),
-      });
-    }
-  }
-  return Response.json({ upgraded, failed });
+  const { status, payload } = await callGallery(env, "schema-converge", {
+    apply: true,
+  });
+  return Response.json(payload, { status });
 }
 
 /**
@@ -1455,6 +1579,44 @@ export async function routeGalleryRequest(
     }
     const { payload } = await callGallery(env, "recycled", {});
     return Response.json(payload, {
+      headers: { "cache-control": "no-store" },
+    });
+  }
+  if (
+    segments.length === 2 &&
+    segments[0] === "maintenance" &&
+    segments[1] === "schema-backup" &&
+    request.method === "GET"
+  ) {
+    if (!(await isAdmin(request, env))) {
+      return Response.json({ error: "unauthorized" }, { status: 401 });
+    }
+    const { status, payload } = await callGallery(env, "schema-backup", {});
+    return Response.json(payload, {
+      status,
+      headers: {
+        "cache-control": "no-store",
+        "content-disposition": `attachment; filename="analog-canvas-gallery-schema-backup-${new Date().toISOString().slice(0, 10)}.json"`,
+      },
+    });
+  }
+  if (
+    segments.length === 2 &&
+    segments[0] === "maintenance" &&
+    segments[1] === "schema23" &&
+    request.method === "POST"
+  ) {
+    if (!(await isAdmin(request, env))) {
+      return Response.json({ error: "unauthorized" }, { status: 401 });
+    }
+    const body = (await request.json().catch(() => null)) as {
+      apply?: unknown;
+    } | null;
+    const { status, payload } = await callGallery(env, "schema-converge", {
+      apply: body?.apply === true,
+    });
+    return Response.json(payload, {
+      status,
       headers: { "cache-control": "no-store" },
     });
   }


### PR DESCRIPTION
## Summary
- introduce schema 23 with topology-only Base Net serialization
- repair schema-21 object-anchored VDD migration
- add administrator backup, dry-run, and atomic migration across Gallery entries, history, and workspace slots
- canonicalize workspace saves and history restores

## Validation
- public Gallery audit: 28/28 current entries converge to schema 23
- pnpm ci:check (196 unit files / 1316 tests, build/release checks, 233 browser tests)

Test-Impact: tests-updated