### PR TITLE
Add Change Log and Owner links to Help

### DIFF
--- a/apps/editor/e2e/chrome-isolation.spec.ts
+++ b/apps/editor/e2e/chrome-isolation.spec.ts
@@ -40,7 +40,7 @@ test("dismisses Help with Escape or a backdrop pointer", async ({ page }) => {
   await expect(help).toHaveCount(0);
 });
 
-test("carries the version and repository link inside Help", async ({
+test("carries the version and project resource links inside Help", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -52,14 +52,20 @@ test("carries the version and repository link inside Help", async ({
   const about = page.getByRole("dialog");
   await expect(about).toContainText("About Analog Canvas");
   await expect(about).toContainText("Version 0.1.0");
-  const repositoryLink = about.getByRole("link", {
-    name: "https://github.com/cascode-ai/analog-canvas",
-  });
+  const repositoryLink = about.getByRole("link", { name: "Repository" });
   await expect(repositoryLink).toHaveAttribute(
     "href",
     "https://github.com/cascode-ai/analog-canvas",
   );
   await expect(repositoryLink).toHaveAttribute("target", "_blank");
+  await expect(about.getByRole("link", { name: "Change Log" })).toHaveAttribute(
+    "href",
+    "https://github.com/cascode-ai/analog-canvas/commits/main",
+  );
+  await expect(about.getByRole("link", { name: "Owner" })).toHaveAttribute(
+    "href",
+    "https://www.tokenzhang.com",
+  );
   await page.keyboard.press("Escape");
   await expect(about).toHaveCount(0);
 });

--- a/apps/editor/src/components/editor-help-dialog.test.tsx
+++ b/apps/editor/src/components/editor-help-dialog.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { EditorHelpDialog } from "./editor-help-dialog";
 
 describe("EditorHelpDialog", () => {
-  it("identifies the editor, package version, and repository", () => {
+  it("identifies the editor, package version, and project resources", () => {
     // About was a second entry saying what Help already frames, so its
     // content lives here as a section rather than in its own dialog.
     const markup = renderToStaticMarkup(
@@ -17,6 +17,12 @@ describe("EditorHelpDialog", () => {
     expect(markup).toContain(
       'href="https://github.com/cascode-ai/analog-canvas"',
     );
+    expect(markup).toContain(
+      'href="https://github.com/cascode-ai/analog-canvas/commits/main"',
+    );
+    expect(markup).toContain('href="https://www.tokenzhang.com"');
+    expect(markup).toContain(">Change Log</a>");
+    expect(markup).toContain(">Owner</a>");
     expect(markup).toContain('target="_blank"');
     expect(markup).toContain('rel="noreferrer"');
   });

--- a/apps/editor/src/components/editor-help-dialog.tsx
+++ b/apps/editor/src/components/editor-help-dialog.tsx
@@ -3,6 +3,8 @@ import type { RefObject } from "react";
 import editorPackage from "../../package.json";
 
 const REPOSITORY_URL = "https://github.com/cascode-ai/analog-canvas";
+const CHANGE_LOG_URL = `${REPOSITORY_URL}/commits/main`;
+const OWNER_URL = "https://www.tokenzhang.com";
 
 const SHORTCUT_GROUPS = [
   {
@@ -212,7 +214,7 @@ export function EditorHelpDialog({
               work to another device.
             </p>
           </section>
-          <section>
+          <section className="help-about">
             <h3>About Analog Canvas</h3>
             <p>
               <strong>Analog Canvas</strong> is a local-first schematic editor
@@ -221,11 +223,20 @@ export function EditorHelpDialog({
             <p>
               Version <strong>{editorPackage.version}</strong>
             </p>
-            <p>
+            <nav
+              className="help-resource-links"
+              aria-label="Analog Canvas resources"
+            >
               <a href={REPOSITORY_URL} target="_blank" rel="noreferrer">
-                {REPOSITORY_URL}
+                Repository
               </a>
-            </p>
+              <a href={CHANGE_LOG_URL} target="_blank" rel="noreferrer">
+                Change Log
+              </a>
+              <a href={OWNER_URL} target="_blank" rel="noreferrer">
+                Owner
+              </a>
+            </nav>
           </section>
         </div>
       </section>

--- a/apps/editor/src/styles/editor-overlays.css
+++ b/apps/editor/src/styles/editor-overlays.css
@@ -391,3 +391,48 @@
   border-radius: var(--icm-radius-md);
   background: linear-gradient(135deg, var(--icm-surface-muted), #fff);
 }
+
+.help-about {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.help-resource-links {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.55rem;
+  margin-top: 0.25rem;
+}
+
+.help-resource-links a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-width: 0;
+  padding: 0.62rem 0.7rem;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-md);
+  background: var(--icm-surface-muted);
+  color: var(--icm-accent);
+  font-size: var(--icm-font-md);
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.help-resource-links a::after {
+  flex: 0 0 auto;
+  color: var(--icm-text-muted);
+  content: "\2197";
+}
+
+.help-resource-links a:hover {
+  border-color: var(--icm-border-strong);
+  background: var(--icm-surface);
+}
+
+@media (max-width: 38rem) {
+  .help-resource-links {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}


### PR DESCRIPTION
## Summary
- replace the raw repository URL in Help with a responsive resource link row
- add a Change Log link to the main-branch history
- add an Owner link to https://www.tokenzhang.com

## Validation
- `pnpm test:local apps/editor/src/components/editor-help-dialog.test.tsx`
- `pnpm gate:preflight -- --base origin/main`
- `pnpm gate:affected -- --base origin/main` (203 files, 1,388 tests)