### PR TITLE
Move onboarding shortcuts to the canvas corner

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -199,11 +199,26 @@ test("refreshes explicitly only after flushing and automatically restoring recov
     .toBeNull();
 });
 
-test("inserts from the master-detail dialog with keyboard and live placement preview", async ({
+test("keeps quick-start shortcuts in the corner until the first component is inserted", async ({
   page,
 }) => {
   await page.goto("/editor");
-  await expect(page.getByTestId("canvas-empty-state")).toBeVisible();
+  const quickStart = page.getByTestId("canvas-empty-state");
+  await expect(quickStart).toBeVisible();
+  await expect(quickStart).toHaveAttribute(
+    "aria-label",
+    "Quick start shortcuts",
+  );
+  await expect(quickStart).toContainText("Quick start");
+  await expect(quickStart.locator("kbd")).toHaveText(["I", "W"]);
+  await expect(quickStart).toContainText("Insert component");
+  await expect(quickStart).toContainText("Draw wire");
+  expect(
+    await quickStart.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return { top: style.top, left: style.left, transform: style.transform };
+    }),
+  ).toEqual({ top: "12px", left: "12px", transform: "none" });
 
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
@@ -238,7 +253,7 @@ test("inserts from the master-detail dialog with keyboard and live placement pre
   await canvas.click({ position: { x: 360, y: 230 } });
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("hit-R1")).toBeVisible();
-  await expect(page.getByTestId("canvas-empty-state")).toHaveCount(0);
+  await expect(quickStart).toHaveCount(0);
   await page.getByTestId("selection-shelf").click();
   await expect(page.getByTestId("selection-shelf")).toContainText(
     "R1 · resistor",

--- a/apps/editor/src/canvas/editor-canvas-surface.tsx
+++ b/apps/editor/src/canvas/editor-canvas-surface.tsx
@@ -61,12 +61,23 @@ export function EditorCanvasSurface({
   return (
     <section className="canvas-panel">
       {empty ? (
-        <div className="canvas-empty-state" data-testid="canvas-empty-state">
-          <strong>Start a schematic</strong>
-          <span>
-            Press <kbd>I</kbd> to insert a component or <kbd>W</kbd> to wire.
-          </span>
-        </div>
+        <aside
+          className="canvas-shortcut-menu"
+          data-testid="canvas-empty-state"
+          aria-label="Quick start shortcuts"
+        >
+          <p className="canvas-shortcut-menu-title">Quick start</p>
+          <ul className="canvas-shortcut-list">
+            <li>
+              <kbd>I</kbd>
+              <span>Insert component</span>
+            </li>
+            <li>
+              <kbd>W</kbd>
+              <span>Draw wire</span>
+            </li>
+          </ul>
+        </aside>
       ) : null}
       <svg
         className={className}

--- a/apps/editor/src/styles/editor-canvas-state.css
+++ b/apps/editor/src/styles/editor-canvas-state.css
@@ -38,99 +38,67 @@
   stroke-dasharray: 3 5;
 }
 
-.canvas-empty-state {
+.canvas-shortcut-menu {
   position: absolute;
   z-index: 3;
-  top: 50%;
-  left: 50%;
+  top: var(--icm-space-3);
+  left: var(--icm-space-3);
   display: grid;
   gap: var(--icm-space-2);
-  width: min(22rem, calc(100% - 2rem));
-  padding: var(--icm-space-4);
+  width: max-content;
+  max-width: calc(100% - var(--icm-space-6));
+  padding: 10px var(--icm-space-3);
   border: 1px solid var(--icm-border);
   color: var(--icm-text-muted);
-  background: rgb(255 255 255 / 96%);
-  border-radius: var(--icm-radius-lg);
-  box-shadow: var(--icm-shadow-md);
+  background: rgb(255 255 255 / 92%);
+  border-radius: var(--icm-radius-md);
+  box-shadow: var(--icm-shadow-sm);
   pointer-events: none;
   text-align: left;
-  transform: translate(-50%, -50%);
   backdrop-filter: blur(8px);
 }
 
-.canvas-empty-kicker {
+.canvas-shortcut-menu-title {
   margin: 0;
   color: var(--icm-text-muted);
   font-size: var(--icm-font-xs);
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  font-weight: 700;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   line-height: var(--icm-line-tight);
 }
 
-.canvas-empty-state strong {
-  color: var(--icm-text);
-  font-size: var(--icm-font-lg);
-  font-weight: 600;
-  letter-spacing: -0.01em;
+.canvas-shortcut-list {
+  display: grid;
+  gap: var(--icm-space-1);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.canvas-shortcut-list li {
+  display: grid;
+  grid-template-columns: 24px auto;
+  align-items: center;
+  gap: var(--icm-space-2);
+  font-size: var(--icm-font-sm);
   line-height: var(--icm-line-tight);
 }
 
-.canvas-empty-state span {
-  font-size: var(--icm-font-sm);
-  line-height: var(--icm-line);
-}
-
-.canvas-empty-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--icm-space-2);
-  margin-top: var(--icm-space-1);
-  pointer-events: auto;
-}
-
-.canvas-empty-actions button {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--icm-space-2);
-  min-height: var(--icm-control-h-lg);
-  padding: 0 var(--icm-space-3);
-  border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-sm);
-  background: var(--icm-surface);
-  box-shadow: none;
-  font-size: var(--icm-font-md);
-  font-weight: 600;
-}
-
-.canvas-empty-actions button:hover:not(:disabled) {
-  background: var(--icm-surface-hover);
-}
-
-.canvas-empty-primary {
-  border-color: transparent !important;
-  color: #fff !important;
-  background: var(--icm-accent) !important;
-}
-
-.canvas-empty-primary:hover:not(:disabled) {
-  filter: brightness(0.96);
-  background: var(--icm-accent) !important;
-}
-
-.canvas-empty-actions kbd {
-  padding: 0.05rem 0.28rem;
-  border: 1px solid rgb(255 255 255 / 35%);
-  border-radius: 0.25rem;
-  background: rgb(255 255 255 / 16%);
-  font: inherit;
-  font-size: 0.72em;
-}
-
-.canvas-empty-actions button:not(.canvas-empty-primary) kbd {
-  border-color: var(--icm-border-strong);
+.canvas-shortcut-menu kbd {
+  display: inline-grid;
+  min-width: 24px;
+  height: 22px;
+  place-items: center;
+  padding: 0 5px;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: 5px;
+  color: var(--icm-text);
   background: var(--icm-surface-muted);
-  color: var(--icm-text-muted);
+  box-shadow: 0 1px 0 var(--icm-border-strong);
+  font: inherit;
+  font-size: var(--icm-font-sm);
+  font-weight: 650;
 }
 
 .canvas-controls {

--- a/apps/editor/src/styles/editor-dialogs.css
+++ b/apps/editor/src/styles/editor-dialogs.css
@@ -157,8 +157,7 @@
   font-size: 16px;
 }
 
-.insert-dialog-header kbd,
-.canvas-empty-state kbd {
+.insert-dialog-header kbd {
   padding: 0.15rem 0.42rem;
   border: 1px solid var(--icm-border-strong);
   border-radius: 0.3rem;


### PR DESCRIPTION
## Summary
- replace the centered empty-canvas prompt with a compact Quick start shortcut menu in the upper-left
- keep the menu click-through and remove it automatically after the first component is placed
- keep shortcut-key styling with the canvas state and add browser coverage for content, position, and dismissal

## Validation
- `pnpm gate:preflight -- --base origin/main`
- `ICM_E2E_ISOLATED=1 ICM_E2E_PORT=4174 pnpm gate:affected -- --base origin/main`
  - 243 files / 1521 unit tests
  - 27 component-insert E2E tests
  - 111 manual-editor E2E tests
- visual browser inspection at the default editor viewport
- `git diff --check`