### PR TITLE
style(editor): keep the visitor readout at every width

### DIFF
--- a/apps/editor/src/styles/editor-chrome.css
+++ b/apps/editor/src/styles/editor-chrome.css
@@ -742,12 +742,6 @@
   text-underline-offset: 0.15rem;
 }
 
-@media (max-width: 760px) {
-  .statusbar-analytics {
-    display: none;
-  }
-}
-
 /* Root crash screen shown by the editor error boundary. */
 .editor-crash-screen {
   display: grid;


### PR DESCRIPTION
The ≤760px hide rule hid the statusbar readout exactly at MacBook half-screen widths (~720-756px) — the very case the owner checks. The bar has room at any usable width; the readout now always shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)