### PR TITLE
feat(editor): copy drafting objects with C

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -217,6 +217,43 @@ test("snaps quick Text creation after a non-grid viewport zoom", async ({
   expect(textObject.anchor.position.y % 10).toBe(0);
 });
 
+test("copies a selected text with C", async ({ page }) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+
+  await clickDrawTool(page, "text");
+  const draftInput = page.getByRole("textbox", { name: "Canvas text editor" });
+  await draftInput.fill("Design note");
+  await page.getByRole("button", { name: "Apply text changes" }).click();
+  await page.keyboard.press("Escape");
+
+  const texts = page.locator('[data-kind="draft-text"]');
+  await expect(texts).toHaveCount(1);
+  const origin = (await texts.first().boundingBox())!;
+
+  // Select the text and copy it. A drawing-only selection used to be refused
+  // outright — "Select at least one component to copy".
+  await page.mouse.click(
+    origin.x + origin.width / 2,
+    origin.y + origin.height / 2,
+  );
+  await page.keyboard.press("c");
+  await expect(page.getByTestId("status")).toContainText("Place copy");
+
+  const box = (await canvas.boundingBox())!;
+  await page.mouse.move(box.x + 420, box.y + 380);
+  await canvas.click({ position: { x: 420, y: 380 } });
+  await page.keyboard.press("Escape");
+
+  await expect(texts).toHaveCount(2);
+  const both = await texts.evaluateAll((elements) =>
+    elements.map((element) => element.textContent),
+  );
+  expect(both.filter((value) => value?.includes("Design note"))).toHaveLength(
+    2,
+  );
+});
+
 test("fits drafting text with F using an integer grid camera", async ({
   page,
 }) => {

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -11,11 +11,13 @@ import {
   type OperationIdRemap,
   type RoutingOperationPlan,
 } from "@icm/edit-engine";
+import { translateDraftingObject } from "@icm/edit-engine";
 import type { SchematicEdit } from "@icm/edit-engine";
 import type {
   Annotation,
   CellNetlistTerminal,
   ConnectivityEvidence,
+  DraftingObject,
   Instance,
   Net,
   NoConnect,
@@ -53,6 +55,12 @@ export interface SchematicClipboard {
   annotations: Annotation[];
   noConnects: NoConnect[];
   connectivityEvidence: ConnectivityEvidence[];
+  /**
+   * Selected drafting objects — text, arrows, lines, rectangles, circles.
+   * They carry no connectivity, so they copy as themselves and are the only
+   * thing a copy needs when nothing electrical is selected.
+   */
+  draftingObjects: DraftingObject[];
 }
 
 export interface PasteProposal {
@@ -130,8 +138,22 @@ export function clipboardPlacementAnchor(
     clipboard.junctions[0]?.position ??
     (clipboard.routes[0] ? routeBends(clipboard.routes[0])[0] : undefined) ??
     annotationPosition ??
+    draftingOrigin(clipboard.draftingObjects[0]) ??
     null
   );
+}
+
+/** Where a drafting object sits, for a copy that holds only drawing. */
+function draftingOrigin(object: DraftingObject | undefined): Point | null {
+  if (!object) return null;
+  if (object.kind === "rectangle" || object.kind === "circle") {
+    return object.center;
+  }
+  return object.anchor.kind === "free"
+    ? object.anchor.position
+    : object.anchor.kind === "object"
+      ? object.anchor.fallbackPosition
+      : null;
 }
 
 /** Builds the isolated fallback copy ghost used when dry-run is unavailable. */
@@ -241,7 +263,10 @@ function fallbackClipboardPreviewDocument(
     })),
     noConnects: structuredClone(clipboard.noConnects),
     annotations,
-    drafting: undefined,
+    drafting:
+      clipboard.draftingObjects.length > 0
+        ? { objects: structuredClone(clipboard.draftingObjects) }
+        : undefined,
     // A copy ghost is an isolated fragment, not a filtered view of the base
     // Document. Every reference-bearing Document field must therefore be
     // owned explicitly here. Inheriting any of these through `...base` leaves
@@ -356,6 +381,7 @@ export function clipboardPreviewDocument(
           connectivityEvidence: result.document.connectivityEvidence.filter(
             (evidence) => evidenceIds.has(evidence.id),
           ),
+          draftingObjects: [],
         });
         return fallbackClipboardPreviewDocument(
           result.document,
@@ -444,18 +470,27 @@ export function copyWholeDocument(
         ? evidence.memberNetIds.every((netId) => netIds.has(netId))
         : netIds.has(evidence.netId),
     ),
+    draftingObjects: [],
   });
 }
 
 export function copySelection(
   document: SchematicDocument,
   instanceIds: readonly string[],
+  draftingIds: readonly string[] = [],
 ): SchematicClipboard | null {
   const selectedIds = new Set(instanceIds);
   const instances = document.instances.filter((instance) =>
     selectedIds.has(instance.id),
   );
-  if (instances.length === 0) return null;
+  const selectedDrafting = new Set(draftingIds);
+  const draftingObjects = (document.drafting?.objects ?? []).filter((object) =>
+    selectedDrafting.has(object.id),
+  );
+  // A drawing-only selection is a complete copy: notes and callouts are
+  // worth duplicating on their own, and requiring a part alongside them made
+  // C look broken to anyone who had only selected a piece of text.
+  if (instances.length === 0 && draftingObjects.length === 0) return null;
   const capture = captureRoutingCopyFragment(document, {
     instanceIds,
     routeIds: [],
@@ -531,6 +566,7 @@ export function copySelection(
           );
       }
     }),
