### PR TITLE
ci: split browser tests into four shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,11 +160,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Preserve the required-check names while using two workers in each
-        # shard: four browser workers without a branch-protection migration.
+        # Four shards, two Playwright workers each: eight browser workers.
+        # The required-check names migrated with this split (ruleset updated
+        # in the same change window).
         shard:
-          - 1/2
-          - 2/2
+          - 1/4
+          - 2/4
+          - 3/4
+          - 4/4
     steps:
       - if: needs.changes.outputs.heavy != 'true'
         run: echo "Documentation-only change; browser contracts are unchanged."


### PR DESCRIPTION
Halves browser-suite wall time by splitting the Playwright run into four shards (two workers each — eight browser workers total, up from four). Required-check contexts migrate from "Browser tests (1/2)/(2/2)" to "(1/4)…(4/4)"; the main ruleset swaps to the new names in the same change window, so there is no moment without required browser checks.

Test-Impact: no-test-change — workflow sharding only; the same spec set runs, partitioned differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)