### PR TITLE
fix(gallery): make schema apply automation-safe

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -879,6 +879,7 @@ test("the retired review queue is gone from the moderation page", async ({
     "href",
     "/api/gallery/maintenance/schema-backup",
   );
+  await expect(page.getByTestId("schema23-apply")).toBeDisabled();
   await page.getByTestId("schema23-dry-run").click();
   await expect(page.getByTestId("schema23-report")).toContainText(
     "Validated: 5/5 records ready for schema 23; 0 failures.",
@@ -886,7 +887,8 @@ test("the retired review queue is gone from the moderation page", async ({
   await expect(page.getByTestId("schema23-report")).toContainText(
     "gallery_entries: v21=2, v22=1",
   );
-  page.once("dialog", (dialog) => void dialog.accept());
+  await expect(page.getByTestId("schema23-apply")).toBeDisabled();
+  await page.getByTestId("schema23-backup-confirmed").check();
   await page.getByTestId("schema23-apply").click();
   await expect(page.getByTestId("schema23-report")).toContainText(
     "Applied: 5/5 records ready for schema 23; 0 failures.",

--- a/apps/editor/src/components/moderation.tsx
+++ b/apps/editor/src/components/moderation.tsx
@@ -75,18 +75,16 @@ function SchemaMaintenance() {
   const [running, setRunning] = useState(false);
   const [report, setReport] = useState<SchemaConvergenceReport | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [backupConfirmed, setBackupConfirmed] = useState(false);
+  const [validated, setValidated] = useState(false);
 
   async function converge(apply: boolean): Promise<void> {
-    if (
-      apply &&
-      !window.confirm(
-        "Apply schema 23 to every Gallery entry, saved version, and workspace slot? A full backup should already exist.",
-      )
-    ) {
-      return;
-    }
     setRunning(true);
     setError(null);
+    if (!apply) {
+      setValidated(false);
+      setBackupConfirmed(false);
+    }
     try {
       const response = await fetch("/api/gallery/maintenance/schema23", {
         method: "POST",
@@ -100,6 +98,12 @@ function SchemaMaintenance() {
         throw new Error("error" in payload ? payload.error : undefined);
       }
       setReport(payload);
+      if (!apply) {
+        setValidated(payload.failures.length === 0);
+      } else {
+        setValidated(false);
+        setBackupConfirmed(false);
+      }
     } catch (cause) {
       setError(
         cause instanceof Error && cause.message
@@ -136,13 +140,23 @@ function SchemaMaintenance() {
         <button
           type="button"
           className="review-approve"
-          disabled={running || (report !== null && report.failures.length > 0)}
+          disabled={running || !validated || !backupConfirmed}
           data-testid="schema23-apply"
           onClick={() => void converge(true)}
         >
           Apply schema 23
         </button>
       </div>
+      <label className="review-card-meta">
+        <input
+          type="checkbox"
+          checked={backupConfirmed}
+          disabled={running || !validated}
+          data-testid="schema23-backup-confirmed"
+          onChange={(event) => setBackupConfirmed(event.currentTarget.checked)}
+        />{" "}
+        I verified the full backup and the zero-failure validation report.
+      </label>
       {error ? <p className="account-notice">{error}</p> : null}
       {report ? (
         <div className="gallery-status" data-testid="schema23-report">


### PR DESCRIPTION
## Summary
- replace the blocking native confirmation dialog with an explicit backup-verification checkbox
- enable schema application only after a zero-failure validation
- cover the maintenance gate in the existing moderation browser test

## Validation
- `pnpm test:e2e:local apps/editor/e2e/gallery.spec.ts --grep "retired review queue"`
- `pnpm gate:preflight -- --base origin/main`
- `pnpm install --frozen-lockfile`
- `pnpm ci:check`

Test-Impact: tests-updated