### PR TITLE
feat(editor): credit reads Presented by TokenZhang

### DIFF
--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -158,7 +158,7 @@ describe("editor shell", () => {
     expect(markup).not.toContain(">About</button>");
     expect(markup).toContain(">Help</button>");
     expect(markup).toContain('class="app-chrome-actions"');
-    expect(markup).toContain("Provided by");
+    expect(markup).toContain("Presented by");
     expect(markup).toContain('href="https://tokenzhang.com"');
     expect(markup).toContain('src="/tokenzhang-favicon.png"');
     const navigationEnd = markup.indexOf("</nav>");

--- a/apps/editor/src/app/editor-app-chrome.tsx
+++ b/apps/editor/src/app/editor-app-chrome.tsx
@@ -292,14 +292,14 @@ export function EditorAppChrome({
             Help
           </button>
           <div className="tokenzhang-credit">
-            <span className="tokenzhang-credit-kicker">Provided by</span>
+            <span className="tokenzhang-credit-kicker">Presented by</span>
             <a
               className="tokenzhang-link"
               href="https://tokenzhang.com"
               target="_blank"
               rel="noreferrer"
-              aria-label="tokenzhang.com"
-              title="tokenzhang.com"
+              aria-label="TokenZhang"
+              title="TokenZhang"
             >
               <img
                 className="tokenzhang-link-icon"
@@ -308,7 +308,7 @@ export function EditorAppChrome({
                 width={12}
                 height={12}
               />
-              <span className="tokenzhang-link-label">tokenzhang.com</span>
+              <span className="tokenzhang-link-label">TokenZhang</span>
             </a>
           </div>
         </div>

--- a/apps/editor/src/components/gallery-chrome.tsx
+++ b/apps/editor/src/components/gallery-chrome.tsx
@@ -25,14 +25,14 @@ export function GalleryChrome({ subtitle }: { subtitle: string }) {
         </div>
       </div>
       <div className="tokenzhang-credit">
-        <span className="tokenzhang-credit-kicker">Provided by</span>
+        <span className="tokenzhang-credit-kicker">Presented by</span>
         <a
           className="tokenzhang-link"
           href="https://tokenzhang.com"
           target="_blank"
           rel="noreferrer"
-          aria-label="tokenzhang.com"
-          title="tokenzhang.com"
+          aria-label="TokenZhang"
+          title="TokenZhang"
         >
           <img
             className="tokenzhang-link-icon"
@@ -41,7 +41,7 @@ export function GalleryChrome({ subtitle }: { subtitle: string }) {
             width={16}
             height={16}
           />
-          <span className="tokenzhang-link-label">tokenzhang.com</span>
+          <span className="tokenzhang-link-label">TokenZhang</span>
         </a>
       </div>
       <nav className="gallery-actions">

--- a/apps/editor/src/components/gallery-feed.test.tsx
+++ b/apps/editor/src/components/gallery-feed.test.tsx
@@ -65,7 +65,7 @@ describe("GalleryFeed", () => {
     expect(markup).toContain("Analog Canvas");
     expect(markup).toContain('data-testid="gallery-new-circuit"');
     expect(markup).toContain('href="/editor"');
-    expect(markup).toContain("Provided by");
+    expect(markup).toContain("Presented by");
     expect(markup).toContain('href="https://tokenzhang.com"');
     expect(markup).toContain('src="/tokenzhang-favicon.png"');
     expect(markup).toContain('data-testid="gallery-loading"');

--- a/apps/editor/src/styles/editor-chrome.css
+++ b/apps/editor/src/styles/editor-chrome.css
@@ -828,6 +828,18 @@
   .app-brand {
     min-width: 9rem;
   }
+
+  /* Collapsed chrome keeps just the Z mark; the wording returns with
+     room. */
+  .app-chrome-actions .tokenzhang-credit-kicker,
+  .app-chrome-actions .tokenzhang-link-label {
+    display: none;
+  }
+
+  .app-chrome-actions .tokenzhang-link-icon {
+    width: 16px;
+    height: 16px;
+  }
 }
 
 @media (max-width: 860px) {


### PR DESCRIPTION
## Summary
Owner request: 署名统一为 **Presented by TokenZhang**(不带 .com);编辑器窄屏时只留 **Z** 图标,全宽才显示文字。gallery 头部同步。链接与 hostname 逻辑不变。

Verified: wide editor shows "Presented by · Z TokenZhang"; 900px editor shows the bare Z mark; gallery header wide shows "Presented by Z TokenZhang".

## Validation
- vitest apps/editor/src — 584 passed (two credit-text assertions updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)