### PR TITLE
Fix transaction connectivity normalization

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -27,7 +27,6 @@ import {
   proposeWireCommitThroughContacts,
   proposeWireSegmentMove,
   planEnsureNamedNet,
-  planDirectEndpointConnection,
   planCreateCell,
   planDeleteCell,
   planRenameCell,
@@ -4866,19 +4865,6 @@ export function App({
           );
           if (instance?.placement) instance.placement.position = move.position;
         }
-        const directContactPlan =
-          movingElectrical?.kind === "endpoint" &&
-          targetElectrical?.kind === "endpoint"
-            ? planDirectEndpointConnection(projected, {
-                from: movingElectrical.endpoint,
-                to: targetElectrical.endpoint,
-                newNetId: `net-ui-${nextRoutingSuffix()}`,
-              })
-            : null;
-        if (directContactPlan && !directContactPlan.ok) {
-          setStatus(directContactPlan.message);
-          return;
-        }
         const contactEdits: readonly SchematicEdit[] =
           movingElectrical?.kind === "endpoint" &&
           targetElectrical?.kind === "route"
@@ -4891,10 +4877,7 @@ export function App({
                 targetElectrical.segmentIndex,
                 `move-${nextRoutingSuffix()}`,
               ).edits
-            : movingElectrical?.kind === "endpoint" &&
-                targetElectrical?.kind === "endpoint"
-              ? (directContactPlan?.edits ?? [])
-              : [];
+            : [];
         const result = transactConnectivity(
           targetElectrical?.kind === "route"
             ? "attach_endpoint_to_wire"

--- a/apps/editor/src/features/component-insert/placement-connectivity.test.ts
+++ b/apps/editor/src/features/component-insert/placement-connectivity.test.ts
@@ -396,11 +396,14 @@ describe("component placement electrical contacts", () => {
     });
     expect(removed.document.connectivityEvidence).toEqual([]);
 
+    // Reusing the designator is the behavior under test. Keep the marker away
+    // from the surviving route anchor: exact physical contact would correctly
+    // rejoin that conductor under the transaction connectivity contract.
     const vddPort = {
       id: "VDD2",
       symbolId: "vdd-port",
       placement: {
-        position: { x: 100, y: 100 },
+        position: { x: 300, y: 100 },
         rotation: 0 as const,
         mirror: "none" as const,
       },

--- a/docs/specs/connectivity-and-routing.md
+++ b/docs/specs/connectivity-and-routing.md
@@ -30,17 +30,22 @@ Route transaction.
   compiler persists only grid landings and ordinary grid waypoints. An offset
   MOS B anchor therefore uses the same Route transaction as every other pin;
   `bulk-dashed` changes only presentation.
-- Exact visible endpoint coincidence is a derived zero-length physical contact
-  only for endpoints already in the same Base Net. New contact intent is still
-  authored explicitly by the snap/placement planner through
-  `connect_endpoints`; raw coordinate overlap never merges or creates a Net.
+- Exact visible endpoint coincidence is a zero-length physical contact. After
+  placement or geometry edits reach their final coordinates, the Edit Engine
+  deterministically creates or merges the participating Base Net; incompatible
+  power domains or Net-name contracts reject the whole transaction. An
+  explicit `disconnect_endpoint` in the same transaction suppresses this
+  normalization so deletion cannot immediately reconnect itself.
 - If a move, rotation, or mirror separates a confirmed direct contact, the
   transaction materializes one ordinary manual Route after all transforms have
   reached their final positions. Jointly transformed endpoints remain a
   route-free direct contact, and an existing alternate physical path prevents
   duplicate Route creation.
-- A Route-segment tap splits geometry at an explicit Junction. A mere crossing
-  remains disconnected.
+- A Route-segment tap splits geometry at an explicit Junction. A Junction that
+  lands on another ordinary Route joins and splits that conductor as well; a
+  mere route-interior crossing remains disconnected. Pin-to-route attachment
+  remains a snapped typed intent because it changes the selected Route's
+  identity and geometry.
 - Moving a connected Instance stretches the attached Route while preserving
   endpoint identity.
 - `remove_route_geometry` removes presentation geometry only. The ordinary
@@ -113,8 +118,12 @@ coordinates.
 marker attachment, diagnostics, export, and Agent Snapshot. It publishes the
 same resolved endpoint connections consumed by those readers; consumers do not
 reconstruct terminal contacts from Symbol coordinates.
-`deriveDocumentContactEvidence` is the sole coincident-endpoint contact source;
-consumers do not infer contact independently from pixels or bounds.
+`deriveDocumentContactEvidence` is the sole read model for confirmed same-Net
+coincident contacts; consumers do not infer contact independently from pixels
+or bounds. The transaction connectivity normalizer is the corresponding write
+boundary: it derives gained endpoint and explicit Junction-on-route contacts
+from exact resolved geometry and commits them through the ordinary Base-Net and
+Route mutations.
 
 Route queries (tap, nearest segment, crossings) and attachment placement are
 read-only derived modules. Route normalization, constraint-aware authoring, segment

--- a/docs/specs/edit-engine.md
+++ b/docs/specs/edit-engine.md
@@ -254,8 +254,10 @@ Topology operations have these preconditions:
   Junctions, terminals, NoConnects, instance-owned annotations, and unlocked
   layout references are removed explicitly, and only then is the unreferenced
   instance removed.
-- Endpoints on different Nets require an explicit preceding `merge_nets` edit
-  in the same transaction.
+- Explicit `connect_endpoints` and `attach_endpoint_to_route` edits on different
+  Nets require their planned merge in the same transaction. Independently,
+  final exact endpoint coincidence and explicit Junction-on-route contact are
+  normalized by the transaction itself, using the same Base-Net merge path.
 - `merge_nets` retargets routes, junctions, annotations, and layout references
   before removing the source Net.
 - `disconnect_endpoint` requires all route geometry that uses the endpoint to

--- a/packages/derived/src/contact.ts
+++ b/packages/derived/src/contact.ts
@@ -47,8 +47,9 @@ export interface DocumentContactEvidence {
 /**
  * One pairwise projection of a confirmed same-Net {@link CoincidentContact}.
  * It is the transform-time input used to detect when a previously confirmed
- * direct contact has been separated. New contact intent remains an explicit
- * authoring operation.
+ * direct contact has been separated. Gained contacts are committed by the Edit
+ * Engine's transaction connectivity normalizer; this read model continues to
+ * describe only already-confirmed same-Net contacts.
  */
 export interface DirectContactPair {
   id: string;

--- a/packages/edit-engine/src/direct-contact-lifecycle.test.ts
+++ b/packages/edit-engine/src/direct-contact-lifecycle.test.ts
@@ -270,7 +270,7 @@ describe("direct-contact transform lifecycle", () => {
     expect(aOwner).toBe(bOwner);
   });
 
-  it("does not merge different Base Nets from raw geometric coincidence", () => {
+  it("merges different Base Nets when a moved endpoint makes exact contact", () => {
     const document = fixture();
     document.instances.find((instance) => instance.id === "B")!.placement = {
       position: { x: 460, y: 300 },
@@ -308,11 +308,288 @@ describe("direct-contact transform lifecycle", () => {
     );
 
     if (!result.ok) throw new Error(result.error.message);
-    expect(result.document.nets).toHaveLength(2);
-    expect(result.document.nets.map((net) => net.id).sort()).toEqual([
-      "net-a",
-      "net-b",
+    expect(result.document.nets).toHaveLength(1);
+    expect(result.document.nets[0]?.terminals).toEqual(
+      expect.arrayContaining([
+        { instanceId: "A", pinName: "P" },
+        { instanceId: "B", pinName: "P" },
+      ]),
+    );
+  });
+
+  it("rejects exact contact between incompatible power domains", () => {
+    const document = fixture();
+    document.instances.find((instance) => instance.id === "B")!.placement = {
+      position: { x: 460, y: 300 },
+      rotation: 0,
+      mirror: "x",
+    };
+    document.nets = [
+      {
+        id: "net-vdd",
+        terminals: [{ instanceId: "A", pinName: "P" }],
+      },
+      {
+        id: "net-ground",
+        terminals: [{ instanceId: "B", pinName: "P" }],
+      },
+    ];
+    document.netlist!.terminals[0]!.netId = "net-vdd";
+    document.netlist!.terminals[1]!.netId = "net-ground";
+    document.connectivityEvidence = [
+      {
+        id: "claim-vdd",
+        kind: "name-claim",
+        netId: "net-vdd",
+        name: "VDD",
+        scope: "global",
+        powerDomain: "vdd",
+        owner: { kind: "explicit-net-property" },
+      },
+      {
+        id: "claim-ground",
+        kind: "name-claim",
+        netId: "net-ground",
+        name: "0",
+        scope: "global",
+        powerDomain: "ground",
+        owner: { kind: "explicit-net-property" },
+      },
+    ];
+
+    const result = executeTransaction(
+      document,
+      transaction(
+        document,
+        [
+          {
+            kind: "move_instance",
+            instanceId: "B",
+            position: { x: 160, y: 300 },
+          },
+        ],
+        "power-conflict",
+      ),
+      context,
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "EDIT_PRECONDITION",
+        message: "Cannot merge Nets with incompatible power domains",
+      },
+    });
+  });
+
+  it("assigns an ownerless terminal to the contacted Net and clears NoConnect", () => {
+    const document = fixture();
+    document.instances.find((instance) => instance.id === "B")!.placement = {
+      position: { x: 460, y: 300 },
+      rotation: 0,
+      mirror: "x",
+    };
+    document.nets[0]!.terminals = [{ instanceId: "A", pinName: "P" }];
+    document.noConnects = [
+      {
+        id: "no-connect-b",
+        endpoint: { kind: "terminal", instanceId: "B", pinName: "P" },
+      },
+    ];
+
+    const result = executeTransaction(
+      document,
+      transaction(
+        document,
+        [
+          {
+            kind: "move_instance",
+            instanceId: "B",
+            position: { x: 160, y: 300 },
+          },
+        ],
+        "ownerless-contact",
+      ),
+      context,
+    );
+
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.document.nets).toHaveLength(1);
+    expect(result.document.nets[0]?.terminals).toEqual(
+      expect.arrayContaining([
+        { instanceId: "A", pinName: "P" },
+        { instanceId: "B", pinName: "P" },
+      ]),
+    );
+    expect(result.document.noConnects).toEqual([]);
+  });
+
+  it("connects a newly added instance from its final exact placement", () => {
+    const document = fixture();
+    document.instances = [
+      {
+        id: "A",
+        symbolId: "ground",
+        placement: {
+          position: { x: 100, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+    ];
+    document.netlist!.terminals = [];
+    document.nets = [
+      {
+        id: "net-ground",
+        terminals: [{ instanceId: "A", pinName: "0" }],
+      },
+    ];
+    const result = executeTransaction(
+      document,
+      transaction(
+        document,
+        [
+          {
+            kind: "add_instance",
+            instance: {
+              id: "B",
+              symbolId: "ground",
+              placement: {
+                position: { x: 100, y: 100 },
+                rotation: 0,
+                mirror: "none",
+              },
+            },
+          },
+        ],
+        "add-instance-contact",
+      ),
+      context,
+    );
+
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.document.nets).toEqual([
+      expect.objectContaining({
+        id: "net-ground",
+        terminals: expect.arrayContaining([
+          { instanceId: "A", pinName: "0" },
+          { instanceId: "B", pinName: "0" },
+        ]),
+      }),
     ]);
+  });
+
+  it("honors an explicit disconnect even while endpoints remain coincident", () => {
+    const document = fixture();
+    document.instances = ["A", "B"].map((id) => ({
+      id,
+      symbolId: "ground",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0 as const,
+        mirror: "none" as const,
+      },
+    }));
+    document.netlist!.terminals = [];
+    document.nets = [
+      {
+        id: "net-contact",
+        terminals: ["A", "B"].map((instanceId) => ({
+          instanceId,
+          pinName: "0",
+        })),
+      },
+    ];
+    const groundEndpoint = (instanceId: string): RouteEndpoint => ({
+      kind: "terminal",
+      instanceId,
+      pinName: "0",
+    });
+    const result = executeTransaction(
+      document,
+      transaction(
+        document,
+        [
+          {
+            kind: "disconnect_endpoint",
+            endpoint: groundEndpoint("B"),
+          },
+        ],
+        "explicit-disconnect",
+      ),
+      context,
+    );
+
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.document.nets[0]?.terminals).toEqual([
+      { instanceId: "A", pinName: "0" },
+    ]);
+  });
+
+  it("attaches every explicit Junction crossed by a newly added power rail", () => {
+    const document = fixture();
+    document.instances = [];
+    document.netlist!.terminals = [];
+    document.nets = [
+      { id: "net-left", terminals: [] },
+      { id: "net-right", terminals: [] },
+    ];
+    document.junctions = [
+      {
+        id: "junction-left",
+        netId: "net-left",
+        position: { x: 120, y: 300 },
+        role: "route-anchor",
+      },
+      {
+        id: "junction-right",
+        netId: "net-right",
+        position: { x: 180, y: 300 },
+        role: "route-anchor",
+      },
+    ];
+
+    const result = executeTransaction(
+      document,
+      transaction(
+        document,
+        [
+          {
+            kind: "add_power_rail",
+            netId: "net-rail",
+            routeId: "route-rail",
+            startJunctionId: "rail-start",
+            endJunctionId: "rail-end",
+            labelId: "rail-label",
+            netName: "VDD",
+            scope: "global",
+            powerDomain: "vdd",
+            start: { x: 100, y: 300 },
+            end: { x: 200, y: 300 },
+          },
+        ],
+        "rail-crosses-junctions",
+      ),
+      context,
+    );
+
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.document.nets).toHaveLength(1);
+    expect(
+      new Set(result.document.junctions.map((junction) => junction.netId)),
+    ).toEqual(new Set([result.document.nets[0]!.id]));
+    expect(result.document.routes).toHaveLength(3);
+    expect(
+      result.document.routes.flatMap((route) => [
+        endpointKey(route.from),
+        endpointKey(route.to),
+      ]),
+    ).toEqual(
+      expect.arrayContaining([
+        "junction:junction-left",
+        "junction:junction-right",
+      ]),
+    );
   });
 
   it("restores both zero-length contact and materialized Route with history", () => {

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -864,6 +864,11 @@ describe("routing Edit Engine", () => {
 
   it("turns a multi-part selection as one body about a shared pivot", () => {
     const document = documentFixture();
+    for (const instance of document.instances.filter(
+      (candidate) => !["A", "B"].includes(candidate.id),
+    )) {
+      if (instance.placement) instance.placement.position.x += 1_000;
+    }
     // A and B sit side by side on y=300; a quarter turn about their shared
     // centre has to stand them up, not merely spin each symbol where it is.
     const plan = proposeGroupRotationEdits(document, resolver, ["A", "B"], 90);
@@ -2024,7 +2029,7 @@ describe("routing Edit Engine", () => {
     ]);
   });
 
-  it("splits only the explicitly targeted conductor at a crossing", () => {
+  it("rejects a Junction dot that would join conflicting crossing Nets", () => {
     const document = documentFixture();
     document.routes = [
       {
@@ -2065,20 +2070,12 @@ describe("routing Edit Engine", () => {
     );
 
     expect(result).toMatchObject({
-      ok: true,
-      document: {
-        junctions: [{ id: "ambiguous-dot", netId: "net-h" }],
+      ok: false,
+      error: {
+        code: "INVALID_RESULT",
+        message: "Transaction introduces conflicting Logical Net names",
       },
     });
-    if (!result.ok) throw new Error("Targeted crossing split failed");
-    expect(result.document.routes.map((route) => route.id)).toEqual([
-      "route-h-a",
-      "route-h-b",
-      "route-v",
-    ]);
-    expect(
-      result.document.routes.find((route) => route.id === "route-v"),
-    ).toEqual(document.routes[1]);
   });
 
   it("accepts an arbitrary-angle route and still needs its context", () => {

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -2701,4 +2701,103 @@ describe("routing Edit Engine", () => {
     ).toMatchObject({ terminals: [{ instanceId: "D" }] });
     expect(result.document.sourceStatus).toBe("connectivity-modified");
   });
+
+  it("allows a signal detached from Ground to be reconnected to VDD", () => {
+    const document = createEmptyDocument(
+      "power-reassignment-after-cut",
+      "Power reassignment after cut",
+    );
+    document.instances.push(
+      { id: "GND1", symbolId: "ground", placement: null },
+      { id: "SIG", symbolId: "resistor", placement: null },
+      { id: "VDD1", symbolId: "vdd-port", placement: null },
+    );
+    document.nets.push(
+      {
+        id: "net-ground",
+        terminals: [
+          { instanceId: "GND1", pinName: "0" },
+          { instanceId: "SIG", pinName: "1" },
+        ],
+      },
+      {
+        id: "net-vdd",
+        terminals: [{ instanceId: "VDD1", pinName: "P" }],
+      },
+    );
+    document.routes.push({
+      id: "route-ground-signal",
+      netId: "net-ground",
+      from: { kind: "terminal", instanceId: "GND1", pinName: "0" },
+      to: { kind: "terminal", instanceId: "SIG", pinName: "1" },
+      waypoints: [],
+      segmentModes: ["manual"],
+    });
+    document.connectivityEvidence.push(
+      {
+        id: "claim-ground",
+        kind: "name-claim",
+        netId: "net-ground",
+        name: "0",
+        scope: "global",
+        powerDomain: "ground",
+        owner: { kind: "power-marker", objectId: "GND1" },
+      },
+      {
+        id: "claim-vdd",
+        kind: "name-claim",
+        netId: "net-vdd",
+        name: "VDD",
+        scope: "global",
+        powerDomain: "vdd",
+        owner: { kind: "power-marker", objectId: "VDD1" },
+      },
+    );
+
+    const cut = executeTransaction(
+      document,
+      transaction(document.id, 0, [
+        { kind: "cut_connection", routeId: "route-ground-signal" },
+      ]),
+    );
+    if (!cut.ok) {
+      throw new Error(
+        JSON.stringify({ error: cut.error, diagnostics: cut.diagnostics }),
+      );
+    }
+
+    const signalNet = cut.document.nets.find((net) =>
+      net.terminals.some(
+        (terminal) => terminal.instanceId === "SIG" && terminal.pinName === "1",
+      ),
+    );
+    expect(signalNet).toBeDefined();
+    expect(
+      resolveDocumentLogicalNets(cut.document).byBaseNetId.get(signalNet!.id)
+        ?.powerDomain,
+    ).toBe("none");
+    expect(
+      cut.document.connectivityEvidence.find(
+        (evidence) => evidence.id === "claim-ground",
+      ),
+    ).toMatchObject({ netId: "net-ground" });
+
+    const reconnected = executeTransaction(
+      cut.document,
+      transaction(cut.document.id, cut.document.revision, [
+        {
+          kind: "merge_nets",
+          targetNetId: "net-vdd",
+          sourceNetId: signalNet!.id,
+        },
+      ]),
+    );
+    expect(reconnected.ok).toBe(true);
+    if (!reconnected.ok) return;
+    expect(
+      resolveDocumentLogicalNets(reconnected.document).byBaseNetId.get(
+        "net-vdd",
+      )?.powerDomain,
+    ).toBe("vdd");
+  });
 });

--- a/packages/edit-engine/src/transaction-connectivity-normalizer.ts
+++ b/packages/edit-engine/src/transaction-connectivity-normalizer.ts
@@ -1,0 +1,170 @@
+import type { Point, RouteEndpoint, SchematicDocument } from "@icm/model";
+import {
+  endpointKey,
+  findRouteSegmentsAtPoint,
+  isVisibleEndpoint,
+  resolveDocumentRoutingGeometry,
+  resolveEndpointConnection,
+} from "@icm/derived";
+import type { SymbolResolver } from "@icm/symbols";
+
+import { endpointOwnerNetId } from "./transaction-routing.js";
+
+export type PhysicalContactOperation =
+  | {
+      kind: "connect-endpoints";
+      left: RouteEndpoint;
+      right: RouteEndpoint;
+    }
+  | {
+      kind: "attach-endpoint-to-route";
+      endpoint: RouteEndpoint;
+      routeId: string;
+      segmentIndex: number;
+      point: Point;
+    };
+
+function endpointObjectId(endpoint: RouteEndpoint): string {
+  return endpoint.kind === "terminal"
+    ? endpoint.instanceId
+    : endpoint.junctionId;
+}
+
+function samePoint(left: Point, right: Point): boolean {
+  return left.x === right.x && left.y === right.y;
+}
+
+function visibleEndpoints(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+): RouteEndpoint[] {
+  const terminals = document.instances.flatMap((instance) => {
+    if (!instance.placement) return [];
+    const symbol = resolver.resolve(
+      instance.symbolId,
+      instance.symbolVariantId,
+    );
+    if (!symbol) return [];
+    return symbol.definition.pins.flatMap((pin): RouteEndpoint[] => {
+      const endpoint: RouteEndpoint = {
+        kind: "terminal",
+        instanceId: instance.id,
+        pinName: pin.name,
+      };
+      return isVisibleEndpoint(document, resolver, endpoint) ? [endpoint] : [];
+    });
+  });
+  return [
+    ...terminals,
+    ...document.junctions.map((junction): RouteEndpoint => ({
+      kind: "junction",
+      junctionId: junction.id,
+    })),
+  ].sort((left, right) =>
+    endpointKey(left).localeCompare(endpointKey(right), "en"),
+  );
+}
+
+/**
+ * Return one deterministic physical-contact operation for the current draft.
+ * The transaction applies it and asks again, so route splits and Net merges
+ * are always evaluated against fresh geometry instead of stale segment IDs.
+ *
+ * Only contacts incident to an object changed by the transaction are
+ * normalized. Route-interior crossings are deliberately absent. This module
+ * handles direct endpoint contacts and explicit Junction-on-route contacts;
+ * snapped pin-to-route attachment remains a typed gesture intent.
+ */
+export function nextPhysicalContactOperation(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  changedObjectIds: ReadonlySet<string>,
+  suppressedEndpointKeys: ReadonlySet<string> = new Set(),
+): PhysicalContactOperation | null {
+  const endpoints = visibleEndpoints(document, resolver).filter(
+    (endpoint) => !suppressedEndpointKeys.has(endpointKey(endpoint)),
+  );
+  const positioned = endpoints.flatMap((endpoint) => {
+    const point = resolveEndpointConnection(
+      document,
+      resolver,
+      endpoint,
+    )?.contactPoint;
+    return point ? [{ endpoint, point }] : [];
+  });
+
+  for (let leftIndex = 0; leftIndex < positioned.length; leftIndex += 1) {
+    const left = positioned[leftIndex]!;
+    for (
+      let rightIndex = leftIndex + 1;
+      rightIndex < positioned.length;
+      rightIndex += 1
+    ) {
+      const right = positioned[rightIndex]!;
+      if (!samePoint(left.point, right.point)) continue;
+      if (
+        !changedObjectIds.has(endpointObjectId(left.endpoint)) &&
+        !changedObjectIds.has(endpointObjectId(right.endpoint))
+      ) {
+        continue;
+      }
+      const leftOwner = endpointOwnerNetId(document, left.endpoint);
+      const rightOwner = endpointOwnerNetId(document, right.endpoint);
+      if (leftOwner !== null && leftOwner === rightOwner) continue;
+      return {
+        kind: "connect-endpoints",
+        left: left.endpoint,
+        right: right.endpoint,
+      };
+    }
+  }
+
+  const geometry = resolveDocumentRoutingGeometry(document, resolver);
+  for (const { endpoint, point } of positioned) {
+    // Pin-to-route attachment is a gesture-level intent because it may split
+    // a selected Route and therefore needs the caller's snapped target. The
+    // transaction still validates and applies that typed intent. Junctions,
+    // by contrast, are explicit topology objects: a Junction on a conductor
+    // is unambiguously a physical contact and is normalized here.
+    if (endpoint.kind !== "junction") continue;
+    const endpointChanged = changedObjectIds.has(endpointObjectId(endpoint));
+    for (const address of findRouteSegmentsAtPoint(geometry, point)) {
+      const route = document.routes.find(
+        (candidate) => candidate.id === address.routeId,
+      );
+      const segment = geometry.routes
+        .get(address.routeId)
+        ?.segments.find(
+          (candidate) =>
+            candidate.address.segmentIndex === address.segmentIndex,
+        );
+      if (!route || !segment) continue;
+      if (route.presentation === "bulk-dashed") continue;
+      // Escape segments are derived artwork-to-grid leads, not independently
+      // authored wire geometry. Treating a symbol's other pins as contacts on
+      // that lead can short pins inside the symbol and destabilize the Route
+      // whenever the symbol moves.
+      if (segment.mode === "escape") continue;
+      if (!endpointChanged && !changedObjectIds.has(route.id)) continue;
+      if (
+        endpointKey(route.from) === endpointKey(endpoint) ||
+        endpointKey(route.to) === endpointKey(endpoint)
+      ) {
+        continue;
+      }
+      // Endpoint-to-endpoint coincidence is handled above. Splitting is only
+      // meaningful for a real segment interior.
+      if (samePoint(point, segment.from) || samePoint(point, segment.to)) {
+        continue;
+      }
+      return {
+        kind: "attach-endpoint-to-route",
+        endpoint,
+        routeId: route.id,
+        segmentIndex: address.segmentIndex,
+        point,
+      };
+    }
+  }
+  return null;
+}

--- a/packages/edit-engine/src/transaction-direct-contact.ts
+++ b/packages/edit-engine/src/transaction-direct-contact.ts
@@ -68,8 +68,9 @@ function uniqueDerivedId(
  * Reconcile zero-length endpoint contacts once, after all transform edits have
  * reached their final projected positions.
  *
- * This mutates only ordinary Route geometry. It never creates or merges Base
- * Nets: new direct-contact intent remains an explicit authoring action.
+ * This phase mutates only ordinary Route geometry. Gained exact contacts are
+ * handled later by the transaction connectivity normalizer, after every edit
+ * and route-follow operation has reached its final geometry.
  */
 export function reconcileTransformDirectContacts(
   before: SchematicDocument,

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -18,6 +18,7 @@ import type {
   Point,
   Rotation,
   RouteBranch,
+  RouteEndpoint,
   SchematicDocument,
 } from "@icm/model";
 import {
@@ -62,6 +63,7 @@ import {
   translateObjectAnchoredAnnotation,
 } from "./transaction-instance-annotations.js";
 import { reconcileTransformDirectContacts } from "./transaction-direct-contact.js";
+import { nextPhysicalContactOperation } from "./transaction-connectivity-normalizer.js";
 import {
   addEndpointToNet,
   endpointOwnerNetId,
@@ -162,6 +164,252 @@ function retargetConnectivityEvidence(
     changedObjectIds.add(evidence.id);
     return false;
   });
+}
+
+type BaseNetMergeResult =
+  | { ok: true }
+  | {
+      ok: false;
+      code: "OBJECT_NOT_FOUND" | "EDIT_PRECONDITION";
+      message: string;
+      netIds: readonly string[];
+    };
+
+function mergeBaseNets(
+  draft: SchematicDocument,
+  targetNetId: string,
+  sourceNetId: string,
+  changedObjectIds: Set<string>,
+): BaseNetMergeResult {
+  if (targetNetId === sourceNetId) return { ok: true };
+  const target = draft.nets.find((net) => net.id === targetNetId);
+  const sourceIndex = draft.nets.findIndex((net) => net.id === sourceNetId);
+  const source = draft.nets[sourceIndex];
+  if (!target || !source) {
+    return {
+      ok: false,
+      code: "OBJECT_NOT_FOUND",
+      message: `Net merge target/source does not exist: ${targetNetId}, ${sourceNetId}`,
+      netIds: [targetNetId, sourceNetId],
+    };
+  }
+  const logicalNets = resolveDocumentLogicalNets(draft);
+  const targetPowerDomain =
+    logicalNets.byBaseNetId.get(target.id)?.powerDomain ?? "none";
+  const sourcePowerDomain =
+    logicalNets.byBaseNetId.get(source.id)?.powerDomain ?? "none";
+  if (
+    targetPowerDomain === "conflict" ||
+    sourcePowerDomain === "conflict" ||
+    (targetPowerDomain !== "none" &&
+      sourcePowerDomain !== "none" &&
+      targetPowerDomain !== sourcePowerDomain)
+  ) {
+    return {
+      ok: false,
+      code: "EDIT_PRECONDITION",
+      message: "Cannot merge Nets with incompatible power domains",
+      netIds: [target.id, source.id],
+    };
+  }
+  for (const instance of draft.instances) {
+    if (instance.mosBulkBinding?.netId === source.id) {
+      instance.mosBulkBinding.netId = target.id;
+      changedObjectIds.add(instance.id);
+    }
+  }
+  if (draft.mosBulkDefaults?.nmosNetId === source.id) {
+    draft.mosBulkDefaults.nmosNetId = target.id;
+  }
+  if (draft.mosBulkDefaults?.pmosNetId === source.id) {
+    draft.mosBulkDefaults.pmosNetId = target.id;
+  }
+  for (const terminal of draft.netlist?.terminals ?? []) {
+    if (terminal.netId === source.id) terminal.netId = target.id;
+  }
+  for (const terminal of source.terminals) {
+    if (
+      !target.terminals.some(
+        (candidate) =>
+          candidate.instanceId === terminal.instanceId &&
+          candidate.pinName === terminal.pinName,
+      )
+    ) {
+      target.terminals.push(structuredClone(terminal));
+    }
+  }
+  for (const route of draft.routes) {
+    if (route.netId === source.id) {
+      route.netId = target.id;
+      changedObjectIds.add(route.id);
+    }
+  }
+  for (const junction of draft.junctions) {
+    if (junction.netId === source.id) {
+      junction.netId = target.id;
+      changedObjectIds.add(junction.id);
+    }
+  }
+  for (const annotation of draft.annotations) {
+    if (annotation.netId === source.id) {
+      annotation.netId = target.id;
+      changedObjectIds.add(annotation.id);
+    }
+    if (
+      annotation.binding?.kind === "net-name" &&
+      annotation.binding.netId === source.id
+    ) {
+      annotation.binding = { kind: "net-name", netId: target.id };
+      changedObjectIds.add(annotation.id);
+    }
+  }
+  for (const group of draft.layoutGroups) {
+    const replaced = group.objectIds.includes(source.id);
+    group.objectIds = replaceLayoutReference(
+      group.objectIds,
+      source.id,
+      target.id,
+    );
+    if (replaced) changedObjectIds.add(group.id);
+  }
+  for (const constraint of draft.constraints) {
+    const replaced = constraint.objectIds.includes(source.id);
+    constraint.objectIds = replaceLayoutReference(
+      constraint.objectIds,
+      source.id,
+      target.id,
+    );
+    if (replaced) changedObjectIds.add(constraint.id);
+  }
+  retargetConnectivityEvidence(draft, source.id, target.id, changedObjectIds);
+  draft.nets.splice(sourceIndex, 1);
+  changedObjectIds.add(target.id);
+  changedObjectIds.add(source.id);
+  return { ok: true };
+}
+
+function removeNoConnectForEndpoint(
+  draft: SchematicDocument,
+  endpoint: RouteEndpoint,
+  changedObjectIds: Set<string>,
+): void {
+  if (endpoint.kind !== "terminal") return;
+  draft.noConnects = draft.noConnects.filter((noConnect) => {
+    const matches =
+      noConnect.endpoint.instanceId === endpoint.instanceId &&
+      noConnect.endpoint.pinName === endpoint.pinName;
+    if (matches) changedObjectIds.add(noConnect.id);
+    return !matches;
+  });
+}
+
+function preferredPhysicalMergeTarget(
+  draft: SchematicDocument,
+  leftNetId: string,
+  rightNetId: string,
+): readonly [targetNetId: string, sourceNetId: string] {
+  const logical = resolveDocumentLogicalNets(draft);
+  const score = (netId: string): number => {
+    const resolved = logical.byBaseNetId.get(netId);
+    return (
+      (resolved?.powerDomain !== undefined &&
+      resolved.powerDomain !== "none" &&
+      resolved.powerDomain !== "conflict"
+        ? 4
+        : 0) +
+      (resolved?.scope === "global" ? 2 : 0) +
+      (resolved?.name ? 1 : 0)
+    );
+  };
+  const leftScore = score(leftNetId);
+  const rightScore = score(rightNetId);
+  if (leftScore !== rightScore) {
+    return leftScore > rightScore
+      ? [leftNetId, rightNetId]
+      : [rightNetId, leftNetId];
+  }
+  return leftNetId.localeCompare(rightNetId, "en") <= 0
+    ? [leftNetId, rightNetId]
+    : [rightNetId, leftNetId];
+}
+
+function uniquePhysicalContactId(
+  draft: SchematicDocument,
+  kind: "net" | "route",
+  transactionId: string,
+  seed: string,
+): string {
+  const occupied = new Set([
+    ...draft.instances.map((object) => object.id),
+    ...draft.nets.map((object) => object.id),
+    ...draft.routes.map((object) => object.id),
+    ...draft.junctions.map((object) => object.id),
+    ...draft.noConnects.map((object) => object.id),
+    ...draft.annotations.map((object) => object.id),
+    ...draft.connectivityEvidence.map((object) => object.id),
+    ...draft.layoutGroups.map((object) => object.id),
+    ...draft.constraints.map((object) => object.id),
+    ...(draft.drafting?.objects.map((object) => object.id) ?? []),
+    ...(draft.netlist?.terminals.map((object) => object.id) ?? []),
+  ]);
+  let attempt = 0;
+  while (true) {
+    const id = deriveStableId(
+      kind,
+      draft.id,
+      "physical-contact",
+      transactionId,
+      seed,
+      String(attempt),
+    );
+    if (!occupied.has(id)) return id;
+    attempt += 1;
+  }
+}
+
+function physicalContactObjectIdsForTransaction(
+  transaction: EditTransaction,
+): Set<string> {
+  const result = new Set<string>();
+  for (const edit of transaction.edits) {
+    switch (edit.kind) {
+      case "add_instance":
+        result.add(edit.instance.id);
+        break;
+      case "set_instance_symbol":
+      case "place_instance":
+      case "move_instance":
+      case "rotate_instance":
+      case "mirror_instance":
+        result.add(edit.instanceId);
+        break;
+      case "align_instances":
+        edit.instanceIds.forEach((instanceId) => result.add(instanceId));
+        break;
+      case "set_route_points":
+      case "route_orthogonal":
+        result.add(edit.routeId);
+        break;
+      case "add_junction":
+      case "move_junction":
+        result.add(edit.junctionId);
+        break;
+      case "attach_endpoint_to_route":
+        result.add(
+          edit.endpoint.kind === "terminal"
+            ? edit.endpoint.instanceId
+            : edit.endpoint.junctionId,
+        );
+        result.add(edit.routeId);
+        break;
+      case "add_power_rail":
+        result.add(edit.routeId);
+        result.add(edit.startJunctionId);
+        result.add(edit.endJunctionId);
+        break;
+    }
+  }
+  return result;
 }
 
 function connectivityEvidenceNetIds(
@@ -2993,116 +3241,15 @@ export function executeTransaction(
             "Net merge requires two different Nets",
           );
         }
-        const target = draft.nets.find((net) => net.id === edit.targetNetId);
-        const sourceIndex = draft.nets.findIndex(
-          (net) => net.id === edit.sourceNetId,
-        );
-        const source = draft.nets[sourceIndex];
-        if (!target || !source) {
-          return rejectAt(
-            "OBJECT_NOT_FOUND",
-            `Net merge target/source does not exist: ${edit.targetNetId}, ${edit.sourceNetId}`,
-          );
-        }
-        const logicalNets = resolveDocumentLogicalNets(draft);
-        const targetLogical = logicalNets.byBaseNetId.get(target.id);
-        const sourceLogical = logicalNets.byBaseNetId.get(source.id);
-        const targetPowerDomain = targetLogical?.powerDomain ?? "none";
-        const sourcePowerDomain = sourceLogical?.powerDomain ?? "none";
-        if (
-          targetPowerDomain === "conflict" ||
-          sourcePowerDomain === "conflict" ||
-          (targetPowerDomain !== "none" &&
-            sourcePowerDomain !== "none" &&
-            targetPowerDomain !== sourcePowerDomain)
-        ) {
-          return rejectAt(
-            "EDIT_PRECONDITION",
-            "Cannot merge Nets with incompatible power domains",
-            [],
-            [target.id, source.id],
-          );
-        }
-        for (const instance of draft.instances) {
-          if (instance.mosBulkBinding?.netId === source.id) {
-            instance.mosBulkBinding.netId = target.id;
-            changedObjectIds.add(instance.id);
-          }
-        }
-        if (draft.mosBulkDefaults?.nmosNetId === source.id) {
-          draft.mosBulkDefaults.nmosNetId = target.id;
-        }
-        if (draft.mosBulkDefaults?.pmosNetId === source.id) {
-          draft.mosBulkDefaults.pmosNetId = target.id;
-        }
-        for (const terminal of draft.netlist?.terminals ?? []) {
-          if (terminal.netId === source.id) {
-            terminal.netId = target.id;
-          }
-        }
-        for (const terminal of source.terminals) {
-          if (
-            !target.terminals.some(
-              (candidate) =>
-                candidate.instanceId === terminal.instanceId &&
-                candidate.pinName === terminal.pinName,
-            )
-          ) {
-            target.terminals.push(structuredClone(terminal));
-          }
-        }
-        for (const route of draft.routes) {
-          if (route.netId === source.id) {
-            route.netId = target.id;
-            changedObjectIds.add(route.id);
-          }
-        }
-        for (const junction of draft.junctions) {
-          if (junction.netId === source.id) {
-            junction.netId = target.id;
-            changedObjectIds.add(junction.id);
-          }
-        }
-        for (const annotation of draft.annotations) {
-          if (annotation.netId === source.id) {
-            annotation.netId = target.id;
-            changedObjectIds.add(annotation.id);
-          }
-          if (
-            annotation.binding?.kind === "net-name" &&
-            annotation.binding.netId === source.id
-          ) {
-            annotation.binding = { kind: "net-name", netId: target.id };
-            changedObjectIds.add(annotation.id);
-          }
-        }
-        for (const group of draft.layoutGroups) {
-          const replaced = group.objectIds.includes(source.id);
-          group.objectIds = replaceLayoutReference(
-            group.objectIds,
-            source.id,
-            target.id,
-          );
-          if (replaced) changedObjectIds.add(group.id);
-        }
-        for (const constraint of draft.constraints) {
-          const replaced = constraint.objectIds.includes(source.id);
-          constraint.objectIds = replaceLayoutReference(
-            constraint.objectIds,
-            source.id,
-            target.id,
-          );
-          if (replaced) changedObjectIds.add(constraint.id);
-        }
-        retargetConnectivityEvidence(
+        const merge = mergeBaseNets(
           draft,
-          source.id,
-          target.id,
+          edit.targetNetId,
+          edit.sourceNetId,
           changedObjectIds,
         );
-        draft.nets.splice(sourceIndex, 1);
-        changedObjectIds.add(target.id);
-        changedObjectIds.add(source.id);
+        if (!merge.ok) {
+          return rejectAt(merge.code, merge.message, [], merge.netIds);
+        }
         connectivityChanged = true;
         break;
       }
@@ -3727,6 +3874,233 @@ export function executeTransaction(
     geometryChanged ||= directContact.geometryChanged;
     for (const routeId of directContact.changedRouteIds) {
       changedRouteIds.add(routeId);
+    }
+  }
+
+  if (resolver) {
+    // Keep geometry incidence separate from the broader transaction diff.
+    // Net merges retarget many Routes for bookkeeping, but that must not turn
+    // an otherwise local edit into a whole-document geometry repair.
+    const physicalContactObjectIds =
+      physicalContactObjectIdsForTransaction(transaction);
+    const suppressedPhysicalEndpointKeys = new Set(
+      transaction.edits.flatMap((edit) =>
+        edit.kind === "disconnect_endpoint" ? [endpointKey(edit.endpoint)] : [],
+      ),
+    );
+    const operationLimit = Math.max(
+      32,
+      (draft.instances.length + draft.junctions.length) *
+        Math.max(2, draft.routes.length + 1) *
+        2,
+    );
+    for (
+      let operationIndex = 0;
+      operationIndex < operationLimit;
+      operationIndex += 1
+    ) {
+      const operation = nextPhysicalContactOperation(
+        draft,
+        resolver,
+        physicalContactObjectIds,
+        suppressedPhysicalEndpointKeys,
+      );
+      if (!operation) break;
+
+      if (operation.kind === "connect-endpoints") {
+        let leftOwner = endpointOwnerNetId(draft, operation.left);
+        let rightOwner = endpointOwnerNetId(draft, operation.right);
+        if (!leftOwner && !rightOwner) {
+          const netId = uniquePhysicalContactId(
+            draft,
+            "net",
+            transaction.transactionId,
+            [endpointKey(operation.left), endpointKey(operation.right)]
+              .sort((left, right) => left.localeCompare(right, "en"))
+              .join("--"),
+          );
+          draft.nets.push({ id: netId, terminals: [] });
+          changedObjectIds.add(netId);
+          leftOwner = netId;
+          rightOwner = netId;
+        } else if (!leftOwner) {
+          leftOwner = rightOwner;
+        } else if (!rightOwner) {
+          rightOwner = leftOwner;
+        }
+        if (!leftOwner || !rightOwner) {
+          return rejectTransaction(
+            document,
+            "INVALID_RESULT",
+            "Physical contact normalization could not assign a Base Net",
+          );
+        }
+        if (leftOwner !== rightOwner) {
+          const [targetNetId, sourceNetId] = preferredPhysicalMergeTarget(
+            draft,
+            leftOwner,
+            rightOwner,
+          );
+          const merge = mergeBaseNets(
+            draft,
+            targetNetId,
+            sourceNetId,
+            changedObjectIds,
+          );
+          if (!merge.ok) {
+            return rejectTransaction(
+              document,
+              merge.code,
+              merge.message,
+              [],
+              merge.netIds,
+            );
+          }
+          leftOwner = targetNetId;
+          rightOwner = targetNetId;
+        }
+        addEndpointToNet(draft, leftOwner, operation.left);
+        addEndpointToNet(draft, rightOwner, operation.right);
+        removeNoConnectForEndpoint(draft, operation.left, changedObjectIds);
+        removeNoConnectForEndpoint(draft, operation.right, changedObjectIds);
+        changedObjectIds.add(leftOwner);
+        connectivityChanged = true;
+        continue;
+      }
+
+      let route = draft.routes.find(
+        (candidate) => candidate.id === operation.routeId,
+      );
+      if (!route) {
+        return rejectTransaction(
+          document,
+          "INVALID_RESULT",
+          `Physical contact Route disappeared: ${operation.routeId}`,
+        );
+      }
+      if (routeIsProtected(route)) {
+        return rejectTransaction(
+          document,
+          "EDIT_PRECONDITION",
+          `Cannot attach a physical contact to locked Route ${route.id}`,
+          [],
+          [route.id],
+        );
+      }
+      const endpointOwner = endpointOwnerNetId(draft, operation.endpoint);
+      if (endpointOwner && endpointOwner !== route.netId) {
+        const [targetNetId, sourceNetId] = preferredPhysicalMergeTarget(
+          draft,
+          endpointOwner,
+          route.netId,
+        );
+        const merge = mergeBaseNets(
+          draft,
+          targetNetId,
+          sourceNetId,
+          changedObjectIds,
+        );
+        if (!merge.ok) {
+          return rejectTransaction(
+            document,
+            merge.code,
+            merge.message,
+            [],
+            merge.netIds,
+          );
+        }
+        route = draft.routes.find(
+          (candidate) => candidate.id === operation.routeId,
+        );
+        if (!route) {
+          return rejectTransaction(
+            document,
+            "INVALID_RESULT",
+            `Physical contact Route disappeared after Net merge: ${operation.routeId}`,
+          );
+        }
+      }
+      const markerAnchors = captureRouteMarkerAnchors(draft, resolver).filter(
+        (anchor) => anchor.routeId === route.id,
+      );
+      const seed = `${route.id}:${endpointKey(operation.endpoint)}:${operation.point.x},${operation.point.y}`;
+      // Keep the original ID on the from-side so selection, drag state, and
+      // callers holding a revision-local Route address remain valid after an
+      // automatic split. Only the newly created far side needs a fresh ID.
+      const firstRouteId = route.id;
+      const secondRouteId = uniquePhysicalContactId(
+        draft,
+        "route",
+        transaction.transactionId,
+        `${seed}:second`,
+      );
+      const split = splitRoute(
+        draft,
+        route,
+        operation.endpoint,
+        operation.point,
+        firstRouteId,
+        secondRouteId,
+        operation.segmentIndex,
+        resolver,
+      );
+      if (typeof split === "string") {
+        return rejectTransaction(
+          document,
+          "EDIT_PRECONDITION",
+          split,
+          [],
+          [route.id],
+        );
+      }
+      addEndpointToNet(draft, route.netId, operation.endpoint);
+      const routeIndex = draft.routes.findIndex(
+        (candidate) => candidate.id === route!.id,
+      );
+      draft.routes.splice(routeIndex, 1, split.first, split.second);
+      retargetConnectivityEvidenceOwner(
+        draft,
+        route.id,
+        split.first.id,
+        changedObjectIds,
+      );
+      for (const candidate of [split.first, split.second]) {
+        const routeError = validateRoute(draft, candidate, resolver);
+        if (routeError) {
+          return rejectTransaction(
+            document,
+            "EDIT_PRECONDITION",
+            routeError,
+            [],
+            [candidate.id],
+          );
+        }
+      }
+      remapRouteMarkersAfterSplit(
+        draft,
+        resolver,
+        markerAnchors,
+        [split.first.id, split.second.id],
+        changedObjectIds,
+      );
+      removeNoConnectForEndpoint(draft, operation.endpoint, changedObjectIds);
+      for (const routeId of [route.id, split.first.id, split.second.id]) {
+        changedObjectIds.add(routeId);
+        changedRouteIds.add(routeId);
+      }
+      physicalContactObjectIds.add(split.first.id);
+      physicalContactObjectIds.add(split.second.id);
+      changedObjectIds.add(route.netId);
+      connectivityChanged = true;
+      geometryChanged = true;
+
+      if (operationIndex === operationLimit - 1) {
+        return rejectTransaction(
+          document,
+          "INVALID_RESULT",
+          "Physical contact normalization did not converge",
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- normalize exact endpoint contacts inside the transaction boundary
- attach explicit junctions to contacted route interiors deterministically
- preserve named/power Net authority and reject incompatible supplies atomically
- protect Ground disconnect then VDD reassignment with a focused regression

## Validation
- pnpm install --frozen-lockfile
- pnpm ci:check (1353 unit tests, 235 browser tests, build/golden/release/smoke passed)

Unrelated local untracked file probe-conflicts.mjs was not touched.