### PR TITLE
Expand the empty-canvas shortcut card

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -210,9 +210,28 @@ test("keeps quick-start shortcuts in the corner until the first component is ins
     "Quick start shortcuts",
   );
   await expect(quickStart).toContainText("Quick start");
-  await expect(quickStart.locator("kbd")).toHaveText(["I", "W"]);
-  await expect(quickStart).toContainText("Insert component");
-  await expect(quickStart).toContainText("Draw wire");
+  await expect(quickStart).toContainText("Cadence keys");
+  await expect(quickStart.locator("li")).toHaveText([
+    "IInsert component",
+    "WDraw wire",
+    "PPlace Cell Pin",
+    "LEdit Net Label",
+    "MMove selection",
+    "CCopy selection",
+    "QProperties",
+    "RRotate",
+    "ShiftRMirror left / right",
+    "CtrlRMirror top / bottom",
+    "UUndo",
+    "ShiftURedo",
+    "FFit view",
+    "DeleteDelete selection",
+    "EscCancel tool",
+  ]);
+  await expect(quickStart.locator(".canvas-shortcut-list")).toHaveCSS(
+    "grid-template-columns",
+    /\S+px \S+px/u,
+  );
   expect(
     await quickStart.evaluate((element) => {
       const style = getComputedStyle(element);

--- a/apps/editor/src/canvas/editor-canvas-surface.tsx
+++ b/apps/editor/src/canvas/editor-canvas-surface.tsx
@@ -38,6 +38,34 @@ export interface EditorCanvasSurfaceProps {
   interactionPreviews: ComponentProps<typeof EditorInteractionPreviews>;
 }
 
+const CADENCE_QUICK_SHORTCUTS = [
+  { keys: ["I"], action: "Insert component" },
+  { keys: ["W"], action: "Draw wire" },
+  { keys: ["P"], action: "Place Cell Pin" },
+  { keys: ["L"], action: "Edit Net Label" },
+  { keys: ["M"], action: "Move selection" },
+  { keys: ["C"], action: "Copy selection" },
+  { keys: ["Q"], action: "Properties" },
+  { keys: ["R"], action: "Rotate" },
+  { keys: ["Shift", "R"], action: "Mirror left / right" },
+  { keys: ["Ctrl", "R"], action: "Mirror top / bottom" },
+  { keys: ["U"], action: "Undo" },
+  { keys: ["Shift", "U"], action: "Redo" },
+  { keys: ["F"], action: "Fit view" },
+  { keys: ["Delete"], action: "Delete selection" },
+  { keys: ["Esc"], action: "Cancel tool" },
+] as const;
+
+function CanvasShortcutChord({ keys }: { keys: readonly string[] }) {
+  return (
+    <span className="canvas-shortcut-chord" aria-label={keys.join(" plus ")}>
+      {keys.map((key) => (
+        <kbd key={key}>{key}</kbd>
+      ))}
+    </span>
+  );
+}
+
 /** SVG scene composition; interaction semantics arrive through typed models. */
 export function EditorCanvasSurface({
   empty,
@@ -66,16 +94,17 @@ export function EditorCanvasSurface({
           data-testid="canvas-empty-state"
           aria-label="Quick start shortcuts"
         >
-          <p className="canvas-shortcut-menu-title">Quick start</p>
+          <div className="canvas-shortcut-menu-heading">
+            <p className="canvas-shortcut-menu-title">Quick start</p>
+            <span>Cadence keys</span>
+          </div>
           <ul className="canvas-shortcut-list">
-            <li>
-              <kbd>I</kbd>
-              <span>Insert component</span>
-            </li>
-            <li>
-              <kbd>W</kbd>
-              <span>Draw wire</span>
-            </li>
+            {CADENCE_QUICK_SHORTCUTS.map((shortcut) => (
+              <li key={shortcut.keys.join("-")}>
+                <CanvasShortcutChord keys={shortcut.keys} />
+                <span>{shortcut.action}</span>
+              </li>
+            ))}
           </ul>
         </aside>
       ) : null}

--- a/apps/editor/src/styles/editor-canvas-state.css
+++ b/apps/editor/src/styles/editor-canvas-state.css
@@ -45,7 +45,7 @@
   left: var(--icm-space-3);
   display: grid;
   gap: var(--icm-space-2);
-  width: max-content;
+  width: min(440px, calc(100% - var(--icm-space-6)));
   max-width: calc(100% - var(--icm-space-6));
   padding: 10px var(--icm-space-3);
   border: 1px solid var(--icm-border);
@@ -56,6 +56,20 @@
   pointer-events: none;
   text-align: left;
   backdrop-filter: blur(8px);
+}
+
+.canvas-shortcut-menu-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--icm-space-3);
+}
+
+.canvas-shortcut-menu-heading > span {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  line-height: var(--icm-line-tight);
+  opacity: 0.78;
 }
 
 .canvas-shortcut-menu-title {
@@ -70,7 +84,9 @@
 
 .canvas-shortcut-list {
   display: grid;
-  gap: var(--icm-space-1);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  row-gap: var(--icm-space-1);
+  column-gap: var(--icm-space-4);
   margin: 0;
   padding: 0;
   list-style: none;
@@ -78,11 +94,21 @@
 
 .canvas-shortcut-list li {
   display: grid;
-  grid-template-columns: 24px auto;
+  grid-template-columns: 68px minmax(0, 1fr);
   align-items: center;
   gap: var(--icm-space-2);
   font-size: var(--icm-font-sm);
   line-height: var(--icm-line-tight);
+}
+
+.canvas-shortcut-list li > span:last-child {
+  min-width: 0;
+}
+
+.canvas-shortcut-chord {
+  display: flex;
+  align-items: center;
+  gap: 3px;
 }
 
 .canvas-shortcut-menu kbd {
@@ -97,7 +123,7 @@
   background: var(--icm-surface-muted);
   box-shadow: 0 1px 0 var(--icm-border-strong);
   font: inherit;
-  font-size: var(--icm-font-sm);
+  font-size: var(--icm-font-xs);
   font-weight: 650;
 }
 


### PR DESCRIPTION
## Summary
- expand the top-left empty-canvas quick-start card with Cadence-compatible editor shortcuts
- keep the shortcuts in a compact two-column layout with a clear Cadence label
- preserve automatic dismissal after the first component is inserted
- exclude project bindings whose meaning differs from Cadence

## Validation
- pnpm build
- pnpm gate:preflight
- pnpm test (245 files, 1552 tests)
- component-insert.spec.ts (28/28)
- manual-editor.spec.ts (112/112)
- focused post-rebase quick-start Playwright test (1/1)
- browser visual inspection

Test-Impact: tests-updated