### PR TITLE
feat(routing): smooth degraded boundary routes after transforms

### DIFF
--- a/packages/edit-engine/src/route-operations.ts
+++ b/packages/edit-engine/src/route-operations.ts
@@ -3,8 +3,10 @@ import {
   routeBends,
   routeEnd,
   routeModes,
+  transformPoint,
   type Orientation,
   type Point,
+  type Rect,
   type RouteEndpoint,
   type SchematicDocument,
   type ScreenFlip,
@@ -19,6 +21,8 @@ import {
   resolveDocumentRoutingGeometry,
   resolveEndpointConnection,
   resolveRouteGeometry,
+  visibleSymbolLocalBounds,
+  type EndpointConnection,
   type ResolvedDocumentRoutingGeometry,
 } from "@icm/derived";
 import {
@@ -308,6 +312,215 @@ function stretchRouteEndpoint(
   const modeIndex = side === "from" ? 0 : modes.length - 1;
   const mode = modes[modeIndex]!;
   modes.splice(modeIndex, 1, mode, mode);
+}
+
+/**
+ * A transform's boundary-Route smoothing context: the document with every
+ * transformed placement applied, plus the world bounds of the moved bodies.
+ */
+interface BoundarySmoothing {
+  movedDocument: SchematicDocument;
+  movedBodies: readonly Rect[];
+}
+
+function movedInstanceBodies(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  movedInstanceIds: ReadonlySet<string>,
+): Rect[] {
+  return document.instances.flatMap((instance) => {
+    if (!movedInstanceIds.has(instance.id) || !instance.placement) return [];
+    const resolved = resolver.resolve(
+      instance.symbolId,
+      instance.symbolVariantId,
+    );
+    if (!resolved) return [];
+    const box = visibleSymbolLocalBounds(resolved);
+    const corners = [
+      { x: box.x, y: box.y },
+      { x: box.x + box.width, y: box.y },
+      { x: box.x, y: box.y + box.height },
+      { x: box.x + box.width, y: box.y + box.height },
+    ].map((point) =>
+      transformPoint(point, instance.placement!.position, instance.placement!),
+    );
+    const xs = corners.map((point) => point.x);
+    const ys = corners.map((point) => point.y);
+    const x = Math.min(...xs);
+    const y = Math.min(...ys);
+    return [{ x, y, width: Math.max(...xs) - x, height: Math.max(...ys) - y }];
+  });
+}
+
+/** Count axis-aligned legs that pass through a body's interior. */
+function bodyCrossings(
+  points: readonly Point[],
+  bodies: readonly Rect[],
+): number {
+  const inset = 0.5;
+  let crossings = 0;
+  for (let index = 1; index < points.length; index += 1) {
+    const a = points[index - 1]!;
+    const b = points[index]!;
+    for (const body of bodies) {
+      const left = body.x + inset;
+      const right = body.x + body.width - inset;
+      const top = body.y + inset;
+      const bottom = body.y + body.height - inset;
+      if (right <= left || bottom <= top) continue;
+      const minX = Math.max(Math.min(a.x, b.x), left);
+      const maxX = Math.min(Math.max(a.x, b.x), right);
+      const minY = Math.max(Math.min(a.y, b.y), top);
+      const maxY = Math.min(Math.max(a.y, b.y), bottom);
+      if (minX > maxX || minY > maxY) continue;
+      // Positive clipped length inside the interior counts; touching a
+      // corner or grazing an edge does not.
+      if (maxX - minX > 0.01 || maxY - minY > 0.01) crossings += 1;
+    }
+  }
+  return crossings;
+}
+
+function pathLength(points: readonly Point[]): number {
+  let total = 0;
+  for (let index = 1; index < points.length; index += 1) {
+    total += Math.hypot(
+      points[index]!.x - points[index - 1]!.x,
+      points[index]!.y - points[index - 1]!.y,
+    );
+  }
+  return total;
+}
+
+function axisOf(a: Point, b: Point): "x" | "y" | null {
+  if (a.x === b.x && a.y !== b.y) return "y";
+  if (a.y === b.y && a.x !== b.x) return "x";
+  return null;
+}
+
+/**
+ * Rebuild a stretched boundary Route as a fresh minimal orthogonal path only
+ * when the stretch itself degraded it: the transform grew the bend count (a
+ * hook or double-back appeared) and a fresh landing-to-landing path is
+ * simpler, or the stretched result runs through a moved symbol body a fresh
+ * path avoids. A stretch that merely slides an existing bend keeps the
+ * author's established detour byte-for-byte. Endpoints, Net, and Route
+ * identity never change: this is presentation geometry only.
+ */
+function smoothedBoundaryProposal(
+  route: SchematicDocument["routes"][number],
+  originalBendCount: number,
+  stretched: RouteStretchProposal,
+  smoothing: BoundarySmoothing,
+  resolver: SymbolResolver,
+): RouteStretchProposal {
+  if (
+    route.presentation === "power-rail" ||
+    route.presentation === "bulk-dashed"
+  ) {
+    return stretched;
+  }
+  if (stretched.segmentModes.some((mode) => protectedMode(mode))) {
+    return stretched;
+  }
+  const from = resolveEndpointConnection(
+    smoothing.movedDocument,
+    resolver,
+    route.start,
+  );
+  const to = resolveEndpointConnection(
+    smoothing.movedDocument,
+    resolver,
+    routeEnd(route),
+  );
+  if (!from || !to) return stretched;
+
+  const candidates: Point[][] = [];
+  const a = from.gridLanding;
+  const b = to.gridLanding;
+  if (a.x === b.x || a.y === b.y) {
+    candidates.push([a, b]);
+  } else {
+    candidates.push([a, { x: b.x, y: a.y }, b]);
+    candidates.push([a, { x: a.x, y: b.y }, b]);
+  }
+
+  const escapeAxis = (connection: EndpointConnection): "x" | "y" | null =>
+    connection.outward === null
+      ? null
+      : Math.abs(connection.outward.x) >= Math.abs(connection.outward.y)
+        ? "x"
+        : "y";
+  const fromAxis = escapeAxis(from);
+  const toAxis = escapeAxis(to);
+
+  let best: { points: Point[]; crossings: number } | null = null;
+  let bestScore = -Infinity;
+  for (const landing of candidates) {
+    const full = [
+      { ...from.contactPoint },
+      ...landing.map((point) => ({ ...point })),
+      { ...to.contactPoint },
+    ].filter(
+      (point, index, all) =>
+        index === 0 ||
+        point.x !== all[index - 1]!.x ||
+        point.y !== all[index - 1]!.y,
+    );
+    const crossings = bodyCrossings(full, smoothing.movedBodies);
+    let score = -4 * crossings;
+    if (landing.length > 1) {
+      if (fromAxis && axisOf(landing[0]!, landing[1]!) === fromAxis) score += 1;
+      if (toAxis && axisOf(landing.at(-2)!, landing.at(-1)!) === toAxis) {
+        score += 1;
+      }
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      best = { points: full, crossings };
+    }
+  }
+  if (!best || best.points.length < 2) return stretched;
+
+  const freshModes: SegmentMode[] = [];
+  for (let index = 1; index < best.points.length; index += 1) {
+    const isFirst = index === 1;
+    const isLast = index === best.points.length - 1;
+    const escapeLeg =
+      (isFirst &&
+        (from.contactPoint.x !== a.x || from.contactPoint.y !== a.y)) ||
+      (isLast && (to.contactPoint.x !== b.x || to.contactPoint.y !== b.y));
+    freshModes.push(escapeLeg ? "escape" : "manual");
+  }
+  let fresh: RouteStretchProposal;
+  try {
+    fresh = normalizeProposal(route.id, best.points, freshModes);
+  } catch {
+    return stretched;
+  }
+
+  const stretchedFull = [
+    best.points[0]!,
+    ...stretched.waypoints,
+    best.points.at(-1)!,
+  ];
+  const stretchedCrossings = bodyCrossings(
+    stretchedFull,
+    smoothing.movedBodies,
+  );
+  const grewComplexity = stretched.waypoints.length > originalBendCount;
+  // A wrap-around stretch shows up as sheer length: substantially longer
+  // than the minimal landing-to-landing path means the old shape has gone
+  // stale for the new positions.
+  const lengthDegraded =
+    pathLength(stretchedFull) > pathLength(best.points) * 1.5 + 20;
+  const rebuild =
+    best.crossings <= stretchedCrossings &&
+    ((grewComplexity && fresh.waypoints.length < stretched.waypoints.length) ||
+      best.crossings < stretchedCrossings ||
+      lengthDegraded) &&
+    fresh.waypoints.length <= Math.max(stretched.waypoints.length, 1);
+  return rebuild ? fresh : stretched;
 }
 
 /**
@@ -693,6 +906,14 @@ export function proposeLocalStretch(
     (candidate) => candidate.id === instanceId,
   )!;
   movedInstance.placement!.position = { ...newPosition };
+  const smoothing: BoundarySmoothing = {
+    movedDocument,
+    movedBodies: movedInstanceBodies(
+      movedDocument,
+      resolver,
+      new Set([instanceId]),
+    ),
+  };
   const routingGeometry = resolveDocumentRoutingGeometry(document, resolver);
   const proposals: RouteStretchProposal[] = [];
 
@@ -732,7 +953,15 @@ export function proposeLocalStretch(
         newTo.contactPoint,
       );
     }
-    proposals.push(normalizeProposal(route.id, points, modes));
+    proposals.push(
+      smoothedBoundaryProposal(
+        route,
+        original.points.length - 2,
+        normalizeProposal(route.id, points, modes),
+        smoothing,
+        resolver,
+      ),
+    );
   }
   return proposals.sort((left, right) =>
     left.routeId.localeCompare(right.routeId, "en"),
@@ -789,6 +1018,29 @@ export function proposeGroupMove(
     }
   }
   const routingGeometry = resolveDocumentRoutingGeometry(document, resolver);
+  const movedDocument = structuredClone(document);
+  for (const instance of movedDocument.instances) {
+    const target = moveByInstance.get(instance.id);
+    if (target && instance.placement) {
+      instance.placement.position = { ...target };
+    }
+  }
+  for (const junction of movedDocument.junctions) {
+    if (movableJunctionIds.has(junction.id)) {
+      junction.position = {
+        x: junction.position.x + groupDelta.x,
+        y: junction.position.y + groupDelta.y,
+      };
+    }
+  }
+  const smoothing: BoundarySmoothing = {
+    movedDocument,
+    movedBodies: movedInstanceBodies(
+      movedDocument,
+      resolver,
+      new Set(moveByInstance.keys()),
+    ),
+  };
 
   const proposals = new Map<string, RouteStretchProposal>();
   for (const route of document.routes) {
@@ -853,7 +1105,16 @@ export function proposeGroupMove(
         y: to.y + toDelta.y,
       });
     }
-    proposals.set(route.id, normalizeProposal(route.id, points, modes));
+    proposals.set(
+      route.id,
+      smoothedBoundaryProposal(
+        route,
+        original.points.length - 2,
+        normalizeProposal(route.id, points, modes),
+        smoothing,
+        resolver,
+      ),
+    );
   }
   const internalRouteIds = internalSelection.routeIds;
   const internallyMovedObjectIds = new Set<string>([
@@ -1064,6 +1325,26 @@ function proposeRigidBodyMove(
   const internalNetIds = new Set(internalSelection.netIds);
   const turningJunctionIds = new Set(internalSelection.junctionIds);
   const routingGeometry = resolveDocumentRoutingGeometry(document, resolver);
+  const movedDocument = structuredClone(document);
+  for (const instance of movedDocument.instances) {
+    if (!selected.has(instance.id) || !instance.placement) continue;
+    const oriented = transform.placement(instance.placement);
+    instance.placement = {
+      ...instance.placement,
+      position: transform.point(instance.placement.position),
+      rotation: oriented.rotation,
+      mirror: oriented.mirror,
+    };
+  }
+  for (const junction of movedDocument.junctions) {
+    if (turningJunctionIds.has(junction.id)) {
+      junction.position = transform.point(junction.position);
+    }
+  }
+  const smoothing: BoundarySmoothing = {
+    movedDocument,
+    movedBodies: movedInstanceBodies(movedDocument, resolver, selected),
+  };
 
   const turns = (endpoint: RouteEndpoint): boolean =>
     (endpoint.kind === "terminal" && selected.has(endpoint.instanceId)) ||
@@ -1116,7 +1397,16 @@ function proposeRigidBodyMove(
         transform.point(to),
       );
     }
-    proposals.set(route.id, normalizeProposal(route.id, points, modes));
+    proposals.set(
+      route.id,
+      smoothedBoundaryProposal(
+        route,
+        original.points.length - 2,
+        normalizeProposal(route.id, points, modes),
+        smoothing,
+        resolver,
+      ),
+    );
   }
 
   const turnedObjectIds = new Set<string>([

--- a/packages/edit-engine/src/routing-geometry.integration.test.ts
+++ b/packages/edit-engine/src/routing-geometry.integration.test.ts
@@ -19,7 +19,11 @@ import {
   buildOrthogonalEscapeRoute,
   normalizeRouteGeometry,
 } from "./route-geometry-edit.js";
-import { proposeLocalStretch } from "./route-operations.js";
+import {
+  proposeGroupReflection,
+  proposeGroupRotation,
+  proposeLocalStretch,
+} from "./route-operations.js";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
@@ -249,6 +253,36 @@ describe("derived connectivity and route geometry", () => {
     expect(() =>
       proposeLocalStretch(document, resolver, "A", { x: 140, y: 360 }),
     ).toThrow(/protected adjacent segment/u);
+  });
+
+  it("rebuilds a wrapped boundary path after a far move", () => {
+    const document = documentFixture();
+    document.routes = [
+      createRoutePath({
+        id: "route-hook",
+        netId: "net-h",
+        start: terminal("A"),
+        end: terminal("B"),
+        bends: [
+          { x: 160, y: 220 },
+          { x: 440, y: 220 },
+        ],
+        modes: ["manual", "manual", "manual"],
+      }),
+    ];
+
+    // Moved far past B, the slid up-and-over would wrap around the whole
+    // page; the boundary Route is rebuilt as the minimal orthogonal path
+    // instead. Endpoints and Net stay untouched.
+    expect(
+      proposeLocalStretch(document, resolver, "A", { x: 480, y: 160 }),
+    ).toEqual([
+      {
+        routeId: "route-hook",
+        waypoints: [{ x: 450, y: 160 }],
+        segmentModes: ["manual", "manual"],
+      },
+    ]);
   });
 
   it("changes only endpoint-adjacent geometry during a local stretch", () => {


### PR DESCRIPTION
## Summary
- Owner follow-up to #288: after drags/rotates/mirrors, stretched boundary wires wrapped around the page, sliced through symbols, and doubled back ("拖完之后…以合理的形式顺滑一下").
- `smoothedBoundaryProposal` rebuilds a stretched boundary Route as the **minimal escape-aware orthogonal path** — but only when the stretch objectively degraded it: bend count grew beyond the pre-move path (fresh strictly simpler), fresh strictly reduces moved-body crossings, or the stretched length exceeds **1.5× fresh + 20** (wrap-around). Slid detours from small nudges stay byte-for-byte; endpoints/Net/Route identity never change (presentation geometry only, per 'Routes are visible geometry'); locked/trunk and non-wire presentations exempt.
- Wired into all three transform sites (local stretch, group move, rigid rotate/reflect), each resolving fresh endpoint geometry against a moved-document context — the live drag preview shows the same final geometry.

## Measured effect (real gallery circuits, local replay)
- latch: group rotate visual defects 14 → **11**, mirror 15 → **12**
- ClassAB: rotate 52 → **46**, mirror 61 → **50**
- 2-NMOS partial rotate no longer draws the boundary wire through the second symbol
- Slid-detour preservation contract unchanged (existing unit test), new wrapped-path rebuild integration test

## Validation
- `vitest` engine + editor + derived — 990 passed
- `playwright` manual-editor + component-insert + hierarchy + drafting — 180 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)