### PR TITLE
feat(editor): add orientation-free drafting circles

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -644,6 +644,48 @@ test("R creates a selectable, styleable rectangle with four resize handles", asy
   expect(await rectangle.getAttribute("points")).not.toBe(pointsBeforeResize);
 });
 
+test("O creates a selectable, styleable circle with one radial handle and no rotation", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await awaitEditorReady(page);
+  await page.keyboard.press("o");
+  await clickCreate(page, { x: 260, y: 260 }, { x: 340, y: 260 });
+  await expect(page.getByTestId("revision")).toHaveText("1");
+
+  const circle = page.locator('[data-kind="draft-circle"]');
+  await expect(circle).toHaveCount(1);
+  await expect(circle).toHaveAttribute("fill", "none");
+  await expect(circle).toHaveAttribute("r", "80");
+
+  const hit = page.getByTestId(/^drafting-hit-circle-/);
+  await expect(hit).toHaveCSS("pointer-events", "stroke");
+  const hitPoint = await hit.evaluate((element) => {
+    const circle = element as SVGCircleElement;
+    const matrix = circle.getScreenCTM();
+    if (!matrix) return null;
+    return new DOMPoint(
+      circle.cx.baseVal.value + circle.r.baseVal.value,
+      circle.cy.baseVal.value,
+    ).matrixTransform(matrix);
+  });
+  if (!hitPoint) throw new Error("circle hit target is not measurable");
+  await page.mouse.click(hitPoint.x, hitPoint.y);
+  await expect(
+    page.locator('[data-testid^="draft-handle-radius-circle-"]'),
+  ).toHaveCount(1);
+  await expect(
+    page.getByTestId("drafting-properties").getByLabel("Drawing bearing"),
+  ).toHaveCount(0);
+  await expect(
+    page.getByTestId("drafting-properties").getByLabel("Line style"),
+  ).toHaveCount(1);
+
+  await page.keyboard.press("r");
+  await expect(page.getByTestId("revision")).toHaveText("1");
+  await expect(page.locator('[data-kind="draft-rectangle"]')).toHaveCount(0);
+});
+
 test("E converts a rectangle into a navigable hierarchical Cell", async ({
   page,
 }) => {

--- a/apps/editor/e2e/editor-fixtures.ts
+++ b/apps/editor/e2e/editor-fixtures.ts
@@ -52,6 +52,7 @@ export type DrawTool =
   | "arrow"
   | "line"
   | "rectangle"
+  | "circle"
   | "document-style";
 
 /** Activate one tool from the always-visible drawing toolbar. */

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -2085,11 +2085,13 @@ export function App({
         ? "Wire: choose a pin, junction, route segment, or blank grid point"
         : nextTool === "rectangle"
           ? "Rectangle: click the first corner"
-          : nextTool === "arrow"
-            ? "Arrow: click the start point"
-            : nextTool === "construction-line"
-              ? "Construction line: click the start point"
-              : "Pointer ready",
+          : nextTool === "circle"
+            ? "Circle: click the center"
+            : nextTool === "arrow"
+              ? "Arrow: click the start point"
+              : nextTool === "construction-line"
+                ? "Construction line: click the start point"
+                : "Pointer ready",
     );
   }
 
@@ -2193,7 +2195,8 @@ export function App({
       hasClearableDraftingSelection:
         selectedDrafting?.kind === "arrow" ||
         selectedDrafting?.kind === "construction-line" ||
-        selectedDrafting?.kind === "rectangle",
+        selectedDrafting?.kind === "rectangle" ||
+        selectedDrafting?.kind === "circle",
     }),
     operations: {
       closeHelp,
@@ -2407,7 +2410,8 @@ export function App({
         draftingReadyToFinish:
           (tool === "arrow" ||
             tool === "construction-line" ||
-            tool === "rectangle") &&
+            tool === "rectangle" ||
+            tool === "circle") &&
           draftingSource !== null,
         hasRemovableWireWaypoint: Boolean(
           wireSource && wireDraftSteps.length > 0,
@@ -3493,7 +3497,8 @@ export function App({
               : "",
             tool === "arrow" ||
             tool === "construction-line" ||
-            tool === "rectangle"
+            tool === "rectangle" ||
+            tool === "circle"
               ? "drawing-mode"
               : "",
             projectedMovePreviewDocument ? "semantic-move-preview" : "",

--- a/apps/editor/src/canvas/canvas-gesture-controller.ts
+++ b/apps/editor/src/canvas/canvas-gesture-controller.ts
@@ -328,7 +328,8 @@ export function createCanvasGestureController({
     if (
       (tool === "arrow" ||
         tool === "construction-line" ||
-        tool === "rectangle") &&
+        tool === "rectangle" ||
+        tool === "circle") &&
       draftingSource !== null
     ) {
       const snapped = snapDraftingPoint(

--- a/apps/editor/src/canvas/canvas-gesture-model.ts
+++ b/apps/editor/src/canvas/canvas-gesture-model.ts
@@ -50,7 +50,8 @@ export function classifyCanvasGestureStart({
     tool === "wire" ||
     tool === "construction-line" ||
     tool === "arrow" ||
-    tool === "rectangle";
+    tool === "rectangle" ||
+    tool === "circle";
   if (frameZoomDrag) {
     return !placementOwnsClick && !draftingOwnsClick && targetIsCanvas
       ? "zoom"

--- a/apps/editor/src/canvas/editor-canvas-event-handlers.ts
+++ b/apps/editor/src/canvas/editor-canvas-event-handlers.ts
@@ -220,7 +220,8 @@ export function createEditorCanvasEventHandlers({
         selectedDrafting &&
         (selectedDrafting.kind === "arrow" ||
           selectedDrafting.kind === "construction-line" ||
-          selectedDrafting.kind === "rectangle") &&
+          selectedDrafting.kind === "rectangle" ||
+          selectedDrafting.kind === "circle") &&
         !target.closest(
           `[data-testid="drafting-hit-${selectedDrafting.id}"]`,
         ) &&
@@ -249,7 +250,8 @@ export function createEditorCanvasEventHandlers({
       if (
         (tool === "arrow" ||
           tool === "construction-line" ||
-          tool === "rectangle") &&
+          tool === "rectangle" ||
+          tool === "circle") &&
         event.detail === 1 &&
         onBackground
       ) {
@@ -335,7 +337,8 @@ export function createEditorCanvasEventHandlers({
       if (
         tool === "arrow" ||
         tool === "construction-line" ||
-        tool === "rectangle"
+        tool === "rectangle" ||
+        tool === "circle"
       ) {
         if (target !== event.currentTarget && target.tagName !== "rect") return;
         finishDraftingCreate();
@@ -388,7 +391,8 @@ export function createEditorCanvasEventHandlers({
       if (
         tool === "arrow" ||
         tool === "construction-line" ||
-        tool === "rectangle"
+        tool === "rectangle" ||
+        tool === "circle"
       ) {
         if (draftingSourceActive) {
           cancelDraftingCreate();

--- a/apps/editor/src/canvas/editor-drafting-hit-targets.tsx
+++ b/apps/editor/src/canvas/editor-drafting-hit-targets.tsx
@@ -134,6 +134,19 @@ export function EditorDraftingHitTargets({
         />
       );
     }
+    if (object.kind === "circle" && geometry.kind === "circle") {
+      return (
+        <circle
+          key={object.id}
+          {...common}
+          className={`${selectedClass} drafting-circle-hit`}
+          cx={geometry.center.x}
+          cy={geometry.center.y}
+          r={geometry.radius}
+          fill="none"
+        />
+      );
+    }
     if (object.kind === "leader" && geometry.kind === "leader") {
       return (
         <line
@@ -322,6 +335,29 @@ export function EditorDraftingHandles({
             }
           />
         ))}
+      </g>
+    );
+  }
+  if (object.kind === "circle" && geometry.kind === "circle") {
+    const point = {
+      x: geometry.center.x + geometry.radius,
+      y: geometry.center.y,
+    };
+    return (
+      <g data-testid={`drafting-handles-${object.id}`}>
+        <circle
+          className="draft-handle"
+          data-testid={`draft-handle-radius-${object.id}`}
+          cx={point.x}
+          cy={point.y}
+          r="5"
+          onPointerDown={(event) =>
+            onHandlePointerDown(event, object, {
+              kind: "circle-radius",
+              index: 0,
+            })
+          }
+        />
       </g>
     );
   }

--- a/apps/editor/src/features/drafting/drafting-create-controller.test.ts
+++ b/apps/editor/src/features/drafting/drafting-create-controller.test.ts
@@ -50,4 +50,42 @@ describe("drafting create controller", () => {
     expect(setTool).toHaveBeenCalledWith("pointer");
     expect(clear).toHaveBeenCalledOnce();
   });
+
+  it("creates a circle from its center and radius point", () => {
+    const transact = vi.fn(() => ({ ok: true }));
+    const controller = createDraftingCreateController({
+      document: createEmptyDocument("cell", "Cell"),
+      resolver: new InMemorySymbolResolver(builtInSymbols),
+      visibleEndpoints: [],
+      routeGeometryRecords: [],
+      tool: "circle",
+      source: { x: 20, y: 20 },
+      hover: { x: 50, y: 60 },
+      waypoints: [],
+      setSource: vi.fn(),
+      setHover: vi.fn(),
+      setWaypoints: vi.fn(),
+      setSnapPoint: vi.fn(),
+      clear: vi.fn(),
+      setTool: vi.fn(),
+      transact,
+      setStatus: vi.fn(),
+      nextId: () => "circle-1",
+    });
+
+    controller.finish();
+
+    expect(transact).toHaveBeenCalledWith([
+      expect.objectContaining({
+        kind: "upsert_drafting_object",
+        object: expect.objectContaining({
+          id: "circle-1",
+          kind: "circle",
+          center: { x: 20, y: 20 },
+          radius: 50,
+          lineStyle: "solid",
+        }),
+      }),
+    ]);
+  });
 });

--- a/apps/editor/src/features/drafting/drafting-create-controller.ts
+++ b/apps/editor/src/features/drafting/drafting-create-controller.ts
@@ -20,7 +20,7 @@ import type { RouteGeometryRecord } from "../wiring/route-interaction-geometry";
 type TransactionResult = { ok: boolean };
 type DraftingTool = Extract<
   EditorTool,
-  "arrow" | "construction-line" | "rectangle"
+  "arrow" | "construction-line" | "rectangle" | "circle"
 >;
 
 export function constrainDraftingAngle(
@@ -76,7 +76,10 @@ export function createDraftingCreateController({
   nextId: (prefix: string) => string;
 }) {
   const activeTool = (): DraftingTool | null =>
-    tool === "arrow" || tool === "construction-line" || tool === "rectangle"
+    tool === "arrow" ||
+    tool === "construction-line" ||
+    tool === "rectangle" ||
+    tool === "circle"
       ? tool
       : null;
 
@@ -166,7 +169,37 @@ export function createDraftingCreateController({
     const id = nextId(active === "construction-line" ? "construction" : active);
     const snappedStart = snapGridPoint(start, document.presentation.grid);
     const snappedEnd = snapGridPoint(end, document.presentation.grid);
-    if (active === "rectangle") {
+    if (active === "circle") {
+      const radius = Math.round(
+        Math.hypot(
+          snappedEnd.x - snappedStart.x,
+          snappedEnd.y - snappedStart.y,
+        ),
+      );
+      if (radius < 1) {
+        setStatus("Circle needs a non-zero radius");
+        return;
+      }
+      if (
+        transact([
+          {
+            kind: "upsert_drafting_object",
+            object: {
+              id,
+              kind: "circle",
+              locked: false,
+              zIndex: 0,
+              anchor: { kind: "free", position: snappedStart },
+              center: snappedStart,
+              radius,
+              lineStyle: "solid",
+            },
+          },
+        ]).ok
+      ) {
+        setStatus(`Added circle ${id}`);
+      }
+    } else if (active === "rectangle") {
       const width = Math.round(Math.abs(snappedEnd.x - snappedStart.x));
       const height = Math.round(Math.abs(snappedEnd.y - snappedStart.y));
       if (width < 1 || height < 1) {
@@ -266,9 +299,15 @@ export function createDraftingCreateController({
           ? "Arrow: click the end point (Enter to finish, Esc to cancel)"
           : active === "rectangle"
             ? "Rectangle: click the opposite corner (Esc to cancel)"
-            : "Construction line: click next vertex (Enter to finish, Esc to cancel)",
+            : active === "circle"
+              ? "Circle: click the radius point (Esc to cancel)"
+              : "Construction line: click next vertex (Enter to finish, Esc to cancel)",
       );
-    } else if (active === "arrow" || active === "rectangle") {
+    } else if (
+      active === "arrow" ||
+      active === "rectangle" ||
+      active === "circle"
+    ) {
       commit(active, source, resolved.point);
       clear();
     } else {
@@ -283,7 +322,7 @@ export function createDraftingCreateController({
     const active = activeTool();
     if (!active || source === null) return;
     const end = hover ?? source;
-    if (active === "arrow" || active === "rectangle") {
+    if (active === "arrow" || active === "rectangle" || active === "circle") {
       if (source.x !== end.x || source.y !== end.y) commit(active, source, end);
     } else {
       const points = [source, ...waypoints];

--- a/apps/editor/src/features/drafting/drafting-create-preview.tsx
+++ b/apps/editor/src/features/drafting/drafting-create-preview.tsx
@@ -32,6 +32,7 @@ export function DraftingCreatePreview({
   const angle = (Math.atan2(dy, dx) * 180) / Math.PI;
   const rectangle = normalizedRect(start, hover);
   const isRectangle = tool === "rectangle";
+  const isCircle = tool === "circle";
   const showHead = tool === "arrow" && length > 1;
   const head = styleProfile.annotations.arrowHeadLength;
   const halfHeadWidth = styleProfile.annotations.arrowHeadWidth / 2;
@@ -46,6 +47,14 @@ export function DraftingCreatePreview({
     <g data-testid="drafting-create-preview" pointerEvents="none">
       {isRectangle ? (
         <rect className="drafting-create-preview" {...rectangle} fill="none" />
+      ) : isCircle ? (
+        <circle
+          className="drafting-create-preview"
+          cx={start.x}
+          cy={start.y}
+          r={length}
+          fill="none"
+        />
       ) : (
         <polyline
           className="drafting-create-preview"
@@ -66,6 +75,7 @@ export function DraftingCreatePreview({
         r="3"
       />
       {!isRectangle &&
+        !isCircle &&
         waypoints.map((point, index) => (
           <circle
             key={`draft-preview-vx-${index}`}
@@ -97,7 +107,9 @@ export function DraftingCreatePreview({
       >
         {isRectangle
           ? `${Math.round(rectangle.width)} × ${Math.round(rectangle.height)}`
-          : `${Math.round(length)} · ${Math.round(angle)}°`}
+          : isCircle
+            ? `r ${Math.round(length)}`
+            : `${Math.round(length)} · ${Math.round(angle)}°`}
       </text>
     </g>
   );

--- a/apps/editor/src/features/drafting/drafting-manipulation.test.ts
+++ b/apps/editor/src/features/drafting/drafting-manipulation.test.ts
@@ -64,6 +64,17 @@ const rectangle = (): Extract<DraftingObject, { kind: "rectangle" }> => ({
   lineStyle: "solid",
 });
 
+const circle = (): Extract<DraftingObject, { kind: "circle" }> => ({
+  id: "circle-1",
+  kind: "circle",
+  locked: false,
+  zIndex: 0,
+  anchor: { kind: "free", position: { x: 50, y: 50 } },
+  center: { x: 50, y: 50 },
+  radius: 20,
+  lineStyle: "solid",
+});
+
 describe("drafting manipulation", () => {
   it("translates every free geometry point without detaching anchors", () => {
     const moved = translateDraftingObject(arrow(), { x: 10, y: 20 }, 10);
@@ -141,6 +152,31 @@ describe("drafting manipulation", () => {
       width: 50,
       height: 30,
       anchor: { position: { x: 50, y: 50 } },
+    });
+  });
+
+  it("moves and resizes a circle while keeping it orientation-free", () => {
+    const object = circle();
+    const geometry = resolveDraftingObjectGeometry(document, resolver, object);
+    const resized = applyDraftingHandle(
+      object,
+      { kind: "circle-radius", index: 0 },
+      { x: 90, y: 50 },
+      geometry,
+      10,
+    );
+    expect(resized).toMatchObject({ radius: 40 });
+    expect(
+      translateDraftingObject(object, { x: 20, y: -10 }, 10),
+    ).toMatchObject({
+      center: { x: 70, y: 40 },
+      anchor: { kind: "free", position: { x: 70, y: 40 } },
+    });
+    expect(rotateDraftingObject(object, geometry, 90, 10)).toBeNull();
+    expect(
+      applyDraftingStylePatch(object, { lineStyle: "dotted" }),
+    ).toMatchObject({
+      styleOverride: { lineStyle: "dotted" },
     });
   });
 

--- a/apps/editor/src/features/drafting/drafting-manipulation.ts
+++ b/apps/editor/src/features/drafting/drafting-manipulation.ts
@@ -17,7 +17,8 @@ import {
 export type DraftingHandle =
   | { kind: "from" | "to" }
   | {
-      kind: "waypoint" | "vertex" | "curve" | "rectangle-corner";
+      kind:
+        "waypoint" | "vertex" | "curve" | "rectangle-corner" | "circle-radius";
       index: number;
     };
 
@@ -31,6 +32,7 @@ export type DraftingStylePatch = Partial<{
 export function draftingDragOrigin(object: DraftingObject): GridPoint | null {
   if (object.kind === "construction-line") return object.points[0] ?? null;
   if (object.kind === "rectangle") return object.center;
+  if (object.kind === "circle") return object.center;
   if (object.kind === "arrow") {
     return object.from.kind === "free" && object.to.kind === "free"
       ? object.from.position
@@ -93,6 +95,10 @@ export function translateDraftingObject(
     const center = translatePoint(object.center, delta, grid);
     return { ...object, center, anchor: { kind: "free", position: center } };
   }
+  if (object.kind === "circle") {
+    const center = translatePoint(object.center, delta, grid);
+    return { ...object, center, anchor: { kind: "free", position: center } };
+  }
   return {
     ...object,
     anchor: translateFreeAnchor(object.anchor, delta, grid),
@@ -146,7 +152,11 @@ export function applyDraftingHandle(
       );
       return { ...object, curveControls: controls };
     }
-    if (handle.kind === "vertex" || handle.kind === "rectangle-corner") {
+    if (
+      handle.kind === "vertex" ||
+      handle.kind === "rectangle-corner" ||
+      handle.kind === "circle-radius"
+    ) {
       return object;
     }
     const anchor = handle.kind === "from" ? object.from : object.to;
@@ -204,6 +214,19 @@ export function applyDraftingHandle(
       width: Math.max(grid, Math.round(Math.abs(localWidth) / grid) * grid),
       height: Math.max(grid, Math.round(Math.abs(localHeight) / grid) * grid),
     };
+  }
+  if (
+    object.kind === "circle" &&
+    handle.kind === "circle-radius" &&
+    originalGeometry.kind === "circle"
+  ) {
+    const radius = Math.max(
+      grid,
+      Math.round(
+        Math.hypot(point.x - object.center.x, point.y - object.center.y) / grid,
+      ) * grid,
+    );
+    return { ...object, radius };
   }
   return object;
 }
@@ -304,7 +327,8 @@ export function applyDraftingStylePatch(
     object.locked ||
     (object.kind !== "arrow" &&
       object.kind !== "construction-line" &&
-      object.kind !== "rectangle")
+      object.kind !== "rectangle" &&
+      object.kind !== "circle")
   ) {
     return null;
   }

--- a/apps/editor/src/features/drafting/drafting-properties-panel.tsx
+++ b/apps/editor/src/features/drafting/drafting-properties-panel.tsx
@@ -51,31 +51,41 @@ export function DraftingPropertiesPanel({
   if (
     geometry.kind !== "arrow" &&
     geometry.kind !== "construction-line" &&
-    geometry.kind !== "rectangle"
+    geometry.kind !== "rectangle" &&
+    geometry.kind !== "circle"
   ) {
     return null;
   }
   const lineStyle =
     object.styleOverride?.lineStyle ??
-    (object.kind === "construction-line" || object.kind === "rectangle"
+    (object.kind === "construction-line" ||
+    object.kind === "rectangle" ||
+    object.kind === "circle"
       ? object.lineStyle
       : "solid");
   const isRectangle = geometry.kind === "rectangle";
-  const points = isRectangle ? geometry.corners : geometry.points;
-  const curveControls = isRectangle
-    ? points.slice(0, -1).map(() => null)
-    : geometry.curveControls;
+  const isCircle = geometry.kind === "circle";
+  const points = isRectangle
+    ? geometry.corners
+    : isCircle
+      ? []
+      : geometry.points;
+  const curveControls =
+    isRectangle || isCircle
+      ? points.slice(0, -1).map(() => null)
+      : geometry.curveControls;
   const segmentIndex =
     inspectorSegment?.objectId === object.id
       ? inspectorSegment.index
       : Math.max(0, curveControls.findIndex(Boolean));
-  const tangentAngle = isRectangle
-    ? 0
-    : quadraticTangentAngle(
-        points[segmentIndex]!,
-        curveControls[segmentIndex] ?? null,
-        points[segmentIndex + 1]!,
-      );
+  const tangentAngle =
+    isRectangle || isCircle
+      ? 0
+      : quadraticTangentAngle(
+          points[segmentIndex]!,
+          curveControls[segmentIndex] ?? null,
+          points[segmentIndex + 1]!,
+        );
   const tangentInputKey = `${object.id}:${segmentIndex}`;
   const realizedAngleText = String(Math.round(tangentAngle * 10) / 10);
   const tangentInputValue =
@@ -84,7 +94,9 @@ export function DraftingPropertiesPanel({
       : realizedAngleText;
   const bearing = isRectangle
     ? geometry.rotation
-    : normalizedBearing(points[0]!, points[1]!);
+    : isCircle
+      ? 0
+      : normalizedBearing(points[0]!, points[1]!);
   const realizedBearingText = String(Math.round(bearing * 10) / 10);
   const bearingInputValue =
     bearingInput?.objectId === object.id
@@ -158,7 +170,7 @@ export function DraftingPropertiesPanel({
           </select>
         </label>
       ) : null}
-      {!isRectangle ? (
+      {!isRectangle && !isCircle ? (
         <label>
           Tangent angle (°)
           <input
@@ -185,31 +197,33 @@ export function DraftingPropertiesPanel({
           />
         </label>
       ) : null}
-      <label>
-        Bearing (°)
-        <input
-          aria-label="Drawing bearing"
-          type="number"
-          min="0"
-          max="359"
-          step="1"
-          value={bearingInputValue}
-          disabled={object.locked}
-          placeholder={realizedBearingText}
-          onFocus={() =>
-            onBearingInputChange({ objectId: object.id, value: "" })
-          }
-          onChange={(event) => {
-            const value = event.currentTarget.value;
-            onBearingInputChange({ objectId: object.id, value });
-            const nextBearing = Number(value);
-            if (value !== "" && Number.isFinite(nextBearing)) {
-              onBearingChange(nextBearing);
+      {!isCircle ? (
+        <label>
+          Bearing (°)
+          <input
+            aria-label="Drawing bearing"
+            type="number"
+            min="0"
+            max="359"
+            step="1"
+            value={bearingInputValue}
+            disabled={object.locked}
+            placeholder={realizedBearingText}
+            onFocus={() =>
+              onBearingInputChange({ objectId: object.id, value: "" })
             }
-          }}
-          onBlur={() => onBearingInputChange(null)}
-        />
-      </label>
+            onChange={(event) => {
+              const value = event.currentTarget.value;
+              onBearingInputChange({ objectId: object.id, value });
+              const nextBearing = Number(value);
+              if (value !== "" && Number.isFinite(nextBearing)) {
+                onBearingChange(nextBearing);
+              }
+            }}
+            onBlur={() => onBearingInputChange(null)}
+          />
+        </label>
+      ) : null}
       {object.kind === "arrow" ? (
         <>
           <label>
@@ -254,10 +268,12 @@ export function DraftingPropertiesPanel({
           </button>
         </>
       ) : null}
-      <button type="button" disabled={object.locked} onClick={onRotate}>
-        <ToolIcon name="rotate" />
-        Rotate
-      </button>
+      {!isCircle ? (
+        <button type="button" disabled={object.locked} onClick={onRotate}>
+          <ToolIcon name="rotate" />
+          Rotate
+        </button>
+      ) : null}
       <button type="button" onClick={onToggleLock}>
         <ToolIcon name="lock" />
         {object.locked ? "Unlock" : "Lock"}

--- a/apps/editor/src/features/editor-shell/drawing-toolbar.tsx
+++ b/apps/editor/src/features/editor-shell/drawing-toolbar.tsx
@@ -132,6 +132,17 @@ export function DrawingToolbar({
         <ToolIcon name="rectangle" />
         <span>Rect</span>
       </button>
+      <button
+        type="button"
+        className="draw-tool"
+        data-testid="draw-tool-circle"
+        aria-pressed={tool === "circle"}
+        title="Circle (O)"
+        onClick={() => onActivateTool("circle")}
+      >
+        <ToolIcon name="circle" />
+        <span>Circle</span>
+      </button>
       <span className="toolbar-divider" aria-hidden="true" />
       <button
         type="button"

--- a/apps/editor/src/features/editor-shell/tool-icon.tsx
+++ b/apps/editor/src/features/editor-shell/tool-icon.tsx
@@ -7,6 +7,7 @@ export type ToolIconName =
   | "arrow"
   | "line"
   | "rectangle"
+  | "circle"
   | "style"
   | "rotate"
   | "mirror-horizontal"
@@ -73,6 +74,9 @@ export function ToolIcon({ name }: { name: ToolIconName }) {
       {name === "line" ? <path d="M3 15L17 5" {...common} /> : null}
       {name === "rectangle" ? (
         <rect x="3" y="5" width="14" height="10" rx="1" {...common} />
+      ) : null}
+      {name === "circle" ? (
+        <circle cx="10" cy="10" r="6.5" {...common} />
       ) : null}
       {name === "style" ? (
         <>

--- a/apps/editor/src/features/selection/marquee-selection.ts
+++ b/apps/editor/src/features/selection/marquee-selection.ts
@@ -120,6 +120,41 @@ export function marqueeSelection(
             ? geometry.corners.every((corner) => pointInRect(corner, rect))
             : rectangleBoundaryIntersectsRect(geometry.corners, rect);
         }
+        if (geometry.kind === "circle") {
+          const centerInRect = pointInRect(geometry.center, rect);
+          const radius = geometry.radius;
+          if (window) {
+            return (
+              pointInRect(
+                {
+                  x: geometry.center.x - radius,
+                  y: geometry.center.y - radius,
+                },
+                rect,
+              ) &&
+              pointInRect(
+                {
+                  x: geometry.center.x + radius,
+                  y: geometry.center.y + radius,
+                },
+                rect,
+              )
+            );
+          }
+          const closestX = Math.max(
+            rect.x,
+            Math.min(geometry.center.x, rect.x + rect.width),
+          );
+          const closestY = Math.max(
+            rect.y,
+            Math.min(geometry.center.y, rect.y + rect.height),
+          );
+          const nearestDistance = Math.hypot(
+            closestX - geometry.center.x,
+            closestY - geometry.center.y,
+          );
+          return !centerInRect && nearestDistance <= radius;
+        }
         return boxSelected(geometry.bounds);
       })
       .map((object) => object.id),

--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -121,6 +121,13 @@ describe("editor shortcut contract", () => {
     expect(resolve("v", { canRotate: true }, { shiftKey: true })).toBeNull();
   });
 
+  it("does not replace a selected non-rotatable drawing with a rectangle", () => {
+    expect(resolve("r", { hasDraftingSelection: true })).toEqual({
+      kind: "blocked-interaction-command",
+      command: "Rotate",
+    });
+  });
+
   it("opens insertion with I and gives placement rotation priority", () => {
     expect(resolve("i")).toEqual(command({ id: "insert.open" }));
     expect(
@@ -163,6 +170,9 @@ describe("editor shortcut contract", () => {
     );
     expect(resolve("k")).toEqual(
       command({ id: "tool.activate", tool: "construction-line" }),
+    );
+    expect(resolve("o")).toEqual(
+      command({ id: "tool.activate", tool: "circle" }),
     );
     expect(resolve("p")).toEqual(command({ id: "insert.cell-pin" }));
     expect(resolve("m")).toEqual(command({ id: "selection.move" }));

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -155,6 +155,12 @@ export function resolveEditorShortcut(
         command: { id: "tool.activate", tool: "construction-line" },
       };
     }
+    if (plain && key === "o") {
+      return {
+        kind: "run-command",
+        command: { id: "tool.activate", tool: "circle" },
+      };
+    }
     if (plain && event.shiftKey && key === "r" && context.canMirror) {
       return {
         kind: "run-command",
@@ -261,10 +267,12 @@ export function resolveEditorShortcut(
           kind: "run-command",
           command: { id: "transform.rotate", deltaDegrees: 90 },
         }
-      : {
-          kind: "run-command",
-          command: { id: "tool.activate", tool: "rectangle" },
-        };
+      : context.hasDraftingSelection
+        ? { kind: "blocked-interaction-command", command: "Rotate" }
+        : {
+            kind: "run-command",
+            command: { id: "tool.activate", tool: "rectangle" },
+          };
   }
   if (plain && key === "w") {
     return {
@@ -293,6 +301,12 @@ export function resolveEditorShortcut(
     return {
       kind: "run-command",
       command: { id: "tool.activate", tool: "construction-line" },
+    };
+  }
+  if (plain && key === "o") {
+    return {
+      kind: "run-command",
+      command: { id: "tool.activate", tool: "circle" },
     };
   }
   if (plain && key === "q") {

--- a/apps/editor/src/interaction/interaction-state.ts
+++ b/apps/editor/src/interaction/interaction-state.ts
@@ -18,11 +18,11 @@ import {
 export type { WireSource } from "@icm/edit-engine";
 
 export type EditorTool =
-  "pointer" | "wire" | "construction-line" | "arrow" | "rectangle";
+  "pointer" | "wire" | "construction-line" | "arrow" | "rectangle" | "circle";
 
 export type DrawingTool = Extract<
   EditorTool,
-  "construction-line" | "arrow" | "rectangle"
+  "construction-line" | "arrow" | "rectangle" | "circle"
 >;
 
 export type InteractionMode = InteractionState<unknown>["kind"];
@@ -167,6 +167,7 @@ export function activateInteractionTool<TClipboard>(
     case "arrow":
     case "construction-line":
     case "rectangle":
+    case "circle":
       return drawingState(tool);
   }
 }

--- a/apps/editor/src/snap/candidates.ts
+++ b/apps/editor/src/snap/candidates.ts
@@ -86,6 +86,14 @@ function draftingGeometryPoints(
       return geometry.vertices;
     case "rectangle":
       return [geometry.center, ...geometry.corners];
+    case "circle":
+      return [
+        geometry.center,
+        { x: geometry.center.x + geometry.radius, y: geometry.center.y },
+        { x: geometry.center.x - geometry.radius, y: geometry.center.y },
+        { x: geometry.center.x, y: geometry.center.y + geometry.radius },
+        { x: geometry.center.x, y: geometry.center.y - geometry.radius },
+      ];
   }
 }
 

--- a/apps/editor/src/styles/editor-canvas.css
+++ b/apps/editor/src/styles/editor-canvas.css
@@ -344,7 +344,9 @@
    screen-space tolerance as other drafting strokes, but let its empty interior
    pass clicks through to the canvas and any components placed underneath. */
 .annotation-hit.drafting-rectangle-hit,
-.annotation-hit.drafting-rectangle-hit.selected {
+.annotation-hit.drafting-rectangle-hit.selected,
+.annotation-hit.drafting-circle-hit,
+.annotation-hit.drafting-circle-hit.selected {
   fill: none;
   stroke: transparent;
   pointer-events: stroke;

--- a/packages/derived/src/anchor.ts
+++ b/packages/derived/src/anchor.ts
@@ -180,5 +180,6 @@ function findObjectPlacement(
     (candidate) => candidate.id === objectId,
   );
   if (drafting?.kind === "rectangle") return drafting.center;
+  if (drafting?.kind === "circle") return drafting.center;
   return null;
 }

--- a/packages/derived/src/drafting-geometry.test.ts
+++ b/packages/derived/src/drafting-geometry.test.ts
@@ -27,6 +27,23 @@ function rectangle(
   };
 }
 
+function circle(
+  id: string,
+  center: { x: number; y: number },
+  radius = 40,
+): Extract<DraftingObject, { kind: "circle" }> {
+  return {
+    id,
+    kind: "circle",
+    locked: false,
+    zIndex: 0,
+    anchor: { kind: "free", position: center },
+    center,
+    radius,
+    lineStyle: "solid",
+  };
+}
+
 function anchoredLabel(
   id: string,
   rectangleId: string,
@@ -57,6 +74,20 @@ function documentWith(objects: DraftingObject[]): SchematicDocument {
 }
 
 describe("object-anchored drafting text on rectangles", () => {
+  it("resolves circle geometry from its center and radius", () => {
+    const object = circle("circle-1", { x: 100, y: 60 }, 30);
+    const geometry = resolveDraftingObjectGeometry(
+      documentWith([object]),
+      resolver,
+      object,
+    );
+    expect(geometry).toMatchObject({
+      kind: "circle",
+      center: { x: 100, y: 60 },
+      radius: 30,
+      bounds: { x: 64, y: 24, width: 72, height: 72 },
+    });
+  });
   it("resolves the label at the rectangle center", () => {
     const document = documentWith([
       rectangle("box-1", { x: 100, y: 60 }),

--- a/packages/derived/src/drafting-geometry.ts
+++ b/packages/derived/src/drafting-geometry.ts
@@ -100,6 +100,13 @@ export type ResolvedDraftingGeometry =
       diagnostics: [];
     }
   | {
+      kind: "circle";
+      center: DerivedPoint;
+      radius: number;
+      bounds: DerivedRect;
+      diagnostics: [];
+    }
+  | {
       kind: "floating-symbol";
       position: DerivedPoint;
       rotation: 0 | 90 | 180 | 270;
@@ -131,6 +138,8 @@ export function resolveDraftingObjectGeometry(
       return resolveConstructionLine(object);
     case "rectangle":
       return resolveRectangle(object);
+    case "circle":
+      return resolveCircle(object);
     case "floating-symbol":
       return resolveFloatingSymbol(document, resolver, object, routingGeometry);
   }
@@ -425,6 +434,24 @@ function resolveRectangle(
     rotation: object.rotation,
     corners,
     bounds: paddedBounds(unionBounds(corners), STROKE_PADDING),
+    diagnostics: [] as [],
+  };
+}
+
+function resolveCircle(object: Extract<DraftingObject, { kind: "circle" }>) {
+  return {
+    kind: "circle" as const,
+    center: { ...object.center },
+    radius: object.radius,
+    bounds: paddedBounds(
+      {
+        x: object.center.x - object.radius,
+        y: object.center.y - object.radius,
+        width: object.radius * 2,
+        height: object.radius * 2,
+      },
+      STROKE_PADDING,
+    ),
     diagnostics: [] as [],
   };
 }

--- a/packages/edit-engine/src/transaction-preflight.ts
+++ b/packages/edit-engine/src/transaction-preflight.ts
@@ -77,6 +77,8 @@ function draftingPoints(object: DraftingObject): LocatedPoint[] {
       ];
     case "rectangle":
       return [...points, { point: object.center, path: ["object", "center"] }];
+    case "circle":
+      return [...points, { point: object.center, path: ["object", "center"] }];
   }
 }
 

--- a/packages/model/src/drafting-geometry-schema.ts
+++ b/packages/model/src/drafting-geometry-schema.ts
@@ -81,6 +81,13 @@ export const ResolvedDraftingGeometrySchema = z.discriminatedUnion("kind", [
     diagnostics: z.array(DraftingDiagnosticSchema),
   }),
   z.strictObject({
+    kind: z.literal("circle"),
+    center: DerivedPointSchema,
+    radius: z.number().positive(),
+    bounds: DerivedRectSchema,
+    diagnostics: z.array(DraftingDiagnosticSchema),
+  }),
+  z.strictObject({
     kind: z.literal("floating-symbol"),
     position: DerivedPointSchema,
     rotation: RotationSchema,

--- a/packages/model/src/schema/document.ts
+++ b/packages/model/src/schema/document.ts
@@ -204,6 +204,9 @@ function reportDraftingObjectGridAlignment(
       return;
     case "rectangle":
       reportGridPoint(object.center, grid, [...path, "center"], context);
+      return;
+    case "circle":
+      reportGridPoint(object.center, grid, [...path, "center"], context);
   }
 }
 

--- a/packages/model/src/schema/drafting.ts
+++ b/packages/model/src/schema/drafting.ts
@@ -71,6 +71,17 @@ export const DraftRectangleSchema = DraftingObjectBaseSchema.extend({
   rotation: z.number().finite().min(0).lt(360),
   lineStyle: z.enum(["solid", "dashed", "dotted"]),
 });
+/**
+ * A circle is a stroke-only drafting primitive.  Unlike a rectangle it is
+ * intentionally orientation-free: its center/radius are the complete
+ * persistent geometry, which avoids a meaningless rotation property.
+ */
+export const DraftCircleSchema = DraftingObjectBaseSchema.extend({
+  kind: z.literal("circle"),
+  center: PointSchema,
+  radius: z.number().int().positive(),
+  lineStyle: z.enum(["solid", "dashed", "dotted"]),
+});
 export const DraftFloatingSymbolSchema = DraftingObjectBaseSchema.extend({
   kind: z.literal("floating-symbol"),
   symbolId: StableIdSchema,
@@ -83,6 +94,7 @@ export const DraftingObjectSchema = z.discriminatedUnion("kind", [
   DraftCalloutSchema,
   DraftConstructionLineSchema,
   DraftRectangleSchema,
+  DraftCircleSchema,
   DraftFloatingSymbolSchema,
 ]);
 export const DraftingLayerSchema = z.strictObject({

--- a/packages/model/src/schema/types.ts
+++ b/packages/model/src/schema/types.ts
@@ -73,6 +73,7 @@ export type DraftConstructionLine = z.infer<
   typeof Schema.DraftConstructionLineSchema
 >;
 export type DraftRectangle = z.infer<typeof Schema.DraftRectangleSchema>;
+export type DraftCircle = z.infer<typeof Schema.DraftCircleSchema>;
 export type DraftFloatingSymbol = z.infer<
   typeof Schema.DraftFloatingSymbolSchema
 >;

--- a/packages/render-svg/src/drafting-render.test.ts
+++ b/packages/render-svg/src/drafting-render.test.ts
@@ -163,6 +163,30 @@ describe("drafting layer rendering", () => {
     expect(svg).toContain('points="10,30 90,30 90,70 10,70"');
   });
 
+  it("renders an orientation-free outline circle with the shared drafting style", () => {
+    const document = createEmptyDocument("doc", "Circle");
+    document.drafting = {
+      objects: [
+        {
+          id: "circle-1",
+          kind: "circle",
+          locked: false,
+          zIndex: 0,
+          anchor: { kind: "free", position: { x: 50, y: 50 } },
+          center: { x: 50, y: 50 },
+          radius: 30,
+          lineStyle: "dashed",
+          styleOverride: { strokeScale: 1.5 },
+        },
+      ],
+    };
+    const svg = renderDocumentSvg(document, resolver);
+    expect(svg).toContain('data-kind="draft-circle"');
+    expect(svg).toContain('cx="50" cy="50" r="30"');
+    expect(svg).toContain('fill="none"');
+    expect(svg).toContain('stroke-dasharray="6 4"');
+  });
+
   it("renders a draft arrow with a head", () => {
     const document = createEmptyDocument("doc", "Drafting");
     document.drafting = {

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -867,6 +867,12 @@ function renderDraftingLayer(
             >,
             profile,
           );
+        case "circle":
+          return renderDraftCircle(
+            object,
+            geometry as Extract<ResolvedDraftingGeometry, { kind: "circle" }>,
+            profile,
+          );
         case "arrow":
           return renderDraftArrow(
             object,
@@ -1014,6 +1020,23 @@ function renderDraftRectangle(
     .map((point) => `${point.x},${point.y}`)
     .join(" ");
   return `<polygon data-object-id="${object.id}" data-kind="draft-rectangle" points="${points}" fill="none" stroke="${profile.foreground}" stroke-width="${strokeWidth}" stroke-linecap="${profile.lineCap}" stroke-linejoin="${profile.lineJoin}"${dash}/>`;
+}
+
+function renderDraftCircle(
+  object: Extract<DraftingObject, { kind: "circle" }>,
+  geometry: Extract<ResolvedDraftingGeometry, { kind: "circle" }>,
+  profile: SchematicStyleProfile,
+): string {
+  const lineStyle = object.styleOverride?.lineStyle ?? object.lineStyle;
+  const dash =
+    lineStyle === "dashed"
+      ? ' stroke-dasharray="6 4"'
+      : lineStyle === "dotted"
+        ? ' stroke-dasharray="2 3"'
+        : "";
+  const strokeWidth =
+    profile.strokes.annotation * (object.styleOverride?.strokeScale ?? 1);
+  return `<circle data-object-id="${object.id}" data-kind="draft-circle" cx="${geometry.center.x}" cy="${geometry.center.y}" r="${geometry.radius}" fill="none" stroke="${profile.foreground}" stroke-width="${strokeWidth}" stroke-linecap="${profile.lineCap}" stroke-linejoin="${profile.lineJoin}"${dash}/>`;
 }
 
 function draftingPathData(


### PR DESCRIPTION
## Summary
- add circle as a first-class drafting primitive with center/radius persistence
- reuse rectangle drafting style, lock, selection, move, snap, and export contracts
- provide O shortcut, center-to-radius creation, stroke-only hits, and radial resize

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- pnpm gate:full

All local gates passed, including 1,484 unit and 240 browser tests.