### PR TITLE
fix(editor): statusbar readout loads from /api/stats

### DIFF
--- a/apps/editor/src/main.tsx
+++ b/apps/editor/src/main.tsx
@@ -116,13 +116,23 @@ function Root() {
     const analyticsHost =
       window.location.hostname === "analog-canvas.tokenzhang.com" ||
       window.location.hostname.endsWith(".workers.dev");
-    if (
-      !analyticsHost ||
-      navigator.doNotTrack === "1" ||
-      /^\/analytics\/?$/.test(path)
-    ) {
+    if (!analyticsHost || /^\/analytics\/?$/.test(path)) {
       return;
     }
+    // The statusbar readout is a public counter, not tracking: it loads for
+    // every visitor — Do Not Track included — and never depends on whether
+    // the beacon below chose to report.
+    void fetch("/api/stats", { cache: "no-store" })
+      .then(async (response) =>
+        response.ok ? ((await response.json()) as VisitStats) : null,
+      )
+      .then((value) => {
+        if (value) setStats(value);
+      })
+      .catch(() => {
+        // Analytics must never interfere with editor startup.
+      });
+    if (navigator.doNotTrack === "1") return;
     let referrerOrigin = "";
     try {
       const referrer = new URL(document.referrer);
@@ -143,15 +153,9 @@ function Root() {
       keepalive: true,
       cache: "no-store",
       body: JSON.stringify({ p: path, r: referrerOrigin, s: source }),
-    })
-      .then(async (response) => {
-        if (!response.ok || response.status === 204) return null;
-        return response.json() as Promise<VisitStats>;
-      })
-      .then((value) => setStats(value))
-      .catch(() => {
-        // Analytics must never interfere with editor startup.
-      });
+    }).catch(() => {
+      // The beacon is fire-and-forget.
+    });
   }, [path]);
 
   if (/^\/analytics\/?$/.test(path)) {


### PR DESCRIPTION
## Summary
Owner report: 状态栏读数不显示。Root cause: the readout rode on the **/api/track beacon**, which answers **204** for repeat sessions and is skipped entirely under **Do Not Track** — most loads therefore had no numbers to show (the old header link had an 'Analytics' text fallback; the statusbar hides when empty).

Fix: the readout is a public counter, not tracking — it now fetches **GET /api/stats** (always returns `{pv, uv}`; verified live: `{"pv":10808,"uv":3924}`) for every visitor including DNT, and /api/track returns to fire-and-forget.

## Validation
- vitest apps/editor/src — green
- Live `GET /api/stats` returns counts unconditionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)