### PR TITLE
fix(editor): keep copied Cell Pins independent

### DIFF
--- a/apps/editor/e2e/hierarchy.spec.ts
+++ b/apps/editor/e2e/hierarchy.spec.ts
@@ -340,9 +340,7 @@ test("declares a top Formal Cell Pin and exports the top interface", async ({
   await expect(preflight).not.toContainText("MISSING_DEVICE_DEFINITION");
 });
 
-test("copies and independently deletes repeated Formal Cell Pin markers", async ({
-  page,
-}) => {
+test("copies and independently deletes Formal Cell Pins", async ({ page }) => {
   await page.addInitScript(() => {
     window.localStorage.clear();
     window.sessionStorage.clear();
@@ -386,13 +384,13 @@ test("copies and independently deletes repeated Formal Cell Pin markers", async 
   }
   await expect(
     page.getByLabel("Cell Pin properties").getByLabel("Cell Pin name"),
-  ).toHaveValue("VIN");
+  ).toHaveValue("VIN_copy");
   await clickCommand(page, "Netlist", "Check Report…");
   await expect(
     page
       .getByRole("dialog", { name: "Check Report" })
       .getByTestId("netlist-preview"),
-  ).toContainText(".subckt Main VIN");
+  ).toContainText(".subckt Main VIN_copy");
 });
 
 test("edits a Cell Pin name and RichText presentation in place", async ({

--- a/apps/editor/src/features/clipboard/clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard.test.ts
@@ -23,7 +23,7 @@ import {
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
 describe("schematic clipboard", () => {
-  it("copies a Cell Pin as another marker of the same interface and Net", () => {
+  it("copies a Cell Pin with an independent interface and Base Net", () => {
     const document = createEmptyDocument("document-main", "Clipboard");
     document.instances.push({
       id: "P1",
@@ -52,6 +52,23 @@ describe("schematic clipboard", () => {
       ],
       formalParameters: [],
     };
+    document.annotations.push({
+      id: "cell-pin-label-p1",
+      kind: "instance-label",
+      binding: {
+        kind: "cell-terminal-name",
+        terminalId: "terminal-input",
+      },
+      anchor: {
+        kind: "object",
+        objectId: "P1",
+        localOffset: { x: 0, y: -20 },
+        fallbackPosition: { x: 100, y: 80 },
+      },
+      alignment: "middle",
+      rotation: 0,
+      locked: false,
+    });
 
     const clipboard = copySelection(document, ["P1"]);
     expect(clipboard).not.toBeNull();
@@ -69,10 +86,66 @@ describe("schematic clipboard", () => {
     );
 
     if (!result.ok) throw new Error(JSON.stringify(result, null, 2));
-    expect(result.document.netlist?.terminals).toMatchObject([
-      { interfaceInstanceIds: ["P1", "P1-copy-1"], name: "VIN" },
-    ]);
-    expect(result.document.nets).toHaveLength(1);
+    const originalTerminal = result.document.netlist?.terminals.find(
+      (terminal) => terminal.id === "terminal-input",
+    );
+    const copiedTerminal = result.document.netlist?.terminals.find((terminal) =>
+      terminal.interfaceInstanceIds.includes("P1-copy-1"),
+    );
+    expect(originalTerminal).toMatchObject({
+      name: "VIN",
+      netId: "net-input",
+      direction: "input",
+      interfaceInstanceIds: ["P1"],
+    });
+    expect(copiedTerminal).toMatchObject({
+      name: "VIN_copy",
+      direction: "input",
+      interfaceInstanceIds: ["P1-copy-1"],
+    });
+    expect(copiedTerminal?.id).not.toBe(originalTerminal?.id);
+    expect(copiedTerminal?.netId).not.toBe(originalTerminal?.netId);
+    expect(result.document.nets).toHaveLength(2);
+    expect(
+      result.document.annotations.find(
+        (annotation) =>
+          annotation.anchor.kind === "object" &&
+          annotation.anchor.objectId === "P1-copy-1",
+      )?.binding,
+    ).toEqual({
+      kind: "cell-terminal-name",
+      terminalId: copiedTerminal?.id,
+    });
+
+    const rename = executeTransaction(
+      result.document,
+      {
+        transactionId: "rename-copied-formal-pin",
+        documentId: result.document.id,
+        expectedRevision: result.document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: [
+          {
+            kind: "update_cell_terminal",
+            terminalId: copiedTerminal!.id,
+            name: "VIN_COPY_RENAMED",
+            direction: "output",
+          },
+        ],
+      },
+      { symbolResolver: resolver },
+    );
+    if (!rename.ok) throw new Error(JSON.stringify(rename, null, 2));
+    expect(
+      rename.document.netlist?.terminals.find(
+        (terminal) => terminal.id === "terminal-input",
+      ),
+    ).toMatchObject({ name: "VIN", direction: "input" });
+    expect(
+      rename.document.netlist?.terminals.find(
+        (terminal) => terminal.id === copiedTerminal?.id,
+      ),
+    ).toMatchObject({ name: "VIN_COPY_RENAMED", direction: "output" });
 
     const preview = clipboardPreviewDocument(
       document,
@@ -811,7 +884,7 @@ describe("a copy stands on its own", () => {
     expect(copy.schematicReference).not.toMatch(/copy/u);
   });
 
-  it("copies a Cell Pin as another marker of the same interface and Net", () => {
+  it("keeps a copied Cell Pin separate from its source", () => {
     const document = createEmptyDocument("document-main", "Copy");
     document.instances.push({
       id: "P1",
@@ -858,11 +931,37 @@ describe("a copy stands on its own", () => {
       result.document.nets.find((net) =>
         net.terminals.some((terminal) => terminal.instanceId === instanceId),
       );
-    expect(netOf("P1")?.id).toBe(netOf(copyId)?.id);
+    expect(netOf("P1")?.id).not.toBe(netOf(copyId)?.id);
     expect(
       result.document.netlist?.terminals.find((terminal) =>
         terminal.interfaceInstanceIds.includes(copyId),
       )?.name,
-    ).toBe("P12");
+    ).toBe("P12_copy");
+
+    const secondProposal = proposePaste(
+      result.document,
+      clipboard!,
+      { x: 240, y: 0 },
+      2,
+    );
+    const secondResult = executeTransaction(
+      result.document,
+      {
+        transactionId: "paste-port-again",
+        documentId: result.document.id,
+        expectedRevision: result.document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: secondProposal.edits,
+      },
+      { symbolResolver: resolver },
+    );
+    if (!secondResult.ok)
+      throw new Error(JSON.stringify(secondResult.diagnostics));
+    const secondCopyId = secondProposal.instanceIds[0]!;
+    expect(
+      secondResult.document.netlist?.terminals.find((terminal) =>
+        terminal.interfaceInstanceIds.includes(secondCopyId),
+      )?.name,
+    ).toBe("P12_copy2");
   });
 });

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -531,6 +531,35 @@ function pastedSchematicReference(
 }
 
 /**
+ * A copied Cell Pin is a new formal interface, not another visual projection
+ * of the source terminal. Preserve the source name when pasting into another
+ * Document where it is free; an in-place copy receives a stable, readable
+ * suffix instead. Cell-terminal names are unique case-insensitively.
+ */
+function pastedCellTerminalName(
+  sourceName: string,
+  occupiedNames: Set<string>,
+): string {
+  const claim = (candidate: string): string | null => {
+    const folded = candidate.toLowerCase();
+    if (occupiedNames.has(folded)) return null;
+    occupiedNames.add(folded);
+    return candidate;
+  };
+  const unchanged = claim(sourceName);
+  if (unchanged) return unchanged;
+
+  let ordinal = 1;
+  while (true) {
+    const suffix = ordinal === 1 ? "_copy" : `_copy${ordinal}`;
+    const candidate = `${sourceName.slice(0, 128 - suffix.length)}${suffix}`;
+    const available = claim(candidate);
+    if (available) return available;
+    ordinal += 1;
+  }
+}
+
+/**
  * Rewrites a pasted instance-label whose text is still the copied reference
  * (or copied id) to the new reference, so a pasted R1 reads R2 on canvas.
  * The replacement content is rebuilt exactly like a freshly placed label
@@ -734,42 +763,26 @@ export function proposePaste(
       uniqueCopyId(evidence.id, sequence, occupied),
     ]),
   );
-  const existingAnchors = new Map<string, RouteEndpoint>();
   const errors: string[] = [];
-  const targetTerminalBySourceId = new Map(
-    clipboard.cellTerminals.flatMap((terminal) => {
-      const existing = document.netlist?.terminals.find(
-        (candidate) =>
-          candidate.id === terminal.id ||
-          candidate.name.toLowerCase() === terminal.name.toLowerCase(),
-      );
-      return existing ? [[terminal.id, existing] as const] : [];
-    }),
-  );
   const terminalIds = new Map(
     clipboard.cellTerminals.map((terminal) => [
       terminal.id,
-      targetTerminalBySourceId.get(terminal.id)?.id ??
-        uniqueCopyId(terminal.id, sequence, occupied),
+      uniqueCopyId(terminal.id, sequence, occupied),
+    ]),
+  );
+  const occupiedTerminalNames = new Set(
+    (document.netlist?.terminals ?? []).map((terminal) =>
+      terminal.name.toLowerCase(),
+    ),
+  );
+  const terminalNames = new Map(
+    clipboard.cellTerminals.map((terminal) => [
+      terminal.id,
+      pastedCellTerminalName(terminal.name, occupiedTerminalNames),
     ]),
   );
   for (const net of clipboard.nets) {
-    const formalTerminal = clipboard.cellTerminals.find(
-      (terminal) => terminal.netId === net.id,
-    );
-    const existingTerminal = formalTerminal
-      ? targetTerminalBySourceId.get(formalTerminal.id)
-      : undefined;
-    if (existingTerminal) {
-      netIds.set(net.id, existingTerminal.netId);
-      const existingNet = document.nets.find(
-        (candidate) => candidate.id === existingTerminal.netId,
-      );
-      const anchor = existingNet ? firstNetEndpoint(existingNet) : null;
-      if (anchor) existingAnchors.set(net.id, anchor);
-    } else {
-      netIds.set(net.id, uniqueCopyId(net.id, sequence, occupied));
-    }
+    netIds.set(net.id, uniqueCopyId(net.id, sequence, occupied));
   }
   const objectIds = new Map<string, string>([
     ...instanceIds,
@@ -824,27 +837,16 @@ export function proposePaste(
       },
     );
     if (copiedMarkerIds.length === 0) continue;
-    const existingTerminal = targetTerminalBySourceId.get(terminal.id);
-    edits.push(
-      existingTerminal
-        ? {
-            kind: "update_cell_terminal",
-            terminalId: existingTerminal.id,
-            interfaceInstanceIds: [
-              ...existingTerminal.interfaceInstanceIds,
-              ...copiedMarkerIds,
-            ],
-          }
-        : {
-            kind: "add_cell_terminal",
-            terminal: {
-              ...terminal,
-              id: terminalIds.get(terminal.id)!,
-              netId: netIds.get(terminal.netId) ?? terminal.netId,
-              interfaceInstanceIds: copiedMarkerIds,
-            },
-          },
-    );
+    edits.push({
+      kind: "add_cell_terminal",
+      terminal: {
+        ...terminal,
+        id: terminalIds.get(terminal.id)!,
+        name: terminalNames.get(terminal.id)!,
+        netId: netIds.get(terminal.netId) ?? terminal.netId,
+        interfaceInstanceIds: copiedMarkerIds,
+      },
+    });
   }
 
   for (const net of clipboard.nets) {
@@ -854,16 +856,7 @@ export function proposePaste(
       pinName: terminal.pinName,
     }));
     const netId = netIds.get(net.id)!;
-    const existingAnchor = existingAnchors.get(net.id);
-    if (existingAnchor) {
-      for (const terminal of mappedTerminals) {
-        edits.push({
-          kind: "connect_endpoints",
-          from: existingAnchor,
-          to: terminal,
-        });
-      }
-    } else if (mappedTerminals[0]) {
+    if (mappedTerminals[0]) {
       edits.push({
         kind: "connect_endpoints",
         from: mappedTerminals[0],

--- a/docs/adr/0037-repeated-formal-port-markers.md
+++ b/docs/adr/0037-repeated-formal-port-markers.md
@@ -2,6 +2,10 @@
 
 Status: accepted
 
+The clipboard-copy clause is superseded by
+[ADR 0045](0045-independent-cell-pin-copy.md). Explicitly authored repeated
+markers remain part of this decision.
+
 Date: 2026-08-21
 
 Owners: `packages/model`, `packages/project-protocol`,

--- a/docs/adr/0043-cell-pin-contract-convergence.md
+++ b/docs/adr/0043-cell-pin-contract-convergence.md
@@ -2,6 +2,10 @@
 
 Status: accepted
 
+The clipboard-copy clause is superseded by
+[ADR 0045](0045-independent-cell-pin-copy.md). The unified Cell Pin model and
+explicit repeated-marker behavior remain accepted.
+
 Date: 2026-08-25
 
 Owners: `packages/model`, `packages/edit-engine`, `apps/editor`,

--- a/docs/adr/0045-independent-cell-pin-copy.md
+++ b/docs/adr/0045-independent-cell-pin-copy.md
@@ -1,0 +1,64 @@
+# 0045 - Cell Pin copies own their interface identity
+
+Status: `accepted`
+
+Date: `2026-08-26`
+
+Owners: `apps/editor`, `packages/edit-engine`, `packages/model`
+
+## Context
+
+One formal Cell terminal may intentionally own several visual markers. The
+clipboard previously treated every copied Cell Pin as another such marker,
+which made the source and copy share their terminal name, direction, Net, and
+caller pin. A copy operation is expected to create a separately editable Pin;
+sharing those properties made ordinary duplication behave like an implicit
+interface-merge command.
+
+## Decision
+
+Clipboard duplication creates a new formal terminal for each copied terminal
+group. The copy receives a fresh terminal ID, its own marker IDs, and the
+source direction as an initial value. Its name is preserved when free in the
+target Document; otherwise a case-insensitively unique `_copy`, `_copy2`, …
+suffix is allocated. A Base Net wholly owned by the copied selection is cloned.
+
+The ordinary clipboard boundary rule remains unchanged: when a copied Pin's
+Net also contains unselected objects, the copied Pin remains electrically
+attached to that existing Net while retaining independent formal-terminal
+identity.
+
+Explicitly placing an already-used Cell Pin name may still add another marker
+to that existing terminal. Explicitly renaming one terminal onto another may
+still invoke the existing merge behavior. Those deliberate operations remain
+the way to request shared terminal identity.
+
+This supersedes only the clipboard-copy clauses of
+[ADR 0037](0037-repeated-formal-port-markers.md) and
+[ADR 0043](0043-cell-pin-contract-convergence.md).
+
+## Consequences
+
+- Renaming, changing direction, or deleting a copied Pin does not mutate its
+  source Pin.
+- In-place copies appear as distinct `.subckt` terminals with readable unique
+  names.
+- The repeated-marker model and Project schema remain unchanged.
+
+## Compatibility and migration
+
+No Project schema or persisted object changes. Existing repeated-marker
+Projects retain their current meaning; the decision changes only future
+clipboard proposals.
+
+## Validation
+
+- Clipboard unit coverage proves fresh terminal identity, unique naming,
+  independent Base Net ownership, annotation rebinding, and independent rename.
+- Browser coverage proves copied-Pin properties, deletion, and netlist export.
+
+## Related documents
+
+- [Schematic hierarchy](../user/schematic-hierarchy.md)
+- [Schematic model](../specs/schematic-model.md)
+- [Editor interaction](../specs/editor-interaction.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -93,6 +93,9 @@ visual markers for one formal terminal is
 The separation of imported source provenance from electrical equivalence, and
 the reviewed external-master ERC classification, is
 [`0044-imported-source-provenance.md`](0044-imported-source-provenance.md).
+The independent Cell-Pin clipboard identity decision, partially superseding
+the copy clauses of ADRs 0037 and 0043, is
+[`0045-independent-cell-pin-copy.md`](0045-independent-cell-pin-copy.md).
 The arbitrary-angle Route authoring decision is
 [`0039-any-angle-route-authoring.md`](0039-any-angle-route-authoring.md).
 

--- a/docs/user/schematic-hierarchy.md
+++ b/docs/user/schematic-hierarchy.md
@@ -42,12 +42,15 @@ other directions are balanced automatically. The symbol body and pin placement
 adapt without a separate interface editor.
 
 Each visible marker remains an ordinary Instance for selection, move, wiring,
-copy, and deletion. Copying a Cell Pin, or placing the same Pin name again,
-creates another visual marker for the same formal terminal and Net. The
-`.subckt` interface still contains that Pin exactly once. Repeated names that
-only name an internal Net use Net Labels instead. The Cell terminal adds stable
-identity, ordering, and the Net binding used by parent blocks and netlist
-export.
+copy, and deletion. Copying a Cell Pin creates a new formal terminal with an
+independent stable identity, name, direction, and internal Base Net. An
+in-place copy receives a unique name such as `VIN_copy`; later edits to either
+Pin do not affect the other. As with every copied connected component, a Pin
+whose Net crosses the selection boundary remains attached to that existing
+Net, but its formal interface identity is still independent. Explicitly
+placing the same Pin name again remains the way to create another visual marker
+for one shared formal terminal. Repeated names that only name an internal Net
+use Net Labels instead.
 
 Renaming that annotation updates all connected parent Instances atomically.
 Deleting a Cell Pin removes its terminal and automatically detaches every child


### PR DESCRIPTION
## Summary
- clone Cell Pin terminal identity and internal Net during clipboard paste
- allocate collision-free copied Pin names and rebind their labels
- retain explicit same-name repeated-marker authoring
- document the corrected clipboard contract

## Validation
- `pnpm gate:preflight -- --base origin/main`
- `pnpm gate:affected -- --base origin/main`
- 1,371 unit tests, 14 hierarchy browser tests, and 109 editor browser tests passed

Test-Impact: tests-updated