### PR TITLE
fix(editor): restore Gallery scene deletion

### DIFF
--- a/packages/edit-engine/src/edit-schema.ts
+++ b/packages/edit-engine/src/edit-schema.ts
@@ -138,7 +138,7 @@ export const BulkInstanceNetlistAssignmentSchema = z
       (assignment.unset?.length ?? 0) > 0,
     "Bulk assignment must change a typed netlist field",
   );
-/** Bounded atomic alternative to expanding a bulk request into 256 edits. */
+/** Bounded atomic alternative to expanding one bulk request into many edits. */
 export const BulkPatchInstanceNetlistEditSchema = z.strictObject({
   kind: z.literal("bulk_patch_instance_netlist"),
   assignments: z.array(BulkInstanceNetlistAssignmentSchema).min(1).max(5000),
@@ -418,13 +418,21 @@ export const SchematicEditSchema = z.discriminatedUnion("kind", [
   RedoEditSchema,
 ]);
 
+// Whole-document Gallery placement compiles one bounded edit per imported
+// object. Dense but legitimate circuits can exceed 256 edits, so keep a
+// deliberate denial-of-service ceiling while allowing current library scenes.
+export const MAX_SCHEMATIC_EDITS_PER_TRANSACTION = 1024;
+
 export const EditTransactionSchema = z.strictObject({
   transactionId: StableIdSchema,
   documentId: StableIdSchema,
   expectedRevision: z.number().int().nonnegative(),
   actor: EditActorSchema,
   dryRun: z.boolean().optional(),
-  edits: z.array(SchematicEditSchema).min(1).max(256),
+  edits: z
+    .array(SchematicEditSchema)
+    .min(1)
+    .max(MAX_SCHEMATIC_EDITS_PER_TRANSACTION),
 });
 
 export type EditActor = z.infer<typeof EditActorSchema>;

--- a/packages/edit-engine/src/project-transaction.test.ts
+++ b/packages/edit-engine/src/project-transaction.test.ts
@@ -43,6 +43,50 @@ function hierarchyInstance(
 }
 
 describe("Project structural transaction", () => {
+  it("accepts a Gallery-sized nested document transaction within its bound", () => {
+    const project = createEmptyProject("gallery-sized-project", "Gallery");
+    const edits = Array.from({ length: 272 }, () => ({
+      kind: "set_presentation_style" as const,
+      styleProfileId: "razavi-textbook-v1",
+    }));
+
+    const result = executeProjectTransaction(project, {
+      transactionId: "gallery-sized-paste",
+      projectId: project.id,
+      expectedStructureRevision: project.structureRevision,
+      actor: { kind: "human", id: "human-local" },
+      edits: [
+        {
+          kind: "transact_document",
+          documentId: project.documents[0]!.id,
+          expectedRevision: project.documents[0]!.revision,
+          edits,
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+
+    const oversized = executeProjectTransaction(project, {
+      transactionId: "oversized-gallery-paste",
+      projectId: project.id,
+      expectedStructureRevision: project.structureRevision,
+      actor: { kind: "human", id: "human-local" },
+      edits: [
+        {
+          kind: "transact_document",
+          documentId: project.documents[0]!.id,
+          expectedRevision: project.documents[0]!.revision,
+          edits: Array.from({ length: 1_025 }, () => edits[0]!),
+        },
+      ],
+    });
+    expect(oversized).toMatchObject({
+      ok: false,
+      error: { code: "INVALID_TRANSACTION" },
+    });
+  });
+
   it("deletes a Cell Pin and automatically disconnects every caller", () => {
     const project = createEmptyProject("project", "Project");
     const child = createEmptyDocument("document-child", "Child");

--- a/packages/edit-engine/src/project-transaction.ts
+++ b/packages/edit-engine/src/project-transaction.ts
@@ -14,7 +14,11 @@ import {
 } from "@icm/symbols";
 import { z } from "zod";
 
-import { SchematicEditSchema, type EditActor } from "./edit-schema.js";
+import {
+  MAX_SCHEMATIC_EDITS_PER_TRANSACTION,
+  SchematicEditSchema,
+  type EditActor,
+} from "./edit-schema.js";
 import { executeTransaction } from "./transaction.js";
 import { planInstanceSymbolGeometryRouteFollow } from "./transaction-route-follow.js";
 import type {
@@ -52,7 +56,10 @@ export const ProjectStructureEditSchema = z.discriminatedUnion("kind", [
     kind: z.literal("transact_document"),
     documentId: z.string().min(1),
     expectedRevision: z.number().int().nonnegative(),
-    edits: z.array(SchematicEditSchema).min(1).max(256),
+    edits: z
+      .array(SchematicEditSchema)
+      .min(1)
+      .max(MAX_SCHEMATIC_EDITS_PER_TRANSACTION),
   }),
 ]);
 

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -2281,6 +2281,95 @@ describe("routing Edit Engine", () => {
     }
   });
 
+  it("keeps repeated markers of one Cell Pin together when a route is cut", () => {
+    const document = createEmptyDocument(
+      "repeated-cell-pin-cut",
+      "Repeated Cell pin cut",
+    );
+    document.instances.push(
+      {
+        id: "P1",
+        symbolId: "port",
+        placement: {
+          position: { x: 100, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        id: "P2",
+        symbolId: "port",
+        placement: {
+          position: { x: 100, y: 300 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        id: "R1",
+        symbolId: "resistor",
+        placement: {
+          position: { x: 300, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+    );
+    document.nets.push({
+      id: "net-vin",
+      terminals: [
+        { instanceId: "P1", pinName: "P" },
+        { instanceId: "P2", pinName: "P" },
+        { instanceId: "R1", pinName: "1" },
+      ],
+    });
+    document.netlist!.terminals.push({
+      id: "terminal-vin",
+      name: "VIN",
+      netId: "net-vin",
+      direction: "input",
+      interfaceInstanceIds: ["P1", "P2"],
+    });
+    document.routes.push({
+      id: "route-vin-r1",
+      netId: "net-vin",
+      from: { kind: "terminal", instanceId: "P1", pinName: "P" },
+      to: { kind: "terminal", instanceId: "R1", pinName: "1" },
+      waypoints: [],
+      segmentModes: ["manual"],
+    });
+
+    const result = executeTransaction(
+      document,
+      transaction(document.id, 0, [
+        { kind: "cut_connection", routeId: "route-vin-r1" },
+      ]),
+      context,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const cellTerminal = result.document.netlist!.terminals[0]!;
+    expect(cellTerminal).toMatchObject({
+      netId: "net-vin",
+      interfaceInstanceIds: ["P1", "P2"],
+    });
+    expect(
+      result.document.nets.find((net) => net.id === "net-vin")?.terminals,
+    ).toEqual([
+      { instanceId: "P1", pinName: "P" },
+      { instanceId: "P2", pinName: "P" },
+    ]);
+    expect(
+      result.document.nets.find((net) =>
+        net.terminals.some(
+          (terminal) =>
+            terminal.instanceId === "R1" && terminal.pinName === "1",
+        ),
+      )?.id,
+    ).not.toBe("net-vin");
+  });
+
   it("removes redundant cycle geometry without splitting the Net", () => {
     const document = documentFixture();
     document.routes = [

--- a/packages/edit-engine/src/transaction-routing.ts
+++ b/packages/edit-engine/src/transaction-routing.ts
@@ -84,6 +84,22 @@ export function netEndpointGroups(
   )) {
     union(endpointKey(route.from), endpointKey(route.to));
   }
+  // Repeated Cell Pin markers are multiple canvas representations of one
+  // formal interface terminal. They are therefore an explicit electrical
+  // equivalence edge even when the markers are not joined by Route geometry.
+  // Keeping them in one component lets a cut detach ordinary circuitry
+  // without falsely treating the formal interface itself as separated.
+  for (const terminal of document.netlist?.terminals ?? []) {
+    if (terminal.netId !== netId) continue;
+    const markerKeys = terminal.interfaceInstanceIds
+      .map((instanceId) =>
+        endpointKey({ kind: "terminal", instanceId, pinName: "P" }),
+      )
+      .filter((key) => parent.has(key));
+    const [first, ...rest] = markerKeys;
+    if (!first) continue;
+    for (const key of rest) union(first, key);
+  }
   // A pin or Junction placed directly on another explicit same-Net endpoint
   // is a real electrical contact even when no Route object exists between the
   // coincident endpoints. Preserve that contact when a different Route is cut.


### PR DESCRIPTION
## Summary
- treat repeated formal Cell Pin markers as one connectivity component during route cuts
- allow dense Gallery whole-document placements up to the bounded 1024-edit ceiling
- cover the deletion regression and the 272-edit Gallery transaction

## Validation
- pnpm install --frozen-lockfile
- pnpm ci:check (1371 unit tests, production/release smoke, 235 Playwright tests)
- public Gallery probe across 34 scenes
- git diff --check

Test-Impact: tests-updated