### PR TITLE
Redesign Help keyboard shortcuts

### DIFF
--- a/apps/editor/src/components/editor-help-dialog.test.tsx
+++ b/apps/editor/src/components/editor-help-dialog.test.tsx
@@ -20,4 +20,26 @@ describe("EditorHelpDialog", () => {
     expect(markup).toContain('target="_blank"');
     expect(markup).toContain('rel="noreferrer"');
   });
+
+  it("presents the focused shortcut set as scannable grouped rows", () => {
+    const markup = renderToStaticMarkup(
+      <EditorHelpDialog closeButtonRef={{ current: null }} onClose={vi.fn()} />,
+    );
+    const shortcuts = markup.slice(
+      markup.indexOf('id="help-shortcuts"'),
+      markup.indexOf('id="help-data"'),
+    );
+
+    expect(shortcuts).toContain("Create");
+    expect(shortcuts).toContain("Edit");
+    expect(shortcuts).toContain("Workspace");
+    expect(shortcuts.match(/class="help-shortcut-item"/gu)).toHaveLength(12);
+    for (const key of ["I", "P", "W", "T", "Q", "U", "C", "R", "F"]) {
+      expect(shortcuts).toContain(`>${key}</kbd>`);
+    }
+    expect(shortcuts).toContain("Mirror left / right");
+    expect(shortcuts).toContain("Mirror top / bottom");
+    expect(shortcuts).not.toContain("File and history");
+    expect(shortcuts).not.toContain("Select all placed components");
+  });
 });

--- a/apps/editor/src/components/editor-help-dialog.tsx
+++ b/apps/editor/src/components/editor-help-dialog.tsx
@@ -4,6 +4,56 @@ import editorPackage from "../../package.json";
 
 const REPOSITORY_URL = "https://github.com/cascode-ai/analog-canvas";
 
