### PR TITLE
feat(editor): visitor numbers read out in the statusbar

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -1387,17 +1387,15 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
   await page.goto("/editor");
 
   const chrome = page.locator(".app-chrome-main");
-  const analytics = page.getByRole("link", { name: "Open visitor analytics" });
+  // The analytics readout lives in the statusbar now; the top bar ends
+  // with Help inside the chrome bounds.
   const help = page.getByRole("button", { name: "Help" });
-  await expect(analytics).toBeVisible();
   await expect(help).toBeVisible();
   const chromeBox = await chrome.boundingBox();
-  const analyticsBox = await analytics.boundingBox();
   const helpBox = await help.boundingBox();
-  if (!chromeBox || !analyticsBox || !helpBox) {
+  if (!chromeBox || !helpBox) {
     throw new Error("Top navigation is not measurable");
   }
-  expect(helpBox.x).toBeGreaterThan(analyticsBox.x);
   expect(helpBox.x + helpBox.width).toBeLessThanOrEqual(
     chromeBox.x + chromeBox.width,
   );

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -162,11 +162,9 @@ describe("editor shell", () => {
     expect(markup).toContain('href="https://tokenzhang.com"');
     expect(markup).toContain('src="/tokenzhang-favicon.png"');
     const navigationEnd = markup.indexOf("</nav>");
-    const analyticsLink = markup.indexOf('href="/analytics"');
     const helpButton = markup.indexOf(">Help</button>");
     const ownerLink = markup.indexOf('href="https://tokenzhang.com"');
-    expect(analyticsLink).toBeGreaterThan(navigationEnd);
-    expect(helpButton).toBeGreaterThan(analyticsLink);
+    expect(helpButton).toBeGreaterThan(navigationEnd);
     expect(ownerLink).toBeGreaterThan(helpButton);
     expect(markup).not.toContain('role="dialog"');
     // The Connect Agent command is available (WP-WA5), but the authorization
@@ -195,12 +193,15 @@ describe("editor shell", () => {
       <App project={project} visitStats={{ pv: 42, uv: 17 }} />,
     );
 
+    // The live numbers read out in the otherwise-empty statusbar and the
+    // whole readout links to /analytics; the menubar carries no entry.
+    expect(markup).toContain('data-testid="statusbar-analytics"');
     expect(markup).toContain('href="/analytics"');
-    // The label stays compact; the live numbers ride in the tooltip so the
-    // menubar fits a half-width window.
-    expect(markup).toContain(">Analytics</a>");
-    expect(markup).toContain("17 visitors · 42 views");
-    expect(markup).not.toContain("<summary>Analytics</summary>");
+    expect(markup).toContain("17 visitors");
+    expect(markup).toContain("42 views");
+    expect(markup).not.toContain(">Analytics</a>");
+    const statusbar = markup.indexOf('class="app-statusbar"');
+    expect(markup.indexOf('href="/analytics"')).toBeGreaterThan(statusbar);
   });
 
   it("keeps Properties docked with shapes quick-place, not a searchable catalog", () => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -2806,7 +2806,6 @@ export function App({
         onCheckAndSave={() => void checkAndSave()}
         publishGalleryOpen={publishGalleryOpen}
         onPublishGallery={() => setPublishGalleryOpen(true)}
-        visitStats={visitStats}
         helpButtonRef={helpButtonRef}
         helpOpen={helpOpen}
         onOpenHelp={() => setHelpOpen(true)}
@@ -3845,6 +3844,7 @@ export function App({
         />
       </div>
       <EditorStatusbar
+        visitStats={visitStats}
         status={status}
         tool={tool}
         vddRailMode={vddRailMode}

--- a/apps/editor/src/app/editor-app-chrome.tsx
+++ b/apps/editor/src/app/editor-app-chrome.tsx
@@ -45,7 +45,6 @@ export interface EditorAppChromeProps {
   onCheckAndSave: () => void;
   publishGalleryOpen: boolean;
   onPublishGallery: () => void;
-  visitStats: { uv: number; pv: number } | null | undefined;
   helpButtonRef: RefObject<HTMLButtonElement | null>;
   helpOpen: boolean;
   onOpenHelp: () => void;
@@ -82,7 +81,6 @@ export function EditorAppChrome({
   onCheckAndSave,
   publishGalleryOpen,
   onPublishGallery,
-  visitStats,
   helpButtonRef,
   helpOpen,
   onOpenHelp,
@@ -268,18 +266,6 @@ export function EditorAppChrome({
           </div>
         </nav>
         <div className="app-chrome-actions">
-          <a
-            className="analytics-link"
-            href="/analytics"
-            aria-label="Open visitor analytics"
-            title={
-              visitStats
-                ? `${visitStats.uv.toLocaleString()} visitors · ${visitStats.pv.toLocaleString()} views`
-                : undefined
-            }
-          >
-            Analytics
-          </a>
           <button
             type="button"
             className="menubar-help"

--- a/apps/editor/src/features/editor-shell/editor-statusbar.tsx
+++ b/apps/editor/src/features/editor-shell/editor-statusbar.tsx
@@ -16,6 +16,7 @@ function toolLabel(
 }
 
 export function EditorStatusbar({
+  visitStats,
   status,
   tool,
   vddRailMode,
@@ -34,6 +35,7 @@ export function EditorStatusbar({
   onZoomIn,
   onFitView,
 }: {
+  visitStats?: { pv: number; uv: number } | null | undefined;
   status: string;
   tool: EditorTool;
   vddRailMode: boolean;
@@ -117,6 +119,17 @@ export function EditorStatusbar({
           </output>
         ) : null}
       </div>
+      {visitStats ? (
+        <a
+          className="statusbar-analytics"
+          href="/analytics"
+          data-testid="statusbar-analytics"
+          title="Open visitor analytics"
+        >
+          {visitStats.uv.toLocaleString()} visitors ·{" "}
+          {visitStats.pv.toLocaleString()} views
+        </a>
+      ) : null}
       <div className="canvas-controls" aria-label="Canvas view controls">
         <button
           type="button"

--- a/apps/editor/src/styles/editor-chrome.css
+++ b/apps/editor/src/styles/editor-chrome.css
@@ -727,6 +727,27 @@
   background: var(--icm-surface);
 }
 
+.statusbar-analytics {
+  margin-left: auto;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  text-decoration: none;
+}
+
+.statusbar-analytics:hover {
+  color: var(--icm-accent);
+  text-decoration: underline;
+  text-underline-offset: 0.15rem;
+}
+
+@media (max-width: 760px) {
+  .statusbar-analytics {
+    display: none;
+  }
+}
+
 /* Root crash screen shown by the editor error boundary. */
 .editor-crash-screen {
   display: grid;


### PR DESCRIPTION
## Summary
Owner request: show the analytics **numbers** directly — "N visitors · M views" — and put them in the mostly-empty bottom statusbar instead of the top bar.

- The statusbar (left of the zoom controls, `margin-left:auto`) reads **"3,829 visitors · 10,494 views"** style live counts; the whole readout links to /analytics.
- The menubar's Analytics entry is removed (numbers were hiding in its tooltip since the half-width compaction; now they are simply visible).
- Hidden under 760px; absent until counts arrive (analytics remains production-hostname-only, so dev canvases stay clean).

## Validation
- vitest apps/editor/src — 592 passed (header-order and analytics assertions rewritten for the statusbar location)
- Local screenshot: menubar right side is now just Help + credit

🤖 Generated with [Claude Code](https://claude.com/claude-code)