### PR TITLE
feat(export): preserve browser PDF as vector

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3484,6 +3484,8 @@ test("exports one formal visual scene as Project, SVG, PNG, and PDF", async ({
   page,
 }) => {
   await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 420, y: 240 });
+  await page.keyboard.press("Escape");
 
   const projectBytes = await downloadBytes(page, "File", "Save Project");
   expect(JSON.parse(projectBytes.toString("utf8")).topDocumentId).toBeTruthy();
@@ -3497,6 +3499,11 @@ test("exports one formal visual scene as Project, SVG, PNG, and PDF", async ({
   expect([...png.subarray(0, 8)]).toEqual([137, 80, 78, 71, 13, 10, 26, 10]);
   const pdf = await downloadBytes(page, "File", "Export PDF");
   expect(pdf.subarray(0, 5).toString("ascii")).toBe("%PDF-");
+  const pdfText = pdf.toString("latin1");
+  // A page-cover PNG was the former PDF implementation. The browser PDF must
+  // retain the formal SVG as PDF paths/text, so it cannot contain an image XObject.
+  expect(pdfText).not.toContain("/Subtype /Image");
+  expect(pdfText).toContain("/Type /Font");
 });
 
 test("exports structural SPICE and Spectre netlists while exposing instance authoring", async ({

--- a/apps/editor/src/features/editor-shell/editor-export-commands.ts
+++ b/apps/editor/src/features/editor-shell/editor-export-commands.ts
@@ -68,7 +68,7 @@ export function planDesignNetlistExport({
   };
 }
 
-export async function createRasterExportArtifact(
+export async function createVisualExportArtifact(
   format: "png" | "pdf",
   document: SchematicDocument,
   resolver: SymbolResolver,

--- a/apps/editor/src/features/editor-shell/editor-file-commands.ts
+++ b/apps/editor/src/features/editor-shell/editor-file-commands.ts
@@ -8,7 +8,7 @@ import { planCheckBulkDefaults } from "../netlist-export/check-and-save";
 import type { WorkspaceSlot } from "./workspace-shelf";
 import { saveToWorkspaceShelf } from "./workspace-shelf";
 import {
-  createRasterExportArtifact,
+  createVisualExportArtifact,
   createSvgExportArtifact,
   planDesignNetlistExport,
   requestBrowserDownload,
@@ -137,7 +137,7 @@ export function createEditorFileCommands({
   const exportRaster = async (format: "png" | "pdf"): Promise<void> => {
     setStatus(`Preparing ${format.toUpperCase()} export`);
     try {
-      const artifact = await createRasterExportArtifact(
+      const artifact = await createVisualExportArtifact(
         format,
         document,
         resolver,

--- a/docs/specs/export.md
+++ b/docs/specs/export.md
@@ -15,29 +15,32 @@ Every export starts from one validated `SchematicDocument`, one symbol
 resolver, and the formal SVG scene. Editor overlays, hit targets, selections,
 flightlines, and diagnostics are never part of a formal artifact.
 
-| Format | v0.1 derivation                           | Media type        |
-| ------ | ----------------------------------------- | ----------------- |
-| SVG    | canonical formal scene                    | `image/svg+xml`   |
-| PNG    | white-background raster of that SVG at 3x | `image/png`       |
-| PDF    | same PNG fitted to the same viewBox page  | `application/pdf` |
+| Format | v0.1 derivation                             | Media type        |
+| ------ | ------------------------------------------- | ----------------- |
+| SVG    | canonical formal scene                      | `image/svg+xml`   |
+| PNG    | white-background raster of that SVG at 3x   | `image/png`       |
+| PDF    | browser: formal SVG converted to vector PDF | `application/pdf` |
 
-The SVG viewBox is the authoritative page bound. Node raster export substitutes
-the formal serif stack with a bundled DejaVu Serif family before rasterization,
-so missing host fonts cannot remove labels. The original SVG is unchanged.
-Export filenames are normalized and all three formats use the same base name.
+The SVG viewBox is the authoritative page bound. Browser PDF export converts
+that same curated, renderer-generated SVG through `svg2pdf.js` into PDF paths
+and text; it never embeds the page-cover PNG used by the PNG artifact. The
+original SVG is unchanged. Export filenames are normalized and all three
+formats use the same base name.
 
-## Known limit
+Node/headless export retains a high-resolution raster-PDF fallback for release
+tooling because the browser vector converter requires a live DOM. It is not the
+interactive editor's user-facing PDF path.
 
-PDF 0.1 is a high-resolution raster PDF. It preserves page bounds and visual
-content but not selectable vector primitives. Vector PDF is a later compatible
-enhancement, not a reason to introduce a second renderer.
+If vector conversion fails, browser export fails visibly; it must not silently
+downgrade the requested PDF to a bitmap. SVG remains the portable vector
+fallback.
 
 ## Validation
 
 - parse the SVG viewBox and reject invalid bounds;
 - check PNG signature and dimensions against viewBox times scale;
-- reopen PDF, check one page and page bounds, render it with Poppler, and
-  visually compare it with the SVG/PNG fixture;
+- reopen browser PDF, check one page and page bounds, assert it contains no
+  page-cover image XObject, and visually compare it with the SVG fixture;
 - assert formal SVG has no editor-only layers.
 
 ## Agent File Resource

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -75,8 +75,9 @@ when you need to import them again.
 ## Export
 
 The **File** menu exports SVG, PNG, and PDF containing only formal schematic
-layers. PNG uses 3x raster scale. PDF contains that same high-resolution raster
-on a page matching the SVG viewBox.
+layers. PNG uses 3x raster scale. Browser PDF converts the same formal SVG to
+vector paths and text on a page matching the SVG viewBox, so circuit geometry
+stays sharp when enlarged.
 
 For an electrical design netlist, choose **Netlist / Check Report**. **Check and
 Save** is separate: it settles available MOS-body defaults and keeps a copy on

--- a/packages/exporters/package.json
+++ b/packages/exporters/package.json
@@ -29,6 +29,8 @@
     "@icm/symbols": "workspace:*",
     "@resvg/resvg-js": "2.6.2",
     "dejavu-fonts-ttf": "2.37.3",
-    "pdf-lib": "1.17.1"
+    "jspdf": "4.2.1",
+    "pdf-lib": "1.17.1",
+    "svg2pdf.js": "2.8.0"
   }
 }

--- a/packages/exporters/src/browser.ts
+++ b/packages/exporters/src/browser.ts
@@ -1,5 +1,7 @@
+import { jsPDF } from "jspdf";
+
 import type { FormalExportSource, RasterExport } from "./index.js";
-import { DEFAULT_EXPORT_SCALE } from "./index.js";
+import { DEFAULT_EXPORT_SCALE, EXPORT_VERSION } from "./index.js";
 
 function loadImage(url: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
@@ -47,10 +49,78 @@ export async function rasterizeFormalSvgInBrowser(
   }
 }
 
+function formalSvgElement(source: FormalExportSource): {
+  host: HTMLDivElement;
+  svg: SVGSVGElement;
+} {
+  const template = document.createElement("template");
+  template.innerHTML = source.svg;
+  const svg = template.content.querySelector("svg");
+  if (!(svg instanceof SVGSVGElement)) {
+    throw new Error("Formal export did not produce an SVG element");
+  }
+
+  // svg2pdf reads inherited styles and computed geometry from the live DOM. The
+  // formal scene is renderer-generated, not user-supplied SVG, and this hidden
+  // host is removed immediately after conversion.
+  svg.setAttribute("width", String(source.bounds.width));
+  svg.setAttribute("height", String(source.bounds.height));
+  const host = document.createElement("div");
+  host.setAttribute("aria-hidden", "true");
+  host.style.cssText =
+    "position:fixed;left:-100000px;top:0;visibility:hidden;pointer-events:none;";
+  host.append(svg);
+  document.body.append(host);
+  return { host, svg };
+}
+
+/**
+ * Converts the canonical formal SVG into a vector PDF in the browser. This is
+ * deliberately separate from PNG rasterization: PDF paths and text are
+ * emitted by svg2pdf, while PNG remains the explicit raster artifact.
+ */
+export async function vectorizeFormalSvgInBrowser(
+  source: FormalExportSource,
+): Promise<Uint8Array> {
+  const widthPoints = source.bounds.width * 0.75;
+  const heightPoints = source.bounds.height * 0.75;
+  const pdf = new jsPDF({
+    orientation: widthPoints > heightPoints ? "landscape" : "portrait",
+    unit: "pt",
+    format: [widthPoints, heightPoints],
+    compress: true,
+    precision: 16,
+  });
+  pdf.setProperties({
+    title: "Interactive Circuit Maker schematic",
+    author: "Interactive Circuit Maker",
+    creator: `Interactive Circuit Maker exporter ${EXPORT_VERSION}`,
+  });
+  pdf.setCreationDate(new Date("2000-01-01T00:00:00.000Z"));
+
+  const { host, svg } = formalSvgElement(source);
+  try {
+    // svg2pdf's published UMD entry reads browser globals while it is loaded.
+    // Loading it only for an actual browser PDF request keeps the exporter
+    // module usable in Node-based editor tests and headless tooling.
+    const { svg2pdf } = await import("svg2pdf.js");
+    await svg2pdf(svg, pdf, {
+      x: 0,
+      y: 0,
+      width: widthPoints,
+      height: heightPoints,
+      loadExternalStyleSheets: false,
+      loadImages: false,
+    });
+    return new Uint8Array(pdf.output("arraybuffer"));
+  } finally {
+    host.remove();
+  }
+}
+
 export async function exportFormalArtifactsInBrowser(
   source: FormalExportSource,
 ): Promise<{ png: RasterExport; pdf: Uint8Array }> {
   const png = await rasterizeFormalSvgInBrowser(source);
-  const { createPdfFromPng } = await import("./pdf.js");
-  return { png, pdf: await createPdfFromPng(png, source.bounds) };
+  return { png, pdf: await vectorizeFormalSvgInBrowser(source) };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,9 +242,15 @@ importers:
       dejavu-fonts-ttf:
         specifier: 2.37.3
         version: 2.37.3
+      jspdf:
+        specifier: 4.2.1
+        version: 4.2.1
       pdf-lib:
         specifier: 1.17.1
         version: 1.17.1
+      svg2pdf.js:
+        specifier: 2.8.0
+        version: 2.8.0(jspdf@4.2.1)
 
   packages/model:
     dependencies:
@@ -324,6 +330,13 @@ importers:
         version: link:../devices
 
 packages:
+  "@babel/runtime@7.29.7":
+    resolution:
+      {
+        integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@fontsource-variable/google-sans-code@5.3.0":
     resolution:
       {
@@ -649,6 +662,18 @@ packages:
         integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==,
       }
 
+  "@types/pako@2.0.0":
+    resolution:
+      {
+        integrity: sha512-10+iaz93qR5WYxTo+PMifD5TSxiOtdRaxBf7INGGXMQgTCu8Z/7GYWYFUOS3q/G0nE5boj1r4FEB+WSy7s5gbA==,
+      }
+
+  "@types/raf@3.4.3":
+    resolution:
+      {
+        integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==,
+      }
+
   "@types/react-dom@19.2.4":
     resolution:
       {
@@ -661,6 +686,12 @@ packages:
     resolution:
       {
         integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==,
+      }
+
+  "@types/trusted-types@2.0.7":
+    resolution:
+      {
+        integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==,
       }
 
   "@typescript/typescript-aix-ppc64@7.0.2":
@@ -916,6 +947,20 @@ packages:
       }
     engines: { node: ">=12" }
 
+  base64-arraybuffer@1.0.2:
+    resolution:
+      {
+        integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==,
+      }
+    engines: { node: ">= 0.6.0" }
+
+  canvg@3.0.11:
+    resolution:
+      {
+        integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==,
+      }
+    engines: { node: ">=10.0.0" }
+
   chai@6.2.2:
     resolution:
       {
@@ -928,6 +973,26 @@ packages:
       {
         integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
       }
+
+  core-js@3.50.0:
+    resolution:
+      {
+        integrity: sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==,
+      }
+
+  css-line-break@2.1.0:
+    resolution:
+      {
+        integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==,
+      }
+
+  cssesc@3.0.0:
+    resolution:
+      {
+        integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==,
+      }
+    engines: { node: ">=4" }
+    hasBin: true
 
   csstype@3.2.3:
     resolution:
@@ -947,6 +1012,12 @@ packages:
         integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
       }
     engines: { node: ">=8" }
+
+  dompurify@3.4.14:
+    resolution:
+      {
+        integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==,
+      }
 
   es-module-lexer@2.3.1:
     resolution:
@@ -974,6 +1045,12 @@ packages:
       }
     engines: { node: ">=18" }
 
+  fast-png@6.2.0:
+    resolution:
+      {
+        integrity: sha512-fO4DewoEd9WwuP8DQcfj8Tlc88Jno6lJAjlDYzvJSqMIZwxUpRT4zuzPXgqygjJqngBdCbeQRaL/FVz3InExhA==,
+      }
+
   fdir@6.5.0:
     resolution:
       {
@@ -985,6 +1062,18 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution:
+      {
+        integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==,
+      }
+
+  font-family-papandreou@0.2.0-patch2:
+    resolution:
+      {
+        integrity: sha512-l/YiRdBSH/eWv6OF3sLGkwErL+n0MqCICi9mppTZBOCL5vixWGDqCYvRcuxB2h7RGCTzaTKOHT2caHvCXQPRlw==,
+      }
 
   fsevents@2.3.2:
     resolution:
@@ -1001,6 +1090,25 @@ packages:
       }
     engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
     os: [darwin]
+
+  html2canvas@1.4.1:
+    resolution:
+      {
+        integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==,
+      }
+    engines: { node: ">=8.0.0" }
+
+  iobuffer@5.4.0:
+    resolution:
+      {
+        integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==,
+      }
+
+  jspdf@4.2.1:
+    resolution:
+      {
+        integrity: sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==,
+      }
 
   lightningcss-android-arm64@1.33.0:
     resolution:
@@ -1139,6 +1247,12 @@ packages:
         integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==,
       }
 
+  pako@2.2.0:
+    resolution:
+      {
+        integrity: sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==,
+      }
+
   pathe@2.0.3:
     resolution:
       {
@@ -1149,6 +1263,12 @@ packages:
     resolution:
       {
         integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==,
+      }
+
+  performance-now@2.1.0:
+    resolution:
+      {
+        integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==,
       }
 
   picocolors@1.1.1:
@@ -1202,6 +1322,12 @@ packages:
     engines: { node: ">=14" }
     hasBin: true
 
+  raf@3.4.1:
+    resolution:
+      {
+        integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==,
+      }
+
   react-dom@19.2.8:
     resolution:
       {
@@ -1216,6 +1342,19 @@ packages:
         integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==,
       }
     engines: { node: ">=0.10.0" }
+
+  regenerator-runtime@0.13.11:
+    resolution:
+      {
+        integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==,
+      }
+
+  rgbcolor@1.0.1:
+    resolution:
+      {
+        integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==,
+      }
+    engines: { node: ">= 0.8.15" }
 
   rolldown@1.2.3:
     resolution:
@@ -1244,16 +1383,57 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  specificity@0.4.1:
+    resolution:
+      {
+        integrity: sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==,
+      }
+    hasBin: true
+
   stackback@0.0.2:
     resolution:
       {
         integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
       }
 
+  stackblur-canvas@2.0.0:
+    resolution:
+      {
+        integrity: sha512-660gH1SpjeKyfUYnne9nuIya7CDGds6NdIrxzOToSgaSlOqbh7UYGP9VlxlQ8IX7af/nPuAHLkN03l84OesX7Q==,
+      }
+    deprecated: Fixed build bug in 2.2.0 as not converting ES6 source for older browsers
+
   std-env@4.2.0:
     resolution:
       {
         integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==,
+      }
+
+  svg-pathdata@6.0.3:
+    resolution:
+      {
+        integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==,
+      }
+    engines: { node: ">=12.0.0" }
+
+  svg2pdf.js@2.8.0:
+    resolution:
+      {
+        integrity: sha512-/15EDtt7A836uHh+y74cNdDaZy0JJEp4UR9IskJr5H+3F9AYDnUl6cjonbn2bEBDtCrEwXiIZWqO7N0wEUK4Uw==,
+      }
+    peerDependencies:
+      jspdf: ^4.0.0 || ^3.0.0 || ^2.0.0
+
+  svgpath@2.6.0:
+    resolution:
+      {
+        integrity: sha512-OIWR6bKzXvdXYyO4DK/UWa1VA1JeKq8E+0ug2DG98Y/vOmMpfZNj+TIG988HjfYSqtcy/hFOtZq/n/j5GSESNg==,
+      }
+
+  text-segmentation@1.0.3:
+    resolution:
+      {
+        integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==,
       }
 
   tinybench@2.9.0:
@@ -1301,6 +1481,12 @@ packages:
     resolution:
       {
         integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==,
+      }
+
+  utrie@1.0.2:
+    resolution:
+      {
+        integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==,
       }
 
   vite@8.2.1:
@@ -1408,6 +1594,8 @@ packages:
       }
 
 snapshots:
+  "@babel/runtime@7.29.7": {}
+
   "@fontsource-variable/google-sans-code@5.3.0": {}
 
   "@jridgewell/sourcemap-codec@1.5.5": {}
@@ -1536,6 +1724,11 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  "@types/pako@2.0.0": {}
+
+  "@types/raf@3.4.3":
+    optional: true
+
   "@types/react-dom@19.2.4(@types/react@19.2.18)":
     dependencies:
       "@types/react": 19.2.18
@@ -1543,6 +1736,9 @@ snapshots:
   "@types/react@19.2.18":
     dependencies:
       csstype: 3.2.3
+
+  "@types/trusted-types@2.0.7":
+    optional: true
 
   "@typescript/typescript-aix-ppc64@7.0.2":
     optional: true
@@ -1652,15 +1848,45 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  base64-arraybuffer@1.0.2:
+    optional: true
+
+  canvg@3.0.11:
+    dependencies:
+      "@babel/runtime": 7.29.7
+      "@types/raf": 3.4.3
+      core-js: 3.50.0
+      raf: 3.4.1
+      regenerator-runtime: 0.13.11
+      rgbcolor: 1.0.1
+      stackblur-canvas: 2.0.0
+      svg-pathdata: 6.0.3
+    optional: true
+
   chai@6.2.2: {}
 
   convert-source-map@2.0.0: {}
+
+  core-js@3.50.0:
+    optional: true
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
+
+  cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
 
   dejavu-fonts-ttf@2.37.3: {}
 
   detect-libc@2.1.2: {}
+
+  dompurify@3.4.14:
+    optionalDependencies:
+      "@types/trusted-types": 2.0.7
+    optional: true
 
   es-module-lexer@2.3.1: {}
 
@@ -1672,15 +1898,44 @@ snapshots:
 
   fake-indexeddb@6.2.5: {}
 
+  fast-png@6.2.0:
+    dependencies:
+      "@types/pako": 2.0.0
+      iobuffer: 5.4.0
+      pako: 2.2.0
+
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  fflate@0.8.3: {}
+
+  font-family-papandreou@0.2.0-patch2: {}
 
   fsevents@2.3.2:
     optional: true
 
   fsevents@2.3.3:
     optional: true
+
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+    optional: true
+
+  iobuffer@5.4.0: {}
+
+  jspdf@4.2.1:
+    dependencies:
+      "@babel/runtime": 7.29.7
+      fast-png: 6.2.0
+      fflate: 0.8.3
+    optionalDependencies:
+      canvg: 3.0.11
+      core-js: 3.50.0
+      dompurify: 3.4.14
+      html2canvas: 1.4.1
 
   lightningcss-android-arm64@1.33.0:
     optional: true
@@ -1741,6 +1996,8 @@ snapshots:
 
   pako@1.0.11: {}
 
+  pako@2.2.0: {}
+
   pathe@2.0.3: {}
 
   pdf-lib@1.17.1:
@@ -1749,6 +2006,9 @@ snapshots:
       "@pdf-lib/upng": 1.0.1
       pako: 1.0.11
       tslib: 1.14.1
+
+  performance-now@2.1.0:
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -1772,12 +2032,23 @@ snapshots:
 
   prettier@3.9.6: {}
 
+  raf@3.4.1:
+    dependencies:
+      performance-now: 2.1.0
+    optional: true
+
   react-dom@19.2.8(react@19.2.8):
     dependencies:
       react: 19.2.8
       scheduler: 0.27.0
 
   react@19.2.8: {}
+
+  regenerator-runtime@0.13.11:
+    optional: true
+
+  rgbcolor@1.0.1:
+    optional: true
 
   rolldown@1.2.3:
     dependencies:
@@ -1805,9 +2076,32 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  specificity@0.4.1: {}
+
   stackback@0.0.2: {}
 
+  stackblur-canvas@2.0.0:
+    optional: true
+
   std-env@4.2.0: {}
+
+  svg-pathdata@6.0.3:
+    optional: true
+
+  svg2pdf.js@2.8.0(jspdf@4.2.1):
+    dependencies:
+      cssesc: 3.0.0
+      font-family-papandreou: 0.2.0-patch2
+      jspdf: 4.2.1
+      specificity: 0.4.1
+      svgpath: 2.6.0
+
+  svgpath@2.6.0: {}
+
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   tinybench@2.9.0: {}
 
@@ -1846,6 +2140,11 @@ snapshots:
       "@typescript/typescript-win32-x64": 7.0.2
 
   undici-types@7.18.2: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
+    optional: true
 
   vite@8.2.1(@types/node@24.13.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,10 @@
 packages:
   - apps/*
   - packages/*
+allowBuilds:
+  # core-js only prints a funding banner from its postinstall script; its
+  # runtime modules are already shipped in the package, so no build is needed.
+  core-js: false
 minimumReleaseAgeExclude:
   - vite@8.2.1
+  - svg2pdf.js@2.8.0


### PR DESCRIPTION
## Summary
- convert browser PDF downloads directly from the canonical formal SVG with svg2pdf.js/jsPDF
- retain explicit PNG and headless Node raster paths; never silently downgrade a browser vector PDF
- cover the formal export flow with an assertion that the browser PDF is not a page-cover image

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- ICM_E2E_ISOLATED=1; ICM_E2E_PORT=4175; pnpm ci:check -- --base origin/main (235 unit + 239 browser tests)

The isolated browser run ensures the tests used this worktree rather than an existing local dev server.