### PR TITLE
feat(gallery): add direct Owner rejection controls

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -159,10 +159,36 @@ test("the Owner rejects a Gallery entry with an author-visible reason", async ({
   await expect(
     page.getByTestId(`gallery-owner-edit-${ENTRY.id}`),
   ).toHaveAttribute("href", `/g/${ENTRY.id}`);
+  await menu.locator("summary").click();
+
+  // Rejection is a direct card action, beside the management menu.
   await page.getByTestId(`gallery-owner-reject-${ENTRY.id}`).click();
   await expect(page.getByTestId("gallery-owner-reject-confirm")).toBeDisabled();
+  for (const reason of [
+    "too ugly",
+    "circuit incorrect",
+    "too simple",
+    "duplicate",
+  ]) {
+    await expect(
+      page.getByTestId(
+        `gallery-owner-reject-option-${reason.replace(/\s/gu, "-")}`,
+      ),
+    ).toBeVisible();
+  }
+  // A free-form other reason is independently sufficient.
+  await page.getByTestId("gallery-owner-reject-note").fill("Other reason");
+  await expect(page.getByTestId("gallery-owner-reject-confirm")).toBeEnabled();
+  await page.getByTestId("gallery-owner-reject-note").fill("");
+  await expect(page.getByTestId("gallery-owner-reject-confirm")).toBeDisabled();
+
+  await page.getByTestId("gallery-owner-reject-option-too-ugly").check();
   await page
-    .getByTestId("gallery-owner-reject-reason")
+    .getByTestId("gallery-owner-reject-option-circuit-incorrect")
+    .check();
+  await expect(page.getByTestId("gallery-owner-reject-confirm")).toBeEnabled();
+  await page
+    .getByTestId("gallery-owner-reject-note")
     .fill("Label the ports and remove the loose wire.");
   await page.getByTestId("gallery-owner-reject-confirm").click();
 
@@ -170,7 +196,9 @@ test("the Owner rejects a Gallery entry with an author-visible reason", async ({
   await expect(page.getByTestId("gallery-owner-notice")).toContainText(
     "rejected",
   );
-  expect(rejectReason).toBe("Label the ports and remove the loose wire.");
+  expect(rejectReason).toBe(
+    "too ugly; circuit incorrect — Note: Label the ports and remove the loose wire.",
+  );
 });
 
 test("the Owner withdraws a Gallery entry into the recycle bin", async ({

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -39,17 +39,28 @@ export interface GalleryFeedState {
 }
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
+const OWNER_REJECT_REASONS = [
+  "too ugly",
+  "circuit incorrect",
+  "too simple",
+  "duplicate",
+] as const;
+
+function joinedRejectReason(reasons: readonly string[], note: string): string {
+  const selected = reasons.join("; ");
+  const detail = note.trim();
+  if (selected && detail) return `${selected} — Note: ${detail}`;
+  return selected || detail;
+}
 
 function GalleryOwnerMenu({
   entry,
   busy,
   onWithdraw,
-  onReject,
 }: {
   entry: GalleryFeedEntry;
   busy: boolean;
   onWithdraw: () => void;
-  onReject: () => void;
 }) {
   return (
     <details
@@ -77,35 +88,58 @@ function GalleryOwnerMenu({
         >
           Withdraw
         </button>
-        <button
-          type="button"
-          className="gallery-owner-danger"
-          disabled={busy}
-          data-testid={`gallery-owner-reject-${entry.id}`}
-          onClick={onReject}
-        >
-          Reject with reason
-        </button>
       </div>
     </details>
   );
 }
 
+function GalleryOwnerRejectButton({
+  entry,
+  busy,
+  onReject,
+}: {
+  entry: GalleryFeedEntry;
+  busy: boolean;
+  onReject: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="gallery-owner-reject-shortcut"
+      aria-label={`Reject ${entry.name}`}
+      title={`Reject ${entry.name}`}
+      disabled={busy}
+      data-testid={`gallery-owner-reject-${entry.id}`}
+      onClick={onReject}
+    >
+      ×
+    </button>
+  );
+}
+
 function RejectEntryDialog({
   entry,
-  reason,
   busy,
-  onReasonChange,
   onSubmit,
   onClose,
 }: {
   entry: GalleryFeedEntry;
-  reason: string;
   busy: boolean;
-  onReasonChange: (reason: string) => void;
-  onSubmit: () => void;
+  onSubmit: (reason: string) => void;
   onClose: () => void;
 }) {
+  const [selectedReasons, setSelectedReasons] = useState<string[]>([]);
+  const [note, setNote] = useState("");
+  const reason = joinedRejectReason(selectedReasons, note);
+
+  function toggleReason(candidate: string): void {
+    setSelectedReasons((previous) =>
+      previous.includes(candidate)
+        ? previous.filter((reason) => reason !== candidate)
+        : [...previous, candidate],
+    );
+  }
+
   return (
     <div
       className="gallery-owner-dialog-backdrop"
@@ -128,19 +162,36 @@ function RejectEntryDialog({
         <form
           onSubmit={(event) => {
             event.preventDefault();
-            if (reason.trim()) onSubmit();
+            if (reason) onSubmit(reason);
           }}
         >
-          <label htmlFor="gallery-reject-reason">Reason</label>
+          <fieldset className="gallery-owner-reason-options">
+            <legend>Common reasons (choose all that apply)</legend>
+            <div>
+              {OWNER_REJECT_REASONS.map((candidate, index) => (
+                <label key={candidate}>
+                  <input
+                    type="checkbox"
+                    checked={selectedReasons.includes(candidate)}
+                    autoFocus={index === 0}
+                    data-testid={`gallery-owner-reject-option-${candidate.replace(/\s/gu, "-")}`}
+                    onChange={() => toggleReason(candidate)}
+                  />
+                  <span>{candidate}</span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+          <label htmlFor="gallery-reject-note">
+            Additional note or other reason <span>(optional)</span>
+          </label>
           <textarea
-            id="gallery-reject-reason"
-            value={reason}
-            maxLength={500}
-            required
-            autoFocus
-            placeholder="Explain what should be corrected…"
-            data-testid="gallery-owner-reject-reason"
-            onChange={(event) => onReasonChange(event.currentTarget.value)}
+            id="gallery-reject-note"
+            value={note}
+            maxLength={360}
+            placeholder="Add context for the submitter…"
+            data-testid="gallery-owner-reject-note"
+            onChange={(event) => setNote(event.currentTarget.value)}
           />
           <div className="gallery-owner-dialog-actions">
             <button type="button" disabled={busy} onClick={onClose}>
@@ -149,7 +200,7 @@ function RejectEntryDialog({
             <button
               type="submit"
               className="gallery-owner-danger"
-              disabled={busy || !reason.trim()}
+              disabled={busy || !reason}
               data-testid="gallery-owner-reject-confirm"
             >
               {busy ? "Rejecting…" : "Reject entry"}
@@ -261,7 +312,6 @@ export function GalleryFeed() {
   const [ownerBusy, setOwnerBusy] = useState<string | null>(null);
   const [ownerNotice, setOwnerNotice] = useState<string | null>(null);
   const [rejecting, setRejecting] = useState<GalleryFeedEntry | null>(null);
-  const [rejectReason, setRejectReason] = useState("");
   const [author, setAuthor] = useState<string | null>(() =>
     typeof window === "undefined"
       ? null
@@ -479,8 +529,8 @@ export function GalleryFeed() {
     }
   }
 
-  async function rejectEntry(): Promise<void> {
-    if (!rejecting || !rejectReason.trim()) return;
+  async function rejectEntry(reason: string): Promise<void> {
+    if (!rejecting || !reason.trim()) return;
     setOwnerBusy(rejecting.id);
     setOwnerNotice(null);
     try {
@@ -488,7 +538,7 @@ export function GalleryFeed() {
         method: "POST",
         credentials: "same-origin",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ reason: rejectReason.trim() }),
+        body: JSON.stringify({ reason: reason.trim() }),
       });
       if (!response.ok) throw new Error();
       removeManagedEntry(rejecting);
@@ -496,7 +546,6 @@ export function GalleryFeed() {
         `“${rejecting.name}” was rejected and hidden from the Gallery.`,
       );
       setRejecting(null);
-      setRejectReason("");
     } catch {
       setOwnerNotice(`Could not reject “${rejecting.name}”.`);
     } finally {
@@ -674,15 +723,18 @@ export function GalleryFeed() {
                       </span>
                     </a>
                     {isOwner ? (
-                      <GalleryOwnerMenu
-                        entry={entry}
-                        busy={ownerBusy === entry.id}
-                        onWithdraw={() => void withdrawEntry(entry)}
-                        onReject={() => {
-                          setRejecting(entry);
-                          setRejectReason("");
-                        }}
-                      />
+                      <>
+                        <GalleryOwnerRejectButton
+                          entry={entry}
+                          busy={ownerBusy === entry.id}
+                          onReject={() => setRejecting(entry)}
+                        />
+                        <GalleryOwnerMenu
+                          entry={entry}
+                          busy={ownerBusy === entry.id}
+                          onWithdraw={() => void withdrawEntry(entry)}
+                        />
+                      </>
                     ) : null}
                   </div>
                 ),
@@ -736,14 +788,9 @@ export function GalleryFeed() {
       {rejecting ? (
         <RejectEntryDialog
           entry={rejecting}
-          reason={rejectReason}
           busy={ownerBusy === rejecting.id}
-          onReasonChange={setRejectReason}
-          onSubmit={() => void rejectEntry()}
-          onClose={() => {
-            setRejecting(null);
-            setRejectReason("");
-          }}
+          onSubmit={(reason) => void rejectEntry(reason)}
+          onClose={() => setRejecting(null)}
         />
       ) : null}
     </main>

--- a/apps/editor/src/gallery.css
+++ b/apps/editor/src/gallery.css
@@ -648,6 +648,37 @@
   right: 8px;
 }
 
+.gallery-owner-reject-shortcut {
+  position: absolute;
+  z-index: 3;
+  top: 8px;
+  right: 46px;
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  padding: 0;
+  border: 1px solid rgb(180 35 24 / 30%);
+  border-radius: 999px;
+  color: var(--icm-danger, #b42318);
+  background: rgb(255 255 255 / 94%);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 12%);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.gallery-owner-reject-shortcut:hover {
+  color: #fff;
+  background: var(--icm-danger, #b42318);
+  box-shadow: 0 4px 12px rgb(0 0 0 / 18%);
+}
+
+.gallery-owner-reject-shortcut:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+
 .gallery-owner-menu > summary {
   display: grid;
   width: 30px;
@@ -757,9 +788,77 @@
   gap: 8px;
 }
 
+.gallery-owner-reason-options {
+  min-width: 0;
+  margin: 0 0 4px;
+  padding: 0;
+  border: 0;
+}
+
+.gallery-owner-reason-options legend {
+  margin-bottom: 8px;
+  padding: 0;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.gallery-owner-reason-options > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.gallery-owner-reason-options label {
+  position: relative;
+  cursor: pointer;
+}
+
+.gallery-owner-reason-options input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+
+.gallery-owner-reason-options span {
+  display: block;
+  padding: 6px 10px;
+  border: 1px solid var(--icm-border);
+  border-radius: 999px;
+  color: var(--icm-text-muted);
+  background: var(--icm-surface);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.gallery-owner-reason-options label:hover span {
+  border-color: var(--icm-border-hover);
+  background: var(--icm-surface-hover);
+}
+
+.gallery-owner-reason-options input:focus-visible + span {
+  outline: 2px solid color-mix(in srgb, var(--icm-accent) 30%, transparent);
+  outline-offset: 2px;
+}
+
+.gallery-owner-reason-options input:checked + span {
+  border-color: var(--icm-danger, #b42318);
+  color: var(--icm-danger, #b42318);
+  background: color-mix(
+    in srgb,
+    var(--icm-danger, #b42318) 9%,
+    var(--icm-surface)
+  );
+}
+
 .gallery-owner-dialog label {
   font-size: 13px;
   font-weight: 600;
+}
+
+.gallery-owner-dialog > form > label span {
+  color: var(--icm-text-muted);
+  font-weight: 400;
 }
 
 .gallery-owner-dialog textarea {

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -105,12 +105,15 @@ submitter until the Owner restores the entry.
   moderator curates and bypasses the quality gates; the recycle bin and
   maintenance stay admin-only.
 
-The Gallery feed gives the super-admin an Owner menu on every community tile:
-Edit and replace, Withdraw, and Reject with reason. The editor surfaces the
-full administration lifecycle at `/moderation` (rejected entries, recycle
-bin, plus admin-only moderator appointment) and the submitter's view at
-`/mine` (status chips, rejection reason, owner-visible preview,
-open-in-editor). Every gallery page state wears the shared site chrome.
+The Gallery feed gives the super-admin direct Like and Reject (`×`) controls
+on every community tile, plus an Owner menu for Edit and replace and Withdraw.
+Reject opens a multi-select form with common reasons (`too ugly`,
+`circuit incorrect`, `too simple`, `duplicate`) and an independent optional
+note/other-reason field. The editor surfaces the full administration lifecycle
+at `/moderation` (rejected entries, recycle bin, plus admin-only moderator
+appointment) and the submitter's view at `/mine` (status chips, rejection
+reason, owner-visible preview, open-in-editor). Every gallery page state wears
+the shared site chrome.
 
 ## Owner editing
 


### PR DESCRIPTION
## Summary

- add a visible Owner-only reject × directly on every community Gallery card
- keep Edit and replace / Withdraw in the Owner menu
- make common rejection reasons multi-select and allow an independent optional note or other reason
- combine the selected reasons and note into the author-visible rejection reason

## Validation

- `pnpm gate:preflight -- --base origin/main`
- `pnpm gate:affected -- --base origin/main`
- workspace unit suite: 1468 passed
- Gallery Playwright suite: 31 passed
