### PR TITLE
fix(text): stack scripts beneath one overbar

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -105,6 +105,50 @@ async function openSelectionShelf(page: Page): Promise<void> {
   }
 }
 
+async function selectRichTextOffsets(
+  editable: Locator,
+  start: number,
+  end: number,
+): Promise<void> {
+  await editable.evaluate(
+    (root, offsets) => {
+      const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+      const nodes: Text[] = [];
+      let node: Node | null;
+      while ((node = walker.nextNode())) nodes.push(node as Text);
+
+      const boundary = (offset: number, isEnd: boolean): [Text, number] => {
+        let consumed = 0;
+        for (const text of nodes) {
+          const next = consumed + text.data.length;
+          if (
+            (isEnd && offset <= next) ||
+            (!isEnd && (offset < next || text === nodes.at(-1)))
+          ) {
+            return [
+              text,
+              Math.max(0, Math.min(text.data.length, offset - consumed)),
+            ];
+          }
+          consumed = next;
+        }
+        throw new Error("Rich-text selection offset is outside the editor");
+      };
+
+      const [startNode, startOffset] = boundary(offsets.start, false);
+      const [endNode, endOffset] = boundary(offsets.end, true);
+      const range = document.createRange();
+      range.setStart(startNode, startOffset);
+      range.setEnd(endNode, endOffset);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      root.dispatchEvent(new Event("select", { bubbles: true }));
+    },
+    { start, end },
+  );
+}
+
 async function clickRoute(
   page: Page,
   routeId: string,
@@ -1897,8 +1941,8 @@ test("keeps literal text line breaks and overbars visible while editing", async 
   await editor.press("ControlOrMeta+A");
   await page.getByRole("button", { name: "Overbar" }).click();
   await expect(editor.locator('[data-rich-text-style="overbar"]')).toHaveCSS(
-    "text-decoration-line",
-    "overline",
+    "border-top-style",
+    "solid",
   );
   await page.getByRole("button", { name: "Overbar" }).click();
   await expect(editor.locator('[data-rich-text-style="overbar"]')).toHaveCount(
@@ -1915,6 +1959,263 @@ test("keeps literal text line breaks and overbars visible while editing", async 
     page.locator('[data-layer="drafting"] [data-text-run="line-break"]'),
   ).toHaveCount(1);
   await expect(page.locator('[data-layer="drafting"]')).toContainText("Vxbias");
+});
+
+test("stacks complementary scripts under one uninterrupted overbar", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await clickDrawTool(page, "text");
+  const editor = page.getByRole("textbox", { name: "Canvas text editor" });
+  await editor.fill("In22");
+
+  await selectRichTextOffsets(editor, 1, 3);
+  await page.getByRole("button", { name: "Subscript" }).click();
+  await selectRichTextOffsets(editor, 3, 4);
+  await page.getByRole("button", { name: "Superscript" }).click();
+  await selectRichTextOffsets(editor, 0, 4);
+  await page.getByRole("button", { name: "Overbar" }).click();
+
+  const editableOverbar = editor.locator('[data-rich-text-style="overbar"]');
+  const editableStack = editableOverbar.locator(
+    "[data-rich-text-script-stack]",
+  );
+  await expect(editableStack).toHaveCount(1);
+  await expect(editor.locator("[data-rich-text-script-stack]")).toHaveCount(1);
+  const editableLayout = await editableOverbar.evaluate((overbar) => {
+    const stack = overbar.querySelector("[data-rich-text-script-stack]");
+    const superscript = stack?.querySelector("sup");
+    const subscript = stack?.querySelector("sub");
+    if (!superscript || !subscript) {
+      throw new Error("Editable script stack is incomplete");
+    }
+    const superscriptBounds = superscript.getBoundingClientRect();
+    const subscriptBounds = subscript.getBoundingClientRect();
+    const overbarBounds = overbar.getBoundingClientRect();
+    const contentRange = document.createRange();
+    contentRange.selectNodeContents(overbar);
+    const contentBounds = contentRange.getBoundingClientRect();
+    return {
+      scriptOffset: Math.abs(superscriptBounds.left - subscriptBounds.left),
+      superscriptTop: superscriptBounds.top,
+      subscriptTop: subscriptBounds.top,
+      barTop: overbarBounds.top,
+      barLeft: overbarBounds.left,
+      barRight: overbarBounds.right,
+      contentLeft: contentBounds.left,
+      contentRight: contentBounds.right,
+    };
+  });
+  expect(editableLayout.scriptOffset).toBeLessThan(1);
+  expect(editableLayout.superscriptTop).toBeLessThan(
+    editableLayout.subscriptTop,
+  );
+  expect(editableLayout.barTop).toBeLessThanOrEqual(
+    editableLayout.superscriptTop,
+  );
+  expect(
+    Math.abs(editableLayout.barLeft - editableLayout.contentLeft),
+  ).toBeLessThan(1);
+  expect(
+    Math.abs(editableLayout.barRight - editableLayout.contentRight),
+  ).toBeLessThan(1);
+  await expect(editableOverbar).toHaveCSS("border-top-style", "solid");
+
+  await page.getByRole("button", { name: "Apply text changes" }).click();
+  const formalSvg = (await downloadBytes(page, "File", "Export SVG")).toString(
+    "utf8",
+  );
+  const formalLayout = await page.evaluate((source) => {
+    const svg = new DOMParser().parseFromString(source, "image/svg+xml");
+    const lines = [...svg.querySelectorAll('[data-text-decoration="overbar"]')];
+    const line = lines[0];
+    const base = [...svg.querySelectorAll('[data-text-run="base"]')];
+    const superscript = svg.querySelector('[data-text-run="superscript"]');
+    const subscript = svg.querySelector('[data-text-run="subscript"]');
+    if (!line || base.length === 0 || !superscript || !subscript) return null;
+    const numberAttribute = (element: Element, name: string): number =>
+      Number(element.getAttribute(name));
+    const content = [...base, superscript, subscript];
+    const contentLeft = Math.min(
+      ...content.map((run) => numberAttribute(run, "x")),
+    );
+    const contentRight = Math.max(
+      ...content.map(
+        (run) => numberAttribute(run, "x") + numberAttribute(run, "textLength"),
+      ),
+    );
+    const viewBox = (svg.documentElement.getAttribute("viewBox") ?? "")
+      .trim()
+      .split(/\s+/u)
+      .map(Number);
+    return {
+      lineCount: lines.length,
+      text: svg.querySelector('[data-text-run="overbar"]')?.textContent,
+      superscriptX: numberAttribute(superscript, "x"),
+      subscriptX: numberAttribute(subscript, "x"),
+      superscriptY: numberAttribute(superscript, "y"),
+      subscriptY: numberAttribute(subscript, "y"),
+      lineLeft: numberAttribute(line, "x1"),
+      lineRight: numberAttribute(line, "x2"),
+      lineY: numberAttribute(line, "y1"),
+      contentLeft,
+      contentRight,
+      viewBox,
+    };
+  }, formalSvg);
+  expect(formalLayout).not.toBeNull();
+  if (!formalLayout) throw new Error("Formal SVG lacks the positioned formula");
+  expect(formalLayout.lineCount).toBe(1);
+  expect(formalLayout.text).toBe("In22");
+  expect(formalLayout.superscriptX).toBeCloseTo(formalLayout.subscriptX, 6);
+  expect(formalLayout.superscriptY).toBeLessThan(formalLayout.subscriptY);
+  expect(formalLayout.lineLeft).toBeCloseTo(formalLayout.contentLeft, 6);
+  expect(formalLayout.lineRight).toBeCloseTo(formalLayout.contentRight, 6);
+
+  const png = await downloadBytes(page, "File", "Export PNG");
+  expect([...png.subarray(0, 8)]).toEqual([137, 80, 78, 71, 13, 10, 26, 10]);
+  const rasterOverbar = await page.evaluate(
+    async ({ source, lineLeft, lineRight, lineY, viewBox }) => {
+      if (
+        viewBox.length !== 4 ||
+        viewBox.some((value) => !Number.isFinite(value))
+      ) {
+        throw new Error("Formal SVG viewBox is invalid");
+      }
+      const image = new Image();
+      const loaded = new Promise<void>((resolve, reject) => {
+        image.onload = () => resolve();
+        image.onerror = () => reject(new Error("PNG could not be decoded"));
+      });
+      image.src = source;
+      await loaded;
+      const canvas = document.createElement("canvas");
+      canvas.width = image.naturalWidth;
+      canvas.height = image.naturalHeight;
+      const context = canvas.getContext("2d");
+      if (!context) throw new Error("Canvas 2D is unavailable");
+      context.drawImage(image, 0, 0);
+      const pixels = context.getImageData(
+        0,
+        0,
+        canvas.width,
+        canvas.height,
+      ).data;
+      const [viewX, viewY, viewWidth, viewHeight] = viewBox as [
+        number,
+        number,
+        number,
+        number,
+      ];
+      const scaleX = canvas.width / viewWidth;
+      const scaleY = canvas.height / viewHeight;
+      const firstX = Math.ceil((lineLeft - viewX) * scaleX) + 2;
+      const lastX = Math.floor((lineRight - viewX) * scaleX) - 2;
+      const centerY = (lineY - viewY) * scaleY;
+      let sampledColumns = 0;
+      let inkColumns = 0;
+      let blankRun = 0;
+      let longestBlankRun = 0;
+      for (let x = firstX; x <= lastX; x += 1) {
+        sampledColumns += 1;
+        let hasInk = false;
+        for (
+          let y = Math.floor(centerY - 3);
+          y <= Math.ceil(centerY + 3);
+          y += 1
+        ) {
+          if (x < 0 || x >= canvas.width || y < 0 || y >= canvas.height) {
+            continue;
+          }
+          const offset = (y * canvas.width + x) * 4;
+          if (
+            pixels[offset]! < 128 &&
+            pixels[offset + 1]! < 128 &&
+            pixels[offset + 2]! < 128
+          ) {
+            hasInk = true;
+            break;
+          }
+        }
+        if (hasInk) {
+          inkColumns += 1;
+          blankRun = 0;
+        } else {
+          blankRun += 1;
+          longestBlankRun = Math.max(longestBlankRun, blankRun);
+        }
+      }
+      return { sampledColumns, inkColumns, longestBlankRun };
+    },
+    {
+      source: `data:image/png;base64,${png.toString("base64")}`,
+      lineLeft: formalLayout.lineLeft,
+      lineRight: formalLayout.lineRight,
+      lineY: formalLayout.lineY,
+      viewBox: formalLayout.viewBox,
+    },
+  );
+  expect(rasterOverbar.sampledColumns).toBeGreaterThan(5);
+  expect(rasterOverbar.inkColumns).toBe(rasterOverbar.sampledColumns);
+  expect(rasterOverbar.longestBlankRun).toBe(0);
+  const pdf = await downloadBytes(page, "File", "Export PDF");
+  expect(pdf.subarray(0, 5).toString("ascii")).toBe("%PDF-");
+
+  type SavedRichTextRun = {
+    kind: string;
+    value?: string;
+    style?: string;
+    children?: SavedRichTextRun[];
+    numerator?: { runs: SavedRichTextRun[] };
+    denominator?: { runs: SavedRichTextRun[] };
+  };
+  const project = JSON.parse(
+    (await downloadBytes(page, "File", "Save Project")).toString("utf8"),
+  ) as {
+    documents: Array<{
+      drafting: {
+        objects: Array<{
+          kind: string;
+          content?: { runs: SavedRichTextRun[] };
+        }>;
+      };
+    }>;
+  };
+  const textObject = project.documents[0]!.drafting.objects.find(
+    (object) => object.kind === "text",
+  );
+  expect(textObject?.content).toBeTruthy();
+  if (!textObject?.content) throw new Error("Saved drafting text is missing");
+
+  const descendants = (runs: SavedRichTextRun[]): SavedRichTextRun[] =>
+    runs.flatMap((run) => [
+      run,
+      ...(run.children ? descendants(run.children) : []),
+      ...(run.numerator ? descendants(run.numerator.runs) : []),
+      ...(run.denominator ? descendants(run.denominator.runs) : []),
+    ]);
+  const savedRuns = descendants(textObject.content.runs);
+  const overbar = savedRuns.find(
+    (run) => run.kind === "span" && run.style === "overbar",
+  );
+  expect(overbar?.children).toEqual([
+    { kind: "text", value: "I" },
+    {
+      kind: "span",
+      style: "subscript",
+      children: [{ kind: "text", value: "n2" }],
+    },
+    {
+      kind: "span",
+      style: "superscript",
+      children: [{ kind: "text", value: "2" }],
+    },
+  ]);
+  expect(
+    savedRuns.filter(
+      (run) => run.kind === "span" && (run.children?.length ?? 0) === 0,
+    ),
+  ).toEqual([]);
 });
 
 test("L edits a selected route Net Label without opening Properties", async ({

--- a/apps/editor/src/features/text-editing/rich-text-editor.tsx
+++ b/apps/editor/src/features/text-editing/rich-text-editor.tsx
@@ -33,6 +33,34 @@ function escapeHtml(value: string): string {
 }
 
 function toEditableHtml(document: RichTextDocument): string {
+  const isScriptRun = (
+    run: RichTextRun,
+  ): run is Extract<RichTextRun, { kind: "span" }> & {
+    style: "subscript" | "superscript";
+  } =>
+    run.kind === "span" &&
+    (run.style === "subscript" || run.style === "superscript");
+
+  const renderRuns = (runs: RichTextRun[]): string => {
+    let output = "";
+    for (let index = 0; index < runs.length; index += 1) {
+      const run = runs[index]!;
+      const next = runs[index + 1];
+      if (
+        next &&
+        isScriptRun(run) &&
+        isScriptRun(next) &&
+        run.style !== next.style
+      ) {
+        output += `<span data-rich-text-script-stack>${render(run)}${render(next)}</span>`;
+        index += 1;
+        continue;
+      }
+      output += render(run);
+    }
+    return output;
+  };
+
   const render = (run: RichTextRun): string => {
     switch (run.kind) {
       case "text":
@@ -43,9 +71,9 @@ function toEditableHtml(document: RichTextDocument): string {
         // Editing surfaces a fraction in its slash form; committing that
         // text replaces the fraction with plain runs, which the value
         // refresh deliberately treats as hand-edited content.
-        return `${run.numerator.runs.map(render).join("")}/${run.denominator.runs.map(render).join("")}`;
+        return `${renderRuns(run.numerator.runs)}/${renderRuns(run.denominator.runs)}`;
       case "span": {
-        const children = run.children.map(render).join("");
+        const children = renderRuns(run.children);
         if (run.style === "overbar") {
           return `<span data-rich-text-style="overbar">${children}</span>`;
         }
@@ -61,7 +89,7 @@ function toEditableHtml(document: RichTextDocument): string {
       }
     }
   };
-  return document.runs.map(render).join("");
+  return renderRuns(document.runs);
 }
 
 function isElement(node: Node): node is HTMLElement {
@@ -90,6 +118,7 @@ function readNode(node: Node): RichTextRun[] {
   const tag = node.tagName.toLowerCase();
   if (tag === "br") return [{ kind: "line-break" }];
   const children = readChildren(node);
+  if (children.length === 0 && tag !== "div" && tag !== "p") return [];
   if (tag === "strong" || tag === "b") {
     return [{ kind: "span", style: "bold", children }];
   }
@@ -109,6 +138,51 @@ function readNode(node: Node): RichTextRun[] {
     return [...children, { kind: "line-break" }];
   }
   return children;
+}
+
+function isScriptElement(node: Node): node is HTMLElement {
+  return (
+    isElement(node) &&
+    (node.tagName.toLowerCase() === "sub" ||
+      node.tagName.toLowerCase() === "sup")
+  );
+}
+
+/** Keep the browser's editable DOM aligned with the canonical script layout. */
+function normalizeEditableMarkup(editable: HTMLElement): void {
+  const formattingElements = [
+    ...editable.querySelectorAll<HTMLElement>(
+      "sub, sup, strong, em, b, i, span",
+    ),
+  ].reverse();
+  formattingElements.forEach((element) => {
+    if (!element.textContent && !element.querySelector("br")) element.remove();
+  });
+
+  const containers: HTMLElement[] = [
+    editable,
+    ...editable.querySelectorAll<HTMLElement>("*"),
+  ];
+  for (const container of containers) {
+    if (container.hasAttribute("data-rich-text-script-stack")) continue;
+    const children = [...container.childNodes];
+    for (let index = 0; index < children.length - 1; index += 1) {
+      const first = children[index]!;
+      const second = children[index + 1]!;
+      if (
+        !isScriptElement(first) ||
+        !isScriptElement(second) ||
+        first.tagName === second.tagName
+      ) {
+        continue;
+      }
+      const stack = globalThis.document.createElement("span");
+      stack.setAttribute("data-rich-text-script-stack", "");
+      container.insertBefore(stack, first);
+      stack.append(first, second);
+      index += 1;
+    }
+  }
 }
 
 function editableDocument(element: HTMLElement): RichTextDocument {
@@ -203,6 +277,7 @@ export function RichTextEditor({
         while (startOverbar.firstChild)
           contents.append(startOverbar.firstChild);
         parent.replaceChild(contents, startOverbar);
+        normalizeEditableMarkup(editableRef.current);
         rememberSelection();
         sync();
         return;
@@ -222,6 +297,7 @@ export function RichTextEditor({
     } else {
       document.execCommand(name);
     }
+    normalizeEditableMarkup(editableRef.current);
     rememberSelection();
     sync();
   };

--- a/apps/editor/src/styles/editor-canvas.css
+++ b/apps/editor/src/styles/editor-canvas.css
@@ -493,8 +493,36 @@
 
 .rich-text-editable[data-rich-text-style="overbar"],
 .rich-text-editable [data-rich-text-style="overbar"] {
-  text-decoration-line: overline;
-  text-decoration-thickness: 1px;
+  display: inline-block;
+  box-sizing: content-box;
+  padding-top: 0.04em;
+  border-top: 1px solid currentcolor;
+  line-height: 1;
+  text-decoration: none;
+}
+
+.rich-text-editable [data-rich-text-script-stack] {
+  display: inline-grid;
+  margin-left: 0.046em;
+  line-height: 1;
+  vertical-align: baseline;
+}
+
+.rich-text-editable [data-rich-text-script-stack] > sub,
+.rich-text-editable [data-rich-text-script-stack] > sup {
+  position: relative;
+  grid-area: 1 / 1;
+  font-size: 76%;
+  line-height: 1;
+  vertical-align: baseline;
+}
+
+.rich-text-editable [data-rich-text-script-stack] > sup {
+  top: -0.28em;
+}
+
+.rich-text-editable [data-rich-text-script-stack] > sub {
+  top: 0.28em;
 }
 
 .rich-text-source-input {

--- a/packages/derived/src/rich-text-layout.test.ts
+++ b/packages/derived/src/rich-text-layout.test.ts
@@ -7,6 +7,7 @@ import {
   fractionGeometry,
   fractionPartScale,
   measureRichTextDocument,
+  richTextAdvanceEm,
   richTextMetrics,
 } from "./rich-text-layout.js";
 import { razaviTextbookProfile } from "./style-profile.js";
@@ -46,6 +47,52 @@ describe("shared rich-text layout", () => {
     expect(razaviScaled.width).toBe(base.width * 2);
   });
 
+  it("keeps automatic bounds at least as wide as positioned glyph advances", () => {
+    const metrics = richTextMetrics(razaviTextbookProfile);
+    const expression = (base: string): RichTextDocument => ({
+      runs: [
+        {
+          kind: "span",
+          style: "overbar",
+          children: [
+            { kind: "text", value: base },
+            {
+              kind: "span",
+              style: "subscript",
+              children: [{ kind: "text", value: "n2" }],
+            },
+            {
+              kind: "span",
+              style: "superscript",
+              children: [{ kind: "text", value: "2" }],
+            },
+          ],
+        },
+      ],
+    });
+    const wideText = "WWWWWWWWWWW";
+    const narrowText = "iiiiiiiiiii";
+    const wide = measureRichTextDocument(expression(wideText), metrics);
+    const narrow = measureRichTextDocument(expression(narrowText), metrics);
+    const scriptWidth =
+      metrics.subscriptScale *
+      Math.max(richTextAdvanceEm("n2"), richTextAdvanceEm("2"));
+
+    expect(wide.width).toBeGreaterThanOrEqual(
+      (richTextAdvanceEm(wideText) +
+        metrics.subscriptHorizontalGapEm +
+        scriptWidth) *
+        metrics.fontSize,
+    );
+    expect(narrow.width).toBeGreaterThanOrEqual(
+      (richTextAdvanceEm(narrowText) +
+        metrics.subscriptHorizontalGapEm +
+        scriptWidth) *
+        metrics.fontSize,
+    );
+    expect(wide.width).toBeGreaterThan(narrow.width);
+  });
+
   it("uses the profile baseline shift when reserving subscript bounds", () => {
     const metrics = {
       ...richTextMetrics(razaviTextbookProfile),
@@ -68,6 +115,41 @@ describe("shared rich-text layout", () => {
           metrics.lineHeight,
           metrics.subscriptScale + metrics.subscriptBaselineShiftEm,
         ),
+    );
+  });
+
+  it("places adjacent subscript and superscript in one attachment column", () => {
+    const metrics = richTextMetrics(razaviTextbookProfile);
+    const content = {
+      runs: [
+        { kind: "text", value: "I" },
+        {
+          kind: "span",
+          style: "superscript",
+          children: [{ kind: "text", value: "2" }],
+        },
+        {
+          kind: "span",
+          style: "subscript",
+          children: [{ kind: "text", value: "n2" }],
+        },
+      ],
+    } as RichTextDocument;
+    const layout = measureRichTextDocument(content, metrics);
+    const baseWidth = metrics.fontSize * 0.6;
+    const scriptWidth = metrics.fontSize * metrics.subscriptScale * 0.6 * 2;
+    const attachmentGap = metrics.fontSize * metrics.subscriptHorizontalGapEm;
+
+    expect(layout.width).toBeCloseTo(baseWidth + attachmentGap + scriptWidth);
+    expect(layout.width).toBeLessThan(
+      baseWidth +
+        attachmentGap +
+        metrics.fontSize * metrics.subscriptScale * 0.6 * 3,
+    );
+    expect(layout.height).toBeCloseTo(
+      metrics.fontSize *
+        (metrics.subscriptScale * metrics.lineHeight +
+          2 * metrics.subscriptBaselineShiftEm),
     );
   });
 

--- a/packages/derived/src/rich-text-layout.ts
+++ b/packages/derived/src/rich-text-layout.ts
@@ -7,6 +7,7 @@ export interface RichTextMetrics {
   lineHeight: number;
   subscriptScale: number;
   subscriptBaselineShiftEm: number;
+  subscriptHorizontalGapEm: number;
 }
 
 export interface RichTextLayout {
@@ -14,6 +15,31 @@ export interface RichTextLayout {
   height: number;
   lineWidths: number[];
   lineHeights: number[];
+}
+
+/**
+ * Deterministic proportional advance used by explicitly positioned rich text.
+ * Matching export bounds reserve at least the same width, so wide glyph runs
+ * cannot outgrow their automatic crop.
+ */
+function richTextGlyphAdvanceEm(glyph: string): number {
+  if (/\s/u.test(glyph)) return 0.32;
+  if (/[ilI1|!.,:;'`]/u.test(glyph)) return 0.36;
+  if (/[MW@%&Ω]/u.test(glyph)) return 0.9;
+  if (/[mw]/u.test(glyph)) return 0.78;
+  if (/[A-Z]/u.test(glyph)) return 0.67;
+  if (/[a-zα-ω]/u.test(glyph)) return 0.56;
+  if (/[0-9x]/u.test(glyph)) return 0.5;
+  if (/[+≈≤≥=<>]/u.test(glyph)) return 0.57;
+  if (/[-−]/u.test(glyph)) return 0.33;
+  return 0.6;
+}
+
+export function richTextAdvanceEm(value: string): number {
+  return [...value].reduce(
+    (sum, glyph) => sum + richTextGlyphAdvanceEm(glyph),
+    0,
+  );
 }
 
 /**
@@ -79,6 +105,7 @@ export function richTextMetrics(
     lineHeight: profile.typography.lineHeight,
     subscriptScale: profile.typography.subscriptScale,
     subscriptBaselineShiftEm: profile.typography.subscriptBaselineShiftEm,
+    subscriptHorizontalGapEm: profile.typography.subscriptHorizontalGapEm,
   };
 }
 
@@ -99,12 +126,123 @@ export function measureRichTextDocument(
 function measureRuns(runs: RichTextRun[], metrics: RichTextMetrics): Line[] {
   const baseHeight = metrics.fontSize * metrics.lineHeight;
   const lines: Line[] = [{ width: 0, height: baseHeight }];
-  for (const run of runs) {
+  for (let index = 0; index < runs.length; index += 1) {
+    const run = runs[index]!;
     if (run.kind === "line-break") {
       lines.push({ width: 0, height: baseHeight });
       continue;
     }
+    const next = runs[index + 1];
+    if (
+      next &&
+      isScriptRun(run) &&
+      isScriptRun(next) &&
+      run.style !== next.style
+    ) {
+      appendInline(lines, measureScriptStack(run, next, metrics));
+      index += 1;
+      continue;
+    }
     appendInline(lines, measureRun(run, metrics));
+  }
+  return lines;
+}
+
+type ScriptRun = Extract<RichTextRun, { kind: "span" }> & {
+  style: "subscript" | "superscript";
+};
+
+function isScriptRun(run: RichTextRun | undefined): run is ScriptRun {
+  return (
+    run?.kind === "span" &&
+    (run.style === "subscript" || run.style === "superscript")
+  );
+}
+
+function unwrapWholeTextStyleRuns(initialRuns: RichTextRun[]): RichTextRun[] {
+  let runs = initialRuns;
+  while (
+    runs.length === 1 &&
+    runs[0]!.kind === "span" &&
+    (runs[0]!.style === "italic" || runs[0]!.style === "bold")
+  ) {
+    runs = runs[0]!.children;
+  }
+  return runs;
+}
+
+function plainStyledText(runs: RichTextRun[]): string | null {
+  let text = "";
+  const visit = (run: RichTextRun): boolean => {
+    if (run.kind === "text") {
+      text += run.value;
+      return true;
+    }
+    if (
+      run.kind === "span" &&
+      (run.style === "italic" || run.style === "bold")
+    ) {
+      return run.children.every(visit);
+    }
+    return false;
+  };
+  return runs.every(visit) && text.length > 0 ? text : null;
+}
+
+function positionedOverbarScriptWidth(
+  initialRuns: RichTextRun[],
+  metrics: RichTextMetrics,
+): number | null {
+  const runs = unwrapWholeTextStyleRuns(initialRuns);
+  if (runs.length < 3) return null;
+  const firstScript = runs.at(-2);
+  const secondScript = runs.at(-1);
+  if (
+    !isScriptRun(firstScript) ||
+    !isScriptRun(secondScript) ||
+    firstScript.style === secondScript.style
+  ) {
+    return null;
+  }
+  const base = plainStyledText(runs.slice(0, -2));
+  const firstText = plainStyledText(firstScript.children);
+  const secondText = plainStyledText(secondScript.children);
+  if (!base || !firstText || !secondText) return null;
+  return (
+    metrics.fontSize *
+    (richTextAdvanceEm(base) +
+      metrics.subscriptHorizontalGapEm +
+      metrics.subscriptScale *
+        Math.max(richTextAdvanceEm(firstText), richTextAdvanceEm(secondText)))
+  );
+}
+
+/** Adjacent complementary scripts share one attachment column. */
+function measureScriptStack(
+  first: ScriptRun,
+  second: ScriptRun,
+  metrics: RichTextMetrics,
+): Line[] {
+  const firstLines = measureRun(first, metrics);
+  const secondLines = measureRun(second, metrics);
+  const lineCount = Math.max(firstLines.length, secondLines.length);
+  const lines: Line[] = [];
+  for (let index = 0; index < lineCount; index += 1) {
+    const firstLine = firstLines[index];
+    const secondLine = secondLines[index];
+    lines.push({
+      width: Math.max(firstLine?.width ?? 0, secondLine?.width ?? 0),
+      height: Math.max(firstLine?.height ?? 0, secondLine?.height ?? 0),
+    });
+  }
+  if (lines[0]) {
+    lines[0].width += metrics.fontSize * metrics.subscriptHorizontalGapEm;
+    lines[0].height = Math.max(
+      lines[0].height,
+      metrics.fontSize *
+        (metrics.subscriptScale * metrics.lineHeight +
+          2 * metrics.subscriptBaselineShiftEm),
+    );
   }
   return lines;
 }
@@ -133,6 +271,15 @@ function measureRun(run: RichTextRun, metrics: RichTextMetrics): Line[] {
       ...metrics,
       fontSize: metrics.fontSize * scale,
     });
+    if (run.style === "overbar" && child[0]) {
+      const positionedWidth = positionedOverbarScriptWidth(
+        run.children,
+        metrics,
+      );
+      if (positionedWidth !== null) {
+        child[0].width = Math.max(child[0].width, positionedWidth);
+      }
+    }
     if (scale < 1) {
       const shift = metrics.fontSize * metrics.subscriptBaselineShiftEm;
       child.forEach((line) => {

--- a/packages/render-svg/src/drafting-render.test.ts
+++ b/packages/render-svg/src/drafting-render.test.ts
@@ -55,6 +55,59 @@ describe("drafting layer rendering", () => {
     expect(svg).not.toContain("a<b>&c");
   });
 
+  it("renders a squared subscript under one explicit overbar", () => {
+    const document = createEmptyDocument("doc", "Squared noise current");
+    document.drafting = {
+      objects: [
+        {
+          id: "noise-current",
+          kind: "text",
+          locked: false,
+          zIndex: 0,
+          anchor: { kind: "free", position: { x: 100, y: 100 } },
+          content: {
+            runs: [
+              {
+                kind: "span",
+                style: "overbar",
+                children: [
+                  { kind: "text", value: "I" },
+                  {
+                    kind: "span",
+                    style: "subscript",
+                    children: [{ kind: "text", value: "n2" }],
+                  },
+                  {
+                    kind: "span",
+                    style: "superscript",
+                    children: [{ kind: "text", value: "2" }],
+                  },
+                ],
+              },
+            ],
+          },
+          alignment: "start",
+          rotation: 0,
+        },
+      ],
+    };
+
+    const svg = renderDocumentSvg(document, resolver);
+    const subscript = svg.match(
+      /<tspan data-text-run="subscript" x="([^"]+)" y="([^"]+)"/u,
+    );
+    const superscript = svg.match(
+      /<tspan data-text-run="superscript" x="([^"]+)" y="([^"]+)"/u,
+    );
+
+    expect(subscript).not.toBeNull();
+    expect(superscript).not.toBeNull();
+    expect(subscript?.[1]).toBe(superscript?.[1]);
+    expect(Number(superscript?.[2])).toBeLessThan(Number(subscript?.[2]));
+    expect(svg.match(/data-text-decoration="overbar"/gu)).toHaveLength(1);
+    expect(svg).not.toContain("&#160;");
+  });
+
   it("omits the drafting group when there are no drafting objects", () => {
     const document = createEmptyDocument("doc", "Empty");
     const svg = renderDocumentSvg(document, resolver);

--- a/packages/render-svg/src/positioned-rich-text.test.ts
+++ b/packages/render-svg/src/positioned-rich-text.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+
+import { razaviTextbookProfile } from "@icm/derived";
+import type { RichTextDocument, RichTextRun } from "@icm/model";
+
+import { renderPositionedOverbarScriptDocument } from "./positioned-rich-text.js";
+
+type ScriptStyle = "subscript" | "superscript";
+
+function overbarExpression(options?: {
+  base?: string;
+  subscript?: string;
+  superscript?: string;
+  order?: readonly ScriptStyle[];
+}): RichTextDocument {
+  const subscript = options?.subscript ?? "n2";
+  const superscript = options?.superscript ?? "2";
+  const scriptText: Record<ScriptStyle, string> = { subscript, superscript };
+  const scripts = (options?.order ?? ["subscript", "superscript"]).map(
+    (style): RichTextRun => ({
+      kind: "span",
+      style,
+      children: [{ kind: "text", value: scriptText[style] }],
+    }),
+  );
+
+  return {
+    runs: [
+      {
+        kind: "span",
+        style: "overbar",
+        children: [{ kind: "text", value: options?.base ?? "I" }, ...scripts],
+      },
+    ],
+  };
+}
+
+function render(document: RichTextDocument) {
+  const rendered = renderPositionedOverbarScriptDocument(
+    document,
+    razaviTextbookProfile,
+    {
+      x: 100,
+      y: 50,
+      fontSize: 20,
+      alignment: "start",
+    },
+  );
+  expect(rendered).not.toBeNull();
+  if (!rendered) throw new Error("Expected the positioned renderer to match");
+  return rendered;
+}
+
+function tagAttributes(
+  markup: string,
+  tagName: "line" | "tspan",
+  identifyingAttribute: string,
+): Record<string, string> {
+  const tag = markup.match(
+    new RegExp(`<${tagName}[^>]*${identifyingAttribute}[^>]*>`),
+  )?.[0];
+  if (!tag) {
+    throw new Error(
+      `Missing <${tagName}> with ${identifyingAttribute} in ${markup}`,
+    );
+  }
+
+  return Object.fromEntries(
+    [...tag.matchAll(/([\w:-]+)="([^"]*)"/g)].map((match) => [
+      match[1]!,
+      match[2]!,
+    ]),
+  );
+}
+
+function numericAttribute(
+  attributes: Record<string, string>,
+  name: string,
+): number {
+  const value = Number(attributes[name]);
+  if (!Number.isFinite(value)) throw new Error(`Missing numeric ${name}`);
+  return value;
+}
+
+describe("renderPositionedOverbarScriptDocument", () => {
+  it("stacks I sub n2 and sup 2 at one attachment column under one exact overbar", () => {
+    const rendered = render(overbarExpression());
+    const base = tagAttributes(
+      rendered.tspans,
+      "tspan",
+      'data-text-run="base"',
+    );
+    const subscript = tagAttributes(
+      rendered.tspans,
+      "tspan",
+      'data-text-run="subscript"',
+    );
+    const superscript = tagAttributes(
+      rendered.tspans,
+      "tspan",
+      'data-text-run="superscript"',
+    );
+    const overbar = tagAttributes(
+      rendered.decorations,
+      "line",
+      'data-text-decoration="overbar"',
+    );
+
+    const subscriptX = numericAttribute(subscript, "x");
+    const superscriptX = numericAttribute(superscript, "x");
+    expect(subscriptX).toBe(superscriptX);
+    expect(numericAttribute(superscript, "y")).toBeLessThan(
+      numericAttribute(base, "y"),
+    );
+    expect(numericAttribute(subscript, "y")).toBeGreaterThan(
+      numericAttribute(base, "y"),
+    );
+
+    const lineX1 = numericAttribute(overbar, "x1");
+    const lineX2 = numericAttribute(overbar, "x2");
+    const contentRight = Math.max(
+      subscriptX + numericAttribute(subscript, "textLength"),
+      superscriptX + numericAttribute(superscript, "textLength"),
+    );
+    expect(lineX1).toBe(numericAttribute(base, "x"));
+    expect(lineX2).toBeCloseTo(lineX1 + rendered.width, 6);
+    expect(lineX2).toBeCloseTo(contentRight, 6);
+    expect(numericAttribute(overbar, "y1")).toBe(
+      numericAttribute(overbar, "y2"),
+    );
+    expect(rendered.decorations.match(/<line\b/g)).toHaveLength(1);
+  });
+
+  it("preserves a superscript-before-subscript document while sharing its attachment column", () => {
+    const rendered = render(
+      overbarExpression({ order: ["superscript", "subscript"] }),
+    );
+    const subscript = tagAttributes(
+      rendered.tspans,
+      "tspan",
+      'data-text-run="subscript"',
+    );
+    const superscript = tagAttributes(
+      rendered.tspans,
+      "tspan",
+      'data-text-run="superscript"',
+    );
+
+    expect(rendered.tspans.indexOf('data-text-run="superscript"')).toBeLessThan(
+      rendered.tspans.indexOf('data-text-run="subscript"'),
+    );
+    expect(numericAttribute(subscript, "x")).toBe(
+      numericAttribute(superscript, "x"),
+    );
+    expect(numericAttribute(superscript, "y")).toBeLessThan(
+      numericAttribute(subscript, "y"),
+    );
+  });
+
+  it("gives proportional WW and ii text different advances and exact line endpoints", () => {
+    const wideBase = render(overbarExpression({ base: "WW" }));
+    const narrowBase = render(overbarExpression({ base: "ii" }));
+    const wideScript = tagAttributes(
+      wideBase.tspans,
+      "tspan",
+      'data-text-run="subscript"',
+    );
+    const narrowScript = tagAttributes(
+      narrowBase.tspans,
+      "tspan",
+      'data-text-run="subscript"',
+    );
+
+    expect(numericAttribute(wideScript, "x")).toBeGreaterThan(
+      numericAttribute(narrowScript, "x"),
+    );
+    expect(wideBase.width).toBeGreaterThan(narrowBase.width);
+
+    const mixedScripts = render(
+      overbarExpression({ subscript: "WW", superscript: "ii" }),
+    );
+    const subscript = tagAttributes(
+      mixedScripts.tspans,
+      "tspan",
+      'data-text-run="subscript"',
+    );
+    const superscript = tagAttributes(
+      mixedScripts.tspans,
+      "tspan",
+      'data-text-run="superscript"',
+    );
+    const overbar = tagAttributes(
+      mixedScripts.decorations,
+      "line",
+      'data-text-decoration="overbar"',
+    );
+    expect(numericAttribute(subscript, "textLength")).toBeGreaterThan(
+      numericAttribute(superscript, "textLength"),
+    );
+    expect(numericAttribute(overbar, "x2")).toBeCloseTo(
+      numericAttribute(subscript, "x") +
+        numericAttribute(subscript, "textLength"),
+      6,
+    );
+  });
+
+  it("leaves a plain overbar to the general rich-text renderer", () => {
+    expect(
+      renderPositionedOverbarScriptDocument(
+        {
+          runs: [
+            {
+              kind: "span",
+              style: "overbar",
+              children: [{ kind: "text", value: "Vout" }],
+            },
+          ],
+        },
+        razaviTextbookProfile,
+        { x: 0, y: 0, fontSize: 20, alignment: "start" },
+      ),
+    ).toBeNull();
+  });
+
+  it("leaves multiline overbars to the general rich-text renderer", () => {
+    const document = overbarExpression();
+    const overbar = document.runs[0];
+    if (overbar?.kind !== "span") throw new Error("Expected an overbar span");
+    overbar.children.splice(1, 0, { kind: "line-break" });
+
+    expect(
+      renderPositionedOverbarScriptDocument(document, razaviTextbookProfile, {
+        x: 0,
+        y: 0,
+        fontSize: 20,
+        alignment: "start",
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/render-svg/src/positioned-rich-text.ts
+++ b/packages/render-svg/src/positioned-rich-text.ts
@@ -1,0 +1,260 @@
+import { richTextAdvanceEm } from "@icm/derived";
+import type { SchematicStyleProfile } from "@icm/derived";
+import type { RichTextDocument, RichTextRun } from "@icm/model";
+
+interface TextStyle {
+  italic: boolean;
+  bold: boolean;
+}
+
+interface TextSegment extends TextStyle {
+  text: string;
+}
+
+type ScriptRun = Extract<RichTextRun, { kind: "span" }> & {
+  style: "subscript" | "superscript";
+};
+
+export interface PositionedOverbarScript {
+  tspans: string;
+  decorations: string;
+  width: number;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function number(value: number): string {
+  return String(Number(value.toFixed(6)));
+}
+
+function isScriptRun(run: RichTextRun | undefined): run is ScriptRun {
+  return (
+    run?.kind === "span" &&
+    (run.style === "subscript" || run.style === "superscript")
+  );
+}
+
+function unwrapWholeTextStyles(
+  initialRuns: RichTextRun[],
+  initialStyle: TextStyle,
+): { runs: RichTextRun[]; style: TextStyle } {
+  let runs = initialRuns;
+  let style = initialStyle;
+  while (
+    runs.length === 1 &&
+    runs[0]!.kind === "span" &&
+    (runs[0]!.style === "italic" || runs[0]!.style === "bold")
+  ) {
+    const span = runs[0] as Extract<RichTextRun, { kind: "span" }>;
+    style = {
+      italic: style.italic || span.style === "italic",
+      bold: style.bold || span.style === "bold",
+    };
+    runs = span.children;
+  }
+  return { runs, style };
+}
+
+function plainSegments(
+  runs: RichTextRun[],
+  inherited: TextStyle,
+): TextSegment[] | null {
+  const segments: TextSegment[] = [];
+  const visit = (run: RichTextRun, style: TextStyle): boolean => {
+    if (run.kind === "text") {
+      const previous = segments.at(-1);
+      if (
+        previous &&
+        previous.italic === style.italic &&
+        previous.bold === style.bold
+      ) {
+        previous.text += run.value;
+      } else {
+        segments.push({ text: run.value, ...style });
+      }
+      return true;
+    }
+    if (
+      run.kind === "span" &&
+      (run.style === "italic" || run.style === "bold")
+    ) {
+      return run.children.every((child) =>
+        visit(child, {
+          italic: style.italic || run.style === "italic",
+          bold: style.bold || run.style === "bold",
+        }),
+      );
+    }
+    return false;
+  };
+  return runs.every((run) => visit(run, inherited)) && segments.length > 0
+    ? segments
+    : null;
+}
+
+function segmentWidth(
+  segment: TextSegment,
+  fontSize: number,
+  scale: number,
+): number {
+  return richTextAdvanceEm(segment.text) * fontSize * scale;
+}
+
+function segmentsWidth(
+  segments: TextSegment[],
+  fontSize: number,
+  scale: number,
+): number {
+  return segments.reduce(
+    (sum, segment) => sum + segmentWidth(segment, fontSize, scale),
+    0,
+  );
+}
+
+function styleAttribute(
+  segment: TextSegment,
+  profile: SchematicStyleProfile,
+): string {
+  return `font-style:${segment.italic ? "italic" : "normal"};font-weight:${segment.bold ? profile.typography.mathWeight : profile.typography.plainWeight}`;
+}
+
+function renderSegments(
+  segments: TextSegment[],
+  options: {
+    x: number;
+    y: number;
+    fontSize: number;
+    scale: number;
+    run: "base" | "subscript" | "superscript";
+    profile: SchematicStyleProfile;
+  },
+): string {
+  let x = options.x;
+  let output = "";
+  for (const segment of segments) {
+    const width = segmentWidth(segment, options.fontSize, options.scale);
+    output += `<tspan data-text-run="${options.run}" x="${number(x)}" y="${number(options.y)}" text-anchor="start" font-size="${number(options.fontSize * options.scale)}" textLength="${number(width)}" lengthAdjust="spacingAndGlyphs" style="${styleAttribute(segment, options.profile)}">${escapeXml(segment.text)}</tspan>`;
+    x += width;
+  }
+  return output;
+}
+
+/**
+ * Position the one expression shape that SVG inline text cannot represent:
+ * an overbar spanning a base with attached complementary sub/superscripts.
+ * Each proportional-font segment receives an explicit deterministic width,
+ * so Chromium and Resvg share the same attachment column and line endpoints.
+ */
+export function renderPositionedOverbarScriptDocument(
+  document: RichTextDocument,
+  profile: SchematicStyleProfile,
+  options: {
+    x: number;
+    y: number;
+    fontSize: number;
+    alignment: "start" | "middle" | "end";
+    defaultItalic?: boolean;
+    defaultBold?: boolean;
+  },
+): PositionedOverbarScript | null {
+  const outer = unwrapWholeTextStyles(document.runs, {
+    italic: options.defaultItalic ?? false,
+    bold: options.defaultBold ?? false,
+  });
+  if (
+    outer.runs.length !== 1 ||
+    outer.runs[0]!.kind !== "span" ||
+    outer.runs[0]!.style !== "overbar"
+  ) {
+    return null;
+  }
+
+  const overbar = outer.runs[0] as Extract<RichTextRun, { kind: "span" }>;
+  const expression = unwrapWholeTextStyles(overbar.children, outer.style);
+  if (expression.runs.length < 3) return null;
+  const firstScript = expression.runs.at(-2);
+  const secondScript = expression.runs.at(-1);
+  if (
+    !isScriptRun(firstScript) ||
+    !isScriptRun(secondScript) ||
+    firstScript.style === secondScript.style
+  ) {
+    return null;
+  }
+
+  const base = plainSegments(expression.runs.slice(0, -2), expression.style);
+  const scripts = [firstScript, secondScript] as const;
+  const subscriptRun = scripts.find((run) => run.style === "subscript")!;
+  const superscriptRun = scripts.find((run) => run.style === "superscript")!;
+  const scriptStyle = { italic: false, bold: expression.style.bold };
+  const subscript = plainSegments(subscriptRun.children, scriptStyle);
+  const superscript = plainSegments(superscriptRun.children, scriptStyle);
+  if (!base || !subscript || !superscript) return null;
+
+  const scale = profile.typography.subscriptScale;
+  const baseWidth = segmentsWidth(base, options.fontSize, 1);
+  const subscriptWidth = segmentsWidth(subscript, options.fontSize, scale);
+  const superscriptWidth = segmentsWidth(superscript, options.fontSize, scale);
+  const attachmentGap =
+    options.fontSize * profile.typography.subscriptHorizontalGapEm;
+  const width =
+    baseWidth + attachmentGap + Math.max(subscriptWidth, superscriptWidth);
+  const startX =
+    options.alignment === "start"
+      ? options.x
+      : options.alignment === "end"
+        ? options.x - width
+        : options.x - width / 2;
+  const scriptX = startX + baseWidth + attachmentGap;
+  const shift =
+    options.fontSize * scale * profile.typography.subscriptBaselineShiftEm;
+  const superscriptY = options.y - shift;
+  const subscriptY = options.y + shift;
+
+  const baseTspans = renderSegments(base, {
+    x: startX,
+    y: options.y,
+    fontSize: options.fontSize,
+    scale: 1,
+    run: "base",
+    profile,
+  });
+  const subscriptTspans = renderSegments(subscript, {
+    x: scriptX,
+    y: subscriptY,
+    fontSize: options.fontSize,
+    scale,
+    run: "subscript",
+    profile,
+  });
+  const superscriptTspans = renderSegments(superscript, {
+    x: scriptX,
+    y: superscriptY,
+    fontSize: options.fontSize,
+    scale,
+    run: "superscript",
+    profile,
+  });
+  const orderedScripts = scripts
+    .map((run) =>
+      run.style === "subscript" ? subscriptTspans : superscriptTspans,
+    )
+    .join("");
+
+  const glyphAscent = 0.78;
+  const overbarGap = options.fontSize * 0.08;
+  const baseTop = options.y - options.fontSize * glyphAscent;
+  const superscriptTop = superscriptY - options.fontSize * scale * glyphAscent;
+  const lineY = Math.min(baseTop, superscriptTop) - overbarGap;
+  const strokeWidth = Math.max(1, profile.strokes.annotation);
+  return {
+    width,
+    tspans: `<tspan data-text-run="overbar">${baseTspans}<tspan data-text-run="script-stack">${orderedScripts}</tspan></tspan>`,
+    decorations: `<line data-text-decoration="overbar" x1="${number(startX)}" y1="${number(lineY)}" x2="${number(startX + width)}" y2="${number(lineY)}" stroke="${profile.foreground}" stroke-width="${number(strokeWidth)}"/>`,
+  };
+}

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -49,6 +49,7 @@ import {
   schematicTextFontSize,
   schematicTextSizeAttribute,
 } from "./schematic-text.js";
+import { renderPositionedOverbarScriptDocument } from "./positioned-rich-text.js";
 import { renderRichTextDocument } from "./rich-text.js";
 
 export interface SvgRenderOptions {
@@ -900,14 +901,29 @@ function renderDraftText(
     object.anchor.kind === "object"
       ? centeredFirstBaselineY(object.content, position.y, fontSize, profile)
       : position.y;
-  const content = renderRichTextDocument(object.content, profile, {
-    lineOriginX: position.x,
-  });
   const weight = object.styleOverride?.weight === "bold" ? "bold" : "normal";
   const italic = object.styleOverride?.italic === true ? "italic" : "normal";
+  const positioned = renderPositionedOverbarScriptDocument(
+    object.content,
+    profile,
+    {
+      x: position.x,
+      y: baselineY,
+      fontSize,
+      alignment: object.alignment,
+      defaultBold: weight === "bold",
+      defaultItalic: italic === "italic",
+    },
+  );
   // P1: the renderer consumes geometry.rotation (the single rotation truth),
   // not the raw persisted object rotation. The rotation pivot stays on the
   // resolved anchor so centered labels rotate about their center.
+  if (positioned) {
+    return `<g transform="rotate(${rotation} ${position.x} ${position.y})"><text data-object-id="${object.id}" data-kind="draft-text"${unresolved} x="${position.x}" y="${baselineY}" text-anchor="start" font-size="${fontSize}" font-weight="${weight}" font-style="${italic}">${positioned.tspans}</text>${positioned.decorations}</g>`;
+  }
+  const content = renderRichTextDocument(object.content, profile, {
+    lineOriginX: position.x,
+  });
   return `<text data-object-id="${object.id}" data-kind="draft-text"${unresolved} x="${position.x}" y="${baselineY}" text-anchor="${object.alignment}" transform="rotate(${rotation} ${position.x} ${position.y})" font-size="${fontSize}" font-weight="${weight}" font-style="${italic}">${content}</text>`;
 }
 

--- a/packages/render-svg/src/rich-text.test.ts
+++ b/packages/render-svg/src/rich-text.test.ts
@@ -60,6 +60,27 @@ describe("renderRichTextDocument", () => {
     expect(svg).not.toContain('font-style:normal;font-weight:700">gm');
   });
 
+  it("keeps a plain overbar on the general renderer without spacer text", () => {
+    const svg = renderRichTextDocument(
+      {
+        runs: [
+          {
+            kind: "span",
+            style: "overbar",
+            children: [{ kind: "text", value: "Vout" }],
+          },
+        ],
+      },
+      razaviTextbookProfile,
+    );
+
+    expect(svg).toContain('data-text-run="overbar"');
+    expect(svg).toContain("text-decoration:overline");
+    expect(svg).toContain(">Vout</tspan>");
+    expect(svg).not.toContain("&#160;");
+    expect(svg).not.toContain("letter-spacing");
+  });
+
   it("renders subscript and superscript with scaled size and baseline shift", () => {
     const svg = renderRichTextDocument(
       {


### PR DESCRIPTION
Summary:
- stack complementary subscript and superscript runs at one attachment column in the rich-text editor
- render the matching overbar expression with deterministic SVG coordinates and one real line
- keep save ASTs clean and export bounds safe for proportional glyph widths

Validation:
- gate:preflight
- gate:affected (1467 unit, 14 hierarchy, 110 editor browser tests)
- gate:full (performance, visual/export/release checks and 236 browser tests)