### PR TITLE
Protect editor dialog presentation contracts

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -1294,11 +1294,19 @@ test("a reviewer browses version history and restores a version", async ({
 
   const history = page.getByTestId("version-history-dialog");
   await expect(history).toBeVisible();
-  await expect(page.locator(".version-history-backdrop")).toHaveCSS(
-    "position",
-    "fixed",
-  );
+  const backdrop = page.locator(".version-history-backdrop");
+  await expect(backdrop).toHaveCSS("position", "fixed");
   await expect(history).toHaveCSS("display", "flex");
+  const backdropBox = await backdrop.boundingBox();
+  const historyBox = await history.boundingBox();
+  expect(backdropBox).not.toBeNull();
+  expect(historyBox).not.toBeNull();
+  const upperGap = historyBox!.y - backdropBox!.y;
+  const lowerGap =
+    backdropBox!.y + backdropBox!.height - historyBox!.y - historyBox!.height;
+  // Loading this lazy dialog must not drop it into normal editor flow. The
+  // overlay owns the viewport and keeps the workbench vertically centered.
+  expect(Math.abs(upperGap - lowerGap)).toBeLessThanOrEqual(2);
   const version = page.getByTestId("version-2");
   await expect(version).toHaveCSS("display", "grid");
   await expect(version).toContainText("Ring Oscillator (older)");


### PR DESCRIPTION
## Summary

- preserve the existing Publish Gallery blocking warning color contract
- strengthen Version History coverage so the lazy dialog must remain a fixed, vertically centered overlay
- add no production style or component changes

## Validation

- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
  - 233 unit test files / 1458 tests
  - 28 Gallery browser tests
- repeated the complete 28-test Gallery suite explicitly
- git diff --check