### PR TITLE
Fix imported routing guidance and external-master ERC

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -978,7 +978,7 @@ test("keeps Wire active for consecutive independent routes until Escape", async 
   await expect(page.getByTestId("active-tool")).toHaveText("pointer");
 });
 
-test("physically cuts an imported Route and retires detached source guidance", async ({
+test("physically cuts an imported Route and restores source guidance for every detached component", async ({
   page,
 }) => {
   const project = createRoutingDemoProject();
@@ -1020,7 +1020,7 @@ test("physically cuts an imported Route and retires detached source guidance", a
   await expect(page.getByTestId("source-status")).toHaveText(
     "connectivity-modified",
   );
-  await expect(page.getByTestId("flightline")).toHaveCount(1);
+  await expect(page.getByTestId("flightline")).toHaveCount(3);
 });
 
 test("keeps remaining imported flightlines after routing one guided connection", async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -1467,12 +1467,17 @@ export function App({
           endpointKey(selectedHighlightEndpoint))),
   );
   const flightlines = useMemo(
-    () =>
-      [
-        ...(projectConnectivityIndex.documents
-          .get(document.id)
-          ?.logicalNets.values() ?? []),
-      ].flatMap((net) => net.routingGuidance),
+    () => [
+      ...new Map(
+        [
+          ...(projectConnectivityIndex.documents
+            .get(document.id)
+            ?.logicalNets.values() ?? []),
+        ]
+          .flatMap((net) => net.routingGuidance)
+          .map((line) => [line.id, line] as const),
+      ).values(),
+    ],
     [document.id, document.nets, projectConnectivityIndex],
   );
   const displayedFlightlines = useMemo(() => {
@@ -1490,11 +1495,20 @@ export function App({
     const scoped =
       routingGuidanceView === "focused" && focusedNetIds.size > 0
         ? flightlines.filter((flightline) =>
-            focusedNetIds.has(flightline.netId),
+            [flightline.netId, flightline.fromNetId, flightline.toNetId].some(
+              (netId) => focusedNetIds.has(netId),
+            ),
           )
         : flightlines;
     return highlightedNetId
-      ? scoped.filter((flightline) => flightline.netId !== highlightedNetId)
+      ? scoped.filter(
+          (flightline) =>
+            ![
+              flightline.netId,
+              flightline.fromNetId,
+              flightline.toNetId,
+            ].includes(highlightedNetId),
+        )
       : scoped;
   }, [
     flightlines,

--- a/apps/editor/src/features/wiring/use-wire-interaction.ts
+++ b/apps/editor/src/features/wiring/use-wire-interaction.ts
@@ -266,7 +266,7 @@ export function useWireInteraction(options: UseWireInteractionOptions) {
     }
     const from: WireSource = {
       endpoint: flightline.from,
-      netId: flightline.netId,
+      netId: flightline.fromNetId,
       connection: fromConnection,
       preludeEdits: [],
       ...(isMosBulkTerminal(options.document, flightline.from)
@@ -275,7 +275,7 @@ export function useWireInteraction(options: UseWireInteractionOptions) {
     };
     const to: WireSource = {
       endpoint: flightline.to,
-      netId: flightline.netId,
+      netId: flightline.toNetId,
       connection: toConnection,
       preludeEdits: [],
       ...(isMosBulkTerminal(options.document, flightline.to)

--- a/docs/adr/0044-imported-source-provenance.md
+++ b/docs/adr/0044-imported-source-provenance.md
@@ -1,0 +1,73 @@
+# 0044 - Imported source provenance is not connectivity
+
+Status: `accepted`
+
+Date: `2026-08-25`
+
+Owners: `packages/spice`, `packages/derived`, `packages/edit-engine`,
+`apps/editor`
+
+## Context
+
+Imported SPICE Nets need two independent facts: their current electrical
+topology and the source Net from which routing guidance can be reconstructed.
+Treating `spice-source` as Logical-Net equivalence kept a deleted Wire
+electrically connected. Retaining it only on the primary split component fixed
+export, but made the detached endpoints disappear from imported guidance.
+
+External X calls had a related classification problem. A reviewed SKY130
+symbol mapping proves that the schematic understands the external master's
+pin contract, but import subsequently marked every external master as missing.
+ERC then reported that state as a missing model even though X calls are
+external-subcircuit bindings rather than device-model bindings.
+
+## Decision
+
+- `spice-source` is persisted provenance and routing intent only. The Logical
+  Net resolver never unions Base Nets by source identity.
+- A physical split copies source provenance to every surviving Base Net. A
+  later merge deduplicates identical `(Base Net, source Net)` facts.
+- Imported routing guidance groups current physical components by source
+  identity, but every guide also carries the actual Base Net at each endpoint.
+  Completing the guide uses the normal Wire/connect transaction; export sees
+  no connection until that transaction succeeds.
+- A reviewed external-master symbol mapping is resolved for schematic ERC.
+  Unknown X-call masters report `ERC_MISSING_EXTERNAL_MASTER`; device-model
+  bindings continue to report `ERC_MISSING_MODEL`.
+- Foundry model-library availability is a future simulation-deck preflight
+  concern. It is not inferred from whether the schematic can resolve a
+  reviewed external-master symbol contract.
+
+No Project schema, UI preference, or new Net object is introduced.
+
+This supersedes ADR 0040 only where it made SPICE source identity an input to
+Logical-Net equivalence, and ADR 0041 only where it retained non-owner source
+Evidence on the primary split component alone. Their naming, physical-cut,
+and endpoint-readiness decisions otherwise remain unchanged.
+
+## Consequences
+
+- Cutting an imported Wire changes electrical export immediately while still
+  leaving an accurate visual suggestion for restoring the source topology.
+- A few authored Wires cannot accidentally dismiss guidance for unrelated
+  detached components of the same imported source Net.
+- SKY130 X-call MOS instances retain their external-subcircuit binding and
+  original master spelling without producing a false missing-model ERC.
+- Missing model and missing external-master diagnostics now describe distinct
+  contracts and can lead to different repair actions.
+
+## Validation
+
+- Logical-Net tests prove shared source provenance does not join Base Nets.
+- Routing-guidance tests prove separate Base Nets sharing a source receive a
+  guide with their real endpoint Net IDs.
+- Cut and merge tests prove source provenance propagation and deduplication.
+- SKY130 corpus import and ERC tests prove reviewed versus unknown external
+  master classification.
+
+## Related documents
+
+- [ADR 0035](0035-imported-net-routing-guidance.md)
+- [ADR 0040](0040-connectivity-evidence.md)
+- [ADR 0041](0041-physical-cut-and-endpoint-readiness.md)
+- [Connectivity and routing](../specs/connectivity-and-routing.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -90,6 +90,9 @@ The schema-23 Base-Net cleanup and full Gallery storage convergence decision is
 The unified Cell Pin contract that retires Free Port while preserving repeated
 visual markers for one formal terminal is
 [`0043-cell-pin-contract-convergence.md`](0043-cell-pin-contract-convergence.md).
+The separation of imported source provenance from electrical equivalence, and
+the reviewed external-master ERC classification, is
+[`0044-imported-source-provenance.md`](0044-imported-source-provenance.md).
 The arbitrary-angle Route authoring decision is
 [`0039-any-angle-route-authoring.md`](0039-any-angle-route-authoring.md).
 

--- a/docs/specs/connectivity-and-routing.md
+++ b/docs/specs/connectivity-and-routing.md
@@ -81,11 +81,13 @@ label evidence for their visible connectivity.
 
 ## Imported routing guidance
 
-SPICE import creates electrical membership before drawing. Only a Net whose
-persisted `origin.kind` is `spice-import` is eligible for derived routing
-guidance. `deriveRoutingGuidance` is a pure, device-neutral minimum-spanning
-tree over current visible components supplied by the connectivity adapter: it
-does not read symbols, MOS/Bulk semantics, SPICE records, labels, or editor
+SPICE import creates electrical membership before drawing and persists one
+`spice-source` provenance record per imported Base Net. Source provenance is
+not an electrical equivalence rule. When a cut partitions that Base Net, every
+surviving component retains the same source identity while remaining a
+separate electrical Base Net. `deriveRoutingGuidance` is a pure,
+device-neutral minimum-spanning tree over current visible components grouped
+by source identity: it does not read MOS/Bulk semantics, labels, or editor
 state. Symbol pin visibility, implicit terminals, and named-global-Net
 exemptions are adapter policy before this calculation.
 
@@ -95,11 +97,14 @@ or transform edits cannot dismiss guidance; the current graph simply yields a
 new result. `remove_route_geometry` retains Net membership and therefore
 re-exposes unresolved imported components. A normal connection cut splits all
 physical components, including imported and global Base Nets; only the primary
-component retains source/equivalence Evidence, while owner-addressed markers
-follow their surviving component. The editor may show
-focused, all, or hidden imported guides; Net highlight suppresses only the
-highlighted Net's guides. Unplaced endpoints remain in the Placement Tray and
-do not receive invented page coordinates.
+component retains non-source electrical Evidence such as explicit equivalence,
+while owner-addressed markers follow their surviving component and source
+provenance is copied to every component. The editor may show
+focused, all, or hidden imported guides; each guide carries the actual Base
+Net at both endpoints, so clicking it uses the ordinary Wire merge path. Net
+highlight suppresses guides incident to the highlighted Net. Unplaced
+endpoints remain in the Placement Tray and do not receive invented page
+coordinates.
 
 ## Derived read models
 

--- a/packages/derived/src/connectivity-index.ts
+++ b/packages/derived/src/connectivity-index.ts
@@ -147,6 +147,8 @@ function normalizeRoutingGuidance(line: RoutingGuide): RoutingGuide {
   const to = swap ? line.from : line.to;
   const fromPoint = swap ? line.toPoint : line.fromPoint;
   const toPoint = swap ? line.fromPoint : line.toPoint;
+  const fromNetId = swap ? line.toNetId : line.fromNetId;
+  const toNetId = swap ? line.fromNetId : line.toNetId;
   return {
     id: deriveStableId(
       "routing-guidance",
@@ -155,6 +157,9 @@ function normalizeRoutingGuidance(line: RoutingGuide): RoutingGuide {
       endpointKey(to),
     ),
     netId: line.netId,
+    fromNetId,
+    toNetId,
+    ...(line.sourceNetId ? { sourceNetId: line.sourceNetId } : {}),
     from,
     to,
     fromPoint,
@@ -180,9 +185,12 @@ function buildDocumentIndex(
 
   const routingGuidanceByNet = new Map<string, RoutingGuide[]>();
   for (const line of deriveImportedRoutingGuidance(document, resolver)) {
-    const lines = routingGuidanceByNet.get(line.netId) ?? [];
-    lines.push(normalizeRoutingGuidance(line));
-    routingGuidanceByNet.set(line.netId, lines);
+    const normalized = normalizeRoutingGuidance(line);
+    for (const netId of new Set([line.fromNetId, line.toNetId])) {
+      const lines = routingGuidanceByNet.get(netId) ?? [];
+      lines.push(normalized);
+      routingGuidanceByNet.set(netId, lines);
+    }
   }
 
   const baseRecords = new Map<string, NetConnectivityRecord>();
@@ -214,7 +222,9 @@ function buildDocumentIndex(
       routes: uniqueStrings(records.flatMap((record) => record.routes)),
       junctions: uniqueStrings(records.flatMap((record) => record.junctions)),
       virtualEdges: records.flatMap((record) => record.virtualEdges),
-      routingGuidance: routingGuidanceByNet.get(group.id) ?? [],
+      routingGuidance: uniqueRoutingGuidance(
+        records.flatMap((record) => record.routingGuidance),
+      ),
     };
     logicalNets.set(group.id, aggregate);
     for (const baseNetId of group.baseNetIds) {
@@ -251,6 +261,14 @@ function uniqueEndpoints(values: readonly EndpointRef[]): EndpointRef[] {
     ).values(),
   ].sort((left, right) =>
     endpointKey(left).localeCompare(endpointKey(right), "en"),
+  );
+}
+
+function uniqueRoutingGuidance(
+  values: readonly RoutingGuide[],
+): RoutingGuide[] {
+  return [...new Map(values.map((line) => [line.id, line])).values()].sort(
+    (left, right) => left.id.localeCompare(right.id, "en"),
   );
 }
 

--- a/packages/derived/src/connectivity.ts
+++ b/packages/derived/src/connectivity.ts
@@ -222,6 +222,7 @@ function guidanceGraphForNet(
   const components = deriveNetConnectivity(document, resolver, net)
     .components.map((component) => ({
       id: component.id,
+      netId: net.id,
       nodes: component.nodes.flatMap((node) =>
         node.point === null
           ? []
@@ -242,20 +243,39 @@ function guidanceGraphForNet(
 function importedGuidanceGraph(
   document: SchematicDocument,
   resolver: SymbolResolver,
-  logicalNetId: string,
+  sourceNetId: string,
   baseNetIds: readonly string[],
 ): NetGuidanceGraph | null {
-  const logicalNet =
-    resolveDocumentLogicalNets(document).byId.get(logicalNetId);
-  if (logicalNet?.scope === "global" && logicalNet.name) return null;
   const baseNetIdSet = new Set(baseNetIds);
+  const logicalNets = resolveDocumentLogicalNets(document);
+  const logicalGroups = new Map(
+    baseNetIds.flatMap((baseNetId) => {
+      const group = logicalNets.byBaseNetId.get(baseNetId);
+      return group ? [[group.id, group] as const] : [];
+    }),
+  );
+  if (
+    logicalGroups.size === 1 &&
+    [...logicalGroups.values()].every(
+      (group) => group.scope === "global" && Boolean(group.name),
+    )
+  ) {
+    return null;
+  }
   const components = document.nets
     .filter((net) => baseNetIdSet.has(net.id))
     .sort((left, right) => left.id.localeCompare(right.id, "en"))
     .flatMap(
       (net) => guidanceGraphForNet(document, resolver, net)?.components ?? [],
     );
-  return { netId: logicalNetId, components };
+  const representativeNetId = baseNetIdSet.has(sourceNetId)
+    ? sourceNetId
+    : [...baseNetIdSet].sort((left, right) =>
+        left.localeCompare(right, "en"),
+      )[0];
+  return representativeNetId
+    ? { netId: representativeNetId, sourceNetId, components }
+    : null;
 }
 
 /**
@@ -282,15 +302,19 @@ export function deriveImportedRoutingGuidance(
   document: SchematicDocument,
   resolver: SymbolResolver,
 ): RoutingGuide[] {
-  return resolveDocumentLogicalNets(document)
-    .groups.filter((logicalNet) => logicalNet.sourceNetIds.length > 0)
-    .flatMap((logicalNet) => {
-      const graph = importedGuidanceGraph(
-        document,
-        resolver,
-        logicalNet.id,
-        logicalNet.baseNetIds,
-      );
+  const baseNetIdsBySource = new Map<string, Set<string>>();
+  for (const evidence of document.connectivityEvidence) {
+    if (evidence.kind !== "spice-source") continue;
+    const netIds = baseNetIdsBySource.get(evidence.sourceNetId) ?? new Set();
+    netIds.add(evidence.netId);
+    baseNetIdsBySource.set(evidence.sourceNetId, netIds);
+  }
+  return [...baseNetIdsBySource]
+    .sort(([left], [right]) => left.localeCompare(right, "en"))
+    .flatMap(([sourceNetId, baseNetIds]) => {
+      const graph = importedGuidanceGraph(document, resolver, sourceNetId, [
+        ...baseNetIds,
+      ]);
       return graph ? deriveRoutingGuidance(graph) : [];
     });
 }

--- a/packages/derived/src/diagnostics/erc.test.ts
+++ b/packages/derived/src/diagnostics/erc.test.ts
@@ -507,6 +507,42 @@ describe("ERC engine", () => {
     expect(codes(project)).not.toContain("ERC_MISSING_MODEL");
   });
 
+  it("reports a missing X-call master separately from a missing device model", () => {
+    const project = emptyProject();
+    const document = project.documents[0]!;
+    document.instances = [
+      {
+        ...instance("I1"),
+        netlist: {
+          reference: "XI1",
+          binding: {
+            kind: "external-subcircuit",
+            definitionId: "external-missing",
+          },
+          parameters: {},
+        },
+        importProvenance: {
+          kind: "opaque",
+          name: "missing_external_master",
+          sourceTarget: "external-subcircuit:missing_external_master",
+          status: "missing",
+        },
+      },
+    ];
+    document.nets = [
+      {
+        id: "net-1",
+        terminals: [
+          { instanceId: "I1", pinName: "L" },
+          { instanceId: "I1", pinName: "R" },
+        ],
+      },
+    ];
+
+    expect(codes(project)).toContain("ERC_MISSING_EXTERNAL_MASTER");
+    expect(codes(project)).not.toContain("ERC_MISSING_MODEL");
+  });
+
   it("diagnoses only persisted imported pin facts that drift from a symbol", () => {
     const project = emptyProject();
     const document = project.documents[0]!;

--- a/packages/derived/src/diagnostics/erc.ts
+++ b/packages/derived/src/diagnostics/erc.ts
@@ -83,15 +83,23 @@ export function runErcChecks(
     // ERC_UNRESOLVED_SYMBOL and hierarchy interface checks. These run before
     // pin connectivity checks so unknown symbols never get silently skipped.
     for (const instance of document.instances) {
+      const missingExternalMaster =
+        instance.netlist?.binding?.kind === "external-subcircuit" ||
+        instance.netlist?.binding?.kind === "unresolved-subcircuit";
       if (instance.importProvenance?.status === "missing") {
+        const code = missingExternalMaster
+          ? "ERC_MISSING_EXTERNAL_MASTER"
+          : "ERC_MISSING_MODEL";
         diagnostics.push({
-          id: `erc:missing-model:${document.id}:${instance.id}`,
+          id: `erc:${missingExternalMaster ? "missing-external-master" : "missing-model"}:${document.id}:${instance.id}`,
           domain: "erc",
-          code: "ERC_MISSING_MODEL",
+          code,
           severity: "error",
           confidence: "high",
           gateEligible: true,
-          message: `Instance ${instance.id} binding ${instance.importProvenance.kind}:${instance.importProvenance.name} is missing`,
+          message: missingExternalMaster
+            ? `Instance ${instance.id} external master ${instance.importProvenance.name} is missing`
+            : `Instance ${instance.id} binding ${instance.importProvenance.kind}:${instance.importProvenance.name} is missing`,
           primary: directObjectLocator(document.id, "instance", instance.id),
           related: [],
           parameters: {

--- a/packages/derived/src/logical-net.test.ts
+++ b/packages/derived/src/logical-net.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { resolveDocumentLogicalNets } from "./logical-net.js";
 
 describe("resolved logical Nets", () => {
-  it("unions scoped names, source identity, and explicit equivalence deterministically", () => {
+  it("keeps source provenance non-electrical while resolving explicit identity deterministically", () => {
     const document = createEmptyDocument("document", "Document");
     document.nets.push(
       { id: "net-d", terminals: [] },
@@ -52,14 +52,20 @@ describe("resolved logical Nets", () => {
     expect(resolved.groups).toEqual([
       expect.objectContaining({
         id: "net-a",
-        baseNetIds: ["net-a", "net-b", "net-c", "net-d"],
+        baseNetIds: ["net-a", "net-b"],
         name: "Bias",
         scope: "local",
         sourceNetIds: ["source-shared"],
         conflicts: [],
       }),
+      expect.objectContaining({
+        id: "net-c",
+        baseNetIds: ["net-c", "net-d"],
+        sourceNetIds: ["source-shared"],
+        conflicts: [],
+      }),
     ]);
-    expect(resolved.byBaseNetId.get("net-d")?.id).toBe("net-a");
+    expect(resolved.byBaseNetId.get("net-d")?.id).toBe("net-c");
   });
 
   it("keeps conflicting explicit equivalence inspectable without choosing a name", () => {

--- a/packages/derived/src/logical-net.ts
+++ b/packages/derived/src/logical-net.ts
@@ -80,8 +80,11 @@ function unionGroups(
 
 /**
  * Resolve Document-local logical identity from schema-23 evidence. Physical
- * Base Nets remain intact; this pure result is the only name/source folding
- * implementation used by editor and netlist consumers.
+ * Base Nets remain intact; this pure result is the only electrical folding
+ * implementation used by editor and netlist consumers. `spice-source`
+ * evidence is provenance for imported routing guidance, not electrical
+ * equivalence: a user cut must not remain connected merely because both
+ * resulting components came from the same source Net.
  */
 export function resolveDocumentLogicalNets(
   document: SchematicDocument,
@@ -107,15 +110,6 @@ export function resolveDocumentLogicalNets(
     byScopedName.set(key, ids);
   }
   unionGroups(set, byScopedName.values());
-
-  const bySource = new Map<string, string[]>();
-  for (const evidence of document.connectivityEvidence) {
-    if (evidence.kind !== "spice-source") continue;
-    const ids = bySource.get(evidence.sourceNetId) ?? [];
-    ids.push(evidence.netId);
-    bySource.set(evidence.sourceNetId, ids);
-  }
-  unionGroups(set, bySource.values());
 
   const membersByRoot = new Map<string, string[]>();
   for (const netId of baseNetIds) {

--- a/packages/derived/src/routing-guidance.test.ts
+++ b/packages/derived/src/routing-guidance.test.ts
@@ -19,6 +19,7 @@ describe("routing guidance", () => {
       components: [
         {
           id: "component-c",
+          netId: "net-imported",
           nodes: [
             {
               key: "C",
@@ -30,6 +31,7 @@ describe("routing guidance", () => {
         },
         {
           id: "component-a",
+          netId: "net-imported",
           nodes: [
             {
               key: "A",
@@ -41,6 +43,7 @@ describe("routing guidance", () => {
         },
         {
           id: "component-b",
+          netId: "net-imported",
           nodes: [
             {
               key: "B",
@@ -236,6 +239,72 @@ describe("routing guidance", () => {
     );
 
     expect(guides).toHaveLength(1);
-    expect(guides[0]).toMatchObject({ netId: "base-a" });
+    expect(guides[0]).toMatchObject({ netId: "base-a", sourceNetId: "VIN" });
+    expect(new Set([guides[0]!.fromNetId, guides[0]!.toNetId])).toEqual(
+      new Set(["base-a", "base-b"]),
+    );
+  });
+
+  it("keeps a resolved named global source exempt from routing guidance", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.instances.push(
+      {
+        id: "A",
+        symbolId: "port",
+        placement: { position: { x: 0, y: 0 }, rotation: 0, mirror: "none" },
+      },
+      {
+        id: "B",
+        symbolId: "port",
+        placement: {
+          position: { x: 100, y: 0 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+    );
+    document.nets.push(
+      { id: "base-a", terminals: [{ instanceId: "A", pinName: "P" }] },
+      { id: "base-b", terminals: [{ instanceId: "B", pinName: "P" }] },
+    );
+    document.connectivityEvidence.push(
+      {
+        id: "source-a",
+        kind: "spice-source",
+        netId: "base-a",
+        sourceNetId: "VDD",
+      },
+      {
+        id: "source-b",
+        kind: "spice-source",
+        netId: "base-b",
+        sourceNetId: "VDD",
+      },
+      {
+        id: "claim-a",
+        kind: "name-claim",
+        netId: "base-a",
+        name: "VDD",
+        owner: { kind: "explicit-net-property" },
+        scope: "global",
+        powerDomain: "vdd",
+      },
+      {
+        id: "claim-b",
+        kind: "name-claim",
+        netId: "base-b",
+        name: "VDD",
+        owner: { kind: "explicit-net-property" },
+        scope: "global",
+        powerDomain: "vdd",
+      },
+    );
+
+    expect(
+      deriveImportedRoutingGuidance(
+        document,
+        new InMemorySymbolResolver(builtInSymbols),
+      ),
+    ).toEqual([]);
   });
 });

--- a/packages/derived/src/routing-guidance.ts
+++ b/packages/derived/src/routing-guidance.ts
@@ -12,18 +12,29 @@ export interface RoutingGuidanceNode {
 
 export interface RoutingGuidanceComponent {
   id: string;
+  /** Current electrical Base Net containing every node in this component. */
+  netId: string;
   nodes: readonly RoutingGuidanceNode[];
 }
 
 export interface NetGuidanceGraph {
+  /** Current representative Base Net used only for guide grouping/focus. */
   netId: string;
+  /** Original imported Net identity; never an electrical Net authority. */
+  sourceNetId?: string;
   components: readonly RoutingGuidanceComponent[];
 }
 
 /** A derived, non-persisted route suggestion between visible components. */
 export interface RoutingGuide {
   id: string;
+  /** Current representative Base Net used for grouping and focus. */
   netId: string;
+  /** Actual current Base Nets at the two endpoints. */
+  fromNetId: string;
+  toNetId: string;
+  /** Original imported Net identity when this is source routing guidance. */
+  sourceNetId?: string;
   from: RouteEndpoint;
   to: RouteEndpoint;
   fromPoint: Point;
@@ -136,11 +147,18 @@ export function deriveRoutingGuidance(graph: NetGuidanceGraph): RoutingGuide[] {
     result.push({
       id: deriveStableId(
         "routing-guide",
-        graph.netId,
+        graph.sourceNetId ?? graph.netId,
         edge.from.key,
         edge.to.key,
       ),
       netId: graph.netId,
+      fromNetId: components.find(
+        (component) => component.id === edge.fromComponentId,
+      )!.netId,
+      toNetId: components.find(
+        (component) => component.id === edge.toComponentId,
+      )!.netId,
+      ...(graph.sourceNetId ? { sourceNetId: graph.sourceNetId } : {}),
       from: edge.from.endpoint,
       to: edge.to.endpoint,
       fromPoint: edge.from.point,

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -6,7 +6,9 @@ import { parseProject } from "@icm/project-protocol";
 import {
   deriveCrossings,
   deriveFlightlines,
+  deriveImportedRoutingGuidance,
   resolveRouteGeometry,
+  resolveDocumentLogicalNets,
 } from "@icm/derived";
 import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
@@ -2378,7 +2380,7 @@ describe("routing Edit Engine", () => {
     );
   });
 
-  it("physically splits a partially routed imported Net and keeps source Evidence on the primary component", () => {
+  it("physically splits an imported Net while preserving non-electrical source provenance on every component", () => {
     const document = documentFixture();
     document.connectivityEvidence.push({
       id: "source-net-h",
@@ -2420,14 +2422,33 @@ describe("routing Edit Engine", () => {
         )
         .map((net) => net.terminals.map((terminal) => terminal.instanceId)),
     ).toEqual([["A"], ["B"], ["E"]]);
+    const splitNetIds = result.document.nets
+      .filter((candidate) =>
+        candidate.terminals.some((terminal) =>
+          ["A", "B", "E"].includes(terminal.instanceId),
+        ),
+      )
+      .map((candidate) => candidate.id)
+      .sort();
     expect(
-      result.document.connectivityEvidence.filter(
-        (evidence) => evidence.kind === "spice-source",
+      result.document.connectivityEvidence
+        .flatMap((evidence) =>
+          evidence.kind === "spice-source" &&
+          evidence.sourceNetId === "source-horizontal"
+            ? [evidence.netId]
+            : [],
+        )
+        .sort(),
+    ).toEqual(splitNetIds);
+    expect(
+      resolveDocumentLogicalNets(result.document).groups.filter((group) =>
+        group.sourceNetIds.includes("source-horizontal"),
       ),
-    ).toEqual(
-      expect.arrayContaining([expect.objectContaining({ netId: "net-h" })]),
-    );
+    ).toHaveLength(3);
     expect(deriveFlightlines(result.document, resolver)).toHaveLength(1);
+    expect(
+      deriveImportedRoutingGuidance(result.document, resolver),
+    ).toHaveLength(2);
     expect(result.document.sourceStatus).toBe("connectivity-modified");
   });
 

--- a/packages/edit-engine/src/transaction.test.ts
+++ b/packages/edit-engine/src/transaction.test.ts
@@ -979,6 +979,12 @@ describe("Edit Transaction envelope", () => {
     );
     document.connectivityEvidence.push(
       {
+        id: "source-target",
+        kind: "spice-source",
+        netId: "net-target",
+        sourceNetId: "spice-source",
+      },
+      {
         id: "claim-source",
         kind: "name-claim",
         netId: "net-source",
@@ -1017,17 +1023,31 @@ describe("Edit Transaction envelope", () => {
 
     expect(result).toMatchObject({
       ok: true,
-      document: {
-        connectivityEvidence: [
-          { id: "claim-source", netId: "net-target" },
-          { id: "source-origin", netId: "net-target" },
-          {
-            id: "equivalence-retained",
-            memberNetIds: ["net-target", "net-peer"],
-          },
-        ],
-      },
     });
+    if (!result.ok) return;
+    expect(result.document.connectivityEvidence).toEqual(
+      expect.arrayContaining([
+        {
+          id: "source-target",
+          kind: "spice-source",
+          netId: "net-target",
+          sourceNetId: "spice-source",
+        },
+        expect.objectContaining({ id: "claim-source", netId: "net-target" }),
+        expect.objectContaining({
+          id: "equivalence-retained",
+          memberNetIds: ["net-target", "net-peer"],
+        }),
+      ]),
+    );
+    expect(
+      result.document.connectivityEvidence.filter(
+        (evidence) =>
+          evidence.kind === "spice-source" &&
+          evidence.netId === "net-target" &&
+          evidence.sourceNetId === "spice-source",
+      ),
+    ).toHaveLength(1);
   });
 
   it("upserts and removes explicit Connectivity Evidence with final-Net GC", () => {

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -148,7 +148,17 @@ function retargetConnectivityEvidence(
     }
     retainedEvidence.push(evidence);
   }
-  draft.connectivityEvidence = retainedEvidence;
+  const seenSpiceSources = new Set<string>();
+  draft.connectivityEvidence = retainedEvidence.filter((evidence) => {
+    if (evidence.kind !== "spice-source") return true;
+    const key = `${evidence.netId}\u0000${evidence.sourceNetId}`;
+    if (!seenSpiceSources.has(key)) {
+      seenSpiceSources.add(key);
+      return true;
+    }
+    changedObjectIds.add(evidence.id);
+    return false;
+  });
 }
 
 function connectivityEvidenceNetIds(
@@ -292,6 +302,46 @@ function retargetOwnerEvidenceAfterSplit(
     if (targetNetId && targetNetId !== evidence.netId) {
       evidence.netId = targetNetId;
       changedObjectIds.add(evidence.id);
+    }
+  }
+}
+
+function propagateSpiceSourceEvidenceAfterSplit(
+  draft: SchematicDocument,
+  originalNetId: string,
+  splitNetIds: readonly string[],
+  changedObjectIds: Set<string>,
+): void {
+  const sourceNetIds = draft.connectivityEvidence.flatMap((evidence) =>
+    evidence.kind === "spice-source" && evidence.netId === originalNetId
+      ? [evidence.sourceNetId]
+      : [],
+  );
+  for (const sourceNetId of new Set(sourceNetIds)) {
+    for (const netId of splitNetIds) {
+      if (
+        draft.connectivityEvidence.some(
+          (evidence) =>
+            evidence.kind === "spice-source" &&
+            evidence.netId === netId &&
+            evidence.sourceNetId === sourceNetId,
+        )
+      ) {
+        continue;
+      }
+      const id = deriveStableId(
+        "connectivity-evidence",
+        "spice-source",
+        sourceNetId,
+        netId,
+      );
+      draft.connectivityEvidence.push({
+        id,
+        kind: "spice-source",
+        netId,
+        sourceNetId,
+      });
+      changedObjectIds.add(id);
     }
   }
 }
@@ -2553,6 +2603,12 @@ export function executeTransaction(
             draft,
             net.id,
             netIdByEndpoint,
+            changedObjectIds,
+          );
+          propagateSpiceSourceEvidenceAfterSplit(
+            draft,
+            net.id,
+            [...new Set(netIdByEndpoint.values())],
             changedObjectIds,
           );
           connectivityChanged = true;

--- a/packages/spice/src/compiler.test.ts
+++ b/packages/spice/src/compiler.test.ts
@@ -269,7 +269,7 @@ Q2 collector base emitter QPREF
     expect(document.instances[0]!.importProvenance).toMatchObject({
       kind: "opaque",
       name: "sky130_fd_pr__nfet_01v8",
-      status: "missing",
+      status: "resolved",
       sourceTarget: "external-subcircuit:sky130_fd_pr__nfet_01v8",
       symbolMappingRegistryId: "sky130-nfet-four-terminal",
       terminalMapping: [

--- a/packages/spice/src/importer.ts
+++ b/packages/spice/src/importer.ts
@@ -513,9 +513,12 @@ function bindImportedChildDocuments(documents: readonly SchematicDocument[]): {
         ...referencedInstance,
         importProvenance: {
           ...instance.importProvenance,
-          status: childDocumentId
-            ? ("resolved" as const)
-            : ("missing" as const),
+          status:
+            childDocumentId ||
+            (isImportedExternal &&
+              Boolean(instance.importProvenance?.symbolMappingRegistryId))
+              ? ("resolved" as const)
+              : ("missing" as const),
         } as NonNullable<Instance["importProvenance"]>,
         netlist: instance.netlist
           ? {


### PR DESCRIPTION
## Summary
- treat SPICE source identity as non-electrical routing provenance
- preserve provenance across cuts and reconnect using actual endpoint Base Nets
- resolve reviewed SKY130 external masters on fresh import and classify unknown X masters separately from missing models
- intentionally do not migrate historical missing imports

## Validation
- static contracts and test-impact
- 125 focused unit tests
- hierarchy E2E 14/14
- manual editor E2E 108 existing tests plus updated imported-cut regression
- verify:branch: 198 files / 1333 tests, workspace build, production smoke

Test-Impact: tests-updated