### PR TITLE
fix(editor): fit the drawing into the canvas nobody is standing on

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -4631,6 +4631,44 @@ test("flips a marquee selection as one body, not three parts in place", async ({
   expect(await order()).toEqual([...before].reverse());
 });
 
+test("Fit View keeps the drawing clear of the Properties dock", async ({
+  page,
+}) => {
+  // Below 860px the Properties dock stops being a column and floats over the
+  // canvas — the half-screen case where fitting to the element hid work.
+  await page.setViewportSize({ width: 800, height: 800 });
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+
+  await placeComponent(page, "resistor", { x: 120, y: 160 });
+  await placeComponent(page, "capacitor", { x: 320, y: 260 });
+  await placeComponent(page, "resistor", { x: 520, y: 360 });
+  await page.keyboard.press("Escape");
+
+  // Open Properties so it floats over the canvas at full width.
+  await canvas.click({ position: { x: 120, y: 160 } });
+  await openSelectionShelf(page);
+  const dock = page.locator(".selection-dock");
+  // The dock animates open over 160ms; measure the settled width.
+  await expect
+    .poll(async () => (await dock.boundingBox())?.width ?? 0)
+    .toBeGreaterThan(120);
+  const dockBox = (await dock.boundingBox())!;
+
+  await page.keyboard.press("Escape");
+  await page.keyboard.press("f");
+
+  // Every symbol has to land left of the dock: the canvas runs underneath it,
+  // so fitting to the element alone put part of the drawing out of sight.
+  const rights = await page
+    .locator('[data-layer="symbols"] [data-object-id]')
+    .evaluateAll((elements) =>
+      elements.map((element) => element.getBoundingClientRect().right),
+    );
+  expect(rights).toHaveLength(3);
+  for (const right of rights) expect(right).toBeLessThanOrEqual(dockBox.x);
+});
+
 test("drags a marquee selection that holds no instance", async ({ page }) => {
   await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -61,9 +61,11 @@ import {
 } from "../features/clipboard/clipboard";
 import type { SchematicClipboard } from "../features/clipboard/clipboard";
 import {
+  canvasInsetsFromOverlays,
   fitCameraToBounds,
   normalizeCameraRect,
   type CameraRectInput,
+  type CanvasInsets,
 } from "../canvas/fit-view";
 import type { CanvasDragSession } from "../canvas/canvas-drag-session";
 import { createCanvasHitController } from "../canvas/canvas-hit-controller";
@@ -1747,6 +1749,7 @@ export function App({
         lastCanvasPointRef.current = point;
       },
       setStatus,
+      measureCanvasView,
     },
     selection: {
       updateCommandMovePreview: updateCommandMovePreviewFromSelection,
@@ -1784,6 +1787,29 @@ export function App({
       completeDrag: completeCellSymbolLayoutDrag,
     },
   });
+  /**
+   * The canvas element and the docks floating over it. Fit reads this at the
+   * moment it runs, so a panel opened since the last fit is accounted for.
+   */
+  function measureCanvasView(): {
+    viewport: { width: number; height: number };
+    insets: CanvasInsets;
+  } | null {
+    const canvas = window.document.querySelector(
+      '[data-testid="schematic-canvas"]',
+    );
+    if (!canvas) return null;
+    const canvasRect = canvas.getBoundingClientRect();
+    if (canvasRect.width <= 0 || canvasRect.height <= 0) return null;
+    const overlays = [
+      ...window.document.querySelectorAll("[data-canvas-overlay]"),
+    ].map((element) => element.getBoundingClientRect());
+    return {
+      viewport: { width: canvasRect.width, height: canvasRect.height },
+      insets: canvasInsetsFromOverlays(canvasRect, overlays),
+    };
+  }
+
   const {
     switchDocument,
     selectDocumentFromHierarchy,
@@ -1812,6 +1838,7 @@ export function App({
     viewBox,
     defaultViewBox: DEFAULT_VIEWBOX,
     setViewBox,
+    measureCanvasView,
     openDocument,
     resetInteractionState,
     selectOnly,

--- a/apps/editor/src/app/editor-properties-dock.tsx
+++ b/apps/editor/src/app/editor-properties-dock.tsx
@@ -83,6 +83,9 @@ export function EditorPropertiesDock({
   return (
     <aside
       className={open ? "selection-dock open" : "selection-dock"}
+      // Fit View insets the camera by the docks that float over the
+      // canvas, so the drawing lands where it can be seen.
+      data-canvas-overlay="true"
       aria-label="Properties"
       role="complementary"
     >

--- a/apps/editor/src/canvas/canvas-gesture-controller.ts
+++ b/apps/editor/src/canvas/canvas-gesture-controller.ts
@@ -34,8 +34,10 @@ import {
 import { normalizedRect } from "./canvas-geometry";
 import {
   fitCameraToBounds,
+  fitCameraToVisibleBounds,
   zoomCameraAtAnchor,
   type CameraRectInput,
+  type CanvasInsets,
 } from "./fit-view";
 
 // A stiff middle button drifts under the hand; keep a larger slop than an
@@ -81,6 +83,11 @@ export interface CanvasGestureControllerDependencies {
     paintSnapGuides: (guides: readonly SnapGuideLine[]) => void;
     noteCanvasPoint: (point: Point) => void;
     setStatus: (status: string) => void;
+    /** Canvas size and how far floating docks reach over it; see fitView. */
+    measureCanvasView?: () => {
+      viewport: { width: number; height: number };
+      insets: CanvasInsets;
+    } | null;
   };
   selection: {
     updateCommandMovePreview: (
@@ -153,6 +160,7 @@ export function createCanvasGestureController({
     paintSnapGuides,
     noteCanvasPoint,
     setStatus,
+    measureCanvasView,
   },
   selection: {
     updateCommandMovePreview,
@@ -189,11 +197,21 @@ export function createCanvasGestureController({
   },
 }: CanvasGestureControllerDependencies) {
   const fitView = (): void => {
+    const bounds = contentBounds ?? defaultViewBox;
+    const grid = document.presentation.grid;
+    // Below the layout's narrow breakpoint the Properties dock stops being a
+    // column and floats over the canvas, so fitting to the element put part
+    // of the drawing underneath it.
+    const measured = measureCanvasView?.() ?? null;
     setViewBox(
-      fitCameraToBounds(
-        contentBounds ?? defaultViewBox,
-        document.presentation.grid,
-      ),
+      measured
+        ? fitCameraToVisibleBounds(
+            bounds,
+            grid,
+            measured.viewport,
+            measured.insets,
+          )
+        : fitCameraToBounds(bounds, grid),
     );
     setStatus("Fit Document");
   };

--- a/apps/editor/src/canvas/fit-view.test.ts
+++ b/apps/editor/src/canvas/fit-view.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   CAMERA_ZOOM_LIMITS,
+  canvasInsetsFromOverlays,
   fitCameraToBounds,
+  fitCameraToVisibleBounds,
   normalizeCameraRect,
   zoomCameraAtAnchor,
 } from "./fit-view";
@@ -73,5 +75,59 @@ describe("zoomCameraAtAnchor", () => {
     );
     expect(grown.width).toBe(CAMERA_ZOOM_LIMITS.maxWidth);
     expect(grown.height).toBe(CAMERA_ZOOM_LIMITS.maxHeight);
+  });
+});
+
+describe("fit around floating panels", () => {
+  const canvas = { x: 0, y: 82, width: 760, height: 780 };
+
+  it("insets only for panels anchored to an edge", () => {
+    expect(
+      canvasInsetsFromOverlays(canvas, [
+        // The Properties dock, open, on the right edge.
+        { x: 410, y: 82, width: 350, height: 780 },
+        // A floating menu in the middle: dodging it would cost more width
+        // than being overlapped by it.
+        { x: 200, y: 300, width: 158, height: 40 },
+      ]),
+    ).toEqual({ left: 0, right: 350, top: 0, bottom: 0 });
+  });
+
+  it("ignores a panel that is closed away to nothing", () => {
+    expect(
+      canvasInsetsFromOverlays(canvas, [
+        { x: 760, y: 82, width: 0, height: 780 },
+      ]),
+    ).toEqual({ left: 0, right: 0, top: 0, bottom: 0 });
+  });
+
+  it("centres the drawing in what is left, not under the panel", () => {
+    const bounds = { x: 0, y: 0, width: 400, height: 400 };
+    const camera = fitCameraToVisibleBounds(
+      bounds,
+      10,
+      { width: 760, height: 780 },
+      { left: 0, right: 350, top: 0, bottom: 0 },
+    );
+    // 410px of canvas for 400 units, so 1.025 px per unit; the camera spans
+    // the whole element at that scale.
+    expect(camera.width).toBeCloseTo(740, -1);
+    // The drawing's centre lands at the centre of the visible strip (205px),
+    // not at the element's centre (380px), so nothing sits under the dock.
+    const scale = 410 / 400;
+    const centreOnScreen = (200 - camera.x) * scale;
+    expect(centreOnScreen).toBeCloseTo(205, 0);
+  });
+
+  it("falls back to fitting the element when nothing is visible", () => {
+    const bounds = { x: 0, y: 0, width: 400, height: 400 };
+    expect(
+      fitCameraToVisibleBounds(
+        bounds,
+        10,
+        { width: 760, height: 780 },
+        { left: 400, right: 400, top: 0, bottom: 0 },
+      ),
+    ).toEqual(fitCameraToBounds(bounds, 10));
   });
 });

--- a/apps/editor/src/canvas/fit-view.ts
+++ b/apps/editor/src/canvas/fit-view.ts
@@ -75,6 +75,99 @@ export function fitCameraToBounds(bounds: DerivedRect, grid: number): GridRect {
   };
 }
 
+/** Pixels of the canvas element hidden behind a floating panel, per side. */
+export interface CanvasInsets {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+/**
+ * How far floating panels reach in over each edge of the canvas.
+ *
+ * Only a panel anchored to an edge can be avoided by insetting: one floating
+ * in the middle of the canvas would cost the whole drawing its width to dodge,
+ * which is worse than being overlapped. Edge panels are the docks, and they
+ * are the ones wide enough to hide work behind.
+ */
+export function canvasInsetsFromOverlays(
+  canvas: { x: number; y: number; width: number; height: number },
+  overlays: readonly { x: number; y: number; width: number; height: number }[],
+): CanvasInsets {
+  const insets: CanvasInsets = { left: 0, right: 0, top: 0, bottom: 0 };
+  const canvasRight = canvas.x + canvas.width;
+  const canvasBottom = canvas.y + canvas.height;
+  const touches = 1;
+  for (const overlay of overlays) {
+    if (overlay.width <= 0 || overlay.height <= 0) continue;
+    const right = overlay.x + overlay.width;
+    const bottom = overlay.y + overlay.height;
+    if (right <= canvas.x || overlay.x >= canvasRight) continue;
+    if (bottom <= canvas.y || overlay.y >= canvasBottom) continue;
+    if (overlay.x <= canvas.x + touches) {
+      insets.left = Math.max(insets.left, right - canvas.x);
+    } else if (right >= canvasRight - touches) {
+      insets.right = Math.max(insets.right, canvasRight - overlay.x);
+    } else if (overlay.y <= canvas.y + touches) {
+      insets.top = Math.max(insets.top, bottom - canvas.y);
+    } else if (bottom >= canvasBottom - touches) {
+      insets.bottom = Math.max(insets.bottom, canvasBottom - overlay.y);
+    }
+  }
+  return insets;
+}
+
+/**
+ * Fit the Document into the part of the canvas nobody is standing on.
+ *
+ * The canvas element spans the whole workspace and the Properties dock floats
+ * over its right-hand side, so fitting to the element put a slice of the
+ * drawing underneath the panel — the wider the panel, the more went missing.
+ * Fit centres the Document in the unobscured region instead.
+ *
+ * The camera is given the element's aspect ratio, so `xMidYMid meet` adds no
+ * letterboxing of its own and the offset below lands exactly where intended.
+ */
+export function fitCameraToVisibleBounds(
+  bounds: DerivedRect,
+  grid: number,
+  viewport: { width: number; height: number },
+  insets: CanvasInsets,
+): GridRect {
+  assertFinitePositiveRect(bounds, grid, "Fit View");
+  const visibleWidth = viewport.width - insets.left - insets.right;
+  const visibleHeight = viewport.height - insets.top - insets.bottom;
+  // Nothing to centre in: fall back to fitting the element itself rather than
+  // inventing a camera from a non-positive region.
+  if (
+    !Number.isFinite(visibleWidth) ||
+    !Number.isFinite(visibleHeight) ||
+    visibleWidth <= 0 ||
+    visibleHeight <= 0 ||
+    viewport.width <= 0 ||
+    viewport.height <= 0
+  ) {
+    return fitCameraToBounds(bounds, grid);
+  }
+
+  // Pixels per Document unit that shows the whole drawing inside the region.
+  const scale = Math.min(
+    visibleWidth / bounds.width,
+    visibleHeight / bounds.height,
+  );
+  const cameraWidth = viewport.width / scale;
+  const cameraHeight = viewport.height / scale;
+  const centreX = bounds.x + bounds.width / 2;
+  const centreY = bounds.y + bounds.height / 2;
+  const cameraX = centreX - (insets.left + visibleWidth / 2) / scale;
+  const cameraY = centreY - (insets.top + visibleHeight / 2) / scale;
+  return normalizeCameraRect(
+    { x: cameraX, y: cameraY, width: cameraWidth, height: cameraHeight },
+    grid,
+  );
+}
+
 export interface CameraZoomLimits {
   minWidth: number;
   maxWidth: number;

--- a/apps/editor/src/features/hierarchy/editor-navigation-controller.ts
+++ b/apps/editor/src/features/hierarchy/editor-navigation-controller.ts
@@ -24,7 +24,12 @@ import type {
 import { buildSvgScene } from "@icm/render-svg";
 import type { SymbolResolver } from "@icm/symbols";
 
-import { fitCameraToBounds, type CameraRectInput } from "../../canvas/fit-view";
+import {
+  fitCameraToBounds,
+  fitCameraToVisibleBounds,
+  type CameraRectInput,
+  type CanvasInsets,
+} from "../../canvas/fit-view";
 import { referencedDocumentId } from "../../document/editor-session";
 import { endpointNetId } from "../wiring/route-interaction-geometry";
 
@@ -46,6 +51,14 @@ export interface EditorNavigationControllerDependencies {
   viewBox: GridRect;
   defaultViewBox: GridRect;
   setViewBox: SetViewBox;
+  /**
+   * The canvas element's size and how much of it floating panels cover.
+   * Absent when the canvas is not mounted, which leaves fit to the element.
+   */
+  measureCanvasView?: () => {
+    viewport: { width: number; height: number };
+    insets: CanvasInsets;
+  } | null;
   openDocument: (documentId: string) => SchematicDocument | null | undefined;
   resetInteractionState: () => void;
   selectOnly: (kind: SelectionKind, ids: readonly string[]) => void;
@@ -81,6 +94,7 @@ export function createEditorNavigationController({
   viewBox,
   defaultViewBox,
   setViewBox,
+  measureCanvasView,
   openDocument,
   resetInteractionState,
   selectOnly,
@@ -304,12 +318,19 @@ export function createEditorNavigationController({
         statusMessage,
       );
     }
+    const bounds = buildSvgScene(target, resolver).viewBox;
+    const grid = target.presentation.grid;
+    const measured = measureCanvasView?.() ?? null;
     setViewBox(
-      fitCameraToBounds(
-        buildSvgScene(target, resolver).viewBox,
-        target.presentation.grid,
-      ),
-      target.presentation.grid,
+      measured
+        ? fitCameraToVisibleBounds(
+            bounds,
+            grid,
+            measured.viewport,
+            measured.insets,
+          )
+        : fitCameraToBounds(bounds, grid),
+      grid,
     );
   };
 


### PR DESCRIPTION
Below 860px the Properties dock stops being a grid column and becomes `position: absolute`, floating over a canvas that still spans the whole workspace. Fit measured the element, so on a half screen it spread the drawing across the full width and the dock covered the right-hand slice of it.

Measured in the running editor at an 800px viewport, with Properties open:

```
canvas          x=0    width=800
Properties dock x=531  width=269   ← absolute, over the canvas
after F:  a symbol's right edge at 702, i.e. 170px behind the panel
```

Fit now insets the camera by the docks that overlap the canvas and centres the Document in what is left. Only a panel anchored to an edge counts — one floating in the middle of the canvas would cost the whole drawing its width to dodge, which is worse than being overlapped by it, and the small shortcut menu is exactly that case.

The camera is given the element's aspect ratio, so `xMidYMid meet` adds no letterboxing of its own and the computed offset lands where intended.

**Both fit entry points now use it.** `F` and `Fit Document` had separate implementations in different files; only fixing one would have left the other wrong.

## Validation

- unit: 1537 pass, including new cases for the inset derivation (an edge dock insets, a floating menu does not, a closed dock contributes nothing), the centring maths, and the fallback when no visible region remains.
- Playwright: 240 pass. A new spec sets an 800px viewport — below the layout breakpoint — places three parts, opens Properties, presses `F`, and asserts every symbol's right edge is left of the dock. That spec failed before the change with the numbers above, so it is load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)