### PR TITLE
fix(worker): keep the Worker out of the asset path

### DIFF
--- a/worker/index.test.ts
+++ b/worker/index.test.ts
@@ -120,12 +120,12 @@ describe("assets binding wiring", () => {
     return JSON.parse(stripped) as ReturnType<typeof wranglerConfig>;
   }
 
-  it("routes asset requests through the Worker", () => {
-    // Assets are served without invoking the Worker unless the path is listed
-    // here, so the 404 above is unreachable code without this entry — which is
-    // how a correct fix shipped once and changed nothing.
+  it("keeps the Worker out of the asset path", () => {
+    // Listing "/assets/*" in run_worker_first made env.ASSETS.fetch re-enter
+    // the Worker and every asset request returned 1101. Assets are served
+    // directly; the missing-asset 404 has to be built some other way.
     const { assets } = wranglerConfig();
-    expect(assets.run_worker_first).toContain("/assets/*");
+    expect(assets.run_worker_first).not.toContain("/assets/*");
     expect(assets.run_worker_first).toContain("/api/*");
     expect(assets.not_found_handling).toBe("single-page-application");
   });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,12 +17,7 @@
   "assets": {
     "directory": "./apps/editor/dist",
     "not_found_handling": "single-page-application",
-    // Assets are served without invoking the Worker unless a path is listed
-    // here. "/assets/*" is listed so a request the build cannot satisfy can be
-    // answered as missing: single-page-application handling would otherwise
-    // hand back the shell at 200 text/html under a content-hashed name, which
-    // the browser reads as a module and every cache treats as permanent.
-    "run_worker_first": ["/api/*", "/assets/*"],
+    "run_worker_first": ["/api/*"],
   },
   "durable_objects": {
     "bindings": [


### PR DESCRIPTION
**Reverts the wrangler change from #291. The site is currently serving no scripts.**

Listing `/assets/*` in `run_worker_first` put every asset request through the Worker, where `serveAsset` calls `env.ASSETS.fetch` — which, for a path in `run_worker_first`, re-enters the Worker. The result:

```
$ curl -sI https://analog-canvas.tokenzhang.com/assets/index-<hash>.js
HTTP/2 500
error code: 1101          ← Worker exception, on a real asset
```

That is worse than the fault it was meant to fix. The entry is removed and assets are served directly again.

## Where that leaves the original bug

A missing hashed asset goes back to answering with the shell at `200 text/html`. The other two parts of #290 still stand and still help:

- the **service worker refuses to cache** a response whose type does not match the request, so the shell never gets stored under a `.js` name — this is what made the failure *permanent* rather than momentary;
- the **client reloads once** per route per session when a chunk fails, and `index.html` is `must-revalidate` and network-first, so the reload lands on assets that exist.

So the reported symptom should still be fixed; what is lost is the clean `404`, which was defence in depth rather than the cure.

## What I got wrong

I verified #290 against the deployed site, found it had changed nothing, and correctly diagnosed why — then shipped the wiring fix without checking that the Worker could serve assets at all once it was in that path. The test I added pinned the config but could not exercise it. It now pins the opposite, with the reason attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)