### PR TITLE
Reorder quick-start shortcuts

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -212,20 +212,20 @@ test("keeps quick-start shortcuts in the corner until the first component is ins
   await expect(quickStart).toContainText("Quick start");
   await expect(quickStart).toContainText("Cadence keys");
   await expect(quickStart.locator("li")).toHaveText([
-    "IInsert component",
-    "WDraw wire",
-    "PPlace Cell Pin",
-    "LEdit Net Label",
-    "MMove selection",
+    "FFit view",
+    "UUndo",
     "CCopy selection",
     "QProperties",
     "RRotate",
+    "WDraw wire",
+    "IInsert component",
+    "PPlace Cell Pin",
+    "LEdit Net Label",
+    "MMove selection",
     "ShiftRMirror left / right",
     "CtrlRMirror top / bottom",
-    "UUndo",
-    "ShiftURedo",
-    "FFit view",
     "EscCancel tool",
+    "ShiftURedo",
   ]);
   await expect(quickStart.locator(".canvas-shortcut-list")).toHaveCSS(
     "grid-template-columns",

--- a/apps/editor/src/canvas/editor-canvas-surface.tsx
+++ b/apps/editor/src/canvas/editor-canvas-surface.tsx
@@ -39,20 +39,20 @@ export interface EditorCanvasSurfaceProps {
 }
 
 const CADENCE_QUICK_SHORTCUTS = [
-  { keys: ["I"], action: "Insert component" },
-  { keys: ["W"], action: "Draw wire" },
-  { keys: ["P"], action: "Place Cell Pin" },
-  { keys: ["L"], action: "Edit Net Label" },
-  { keys: ["M"], action: "Move selection" },
+  { keys: ["F"], action: "Fit view" },
+  { keys: ["U"], action: "Undo" },
   { keys: ["C"], action: "Copy selection" },
   { keys: ["Q"], action: "Properties" },
   { keys: ["R"], action: "Rotate" },
+  { keys: ["W"], action: "Draw wire" },
+  { keys: ["I"], action: "Insert component" },
+  { keys: ["P"], action: "Place Cell Pin" },
+  { keys: ["L"], action: "Edit Net Label" },
+  { keys: ["M"], action: "Move selection" },
   { keys: ["Shift", "R"], action: "Mirror left / right" },
   { keys: ["Ctrl", "R"], action: "Mirror top / bottom" },
-  { keys: ["U"], action: "Undo" },
-  { keys: ["Shift", "U"], action: "Redo" },
-  { keys: ["F"], action: "Fit view" },
   { keys: ["Esc"], action: "Cancel tool" },
+  { keys: ["Shift", "U"], action: "Redo" },
 ] as const;
 
 function CanvasShortcutChord({ keys }: { keys: readonly string[] }) {


### PR DESCRIPTION
## Summary\n- put Fit View first\n- prioritize F, U, C, Q, R, and W\n- move Redo to the final row\n\n## Validation\n- pnpm gate:preflight -- --base origin/main\n- ICM_E2E_ISOLATED=1 ICM_E2E_PORT=4188 pnpm gate:affected -- --base origin/main