### PR TITLE
fix(editor): size the canvas text editor against the chrome, not the drawing

### DIFF
--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.test.ts
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.test.ts
@@ -11,10 +11,43 @@ const camera = (width: number, height: number) => ({
 });
 
 describe("canvas text editor frame", () => {
+  it("lays out in real screen pixels when the canvas has been measured", () => {
+    // The panel is chrome, not artwork: its type has to be set against the
+    // menus, which means its layout has to be in the same pixels they are.
+    const pixelsPerUnit = 0.95;
+    const frame = resolveCanvasTextEditorFrame(
+      target,
+      camera(960, 640),
+      1,
+      pixelsPerUnit,
+    );
+    expect(frame.scale * pixelsPerUnit).toBeCloseTo(1, 10);
+    // One layout pixel paints as one screen pixel, so a 15px font is 15px.
+    expect(frame.layoutWidth).toBeCloseTo(frame.width * pixelsPerUnit, 10);
+  });
+
+  it("covers two thirds of the canvas", () => {
+    for (const [view, pixelsPerUnit] of [
+      [camera(960, 640), 0.95],
+      [camera(240, 160), 3.8],
+      [camera(3840, 2560), 0.2375],
+    ] as const) {
+      const frame = resolveCanvasTextEditorFrame(
+        target,
+        view,
+        1,
+        pixelsPerUnit,
+      );
+      expect(frame.width / view.width).toBeCloseTo(2 / 3, 10);
+      // Which is two thirds of the canvas, in pixels, at every zoom.
+      const canvasPx = view.width * pixelsPerUnit;
+      expect((frame.width * pixelsPerUnit) / canvasPx).toBeCloseTo(2 / 3, 10);
+    }
+  });
+
   it("holds one apparent size however far the camera is zoomed", () => {
     // Sized in Document units, the panel was part of the drawing: it grew on
-    // zoom in and shrank to illegibility on zoom out. What has to stay
-    // constant is its share of the camera, which is its share of the canvas.
+    // zoom in and shrank to illegibility on zoom out.
     const shares = [240, 960, 3840].map((width) => {
       const frame = resolveCanvasTextEditorFrame(
         target,
@@ -24,25 +57,18 @@ describe("canvas text editor frame", () => {
       return frame.width / width;
     });
     for (const share of shares) expect(share).toBeCloseTo(shares[0]!, 10);
-    // And a sensible share: neither a sliver nor the whole canvas.
-    expect(shares[0]!).toBeGreaterThan(0.25);
-    expect(shares[0]!).toBeLessThan(0.6);
   });
 
-  it("lays its contents out at a fixed pixel size and scales them as one", () => {
-    const near = resolveCanvasTextEditorFrame(target, camera(240, 160), 1);
-    const far = resolveCanvasTextEditorFrame(target, camera(3840, 2560), 1);
-    // The layout never changes, so the panel never reflows on zoom; only the
-    // scale that maps it onto the camera does.
-    expect(near.layoutWidth).toBe(far.layoutWidth);
-    expect(near.layoutHeight).toBe(far.layoutHeight);
-    expect(near.width).toBeCloseTo(near.layoutWidth * near.scale, 10);
-    expect(far.scale / near.scale).toBeCloseTo(3840 / 240, 10);
+  it("stays proportional before the canvas has been measured", () => {
+    // The first paint has no measurement; the panel must still be sensible.
+    const frame = resolveCanvasTextEditorFrame(target, camera(960, 640), 1);
+    expect(frame.width / 960).toBeCloseTo(2 / 3, 10);
+    expect(frame.layoutWidth).toBeGreaterThan(0);
   });
 
   it("gives larger text more room, in layout pixels", () => {
-    const small = resolveCanvasTextEditorFrame(target, camera(960, 640), 1);
-    const large = resolveCanvasTextEditorFrame(target, camera(960, 640), 3);
+    const small = resolveCanvasTextEditorFrame(target, camera(960, 640), 1, 1);
+    const large = resolveCanvasTextEditorFrame(target, camera(960, 640), 3, 1);
     expect(large.layoutHeight).toBeGreaterThan(small.layoutHeight);
     // The width is the panel's own; only the height follows the text.
     expect(large.layoutWidth).toBe(small.layoutWidth);
@@ -52,7 +78,7 @@ describe("canvas text editor frame", () => {
     // The frame is sized from the committed bounds, before any longer name is
     // typed, and the overlay is a foreignObject that clips silently.
     const oneLine = 15.116 * 1.2;
-    const frame = resolveCanvasTextEditorFrame(target, camera(960, 640), 1);
+    const frame = resolveCanvasTextEditorFrame(target, camera(960, 640), 1, 1);
     expect(frame.layoutHeight).toBeGreaterThan(54 + oneLine * 2);
   });
 
@@ -62,6 +88,7 @@ describe("canvas text editor frame", () => {
       { x: -20, y: -10, width: 40, height: 20 },
       view,
       1,
+      1,
     );
     expect(topLeft.x).toBe(8);
     expect(topLeft.y).toBe(18);
@@ -69,6 +96,7 @@ describe("canvas text editor frame", () => {
     const bottomRight = resolveCanvasTextEditorFrame(
       { x: 950, y: 630, width: 200, height: 50 },
       view,
+      1,
       1,
     );
     expect(bottomRight.x + bottomRight.width).toBeLessThanOrEqual(960 - 8);
@@ -79,6 +107,7 @@ describe("canvas text editor frame", () => {
     const frame = resolveCanvasTextEditorFrame(
       { x: -100, y: -100, width: 1200, height: 800 },
       { x: 20, y: 30, width: 960, height: 640 },
+      1,
       1,
     );
     expect(frame.x).toBeGreaterThanOrEqual(28);

--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
@@ -1,3 +1,5 @@
+import { useLayoutEffect, useRef, useState } from "react";
+
 import type { DerivedRect, GridRect } from "@icm/model";
 
 import { RichTextEditor } from "./rich-text-editor";
@@ -23,7 +25,7 @@ export interface CanvasTextEditorOverlayProps {
  * text — are laid out at this size and then scaled as one, so the panel keeps
  * its proportions instead of reflowing as the camera moves.
  */
-const EDITOR_LAYOUT_WIDTH = 420;
+const EDITOR_FALLBACK_LAYOUT_WIDTH = 420;
 const EDITOR_LAYOUT_MIN_HEIGHT = 150;
 
 /**
@@ -35,7 +37,7 @@ const EDITOR_LAYOUT_MIN_HEIGHT = 150;
  * apparent size — and because its contents are laid out at a fixed pixel size
  * and scaled with it, they hold their size too.
  */
-const EDITOR_VIEW_FRACTION = 0.44;
+const EDITOR_VIEW_FRACTION = 2 / 3;
 
 export interface CanvasTextEditorFrame {
   /** Where the panel sits, in Document units. */
@@ -54,15 +56,24 @@ export function resolveCanvasTextEditorFrame(
   bounds: DerivedRect,
   viewBox: GridRect,
   sizeScale: number,
+  pixelsPerUnit?: number | null,
 ): CanvasTextEditorFrame {
-  const scale = (viewBox.width * EDITOR_VIEW_FRACTION) / EDITOR_LAYOUT_WIDTH;
+  const width = viewBox.width * EDITOR_VIEW_FRACTION;
+  // Laying the panel out at true screen pixels is what lets its type be set
+  // against the rest of the chrome rather than against the drawing. Without a
+  // measurement — the first render, before the canvas is on screen — fall back
+  // to a fixed layout width, which still keeps the panel proportional.
+  const scale =
+    pixelsPerUnit && pixelsPerUnit > 0
+      ? 1 / pixelsPerUnit
+      : width / EDITOR_FALLBACK_LAYOUT_WIDTH;
+  const layoutWidth = width / scale;
   // A name longer than the box wraps, and the frame is sized before any of it
   // is typed, so budget for a few wrapped lines instead of the one the
   // committed bounds imply. Anything past that scrolls rather than being
   // clipped away by the foreignObject.
   const lineHeight = 15.116 * sizeScale * 1.2;
   const layoutHeight = Math.max(EDITOR_LAYOUT_MIN_HEIGHT, 54 + lineHeight * 3);
-  const width = EDITOR_LAYOUT_WIDTH * scale;
   const height = layoutHeight * scale;
   const viewportInset = 8;
   const targetGap = 8;
@@ -85,7 +96,7 @@ export function resolveCanvasTextEditorFrame(
     width,
     height,
     scale,
-    layoutWidth: EDITOR_LAYOUT_WIDTH,
+    layoutWidth,
     layoutHeight,
   };
 }
@@ -100,14 +111,48 @@ export function CanvasTextEditorOverlay({
   onDelete,
   onReverseCurrentArrow,
 }: CanvasTextEditorOverlayProps) {
+  const anchorRef = useRef<SVGGElement | null>(null);
+  const [canvasSize, setCanvasSize] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
+
+  // How many screen pixels one Document unit covers. The panel is laid out in
+  // those pixels so its type can be set against the rest of the chrome, and
+  // the canvas can be resized under it, so the measurement is observed.
+  useLayoutEffect(() => {
+    const svg = anchorRef.current?.ownerSVGElement;
+    if (!svg) return;
+    const measure = () => {
+      const rect = svg.getBoundingClientRect();
+      setCanvasSize({ width: rect.width, height: rect.height });
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(svg);
+    return () => observer.disconnect();
+  }, []);
+
   const frame = resolveCanvasTextEditorFrame(
     bounds,
     viewBox,
     session.sizeScale,
+    // preserveAspectRatio="meet" fits the camera inside the element, so the
+    // painted scale is the smaller of the two ratios — not the width's alone.
+    canvasSize && viewBox.width > 0 && viewBox.height > 0
+      ? Math.min(
+          canvasSize.width / viewBox.width,
+          canvasSize.height / viewBox.height,
+        )
+      : null,
   );
 
   return (
-    <g transform={`translate(${frame.x} ${frame.y}) scale(${frame.scale})`}>
+    <g
+      ref={anchorRef}
+      transform={`translate(${frame.x} ${frame.y}) scale(${frame.scale})`}
+    >
       <foreignObject
         data-testid="canvas-text-editor"
         className="canvas-text-editor-overlay"


### PR DESCRIPTION
The panel was laid out in Document units, so its type was set against the schematic rather than against the menus beside it. Measured in the running editor:

```
chrome (File, Edit)   13px
editor text           11.8px painted
panel width           40% of the canvas
```

It now measures the canvas and lays itself out in **real screen pixels**, so one layout pixel paints as one screen pixel and its 15px font is 15px — larger than the chrome around it. The panel spans **two thirds of the canvas**, which holds at every zoom because the width is a share of the camera.

Verified in the running editor after the change: `foreignObject` 608 × 150 units, painted 608 × 150 px, share `0.667`.

Getting there needed the painted scale, and `preserveAspectRatio="meet"` fits the camera *inside* the element — so it is the smaller of the two axis ratios, not the width's alone. Using the width alone made the panel fill the canvas edge to edge.

The measurement is observed rather than taken once, so resizing the window under an open editor keeps it honest. Before the first measurement lands, the panel falls back to a proportional layout, so it is never mis-sized on the frame it appears.

## Validation

- unit: 1563 pass. New cases pin that one layout pixel is one screen pixel, that the panel is two thirds of the canvas across a 16× zoom range, and that the unmeasured first paint is still proportional. Clamping to all four edges and the wrapped-line budget are unchanged.
- Playwright: 30 drafting specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)