### PR TITLE
fix(routing): make connected reflections atomic

### DIFF
--- a/packages/edit-engine/src/endpoint-connection.integration.test.ts
+++ b/packages/edit-engine/src/endpoint-connection.integration.test.ts
@@ -1,4 +1,8 @@
-import { createEmptyDocument } from "@icm/model";
+import {
+  createEmptyDocument,
+  reflectOrientation,
+  type ScreenFlip,
+} from "@icm/model";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
@@ -55,7 +59,217 @@ function execute(edit: SchematicEdit) {
   );
 }
 
+function reflectInstance(
+  document: ReturnType<typeof createEmptyDocument>,
+  direction: ScreenFlip,
+  suffix: string,
+) {
+  const before = document.instances.find(
+    (instance) => instance.id === "M1",
+  )!.placement!;
+  const reflected = reflectOrientation(before, direction);
+  return executeTransaction(
+    document,
+    {
+      transactionId: `reflect-${suffix}`,
+      documentId: document.id,
+      expectedRevision: document.revision,
+      actor: { kind: "human", id: "test" },
+      edits: [
+        {
+          kind: "mirror_instance",
+          instanceId: "M1",
+          mirror: reflected.mirror,
+        },
+        ...(reflected.rotation === before.rotation
+          ? []
+          : [
+              {
+                kind: "rotate_instance" as const,
+                instanceId: "M1",
+                rotation: reflected.rotation,
+              },
+            ]),
+      ],
+    },
+    { symbolResolver: resolver },
+  );
+}
+
+function gateRouteDocument(symbolId: "nmos" | "pmos") {
+  const document = createEmptyDocument(
+    `connected-${symbolId}`,
+    "Connected MOS reflection",
+  );
+  document.instances.push({
+    id: "M1",
+    symbolId,
+    symbolVariantId: "textbook-3terminal",
+    placement: {
+      position: { x: 100, y: 100 },
+      rotation: 0,
+      mirror: "none",
+    },
+  });
+  document.nets.push({
+    id: "signal",
+    terminals: [{ instanceId: "M1", pinName: "G" }],
+  });
+  document.junctions.push({
+    id: "J1",
+    netId: "signal",
+    position: { x: 120, y: 100 },
+  });
+  document.routes.push({
+    id: "gate-route",
+    netId: "signal",
+    from: { kind: "terminal", instanceId: "M1", pinName: "G" },
+    to: { kind: "junction", junctionId: "J1" },
+    waypoints: [],
+    segmentModes: ["manual"],
+  });
+  return document;
+}
+
 describe("EndpointConnection transform lifecycle", () => {
+  it.each(["nmos", "pmos"] as const)(
+    "follows a connected %s Route once at the final reflected pose",
+    (symbolId) => {
+      const document = gateRouteDocument(symbolId);
+      const result = reflectInstance(document, "top-bottom", "atomic");
+      expect(result).toMatchObject({ ok: true });
+      if (!result.ok) return;
+      expect(result.document.routes).toEqual(document.routes);
+    },
+  );
+
+  it.each(["nmos", "pmos"] as const)(
+    "replaces a collapsed %s Route with direct contact and restores wiring",
+    (symbolId) => {
+      const document = gateRouteDocument(symbolId);
+      const collapsed = reflectInstance(document, "left-right", "collapse");
+      expect(collapsed).toMatchObject({ ok: true });
+      if (!collapsed.ok) return;
+      expect(collapsed.document.routes).toEqual([]);
+
+      const restored = reflectInstance(
+        collapsed.document,
+        "left-right",
+        "restore",
+      );
+      expect(restored).toMatchObject({ ok: true });
+      if (!restored.ok) return;
+      expect(restored.document.routes).toHaveLength(1);
+      expect(restored.document.routes[0]!.segmentModes).toHaveLength(
+        restored.document.routes[0]!.waypoints.length + 1,
+      );
+    },
+  );
+
+  it("refuses to collapse referenced Route geometry without losing its annotation", () => {
+    const document = gateRouteDocument("pmos");
+    document.annotations.push({
+      id: "gate-label",
+      kind: "net-label",
+      binding: { kind: "net-name", netId: "signal" },
+      anchor: {
+        kind: "route",
+        routeId: "gate-route",
+        segmentIndex: 0,
+        t: 0.5,
+        normalOffset: 0,
+        direction: "forward",
+        orientation: "horizontal",
+        fallbackPosition: { x: 100, y: 100 },
+      },
+      netId: "signal",
+      alignment: "middle",
+      rotation: 0,
+      locked: false,
+    });
+
+    const result = reflectInstance(
+      document,
+      "left-right",
+      "referenced-collapse",
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "EDIT_PRECONDITION",
+        message: expect.stringContaining("gate-label still references it"),
+      },
+    });
+    expect(result.document).toEqual(document);
+  });
+
+  it("round-trips the attached PMOS/VDD Route topology", () => {
+    const document = createEmptyDocument(
+      "pmos-vdd-debug",
+      "Attached PMOS/VDD Route",
+    );
+    document.instances.push(
+      {
+        id: "M1",
+        symbolId: "pmos",
+        symbolVariantId: "textbook-3terminal",
+        placement: {
+          position: { x: 260, y: 190 },
+          rotation: 0,
+          mirror: "x",
+        },
+        mosBulkBinding: {
+          netId: "net-vdd",
+          origin: "cell-default",
+        },
+      },
+      {
+        id: "VDD1",
+        symbolId: "vdd-port",
+        placement: {
+          position: { x: 270, y: 150 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+    );
+    document.nets.push({
+      id: "net-vdd",
+      terminals: [
+        { instanceId: "M1", pinName: "S" },
+        { instanceId: "M1", pinName: "B" },
+        { instanceId: "VDD1", pinName: "P" },
+      ],
+    });
+    document.routes.push({
+      id: "route-99c5b7423f110b2d",
+      netId: "net-vdd",
+      from: { kind: "terminal", instanceId: "M1", pinName: "S" },
+      to: { kind: "terminal", instanceId: "VDD1", pinName: "P" },
+      waypoints: [],
+      segmentModes: ["manual"],
+    });
+
+    for (const direction of ["left-right", "top-bottom"] as const) {
+      const result = reflectInstance(document, direction, direction);
+      expect(result).toMatchObject({ ok: true });
+      if (!result.ok) continue;
+      for (const route of result.document.routes) {
+        expect(route.segmentModes).toHaveLength(route.waypoints.length + 1);
+      }
+      const restored = reflectInstance(
+        result.document,
+        direction,
+        `${direction}-restore`,
+      );
+      expect(restored).toMatchObject({ ok: true });
+      if (!restored.ok) continue;
+      for (const route of restored.document.routes) {
+        expect(route.segmentModes).toHaveLength(route.waypoints.length + 1);
+      }
+    }
+  });
+
   it("routes the advanced Agent orthogonal edit through the same grid landing", () => {
     const document = bulkDocument();
     document.routes = [];

--- a/packages/edit-engine/src/transaction-instance-transform.ts
+++ b/packages/edit-engine/src/transaction-instance-transform.ts
@@ -4,7 +4,6 @@ import type { SymbolResolver } from "@icm/symbols";
 import type { EditTransaction } from "./edit-schema.js";
 import type { EditMutationOutcome, RejectEdit } from "./transaction-domain.js";
 import { followAttachedAnnotations } from "./transaction-instance-annotations.js";
-import { applyInstanceRouteFollow } from "./transaction-route-follow.js";
 import { lockedLayoutOwner } from "./transaction-routing.js";
 
 type InstanceTransformEdit = Extract<
@@ -22,7 +21,6 @@ type InstanceTransformEdit = Extract<
 export interface InstanceTransformEditContext {
   draft: SchematicDocument;
   resolver: SymbolResolver | undefined;
-  explicitlyAuthoredRouteIds: ReadonlySet<string>;
   changedObjectIds: Set<string>;
   reject: RejectEdit;
 }
@@ -33,13 +31,7 @@ export function applyInstanceTransformEdit(
   edit: InstanceTransformEdit,
   context: InstanceTransformEditContext,
 ): InstanceTransformEditOutcome {
-  const {
-    draft,
-    resolver,
-    explicitlyAuthoredRouteIds,
-    changedObjectIds,
-    reject,
-  } = context;
+  const { draft, resolver, changedObjectIds, reject } = context;
   const instance = draft.instances.find(
     (candidate) => candidate.id === edit.instanceId,
   );
@@ -121,7 +113,6 @@ export function applyInstanceTransformEdit(
           ),
         };
       }
-      const beforeTransform = structuredClone(draft);
       const oldPlacement = structuredClone(instance.placement);
       if (edit.kind === "move_instance") {
         instance.placement.position = structuredClone(edit.position);
@@ -140,17 +131,6 @@ export function applyInstanceTransformEdit(
         changedObjectIds,
         resolver,
       );
-      if (resolver) {
-        for (const routeId of applyInstanceRouteFollow(
-          draft,
-          beforeTransform,
-          resolver,
-          edit.instanceId,
-          explicitlyAuthoredRouteIds,
-        )) {
-          changedObjectIds.add(routeId);
-        }
-      }
       changedObjectIds.add(edit.instanceId);
       return { ok: true };
     }

--- a/packages/edit-engine/src/transaction-route-follow.ts
+++ b/packages/edit-engine/src/transaction-route-follow.ts
@@ -295,6 +295,22 @@ export function applyInstancesRouteFollow(
     }
 
     const normalized = normalizeRouteGeometry(points, modes);
+    if (normalized.points.length < 2) {
+      // A transformed endpoint can land exactly on the Route's other
+      // endpoint. Persisting that direct contact as a zero-length Route would
+      // violate the canonical one-mode-per-segment invariant. Remove only the
+      // redundant geometry; the endpoints and their Net membership remain,
+      // so a later transform can materialize an ordinary Route again through
+      // the direct-contact lifecycle.
+      if (samePoint(newFrom.contactPoint, newTo.contactPoint)) {
+        const routeIndex = draft.routes.findIndex(
+          (candidate) => candidate.id === route.id,
+        );
+        if (routeIndex >= 0) draft.routes.splice(routeIndex, 1);
+        changed.push(route.id);
+      }
+      continue;
+    }
     // Any heading is legal geometry (ADR 0039), so a follow-stretch is skipped
     // only when it would leave a degenerate segment behind — previously a
     // free-angle Route simply stopped following its instance.
@@ -317,7 +333,7 @@ export function planInstanceSymbolGeometryRouteFollow(
   originalResolver: SymbolResolver,
   resolver: SymbolResolver,
   instanceIds: ReadonlySet<string>,
-): Extract<SchematicEdit, { kind: "set_route_points" }>[] {
+): SchematicEdit[] {
   const draft = structuredClone(document);
   const changedRouteIds = applyInstancesRouteFollow(
     draft,
@@ -327,8 +343,9 @@ export function planInstanceSymbolGeometryRouteFollow(
     instanceIds,
     new Set(),
   );
-  return changedRouteIds.map((routeId) => {
-    const route = draft.routes.find((candidate) => candidate.id === routeId)!;
+  return changedRouteIds.map((routeId): SchematicEdit => {
+    const route = draft.routes.find((candidate) => candidate.id === routeId);
+    if (!route) return { kind: "remove_route_geometry", routeId };
     return {
       kind: "set_route_points",
       routeId: route.id,

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -20,7 +20,10 @@ import {
   type NetLabelRouteAnchor,
   type RouteMarkerAnchor,
 } from "./transaction-route-annotations.js";
-import { splitRoute } from "./transaction-route-follow.js";
+import {
+  applyInstancesRouteFollow,
+  splitRoute,
+} from "./transaction-route-follow.js";
 import { reconcileTransformDirectContacts } from "./transaction-direct-contact.js";
 import { nextPhysicalContactOperation } from "./transaction-connectivity-normalizer.js";
 import { applyCellResetEdit } from "./transaction-cell-reset.js";
@@ -150,6 +153,15 @@ export function executeTransaction(
     ? captureRouteMarkerAnchors(document, resolver)
     : [];
   const changedRouteIds = new Set<string>();
+  const transformedInstanceIds = new Set(
+    transaction.edits.flatMap((edit) =>
+      edit.kind === "move_instance" ||
+      edit.kind === "rotate_instance" ||
+      edit.kind === "mirror_instance"
+        ? [edit.instanceId]
+        : [],
+    ),
+  );
   let geometryChanged = false;
   let connectivityChanged = false;
 
@@ -243,7 +255,6 @@ export function executeTransaction(
         const outcome = applyInstanceTransformEdit(edit, {
           draft,
           resolver,
-          explicitlyAuthoredRouteIds,
           changedObjectIds,
           reject: rejectAt,
         });
@@ -401,6 +412,57 @@ export function executeTransaction(
       }
     }
     geometryChanged = true;
+  }
+
+  if (resolver && transformedInstanceIds.size > 0) {
+    // One user-visible transform may require several persisted orientation
+    // edits (for example a top-bottom screen reflection is mirror + rotate).
+    // Follow Routes once from the transaction's original geometry to the
+    // final placement, never through invalid intermediate orientations.
+    const followedRouteIds = applyInstancesRouteFollow(
+      draft,
+      document,
+      resolver,
+      resolver,
+      transformedInstanceIds,
+      explicitlyAuthoredRouteIds,
+    );
+    for (const routeId of followedRouteIds) {
+      const collapsed = !draft.routes.some((route) => route.id === routeId);
+      if (collapsed) {
+        const anchoredAnnotation = draft.annotations.find(
+          (annotation) =>
+            annotation.anchor.kind === "route" &&
+            annotation.anchor.routeId === routeId,
+        );
+        const layoutReference = [
+          ...draft.layoutGroups,
+          ...draft.constraints,
+        ].find((item) => item.objectIds.includes(routeId));
+        const evidenceReference = draft.connectivityEvidence.find(
+          (evidence) =>
+            evidence.kind === "name-claim" &&
+            evidence.owner.kind === "power-marker" &&
+            evidence.owner.objectId === routeId,
+        );
+        const referenceId =
+          anchoredAnnotation?.id ??
+          layoutReference?.id ??
+          evidenceReference?.id ??
+          null;
+        if (referenceId) {
+          return rejectTransaction(
+            document,
+            "EDIT_PRECONDITION",
+            `Transform would collapse Route ${routeId} into direct contact while ${referenceId} still references it`,
+            [],
+            [routeId, referenceId],
+          );
+        }
+      }
+      changedObjectIds.add(routeId);
+      changedRouteIds.add(routeId);
+    }
   }
 
   if (


### PR DESCRIPTION
## Summary
- follow connected Routes once from the transaction's original Document to the final transformed pose
- collapse redundant zero-length geometry into direct contact and rematerialize wiring when endpoints separate
- protect referenced Route geometry from lossy collapse
- cover NMOS, PMOS, and the reported PMOS/VDD round trip

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- pnpm gate:full (1474 unit tests, 239 browser tests, builds, release/performance/golden/smoke checks)

The pre-existing untracked probe-conflicts.mjs was not included.