### PR TITLE
feat(auth): support additive administrator emails

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -47,7 +47,7 @@ jobs:
       # GITHUB_, hence GH_OAUTH_*.
       - name: Sync worker secrets
         run: |
-          for name in GH_OAUTH_CLIENT_ID GH_OAUTH_CLIENT_SECRET GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET RESEND_API_KEY AUTH_EMAIL_FROM ADMIN_EMAILS; do
+          for name in GH_OAUTH_CLIENT_ID GH_OAUTH_CLIENT_SECRET GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET RESEND_API_KEY AUTH_EMAIL_FROM ADMIN_EMAILS ADMIN_EMAILS_EXTRA; do
             value="${!name}"
             if [ -z "$value" ]; then
               echo "$name is not configured; skipping"
@@ -65,3 +65,4 @@ jobs:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           AUTH_EMAIL_FROM: ${{ secrets.AUTH_EMAIL_FROM }}
           ADMIN_EMAILS: ${{ secrets.ADMIN_EMAILS }}
+          ADMIN_EMAILS_EXTRA: ${{ secrets.ADMIN_EMAILS_EXTRA }}

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -182,10 +182,12 @@ database stores only SHA-256 hashes of session and login tokens.
 
 Identities from different providers are distinct accounts in G2 (linking
 is a later refinement). Super-admin is computed per request: a session
-whose email appears in the `ADMIN_EMAILS` secret (comma-separated,
-case-insensitive) has admin authority — including the administration
-routes below — and rotation of `ADMIN_EMAILS` needs no re-login. The
-session cookie is the only publishing credential there is: there is no
+whose email appears in the union of the `ADMIN_EMAILS` and additive
+`ADMIN_EMAILS_EXTRA` secrets (both comma-separated and case-insensitive)
+has admin authority — including the administration routes below — and
+rotation of either secret needs no re-login. The additive secret allows
+operators to grant access without replacing the primary administrator
+list. The session cookie is the only publishing credential there is: there is no
 passphrase, bearer token, or shared secret anywhere on the gallery
 write path.
 

--- a/worker/auth.test.ts
+++ b/worker/auth.test.ts
@@ -213,6 +213,22 @@ describe("email magic-link sign-in", () => {
     expect(await me(auth)).toBeNull();
   });
 
+  it("unions the primary and additive administrator email secrets", async () => {
+    const auth = harness({
+      RESEND_API_KEY: "rk",
+      ADMIN_EMAILS: "owner@example.com",
+      ADMIN_EMAILS_EXTRA: " Added.Admin@Example.com ",
+    });
+
+    const ownerCookie = await emailSignIn(auth, "owner@example.com");
+    const addedCookie = await emailSignIn(auth, "added.admin@example.com");
+    const ordinaryCookie = await emailSignIn(auth, "user@example.com");
+
+    expect((await me(auth, ownerCookie))?.isAdmin).toBe(true);
+    expect((await me(auth, addedCookie))?.isAdmin).toBe(true);
+    expect((await me(auth, ordinaryCookie))?.isAdmin).toBe(false);
+  });
+
   it("magic links are single-use, expire, and are rate-limited", async () => {
     const auth = harness({ RESEND_API_KEY: "rk" });
     const sent: { to: string; text: string }[] = [];

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -6,9 +6,10 @@
 // until its secrets are configured. The browser holds a random session
 // token in an HttpOnly cookie; the database stores only SHA-256 hashes of
 // session and login tokens, so a copied database cannot impersonate
-// anyone. Super-admin is computed per request from the `ADMIN_EMAILS`
-// secret (comma-separated, case-insensitive) — rotating it needs no
-// re-login. Provider HTTP calls go through an injectable fetch seam so
+// anyone. Super-admin is computed per request from the union of the
+// `ADMIN_EMAILS` and additive `ADMIN_EMAILS_EXTRA` secrets
+// (comma-separated, case-insensitive) — rotating either needs no re-login.
+// Provider HTTP calls go through an injectable fetch seam so
 // tests never touch the network.
 
 export const AUTH_SESSION_COOKIE = "icm_session";
@@ -49,6 +50,7 @@ export type AuthEnv = {
   RESEND_API_KEY?: string;
   AUTH_EMAIL_FROM?: string;
   ADMIN_EMAILS?: string;
+  ADMIN_EMAILS_EXTRA?: string;
 };
 
 export interface SessionUser {
@@ -84,7 +86,9 @@ function enabledProviders(env: AuthEnv): {
 }
 
 function adminEmails(env: AuthEnv): string[] {
-  return (env.ADMIN_EMAILS ?? "")
+  return [env.ADMIN_EMAILS, env.ADMIN_EMAILS_EXTRA]
+    .filter((value): value is string => typeof value === "string")
+    .join(",")
     .split(",")
     .map((email) => email.trim().toLowerCase())
     .filter((email) => email.length > 0);

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -106,6 +106,7 @@ export type GalleryEnv = {
   /** Sessions are the only identity: publishing requires one. */
   AUTH?: AuthNamespaceLike;
   ADMIN_EMAILS?: string;
+  ADMIN_EMAILS_EXTRA?: string;
 };
 
 export interface GalleryEntrySummary {

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -36,6 +36,7 @@ type Env = {
   RESEND_API_KEY?: string;
   AUTH_EMAIL_FROM?: string;
   ADMIN_EMAILS?: string;
+  ADMIN_EMAILS_EXTRA?: string;
 };
 
 type RequestCf = {


### PR DESCRIPTION
Adds an independently rotatable ADMIN_EMAILS_EXTRA secret and unions it with the existing primary administrator list. This grants the current Google operator access without overwriting established admins.\n\nValidation:\n- corepack pnpm test:local worker/auth.test.ts\n- corepack pnpm gate:preflight -- --base origin/main\n- corepack pnpm install --frozen-lockfile\n- corepack pnpm ci:check (196 files / 1317 unit tests; build/release smoke; 233 E2E)\n\nTest-Impact: tests-updated