### PR TITLE
fix(gallery): restore the shared brand mark

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -106,6 +106,10 @@ test("the site lands on the full-screen gallery feed", async ({ page }) => {
   await page.goto("/");
   const feed = page.getByTestId("gallery-feed");
   await expect(feed).toBeVisible();
+  const brand = page.getByTestId("gallery-editor-link");
+  await expect(brand).toHaveCSS("display", "flex");
+  await expect(brand).toHaveCSS("text-decoration-line", "none");
+  await expect(brand.locator(".app-brand-mark")).toBeVisible();
 
   // With community entries present the wall shows them alone: the bundled
   // starter tiles exist only while the gallery is empty.

--- a/apps/editor/src/editor.css
+++ b/apps/editor/src/editor.css
@@ -4811,21 +4811,6 @@
   font-size: var(--icm-font-sm);
 }
 
-/* The wordmark is the editor's half of the two-way gallery/editor switch, so
-   the whole brand is one link that still reads as plain chrome. */
-.gallery-home-link {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--icm-space-2);
-  min-width: 0;
-  color: inherit;
-  text-decoration: none;
-}
-
-.gallery-home-link:hover h1 {
-  color: var(--icm-accent);
-}
-
 /* The panel toggles lead the drawing toolbar; a hairline separates them from
    the drawing tools so the row still reads as two groups. */
 .draw-toolbar-divider {

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -241,6 +241,22 @@ body {
   box-shadow: inset 0 0 0 1px rgb(255 255 255 / 8%);
 }
 
+/* The wordmark is the shared two-way gallery/editor switch. Keep this beside
+   the shared brand primitives: both route bundles render it, and an inline
+   anchor would collapse the otherwise empty brand mark. */
+.gallery-home-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--icm-space-2);
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+}
+
+.gallery-home-link:hover h1 {
+  color: var(--icm-accent);
+}
+
 .app-brand-copy {
   min-width: 0;
   overflow: hidden;


### PR DESCRIPTION
## Cause

The route-level CSS split moved `.gallery-home-link` into `editor.css`. Gallery routes do not load that bundle, so the empty brand-mark span collapsed and the wordmark rendered as a default purple underlined link.

## Fix

- move the shared wordmark layout back beside the shared brand primitives
- keep editor and Gallery markup visually identical without duplicating CSS
- assert the Gallery mark is visible and the wordmark is not underlined

## Validation

- `pnpm ci:static`
- `pnpm test:local`: 1371 passed
- `pnpm test:e2e:local apps/editor/e2e/gallery.spec.ts`: 28 passed
- `node scripts/performance-baseline.mjs`: passed
