### PR TITLE
feat(gallery): add Owner lifecycle controls

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -127,6 +127,91 @@ test("the site lands on the full-screen gallery feed", async ({ page }) => {
   );
 });
 
+test("the Owner rejects a Gallery entry with an author-visible reason", async ({
+  page,
+}) => {
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      json: {
+        user: {
+          id: "owner-1",
+          displayName: "Owner",
+          email: "owner@example.com",
+          provider: "github",
+          role: "user",
+          isAdmin: true,
+        },
+      },
+    }),
+  );
+  await mockGallery(page, [ENTRY]);
+  let rejectReason = "";
+  await page.route(`**/api/gallery/${ENTRY.id}/reject`, async (route) => {
+    rejectReason = (route.request().postDataJSON() as { reason: string })
+      .reason;
+    await route.fulfill({ json: { id: ENTRY.id, status: "rejected" } });
+  });
+
+  await page.goto("/");
+  const menu = page.getByTestId(`gallery-owner-menu-${ENTRY.id}`);
+  await expect(menu).toBeVisible();
+  await menu.locator("summary").click();
+  await expect(
+    page.getByTestId(`gallery-owner-edit-${ENTRY.id}`),
+  ).toHaveAttribute("href", `/g/${ENTRY.id}`);
+  await page.getByTestId(`gallery-owner-reject-${ENTRY.id}`).click();
+  await expect(page.getByTestId("gallery-owner-reject-confirm")).toBeDisabled();
+  await page
+    .getByTestId("gallery-owner-reject-reason")
+    .fill("Label the ports and remove the loose wire.");
+  await page.getByTestId("gallery-owner-reject-confirm").click();
+
+  await expect(page.getByTestId(`gallery-tile-${ENTRY.id}`)).toHaveCount(0);
+  await expect(page.getByTestId("gallery-owner-notice")).toContainText(
+    "rejected",
+  );
+  expect(rejectReason).toBe("Label the ports and remove the loose wire.");
+});
+
+test("the Owner withdraws a Gallery entry into the recycle bin", async ({
+  page,
+}) => {
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      json: {
+        user: {
+          id: "owner-1",
+          displayName: "Owner",
+          email: "owner@example.com",
+          provider: "github",
+          role: "user",
+          isAdmin: true,
+        },
+      },
+    }),
+  );
+  await mockGallery(page, [ENTRY]);
+  let withdrawn = 0;
+  await page.route(`**/api/gallery/${ENTRY.id}/recycle`, (route) => {
+    withdrawn += 1;
+    return route.fulfill({ json: { id: ENTRY.id, status: "recycled" } });
+  });
+
+  await page.goto("/");
+  await page
+    .getByTestId(`gallery-owner-menu-${ENTRY.id}`)
+    .locator("summary")
+    .click();
+  page.once("dialog", (dialog) => void dialog.accept());
+  await page.getByTestId(`gallery-owner-withdraw-${ENTRY.id}`).click();
+
+  await expect(page.getByTestId(`gallery-tile-${ENTRY.id}`)).toHaveCount(0);
+  await expect(page.getByTestId("gallery-owner-notice")).toContainText(
+    "recycle bin",
+  );
+  expect(withdrawn).toBe(1);
+});
+
 test("masonry places the top row left-to-right in distinct columns", async ({
   page,
 }) => {
@@ -399,6 +484,9 @@ test("the admin recycle bin restores a recycled entry", async ({ page }) => {
     }),
   );
   let restored = 0;
+  await page.route("**/api/gallery/rejected", (route) =>
+    route.fulfill({ json: { entries: [] } }),
+  );
   await page.route("**/api/gallery/recycled", (route) =>
     route.fulfill({
       json: {
@@ -424,6 +512,97 @@ test("the admin recycle bin restores a recycled entry", async ({ page }) => {
   await page.getByTestId("bin-restore-bin-1").click();
   await expect(page.getByTestId("bin-empty")).toBeVisible();
   expect(restored).toBe(1);
+});
+
+test("the Owner restores rejected work or moves it through the bin before deletion", async ({
+  page,
+}) => {
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      json: {
+        user: {
+          id: "u1",
+          displayName: "Token Zhang",
+          email: "owner@example.com",
+          provider: "github",
+          role: "user",
+          isAdmin: true,
+        },
+      },
+    }),
+  );
+  let rejected = [
+    {
+      id: "rejected-restore",
+      name: "Corrected Amp",
+      rejectReason: "Remove the loose wire",
+      reviewedAt: "2026-08-22T09:00:00.000Z",
+    },
+    {
+      id: "rejected-delete",
+      name: "Spam",
+      rejectReason: "Not a circuit",
+      reviewedAt: "2026-08-22T08:00:00.000Z",
+    },
+  ];
+  let recycled: Array<{ id: string; name: string; recycledAt: string }> = [];
+  let deleted = 0;
+  await page.route("**/api/gallery/rejected", (route) =>
+    route.fulfill({ json: { entries: rejected } }),
+  );
+  await page.route("**/api/gallery/recycled", (route) =>
+    route.fulfill({ json: { entries: recycled } }),
+  );
+  await page.route("**/api/gallery/rejected-restore/restore", (route) => {
+    rejected = rejected.filter((entry) => entry.id !== "rejected-restore");
+    return route.fulfill({
+      json: { id: "rejected-restore", status: "public" },
+    });
+  });
+  await page.route("**/api/gallery/rejected-delete/recycle", (route) => {
+    rejected = rejected.filter((entry) => entry.id !== "rejected-delete");
+    recycled = [
+      {
+        id: "rejected-delete",
+        name: "Spam",
+        recycledAt: "2026-08-22T10:00:00.000Z",
+      },
+    ];
+    return route.fulfill({
+      json: { id: "rejected-delete", status: "recycled" },
+    });
+  });
+  await page.route("**/api/gallery/rejected-delete", (route) => {
+    deleted += 1;
+    recycled = [];
+    return route.fulfill({ json: { id: "rejected-delete", deleted: true } });
+  });
+
+  await page.goto("/moderation");
+  await expect(
+    page.getByTestId("rejected-card-rejected-restore"),
+  ).toContainText("Remove the loose wire");
+  await expect(
+    page.getByTestId("rejected-edit-rejected-restore"),
+  ).toHaveAttribute("href", "/g/rejected-restore");
+  await page.getByTestId("rejected-restore-rejected-restore").click();
+  await expect(page.getByTestId("rejected-card-rejected-restore")).toHaveCount(
+    0,
+  );
+
+  await page.getByTestId("rejected-recycle-rejected-delete").click();
+  await expect(page.getByTestId("rejected-empty")).toBeVisible();
+  await expect(page.getByTestId("bin-card-rejected-delete")).toBeVisible();
+
+  page.once("dialog", (dialog) => void dialog.dismiss());
+  await page.getByTestId("bin-delete-rejected-delete").click();
+  expect(deleted).toBe(0);
+  await expect(page.getByTestId("bin-card-rejected-delete")).toBeVisible();
+
+  page.once("dialog", (dialog) => void dialog.accept());
+  await page.getByTestId("bin-delete-rejected-delete").click();
+  await expect(page.getByTestId("bin-empty")).toBeVisible();
+  expect(deleted).toBe(1);
 });
 
 test("falls back to bundled tiles when the gallery is empty or unreachable", async ({
@@ -628,7 +807,7 @@ test("a signed-in member publishes directly, bylined by the account", async ({
       hasAuthor: false,
       name: "Session Publish",
       tags: ["amplifier", "latch"],
-      schemaVersion: createEmptyProject("current", "Current").schemaVersion,
+      schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION,
     },
   ]);
 });
@@ -961,7 +1140,7 @@ test("the publish dialog resolves internal Cell instances from the open Project"
   await expect(dialog.getByRole("button", { name: "Publish" })).toBeEnabled();
 });
 
-test("the retired review queue is gone from the moderation page", async ({
+test("post-publication moderation has rejected work but no approval queue", async ({
   page,
 }) => {
   const convergenceCalls: boolean[] = [];
@@ -980,6 +1159,9 @@ test("the retired review queue is gone from the moderation page", async ({
     }),
   );
   await page.route("**/api/gallery/recycled", (route) =>
+    route.fulfill({ json: { entries: [] } }),
+  );
+  await page.route("**/api/gallery/rejected", (route) =>
     route.fulfill({ json: { entries: [] } }),
   );
   await page.route(
@@ -1031,7 +1213,8 @@ test("the retired review queue is gone from the moderation page", async ({
     `Applied: 5/5 records ready for schema ${CURRENT_PROJECT_SCHEMA_VERSION}; 0 failures.`,
   );
   expect(convergenceCalls).toEqual([false, true]);
-  // Curation is post-publication now: a bin to restore from, no inbox.
+  // Curation is post-publication: rejected work and a bin, never an inbox.
+  await expect(page.getByTestId("rejected-empty")).toBeVisible();
   await expect(page.getByTestId("bin-empty")).toBeVisible();
   await expect(page.getByTestId("review-empty")).toHaveCount(0);
   await expect(page.getByText("Nothing waiting for review")).toHaveCount(0);
@@ -1089,6 +1272,10 @@ test("/mine wears the site chrome and links every entry back to the editor", asy
   await expect(page.getByTestId("gallery-new-circuit")).toBeVisible();
   await expect(page.getByTestId("mine-reason-mine-1")).toContainText(
     "Label the ports",
+  );
+  await expect(page.getByTestId("mine-withdraw-mine-1")).toHaveCount(0);
+  await expect(page.getByTestId("mine-card-mine-1")).toContainText(
+    "remains hidden until the Owner restores it",
   );
   await expect(page.getByTestId("mine-edit-mine-2")).toHaveAttribute(
     "href",
@@ -1171,8 +1358,7 @@ test("/mine offers owner withdrawal, restore, and version history", async ({
   await page.getByTestId("mine-withdraw-confirm-mine-2").click();
   await expect(page.getByTestId("mine-status-mine-2")).toHaveText("Withdrawn");
   await expect(page.getByTestId("mine-notice")).toContainText("Withdrew");
-  // Restore (the worker re-enters review for ordinary owners; the mock
-  // simply flips the entry back).
+  // Restore republishes a voluntary withdrawal.
   await page.getByTestId("mine-restore-mine-2").click();
   await expect(page.getByTestId("mine-status-mine-2")).toHaveText("Published");
   // The version history dialog lists the snapshot with its preview.
@@ -1384,9 +1570,9 @@ test("replacing the project retires the stale update offer", async ({
       serializeProject(createEmptyProject("fresh-project", "Fresh Start")),
     ),
   });
-  await expect(page.getByTestId("status")).toContainText(
-    "Opened fresh.icproj.json",
-  );
+  // The fixture may pass through the rolling schema upgrade; either status
+  // still proves that this different Project replaced the gallery entry.
+  await expect(page.getByTestId("status")).toContainText("fresh.icproj.json");
 
   await page.getByTestId("publish-gallery-button").click();
   const dialog = page.getByTestId("publish-gallery-dialog");

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -5,6 +5,7 @@ import { renderDocumentSvg } from "@icm/render-svg";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 
 import { libraryProjectExamples } from "../examples/library-examples";
+import { fetchSessionUser } from "./account";
 import { GalleryChrome } from "./gallery-chrome";
 import { Masonry } from "./masonry";
 
@@ -38,6 +39,127 @@ export interface GalleryFeedState {
 }
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+function GalleryOwnerMenu({
+  entry,
+  busy,
+  onWithdraw,
+  onReject,
+}: {
+  entry: GalleryFeedEntry;
+  busy: boolean;
+  onWithdraw: () => void;
+  onReject: () => void;
+}) {
+  return (
+    <details
+      className="gallery-owner-menu"
+      data-testid={`gallery-owner-menu-${entry.id}`}
+    >
+      <summary
+        aria-label={`Manage ${entry.name}`}
+        title={`Manage ${entry.name}`}
+      >
+        ⋯
+      </summary>
+      <div className="gallery-owner-popover">
+        <a
+          href={`/g/${entry.id}`}
+          data-testid={`gallery-owner-edit-${entry.id}`}
+        >
+          Edit and replace
+        </a>
+        <button
+          type="button"
+          disabled={busy}
+          data-testid={`gallery-owner-withdraw-${entry.id}`}
+          onClick={onWithdraw}
+        >
+          Withdraw
+        </button>
+        <button
+          type="button"
+          className="gallery-owner-danger"
+          disabled={busy}
+          data-testid={`gallery-owner-reject-${entry.id}`}
+          onClick={onReject}
+        >
+          Reject with reason
+        </button>
+      </div>
+    </details>
+  );
+}
+
+function RejectEntryDialog({
+  entry,
+  reason,
+  busy,
+  onReasonChange,
+  onSubmit,
+  onClose,
+}: {
+  entry: GalleryFeedEntry;
+  reason: string;
+  busy: boolean;
+  onReasonChange: (reason: string) => void;
+  onSubmit: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="gallery-owner-dialog-backdrop"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget && !busy) onClose();
+      }}
+    >
+      <section
+        className="gallery-owner-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="gallery-reject-title"
+        data-testid="gallery-owner-reject-dialog"
+      >
+        <h2 id="gallery-reject-title">Reject “{entry.name}”</h2>
+        <p>
+          The circuit will leave the Gallery immediately. The submitter will see
+          this reason in My submissions.
+        </p>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (reason.trim()) onSubmit();
+          }}
+        >
+          <label htmlFor="gallery-reject-reason">Reason</label>
+          <textarea
+            id="gallery-reject-reason"
+            value={reason}
+            maxLength={500}
+            required
+            autoFocus
+            placeholder="Explain what should be corrected…"
+            data-testid="gallery-owner-reject-reason"
+            onChange={(event) => onReasonChange(event.currentTarget.value)}
+          />
+          <div className="gallery-owner-dialog-actions">
+            <button type="button" disabled={busy} onClick={onClose}>
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="gallery-owner-danger"
+              disabled={busy || !reason.trim()}
+              data-testid="gallery-owner-reject-confirm"
+            >
+              {busy ? "Rejecting…" : "Reject entry"}
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+}
 
 /**
  * The like mark, drawn rather than typed.
@@ -135,6 +257,11 @@ export async function loadGalleryFeed(
  * worker), so the landing page is never blank.
  */
 export function GalleryFeed() {
+  const [isOwner, setIsOwner] = useState(false);
+  const [ownerBusy, setOwnerBusy] = useState<string | null>(null);
+  const [ownerNotice, setOwnerNotice] = useState<string | null>(null);
+  const [rejecting, setRejecting] = useState<GalleryFeedEntry | null>(null);
+  const [rejectReason, setRejectReason] = useState("");
   const [author, setAuthor] = useState<string | null>(() =>
     typeof window === "undefined"
       ? null
@@ -150,6 +277,16 @@ export function GalleryFeed() {
   const [tagOptions, setTagOptions] = useState<
     { tag: string; count: number }[]
   >([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchSessionUser().then((user) => {
+      if (!cancelled) setIsOwner(user?.isAdmin === true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -302,6 +439,71 @@ export function GalleryFeed() {
     });
   }
 
+  function removeManagedEntry(entry: GalleryFeedEntry): void {
+    setState((previous) => ({
+      ...previous,
+      entries: previous.entries.filter(
+        (candidate) => candidate.id !== entry.id,
+      ),
+    }));
+    const removedTags = new Set(entry.tags ?? []);
+    if (removedTags.size > 0) {
+      setTagOptions((previous) =>
+        previous
+          .map((option) =>
+            removedTags.has(option.tag)
+              ? { ...option, count: option.count - 1 }
+              : option,
+          )
+          .filter((option) => option.count > 0),
+      );
+    }
+  }
+
+  async function withdrawEntry(entry: GalleryFeedEntry): Promise<void> {
+    if (!window.confirm(`Withdraw “${entry.name}” from the Gallery?`)) return;
+    setOwnerBusy(entry.id);
+    setOwnerNotice(null);
+    try {
+      const response = await fetch(`/api/gallery/${entry.id}/recycle`, {
+        method: "POST",
+        credentials: "same-origin",
+      });
+      if (!response.ok) throw new Error();
+      removeManagedEntry(entry);
+      setOwnerNotice(`“${entry.name}” was moved to the recycle bin.`);
+    } catch {
+      setOwnerNotice(`Could not withdraw “${entry.name}”.`);
+    } finally {
+      setOwnerBusy(null);
+    }
+  }
+
+  async function rejectEntry(): Promise<void> {
+    if (!rejecting || !rejectReason.trim()) return;
+    setOwnerBusy(rejecting.id);
+    setOwnerNotice(null);
+    try {
+      const response = await fetch(`/api/gallery/${rejecting.id}/reject`, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ reason: rejectReason.trim() }),
+      });
+      if (!response.ok) throw new Error();
+      removeManagedEntry(rejecting);
+      setOwnerNotice(
+        `“${rejecting.name}” was rejected and hidden from the Gallery.`,
+      );
+      setRejecting(null);
+      setRejectReason("");
+    } catch {
+      setOwnerNotice(`Could not reject “${rejecting.name}”.`);
+    } finally {
+      setOwnerBusy(null);
+    }
+  }
+
   const entries = state.entries;
 
   return (
@@ -353,6 +555,11 @@ export function GalleryFeed() {
           </button>
         </div>
       ) : null}
+      {ownerNotice ? (
+        <p className="gallery-status" data-testid="gallery-owner-notice">
+          {ownerNotice}
+        </p>
+      ) : null}
       {state.status === "loading" ? (
         <p className="gallery-status" data-testid="gallery-loading">
           Loading gallery…
@@ -365,105 +572,119 @@ export function GalleryFeed() {
               ...entries.map((entry) => ({
                 key: entry.id,
                 node: (
-                  <a
-                    className="gallery-tile"
-                    href={`/g/${entry.id}`}
-                    data-testid={`gallery-tile-${entry.id}`}
-                  >
-                    <span className="gallery-tile-preview">
-                      <img
-                        src={`/api/gallery/${entry.id}/preview.svg`}
-                        alt={`Preview of ${entry.name}`}
-                        loading="lazy"
-                      />
-                    </span>
-                    <span className="gallery-tile-copy">
-                      <span className="gallery-tile-name">
-                        {entry.name}
-                        {entry.netlistable ? (
-                          <span
-                            className="gallery-tile-star"
-                            data-testid={`gallery-star-${entry.id}`}
-                            title="Extracts to a SPICE netlist"
-                            aria-label="Extracts to a SPICE netlist"
+                  <div className="gallery-tile-wrap">
+                    <a
+                      className="gallery-tile"
+                      href={`/g/${entry.id}`}
+                      data-testid={`gallery-tile-${entry.id}`}
+                    >
+                      <span className="gallery-tile-preview">
+                        <img
+                          src={`/api/gallery/${entry.id}/preview.svg`}
+                          alt={`Preview of ${entry.name}`}
+                          loading="lazy"
+                        />
+                      </span>
+                      <span className="gallery-tile-copy">
+                        <span className="gallery-tile-name">
+                          {entry.name}
+                          {entry.netlistable ? (
+                            <span
+                              className="gallery-tile-star"
+                              data-testid={`gallery-star-${entry.id}`}
+                              title="Extracts to a SPICE netlist"
+                              aria-label="Extracts to a SPICE netlist"
+                            >
+                              ★
+                            </span>
+                          ) : null}
+                        </span>
+                        <span className="gallery-tile-meta">
+                          {entry.author ? (
+                            <>
+                              <button
+                                type="button"
+                                className="gallery-tile-author"
+                                data-testid={`gallery-author-${entry.id}`}
+                                title={`Show circuits by ${entry.author}`}
+                                onClick={(event) => {
+                                  event.preventDefault();
+                                  event.stopPropagation();
+                                  selectAuthor(entry.author);
+                                }}
+                              >
+                                {entry.author}
+                              </button>
+                              {" · "}
+                            </>
+                          ) : null}
+                          {savedAtLabel(entry.createdAt)}
+                          {" · "}
+                          <button
+                            type="button"
+                            className="gallery-tile-like"
+                            data-testid={`gallery-like-${entry.id}`}
+                            aria-pressed={entry.likedByViewer === true}
+                            title={
+                              entry.likedByViewer
+                                ? "Remove your like"
+                                : "Like this circuit"
+                            }
+                            aria-label={
+                              entry.likedByViewer
+                                ? `Remove your like from ${entry.name}`
+                                : `Like ${entry.name}`
+                            }
+                            onClick={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                              void toggleLike(entry.id);
+                            }}
                           >
-                            ★
+                            <HeartIcon filled={entry.likedByViewer === true} />
+                            {entry.likes ?? 0}
+                          </button>
+                        </span>
+                        {entry.description ? (
+                          <span className="gallery-tile-description">
+                            {entry.description}
+                          </span>
+                        ) : null}
+                        {entry.tags && entry.tags.length > 0 ? (
+                          <span className="gallery-tile-tags">
+                            {entry.tags.map((tag) => (
+                              <button
+                                key={tag}
+                                type="button"
+                                className="gallery-tile-tag"
+                                data-testid={`gallery-tile-tag-${entry.id}-${tag.replace(/\s/gu, "-")}`}
+                                title={`Filter by ${tag}`}
+                                onClick={(event) => {
+                                  event.preventDefault();
+                                  event.stopPropagation();
+                                  if (!selectedTags.includes(tag))
+                                    toggleTag(tag);
+                                }}
+                              >
+                                {tag}
+                              </button>
+                            ))}
                           </span>
                         ) : null}
                       </span>
-                      <span className="gallery-tile-meta">
-                        {entry.author ? (
-                          <>
-                            <button
-                              type="button"
-                              className="gallery-tile-author"
-                              data-testid={`gallery-author-${entry.id}`}
-                              title={`Show circuits by ${entry.author}`}
-                              onClick={(event) => {
-                                event.preventDefault();
-                                event.stopPropagation();
-                                selectAuthor(entry.author);
-                              }}
-                            >
-                              {entry.author}
-                            </button>
-                            {" · "}
-                          </>
-                        ) : null}
-                        {savedAtLabel(entry.createdAt)}
-                        {" · "}
-                        <button
-                          type="button"
-                          className="gallery-tile-like"
-                          data-testid={`gallery-like-${entry.id}`}
-                          aria-pressed={entry.likedByViewer === true}
-                          title={
-                            entry.likedByViewer
-                              ? "Remove your like"
-                              : "Like this circuit"
-                          }
-                          aria-label={
-                            entry.likedByViewer
-                              ? `Remove your like from ${entry.name}`
-                              : `Like ${entry.name}`
-                          }
-                          onClick={(event) => {
-                            event.preventDefault();
-                            event.stopPropagation();
-                            void toggleLike(entry.id);
-                          }}
-                        >
-                          <HeartIcon filled={entry.likedByViewer === true} />
-                          {entry.likes ?? 0}
-                        </button>
-                      </span>
-                      {entry.description ? (
-                        <span className="gallery-tile-description">
-                          {entry.description}
-                        </span>
-                      ) : null}
-                      {entry.tags && entry.tags.length > 0 ? (
-                        <span className="gallery-tile-tags">
-                          {entry.tags.map((tag) => (
-                            <button
-                              key={tag}
-                              type="button"
-                              className="gallery-tile-tag"
-                              data-testid={`gallery-tile-tag-${entry.id}-${tag.replace(/\s/gu, "-")}`}
-                              title={`Filter by ${tag}`}
-                              onClick={(event) => {
-                                event.preventDefault();
-                                event.stopPropagation();
-                                if (!selectedTags.includes(tag)) toggleTag(tag);
-                              }}
-                            >
-                              {tag}
-                            </button>
-                          ))}
-                        </span>
-                      ) : null}
-                    </span>
-                  </a>
+                    </a>
+                    {isOwner ? (
+                      <GalleryOwnerMenu
+                        entry={entry}
+                        busy={ownerBusy === entry.id}
+                        onWithdraw={() => void withdrawEntry(entry)}
+                        onReject={() => {
+                          setRejecting(entry);
+                          setRejectReason("");
+                        }}
+                      />
+                    ) : null}
+                  </div>
                 ),
               })),
               ...(entries.length === 0 && author === null
@@ -512,6 +733,19 @@ export function GalleryFeed() {
         Browse freely; open any circuit and edit your own copy. Publishing joins
         in a later release with sign-in.
       </footer>
+      {rejecting ? (
+        <RejectEntryDialog
+          entry={rejecting}
+          reason={rejectReason}
+          busy={ownerBusy === rejecting.id}
+          onReasonChange={setRejectReason}
+          onSubmit={() => void rejectEntry()}
+          onClose={() => {
+            setRejecting(null);
+            setRejectReason("");
+          }}
+        />
+      ) : null}
     </main>
   );
 }

--- a/apps/editor/src/components/moderation.tsx
+++ b/apps/editor/src/components/moderation.tsx
@@ -7,8 +7,8 @@ import { GalleryChrome } from "./gallery-chrome";
 /**
  * Moderation, the post-publication surface. Publishing is direct, so there
  * is nothing to approve in advance; what a curator needs is the ability to
- * take an entry down afterwards, put it back, and finally delete it. The
- * super-admin also appoints moderators by email from here.
+ * take an entry down afterwards, explain a rejection, put it back, and finally
+ * delete it. The super-admin also appoints moderators by email from here.
  */
 
 type ModerationState =
@@ -56,6 +56,13 @@ interface RecycledEntry {
   id: string;
   name: string;
   recycledAt?: string | null;
+}
+
+interface RejectedEntry {
+  id: string;
+  name: string;
+  rejectReason?: string | null;
+  reviewedAt?: string | null;
 }
 
 interface SchemaConvergenceReport {
@@ -182,12 +189,129 @@ function SchemaMaintenance() {
   );
 }
 
+/** Owner decisions waiting for correction, restoration, or archival. */
+function RejectedList({
+  refreshVersion,
+  onChanged,
+}: {
+  refreshVersion: number;
+  onChanged: () => void;
+}) {
+  const [entries, setEntries] = useState<RejectedEntry[] | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetch("/api/gallery/rejected", {
+          credentials: "same-origin",
+        });
+        const payload = response.ok
+          ? ((await response.json()) as { entries?: RejectedEntry[] })
+          : { entries: [] };
+        if (!cancelled) setEntries(payload.entries ?? []);
+      } catch {
+        if (!cancelled) setEntries([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshVersion]);
+
+  async function act(id: string, action: "restore" | "recycle") {
+    setBusy(id);
+    try {
+      const response = await fetch(`/api/gallery/${id}/${action}`, {
+        method: "POST",
+        credentials: "same-origin",
+      });
+      if (response.ok) onChanged();
+    } catch {
+      // Leave the row in place; it still reflects the last confirmed state.
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (entries === null) return null;
+  return (
+    <section className="review-bin" data-testid="rejected-list">
+      <h2>Rejected entries</h2>
+      <p className="review-card-meta">
+        Restore a corrected circuit, or move it to the recycle bin before
+        permanent deletion.
+      </p>
+      {entries.length === 0 ? (
+        <p className="gallery-status" data-testid="rejected-empty">
+          No rejected entries.
+        </p>
+      ) : (
+        <div className="mine-list">
+          {entries.map((entry) => (
+            <article
+              key={entry.id}
+              className="mine-card"
+              data-testid={`rejected-card-${entry.id}`}
+            >
+              <div className="mine-card-copy">
+                <h2>{entry.name}</h2>
+                {entry.rejectReason ? (
+                  <p className="mine-reason">Reason: {entry.rejectReason}</p>
+                ) : null}
+                {entry.reviewedAt ? (
+                  <p className="review-card-meta">
+                    Rejected {new Date(entry.reviewedAt).toLocaleString()}
+                  </p>
+                ) : null}
+              </div>
+              <div className="review-card-actions">
+                <a
+                  className="account-link"
+                  href={`/g/${entry.id}`}
+                  data-testid={`rejected-edit-${entry.id}`}
+                >
+                  Edit and replace
+                </a>
+                <button
+                  type="button"
+                  disabled={busy === entry.id}
+                  data-testid={`rejected-recycle-${entry.id}`}
+                  onClick={() => void act(entry.id, "recycle")}
+                >
+                  Move to recycle bin
+                </button>
+                <button
+                  type="button"
+                  className="review-approve"
+                  disabled={busy === entry.id}
+                  data-testid={`rejected-restore-${entry.id}`}
+                  onClick={() => void act(entry.id, "restore")}
+                >
+                  Restore
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
 /**
  * The recycle bin: the takedown surface. Restore returns an entry to the
  * public wall; Delete forever is the only hard deletion and asks for
  * confirmation first.
  */
-function RecycleBin() {
+function RecycleBin({
+  refreshVersion,
+  onChanged,
+}: {
+  refreshVersion: number;
+  onChanged: () => void;
+}) {
   const [entries, setEntries] = useState<RecycledEntry[] | null>(null);
 
   async function refresh(): Promise<void> {
@@ -210,8 +334,8 @@ function RecycleBin() {
 
   useEffect(() => {
     void refresh();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- load once
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refresh is local
+  }, [refreshVersion]);
 
   async function act(id: string, kind: "restore" | "delete"): Promise<void> {
     if (
@@ -233,7 +357,7 @@ function RecycleBin() {
     } catch {
       // The refresh below shows the true state either way.
     }
-    void refresh();
+    onChanged();
   }
 
   if (entries === null) return null;
@@ -289,6 +413,7 @@ export function Moderation() {
   const [state, setState] = useState<ModerationState>({ status: "loading" });
   const [email, setEmail] = useState("");
   const [notice, setNotice] = useState<string | null>(null);
+  const [inventoryVersion, setInventoryVersion] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -348,7 +473,14 @@ export function Moderation() {
         {state.user.isAdmin ? (
           <>
             <SchemaMaintenance />
-            <RecycleBin />
+            <RejectedList
+              refreshVersion={inventoryVersion}
+              onChanged={() => setInventoryVersion((version) => version + 1)}
+            />
+            <RecycleBin
+              refreshVersion={inventoryVersion}
+              onChanged={() => setInventoryVersion((version) => version + 1)}
+            />
           </>
         ) : (
           <p className="gallery-status">

--- a/apps/editor/src/components/my-submissions.tsx
+++ b/apps/editor/src/components/my-submissions.tsx
@@ -7,11 +7,10 @@ import { VersionHistoryDialog } from "./version-history-dialog";
 
 /**
  * "My submissions" (roadmap phase G3): a signed-in user's gallery entries
- * with their review status; a rejection shows the reviewer's optional
- * reason, and every entry opens back into the editor for another round
- * (an owner update re-enters review server-side). Owners can withdraw an
- * entry from the gallery, bring it back (through review for ordinary
- * accounts), and browse its version history.
+ * with their review status; a rejection shows the Owner's required
+ * reason, and every entry opens back into the editor for correction. Owners
+ * can withdraw and restore their own public entries and browse version
+ * history; an Owner rejection stays hidden until the Owner restores it.
  */
 
 export interface MineEntry {
@@ -61,9 +60,8 @@ export async function setMyEntryRecycled(
   }
 }
 
-// Publishing is direct, so nothing new is ever "pending". `rejected` is
-// kept for the handful of entries a reviewer turned down before the queue
-// was retired; their owners still need to see why.
+// Publishing is direct, so nothing new is ever "pending". Rejection is the
+// Owner's post-publication takedown with an author-visible reason.
 const STATUS_LABELS: Record<string, string> = {
   public: "Published",
   rejected: "Rejected",
@@ -109,7 +107,7 @@ export function MySubmissions() {
     setNotice(
       action === "recycle"
         ? `Withdrew "${entry.name}" from the gallery.`
-        : `"${entry.name}" is on its way back — it re-enters review first.`,
+        : `Restored "${entry.name}" to the gallery.`,
     );
     await reload();
   }
@@ -174,7 +172,7 @@ export function MySubmissions() {
                     >
                       Version history
                     </button>
-                    {entry.status === "recycled" ? (
+                    {entry.status === "recycled" && !entry.rejectReason ? (
                       <button
                         type="button"
                         className="account-link mine-card-restore"
@@ -182,9 +180,9 @@ export function MySubmissions() {
                         disabled={busy === entry.id}
                         onClick={() => void act(entry, "restore")}
                       >
-                        Restore (re-enters review)
+                        Restore
                       </button>
-                    ) : confirming === entry.id ? (
+                    ) : entry.status === "public" && confirming === entry.id ? (
                       <>
                         <button
                           type="button"
@@ -203,7 +201,7 @@ export function MySubmissions() {
                           Keep it
                         </button>
                       </>
-                    ) : (
+                    ) : entry.status === "public" ? (
                       <button
                         type="button"
                         className="mine-withdraw"
@@ -212,7 +210,7 @@ export function MySubmissions() {
                       >
                         Withdraw
                       </button>
-                    )}
+                    ) : null}
                   </div>
                 </div>
                 <div className="mine-card-status">
@@ -232,14 +230,15 @@ export function MySubmissions() {
                   ) : null}
                   {entry.status === "rejected" ? (
                     <p className="mine-reason">
-                      Edit it in the editor and publish again — the update
-                      re-enters review.
+                      You may correct it in the editor. It remains hidden until
+                      the Owner restores it.
                     </p>
                   ) : null}
                   {entry.status === "recycled" ? (
                     <p className="mine-reason">
-                      Not shown in the gallery. Restore sends it back through
-                      review.
+                      {entry.rejectReason
+                        ? "Removed after rejection. Only the Owner can restore it."
+                        : "Not shown in the Gallery. Restore republishes it."}
                     </p>
                   ) : null}
                 </div>
@@ -255,7 +254,7 @@ export function MySubmissions() {
           onRestored={() => {
             setHistoryFor(null);
             setNotice(
-              `Restored an earlier version of "${historyFor.name}" — it re-enters review unless you are a reviewer.`,
+              `Restored an earlier version of "${historyFor.name}". Its publication status did not change.`,
             );
             void reload();
           }}

--- a/apps/editor/src/gallery.css
+++ b/apps/editor/src/gallery.css
@@ -637,6 +637,178 @@
     box-shadow 120ms ease;
 }
 
+.gallery-tile-wrap {
+  position: relative;
+}
+
+.gallery-owner-menu {
+  position: absolute;
+  z-index: 3;
+  top: 8px;
+  right: 8px;
+}
+
+.gallery-owner-menu > summary {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 1px solid rgb(0 0 0 / 12%);
+  border-radius: 999px;
+  color: #202124;
+  background: rgb(255 255 255 / 94%);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 12%);
+  font-size: 19px;
+  font-weight: 700;
+  line-height: 1;
+  list-style: none;
+  cursor: pointer;
+}
+
+.gallery-owner-menu > summary::-webkit-details-marker {
+  display: none;
+}
+
+.gallery-owner-menu[open] > summary,
+.gallery-owner-menu > summary:hover {
+  background: #fff;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 18%);
+}
+
+.gallery-owner-popover {
+  position: absolute;
+  top: 36px;
+  right: 0;
+  display: grid;
+  min-width: 11.5rem;
+  gap: 2px;
+  padding: 6px;
+  border: 1px solid var(--icm-border);
+  border-radius: 10px;
+  background: var(--icm-surface);
+  box-shadow: 0 12px 32px rgb(15 15 15 / 18%);
+}
+
+.gallery-owner-popover a,
+.gallery-owner-popover button {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 7px;
+  color: var(--icm-text);
+  background: transparent;
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.gallery-owner-popover a:hover,
+.gallery-owner-popover button:hover {
+  background: var(--icm-surface-hover);
+}
+
+.gallery-owner-popover button:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+
+.gallery-owner-danger {
+  color: var(--icm-danger, #b42318) !important;
+}
+
+.gallery-owner-dialog-backdrop {
+  position: fixed;
+  z-index: 100;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  background: rgb(15 23 42 / 42%);
+}
+
+.gallery-owner-dialog {
+  box-sizing: border-box;
+  width: min(30rem, 100%);
+  padding: 20px;
+  border: 1px solid var(--icm-border);
+  border-radius: 14px;
+  color: var(--icm-text);
+  background: var(--icm-surface);
+  box-shadow: 0 24px 64px rgb(0 0 0 / 24%);
+}
+
+.gallery-owner-dialog h2 {
+  margin: 0;
+  font-size: 19px;
+}
+
+.gallery-owner-dialog p {
+  margin: 8px 0 18px;
+  color: var(--icm-text-muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.gallery-owner-dialog form {
+  display: grid;
+  gap: 8px;
+}
+
+.gallery-owner-dialog label {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.gallery-owner-dialog textarea {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 7rem;
+  resize: vertical;
+  padding: 10px 12px;
+  border: 1px solid var(--icm-border);
+  border-radius: 8px;
+  color: var(--icm-text);
+  background: var(--icm-surface);
+  font: inherit;
+  font-size: 13px;
+}
+
+.gallery-owner-dialog textarea:focus {
+  border-color: var(--icm-accent);
+  outline: 2px solid color-mix(in srgb, var(--icm-accent) 18%, transparent);
+}
+
+.gallery-owner-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.gallery-owner-dialog-actions button {
+  padding: 7px 12px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  color: var(--icm-text);
+  background: var(--icm-surface);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.gallery-owner-dialog-actions .gallery-owner-danger {
+  border-color: var(--icm-danger, #b42318);
+  color: #fff !important;
+  background: var(--icm-danger, #b42318);
+}
+
+.gallery-owner-dialog-actions button:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+
 .gallery-tile:hover {
   border-color: var(--icm-border-hover);
   box-shadow: 0 4px 16px rgb(0 0 0 / 8%);

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -20,8 +20,8 @@ restrictive content-security-policy.
 - `GET /api/gallery` — newest-first `public` entries
   (`{entries, nextCursor}`; keyset cursor; limit clamps at 60; optional
   `author` filters to that exact byline and optional `tags=a,b` to
-  entries carrying ANY listed tag, both ahead of pagination). Recycled
-  entries never appear.
+  entries carrying ANY listed tag, both ahead of pagination). Rejected and
+  recycled entries never appear.
 - `GET /api/gallery/tags` — distinct public tags with counts, most
   frequent first (feeds the multi-select menu).
 - `GET /api/gallery/<id>` — one public entry with its canonical
@@ -92,10 +92,10 @@ nothing new ever enters a queue; curation is post-publication. A
 detail, preview); its detail and preview answer only to a moderator or
 the owning session.
 
-`pending` is retired. `rejected` remains only for the entries a reviewer
-turned down before the queue was removed, so their owners still see why;
-opening the storage promotes any leftover `pending` row to `public`
-rather than stranding it, and leaves a real rejection alone.
+`pending` is retired. Opening the storage promotes any leftover `pending` row
+to `public` rather than stranding it. `rejected` is now the Owner's explicit
+post-publication decision: its required reason remains visible to the
+submitter until the Owner restores the entry.
 
 - `GET /api/gallery/mine` — the calling session's entries with `status`
   and `rejectReason`.
@@ -105,10 +105,12 @@ rather than stranding it, and leaves a real rejection alone.
   moderator curates and bypasses the quality gates; the recycle bin and
   maintenance stay admin-only.
 
-The editor surfaces moderation at `/moderation` (the recycle bin, plus
-admin-only moderator appointment) and the submitter's view at `/mine`
-(status chips, owner-visible preview, open-in-editor). Every gallery
-page state wears the shared site chrome.
+The Gallery feed gives the super-admin an Owner menu on every community tile:
+Edit and replace, Withdraw, and Reject with reason. The editor surfaces the
+full administration lifecycle at `/moderation` (rejected entries, recycle
+bin, plus admin-only moderator appointment) and the submitter's view at
+`/mine` (status chips, rejection reason, owner-visible preview,
+open-in-editor). Every gallery page state wears the shared site chrome.
 
 ## Owner editing
 
@@ -125,10 +127,12 @@ opened entry" exactly to owners and moderators.
 
 Owner withdrawal: `POST /api/gallery/<id>/recycle` (same-origin) also
 accepts the owning session — the entry moves to `recycled` and leaves
-every public surface, exactly like an admin recycle. The owner brings it
-back with `POST /api/gallery/<id>/restore`, which republishes it — for
-the owner exactly as for an admin. `/mine` surfaces both actions (a
-two-step Withdraw and a Restore on withdrawn entries).
+every public surface, exactly like an admin recycle. The owner brings a
+voluntary withdrawal back with `POST /api/gallery/<id>/restore`, which
+republishes it. An ordinary owner cannot restore or recycle an Owner-rejected
+entry; it remains editable but hidden until the Owner restores it. `/mine`
+surfaces the available actions: a two-step Withdraw and a Restore on
+voluntarily withdrawn entries.
 
 ## Version history
 
@@ -201,10 +205,14 @@ header buys nothing. Without such a session every admin route answers
 - `POST /api/gallery/<id>/recycle` — soft delete into the restorable bin;
   the entry disappears from every public surface. (Also open to the
   owning session as withdrawal — see Owner editing.)
+- `POST /api/gallery/<id>/reject` — hide a public entry and record a required
+  `{reason}` (trimmed, at most 500 characters), the reviewing account, and the
+  review time. The submitter sees the reason on `/mine`.
 - `POST /api/gallery/<id>/restore` — back to `public`.
 - `DELETE /api/gallery/<id>` — permanent, and only for entries already in
   the bin (`409` otherwise).
 - `GET /api/gallery/recycled` — the bin.
+- `GET /api/gallery/rejected` — rejected entries and their reasons.
 - `GET /api/gallery/maintenance/schema-backup` — download a full-fidelity
   administrator backup of entries, saved versions, and workspace slots.
 - `POST /api/gallery/maintenance/schema-current` — validate or transactionally

--- a/worker/gallery-do.ts
+++ b/worker/gallery-do.ts
@@ -7,8 +7,9 @@
 // is ever stored or echoed. Signing in is the whole publishing gate: any
 // signed-in account publishes straight to the wall, and every entry records
 // the submitting account's email and provider so it stays traceable. An
-// admin session can recycle (soft, restorable),
-// hard-delete from the bin only, and batch re-serialize every entry to keep
+// admin session can reject with an author-visible reason, recycle (soft,
+// restorable), hard-delete from the bin only, and batch re-serialize every
+// entry to keep
 // long-lived records inside the rolling schema window. Previews are stored
 // independently so browsing survives an entry the current window can no
 // longer open.
@@ -55,6 +56,7 @@ export function shortId(length = SHORT_ID_LENGTH): string {
 }
 
 export const GALLERY_MAX_PROJECT_BYTES = 2 * 1024 * 1024;
+export const GALLERY_MAX_REJECT_REASON_LENGTH = 500;
 /** How many circuits an account's scratch shelf keeps. */
 export const WORKSPACE_SLOT_LIMIT = 3;
 
@@ -397,10 +399,14 @@ export class GalleryDO {
           String(body.status),
           String(body.at),
         );
+      case "reject":
+        return this.reject(body);
       case "delete":
         return this.delete(String(body.id));
       case "recycled":
         return this.recycled();
+      case "rejected":
+        return this.rejected();
       case "mine":
         return this.mine(String(body.ownerUserId));
       case "all-ids":
@@ -624,6 +630,7 @@ export class GalleryDO {
       ownerUserId: row.owner_user_id,
       submitterEmail: row.submitter_email,
       submitterProvider: row.submitter_provider,
+      rejectReason: row.reject_reason,
       projectText: row.project_text,
       svgText: row.svg_text,
     });
@@ -677,8 +684,7 @@ export class GalleryDO {
       this.sql.exec(
         `UPDATE gallery_entries
          SET name = ?, author = ?, description = ?, project_text = ?,
-             svg_text = ?, schema_version = ?, status = ?, tags = ?,
-             reject_reason = NULL, reviewed_at = NULL, reviewed_by = NULL
+             svg_text = ?, schema_version = ?, status = ?, tags = ?
          WHERE id = ?`,
         String(body.name),
         String(body.author),
@@ -1162,13 +1168,45 @@ export class GalleryDO {
       .exec<EntryRow>("SELECT * FROM gallery_entries WHERE id = ?", id)
       .toArray()[0];
     if (!row) return Response.json({ error: "not-found" }, { status: 404 });
+    if (status === "public") {
+      this.sql.exec(
+        `UPDATE gallery_entries
+         SET status = 'public', recycled_at = NULL, reject_reason = NULL,
+             reviewed_at = NULL, reviewed_by = NULL
+         WHERE id = ?`,
+        id,
+      );
+    } else {
+      this.sql.exec(
+        "UPDATE gallery_entries SET status = ?, recycled_at = ? WHERE id = ?",
+        status,
+        status === "recycled" ? at : null,
+        id,
+      );
+    }
+    return Response.json({ id, status });
+  }
+
+  private reject(body: Record<string, unknown>): Response {
+    const id = String(body.id);
+    const row = this.sql
+      .exec<EntryRow>("SELECT * FROM gallery_entries WHERE id = ?", id)
+      .toArray()[0];
+    if (!row) return Response.json({ error: "not-found" }, { status: 404 });
+    if (row.status !== "public") {
+      return Response.json({ error: "not-public" }, { status: 409 });
+    }
     this.sql.exec(
-      "UPDATE gallery_entries SET status = ?, recycled_at = ? WHERE id = ?",
-      status,
-      status === "recycled" ? at : null,
+      `UPDATE gallery_entries
+       SET status = 'rejected', recycled_at = NULL, reject_reason = ?,
+           reviewed_at = ?, reviewed_by = ?
+       WHERE id = ?`,
+      String(body.reason),
+      String(body.at),
+      String(body.reviewerId),
       id,
     );
-    return Response.json({ id, status });
+    return Response.json({ id, status: "rejected" });
   }
 
   private delete(id: string): Response {
@@ -1194,6 +1232,22 @@ export class GalleryDO {
       entries: rows.map((row) => ({
         ...summaryOf(row),
         recycledAt: row.recycled_at,
+      })),
+    });
+  }
+
+  private rejected(): Response {
+    const rows = this.sql
+      .exec<EntryRow>(
+        `SELECT * FROM gallery_entries WHERE status = 'rejected'
+         ORDER BY reviewed_at DESC, created_at DESC, id DESC`,
+      )
+      .toArray();
+    return Response.json({
+      entries: rows.map((row) => ({
+        ...summaryOf(row),
+        rejectReason: row.reject_reason,
+        reviewedAt: row.reviewed_at,
       })),
     });
   }

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -1007,7 +1007,7 @@ describe("direct publishing (the review queue is retired)", () => {
     );
   });
 
-  it("has no queue to read and no decision to hand down", async () => {
+  it("has no queue to read and no approval step", async () => {
     const env = environment();
     const adminCookie = await adminOf(env);
     const id = await submitOne(env, "Live", { cookie: adminCookie });
@@ -1015,7 +1015,6 @@ describe("direct publishing (the review queue is retired)", () => {
     for (const [path, method] of [
       [`${ORIGIN}/api/gallery/review`, "GET"],
       [`${ORIGIN}/api/gallery/${id}/approve`, "POST"],
-      [`${ORIGIN}/api/gallery/${id}/reject`, "POST"],
     ] as const) {
       const response = await route(
         env,
@@ -1671,6 +1670,150 @@ describe("gallery administration", () => {
       }),
     );
     expect(((await gone.json()) as { entries: unknown[] }).entries).toEqual([]);
+  });
+
+  it("rejects with an owner-visible reason and prevents owner self-restore", async () => {
+    const env = environment();
+    const adminCookie = await adminOf(env);
+    const ownerCookie = await makerOf(env);
+    const id = await submitOne(env, "Needs cleanup", {
+      cookie: ownerCookie,
+      text: wiredProjectText("Needs cleanup"),
+    });
+
+    function rejectRequest(cookie: string, reason: unknown, origin = ORIGIN) {
+      return new Request(`${ORIGIN}/api/gallery/${id}/reject`, {
+        method: "POST",
+        headers: {
+          Cookie: cookie,
+          Origin: origin,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ reason }),
+      });
+    }
+
+    expect((await route(env, rejectRequest(ownerCookie, "No"))).status).toBe(
+      401,
+    );
+    expect(
+      (await route(env, rejectRequest(adminCookie, "No", "https://evil.test")))
+        .status,
+    ).toBe(403);
+    expect((await route(env, rejectRequest(adminCookie, "   "))).status).toBe(
+      400,
+    );
+
+    const rejected = await route(
+      env,
+      rejectRequest(adminCookie, "Label the ports and remove loose wires."),
+    );
+    expect(rejected.status).toBe(200);
+    expect(await rejected.json()).toMatchObject({ id, status: "rejected" });
+
+    const publicList = await route(env, new Request(`${ORIGIN}/api/gallery`));
+    expect(
+      ((await publicList.json()) as { entries: unknown[] }).entries,
+    ).toEqual([]);
+    const mine = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/mine`, {
+        headers: cookieHeaders(ownerCookie),
+      }),
+    );
+    expect(await mine.json()).toMatchObject({
+      entries: [
+        {
+          id,
+          status: "rejected",
+          rejectReason: "Label the ports and remove loose wires.",
+        },
+      ],
+    });
+
+    const adminRejected = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/rejected`, {
+        headers: cookieHeaders(adminCookie),
+      }),
+    );
+    expect(adminRejected.status).toBe(200);
+    expect(await adminRejected.json()).toMatchObject({
+      entries: [
+        {
+          id,
+          rejectReason: "Label the ports and remove loose wires.",
+        },
+      ],
+    });
+    const memberRejected = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/rejected`, {
+        headers: cookieHeaders(ownerCookie),
+      }),
+    );
+    expect(memberRejected.status).toBe(401);
+
+    const ownerRestore = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/restore`, {
+        method: "POST",
+        headers: { Cookie: ownerCookie, Origin: ORIGIN },
+      }),
+    );
+    expect(ownerRestore.status).toBe(409);
+    const earlyDelete = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}`, {
+        method: "DELETE",
+        headers: cookieHeaders(adminCookie),
+      }),
+    );
+    expect(earlyDelete.status).toBe(409);
+
+    expect(
+      (
+        await route(
+          env,
+          new Request(`${ORIGIN}/api/gallery/${id}/recycle`, {
+            method: "POST",
+            headers: { Cookie: adminCookie, Origin: ORIGIN },
+          }),
+        )
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await route(
+          env,
+          new Request(`${ORIGIN}/api/gallery/${id}/restore`, {
+            method: "POST",
+            headers: { Cookie: ownerCookie, Origin: ORIGIN },
+          }),
+        )
+      ).status,
+    ).toBe(409);
+    expect(
+      (
+        await route(
+          env,
+          new Request(`${ORIGIN}/api/gallery/${id}/restore`, {
+            method: "POST",
+            headers: { Cookie: adminCookie, Origin: ORIGIN },
+          }),
+        )
+      ).status,
+    ).toBe(200);
+
+    const restoredMine = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/mine`, {
+        headers: cookieHeaders(ownerCookie),
+      }),
+    );
+    expect(await restoredMine.json()).toMatchObject({
+      entries: [{ id, status: "public", rejectReason: null }],
+    });
   });
 
   it("converges stored entries back into the rolling window", async () => {

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -24,6 +24,7 @@ import {
   GALLERY_MAX_LIST_LIMIT,
   GALLERY_MAX_NAME_LENGTH,
   GALLERY_MAX_PROJECT_BYTES,
+  GALLERY_MAX_REJECT_REASON_LENGTH,
   GALLERY_MAX_VERSIONS_PER_ENTRY,
   WORKSPACE_SLOT_LIMIT,
   sanitizeGalleryTags,
@@ -86,14 +87,26 @@ async function entryManager(
   request: Request,
   env: GalleryEnv,
   id: string,
-): Promise<{ found: boolean; reviewer: boolean; owner: boolean }> {
-  const existing = await callGallery<{ ownerUserId?: string | null }>(
-    env,
-    "any-entry",
-    { id },
-  );
+): Promise<{
+  found: boolean;
+  reviewer: boolean;
+  owner: boolean;
+  status: string | null;
+  rejectReason: string | null;
+}> {
+  const existing = await callGallery<{
+    ownerUserId?: string | null;
+    status?: string;
+    rejectReason?: string | null;
+  }>(env, "any-entry", { id });
   if (existing.status !== 200) {
-    return { found: false, reviewer: false, owner: false };
+    return {
+      found: false,
+      reviewer: false,
+      owner: false,
+      status: null,
+      rejectReason: null,
+    };
   }
   const reviewer = await canReview(request, env);
   const user = await sessionUserOf(request, env);
@@ -101,7 +114,13 @@ async function entryManager(
     user !== null &&
     existing.payload.ownerUserId != null &&
     existing.payload.ownerUserId === user.id;
-  return { found: true, reviewer, owner };
+  return {
+    found: true,
+    reviewer,
+    owner,
+    status: existing.payload.status ?? null,
+    rejectReason: existing.payload.rejectReason ?? null,
+  };
 }
 
 async function submitterHash(request: Request): Promise<string> {
@@ -464,6 +483,19 @@ export async function routeGalleryRequest(
     });
   }
   if (
+    segments.length === 1 &&
+    segments[0] === "rejected" &&
+    request.method === "GET"
+  ) {
+    if (!(await isAdmin(request, env))) {
+      return Response.json({ error: "unauthorized" }, { status: 401 });
+    }
+    const { payload } = await callGallery(env, "rejected", {});
+    return Response.json(payload, {
+      headers: { "cache-control": "no-store" },
+    });
+  }
+  if (
     segments.length === 2 &&
     segments[0] === "maintenance" &&
     segments[1] === "schema-backup" &&
@@ -694,6 +726,33 @@ export async function routeGalleryRequest(
   if (segments.length === 1 && request.method === "PUT") {
     return handleEntryUpdate(request, env, segments[0]!);
   }
+  if (
+    segments.length === 2 &&
+    segments[1] === "reject" &&
+    request.method === "POST"
+  ) {
+    if (!sameOrigin(request)) {
+      return Response.json({ error: "forbidden" }, { status: 403 });
+    }
+    const reviewer = await sessionUserOf(request, env);
+    if (!reviewer?.isAdmin) {
+      return Response.json({ error: "unauthorized" }, { status: 401 });
+    }
+    const body = (await request.json().catch(() => null)) as {
+      reason?: unknown;
+    } | null;
+    const reason = fieldText(body?.reason, GALLERY_MAX_REJECT_REASON_LENGTH);
+    if (!reason) {
+      return Response.json({ error: "invalid-fields" }, { status: 400 });
+    }
+    const { status, payload } = await callGallery(env, "reject", {
+      id: segments[0],
+      reason,
+      at: new Date().toISOString(),
+      reviewerId: reviewer.id,
+    });
+    return Response.json(payload, { status });
+  }
   if (segments.length === 2 && request.method === "POST") {
     const [id, action] = segments;
     if (action !== "recycle" && action !== "restore") {
@@ -702,8 +761,8 @@ export async function routeGalleryRequest(
     if (!sameOrigin(request)) {
       return Response.json({ error: "forbidden" }, { status: 403 });
     }
-    // Admins curate anything; an owner may withdraw their own entry and
-    // bring it back, which republishes it.
+    // Admins curate anything. An ordinary owner may withdraw a public entry
+    // or restore a voluntary withdrawal, but cannot undo an Owner rejection.
     const admin = await isAdmin(request, env);
     if (!admin) {
       const access = await entryManager(request, env, id!);
@@ -712,6 +771,13 @@ export async function routeGalleryRequest(
       }
       if (!access.owner) {
         return Response.json({ error: "unauthorized" }, { status: 401 });
+      }
+      const validOwnerTransition =
+        action === "recycle"
+          ? access.status === "public"
+          : access.status === "recycled" && access.rejectReason === null;
+      if (!validOwnerTransition) {
+        return Response.json({ error: "invalid-status" }, { status: 409 });
       }
     }
     const { status, payload } = await callGallery(env, "set-status", {


### PR DESCRIPTION
## Summary

- add an Owner-only management menu to every community Gallery tile with Edit and replace, Withdraw, and Reject with reason
- persist reasoned rejection metadata and show it to the submitter without allowing self-restore
- add rejected-entry Restore / Move to recycle bin management, while retaining the recycle-bin-only hard-delete guard and confirmation
- update lifecycle documentation and regression coverage

## Validation

- `pnpm gate:preflight -- --base origin/main`
- `pnpm gate:affected -- --base origin/main`
- `pnpm build`
- Gallery Playwright suite: 31 passed
- workspace unit suite: 1459 passed
