### PR TITLE
Add reusable annotation palette entries

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -317,6 +317,99 @@ test("groups and places high-voltage DMOS from Extended Devices", async ({
     .toContain('"symbolId": "ndmos"');
 });
 
+test("groups drafting tools and editable polarity labels under Annotations", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await awaitEditorReady(page);
+  const panel = page.getByTestId("shapes-library-panel");
+  if ((await panel.getAttribute("data-open")) !== "true") {
+    await page.getByTestId("library-toggle").click();
+  }
+
+  const annotations = page.getByTestId("shapes-category-annotations");
+  await expect(annotations).toBeVisible();
+  await expect(annotations.locator(".shapes-category-count")).toHaveText("7");
+  await expect(
+    annotations.getByTestId("shapes-chip-annotation-polarity-both"),
+  ).toBeVisible();
+  await expect(
+    annotations.getByTestId("shapes-chip-annotation-polarity-positive"),
+  ).toBeVisible();
+  await expect(
+    annotations.getByTestId("shapes-chip-annotation-polarity-negative"),
+  ).toBeVisible();
+
+  // The Library entries reuse the authoritative toolbar tools rather than
+  // creating fixed-size decorative symbols.
+  await annotations.getByTestId("shapes-chip-annotation-arrow").click();
+  await expect(page.getByTestId("draw-tool-arrow")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("draw-tool-arrow")).not.toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await expect(page.getByTestId("draw-tool-rectangle")).toBeVisible();
+  await expect(page.getByTestId("draw-tool-circle")).toBeVisible();
+
+  await annotations.getByTestId("shapes-chip-annotation-polarity-both").click();
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.hover({ position: { x: 460, y: 260 } });
+  const preview = page.getByTestId("component-placement-preview");
+  await expect(preview).toBeVisible();
+  await page.keyboard.press("r");
+  await expect(preview).toHaveAttribute("transform", /rotate\(90\)/u);
+
+  await canvas.click({ position: { x: 460, y: 260 } });
+  const editor = page.getByRole("textbox", { name: "Canvas text editor" });
+  await expect(editor).toBeVisible();
+  await editor.fill("VGS");
+  await page.getByRole("button", { name: "Apply text changes" }).click();
+
+  const polarity = canvas.locator('[data-polarity="both"]');
+  await expect(polarity).toBeVisible();
+  await expect(polarity).toHaveAttribute("transform", /rotate\(90 /u);
+  await expect(
+    polarity.locator('[data-role^="polarity-positive"]'),
+  ).toHaveCount(2);
+  await expect(polarity.locator('[data-role="polarity-negative"]')).toHaveCount(
+    1,
+  );
+  await expect(polarity.locator("text")).toContainText("VGS");
+  await expect
+    .poll(() => recoveryProjectTexts(page))
+    .toContain('"polarity": "both"');
+
+  // The full Insert picker exposes the same semantic entry and omits device
+  // reference/value controls that do not apply to drafting text.
+  await page.keyboard.press("i");
+  const dialog = page.getByRole("dialog", { name: "Insert Component" });
+  await dialog.getByLabel("Component search").fill("negative polarity");
+  await dialog
+    .getByTestId("insert-component-annotation-polarity-negative")
+    .click();
+  await expect(dialog.getByLabel("Initial rotation")).toBeVisible();
+  await expect(dialog.getByLabel("Reference name")).toHaveCount(0);
+  await dialog.getByRole("button", { name: "Apply" }).click();
+  await canvas.hover({ position: { x: 600, y: 260 } });
+  await canvas.click({ position: { x: 600, y: 260 } });
+  await expect(editor).toBeVisible();
+  await editor.fill("VDS");
+  await page.getByRole("button", { name: "Apply text changes" }).click();
+
+  const negative = canvas.locator('[data-polarity="negative"]');
+  await expect(negative).toBeVisible();
+  await expect(negative.locator('[data-role="polarity-negative"]')).toHaveCount(
+    1,
+  );
+  await expect(
+    negative.locator('[data-role^="polarity-positive"]'),
+  ).toHaveCount(0);
+});
+
 test("places a named vertical Power Rail from I", async ({ page }) => {
   await emulateDownloadOnlyBrowser(page);
   await page.goto("/editor");
@@ -1010,7 +1103,7 @@ test("shows the complete foldable categorized Library, quick-places a device, an
   await expect(panel).toHaveAttribute("data-open", "true");
   const libraryChipCount = await libraryChips.count();
   expect(libraryChipCount).toBeGreaterThanOrEqual(35);
-  await expect(categories).toHaveCount(8);
+  await expect(categories).toHaveCount(9);
   const transistorCategory = page.getByTestId("shapes-category-transistors");
   const transistorChips = transistorCategory.locator(
     '[data-testid^="shapes-chip-"]',

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -95,6 +95,7 @@ import {
   fullInsertLaunch,
 } from "../features/component-insert/insert-launch";
 import { useComponentPlacement } from "../features/component-insert/use-component-placement";
+import { findPaletteSymbol } from "../features/component-insert/symbol-catalog";
 import { createPlacementTrayCommands } from "../features/component-insert/placement-tray-commands";
 import { componentTargetDescription } from "../features/properties/component-identity-properties";
 import {
@@ -1198,7 +1199,8 @@ export function App({
     [project.externalSubcircuitDefinitions, resolver],
   );
   const pendingPlacementSymbol = pendingSymbolId
-    ? resolver.resolve(pendingSymbolId)?.definition
+    ? (resolver.resolve(pendingSymbolId)?.definition ??
+      findPaletteSymbol(document.presentation.styleProfileId, pendingSymbolId))
     : undefined;
   const {
     beginRetainedInstancePlacement: beginRetainedInstancePlacementFromHook,
@@ -1229,9 +1231,15 @@ export function App({
     clearTransientCanvasState,
     paintSnapGuides,
     beginVddRailInteraction,
+    activateDrawingTool: setTool,
     beginComponentPlacement: (request) => {
       beginComponentPlacement(request);
       seedComponentPreviewFromPointer();
+    },
+    beginDraftingTextEditing,
+    nextId: (prefix) => {
+      uniqueSuffixCounter.current += 1;
+      return `${prefix}-${uniqueSuffixCounter.current}`;
     },
     rotateComponentPlacement,
     mirrorComponentPlacement,

--- a/apps/editor/src/examples/common-source-amplifier.icproj.json
+++ b/apps/editor/src/examples/common-source-amplifier.icproj.json
@@ -1380,7 +1380,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 27,
+  "schemaVersion": 28,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/current-mirror-loaded-differential-pair.icproj.json
+++ b/apps/editor/src/examples/current-mirror-loaded-differential-pair.icproj.json
@@ -1287,7 +1287,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 27,
+  "schemaVersion": 28,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/fully-differential-two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/fully-differential-two-stage-op-amp.icproj.json
@@ -2521,7 +2521,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 27,
+  "schemaVersion": 28,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/two-stage-op-amp.icproj.json
@@ -801,7 +801,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 27,
+  "schemaVersion": 28,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/features/component-insert/annotation-preview-symbols.ts
+++ b/apps/editor/src/features/component-insert/annotation-preview-symbols.ts
@@ -1,0 +1,193 @@
+import type { SymbolDefinition } from "@icm/symbols";
+
+import type { DrawingTool } from "../../interaction/interaction-state";
+
+export const ANNOTATION_CATEGORY = "Annotations";
+
+export type PolarityAnnotationKind = "both" | "positive" | "negative";
+
+const drawingToolBySymbolId = {
+  "annotation-arrow": "arrow",
+  "annotation-line": "construction-line",
+  "annotation-rectangle": "rectangle",
+  "annotation-circle": "circle",
+} as const satisfies Readonly<Record<string, DrawingTool>>;
+
+const polarityBySymbolId = {
+  "annotation-polarity-both": "both",
+  "annotation-polarity-positive": "positive",
+  "annotation-polarity-negative": "negative",
+} as const satisfies Readonly<Record<string, PolarityAnnotationKind>>;
+
+export function annotationDrawingTool(
+  symbolId: string,
+): DrawingTool | undefined {
+  return drawingToolBySymbolId[symbolId as keyof typeof drawingToolBySymbolId];
+}
+
+export function annotationPolarity(
+  symbolId: string,
+): PolarityAnnotationKind | undefined {
+  return polarityBySymbolId[symbolId as keyof typeof polarityBySymbolId];
+}
+
+export function isAnnotationPaletteSymbol(symbolId: string): boolean {
+  return Boolean(
+    annotationDrawingTool(symbolId) ?? annotationPolarity(symbolId),
+  );
+}
+
+const shared: Pick<
+  SymbolDefinition,
+  "schemaVersion" | "pins" | "variants" | "labelVisibility" | "decorative"
+> = {
+  schemaVersion: 1,
+  pins: [],
+  variants: [],
+  labelVisibility: "hidden",
+  decorative: true,
+};
+
+const annotationArrow = {
+  ...shared,
+  id: "annotation-arrow",
+  name: "Arrow",
+  viewBox: { x: -22, y: -12, width: 44, height: 24 },
+  primitives: [
+    { kind: "line", from: { x: -18, y: 0 }, to: { x: 13, y: 0 } },
+    {
+      kind: "polygon",
+      points: [
+        { x: 20, y: 0 },
+        { x: 12, y: -5 },
+        { x: 12, y: 5 },
+      ],
+      fill: "foreground",
+      stroke: "none",
+    },
+  ],
+} satisfies SymbolDefinition;
+
+const annotationLine = {
+  ...shared,
+  id: "annotation-line",
+  name: "Line",
+  viewBox: { x: -22, y: -12, width: 44, height: 24 },
+  primitives: [{ kind: "line", from: { x: -18, y: 0 }, to: { x: 18, y: 0 } }],
+} satisfies SymbolDefinition;
+
+const annotationRectangle = {
+  ...shared,
+  id: "annotation-rectangle",
+  name: "Rectangle",
+  viewBox: { x: -22, y: -16, width: 44, height: 32 },
+  primitives: [
+    {
+      kind: "polyline",
+      points: [
+        { x: -18, y: -12 },
+        { x: 18, y: -12 },
+        { x: 18, y: 12 },
+        { x: -18, y: 12 },
+        { x: -18, y: -12 },
+      ],
+    },
+  ],
+} satisfies SymbolDefinition;
+
+const annotationCircle = {
+  ...shared,
+  id: "annotation-circle",
+  name: "Circle",
+  viewBox: { x: -18, y: -18, width: 36, height: 36 },
+  primitives: [
+    {
+      kind: "circle",
+      center: { x: 0, y: 0 },
+      radius: 14,
+      fill: "none",
+      stroke: "foreground",
+    },
+  ],
+} satisfies SymbolDefinition;
+
+function textStrokes(centerY: number): SymbolDefinition["primitives"] {
+  return [
+    {
+      kind: "line",
+      from: { x: -9, y: centerY - 5 },
+      to: { x: -5, y: centerY + 5 },
+    },
+    {
+      kind: "line",
+      from: { x: -5, y: centerY + 5 },
+      to: { x: -1, y: centerY - 5 },
+    },
+    {
+      kind: "line",
+      from: { x: 2, y: centerY + 2 },
+      to: { x: 7, y: centerY + 7 },
+    },
+    {
+      kind: "line",
+      from: { x: 7, y: centerY + 2 },
+      to: { x: 2, y: centerY + 7 },
+    },
+  ];
+}
+
+function plusStrokes(centerY: number): SymbolDefinition["primitives"] {
+  return [
+    { kind: "line", from: { x: -4, y: centerY }, to: { x: 4, y: centerY } },
+    {
+      kind: "line",
+      from: { x: 0, y: centerY - 4 },
+      to: { x: 0, y: centerY + 4 },
+    },
+  ];
+}
+
+function minusStrokes(centerY: number): SymbolDefinition["primitives"] {
+  return [
+    { kind: "line", from: { x: -4, y: centerY }, to: { x: 4, y: centerY } },
+  ];
+}
+
+const annotationPolarityBoth = {
+  ...shared,
+  id: "annotation-polarity-both",
+  name: "Polarity (+ / text / −)",
+  viewBox: { x: -14, y: -25, width: 28, height: 50 },
+  primitives: [...plusStrokes(-18), ...textStrokes(0), ...minusStrokes(18)],
+} satisfies SymbolDefinition;
+
+const annotationPolarityPositive = {
+  ...shared,
+  id: "annotation-polarity-positive",
+  name: "Positive polarity (+ / text)",
+  viewBox: { x: -14, y: -20, width: 28, height: 40 },
+  primitives: [...plusStrokes(-11), ...textStrokes(7)],
+} satisfies SymbolDefinition;
+
+const annotationPolarityNegative = {
+  ...shared,
+  id: "annotation-polarity-negative",
+  name: "Negative polarity (text / −)",
+  viewBox: { x: -14, y: -20, width: 28, height: 40 },
+  primitives: [...textStrokes(-7), ...minusStrokes(11)],
+} satisfies SymbolDefinition;
+
+/**
+ * Editor-only catalog artwork. These definitions never enter the electrical
+ * SymbolResolver: drawing entries activate an existing tool, while polarity
+ * entries create editable DraftText objects.
+ */
+export const annotationPreviewSymbols: readonly SymbolDefinition[] = [
+  annotationArrow,
+  annotationLine,
+  annotationRectangle,
+  annotationCircle,
+  annotationPolarityBoth,
+  annotationPolarityPositive,
+  annotationPolarityNegative,
+];

--- a/apps/editor/src/features/component-insert/component-insert-request.ts
+++ b/apps/editor/src/features/component-insert/component-insert-request.ts
@@ -18,6 +18,21 @@ export interface VddRailInsertRequest {
   netName: string;
 }
 
+export interface DrawingToolInsertRequest {
+  kind: "drawing-tool";
+  symbolId: string;
+  symbolName: string;
+  tool: "arrow" | "construction-line" | "rectangle" | "circle";
+}
+
+export interface PolarityAnnotationInsertRequest {
+  kind: "polarity-annotation";
+  symbolId: string;
+  symbolName: string;
+  polarity: "both" | "positive" | "negative";
+  initialRotation: 0 | 90 | 180 | 270;
+}
+
 export interface CellInsertRequest {
   kind: "cell";
   symbolId: string;
@@ -48,4 +63,6 @@ export type ComponentInsertRequest =
   | SymbolInsertRequest
   | CellInsertRequest
   | ExternalSubcircuitInsertRequest
-  | VddRailInsertRequest;
+  | VddRailInsertRequest
+  | DrawingToolInsertRequest
+  | PolarityAnnotationInsertRequest;

--- a/apps/editor/src/features/component-insert/insert-component-dialog.test.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.test.tsx
@@ -34,9 +34,14 @@ describe("InsertComponentDialog", () => {
     expect(markup).toContain('aria-label="Initial rotation"');
     expect(markup).toContain('aria-label="Reference name"');
     expect(markup).toContain(">Extended Devices</h3>");
+    expect(markup).toContain(">Annotations</h3>");
     expect(markup).toContain(">High-voltage devices</h4>");
     expect(markup).toContain('data-testid="insert-component-ndmos"');
     expect(markup).toContain('data-testid="insert-component-pdmos"');
+    expect(markup).toContain('data-testid="insert-component-annotation-arrow"');
+    expect(markup).toContain(
+      'data-testid="insert-component-annotation-polarity-both"',
+    );
     expect(markup).toContain("W / m");
     expect(markup).toContain("(Total channel width)");
     expect(markup).toContain("(Finger count, so finger width is W / NF)");

--- a/apps/editor/src/features/component-insert/insert-component-dialog.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.tsx
@@ -8,6 +8,10 @@ import {
   initialComponentParameterValues,
 } from "./component-parameters";
 import {
+  annotationDrawingTool,
+  annotationPolarity,
+} from "./annotation-preview-symbols";
+import {
   componentCatalog,
   libraryDescription,
   libraryDisplayName,
@@ -189,6 +193,14 @@ export function InsertComponentDialog({
   const selectedIsPort =
     selected?.kind === "symbol" &&
     (selected.symbol.id === "port" || selected.symbol.id === "port-filled");
+  const selectedDrawingTool =
+    selected?.kind === "symbol"
+      ? annotationDrawingTool(selected.symbol.id)
+      : undefined;
+  const selectedPolarity =
+    selected?.kind === "symbol"
+      ? annotationPolarity(selected.symbol.id)
+      : undefined;
   const parameters = componentParameters(
     selected?.kind === "symbol" ? selected.symbol.id : "",
   );
@@ -264,7 +276,7 @@ export function InsertComponentDialog({
   };
 
   const rotatePreview = (): void => {
-    if (selectedIsVddRail) return;
+    if (selectedIsVddRail || selectedDrawingTool) return;
     setInitialRotation(
       (current) => ((current + 90) % 360) as 0 | 90 | 180 | 270,
     );
@@ -280,6 +292,25 @@ export function InsertComponentDialog({
         symbolId: "vdd",
         symbolName: "Power Rail",
         netName,
+      });
+      return;
+    }
+    if (selectedDrawingTool) {
+      onApply({
+        kind: "drawing-tool",
+        symbolId: selected.symbol.id,
+        symbolName: selected.symbol.name,
+        tool: selectedDrawingTool,
+      });
+      return;
+    }
+    if (selectedPolarity) {
+      onApply({
+        kind: "polarity-annotation",
+        symbolId: selected.symbol.id,
+        symbolName: selected.symbol.name,
+        polarity: selectedPolarity,
+        initialRotation,
       });
       return;
     }
@@ -503,6 +534,16 @@ export function InsertComponentDialog({
                   />
                 </label>
               </section>
+            ) : selectedDrawingTool ? (
+              <section
+                className="insert-placement-options"
+                aria-label="Drawing tool"
+              >
+                <p className="insert-cell-label-note">
+                  Starts the existing {selected!.symbol.name.toLowerCase()}{" "}
+                  tool. Click the canvas to draw; press Esc when finished.
+                </p>
+              </section>
             ) : (
               <section
                 className="insert-placement-options"
@@ -525,7 +566,12 @@ export function InsertComponentDialog({
                     <option value="270">270°</option>
                   </select>
                 </label>
-                {selectedIsPort ? (
+                {selectedPolarity ? (
+                  <p className="insert-cell-label-note">
+                    Place the annotation, then edit its center text directly on
+                    the canvas.
+                  </p>
+                ) : selectedIsPort ? (
                   <p className="insert-cell-label-note">
                     {libraryDescription(selected.symbol.id) ??
                       "Names a net on this sheet."}{" "}

--- a/apps/editor/src/features/component-insert/symbol-catalog.test.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.test.ts
@@ -21,6 +21,7 @@ describe("component insertion catalog", () => {
       "Switches",
       "Analog Blocks",
       "Logic Gates",
+      "Annotations",
       "Extended Devices",
     ]);
   });
@@ -54,7 +55,27 @@ describe("component insertion catalog", () => {
     expect(symbolCategory("closed-switch")).toBe("Switches");
     expect(symbolCategory("ndmos")).toBe("Extended Devices");
     expect(symbolCategory("pdmos")).toBe("Extended Devices");
+    expect(symbolCategory("annotation-arrow")).toBe("Annotations");
+    expect(symbolCategory("annotation-polarity-both")).toBe("Annotations");
     expect(symbolSubcategory("ndmos")).toBe("High-voltage devices");
+  });
+
+  it("offers drawing tools and editable polarity labels as annotations", () => {
+    const groups = componentCatalog("razavi-textbook-v1", "");
+    const annotations = groups.find(
+      (group) => group.category === "Annotations",
+    );
+
+    expect(annotations?.symbols.map((symbol) => symbol.id)).toEqual([
+      "annotation-arrow",
+      "annotation-circle",
+      "annotation-line",
+      "annotation-polarity-negative",
+      "annotation-polarity-both",
+      "annotation-polarity-positive",
+      "annotation-rectangle",
+    ]);
+    expect(groups.at(-1)?.category).toBe("Extended Devices");
   });
 
   it("offers marked and unmarked comparators as separate analog blocks", () => {

--- a/apps/editor/src/features/component-insert/symbol-catalog.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.ts
@@ -7,6 +7,11 @@ import {
 } from "@icm/symbols";
 import type { SymbolDefinition } from "@icm/symbols";
 
+import {
+  ANNOTATION_CATEGORY,
+  annotationPreviewSymbols,
+  isAnnotationPaletteSymbol,
+} from "./annotation-preview-symbols";
 import { vddRailPreviewSymbol } from "./vdd-rail-preview-symbol";
 
 /**
@@ -27,6 +32,7 @@ const CATALOG_SECTIONS: readonly CatalogSection[] = [
   { category: "Switches" },
   { category: "Analog Blocks" },
   { category: "Logic Gates" },
+  { category: ANNOTATION_CATEGORY },
   {
     category: EXTENDED_DEVICE_CATEGORY,
     subcategory: HIGH_VOLTAGE_DEVICE_SUBCATEGORY,
@@ -40,6 +46,7 @@ export interface ComponentCatalogGroup {
 }
 
 export function symbolCategory(symbolId: string): string {
+  if (isAnnotationPaletteSymbol(symbolId)) return ANNOTATION_CATEGORY;
   const expanded = expandedDeviceCatalogEntry(symbolId);
   if (expanded) return expanded.category;
   if (["nmos", "pmos", "npn", "pnp"].includes(symbolId)) {
@@ -130,6 +137,7 @@ export function paletteSymbols(_styleProfileId: string): SymbolDefinition[] {
   return [
     vddRailPreviewSymbol,
     ...razaviProductSymbols,
+    ...annotationPreviewSymbols,
     ...expandedDeviceSymbols,
   ];
 }

--- a/apps/editor/src/features/component-insert/use-component-placement.ts
+++ b/apps/editor/src/features/component-insert/use-component-placement.ts
@@ -22,11 +22,12 @@ import {
 } from "@icm/devices";
 import type {
   CircuitProject,
+  DraftingObject,
   Point,
   RouteEndpoint,
   SchematicDocument,
 } from "@icm/model";
-import { deriveStableId } from "@icm/model";
+import { defaultDraftTextDocument, deriveStableId } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 
 import type { ComponentInsertRequest } from "./component-insert-request";
@@ -58,6 +59,7 @@ import {
 } from "../../presentation/razavi-presentation";
 import type { ScreenFlip } from "../../interaction/shortcut-orientation";
 import type { PendingComponentPlacement } from "../../interaction/interaction-state";
+import type { DrawingTool } from "../../interaction/interaction-state";
 
 type TransactionResult = { ok: boolean; revision: number };
 
@@ -93,13 +95,21 @@ export interface UseComponentPlacementOptions {
     transactionId: string,
     edits: ProjectStructureEdit[],
   ) => boolean;
-  selectOnly: (kind: "instance" | "route", ids: readonly string[]) => void;
+  selectOnly: (
+    kind: "instance" | "route" | "drafting",
+    ids: readonly string[],
+  ) => void;
   cancelAllTransientInteraction: () => void;
   cancelCanvasDrag: () => void;
   clearTransientCanvasState: () => void;
   paintSnapGuides: (guides: []) => void;
   beginVddRailInteraction: (netName: string) => void;
+  activateDrawingTool: (tool: DrawingTool) => void;
   beginComponentPlacement: (request: PendingComponentPlacement) => void;
+  beginDraftingTextEditing: (
+    object: Extract<DraftingObject, { kind: "text" }>,
+  ) => void;
+  nextId: (prefix: string) => string;
   rotateComponentPlacement: (delta: 90 | -90) => void;
   mirrorComponentPlacement: (direction: ScreenFlip) => void;
   componentPlacementRotation: 0 | 90 | 180 | 270;
@@ -593,6 +603,43 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     );
   };
 
+  const placePolarityAnnotation = (
+    position: Point,
+    placementRequest: PendingComponentPlacement,
+  ): void => {
+    if (
+      placementRequest.kind !== "drafting-text" ||
+      !placementRequest.polarity
+    ) {
+      return;
+    }
+    let id = options.nextId("polarity");
+    while (
+      options.document.drafting?.objects.some((object) => object.id === id)
+    ) {
+      id = options.nextId("polarity");
+    }
+    const object: Extract<DraftingObject, { kind: "text" }> = {
+      id,
+      kind: "text",
+      locked: false,
+      zIndex: 0,
+      anchor: { kind: "free", position },
+      content: defaultDraftTextDocument("V_x"),
+      alignment: "middle",
+      rotation: options.componentPlacementRotation,
+      typographyToken: "label",
+      polarity: placementRequest.polarity,
+    };
+    if (!options.transact([{ kind: "upsert_drafting_object", object }]).ok) {
+      return;
+    }
+    options.cancelAllTransientInteraction();
+    options.selectOnly("drafting", [object.id]);
+    options.beginDraftingTextEditing(object);
+    options.setStatus(`Added ${placementRequest.polarity} polarity annotation`);
+  };
+
   const openInsertPicker = ({
     scope = "all",
     initialSelectionId = null,
@@ -629,6 +676,13 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     setInsertDialogOpen(false);
     setInsertScope("all");
     setInsertInitialSelectionId(null);
+    if (request.kind === "drawing-tool") {
+      options.activateDrawingTool(request.tool);
+      options.setStatus(
+        `${request.symbolName}: click the canvas to start · double-click to finish · Esc exits`,
+      );
+      return;
+    }
     if (request.kind === "vdd-rail") {
       options.beginVddRailInteraction(request.netName);
       options.setStatus(
@@ -637,23 +691,36 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       return;
     }
     const pendingRequest: PendingComponentPlacement =
-      request.kind === "symbol" &&
-      (request.symbolId === "port" || request.symbolId === "port-filled")
+      request.kind === "polarity-annotation"
         ? {
-            kind: "cell-pin",
+            kind: "drafting-text",
             symbolId: request.symbolId,
             parameters: {},
             initialRotation: request.initialRotation,
             showReference: false,
             referenceText: null,
             showValue: false,
-            direction: request.portDirection ?? "passive",
-            ...(request.portName ? { portName: request.portName } : {}),
+            polarity: request.polarity,
           }
-        : request;
+        : request.kind === "symbol" &&
+            (request.symbolId === "port" || request.symbolId === "port-filled")
+          ? {
+              kind: "cell-pin",
+              symbolId: request.symbolId,
+              parameters: {},
+              initialRotation: request.initialRotation,
+              showReference: false,
+              referenceText: null,
+              showValue: false,
+              direction: request.portDirection ?? "passive",
+              ...(request.portName ? { portName: request.portName } : {}),
+            }
+          : request;
     options.beginComponentPlacement(pendingRequest);
     options.setStatus(
-      `Place ${request.symbolName} on the canvas · R rotates · Shift+R / Ctrl+R mirrors · Esc cancels`,
+      request.kind === "polarity-annotation"
+        ? `Place ${request.symbolName} on the canvas · R rotates · Esc cancels`
+        : `Place ${request.symbolName} on the canvas · R rotates · Shift+R / Ctrl+R mirrors · Esc cancels`,
     );
   };
 
@@ -715,7 +782,9 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       return;
     }
     if (!options.pendingSymbolId || !options.pendingComponentPlacement) return;
-    if (options.pendingComponentPlacement.kind === "retained-instance") {
+    if (options.pendingComponentPlacement.kind === "drafting-text") {
+      placePolarityAnnotation(point, options.pendingComponentPlacement);
+    } else if (options.pendingComponentPlacement.kind === "retained-instance") {
       const instanceId = options.pendingComponentPlacement.instanceId;
       if (instanceId) placeRetainedInstance(instanceId, point);
     } else if (options.pendingComponentPlacement.kind === "cell-pin") {

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -20,7 +20,7 @@ describe("shapes quick-place", () => {
       }),
     );
 
-    expect(symbols).toHaveLength(39);
+    expect(symbols).toHaveLength(46);
     expect(markup).toContain("All devices");
     expect(markup.match(/data-testid="shapes-chip-/g)).toHaveLength(
       symbols.length,
@@ -39,6 +39,7 @@ describe("shapes quick-place", () => {
       ["Switches", 2],
       ["Analog Blocks", 6],
       ["Logic Gates", 10],
+      ["Annotations", 7],
       ["Extended Devices", 2],
     ]);
     const categoryTestIds = [
@@ -49,6 +50,7 @@ describe("shapes quick-place", () => {
       "switches",
       "analog-blocks",
       "logic-gates",
+      "annotations",
       "extended-devices",
     ];
     for (let index = 0; index < categoryTestIds.length; index += 1) {
@@ -62,8 +64,8 @@ describe("shapes quick-place", () => {
         );
       }
     }
-    expect(markup.match(/class="shapes-category" open=""/g)).toHaveLength(8);
-    expect(markup.match(/class="shapes-category-header"/g)).toHaveLength(8);
+    expect(markup.match(/class="shapes-category" open=""/g)).toHaveLength(9);
+    expect(markup.match(/class="shapes-category-header"/g)).toHaveLength(9);
     expect(markup).toContain('aria-label="Place Independent Voltage Source"');
     expect(markup).toContain('title="Place Capacitor"');
     expect(markup).toContain('aria-label="Place Variable Resistor"');
@@ -109,6 +111,35 @@ describe("shapes quick-place", () => {
       symbolName: "Power Rail",
       netName: "VDD",
     });
+  });
+
+  it("starts annotation drawing tools and polarity-label placement", () => {
+    for (const [symbolId, symbolName, tool] of [
+      ["annotation-arrow", "Arrow", "arrow"],
+      ["annotation-line", "Line", "construction-line"],
+      ["annotation-rectangle", "Rectangle", "rectangle"],
+      ["annotation-circle", "Circle", "circle"],
+    ] as const) {
+      expect(quickPlaceRequest("razavi", symbolId)).toEqual({
+        kind: "drawing-tool",
+        symbolId,
+        symbolName,
+        tool,
+      });
+    }
+    expect(quickPlaceRequest("razavi", "annotation-polarity-both")).toEqual({
+      kind: "polarity-annotation",
+      symbolId: "annotation-polarity-both",
+      symbolName: "Polarity (+ / text / −)",
+      polarity: "both",
+      initialRotation: 0,
+    });
+    expect(
+      quickPlaceRequest("razavi", "annotation-polarity-positive"),
+    ).toMatchObject({ kind: "polarity-annotation", polarity: "positive" });
+    expect(
+      quickPlaceRequest("razavi", "annotation-polarity-negative"),
+    ).toMatchObject({ kind: "polarity-annotation", polarity: "negative" });
   });
 
   it("quick-places high-voltage DMOS with MOS parameters", () => {

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -8,6 +8,10 @@ import {
 import { SymbolArtwork } from "../component-insert/symbol-artwork";
 import { initialComponentParameterValues } from "../component-insert/component-parameters";
 import {
+  annotationDrawingTool,
+  annotationPolarity,
+} from "../component-insert/annotation-preview-symbols";
+import {
   componentCatalog,
   findPaletteSymbol,
   libraryDescription,
@@ -53,6 +57,13 @@ const COMPACT_LIBRARY_LABELS: Readonly<Record<string, string>> = {
   "vdd-port": "VDD",
   "voltage-amplifier": "V Amp",
   "voltage-source": "V Src",
+  "annotation-arrow": "Arrow",
+  "annotation-line": "Line",
+  "annotation-rectangle": "Rect",
+  "annotation-circle": "Circle",
+  "annotation-polarity-both": "+ V −",
+  "annotation-polarity-positive": "+ V",
+  "annotation-polarity-negative": "V −",
 };
 
 function libraryLabel(symbolId: string, symbolName: string): string {
@@ -71,6 +82,25 @@ export function quickPlaceRequest(
 ): ComponentInsertRequest | null {
   const symbol = findPaletteSymbol(styleProfileId, symbolId);
   if (!symbol) return null;
+  const drawingTool = annotationDrawingTool(symbolId);
+  if (drawingTool) {
+    return {
+      kind: "drawing-tool",
+      symbolId,
+      symbolName: symbol.name,
+      tool: drawingTool,
+    };
+  }
+  const polarity = annotationPolarity(symbolId);
+  if (polarity) {
+    return {
+      kind: "polarity-annotation",
+      symbolId,
+      symbolName: symbol.name,
+      polarity,
+      initialRotation: 0,
+    };
+  }
   if (symbolId === "vdd") {
     return {
       kind: "vdd-rail",

--- a/apps/editor/src/interaction/interaction-state.ts
+++ b/apps/editor/src/interaction/interaction-state.ts
@@ -33,7 +33,8 @@ export interface PendingComponentPlacement {
     | "cell"
     | "external-subcircuit"
     | "cell-pin"
-    | "retained-instance";
+    | "retained-instance"
+    | "drafting-text";
   symbolId: string;
   parameters: Record<string, string>;
   initialRotation: 0 | 90 | 180 | 270;
@@ -46,6 +47,7 @@ export interface PendingComponentPlacement {
   masterName?: string;
   portName?: string;
   direction?: "input" | "output" | "inout" | "passive";
+  polarity?: "both" | "positive" | "negative";
   /** Existing unplaced Instance being returned from the Placement Tray. */
   instanceId?: string;
 }
@@ -190,6 +192,7 @@ function sameComponentPlacement(
     left.definitionId !== right.definitionId ||
     left.masterName !== right.masterName ||
     left.direction !== right.direction ||
+    left.polarity !== right.polarity ||
     left.instanceId !== right.instanceId
   ) {
     return false;

--- a/docs/adr/0046-independent-cell-pins-and-formal-port-projection.md
+++ b/docs/adr/0046-independent-cell-pins-and-formal-port-projection.md
@@ -18,7 +18,7 @@ which could not be seen from the schematic geometry.
 ## Decision
 
 Schema 25 introduced every visible Cell Pin as an independent authored
-declaration; the contract remains present in current Schema 27.
+declaration; the contract remains present in current Schema 28.
 Each declaration owns exactly one Port Instance, one stable terminal identity,
 one name, one direction, and one physical Base Net. Duplicate names are valid.
 Placement, rename, copy, direction editing, deletion, and Wire cutting never

--- a/docs/overall-product-plan.md
+++ b/docs/overall-product-plan.md
@@ -67,7 +67,7 @@ revision, lock, or transaction invariants.
   ordered hierarchy interface rather than another Net-label mechanism.
 - Routes describe visible geometry; they may stretch locally during movement
   without changing logical connectivity.
-- A Project is a canonical schema-27 JSON file. Browser recovery is an
+- A Project is a canonical schema-28 JSON file. Browser recovery is an
   origin-local, non-authoritative copy.
 - Visual variants may change presentation but never remove electrical terminal
   semantics. The Razavi raster manifest is the sole visual authority.

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -337,8 +337,8 @@ no electrical meaning.
 Open, demo load, restore, and human-approved staged import replace the entire
 Project through one replacement boundary; they are not Edit Engine
 transactions. Replacement cancels pending recovery for the outgoing Project
-and terminates its Agent session. A complete schema-24 Project may be upgraded
-at the read boundary and then enters the editor only as schema-27; migrated
+and terminates its Agent session. A complete schema-27 Project may be upgraded
+at the read boundary and then enters the editor only as schema-28; migrated
 files are marked as needing save.
 
 Selection, viewport, active tool, previews, Agent tokens, and approval UI are

--- a/docs/specs/persistence-and-recovery.md
+++ b/docs/specs/persistence-and-recovery.md
@@ -4,17 +4,17 @@ Status: `accepted`
 
 Primary owner: `packages/project-protocol` and the editor document lifecycle
 
-Portable Projects use canonical schema-27 `.icproj.json`. The current-only
+Portable Projects use canonical schema-28 `.icproj.json`. The current-only
 model in `packages/model` validates the normalized shape;
 `packages/project-protocol` owns parsing, rolling compatibility diagnostics,
 and canonical serialization. Persistence validates
 the complete current schema before open or save and writes atomically where the
-platform supports it. Schema 25 upgrades to 26 at ingestion; serialization
-always writes schema 27. Older schemas are rejected outside the rolling
+platform supports it. Schema 27 upgrades to 28 at ingestion; serialization
+always writes schema 28. Older schemas are rejected outside the rolling
 current-and-previous compatibility window.
 
 Recovery state is a non-authoritative browser safety copy. It may restore a
-complete schema-27 Project or a schema-25 record that validates after the
+complete schema-28 Project or a schema-27 record that validates after the
 bounded upgrade, associated with a recorded working-copy session.
 Corrupt, incompatible, or partial recovery data is discarded or retained as raw
 data without changing the live Project. User-saved Library examples are the

--- a/docs/specs/project-file-format.md
+++ b/docs/specs/project-file-format.md
@@ -2,16 +2,16 @@
 
 Status: `accepted`
 
-Current Project schema: `27`
+Current Project schema: `28`
 
 Primary owners: `packages/model` (current shape) and
 `packages/project-protocol` (file boundary)
 
 An `.icproj.json` file is canonical JSON for one complete `CircuitProject`.
-`@icm/project-protocol` exposes `parseProject`. It accepts schemas 25 and 26,
-migrates previous parallel Route arrays and positional attachments to stable
-Route legs, supplies only schema-27 in memory, and writes only schema 27.
-Older project files are rejected.
+`@icm/project-protocol` exposes `parseProject`. It accepts schemas 27 and 28,
+adds the optional polarity-annotation intent when reading schema 27, supplies
+only schema 28 in memory, and writes only schema 28. Older project files are
+rejected.
 
 ## Current authorities
 
@@ -62,8 +62,8 @@ Older project files are rejected.
 ## Read and write
 
 ```text
-read text -> parse JSON -> require Project schema 25 or 26
--> converge to schema 27 -> strict schema-27 validation -> open
+read text -> parse JSON -> require Project schema 27 or 28
+-> converge to schema 28 -> strict schema-28 validation -> open
 save -> strict validation -> canonical key ordering -> atomic write
 ```
 
@@ -73,7 +73,7 @@ after explicit human approval in the editor.
 
 A migrated formal file is marked as needing save. The editor does not silently
 overwrite the source selected through the browser file input. Browser recovery
-records may be canonicalized to v26 only after a successful validated write.
+records may be canonicalized to v28 only after a successful validated write.
 
 Project entry does not repair duplicate canonical supply Nets (`0` or `VDD`).
 Duplicate folded Net names are invalid input and remain a blocking diagnostic
@@ -82,7 +82,7 @@ until the author explicitly renames or merges the Nets.
 Canonical serialization ends with one newline and is byte-stable across
 save/load/save. The current corpus is listed in
 `fixtures/projects/compatibility-corpus.json`; its accepted entries must all be
-already canonical Project schema 27. The rejected corpus names expected
+already canonical Project schema 28. The rejected corpus names expected
 validation failures.
 
 Viewport, selection, undo history, canvas overlays, Agent credentials,

--- a/docs/specs/schematic-model.md
+++ b/docs/specs/schematic-model.md
@@ -5,7 +5,7 @@ Status: `accepted`
 Primary owner: `packages/model`
 
 The Project contains Documents; each Document owns revisioned electrical,
-geometric, and presentation facts. The current model is strict schema 27 and has
+geometric, and presentation facts. The current model is strict schema 28 and has
 no compatibility shape.
 
 ## Coordinate domains

--- a/docs/user/project-compatibility.md
+++ b/docs/user/project-compatibility.md
@@ -1,6 +1,6 @@
 # Project File Compatibility
 
-The released Project schema version is `27`. It retains schematic-only
+The released Project schema version is `28`. It retains schematic-only
 hierarchy integrity, a Project structural revision, stable formal Cell ports,
 and definition-level Cell symbol presentation. It also has one typed Instance
 netlist authority, formal Cell parameters, and Project-local external
@@ -12,14 +12,16 @@ Port Name, such as `Vout`; `port` and `port-filled` are only hollow and filled
 artwork variants for that independent interface declaration.
 Its bound annotation may persist same-text RichText formatting but cannot store
 a divergent alias. Equal Port Names remain independent in the saved drawing
-and are grouped only by the read-only formal interface projection. A canonical
-v25 file can be opened, saved, reopened, and saved again without byte drift.
+and are grouped only by the read-only formal interface projection. Drafting
+text may also carry one of three polarity-label forms while its editable RichText
+content remains independent from the fixed vector marks. A canonical v28 file
+can be opened, saved, reopened, and saved again without byte drift.
 
-Schema v24 is accepted through a bounded upgrade to v25. The upgrade splits
-every previous multi-marker terminal into independent singleton declarations,
-rebinds marker-owned annotations, and preserves existing Net/Route/Junction
-topology. The next save writes v25. The original file is never overwritten
-silently. Schema v23 and older, and versions newer than v25, are rejected.
+Schema v27 is accepted through a bounded upgrade to v28. The new polarity
+field is optional, so the upgrade preserves all existing circuit and drafting
+content and stamps the current version. The next save writes v28. The original
+file is never overwritten silently. Schema v26 and older, and versions newer
+than v28, are rejected by the interactive project-file boundary.
 
 The canonical-current corpus at
 [`fixtures/projects/compatibility-corpus.json`](../../fixtures/projects/compatibility-corpus.json)
@@ -31,7 +33,7 @@ Retired fields such as first-class
 
 An incompatible Project is rejected before it can replace the current browser
 Project. Conversion, when needed, is an explicit external operation that must
-produce and validate a complete v25 candidate before a human chooses to load it.
+produce and validate a complete v28 candidate before a human chooses to load it.
 
 The editor never silently merges duplicate canonical Ground (`0`) or VDD Nets.
 Duplicate folded Net names are invalid and remain diagnostics until the author

--- a/fixtures/projects/instance-value-display/project.icproj.json
+++ b/fixtures/projects/instance-value-display/project.icproj.json
@@ -1048,7 +1048,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "instance-value-display",
   "name": "Instance Value Display",
-  "schemaVersion": 27,
+  "schemaVersion": 28,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/minimal/project.icproj.json
+++ b/fixtures/projects/minimal/project.icproj.json
@@ -32,7 +32,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-minimal",
   "name": "Minimal Project",
-  "schemaVersion": 27,
+  "schemaVersion": 28,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-1-manual/project.icproj.json
+++ b/fixtures/projects/phase-1-manual/project.icproj.json
@@ -59,7 +59,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-1-manual",
   "name": "Phase 1 Manual Editor",
-  "schemaVersion": 27,
+  "schemaVersion": 28,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-3-routing/project.icproj.json
+++ b/fixtures/projects/phase-3-routing/project.icproj.json
@@ -191,7 +191,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-routing",
   "name": "Phase 3 Routing Demo",
-  "schemaVersion": 27,
+  "schemaVersion": 28,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-5-dense-analog/project.icproj.json
+++ b/fixtures/projects/phase-5-dense-analog/project.icproj.json
@@ -428,7 +428,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-5-dense-analog",
   "name": "Current Differential Stage",
-  "schemaVersion": 27,
+  "schemaVersion": 28,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/rejected-missing-top/project.icproj.json
+++ b/fixtures/projects/rejected-missing-top/project.icproj.json
@@ -32,7 +32,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-rejected",
   "name": "Rejected",
-  "schemaVersion": 27,
+  "schemaVersion": 28,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/packages/derived/src/drafting-geometry.test.ts
+++ b/packages/derived/src/drafting-geometry.test.ts
@@ -184,3 +184,98 @@ describe("object-anchored drafting text on rectangles", () => {
     );
   });
 });
+
+describe("polarity drafting text", () => {
+  function polarityText(
+    polarity: "both" | "positive" | "negative",
+    rotation: 0 | 90 | 180 | 270 = 0,
+  ): Extract<DraftingObject, { kind: "text" }> {
+    return {
+      id: `polarity-${polarity}`,
+      kind: "text",
+      locked: false,
+      zIndex: 0,
+      anchor: { kind: "free", position: { x: 100, y: 80 } },
+      content: { runs: [{ kind: "text", value: "V_x" }] },
+      alignment: "middle",
+      rotation,
+      typographyToken: "label",
+      polarity,
+    };
+  }
+
+  it("includes fixed plus and minus strokes in shared bounds", () => {
+    const object = polarityText("both");
+    const geometry = resolveDraftingObjectGeometry(
+      documentWith([object]),
+      resolver,
+      object,
+    );
+    if (geometry.kind !== "text") throw new Error("expected text geometry");
+
+    expect(geometry.textPosition).toEqual({ x: 100, y: 80 });
+    expect(geometry.polarityLines.map((line) => line.role)).toEqual([
+      "positive-horizontal",
+      "positive-vertical",
+      "negative",
+    ]);
+    expect(geometry.bounds.y).toBeLessThan(geometry.polarityLines[0]!.from.y);
+    expect(geometry.bounds.y + geometry.bounds.height).toBeGreaterThan(
+      geometry.polarityLines[2]!.from.y,
+    );
+  });
+
+  it("centers each one-sided form around the stable rotation anchor", () => {
+    const positive = polarityText("positive");
+    const negative = polarityText("negative");
+    const positiveGeometry = resolveDraftingObjectGeometry(
+      documentWith([positive]),
+      resolver,
+      positive,
+    );
+    const negativeGeometry = resolveDraftingObjectGeometry(
+      documentWith([negative]),
+      resolver,
+      negative,
+    );
+    if (positiveGeometry.kind !== "text" || negativeGeometry.kind !== "text") {
+      throw new Error("expected text geometry");
+    }
+
+    expect(positiveGeometry.textPosition.y).toBeGreaterThan(80);
+    expect(negativeGeometry.textPosition.y).toBeLessThan(80);
+    expect(positiveGeometry.polarityLines).toHaveLength(2);
+    expect(negativeGeometry.polarityLines).toHaveLength(1);
+    expect(positiveGeometry.position).toEqual({ x: 100, y: 80 });
+    expect(negativeGeometry.position).toEqual({ x: 100, y: 80 });
+  });
+
+  it("rotates the complete three-part annotation around its center", () => {
+    const horizontal = polarityText("both", 0);
+    const vertical = polarityText("both", 90);
+    const horizontalGeometry = resolveDraftingObjectGeometry(
+      documentWith([horizontal]),
+      resolver,
+      horizontal,
+    );
+    const verticalGeometry = resolveDraftingObjectGeometry(
+      documentWith([vertical]),
+      resolver,
+      vertical,
+    );
+    if (
+      horizontalGeometry.kind !== "text" ||
+      verticalGeometry.kind !== "text"
+    ) {
+      throw new Error("expected text geometry");
+    }
+
+    expect(verticalGeometry.bounds.width).toBeCloseTo(
+      horizontalGeometry.bounds.height,
+    );
+    expect(verticalGeometry.bounds.height).toBeCloseTo(
+      horizontalGeometry.bounds.width,
+    );
+    expect(verticalGeometry.position).toEqual({ x: 100, y: 80 });
+  });
+});

--- a/packages/derived/src/drafting-geometry.ts
+++ b/packages/derived/src/drafting-geometry.ts
@@ -43,8 +43,16 @@ export interface DraftingDiagnostic {
 export type ResolvedDraftingGeometry =
   | {
       kind: "text";
+      /** Rotation pivot and stable placement anchor for the whole object. */
       position: DerivedPoint;
+      /** Center of the editable text, which may shift between polarity marks. */
+      textPosition: DerivedPoint;
       rotation: 0 | 90 | 180 | 270;
+      polarityLines: Array<{
+        role: "positive-horizontal" | "positive-vertical" | "negative";
+        from: DerivedPoint;
+        to: DerivedPoint;
+      }>;
       bounds: DerivedRect;
       diagnostics: DraftingDiagnostic[];
     }
@@ -230,23 +238,108 @@ function resolveText(
   const follow =
     object.anchor.kind === "route" && object.anchor.orientation === "follow";
   const rotation = composeRotation(resolved.rotation, object.rotation, follow);
-  const bounds = textBounds(
-    position,
-    object.alignment,
-    rotation,
-    object.content,
-    richTextMetrics(
-      resolveDocumentStyleProfile(document.presentation),
-      object.typographyToken,
-      object.styleOverride?.sizeScale,
-    ),
+  const profile = resolveDocumentStyleProfile(document.presentation);
+  const metrics = richTextMetrics(
+    profile,
+    object.typographyToken,
+    object.styleOverride?.sizeScale,
   );
+  const polarity = object.polarity
+    ? resolvePolarityTextGeometry(
+        position,
+        object.polarity,
+        object.content,
+        metrics,
+      )
+    : null;
+  const textPosition = polarity?.textPosition ?? position;
+  const unrotatedTextBounds = textBounds(
+    textPosition,
+    object.alignment,
+    0,
+    object.content,
+    metrics,
+  );
+  const unrotatedBounds = polarity
+    ? unionRects([
+        unrotatedTextBounds,
+        paddedBounds(
+          unionBounds(polarity.lines.flatMap((line) => [line.from, line.to])),
+          STROKE_PADDING / 2,
+        ),
+      ])
+    : unrotatedTextBounds;
+  const bounds =
+    rotation === 0
+      ? unrotatedBounds
+      : rotatedRectBounds(unrotatedBounds, position, rotation);
   return {
     kind: "text" as const,
     position,
+    textPosition,
     rotation,
+    polarityLines: polarity?.lines ?? [],
     bounds,
     diagnostics,
+  };
+}
+
+function resolvePolarityTextGeometry(
+  position: DerivedPoint,
+  polarity: "both" | "positive" | "negative",
+  content: RichTextDocument,
+  metrics: ReturnType<typeof richTextMetrics>,
+): {
+  textPosition: DerivedPoint;
+  lines: Extract<ResolvedDraftingGeometry, { kind: "text" }>["polarityLines"];
+} {
+  const layout = measureRichTextDocument(content, metrics);
+  const textHalfHeight = layout.height / 2;
+  const markerHalfArm = metrics.fontSize * 0.23;
+  const separation = textHalfHeight + markerHalfArm + metrics.fontSize * 0.18;
+  let textOffset = 0;
+  let positiveOffset: number | null = null;
+  let negativeOffset: number | null = null;
+  if (polarity === "both") {
+    positiveOffset = -separation;
+    negativeOffset = separation;
+  } else if (polarity === "positive") {
+    positiveOffset = (-separation - textHalfHeight + markerHalfArm) / 2;
+    textOffset = positiveOffset + separation;
+  } else {
+    textOffset = -(separation - textHalfHeight + markerHalfArm) / 2;
+    negativeOffset = textOffset + separation;
+  }
+  const lines: Extract<
+    ResolvedDraftingGeometry,
+    { kind: "text" }
+  >["polarityLines"] = [];
+  if (positiveOffset !== null) {
+    const y = position.y + positiveOffset;
+    lines.push(
+      {
+        role: "positive-horizontal",
+        from: { x: position.x - markerHalfArm, y },
+        to: { x: position.x + markerHalfArm, y },
+      },
+      {
+        role: "positive-vertical",
+        from: { x: position.x, y: y - markerHalfArm },
+        to: { x: position.x, y: y + markerHalfArm },
+      },
+    );
+  }
+  if (negativeOffset !== null) {
+    const y = position.y + negativeOffset;
+    lines.push({
+      role: "negative",
+      from: { x: position.x - markerHalfArm, y },
+      to: { x: position.x + markerHalfArm, y },
+    });
+  }
+  return {
+    textPosition: { x: position.x, y: position.y + textOffset },
+    lines,
   };
 }
 

--- a/packages/model/src/drafting-geometry-schema.ts
+++ b/packages/model/src/drafting-geometry-schema.ts
@@ -31,7 +31,15 @@ export const ResolvedDraftingGeometrySchema = z.discriminatedUnion("kind", [
   z.strictObject({
     kind: z.literal("text"),
     position: DerivedPointSchema,
+    textPosition: DerivedPointSchema,
     rotation: RotationSchema,
+    polarityLines: z.array(
+      z.strictObject({
+        role: z.enum(["positive-horizontal", "positive-vertical", "negative"]),
+        from: DerivedPointSchema,
+        to: DerivedPointSchema,
+      }),
+    ),
     bounds: DerivedRectSchema,
     diagnostics: z.array(DraftingDiagnosticSchema),
   }),

--- a/packages/model/src/schema.test.ts
+++ b/packages/model/src/schema.test.ts
@@ -5,10 +5,32 @@ import {
   AnnotationSchema,
   CircuitProjectJsonSchema,
   CircuitProjectSchema,
+  DraftTextSchema,
   SchematicDocumentSchema,
 } from "./schema.js";
 
 describe("CircuitProject schema", () => {
+  it("accepts only the three persisted polarity-label forms", () => {
+    const text = {
+      id: "polarity-1",
+      kind: "text" as const,
+      locked: false,
+      zIndex: 0,
+      anchor: { kind: "free" as const, position: { x: 20, y: 20 } },
+      content: { runs: [{ kind: "text" as const, value: "V_x" }] },
+      alignment: "middle" as const,
+      rotation: 0 as const,
+    };
+    for (const polarity of ["both", "positive", "negative"] as const) {
+      expect(DraftTextSchema.safeParse({ ...text, polarity }).success).toBe(
+        true,
+      );
+    }
+    expect(
+      DraftTextSchema.safeParse({ ...text, polarity: "plus-minus" }).success,
+    ).toBe(false);
+  });
+
   it("accepts a minimal Project with one Document", () => {
     const project = createEmptyProject("project-test", "Test Project");
     expect(CircuitProjectSchema.parse(project)).toEqual(project);

--- a/packages/model/src/schema/common.ts
+++ b/packages/model/src/schema/common.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-export const CURRENT_PROJECT_SCHEMA_VERSION = 27;
+export const CURRENT_PROJECT_SCHEMA_VERSION = 28;
 
 export const StableIdSchema = z.string().min(1).max(256);
 /** A persisted Document page point before its Document-grid relation is known. */

--- a/packages/model/src/schema/drafting.ts
+++ b/packages/model/src/schema/drafting.ts
@@ -43,6 +43,8 @@ export const DraftTextSchema = DraftingObjectBaseSchema.extend({
   alignment: z.enum(["start", "middle", "end"]),
   rotation: RotationSchema,
   typographyToken: z.enum(["caption", "body", "label"]).optional(),
+  /** Fixed vector polarity marks surrounding editable center text. */
+  polarity: z.enum(["both", "positive", "negative"]).optional(),
 });
 export const DraftArrowSchema = DraftingObjectBaseSchema.extend({
   kind: z.literal("arrow"),

--- a/packages/project-protocol/src/load.ts
+++ b/packages/project-protocol/src/load.ts
@@ -12,7 +12,7 @@ import {
 } from "./diagnostics.js";
 import {
   ProjectMigrationError,
-  upgradeSchema26To27,
+  upgradeSchema27To28,
 } from "./previous-to-current.js";
 import { PREVIOUS_PROJECT_SCHEMA_VERSION } from "./version.js";
 
@@ -108,7 +108,7 @@ export function tryParseProjectWithMetadata(
   try {
     current =
       sourceSchemaVersion === PREVIOUS_PROJECT_SCHEMA_VERSION
-        ? upgradeSchema26To27(parsed)
+        ? upgradeSchema27To28(parsed)
         : parsed;
   } catch (error) {
     if (error instanceof ProjectMigrationError) {

--- a/packages/project-protocol/src/persistence.test.ts
+++ b/packages/project-protocol/src/persistence.test.ts
@@ -16,6 +16,7 @@ import {
   upgradeSchema25To26,
   upgradeSchema25To26WithReport,
   upgradeSchema26To27,
+  upgradeSchema27To28,
 } from "./index.js";
 
 class MemoryStorage implements ProjectStorage {
@@ -171,12 +172,16 @@ describe("Project persistence", () => {
     }).toEqual(topology);
 
     const migrated = parseProjectWithMetadata(
-      JSON.stringify(upgradeSchema26To27(upgradeSchema25To26(direct.project))),
+      JSON.stringify(
+        upgradeSchema27To28(
+          upgradeSchema26To27(upgradeSchema25To26(direct.project)),
+        ),
+      ),
     );
     expect(migrated).toMatchObject({
-      sourceSchemaVersion: 27,
+      sourceSchemaVersion: 28,
       migrated: false,
-      project: { schemaVersion: 27 },
+      project: { schemaVersion: 28 },
     });
     const migratedDocument = migrated.project.documents[0]!;
     expect(migratedDocument.netlist?.terminals).toMatchObject([
@@ -313,15 +318,17 @@ describe("Project persistence", () => {
       routeId: "route-1",
       reboundAnnotationIds: ["route-label"],
     });
-    // Schema 25 has left the rolling window; the retained transform lifts
-    // it to 26, and the boundary migrates that previous version to 27.
+    // Schema 25 has left the rolling window; retained transforms can still
+    // replay the complete history before the current boundary validates it.
     const parsed = parseProjectWithMetadata(
-      JSON.stringify(upgradeSchema25To26(source)),
+      JSON.stringify(
+        upgradeSchema27To28(upgradeSchema26To27(upgradeSchema25To26(source))),
+      ),
     );
     expect(parsed).toMatchObject({
-      sourceSchemaVersion: 27,
+      sourceSchemaVersion: 28,
       migrated: false,
-      project: { schemaVersion: 27 },
+      project: { schemaVersion: 28 },
     });
     const route = parsed.project.documents[0]!.routes[0]!;
     const annotation = parsed.project.documents[0]!.annotations[0]!;
@@ -339,10 +346,10 @@ describe("Project persistence", () => {
 
   it("rejects schemas outside the current-and-previous window", () => {
     const project = createEmptyProject("project-test", "Test Project");
-    for (const schemaVersion of [23, 24, 25, 28, 99]) {
+    for (const schemaVersion of [23, 24, 25, 29, 99]) {
       expect(() =>
         parseProject(JSON.stringify({ ...project, schemaVersion })),
-      ).toThrow(/must be 26 or 27/);
+      ).toThrow(/must be 27 or 28/);
     }
   });
 });

--- a/packages/project-protocol/src/previous-to-current.ts
+++ b/packages/project-protocol/src/previous-to-current.ts
@@ -26,3 +26,11 @@ export type {
   Schema26To27MigrationReport,
   Schema26To27MigrationResult,
 } from "./transforms/drafting-style.js";
+export {
+  upgradeSchema27To28,
+  upgradeSchema27To28WithReport,
+} from "./transforms/polarity-drafting.js";
+export type {
+  Schema27To28MigrationReport,
+  Schema27To28MigrationResult,
+} from "./transforms/polarity-drafting.js";

--- a/packages/project-protocol/src/protocol.test.ts
+++ b/packages/project-protocol/src/protocol.test.ts
@@ -16,21 +16,21 @@ describe("Project protocol boundary", () => {
     });
   });
 
-  it("upgrades the previous schema to schema 27", () => {
+  it("upgrades the previous schema to schema 28", () => {
     const current = JSON.parse(
       serializeProject(createEmptyProject("protocol-project", "Protocol")),
     ) as Record<string, unknown>;
     const result = tryParseProjectWithMetadata(
       JSON.stringify({
         ...current,
-        schemaVersion: 26,
+        schemaVersion: 27,
       }),
     );
     expect(result).toMatchObject({
       ok: true,
-      sourceSchemaVersion: 26,
+      sourceSchemaVersion: 27,
       migrated: true,
-      project: { schemaVersion: 27, structureRevision: 0 },
+      project: { schemaVersion: 28, structureRevision: 0 },
     });
   });
 

--- a/packages/project-protocol/src/transforms/drafting-style.ts
+++ b/packages/project-protocol/src/transforms/drafting-style.ts
@@ -1,5 +1,3 @@
-import { CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
-
 export interface Schema26To27MigrationReport {
   /** Schema 27 only widens drafting style capacity; nothing migrates. */
   readonly changed: false;
@@ -20,7 +18,7 @@ export function upgradeSchema26To27WithReport(
   raw: Record<string, unknown>,
 ): Schema26To27MigrationResult {
   const project = structuredClone(raw);
-  project.schemaVersion = CURRENT_PROJECT_SCHEMA_VERSION;
+  project.schemaVersion = 27;
   return { project, report: { changed: false } };
 }
 

--- a/packages/project-protocol/src/transforms/polarity-drafting.ts
+++ b/packages/project-protocol/src/transforms/polarity-drafting.ts
@@ -1,0 +1,29 @@
+import { CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
+
+export interface Schema27To28MigrationReport {
+  /** Schema 28 adds optional polarity intent; existing projects are unchanged. */
+  readonly changed: false;
+}
+
+export interface Schema27To28MigrationResult {
+  readonly project: Record<string, unknown>;
+  readonly report: Schema27To28MigrationReport;
+}
+
+/**
+ * Upgrade schema 27 to 28. The new DraftText polarity field is optional, so
+ * every valid schema-27 project is already valid schema-28 data.
+ */
+export function upgradeSchema27To28WithReport(
+  raw: Record<string, unknown>,
+): Schema27To28MigrationResult {
+  const project = structuredClone(raw);
+  project.schemaVersion = CURRENT_PROJECT_SCHEMA_VERSION;
+  return { project, report: { changed: false } };
+}
+
+export function upgradeSchema27To28(
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  return upgradeSchema27To28WithReport(raw).project;
+}

--- a/packages/project-protocol/src/transforms/project.ts
+++ b/packages/project-protocol/src/transforms/project.ts
@@ -1,4 +1,4 @@
-import { CURRENT_PROJECT_SCHEMA_VERSION, deriveStableId } from "@icm/model";
+import { deriveStableId } from "@icm/model";
 
 export class ProjectMigrationError extends Error {
   constructor(
@@ -80,7 +80,7 @@ export function upgradeSchema24To25WithReport(
     }
   }
 
-  project.schemaVersion = CURRENT_PROJECT_SCHEMA_VERSION;
+  project.schemaVersion = 25;
   return {
     project,
     report: {

--- a/packages/project-protocol/src/transforms/route-leg.ts
+++ b/packages/project-protocol/src/transforms/route-leg.ts
@@ -1,4 +1,4 @@
-import { CURRENT_PROJECT_SCHEMA_VERSION, deriveStableId } from "@icm/model";
+import { deriveStableId } from "@icm/model";
 
 import { ProjectMigrationError } from "./project.js";
 
@@ -33,7 +33,7 @@ export function upgradeSchema25To26WithReport(
     }
   }
 
-  project.schemaVersion = CURRENT_PROJECT_SCHEMA_VERSION;
+  project.schemaVersion = 26;
   return { project, report: { routes: migratedRoutes } };
 }
 

--- a/packages/project-protocol/src/version.ts
+++ b/packages/project-protocol/src/version.ts
@@ -2,4 +2,4 @@
  * The rolling compatibility window is deliberately explicit. Advancing the
  * current schema replaces this adapter instead of extending a migration chain.
  */
-export const PREVIOUS_PROJECT_SCHEMA_VERSION = 26;
+export const PREVIOUS_PROJECT_SCHEMA_VERSION = 27;

--- a/packages/render-svg/src/drafting-render.test.ts
+++ b/packages/render-svg/src/drafting-render.test.ts
@@ -55,6 +55,45 @@ describe("drafting layer rendering", () => {
     expect(svg).not.toContain("a<b>&c");
   });
 
+  it.each([
+    ["both", 3],
+    ["positive", 2],
+    ["negative", 1],
+  ] as const)(
+    "renders the %s polarity label with fixed vector marks",
+    (polarity, lineCount) => {
+      const document = createEmptyDocument("doc", "Polarity label");
+      document.drafting = {
+        objects: [
+          {
+            id: `polarity-${polarity}`,
+            kind: "text",
+            locked: false,
+            zIndex: 0,
+            anchor: { kind: "free", position: { x: 100, y: 100 } },
+            content: { runs: [{ kind: "text", value: "V_x" }] },
+            alignment: "middle",
+            rotation: 90,
+            typographyToken: "label",
+            polarity,
+          },
+        ],
+      };
+
+      const svg = renderDocumentSvg(document, resolver);
+      const group = svg.match(
+        new RegExp(
+          `<g data-object-id="polarity-${polarity}" data-kind="draft-text"[\\s\\S]*?</g>`,
+          "u",
+        ),
+      )?.[0];
+      expect(group).toBeDefined();
+      expect(group?.match(/data-role="polarity-/gu)).toHaveLength(lineCount);
+      expect(group).toContain('transform="rotate(90 100 100)"');
+      expect(group).toContain("V_x");
+    },
+  );
+
   it("renders a squared subscript under one explicit overbar", () => {
     const document = createEmptyDocument("doc", "Squared noise current");
     document.drafting = {

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -925,7 +925,7 @@ function renderDraftText(
   profile: SchematicStyleProfile,
   unresolved: string,
 ): string {
-  const { position, rotation } = geometry;
+  const { position, textPosition, rotation } = geometry;
   const fontSize =
     typographyFontSize(object.typographyToken ?? "body", profile) *
     (object.styleOverride?.sizeScale ?? 1);
@@ -933,16 +933,21 @@ function renderDraftText(
   // its uniform line grid centered on the resolved anchor position. Free and
   // route-anchored text keep the first-line-baseline placement unchanged.
   const baselineY =
-    object.anchor.kind === "object"
-      ? centeredFirstBaselineY(object.content, position.y, fontSize, profile)
-      : position.y;
+    object.anchor.kind === "object" || object.polarity
+      ? centeredFirstBaselineY(
+          object.content,
+          textPosition.y,
+          fontSize,
+          profile,
+        )
+      : textPosition.y;
   const weight = object.styleOverride?.weight === "bold" ? "bold" : "normal";
   const italic = object.styleOverride?.italic === true ? "italic" : "normal";
   const positioned = renderPositionedOverbarScriptDocument(
     object.content,
     profile,
     {
-      x: position.x,
+      x: textPosition.x,
       y: baselineY,
       fontSize,
       alignment: object.alignment,
@@ -950,16 +955,31 @@ function renderDraftText(
       defaultItalic: italic === "italic",
     },
   );
+  if (object.polarity) {
+    const color = object.styleOverride?.color ?? profile.foreground;
+    const strokeWidth =
+      profile.strokes.annotation * (object.styleOverride?.strokeScale ?? 1);
+    const markers = geometry.polarityLines
+      .map(
+        (line) =>
+          `<line data-role="polarity-${line.role}" x1="${line.from.x}" y1="${line.from.y}" x2="${line.to.x}" y2="${line.to.y}" stroke="${color}" stroke-width="${strokeWidth}" stroke-linecap="${profile.lineCap}"/>`,
+      )
+      .join("");
+    const text = positioned
+      ? `<text x="${textPosition.x}" y="${baselineY}" text-anchor="start" font-size="${fontSize}" font-weight="${weight}" font-style="${italic}" fill="${color}">${positioned.tspans}</text>${positioned.decorations}`
+      : `<text x="${textPosition.x}" y="${baselineY}" text-anchor="${object.alignment}" font-size="${fontSize}" font-weight="${weight}" font-style="${italic}" fill="${color}">${renderRichTextDocument(object.content, profile, { lineOriginX: textPosition.x })}</text>`;
+    return `<g data-object-id="${object.id}" data-kind="draft-text" data-polarity="${object.polarity}"${unresolved} transform="rotate(${rotation} ${position.x} ${position.y})">${markers}${text}</g>`;
+  }
   // P1: the renderer consumes geometry.rotation (the single rotation truth),
   // not the raw persisted object rotation. The rotation pivot stays on the
   // resolved anchor so centered labels rotate about their center.
   if (positioned) {
-    return `<g transform="rotate(${rotation} ${position.x} ${position.y})"><text data-object-id="${object.id}" data-kind="draft-text"${unresolved} x="${position.x}" y="${baselineY}" text-anchor="start" font-size="${fontSize}" font-weight="${weight}" font-style="${italic}">${positioned.tspans}</text>${positioned.decorations}</g>`;
+    return `<g transform="rotate(${rotation} ${position.x} ${position.y})"><text data-object-id="${object.id}" data-kind="draft-text"${unresolved} x="${textPosition.x}" y="${baselineY}" text-anchor="start" font-size="${fontSize}" font-weight="${weight}" font-style="${italic}">${positioned.tspans}</text>${positioned.decorations}</g>`;
   }
   const content = renderRichTextDocument(object.content, profile, {
-    lineOriginX: position.x,
+    lineOriginX: textPosition.x,
   });
-  return `<text data-object-id="${object.id}" data-kind="draft-text"${unresolved} x="${position.x}" y="${baselineY}" text-anchor="${object.alignment}" transform="rotate(${rotation} ${position.x} ${position.y})" font-size="${fontSize}" font-weight="${weight}" font-style="${italic}">${content}</text>`;
+  return `<text data-object-id="${object.id}" data-kind="draft-text"${unresolved} x="${textPosition.x}" y="${baselineY}" text-anchor="${object.alignment}" transform="rotate(${rotation} ${position.x} ${position.y})" font-size="${fontSize}" font-weight="${weight}" font-style="${italic}">${content}</text>`;
 }
 
 /** Glyph cap height is ~0.7 em; dropping the baseline by 0.35 em sits the

--- a/worker/gallery-do.ts
+++ b/worker/gallery-do.ts
@@ -21,7 +21,8 @@ import {
   serializeProject,
   upgradeSchema24To25,
   upgradeSchema25To26,
-  upgradeSchema26To27WithReport,
+  upgradeSchema26To27,
+  upgradeSchema27To28WithReport,
 } from "@icm/project-protocol";
 import { renderDocumentSvg } from "@icm/render-svg";
 import {
@@ -1091,7 +1092,7 @@ export class GalleryDO {
     const migrationReports: Array<{
       table: string;
       id: string;
-      report: ReturnType<typeof upgradeSchema26To27WithReport>["report"];
+      report: ReturnType<typeof upgradeSchema27To28WithReport>["report"];
     }> = [];
     for (const source of sources) {
       const versions: Record<string, number> = {};
@@ -1101,25 +1102,26 @@ export class GalleryDO {
         versions[versionKey] = (versions[versionKey] ?? 0) + 1;
         try {
           const raw = JSON.parse(row.project_text) as Record<string, unknown>;
-          // Rows can lag more than one version between converge runs; the
-          // retained adapters chain older stock link by link. Each retained
-          // adapter stamps the CURRENT constant, so the stamp is rewound to
-          // the link's real target before the next adapter decides to run —
-          // otherwise a 24 row would skip the 25->26 Route-leg migration.
+          // Rows can lag more than one version between converge runs; chain
+          // every retained adapter link by link before crossing the rolling
+          // project-file boundary.
           let lifted = raw;
           if (lifted.schemaVersion === 24) {
             lifted = upgradeSchema24To25(lifted);
-            lifted.schemaVersion = 25;
           }
           if (lifted.schemaVersion === 25) {
             lifted = upgradeSchema25To26(lifted);
           }
+          if (lifted.schemaVersion === 26) {
+            lifted = upgradeSchema26To27(lifted);
+          }
           const migration =
-            lifted.schemaVersion === CURRENT_PROJECT_SCHEMA_VERSION - 1
-              ? upgradeSchema26To27WithReport(lifted)
+            lifted.schemaVersion === 27
+              ? upgradeSchema27To28WithReport(lifted)
               : null;
+          lifted = migration?.project ?? lifted;
           const project = parseProject(
-            JSON.stringify(migration?.project ?? lifted),
+            JSON.stringify(lifted),
           );
           if (migration) {
             migrationReports.push({


### PR DESCRIPTION
## Summary
- add a dedicated Annotations library category for Arrow, Line, Rectangle, and Circle while preserving toolbar access
- add editable `+ / text / −`, `+ / text`, and `text / −` drafting components
- persist polarity intent in project schema 28 and keep Gallery migrations and Agent snapshots compatible

## Validation
- `pnpm ci:check` (1542 unit tests, 245 Playwright tests, build, performance, visual/export goldens, release smoke)
- post-rebase focused regression: 112 unit tests and the Annotations browser scenario