### PR TITLE
chore(schema): purge retired schema 21 noise

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -12,7 +12,7 @@ const ENTRY = {
   author: "tz",
   description: "Three-stage loop",
   createdAt: "2026-08-21T10:00:00.000Z",
-  schemaVersion: 21,
+  schemaVersion: 23,
 };
 
 /**
@@ -70,7 +70,7 @@ test("masonry places the top row left-to-right in distinct columns", async ({
     author: "tz",
     description: index === 0 ? "taller card" : "",
     createdAt: "2026-08-22T10:00:00.000Z",
-    schemaVersion: 21,
+    schemaVersion: 23,
   }));
   await page.route(galleryListUrl, (route) =>
     route.fulfill({ json: { entries, nextCursor: null } }),
@@ -122,7 +122,7 @@ test("the feed pages through the cursor as the sentinel comes into view", async 
           author: "tz",
           description: "",
           createdAt: "2026-08-22T10:00:00.000Z",
-          schemaVersion: 21,
+          schemaVersion: 23,
         })),
         nextCursor: second ? null : "c1",
         total: 5,
@@ -168,7 +168,7 @@ test("the feed scrolls inside its shell despite the locked app root", async ({
     author: "tz",
     description: "",
     createdAt: "2026-08-22T10:00:00.000Z",
-    schemaVersion: 21,
+    schemaVersion: 23,
   }));
   await page.route(galleryListUrl, (route) =>
     route.fulfill({ json: { entries, nextCursor: null } }),
@@ -209,7 +209,7 @@ test("clicking a byline filters the wall to that author, clearable", async ({
         author: "alice",
         description: "",
         createdAt: "2026-08-22T10:00:00.000Z",
-        schemaVersion: 21,
+        schemaVersion: 23,
       },
       ...(alice
         ? []
@@ -220,7 +220,7 @@ test("clicking a byline filters the wall to that author, clearable", async ({
               author: "bob",
               description: "",
               createdAt: "2026-08-22T09:00:00.000Z",
-              schemaVersion: 21,
+              schemaVersion: 23,
             },
           ]),
     ];
@@ -285,7 +285,7 @@ test("the tag menu multi-selects and tile tags join the selection", async ({
         author: "tz",
         description: "",
         createdAt: "2026-08-22T10:00:00.000Z",
-        schemaVersion: 21,
+        schemaVersion: 23,
         tags: entry.tags,
       }));
     return route.fulfill({ json: { entries, nextCursor: null } });
@@ -862,9 +862,9 @@ test("the retired review queue is gone from the moderation page", async ({
         applied: body.apply === true,
         targetSchemaVersion: 23,
         inventory: {
-          gallery_entries: { "21": 2, "22": 1 },
-          gallery_entry_versions: { "21": 1 },
-          workspace_slots: { "22": 1 },
+          gallery_entries: { "23": 3 },
+          gallery_entry_versions: { "23": 1 },
+          workspace_slots: { "23": 1 },
         },
         records: 5,
         ready: 5,
@@ -885,7 +885,7 @@ test("the retired review queue is gone from the moderation page", async ({
     "Validated: 5/5 records ready for schema 23; 0 failures.",
   );
   await expect(page.getByTestId("schema23-report")).toContainText(
-    "gallery_entries: v21=2, v22=1",
+    "gallery_entries: v23=3",
   );
   await expect(page.getByTestId("schema23-apply")).toBeDisabled();
   await page.getByTestId("schema23-backup-confirmed").check();

--- a/apps/editor/src/components/gallery-feed.test.tsx
+++ b/apps/editor/src/components/gallery-feed.test.tsx
@@ -23,7 +23,7 @@ describe("loadGalleryFeed", () => {
             author: "tz",
             description: "",
             createdAt: "2026-08-21T00:00:00.000Z",
-            schemaVersion: 21,
+            schemaVersion: 23,
           },
         ],
         nextCursor: "2026-08-21T00:00:00.000Z|g1",

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -340,7 +340,7 @@ no electrical meaning.
 Open, demo load, restore, and human-approved staged import replace the entire
 Project through one replacement boundary; they are not Edit Engine
 transactions. Replacement cancels pending recovery for the outgoing Project
-and terminates its Agent session. A complete schema-21 Project may be upgraded
+and terminates its Agent session. A complete schema-22 Project may be upgraded
 at the read boundary and then enters the editor only as schema-23; migrated
 files are marked as needing save.
 

--- a/docs/specs/persistence-and-recovery.md
+++ b/docs/specs/persistence-and-recovery.md
@@ -9,12 +9,12 @@ model in `packages/model` validates the normalized shape;
 `packages/project-protocol` owns parsing, rolling compatibility diagnostics,
 and canonical serialization. Persistence validates
 the complete current schema before open or save and writes atomically where the
-platform supports it. During Gallery convergence, schemas 21 and 22 upgrade to
-23 at ingestion; serialization always writes schema 23. The schema-21 hop is a
-bounded deployment bridge and is removed after online storage convergence.
+platform supports it. Schema 22 upgrades to 23 at ingestion; serialization
+always writes schema 23. Older schemas are rejected outside the rolling
+current-and-previous compatibility window.
 
 Recovery state is a non-authoritative browser safety copy. It may restore a
-complete schema-23 Project or a schema-21/22 record that validates after the
+complete schema-23 Project or a schema-22 record that validates after the
 bounded upgrade, associated with a recorded working-copy session.
 Corrupt, incompatible, or partial recovery data is discarded or retained as raw
 data without changing the live Project. User-saved Library examples are the

--- a/docs/specs/project-file-format.md
+++ b/docs/specs/project-file-format.md
@@ -8,13 +8,11 @@ Primary owners: `packages/model` (current shape) and
 `packages/project-protocol` (file boundary)
 
 An `.icproj.json` file is canonical JSON for one complete `CircuitProject`.
-`@icm/project-protocol` exposes `parseProject`. During the Gallery convergence
-release it accepts schemas 21, 22, and 23, upgrades every accepted input to the
-sole schema-23 in-memory Project, and writes only schema 23. Schema 21 first
-gains deterministic Connectivity Evidence; schema 22 then drops the inert
-Base-Net name, scope, power-role, and origin projections. This temporary
-two-hop reader is removed after Gallery entries, history, and workspaces have
-all been rewritten to 23.
+`@icm/project-protocol` exposes `parseProject`. It accepts schemas 22 and 23,
+upgrades schema 22 to the sole schema-23 in-memory Project, and writes only
+schema 23. The bounded schema-22 adapter repairs power-role Evidence where
+needed and drops the inert Base-Net name, scope, power-role, and origin
+projections before strict current-schema validation.
 
 ## Current authorities
 

--- a/docs/specs/schematic-model.md
+++ b/docs/specs/schematic-model.md
@@ -150,6 +150,6 @@ ordinary Schematic edits inside one Project structural transaction. The
 Project's `structureRevision` protects this cross-Document boundary and the
 editor records it as one undoable structural commit.
 
-Persistence writes only schema 23. The convergence reader accepts schemas 21
-and 22 at the file boundary, then supplies the current model only; no
+Persistence writes only schema 23. The rolling reader accepts schema 22 at the
+file boundary, then supplies the current model only; no
 compatibility shape enters runtime electrical derivation.

--- a/docs/user/project-compatibility.md
+++ b/docs/user/project-compatibility.md
@@ -13,12 +13,11 @@ RichText formatting but cannot store a divergent alias. A
 canonical v23 file can be opened, saved, reopened, and saved again without
 byte drift.
 
-During Gallery convergence, schemas v21 and v22 are accepted through a bounded
-upgrade to v23. The upgrade adds deterministic ownership evidence where needed
-and removes inert Base-Net projections without changing the visible drawing.
-The next save writes v23. The original file is never overwritten silently.
-Schema v20 and older, and versions newer than v23, are rejected. The temporary
-v21 hop is removed after online Gallery storage has converged.
+Schema v22 is accepted through a bounded upgrade to v23. The upgrade repairs
+power-role Evidence where needed and removes inert Base-Net projections without
+changing the visible drawing. The next save writes v23. The original file is
+never overwritten silently. Schema v21 and older, and versions newer than v23,
+are rejected.
 
 The canonical-current corpus at
 [`fixtures/projects/compatibility-corpus.json`](../../fixtures/projects/compatibility-corpus.json)

--- a/docs/user/schematic-hierarchy.md
+++ b/docs/user/schematic-hierarchy.md
@@ -74,8 +74,8 @@ the Properties values remain the precise fallback. These are definition operatio
 not top-level drawing tools.
 
 Hierarchy presentation is saved as definition-level size and pin-placement
-intent in current Project schema 23. During Gallery convergence, schema-21 and
-schema-22 projects open through the bounded upgrade; schema-20 files remain
-unsupported. The block uses a closed polygon body and the shared
-Razavi rich-text renderer for pin and Cell names; it is compatible with that
-visual grammar rather than a pixel-for-pixel textbook symbol asset.
+intent in current Project schema 23. Schema-22 projects open through the
+bounded upgrade; schema-21 and older files remain unsupported. The block uses
+a closed polygon body and the shared Razavi rich-text renderer for pin and Cell
+names; it is compatible with that visual grammar rather than a pixel-for-pixel
+textbook symbol asset.

--- a/packages/project-protocol/src/transforms/project.ts
+++ b/packages/project-protocol/src/transforms/project.ts
@@ -12,8 +12,8 @@ export class ProjectMigrationError extends Error {
 /**
  * Repair the narrow schema-22 shape emitted before power roles were copied
  * into Connectivity Evidence. Runtime code still reads Evidence only; this
- * load-boundary normalization merely restores information that the same file
- * already carries in its inert schema-21 Net projection.
+ * load-boundary normalization merely restores information that the same
+ * schema-22 file already carries in its inert Base-Net projection.
  */
 export function repairSchema22ProjectEvidence(
   raw: Record<string, unknown>,


### PR DESCRIPTION
## Summary
- align accepted specs and user guidance with the schema 22/23 rolling window
- replace stale schema-21 Gallery fixtures with schema-23 steady-state data
- retain the explicit schema-21 rejection regression as the compatibility boundary

## Validation
- focused Gallery/protocol unit tests
- focused moderation E2E
- gate:affected (1319 unit, 137 browser)
- frozen install + pnpm ci:check (1319 unit, 233 browser)