### PR TITLE
fix(editor): make R mean rotate, never draw a rectangle

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -565,7 +565,7 @@ test("R creates a selectable, styleable rectangle with four resize handles", asy
 }) => {
   await page.goto("/editor");
   await awaitEditorReady(page);
-  await page.keyboard.press("r");
+  await clickDrawTool(page, "rectangle");
   await clickCreate(page, { x: 220, y: 220 }, { x: 380, y: 320 });
   await expect(page.getByTestId("revision")).toHaveText("1");
 
@@ -691,7 +691,7 @@ test("E leaves a selected drafting rectangle as drawing geometry", async ({
 }) => {
   await page.goto("/editor");
   await awaitEditorReady(page);
-  await page.keyboard.press("r");
+  await clickDrawTool(page, "rectangle");
   await clickCreate(page, { x: 220, y: 220 }, { x: 380, y: 320 });
 
   await page.getByTestId(/^drafting-hit-rectangle-/).click({ force: true });
@@ -884,7 +884,7 @@ test("double-click inside a rectangle writes a centered, anchored label", async 
 }) => {
   await page.goto("/editor");
   await awaitEditorReady(page);
-  await page.keyboard.press("r");
+  await clickDrawTool(page, "rectangle");
   await clickCreate(page, { x: 220, y: 220 }, { x: 380, y: 320 });
   await expect(page.getByTestId("revision")).toHaveText("1");
 
@@ -982,7 +982,7 @@ test("double-click inside a rectangle writes a centered, anchored label", async 
 
   // An untouched empty label vanishes on commit instead of persisting.
   await page.keyboard.press("Escape");
-  await page.keyboard.press("r");
+  await clickDrawTool(page, "rectangle");
   await clickCreate(page, { x: 430, y: 220 }, { x: 560, y: 300 });
   const canvas = page.getByTestId("schematic-canvas");
   const box = await canvas.boundingBox();

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -731,6 +731,12 @@ export function App({
   const [publishDraft, setPublishDraft] = useState<PublishGalleryDraft | null>(
     null,
   );
+  /**
+   * R pressed with nothing selected: the next part pointed at is turned.
+   * The key means rotate whether or not something is selected yet, rather
+   * than meaning rotate sometimes and draw a rectangle the rest of the time.
+   */
+  const [rotateArmed, setRotateArmed] = useState(false);
   /** The signed-in account's last few checked circuits, newest first. */
   const [workspaceSlots, setWorkspaceSlots] = useState<
     readonly WorkspaceSlot[]
@@ -1267,6 +1273,35 @@ export function App({
     transact,
     setStatus,
   });
+
+  /** Arm R so the next part pointed at is the one that turns. */
+  function armRotateOnNextPart(): void {
+    setRotateArmed(true);
+    setStatus("Rotate: click a part to turn it, Escape to stop");
+  }
+
+  /** Turn one part where it stands. Returns false when nothing was armed. */
+  function rotateArmedInstance(instanceId: string): boolean {
+    if (!rotateArmed) return false;
+    const instance = document.instances.find(
+      (candidate) => candidate.id === instanceId,
+    );
+    if (!instance?.placement) return false;
+    const next = (instance.placement.rotation + 90) % 360;
+    const applied = transact([
+      {
+        kind: "rotate_instance",
+        instanceId,
+        rotation: next as 0 | 90 | 180 | 270,
+      },
+    ]);
+    if (applied.ok) {
+      setStatus(
+        `Rotated ${instanceId} to ${next}° — click another, Escape to stop`,
+      );
+    }
+    return true;
+  }
   const {
     handleDrop,
     placeAll: placeAllFromTray,
@@ -1921,6 +1956,7 @@ export function App({
     cancelInteraction();
     setBulkDrawInstanceId(null);
     setBoxPreview(null);
+    setRotateArmed(false);
   }
 
   function selectEndpoint(candidate: WireSource): void {
@@ -2258,6 +2294,7 @@ export function App({
       rotateCopy: rotatePendingCopy,
       rotateMove: rotateCommandMoveFromSelection,
       rotateSelection: rotateSelected,
+      armRotate: () => armRotateOnNextPart(),
       mirrorPlacement: mirrorPendingComponentFromHook,
       mirrorCopy: mirrorPendingCopy,
       mirrorMove: mirrorCommandMoveFromSelection,
@@ -3633,8 +3670,16 @@ export function App({
                   enterHierarchy(instance.id);
                 else inspectInstance(instance.id);
               },
-              onInstancePointerDown: (event, instance) =>
-                beginMoveFromSelection(event, instance.id),
+              onInstancePointerDown: (event, instance) => {
+                // While R is armed the click turns the part rather than
+                // picking it up, so the gesture reads as "rotate that one".
+                if (rotateArmedInstance(instance.id)) {
+                  event.stopPropagation();
+                  event.preventDefault();
+                  return;
+                }
+                beginMoveFromSelection(event, instance.id);
+              },
               onRoutePointerDown: handleRoutePointerDown,
               onAnnotationPointerDown: beginAnnotationDrag,
               onAnnotationEdit: beginAnnotationTextEditing,

--- a/apps/editor/src/commands/editor-command.test.ts
+++ b/apps/editor/src/commands/editor-command.test.ts
@@ -42,6 +42,7 @@ function fixture(overrides: Partial<EditorCommandContext> = {}) {
     rotateCopy: vi.fn(),
     rotateMove: vi.fn(),
     rotateSelection: vi.fn(),
+    armRotate: vi.fn(),
     mirrorPlacement: vi.fn(),
     mirrorCopy: vi.fn(),
     mirrorMove: vi.fn(),

--- a/apps/editor/src/commands/editor-command.ts
+++ b/apps/editor/src/commands/editor-command.ts
@@ -15,6 +15,7 @@ export type EditorCommandRequest =
   | { id: "selection.copy" }
   | { id: "selection.move" }
   | { id: "transform.rotate"; deltaDegrees?: 90 | -90 }
+  | { id: "transform.rotate-next" }
   | { id: "transform.mirror"; direction: ScreenFlip }
   | { id: "insert.start"; launch: InsertLaunch }
   | { id: "insert.open" }
@@ -70,6 +71,8 @@ export interface EditorCommandOperations {
   rotateCopy(deltaDegrees: 90 | -90): void;
   rotateMove(deltaDegrees: 90 | -90): void;
   rotateSelection(deltaDegrees: 90 | -90): void;
+  /** Wait for a part to be pointed at, then turn that one. */
+  armRotate(): void;
   mirrorPlacement(direction: ScreenFlip): void;
   mirrorCopy(direction: ScreenFlip): void;
   mirrorMove(direction: ScreenFlip): void;
@@ -203,6 +206,12 @@ export function createEditorCommandRouter(
           ? disabled(resolution.reason)
           : enabled(resolution.active);
       }
+      case "transform.rotate-next":
+        // Arming needs nothing selected and nothing in progress: it is what R
+        // does when there is not yet anything to turn.
+        return context.interactionMode === "idle"
+          ? enabled()
+          : disabled("Finish the current action before rotating");
       case "transform.mirror": {
         const resolution = resolveTransformOwner(context, "mirror");
         return resolution.owner === "unavailable"
@@ -286,6 +295,9 @@ export function createEditorCommandRouter(
         break;
       case "selection.move":
         options.operations.beginMove();
+        break;
+      case "transform.rotate-next":
+        options.operations.armRotate();
         break;
       case "transform.rotate": {
         const deltaDegrees = request.deltaDegrees ?? 90;

--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -109,9 +109,10 @@ describe("editor shortcut contract", () => {
   });
 
   it("resolves R rotation and the two agreed mirror shortcuts", () => {
-    expect(resolve("r")).toEqual(
-      command({ id: "tool.activate", tool: "rectangle" }),
-    );
+    // R means rotate whether or not something is selected. With nothing
+    // selected it arms the turn; it used to reach the rectangle tool, so one
+    // key did two unrelated things depending on state.
+    expect(resolve("r")).toEqual(command({ id: "transform.rotate-next" }));
     expect(resolve("r", { canRotate: true })).toEqual(
       command({ id: "transform.rotate", deltaDegrees: 90 }),
     );
@@ -119,6 +120,18 @@ describe("editor shortcut contract", () => {
       command({ id: "transform.mirror", direction: "left-right" }),
     );
     expect(resolve("v", { canRotate: true }, { shiftKey: true })).toBeNull();
+  });
+
+  it("never reaches the rectangle tool from R", () => {
+    for (const context of [
+      {},
+      { canRotate: true },
+      { hasDraftingSelection: true },
+      { interactionMode: "placing-component" as const },
+    ]) {
+      const resolved = resolve("r", context);
+      expect(JSON.stringify(resolved)).not.toContain("rectangle");
+    }
   });
 
   it("does not replace a selected non-rotatable drawing with a rectangle", () => {

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -262,17 +262,21 @@ export function resolveEditorShortcut(
           }
         : null;
     }
-    return context.canRotate
-      ? {
-          kind: "run-command",
-          command: { id: "transform.rotate", deltaDegrees: 90 },
-        }
-      : context.hasDraftingSelection
-        ? { kind: "blocked-interaction-command", command: "Rotate" }
-        : {
-            kind: "run-command",
-            command: { id: "tool.activate", tool: "rectangle" },
-          };
+    if (context.canRotate) {
+      return {
+        kind: "run-command",
+        command: { id: "transform.rotate", deltaDegrees: 90 },
+      };
+    }
+    if (context.hasDraftingSelection) {
+      return { kind: "blocked-interaction-command", command: "Rotate" };
+    }
+    // R means rotate, with or without something selected already. It used to
+    // reach the rectangle tool when nothing was selected, so the key did two
+    // unrelated things depending on state — press it meaning "turn this" and
+    // get a rectangle. With nothing selected it now arms the turn and waits
+    // for a part to be pointed at.
+    return { kind: "run-command", command: { id: "transform.rotate-next" } };
   }
   if (plain && key === "w") {
     return {


### PR DESCRIPTION
`R` rotated the selection when something rotatable was selected, and **activated the rectangle tool when nothing was**. One key did two unrelated things depending on state, so pressing it meaning "turn this" produced a rectangle.

With nothing selected, `R` now arms the turn and waits: the next part pointed at is the one that rotates. It stays armed, so several parts can be turned in a row, and Escape stops it. With a selection `R` still turns it immediately, and placement rotation still takes priority while a component is being placed.

The rectangle tool keeps its toolbar button. It no longer has a key that belongs to something else.

## Validation

- unit: 29 pass across the shortcut contract and command registry. The contract test that pinned `R → rectangle` now pins `R → transform.rotate-next`, and a new case sweeps every context — nothing selected, rotatable selection, drafting selection, mid-placement — asserting `R` never resolves to the rectangle tool from any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)