### PR TITLE
fix(editor): hold the canvas text editor at one apparent size

### DIFF
--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.test.ts
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.test.ts
@@ -2,69 +2,87 @@ import { describe, expect, it } from "vitest";
 
 import { resolveCanvasTextEditorFrame } from "./canvas-text-editor-overlay";
 
+const target = { x: 100, y: 200, width: 200, height: 30 };
+const camera = (width: number, height: number) => ({
+  x: 0,
+  y: 0,
+  width,
+  height,
+});
+
 describe("canvas text editor frame", () => {
-  it("uses the default editor size near the target", () => {
-    expect(
-      resolveCanvasTextEditorFrame(
-        { x: 100, y: 200, width: 200, height: 30 },
-        { x: 0, y: 0, width: 960, height: 640 },
+  it("holds one apparent size however far the camera is zoomed", () => {
+    // Sized in Document units, the panel was part of the drawing: it grew on
+    // zoom in and shrank to illegibility on zoom out. What has to stay
+    // constant is its share of the camera, which is its share of the canvas.
+    const shares = [240, 960, 3840].map((width) => {
+      const frame = resolveCanvasTextEditorFrame(
+        target,
+        camera(width, width * (2 / 3)),
         1,
-      ),
-    ).toEqual({ x: 94, y: 83.5824, width: 420, height: 108.4176 });
+      );
+      return frame.width / width;
+    });
+    for (const share of shares) expect(share).toBeCloseTo(shares[0]!, 10);
+    // And a sensible share: neither a sliver nor the whole canvas.
+    expect(shares[0]!).toBeGreaterThan(0.25);
+    expect(shares[0]!).toBeLessThan(0.6);
   });
 
-  it("grows with text scale before reaching the viewport boundary", () => {
-    const frame = resolveCanvasTextEditorFrame(
-      { x: 100, y: 200, width: 200, height: 30 },
-      { x: 0, y: 0, width: 960, height: 640 },
-      3,
-    );
-
-    expect(frame.x).toBe(94);
-    expect(frame.y).toBeCloseTo(238);
-    expect(frame.width).toBe(420);
-    expect(frame.height).toBeCloseTo(217.2528);
+  it("lays its contents out at a fixed pixel size and scales them as one", () => {
+    const near = resolveCanvasTextEditorFrame(target, camera(240, 160), 1);
+    const far = resolveCanvasTextEditorFrame(target, camera(3840, 2560), 1);
+    // The layout never changes, so the panel never reflows on zoom; only the
+    // scale that maps it onto the camera does.
+    expect(near.layoutWidth).toBe(far.layoutWidth);
+    expect(near.layoutHeight).toBe(far.layoutHeight);
+    expect(near.width).toBeCloseTo(near.layoutWidth * near.scale, 10);
+    expect(far.scale / near.scale).toBeCloseTo(3840 / 240, 10);
   });
 
-  it("clamps the frame to all four viewport edges", () => {
-    expect(
-      resolveCanvasTextEditorFrame(
-        { x: -20, y: -10, width: 40, height: 20 },
-        { x: 0, y: 0, width: 960, height: 640 },
-        1,
-      ),
-    ).toEqual({ x: 8, y: 18, width: 420, height: 108.4176 });
-
-    expect(
-      resolveCanvasTextEditorFrame(
-        { x: 950, y: 630, width: 200, height: 50 },
-        { x: 0, y: 0, width: 960, height: 640 },
-        1,
-      ),
-    ).toEqual({ x: 532, y: 513.5824, width: 420, height: 108.4176 });
-  });
-
-  it("fits oversized content inside a translated viewport", () => {
-    expect(
-      resolveCanvasTextEditorFrame(
-        { x: -100, y: -100, width: 1200, height: 800 },
-        { x: 20, y: 30, width: 960, height: 640 },
-        1,
-      ),
-    ).toEqual({ x: 28, y: 38, width: 944, height: 624 });
+  it("gives larger text more room, in layout pixels", () => {
+    const small = resolveCanvasTextEditorFrame(target, camera(960, 640), 1);
+    const large = resolveCanvasTextEditorFrame(target, camera(960, 640), 3);
+    expect(large.layoutHeight).toBeGreaterThan(small.layoutHeight);
+    // The width is the panel's own; only the height follows the text.
+    expect(large.layoutWidth).toBe(small.layoutWidth);
   });
 
   it("budgets several wrapped lines so a long name is not clipped away", () => {
     // The frame is sized from the committed bounds, before any longer name is
-    // typed, and the overlay is a foreignObject that clips silently. One
-    // line's worth of height left a wrapped name unreadable.
+    // typed, and the overlay is a foreignObject that clips silently.
     const oneLine = 15.116 * 1.2;
-    const frame = resolveCanvasTextEditorFrame(
-      { x: 100, y: 200, width: 200, height: 30 },
-      { x: 0, y: 0, width: 960, height: 640 },
+    const frame = resolveCanvasTextEditorFrame(target, camera(960, 640), 1);
+    expect(frame.layoutHeight).toBeGreaterThan(54 + oneLine * 2);
+  });
+
+  it("clamps the frame to all four viewport edges", () => {
+    const view = camera(960, 640);
+    const topLeft = resolveCanvasTextEditorFrame(
+      { x: -20, y: -10, width: 40, height: 20 },
+      view,
       1,
     );
+    expect(topLeft.x).toBe(8);
+    expect(topLeft.y).toBe(18);
 
-    expect(frame.height).toBeGreaterThan(54 + oneLine * 2);
+    const bottomRight = resolveCanvasTextEditorFrame(
+      { x: 950, y: 630, width: 200, height: 50 },
+      view,
+      1,
+    );
+    expect(bottomRight.x + bottomRight.width).toBeLessThanOrEqual(960 - 8);
+    expect(bottomRight.y + bottomRight.height).toBeLessThanOrEqual(640 - 8);
+  });
+
+  it("stays inside a translated viewport", () => {
+    const frame = resolveCanvasTextEditorFrame(
+      { x: -100, y: -100, width: 1200, height: 800 },
+      { x: 20, y: 30, width: 960, height: 640 },
+      1,
+    );
+    expect(frame.x).toBeGreaterThanOrEqual(28);
+    expect(frame.y).toBeGreaterThanOrEqual(38);
+    expect(frame.x + frame.width).toBeLessThanOrEqual(20 + 960 - 8);
   });
 });

--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
@@ -18,21 +18,52 @@ export interface CanvasTextEditorOverlayProps {
   onReverseCurrentArrow?(): void;
 }
 
+/**
+ * The editor's own layout, in CSS pixels. Its contents — toolbar, buttons,
+ * text — are laid out at this size and then scaled as one, so the panel keeps
+ * its proportions instead of reflowing as the camera moves.
+ */
+const EDITOR_LAYOUT_WIDTH = 420;
+const EDITOR_LAYOUT_MIN_HEIGHT = 150;
+
+/**
+ * How much of the camera the panel occupies.
+ *
+ * Sizing the panel in Document units made it a part of the drawing: it grew
+ * on zoom in and shrank to illegibility on zoom out. A fraction of the camera
+ * is the same fraction of the canvas at every zoom, so the panel holds one
+ * apparent size — and because its contents are laid out at a fixed pixel size
+ * and scaled with it, they hold their size too.
+ */
+const EDITOR_VIEW_FRACTION = 0.44;
+
+export interface CanvasTextEditorFrame {
+  /** Where the panel sits, in Document units. */
+  x: number;
+  y: number;
+  /** Document units covered, for clamping and for the counter-scale. */
+  width: number;
+  height: number;
+  /** Document units per CSS pixel of the panel's own layout. */
+  scale: number;
+  layoutWidth: number;
+  layoutHeight: number;
+}
+
 export function resolveCanvasTextEditorFrame(
   bounds: DerivedRect,
   viewBox: GridRect,
   sizeScale: number,
-): DerivedRect {
-  const width = Math.min(Math.max(420, bounds.width + 12), viewBox.width - 16);
+): CanvasTextEditorFrame {
+  const scale = (viewBox.width * EDITOR_VIEW_FRACTION) / EDITOR_LAYOUT_WIDTH;
   // A name longer than the box wraps, and the frame is sized before any of it
   // is typed, so budget for a few wrapped lines instead of the one the
   // committed bounds imply. Anything past that scrolls rather than being
   // clipped away by the foreignObject.
   const lineHeight = 15.116 * sizeScale * 1.2;
-  const height = Math.min(
-    Math.max(76, bounds.height + 36, 54 + lineHeight * 3),
-    viewBox.height - 16,
-  );
+  const layoutHeight = Math.max(EDITOR_LAYOUT_MIN_HEIGHT, 54 + lineHeight * 3);
+  const width = EDITOR_LAYOUT_WIDTH * scale;
+  const height = layoutHeight * scale;
   const viewportInset = 8;
   const targetGap = 8;
   const minX = viewBox.x + viewportInset;
@@ -48,7 +79,15 @@ export function resolveCanvasTextEditorFrame(
       : below <= maxY
         ? below
         : Math.max(minY, Math.min(maxY, above));
-  return { x, y, width, height };
+  return {
+    x,
+    y,
+    width,
+    height,
+    scale,
+    layoutWidth: EDITOR_LAYOUT_WIDTH,
+    layoutHeight,
+  };
 }
 
 export function CanvasTextEditorOverlay({
@@ -68,39 +107,44 @@ export function CanvasTextEditorOverlay({
   );
 
   return (
-    <foreignObject
-      data-testid="canvas-text-editor"
-      className="canvas-text-editor-overlay"
-      pointerEvents="all"
-      {...frame}
-      onPointerDown={(event) => event.stopPropagation()}
-      onPointerMove={(event) => event.stopPropagation()}
-      onPointerUp={(event) => event.stopPropagation()}
-      onClick={(event) => event.stopPropagation()}
-      onDoubleClick={(event) => event.stopPropagation()}
-      onContextMenu={(event) => event.stopPropagation()}
-      onWheel={(event) => event.stopPropagation()}
-    >
-      <RichTextEditor
-        targetKey={`${session.owner}:${session.id}`}
-        content={session.content}
-        disabled={disabled}
-        sizeScale={session.sizeScale}
-        alignment={session.alignment}
-        sourceOnly={
-          session.bound &&
-          session.bindingKind !== "instance-schematic-name" &&
-          session.bindingKind !== "net-name" &&
-          session.bindingKind !== "cell-terminal-name"
-        }
-        multiline={!session.bound}
-        onChange={(content) => onUpdate({ content })}
-        onSizeChange={(sizeScale) => onUpdate({ sizeScale })}
-        onAlignmentChange={(alignment) => onUpdate({ alignment })}
-        onCommit={onCommit}
-        onDelete={onDelete}
-        {...(onReverseCurrentArrow ? { onReverseCurrentArrow } : {})}
-      />
-    </foreignObject>
+    <g transform={`translate(${frame.x} ${frame.y}) scale(${frame.scale})`}>
+      <foreignObject
+        data-testid="canvas-text-editor"
+        className="canvas-text-editor-overlay"
+        pointerEvents="all"
+        x={0}
+        y={0}
+        width={frame.layoutWidth}
+        height={frame.layoutHeight}
+        onPointerDown={(event) => event.stopPropagation()}
+        onPointerMove={(event) => event.stopPropagation()}
+        onPointerUp={(event) => event.stopPropagation()}
+        onClick={(event) => event.stopPropagation()}
+        onDoubleClick={(event) => event.stopPropagation()}
+        onContextMenu={(event) => event.stopPropagation()}
+        onWheel={(event) => event.stopPropagation()}
+      >
+        <RichTextEditor
+          targetKey={`${session.owner}:${session.id}`}
+          content={session.content}
+          disabled={disabled}
+          sizeScale={session.sizeScale}
+          alignment={session.alignment}
+          sourceOnly={
+            session.bound &&
+            session.bindingKind !== "instance-schematic-name" &&
+            session.bindingKind !== "net-name" &&
+            session.bindingKind !== "cell-terminal-name"
+          }
+          multiline={!session.bound}
+          onChange={(content) => onUpdate({ content })}
+          onSizeChange={(sizeScale) => onUpdate({ sizeScale })}
+          onAlignmentChange={(alignment) => onUpdate({ alignment })}
+          onCommit={onCommit}
+          onDelete={onDelete}
+          {...(onReverseCurrentArrow ? { onReverseCurrentArrow } : {})}
+        />
+      </foreignObject>
+    </g>
   );
 }


### PR DESCRIPTION
The text editor panel was sized in Document units, which made it part of the drawing: it grew on zoom in and shrank to illegibility on zoom out. It is a control, not artwork.

It now occupies a fixed share of the camera — the same share of the canvas at every zoom — and its contents are laid out at a fixed pixel size and scaled with it as one, so the panel never reflows on zoom either. Only the transform mapping it onto the camera changes.

Measured in the running editor at 100%: **397 × 142 px on a 992 px canvas**, with the toolbar and the text both fully visible.

Larger text still gets more room, in layout pixels, so a wrapped name is still not clipped away by the `foreignObject`.

## Validation

- unit: 1559 pass. The old tests pinned the Document-unit sizes, which was the behaviour being removed; they now pin the property that matters — the panel's share of the camera is identical across a 16× zoom range (240 / 960 / 3840 unit cameras), the layout never changes size, and the scale tracks the camera exactly. Clamping to all four viewport edges and the wrapped-line budget are still covered.
- Playwright: 132 pass across the drafting and editor specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)