### PR TITLE
fix(editor): restore route-safe dialog styles

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -530,6 +530,9 @@ test("a signed-in owner renames the display name and signs out", async ({
   expect(renames).toEqual(["Token Zhang"]);
 
   await page.locator(".account-more > summary").click();
+  const accountPopover = page.locator(".account-popover");
+  await expect(accountPopover).toHaveCSS("position", "absolute");
+  await expect(accountPopover).toHaveCSS("display", "grid");
   await page.getByTestId("account-signout").click();
   await expect(page.getByTestId("account-signin")).toBeVisible();
   expect(loggedOut).toBe(1);
@@ -895,6 +898,11 @@ test("an ordinary user sees blocking quality gates on an empty project", async (
   await expect(gates).toBeVisible();
   await expect(gates).toContainText("Fix these before publishing");
   await expect(gates).toContainText("Too little content");
+  await expect(gates).toHaveCSS("border-top-color", "rgb(235, 87, 87)");
+  await expect(gates).toHaveCSS("background-color", "rgba(235, 87, 87, 0.08)");
+  const tags = dialog.getByTestId("publish-tags");
+  await expect(tags).toHaveCSS("display", "flex");
+  await expect(tags).toHaveCSS("flex-direction", "column");
   await expect(dialog.getByLabel("Owner passphrase")).toHaveCount(0);
   // The gates still hold, but the button says what actually happens next.
   await expect(dialog.getByRole("button", { name: "Publish" })).toBeDisabled();
@@ -1148,8 +1156,16 @@ test("/mine offers owner withdrawal, restore, and version history", async ({
   await expect(page.getByTestId("mine-status-mine-2")).toHaveText("Published");
   // The version history dialog lists the snapshot with its preview.
   await page.getByTestId("mine-history-mine-2").click();
-  await expect(page.getByTestId("version-history-dialog")).toBeVisible();
-  await expect(page.getByTestId("version-1")).toContainText("Live Amp v1");
+  const history = page.getByTestId("version-history-dialog");
+  await expect(history).toBeVisible();
+  await expect(page.locator(".version-history-backdrop")).toHaveCSS(
+    "position",
+    "fixed",
+  );
+  await expect(history).toHaveCSS("display", "flex");
+  const version = page.getByTestId("version-1");
+  await expect(version).toHaveCSS("display", "grid");
+  await expect(version).toContainText("Live Amp v1");
 });
 
 test("an opened gallery entry offers updating in place", async ({ page }) => {
@@ -1278,9 +1294,14 @@ test("a reviewer browses version history and restores a version", async ({
 
   const history = page.getByTestId("version-history-dialog");
   await expect(history).toBeVisible();
-  await expect(page.getByTestId("version-2")).toContainText(
-    "Ring Oscillator (older)",
+  await expect(page.locator(".version-history-backdrop")).toHaveCSS(
+    "position",
+    "fixed",
   );
+  await expect(history).toHaveCSS("display", "flex");
+  const version = page.getByTestId("version-2");
+  await expect(version).toHaveCSS("display", "grid");
+  await expect(version).toContainText("Ring Oscillator (older)");
   await page.getByTestId("version-restore-2").click();
   await expect(page.getByTestId("status")).toContainText(
     `Opened gallery circuit: ${ENTRY.name}`,

--- a/apps/editor/src/components/account.tsx
+++ b/apps/editor/src/components/account.tsx
@@ -192,7 +192,7 @@ export function AccountMenuView({
             ) : null}
             <span aria-hidden="true">⋯</span>
           </summary>
-          <div className="command-popover account-popover">
+          <div className="account-popover">
             {user.isAdmin || user.role === "moderator" ? (
               <a
                 className="account-link"

--- a/apps/editor/src/components/version-history-dialog.css
+++ b/apps/editor/src/components/version-history-dialog.css
@@ -1,0 +1,157 @@
+.version-history-backdrop {
+  position: fixed;
+  z-index: 80;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  background: rgb(55 53 47 / 28%);
+  backdrop-filter: blur(4px);
+}
+
+.version-history-dialog {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: min(36rem, calc(100vw - 2.5rem));
+  max-height: calc(100dvh - 2.5rem);
+  padding: 1.5rem;
+  overflow-y: auto;
+  border: 1px solid var(--icm-border);
+  border-radius: 14px;
+  color: var(--icm-text);
+  background: var(--icm-surface);
+  box-shadow: 0 24px 48px rgb(15 15 15 / 18%);
+}
+
+.version-history-header p {
+  margin: 0;
+  color: var(--icm-text-muted);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.version-history-header h2 {
+  margin: 0.3rem 0 0;
+  font-size: 1.3rem;
+}
+
+.version-history-note,
+.version-history-error {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.version-history-note {
+  color: var(--icm-text-muted);
+}
+
+.version-history-error {
+  color: var(--icm-error);
+}
+
+.version-list {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  gap: 10px;
+  overflow-y: auto;
+}
+
+.version-row {
+  display: grid;
+  grid-template-columns: 110px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 8px;
+  border: 1px solid var(--icm-border);
+  border-radius: 10px;
+}
+
+.version-row img {
+  width: 110px;
+  height: 74px;
+  object-fit: contain;
+  border: 1px solid var(--icm-border);
+  border-radius: 6px;
+  background: #fff;
+}
+
+.version-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.version-copy b {
+  overflow-wrap: anywhere;
+  font-size: 0.9rem;
+}
+
+.version-copy small {
+  color: var(--icm-text-muted);
+  overflow-wrap: anywhere;
+}
+
+.version-history-primary,
+.version-history-actions button {
+  padding: 0.5rem 1.1rem;
+  border: 1px solid var(--icm-border);
+  border-radius: 8px;
+  color: var(--icm-text);
+  background: var(--icm-surface);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.version-history-primary {
+  padding: 0.4rem 0.9rem;
+  border-color: var(--icm-accent);
+  color: #fff;
+  background: var(--icm-accent);
+}
+
+.version-history-primary:hover:not(:disabled) {
+  background: rgb(var(--icm-accent-rgb) / 88%);
+}
+
+.version-history-primary:disabled,
+.version-history-actions button:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.version-history-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.version-history-actions button:hover:not(:disabled) {
+  background: var(--icm-surface-hover);
+}
+
+@media (width <= 560px) {
+  .version-history-dialog {
+    padding: 1rem;
+  }
+
+  .version-row {
+    grid-template-columns: 80px minmax(0, 1fr);
+  }
+
+  .version-row img {
+    width: 80px;
+    height: 54px;
+  }
+
+  .version-history-primary {
+    grid-column: 1 / -1;
+    justify-self: end;
+  }
+}

--- a/apps/editor/src/components/version-history-dialog.tsx
+++ b/apps/editor/src/components/version-history-dialog.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 
+import "./version-history-dialog.css";
+
 /**
  * Version history of one gallery entry, for reviewers and the entry's
  * owner: every update snapshotted the previous state; Restore adopts a
@@ -88,26 +90,26 @@ export function VersionHistoryDialog({
 
   return (
     <div
-      className="insert-dialog-backdrop"
+      className="version-history-backdrop"
       onPointerDown={(event) => {
         if (event.target === event.currentTarget && !busy) onClose();
       }}
     >
       <section
-        className="publish-gallery-dialog version-history-dialog"
+        className="version-history-dialog"
         role="dialog"
         aria-modal="true"
         aria-labelledby="version-history-title"
         data-testid="version-history-dialog"
       >
-        <header className="publish-gallery-header">
+        <header className="version-history-header">
           <p>Every update keeps the previous state</p>
           <h2 id="version-history-title">Version history — {entryName}</h2>
         </header>
         {versions === null ? (
-          <p className="publish-gallery-note">Loading history…</p>
+          <p className="version-history-note">Loading history…</p>
         ) : versions.length === 0 ? (
-          <p className="publish-gallery-note" data-testid="version-empty">
+          <p className="version-history-note" data-testid="version-empty">
             No earlier versions yet — history starts with the first update.
           </p>
         ) : (
@@ -137,7 +139,7 @@ export function VersionHistoryDialog({
                 </div>
                 <button
                   type="button"
-                  className="publish-gallery-primary"
+                  className="version-history-primary"
                   data-testid={`version-restore-${version.versionNo}`}
                   disabled={busy}
                   onClick={() => void restore(version.versionId)}
@@ -149,11 +151,11 @@ export function VersionHistoryDialog({
           </div>
         )}
         {error ? (
-          <p role="alert" className="publish-gallery-error">
+          <p role="alert" className="version-history-error">
             {error}
           </p>
         ) : null}
-        <div className="publish-gallery-actions">
+        <div className="version-history-actions">
           <button type="button" disabled={busy} onClick={onClose}>
             Close
           </button>

--- a/apps/editor/src/editor.css
+++ b/apps/editor/src/editor.css
@@ -686,7 +686,7 @@
   min-height: auto;
   padding: 0;
   border: 0;
-  color: var(--icm-accent-strong);
+  color: var(--icm-accent);
   background: transparent;
   font: inherit;
   font-weight: 650;
@@ -3137,7 +3137,7 @@
 }
 
 .port-setup-error {
-  color: var(--icm-danger);
+  color: var(--icm-error);
   font-size: var(--icm-font-sm);
 }
 
@@ -3955,198 +3955,6 @@
   color: #fff;
   background: var(--icm-accent);
   font-weight: 600;
-}
-
-.publish-gallery-dialog {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  width: min(30rem, 100%);
-  max-height: 100%;
-  overflow-y: auto;
-  padding: 1.5rem;
-  border: 1px solid var(--icm-border);
-  border-radius: 14px;
-  background: var(--icm-surface);
-  box-shadow: 0 24px 48px rgb(15 15 15 / 18%);
-}
-
-.publish-gallery-header p {
-  margin: 0;
-  color: var(--icm-text-muted);
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.publish-gallery-header h2 {
-  margin: 0.3rem 0 0;
-  font-size: 1.3rem;
-}
-
-.publish-gallery-mode {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 10px 12px;
-  border: 1px solid var(--icm-accent);
-  border-radius: 8px;
-  background: var(--icm-accent-soft);
-  font-size: 0.85rem;
-}
-
-.publish-gallery-mode label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  cursor: pointer;
-}
-
-.publish-gallery-history-link {
-  align-self: flex-start;
-  padding: 0;
-  border: none;
-  color: var(--icm-accent);
-  background: none;
-  font-size: 0.78rem;
-  text-decoration: underline;
-  cursor: pointer;
-}
-
-.publish-gallery-fields {
-  display: flex;
-  flex-direction: column;
-  gap: 0.85rem;
-}
-
-.publish-gallery-fields label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  color: var(--icm-text);
-  font-size: 0.8rem;
-  font-weight: 500;
-}
-
-.publish-gallery-optional {
-  color: var(--icm-text-muted);
-  font-weight: 400;
-}
-
-.publish-gallery-fields input,
-.publish-gallery-fields textarea {
-  box-sizing: border-box;
-  width: 100%;
-  padding: 0.55rem 0.7rem;
-  border: 1px solid var(--icm-border);
-  border-radius: 8px;
-  color: var(--icm-text);
-  background: var(--icm-surface);
-  font: inherit;
-  font-size: 0.9rem;
-}
-
-.publish-gallery-fields textarea {
-  resize: vertical;
-}
-
-.publish-gallery-fields input:focus-visible,
-.publish-gallery-fields textarea:focus-visible {
-  border-color: var(--icm-accent);
-  outline: none;
-  box-shadow: 0 0 0 3px var(--icm-accent-soft);
-}
-
-.publish-gallery-note {
-  margin: 0;
-  color: var(--icm-text-muted, #667085);
-  font-size: 0.78rem;
-  line-height: 1.45;
-}
-
-.publish-gallery-error {
-  margin: 0;
-  color: var(--icm-danger, #b42318);
-  font-size: 0.8rem;
-  line-height: 1.4;
-}
-
-/* Signed out, the dialog is a sign-in prompt rather than a form: the byline,
-   the ownership, and the credential all come from the account. */
-.publish-gallery-signin {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.publish-gallery-signin p {
-  margin: 0;
-  color: var(--icm-text-muted, #667085);
-  font-size: 0.82rem;
-  line-height: 1.5;
-}
-
-.publish-gallery-signin-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.publish-gallery-signin-actions a {
-  flex: 1 1 12rem;
-  padding: 0.5rem 0.85rem;
-  border: 1px solid var(--icm-border, #d0d5dd);
-  border-radius: 0.5rem;
-  background: var(--icm-surface, #fff);
-  color: inherit;
-  font-size: 0.85rem;
-  text-align: center;
-  text-decoration: none;
-}
-
-.publish-gallery-signin-actions a:hover {
-  border-color: var(--icm-accent, #1570ef);
-}
-
-.publish-gallery-signin-note {
-  font-size: 0.75rem;
-}
-
-.publish-gallery-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.5rem;
-}
-
-.publish-gallery-actions button {
-  padding: 0.5rem 1.1rem;
-  border: 1px solid var(--icm-border);
-  border-radius: 8px;
-  color: var(--icm-text);
-  background: var(--icm-surface);
-  font-size: 0.85rem;
-  font-weight: 500;
-  cursor: pointer;
-}
-
-.publish-gallery-actions button:hover:not(:disabled) {
-  background: var(--icm-surface-hover);
-}
-
-.publish-gallery-actions button:disabled {
-  opacity: 0.55;
-  cursor: default;
-}
-
-.publish-gallery-actions .publish-gallery-primary {
-  border-color: var(--icm-accent);
-  color: #fff;
-  background: var(--icm-accent);
-}
-
-.publish-gallery-actions .publish-gallery-primary:hover:not(:disabled) {
-  background: rgb(var(--icm-accent-rgb) / 88%);
 }
 
 .netlist-preview {
@@ -4987,38 +4795,6 @@
   width: 100%;
   height: 100%;
   object-fit: contain;
-}
-
-/* Account actions collapse behind one disclosure: at half-screen width a row
-   of links wrapped onto two lines each and the header stopped being readable. */
-.account-more {
-  position: relative;
-}
-
-.account-more > summary {
-  display: inline-flex;
-  gap: var(--icm-space-1);
-  align-items: center;
-  height: var(--icm-control-h);
-  padding: 0 var(--icm-space-2);
-  border-radius: var(--icm-radius-sm);
-  cursor: pointer;
-  list-style: none;
-}
-
-.account-more > summary::-webkit-details-marker {
-  display: none;
-}
-
-.account-more > summary:hover {
-  background: var(--icm-surface-hover, rgb(0 0 0 / 4%));
-}
-
-.account-popover {
-  position: absolute;
-  right: 0;
-  z-index: 20;
-  min-width: 11rem;
 }
 
 /* The circuit name is edited where it is read, so the field carries no chrome

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.css
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.css
@@ -1,0 +1,260 @@
+.publish-gallery-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: min(30rem, 100%);
+  max-height: 100%;
+  overflow-y: auto;
+  padding: 1.5rem;
+  border: 1px solid var(--icm-border);
+  border-radius: 14px;
+  background: var(--icm-surface);
+  box-shadow: 0 24px 48px rgb(15 15 15 / 18%);
+}
+
+.publish-gallery-header p {
+  margin: 0;
+  color: var(--icm-text-muted);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.publish-gallery-header h2 {
+  margin: 0.3rem 0 0;
+  font-size: 1.3rem;
+}
+
+.publish-gallery-mode {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border: 1px solid var(--icm-accent);
+  border-radius: 8px;
+  background: var(--icm-accent-soft);
+  font-size: 0.85rem;
+}
+
+.publish-gallery-mode label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.publish-gallery-history-link {
+  align-self: flex-start;
+  padding: 0;
+  border: none;
+  color: var(--icm-accent);
+  background: none;
+  font-size: 0.78rem;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.publish-gallery-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.publish-gallery-fields label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: var(--icm-text);
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.publish-gallery-optional {
+  color: var(--icm-text-muted);
+  font-weight: 400;
+}
+
+.publish-gallery-fields input,
+.publish-gallery-fields textarea,
+.publish-gallery-tags input {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--icm-border);
+  border-radius: 8px;
+  color: var(--icm-text);
+  background: var(--icm-surface);
+  font: inherit;
+  font-size: 0.9rem;
+}
+
+.publish-gallery-fields textarea {
+  resize: vertical;
+}
+
+.publish-gallery-fields input:focus-visible,
+.publish-gallery-fields textarea:focus-visible,
+.publish-gallery-tags input:focus-visible {
+  border-color: var(--icm-accent);
+  outline: none;
+  box-shadow: 0 0 0 3px var(--icm-accent-soft);
+}
+
+.publish-gallery-tags {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.publish-gallery-tag-chips,
+.publish-gallery-tag-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.publish-gallery-tag {
+  padding: 3px 10px;
+  border: 1px solid var(--icm-accent);
+  border-radius: 999px;
+  color: var(--icm-accent);
+  background: var(--icm-accent-soft);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.publish-gallery-tag-presets button {
+  padding: 3px 10px;
+  border: 1px solid var(--icm-border);
+  border-radius: 999px;
+  color: var(--icm-text-muted);
+  background: var(--icm-surface);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.publish-gallery-tag-presets button:hover {
+  color: var(--icm-accent);
+  border-color: var(--icm-accent);
+}
+
+.publish-gallery-gates {
+  padding: 10px 12px;
+  border: 1px solid var(--icm-border);
+  border-radius: 8px;
+  background: var(--icm-surface-muted);
+  font-size: 0.8rem;
+}
+
+.publish-gallery-gates p {
+  margin: 0 0 4px;
+  font-weight: 600;
+}
+
+.publish-gallery-gates ul {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.publish-gallery-gates-blocking {
+  border-color: var(--icm-error);
+  background: rgb(235 87 87 / 8%);
+}
+
+.publish-gallery-gates-blocking p {
+  color: var(--icm-error);
+}
+
+.publish-gallery-note {
+  margin: 0;
+  color: var(--icm-text-muted, #667085);
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.publish-gallery-error {
+  margin: 0;
+  color: var(--icm-error);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+/* Signed out, the dialog is a sign-in prompt rather than a form: the byline,
+   the ownership, and the credential all come from the account. */
+.publish-gallery-signin {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.publish-gallery-signin p {
+  margin: 0;
+  color: var(--icm-text-muted, #667085);
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.publish-gallery-signin-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.publish-gallery-signin-actions a {
+  flex: 1 1 12rem;
+  padding: 0.5rem 0.85rem;
+  border: 1px solid var(--icm-border, #d0d5dd);
+  border-radius: 0.5rem;
+  background: var(--icm-surface, #fff);
+  color: inherit;
+  font-size: 0.85rem;
+  text-align: center;
+  text-decoration: none;
+}
+
+.publish-gallery-signin-actions a:hover {
+  border-color: var(--icm-accent, #1570ef);
+}
+
+.publish-gallery-signin-note {
+  font-size: 0.75rem;
+}
+
+.publish-gallery-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.publish-gallery-actions button {
+  padding: 0.5rem 1.1rem;
+  border: 1px solid var(--icm-border);
+  border-radius: 8px;
+  color: var(--icm-text);
+  background: var(--icm-surface);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.publish-gallery-actions button:hover:not(:disabled) {
+  background: var(--icm-surface-hover);
+}
+
+.publish-gallery-actions button:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.publish-gallery-actions .publish-gallery-primary {
+  border-color: var(--icm-accent);
+  color: #fff;
+  background: var(--icm-accent);
+}
+
+.publish-gallery-actions .publish-gallery-primary:hover:not(:disabled) {
+  background: rgb(var(--icm-accent-rgb) / 88%);
+}

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 
+import "./publish-gallery-dialog.css";
+
 import type { SubmissionGateReport } from "@icm/derived";
 
 import {

--- a/apps/editor/src/gallery.css
+++ b/apps/editor/src/gallery.css
@@ -202,6 +202,49 @@
   background: var(--icm-surface-hover);
 }
 
+/* Account actions collapse behind one disclosure so the Gallery header stays
+   readable at half-screen widths. The popover is complete in this route-level
+   stylesheet and no longer depends on the editor command-menu stylesheet. */
+.account-more {
+  position: relative;
+}
+
+.account-more > summary {
+  display: inline-flex;
+  gap: var(--icm-space-1);
+  align-items: center;
+  height: var(--icm-control-h);
+  padding: 0 var(--icm-space-2);
+  border-radius: var(--icm-radius-sm);
+  cursor: pointer;
+  list-style: none;
+}
+
+.account-more > summary::-webkit-details-marker {
+  display: none;
+}
+
+.account-more > summary:hover {
+  background: var(--icm-surface-hover, rgb(0 0 0 / 4%));
+}
+
+.account-popover {
+  position: absolute;
+  z-index: 60;
+  top: calc(100% + 6px);
+  right: 0;
+  display: grid;
+  min-width: 11rem;
+  gap: 2px;
+  padding: 6px;
+  border: 1px solid var(--icm-border);
+  border-radius: 10px;
+  background: var(--icm-surface);
+  box-shadow:
+    0 0 0 1px rgb(15 15 15 / 3%),
+    0 12px 32px rgb(15 15 15 / 12%);
+}
+
 .review-shell {
   /* Same scroll-inside-the-shell rule as .gallery-shell: the app root is
      overflow: hidden, so these pages own their scrolling. */
@@ -391,112 +434,6 @@
   color: var(--icm-accent);
 }
 
-.version-history-dialog {
-  width: min(36rem, 100%);
-}
-
-.version-list {
-  display: flex;
-  max-height: 22rem;
-  flex-direction: column;
-  gap: 10px;
-  overflow-y: auto;
-}
-
-.version-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 8px;
-  border: 1px solid var(--icm-border);
-  border-radius: 10px;
-}
-
-.version-row img {
-  width: 110px;
-  height: 74px;
-  object-fit: contain;
-  border: 1px solid var(--icm-border);
-  border-radius: 6px;
-  background: #fff;
-}
-
-.version-copy {
-  display: flex;
-  min-width: 0;
-  flex: 1;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.version-copy b {
-  font-size: 0.9rem;
-}
-
-.version-copy small {
-  color: var(--icm-text-muted);
-}
-
-.version-row .publish-gallery-primary {
-  padding: 0.4rem 0.9rem;
-  border: 1px solid var(--icm-accent);
-  border-radius: 8px;
-  color: #fff;
-  background: var(--icm-accent);
-  font-size: 0.8rem;
-  cursor: pointer;
-}
-
-.publish-gallery-tags {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  font-size: 0.8rem;
-  font-weight: 500;
-}
-
-.publish-gallery-tags input {
-  box-sizing: border-box;
-  width: 100%;
-  padding: 0.55rem 0.7rem;
-  border: 1px solid var(--icm-border);
-  border-radius: 8px;
-  font: inherit;
-  font-size: 0.9rem;
-}
-
-.publish-gallery-tag-chips,
-.publish-gallery-tag-presets {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.publish-gallery-tag {
-  padding: 3px 10px;
-  border: 1px solid var(--icm-accent);
-  border-radius: 999px;
-  color: var(--icm-accent);
-  background: var(--icm-accent-soft);
-  font-size: 12px;
-  cursor: pointer;
-}
-
-.publish-gallery-tag-presets button {
-  padding: 3px 10px;
-  border: 1px solid var(--icm-border);
-  border-radius: 999px;
-  color: var(--icm-text-muted);
-  background: var(--icm-surface);
-  font-size: 12px;
-  cursor: pointer;
-}
-
-.publish-gallery-tag-presets button:hover {
-  color: var(--icm-accent);
-  border-color: var(--icm-accent);
-}
-
 .gallery-tile-author {
   padding: 0;
   border: none;
@@ -637,33 +574,6 @@
   max-width: 24rem;
   color: var(--icm-text-muted);
   font-size: 12px;
-}
-
-.publish-gallery-gates {
-  padding: 10px 12px;
-  border: 1px solid var(--icm-border);
-  border-radius: 8px;
-  background: var(--icm-surface-muted);
-  font-size: 0.8rem;
-}
-
-.publish-gallery-gates p {
-  margin: 0 0 4px;
-  font-weight: 600;
-}
-
-.publish-gallery-gates ul {
-  margin: 0;
-  padding-left: 1.1rem;
-}
-
-.publish-gallery-gates-blocking {
-  border-color: var(--icm-danger, #b42318);
-  background: rgb(180 35 24 / 6%);
-}
-
-.publish-gallery-gates-blocking p {
-  color: var(--icm-danger, #b42318);
 }
 
 .gallery-open-editor {


### PR DESCRIPTION
## Summary

- move Publish to Gallery styling beside the lazy-loaded dialog component so tags and blocking gates render on /editor
- give Version History a standalone fixed, centered, responsive modal stylesheet shared by /mine and editor gallery flows
- make the Gallery account disclosure own its full popover styling and remove its dependency on editor command-menu CSS
- replace two undefined editor color tokens with existing theme tokens
- add computed-style browser regressions for all three route-splitting failures

## Root cause

The route stylesheet split in 53fa4f9c divided component selectors between ditor.css and gallery.css. Components rendered on routes that loaded only one half, which made the publish warning white and allowed Version History to participate in normal document flow at the bottom of the page.

## Validation

- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main (232 unit files / 1449 tests; 28 Gallery browser tests)
- pnpm --filter @icm/editor... build
- 
ode scripts/editor-production-smoke.mjs --check
- in-app browser route/CSSOM verification on /editor and /mine

This PR is intentionally not merged.