### PR TITLE
feat(gallery): add schema maintenance controls

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -836,6 +836,7 @@ test("an ordinary user sees blocking quality gates on an empty project", async (
 test("the retired review queue is gone from the moderation page", async ({
   page,
 }) => {
+  const convergenceCalls: boolean[] = [];
   await page.route("**/api/auth/me", (route) =>
     route.fulfill({
       json: {
@@ -853,9 +854,44 @@ test("the retired review queue is gone from the moderation page", async ({
   await page.route("**/api/gallery/recycled", (route) =>
     route.fulfill({ json: { entries: [] } }),
   );
+  await page.route("**/api/gallery/maintenance/schema23", async (route) => {
+    const body = route.request().postDataJSON() as { apply?: boolean };
+    convergenceCalls.push(body.apply === true);
+    await route.fulfill({
+      json: {
+        applied: body.apply === true,
+        targetSchemaVersion: 23,
+        inventory: {
+          gallery_entries: { "21": 2, "22": 1 },
+          gallery_entry_versions: { "21": 1 },
+          workspace_slots: { "22": 1 },
+        },
+        records: 5,
+        ready: 5,
+        failures: [],
+      },
+    });
+  });
 
   await page.goto("/moderation");
   await expect(page.getByTestId("moderation")).toBeVisible();
+  await expect(page.getByTestId("schema-backup-download")).toHaveAttribute(
+    "href",
+    "/api/gallery/maintenance/schema-backup",
+  );
+  await page.getByTestId("schema23-dry-run").click();
+  await expect(page.getByTestId("schema23-report")).toContainText(
+    "Validated: 5/5 records ready for schema 23; 0 failures.",
+  );
+  await expect(page.getByTestId("schema23-report")).toContainText(
+    "gallery_entries: v21=2, v22=1",
+  );
+  page.once("dialog", (dialog) => void dialog.accept());
+  await page.getByTestId("schema23-apply").click();
+  await expect(page.getByTestId("schema23-report")).toContainText(
+    "Applied: 5/5 records ready for schema 23; 0 failures.",
+  );
+  expect(convergenceCalls).toEqual([false, true]);
   // Curation is post-publication now: a bin to restore from, no inbox.
   await expect(page.getByTestId("bin-empty")).toBeVisible();
   await expect(page.getByTestId("review-empty")).toHaveCount(0);

--- a/apps/editor/src/components/moderation.tsx
+++ b/apps/editor/src/components/moderation.tsx
@@ -57,6 +57,116 @@ interface RecycledEntry {
   recycledAt?: string | null;
 }
 
+interface SchemaConvergenceReport {
+  applied: boolean;
+  targetSchemaVersion: number;
+  inventory: Record<string, Record<string, number>>;
+  records: number;
+  ready: number;
+  failures: Array<{
+    table: string;
+    id: string;
+    storedSchemaVersion: number;
+    message: string;
+  }>;
+}
+
+function SchemaMaintenance() {
+  const [running, setRunning] = useState(false);
+  const [report, setReport] = useState<SchemaConvergenceReport | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function converge(apply: boolean): Promise<void> {
+    if (
+      apply &&
+      !window.confirm(
+        "Apply schema 23 to every Gallery entry, saved version, and workspace slot? A full backup should already exist.",
+      )
+    ) {
+      return;
+    }
+    setRunning(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/gallery/maintenance/schema23", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ apply }),
+      });
+      const payload = (await response.json()) as
+        SchemaConvergenceReport | { error?: string };
+      if (!response.ok || !("inventory" in payload)) {
+        throw new Error("error" in payload ? payload.error : undefined);
+      }
+      setReport(payload);
+    } catch (cause) {
+      setError(
+        cause instanceof Error && cause.message
+          ? cause.message
+          : "Schema maintenance failed.",
+      );
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  return (
+    <section className="review-bin" data-testid="schema-maintenance">
+      <h2>Project schema maintenance</h2>
+      <p className="review-card-meta">
+        Back up all stored Projects, validate the complete inventory, then apply
+        one transactional schema 23 convergence.
+      </p>
+      <div className="review-card-actions">
+        <a
+          href="/api/gallery/maintenance/schema-backup"
+          data-testid="schema-backup-download"
+        >
+          Download full backup
+        </a>
+        <button
+          type="button"
+          disabled={running}
+          data-testid="schema23-dry-run"
+          onClick={() => void converge(false)}
+        >
+          Validate schema 23
+        </button>
+        <button
+          type="button"
+          className="review-approve"
+          disabled={running || (report !== null && report.failures.length > 0)}
+          data-testid="schema23-apply"
+          onClick={() => void converge(true)}
+        >
+          Apply schema 23
+        </button>
+      </div>
+      {error ? <p className="account-notice">{error}</p> : null}
+      {report ? (
+        <div className="gallery-status" data-testid="schema23-report">
+          <p>
+            {report.applied ? "Applied" : "Validated"}: {report.ready}/
+            {report.records} records ready for schema{" "}
+            {report.targetSchemaVersion}; {report.failures.length} failures.
+          </p>
+          <ul>
+            {Object.entries(report.inventory).map(([table, versions]) => (
+              <li key={table}>
+                {table}:{" "}
+                {Object.entries(versions)
+                  .map(([version, count]) => `v${version}=${count}`)
+                  .join(", ") || "empty"}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
 /**
  * The recycle bin: the takedown surface. Restore returns an entry to the
  * public wall; Delete forever is the only hard deletion and asks for
@@ -221,7 +331,10 @@ export function Moderation() {
           </form>
         ) : null}
         {state.user.isAdmin ? (
-          <RecycleBin />
+          <>
+            <SchemaMaintenance />
+            <RecycleBin />
+          </>
         ) : (
           <p className="gallery-status">
             Withdraw an entry from its page; the owner and the admin can bring


### PR DESCRIPTION
Adds an administrator-only maintenance panel for full backups, schema23 dry-runs, inventory review, and confirmed transactional apply.\n\nValidation:\n- pnpm test:e2e:local apps/editor/e2e/gallery.spec.ts --grep 'retired review queue'\n- pnpm gate:preflight -- --base origin/main\n- pnpm install --frozen-lockfile\n- pnpm ci:check (196 files / 1317 unit tests; build/release smoke; 233 E2E)\n\nTest-Impact: tests-updated