### PR TITLE
refactor(project): retire the schema 21 convergence bridge

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -2770,7 +2770,6 @@ test("derives crossings and creates junctions only when a wire ends on a route",
   // deliberately captures D.P, so named HORIZONTAL/VERTICAL claims would
   // correctly turn it into an electrical name conflict instead.
   project.documents[0]!.connectivityEvidence = [];
-  for (const net of project.documents[0]!.nets) delete net.name;
   await page.getByTestId("project-file").setInputFiles({
     name: "routing-example.icproj.json",
     mimeType: "application/json",
@@ -2830,15 +2829,11 @@ test("places a Ground pin onto a canonical Route and keeps real split topology",
   const document = project.documents[0]!;
   const horizontalNet = document.nets.find((net) => net.id === "net-h");
   if (!horizontalNet) throw new Error("Routing demo is missing net-h");
-  Object.assign(horizontalNet, {
-    name: "0",
-    scope: "global" as const,
-    powerDomain: "ground" as const,
-  });
   for (const evidence of document.connectivityEvidence) {
     if (evidence.kind === "name-claim" && evidence.netId === horizontalNet.id) {
       evidence.name = "0";
       evidence.scope = "global";
+      evidence.powerDomain = "ground";
     }
   }
   document.routes.push({
@@ -2943,9 +2938,17 @@ test("connects every compatible pin crossed by one wire", async ({ page }) => {
   );
   document.nets.push({
     id: "net-ground",
-    name: "0",
-    scope: "global",
+
     terminals: [{ instanceId: "GND1", pinName: "0" }],
+  });
+  document.connectivityEvidence.push({
+    id: "claim-ground",
+    kind: "name-claim",
+    netId: "net-ground",
+    name: "0",
+    owner: { kind: "power-marker", objectId: "GND1" },
+    scope: "global",
+    powerDomain: "ground",
   });
 
   await page.goto("/editor");
@@ -3120,7 +3123,7 @@ test("requires warning review before exporting generated NoConnect nodes", async
   });
   document.nets.push({
     id: "net-in",
-    scope: "local",
+
     terminals: [{ instanceId: "R1", pinName: "1" }],
   });
   document.connectivityEvidence.push({
@@ -3673,7 +3676,7 @@ test("recomputes highlighted routed components after a Net Label is deleted", as
   document.nets = [
     {
       id: "net-historically-merged",
-      scope: "local",
+
       terminals: [],
     },
   ];

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -46,15 +46,12 @@ describe("editor shell", () => {
     document.nets.push(
       {
         id: "net-vdd",
-        name: "VDD",
-        scope: "global",
-        powerDomain: "vdd",
+
         terminals: [{ instanceId: "Msupply", pinName: "B" }],
       },
       {
         id: "net-body-bias",
-        name: "Vbody",
-        scope: "local",
+
         terminals: [{ instanceId: "MbodyBias", pinName: "B" }],
       },
     );

--- a/apps/editor/src/app/editor-document-helpers.test.ts
+++ b/apps/editor/src/app/editor-document-helpers.test.ts
@@ -65,8 +65,7 @@ describe("editor document helpers", () => {
     const document = createEmptyDocument("doc", "Doc");
     document.nets.push({
       id: "net-ui-7",
-      name: "N",
-      scope: "local",
+
       terminals: [],
     });
     document.routes.push({

--- a/apps/editor/src/document/browser-recovery-contract.test.ts
+++ b/apps/editor/src/document/browser-recovery-contract.test.ts
@@ -185,14 +185,13 @@ describe("reviewBrowserRecoveryProject", () => {
     }
   });
 
-  it("accepts a schema-21 recovery envelope after upgrading its Project", () => {
+  it("accepts a schema-22 recovery envelope after upgrading its Project", () => {
     const previous = JSON.parse(projectText);
-    previous.schemaVersion = 21;
-    delete previous.documents[0].connectivityEvidence;
+    previous.schemaVersion = 22;
     const previousText = JSON.stringify(previous);
     const review = reviewBrowserRecoveryProject(
       finalizeBrowserRecoveryRecord(
-        draft({ projectText: previousText, projectSchemaVersion: 21 }),
+        draft({ projectText: previousText, projectSchemaVersion: 22 }),
       ),
     );
 

--- a/apps/editor/src/document/browser-recovery-store.test.ts
+++ b/apps/editor/src/document/browser-recovery-store.test.ts
@@ -533,11 +533,10 @@ describe("migrateLegacyProjectRecovery", () => {
     expect(firstSession(read).latest?.source).toBe("recovered");
   });
 
-  it("stores a schema-21 legacy slot as internally consistent schema 23", async () => {
+  it("stores a schema-22 legacy slot as internally consistent schema 23", async () => {
     const { store } = freshStore();
     const previous = JSON.parse(projectText);
-    previous.schemaVersion = 21;
-    delete previous.documents[0].connectivityEvidence;
+    previous.schemaVersion = 22;
     const previousText = JSON.stringify(previous);
     const storage = memoryStorage({ [PROJECT_RECOVERY_KEY]: previousText });
 

--- a/apps/editor/src/document/project-file-service.test.ts
+++ b/apps/editor/src/document/project-file-service.test.ts
@@ -390,20 +390,19 @@ describe("stageProjectFile", () => {
     });
   });
 
-  it("stages schema 21 as an upgraded schema-23 Project", async () => {
+  it("stages schema 22 as an upgraded schema-23 Project", async () => {
     const previous = JSON.parse(serializeProject(project));
-    previous.schemaVersion = 21;
-    delete previous.documents[0].connectivityEvidence;
+    previous.schemaVersion = 22;
     const previousText = JSON.stringify(previous);
     const outcome = await stageProjectFile(
-      fakeFile("amp-v21.icproj.json", previousText),
+      fakeFile("amp-v22.icproj.json", previousText),
       () => [],
     );
 
     expect(outcome).toMatchObject({
       status: "opened",
-      fileName: "amp-v21.icproj.json",
-      sourceSchemaVersion: 21,
+      fileName: "amp-v22.icproj.json",
+      sourceSchemaVersion: 22,
       migrated: true,
       project: { schemaVersion: 23 },
     });

--- a/apps/editor/src/features/clipboard/clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard.test.ts
@@ -36,7 +36,7 @@ describe("schematic clipboard", () => {
     });
     document.nets.push({
       id: "net-input",
-      scope: "local",
+
       terminals: [{ instanceId: "P1", pinName: "P" }],
     });
     document.netlist = {
@@ -122,8 +122,7 @@ describe("schematic clipboard", () => {
     );
     document.nets.push({
       id: "net-signal",
-      name: "SIGNAL",
-      scope: "local",
+
       terminals: [
         { instanceId: "R1", pinName: "2" },
         { instanceId: "R2", pinName: "1" },
@@ -254,12 +253,12 @@ describe("schematic clipboard", () => {
     document.nets.push(
       {
         id: "net-r1",
-        scope: "local",
+
         terminals: [{ instanceId: "R1", pinName: "1" }],
       },
       {
         id: "net-r2",
-        scope: "local",
+
         terminals: [{ instanceId: "R2", pinName: "1" }],
       },
     );
@@ -647,9 +646,7 @@ describe("schematic clipboard", () => {
     );
     document.nets.push({
       id: "net-global-0",
-      name: "0",
-      scope: "global",
-      powerDomain: "ground",
+
       terminals: [
         { instanceId: "M1", pinName: "B" },
         { instanceId: "M2", pinName: "B" },
@@ -703,11 +700,17 @@ describe("copyWholeDocument", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.nets.push({
       id: "net-vdd",
-      name: "VDD",
-      scope: "local",
-      powerDomain: "vdd",
+
       terminals: [],
-      origin: { kind: "authored" },
+    });
+    document.connectivityEvidence.push({
+      id: "claim-vdd",
+      kind: "name-claim",
+      netId: "net-vdd",
+      name: "VDD",
+      owner: { kind: "explicit-net-property" },
+      scope: "global",
+      powerDomain: "vdd",
     });
     document.junctions.push(
       {
@@ -741,7 +744,11 @@ describe("copyWholeDocument", () => {
     expect(whole?.routes).toHaveLength(1);
     expect(whole?.routes[0]?.presentation).toBe("power-rail");
     expect(whole?.junctions).toHaveLength(2);
-    expect(whole?.nets.map((net) => net.name)).toEqual(["VDD"]);
+    expect(whole?.connectivityEvidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "name-claim", name: "VDD" }),
+      ]),
+    );
   });
 
   it("retains migrated Power Rail name claims when inserting an example", () => {
@@ -817,9 +824,16 @@ describe("a copy stands on its own", () => {
     });
     document.nets.push({
       id: "net-p12",
-      scope: "local",
-      name: "P12",
+
       terminals: [{ instanceId: "P1", pinName: "P" }],
+    });
+    document.connectivityEvidence.push({
+      id: "claim-p12",
+      kind: "name-claim",
+      netId: "net-p12",
+      name: "P12",
+      owner: { kind: "free-port", instanceId: "P1" },
+      scope: "local",
     });
 
     const clipboard = copySelection(document, ["P1"]);
@@ -848,7 +862,13 @@ describe("a copy stands on its own", () => {
     expect(netOf("P1")?.id).not.toBe(netOf(copyId)?.id);
     // The copy brings its own, unnamed Net rather than joining the source's,
     // so naming one of them cannot rename the other.
-    expect(netOf(copyId)?.name).toBeUndefined();
-    expect(netOf("P1")?.name).toBe("P12");
+    const names = new Map(
+      [...resolveDocumentLogicalNets(result.document).groups].map((group) => [
+        group.id,
+        group.name,
+      ]),
+    );
+    expect(names.get(netOf(copyId)?.id ?? "")).toBeUndefined();
+    expect(names.get(netOf("P1")?.id ?? "")).toBe("P12");
   });
 });

--- a/apps/editor/src/features/component-insert/mos-bulk-defaults.test.ts
+++ b/apps/editor/src/features/component-insert/mos-bulk-defaults.test.ts
@@ -76,9 +76,7 @@ describe("initial MOS bulk defaults", () => {
     document.nets.push(
       {
         id: "net-avdd",
-        name: "AVDD",
-        scope: "local",
-        powerDomain: "vdd",
+
         terminals: [
           { instanceId: "M1", pinName: "B" },
           { instanceId: "M2", pinName: "B" },
@@ -86,9 +84,7 @@ describe("initial MOS bulk defaults", () => {
       },
       {
         id: "net-dvdd",
-        name: "DVDD",
-        scope: "local",
-        powerDomain: "vdd",
+
         terminals: [],
       },
     );

--- a/apps/editor/src/features/component-insert/placement-connectivity.test.ts
+++ b/apps/editor/src/features/component-insert/placement-connectivity.test.ts
@@ -118,9 +118,7 @@ describe("component placement electrical contacts", () => {
     const document = createEmptyDocument("main", "Main");
     document.nets.push({
       id: "net-global-0",
-      name: "0",
-      scope: "global",
-      powerDomain: "ground",
+
       terminals: [{ instanceId: "M1", pinName: "B" }],
     });
     addSupplyClaim(document, "net-global-0", "0", "global", "ground");
@@ -178,8 +176,7 @@ describe("component placement electrical contacts", () => {
     });
     document.nets.push({
       id: "net-tail",
-      name: "TAIL",
-      scope: "global",
+
       terminals: [{ instanceId: "R1", pinName: "1" }],
     });
     const ground = {
@@ -290,9 +287,7 @@ describe("component placement electrical contacts", () => {
     const document = createEmptyDocument("main", "Main");
     document.nets.push({
       id: "net-power-vdd1",
-      name: "VDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [],
     });
     addSupplyClaim(document, "net-power-vdd1", "VDD", "global", "vdd");
@@ -336,9 +331,7 @@ describe("component placement electrical contacts", () => {
     const document = createEmptyDocument("main", "Main");
     document.nets.push({
       id: "net-avdd",
-      name: "AVDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [],
     });
     addSupplyClaim(document, "net-avdd", "AVDD", "global", "vdd");
@@ -419,16 +412,12 @@ describe("component placement electrical contacts", () => {
     document.nets.push(
       {
         id: "net-avdd",
-        name: "AVDD",
-        scope: "global",
-        powerDomain: "vdd",
+
         terminals: [],
       },
       {
         id: "net-dvdd",
-        name: "DVDD",
-        scope: "global",
-        powerDomain: "vdd",
+
         terminals: [],
       },
     );

--- a/apps/editor/src/features/component-insert/vdd-power-label.test.ts
+++ b/apps/editor/src/features/component-insert/vdd-power-label.test.ts
@@ -149,9 +149,7 @@ describe("vdd power label annotation", () => {
     document.instances.push(instance);
     document.nets.push({
       id: "net-vdd",
-      name: "VDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [],
     });
     document.annotations.push(
@@ -241,9 +239,7 @@ describe("vdd power label annotation", () => {
     document.instances.push(instance);
     document.nets.push({
       id: "net-vdd",
-      name: "VDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [],
     });
     document.annotations.push(
@@ -334,9 +330,7 @@ describe("vdd power label annotation", () => {
     document.instances.push(instance);
     document.nets.push({
       id: "net-vdd",
-      name: "VDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [],
     });
     document.annotations.push(
@@ -430,9 +424,7 @@ describe("vdd power label annotation", () => {
     document.instances.push(instance);
     document.nets.push({
       id: "net-vdd",
-      name: "VDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [],
     });
     document.annotations.push(annotation);

--- a/apps/editor/src/features/component-insert/vdd-rail.test.ts
+++ b/apps/editor/src/features/component-insert/vdd-rail.test.ts
@@ -68,9 +68,7 @@ describe("drawn VDD rail construction", () => {
     const document = createEmptyDocument("main", "Main");
     document.nets.push({
       id: "net-avdd",
-      name: "AVDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [],
     });
 
@@ -211,9 +209,7 @@ describe("drawn VDD rail construction", () => {
     });
     document.nets.push({
       id: "net-global-vdd",
-      name: "VDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [{ instanceId: "M1", pinName: "B" }],
     });
 
@@ -303,9 +299,7 @@ describe("drawn VDD rail construction", () => {
     const document = createEmptyDocument("main", "Main");
     document.nets.push({
       id: "net-port-avdd",
-      name: "AVDD",
-      scope: "local",
-      powerDomain: "vdd",
+
       terminals: [],
     });
     document.connectivityEvidence.push({

--- a/apps/editor/src/features/drafting/current-arrow.test.ts
+++ b/apps/editor/src/features/drafting/current-arrow.test.ts
@@ -28,7 +28,7 @@ describe("route-attached current arrows", () => {
     );
     document.nets.push({
       id: "net-signal",
-      scope: "local",
+
       terminals: [
         { instanceId: "R1", pinName: "2" },
         { instanceId: "R2", pinName: "1" },
@@ -104,7 +104,7 @@ describe("route-attached current arrows", () => {
     );
     document.nets.push({
       id: "net-signal",
-      scope: "local",
+
       terminals: [
         { instanceId: "R1", pinName: "2" },
         { instanceId: "R2", pinName: "1" },

--- a/apps/editor/src/features/instance-display/default-instance-display.test.ts
+++ b/apps/editor/src/features/instance-display/default-instance-display.test.ts
@@ -93,8 +93,7 @@ describe("default instance display annotations", () => {
     document.instances.push(instance);
     document.nets.push({
       id: "net-vin",
-      name: "VIN",
-      scope: "local",
+
       terminals: [{ instanceId: instance.id, pinName: "P" }],
     });
 

--- a/apps/editor/src/features/properties/capacitor-plate-properties.test.ts
+++ b/apps/editor/src/features/properties/capacitor-plate-properties.test.ts
@@ -19,13 +19,12 @@ describe("capacitor plate Properties projection", () => {
     document.nets.push(
       {
         id: "net-out",
-        name: "OUT",
-        scope: "local",
+
         terminals: [{ instanceId: "C1", pinName: "1" }],
       },
       {
         id: "net-return",
-        scope: "local",
+
         terminals: [{ instanceId: "C1", pinName: "2" }],
       },
     );

--- a/apps/editor/src/features/properties/electrical-marker-name.test.ts
+++ b/apps/editor/src/features/properties/electrical-marker-name.test.ts
@@ -16,8 +16,7 @@ function documentWithMarker(symbolId: "port" | "vdd-port") {
   });
   document.nets.push({
     id: "net-p1",
-    scope: symbolId === "vdd-port" ? "global" : "local",
-    powerDomain: symbolId === "vdd-port" ? "vdd" : "none",
+
     terminals: [{ instanceId: "P1", pinName: "P" }],
   });
   document.connectivityEvidence.push({

--- a/apps/editor/src/features/selection/delete-selection.test.ts
+++ b/apps/editor/src/features/selection/delete-selection.test.ts
@@ -85,7 +85,7 @@ describe("connected instance deletion", () => {
     );
     document.nets.push({
       id: "net-1",
-      scope: "local",
+
       terminals: [
         { instanceId: "R1", pinName: "2" },
         { instanceId: "R2", pinName: "1" },
@@ -138,8 +138,7 @@ function documentWithJunctionRoute() {
     .documents[0]!;
   document.nets.push({
     id: "net-1",
-    name: "N1",
-    scope: "local",
+
     terminals: [],
   });
   document.junctions.push(
@@ -162,8 +161,7 @@ function documentWithBranchedJunction() {
     .documents[0]!;
   document.nets.push({
     id: "net-1",
-    name: "N1",
-    scope: "local",
+
     terminals: [],
   });
   document.junctions.push(

--- a/apps/editor/src/features/selection/marquee-selection.test.ts
+++ b/apps/editor/src/features/selection/marquee-selection.test.ts
@@ -35,7 +35,7 @@ function fixture(): {
   labelBounds: Rect;
 } {
   const document = createEmptyDocument("marquee", "Marquee");
-  document.nets.push({ id: "net-1", scope: "local", terminals: [] });
+  document.nets.push({ id: "net-1", terminals: [] });
   document.junctions.push(
     {
       id: "j1",

--- a/apps/editor/src/features/selection/selection-move-plan.test.ts
+++ b/apps/editor/src/features/selection/selection-move-plan.test.ts
@@ -29,8 +29,7 @@ describe("selection move plan", () => {
     );
     document.nets.push({
       id: "n1",
-      name: "n1",
-      scope: "local",
+
       terminals: [
         { instanceId: "R1", pinName: "1" },
         { instanceId: "R2", pinName: "1" },

--- a/apps/editor/src/features/wiring/route-interaction-geometry.test.ts
+++ b/apps/editor/src/features/wiring/route-interaction-geometry.test.ts
@@ -24,7 +24,7 @@ function looseRouteDocument() {
   const document = createEmptyDocument("route-geometry", "Route geometry");
   document.nets.push({
     id: "net-1",
-    scope: "local",
+
     terminals: [],
   });
   document.junctions.push(

--- a/apps/editor/src/presentation/razavi-presentation.test.ts
+++ b/apps/editor/src/presentation/razavi-presentation.test.ts
@@ -23,9 +23,7 @@ describe("Razavi hidden bulk policy", () => {
     document.instances.push(manualMos("M1", "nmos"));
     document.nets.push({
       id: "net-ground",
-      name: "0",
-      scope: "global",
-      powerDomain: "ground",
+
       terminals: [],
     });
     document.mosBulkDefaults = { nmosNetId: "net-ground" };
@@ -45,9 +43,7 @@ describe("Razavi hidden bulk policy", () => {
     document.instances.push(manualMos("M4", "pmos"));
     document.nets.push({
       id: "net-vdd",
-      name: "VDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [],
     });
     document.mosBulkDefaults = { pmosNetId: "net-vdd" };
@@ -67,9 +63,7 @@ describe("Razavi hidden bulk policy", () => {
     document.instances.push(manualMos("M4", "pmos"));
     document.nets.push({
       id: "net-ui-2",
-      name: "VDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [],
     });
 
@@ -113,16 +107,12 @@ describe("Razavi hidden bulk policy", () => {
     project.documents[0]!.nets.push(
       {
         id: "net-ground-a",
-        name: "0",
-        scope: "global",
-        powerDomain: "ground",
+
         terminals: [],
       },
       {
         id: "net-ground-b",
-        name: "0",
-        scope: "global",
-        powerDomain: "ground",
+
         terminals: [],
       },
     );

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -205,11 +205,12 @@ header buys nothing. Without such a session every admin route answers
 - `DELETE /api/gallery/<id>` — permanent, and only for entries already in
   the bin (`409` otherwise).
 - `GET /api/gallery/recycled` — the bin.
-- `POST /api/gallery/maintenance/reserialize` — re-parse and re-serialize
-  every stored entry through the current protocol and refresh its preview;
-  run once per schema advance while the rolling window still reads the old
-  version. Failures are reported per entry and never destroy the record;
-  the independently stored preview keeps expired entries browsable.
+- `GET /api/gallery/maintenance/schema-backup` — download a full-fidelity
+  administrator backup of entries, saved versions, and workspace slots.
+- `POST /api/gallery/maintenance/schema23` — validate or transactionally
+  converge every stored Project to schema 23. The request body is
+  `{ "apply": false }` for a dry run and `{ "apply": true }` to commit only
+  when every record is valid.
 
 ## Retention and privacy
 

--- a/docs/specs/project-file-format.md
+++ b/docs/specs/project-file-format.md
@@ -65,7 +65,7 @@ all been rewritten to 23.
 ## Read and write
 
 ```text
-read text -> parse JSON -> require Project schema 21, 22, or 23
+read text -> parse JSON -> require Project schema 22 or 23
 -> converge to schema 23 -> strict schema-23 validation -> open
 save -> strict validation -> canonical key ordering -> atomic write
 ```

--- a/packages/agent-adapter/src/snapshot.test.ts
+++ b/packages/agent-adapter/src/snapshot.test.ts
@@ -118,9 +118,7 @@ describe("Agent Document Snapshot", () => {
     const document = createEmptyDocument("power-snapshot", "Power Snapshot");
     document.nets.push({
       id: "net-vdd",
-      name: "VDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [],
     });
     document.connectivityEvidence.push({
@@ -152,9 +150,7 @@ describe("Agent Document Snapshot", () => {
     });
     document.nets.push({
       id: "net-global-0",
-      name: "0",
-      scope: "global",
-      powerDomain: "ground",
+
       terminals: [{ instanceId: "M1", pinName: "B" }],
     });
 

--- a/packages/derived/src/annotation-text.test.ts
+++ b/packages/derived/src/annotation-text.test.ts
@@ -93,7 +93,7 @@ describe("bound annotation text", () => {
     });
     document.nets.push({
       id: "net-vout",
-      scope: "local",
+
       terminals: [{ instanceId: "port-object", pinName: "P" }],
     });
     document.netlist = {
@@ -149,8 +149,7 @@ describe("bound annotation text", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.nets.push({
       id: "net-vin",
-      name: "V_{in,cm}",
-      scope: "local",
+
       terminals: [],
     });
     const annotation = {
@@ -185,7 +184,6 @@ describe("bound annotation text", () => {
     expect(flattenRichText(resolveAnnotationText(document, annotation))).toBe(
       "Vin,cm",
     );
-    document.nets[0]!.name = "V_{refp}";
     expect(flattenRichText(resolveAnnotationText(document, annotation))).toBe(
       "Vin,cm",
     );

--- a/packages/derived/src/connectivity-index.test.ts
+++ b/packages/derived/src/connectivity-index.test.ts
@@ -18,12 +18,12 @@ describe("Project Connectivity Index logical aliases", () => {
     document.nets.push(
       {
         id: "net-a",
-        scope: "local",
+
         terminals: [{ instanceId: "P1", pinName: "P" }],
       },
       {
         id: "net-b",
-        scope: "local",
+
         terminals: [{ instanceId: "P2", pinName: "P" }],
       },
     );

--- a/packages/derived/src/current-contract.test.ts
+++ b/packages/derived/src/current-contract.test.ts
@@ -26,8 +26,7 @@ describe("current terminal-only connectivity contract", () => {
       });
       document.nets.push({
         id: "net-in",
-        name: "VIN",
-        scope: "local",
+
         terminals: [{ instanceId: "VIN", pinName: "P" }],
       });
       const endpoint = {
@@ -54,7 +53,7 @@ describe("current terminal-only connectivity contract", () => {
     });
     document.nets.push({
       id: "net-out",
-      scope: "local",
+
       terminals: [{ instanceId: "VOUT", pinName: "P" }],
     });
     expect(electricalTopologyHash(project)).not.toBe(before);

--- a/packages/derived/src/diagnostics/diagnostic.test.ts
+++ b/packages/derived/src/diagnostics/diagnostic.test.ts
@@ -173,7 +173,7 @@ describe("diagnostic aggregation", () => {
     resolved.documents[0]!.nets = [
       {
         id: "net-left",
-        scope: "local",
+
         terminals: [
           { instanceId: "I1", pinName: "L" },
           { instanceId: "I2", pinName: "L" },
@@ -181,7 +181,7 @@ describe("diagnostic aggregation", () => {
       },
       {
         id: "net-right",
-        scope: "local",
+
         terminals: [
           { instanceId: "I1", pinName: "R" },
           { instanceId: "I2", pinName: "R" },

--- a/packages/derived/src/diagnostics/erc.test.ts
+++ b/packages/derived/src/diagnostics/erc.test.ts
@@ -121,7 +121,7 @@ function roleInstance(variant?: string) {
 function connectDrainAndSource(project: CircuitProject): void {
   project.documents[0]!.nets.push({
     id: "net-channel",
-    scope: "local",
+
     terminals: [
       { instanceId: "M1", pinName: "D" },
       { instanceId: "M1", pinName: "S" },
@@ -137,8 +137,7 @@ describe("ERC engine", () => {
     document.nets = [
       {
         id: "net-1",
-        name: "sig",
-        scope: "local",
+
         terminals: [
           { instanceId: "I1", pinName: "L" },
           { instanceId: "I1", pinName: "R" },
@@ -194,8 +193,7 @@ describe("ERC engine", () => {
     project.documents[0]!.nets = [
       {
         id: "net-1",
-        name: "sig",
-        scope: "local",
+
         terminals: [
           { instanceId: "I1", pinName: "L" },
           { instanceId: "I1", pinName: "R" },
@@ -220,13 +218,12 @@ describe("ERC engine", () => {
     document.nets.push(
       {
         id: "net-gate-only",
-        scope: "local",
+
         terminals: [{ instanceId: "M1", pinName: "G" }],
       },
       {
         id: "net-vss",
-        name: "VSS",
-        scope: "local",
+
         terminals: [{ instanceId: "M1", pinName: "B" }],
       },
     );
@@ -254,8 +251,7 @@ describe("ERC engine", () => {
     document.nets = [
       {
         id: "net-short",
-        scope: "local",
-        powerDomain: "conflict",
+
         terminals: [
           { instanceId: "VDD1", pinName: "P" },
           { instanceId: "GND1", pinName: "0" },
@@ -320,7 +316,7 @@ describe("ERC engine", () => {
     ];
     document.nets.push({
       id: "net-bulk-only",
-      scope: "local",
+
       terminals: [
         { instanceId: "M1", pinName: "B" },
         { instanceId: "M2", pinName: "B" },
@@ -343,8 +339,7 @@ describe("ERC engine", () => {
     project.documents[0]!.nets = [
       {
         id: "net-1",
-        name: "sig",
-        scope: "local",
+
         terminals: [
           { instanceId: "I1", pinName: "L" },
           { instanceId: "I1", pinName: "R" },
@@ -367,8 +362,7 @@ describe("ERC engine", () => {
     project.documents[0]!.nets = [
       {
         id: "net-a",
-        name: "out",
-        scope: "local",
+
         terminals: [
           { instanceId: "I1", pinName: "L" },
           { instanceId: "I2", pinName: "L" },
@@ -376,8 +370,7 @@ describe("ERC engine", () => {
       },
       {
         id: "net-b",
-        name: "OUT",
-        scope: "local",
+
         terminals: [{ instanceId: "I1", pinName: "R" }],
       },
     ];
@@ -408,23 +401,17 @@ describe("ERC engine", () => {
     project.documents[0]!.nets = [
       {
         id: "net-ground-1",
-        name: "0",
-        scope: "global",
-        powerDomain: "ground",
+
         terminals: [{ instanceId: "GND1", pinName: "0" }],
       },
       {
         id: "net-ground-2",
-        name: "0",
-        scope: "global",
-        powerDomain: "ground",
+
         terminals: [{ instanceId: "GND2", pinName: "0" }],
       },
       {
         id: "net-global-0",
-        name: "0",
-        scope: "global",
-        powerDomain: "ground",
+
         terminals: [{ instanceId: "M1", pinName: "B" }],
       },
     ];
@@ -441,8 +428,7 @@ describe("ERC engine", () => {
     project.documents[0]!.nets = [
       {
         id: "net-1",
-        name: "sig",
-        scope: "local",
+
         terminals: [
           { instanceId: "I1", pinName: "L" },
           { instanceId: "I2", pinName: "L" },
@@ -496,7 +482,7 @@ describe("ERC engine", () => {
     document.nets = [
       {
         id: "net-1",
-        scope: "local",
+
         terminals: [
           { instanceId: "I1", pinName: "L" },
           { instanceId: "I1", pinName: "R" },
@@ -546,7 +532,7 @@ describe("ERC engine", () => {
     document.nets = [
       {
         id: "net-1",
-        scope: "local",
+
         terminals: [
           { instanceId: "I1", pinName: "L" },
           { instanceId: "I1", pinName: "R" },

--- a/packages/derived/src/endpoint-connectivity.test.ts
+++ b/packages/derived/src/endpoint-connectivity.test.ts
@@ -73,12 +73,12 @@ describe("endpoint connectivity assessment", () => {
     document.nets.push(
       {
         id: "single",
-        scope: "local",
+
         terminals: [{ instanceId: "A", pinName: "L" }],
       },
       {
         id: "peer",
-        scope: "local",
+
         terminals: [
           { instanceId: "A", pinName: "R" },
           { instanceId: "B", pinName: "L" },
@@ -111,12 +111,12 @@ describe("endpoint connectivity assessment", () => {
     document.nets.push(
       {
         id: "formal",
-        scope: "local",
+
         terminals: [{ instanceId: "A", pinName: "L" }],
       },
       {
         id: "supply",
-        scope: "local",
+
         terminals: [{ instanceId: "A", pinName: "R" }],
       },
     );

--- a/packages/derived/src/endpoint.test.ts
+++ b/packages/derived/src/endpoint.test.ts
@@ -202,7 +202,7 @@ describe("endpoint primitives", () => {
       const document = createEmptyProject("ep", "EP").documents[0]!;
       const net: Net = {
         id: "net-a",
-        scope: "local",
+
         terminals: [
           { instanceId: "I1", pinName: "L" },
           { instanceId: "I1", pinName: "R" },

--- a/packages/derived/src/hierarchy-navigation.test.ts
+++ b/packages/derived/src/hierarchy-navigation.test.ts
@@ -55,12 +55,12 @@ describe("hierarchy navigation", () => {
     child.nets.push(
       {
         id: "child-l",
-        scope: "local",
+
         terminals: [{ instanceId: "P1", pinName: "P" }],
       },
       {
         id: "child-r",
-        scope: "local",
+
         terminals: [{ instanceId: "P2", pinName: "P" }],
       },
     );

--- a/packages/derived/src/logical-net.test.ts
+++ b/packages/derived/src/logical-net.test.ts
@@ -7,10 +7,10 @@ describe("resolved logical Nets", () => {
   it("unions scoped names, source identity, and explicit equivalence deterministically", () => {
     const document = createEmptyDocument("document", "Document");
     document.nets.push(
-      { id: "net-d", scope: "local", terminals: [] },
-      { id: "net-a", scope: "local", terminals: [] },
-      { id: "net-c", scope: "local", terminals: [] },
-      { id: "net-b", scope: "local", terminals: [] },
+      { id: "net-d", terminals: [] },
+      { id: "net-a", terminals: [] },
+      { id: "net-c", terminals: [] },
+      { id: "net-b", terminals: [] },
     );
     document.connectivityEvidence.push(
       {
@@ -65,8 +65,8 @@ describe("resolved logical Nets", () => {
   it("keeps conflicting explicit equivalence inspectable without choosing a name", () => {
     const document = createEmptyDocument("document", "Document");
     document.nets.push(
-      { id: "net-a", scope: "local", terminals: [] },
-      { id: "net-b", scope: "global", terminals: [] },
+      { id: "net-a", terminals: [] },
+      { id: "net-b", terminals: [] },
     );
     document.connectivityEvidence.push(
       {
@@ -103,8 +103,8 @@ describe("resolved logical Nets", () => {
   it("ignores inert legacy projections when resolving marker-owned names", () => {
     const document = createEmptyDocument("document", "Document");
     document.nets.push(
-      { id: "legacy", name: "VDD", scope: "local", terminals: [] },
-      { id: "marker", scope: "local", terminals: [] },
+      { id: "legacy", terminals: [] },
+      { id: "marker", terminals: [] },
     );
     document.connectivityEvidence.push({
       id: "claim-vdd",
@@ -130,8 +130,7 @@ describe("resolved logical Nets", () => {
     const document = createEmptyDocument("document", "Document");
     document.nets.push({
       id: "net",
-      name: "VDD",
-      scope: "local",
+
       terminals: [],
     });
     document.connectivityEvidence.push({
@@ -153,8 +152,8 @@ describe("resolved logical Nets", () => {
   it("keeps a formal Cell Port name distinct from the connected logical Net name", () => {
     const document = createEmptyDocument("document", "Document");
     document.nets.push(
-      { id: "net-port", scope: "local", terminals: [] },
-      { id: "net-label", scope: "local", terminals: [] },
+      { id: "net-port", terminals: [] },
+      { id: "net-label", terminals: [] },
     );
     document.netlist = {
       name: "Document",

--- a/packages/derived/src/mos-bulk.test.ts
+++ b/packages/derived/src/mos-bulk.test.ts
@@ -47,14 +47,12 @@ describe("MOS bulk resolution", () => {
     document.nets.push(
       {
         id: "net-vss",
-        name: "VSS",
-        scope: "global",
+
         terminals: [],
       },
       {
         id: "net-body",
-        name: "VBODY",
-        scope: "local",
+
         terminals: [{ instanceId: "M1", pinName: "B" }],
       },
     );
@@ -73,14 +71,12 @@ describe("MOS bulk resolution", () => {
     document.nets.push(
       {
         id: "net-cell-substrate",
-        name: "SUBSTRATE",
-        scope: "local",
+
         terminals: [],
       },
       {
         id: "net-vss",
-        name: "VSS",
-        scope: "global",
+
         terminals: [],
       },
     );
@@ -99,16 +95,12 @@ describe("MOS bulk resolution", () => {
     document.nets.push(
       {
         id: "net-avdd",
-        name: "AVDD",
-        scope: "global",
-        powerDomain: "vdd",
+
         terminals: [],
       },
       {
         id: "net-vdd",
-        name: "VDD",
-        scope: "global",
-        powerDomain: "vdd",
+
         terminals: [],
       },
     );
@@ -144,8 +136,7 @@ describe("MOS bulk resolution", () => {
     });
     document.nets.push({
       id: "net-cell-substrate",
-      name: "SUBSTRATE",
-      scope: "local",
+
       terminals: [{ instanceId: "M1", pinName: "B" }],
     });
     document.mosBulkDefaults = { nmosNetId: "net-cell-substrate" };

--- a/packages/derived/src/net-highlight.test.ts
+++ b/packages/derived/src/net-highlight.test.ts
@@ -31,9 +31,7 @@ describe("Net highlight", () => {
     project.documents[0]!.id = "top";
     project.documents[0]!.nets.push({
       id: "net-vdd-top",
-      name: "VDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [],
     });
     project.documents[0]!.connectivityEvidence.push({
@@ -48,9 +46,7 @@ describe("Net highlight", () => {
     const child = createEmptyDocument("child", "Child");
     child.nets.push({
       id: "net-vdd-child",
-      name: "vdd",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [],
     });
     child.connectivityEvidence.push({
@@ -113,10 +109,10 @@ describe("Net highlight", () => {
       },
     });
     top.nets.push(
-      { id: "net-a", scope: "local", terminals: [] },
+      { id: "net-a", terminals: [] },
       {
         id: "net-b",
-        scope: "local",
+
         terminals: [{ instanceId: "X1", pinName: "P" }],
       },
     );
@@ -142,7 +138,7 @@ describe("Net highlight", () => {
     child.instances.push({ id: "P1", symbolId: "port", placement: null });
     child.nets.push({
       id: "child-net",
-      scope: "local",
+
       terminals: [{ instanceId: "P1", pinName: "P" }],
     });
     child.netlist = {
@@ -212,12 +208,12 @@ describe("Net highlight", () => {
     top.nets.push(
       {
         id: "parent-a",
-        scope: "local",
+
         terminals: [{ instanceId: "X1", pinName: "P" }],
       },
       {
         id: "parent-b",
-        scope: "local",
+
         terminals: [{ instanceId: "X2", pinName: "P" }],
       },
     );
@@ -225,7 +221,7 @@ describe("Net highlight", () => {
     child.instances.push({ id: "P1", symbolId: "port", placement: null });
     child.nets.push({
       id: "child-net",
-      scope: "local",
+
       terminals: [{ instanceId: "P1", pinName: "P" }],
     });
     child.netlist = {

--- a/packages/derived/src/routing-guidance.test.ts
+++ b/packages/derived/src/routing-guidance.test.ts
@@ -105,7 +105,7 @@ describe("routing guidance", () => {
     document.nets.push(
       {
         id: "net-imported",
-        scope: "local",
+
         terminals: [
           { instanceId: "A", pinName: "P" },
           { instanceId: "B", pinName: "P" },
@@ -113,7 +113,7 @@ describe("routing guidance", () => {
       },
       {
         id: "net-authored",
-        scope: "local",
+
         terminals: [
           { instanceId: "C", pinName: "P" },
           { instanceId: "D", pinName: "P" },
@@ -159,7 +159,7 @@ describe("routing guidance", () => {
     );
     document.nets.push({
       id: "net-imported-body",
-      scope: "local",
+
       terminals: [
         { instanceId: "XM1", pinName: "B" },
         { instanceId: "P1", pinName: "P" },
@@ -206,12 +206,12 @@ describe("routing guidance", () => {
     document.nets.push(
       {
         id: "base-a",
-        scope: "local",
+
         terminals: [{ instanceId: "A", pinName: "P" }],
       },
       {
         id: "base-b",
-        scope: "local",
+
         terminals: [{ instanceId: "B", pinName: "P" }],
       },
     );

--- a/packages/derived/src/submission-gates.test.ts
+++ b/packages/derived/src/submission-gates.test.ts
@@ -96,7 +96,7 @@ describe("evaluateSubmissionGates", () => {
     document.nets = [
       {
         id: "n1",
-        scope: "local",
+
         terminals: [
           { instanceId: "I1", pinName: "L" },
           { instanceId: "I2", pinName: "L" },
@@ -104,7 +104,7 @@ describe("evaluateSubmissionGates", () => {
       },
       {
         id: "n2",
-        scope: "local",
+
         terminals: [
           { instanceId: "I1", pinName: "R" },
           { instanceId: "I2", pinName: "R" },
@@ -121,7 +121,7 @@ describe("evaluateSubmissionGates", () => {
     document.nets = [
       {
         id: "n1",
-        scope: "local",
+
         terminals: [
           { instanceId: "I1", pinName: "L" },
           { instanceId: "I2", pinName: "L" },
@@ -159,7 +159,7 @@ describe("evaluateSubmissionGates", () => {
     document.nets = [
       {
         id: "channel",
-        scope: "local",
+
         terminals: [
           { instanceId: "M1", pinName: "D" },
           { instanceId: "M1", pinName: "S" },
@@ -170,7 +170,7 @@ describe("evaluateSubmissionGates", () => {
       },
       {
         id: "gate-net",
-        scope: "local",
+
         terminals: [{ instanceId: "M1", pinName: "G" }],
       },
     ];
@@ -194,7 +194,7 @@ describe("evaluateSubmissionGates", () => {
     document.nets = [
       {
         id: "n1",
-        scope: "local",
+
         terminals: [
           { instanceId: "I1", pinName: "L" },
           { instanceId: "I2", pinName: "L" },
@@ -202,7 +202,7 @@ describe("evaluateSubmissionGates", () => {
       },
       {
         id: "n2",
-        scope: "local",
+
         terminals: [
           { instanceId: "I1", pinName: "R" },
           { instanceId: "I2", pinName: "R" },

--- a/packages/derived/src/visual.test.ts
+++ b/packages/derived/src/visual.test.ts
@@ -142,7 +142,7 @@ describe("visual quality diagnostics", () => {
     );
     document.nets.push({
       id: "net-ui-2",
-      scope: "local",
+
       terminals: [
         { instanceId: "P1", pinName: "P" },
         { instanceId: "P2", pinName: "P" },

--- a/packages/edit-engine/src/authoring.test.ts
+++ b/packages/edit-engine/src/authoring.test.ts
@@ -127,22 +127,22 @@ describe("semantic authoring", () => {
     document.nets.push(
       {
         id: "net-d",
-        scope: "local",
+
         terminals: [{ instanceId: "XM1", pinName: "P1" }],
       },
       {
         id: "net-g",
-        scope: "local",
+
         terminals: [{ instanceId: "XM1", pinName: "P2" }],
       },
       {
         id: "net-s",
-        scope: "local",
+
         terminals: [{ instanceId: "XM1", pinName: "P3" }],
       },
       {
         id: "net-b",
-        scope: "local",
+
         terminals: [{ instanceId: "XM1", pinName: "P4" }],
       },
     );
@@ -241,7 +241,7 @@ describe("semantic authoring", () => {
     });
     document.nets.push({
       id: "net-a",
-      scope: "local",
+
       terminals: [{ instanceId: "X1", pinName: "P1" }],
     });
     const result = executeTransaction(
@@ -269,12 +269,12 @@ describe("semantic authoring", () => {
     document.nets.push(
       {
         id: "net-a",
-        scope: "local",
+
         terminals: [{ instanceId: "R1", pinName: "2" }],
       },
       {
         id: "net-b",
-        scope: "local",
+
         terminals: [{ instanceId: "R2", pinName: "1" }],
       },
     );
@@ -320,12 +320,12 @@ describe("semantic authoring", () => {
     document.nets.push(
       {
         id: "net-a",
-        scope: "local",
+
         terminals: [{ instanceId: "P1", pinName: "P" }],
       },
       {
         id: "net-b",
-        scope: "local",
+
         terminals: [{ instanceId: "P2", pinName: "P" }],
       },
     );
@@ -373,7 +373,7 @@ describe("semantic authoring", () => {
     document.instances.push(addInstance("R1", "resistor", 100).instance);
     document.nets.push({
       id: "net-a",
-      scope: "local",
+
       terminals: [{ instanceId: "R1", pinName: "1" }],
     });
     const before = structuredClone(document);
@@ -392,8 +392,8 @@ describe("semantic authoring", () => {
   it("joins equal name claims logically without a physical merge", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.nets.push(
-      { id: "net-a", name: "SIGNAL", scope: "local", terminals: [] },
-      { id: "net-b", scope: "local", terminals: [] },
+      { id: "net-a", terminals: [] },
+      { id: "net-b", terminals: [] },
     );
     document.connectivityEvidence.push({
       id: "claim-net-a",
@@ -430,7 +430,7 @@ describe("semantic authoring", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.nets.push({
       id: "net-a",
-      scope: "local",
+
       terminals: [],
     });
     document.junctions.push({

--- a/packages/edit-engine/src/cell-reset-planner.test.ts
+++ b/packages/edit-engine/src/cell-reset-planner.test.ts
@@ -36,13 +36,13 @@ function fixture() {
   );
   child.nets.push({
     id: "net-in",
-    scope: "local",
+
     terminals: [
       { instanceId: "P1", pinName: "P" },
       { instanceId: "R1", pinName: "P" },
     ],
   });
-  child.nets.push({ id: "net-body", scope: "local", terminals: [] });
+  child.nets.push({ id: "net-body", terminals: [] });
   child.connectivityEvidence.push(
     {
       id: "claim-interface",

--- a/packages/edit-engine/src/direct-contact-lifecycle.test.ts
+++ b/packages/edit-engine/src/direct-contact-lifecycle.test.ts
@@ -34,8 +34,7 @@ function fixture(): SchematicDocument {
   document.nets = [
     {
       id: "net-contact",
-      scope: "local",
-      powerDomain: "none",
+
       terminals: [
         { instanceId: "A", pinName: "P" },
         { instanceId: "B", pinName: "P" },
@@ -303,14 +302,12 @@ describe("direct-contact transform lifecycle", () => {
     document.nets = [
       {
         id: "net-a",
-        scope: "local",
-        powerDomain: "none",
+
         terminals: [{ instanceId: "A", pinName: "P" }],
       },
       {
         id: "net-b",
-        scope: "local",
-        powerDomain: "none",
+
         terminals: [{ instanceId: "B", pinName: "P" }],
       },
     ];

--- a/packages/edit-engine/src/direct-contact-planner.test.ts
+++ b/packages/edit-engine/src/direct-contact-planner.test.ts
@@ -38,12 +38,12 @@ describe("direct endpoint connection planner", () => {
     document.nets.push(
       {
         id: "net-a",
-        scope: "local",
+
         terminals: [{ instanceId: "A", pinName: "P" }],
       },
       {
         id: "net-b",
-        scope: "local",
+
         terminals: [{ instanceId: "B", pinName: "P" }],
       },
     );
@@ -69,12 +69,12 @@ describe("direct endpoint connection planner", () => {
     document.nets.push(
       {
         id: "net-a",
-        scope: "local",
+
         terminals: [{ instanceId: "A", pinName: "P" }],
       },
       {
         id: "net-b",
-        scope: "local",
+
         terminals: [{ instanceId: "B", pinName: "P" }],
       },
     );

--- a/packages/edit-engine/src/hierarchy-planner.test.ts
+++ b/packages/edit-engine/src/hierarchy-planner.test.ts
@@ -265,7 +265,7 @@ describe("reviewed external MOS model targets", () => {
     });
     document.nets.push({
       id: "net-drain",
-      scope: "local",
+
       terminals: [{ instanceId: "M1", pinName: "D" }],
     });
     document.junctions.push({

--- a/packages/edit-engine/src/history.test.ts
+++ b/packages/edit-engine/src/history.test.ts
@@ -47,8 +47,7 @@ describe("DocumentHistory", () => {
     });
     document.nets.push({
       id: "net-vss",
-      name: "VSS",
-      scope: "global",
+
       terminals: [],
     });
     document.mosBulkDefaults = { nmosNetId: "net-vss" };

--- a/packages/edit-engine/src/instance-lifecycle.test.ts
+++ b/packages/edit-engine/src/instance-lifecycle.test.ts
@@ -41,7 +41,7 @@ function lifecycleDocument() {
   );
   document.nets.push({
     id: "net-1",
-    scope: "local",
+
     terminals: [
       { instanceId: "R1", pinName: "2" },
       { instanceId: "R2", pinName: "1" },
@@ -123,7 +123,7 @@ describe("Instance lifecycle planning", () => {
     });
     document.nets.push({
       id: "net-vin",
-      scope: "local",
+
       terminals: [{ instanceId: "P1", pinName: "P" }],
     });
     document.netlist = {
@@ -273,8 +273,7 @@ describe("Instance lifecycle planning", () => {
     });
     document.nets.push({
       id: "net-port-p1",
-      name: "BUS",
-      scope: "local",
+
       terminals: [{ instanceId: "P1", pinName: "P" }],
     });
     document.annotations.push({
@@ -321,10 +320,8 @@ describe("Instance lifecycle planning", () => {
     });
     document.nets.push({
       id: "net-port-p1",
-      name: "BUS",
-      scope: "local",
+
       terminals: [{ instanceId: "P1", pinName: "P" }],
-      origin: { kind: "spice-import", sourceNetIds: ["source-bus"] },
     });
     document.connectivityEvidence.push({
       id: "source-bus-evidence",
@@ -387,8 +384,7 @@ describe("Instance lifecycle planning", () => {
     });
     document.nets.push({
       id: "net-vin",
-      name: "VIN",
-      scope: "local",
+
       terminals: [{ instanceId: "P1", pinName: "P" }],
     });
     document.netlist = {
@@ -422,7 +418,6 @@ describe("Instance lifecycle planning", () => {
         nets: [
           {
             id: "net-vin",
-            name: "VIN",
             terminals: [{ instanceId: "P1", pinName: "P" }],
           },
         ],

--- a/packages/edit-engine/src/named-net-planner.test.ts
+++ b/packages/edit-engine/src/named-net-planner.test.ts
@@ -8,7 +8,7 @@ const owner = { kind: "explicit-net-property" as const };
 describe("named Net planner", () => {
   it("writes an unused name only as an owner-addressed claim", () => {
     const document = createEmptyDocument("main", "Main");
-    document.nets.push({ id: "net-source", scope: "local", terminals: [] });
+    document.nets.push({ id: "net-source", terminals: [] });
     expect(
       planEnsureNamedNet(document, {
         candidateNetId: "net-source",
@@ -39,8 +39,8 @@ describe("named Net planner", () => {
   it("keeps same-name Base Nets separate and emits no semantic merge", () => {
     const document = createEmptyDocument("main", "Main");
     document.nets.push(
-      { id: "net-a", name: "BIAS", scope: "local", terminals: [] },
-      { id: "net-source", scope: "local", terminals: [] },
+      { id: "net-a", terminals: [] },
+      { id: "net-source", terminals: [] },
     );
     const plan = planEnsureNamedNet(document, {
       candidateNetId: "net-source",
@@ -68,15 +68,12 @@ describe("named Net planner", () => {
     document.nets.push(
       {
         id: "net-vdd",
-        name: "VDD",
-        scope: "local",
-        powerDomain: "vdd",
+
         terminals: [],
       },
       {
         id: "net-source",
-        scope: "local",
-        powerDomain: "ground",
+
         terminals: [],
       },
     );
@@ -104,8 +101,7 @@ describe("named Net planner", () => {
     const document = createEmptyDocument("main", "Main");
     document.nets.push({
       id: "net-source",
-      name: "OLD",
-      scope: "local",
+
       terminals: [],
     });
     document.connectivityEvidence.push({

--- a/packages/edit-engine/src/power-net-planner.test.ts
+++ b/packages/edit-engine/src/power-net-planner.test.ts
@@ -14,16 +14,12 @@ describe("power Net planner", () => {
     document.nets.push(
       {
         id: "net-avdd",
-        name: "AVDD",
-        scope: "global",
-        powerDomain: "vdd",
+
         terminals: [],
       },
       {
         id: "net-vdd",
-        name: "VDD",
-        scope: "global",
-        powerDomain: "vdd",
+
         terminals: [],
       },
     );
@@ -57,7 +53,7 @@ describe("power Net planner", () => {
 
   it("promotes an unnamed contacted Net to the requested canonical supply", () => {
     const document = createEmptyDocument("main", "Main");
-    document.nets.push({ id: "net-contact", scope: "local", terminals: [] });
+    document.nets.push({ id: "net-contact", terminals: [] });
 
     expect(
       planEnsurePowerNet(document, {
@@ -91,15 +87,12 @@ describe("power Net planner", () => {
     document.nets.push(
       {
         id: "net-tail",
-        name: "TAIL",
-        scope: "local",
+
         terminals: [],
       },
       {
         id: "net-global-0",
-        name: "0",
-        scope: "global",
-        powerDomain: "ground",
+
         terminals: [],
       },
     );
@@ -126,7 +119,7 @@ describe("power Net planner", () => {
     const document = createEmptyDocument("main", "Main");
     document.nets.push({
       id: "net-tail",
-      scope: "local",
+
       terminals: [],
     });
     expect(
@@ -156,9 +149,7 @@ describe("power Net planner", () => {
     const document = createEmptyDocument("main", "Main");
     document.nets.push({
       id: "net-avdd",
-      name: "AVDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [],
     });
     document.connectivityEvidence.push({

--- a/packages/edit-engine/src/project-transaction.test.ts
+++ b/packages/edit-engine/src/project-transaction.test.ts
@@ -52,7 +52,7 @@ describe("Project structural transaction", () => {
     );
     child.nets.push({
       id: "net-in",
-      scope: "local",
+
       terminals: [
         { instanceId: "P1", pinName: "P" },
         { instanceId: "P2", pinName: "P" },
@@ -71,7 +71,7 @@ describe("Project structural transaction", () => {
     );
     project.documents[0]!.nets.push({
       id: "net-parent-in",
-      scope: "local",
+
       terminals: [{ instanceId: "X1", pinName: "IN" }],
     });
 
@@ -327,7 +327,7 @@ describe("Project structural transaction", () => {
     });
     child.nets.push({
       id: "net-in",
-      scope: "local",
+
       terminals: [{ instanceId: "port-in", pinName: "P" }],
     });
     child.netlist!.terminals.push({
@@ -350,7 +350,7 @@ describe("Project structural transaction", () => {
     project.documents[0]!.instances.push(caller);
     project.documents[0]!.nets.push({
       id: "net-parent",
-      scope: "local",
+
       terminals: [{ instanceId: "X1", pinName: "IN" }],
     });
 
@@ -397,7 +397,7 @@ describe("Project structural transaction", () => {
     });
     child.nets.push({
       id: "net-vout",
-      scope: "local",
+
       terminals: [{ instanceId: "port-vout", pinName: "P" }],
     });
     child.netlist!.terminals.push({
@@ -481,7 +481,7 @@ describe("Project structural transaction", () => {
     });
     child.nets.push({
       id: "net-unused",
-      scope: "local",
+
       terminals: [{ instanceId: "port-unused", pinName: "P" }],
     });
     child.netlist!.terminals.push({
@@ -534,12 +534,12 @@ describe("Project structural transaction", () => {
     child.nets.push(
       {
         id: "net-a",
-        scope: "local",
+
         terminals: [{ instanceId: "port-a", pinName: "P" }],
       },
       {
         id: "net-b",
-        scope: "local",
+
         terminals: [{ instanceId: "port-b", pinName: "P" }],
       },
     );
@@ -625,7 +625,7 @@ describe("Project structural transaction", () => {
     });
     child.nets.push({
       id: "net-in",
-      scope: "local",
+
       terminals: [{ instanceId: "P1", pinName: "P" }],
     });
     child.netlist!.terminals.push({
@@ -640,7 +640,7 @@ describe("Project structural transaction", () => {
     parent.instances.push(hierarchyInstance("X1", "Child", child.id));
     parent.nets.push({
       id: "net-parent",
-      scope: "local",
+
       terminals: [{ instanceId: "X1", pinName: "IN" }],
     });
     parent.junctions.push({

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -79,7 +79,7 @@ function transaction(documentId: string, revision: number, edits: unknown[]) {
 describe("routing Edit Engine", () => {
   it("accepts one octilinear Route without creating a second topology protocol", () => {
     const document = createEmptyDocument("octilinear", "Octilinear");
-    document.nets.push({ id: "n1", scope: "local", terminals: [] });
+    document.nets.push({ id: "n1", terminals: [] });
     document.junctions.push(
       {
         id: "J1",
@@ -118,7 +118,7 @@ describe("routing Edit Engine", () => {
       "agent-octilinear",
       "Agent octilinear",
     );
-    document.nets.push({ id: "n1", scope: "local", terminals: [] });
+    document.nets.push({ id: "n1", terminals: [] });
     document.junctions.push(
       { id: "J1", netId: "n1", position: { x: 0, y: 0 }, role: "route-anchor" },
       {
@@ -150,7 +150,7 @@ describe("routing Edit Engine", () => {
 
   it("rejects a Junction move that would leave an incident Route geometry stale", () => {
     const document = createEmptyDocument("junction-integrity", "Junction");
-    document.nets.push({ id: "n1", scope: "local", terminals: [] });
+    document.nets.push({ id: "n1", terminals: [] });
     document.junctions.push(
       {
         id: "J1",
@@ -209,9 +209,7 @@ describe("routing Edit Engine", () => {
     const document = createEmptyDocument("vdd-manipulation", "VDD edit");
     document.nets.push({
       id: "VDD",
-      name: "VDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [],
     });
     addNameClaim(document, "VDD", "VDD", "global", "vdd");
@@ -345,9 +343,7 @@ describe("routing Edit Engine", () => {
     const document = createEmptyDocument("vertical-rail", "Vertical rail");
     document.nets.push({
       id: "VDD",
-      name: "VDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [],
     });
     addNameClaim(document, "VDD", "VDD", "global", "vdd");
@@ -398,7 +394,7 @@ describe("routing Edit Engine", () => {
     const document = createEmptyDocument("vdd-delete", "VDD delete");
     document.nets.push({
       id: "VDD",
-      scope: "global",
+
       terminals: [],
     });
     document.junctions.push(
@@ -620,7 +616,7 @@ describe("routing Edit Engine", () => {
 
   it("moves a three-way Junction with its dragged segment", () => {
     const document = createEmptyDocument("junction-follow", "Junction follow");
-    document.nets.push({ id: "net-j", scope: "local", terminals: [] });
+    document.nets.push({ id: "net-j", terminals: [] });
     document.junctions.push(
       { id: "junction-center", netId: "net-j", position: { x: 100, y: 100 } },
       {
@@ -763,7 +759,7 @@ describe("routing Edit Engine", () => {
   it("never drags a Junction so far that a branch hides inside a wire", () => {
     // A T: two arms on y=300 meeting a tap that rises to y=200.
     const document = createEmptyDocument("tap", "Tap");
-    document.nets.push({ id: "n1", scope: "local", terminals: [] });
+    document.nets.push({ id: "n1", terminals: [] });
     document.junctions.push({
       id: "J",
       netId: "n1",
@@ -2265,7 +2261,7 @@ describe("routing Edit Engine", () => {
     const document = documentFixture();
     document.nets.push({
       id: "net-free",
-      scope: "local",
+
       terminals: [],
     });
     document.junctions.push(
@@ -2370,7 +2366,6 @@ describe("routing Edit Engine", () => {
   it("physically splits a global-Net Route instead of hiding the cut behind global Evidence", () => {
     const document = documentFixture();
     const net = document.nets.find((candidate) => candidate.id === "net-v")!;
-    net.scope = "global";
     for (const evidence of document.connectivityEvidence) {
       if (evidence.kind === "name-claim" && evidence.netId === net.id) {
         evidence.scope = "global";

--- a/packages/edit-engine/src/subcircuit-interface.test.ts
+++ b/packages/edit-engine/src/subcircuit-interface.test.ts
@@ -69,7 +69,7 @@ describe("subcircuit interface proposals", () => {
     });
     document.nets.push({
       id: "net-out",
-      scope: "local",
+
       terminals: [{ instanceId: "X1", pinName: "OUT" }],
     });
 
@@ -152,7 +152,7 @@ describe("subcircuit interface proposals", () => {
     });
     document.nets.push({
       id: "net-out",
-      scope: "local",
+
       terminals: [{ instanceId: "X1", pinName: "OUT" }],
     });
 

--- a/packages/edit-engine/src/transaction.test.ts
+++ b/packages/edit-engine/src/transaction.test.ts
@@ -89,7 +89,7 @@ describe("Edit Transaction envelope", () => {
     expect(result.document.nets).toEqual([
       expect.objectContaining({ id: "net-authored" }),
     ]);
-    expect(result.document.nets[0]?.origin).toBeUndefined();
+    expect(Object.hasOwn(result.document.nets[0]!, "origin")).toBe(false);
     expect(resolveDocumentLogicalNets(result.document).groups).toEqual([
       expect.objectContaining({
         id: "net-authored",
@@ -133,7 +133,7 @@ describe("Edit Transaction envelope", () => {
     });
     document.nets.push({
       id: "net-vout",
-      scope: "local",
+
       terminals: [{ instanceId: "port-object", pinName: "P" }],
     });
     document.netlist = {
@@ -176,7 +176,7 @@ describe("Edit Transaction envelope", () => {
     });
     document.nets.push({
       id: "net-vout",
-      scope: "local",
+
       terminals: [{ instanceId: "port-object", pinName: "P" }],
     });
     document.netlist = {
@@ -256,8 +256,7 @@ describe("Edit Transaction envelope", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.nets.push({
       id: "net-vin",
-      name: "VIN",
-      scope: "local",
+
       terminals: [],
     });
     document.annotations.push({
@@ -572,9 +571,7 @@ describe("Edit Transaction envelope", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.nets.push({
       id: "net-vdd",
-      name: "VDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [],
     });
     document.connectivityEvidence.push({
@@ -624,8 +621,7 @@ describe("Edit Transaction envelope", () => {
     });
     document.nets.push({
       id: "net-substrate",
-      name: "SUBSTRATE",
-      scope: "local",
+
       terminals: [],
     });
     const result = executeTransaction(
@@ -699,7 +695,7 @@ describe("Edit Transaction envelope", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.nets.push({
       id: "net-signal",
-      scope: "local",
+
       terminals: [],
     });
     const annotation = {
@@ -745,12 +741,17 @@ describe("Edit Transaction envelope", () => {
     };
     document.nets.push({
       id: "net-ab",
-      scope: "local",
+
       terminals: [
         { instanceId: "A", pinName: "P" },
         { instanceId: "B", pinName: "P" },
       ],
-      origin: { kind: "spice-import", sourceNetIds: ["net-ab"] },
+    });
+    document.connectivityEvidence.push({
+      id: "source-net-ab",
+      kind: "spice-source",
+      netId: "net-ab",
+      sourceNetId: "net-ab",
     });
     document.instances.push(
       {
@@ -790,9 +791,11 @@ describe("Edit Transaction envelope", () => {
     expect(placed).toMatchObject({
       ok: true,
       document: {
-        nets: [
+        connectivityEvidence: [
           expect.objectContaining({
-            origin: { kind: "spice-import", sourceNetIds: ["net-ab"] },
+            kind: "spice-source",
+            netId: "net-ab",
+            sourceNetId: "net-ab",
           }),
         ],
       },
@@ -813,9 +816,11 @@ describe("Edit Transaction envelope", () => {
     expect(moved).toMatchObject({
       ok: true,
       document: {
-        nets: [
+        connectivityEvidence: [
           expect.objectContaining({
-            origin: { kind: "spice-import", sourceNetIds: ["net-ab"] },
+            kind: "spice-source",
+            netId: "net-ab",
+            sourceNetId: "net-ab",
           }),
         ],
       },
@@ -843,9 +848,11 @@ describe("Edit Transaction envelope", () => {
     expect(wired).toMatchObject({
       ok: true,
       document: {
-        nets: [
+        connectivityEvidence: [
           expect.objectContaining({
-            origin: { kind: "spice-import", sourceNetIds: ["net-ab"] },
+            kind: "spice-source",
+            netId: "net-ab",
+            sourceNetId: "net-ab",
           }),
         ],
       },
@@ -874,9 +881,11 @@ describe("Edit Transaction envelope", () => {
     expect(labelled).toMatchObject({
       ok: true,
       document: {
-        nets: [
+        connectivityEvidence: [
           expect.objectContaining({
-            origin: { kind: "spice-import", sourceNetIds: ["net-ab"] },
+            kind: "spice-source",
+            netId: "net-ab",
+            sourceNetId: "net-ab",
           }),
         ],
       },
@@ -892,16 +901,29 @@ describe("Edit Transaction envelope", () => {
     document.nets.push(
       {
         id: "net-imported-bus",
-        name: "BUS",
-        scope: "local",
+
         terminals: [{ instanceId: "P1", pinName: "P" }],
-        origin: { kind: "spice-import", sourceNetIds: ["source-bus"] },
       },
       {
         id: "net-authored-port",
-        scope: "local",
+
         terminals: [{ instanceId: "P2", pinName: "P" }],
-        origin: { kind: "authored" },
+      },
+    );
+    document.connectivityEvidence.push(
+      {
+        id: "claim-imported-bus",
+        kind: "name-claim",
+        netId: "net-imported-bus",
+        name: "BUS",
+        owner: { kind: "explicit-net-property" },
+        scope: "local",
+      },
+      {
+        id: "source-imported-bus",
+        kind: "spice-source",
+        netId: "net-imported-bus",
+        sourceNetId: "source-bus",
       },
     );
 
@@ -922,24 +944,37 @@ describe("Edit Transaction envelope", () => {
         nets: [
           {
             id: "net-imported-bus",
-            name: "BUS",
             terminals: [
               { instanceId: "P1", pinName: "P" },
               { instanceId: "P2", pinName: "P" },
             ],
-            origin: { kind: "spice-import", sourceNetIds: ["source-bus"] },
           },
         ],
       },
     });
+    if (!result.ok) return;
+    expect(result.document.connectivityEvidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "name-claim",
+          netId: "net-imported-bus",
+          name: "BUS",
+        }),
+        expect.objectContaining({
+          kind: "spice-source",
+          netId: "net-imported-bus",
+          sourceNetId: "source-bus",
+        }),
+      ]),
+    );
   });
 
   it("retargets every connectivity evidence reference when Nets merge", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.nets.push(
-      { id: "net-target", scope: "local", terminals: [] },
-      { id: "net-source", scope: "local", terminals: [] },
-      { id: "net-peer", scope: "local", terminals: [] },
+      { id: "net-target", terminals: [] },
+      { id: "net-source", terminals: [] },
+      { id: "net-peer", terminals: [] },
     );
     document.connectivityEvidence.push(
       {
@@ -998,7 +1033,7 @@ describe("Edit Transaction envelope", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.nets.push({
       id: "net-evidence",
-      scope: "local",
+
       terminals: [],
     });
 
@@ -1045,7 +1080,7 @@ describe("Edit Transaction envelope", () => {
 
   it("rejects evidence ID collisions and missing owners atomically", () => {
     const document = createEmptyDocument("document-main", "Main");
-    document.nets.push({ id: "net-a", scope: "local", terminals: [] });
+    document.nets.push({ id: "net-a", terminals: [] });
     const collision = executeTransaction(document, {
       ...transaction(),
       edits: [
@@ -1111,7 +1146,7 @@ describe("Edit Transaction envelope", () => {
     document.instances.push({ id: "P1", symbolId: "port", placement: null });
     document.nets.push({
       id: "net-port",
-      scope: "local",
+
       terminals: [{ instanceId: "P1", pinName: "P" }],
     });
     document.connectivityEvidence.push({
@@ -1159,7 +1194,7 @@ describe("Edit Transaction envelope", () => {
     });
     document.nets.push({
       id: "net-power-gnd1",
-      scope: "local",
+
       terminals: [{ instanceId: "GND1", pinName: "0" }],
     });
     document.connectivityEvidence.push({
@@ -1248,7 +1283,7 @@ describe("Edit Transaction envelope", () => {
     );
     document.nets.push({
       id: "net-power-vdd1",
-      scope: "local",
+
       terminals: [
         { instanceId: "M1", pinName: "B" },
         { instanceId: "VDD1", pinName: "P" },
@@ -1301,7 +1336,7 @@ describe("Edit Transaction envelope", () => {
     });
     document.nets.push({
       id: "net-body",
-      scope: "local",
+
       terminals: [{ instanceId: "M1", pinName: "B" }],
     });
     document.mosBulkDefaults = { pmosNetId: "net-body" };
@@ -1336,7 +1371,7 @@ describe("Edit Transaction envelope", () => {
     document.nets.push(
       {
         id: "net-vdd-1",
-        scope: "local",
+
         terminals: [
           { instanceId: "M1", pinName: "B" },
           { instanceId: "VDD1", pinName: "P" },
@@ -1344,7 +1379,7 @@ describe("Edit Transaction envelope", () => {
       },
       {
         id: "net-vdd-2",
-        scope: "local",
+
         terminals: [{ instanceId: "VDD2", pinName: "P" }],
       },
     );
@@ -1407,7 +1442,7 @@ describe("Edit Transaction envelope", () => {
 
   it("removes only evidence owned by a deleted Net Label", () => {
     const document = createEmptyDocument("document-main", "Main");
-    document.nets.push({ id: "net-a", scope: "local", terminals: [] });
+    document.nets.push({ id: "net-a", terminals: [] });
     document.annotations.push({
       id: "label-a",
       kind: "net-label",
@@ -1993,8 +2028,7 @@ describe("Edit Transaction envelope", () => {
     document.instances.push(instance);
     document.nets.push({
       id: "net-vin",
-      name: "VIN",
-      scope: "local",
+
       terminals: [{ instanceId: "P1", pinName: "P" }],
     });
     const resolved = resolver.resolve("port");

--- a/packages/model/src/schema.test.ts
+++ b/packages/model/src/schema.test.ts
@@ -15,6 +15,24 @@ describe("CircuitProject schema", () => {
     expect(CircuitProjectJsonSchema).toMatchObject({ type: "object" });
   });
 
+  it("rejects retired logical projections on physical Base Nets", () => {
+    const project = createEmptyProject("project-net", "Net");
+    for (const projection of [
+      { name: "VDD" },
+      { scope: "global" },
+      { powerDomain: "vdd" },
+      { origin: { kind: "authored" } },
+    ]) {
+      const candidate = structuredClone(project) as unknown as Record<
+        string,
+        unknown
+      >;
+      const documents = candidate.documents as Array<Record<string, unknown>>;
+      documents[0]!.nets = [{ id: "net-vdd", terminals: [], ...projection }];
+      expect(CircuitProjectSchema.safeParse(candidate).success).toBe(false);
+    }
+  });
+
   it("has no legacy Instance property authority and validates external definitions", () => {
     const project = createEmptyProject("project-netlist", "Netlist");
     const document = project.documents[0]!;
@@ -91,7 +109,7 @@ describe("CircuitProject schema", () => {
     });
     document.nets.push({
       id: "net-vout",
-      scope: "local",
+
       terminals: [{ instanceId: "port-object", pinName: "P" }],
     });
     document.netlist = {
@@ -200,7 +218,7 @@ describe("CircuitProject schema", () => {
 
     parent.nets.push({
       id: "net-parent",
-      scope: "local",
+
       terminals: [{ instanceId: "X1", pinName: "MISSING" }],
     });
     expect(() => CircuitProjectSchema.parse(project)).toThrow(
@@ -244,8 +262,7 @@ describe("CircuitProject schema", () => {
     });
     document.nets.push({
       id: "net-input",
-      name: "VIN",
-      scope: "local",
+
       terminals: [{ instanceId: "P1", pinName: "P" }],
     });
     document.netlist!.terminals.push({
@@ -274,11 +291,10 @@ describe("CircuitProject schema", () => {
     document.nets.push(
       {
         id: "net-a",
-        name: "A",
-        scope: "local",
+
         terminals: [{ instanceId: "P1", pinName: "P" }],
       },
-      { id: "net-b", scope: "local", terminals: [] },
+      { id: "net-b", terminals: [] },
     );
     document.annotations.push({
       id: "label-a",
@@ -513,8 +529,7 @@ describe("CircuitProject schema", () => {
     });
     document.nets.push({
       id: "net-input",
-      name: "VIN",
-      scope: "local",
+
       terminals: [{ instanceId: "P1", pinName: "P" }],
     });
     document.netlist!.terminals.push({

--- a/packages/model/src/schema/connectivity.ts
+++ b/packages/model/src/schema/connectivity.ts
@@ -11,26 +11,9 @@ export const NetPowerDomainSchema = z.enum([
   "ground",
   "conflict",
 ]);
-/** Temporary schema-23 convergence input; removed after Gallery migration. */
-export const NetOriginSchema = z.discriminatedUnion("kind", [
-  z.strictObject({ kind: z.literal("authored") }),
-  z.strictObject({
-    kind: z.literal("spice-import"),
-    sourceNetIds: z.array(StableIdSchema).min(1).max(256),
-  }),
-]);
-
 export const NetSchema = z.strictObject({
   id: StableIdSchema,
-  /** Temporary migration projection; never authoritative in schema 23. */
-  name: z.string().min(1).optional(),
-  /** Temporary migration projection; never authoritative in schema 23. */
-  scope: z.enum(["local", "global"]).optional(),
-  /** Temporary migration projection; never authoritative in schema 23. */
-  powerDomain: NetPowerDomainSchema.optional(),
   terminals: z.array(TerminalRefSchema),
-  /** Temporary migration projection; never authoritative in schema 23. */
-  origin: NetOriginSchema.optional(),
 });
 
 export const ConnectivityNameClaimOwnerSchema = z.discriminatedUnion("kind", [

--- a/packages/netlist/src/current-contract.test.ts
+++ b/packages/netlist/src/current-contract.test.ts
@@ -8,31 +8,25 @@ import {
 import { analyzeDesignNetlist as analyzeCurrentDesignNetlist } from "./index.js";
 
 function analyzeDesignNetlist(project: CircuitProject) {
-  for (const document of project.documents) {
-    for (const net of document.nets) {
-      if (
-        !net.name ||
-        document.connectivityEvidence.some(
-          (evidence) =>
-            evidence.kind === "name-claim" && evidence.netId === net.id,
-        )
-      ) {
-        continue;
-      }
-      document.connectivityEvidence.push({
-        id: deriveStableId("fixture-net-name", document.id, net.id),
-        kind: "name-claim",
-        netId: net.id,
-        name: net.name,
-        owner: { kind: "explicit-net-property" },
-        scope: net.scope ?? "local",
-        ...(net.powerDomain === "vdd" || net.powerDomain === "ground"
-          ? { powerDomain: net.powerDomain }
-          : {}),
-      });
-    }
-  }
   return analyzeCurrentDesignNetlist(project);
+}
+
+function claimNet(
+  document: CircuitProject["documents"][number],
+  netId: string,
+  name: string,
+  scope: "local" | "global" = "local",
+  powerDomain?: "vdd" | "ground",
+): void {
+  document.connectivityEvidence.push({
+    id: deriveStableId("fixture-net-name", document.id, netId),
+    kind: "name-claim",
+    netId,
+    name,
+    owner: { kind: "explicit-net-property" },
+    scope,
+    ...(powerDomain ? { powerDomain } : {}),
+  });
 }
 
 function resistorProject(parameters: Record<string, string>) {
@@ -51,17 +45,17 @@ function resistorProject(parameters: Record<string, string>) {
   document.nets.push(
     {
       id: "net-in",
-      name: "VIN",
-      scope: "local",
+
       terminals: [{ instanceId: "R1", pinName: "1" }],
     },
     {
       id: "net-out",
-      name: "VOUT",
-      scope: "local",
+
       terminals: [{ instanceId: "R1", pinName: "2" }],
     },
   );
+  claimNet(document, "net-in", "VIN");
+  claimNet(document, "net-out", "VOUT");
   return project;
 }
 
@@ -96,12 +90,12 @@ describe("current formal cell interface", () => {
     document.nets.push(
       {
         id: "net-in",
-        scope: "local",
+
         terminals: [{ instanceId: "P1", pinName: "P" }],
       },
       {
         id: "net-out",
-        scope: "local",
+
         terminals: [{ instanceId: "P2", pinName: "P" }],
       },
     );
@@ -128,10 +122,10 @@ describe("current formal cell interface", () => {
     });
     document.nets.push({
       id: "net-vin",
-      name: "VIN",
-      scope: "local",
+
       terminals: [{ instanceId: "P1", pinName: "P" }],
     });
+    claimNet(document, "net-vin", "VIN");
 
     const result = analyzeDesignNetlist(project);
 
@@ -160,12 +154,12 @@ describe("current formal cell interface", () => {
     document.nets.push(
       {
         id: "net-a",
-        scope: "local",
+
         terminals: [{ instanceId: "R1", pinName: "1" }],
       },
       {
         id: "net-b",
-        scope: "local",
+
         terminals: [{ instanceId: "R1", pinName: "2" }],
       },
     );
@@ -224,10 +218,10 @@ describe("current formal cell interface", () => {
     document.nets[1]!.terminals = [];
     document.nets.push({
       id: "occupied-no-connect-name",
-      name: "NC0001",
-      scope: "local",
+
       terminals: [],
     });
+    claimNet(document, "occupied-no-connect-name", "NC0001");
     document.noConnects.push({
       id: "no-connect-r1-2",
       endpoint: { kind: "terminal", instanceId: "R1", pinName: "2" },
@@ -320,7 +314,7 @@ describe("current formal cell interface", () => {
     const document = project.documents[0]!;
     document.nets.push({
       id: "net-global",
-      scope: "local",
+
       terminals: [],
     });
     document.connectivityEvidence.push(
@@ -363,10 +357,10 @@ describe("current formal cell interface", () => {
     });
     document.nets.push({
       id: "net-ground",
-      name: "0",
-      scope: "global",
+
       terminals: [{ instanceId: "GND", pinName: "0" }],
     });
+    claimNet(document, "net-ground", "0", "global", "ground");
 
     const result = analyzeDesignNetlist(project);
 
@@ -385,11 +379,10 @@ describe("current formal cell interface", () => {
     });
     document.nets.push({
       id: "net-vdd",
-      name: "VDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [{ instanceId: "VDD1", pinName: "P" }],
     });
+    claimNet(document, "net-vdd", "VDD", "global", "vdd");
 
     const result = analyzeDesignNetlist(project);
 
@@ -413,10 +406,10 @@ describe("current formal cell interface", () => {
     });
     document.nets.push({
       id: "net-signal",
-      name: "SIGNAL",
-      scope: "local",
+
       terminals: [{ instanceId: "VDD1", pinName: "P" }],
     });
+    claimNet(document, "net-signal", "SIGNAL");
 
     const result = analyzeDesignNetlist(project);
 
@@ -460,10 +453,10 @@ describe("current formal cell interface", () => {
     ] as const) {
       document.nets.push({
         id,
-        name,
-        scope: "local",
+
         terminals: [{ instanceId: "X1", pinName }],
       });
+      claimNet(document, id, name);
     }
 
     const result = analyzeDesignNetlist(project);
@@ -517,10 +510,10 @@ describe("current formal cell interface", () => {
     });
     document.nets.push({
       id: "net-in",
-      name: "IN",
-      scope: "local",
+
       terminals: [{ instanceId: "X1", pinName: "IN" }],
     });
+    claimNet(document, "net-in", "IN");
 
     const result = analyzeDesignNetlist(project);
 
@@ -560,10 +553,10 @@ describe("current formal cell interface", () => {
     });
     document.nets.push({
       id: "net-in",
-      name: "IN",
-      scope: "local",
+
       terminals: [{ instanceId: "X1", pinName: "P1" }],
     });
+    claimNet(document, "net-in", "IN");
 
     const result = analyzeDesignNetlist(project);
 
@@ -604,17 +597,17 @@ describe("current formal cell interface", () => {
     document.nets.push(
       {
         id: "net-a",
-        name: "NET_A",
-        scope: "local",
+
         terminals: [{ instanceId: "X1", pinName: "A" }],
       },
       {
         id: "net-b",
-        name: "NET_B",
-        scope: "local",
+
         terminals: [{ instanceId: "X1", pinName: "B" }],
       },
     );
+    claimNet(document, "net-a", "NET_A");
+    claimNet(document, "net-b", "NET_B");
 
     const result = analyzeDesignNetlist(project);
 
@@ -660,10 +653,10 @@ describe("current formal cell interface", () => {
     ] as const) {
       document.nets.push({
         id: `net-${pinName.toLowerCase()}`,
-        name: netName,
-        scope: "local",
+
         terminals: [{ instanceId: "XM1", pinName }],
       });
+      claimNet(document, `net-${pinName.toLowerCase()}`, netName);
     }
 
     const result = analyzeDesignNetlist(project);

--- a/packages/netlist/src/roundtrip.test.ts
+++ b/packages/netlist/src/roundtrip.test.ts
@@ -11,6 +11,22 @@ import type { DesignNetlistIR } from "./ir.js";
 import { analyzeDesignNetlist } from "./extract.js";
 import { printSpiceNetlist } from "./printers.js";
 
+function claimNet(
+  document: CircuitProject["documents"][number],
+  netId: string,
+  name: string,
+  scope: "local" | "global" = "local",
+): void {
+  document.connectivityEvidence.push({
+    id: deriveStableId("fixture-net-name", document.id, netId),
+    kind: "name-claim",
+    netId,
+    name,
+    owner: { kind: "explicit-net-property" },
+    scope,
+  });
+}
+
 function structuralProject(): CircuitProject {
   const project = createEmptyProject("roundtrip-project", "Roundtrip", "top");
   const top = project.documents[0]!;
@@ -75,8 +91,7 @@ function structuralProject(): CircuitProject {
   top.nets.push(
     {
       id: "top-net-vin",
-      name: "internal_vin",
-      scope: "local",
+
       terminals: [
         { instanceId: "top-port-vin", pinName: "P" },
         { instanceId: "X1", pinName: "A" },
@@ -85,8 +100,7 @@ function structuralProject(): CircuitProject {
     },
     {
       id: "top-net-vout",
-      name: "internal_vout",
-      scope: "local",
+
       terminals: [
         { instanceId: "top-port-vout", pinName: "P" },
         { instanceId: "X1", pinName: "B" },
@@ -95,17 +109,19 @@ function structuralProject(): CircuitProject {
     },
     {
       id: "top-net-vdd",
-      name: "VDD",
-      scope: "global",
+
       terminals: [{ instanceId: "I1", pinName: "+" }],
     },
     {
       id: "top-net-ground",
-      name: "0",
-      scope: "global",
+
       terminals: [{ instanceId: "I1", pinName: "-" }],
     },
   );
+  claimNet(top, "top-net-vin", "internal_vin");
+  claimNet(top, "top-net-vout", "internal_vout");
+  claimNet(top, "top-net-vdd", "VDD", "global");
+  claimNet(top, "top-net-ground", "0", "global");
 
   const leaf = createEmptyDocument("leaf", "leaf");
   leaf.netlist = {
@@ -155,8 +171,7 @@ function structuralProject(): CircuitProject {
   leaf.nets.push(
     {
       id: "leaf-net-a",
-      name: "leaf_internal_a",
-      scope: "local",
+
       terminals: [
         { instanceId: "leaf-port-a", pinName: "P" },
         { instanceId: "C1", pinName: "1" },
@@ -165,14 +180,15 @@ function structuralProject(): CircuitProject {
     },
     {
       id: "leaf-net-b",
-      name: "leaf_internal_b",
-      scope: "local",
+
       terminals: [
         { instanceId: "leaf-port-b", pinName: "P" },
         { instanceId: "C1", pinName: "2" },
       ],
     },
   );
+  claimNet(leaf, "leaf-net-a", "leaf_internal_a");
+  claimNet(leaf, "leaf-net-b", "leaf_internal_b");
   leaf.noConnects.push({
     id: "leaf-r1-open",
     endpoint: { kind: "terminal", instanceId: "R1", pinName: "2" },
@@ -188,19 +204,6 @@ function structuralProject(): CircuitProject {
     formalParameters: [],
     interfaceStatus: "declared",
   });
-  for (const document of project.documents) {
-    for (const net of document.nets) {
-      if (!net.name) continue;
-      document.connectivityEvidence.push({
-        id: deriveStableId("fixture-net-name", document.id, net.id),
-        kind: "name-claim",
-        netId: net.id,
-        name: net.name,
-        owner: { kind: "explicit-net-property" },
-        scope: net.scope ?? "local",
-      });
-    }
-  }
   return project;
 }
 

--- a/packages/project-protocol/src/load.ts
+++ b/packages/project-protocol/src/load.ts
@@ -12,14 +12,9 @@ import {
 } from "./diagnostics.js";
 import {
   ProjectMigrationError,
-  upgradeSchema21To22,
   upgradeSchema22To23,
 } from "./previous-to-current.js";
-import { canonicalizeSchema23Project } from "./transforms/project.js";
-import {
-  GALLERY_MIGRATION_SCHEMA_VERSION,
-  PREVIOUS_PROJECT_SCHEMA_VERSION,
-} from "./version.js";
+import { PREVIOUS_PROJECT_SCHEMA_VERSION } from "./version.js";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -93,7 +88,6 @@ export function tryParseProjectWithMetadata(
   const sourceSchemaVersion = parsed.schemaVersion as number;
   const migrated = sourceSchemaVersion !== CURRENT_PROJECT_SCHEMA_VERSION;
   const supported = new Set([
-    GALLERY_MIGRATION_SCHEMA_VERSION,
     PREVIOUS_PROJECT_SCHEMA_VERSION,
     CURRENT_PROJECT_SCHEMA_VERSION,
   ]);
@@ -103,7 +97,7 @@ export function tryParseProjectWithMetadata(
       diagnostics: [
         {
           code: "UNSUPPORTED_SCHEMA_VERSION",
-          message: `Project schemaVersion must be ${GALLERY_MIGRATION_SCHEMA_VERSION}, ${PREVIOUS_PROJECT_SCHEMA_VERSION}, or ${CURRENT_PROJECT_SCHEMA_VERSION}`,
+          message: `Project schemaVersion must be ${PREVIOUS_PROJECT_SCHEMA_VERSION} or ${CURRENT_PROJECT_SCHEMA_VERSION}`,
           path: ["schemaVersion"],
         },
       ],
@@ -113,11 +107,9 @@ export function tryParseProjectWithMetadata(
   let current: Record<string, unknown>;
   try {
     current =
-      sourceSchemaVersion === GALLERY_MIGRATION_SCHEMA_VERSION
-        ? upgradeSchema22To23(upgradeSchema21To22(parsed))
-        : sourceSchemaVersion === PREVIOUS_PROJECT_SCHEMA_VERSION
-          ? upgradeSchema22To23(parsed)
-          : canonicalizeSchema23Project(parsed);
+      sourceSchemaVersion === PREVIOUS_PROJECT_SCHEMA_VERSION
+        ? upgradeSchema22To23(parsed)
+        : parsed;
   } catch (error) {
     if (error instanceof ProjectMigrationError) {
       return {

--- a/packages/project-protocol/src/persistence.test.ts
+++ b/packages/project-protocol/src/persistence.test.ts
@@ -68,12 +68,11 @@ describe("Project persistence", () => {
     }
   });
 
-  it("upgrades schema-21 names, labels, and source membership to evidence", () => {
+  it("upgrades schema-22 evidence while preserving bound identities", () => {
     const source = JSON.parse(
       serializeProject(createEmptyProject("project-test", "Test Project")),
     );
-    source.schemaVersion = 21;
-    delete source.documents[0].connectivityEvidence;
+    source.schemaVersion = 22;
     source.documents[0].instances.push({
       id: "P-object",
       symbolId: "port",
@@ -113,6 +112,48 @@ describe("Project persistence", () => {
       powerDomain: "vdd",
       terminals: [],
     });
+    source.documents[0].connectivityEvidence.push(
+      {
+        id: "claim-vout",
+        kind: "name-claim",
+        netId: "net-vout",
+        name: "Vout",
+        owner: { kind: "explicit-net-property" },
+        scope: "local",
+      },
+      {
+        id: "source-vout",
+        kind: "spice-source",
+        netId: "net-vout",
+        sourceNetId: "source-vout",
+      },
+      {
+        id: "claim-vdd",
+        kind: "name-claim",
+        netId: "net-vdd",
+        name: "VDD",
+        owner: { kind: "explicit-net-property" },
+        scope: "global",
+        powerDomain: "vdd",
+      },
+      {
+        id: "label-claim-vout",
+        kind: "name-claim",
+        netId: "net-vout",
+        name: "Vout",
+        owner: { kind: "net-label", annotationId: "label-vout" },
+        scope: "local",
+      },
+      {
+        id: "label-claim-vdd",
+        kind: "name-claim",
+        netId: "net-vdd",
+        name: "VDD",
+        owner: { kind: "power-marker", objectId: "label-vdd" },
+        scope: "global",
+        powerDomain: "vdd",
+      },
+    );
     source.documents[0].annotations.push(
       {
         id: "reference-R7",
@@ -162,7 +203,7 @@ describe("Project persistence", () => {
     const previousText = JSON.stringify(source);
     const migrated = parseProjectWithMetadata(previousText);
     expect(migrated).toMatchObject({
-      sourceSchemaVersion: 21,
+      sourceSchemaVersion: 22,
       migrated: true,
       project: { schemaVersion: 23 },
     });
@@ -228,8 +269,7 @@ describe("Project persistence", () => {
     const source = JSON.parse(
       serializeProject(createEmptyProject("project-test", "Test Project")),
     );
-    source.schemaVersion = 21;
-    delete source.documents[0].connectivityEvidence;
+    source.schemaVersion = 22;
     const project = parseProject(JSON.stringify(source));
     project.documents[0]!.annotations.push({
       id: "value-fraction",
@@ -312,12 +352,11 @@ describe("Project persistence", () => {
     ]);
   });
 
-  it("migrates an object-anchored schema-21 VDD format override", () => {
+  it("preserves an object-anchored schema-22 VDD format override", () => {
     const source = JSON.parse(
       serializeProject(createEmptyProject("project-test", "Gallery VDD")),
     );
-    source.schemaVersion = 21;
-    delete source.documents[0].connectivityEvidence;
+    source.schemaVersion = 22;
     source.documents[0].instances.push({
       id: "VDD1",
       symbolId: "vdd-port",
@@ -335,6 +374,15 @@ describe("Project persistence", () => {
       powerDomain: "vdd",
       origin: { kind: "authored" },
       terminals: [{ instanceId: "VDD1", pinName: "P" }],
+    });
+    source.documents[0].connectivityEvidence.push({
+      id: "claim-vdd1",
+      kind: "name-claim",
+      netId: "net-power-vdd1",
+      name: "VDD",
+      owner: { kind: "power-marker", objectId: "VDD1" },
+      scope: "global",
+      powerDomain: "vdd",
     });
     source.documents[0].annotations.push({
       id: "power-label-vdd1",
@@ -399,9 +447,9 @@ describe("Project persistence", () => {
     const project = createEmptyProject("project-test", "Test Project");
     expect(() =>
       parseProject(JSON.stringify({ ...project, schemaVersion: 99 })),
-    ).toThrow(/must be 21, 22, or 23/);
+    ).toThrow(/must be 22 or 23/);
     expect(() =>
       parseProject(JSON.stringify({ ...project, schemaVersion: 20 })),
-    ).toThrow(/must be 21, 22, or 23/);
+    ).toThrow(/must be 22 or 23/);
   });
 });

--- a/packages/project-protocol/src/previous-to-current.ts
+++ b/packages/project-protocol/src/previous-to-current.ts
@@ -1,5 +1,4 @@
 export {
   ProjectMigrationError,
-  upgradeSchema21To22,
   upgradeSchema22To23,
 } from "./transforms/project.js";

--- a/packages/project-protocol/src/protocol.test.ts
+++ b/packages/project-protocol/src/protocol.test.ts
@@ -16,23 +16,35 @@ describe("Project protocol boundary", () => {
     });
   });
 
-  it("converges schema 21 directly to schema 23", () => {
+  it("upgrades the previous schema to schema 23", () => {
     const current = JSON.parse(
       serializeProject(createEmptyProject("protocol-project", "Protocol")),
     ) as Record<string, unknown>;
-    const documents = current.documents as Array<Record<string, unknown>>;
-    delete documents[0]!.connectivityEvidence;
     const result = tryParseProjectWithMetadata(
       JSON.stringify({
         ...current,
-        schemaVersion: 21,
+        schemaVersion: 22,
       }),
     );
     expect(result).toMatchObject({
       ok: true,
-      sourceSchemaVersion: 21,
+      sourceSchemaVersion: 22,
       migrated: true,
       project: { schemaVersion: 23, structureRevision: 0 },
+    });
+  });
+
+  it("rejects projects older than the rolling compatibility window", () => {
+    const current = JSON.parse(
+      serializeProject(createEmptyProject("protocol-project", "Protocol")),
+    ) as Record<string, unknown>;
+    expect(
+      tryParseProjectWithMetadata(
+        JSON.stringify({ ...current, schemaVersion: 21 }),
+      ),
+    ).toMatchObject({
+      ok: false,
+      diagnostics: [{ code: "UNSUPPORTED_SCHEMA_VERSION" }],
     });
   });
 

--- a/packages/project-protocol/src/transforms/project.ts
+++ b/packages/project-protocol/src/transforms/project.ts
@@ -1,9 +1,4 @@
-import {
-  CURRENT_PROJECT_SCHEMA_VERSION,
-  deriveStableId,
-  flattenRichText,
-  RichTextDocumentSchema,
-} from "@icm/model";
+import { CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
 
 export class ProjectMigrationError extends Error {
   constructor(
@@ -12,122 +7,6 @@ export class ProjectMigrationError extends Error {
   ) {
     super(message);
   }
-}
-
-/**
- * Schema 22 introduces owner-addressable Connectivity Evidence. Schema-21
- * names and imported origin records are retained as transitional projections
- * while deterministic evidence is added beside them. Historical destructive
- * merge lineage cannot be reconstructed and is never fabricated here.
- */
-export function upgradeSchema21To22(
-  raw: Record<string, unknown>,
-): Record<string, unknown> {
-  const project = structuredClone(raw);
-  if (Array.isArray(project.documents)) {
-    for (const rawDocument of project.documents) {
-      if (!isRecord(rawDocument)) continue;
-      const documentId =
-        typeof rawDocument.id === "string" ? rawDocument.id : "document";
-      const nets = Array.isArray(rawDocument.nets)
-        ? rawDocument.nets.filter(isRecord)
-        : [];
-      const netById = new Map(
-        nets.flatMap((net) =>
-          typeof net.id === "string" ? [[net.id, net] as const] : [],
-        ),
-      );
-      const evidence: Record<string, unknown>[] = [];
-      for (const net of nets) {
-        if (typeof net.id !== "string") continue;
-        if (typeof net.name === "string" && net.name.trim()) {
-          const powerDomain = legacyPowerDomain(net);
-          evidence.push({
-            id: evidenceId(
-              documentId,
-              "explicit-net-property",
-              net.id,
-              net.name,
-            ),
-            kind: "name-claim",
-            netId: net.id,
-            name: net.name,
-            owner: { kind: "explicit-net-property" },
-            scope: net.scope === "global" ? "global" : "local",
-            ...(powerDomain ? { powerDomain } : {}),
-          });
-        }
-        const origin = isRecord(net.origin) ? net.origin : null;
-        if (
-          origin?.kind === "spice-import" &&
-          Array.isArray(origin.sourceNetIds)
-        ) {
-          for (const sourceNetId of origin.sourceNetIds) {
-            if (typeof sourceNetId !== "string") continue;
-            evidence.push({
-              id: evidenceId(documentId, "spice-source", net.id, sourceNetId),
-              kind: "spice-source",
-              netId: net.id,
-              sourceNetId,
-            });
-          }
-        }
-      }
-      const annotations = Array.isArray(rawDocument.annotations)
-        ? rawDocument.annotations.filter(isRecord)
-        : [];
-      for (const annotation of annotations) {
-        if (
-          (annotation.kind !== "net-label" &&
-            annotation.kind !== "power-label") ||
-          typeof annotation.id !== "string" ||
-          typeof annotation.netId !== "string"
-        ) {
-          continue;
-        }
-        const net = netById.get(annotation.netId);
-        if (!net) continue;
-        const content = RichTextDocumentSchema.safeParse(annotation.content);
-        const name =
-          typeof net.name === "string" && net.name.trim()
-            ? net.name
-            : content.success
-              ? flattenRichText(content.data).trim()
-              : "";
-        if (!name) continue;
-        const powerDomain = legacyPowerDomain(net);
-        const ownerKind =
-          annotation.kind === "power-label" ? "power-marker" : "net-label";
-        const markerObjectId =
-          annotation.kind === "power-label" &&
-          isRecord(annotation.anchor) &&
-          annotation.anchor.kind === "object" &&
-          typeof annotation.anchor.objectId === "string"
-            ? annotation.anchor.objectId
-            : annotation.id;
-        evidence.push({
-          id: evidenceId(
-            documentId,
-            ownerKind,
-            annotation.netId,
-            annotation.id,
-          ),
-          kind: "name-claim",
-          netId: annotation.netId,
-          name,
-          owner:
-            ownerKind === "power-marker"
-              ? { kind: "power-marker", objectId: markerObjectId }
-              : { kind: "net-label", annotationId: annotation.id },
-          scope: net.scope === "global" ? "global" : "local",
-          ...(powerDomain ? { powerDomain } : {}),
-        });
-      }
-      rawDocument.connectivityEvidence = evidence;
-    }
-  }
-  project.schemaVersion = 22;
-  return project;
 }
 
 /**
@@ -249,19 +128,4 @@ function legacyPowerDomain(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function evidenceId(
-  documentId: string,
-  kind: string,
-  netId: string,
-  ownerId: string,
-): string {
-  return deriveStableId(
-    "connectivity-evidence",
-    documentId,
-    kind,
-    netId,
-    ownerId,
-  );
 }

--- a/packages/project-protocol/src/version.ts
+++ b/packages/project-protocol/src/version.ts
@@ -3,5 +3,3 @@
  * current schema replaces this adapter instead of extending a migration chain.
  */
 export const PREVIOUS_PROJECT_SCHEMA_VERSION = 22;
-/** Temporary online-convergence input. Removed after Gallery storage reaches 23. */
-export const GALLERY_MIGRATION_SCHEMA_VERSION = 21;

--- a/packages/render-svg/src/current-contract.test.ts
+++ b/packages/render-svg/src/current-contract.test.ts
@@ -192,7 +192,7 @@ describe("current rendering contract", () => {
     );
     document.nets.push({
       id: "signal",
-      scope: "local",
+
       terminals: [
         { instanceId: "VIN", pinName: "P" },
         { instanceId: "VOUT", pinName: "P" },
@@ -224,9 +224,7 @@ describe("current rendering contract", () => {
     const document = createEmptyDocument("doc", "Power rail");
     document.nets.push({
       id: "net-vdd",
-      name: "VDD",
-      scope: "global",
-      powerDomain: "vdd",
+
       terminals: [],
     });
     document.junctions.push(
@@ -313,7 +311,7 @@ describe("current rendering contract", () => {
     });
     document.nets.push({
       id: "base-net",
-      scope: "local",
+
       terminals: [{ instanceId: "Q1", pinName: "B" }],
     });
     document.junctions.push({

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -122,9 +122,8 @@ function previousVersionText(): string {
 
 function previousPowerRailVersionText(): string {
   const raw = JSON.parse(projectText("Legacy VDD")) as any;
-  raw.schemaVersion = 21;
+  raw.schemaVersion = 22;
   const document = raw.documents[0];
-  delete document.connectivityEvidence;
   document.nets.push({
     id: "net-vdd",
     name: "VDD",
@@ -132,6 +131,15 @@ function previousPowerRailVersionText(): string {
     powerDomain: "vdd",
     origin: { kind: "authored" },
     terminals: [],
+  });
+  document.connectivityEvidence.push({
+    id: "legacy-label-vdd",
+    kind: "name-claim",
+    netId: "net-vdd",
+    name: "VDD",
+    owner: { kind: "power-marker", objectId: "label-vdd" },
+    scope: "global",
+    powerDomain: "vdd",
   });
   document.junctions.push(
     {
@@ -1043,7 +1051,6 @@ function wiredProjectText(name = "Wired"): string {
   document.nets = [
     {
       id: "n1",
-      scope: "local",
       terminals: [
         { instanceId: "R1", pinName: "1" },
         { instanceId: "R2", pinName: "1" },
@@ -1051,7 +1058,6 @@ function wiredProjectText(name = "Wired"): string {
     },
     {
       id: "n2",
-      scope: "local",
       terminals: [
         { instanceId: "R1", pinName: "2" },
         { instanceId: "R2", pinName: "2" },
@@ -1561,7 +1567,7 @@ describe("gallery administration", () => {
     expect(((await gone.json()) as { entries: unknown[] }).entries).toEqual([]);
   });
 
-  it("re-serializes stored entries back into the rolling window", async () => {
+  it("converges stored entries back into the rolling window", async () => {
     const env = environment();
     const adminCookie = await adminOf(env);
     const id = await submitOne(env, "Aging Entry", { cookie: adminCookie });
@@ -1584,9 +1590,13 @@ describe("gallery administration", () => {
 
     const maintenance = await route(
       env,
-      new Request(`${ORIGIN}/api/gallery/maintenance/reserialize`, {
+      new Request(`${ORIGIN}/api/gallery/maintenance/schema23`, {
         method: "POST",
-        headers: cookieHeaders(adminCookie),
+        headers: {
+          ...cookieHeaders(adminCookie),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ apply: true }),
       }),
     );
     expect(await maintenance.json()).toMatchObject({
@@ -1624,7 +1634,7 @@ describe("gallery administration", () => {
         body: JSON.stringify({
           id,
           projectText: brokenCurrentPowerRailText(),
-          schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION,
+          schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION - 1,
           svgText: "<svg/>",
         }),
       },
@@ -1632,9 +1642,13 @@ describe("gallery administration", () => {
 
     const maintenance = await route(
       env,
-      new Request(`${ORIGIN}/api/gallery/maintenance/reserialize`, {
+      new Request(`${ORIGIN}/api/gallery/maintenance/schema23`, {
         method: "POST",
-        headers: cookieHeaders(adminCookie),
+        headers: {
+          ...cookieHeaders(adminCookie),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ apply: true }),
       }),
     );
     expect(await maintenance.json()).toMatchObject({
@@ -1698,7 +1712,7 @@ describe("gallery administration", () => {
     );
     env.gallerySql.exec(
       "UPDATE gallery_entry_versions SET schema_version = ?, project_text = ? WHERE id = ?",
-      21,
+      22,
       previousPowerRailVersionText(),
       versionId,
     );
@@ -1711,7 +1725,7 @@ describe("gallery administration", () => {
       "Legacy workspace",
       "2026-08-24T00:00:00.000Z",
       1,
-      21,
+      22,
       previousPowerRailVersionText(),
     );
 
@@ -1745,8 +1759,8 @@ describe("gallery administration", () => {
       failures: [],
       inventory: {
         gallery_entries: { "22": 1 },
-        gallery_entry_versions: { "21": 1 },
-        workspace_slots: { "21": 1 },
+        gallery_entry_versions: { "22": 1 },
+        workspace_slots: { "22": 1 },
       },
     });
     expect(

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -1492,13 +1492,6 @@ async function handleEntryUpdate(
   return Response.json(payload, { status });
 }
 
-async function handleReserialize(env: GalleryEnv): Promise<Response> {
-  const { status, payload } = await callGallery(env, "schema-converge", {
-    apply: true,
-  });
-  return Response.json(payload, { status });
-}
-
 /**
  * All `/api/gallery*` routing. Returns null for unrelated paths so the
  * worker entry keeps its ordinary dispatch.
@@ -1620,17 +1613,6 @@ export async function routeGalleryRequest(
       status,
       headers: { "cache-control": "no-store" },
     });
-  }
-  if (
-    segments.length === 2 &&
-    segments[0] === "maintenance" &&
-    segments[1] === "reserialize" &&
-    request.method === "POST"
-  ) {
-    if (!(await isAdmin(request, env))) {
-      return Response.json({ error: "unauthorized" }, { status: 401 });
-    }
-    return handleReserialize(env);
   }
   if (
     segments.length === 1 &&


### PR DESCRIPTION
## Summary
- close the temporary schema 21 Gallery migration bridge after all online records reached schema 23
- keep only the rolling schema 22/23 read window
- make current Base Nets strictly physical and move all fixture semantics to Connectivity Evidence
- remove the legacy reserialize endpoint alias and update current specifications

## Online migration evidence
- gallery_entries: 29/29 schema 23
- gallery_entry_versions: 5/5 schema 23
- workspace_slots: 8/8 schema 23
- public Gallery: 28/28 schema 23

## Validation
- focused protocol, recovery, Gallery, Netlist, and Edit Engine suites
- hierarchy and project-file browser suites: 28 passed
- `pnpm install --frozen-lockfile`
- `pnpm ci:check`: 196 unit files / 1319 tests, build/release/golden checks, 233 browser tests

Test-Impact: tests-updated