+const SHORTCUT_GROUPS = [
+  {
+    id: "create",
+    title: "Create",
+    shortcuts: [
+      { keys: ["I"], action: "Insert component" },
+      { keys: ["P"], action: "Place Cell Pin" },
+      { keys: ["W"], action: "Draw wire" },
+      { keys: ["T"], action: "Add text" },
+    ],
+  },
+  {
+    id: "edit",
+    title: "Edit",
+    shortcuts: [
+      { keys: ["U"], action: "Undo last edit" },
+      { keys: ["Shift", "U"], action: "Redo last edit" },
+      { keys: ["C"], action: "Copy and place selection" },
+      { keys: ["R"], action: "Rotate selection / draw Rectangle when idle" },
+      { keys: ["Shift", "R"], action: "Mirror left / right" },
+      { keys: ["Ctrl", "R"], action: "Mirror top / bottom" },
+    ],
+  },
+  {
+    id: "workspace",
+    title: "Workspace",
+    shortcuts: [
+      { keys: ["Q"], action: "Toggle Properties" },
+      { keys: ["F"], action: "Fit circuit in view" },
+    ],
+  },
+] as const;
+
+function ShortcutChord({ keys }: { keys: readonly string[] }) {
+  return (
+    <span className="help-shortcut-chord" aria-label={keys.join(" plus ")}>
+      {keys.map((key, index) => (
+        <span key={key} className="help-shortcut-key-part">
+          {index > 0 ? (
+            <span className="help-shortcut-plus" aria-hidden="true">
+              +
+            </span>
+          ) : null}
+          <kbd>{key}</kbd>
+        </span>
+      ))}
+    </span>
+  );
+}
+
 export interface EditorHelpDialogProps {
   closeButtonRef: RefObject<HTMLButtonElement | null>;
   onClose(): void;
@@ -118,52 +168,33 @@ export function EditorHelpDialog({
           </section>
           <section id="help-shortcuts" className="help-shortcuts">
             <h3>Keyboard shortcuts</h3>
-            <dl>
-              <div>
-                <dt>File and history</dt>
-                <dd>
-                  <kbd>Ctrl</kbd> + <kbd>S</kbd> save; <kbd>Ctrl</kbd> +
-                  <kbd>O</kbd> open; <kbd>U</kbd> undo; <kbd>Shift</kbd> +
-                  <kbd>U</kbd> redo; <kbd>Ctrl</kbd> + <kbd>Z</kbd> undo;
-                  <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Z</kbd> or
-                  <kbd>Ctrl</kbd> + <kbd>Y</kbd> redo.
-                </dd>
-              </div>
-              <div>
-                <dt>Selection and edit</dt>
-                <dd>
-                  <kbd>Ctrl</kbd> + <kbd>A</kbd> selects all placed components;
-                  <kbd>C</kbd> copy-place (click to place, <kbd>Esc</kbd> to
-                  cancel); <kbd>M</kbd> move/stretch the current selection;
-                  <kbd>R</kbd> rotate; <kbd>Shift</kbd> + <kbd>R</kbd>
-                  mirror left/right; <kbd>Ctrl</kbd> + <kbd>R</kbd> mirror
-                  top/bottom; <kbd>Ctrl</kbd> + <kbd>D</kbd> deselect;{" "}
-                  <kbd>F</kbd> fit view;
-                  <kbd>E</kbd> enter or create a hierarchical Cell;{" "}
-                  <kbd>Shift</kbd> + <kbd>E</kbd> return to its parent;
-                  <kbd>Delete</kbd> or <kbd>Backspace</kbd> delete.
-                </dd>
-              </div>
-              <div>
-                <dt>Tools and view</dt>
-                <dd>
-                  <kbd>I</kbd> insert a component; <kbd>P</kbd> place a Port;
-                  <kbd>W</kbd> wire; <kbd>L</kbd> edits a selected Net Label;
-                  <kbd>T</kbd> text; <kbd>A</kbd> arrow; <kbd>K</kbd>
-                  construction line; <kbd>Q</kbd> Properties open/close;{" "}
-                  <kbd>Home</kbd> fit view; <kbd>X</kbd> reverses a selected
-                  current arrow.
-                </dd>
-              </div>
-              <div>
-                <dt>In-progress drawing</dt>
-                <dd>
-                  <kbd>Enter</kbd> completes an active wire or drawing;
-                  <kbd>Esc</kbd> cancels the active tool or closes Help.
-                </dd>
-              </div>
-            </dl>
-            <p>Shortcuts do not run while you are typing in a text field.</p>
+            <div className="help-shortcut-grid">
+              {SHORTCUT_GROUPS.map((group) => (
+                <section
+                  key={group.id}
+                  className={`help-shortcut-group help-shortcut-group-${group.id}`}
+                  aria-labelledby={`help-shortcut-group-${group.id}`}
+                >
+                  <h4 id={`help-shortcut-group-${group.id}`}>{group.title}</h4>
+                  <ul>
+                    {group.shortcuts.map((shortcut) => (
+                      <li
+                        key={`${group.id}-${shortcut.keys.join("-")}`}
+                        className="help-shortcut-item"
+                      >
+                        <span className="help-shortcut-action">
+                          {shortcut.action}
+                        </span>
+                        <ShortcutChord keys={shortcut.keys} />
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </div>
+            <p className="help-shortcut-note">
+              Shortcuts pause while you are typing in a text field.
+            </p>
           </section>
           <section id="help-data" className="help-data-note">
             <h3>Project data and recovery</h3>

--- a/apps/editor/src/editor.css
+++ b/apps/editor/src/editor.css
@@ -1561,6 +1561,10 @@
   line-height: 1.55;
 }
 
+.help-dialog-content > section {
+  scroll-margin-top: 5.5rem;
+}
+
 .replace-guard-actions {
   display: flex;
   flex-wrap: wrap;
@@ -1743,39 +1747,141 @@
   gap: 0.7rem;
 }
 
-.help-shortcuts dl {
+.help-shortcut-grid {
   display: grid;
-  gap: 0.55rem;
-  margin: 0;
-}
-
-.help-shortcuts dl > div {
-  display: grid;
-  grid-template-columns: 8rem minmax(0, 1fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.75rem;
+  align-items: start;
 }
 
-.help-shortcuts dt {
+.help-shortcut-group {
+  overflow: hidden;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-md);
+  background: #fff;
+  box-shadow: 0 1px 2px rgb(15 23 42 / 5%);
+}
+
+.help-shortcut-group-edit {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+}
+
+.help-shortcut-group-workspace {
+  grid-column: 1;
+}
+
+.help-shortcut-group h4 {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0.58rem 0.7rem;
+  border-bottom: 1px solid var(--icm-border);
+  background: linear-gradient(135deg, var(--icm-surface-muted), #fff);
   color: var(--icm-text);
-  font-size: var(--icm-font-md);
+  font-size: var(--icm-font-sm);
+  font-weight: 700;
+  letter-spacing: 0.045em;
+  text-transform: uppercase;
+}
+
+.help-shortcut-group h4::before {
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: 50%;
+  background: var(--icm-accent);
+  box-shadow: 0 0 0 3px rgb(37 99 235 / 10%);
+  content: "";
+}
+
+.help-shortcut-group ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.help-shortcut-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  align-items: center;
+  gap: 0.7rem;
+  min-height: 2.55rem;
+  padding: 0.5rem 0.7rem;
+}
+
+.help-shortcut-item + .help-shortcut-item {
+  border-top: 1px solid var(--icm-border);
+}
+
+.help-shortcut-action {
+  margin: 0;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-sm);
+  line-height: 1.3;
+}
+
+.help-shortcut-chord,
+.help-shortcut-key-part {
+  display: inline-flex;
+  align-items: center;
+}
+
+.help-shortcut-chord {
+  justify-self: end;
+  white-space: nowrap;
+}
+
+.help-shortcut-plus {
+  margin: 0 0.18rem;
+  color: var(--icm-text-muted);
+  font-size: 0.68rem;
   font-weight: 700;
 }
 
-.help-shortcuts dd {
-  margin: 0;
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-md);
-}
-
 .help-dialog-content kbd {
-  padding: 0.05rem 0.25rem;
+  min-width: 1.55rem;
+  padding: 0.11rem 0.32rem;
   border: 1px solid var(--icm-border-strong);
   border-radius: 0.3rem;
   color: var(--icm-text);
   background: linear-gradient(180deg, #fff, var(--icm-surface-muted));
   box-shadow: 0 1px 0 var(--icm-border-strong);
-  font: inherit;
-  font-size: 0.8em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1.15;
+  text-align: center;
+}
+
+.help-shortcut-note {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.58rem 0.7rem;
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface-muted);
+}
+
+.help-shortcut-note::before {
+  flex: 0 0 auto;
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 50%;
+  background: var(--icm-text-muted);
+  content: "";
+}
+
+@media (max-width: 38rem) {
+  .help-shortcut-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .help-shortcut-group-edit,
+  .help-shortcut-group-workspace {
+    grid-column: auto;
+    grid-row: auto;
+  }
 }
 
 .help-data-note {


### PR DESCRIPTION
## Summary\n- replace dense shortcut paragraphs with grouped, scannable rows\n- limit the reference to I, P, W, T, Q, U, Shift+U, C, R, Shift+R, Ctrl+R, and F\n- keep the responsive shortcut section clear of the sticky Help header\n\n## Validation\n- pnpm ci:static\n- pnpm test:impact -- --base origin/main\n- pnpm test:local (202 files, 1373 tests)\n- wide and narrow in-app browser visual checks