+    draftingObjects,
   });
 }
 
@@ -1167,6 +1203,18 @@ export function proposePaste(
       message,
     })),
   });
+  // Drafting objects carry no connectivity, so a copy is the object itself
+  // under a fresh id, shifted by the same placement offset as everything else.
+  for (const object of clipboard.draftingObjects) {
+    edits.push({
+      kind: "upsert_drafting_object",
+      object: {
+        ...translateDraftingObject(object, offset, document.presentation.grid),
+        id: uniqueCopyId(object.id, sequence, occupied),
+      },
+    });
+  }
+
   return {
     edits,
     instanceIds: [...instanceIds.values()],

--- a/apps/editor/src/features/drafting/drafting-manipulation.ts
+++ b/apps/editor/src/features/drafting/drafting-manipulation.ts
@@ -1,5 +1,8 @@
 import type { ResolvedDraftingGeometry } from "@icm/derived";
 import { snapGridPoint } from "@icm/model";
+import { translateDraftingObject } from "@icm/edit-engine";
+
+export { translateDraftingObject };
 import type {
   DerivedPoint,
   DraftingObject,
@@ -76,70 +79,6 @@ export function draftingDragOrigin(object: DraftingObject): GridPoint | null {
       : null;
   }
   return object.anchor.kind === "free" ? object.anchor.position : null;
-}
-
-function translatePoint(
-  point: GridPoint,
-  delta: GridPoint,
-  grid: number,
-): GridPoint {
-  return snapGridPoint({ x: point.x + delta.x, y: point.y + delta.y }, grid);
-}
-
-function translateFreeAnchor<T extends VisualAnchor>(
-  anchor: T,
-  delta: GridPoint,
-  grid: number,
-): T {
-  return anchor.kind === "free"
-    ? ({
-        ...anchor,
-        position: translatePoint(anchor.position, delta, grid),
-      } as T)
-    : anchor;
-}
-
-export function translateDraftingObject(
-  object: DraftingObject,
-  delta: GridPoint,
-  grid: number,
-): DraftingObject {
-  if (object.kind === "construction-line") {
-    return {
-      ...object,
-      anchor: translateFreeAnchor(object.anchor, delta, grid),
-      points: object.points.map((point) => translatePoint(point, delta, grid)),
-      curveControls: object.curveControls?.map((point) =>
-        point ? translatePoint(point, delta, grid) : null,
-      ),
-    };
-  }
-  if (object.kind === "arrow") {
-    return {
-      ...object,
-      anchor: translateFreeAnchor(object.anchor, delta, grid),
-      from: translateFreeAnchor(object.from, delta, grid),
-      to: translateFreeAnchor(object.to, delta, grid),
-      waypoints: object.waypoints?.map((point) =>
-        translatePoint(point, delta, grid),
-      ),
-      curveControls: object.curveControls?.map((point) =>
-        point ? translatePoint(point, delta, grid) : null,
-      ),
-    };
-  }
-  if (object.kind === "rectangle") {
-    const center = translatePoint(object.center, delta, grid);
-    return { ...object, center, anchor: { kind: "free", position: center } };
-  }
-  if (object.kind === "circle") {
-    const center = translatePoint(object.center, delta, grid);
-    return { ...object, center, anchor: { kind: "free", position: center } };
-  }
-  return {
-    ...object,
-    anchor: translateFreeAnchor(object.anchor, delta, grid),
-  };
 }
 
 function controlForQuadraticMidpoint(

--- a/apps/editor/src/features/selection/use-selection-interaction.ts
+++ b/apps/editor/src/features/selection/use-selection-interaction.ts
@@ -1088,9 +1088,13 @@ export function useSelectionInteraction(
       options.setStatus("Finish or cancel the active tool before copying");
       return;
     }
-    const copied = copySelection(options.document, options.selectedIds);
+    const copied = copySelection(
+      options.document,
+      options.selectedIds,
+      options.visualSelection.draftingIds,
+    );
     if (!copied) {
-      options.setStatus("Select at least one component to copy");
+      options.setStatus("Select something to copy");
       return;
     }
     const anchor = clipboardPlacementAnchor(copied);

--- a/packages/edit-engine/src/drafting-transform.ts
+++ b/packages/edit-engine/src/drafting-transform.ts
@@ -1,0 +1,74 @@
+import { snapGridPoint } from "@icm/model";
+import type { DraftingObject, GridPoint, VisualAnchor } from "@icm/model";
+
+/**
+ * Move a drafting object by a delta.
+ *
+ * Drafting objects carry no connectivity, so moving one is a pure coordinate
+ * transform on the model. It lives in the engine because both the editor's
+ * drag and the paste planner need it, and a planner may not reach into an
+ * editor feature for it.
+ */
+function translatePoint(
+  point: GridPoint,
+  delta: GridPoint,
+  grid: number,
+): GridPoint {
+  return snapGridPoint({ x: point.x + delta.x, y: point.y + delta.y }, grid);
+}
+
+function translateFreeAnchor<T extends VisualAnchor>(
+  anchor: T,
+  delta: GridPoint,
+  grid: number,
+): T {
+  return anchor.kind === "free"
+    ? ({
+        ...anchor,
+        position: translatePoint(anchor.position, delta, grid),
+      } as T)
+    : anchor;
+}
+
+export function translateDraftingObject(
+  object: DraftingObject,
+  delta: GridPoint,
+  grid: number,
+): DraftingObject {
+  if (object.kind === "construction-line") {
+    return {
+      ...object,
+      anchor: translateFreeAnchor(object.anchor, delta, grid),
+      points: object.points.map((point) => translatePoint(point, delta, grid)),
+      curveControls: object.curveControls?.map((point) =>
+        point ? translatePoint(point, delta, grid) : null,
+      ),
+    };
+  }
+  if (object.kind === "arrow") {
+    return {
+      ...object,
+      anchor: translateFreeAnchor(object.anchor, delta, grid),
+      from: translateFreeAnchor(object.from, delta, grid),
+      to: translateFreeAnchor(object.to, delta, grid),
+      waypoints: object.waypoints?.map((point) =>
+        translatePoint(point, delta, grid),
+      ),
+      curveControls: object.curveControls?.map((point) =>
+        point ? translatePoint(point, delta, grid) : null,
+      ),
+    };
+  }
+  if (object.kind === "rectangle") {
+    const center = translatePoint(object.center, delta, grid);
+    return { ...object, center, anchor: { kind: "free", position: center } };
+  }
+  if (object.kind === "circle") {
+    const center = translatePoint(object.center, delta, grid);
+    return { ...object, center, anchor: { kind: "free", position: center } };
+  }
+  return {
+    ...object,
+    anchor: translateFreeAnchor(object.anchor, delta, grid),
+  };
+}

--- a/packages/edit-engine/src/index.ts
+++ b/packages/edit-engine/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./drafting-transform.js";
 export * from "./history.js";
 export * from "./route-geometry-edit.js";
 export * from "./route-operations.js";


### PR DESCRIPTION
`copySelection` read only the instance selection, so a selected note was never in the clipboard and `C` answered **"Select at least one component to copy"** — which reads as broken when a piece of text is plainly selected.

Text, arrows, lines, rectangles, and circles are worth duplicating on their own, so a drawing-only selection is now a complete copy:

- the clipboard carries drafting objects alongside the electrical fragment;
- a copy holding only drawing takes its placement anchor from one of them, since there is no instance or junction to take it from;
- paste emits each under a fresh id, shifted by the same offset as everything else.

They carry no connectivity, so nothing else about the copy changes — no nets, no reference designators, no routing plan.

## One move on the way

`translateDraftingObject` moved to `@icm/edit-engine`. The paste planner needs it, and `features/clipboard` may not reach into `features/drafting` for it (the layering rule in `apps/editor/src/README.md`). It is a pure coordinate transform on a model type, so the engine is where it belongs; the drafting module re-exports it and its existing callers are untouched.

## Validation

- unit: 1537 pass.
- Playwright: 241 pass, including a new spec that writes a text, selects it, presses `C`, places the copy, and asserts two texts carrying the same content exist. It fails before this change at the `C` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)