### PR TITLE
Unify tokenzhang gallery byline

### DIFF
--- a/worker/auth.test.ts
+++ b/worker/auth.test.ts
@@ -146,6 +146,57 @@ describe("runtime binding", () => {
   });
 });
 
+describe("account data migrations", () => {
+  it("renames the legacy tokenzhang account once without touching other users", () => {
+    const state = sqliteState();
+    new AuthDO(state, {} as AuthEnv);
+    state.storage.sql.exec(
+      `INSERT INTO users
+       (id, provider, provider_id, email, display_name, role, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?)`,
+      "legacy-user",
+      "github",
+      "1",
+      null,
+      "Token Zhang",
+      "user",
+      "2026-08-01T00:00:00.000Z",
+      "other-user",
+      "github",
+      "2",
+      null,
+      "Zhishuai Zhang",
+      "user",
+      "2026-08-01T00:00:00.000Z",
+    );
+    state.storage.sql.exec("DELETE FROM data_migrations");
+
+    new AuthDO(state, {} as AuthEnv);
+    expect(
+      state.storage.sql
+        .exec<{ id: string; display_name: string }>(
+          "SELECT id, display_name FROM users ORDER BY id",
+        )
+        .toArray(),
+    ).toEqual([
+      { id: "legacy-user", display_name: "Zhishuai Zhang" },
+      { id: "other-user", display_name: "Zhishuai Zhang" },
+    ]);
+
+    state.storage.sql.exec(
+      "UPDATE users SET display_name = 'Token Zhang' WHERE id = 'legacy-user'",
+    );
+    new AuthDO(state, {} as AuthEnv);
+    expect(
+      state.storage.sql
+        .exec<{ display_name: string }>(
+          "SELECT display_name FROM users WHERE id = 'legacy-user'",
+        )
+        .one().display_name,
+    ).toBe("Token Zhang");
+  });
+});
+
 describe("providers visibility (dark ship)", () => {
   it("reports exactly the providers whose secrets exist", async () => {
     const dark = harness();

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -19,6 +19,10 @@ export const AUTH_LOGIN_TOKEN_TTL_MS = 15 * 60 * 1000;
 export const AUTH_EMAIL_DAILY_LIMIT = 5;
 export const AUTH_DISPLAY_NAME_MAX = 40;
 
+const TOKENZHANG_DISPLAY_NAME_MIGRATION =
+  "2026-08-26-tokenzhang-to-zhishuai-zhang";
+const TOKENZHANG_DISPLAY_NAME = "Zhishuai Zhang";
+
 type SqlResult<T> = {
   toArray(): T[];
   one(): T;
@@ -216,6 +220,34 @@ export class AuthDO {
     } catch {
       // Column already present.
     }
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS data_migrations (
+        id TEXT PRIMARY KEY,
+        applied_at TEXT NOT NULL
+      ) WITHOUT ROWID
+    `);
+    state.storage.transactionSync(() => {
+      const applied = this.sql
+        .exec<{ id: string }>(
+          "SELECT id FROM data_migrations WHERE id = ?",
+          TOKENZHANG_DISPLAY_NAME_MIGRATION,
+        )
+        .toArray();
+      if (applied.length > 0) return;
+      // One production account was initially named from its GitHub login.
+      // Change only that legacy spelling; the marker preserves any later
+      // display-name choice made by the account holder.
+      this.sql.exec(
+        `UPDATE users SET display_name = ?
+         WHERE LOWER(REPLACE(TRIM(display_name), ' ', '')) = 'tokenzhang'`,
+        TOKENZHANG_DISPLAY_NAME,
+      );
+      this.sql.exec(
+        "INSERT INTO data_migrations(id, applied_at) VALUES (?, ?)",
+        TOKENZHANG_DISPLAY_NAME_MIGRATION,
+        new Date().toISOString(),
+      );
+    });
     this.sql.exec(`
       CREATE TABLE IF NOT EXISTS sessions (
         token_hash TEXT PRIMARY KEY,

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -239,6 +239,85 @@ async function submitOne(
   return payload.id;
 }
 
+describe("gallery data migrations", () => {
+  it("renames tokenzhang across entries and restorable versions once", () => {
+    const state = sqliteState();
+    new GalleryDO(state);
+    state.storage.sql.exec(
+      `INSERT INTO gallery_entries
+       (id, name, author, description, created_at, schema_version, status,
+        project_text, svg_text)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      "legacy-entry",
+      "Legacy",
+      "tokenzhang",
+      "",
+      "2026-08-01T00:00:00.000Z",
+      CURRENT_PROJECT_SCHEMA_VERSION,
+      "public",
+      projectText("Legacy"),
+      "<svg/>",
+      "other-entry",
+      "Other",
+      "Other Author",
+      "",
+      "2026-08-01T00:00:00.000Z",
+      CURRENT_PROJECT_SCHEMA_VERSION,
+      "recycled",
+      projectText("Other"),
+      "<svg/>",
+    );
+    state.storage.sql.exec(
+      `INSERT INTO gallery_entry_versions
+       (id, entry_id, version_no, name, author, description, schema_version,
+        project_text, svg_text, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      "legacy-version",
+      "legacy-entry",
+      1,
+      "Legacy",
+      "Token Zhang",
+      "",
+      CURRENT_PROJECT_SCHEMA_VERSION,
+      projectText("Legacy"),
+      "<svg/>",
+      "2026-08-01T00:00:00.000Z",
+    );
+    state.storage.sql.exec("DELETE FROM data_migrations");
+
+    new GalleryDO(state);
+    expect(
+      state.storage.sql
+        .exec<{ id: string; author: string }>(
+          "SELECT id, author FROM gallery_entries ORDER BY id",
+        )
+        .toArray(),
+    ).toEqual([
+      { id: "legacy-entry", author: "Zhishuai Zhang" },
+      { id: "other-entry", author: "Other Author" },
+    ]);
+    expect(
+      state.storage.sql
+        .exec<{ author: string }>(
+          "SELECT author FROM gallery_entry_versions WHERE id = 'legacy-version'",
+        )
+        .one().author,
+    ).toBe("Zhishuai Zhang");
+
+    state.storage.sql.exec(
+      "UPDATE gallery_entries SET author = 'Token Zhang' WHERE id = 'legacy-entry'",
+    );
+    new GalleryDO(state);
+    expect(
+      state.storage.sql
+        .exec<{ author: string }>(
+          "SELECT author FROM gallery_entries WHERE id = 'legacy-entry'",
+        )
+        .one().author,
+    ).toBe("Token Zhang");
+  });
+});
+
 describe("newest-first gallery feed", () => {
   async function galleryPage(
     env: Harness,

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -212,6 +212,10 @@ interface EntryRow {
   netlistable: number;
 }
 
+const TOKENZHANG_BYLINE_MIGRATION =
+  "2026-08-26-tokenzhang-to-zhishuai-zhang";
+const TOKENZHANG_BYLINE = "Zhishuai Zhang";
+
 function summaryOf(
   row: EntryRow & { likes?: number; liked_by_viewer?: number },
 ): GalleryEntrySummary {
@@ -331,6 +335,35 @@ export class GalleryDO {
         // Column already present.
       }
     }
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS data_migrations (
+        id TEXT PRIMARY KEY,
+        applied_at TEXT NOT NULL
+      ) WITHOUT ROWID
+    `);
+    state.storage.transactionSync(() => {
+      const applied = this.sql
+        .exec<{ id: string }>(
+          "SELECT id FROM data_migrations WHERE id = ?",
+          TOKENZHANG_BYLINE_MIGRATION,
+        )
+        .toArray();
+      if (applied.length > 0) return;
+      // Keep every surface consistent, including recycled entries and the
+      // snapshots that can later be restored from version history.
+      for (const table of ["gallery_entries", "gallery_entry_versions"]) {
+        this.sql.exec(
+          `UPDATE ${table} SET author = ?
+           WHERE LOWER(REPLACE(TRIM(author), ' ', '')) = 'tokenzhang'`,
+          TOKENZHANG_BYLINE,
+        );
+      }
+      this.sql.exec(
+        "INSERT INTO data_migrations(id, applied_at) VALUES (?, ?)",
+        TOKENZHANG_BYLINE_MIGRATION,
+        new Date().toISOString(),
+      );
+    });
     // Direct publishing retired the review queue. An entry still waiting for
     // a reviewer would otherwise be stranded — listed nowhere, approvable by
     // nothing — so publish it, which is what its author asked for. An entry a


### PR DESCRIPTION
## Summary
- migrate the legacy `tokenzhang` account display name to `Zhishuai Zhang`
- migrate matching Gallery entries, recycled entries, and saved versions
- record the migration independently in AuthDO and GalleryDO so it runs once
- preserve unrelated authors and any later user-selected display name

## Verification
- `pnpm ci:check` (1355 unit tests, 235 Playwright tests)

Test-Impact: tests-updated