### PR TITLE
Simplify the empty-canvas shortcut card

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -225,12 +225,11 @@ test("keeps quick-start shortcuts in the corner until the first component is ins
     "UUndo",
     "ShiftURedo",
     "FFit view",
-    "DeleteDelete selection",
     "EscCancel tool",
   ]);
   await expect(quickStart.locator(".canvas-shortcut-list")).toHaveCSS(
     "grid-template-columns",
-    /\S+px \S+px/u,
+    /^\d+(?:\.\d+)?px$/u,
   );
   expect(
     await quickStart.evaluate((element) => {

--- a/apps/editor/src/canvas/editor-canvas-surface.tsx
+++ b/apps/editor/src/canvas/editor-canvas-surface.tsx
@@ -52,7 +52,6 @@ const CADENCE_QUICK_SHORTCUTS = [
   { keys: ["U"], action: "Undo" },
   { keys: ["Shift", "U"], action: "Redo" },
   { keys: ["F"], action: "Fit view" },
-  { keys: ["Delete"], action: "Delete selection" },
   { keys: ["Esc"], action: "Cancel tool" },
 ] as const;
 

--- a/apps/editor/src/styles/editor-canvas-state.css
+++ b/apps/editor/src/styles/editor-canvas-state.css
@@ -45,7 +45,7 @@
   left: var(--icm-space-3);
   display: grid;
   gap: var(--icm-space-2);
-  width: min(440px, calc(100% - var(--icm-space-6)));
+  width: max-content;
   max-width: calc(100% - var(--icm-space-6));
   padding: 10px var(--icm-space-3);
   border: 1px solid var(--icm-border);
@@ -84,9 +84,8 @@
 
 .canvas-shortcut-list {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 1fr);
   row-gap: var(--icm-space-1);
-  column-gap: var(--icm-space-4);
   margin: 0;
   padding: 0;
   list-style: none;


### PR DESCRIPTION
## Summary
- show the empty-canvas Cadence shortcut reference as one narrow column
- remove the self-evident Delete mapping
- preserve its top-left placement and first-component dismissal

## Validation
- pnpm build
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- focused post-rebase quick-start Playwright scenario (1/1)

Test-Impact: tests-updated