### PR TITLE
feat(editor): compact the menubar for half-width windows

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -890,7 +890,7 @@ test("a mistaken click beside the publish form keeps what was written", async ({
   await expect(dialog.getByTestId("publish-tag-cascode")).toBeVisible();
 });
 
-test("Check and Save shelves the circuit without cluttering File", async ({
+test("Check and Save shelves the circuit from the File menu", async ({
   page,
 }) => {
   await page.route("**/api/auth/me", (route) =>
@@ -934,6 +934,7 @@ test("Check and Save shelves the circuit without cluttering File", async ({
     .getByTestId("schematic-canvas")
     .click({ position: { x: 360, y: 280 } });
   await page.keyboard.press("Escape");
+  await openMenu(page, "File");
   await page.getByTestId("check-and-save-button").click();
 
   // A lone transistor is not a netlistable circuit, and that is not an error:

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -108,6 +108,8 @@ describe("editor shell", () => {
     // "Preflight" named a stage of a netlist pipeline, not the question the
     // person is asking; the toolbar carries the plain action.
     expect(markup).not.toContain("Preflight…");
+    // Check and Save lives in the File menu now — narrow windows keep a
+    // one-row menubar.
     expect(markup).toContain('data-testid="check-and-save-button"');
     expect(markup).not.toContain("Edit Cell Interface…");
   });
@@ -194,8 +196,10 @@ describe("editor shell", () => {
     );
 
     expect(markup).toContain('href="/analytics"');
-    expect(markup).toContain("17 visitors");
-    expect(markup).toContain("42 views");
+    // The label stays compact; the live numbers ride in the tooltip so the
+    // menubar fits a half-width window.
+    expect(markup).toContain(">Analytics</a>");
+    expect(markup).toContain("17 visitors · 42 views");
     expect(markup).not.toContain("<summary>Analytics</summary>");
   });
 

--- a/apps/editor/src/app/editor-app-chrome.tsx
+++ b/apps/editor/src/app/editor-app-chrome.tsx
@@ -25,7 +25,7 @@ export interface EditorAppChromeProps {
   onProjectNameDraftChange: (value: string) => void;
   onProjectNameCommit: () => void;
   onProjectNameCancel: () => void;
-  fileCommands: ComponentProps<typeof FileCommandMenu>;
+  fileCommands: Omit<ComponentProps<typeof FileCommandMenu>, "onCheckAndSave">;
   searchOpen: boolean;
   onManageCells: () => void;
   onOpenSearch: () => void;
@@ -139,7 +139,7 @@ export function EditorAppChrome({
           }}
         >
           <div className="menubar-row">
-            <FileCommandMenu {...fileCommands} />
+            <FileCommandMenu {...fileCommands} onCheckAndSave={onCheckAndSave} />
             <details className="command-menu" name="editor-command-menu">
               <summary>Edit</summary>
               <div className="command-popover">
@@ -254,23 +254,13 @@ export function EditorAppChrome({
             ) : null}
             <button
               type="button"
-              className="toolbar-check-save"
-              data-testid="check-and-save-button"
-              title="Check the circuit and save it to your shelf"
-              onClick={onCheckAndSave}
-            >
-              <span className="toolbar-check-glyph" aria-hidden="true" />
-              Check and Save
-            </button>
-            <button
-              type="button"
               data-testid="publish-gallery-button"
               aria-haspopup="dialog"
               aria-expanded={publishGalleryOpen}
               title="Publish to Gallery"
               onClick={onPublishGallery}
             >
-              Publish to Gallery
+              Publish<span className="publish-label-long"> to Gallery</span>
             </button>
           </div>
         </nav>
@@ -279,16 +269,13 @@ export function EditorAppChrome({
             className="analytics-link"
             href="/analytics"
             aria-label="Open visitor analytics"
+            title={
+              visitStats
+                ? `${visitStats.uv.toLocaleString()} visitors · ${visitStats.pv.toLocaleString()} views`
+                : undefined
+            }
           >
-            {visitStats ? (
-              <>
-                <span>{visitStats.uv.toLocaleString()} visitors</span>
-                <span aria-hidden="true">·</span>
-                <span>{visitStats.pv.toLocaleString()} views</span>
-              </>
-            ) : (
-              "Analytics"
-            )}
+            Analytics
           </a>
           <button
             type="button"

--- a/apps/editor/src/app/editor-app-chrome.tsx
+++ b/apps/editor/src/app/editor-app-chrome.tsx
@@ -139,7 +139,10 @@ export function EditorAppChrome({
           }}
         >
           <div className="menubar-row">
-            <FileCommandMenu {...fileCommands} onCheckAndSave={onCheckAndSave} />
+            <FileCommandMenu
+              {...fileCommands}
+              onCheckAndSave={onCheckAndSave}
+            />
             <details className="command-menu" name="editor-command-menu">
               <summary>Edit</summary>
               <div className="command-popover">

--- a/apps/editor/src/features/editor-shell/file-command-menu.test.tsx
+++ b/apps/editor/src/features/editor-shell/file-command-menu.test.tsx
@@ -22,6 +22,7 @@ describe("FileCommandMenu", () => {
         projectInputRef={createRef<HTMLInputElement>()}
         onNewProject={vi.fn()}
         onSaveProject={vi.fn()}
+        onCheckAndSave={vi.fn()}
         onOpenShelfSlot={vi.fn()}
         onRefresh={vi.fn()}
         onOpenProject={vi.fn()}
@@ -36,6 +37,7 @@ describe("FileCommandMenu", () => {
     );
 
     expect(markup).toContain("Save Project As…");
+    expect(markup).toContain("Check and Save");
     expect(markup).not.toContain("Your shelf");
     expect(markup).not.toContain("Saved Circuit");
     expect(markup).not.toContain("shelf-slot-slot-1");

--- a/apps/editor/src/features/editor-shell/file-command-menu.tsx
+++ b/apps/editor/src/features/editor-shell/file-command-menu.tsx
@@ -10,6 +10,7 @@ export interface FileCommandMenuProps {
   projectInputRef: RefObject<HTMLInputElement | null>;
   onNewProject: () => void;
   onSaveProject: (pickLocation: boolean) => void;
+  onCheckAndSave: () => void;
   onOpenShelfSlot: (slot: WorkspaceSlot) => void;
   onRefresh: () => void;
   onOpenProject: (file: File | null) => void;
@@ -29,6 +30,7 @@ export function FileCommandMenu({
   projectInputRef,
   onNewProject,
   onSaveProject,
+  onCheckAndSave,
   onRefresh,
   onOpenProject,
   onImportSpice,
@@ -55,6 +57,15 @@ export function FileCommandMenu({
           onClick={() => onSaveProject(true)}
         >
           Save Project As…
+        </button>
+        <button
+          type="button"
+          data-testid="check-and-save-button"
+          title="Check the circuit and save it to your shelf"
+          onClick={onCheckAndSave}
+        >
+          <span className="toolbar-check-glyph" aria-hidden="true" />
+          Check and Save
         </button>
         <button type="button" onClick={onRefresh}>
           Refresh app

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -386,6 +386,11 @@ body {
   .tokenzhang-link-label {
     display: none;
   }
+
+  /* Narrow windows keep the verb; the tooltip still says where. */
+  .publish-label-long {
+    display: none;
+  }
 }
 
 /* Visitor analytics entry (compact, does not crowd menubar commands). */

--- a/apps/editor/src/styles/editor-chrome.css
+++ b/apps/editor/src/styles/editor-chrome.css
@@ -119,28 +119,6 @@
   white-space: nowrap;
 }
 
-/* Check and Save reads as the one forward action in the bar, so it carries a
-   green run glyph rather than another word among words. */
-.toolbar-check-save {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--icm-space-1);
-  min-height: var(--icm-control-h);
-  padding: 0 var(--icm-space-2);
-  border: 1px solid transparent;
-  border-radius: var(--icm-radius-sm);
-  background: transparent;
-  color: var(--icm-text);
-  font-size: var(--icm-font-md);
-  font-weight: 500;
-  line-height: var(--icm-line-tight);
-  white-space: nowrap;
-}
-
-.toolbar-check-save:hover:not(:disabled) {
-  background: var(--icm-surface-hover);
-}
-
 /* The check report had no styles at all, so each finding rendered its code
    and its sentence as one unbroken run: "GROUND_NAME_MISMATCHGround marker
    must connect to…". The code is a label for the sentence, so it sits above
@@ -346,9 +324,12 @@
   }
 }
 
+/* Check and Save keeps its green run glyph inside the File menu. */
 .toolbar-check-glyph {
+  display: inline-block;
   width: 0;
   height: 0;
+  margin-right: var(--icm-space-1);
   border-top: 5px solid transparent;
   border-bottom: 5px solid transparent;
   border-left: 8px solid #1a8f4c;
@@ -841,5 +822,15 @@
   .app-chrome-main {
     column-gap: var(--icm-space-2);
     padding: 0 var(--icm-space-2);
+  }
+}
+
+/* Half-screen windows: tighten every menubar pill so File…Publish and the
+   right-side actions share one uncut row. */
+@media (max-width: 940px) {
+  .command-menu summary,
+  .toolbar-button,
+  .menubar-help {
+    padding-inline: 0.35rem;
   }
 }


### PR DESCRIPTION
## Summary
Owner request: at half-screen width the top bar overflowed.
- **Check and Save → File menu** (after Save Project As…, same glyph + testid; Netlist menu still has Check Report…). The e2e moved to the menu path and its old 'without cluttering File' framing was updated — the owner asked for the compaction.
- **Visitor stats → compact "Analytics" link**; live "N visitors · M views" now rides in the tooltip (and stays on /analytics itself).
- Publish button shows just **Publish** under 900px (tooltip keeps the full name); menubar pills tighten under 940px.
- Verified at 730px: one uncut row (File · Edit · Netlist · Agent · Publish · Analytics · Help · credit).

## Validation
- vitest apps/editor/src — 574 passed
- playwright gallery + chrome-isolation — 34 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)