### PR TITLE
feat(editor): moderation thumbnails and narrow-width chrome polish

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -1217,6 +1217,7 @@ test("post-publication moderation has rejected work but no approval queue", asyn
 
   await page.goto("/moderation");
   await expect(page.getByTestId("moderation")).toBeVisible();
+  await page.getByTestId("owner-settings").locator("summary").click();
   await expect(page.getByTestId("schema-backup-download")).toHaveAttribute(
     "href",
     "/api/gallery/maintenance/schema-backup",

--- a/apps/editor/src/components/moderation.tsx
+++ b/apps/editor/src/components/moderation.tsx
@@ -255,6 +255,17 @@ function RejectedList({
               className="mine-card"
               data-testid={`rejected-card-${entry.id}`}
             >
+              <a
+                className="mine-card-preview"
+                href={`/g/${entry.id}`}
+                title="Open in the editor"
+              >
+                <img
+                  src={`/api/gallery/${entry.id}/preview.svg`}
+                  alt={`Preview of ${entry.name}`}
+                  loading="lazy"
+                />
+              </a>
               <div className="mine-card-copy">
                 <h2>{entry.name}</h2>
                 {entry.rejectReason ? (
@@ -376,6 +387,13 @@ function RecycleBin({
               className="mine-card"
               data-testid={`bin-card-${entry.id}`}
             >
+              <span className="mine-card-preview">
+                <img
+                  src={`/api/gallery/${entry.id}/preview.svg`}
+                  alt={`Preview of ${entry.name}`}
+                  loading="lazy"
+                />
+              </span>
               <div className="mine-card-copy">
                 <h2>{entry.name}</h2>
                 {entry.recycledAt ? (
@@ -450,29 +468,34 @@ export function Moderation() {
       <GalleryChrome subtitle="Moderation" />
       <div className="page-body">
         {state.user.isAdmin ? (
-          <form
-            className="review-appoint"
-            data-testid="review-appoint"
-            onSubmit={(event) => {
-              event.preventDefault();
-              if (!email.trim()) return;
-              void appointModerator(email.trim(), "moderator").then(setNotice);
-            }}
-          >
-            <input
-              type="email"
-              aria-label="Moderator email"
-              placeholder="Appoint a moderator by email"
-              value={email}
-              onChange={(event) => setEmail(event.currentTarget.value)}
-            />
-            <button type="submit">Appoint</button>
-            {notice ? <span className="account-notice">{notice}</span> : null}
-          </form>
+          <details className="owner-settings" data-testid="owner-settings">
+            <summary>Owner settings</summary>
+            <form
+              className="review-appoint"
+              data-testid="review-appoint"
+              onSubmit={(event) => {
+                event.preventDefault();
+                if (!email.trim()) return;
+                void appointModerator(email.trim(), "moderator").then(
+                  setNotice,
+                );
+              }}
+            >
+              <input
+                type="email"
+                aria-label="Moderator email"
+                placeholder="Appoint a moderator by email"
+                value={email}
+                onChange={(event) => setEmail(event.currentTarget.value)}
+              />
+              <button type="submit">Appoint</button>
+              {notice ? <span className="account-notice">{notice}</span> : null}
+            </form>
+            <SchemaMaintenance />
+          </details>
         ) : null}
         {state.user.isAdmin ? (
           <>
-            <SchemaMaintenance />
             <RejectedList
               refreshVersion={inventoryVersion}
               onChanged={() => setInventoryVersion((version) => version + 1)}

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -393,6 +393,29 @@ body {
   }
 }
 
+/* The gallery header centers the credit absolutely, and a signed-in
+   account chip makes the right side wide, so the "Provided by" kicker
+   collides well above half width. The kicker goes first, then the label
+   (icon+tooltip remain), and once even the icon would collide the credit
+   yields entirely. */
+@media (max-width: 1400px) {
+  .gallery-chrome .tokenzhang-credit-kicker {
+    display: none;
+  }
+}
+
+@media (max-width: 1180px) {
+  .gallery-chrome .tokenzhang-link-label {
+    display: none;
+  }
+}
+
+@media (max-width: 860px) {
+  .gallery-chrome .tokenzhang-credit {
+    display: none;
+  }
+}
+
 /* Visitor analytics entry (compact, does not crowd menubar commands). */
 .analytics-link {
   display: inline-flex;
@@ -425,4 +448,35 @@ body {
 html.light .analytics-loading {
   color: #68738a;
   background: #ffffff;
+}
+
+/* Owner-only heavy tools live behind one collapsed disclosure so the
+   moderation page leads with the work lists. */
+.owner-settings {
+  margin: 4px 0 10px;
+  border: 1px solid var(--icm-border);
+  border-radius: 10px;
+  background: var(--icm-surface);
+}
+
+.owner-settings > summary {
+  padding: 10px 14px;
+  color: var(--icm-text-muted);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.owner-settings[open] > summary {
+  border-bottom: 1px solid var(--icm-border);
+  color: var(--icm-text);
+}
+
+.owner-settings > *:not(summary) {
+  padding-right: 14px;
+  padding-left: 14px;
+}
+
+.owner-settings > *:last-child {
+  padding-bottom: 12px;
 }

--- a/apps/editor/src/styles/editor-chrome.css
+++ b/apps/editor/src/styles/editor-chrome.css
@@ -813,6 +813,18 @@
     padding-inline: 0.4rem;
   }
 
+  /* Half-width windows: the drawing toolbar collapses to icons so Style
+     never runs off the edge; every button keeps its tooltip. */
+  .draw-tool > span:not(.tool-icon):not([class]) {
+    display: none;
+  }
+
+  .draw-tool {
+    min-width: 2rem;
+    justify-content: center;
+    padding-inline: 0.4rem;
+  }
+
   .app-brand {
     min-width: 9rem;
   }


### PR DESCRIPTION
## Summary
Owner-reported UX items:
- **/moderation 无缩略图** → Rejected entries + Recycle bin cards now carry the same `/preview.svg` thumbnails as /mine (reviewer sessions can already read non-public previews).
- **Owner 工具占满主界面** → moderator appointment + Project schema maintenance fold behind a closed-by-default **Owner settings** disclosure; the curation lists lead.
- **半屏 "Provided by" 与账号芯片碰撞**(gallery 头部,含主画廊) → the centered credit degrades progressively: kicker hidden ≤1400px, label ≤1180px, whole credit ≤860px.
- **半屏画图工具栏溢出(Style 出界)** → draw tools collapse to icon-only ≤1100px; tooltips keep the names; verified at 730px: one clean icon row.

## Validation
- vitest apps/editor/src — 584 passed
- playwright gallery.spec (CI Chromium) — 31 passed (schema e2e opens the new disclosure first)
- Screenshots at 730px (editor) and 1200px (gallery) verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)