### PR TITLE
Fix MOS bulk route ownership and deletion

### DIFF
--- a/apps/editor/src/features/netlist-export/check-and-save.ts
+++ b/apps/editor/src/features/netlist-export/check-and-save.ts
@@ -1,5 +1,6 @@
 import type { SchematicEdit } from "@icm/edit-engine";
 import {
+  hasExplicitMosBulkRoute,
   resolveDocumentLogicalNets,
   resolveDetachedMosBulkDefault,
   resolveMosBulkConnection,
@@ -59,6 +60,9 @@ function pendingDefaultCount(
   return document.instances.filter((instance) => {
     if (instance.symbolId !== symbolId || instance.placement === null)
       return false;
+    if (hasExplicitMosBulkRoute(document, instance.id)) {
+      return instance.mosBulkBinding !== undefined;
+    }
     const resolution = resolveMosBulkConnection(document, instance);
     return Boolean(
       resolution &&

--- a/apps/editor/src/presentation/razavi-presentation.ts
+++ b/apps/editor/src/presentation/razavi-presentation.ts
@@ -1,5 +1,6 @@
 import { executeTransaction, type SchematicEdit } from "@icm/edit-engine";
 import {
+  hasExplicitMosBulkRoute,
   mosBulkShouldBeVisible,
   resolveDetachedMosBulkDefault,
   resolveMosBulkConnection,
@@ -39,6 +40,9 @@ export function razaviManualBulkConnectionEdits(
   const instanceIds = instances
     .filter((instance) => {
       const resolution = resolveMosBulkConnection(document, instance);
+      if (hasExplicitMosBulkRoute(document, instance.id)) {
+        return instance.mosBulkBinding !== undefined;
+      }
       const configuredNetId =
         instance.symbolId === "nmos"
           ? document.mosBulkDefaults?.nmosNetId

--- a/packages/derived/src/mos-bulk.test.ts
+++ b/packages/derived/src/mos-bulk.test.ts
@@ -2,6 +2,8 @@ import { createEmptyDocument } from "@icm/model";
 import { describe, expect, it } from "vitest";
 
 import {
+  deriveMosBulkRouteFamily,
+  hasExplicitMosBulkRoute,
   isMosBulkTerminal,
   mosBulkShouldBeVisible,
   resolveMosBulkConnection,
@@ -142,6 +144,57 @@ describe("MOS bulk resolution", () => {
     document.mosBulkDefaults = { nmosNetId: "net-cell-substrate" };
 
     expect(mosBulkShouldBeVisible(document, "M1")).toBe(false);
+  });
+
+  it("gives an explicit multi-segment bulk route precedence over stale default metadata", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.instances.push({
+      ...mos("M1", "nmos"),
+      mosBulkBinding: {
+        netId: "net-vss",
+        origin: "cell-default",
+      },
+    });
+    document.nets.push({
+      id: "net-vss",
+      terminals: [{ instanceId: "M1", pinName: "B" }],
+    });
+    document.junctions.push(
+      { id: "J1", netId: "net-vss", position: { x: 100, y: 100 } },
+      { id: "J2", netId: "net-vss", position: { x: 200, y: 100 } },
+    );
+    document.routes.push(
+      {
+        id: "bulk-near",
+        netId: "net-vss",
+        from: { kind: "terminal", instanceId: "M1", pinName: "B" },
+        to: { kind: "junction", junctionId: "J1" },
+        waypoints: [],
+        segmentModes: ["manual"],
+        presentation: "bulk-dashed",
+      },
+      {
+        id: "bulk-distal",
+        netId: "net-vss",
+        from: { kind: "junction", junctionId: "J1" },
+        to: { kind: "junction", junctionId: "J2" },
+        waypoints: [],
+        segmentModes: ["manual"],
+        presentation: "bulk-dashed",
+      },
+    );
+    document.mosBulkDefaults = { nmosNetId: "net-vss" };
+
+    expect(hasExplicitMosBulkRoute(document, "M1")).toBe(true);
+    expect(deriveMosBulkRouteFamily(document, document.routes[1]!)).toEqual({
+      routeIds: ["bulk-distal", "bulk-near"],
+      instanceIds: ["M1"],
+    });
+    expect(resolveMosBulkConnection(document, "M1")).toMatchObject({
+      status: "explicit",
+      net: { id: "net-vss" },
+    });
+    expect(mosBulkShouldBeVisible(document, "M1")).toBe(true);
   });
 
   it("does not guess when imported fourth-node evidence is missing", () => {

--- a/packages/derived/src/mos-bulk.ts
+++ b/packages/derived/src/mos-bulk.ts
@@ -43,17 +43,97 @@ export function isMosBulkTerminal(
   return Boolean(instance && mosBulkKind(instance));
 }
 
-/** A dashed Route is meaningful only when it visibly represents MOS bulk. */
+export interface MosBulkRouteFamily {
+  routeIds: string[];
+  instanceIds: string[];
+}
+
+function bulkFamilyContactKeys(
+  document: SchematicDocument,
+  route: RouteBranch,
+): string[] {
+  return [route.from, route.to].flatMap((endpoint) => {
+    if (endpoint.kind === "junction")
+      return [`junction:${endpoint.junctionId}`];
+    return isMosBulkTerminal(document, endpoint)
+      ? [`terminal:${endpoint.instanceId}:B`]
+      : [];
+  });
+}
+
+/**
+ * Resolve every dashed segment in the connected visual path that originates
+ * at one or more MOS B terminals. Route splitting can move the B terminal off
+ * the selected segment, so direct terminal incidence is not a sufficient
+ * family test.
+ */
+export function deriveMosBulkRouteFamily(
+  document: SchematicDocument,
+  seedRoute: RouteBranch,
+): MosBulkRouteFamily | undefined {
+  if (seedRoute.presentation !== "bulk-dashed") return undefined;
+  const routeIds = new Set([seedRoute.id]);
+  const contactKeys = new Set(bulkFamilyContactKeys(document, seedRoute));
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const route of document.routes) {
+      if (route.presentation !== "bulk-dashed" || routeIds.has(route.id)) {
+        continue;
+      }
+      const routeKeys = bulkFamilyContactKeys(document, route);
+      if (!routeKeys.some((key) => contactKeys.has(key))) continue;
+      routeIds.add(route.id);
+      routeKeys.forEach((key) => contactKeys.add(key));
+      changed = true;
+    }
+  }
+  const familyRoutes = document.routes.filter((route) =>
+    routeIds.has(route.id),
+  );
+  const instanceIds = new Set(
+    familyRoutes.flatMap((route) =>
+      [route.from, route.to].flatMap((endpoint) =>
+        isMosBulkTerminal(document, endpoint) && endpoint.kind === "terminal"
+          ? [endpoint.instanceId]
+          : [],
+      ),
+    ),
+  );
+  if (instanceIds.size === 0) return undefined;
+  return {
+    routeIds: [...routeIds].sort((left, right) =>
+      left.localeCompare(right, "en"),
+    ),
+    instanceIds: [...instanceIds].sort((left, right) =>
+      left.localeCompare(right, "en"),
+    ),
+  };
+}
+
+export function hasExplicitMosBulkRoute(
+  document: SchematicDocument,
+  instanceId: string,
+): boolean {
+  return document.routes.some(
+    (route) =>
+      route.presentation === "bulk-dashed" &&
+      [route.from, route.to].some(
+        (endpoint) =>
+          endpoint.kind === "terminal" &&
+          endpoint.instanceId === instanceId &&
+          endpoint.pinName === "B" &&
+          isMosBulkTerminal(document, endpoint),
+      ),
+  );
+}
+
+/** A dashed Route is meaningful only when it belongs to a MOS bulk family. */
 export function isMosBulkRoute(
   document: SchematicDocument,
   route: RouteBranch,
 ): boolean {
-  return (
-    route.presentation === "bulk-dashed" &&
-    [route.from, route.to].some((endpoint) =>
-      isMosBulkTerminal(document, endpoint),
-    )
-  );
+  return deriveMosBulkRouteFamily(document, route) !== undefined;
 }
 
 /**
@@ -79,7 +159,9 @@ export function resolveMosBulkConnection(
     ),
   );
   if (connectedNet) {
-    const origin = instance.mosBulkBinding;
+    const origin = hasExplicitMosBulkRoute(document, instance.id)
+      ? undefined
+      : instance.mosBulkBinding;
     return {
       status: origin?.netId === connectedNet.id ? origin.origin : "explicit",
       instance,

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -1,4 +1,5 @@
 import {
+  deriveMosBulkRouteFamily,
   derivePowerRailComponent,
   isMosBulkRoute,
   isMosBulkTerminal,
@@ -24,6 +25,7 @@ import {
 } from "./route-operations.js";
 import type {
   Point,
+  RouteBranch,
   RouteEndpoint,
   RoutePresentation,
   SchematicDocument,
@@ -577,40 +579,34 @@ export function proposeVisualRouteDeletion(
   const instanceIdsScheduledForDeletion = new Set(
     context.instanceIdsScheduledForDeletion ?? [],
   );
-  const routesToRemove = new Set(routeIds);
+  const routesToRemove = new Set<string>();
+  const bulkRoutesToRemove = new Set<string>();
   const junctionsToRemove = new Set(junctionIds);
-  let changed = true;
-  while (changed) {
-    changed = false;
-    const bulkJunctions = new Set(
-      document.routes
-        .filter(
-          (route) =>
-            routesToRemove.has(route.id) && isMosBulkRoute(document, route),
-        )
-        .flatMap((route) => [route.from, route.to])
-        .filter(
-          (
-            endpoint,
-          ): endpoint is Extract<RouteEndpoint, { kind: "junction" }> =>
-            endpoint.kind === "junction",
-        )
-        .map((endpoint) => endpoint.junctionId),
-    );
-    for (const route of document.routes) {
-      if (
-        isMosBulkRoute(document, route) &&
-        !routesToRemove.has(route.id) &&
-        [route.from, route.to].some(
-          (endpoint) =>
-            endpoint.kind === "junction" &&
-            bulkJunctions.has(endpoint.junctionId),
-        )
-      ) {
-        routesToRemove.add(route.id);
+  const includeRouteAndBulkFamily = (route: RouteBranch): boolean => {
+    let changed = false;
+    if (!routesToRemove.has(route.id)) {
+      routesToRemove.add(route.id);
+      changed = true;
+    }
+    const family = deriveMosBulkRouteFamily(document, route);
+    if (!family) return changed;
+    for (const routeId of family.routeIds) {
+      bulkRoutesToRemove.add(routeId);
+      if (!routesToRemove.has(routeId)) {
+        routesToRemove.add(routeId);
         changed = true;
       }
     }
+    return changed;
+  };
+  for (const routeId of routeIds) {
+    const route = document.routes.find((candidate) => candidate.id === routeId);
+    if (route) includeRouteAndBulkFamily(route);
+    else routesToRemove.add(routeId);
+  }
+  let changed = true;
+  while (changed) {
+    changed = false;
     for (const route of document.routes) {
       const touchesDeletedJunction =
         (route.from.kind === "junction" &&
@@ -618,8 +614,7 @@ export function proposeVisualRouteDeletion(
         (route.to.kind === "junction" &&
           junctionsToRemove.has(route.to.junctionId));
       if (touchesDeletedJunction && !routesToRemove.has(route.id)) {
-        routesToRemove.add(route.id);
-        changed = true;
+        changed = includeRouteAndBulkFamily(route) || changed;
       }
     }
     for (const junction of document.junctions) {
@@ -684,10 +679,7 @@ export function proposeVisualRouteDeletion(
   const disconnectedBulkInstances = [
     ...new Set(
       document.routes
-        .filter(
-          (route) =>
-            routesToRemove.has(route.id) && isMosBulkRoute(document, route),
-        )
+        .filter((route) => bulkRoutesToRemove.has(route.id))
         .flatMap((route) => [route.from, route.to])
         .filter(
           (

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -2563,6 +2563,106 @@ describe("routing Edit Engine", () => {
     ).toHaveLength(1);
   });
 
+  it("deletes an entire split bulk route family and restores the default without orphaning ordinary wire", () => {
+    const document = createEmptyDocument("bulk-delete", "Bulk Delete");
+    document.instances.push(
+      {
+        id: "M1",
+        symbolId: "nmos",
+        symbolVariantId: "textbook-3terminal",
+        placement: {
+          position: { x: 100, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+        mosBulkBinding: { origin: "cell-default", netId: "net-vss" },
+      },
+      {
+        id: "GND1",
+        symbolId: "ground",
+        placement: {
+          position: { x: 300, y: 110 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+    );
+    document.nets.push({
+      id: "net-vss",
+      terminals: [
+        { instanceId: "M1", pinName: "B" },
+        { instanceId: "GND1", pinName: "0" },
+      ],
+    });
+    document.junctions.push(
+      { id: "J1", netId: "net-vss", position: { x: 150, y: 100 } },
+      { id: "J2", netId: "net-vss", position: { x: 200, y: 100 } },
+    );
+    document.routes.push(
+      {
+        id: "bulk-near",
+        netId: "net-vss",
+        from: { kind: "terminal", instanceId: "M1", pinName: "B" },
+        to: { kind: "junction", junctionId: "J1" },
+        waypoints: [{ x: 100, y: 100 }],
+        segmentModes: ["escape", "manual"],
+        presentation: "bulk-dashed",
+      },
+      {
+        id: "bulk-distal",
+        netId: "net-vss",
+        from: { kind: "junction", junctionId: "J1" },
+        to: { kind: "junction", junctionId: "J2" },
+        waypoints: [],
+        segmentModes: ["manual"],
+        presentation: "bulk-dashed",
+      },
+      {
+        id: "route-ui-112",
+        netId: "net-vss",
+        from: { kind: "junction", junctionId: "J2" },
+        to: { kind: "terminal", instanceId: "GND1", pinName: "0" },
+        waypoints: [],
+        segmentModes: ["manual"],
+      },
+    );
+    document.connectivityEvidence.push({
+      id: "claim-ground",
+      kind: "name-claim",
+      netId: "net-vss",
+      name: "0",
+      scope: "global",
+      powerDomain: "ground",
+      owner: { kind: "power-marker", objectId: "GND1" },
+    });
+    document.mosBulkDefaults = { nmosNetId: "net-vss" };
+
+    const deletion = proposeVisualRouteDeletion(document, ["bulk-distal"], []);
+    expect(deletion.routeIds).toEqual(["bulk-distal", "bulk-near"]);
+    const result = executeTransaction(
+      document,
+      transaction(document.id, 0, deletion.edits),
+      context,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.document.routes).toMatchObject([{ id: "route-ui-112" }]);
+    const defaultNetId = result.document.mosBulkDefaults?.nmosNetId;
+    expect(
+      result.document.instances.find((instance) => instance.id === "M1")
+        ?.mosBulkBinding,
+    ).toEqual({ origin: "cell-default", netId: defaultNetId });
+    expect(
+      result.document.nets.find((net) => net.id === defaultNetId)?.terminals,
+    ).toEqual(
+      expect.arrayContaining([
+        { instanceId: "M1", pinName: "B" },
+        { instanceId: "GND1", pinName: "0" },
+      ]),
+    );
+  });
+
   it("physically splits a global-Net Route instead of hiding the cut behind global Evidence", () => {
     const document = documentFixture();
     const net = document.nets.find((candidate) => candidate.id === "net-v")!;

--- a/packages/edit-engine/src/transaction.test.ts
+++ b/packages/edit-engine/src/transaction.test.ts
@@ -682,6 +682,54 @@ describe("Edit Transaction envelope", () => {
     ]);
   });
 
+  it("releases stale default ownership when a visible bulk route owns B", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.instances.push({
+      id: "M1",
+      symbolId: "nmos",
+      symbolVariantId: "textbook-3terminal",
+      placement: { position: { x: 100, y: 100 }, rotation: 0, mirror: "none" },
+      mosBulkBinding: { origin: "cell-default", netId: "net-vss" },
+    });
+    document.nets.push({
+      id: "net-vss",
+      terminals: [{ instanceId: "M1", pinName: "B" }],
+    });
+    document.junctions.push({
+      id: "J1",
+      netId: "net-vss",
+      position: { x: 180, y: 100 },
+    });
+    document.routes.push({
+      id: "bulk-route",
+      netId: "net-vss",
+      from: { kind: "terminal", instanceId: "M1", pinName: "B" },
+      to: { kind: "junction", junctionId: "J1" },
+      waypoints: [{ x: 100, y: 100 }],
+      segmentModes: ["escape", "manual"],
+      presentation: "bulk-dashed",
+    });
+    document.mosBulkDefaults = { nmosNetId: "net-vss" };
+
+    const result = executeTransaction(
+      document,
+      {
+        ...transaction(),
+        edits: [{ kind: "reconcile_mos_bulk", instanceIds: ["M1"] }],
+      },
+      { symbolResolver: resolver },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.document.instances[0]?.mosBulkBinding).toBeUndefined();
+    expect(result.document.nets[0]?.terminals).toContainEqual({
+      instanceId: "M1",
+      pinName: "B",
+    });
+    expect(result.document.routes).toEqual(document.routes);
+  });
+
   it("repairs a legacy imported B-only split using shared source provenance", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.instances.push({

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -22,6 +22,7 @@ import type {
 } from "@icm/model";
 import {
   endpointKey,
+  hasExplicitMosBulkRoute,
   isMosBulkRoute,
   logicalNetContractIssueKey,
   mosBulkKind,
@@ -596,6 +597,12 @@ function reconcileMaterializedMosBulkBindings(
   let changed = false;
   for (const instance of draft.instances) {
     if (instance.mosBulkBinding?.origin !== "cell-default") continue;
+    if (hasExplicitMosBulkRoute(draft, instance.id)) {
+      delete instance.mosBulkBinding;
+      changedObjectIds.add(instance.id);
+      changed = true;
+      continue;
+    }
     const kind = mosBulkKind(instance);
     const targetNetId =
       kind === "nmos"
@@ -3216,6 +3223,19 @@ export function executeTransaction(
                 terminal.instanceId === instance.id && terminal.pinName === "B",
             ),
           );
+
+          // A visible dashed body connection is user-authored and therefore
+          // owns B even when it happens to land on the configured default Net.
+          // Repair stale dual ownership by releasing only the policy metadata;
+          // the explicit Net membership and Route geometry remain untouched.
+          if (hasExplicitMosBulkRoute(draft, instance.id)) {
+            if (instance.mosBulkBinding) {
+              delete instance.mosBulkBinding;
+              changedObjectIds.add(instance.id);
+              connectivityChanged = true;
+            }
+            continue;
+          }
 
           // Imported four-node MOS data already carries a real B terminal.
           // When the three-terminal presentation hides that terminal and it


### PR DESCRIPTION
## Summary
- give visible explicit MOS bulk routes precedence over fallback binding metadata
- treat split dashed bulk segments as one deletion family
- restore configured fallback only after the explicit family is removed
- preserve adjacent ordinary wire and Net geometry

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm test:local (198 files, 1347 tests)
- pnpm build
- pnpm test:e2e:local apps/editor/e2e/hierarchy.spec.ts (14 passed)
- pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts (109 passed)