### PR TITLE
Converge Cell Pin migration and imported MOS connectivity

### DIFF
--- a/apps/editor/src/features/netlist-export/check-and-save.test.ts
+++ b/apps/editor/src/features/netlist-export/check-and-save.test.ts
@@ -125,4 +125,17 @@ describe("check-time MOS bulk defaults", () => {
     expect(plan.edits).toEqual([]);
     expect(plan.ambiguous).toEqual({ nmos: false, pmos: false });
   });
+
+  it("reconciles an imported hidden body already on the configured default", () => {
+    const plan = planCheckBulkDefaults(
+      documentWith({
+        nets: [{ id: "n-gnd", powerDomain: "ground" }],
+        instances: [{ id: "M1", symbolId: "nmos", bound: true }],
+        defaults: { nmosNetId: "n-gnd" },
+      }),
+    );
+
+    expect(plan.edits).toEqual([{ kind: "reconcile_mos_bulk" }]);
+    expect(plan.ambiguous).toEqual({ nmos: false, pmos: false });
+  });
 });

--- a/apps/editor/src/features/netlist-export/check-and-save.ts
+++ b/apps/editor/src/features/netlist-export/check-and-save.ts
@@ -1,6 +1,7 @@
 import type { SchematicEdit } from "@icm/edit-engine";
 import {
   resolveDocumentLogicalNets,
+  resolveDetachedMosBulkDefault,
   resolveMosBulkConnection,
 } from "@icm/derived";
 import type { SchematicDocument } from "@icm/model";
@@ -51,15 +52,25 @@ function pendingDefaultCount(
   document: SchematicDocument,
   symbolId: "nmos" | "pmos",
 ): number {
+  const configuredNetId =
+    symbolId === "nmos"
+      ? document.mosBulkDefaults?.nmosNetId
+      : document.mosBulkDefaults?.pmosNetId;
   return document.instances.filter((instance) => {
     if (instance.symbolId !== symbolId || instance.placement === null)
       return false;
     const resolution = resolveMosBulkConnection(document, instance);
     return Boolean(
       resolution &&
-      !resolution.materialized &&
-      (resolution.status === "cell-default" ||
-        resolution.status === "supply-default"),
+      ((!resolution.materialized &&
+        (resolution.status === "cell-default" ||
+          resolution.status === "supply-default")) ||
+        (resolution.materialized &&
+          resolution.status === "explicit" &&
+          configuredNetId &&
+          (resolution.net.id === configuredNetId ||
+            resolveDetachedMosBulkDefault(document, instance)?.id ===
+              configuredNetId))),
     );
   }).length;
 }

--- a/apps/editor/src/presentation/razavi-presentation.test.ts
+++ b/apps/editor/src/presentation/razavi-presentation.test.ts
@@ -58,6 +58,79 @@ describe("Razavi hidden bulk policy", () => {
     ]);
   });
 
