### PR TITLE
feat(editor): cloud snapshots restore from the File menu

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -890,7 +890,7 @@ test("a mistaken click beside the publish form keeps what was written", async ({
   await expect(dialog.getByTestId("publish-tag-cascode")).toBeVisible();
 });
 
-test("Check and Save shelves the circuit from the File menu", async ({
+test("Save cloud snapshot keeps and relists the newest copy", async ({
   page,
 }) => {
   await page.route("**/api/auth/me", (route) =>
@@ -940,20 +940,18 @@ test("Check and Save shelves the circuit from the File menu", async ({
   // A lone transistor is not a netlistable circuit, and that is not an error:
   // a schematic is allowed to be abbreviated. Saving neither judges it nor
   // interrupts with a report.
-  await expect(page.getByTestId("status")).toContainText("to your shelf");
+  await expect(page.getByTestId("status")).toContainText("cloud snapshot");
   await expect(page.getByRole("dialog", { name: "Check Report" })).toHaveCount(
     0,
   );
   expect(shelf).toHaveLength(1);
   expect(shelf[0]!.projectText).toContain("nmos");
 
-  // The private save remains available to the save flow, but recent scratch
-  // copies do not belong among formal Project file commands.
+  // The recovery snapshots list the newest copies right in File, so a
+  // crash or a device switch can restore them.
   const fileMenu = await openMenu(page, "File");
-  await expect(fileMenu.getByText("Your shelf", { exact: true })).toHaveCount(
-    0,
-  );
-  await expect(fileMenu.getByTestId("shelf-slot-slot-0")).toHaveCount(0);
+  await expect(fileMenu.getByText(/Cloud snapshots/u)).toBeVisible();
+  await expect(fileMenu.getByTestId("shelf-slot-slot-0")).toBeVisible();
 });
 
 test("keeps newest-first order and stops after the last circuit", async ({

--- a/apps/editor/src/features/editor-shell/editor-file-commands.ts
+++ b/apps/editor/src/features/editor-shell/editor-file-commands.ts
@@ -95,22 +95,22 @@ export function createEditorFileCommands({
     const prefix = notes.length > 0 ? `${notes.join("; ")} — ` : "";
 
     if (!publishSessionPresent) {
-      setStatus(`${prefix}sign in to keep a copy on your shelf`);
+      setStatus(`${prefix}sign in to keep a cloud snapshot`);
       return;
     }
     const currentProject = getCurrentProject();
     const outcome = await saveToWorkspaceShelf(currentProject);
     if (outcome.status === "saved") {
       setWorkspaceSlots(outcome.slots);
-      setStatus(`${prefix}saved "${currentProject.name}" to your shelf`);
+      setStatus(`${prefix}kept a cloud snapshot of "${currentProject.name}"`);
       return;
     }
     setStatus(
       outcome.status === "signed-out"
-        ? `${prefix}sign in again to keep a copy on your shelf`
+        ? `${prefix}sign in again to keep a cloud snapshot`
         : outcome.status === "too-large"
-          ? `${prefix}the circuit is too large for the shelf`
-          : `${prefix}the shelf could not be reached (${outcome.message})`,
+          ? `${prefix}the circuit is too large for a cloud snapshot`
+          : `${prefix}the snapshot server could not be reached (${outcome.message})`,
     );
   };
 

--- a/apps/editor/src/features/editor-shell/file-command-menu.test.tsx
+++ b/apps/editor/src/features/editor-shell/file-command-menu.test.tsx
@@ -37,10 +37,11 @@ describe("FileCommandMenu", () => {
     );
 
     expect(markup).toContain("Save Project As…");
-    expect(markup).toContain("Check and Save");
-    expect(markup).not.toContain("Your shelf");
-    expect(markup).not.toContain("Saved Circuit");
-    expect(markup).not.toContain("shelf-slot-slot-1");
+    expect(markup).toContain("Save cloud snapshot");
+    // The recovery snapshots list restores the newest three in place.
+    expect(markup).toContain("Cloud snapshots (newest 1)");
+    expect(markup).toContain("Saved Circuit");
+    expect(markup).toContain("shelf-slot-slot-1");
     expect(markup).toContain("Import SPICE");
     expect(markup).toContain("Export Spectre netlist");
     expect(markup).toContain("Recover recent work…");

--- a/apps/editor/src/features/editor-shell/file-command-menu.tsx
+++ b/apps/editor/src/features/editor-shell/file-command-menu.tsx
@@ -24,6 +24,8 @@ export interface FileCommandMenuProps {
 }
 
 export function FileCommandMenu({
+  workspaceSlots,
+  onOpenShelfSlot,
   previousProjectName,
   canRevert,
   hasRecoverySessions,
@@ -61,12 +63,30 @@ export function FileCommandMenu({
         <button
           type="button"
           data-testid="check-and-save-button"
-          title="Check the circuit and save it to your shelf"
+          title="Run a quick check and keep a recovery snapshot on the server (newest 3)"
           onClick={onCheckAndSave}
         >
           <span className="toolbar-check-glyph" aria-hidden="true" />
-          Check and Save
+          Save cloud snapshot
         </button>
+        {workspaceSlots.length > 0 ? (
+          <>
+            <span className="command-group-label">
+              Cloud snapshots (newest {workspaceSlots.length})
+            </span>
+            {workspaceSlots.map((slot) => (
+              <button
+                key={slot.id}
+                type="button"
+                data-testid={`shelf-slot-${slot.id}`}
+                title="Restore this snapshot into the editor"
+                onClick={() => onOpenShelfSlot(slot)}
+              >
+                {slot.name} — {new Date(slot.savedAt).toLocaleString()}
+              </button>
+            ))}
+          </>
+        ) : null}
         <button type="button" onClick={onRefresh}>
           Refresh app
         </button>

--- a/apps/editor/src/features/editor-shell/workspace-shelf.ts
+++ b/apps/editor/src/features/editor-shell/workspace-shelf.ts
@@ -2,13 +2,16 @@ import type { CircuitProject } from "@icm/model";
 import { serializeProject } from "@icm/project-protocol";
 
 /**
- * The signed-in account's scratch shelf: the last few circuits it checked.
+ * The signed-in account's cloud recovery snapshots: the newest three
+ * circuits it saved, restorable from the File menu.
  *
- * This is not the Gallery and not a save. The `.icproj.json` file stays
- * canonical, and nothing here is visible to anyone else — the shelf exists so
- * a check does not leave the day's work living only in one browser tab. The
- * session cookie is the whole credential, so this handles no secret, and the
- * fetch seam keeps the mapping testable offline.
+ * This is deliberately NOT a personal library — the Gallery is where
+ * circuits are meant to live — and not a save: the `.icproj.json` file
+ * stays canonical. The snapshots exist so a crash, an accidental close,
+ * or a device switch cannot strand the day's work in one browser tab.
+ * Nothing here is visible to anyone else. The session cookie is the
+ * whole credential, so this handles no secret, and the fetch seam keeps
+ * the mapping testable offline.
  */
 
 /** How many circuits the shelf keeps; the server enforces the same number. */


### PR DESCRIPTION
## Summary
Owner decision: the per-account cloud copies exist **only as crash/exit recovery snapshots** (newest 3), not as personal storage — finished circuits belong in the public Gallery.

- File menu gains **Cloud snapshots (newest N)**: the ≤3 slots list with name + time; one click restores the snapshot into the editor (the write path existed; the restore surface was missing — it was write-only before).
- "Check and Save" → **"Save cloud snapshot"** with an honest tooltip; the quick MOS-bulk check stays.
- All statuses/docs say *snapshot* instead of *shelf*; the module contract now states the anti-library intent explicitly.
- Retention stays the server-enforced newest-3; no other personal-storage affordances added.

## Validation
- vitest apps/editor/src — 586 passed
- playwright gallery.spec (CI Chromium) — 31 passed (snapshot spec now asserts the restore list appears after saving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)