### PR TITLE
fix(gallery): retain two entry versions

### DIFF
--- a/apps/editor/src/components/version-history-dialog.tsx
+++ b/apps/editor/src/components/version-history-dialog.tsx
@@ -116,7 +116,7 @@ export function VersionHistoryDialog({
         data-testid="version-history-dialog"
       >
         <header className="version-history-header">
-          <p>Every update keeps the previous state</p>
+          <p>Up to two previous versions are kept</p>
           <h2 id="version-history-title">Version history — {entryName}</h2>
         </header>
         {versions === null ? (

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -149,7 +149,8 @@ voluntarily withdrawn entries.
 Every content-replacing update (`PUT`, and Restore itself) first
 snapshots the entry's previous state — name, author, description, tags,
 canonical project text, preview — into `gallery_entry_versions`,
-numbered per entry and capped at the newest 20 (older pruned).
+numbered per entry and capped at the newest 2 (older versions are pruned).
+The live current state is separate and does not count toward those 2 snapshots.
 Maintenance re-serialization does not snapshot (content-equivalent).
 Authority: moderators (admin or moderator session) and the entry's
 owning session:
@@ -231,9 +232,10 @@ header buys nothing. Without such a session every admin route answers
   when every record is valid. The response reports each migrated Route leg,
   bend, and route-attachment rebinding.
 - `POST /api/gallery/maintenance/schema-restore` — atomically restore the three
-  Project-bearing tables from an unmodified `schema-backup` payload supplied as
-  `{ "backup": ... }`. This same-origin endpoint is an emergency rollback
-  operation, not a general import surface.
+  Project-bearing tables from a `schema-backup` payload supplied as
+  `{ "backup": ... }`. Current retention is reapplied, so a legacy backup with
+  more than 2 versions for an entry restores only its newest 2. This same-origin
+  endpoint is an emergency rollback operation, not a general import surface.
 
 ## Retention and privacy
 

--- a/worker/gallery-do.ts
+++ b/worker/gallery-do.ts
@@ -113,7 +113,8 @@ export const GALLERY_MAX_DESCRIPTION_LENGTH = 300;
 export const GALLERY_DAILY_SUBMISSION_LIMIT = 10;
 export const GALLERY_MAX_TAGS = 5;
 export const GALLERY_MAX_TAG_LENGTH = 24;
-export const GALLERY_MAX_VERSIONS_PER_ENTRY = 20;
+/** How many previous states each Gallery entry retains. */
+export const GALLERY_MAX_VERSIONS_PER_ENTRY = 2;
 export const GALLERY_DEFAULT_LIST_LIMIT = 30;
 export const GALLERY_MAX_LIST_LIMIT = 60;
 
@@ -125,6 +126,39 @@ type SqlResult<T> = {
 type SqlStorage = {
   exec<T>(query: string, ...bindings: unknown[]): SqlResult<T>;
 };
+
+/** Enforce retention by count, even for imported rows with sparse versions. */
+function pruneGalleryEntryVersions(sql: SqlStorage, entryId?: string): void {
+  const entryFilter = entryId === undefined ? "" : "WHERE entry_id = ?";
+  sql.exec(
+    `DELETE FROM gallery_entry_versions
+     WHERE id IN (
+       SELECT id FROM (
+         SELECT id,
+                ROW_NUMBER() OVER (
+                  PARTITION BY entry_id
+                  ORDER BY version_no DESC, id DESC
+                ) AS retention_rank
+         FROM gallery_entry_versions
+         ${entryFilter}
+       )
+       WHERE retention_rank > ?
+     )`,
+    ...(entryId === undefined ? [] : [entryId]),
+    GALLERY_MAX_VERSIONS_PER_ENTRY,
+  );
+}
+
+function deleteOrphanGalleryData(sql: SqlStorage): void {
+  sql.exec(
+    `DELETE FROM gallery_entry_versions
+     WHERE entry_id NOT IN (SELECT id FROM gallery_entries)`,
+  );
+  sql.exec(
+    `DELETE FROM gallery_likes
+     WHERE entry_id NOT IN (SELECT id FROM gallery_entries)`,
+  );
+}
 
 type DurableObjectStateLike = {
   storage: {
@@ -230,6 +264,7 @@ interface EntryRow {
 
 const TOKENZHANG_BYLINE_MIGRATION = "2026-08-26-tokenzhang-to-zhishuai-zhang";
 const TOKENZHANG_BYLINE = "Zhishuai Zhang";
+const VERSION_RETENTION_MIGRATION = "2026-08-27-gallery-version-retention-2";
 
 function summaryOf(
   row: EntryRow & { likes?: number; liked_by_viewer?: number },
@@ -382,6 +417,22 @@ export class GalleryDO {
       this.sql.exec(
         "INSERT INTO data_migrations(id, applied_at) VALUES (?, ?)",
         TOKENZHANG_BYLINE_MIGRATION,
+        new Date().toISOString(),
+      );
+    });
+    this.state.storage.transactionSync(() => {
+      const applied = this.sql
+        .exec<{ id: string }>(
+          "SELECT id FROM data_migrations WHERE id = ?",
+          VERSION_RETENTION_MIGRATION,
+        )
+        .toArray();
+      if (applied.length > 0) return;
+      deleteOrphanGalleryData(this.sql);
+      pruneGalleryEntryVersions(this.sql);
+      this.sql.exec(
+        "INSERT INTO data_migrations(id, applied_at) VALUES (?, ?)",
+        VERSION_RETENTION_MIGRATION,
         new Date().toISOString(),
       );
     });
@@ -682,12 +733,7 @@ export class GalleryDO {
       row.svg_text,
       at,
     );
-    this.sql.exec(
-      `DELETE FROM gallery_entry_versions
-       WHERE entry_id = ? AND version_no <= ?`,
-      row.id,
-      lastVersion + 1 - GALLERY_MAX_VERSIONS_PER_ENTRY,
-    );
+    pruneGalleryEntryVersions(this.sql, row.id);
   }
 
   private replaceEntry(body: Record<string, unknown>): Response {
@@ -968,7 +1014,7 @@ export class GalleryDO {
     });
   }
 
-  /** Restore exactly the three Project-bearing tables from an owned backup. */
+  /** Restore the Project-bearing tables while enforcing current retention. */
   private schemaRestore(rawBackup: unknown): Response {
     if (
       !isRecord(rawBackup) ||
@@ -989,7 +1035,7 @@ export class GalleryDO {
         { status: 400 },
       );
     }
-    this.state.storage.transactionSync(() => {
+    const retainedVersionCount = this.state.storage.transactionSync(() => {
       this.sql.exec("DELETE FROM gallery_entries");
       this.sql.exec("DELETE FROM gallery_entry_versions");
       this.sql.exec("DELETE FROM workspace_slots");
@@ -1050,6 +1096,8 @@ export class GalleryDO {
           ]),
         );
       }
+      deleteOrphanGalleryData(this.sql);
+      pruneGalleryEntryVersions(this.sql);
       for (const row of workspaceSlots) {
         this.sql.exec(
           `INSERT INTO workspace_slots
@@ -1066,16 +1114,19 @@ export class GalleryDO {
           ]),
         );
       }
+      return this.sql
+        .exec<{ count: number }>(
+          "SELECT COUNT(*) AS count FROM gallery_entry_versions",
+        )
+        .one().count;
     });
     return Response.json({
       restored: true,
       records:
-        galleryEntries.length +
-        galleryEntryVersions.length +
-        workspaceSlots.length,
+        galleryEntries.length + retainedVersionCount + workspaceSlots.length,
       tables: {
         galleryEntries: galleryEntries.length,
-        galleryEntryVersions: galleryEntryVersions.length,
+        galleryEntryVersions: retainedVersionCount,
         workspaceSlots: workspaceSlots.length,
       },
     });
@@ -1156,9 +1207,7 @@ export class GalleryDO {
               ? upgradeSchema27To28WithReport(lifted)
               : null;
           lifted = migration?.project ?? lifted;
-          const project = parseProject(
-            JSON.stringify(lifted),
-          );
+          const project = parseProject(JSON.stringify(lifted));
           if (migration) {
             migrationReports.push({
               table: source.table,
@@ -1270,7 +1319,14 @@ export class GalleryDO {
     if (row.status !== "recycled") {
       return Response.json({ error: "not-recycled" }, { status: 409 });
     }
-    this.sql.exec("DELETE FROM gallery_entries WHERE id = ?", id);
+    this.state.storage.transactionSync(() => {
+      this.sql.exec(
+        "DELETE FROM gallery_entry_versions WHERE entry_id = ?",
+        id,
+      );
+      this.sql.exec("DELETE FROM gallery_likes WHERE entry_id = ?", id);
+      this.sql.exec("DELETE FROM gallery_entries WHERE id = ?", id);
+    });
     return Response.json({ id, deleted: true });
   }
 

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -295,6 +295,80 @@ describe("gallery data migrations", () => {
         .one().author,
     ).toBe("Token Zhang");
   });
+
+  it("migrates histories to two versions and removes orphaned data", () => {
+    const state = sqliteState();
+    new GalleryDO(state);
+    for (const entryId of ["entry-a", "entry-b"]) {
+      state.storage.sql.exec(
+        `INSERT INTO gallery_entries
+         (id, name, author, description, created_at, schema_version, status,
+          project_text, svg_text)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        entryId,
+        entryId,
+        "Author",
+        "",
+        "2026-08-01T00:00:00.000Z",
+        CURRENT_PROJECT_SCHEMA_VERSION,
+        "public",
+        projectText(entryId),
+        "<svg/>",
+      );
+    }
+    for (const [entryId, versionNo] of [
+      ["entry-a", 1],
+      ["entry-a", 2],
+      ["entry-a", 3],
+      ["entry-a", 4],
+      ["entry-b", 1],
+      ["entry-b", 2],
+      ["entry-b", 3],
+      ["missing-entry", 1],
+    ] as const) {
+      state.storage.sql.exec(
+        `INSERT INTO gallery_entry_versions
+         (id, entry_id, version_no, name, author, description,
+          schema_version, project_text, svg_text, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `${entryId}-${versionNo}`,
+        entryId,
+        versionNo,
+        `${entryId} v${versionNo}`,
+        "Author",
+        "",
+        CURRENT_PROJECT_SCHEMA_VERSION,
+        projectText(`${entryId} v${versionNo}`),
+        "<svg/>",
+        `2026-08-${String(versionNo).padStart(2, "0")}T00:00:00.000Z`,
+      );
+    }
+    state.storage.sql.exec(
+      `INSERT INTO gallery_likes(entry_id, user_id, liked_at)
+       VALUES ('missing-entry', 'legacy-user', '2026-08-01T00:00:00.000Z')`,
+    );
+    state.storage.sql.exec("DELETE FROM data_migrations");
+
+    new GalleryDO(state);
+    expect(
+      state.storage.sql
+        .exec<{ entry_id: string; version_no: number }>(
+          `SELECT entry_id, version_no FROM gallery_entry_versions
+           ORDER BY entry_id, version_no DESC`,
+        )
+        .toArray(),
+    ).toEqual([
+      { entry_id: "entry-a", version_no: 4 },
+      { entry_id: "entry-a", version_no: 3 },
+      { entry_id: "entry-b", version_no: 3 },
+      { entry_id: "entry-b", version_no: 2 },
+    ]);
+    expect(
+      state.storage.sql
+        .exec<{ count: number }>("SELECT COUNT(*) AS count FROM gallery_likes")
+        .one().count,
+    ).toBe(0);
+  });
 });
 
 describe("newest-first gallery feed", () => {
@@ -1278,7 +1352,6 @@ describe("gallery version history", () => {
     expect(afterRestore.versions.map((version) => version.name)).toEqual([
       "Versioned v3",
       "Versioned v2",
-      "Versioned v1",
     ]);
   });
 
@@ -1286,7 +1359,8 @@ describe("gallery version history", () => {
     const env = environment();
     const adminCookie = await adminOf(env);
     const id = await submitOne(env, "Cap 0", { cookie: adminCookie });
-    for (let index = 1; index <= 24; index += 1) {
+    let oldestVersionId = "";
+    for (let index = 1; index <= 4; index += 1) {
       await route(
         env,
         new Request(`${ORIGIN}/api/gallery/${id}`, {
@@ -1302,6 +1376,14 @@ describe("gallery version history", () => {
           }),
         }),
       );
+      if (index === 1) {
+        oldestVersionId = env.gallerySql
+          .exec<{ id: string }>(
+            "SELECT id FROM gallery_entry_versions WHERE entry_id = ?",
+            id,
+          )
+          .one().id;
+      }
     }
     const listed = (await (
       await route(
@@ -1311,9 +1393,29 @@ describe("gallery version history", () => {
         }),
       )
     ).json()) as { versions: { versionNo: number }[] };
-    expect(listed.versions).toHaveLength(20);
-    expect(listed.versions[0]!.versionNo).toBe(24);
-    expect(listed.versions.at(-1)!.versionNo).toBe(5);
+    expect(listed.versions).toHaveLength(2);
+    expect(listed.versions[0]!.versionNo).toBe(4);
+    expect(listed.versions.at(-1)!.versionNo).toBe(3);
+
+    const prunedPreview = await route(
+      env,
+      new Request(
+        `${ORIGIN}/api/gallery/${id}/versions/${oldestVersionId}/preview.svg`,
+        { headers: cookieHeaders(adminCookie) },
+      ),
+    );
+    expect(prunedPreview.status).toBe(404);
+    const prunedRestore = await route(
+      env,
+      new Request(
+        `${ORIGIN}/api/gallery/${id}/versions/${oldestVersionId}/restore`,
+        {
+          method: "POST",
+          headers: { Origin: ORIGIN, ...cookieHeaders(adminCookie) },
+        },
+      ),
+    );
+    expect(prunedRestore.status).toBe(404);
   });
 });
 
@@ -1720,6 +1822,48 @@ describe("gallery administration", () => {
       ((await back.json()) as { entries: { id: string }[] }).entries,
     ).toHaveLength(1);
 
+    const updated = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}`, {
+        method: "PUT",
+        headers: {
+          Origin: ORIGIN,
+          Cookie: adminCookie,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "Lifecycle v2",
+          projectText: projectText("Lifecycle v2"),
+        }),
+      }),
+    );
+    expect(updated.status).toBe(200);
+    const likerCookie = await makerOf(env);
+    const liked = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/like`, {
+        method: "POST",
+        headers: { Origin: ORIGIN, Cookie: likerCookie },
+      }),
+    );
+    expect(liked.status).toBe(200);
+    expect(
+      env.gallerySql
+        .exec<{ count: number }>(
+          "SELECT COUNT(*) AS count FROM gallery_entry_versions WHERE entry_id = ?",
+          id,
+        )
+        .one().count,
+    ).toBe(1);
+    expect(
+      env.gallerySql
+        .exec<{ count: number }>(
+          "SELECT COUNT(*) AS count FROM gallery_likes WHERE entry_id = ?",
+          id,
+        )
+        .one().count,
+    ).toBe(1);
+
     await route(
       env,
       new Request(`${ORIGIN}/api/gallery/${id}/recycle`, {
@@ -1742,6 +1886,22 @@ describe("gallery administration", () => {
       }),
     );
     expect(((await gone.json()) as { entries: unknown[] }).entries).toEqual([]);
+    expect(
+      env.gallerySql
+        .exec<{ count: number }>(
+          "SELECT COUNT(*) AS count FROM gallery_entry_versions WHERE entry_id = ?",
+          id,
+        )
+        .one().count,
+    ).toBe(0);
+    expect(
+      env.gallerySql
+        .exec<{ count: number }>(
+          "SELECT COUNT(*) AS count FROM gallery_likes WHERE entry_id = ?",
+          id,
+        )
+        .one().count,
+    ).toBe(0);
   });
 
   it("rejects with an owner-visible reason and prevents owner self-restore", async () => {
@@ -2280,6 +2440,86 @@ describe("gallery administration", () => {
           .one().schema_version,
       ).toBe(CURRENT_PROJECT_SCHEMA_VERSION - 1);
     }
+  });
+
+  it("reapplies two-version retention when restoring a legacy backup", async () => {
+    const env = environment();
+    const adminCookie = await adminOf(env);
+    const id = await submitOne(env, "Legacy backup v1", {
+      cookie: adminCookie,
+    });
+    for (const versionNo of [2, 3]) {
+      const updated = await route(
+        env,
+        new Request(`${ORIGIN}/api/gallery/${id}`, {
+          method: "PUT",
+          headers: {
+            Origin: ORIGIN,
+            Cookie: adminCookie,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            name: `Legacy backup v${versionNo}`,
+            projectText: projectText(`Legacy backup v${versionNo}`),
+          }),
+        }),
+      );
+      expect(updated.status).toBe(200);
+    }
+
+    const backupResponse = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/maintenance/schema-backup`, {
+        headers: cookieHeaders(adminCookie),
+      }),
+    );
+    const backup = (await backupResponse.json()) as any;
+    const versions = backup.tables.galleryEntryVersions as Record<
+      string,
+      unknown
+    >[];
+    expect(
+      versions
+        .map((version) => Number(version.version_no))
+        .sort((left, right) => left - right),
+    ).toEqual([1, 2]);
+    versions.push({
+      ...versions[0],
+      id: "legacy-version-zero",
+      version_no: 0,
+    });
+
+    const restored = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/maintenance/schema-restore`, {
+        method: "POST",
+        headers: {
+          Origin: ORIGIN,
+          Cookie: adminCookie,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ backup }),
+      }),
+    );
+    expect(await restored.json()).toMatchObject({
+      restored: true,
+      records: 3,
+      tables: {
+        galleryEntries: 1,
+        galleryEntryVersions: 2,
+        workspaceSlots: 0,
+      },
+    });
+    expect(
+      env.gallerySql
+        .exec<{ version_no: number }>(
+          `SELECT version_no FROM gallery_entry_versions
+           WHERE entry_id = ? ORDER BY version_no DESC`,
+          id,
+        )
+        .toArray()
+        .map((version) => version.version_no),
+    ).toEqual([2, 1]);
   });
 });
 


### PR DESCRIPTION
## Summary
- retain only the two newest previous snapshots per Gallery entry
- migrate existing histories immediately and reapply the cap to legacy backup restores
- remove version/like dependents on permanent deletion and clean existing orphan rows
- clarify the two-version policy in the UI and Gallery contract

## Validation
- `pnpm gate:preflight -- --base origin/main`
- `pnpm gate:affected -- --base origin/main` (1560 unit/integration tests; 32 Gallery browser tests)
- `pnpm exec prettier --check worker/gallery-do.ts worker/gallery.test.ts apps/editor/src/components/version-history-dialog.tsx docs/specs/community-gallery.md`