### PR TITLE
fix(worker): route asset requests through the Worker so the 404 can happen

### DIFF
--- a/worker/index.test.ts
+++ b/worker/index.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import worker, {
   normalizeAcquisitionSource,
   normalizeTrackedPath,
@@ -99,5 +102,31 @@ describe("static asset serving", () => {
       expect(response.status).toBe(200);
       expect(response.headers.get("content-type")).toContain("text/html");
     }
+  });
+});
+
+describe("assets binding wiring", () => {
+  /** wrangler.jsonc allows comments and trailing commas; JSON does not. */
+  function wranglerConfig(): {
+    assets: { run_worker_first?: string[]; not_found_handling?: string };
+  } {
+    const source = readFileSync(
+      resolve(process.cwd(), "wrangler.jsonc"),
+      "utf8",
+    );
+    const stripped = source
+      .replace(/^\s*\/\/.*$/gmu, "")
+      .replace(/,(\s*[}\]])/gu, "$1");
+    return JSON.parse(stripped) as ReturnType<typeof wranglerConfig>;
+  }
+
+  it("routes asset requests through the Worker", () => {
+    // Assets are served without invoking the Worker unless the path is listed
+    // here, so the 404 above is unreachable code without this entry — which is
+    // how a correct fix shipped once and changed nothing.
+    const { assets } = wranglerConfig();
+    expect(assets.run_worker_first).toContain("/assets/*");
+    expect(assets.run_worker_first).toContain("/api/*");
+    expect(assets.not_found_handling).toBe("single-page-application");
   });
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,7 +17,12 @@
   "assets": {
     "directory": "./apps/editor/dist",
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/api/*"],
+    // Assets are served without invoking the Worker unless a path is listed
+    // here. "/assets/*" is listed so a request the build cannot satisfy can be
+    // answered as missing: single-page-application handling would otherwise
+    // hand back the shell at 200 text/html under a content-hashed name, which
+    // the browser reads as a module and every cache treats as permanent.
+    "run_worker_first": ["/api/*", "/assets/*"],
   },
   "durable_objects": {
     "bindings": [


### PR DESCRIPTION
Follow-up to #290, which shipped and changed nothing.

#290 made a missing hashed asset return `404` instead of the app shell. It deployed successfully, and the live site kept doing exactly what it did before:

```
$ curl -sI https://analog-canvas.tokenzhang.com/assets/App-DOESNOTEXIST.js
HTTP/2 200
content-type: text/html
```

Static assets are served **without invoking the Worker** unless their path is listed in `run_worker_first`, which named only `/api/*`. So `serveAsset` was correct code that nothing ever called, and the assets binding went on answering vanished chunks with the shell.

Listing `/assets/*` puts those requests through the Worker. Routes keep `single-page-application` handling and still render the shell — that part was never the problem.

## The test that was missing

The gap was never in the code under test. `serveAsset` had four passing tests and all of them were meaningful; none of them could tell that the handler was unreachable in production. So the new test reads `wrangler.jsonc` and asserts the wiring itself.

## Validation

- unit: 6 pass in `worker/index.test.ts`, including the new wiring assertion.
- I will verify against the deployed site after this merges, rather than assuming a second time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)