### PR TITLE
Fix Gallery publishing for hierarchical projects

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -1,8 +1,9 @@
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
-import { createEmptyProject } from "@icm/model";
+import { createEmptyDocument, createEmptyProject } from "@icm/model";
 import { serializeProject } from "@icm/project-protocol";
+import { hierarchicalSymbolId } from "@icm/symbols";
 
 import { chooseComponent, clickCommand } from "./editor-fixtures.js";
 
@@ -17,6 +18,66 @@ const ENTRY = {
 
 /** Match the list path with or without filters and a paging cursor. */
 const galleryListUrl = (url: URL): boolean => url.pathname === "/api/gallery";
+
+function hierarchicalPublishProject() {
+  const project = createEmptyProject("hierarchical-publish", "Hierarchical");
+  const top = project.documents[0]!;
+  const child = createEmptyDocument("document-child", "scdac_unit");
+  top.instances = [
+    {
+      id: "R1",
+      symbolId: "resistor",
+      placement: {
+        position: { x: 0, y: 0 },
+        rotation: 0,
+        mirror: "none",
+      },
+      netlist: { reference: "R1", parameters: {} },
+    },
+    {
+      id: "R2",
+      symbolId: "resistor",
+      placement: {
+        position: { x: 200, y: 0 },
+        rotation: 0,
+        mirror: "none",
+      },
+      netlist: { reference: "R2", parameters: {} },
+    },
+    {
+      id: "XU0",
+      symbolId: hierarchicalSymbolId(child.netlist!.name),
+      placement: {
+        position: { x: 100, y: 120 },
+        rotation: 0,
+        mirror: "none",
+      },
+      netlist: {
+        reference: "XU0",
+        parameters: {},
+        binding: { kind: "subcircuit", childDocumentId: child.id },
+      },
+    },
+  ];
+  top.nets = [
+    {
+      id: "n1",
+      terminals: [
+        { instanceId: "R1", pinName: "1" },
+        { instanceId: "R2", pinName: "1" },
+      ],
+    },
+    {
+      id: "n2",
+      terminals: [
+        { instanceId: "R1", pinName: "2" },
+        { instanceId: "R2", pinName: "2" },
+      ],
+    },
+  ];
+  project.documents.push(child);
+  return project;
+}
 
 async function mockGallery(page: Page, entries: object[]): Promise<void> {
   await page.route(galleryListUrl, (route) =>
@@ -829,6 +890,38 @@ test("an ordinary user sees blocking quality gates on an empty project", async (
   await expect(dialog.getByLabel("Owner passphrase")).toHaveCount(0);
   // The gates still hold, but the button says what actually happens next.
   await expect(dialog.getByRole("button", { name: "Publish" })).toBeDisabled();
+});
+
+test("the publish dialog resolves internal Cell instances from the open Project", async ({
+  page,
+}) => {
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      json: {
+        user: {
+          id: "u9",
+          displayName: "Visitor",
+          email: "visitor@example.com",
+          provider: "email",
+          role: "user",
+          isAdmin: false,
+        },
+      },
+    }),
+  );
+
+  await page.goto("/editor");
+  await page.getByTestId("project-file").setInputFiles({
+    name: "hierarchical-publish.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(serializeProject(hierarchicalPublishProject())),
+  });
+  await page.getByTestId("publish-gallery-button").click();
+  const dialog = page.getByTestId("publish-gallery-dialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByTestId("publish-gallery-gates")).toHaveCount(0);
+  await expect(dialog).not.toContainText("ERC_UNRESOLVED_SYMBOL");
+  await expect(dialog.getByRole("button", { name: "Publish" })).toBeEnabled();
 });
 
 test("the retired review queue is gone from the moderation page", async ({

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -134,7 +134,6 @@ import {
   externalSubcircuitSymbolId,
   findUnsupportedProjectSymbolIds,
   hierarchicalSymbolId,
-  InMemorySymbolResolver,
   resolvePdkSymbolMapping,
   resolvePdkSymbolMappingForTerminalOrder,
   reviewedSky130MosModelSuggestions,
@@ -766,12 +765,7 @@ export function App({
       if (!cancelled) setPublishSession(user);
     });
     // The same evaluator the worker enforces, run live on the open Project.
-    setPublishGates(
-      evaluateSubmissionGates(
-        project,
-        new InMemorySymbolResolver(builtInSymbols),
-      ),
-    );
+    setPublishGates(evaluateSubmissionGates(project, resolver));
     return () => {
       cancelled = true;
     };

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -1,8 +1,13 @@
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 
-import { createEmptyProject, CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
+import {
+  createEmptyDocument,
+  createEmptyProject,
+  CURRENT_PROJECT_SCHEMA_VERSION,
+} from "@icm/model";
 import { parseProject, serializeProject } from "@icm/project-protocol";
+import { hierarchicalSymbolId } from "@icm/symbols";
 
 import {
   GALLERY_DAILY_SUBMISSION_LIMIT,
@@ -618,6 +623,57 @@ describe("gallery submissions", () => {
     expect(await preview.text()).toContain("<svg");
   });
 
+  it("publishes and updates a hierarchical Project with its top-level Cell preview", async () => {
+    const env = environment();
+    const cookie = await makerOf(env);
+    const publish = await route(
+      env,
+      submissionRequest(
+        {
+          name: "Hierarchical DAC",
+          projectText: hierarchicalProjectText("Hierarchical DAC"),
+        },
+        { cookie },
+      ),
+    );
+    expect(publish.status).toBe(201);
+    const { id } = (await publish.json()) as { id: string };
+
+    const detail = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}`),
+    );
+    const stored = (await detail.json()) as { projectText: string };
+    expect(parseProject(stored.projectText).documents).toHaveLength(2);
+
+    const preview = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/preview.svg`),
+    );
+    const svg = await preview.text();
+    expect(svg).toContain('data-object-id="XU0"');
+    expect(svg).toContain(
+      `data-symbol-id="${hierarchicalSymbolId("scdac_unit")}"`,
+    );
+
+    const update = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}`, {
+        method: "PUT",
+        headers: {
+          Origin: ORIGIN,
+          Cookie: cookie,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "Hierarchical DAC v2",
+          projectText: hierarchicalProjectText("Hierarchical DAC v2"),
+        }),
+      }),
+    );
+    expect(update.status).toBe(200);
+  });
+
   it("upgrades a previous-schema submission through the protocol", async () => {
     const env = environment();
     const id = await submitOne(env, "Old Schema", {
@@ -1033,6 +1089,28 @@ function wiredProjectText(name = "Wired"): string {
       ],
     },
   ];
+  return serializeProject(project);
+}
+
+function hierarchicalProjectText(name = "Hierarchical"): string {
+  const project = parseProject(wiredProjectText(name));
+  const top = project.documents[0]!;
+  const child = createEmptyDocument("document-child", "scdac_unit");
+  top.instances.push({
+    id: "XU0",
+    symbolId: hierarchicalSymbolId(child.netlist!.name),
+    placement: {
+      position: { x: 100, y: 120 },
+      rotation: 0,
+      mirror: "none",
+    },
+    netlist: {
+      reference: "XU0",
+      parameters: {},
+      binding: { kind: "subcircuit", childDocumentId: child.id },
+    },
+  });
+  project.documents.push(child);
   return serializeProject(project);
 }
 

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -21,7 +21,11 @@ import {
   upgradeSchema23To24WithReport,
 } from "@icm/project-protocol";
 import { renderDocumentSvg } from "@icm/render-svg";
-import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
+import {
+  builtInSymbols,
+  createProjectSymbolResolver,
+  type SymbolResolver,
+} from "@icm/symbols";
 import {
   CURRENT_PROJECT_SCHEMA_VERSION,
   type CircuitProject,
@@ -207,8 +211,6 @@ interface EntryRow {
   svg_text: string;
   netlistable: number;
 }
-
-const resolver = new InMemorySymbolResolver(builtInSymbols);
 
 function summaryOf(
   row: EntryRow & { likes?: number; liked_by_viewer?: number },
@@ -1255,7 +1257,10 @@ function fieldText(value: unknown, maxLength: number): string | null {
   return trimmed.length <= maxLength ? trimmed : null;
 }
 
-function renderPreview(project: CircuitProject): string {
+function renderPreview(
+  project: CircuitProject,
+  resolver: SymbolResolver,
+): string {
   const topDocument = project.documents.find(
     (document) => document.id === project.topDocumentId,
   )!;
@@ -1369,8 +1374,9 @@ async function handleSubmission(
   } catch {
     return Response.json({ error: "invalid-project" }, { status: 400 });
   }
+  const projectResolver = createProjectSymbolResolver(project, builtInSymbols);
   if (!privileged) {
-    const report = evaluateSubmissionGates(project, resolver);
+    const report = evaluateSubmissionGates(project, projectResolver);
     if (!report.ok) {
       return Response.json(
         { error: "quality-gate", failures: report.failures },
@@ -1406,7 +1412,7 @@ async function handleSubmission(
         submitter_provider: user.provider,
         tags: wrapTags(sanitizeGalleryTags(body.tags)),
         project_text: serializeProject(project),
-        svg_text: renderPreview(project),
+        svg_text: renderPreview(project, projectResolver),
       },
     },
   );
@@ -1482,8 +1488,9 @@ async function handleEntryUpdate(
   } catch {
     return Response.json({ error: "invalid-project" }, { status: 400 });
   }
+  const projectResolver = createProjectSymbolResolver(project, builtInSymbols);
   if (!privileged) {
-    const report = evaluateSubmissionGates(project, resolver);
+    const report = evaluateSubmissionGates(project, projectResolver);
     if (!report.ok) {
       return Response.json(
         { error: "quality-gate", failures: report.failures },
@@ -1500,7 +1507,7 @@ async function handleEntryUpdate(
     author,
     description,
     projectText: serializeProject(project),
-    svgText: renderPreview(project),
+    svgText: renderPreview(project, projectResolver),
     schemaVersion: project.schemaVersion,
     status: nextStatus,
     tags: wrapTags(sanitizeGalleryTags(body.tags)),


### PR DESCRIPTION
## Summary\n- use the editor's project-aware symbol resolver for live publish gates\n- build one project-aware resolver per Worker publish/update and reuse it for ERC and top-level SVG previews\n- cover member publish, update, storage, preview, and browser gate parity for internal Cell instances\n\n## Validation\n- pnpm install --frozen-lockfile\n- pnpm ci:check (1344 unit tests, 235 browser tests, build/goldens/performance/release smoke)\n\nThe preview remains top-document-only; child Cell internals are not expanded. Real unresolved symbols still block publishing.