### PR TITLE
fix(gallery): stack publish mode controls

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -1153,6 +1153,7 @@ test("/mine offers owner withdrawal, restore, and version history", async ({
 });
 
 test("an opened gallery entry offers updating in place", async ({ page }) => {
+  await page.setViewportSize({ width: 420, height: 900 });
   await mockGallery(page, [ENTRY]);
   await page.route("**/api/auth/me", (route) =>
     route.fulfill({
@@ -1185,9 +1186,28 @@ test("an opened gallery entry offers updating in place", async ({ page }) => {
   await page.getByTestId("publish-gallery-button").click();
   const dialog = page.getByTestId("publish-gallery-dialog");
   await expect(dialog).toBeVisible();
-  await expect(page.getByTestId("publish-mode")).toBeVisible();
+  const publishMode = page.getByTestId("publish-mode");
+  await expect(publishMode).toBeVisible();
+  await expect(publishMode).toHaveCSS("display", "flex");
+  await expect(publishMode).toHaveCSS("flex-direction", "column");
+  const updateChoice = publishMode
+    .getByRole("radio", { name: /^Update /u })
+    .locator("..");
+  const newChoice = publishMode
+    .getByRole("radio", { name: "Publish as a new entry", exact: true })
+    .locator("..");
+  const [updateBox, newBox, historyBox] = await Promise.all([
+    updateChoice.boundingBox(),
+    newChoice.boundingBox(),
+    page.getByTestId("publish-history").boundingBox(),
+  ]);
+  expect(updateBox).not.toBeNull();
+  expect(newBox).not.toBeNull();
+  expect(historyBox).not.toBeNull();
+  expect(newBox!.y).toBeGreaterThanOrEqual(updateBox!.y + updateBox!.height);
+  expect(historyBox!.y).toBeGreaterThanOrEqual(newBox!.y + newBox!.height);
   // The update option names exactly what it will replace.
-  await expect(page.getByTestId("publish-mode")).toContainText(ENTRY.name);
+  await expect(publishMode).toContainText(ENTRY.name);
   await expect(dialog.getByText("updates the entry in place")).toBeVisible();
 
   await dialog.getByRole("button", { name: "Update entry" }).click();

--- a/apps/editor/src/editor.css
+++ b/apps/editor/src/editor.css
@@ -3985,6 +3985,35 @@
   font-size: 1.3rem;
 }
 
+.publish-gallery-mode {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border: 1px solid var(--icm-accent);
+  border-radius: 8px;
+  background: var(--icm-accent-soft);
+  font-size: 0.85rem;
+}
+
+.publish-gallery-mode label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.publish-gallery-history-link {
+  align-self: flex-start;
+  padding: 0;
+  border: none;
+  color: var(--icm-accent);
+  background: none;
+  font-size: 0.78rem;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 .publish-gallery-fields {
   display: flex;
   flex-direction: column;

--- a/apps/editor/src/gallery.css
+++ b/apps/editor/src/gallery.css
@@ -391,17 +391,6 @@
   color: var(--icm-accent);
 }
 
-.publish-gallery-history-link {
-  align-self: flex-start;
-  padding: 0;
-  border: none;
-  color: var(--icm-accent);
-  background: none;
-  font-size: 0.78rem;
-  text-decoration: underline;
-  cursor: pointer;
-}
-
 .version-history-dialog {
   width: min(36rem, 100%);
 }
@@ -531,24 +520,6 @@
 .review-bin h2 {
   margin: 8px 0 0;
   font-size: 17px;
-}
-
-.publish-gallery-mode {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 10px 12px;
-  border: 1px solid var(--icm-accent);
-  border-radius: 8px;
-  background: var(--icm-accent-soft);
-  font-size: 0.85rem;
-}
-
-.publish-gallery-mode label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  cursor: pointer;
 }
 
 .review-card,


### PR DESCRIPTION
## Summary
- move the update/new mode and version-history link styles into the editor route stylesheet
- keep the two radio choices and history action on successive rows at narrow widths
- add a 420px browser regression for the computed column layout and non-overlapping geometry

## Validation
- pnpm --filter @icm/editor... build
- focused Gallery E2E: 1 passed
- pnpm gate:preflight -- --base origin/main
- CI=1 ICM_E2E_PORT=4194 pnpm gate:affected -- --base origin/main: 1387 unit tests and 28 Gallery browser tests passed