### PR TITLE
style(editor): keep the credit on one line

### DIFF
--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -338,13 +338,13 @@ body {
   transform: translate(-50%, -50%);
 }
 
+/* One line, even if long: "Presented by [Z] TokenZhang" never wraps. */
 .app-chrome-actions .tokenzhang-credit {
-  flex-direction: column;
-  align-items: flex-end;
-  justify-content: center;
-  gap: 0;
+  align-items: center;
+  gap: var(--icm-space-1);
   max-height: var(--icm-menubar-h);
   line-height: 1.1;
+  white-space: nowrap;
 }
 
 .tokenzhang-credit-kicker {


### PR DESCRIPTION
Owner request: 全屏时 "Presented by" 与 "TokenZhang" 不拆行——the editor-chrome credit drops its stacked column layout for a single nowrap row. Verified at 1800px: `Analytics · Help · Presented by Ⓩ TokenZhang` on one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)