### PR TITLE
Fix immediate Gallery thumbnail refresh

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -17,6 +17,7 @@ const ENTRY = {
   author: "tz",
   description: "Three-stage loop",
   createdAt: "2026-08-21T10:00:00.000Z",
+  previewRevision: "revision-0",
   schemaVersion: 23,
 };
 
@@ -87,7 +88,7 @@ async function mockGallery(page: Page, entries: object[]): Promise<void> {
   await page.route(galleryListUrl, (route) =>
     route.fulfill({ json: { entries, nextCursor: null } }),
   );
-  await page.route(`**/api/gallery/${ENTRY.id}/preview.svg`, (route) =>
+  await page.route(`**/api/gallery/${ENTRY.id}/preview.svg*`, (route) =>
     route.fulfill({
       contentType: "image/svg+xml",
       body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10" fill="#fff"/></svg>',
@@ -119,12 +120,62 @@ test("the site lands on the full-screen gallery feed", async ({ page }) => {
   // starter tiles exist only while the gallery is empty.
   await expect(page.getByTestId(`gallery-tile-${ENTRY.id}`)).toBeVisible();
   await expect(
+    page.getByTestId(`gallery-tile-${ENTRY.id}`).locator("img"),
+  ).toHaveAttribute("src", `/api/gallery/${ENTRY.id}/preview.svg?v=revision-0`);
+  await expect(
     page.getByTestId("gallery-bundled-common-source-amplifier"),
   ).toHaveCount(0);
   await expect(page.getByTestId("gallery-new-circuit")).toHaveAttribute(
     "href",
     "/editor",
   );
+});
+
+test("an open Gallery switches to a newly published preview revision", async ({
+  page,
+}) => {
+  let previewRevision = "revision-0";
+  let listRequests = 0;
+  await page.route(galleryListUrl, (route) => {
+    listRequests += 1;
+    return route.fulfill({
+      json: {
+        entries: [{ ...ENTRY, previewRevision }],
+        nextCursor: null,
+      },
+    });
+  });
+  await page.route(`**/api/gallery/${ENTRY.id}/preview.svg*`, (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"/>',
+    }),
+  );
+
+  await page.goto("/");
+  const image = page.getByTestId(`gallery-tile-${ENTRY.id}`).locator("img");
+  await expect(image).toHaveAttribute(
+    "src",
+    `/api/gallery/${ENTRY.id}/preview.svg?v=revision-0`,
+  );
+
+  previewRevision = "revision-1";
+  await page.evaluate(() => {
+    const channel = new BroadcastChannel("analog-canvas-gallery-change-v1");
+    channel.postMessage({
+      type: "gallery-changed",
+      sourceId: "editor-tab",
+      entryId: "g-ring",
+      previewRevision: "revision-1",
+    });
+    channel.close();
+  });
+
+  await expect(image).toHaveAttribute(
+    "src",
+    `/api/gallery/${ENTRY.id}/preview.svg?v=revision-1`,
+  );
+  expect(listRequests).toBeGreaterThanOrEqual(2);
 });
 
 test("the Owner rejects a Gallery entry with an author-visible reason", async ({

--- a/apps/editor/public/sw.js
+++ b/apps/editor/public/sw.js
@@ -50,6 +50,15 @@ function isStaticAsset(request) {
   );
 }
 
+function isSameOriginApi(request) {
+  const requestUrl = new URL(request.url);
+  const scope = scopeUrl();
+  return (
+    requestUrl.origin === scope.origin &&
+    (requestUrl.pathname === "/api" || requestUrl.pathname.startsWith("/api/"))
+  );
+}
+
 /**
  * Whether a response is the kind of thing the request asked for.
  *
@@ -61,6 +70,13 @@ function isStaticAsset(request) {
  * it. Store only what matches.
  */
 function servesWhatWasAsked(request, response) {
+  if (
+    (response.headers.get("cache-control") ?? "")
+      .toLowerCase()
+      .includes("no-store")
+  ) {
+    return false;
+  }
   const type = (response.headers.get("content-type") ?? "").toLowerCase();
   if (!type) return true;
   if (request.destination === "script") return type.includes("javascript");
@@ -70,6 +86,11 @@ function servesWhatWasAsked(request, response) {
 
 self.addEventListener("fetch", (event) => {
   if (event.request.method !== "GET") return;
+
+  // APIs own their own HTTP caching policy. In particular, Gallery previews
+  // use revisioned URLs; putting them in the build-scoped shell cache would
+  // ignore that policy and keep an old or access-controlled image alive.
+  if (isSameOriginApi(event.request)) return;
 
   // Navigation is network-first so a deployed build can replace index.html and
   // point at its fresh, content-hashed Vite assets. Offline falls back only to
@@ -94,7 +115,7 @@ self.addEventListener("fetch", (event) => {
   // arbitrary GETs, imported files, Project downloads, and future APIs.
   if (
     isStaticAsset(event.request) &&
-    event.request.url.startsWith(scopeUrl().origin)
+    new URL(event.request.url).origin === scopeUrl().origin
   ) {
     event.respondWith(
       caches.match(event.request).then((cached) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -153,6 +153,11 @@ import {
   publishProjectToGallery,
   updateGalleryEntry,
 } from "../features/editor-shell/gallery-publish";
+import {
+  announceGalleryChange,
+  primeGalleryPreview,
+  subscribeGalleryRefresh,
+} from "../gallery-client";
 import { fetchSessionUser, type SessionUser } from "../components/account";
 import {
   evaluateSubmissionGates,
@@ -340,9 +345,19 @@ export function App({
   const visibleLibraryPanelOpen = compactLayout
     ? compactLibraryPanelOpen
     : libraryPanelOpen;
+  const [galleryRefreshSignal, setGalleryRefreshSignal] = useState(0);
+  const galleryLoadGenerationRef = useRef(0);
+  useEffect(() => {
+    if (!visibleLibraryPanelOpen) return;
+    return subscribeGalleryRefresh(() => {
+      galleryLoadGenerationRef.current += 1;
+      setGalleryRefreshSignal((previous) => previous + 1);
+    });
+  }, [visibleLibraryPanelOpen]);
   useEffect(() => {
     if (!visibleLibraryPanelOpen) return;
     let cancelled = false;
+    const generation = ++galleryLoadGenerationRef.current;
     void (async () => {
       try {
         const response = await fetch("/api/gallery?limit=60", {
@@ -355,10 +370,11 @@ export function App({
             name: string;
             author: string;
             description: string;
+            previewRevision?: string;
           }[];
         };
-        if (!cancelled && payload.entries && payload.entries.length > 0) {
-          setGalleryExamples(payload.entries);
+        if (!cancelled && generation === galleryLoadGenerationRef.current) {
+          setGalleryExamples(payload.entries ?? []);
         }
       } catch {
         // Unreachable worker (offline dev): the bundled list stands in.
@@ -367,7 +383,7 @@ export function App({
     return () => {
       cancelled = true;
     };
-  }, [visibleLibraryPanelOpen]);
+  }, [visibleLibraryPanelOpen, galleryRefreshSignal]);
 
   const [recoveryFailureDismissed, setRecoveryFailureDismissed] =
     useState(false);
@@ -485,6 +501,7 @@ export function App({
         name: string;
         author: string;
         description: string;
+        previewRevision?: string;
       }[]
     | null
   >(null);
@@ -3043,7 +3060,16 @@ export function App({
                         ),
                     }
                   : {}),
-                onPublished: ({ name, updated }) => {
+                onPublished: ({ id, name, updated, previewRevision }) => {
+                  void primeGalleryPreview(id, previewRevision);
+                  announceGalleryChange({
+                    entryId: id,
+                    ...(previewRevision === undefined
+                      ? {}
+                      : { previewRevision }),
+                  });
+                  galleryLoadGenerationRef.current += 1;
+                  setGalleryRefreshSignal((previous) => previous + 1);
                   setPublishGalleryOpen(false);
                   setPublishDraft(null);
                   setStatus(
@@ -3069,7 +3095,13 @@ export function App({
             ? {
                 entryId: galleryEntryContext.id,
                 entryName: galleryEntryContext.name,
-                onRestored: () => {
+                onRestored: ({ previewRevision }) => {
+                  void primeGalleryPreview(
+                    galleryEntryContext.id,
+                    previewRevision,
+                  );
+                  galleryLoadGenerationRef.current += 1;
+                  setGalleryRefreshSignal((previous) => previous + 1);
                   setVersionHistoryOpen(false);
                   setStatus("Version restored — reloading the entry");
                   void openGalleryEntryById(galleryEntryContext.id);

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -5,6 +5,11 @@ import { renderDocumentSvg } from "@icm/render-svg";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 
 import { libraryProjectExamples } from "../examples/library-examples";
+import {
+  announceGalleryChange,
+  galleryPreviewUrl,
+  subscribeGalleryRefresh,
+} from "../gallery-client";
 import { fetchSessionUser } from "./account";
 import { GalleryChrome } from "./gallery-chrome";
 import { Masonry } from "./masonry";
@@ -15,6 +20,8 @@ export interface GalleryFeedEntry {
   author: string;
   description: string;
   createdAt: string;
+  /** Absent only while a newer client is rolling out against an older API. */
+  previewRevision?: string;
   schemaVersion: number;
   tags?: string[];
   /**
@@ -327,6 +334,7 @@ export function GalleryFeed() {
   const [tagOptions, setTagOptions] = useState<
     { tag: string; count: number }[]
   >([]);
+  const [refreshSignal, setRefreshSignal] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -357,13 +365,40 @@ export function GalleryFeed() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [refreshSignal]);
   const [state, setState] = useState<GalleryFeedState>({
     status: "loading",
     entries: [],
     nextCursor: null,
   });
   const loadingMoreRef = useRef(false);
+  const firstPageLoadingRef = useRef(true);
+  const feedGenerationRef = useRef(0);
+  const loadedQueryRef = useRef<string | null>(null);
+
+  useEffect(
+    () =>
+      subscribeGalleryRefresh((change) => {
+        // Invalidate an older first-page or cursor request immediately. The
+        // effect triggered below will claim a fresh generation.
+        feedGenerationRef.current += 1;
+        firstPageLoadingRef.current = true;
+        loadingMoreRef.current = false;
+        const previewRevision = change?.previewRevision;
+        if (change && previewRevision !== undefined) {
+          setState((previous) => ({
+            ...previous,
+            entries: previous.entries.map((entry) =>
+              entry.id === change.entryId
+                ? { ...entry, previewRevision }
+                : entry,
+            ),
+          }));
+        }
+        setRefreshSignal((previous) => previous + 1);
+      }),
+    [],
+  );
 
   /**
    * One thumb per account, taken back by pressing again. The server owns the
@@ -408,28 +443,37 @@ export function GalleryFeed() {
 
   useEffect(() => {
     let cancelled = false;
+    const generation = ++feedGenerationRef.current;
+    firstPageLoadingRef.current = true;
     loadingMoreRef.current = false;
-    setState({
-      status: "loading",
-      entries: [],
-      nextCursor: null,
-    });
+    const queryKey = `${author ?? ""}\u0000${selectedTags.join(",")}`;
+    const changingQuery = loadedQueryRef.current !== queryKey;
+    if (changingQuery) {
+      setState({
+        status: "loading",
+        entries: [],
+        nextCursor: null,
+      });
+    }
     void loadGalleryFeed(fetch, { author, tags: selectedTags }).then((page) => {
-      if (cancelled) return;
-      setState(
-        page
-          ? { status: "ready", ...page }
-          : {
-              status: "unavailable",
-              entries: [],
-              nextCursor: null,
-            },
-      );
+      if (cancelled || generation !== feedGenerationRef.current) return;
+      firstPageLoadingRef.current = false;
+      if (page) {
+        loadedQueryRef.current = queryKey;
+        setState({ status: "ready", ...page });
+      } else if (changingQuery) {
+        loadedQueryRef.current = queryKey;
+        setState({
+          status: "unavailable",
+          entries: [],
+          nextCursor: null,
+        });
+      }
     });
     return () => {
       cancelled = true;
     };
-  }, [author, selectedTags]);
+  }, [author, selectedTags, refreshSignal]);
 
   // The sentinel appends the next newest-first page as it comes into view.
   // Once the server returns no cursor, the wall is complete and stops.
@@ -441,17 +485,20 @@ export function GalleryFeed() {
     if (typeof IntersectionObserver === "undefined") return;
     const observer = new IntersectionObserver((observed) => {
       if (!observed.some((entry) => entry.isIntersecting)) return;
+      if (firstPageLoadingRef.current) return;
       if (loadingMoreRef.current) return;
       loadingMoreRef.current = true;
+      const generation = feedGenerationRef.current;
       void loadGalleryFeed(fetch, {
         author,
         tags: selectedTags,
         cursor: nextCursor,
       }).then((page) => {
+        if (generation !== feedGenerationRef.current) return;
         loadingMoreRef.current = false;
         if (!page) return;
         setState((previous) =>
-          previous.status === "ready"
+          previous.status === "ready" && previous.nextCursor === nextCursor
             ? {
                 ...previous,
                 entries: [...previous.entries, ...page.entries],
@@ -521,6 +568,7 @@ export function GalleryFeed() {
       });
       if (!response.ok) throw new Error();
       removeManagedEntry(entry);
+      announceGalleryChange({ entryId: entry.id });
       setOwnerNotice(`“${entry.name}” was moved to the recycle bin.`);
     } catch {
       setOwnerNotice(`Could not withdraw “${entry.name}”.`);
@@ -542,6 +590,7 @@ export function GalleryFeed() {
       });
       if (!response.ok) throw new Error();
       removeManagedEntry(rejecting);
+      announceGalleryChange({ entryId: rejecting.id });
       setOwnerNotice(
         `“${rejecting.name}” was rejected and hidden from the Gallery.`,
       );
@@ -629,7 +678,10 @@ export function GalleryFeed() {
                     >
                       <span className="gallery-tile-preview">
                         <img
-                          src={`/api/gallery/${entry.id}/preview.svg`}
+                          src={galleryPreviewUrl(
+                            entry.id,
+                            entry.previewRevision,
+                          )}
                           alt={`Preview of ${entry.name}`}
                           loading="lazy"
                         />

--- a/apps/editor/src/components/moderation.tsx
+++ b/apps/editor/src/components/moderation.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import "../styles/gallery-entry.css";
 
+import { announceGalleryChange, galleryPreviewUrl } from "../gallery-client";
 import { fetchSessionUser, type SessionUser } from "./account";
 import { GalleryChrome } from "./gallery-chrome";
 
@@ -55,12 +56,14 @@ async function appointModerator(
 interface RecycledEntry {
   id: string;
   name: string;
+  previewRevision?: string;
   recycledAt?: string | null;
 }
 
 interface RejectedEntry {
   id: string;
   name: string;
+  previewRevision?: string;
   rejectReason?: string | null;
   reviewedAt?: string | null;
 }
@@ -227,7 +230,10 @@ function RejectedList({
         method: "POST",
         credentials: "same-origin",
       });
-      if (response.ok) onChanged();
+      if (response.ok) {
+        announceGalleryChange({ entryId: id });
+        onChanged();
+      }
     } catch {
       // Leave the row in place; it still reflects the last confirmed state.
     } finally {
@@ -261,7 +267,7 @@ function RejectedList({
                 title="Open in the editor"
               >
                 <img
-                  src={`/api/gallery/${entry.id}/preview.svg`}
+                  src={galleryPreviewUrl(entry.id, entry.previewRevision)}
                   alt={`Preview of ${entry.name}`}
                   loading="lazy"
                 />
@@ -356,7 +362,7 @@ function RecycleBin({
       return;
     }
     try {
-      await fetch(
+      const response = await fetch(
         kind === "restore"
           ? `/api/gallery/${id}/restore`
           : `/api/gallery/${id}`,
@@ -365,6 +371,7 @@ function RecycleBin({
           credentials: "same-origin",
         },
       );
+      if (response.ok) announceGalleryChange({ entryId: id });
     } catch {
       // The refresh below shows the true state either way.
     }
@@ -389,7 +396,7 @@ function RecycleBin({
             >
               <span className="mine-card-preview">
                 <img
-                  src={`/api/gallery/${entry.id}/preview.svg`}
+                  src={galleryPreviewUrl(entry.id, entry.previewRevision)}
                   alt={`Preview of ${entry.name}`}
                   loading="lazy"
                 />

--- a/apps/editor/src/components/my-submissions.tsx
+++ b/apps/editor/src/components/my-submissions.tsx
@@ -1,6 +1,11 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import "../styles/gallery-entry.css";
 
+import {
+  announceGalleryChange,
+  galleryPreviewUrl,
+  subscribeGalleryRefresh,
+} from "../gallery-client";
 import { fetchSessionUser } from "./account";
 import { GalleryChrome } from "./gallery-chrome";
 import { VersionHistoryDialog } from "./version-history-dialog";
@@ -17,6 +22,7 @@ export interface MineEntry {
   id: string;
   name: string;
   createdAt: string;
+  previewRevision?: string;
   status: string;
   rejectReason: string | null;
 }
@@ -54,6 +60,7 @@ export async function setMyEntryRecycled(
       method: "POST",
       credentials: "same-origin",
     });
+    if (response.ok) announceGalleryChange({ entryId: id });
     return response.ok;
   } catch {
     return false;
@@ -74,20 +81,22 @@ export function MySubmissions() {
   const [busy, setBusy] = useState<string | null>(null);
   const [historyFor, setHistoryFor] = useState<MineEntry | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const loadGenerationRef = useRef(0);
 
   const reload = useCallback(async () => {
-    setState(await loadMySubmissions());
+    const generation = ++loadGenerationRef.current;
+    const next = await loadMySubmissions();
+    if (generation === loadGenerationRef.current) setState(next);
   }, []);
 
   useEffect(() => {
-    let cancelled = false;
-    void loadMySubmissions().then((next) => {
-      if (!cancelled) setState(next);
-    });
+    void reload();
     return () => {
-      cancelled = true;
+      loadGenerationRef.current += 1;
     };
-  }, []);
+  }, [reload]);
+
+  useEffect(() => subscribeGalleryRefresh(() => void reload()), [reload]);
 
   async function act(
     entry: MineEntry,
@@ -146,7 +155,7 @@ export function MySubmissions() {
                   title="Open in the editor"
                 >
                   <img
-                    src={`/api/gallery/${entry.id}/preview.svg`}
+                    src={galleryPreviewUrl(entry.id, entry.previewRevision)}
                     alt={`Preview of ${entry.name}`}
                     loading="lazy"
                   />

--- a/apps/editor/src/components/version-history-dialog.tsx
+++ b/apps/editor/src/components/version-history-dialog.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 
+import { announceGalleryChange } from "../gallery-client";
+
 /**
  * Version history of one gallery entry, for reviewers and the entry's
  * owner: every update snapshotted the previous state; Restore adopts a
@@ -38,22 +40,35 @@ async function restoreVersion(
   entryId: string,
   versionId: string,
   fetchLike: typeof fetch = fetch,
-): Promise<boolean> {
+): Promise<{ previewRevision?: string } | null> {
   try {
     const response = await fetchLike(
       `/api/gallery/${entryId}/versions/${versionId}/restore`,
       { method: "POST", credentials: "same-origin" },
     );
-    return response.ok;
+    if (!response.ok) return null;
+    const payload = (await response.json().catch(() => null)) as {
+      previewRevision?: unknown;
+    } | null;
+    const previewRevision =
+      typeof payload?.previewRevision === "string" &&
+      payload.previewRevision.length > 0
+        ? payload.previewRevision
+        : undefined;
+    const restored = {
+      ...(previewRevision === undefined ? {} : { previewRevision }),
+    };
+    announceGalleryChange({ entryId, ...restored });
+    return restored;
   } catch {
-    return false;
+    return null;
   }
 }
 
 export interface VersionHistoryDialogProps {
   entryId: string;
   entryName: string;
-  onRestored(): void;
+  onRestored(result: { previewRevision?: string }): void;
   onClose(): void;
 }
 
@@ -80,9 +95,9 @@ export function VersionHistoryDialog({
   async function restore(versionId: string): Promise<void> {
     setBusy(true);
     setError(null);
-    const ok = await restoreVersion(entryId, versionId);
+    const result = await restoreVersion(entryId, versionId);
     setBusy(false);
-    if (ok) onRestored();
+    if (result) onRestored(result);
     else setError("Could not restore this version.");
   }
 

--- a/apps/editor/src/features/editor-shell/examples-panel.tsx
+++ b/apps/editor/src/features/editor-shell/examples-panel.tsx
@@ -7,12 +7,14 @@ import {
   libraryProjectExamples,
   type LibraryProjectExample,
 } from "../../examples/library-examples";
+import { galleryPreviewUrl } from "../../gallery-client";
 
 export interface GalleryExampleSummary {
   id: string;
   name: string;
   author: string;
   description: string;
+  previewRevision?: string;
 }
 
 export interface ExamplesPanelProps {
@@ -86,7 +88,10 @@ export function ExamplesPanel({
                 >
                   <span className="shapes-example-preview">
                     <img
-                      src={`/api/gallery/${example.id}/preview.svg`}
+                      src={galleryPreviewUrl(
+                        example.id,
+                        example.previewRevision,
+                      )}
                       alt=""
                       loading="lazy"
                     />

--- a/apps/editor/src/features/editor-shell/gallery-publish.test.ts
+++ b/apps/editor/src/features/editor-shell/gallery-publish.test.ts
@@ -30,9 +30,17 @@ describe("publishProjectToGallery", () => {
         description: "Five stages",
         tags: ["Amplifier", "OTA"],
       },
-      fetchReturning(201, { id: "entry-1" }, seen),
+      fetchReturning(
+        201,
+        { id: "entry-1", previewRevision: "revision-0" },
+        seen,
+      ),
     );
-    expect(outcome).toEqual({ status: "published", id: "entry-1" });
+    expect(outcome).toEqual({
+      status: "published",
+      id: "entry-1",
+      previewRevision: "revision-0",
+    });
     expect(seen.url).toBe("/api/gallery/submissions");
     expect(seen.init?.credentials).toBe("same-origin");
 

--- a/apps/editor/src/features/editor-shell/gallery-publish.ts
+++ b/apps/editor/src/features/editor-shell/gallery-publish.ts
@@ -26,7 +26,7 @@ export interface PublishSessionUser {
 }
 
 export type GalleryPublishOutcome =
-  | { status: "published"; id: string }
+  | { status: "published"; id: string; previewRevision?: string }
   | { status: "gate-failed"; failures: readonly SubmissionGateFailure[] }
   | { status: "unauthorized" }
   | { status: "too-large" }
@@ -64,10 +64,17 @@ async function sendGalleryProject(
   if (response.status === 201 || response.status === 200) {
     const payload = (await response.json().catch(() => null)) as {
       id?: unknown;
+      previewRevision?: unknown;
     } | null;
+    const previewRevision =
+      typeof payload?.previewRevision === "string" &&
+      payload.previewRevision.length > 0
+        ? payload.previewRevision
+        : undefined;
     return {
       status: "published",
       id: typeof payload?.id === "string" ? payload.id : "",
+      ...(previewRevision === undefined ? {} : { previewRevision }),
     };
   }
   if (response.status === 422) {

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
@@ -31,6 +31,7 @@ export interface PublishGalleryDialogProps {
     id: string;
     name: string;
     updated: boolean;
+    previewRevision?: string;
   }) => void;
   /** Moderators and the entry's owner: open the version history instead.
    * Rendered only alongside an update target. */
@@ -137,7 +138,14 @@ export function PublishGalleryDialog({
     const send = updating ? (publishUpdate ?? publish) : publish;
     const outcome = await send({ name, description, tags });
     if (outcome.status === "published") {
-      onPublished({ id: outcome.id, name: name.trim(), updated: updating });
+      onPublished({
+        id: outcome.id,
+        name: name.trim(),
+        updated: updating,
+        ...(outcome.previewRevision === undefined
+          ? {}
+          : { previewRevision: outcome.previewRevision }),
+      });
       return;
     }
     setBusy(false);

--- a/apps/editor/src/gallery-client.test.ts
+++ b/apps/editor/src/gallery-client.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  announceGalleryChange,
+  galleryPreviewUrl,
+  primeGalleryPreview,
+  subscribeGalleryRefresh,
+} from "./gallery-client";
+
+class FakeBroadcastChannel {
+  static readonly channels = new Map<string, Set<FakeBroadcastChannel>>();
+
+  private readonly listeners = new Set<
+    (event: MessageEvent<unknown>) => void
+  >();
+
+  constructor(readonly name: string) {
+    const peers = FakeBroadcastChannel.channels.get(name) ?? new Set();
+    peers.add(this);
+    FakeBroadcastChannel.channels.set(name, peers);
+  }
+
+  addEventListener(
+    type: string,
+    listener: (event: MessageEvent<unknown>) => void,
+  ): void {
+    if (type === "message") this.listeners.add(listener);
+  }
+
+  removeEventListener(
+    type: string,
+    listener: (event: MessageEvent<unknown>) => void,
+  ): void {
+    if (type === "message") this.listeners.delete(listener);
+  }
+
+  postMessage(data: unknown): void {
+    for (const peer of FakeBroadcastChannel.channels.get(this.name) ?? []) {
+      if (peer === this) continue;
+      for (const listener of peer.listeners) {
+        listener({ data } as MessageEvent<unknown>);
+      }
+    }
+  }
+
+  close(): void {
+    FakeBroadcastChannel.channels.get(this.name)?.delete(this);
+    this.listeners.clear();
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  FakeBroadcastChannel.channels.clear();
+});
+
+describe("Gallery preview caching", () => {
+  it("uses one immutable URL per preview revision", () => {
+    expect(galleryPreviewUrl("entry-1", "revision 0")).toBe(
+      "/api/gallery/entry-1/preview.svg?v=revision%200",
+    );
+    expect(galleryPreviewUrl("entry-1", "revision-7")).toBe(
+      "/api/gallery/entry-1/preview.svg?v=revision-7",
+    );
+    expect(galleryPreviewUrl("entry-1")).toBe(
+      "/api/gallery/entry-1/preview.svg",
+    );
+  });
+
+  it("warms only a revisioned preview without delaying on failure", async () => {
+    const fetchLike = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("<svg/>"))
+      .mockRejectedValueOnce(new Error("offline")) as unknown as typeof fetch;
+
+    await primeGalleryPreview("entry-1", "revision-3", fetchLike);
+    await primeGalleryPreview("entry-1", "revision-4", fetchLike);
+    await primeGalleryPreview("entry-1", undefined, fetchLike);
+
+    expect(fetchLike).toHaveBeenCalledTimes(2);
+    expect(fetchLike).toHaveBeenNthCalledWith(
+      1,
+      "/api/gallery/entry-1/preview.svg?v=revision-3",
+      { credentials: "same-origin", cache: "reload" },
+    );
+  });
+});
+
+describe("Gallery refresh notifications", () => {
+  it("broadcasts a successful mutation to another tab", () => {
+    vi.stubGlobal(
+      "BroadcastChannel",
+      FakeBroadcastChannel as unknown as typeof BroadcastChannel,
+    );
+    const remote = new FakeBroadcastChannel("analog-canvas-gallery-change-v1");
+    const messages: unknown[] = [];
+    remote.addEventListener("message", (event) => messages.push(event.data));
+
+    announceGalleryChange({
+      entryId: "entry-1",
+      previewRevision: "revision-5",
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      type: "gallery-changed",
+      entryId: "entry-1",
+      previewRevision: "revision-5",
+    });
+  });
+
+  it("accepts valid cross-tab messages and ignores malformed ones", () => {
+    vi.stubGlobal(
+      "BroadcastChannel",
+      FakeBroadcastChannel as unknown as typeof BroadcastChannel,
+    );
+    const changes: unknown[] = [];
+    const unsubscribe = subscribeGalleryRefresh((change) =>
+      changes.push(change),
+    );
+    const remote = new FakeBroadcastChannel("analog-canvas-gallery-change-v1");
+
+    remote.postMessage({ type: "gallery-changed", sourceId: "other-tab" });
+    remote.postMessage({
+      type: "gallery-changed",
+      sourceId: "other-tab",
+      entryId: "entry-2",
+      previewRevision: "revision-6",
+    });
+
+    expect(changes).toEqual([
+      { entryId: "entry-2", previewRevision: "revision-6" },
+    ]);
+    unsubscribe();
+  });
+});

--- a/apps/editor/src/gallery-client.ts
+++ b/apps/editor/src/gallery-client.ts
@@ -1,0 +1,151 @@
+const GALLERY_CHANGE_CHANNEL = "analog-canvas-gallery-change-v1";
+
+export interface GalleryChange {
+  entryId: string;
+  previewRevision?: string;
+}
+
+interface GalleryChangeMessage extends GalleryChange {
+  type: "gallery-changed";
+  sourceId: string;
+}
+
+const SOURCE_ID =
+  typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random()}`;
+
+function validPreviewRevision(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= 128;
+}
+
+function galleryChangeOf(
+  value: unknown,
+): { change: GalleryChange; sourceId: string } | null {
+  if (typeof value !== "object" || value === null) return null;
+  const message = value as Partial<GalleryChangeMessage>;
+  if (message.type !== "gallery-changed") return null;
+  if (typeof message.sourceId !== "string") return null;
+  if (typeof message.entryId !== "string" || message.entryId.length === 0) {
+    return null;
+  }
+  if (
+    message.previewRevision !== undefined &&
+    !validPreviewRevision(message.previewRevision)
+  ) {
+    return null;
+  }
+  return {
+    sourceId: message.sourceId,
+    change: {
+      entryId: message.entryId,
+      ...(message.previewRevision === undefined
+        ? {}
+        : { previewRevision: message.previewRevision }),
+    },
+  };
+}
+
+/** One immutable address for each stored rendering of a Gallery entry. */
+export function galleryPreviewUrl(
+  entryId: string,
+  previewRevision?: string,
+): string {
+  const path = `/api/gallery/${entryId}/preview.svg`;
+  return validPreviewRevision(previewRevision)
+    ? `${path}?v=${encodeURIComponent(previewRevision)}`
+    : path;
+}
+
+/**
+ * Warm the publisher's browser cache without delaying the completed publish.
+ * A missing revision means an older server is still active during a rollout;
+ * its mutable URL must not be prefetched as though it were immutable.
+ */
+export async function primeGalleryPreview(
+  entryId: string,
+  previewRevision: string | undefined,
+  fetchLike: typeof fetch = fetch,
+): Promise<void> {
+  if (!validPreviewRevision(previewRevision)) return;
+  try {
+    const response = await fetchLike(
+      galleryPreviewUrl(entryId, previewRevision),
+      {
+        credentials: "same-origin",
+        cache: "reload",
+      },
+    );
+    if (response.ok) await response.arrayBuffer();
+  } catch {
+    // Publishing already succeeded; cache warming must never turn that into an
+    // apparent failure. The Gallery's <img> will retry the same URL normally.
+  }
+}
+
+/** Tell other same-origin tabs that their no-store Gallery list is stale. */
+export function announceGalleryChange(change: GalleryChange): void {
+  if (typeof BroadcastChannel === "undefined" || !change.entryId) return;
+  try {
+    const channel = new BroadcastChannel(GALLERY_CHANGE_CHANNEL);
+    channel.postMessage({
+      type: "gallery-changed",
+      sourceId: SOURCE_ID,
+      ...change,
+    });
+    channel.close();
+  } catch {
+    // Focus/visibility refresh remains the fallback in unsupported contexts.
+  }
+}
+
+/**
+ * Refresh on a local publication message and whenever this tab becomes the
+ * active view again. Remote visitors are intentionally not polled.
+ */
+export function subscribeGalleryRefresh(
+  listener: (change: GalleryChange | null) => void,
+): () => void {
+  let channel: BroadcastChannel | null = null;
+  const onMessage = (event: MessageEvent<unknown>) => {
+    const message = galleryChangeOf(event.data);
+    if (message && message.sourceId !== SOURCE_ID) listener(message.change);
+  };
+  try {
+    if (typeof BroadcastChannel !== "undefined") {
+      channel = new BroadcastChannel(GALLERY_CHANGE_CHANNEL);
+      channel.addEventListener("message", onMessage);
+    }
+  } catch {
+    channel = null;
+  }
+
+  let activationTimer: ReturnType<typeof setTimeout> | null = null;
+  const scheduleActivationRefresh = () => {
+    if (activationTimer !== null) return;
+    activationTimer = setTimeout(() => {
+      activationTimer = null;
+      listener(null);
+    }, 50);
+  };
+  const onFocus = () => scheduleActivationRefresh();
+  const onVisible = () => {
+    if (document.visibilityState === "visible") scheduleActivationRefresh();
+  };
+  if (typeof window !== "undefined") window.addEventListener("focus", onFocus);
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", onVisible);
+  }
+
+  return () => {
+    if (activationTimer !== null) clearTimeout(activationTimer);
+    channel?.removeEventListener("message", onMessage);
+    channel?.close();
+    if (typeof window !== "undefined") {
+      window.removeEventListener("focus", onFocus);
+    }
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", onVisible);
+    }
+  };
+}

--- a/apps/editor/src/service-worker-cache.test.ts
+++ b/apps/editor/src/service-worker-cache.test.ts
@@ -96,4 +96,36 @@ describe("static shell cache policy", () => {
     );
     expect(stored.has("/assets/App-abc.js")).toBe(false);
   });
+
+  it("leaves Gallery preview APIs to their HTTP cache policy", () => {
+    const { listeners, stored } = loadWorker((() =>
+      Promise.reject(
+        new Error("the service worker must not fetch an API itself"),
+      )) as typeof fetch);
+    const request = new Request(
+      "https://analog-canvas.test/api/gallery/entry-1/preview.svg?v=2",
+    );
+    Object.defineProperty(request, "destination", { value: "image" });
+    let responded = false;
+    listeners.get("fetch")!({
+      request,
+      respondWith: () => {
+        responded = true;
+      },
+    });
+    expect(responded).toBe(false);
+    expect(stored.size).toBe(0);
+  });
+
+  it("does not store an explicitly no-store static response", async () => {
+    const { stored } = await requestScript(
+      new Response("export const dynamic = true;", {
+        headers: {
+          "content-type": "text/javascript",
+          "cache-control": "no-store",
+        },
+      }),
+    );
+    expect(stored.has("/assets/App-abc.js")).toBe(false);
+  });
 });

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -21,12 +21,15 @@ restrictive content-security-policy.
   (`{entries, nextCursor}`; keyset cursor; limit clamps at 60; optional
   `author` filters to that exact byline and optional `tags=a,b` to
   entries carrying ANY listed tag, both ahead of pagination). Rejected and
-  recycled entries never appear.
+  recycled entries never appear. Every entry includes the content-derived
+  `previewRevision` used by its thumbnail URL.
 - `GET /api/gallery/tags` — distinct public tags with counts, most
   frequent first (feeds the multi-select menu).
 - `GET /api/gallery/<id>` — one public entry with its canonical
   `projectText`.
-- `GET /api/gallery/<id>/preview.svg` — the server-rendered preview.
+- `GET /api/gallery/<id>/preview.svg?v=<previewRevision>` — the
+  server-rendered preview. A revision matching the stored SVG is immutable;
+  unversioned, stale-revision, hidden, and missing responses are `no-store`.
 - `/` serves the full-screen feed; each tile links to `/g/<id>`, which the
   editor opens through the ordinary protocol boundary. `/editor` is the
   plain editor; `/editor?example=<id>` opens a bundled example. The
@@ -52,7 +55,10 @@ signed-in account publishes directly as `public`; an ordinary member
 passes the quality gates below first, and a moderator curates past them.
 Anonymous upload stays impossible — an entry has to be attributable to
 the account that published it. A successful submission answers 201
-`{id, status}` with `status` always `public`.
+`{id, status, previewRevision}` with `status` always `public`. The editor
+starts a non-blocking fetch of that revision immediately, then notifies other
+same-origin tabs so an already-open Gallery switches URLs and refreshes its
+no-store metadata without waiting for a cache TTL.
 
 The byline is not a request field: the Worker takes `author` from the
 session's display name, so one account cannot publish under another's
@@ -124,9 +130,10 @@ update any entry; an ordinary session must own the entry (403 otherwise)
 and passes the quality gates (422). Either way the entry keeps its
 byline and its current status, so editing a published circuit neither
 takes it off the wall nor re-attributes it. The Project is re-serialized
-canonically and the preview re-rendered; 200 answers `{id, status}`. The
-detail response carries `ownerUserId` so the editor offers "update the
-opened entry" exactly to owners and moderators.
+canonically, the preview is re-rendered, and the netlistable marker is
+recalculated; 200 answers `{id, status, previewRevision}`. The detail response
+carries `ownerUserId` so the editor offers "update the opened entry" exactly
+to owners and moderators.
 
 Owner withdrawal: `POST /api/gallery/<id>/recycle` (same-origin) also
 accepts the owning session — the entry moves to `recycled` and leaves

--- a/worker/gallery-do.ts
+++ b/worker/gallery-do.ts
@@ -14,7 +14,7 @@
 // independently so browsing survives an entry the current window can no
 // longer open.
 
-import { evaluateSubmissionGates } from "@icm/derived";
+import { evaluateSubmissionGates, sha256Hex } from "@icm/derived";
 import { analyzeDesignNetlist } from "@icm/netlist";
 import {
   parseProject,
@@ -153,6 +153,12 @@ export interface GalleryEntrySummary {
   author: string;
   description: string;
   createdAt: string;
+  /**
+   * Content revision of the stored SVG. The public URL includes this so a
+   * changed rendering gets a new cache key while identical bytes reuse the
+   * existing immutable response.
+   */
+  previewRevision: string;
   schemaVersion: number;
   tags: string[];
   /**
@@ -219,6 +225,7 @@ interface EntryRow {
   project_text: string;
   svg_text: string;
   netlistable: number;
+  preview_revision: string;
 }
 
 const TOKENZHANG_BYLINE_MIGRATION = "2026-08-26-tokenzhang-to-zhishuai-zhang";
@@ -233,6 +240,10 @@ function summaryOf(
     author: row.author,
     description: row.description,
     createdAt: row.created_at,
+    // Existing rows receive the additive column as empty. "legacy" moves
+    // them off the formerly mutable URL once; their next SVG write stores a
+    // content hash like every new row.
+    previewRevision: row.preview_revision || "legacy",
     schemaVersion: row.schema_version,
     tags: unwrapTags(row.tags),
     netlistable: row.netlistable === 1,
@@ -261,7 +272,8 @@ export class GalleryDO {
         submitter_email TEXT,
         submitter_provider TEXT,
         project_text TEXT NOT NULL,
-        svg_text TEXT NOT NULL
+        svg_text TEXT NOT NULL,
+        preview_revision TEXT NOT NULL DEFAULT ''
       ) WITHOUT ROWID
     `);
     this.sql.exec(`
@@ -336,6 +348,7 @@ export class GalleryDO {
       "ALTER TABLE gallery_entries ADD COLUMN submitter_provider TEXT",
       "ALTER TABLE workspace_slots ADD COLUMN seq INTEGER NOT NULL DEFAULT 0",
       "ALTER TABLE gallery_entries ADD COLUMN netlistable INTEGER NOT NULL DEFAULT 0",
+      "ALTER TABLE gallery_entries ADD COLUMN preview_revision TEXT NOT NULL DEFAULT ''",
     ]) {
       try {
         this.sql.exec(alteration);
@@ -512,6 +525,7 @@ export class GalleryDO {
 
   private submit(body: Record<string, unknown>): Response {
     const entry = body.entry as EntryRow;
+    const previewRevision = sha256Hex(entry.svg_text);
     const day = String(body.day);
     const submitterHash = String(body.submitterHash);
     // The daily quota is anti-garbage protection for ordinary submitters;
@@ -544,8 +558,9 @@ export class GalleryDO {
         `INSERT INTO gallery_entries(
           id, name, author, description, created_at, schema_version,
           status, recycled_at, owner_user_id, submitter_email,
-          submitter_provider, tags, project_text, svg_text, netlistable
-        ) VALUES (?, ?, ?, ?, ?, ?, 'public', NULL, ?, ?, ?, ?, ?, ?, ?)`,
+          submitter_provider, tags, project_text, svg_text, netlistable,
+          preview_revision
+        ) VALUES (?, ?, ?, ?, ?, ?, 'public', NULL, ?, ?, ?, ?, ?, ?, ?, ?)`,
         entry.id,
         entry.name,
         entry.author,
@@ -559,13 +574,14 @@ export class GalleryDO {
         entry.project_text,
         entry.svg_text,
         entry.netlistable ?? 0,
+        previewRevision,
       );
       return { status: "stored" as const };
     });
     if (outcome.status === "rate-limited") {
       return Response.json({ error: "rate-limited" }, { status: 429 });
     }
-    return Response.json({ id: entry.id });
+    return Response.json({ id: entry.id, previewRevision });
   }
 
   private list(body: Record<string, unknown>): Response {
@@ -682,25 +698,34 @@ export class GalleryDO {
       )
       .toArray()[0];
     if (!row) return Response.json({ error: "not-found" }, { status: 404 });
+    const svgText = String(body.svgText);
+    const previewRevision = sha256Hex(svgText);
     this.state.storage.transactionSync(() => {
       this.snapshotEntry(row, String(body.at ?? row.created_at));
       this.sql.exec(
         `UPDATE gallery_entries
          SET name = ?, author = ?, description = ?, project_text = ?,
-             svg_text = ?, schema_version = ?, status = ?, tags = ?
+             svg_text = ?, schema_version = ?, status = ?, tags = ?,
+             netlistable = ?, preview_revision = ?
          WHERE id = ?`,
         String(body.name),
         String(body.author),
         String(body.description),
         String(body.projectText),
-        String(body.svgText),
+        svgText,
         Number(body.schemaVersion),
         String(body.status),
         typeof body.tags === "string" ? body.tags : "",
+        Number(body.netlistable) === 1 ? 1 : 0,
+        previewRevision,
         row.id,
       );
     });
-    return Response.json({ id: row.id, status: String(body.status) });
+    return Response.json({
+      id: row.id,
+      status: String(body.status),
+      previewRevision,
+    });
   }
 
   private versions(entryId: string): Response {
@@ -800,12 +825,15 @@ export class GalleryDO {
       );
     }
     const restoredProjectText = serializeProject(restoredProject);
+    const netlistable = analyzeDesignNetlist(restoredProject).ir ? 1 : 0;
+    const previewRevision = sha256Hex(version.svg_text);
     this.state.storage.transactionSync(() => {
       this.snapshotEntry(entry, String(body.at));
       this.sql.exec(
         `UPDATE gallery_entries
          SET name = ?, author = ?, description = ?, project_text = ?,
-             svg_text = ?, schema_version = ?, tags = ?
+             svg_text = ?, schema_version = ?, tags = ?, netlistable = ?,
+             preview_revision = ?
          WHERE id = ?`,
         version.name,
         version.author,
@@ -814,10 +842,12 @@ export class GalleryDO {
         version.svg_text,
         restoredProject.schemaVersion,
         version.tags ?? "",
+        netlistable,
+        previewRevision,
         entry.id,
       );
     });
-    return Response.json({ id: entry.id, restored: true });
+    return Response.json({ id: entry.id, restored: true, previewRevision });
   }
 
   private mine(ownerUserId: string): Response {
@@ -964,33 +994,39 @@ export class GalleryDO {
       this.sql.exec("DELETE FROM gallery_entry_versions");
       this.sql.exec("DELETE FROM workspace_slots");
       for (const row of galleryEntries) {
+        const values = rowValues(row, [
+          "id",
+          "name",
+          "author",
+          "description",
+          "created_at",
+          "schema_version",
+          "status",
+          "recycled_at",
+          "owner_user_id",
+          "submitter_email",
+          "submitter_provider",
+          "project_text",
+          "svg_text",
+          "reject_reason",
+          "reviewed_at",
+          "reviewed_by",
+          "tags",
+          "netlistable",
+        ]);
+        const svgText = values[12];
+        if (typeof svgText !== "string") {
+          throw new Error("Backup row has invalid svg_text");
+        }
         this.sql.exec(
           `INSERT INTO gallery_entries
            (id, name, author, description, created_at, schema_version, status,
             recycled_at, owner_user_id, submitter_email, submitter_provider,
             project_text, svg_text, reject_reason, reviewed_at, reviewed_by,
-            tags, netlistable)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-          ...rowValues(row, [
-            "id",
-            "name",
-            "author",
-            "description",
-            "created_at",
-            "schema_version",
-            "status",
-            "recycled_at",
-            "owner_user_id",
-            "submitter_email",
-            "submitter_provider",
-            "project_text",
-            "svg_text",
-            "reject_reason",
-            "reviewed_at",
-            "reviewed_by",
-            "tags",
-            "netlistable",
-          ]),
+            tags, netlistable, preview_revision)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          ...values,
+          sha256Hex(svgText),
         );
       }
       for (const row of galleryEntryVersions) {
@@ -1303,13 +1339,19 @@ export class GalleryDO {
       )
       .toArray()[0];
     if (!row) return Response.json({ error: "not-found" }, { status: 404 });
+    const svgText = String(body.svgText);
+    const previewRevision = sha256Hex(svgText);
     this.sql.exec(
-      "UPDATE gallery_entries SET project_text = ?, schema_version = ?, svg_text = ? WHERE id = ?",
+      `UPDATE gallery_entries
+       SET project_text = ?, schema_version = ?, svg_text = ?,
+           preview_revision = ?
+       WHERE id = ?`,
       String(body.projectText),
       Number(body.schemaVersion),
-      String(body.svgText),
+      svgText,
+      previewRevision,
       String(body.id),
     );
-    return Response.json({ id: row.id });
+    return Response.json({ id: row.id, previewRevision });
   }
 }

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -210,7 +210,11 @@ async function submitOne(
     ),
   );
   expect(response.status).toBe(201);
-  const payload = (await response.json()) as { id: string };
+  const payload = (await response.json()) as {
+    id: string;
+    previewRevision: string;
+  };
+  expect(payload.previewRevision).toMatch(/^[a-f0-9]{64}$/u);
   return payload.id;
 }
 
@@ -654,13 +658,19 @@ describe("gallery submissions", () => {
 
     const list = await route(env, new Request(`${ORIGIN}/api/gallery`));
     const listed = (await list.json()) as {
-      entries: { id: string; name: string; schemaVersion: number }[];
+      entries: {
+        id: string;
+        name: string;
+        previewRevision: string;
+        schemaVersion: number;
+      }[];
     };
     expect(listed.entries.map((entry) => entry.id)).toEqual([id]);
     expect(listed.entries[0]).toMatchObject({
       name: "Ring Oscillator",
       schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION,
     });
+    expect(listed.entries[0]!.previewRevision).toMatch(/^[a-f0-9]{64}$/u);
 
     const detail = await route(env, new Request(`${ORIGIN}/api/gallery/${id}`));
     const payload = (await detail.json()) as { projectText: string };
@@ -674,7 +684,18 @@ describe("gallery submissions", () => {
       new Request(`${ORIGIN}/api/gallery/${id}/preview.svg`),
     );
     expect(preview.headers.get("content-type")).toBe("image/svg+xml");
+    expect(preview.headers.get("cache-control")).toBe("no-store");
     expect(await preview.text()).toContain("<svg");
+
+    const immutablePreview = await route(
+      env,
+      new Request(
+        `${ORIGIN}/api/gallery/${id}/preview.svg?v=${listed.entries[0]!.previewRevision}`,
+      ),
+    );
+    expect(immutablePreview.headers.get("cache-control")).toBe(
+      "public, max-age=31536000, immutable",
+    );
   });
 
   it("publishes and updates a hierarchical Project with its top-level Cell preview", async () => {
@@ -1089,7 +1110,7 @@ async function signIn(authDurable: AuthDO, email: string): Promise<string> {
     .split(";")[0]!;
 }
 
-function wiredProjectText(name = "Wired"): string {
+function wiredProjectText(name = "Wired", secondResistorX = 200): string {
   const project = createEmptyProject("g3", name);
   const document = project.documents[0]!;
   document.instances = [
@@ -1107,7 +1128,7 @@ function wiredProjectText(name = "Wired"): string {
       id: "R2",
       symbolId: "resistor",
       placement: {
-        position: { x: 200, y: 0 },
+        position: { x: secondResistorX, y: 0 },
         rotation: 0,
         mirror: "none",
       },
@@ -1161,7 +1182,7 @@ describe("gallery version history", () => {
     const adminCookie = await adminOf(env);
     const id = await submitOne(env, "Versioned v1", { cookie: adminCookie });
 
-    function updateRequest(name: string): Request {
+    function updateRequest(name: string, secondResistorX: number): Request {
       return new Request(`${ORIGIN}/api/gallery/${id}`, {
         method: "PUT",
         headers: {
@@ -1172,12 +1193,26 @@ describe("gallery version history", () => {
         body: JSON.stringify({
           name,
           author: "tz",
-          projectText: projectText(name),
+          projectText: wiredProjectText(name, secondResistorX),
         }),
       });
     }
-    await route(env, updateRequest("Versioned v2"));
-    await route(env, updateRequest("Versioned v3"));
+    const initialDetail = (await (
+      await route(env, new Request(`${ORIGIN}/api/gallery/${id}`))
+    ).json()) as { entry: { previewRevision: string } };
+    const updateV2 = (await (
+      await route(env, updateRequest("Versioned v2", 240))
+    ).json()) as { previewRevision: string };
+    const updateV3 = (await (
+      await route(env, updateRequest("Versioned v3", 280))
+    ).json()) as { previewRevision: string };
+    expect(
+      new Set([
+        initialDetail.entry.previewRevision,
+        updateV2.previewRevision,
+        updateV3.previewRevision,
+      ]).size,
+    ).toBe(3);
 
     // Anonymous callers see nothing.
     const denied = await route(
@@ -1221,10 +1256,16 @@ describe("gallery version history", () => {
       ),
     );
     expect(restored.status).toBe(200);
+    expect(
+      ((await restored.json()) as { previewRevision: string }).previewRevision,
+    ).toBe(initialDetail.entry.previewRevision);
     const detail = (await (
       await route(env, new Request(`${ORIGIN}/api/gallery/${id}`))
-    ).json()) as { entry: { name: string } };
+    ).json()) as { entry: { name: string; previewRevision: string } };
     expect(detail.entry.name).toBe("Versioned v1");
+    expect(detail.entry.previewRevision).toBe(
+      initialDetail.entry.previewRevision,
+    );
 
     const afterRestore = (await (
       await route(
@@ -1450,9 +1491,16 @@ describe("gallery owner editing", () => {
         { cookie: ownerCookie },
       ),
     );
-    const { id } = (await submitted.json()) as { id: string };
+    const { id, previewRevision: initialRevision } =
+      (await submitted.json()) as {
+        id: string;
+        previewRevision: string;
+      };
 
-    function updateRequest(cookie: string | null): Request {
+    function updateRequest(
+      cookie: string | null,
+      secondResistorX = 240,
+    ): Request {
       const headers = new Headers({
         "content-type": "application/json",
         Origin: ORIGIN,
@@ -1463,7 +1511,7 @@ describe("gallery owner editing", () => {
         headers,
         body: JSON.stringify({
           name: "Edit Me v2",
-          projectText: wiredProjectText("Edit Me v2"),
+          projectText: wiredProjectText("Edit Me v2", secondResistorX),
         }),
       });
     }
@@ -1476,8 +1524,29 @@ describe("gallery owner editing", () => {
     // The owner's own edit stays live rather than dropping out of the feed.
     const updated = await route(env, updateRequest(ownerCookie));
     expect(updated.status).toBe(200);
-    expect(((await updated.json()) as { status: string }).status).toBe(
-      "public",
+    const updatedPayload = (await updated.json()) as {
+      status: string;
+      previewRevision: string;
+    };
+    expect(updatedPayload.status).toBe("public");
+    expect(updatedPayload.previewRevision).toMatch(/^[a-f0-9]{64}$/u);
+    expect(updatedPayload.previewRevision).not.toBe(initialRevision);
+
+    const stalePreview = await route(
+      env,
+      new Request(
+        `${ORIGIN}/api/gallery/${id}/preview.svg?v=${initialRevision}`,
+      ),
+    );
+    expect(stalePreview.headers.get("cache-control")).toBe("no-store");
+    const freshPreview = await route(
+      env,
+      new Request(
+        `${ORIGIN}/api/gallery/${id}/preview.svg?v=${updatedPayload.previewRevision}`,
+      ),
+    );
+    expect(freshPreview.headers.get("cache-control")).toBe(
+      "public, max-age=31536000, immutable",
     );
 
     const mine = await route(
@@ -1487,15 +1556,23 @@ describe("gallery owner editing", () => {
       }),
     );
     const entries = (await mine.json()) as {
-      entries: { name: string; status: string }[];
+      entries: { name: string; status: string; previewRevision: string }[];
     };
     expect(entries.entries).toMatchObject([
-      { name: "Edit Me v2", status: "public" },
+      {
+        name: "Edit Me v2",
+        status: "public",
+        previewRevision: updatedPayload.previewRevision,
+      },
     ]);
 
     // A curator's edit does not re-attribute the entry to the curator.
-    const adminEdit = await route(env, updateRequest(adminCookie));
+    const adminEdit = await route(env, updateRequest(adminCookie, 280));
     expect(adminEdit.status).toBe(200);
+    const adminRevision = (
+      (await adminEdit.json()) as { previewRevision: string }
+    ).previewRevision;
+    expect(adminRevision).not.toBe(updatedPayload.previewRevision);
     const detail = (await (
       await route(env, new Request(`${ORIGIN}/api/gallery/${id}`))
     ).json()) as { entry: { author: string }; ownerUserId: string | null };
@@ -1585,6 +1662,10 @@ describe("gallery administration", () => {
     const env = environment();
     const adminCookie = await adminOf(env);
     const id = await submitOne(env, "Lifecycle", { cookie: adminCookie });
+    const initial = (await (
+      await route(env, new Request(`${ORIGIN}/api/gallery/${id}`))
+    ).json()) as { entry: { previewRevision: string } };
+    const previewUrl = `${ORIGIN}/api/gallery/${id}/preview.svg?v=${initial.entry.previewRevision}`;
 
     const earlyDelete = await route(
       env,
@@ -1608,6 +1689,9 @@ describe("gallery administration", () => {
     expect(((await list.json()) as { entries: unknown[] }).entries).toEqual([]);
     const hidden = await route(env, new Request(`${ORIGIN}/api/gallery/${id}`));
     expect(hidden.status).toBe(404);
+    const hiddenPreview = await route(env, new Request(previewUrl));
+    expect(hiddenPreview.status).toBe(404);
+    expect(hiddenPreview.headers.get("cache-control")).toBe("no-store");
 
     const bin = await route(
       env,
@@ -1626,6 +1710,11 @@ describe("gallery administration", () => {
       }),
     );
     expect(restore.status).toBe(200);
+    const restoredPreview = await route(env, new Request(previewUrl));
+    expect(restoredPreview.status).toBe(200);
+    expect(restoredPreview.headers.get("cache-control")).toBe(
+      "public, max-age=31536000, immutable",
+    );
     const back = await route(env, new Request(`${ORIGIN}/api/gallery`));
     expect(
       ((await back.json()) as { entries: { id: string }[] }).entries,

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -273,40 +273,46 @@ async function handleSubmission(
   }
   project.name = name;
   const now = new Date();
-  const { status, payload } = await callGallery<{ id?: string }>(
-    env,
-    "submit",
-    {
-      day: now.toISOString().slice(0, 10),
-      submitterHash: await submitterHash(request),
-      enforceLimit: !privileged,
-      entry: {
-        // The id is drawn inside the Durable Object, which is the only place
-        // that can tell whether one is already taken.
-        id: "",
-        // Recorded, never enforced: a circuit that does not extract is
-        // published exactly the same way, it simply does not wear the star.
-        netlistable: analyzeDesignNetlist(project).ir ? 1 : 0,
-        name,
-        author,
-        description,
-        created_at: now.toISOString(),
-        schema_version: project.schemaVersion,
-        owner_user_id: user.id,
-        // Recorded per submission, so an entry stays traceable to the
-        // identity that published it even if the account later changes.
-        submitter_email: user.email,
-        submitter_provider: user.provider,
-        tags: wrapTags(sanitizeGalleryTags(body.tags)),
-        project_text: serializeProject(project),
-        svg_text: renderPreview(project, projectResolver),
-      },
+  const { status, payload } = await callGallery<{
+    id?: string;
+    previewRevision?: string;
+  }>(env, "submit", {
+    day: now.toISOString().slice(0, 10),
+    submitterHash: await submitterHash(request),
+    enforceLimit: !privileged,
+    entry: {
+      // The id is drawn inside the Durable Object, which is the only place
+      // that can tell whether one is already taken.
+      id: "",
+      // Recorded, never enforced: a circuit that does not extract is
+      // published exactly the same way, it simply does not wear the star.
+      netlistable: analyzeDesignNetlist(project).ir ? 1 : 0,
+      name,
+      author,
+      description,
+      created_at: now.toISOString(),
+      schema_version: project.schemaVersion,
+      owner_user_id: user.id,
+      // Recorded per submission, so an entry stays traceable to the
+      // identity that published it even if the account later changes.
+      submitter_email: user.email,
+      submitter_provider: user.provider,
+      tags: wrapTags(sanitizeGalleryTags(body.tags)),
+      project_text: serializeProject(project),
+      svg_text: renderPreview(project, projectResolver),
     },
-  );
+  });
   if (status === 429) {
     return Response.json({ error: "rate-limited" }, { status: 429 });
   }
-  return Response.json({ id: payload.id, status: "public" }, { status: 201 });
+  return Response.json(
+    {
+      id: payload.id,
+      status: "public",
+      previewRevision: payload.previewRevision ?? "legacy",
+    },
+    { status: 201 },
+  );
 }
 
 /**
@@ -387,6 +393,7 @@ async function handleEntryUpdate(
   }
   project.name = name;
   const nextStatus = existing.payload.status ?? "public";
+  const netlistable = analyzeDesignNetlist(project).ir ? 1 : 0;
   const { status, payload } = await callGallery(env, "replace-entry", {
     id,
     at: new Date().toISOString(),
@@ -396,6 +403,7 @@ async function handleEntryUpdate(
     projectText: serializeProject(project),
     svgText: renderPreview(project, projectResolver),
     schemaVersion: project.schemaVersion,
+    netlistable,
     status: nextStatus,
     tags: wrapTags(sanitizeGalleryTags(body.tags)),
   });
@@ -651,17 +659,31 @@ export async function routeGalleryRequest(
   if (segments.length === 2 && segments[1] === "preview.svg") {
     const { status, payload } = await callGallery<{
       status?: string;
+      entry?: GalleryEntrySummary;
       ownerUserId?: string | null;
       svgText?: string;
     }>(env, "any-entry", { id: segments[0] });
     if (status !== 200 || !payload.svgText) {
-      return Response.json({ error: "not-found" }, { status: 404 });
+      return Response.json(
+        { error: "not-found" },
+        { status: 404, headers: { "cache-control": "no-store" } },
+      );
     }
     if (payload.status === "public") {
+      // A matching revision URL names immutable bytes. Old and unversioned
+      // clients still receive the current image, but it is never stored under
+      // a mutable or incorrect cache key.
+      const requestedRevision = url.searchParams.get("v");
+      const currentRevision = payload.entry?.previewRevision;
+      const immutable =
+        typeof currentRevision === "string" &&
+        requestedRevision === String(currentRevision);
       return new Response(payload.svgText, {
         headers: {
           "content-type": "image/svg+xml",
-          "cache-control": "public, max-age=300",
+          "cache-control": immutable
+            ? "public, max-age=31536000, immutable"
+            : "no-store",
           "content-security-policy":
             "default-src 'none'; style-src 'unsafe-inline'",
         },
@@ -672,7 +694,10 @@ export async function routeGalleryRequest(
       (payload.ownerUserId != null &&
         (await sessionUserOf(request, env))?.id === payload.ownerUserId);
     if (!allowed) {
-      return Response.json({ error: "not-found" }, { status: 404 });
+      return Response.json(
+        { error: "not-found" },
+        { status: 404, headers: { "cache-control": "no-store" } },
+      );
     }
     return new Response(payload.svgText, {
       headers: {


### PR DESCRIPTION
## Summary
- version Gallery preview URLs by the SHA-256 of their stored SVG and cache matching revisions immutably
- prefetch the new revision after publish/update and notify open same-origin Gallery tabs
- keep API thumbnails out of the service-worker shell cache and prevent stale/negative caching
- guard Gallery, Examples, and My Submissions refreshes against stale requests; refresh tag and lifecycle changes
- keep `netlistable` metadata current after entry updates and version restores

## Validation
- `pnpm ci:static`
- `pnpm test:impact -- --base origin/main`
- `pnpm test:local` (244 files, 1539 tests)
- `pnpm build`
- `pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts` (111 tests)
- Gallery Playwright suite (32 tests)

Test-Impact: tests-updated