### PR TITLE
fix(editor): give check report a dedicated layout

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -48,6 +48,14 @@ test("opens netlist preflight and navigates its canonical finding", async ({
   await expect(page.getByTestId("active-document-name")).toHaveText("Main");
   await expect(page.getByTestId("status")).toContainText("Preflight:");
   await expect(dialog).toBeVisible();
+
+  const reportBody = dialog.locator(".netlist-preflight-body");
+  const diagnostics = dialog.getByLabel("Netlist diagnostics");
+  const reportBodyBox = await reportBody.boundingBox();
+  const diagnosticsBox = await diagnostics.boundingBox();
+  expect(reportBodyBox).not.toBeNull();
+  expect(diagnosticsBox).not.toBeNull();
+  expect(diagnosticsBox!.width).toBeGreaterThan(reportBodyBox!.width * 0.9);
 });
 
 test("previews a validated structural netlist in both export dialects", async ({
@@ -3132,6 +3140,30 @@ test("requires warning review before exporting generated NoConnect nodes", async
   await expect(dialog).toContainText("GENERATED_NO_CONNECT_NODE");
   await expect(dialog.getByTestId("netlist-preview")).toContainText(
     "R1 IN NC0001 10k",
+  );
+  await expect(dialog.getByLabel("Preflight findings")).toBeVisible();
+  await expect(dialog.getByLabel("Electrical findings")).toBeVisible();
+
+  const previewPane = dialog.locator(".netlist-preflight-export");
+  const diagnosticsPane = dialog.getByLabel("Netlist diagnostics");
+  const desktopPreviewBox = await previewPane.boundingBox();
+  const desktopDiagnosticsBox = await diagnosticsPane.boundingBox();
+  expect(desktopPreviewBox).not.toBeNull();
+  expect(desktopDiagnosticsBox).not.toBeNull();
+  expect(desktopDiagnosticsBox!.x).toBeGreaterThanOrEqual(
+    desktopPreviewBox!.x + desktopPreviewBox!.width - 1,
+  );
+  expect(
+    Math.abs(desktopDiagnosticsBox!.y - desktopPreviewBox!.y),
+  ).toBeLessThan(2);
+
+  await page.setViewportSize({ width: 760, height: 800 });
+  const narrowPreviewBox = await previewPane.boundingBox();
+  const narrowDiagnosticsBox = await diagnosticsPane.boundingBox();
+  expect(narrowPreviewBox).not.toBeNull();
+  expect(narrowDiagnosticsBox).not.toBeNull();
+  expect(narrowDiagnosticsBox!.y).toBeGreaterThanOrEqual(
+    narrowPreviewBox!.y + narrowPreviewBox!.height - 1,
   );
 
   const downloadPromise = page.waitForEvent("download");

--- a/apps/editor/src/features/netlist-export/netlist-preflight-dialog.test.tsx
+++ b/apps/editor/src/features/netlist-export/netlist-preflight-dialog.test.tsx
@@ -44,5 +44,9 @@ describe("NetlistPreflightDialog", () => {
     expect(markup).toContain("Electrical readiness (1)");
     expect(markup).toContain("ERC_UNCONNECTED_PIN");
     expect(markup).toContain("same current-revision connectivity assessment");
+    expect(markup).toContain('aria-label="Readiness"');
+    expect(markup).toContain('aria-label="Netlist diagnostics"');
+    expect(markup).toContain('data-has-preview="false"');
+    expect(markup).toContain('data-has-diagnostics="true"');
   });
 });

--- a/apps/editor/src/features/netlist-export/netlist-preflight-dialog.tsx
+++ b/apps/editor/src/features/netlist-export/netlist-preflight-dialog.tsx
@@ -61,6 +61,8 @@ export function NetlistPreflightDialog({
   const errors = result.diagnostics.filter(
     (diagnostic) => diagnostic.severity === "error",
   );
+  const hasDiagnostics =
+    result.diagnostics.length > 0 || electricalDiagnostics.length > 0;
   return (
     <div
       className="insert-dialog-backdrop"
@@ -69,44 +71,66 @@ export function NetlistPreflightDialog({
       }}
     >
       <section
-        className="insert-component-dialog"
+        className="netlist-preflight-dialog"
         role="dialog"
         aria-modal="true"
         aria-labelledby="netlist-preflight-title"
       >
-        <header className="insert-dialog-header">
+        <header className="netlist-preflight-header">
           <div>
             <p>Canonical design-netlist analysis</p>
             <h2 id="netlist-preflight-title">Check Report</h2>
           </div>
         </header>
-        <div className="insert-dialog-body">
+        <section className="netlist-preflight-summary" aria-label="Readiness">
+          <h3>
+            {result.ir
+              ? electricalDiagnostics.length > 0
+                ? "Structure ready; review electrical findings"
+                : "Ready to export"
+              : `${errors.length} blocking issue${errors.length === 1 ? "" : "s"}`}
+          </h3>
           {result.ir ? (
-            <section className="insert-control-column">
-              <h3>
-                {electricalDiagnostics.length > 0
-                  ? "Structure ready; review electrical findings"
-                  : "Ready to export"}
-              </h3>
-              <p>
-                {result.ir.cells.length} internal Cell
-                {result.ir.cells.length === 1 ? "" : "s"};{" "}
-                {result.ir.externalMasters?.length ?? 0} external interface
-                {(result.ir.externalMasters?.length ?? 0) === 1 ? "" : "s"}.
-              </p>
-              <label>
-                Structural format
-                <select
-                  aria-label="Netlist export format"
-                  value={format}
-                  onChange={(event) =>
-                    setFormat(event.currentTarget.value as NetlistFormat)
-                  }
-                >
-                  <option value="spice">SPICE (.spi)</option>
-                  <option value="spectre">Spectre (.scs)</option>
-                </select>
-              </label>
+            <p>
+              {result.ir.cells.length} internal Cell
+              {result.ir.cells.length === 1 ? "" : "s"};{" "}
+              {result.ir.externalMasters?.length ?? 0} external interface
+              {(result.ir.externalMasters?.length ?? 0) === 1 ? "" : "s"}.
+            </p>
+          ) : (
+            <p>
+              Resolve each issue before a netlist IR is available for export.
+            </p>
+          )}
+        </section>
+        <div
+          className="netlist-preflight-body"
+          data-has-preview={result.ir ? "true" : "false"}
+          data-has-diagnostics={hasDiagnostics ? "true" : "false"}
+        >
+          {result.ir ? (
+            <section
+              className="netlist-preflight-export"
+              aria-label="Structural netlist"
+            >
+              <div className="netlist-preflight-export-controls">
+                <label>
+                  Structural format
+                  <select
+                    aria-label="Netlist export format"
+                    value={format}
+                    onChange={(event) =>
+                      setFormat(event.currentTarget.value as NetlistFormat)
+                    }
+                  >
+                    <option value="spice">SPICE (.spi)</option>
+                    <option value="spectre">Spectre (.scs)</option>
+                  </select>
+                </label>
+                <button type="button" onClick={() => onExport(format)}>
+                  Download {format === "spice" ? "SPICE" : "Spectre"} netlist
+                </button>
+              </div>
               <pre
                 className="netlist-preview"
                 data-testid="netlist-preview"
@@ -114,74 +138,63 @@ export function NetlistPreflightDialog({
               >
                 {preview}
               </pre>
-              <button type="button" onClick={() => onExport(format)}>
-                Download {format === "spice" ? "SPICE" : "Spectre"} netlist
-              </button>
-            </section>
-          ) : (
-            <section className="insert-control-column">
-              <h3>
-                {errors.length} blocking issue{errors.length === 1 ? "" : "s"}
-              </h3>
-              <p>
-                Resolve each issue before a netlist IR is available for export.
-              </p>
-            </section>
-          )}
-          {result.diagnostics.length > 0 ? (
-            <section
-              className="insert-control-column"
-              aria-label="Preflight findings"
-            >
-              <h3>Findings</h3>
-              <ul className="preflight-findings">
-                {groupedFindings.map((group) => (
-                  <li key={`${group.code}-${group.message}`}>
-                    <button
-                      type="button"
-                      data-severity={group.sample.severity}
-                      onClick={() => onNavigate(group.sample)}
-                    >
-                      <strong>{group.code}</strong>
-                      <span>
-                        {group.message}
-                        {group.count > 1 ? ` (×${group.count})` : ""}
-                      </span>
-                    </button>
-                  </li>
-                ))}
-              </ul>
             </section>
           ) : null}
-          {electricalDiagnostics.length > 0 ? (
-            <section
-              className="insert-control-column"
-              aria-label="Electrical findings"
+          {hasDiagnostics ? (
+            <aside
+              className="netlist-preflight-diagnostics"
+              aria-label="Netlist diagnostics"
             >
-              <h3>Electrical readiness ({electricalDiagnostics.length})</h3>
-              <p>
-                These findings use the same current-revision connectivity
-                assessment as ERC and the Gallery gate. Saving remains a
-                separate action and is allowed for unfinished work.
-              </p>
-              <ul className="preflight-findings">
-                {electricalDiagnostics.map((diagnostic) => (
-                  <li key={diagnostic.id}>
-                    <button
-                      type="button"
-                      data-severity={diagnostic.severity}
-                      onClick={() => onNavigateElectrical(diagnostic)}
-                    >
-                      <strong>{diagnostic.code}</strong>
-                      <span>{diagnostic.message}</span>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </section>
+              {result.diagnostics.length > 0 ? (
+                <section aria-label="Preflight findings">
+                  <h3>Findings</h3>
+                  <ul className="preflight-findings">
+                    {groupedFindings.map((group) => (
+                      <li key={`${group.code}-${group.message}`}>
+                        <button
+                          type="button"
+                          data-severity={group.sample.severity}
+                          onClick={() => onNavigate(group.sample)}
+                        >
+                          <strong>{group.code}</strong>
+                          <span>
+                            {group.message}
+                            {group.count > 1 ? ` (×${group.count})` : ""}
+                          </span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ) : null}
+              {electricalDiagnostics.length > 0 ? (
+                <section aria-label="Electrical findings">
+                  <h3>Electrical readiness ({electricalDiagnostics.length})</h3>
+                  <p>
+                    These findings use the same current-revision connectivity
+                    assessment as ERC and the Gallery gate. Saving remains a
+                    separate action and is allowed for unfinished work.
+                  </p>
+                  <ul className="preflight-findings">
+                    {electricalDiagnostics.map((diagnostic) => (
+                      <li key={diagnostic.id}>
+                        <button
+                          type="button"
+                          data-severity={diagnostic.severity}
+                          onClick={() => onNavigateElectrical(diagnostic)}
+                        >
+                          <strong>{diagnostic.code}</strong>
+                          <span>{diagnostic.message}</span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ) : null}
+            </aside>
           ) : null}
         </div>
-        <footer className="insert-dialog-actions">
+        <footer className="netlist-preflight-actions">
           <button
             type="button"
             data-testid="check-report-close"

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -513,6 +513,176 @@ body {
   color: var(--icm-danger, #b4232a);
 }
 
+/* Netlist review is a report workbench, not a component picker. Its summary
+   spans the dialog while preview and diagnostics each own one complete pane;
+   structural and electrical findings share the diagnostics rail instead of
+   becoming a third item in a two-column insertion grid. */
+.netlist-preflight-dialog {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  gap: var(--icm-space-3);
+  width: min(72rem, calc(100vw - 2.5rem));
+  height: min(44rem, calc(100dvh - 2.5rem));
+  padding: 1rem;
+  overflow: hidden;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-lg);
+  color: var(--icm-text);
+  background: var(--icm-surface);
+  box-shadow: var(--icm-shadow-lg);
+}
+
+.netlist-preflight-header,
+.netlist-preflight-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--icm-space-3);
+}
+
+.netlist-preflight-header p,
+.netlist-preflight-header h2,
+.netlist-preflight-summary h3,
+.netlist-preflight-summary p,
+.netlist-preflight-diagnostics h3,
+.netlist-preflight-diagnostics p {
+  margin: 0;
+}
+
+.netlist-preflight-header p {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.netlist-preflight-header h2 {
+  margin-top: 0.15rem;
+  font-size: 16px;
+}
+
+.netlist-preflight-summary {
+  display: grid;
+  gap: var(--icm-space-1);
+  padding: var(--icm-space-3);
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-md);
+  background: var(--icm-surface-muted);
+}
+
+.netlist-preflight-summary h3,
+.netlist-preflight-diagnostics h3 {
+  font-size: var(--icm-font-md);
+}
+
+.netlist-preflight-summary p,
+.netlist-preflight-diagnostics p {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-sm);
+  line-height: 1.45;
+}
+
+.netlist-preflight-body {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(20rem, 2fr);
+  min-height: 0;
+  overflow: hidden;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-md);
+  background: var(--icm-surface-muted);
+}
+
+.netlist-preflight-body[data-has-preview="false"],
+.netlist-preflight-body[data-has-diagnostics="false"] {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.netlist-preflight-export {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: var(--icm-space-3);
+  min-width: 0;
+  min-height: 0;
+  padding: var(--icm-space-3);
+  background: var(--icm-surface);
+}
+
+.netlist-preflight-export-controls {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: var(--icm-space-3);
+}
+
+.netlist-preflight-export-controls label {
+  display: grid;
+  gap: var(--icm-space-1);
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-sm);
+  font-weight: 650;
+}
+
+.netlist-preflight-export-controls select,
+.netlist-preflight-export-controls button,
+.netlist-preflight-actions button {
+  min-height: var(--icm-control-h-lg);
+}
+
+.netlist-preflight-export-controls select {
+  min-width: 9rem;
+}
+
+.netlist-preflight-export .netlist-preview {
+  min-height: 0;
+}
+
+.netlist-preflight-diagnostics {
+  display: grid;
+  align-content: start;
+  gap: var(--icm-space-4);
+  min-width: 0;
+  min-height: 0;
+  padding: var(--icm-space-3);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border-left: 1px solid var(--icm-border);
+  background: var(--icm-surface-muted);
+  scrollbar-width: thin;
+}
+
+.netlist-preflight-body[data-has-preview="false"]
+  .netlist-preflight-diagnostics {
+  border-left: 0;
+}
+
+.netlist-preflight-diagnostics > section {
+  display: grid;
+  gap: var(--icm-space-2);
+}
+
+@media (max-width: 52rem) {
+  .netlist-preflight-dialog {
+    width: calc(100vw - 1rem);
+    height: calc(100dvh - 1rem);
+  }
+
+  .netlist-preflight-body {
+    grid-template-columns: minmax(0, 1fr);
+    overflow-y: auto;
+  }
+
+  .netlist-preflight-export {
+    min-height: 24rem;
+  }
+
+  .netlist-preflight-diagnostics {
+    overflow: visible;
+    border-top: 1px solid var(--icm-border);
+    border-left: 0;
+  }
+}
+
 .toolbar-check-glyph {
   width: 0;
   height: 0;


### PR DESCRIPTION
## Summary
- move netlist readiness into a full-width report summary
- give the structural preview and unified diagnostics rail complete desktop panes
- expand blocking findings to full width and stack report panes on narrow viewports
- preserve all existing findings, navigation, format selection, preview, and download behavior

## Validation
- pnpm install --frozen-lockfile
- pnpm ci:check
- 198 unit files / 1343 tests
- 234 Playwright tests
- workspace build, goldens, release and production smoke