+  it("adopts an imported hidden body already on the configured default at entry", () => {
+    const project = createEmptyProject("project-imported", "Imported");
+    const document = project.documents[0]!;
+    document.instances.push({
+      ...manualMos("XDN", "nmos"),
+      sourceRef: {
+        fileId: "source-spi",
+        start: { offset: 0, line: 1, column: 1 },
+        end: { offset: 1, line: 1, column: 2 },
+      },
+    });
+    document.nets.push({
+      id: "net-vss",
+      terminals: [{ instanceId: "XDN", pinName: "B" }],
+    });
+    document.mosBulkDefaults = { nmosNetId: "net-vss" };
+
+    const prepared = materializeRazaviProjectBulkConnections(project);
+
+    expect(prepared.instanceCount).toBe(1);
+    expect(prepared.project.documents[0]!.instances[0]?.mosBulkBinding).toEqual(
+      { origin: "cell-default", netId: "net-vss" },
+    );
+    expect(prepared.project.documents[0]!.nets[0]?.terminals).toEqual([
+      { instanceId: "XDN", pinName: "B" },
+    ]);
+  });
+
+  it("repairs a detached imported hidden body at the Project entry boundary", () => {
+    const project = createEmptyProject("project-imported", "Imported");
+    const document = project.documents[0]!;
+    document.instances.push({
+      ...manualMos("XDN", "nmos"),
+      sourceRef: {
+        fileId: "source-spi",
+        start: { offset: 0, line: 1, column: 1 },
+        end: { offset: 1, line: 1, column: 2 },
+      },
+    });
+    document.nets.push(
+      { id: "net-vss", terminals: [] },
+      {
+        id: "net-split-bulk",
+        terminals: [{ instanceId: "XDN", pinName: "B" }],
+      },
+    );
+    document.connectivityEvidence.push(
+      {
+        id: "source-vss",
+        kind: "spice-source",
+        netId: "net-vss",
+        sourceNetId: "source-vss",
+      },
+      {
+        id: "source-vss-split",
+        kind: "spice-source",
+        netId: "net-split-bulk",
+        sourceNetId: "source-vss",
+      },
+    );
+    document.mosBulkDefaults = { nmosNetId: "net-vss" };
+
+    const prepared = materializeRazaviProjectBulkConnections(project);
+
+    expect(prepared.instanceCount).toBe(1);
+    expect(prepared.project.documents[0]!.nets).toEqual([
+      {
+        id: "net-vss",
+        terminals: [{ instanceId: "XDN", pinName: "B" }],
+      },
+    ]);
+  });
+
   it("does not infer bulk from an unconfigured VDD Net", () => {
     const document = createEmptyDocument("main", "Main");
     document.instances.push(manualMos("M4", "pmos"));

--- a/apps/editor/src/presentation/razavi-presentation.ts
+++ b/apps/editor/src/presentation/razavi-presentation.ts
@@ -1,5 +1,9 @@
 import { executeTransaction, type SchematicEdit } from "@icm/edit-engine";
-import { mosBulkShouldBeVisible, resolveMosBulkConnection } from "@icm/derived";
+import {
+  mosBulkShouldBeVisible,
+  resolveDetachedMosBulkDefault,
+  resolveMosBulkConnection,
+} from "@icm/derived";
 import { replaceProjectDocument } from "../document/editor-session";
 import type { CircuitProject, SchematicDocument } from "@icm/model";
 import { builtInSymbols, createProjectSymbolResolver } from "@icm/symbols";
@@ -35,10 +39,21 @@ export function razaviManualBulkConnectionEdits(
   const instanceIds = instances
     .filter((instance) => {
       const resolution = resolveMosBulkConnection(document, instance);
+      const configuredNetId =
+        instance.symbolId === "nmos"
+          ? document.mosBulkDefaults?.nmosNetId
+          : instance.symbolId === "pmos"
+            ? document.mosBulkDefaults?.pmosNetId
+            : undefined;
       return Boolean(
         resolution &&
-        !resolution.materialized &&
-        resolution.status === "cell-default",
+        ((!resolution.materialized && resolution.status === "cell-default") ||
+          (resolution.materialized &&
+            resolution.status === "explicit" &&
+            configuredNetId &&
+            (configuredNetId === resolution.net.id ||
+              resolveDetachedMosBulkDefault(document, instance)?.id ===
+                configuredNetId))),
       );
     })
     .map((instance) => instance.id);

--- a/packages/derived/src/diagnostics/erc.test.ts
+++ b/packages/derived/src/diagnostics/erc.test.ts
@@ -330,6 +330,29 @@ describe("ERC engine", () => {
     ).toHaveLength(2);
   });
 
+  it("does not treat SPICE source provenance as an electrical bulk connection", () => {
+    const project = emptyProject();
+    const document = project.documents[0]!;
+    document.instances = [roleInstance("three-terminal")];
+    connectDrainAndSource(project);
+    document.nets.push({
+      id: "net-source-bulk",
+      terminals: [{ instanceId: "M1", pinName: "B" }],
+    });
+    document.connectivityEvidence.push({
+      id: "source-bulk",
+      kind: "spice-source",
+      netId: "net-source-bulk",
+      sourceNetId: "source-vss",
+    });
+
+    expect(
+      roleRun(project).filter(
+        (diagnostic) => diagnostic.code === "ERC_BULK_UNRESOLVED",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("flags two instances sharing a normalized netlist reference", () => {
     const project = emptyProject();
     project.documents[0]!.instances = [

--- a/packages/derived/src/diagnostics/erc.test.ts
+++ b/packages/derived/src/diagnostics/erc.test.ts
@@ -169,6 +169,28 @@ describe("ERC engine", () => {
     });
   });
 
+  it("accepts an otherwise-singleton pin explicitly declared by imported SPICE", () => {
+    const project = emptyProject();
+    const document = project.documents[0]!;
+    document.instances = [instance("I1")];
+    document.nets.push({
+      id: "net-imported-singleton",
+      terminals: [{ instanceId: "I1", pinName: "L" }],
+    });
+    document.connectivityEvidence.push({
+      id: "source-singleton",
+      kind: "spice-source",
+      netId: "net-imported-singleton",
+      sourceNetId: "source-nbit",
+    });
+    document.noConnects.push({
+      id: "nc-right",
+      endpoint: { kind: "terminal", instanceId: "I1", pinName: "R" },
+    });
+
+    expect(run(project)).toEqual([]);
+  });
+
   it("does not flag an implicit pin even when unconnected", () => {
     const implicitResolver = new InMemorySymbolResolver([
       {

--- a/packages/derived/src/diagnostics/erc.ts
+++ b/packages/derived/src/diagnostics/erc.ts
@@ -406,11 +406,7 @@ export function runErcChecks(
           const configuredDefault =
             resolution?.status === "cell-default" ||
             resolution?.status === "supply-default";
-          if (
-            !bulkAssessment.electricallySatisfied &&
-            !configuredDefault &&
-            pin.presentation.visibility !== "implicit"
-          ) {
+          if (!bulkAssessment.electricallySatisfied && !configuredDefault) {
             diagnostics.push({
               id: `erc:bulk-unresolved:${document.id}:${instance.id}:${pin.name}`,
               domain: "erc",

--- a/packages/derived/src/endpoint-connectivity.ts
+++ b/packages/derived/src/endpoint-connectivity.ts
@@ -148,11 +148,6 @@ export function createEndpointConnectivityClassifier(
             ?.role.toLowerCase() !== "bulk"
         );
       });
-      const sourceBacked = Boolean(
-        assessment.baseNetId &&
-        logicalResolution.byBaseNetId.get(assessment.baseNetId)?.sourceNetIds
-          .length,
-      );
       return {
         ...assessment,
         peerEndpoints: externalPeers,
@@ -163,7 +158,6 @@ export function createEndpointConnectivityClassifier(
             : "singleton",
         electricallySatisfied:
           configuredDefault ||
-          sourceBacked ||
           externalPeers.length > 0 ||
           assessment.intent.explicitNoConnect ||
           assessment.intent.formalBoundary ||

--- a/packages/derived/src/endpoint-connectivity.ts
+++ b/packages/derived/src/endpoint-connectivity.ts
@@ -13,6 +13,8 @@ export interface EndpointConnectivityIntent {
   implicit: boolean;
   formalBoundary: boolean;
   globalSupply: boolean;
+  /** The imported source explicitly declared this otherwise-singleton node. */
+  sourceDeclared: boolean;
 }
 
 /**
@@ -78,6 +80,7 @@ export function createEndpointConnectivityClassifier(
       (logicalGroup.powerDomain === "vdd" ||
         logicalGroup.powerDomain === "ground"),
     );
+    const sourceDeclared = Boolean(logicalGroup?.sourceNetIds.length);
     let implicit = false;
     if (endpoint.kind === "terminal") {
       const instance = document.instances.find(
@@ -96,6 +99,7 @@ export function createEndpointConnectivityClassifier(
       implicit,
       formalBoundary,
       globalSupply,
+      sourceDeclared,
     };
     return {
       endpoint,
@@ -109,7 +113,8 @@ export function createEndpointConnectivityClassifier(
         intent.explicitNoConnect ||
         intent.implicit ||
         intent.formalBoundary ||
-        intent.globalSupply,
+        intent.globalSupply ||
+        intent.sourceDeclared,
     };
   };
 

--- a/packages/derived/src/mos-bulk.ts
+++ b/packages/derived/src/mos-bulk.ts
@@ -140,6 +140,69 @@ export function resolveMosBulkConnection(
   };
 }
 
+/**
+ * Recognize the narrow legacy failure produced when an imported source Net was
+ * physically split around hidden body terminals. SPICE source Evidence is
+ * provenance, never electrical union; it is used here only as repair evidence
+ * when the detached Net contains MOS B terminals and no authored geometry.
+ */
+export function resolveDetachedMosBulkDefault(
+  document: SchematicDocument,
+  instanceOrId: Instance | string,
+): Net | undefined {
+  const instance =
+    typeof instanceOrId === "string"
+      ? document.instances.find((candidate) => candidate.id === instanceOrId)
+      : instanceOrId;
+  const kind = instance ? mosBulkKind(instance) : undefined;
+  if (!instance || !kind) return undefined;
+  const configuredNetId =
+    kind === "nmos"
+      ? document.mosBulkDefaults?.nmosNetId
+      : document.mosBulkDefaults?.pmosNetId;
+  const configuredNet = configuredNetId
+    ? document.nets.find((net) => net.id === configuredNetId)
+    : undefined;
+  const connectedNet = document.nets.find((net) =>
+    net.terminals.some(
+      (terminal) =>
+        terminal.instanceId === instance.id && terminal.pinName === "B",
+    ),
+  );
+  if (
+    !configuredNet ||
+    !connectedNet ||
+    connectedNet.id === configuredNet.id ||
+    connectedNet.terminals.length === 0 ||
+    connectedNet.terminals.some((terminal) => {
+      if (terminal.pinName !== "B") return true;
+      const peer = document.instances.find(
+        (candidate) => candidate.id === terminal.instanceId,
+      );
+      return !peer || !mosBulkKind(peer);
+    }) ||
+    document.routes.some((route) => route.netId === connectedNet.id) ||
+    document.junctions.some((junction) => junction.netId === connectedNet.id)
+  ) {
+    return undefined;
+  }
+  const sourceIds = (netId: string) =>
+    new Set(
+      document.connectivityEvidence.flatMap((evidence) =>
+        evidence.kind === "spice-source" && evidence.netId === netId
+          ? [evidence.sourceNetId]
+          : [],
+      ),
+    );
+  const connectedSourceIds = sourceIds(connectedNet.id);
+  const configuredSourceIds = sourceIds(configuredNet.id);
+  return [...connectedSourceIds].some((sourceId) =>
+    configuredSourceIds.has(sourceId),
+  )
+    ? configuredNet
+    : undefined;
+}
+
 export function mosBulkShouldBeVisible(
   document: SchematicDocument,
   instanceOrId: Instance | string,

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -2452,6 +2452,117 @@ describe("routing Edit Engine", () => {
     expect(result.document.sourceStatus).toBe("connectivity-modified");
   });
 
+  it("keeps a default-bound hidden bulk with the supply authority after an imported Net split", () => {
+    const document = createEmptyDocument("bulk-split", "Bulk Split");
+    document.instances.push(
+      {
+        id: "M1",
+        symbolId: "nmos",
+        symbolVariantId: "textbook-3terminal",
+        placement: {
+          position: { x: 0, y: 0 },
+          rotation: 0,
+          mirror: "none",
+        },
+        mosBulkBinding: { origin: "cell-default", netId: "net-vss" },
+      },
+      {
+        id: "GND1",
+        symbolId: "ground",
+        placement: {
+          position: { x: 200, y: 0 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        id: "A",
+        symbolId: "resistor",
+        placement: {
+          position: { x: 400, y: 0 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        id: "B",
+        symbolId: "resistor",
+        placement: {
+          position: { x: 600, y: 0 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+    );
+    document.nets.push({
+      id: "net-vss",
+      terminals: [
+        { instanceId: "M1", pinName: "B" },
+        { instanceId: "GND1", pinName: "P" },
+        { instanceId: "A", pinName: "1" },
+        { instanceId: "B", pinName: "1" },
+      ],
+    });
+    document.routes.push({
+      id: "route-a-b",
+      netId: "net-vss",
+      from: { kind: "terminal", instanceId: "A", pinName: "1" },
+      to: { kind: "terminal", instanceId: "B", pinName: "1" },
+      waypoints: [],
+      segmentModes: ["manual"],
+    });
+    document.connectivityEvidence.push(
+      {
+        id: "claim-ground",
+        kind: "name-claim",
+        netId: "net-vss",
+        name: "0",
+        scope: "global",
+        powerDomain: "ground",
+        owner: { kind: "power-marker", objectId: "GND1" },
+      },
+      {
+        id: "source-vss",
+        kind: "spice-source",
+        netId: "net-vss",
+        sourceNetId: "source-vss",
+      },
+    );
+    document.mosBulkDefaults = { nmosNetId: "net-vss" };
+
+    const result = executeTransaction(
+      document,
+      transaction(document.id, 0, [
+        { kind: "cut_connection", routeId: "route-a-b" },
+      ]),
+      context,
+    );
+
+    expect(result).toMatchObject({ ok: true });
+    if (!result.ok) return;
+    const defaultNetId = result.document.mosBulkDefaults?.nmosNetId;
+    const defaultNet = result.document.nets.find(
+      (net) => net.id === defaultNetId,
+    );
+    expect(defaultNet?.terminals).toEqual(
+      expect.arrayContaining([
+        { instanceId: "GND1", pinName: "P" },
+        { instanceId: "M1", pinName: "B" },
+      ]),
+    );
+    expect(
+      result.document.instances.find((instance) => instance.id === "M1")
+        ?.mosBulkBinding,
+    ).toEqual({ origin: "cell-default", netId: defaultNetId });
+    expect(
+      result.document.nets.filter((net) =>
+        net.terminals.some(
+          (item) => item.instanceId === "M1" && item.pinName === "B",
+        ),
+      ),
+    ).toHaveLength(1);
+  });
+
   it("physically splits a global-Net Route instead of hiding the cut behind global Evidence", () => {
     const document = documentFixture();
     const net = document.nets.find((candidate) => candidate.id === "net-v")!;

--- a/packages/edit-engine/src/transaction.test.ts
+++ b/packages/edit-engine/src/transaction.test.ts
@@ -643,6 +643,112 @@ describe("Edit Transaction envelope", () => {
     });
   });
 
+  it("adopts an imported hidden bulk already connected to the configured default", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.instances.push({
+      id: "M1",
+      symbolId: "nmos",
+      symbolVariantId: "textbook-3terminal",
+      placement: null,
+      sourceRef: {
+        fileId: "main-spi",
+        start: { offset: 0, line: 1, column: 1 },
+        end: { offset: 1, line: 1, column: 2 },
+      },
+    });
+    document.nets.push({
+      id: "net-vss",
+      terminals: [{ instanceId: "M1", pinName: "B" }],
+    });
+    document.mosBulkDefaults = { nmosNetId: "net-vss" };
+
+    const result = executeTransaction(
+      document,
+      {
+        ...transaction(),
+        edits: [{ kind: "reconcile_mos_bulk", instanceIds: ["M1"] }],
+      },
+      { symbolResolver: resolver },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.document.instances[0]?.mosBulkBinding).toEqual({
+      origin: "cell-default",
+      netId: "net-vss",
+    });
+    expect(result.document.nets[0]?.terminals).toEqual([
+      { instanceId: "M1", pinName: "B" },
+    ]);
+  });
+
+  it("repairs a legacy imported B-only split using shared source provenance", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.instances.push({
+      id: "M1",
+      symbolId: "nmos",
+      symbolVariantId: "textbook-3terminal",
+      placement: null,
+      sourceRef: {
+        fileId: "main-spi",
+        start: { offset: 0, line: 1, column: 1 },
+        end: { offset: 1, line: 1, column: 2 },
+      },
+    });
+    document.nets.push(
+      { id: "net-vss", terminals: [] },
+      {
+        id: "net-split-bulk",
+        terminals: [{ instanceId: "M1", pinName: "B" }],
+      },
+    );
+    document.connectivityEvidence.push(
+      {
+        id: "source-vss",
+        kind: "spice-source",
+        netId: "net-vss",
+        sourceNetId: "source-vss",
+      },
+      {
+        id: "source-vss-split",
+        kind: "spice-source",
+        netId: "net-split-bulk",
+        sourceNetId: "source-vss",
+      },
+    );
+    document.mosBulkDefaults = { nmosNetId: "net-vss" };
+
+    const result = executeTransaction(
+      document,
+      {
+        ...transaction(),
+        edits: [{ kind: "reconcile_mos_bulk", instanceIds: ["M1"] }],
+      },
+      { symbolResolver: resolver },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.document.instances[0]?.mosBulkBinding).toEqual({
+      origin: "cell-default",
+      netId: "net-vss",
+    });
+    expect(result.document.nets).toEqual([
+      {
+        id: "net-vss",
+        terminals: [{ instanceId: "M1", pinName: "B" }],
+      },
+    ]);
+    expect(result.document.connectivityEvidence).toEqual([
+      {
+        id: "source-vss",
+        kind: "spice-source",
+        netId: "net-vss",
+        sourceNetId: "source-vss",
+      },
+    ]);
+  });
+
   it("leaves unconfigured bulk unresolved and permits an explicit connection", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.instances.push({

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -24,6 +24,8 @@ import {
   endpointKey,
   isMosBulkRoute,
   logicalNetContractIssueKey,
+  mosBulkKind,
+  resolveDetachedMosBulkDefault,
   resolveDocumentLogicalNets,
   resolveEndpointConnection,
   resolveMosBulkConnection,
@@ -561,6 +563,162 @@ function revokeInvalidatedSupplyBulkDefaults(
   ) {
     delete draft.mosBulkDefaults;
   }
+  return changed;
+}
+
+function implicitBulkPresentation(
+  instance: SchematicDocument["instances"][number],
+  resolver: SymbolResolver | undefined,
+): boolean {
+  const resolved = resolver?.resolve(
+    instance.symbolId,
+    instance.symbolVariantId,
+  );
+  return Boolean(
+    resolved?.variant?.hiddenPinNames.includes("B") ||
+    resolved?.definition.pins.find((pin) => pin.name === "B")?.presentation
+      .visibility === "implicit",
+  );
+}
+
+/**
+ * A materialized cell-default body is policy-owned, not route-owned.  Route
+ * splitting may temporarily place its terminal on a detached Base Net, but it
+ * must converge back to the currently configured default before validation.
+ * An explicit disconnect first removes mosBulkBinding, so explicit four-pin
+ * body editing remains outside this invariant.
+ */
+function reconcileMaterializedMosBulkBindings(
+  draft: SchematicDocument,
+  changedObjectIds: Set<string>,
+  deferNetPrune: (netId: string) => void,
+): boolean {
+  let changed = false;
+  for (const instance of draft.instances) {
+    if (instance.mosBulkBinding?.origin !== "cell-default") continue;
+    const kind = mosBulkKind(instance);
+    const targetNetId =
+      kind === "nmos"
+        ? draft.mosBulkDefaults?.nmosNetId
+        : kind === "pmos"
+          ? draft.mosBulkDefaults?.pmosNetId
+          : undefined;
+    const currentNets = draft.nets.filter((net) =>
+      net.terminals.some(
+        (terminal) =>
+          terminal.instanceId === instance.id && terminal.pinName === "B",
+      ),
+    );
+    const target = targetNetId
+      ? draft.nets.find((net) => net.id === targetNetId)
+      : undefined;
+
+    if (!target) {
+      for (const net of currentNets) {
+        net.terminals = net.terminals.filter(
+          (terminal) =>
+            terminal.instanceId !== instance.id || terminal.pinName !== "B",
+        );
+        changedObjectIds.add(net.id);
+        deferNetPrune(net.id);
+      }
+      delete instance.mosBulkBinding;
+      changedObjectIds.add(instance.id);
+      changed = true;
+      continue;
+    }
+
+    for (const net of currentNets) {
+      if (net.id === target.id) continue;
+      net.terminals = net.terminals.filter(
+        (terminal) =>
+          terminal.instanceId !== instance.id || terminal.pinName !== "B",
+      );
+      changedObjectIds.add(net.id);
+      deferNetPrune(net.id);
+      changed = true;
+    }
+    if (
+      !target.terminals.some(
+        (terminal) =>
+          terminal.instanceId === instance.id && terminal.pinName === "B",
+      )
+    ) {
+      target.terminals.push({ instanceId: instance.id, pinName: "B" });
+      changedObjectIds.add(target.id);
+      changed = true;
+    }
+    if (instance.mosBulkBinding.netId !== target.id) {
+      instance.mosBulkBinding.netId = target.id;
+      changedObjectIds.add(instance.id);
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+interface BulkDefaultIdentity {
+  name?: string;
+  scope?: "local" | "global";
+  powerDomain?: "ground" | "vdd";
+}
+
+function retargetMosBulkDefaultsAfterSplit(
+  draft: SchematicDocument,
+  originalNetId: string,
+  splitNetIds: readonly string[],
+  identity: BulkDefaultIdentity | undefined,
+  changedObjectIds: Set<string>,
+): boolean {
+  if (!identity || (!identity.name && !identity.powerDomain)) return false;
+  const resolution = resolveDocumentLogicalNets(draft);
+  const matchingGroups = [
+    ...new Map(
+      splitNetIds.flatMap((netId) => {
+        const group = resolution.byBaseNetId.get(netId);
+        if (!group) return [];
+        if (
+          identity.name &&
+          (!group.name ||
+            foldNetName(group.name) !== foldNetName(identity.name))
+        ) {
+          return [];
+        }
+        if (identity.scope && group.scope !== identity.scope) return [];
+        if (
+          identity.powerDomain &&
+          group.powerDomain !== identity.powerDomain
+        ) {
+          return [];
+        }
+        return [[group.id, group] as const];
+      }),
+    ).values(),
+  ];
+  if (matchingGroups.length !== 1) return false;
+
+  const matchingBaseNetIds = matchingGroups[0]!.baseNetIds
+    .filter((netId) => splitNetIds.includes(netId))
+    .sort((left, right) => left.localeCompare(right, "en"));
+  const targetNetId = matchingBaseNetIds[0];
+  if (!targetNetId) return false;
+
+  let changed = false;
+  if (
+    draft.mosBulkDefaults?.nmosNetId === originalNetId &&
+    targetNetId !== originalNetId
+  ) {
+    draft.mosBulkDefaults.nmosNetId = targetNetId;
+    changed = true;
+  }
+  if (
+    draft.mosBulkDefaults?.pmosNetId === originalNetId &&
+    targetNetId !== originalNetId
+  ) {
+    draft.mosBulkDefaults.pmosNetId = targetNetId;
+    changed = true;
+  }
+  if (changed) changedObjectIds.add(draft.id);
   return changed;
 }
 
@@ -2405,6 +2563,26 @@ export function executeTransaction(
             `Route Net does not exist: ${route.netId}`,
           );
         }
+        const bulkDefaultBeforeCut =
+          draft.mosBulkDefaults?.nmosNetId === net.id ||
+          draft.mosBulkDefaults?.pmosNetId === net.id
+            ? resolveDocumentLogicalNets(draft).byBaseNetId.get(net.id)
+            : undefined;
+        const bulkDefaultIdentity: BulkDefaultIdentity | undefined =
+          bulkDefaultBeforeCut
+            ? {
+                ...(bulkDefaultBeforeCut.name
+                  ? { name: bulkDefaultBeforeCut.name }
+                  : {}),
+                ...(bulkDefaultBeforeCut.scope
+                  ? { scope: bulkDefaultBeforeCut.scope }
+                  : {}),
+                ...(bulkDefaultBeforeCut.powerDomain === "ground" ||
+                bulkDefaultBeforeCut.powerDomain === "vdd"
+                  ? { powerDomain: bulkDefaultBeforeCut.powerDomain }
+                  : {}),
+              }
+            : undefined;
         const candidateOrphanJunctionIds = new Set(
           [route.from, route.to].flatMap((endpoint) =>
             endpoint.kind === "junction" ? [endpoint.junctionId] : [],
@@ -2609,6 +2787,13 @@ export function executeTransaction(
             draft,
             net.id,
             [...new Set(netIdByEndpoint.values())],
+            changedObjectIds,
+          );
+          retargetMosBulkDefaultsAfterSplit(
+            draft,
+            net.id,
+            [...new Set(netIdByEndpoint.values())],
+            bulkDefaultIdentity,
             changedObjectIds,
           );
           connectivityChanged = true;
@@ -3016,6 +3201,84 @@ export function executeTransaction(
         const selected = edit.instanceIds ? new Set(edit.instanceIds) : null;
         for (const instance of draft.instances) {
           if (selected && !selected.has(instance.id)) continue;
+          const kind = mosBulkKind(instance);
+          if (!kind) continue;
+          const configuredNetId =
+            kind === "nmos"
+              ? draft.mosBulkDefaults?.nmosNetId
+              : draft.mosBulkDefaults?.pmosNetId;
+          const configuredNet = configuredNetId
+            ? draft.nets.find((net) => net.id === configuredNetId)
+            : undefined;
+          const connectedNet = draft.nets.find((net) =>
+            net.terminals.some(
+              (terminal) =>
+                terminal.instanceId === instance.id && terminal.pinName === "B",
+            ),
+          );
+
+          // Imported four-node MOS data already carries a real B terminal.
+          // When the three-terminal presentation hides that terminal and it
+          // is already on the explicitly configured default, adopt the policy
+          // binding instead of leaving an order-sensitive "explicit" orphan.
+          if (
+            configuredNet &&
+            connectedNet?.id === configuredNet.id &&
+            implicitBulkPresentation(instance, resolver)
+          ) {
+            if (
+              instance.mosBulkBinding?.origin !== "cell-default" ||
+              instance.mosBulkBinding.netId !== configuredNet.id
+            ) {
+              instance.mosBulkBinding = {
+                origin: "cell-default",
+                netId: configuredNet.id,
+              };
+              changedObjectIds.add(instance.id);
+            }
+            continue;
+          }
+
+          // Older imported projects may already contain the failure this
+          // invariant prevents: a hidden B-only split Net and the configured
+          // default retain the same SPICE source provenance. Provenance is not
+          // electrical union, but here it is unambiguous repair evidence.
+          if (
+            configuredNet &&
+            connectedNet &&
+            connectedNet.id !== configuredNet.id &&
+            implicitBulkPresentation(instance, resolver) &&
+            resolveDetachedMosBulkDefault(draft, instance)?.id ===
+              configuredNet.id
+          ) {
+            connectedNet.terminals = connectedNet.terminals.filter(
+              (terminal) =>
+                terminal.instanceId !== instance.id || terminal.pinName !== "B",
+            );
+            if (
+              !configuredNet.terminals.some(
+                (terminal) =>
+                  terminal.instanceId === instance.id &&
+                  terminal.pinName === "B",
+              )
+            ) {
+              configuredNet.terminals.push({
+                instanceId: instance.id,
+                pinName: "B",
+              });
+            }
+            instance.mosBulkBinding = {
+              origin: "cell-default",
+              netId: configuredNet.id,
+            };
+            changedObjectIds.add(instance.id);
+            changedObjectIds.add(connectedNet.id);
+            changedObjectIds.add(configuredNet.id);
+            deferNetPrune(connectedNet.id);
+            connectivityChanged = true;
+            continue;
+          }
+
           const resolution = resolveMosBulkConnection(draft, instance);
           if (
             !resolution ||
@@ -3454,6 +3717,12 @@ export function executeTransaction(
     deferNetPrune,
   );
   connectivityChanged ||= invalidatedBulkDefault;
+  const reconciledBulkBinding = reconcileMaterializedMosBulkBindings(
+    draft,
+    changedObjectIds,
+    deferNetPrune,
+  );
+  connectivityChanged ||= reconciledBulkBinding;
   const netCountBeforeDeferredPrune = draft.nets.length;
   const evidenceCountBeforeDeferredPrune = draft.connectivityEvidence.length;
   for (const netId of deferredNetPruneIds) {

--- a/packages/project-protocol/src/persistence.test.ts
+++ b/packages/project-protocol/src/persistence.test.ts
@@ -169,6 +169,92 @@ describe("Project persistence", () => {
     expect(migratedDocument.connectivityEvidence).toEqual([]);
   });
 
+  it("groups an unnamed copied Free Port with its uniquely named peer", () => {
+    const source = JSON.parse(
+      serializeProject(createEmptyProject("project-test", "Test Project")),
+    ) as Record<string, any>;
+    source.schemaVersion = 23;
+    const document = source.documents[0];
+    document.instances.push(
+      { id: "P1", symbolId: "port", placement: null },
+      { id: "P1-copy-1", symbolId: "port", placement: null },
+    );
+    document.nets.push({
+      id: "net-vin",
+      terminals: [
+        { instanceId: "P1", pinName: "P" },
+        { instanceId: "P1-copy-1", pinName: "P" },
+      ],
+    });
+    document.connectivityEvidence.push({
+      id: "claim-p1",
+      kind: "name-claim",
+      netId: "net-vin",
+      name: "VIN",
+      owner: { kind: "free-port", instanceId: "P1" },
+      scope: "local",
+    });
+
+    const migrated = parseProjectWithMetadata(JSON.stringify(source));
+    expect(migrated.project.documents[0]!.netlist?.terminals).toMatchObject([
+      {
+        name: "VIN",
+        netId: "net-vin",
+        interfaceInstanceIds: ["P1", "P1-copy-1"],
+      },
+    ]);
+  });
+
+  it("does not guess for an unnamed Free Port on an ambiguously named Net", () => {
+    const source = JSON.parse(
+      serializeProject(createEmptyProject("project-test", "Test Project")),
+    ) as Record<string, any>;
+    source.schemaVersion = 23;
+    const document = source.documents[0];
+    document.instances.push(
+      { id: "P1", symbolId: "port", placement: null },
+      { id: "P2", symbolId: "port", placement: null },
+      { id: "P3", symbolId: "port", placement: null },
+    );
+    document.nets.push({
+      id: "net-shared",
+      terminals: ["P1", "P2", "P3"].map((instanceId) => ({
+        instanceId,
+        pinName: "P",
+      })),
+    });
+    document.connectivityEvidence.push(
+      {
+        id: "claim-p1",
+        kind: "name-claim",
+        netId: "net-shared",
+        name: "VIN",
+        owner: { kind: "free-port", instanceId: "P1" },
+        scope: "local",
+      },
+      {
+        id: "claim-p2",
+        kind: "name-claim",
+        netId: "net-shared",
+        name: "VOUT",
+        owner: { kind: "free-port", instanceId: "P2" },
+        scope: "local",
+      },
+    );
+
+    const migrated = parseProjectWithMetadata(JSON.stringify(source));
+    expect(
+      migrated.project.documents[0]!.netlist?.terminals.map((terminal) => ({
+        name: terminal.name,
+        interfaceInstanceIds: terminal.interfaceInstanceIds,
+      })),
+    ).toEqual([
+      { name: "VIN", interfaceInstanceIds: ["P1"] },
+      { name: "VOUT", interfaceInstanceIds: ["P2"] },
+      { name: "P3", interfaceInstanceIds: ["P3"] },
+    ]);
+  });
+
   it("rejects schemas outside the current-and-previous window", () => {
     const project = createEmptyProject("project-test", "Test Project");
     for (const schemaVersion of [22, 25, 99]) {

--- a/packages/project-protocol/src/transforms/project.ts
+++ b/packages/project-protocol/src/transforms/project.ts
@@ -161,9 +161,9 @@ function migrateDocumentPorts(
 
   let mergedBaseNets = 0;
   const convertedAnnotationIds = new Set<string>();
-  for (const port of ports) {
+  const legacyPortFacts = ports.flatMap((port) => {
     const markerId = stringValue(port.id);
-    if (!markerId || terminalByMarkerId.has(markerId)) continue;
+    if (!markerId || terminalByMarkerId.has(markerId)) return [];
     const markerNet = nets.find((net) => netOwnsPort(net, markerId));
     const markerNetId = markerNet ? stringValue(markerNet.id) : undefined;
     if (!markerNetId) {
@@ -172,11 +172,30 @@ function migrateDocumentPorts(
         `Port ${markerId} must belong to one Base Net`,
       );
     }
-    const name =
-      freePortClaimName(evidence, markerId) ??
-      anchoredAnnotationText(annotations, markerId) ??
-      stringValue(port.schematicReference) ??
-      markerId;
+    return [
+      {
+        port,
+        markerId,
+        markerNetId,
+        explicitName:
+          freePortClaimName(evidence, markerId) ??
+          anchoredAnnotationText(annotations, markerId) ??
+          stringValue(port.schematicReference),
+      },
+    ];
+  });
+  const explicitNamesByNet = new Map<string, Map<string, string>>();
+  for (const fact of legacyPortFacts) {
+    if (!fact.explicitName) continue;
+    const names = explicitNamesByNet.get(fact.markerNetId) ?? new Map();
+    names.set(fact.explicitName.toLowerCase(), fact.explicitName);
+    explicitNamesByNet.set(fact.markerNetId, names);
+  }
+  for (const { port, markerId, markerNetId, explicitName } of legacyPortFacts) {
+    const peerNames = explicitNamesByNet.get(markerNetId);
+    const uniquePeerName =
+      peerNames?.size === 1 ? [...peerNames.values()][0] : undefined;
+    const name = explicitName ?? uniquePeerName ?? markerId;
     let terminal = terminalByName.get(name.toLowerCase());
     if (terminal) {
       const targetNetId = stringValue(terminal.netId)!;


### PR DESCRIPTION
## Summary
- group copied legacy Free Port markers into one formal Cell Pin during schema 23 to 24 migration
- keep hidden MOS bulk defaults converged across imported Net splits and repair the legacy B-only split shape
- treat source-declared ordinary singleton pins as intentional while keeping MOS bulk electrically strict

## Validation
- pnpm install --frozen-lockfile
- pnpm ci:check
  - 198 Vitest files / 1343 tests
  - all builds, release smoke, performance and golden checks
  - 234/234 Playwright E2E
- attached switched-capacitor DAC export and ERC audit

Test-Impact: tests-updated