### PR TITLE
Show Gallery circuits newest first

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -15,10 +15,7 @@ const ENTRY = {
   schemaVersion: 23,
 };
 
-/**
- * The feed asks for `/api/gallery?seed=…`, so a mock has to match on the path
- * rather than on a glob that assumes no query.
- */
+/** Match the list path with or without filters and a paging cursor. */
 const galleryListUrl = (url: URL): boolean => url.pathname === "/api/gallery";
 
 async function mockGallery(page: Page, entries: object[]): Promise<void> {
@@ -125,7 +122,6 @@ test("the feed pages through the cursor as the sentinel comes into view", async 
           schemaVersion: 23,
         })),
         nextCursor: second ? null : "c1",
-        total: 5,
       },
     });
   });
@@ -150,12 +146,11 @@ test("the feed pages through the cursor as the sentinel comes into view", async 
   expect(cursors.every((cursor) => cursor === null || cursor === "c1")).toBe(
     true,
   );
-  // Every request carries this visit's shuffle, so its pages are one order.
-  const seeds = new Set(
-    listRequests.map((query) => new URLSearchParams(query).get("seed")),
-  );
-  expect(seeds.size).toBe(1);
-  expect([...seeds][0]).toMatch(/^[0-9a-f]{16}$/u);
+  expect(
+    listRequests.every(
+      (query) => new URLSearchParams(query).get("seed") === null,
+    ),
+  ).toBe(true);
 });
 
 test("the feed scrolls inside its shell despite the locked app root", async ({
@@ -687,34 +682,29 @@ test("Check and Save shelves the circuit and the shelf reopens it", async ({
   await expect(page.getByTestId("status")).toContainText("Opened");
 });
 
-test("keeps the wall scrolling past its last circuit, in a new order", async ({
+test("keeps newest-first order and stops after the last circuit", async ({
   page,
 }) => {
-  // Big enough that coming back around lands the repeat off-screen.
   const wall = Array.from({ length: 10 }, (_, index) => ({
     ...ENTRY,
     id: `g-${index}`,
     name: `Circuit ${index}`,
+    createdAt: new Date(Date.UTC(2026, 7, 21, 10, 0, 10 - index)).toISOString(),
   }));
-  const seeds: string[] = [];
-  await page.route("**/api/gallery?*", (route) => {
+  const listRequests: string[] = [];
+  await page.route("**/api/gallery**", (route) => {
     const url = new URL(route.request().url());
-    const seed = url.searchParams.get("seed") ?? "";
+    if (url.pathname !== "/api/gallery") return route.fallback();
+    listRequests.push(url.search);
     const offset = Number(url.searchParams.get("cursor") ?? "0");
-    if (!seeds.includes(seed)) seeds.push(seed);
-    // Each seed orders the wall its own way; three at a time.
-    const ordered = [...wall].sort((left, right) =>
-      `${seed}${left.id}`.localeCompare(`${seed}${right.id}`),
-    );
-    const slice = ordered.slice(offset, offset + 3);
+    const slice = wall.slice(offset, offset + 3);
     return route.fulfill({
       json: {
         entries: slice,
         nextCursor:
-          offset + slice.length < ordered.length
+          offset + slice.length < wall.length
             ? String(offset + slice.length)
             : null,
-        total: ordered.length,
       },
     });
   });
@@ -729,15 +719,23 @@ test("keeps the wall scrolling past its last circuit, in a new order", async ({
   const tiles = page.locator('[data-testid^="gallery-tile-"]');
   await expect(tiles.first()).toBeVisible();
 
-  // The wall keeps filling as long as the bottom stays in view, and past the
-  // sixth circuit it comes back around under a different shuffle rather than
-  // stopping — which is the whole point of a wall smaller than the scroll.
+  // The wall fills through its cursor chain, then remains at exactly one copy
+  // of each circuit no matter how often the exhausted sentinel is exposed.
   for (let scroll = 0; scroll < 6; scroll += 1) {
     await page.mouse.wheel(0, 4000);
     await page.waitForTimeout(250);
   }
-  expect(await tiles.count()).toBeGreaterThan(wall.length);
-  expect(seeds.length).toBeGreaterThan(1);
+  await expect(tiles).toHaveCount(wall.length);
+  expect(
+    await tiles.evaluateAll((items) =>
+      items.map((item) => item.getAttribute("data-testid")),
+    ),
+  ).toEqual(wall.map((entry) => `gallery-tile-${entry.id}`));
+  expect(
+    listRequests.every(
+      (query) => new URLSearchParams(query).get("seed") === null,
+    ),
+  ).toBe(true);
 });
 
 test("stars the circuits that extract and counts thumbs on every card", async ({

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -28,43 +28,12 @@ export interface GalleryFeedEntry {
 export interface GalleryFeedPage {
   entries: GalleryFeedEntry[];
   nextCursor: string | null;
-  /** How many circuits this round covers; 0 means there is nothing to loop. */
-  total: number;
 }
 
 export interface GalleryFeedState {
   status: "loading" | "ready" | "unavailable";
   entries: GalleryFeedEntry[];
   nextCursor: string | null;
-  /** The shuffle this round is ordered by. */
-  seed: string;
-  /** Which pass over the wall these entries came from, counting from 0. */
-  round: number;
-  /** Circuits in the round; 0 means there is nothing to come back to. */
-  total: number;
-}
-
-/**
- * A fresh shuffle. The wall is browsed rather than read newest-first, so each
- * visit gets its own order, and each pass over it gets another one — which is
- * what keeps scrolling worthwhile once the wall is smaller than the scroll.
- */
-/**
- * How many circuits a round needs before the feed comes back around.
- *
- * Repeating is only invisible when the repeat lands well off-screen. A wall of
- * two circuits looped would stack the same two down the page, which reads as
- * a fault rather than as more to look at, so a small wall simply ends. Roughly
- * a screenful of tiles is the point where a second pass reads as more feed.
- */
-const ENDLESS_MIN_ROUND = 8;
-
-function newFeedSeed(): string {
-  const bytes = new Uint8Array(8);
-  crypto.getRandomValues(bytes);
-  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
-    "",
-  );
 }
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
@@ -129,8 +98,6 @@ export async function loadGalleryFeed(
     cursor?: string | null;
     author?: string | null;
     tags?: readonly string[];
-    /** Asks for a shuffled round instead of newest-first. */
-    seed?: string | null;
   } = {},
 ): Promise<GalleryFeedPage | null> {
   const params = new URLSearchParams();
@@ -139,7 +106,6 @@ export async function loadGalleryFeed(
     params.set("tags", options.tags.join(","));
   }
   if (options.cursor) params.set("cursor", options.cursor);
-  if (options.seed) params.set("seed", options.seed);
   const query = params.toString();
   try {
     const response = await fetchLike(
@@ -150,14 +116,11 @@ export async function loadGalleryFeed(
     const payload = (await response.json()) as {
       entries?: GalleryFeedEntry[];
       nextCursor?: unknown;
-      total?: unknown;
     };
-    const entries = payload.entries ?? [];
     return {
-      entries,
+      entries: payload.entries ?? [],
       nextCursor:
         typeof payload.nextCursor === "string" ? payload.nextCursor : null,
-      total: typeof payload.total === "number" ? payload.total : entries.length,
     };
   } catch {
     return null;
@@ -207,21 +170,11 @@ export function GalleryFeed() {
       cancelled = true;
     };
   }, []);
-  /**
-   * The shuffle a reload starts from. Held here rather than made inside the
-   * effect so that running the effect twice — as StrictMode does — reloads
-   * the same order instead of throwing the first one away. Rounds advance
-   * `state.seed`, which deliberately does not feed back into the reload.
-   */
-  const [reloadSeed, setReloadSeed] = useState(newFeedSeed);
-  const [state, setState] = useState<GalleryFeedState>(() => ({
+  const [state, setState] = useState<GalleryFeedState>({
     status: "loading",
     entries: [],
     nextCursor: null,
-    seed: reloadSeed,
-    round: 0,
-    total: 0,
-  }));
+  });
   const loadingMoreRef = useRef(false);
 
   /**
@@ -267,60 +220,45 @@ export function GalleryFeed() {
 
   useEffect(() => {
     let cancelled = false;
-    const seed = reloadSeed;
+    loadingMoreRef.current = false;
     setState({
       status: "loading",
       entries: [],
       nextCursor: null,
-      seed,
-      round: 0,
-      total: 0,
     });
-    void loadGalleryFeed(fetch, { author, tags: selectedTags, seed }).then(
-      (page) => {
-        if (cancelled) return;
-        setState(
-          page
-            ? { status: "ready", seed, round: 0, ...page }
-            : {
-                status: "unavailable",
-                entries: [],
-                nextCursor: null,
-                seed,
-                round: 0,
-                total: 0,
-              },
-        );
-      },
-    );
+    void loadGalleryFeed(fetch, { author, tags: selectedTags }).then((page) => {
+      if (cancelled) return;
+      setState(
+        page
+          ? { status: "ready", ...page }
+          : {
+              status: "unavailable",
+              entries: [],
+              nextCursor: null,
+            },
+      );
+    });
     return () => {
       cancelled = true;
     };
-  }, [author, selectedTags, reloadSeed]);
+  }, [author, selectedTags]);
 
-  // Endless scroll: the sentinel below the wall appends the next page as it
-  // comes into view, and when a round runs out it starts another one under a
-  // fresh shuffle rather than stopping. The wall is smaller than the scroll,
-  // so ending at the last upload would end the browsing too; coming back
-  // around in a different order is the point. A wall too small for a repeat
-  // to land off-screen ends instead — see ENDLESS_MIN_ROUND.
-  const { nextCursor, seed, round, total } = state;
-  const exhausted = nextCursor === null;
+  // The sentinel appends the next newest-first page as it comes into view.
+  // Once the server returns no cursor, the wall is complete and stops.
+  const { nextCursor } = state;
   useEffect(() => {
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
-    if (exhausted && total < ENDLESS_MIN_ROUND) return;
+    if (nextCursor === null) return;
     if (typeof IntersectionObserver === "undefined") return;
     const observer = new IntersectionObserver((observed) => {
       if (!observed.some((entry) => entry.isIntersecting)) return;
       if (loadingMoreRef.current) return;
       loadingMoreRef.current = true;
-      const nextRoundSeed = exhausted ? newFeedSeed() : seed;
       void loadGalleryFeed(fetch, {
         author,
         tags: selectedTags,
-        seed: nextRoundSeed,
-        cursor: exhausted ? null : nextCursor,
+        cursor: nextCursor,
       }).then((page) => {
         loadingMoreRef.current = false;
         if (!page) return;
@@ -330,9 +268,6 @@ export function GalleryFeed() {
                 ...previous,
                 entries: [...previous.entries, ...page.entries],
                 nextCursor: page.nextCursor,
-                seed: nextRoundSeed,
-                round: exhausted ? previous.round + 1 : previous.round,
-                total: page.total,
               }
             : previous,
         );
@@ -340,7 +275,7 @@ export function GalleryFeed() {
     });
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [nextCursor, exhausted, seed, round, total, author, selectedTags]);
+  }, [nextCursor, author, selectedTags]);
 
   function syncQuery(nextAuthor: string | null, nextTags: string[]): void {
     const url = new URL(window.location.href);
@@ -352,13 +287,11 @@ export function GalleryFeed() {
   }
 
   function selectAuthor(next: string | null): void {
-    setReloadSeed(newFeedSeed());
     setAuthor(next);
     syncQuery(next, selectedTags);
   }
 
   function toggleTag(tag: string): void {
-    setReloadSeed(newFeedSeed());
     setSelectedTags((previous) => {
       const next = previous.includes(tag)
         ? previous.filter((candidate) => candidate !== tag)
@@ -428,11 +361,8 @@ export function GalleryFeed() {
           <Masonry
             aria-label="Published circuits"
             items={[
-              // A circuit can come round again in a later shuffle, so the key
-              // is its place in the feed rather than its id. Entries are only
-              // ever appended, so the index is stable.
-              ...entries.map((entry, feedIndex) => ({
-                key: `${feedIndex}-${entry.id}`,
+              ...entries.map((entry) => ({
+                key: entry.id,
                 node: (
                   <a
                     className="gallery-tile"

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -245,28 +245,25 @@ async function submitOne(
   return payload.id;
 }
 
-describe("endless shuffled feed", () => {
-  async function seededPage(
+describe("newest-first gallery feed", () => {
+  async function galleryPage(
     env: Harness,
-    seed: string,
     cursor?: string,
-  ): Promise<{ ids: string[]; nextCursor: string | null; total: number }> {
-    const params = new URLSearchParams({ seed, limit: "3" });
+  ): Promise<{
+    entries: { id: string; createdAt: string }[];
+    nextCursor: string | null;
+  }> {
+    const params = new URLSearchParams({ limit: "3" });
     if (cursor) params.set("cursor", cursor);
     const response = await route(
       env,
       new Request(`${ORIGIN}/api/gallery?${params.toString()}`),
     );
     const payload = (await response.json()) as {
-      entries: { id: string }[];
+      entries: { id: string; createdAt: string }[];
       nextCursor: string | null;
-      total: number;
     };
-    return {
-      ids: payload.entries.map((entry) => entry.id),
-      nextCursor: payload.nextCursor,
-      total: payload.total,
-    };
+    return payload;
   }
 
   async function wallOf(env: Harness, count: number): Promise<string[]> {
@@ -278,53 +275,36 @@ describe("endless shuffled feed", () => {
     return ids;
   }
 
-  it("pages one shuffle without repeating or skipping a circuit", async () => {
+  it("pages newest-first without repeating or skipping a circuit", async () => {
     const env = environment();
     const wall = await wallOf(env, 7);
 
-    const first = await seededPage(env, "seed-a");
-    expect(first.total).toBe(7);
-    const second = await seededPage(env, "seed-a", first.nextCursor!);
-    const third = await seededPage(env, "seed-a", second.nextCursor!);
+    const first = await galleryPage(env);
+    const second = await galleryPage(env, first.nextCursor!);
+    const third = await galleryPage(env, second.nextCursor!);
     expect(third.nextCursor).toBeNull();
 
-    const seen = [...first.ids, ...second.ids, ...third.ids];
+    const entries = [...first.entries, ...second.entries, ...third.entries];
+    const seen = entries.map((entry) => entry.id);
     expect(seen).toHaveLength(7);
     expect(new Set(seen).size).toBe(7);
     expect([...seen].sort()).toEqual([...wall].sort());
+    const order = entries.map((entry) => `${entry.createdAt}|${entry.id}`);
+    expect(order).toEqual([...order].sort().reverse());
   });
 
-  it("gives the same order to the same seed and a different one to another", async () => {
+  it("stops when the newest-first cursor chain is exhausted", async () => {
     const env = environment();
-    await wallOf(env, 7);
-    const again = await seededPage(env, "seed-a");
-    const same = await seededPage(env, "seed-a");
-    expect(same.ids).toEqual(again.ids);
-
-    // Some seed orders the wall differently; the feed would be pointless if
-    // every visit saw the same column.
-    const orders = await Promise.all(
-      ["s1", "s2", "s3", "s4", "s5"].map((seed) => seededPage(env, seed)),
-    );
-    expect(orders.some((order) => order.ids.join() !== again.ids.join())).toBe(
-      true,
-    );
-  });
-
-  it("reports an exhausted round apart from an empty wall", async () => {
-    const env = environment();
-    // Nothing published: no next page and nothing to come back to, which is
-    // what tells the feed to stop rather than loop forever.
-    const empty = await seededPage(env, "seed-a");
-    expect(empty).toMatchObject({ ids: [], nextCursor: null, total: 0 });
+    const empty = await galleryPage(env);
+    expect(empty).toEqual({ entries: [], nextCursor: null });
 
     await wallOf(env, 2);
-    const full = await seededPage(env, "seed-a");
+    const full = await galleryPage(env);
+    expect(full.entries).toHaveLength(2);
     expect(full.nextCursor).toBeNull();
-    expect(full.total).toBe(2);
   });
 
-  it("keeps newest-first when no seed is asked for", async () => {
+  it("returns the same newest-first order on every read", async () => {
     const env = environment();
     await wallOf(env, 3);
     const read = async () => {

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -185,26 +185,6 @@ interface EntryRow {
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
-/**
- * A stable shuffle key for one circuit in one round of the feed.
- *
- * The wall is browsed, not read newest-first, so a visit gets its own order
- * rather than everyone seeing the same column of the most recent uploads.
- * The order has to be stable across pages of that visit — otherwise scrolling
- * would repeat and skip entries — so it is a hash of the round's seed and the
- * entry id rather than anything random per query. FNV-1a is enough: this
- * spreads a list, it does not defend anything.
- */
-function shuffleRank(seed: string, id: string): number {
-  let hash = 0x811c9dc5;
-  const input = `${seed}:${id}`;
-  for (let index = 0; index < input.length; index += 1) {
-    hash ^= input.charCodeAt(index);
-    hash = Math.imul(hash, 0x01000193) >>> 0;
-  }
-  return hash;
-}
-
 function summaryOf(
   row: EntryRow & { likes?: number; liked_by_viewer?: number },
 ): GalleryEntrySummary {
@@ -514,74 +494,6 @@ export class GalleryDO {
     return Response.json({ id: entry.id });
   }
 
-  /**
-   * One page of a shuffled round.
-   *
-   * The matching ids are ranked by the round's shuffle key and the page is
-   * the slice at `offset`, so paging is an index into a fixed order rather
-   * than a comparison against a moving column. The whole id list is
-   * materialized, which is right while the wall is a wall: it is a list of
-   * ids, and the alternative is a hash function SQLite does not have.
-   *
-   * `total` travels with the page so the caller can tell an exhausted round
-   * from an empty wall — one is a reason to start the next round, the other
-   * is a reason to stop.
-   */
-  private shuffledList(options: {
-    seed: string;
-    offset: number;
-    limit: number;
-    viewerId: string;
-    where: string;
-    bindings: (string | number)[];
-  }): Response {
-    const ranked = this.sql
-      .exec<{
-        id: string;
-      }>(
-        `SELECT id FROM gallery_entries e WHERE ${options.where}`,
-        ...options.bindings,
-      )
-      .toArray()
-      .map((row) => ({ id: row.id, rank: shuffleRank(options.seed, row.id) }))
-      .sort(
-        (left, right) =>
-          left.rank - right.rank || left.id.localeCompare(right.id, "en"),
-      );
-
-    const page = ranked.slice(options.offset, options.offset + options.limit);
-    if (page.length === 0) {
-      return Response.json({
-        entries: [],
-        nextCursor: null,
-        total: ranked.length,
-      });
-    }
-    const placeholders = page.map(() => "?").join(", ");
-    const rows = this.sql
-      .exec<EntryRow & { likes: number; liked_by_viewer: number }>(
-        `SELECT e.*,
-           (SELECT COUNT(*) FROM gallery_likes WHERE entry_id = e.id) AS likes,
-           (SELECT COUNT(*) FROM gallery_likes
-             WHERE entry_id = e.id AND user_id = ?) AS liked_by_viewer
-         FROM gallery_entries e WHERE e.id IN (${placeholders})`,
-        options.viewerId,
-        ...page.map((item) => item.id),
-      )
-      .toArray();
-    const byId = new Map(rows.map((row) => [row.id, row]));
-    const entries = page
-      .map((item) => byId.get(item.id))
-      .filter((row): row is (typeof rows)[number] => row !== undefined)
-      .map(summaryOf);
-    const nextOffset = options.offset + page.length;
-    return Response.json({
-      entries,
-      nextCursor: nextOffset < ranked.length ? String(nextOffset) : null,
-      total: ranked.length,
-    });
-  }
-
   private list(body: Record<string, unknown>): Response {
     const limit = Math.min(
       Math.max(Number(body.limit) || GALLERY_DEFAULT_LIST_LIMIT, 1),
@@ -605,17 +517,6 @@ export class GalleryDO {
     }
     // The viewer id leads the bindings because its sub-select comes first.
     const viewerId = typeof body.viewerId === "string" ? body.viewerId : "";
-    const seed = typeof body.seed === "string" ? body.seed.slice(0, 64) : "";
-    if (seed) {
-      return this.shuffledList({
-        seed,
-        offset: Math.max(0, Number(cursor) || 0),
-        limit,
-        viewerId,
-        where: conditions.join(" AND "),
-        bindings,
-      });
-    }
     if (cursor) {
       conditions.push("(created_at || '|' || id) < ?");
       bindings.push(cursor);
@@ -1541,10 +1442,6 @@ export async function routeGalleryRequest(
     const viewer = await sessionUserOf(request, env);
     const { payload } = await callGallery(env, "list", {
       viewerId: viewer?.id ?? "",
-      // A seed asks for a shuffled round instead of newest-first. The caller
-      // owns it, so a visit keeps one order while it scrolls and a new visit
-      // gets a different one.
-      seed: url.searchParams.get("seed") ?? "",
       limit: url.searchParams.get("limit"),
       cursor: url.searchParams.get("cursor"),
       author: url.searchParams.get("author"),


### PR DESCRIPTION
## Summary
- order Gallery circuits by publication time, newest first
- keep cursor pagination but stop after the final page
- remove seeded random ordering and repeated feed rounds
- cover ordering, uniqueness, and pagination exhaustion in worker and browser tests

## Verification
- `pnpm ci:check` (1318 unit tests, 233 Playwright tests)

Test-Impact: tests-updated