### PR TITLE
feat(editor): quick-pick tile grid replaces the Insert setup dialog

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -89,7 +89,7 @@ test("mirrors component and copy placement previews before their commits", async
   await page.keyboard.press("Escape");
 });
 
-test("writes a manual netlist reference into the placed Instance", async ({
+test("writes a manual netlist reference through post-placement Properties", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -98,12 +98,17 @@ test("writes a manual netlist reference into the placed Instance", async ({
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill("resistor");
   await dialog.getByTestId("insert-component-resistor").click();
-  await dialog.getByLabel("Reference name").fill("R7");
-  await dialog.getByRole("button", { name: "Apply" }).click();
   await page
     .getByTestId("schematic-canvas")
     .click({ position: { x: 360, y: 220 } });
   await page.keyboard.press("Escape");
+
+  // The quick pick carries no reference field; naming happens in Properties.
+  await page.getByTestId("hit-R1").click();
+  await page.getByTestId("selection-shelf").click();
+  const netlistReference = page.getByLabel("Component netlist reference");
+  await netlistReference.fill("R7");
+  await netlistReference.press("Tab");
 
   await expect
     .poll(() => recoveryProjectTexts(page))
@@ -243,7 +248,7 @@ test("keeps quick-start shortcuts in the corner until the first component is ins
   const search = dialog.getByLabel("Component search");
   await expect(search).toBeFocused();
   await search.fill("not-a-real-component");
-  await expect(dialog.getByRole("button", { name: "Apply" })).toBeDisabled();
+  await expect(dialog.getByText("No matching components")).toBeVisible();
   await search.fill("mos");
   const before = await search.getAttribute("aria-activedescendant");
   await page.keyboard.press("ArrowDown");
@@ -284,11 +289,9 @@ test("keeps quick-start shortcuts in the corner until the first component is ins
 
   await page.keyboard.press("i");
   const reopened = page.getByRole("dialog", { name: "Insert Component" });
-  await expect(reopened.locator(".insert-component-options")).toBeVisible();
-  const passives = reopened
-    .locator(".insert-option-group")
-    .filter({ hasText: "Passives" });
-  await expect(passives.locator("button").first()).toHaveAttribute(
+  await expect(reopened.locator(".insert-tile-grid")).toBeVisible();
+  // Recent picks float to the front of the flat grid.
+  await expect(reopened.getByRole("option").first()).toHaveAttribute(
     "data-testid",
     "insert-component-resistor",
   );
@@ -301,25 +304,16 @@ test("groups and places high-voltage DMOS from Extended Devices", async ({
   await awaitEditorReady(page);
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
-  const expanded = dialog
-    .locator(".insert-option-group")
-    .filter({ hasText: "Extended Devices" });
-  await expect(expanded.getByRole("heading", { level: 3 })).toHaveText(
-    "Extended Devices",
-  );
-  await expect(expanded.getByRole("heading", { level: 4 })).toHaveText(
-    "High-voltage devices",
-  );
-  await expect(expanded.getByTestId("insert-component-ndmos")).toContainText(
+  // The flat grid tiles both DMOS variants with their full names; clicking
+  // one starts placement with the catalog defaults.
+  await expect(dialog.getByTestId("insert-component-ndmos")).toContainText(
     "N-channel DMOS",
   );
-  await expect(expanded.getByTestId("insert-component-pdmos")).toContainText(
+  await expect(dialog.getByTestId("insert-component-pdmos")).toContainText(
     "P-channel DMOS",
   );
 
-  await expanded.getByTestId("insert-component-ndmos").click();
-  await expect(dialog.getByLabel("Component w")).toHaveValue("1u");
-  await dialog.getByRole("button", { name: "Apply" }).click();
+  await dialog.getByTestId("insert-component-ndmos").click();
   await page
     .getByTestId("schematic-canvas")
     .click({ position: { x: 360, y: 230 } });
@@ -333,6 +327,8 @@ test("groups and places high-voltage DMOS from Extended Devices", async ({
   await expect
     .poll(() => recoveryProjectTexts(page))
     .toContain('"symbolId": "ndmos"');
+  // Quick placement still carries the catalog defaults for the device.
+  await expect.poll(() => recoveryProjectTexts(page)).toContain('"w": "1u"');
 });
 
 test("groups drafting tools and editable polarity labels under Annotations", async ({
@@ -401,17 +397,14 @@ test("groups drafting tools and editable polarity labels under Annotations", asy
     .poll(() => recoveryProjectTexts(page))
     .toContain('"polarity": "both"');
 
-  // The full Insert picker exposes the same semantic entry and omits device
-  // reference/value controls that do not apply to drafting text.
+  // The full Insert picker exposes the same semantic entry; clicking its tile
+  // starts annotation placement directly.
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill("negative polarity");
   await dialog
     .getByTestId("insert-component-annotation-polarity-negative")
     .click();
-  await expect(dialog.getByLabel("Initial rotation")).toBeVisible();
-  await expect(dialog.getByLabel("Reference name")).toHaveCount(0);
-  await dialog.getByRole("button", { name: "Apply" }).click();
   await canvas.hover({ position: { x: 600, y: 260 } });
   await canvas.click({ position: { x: 600, y: 260 } });
   await expect(editor).toBeVisible();
@@ -428,7 +421,9 @@ test("groups drafting tools and editable polarity labels under Annotations", asy
   ).toHaveCount(0);
 });
 
-test("places a named vertical Power Rail from I", async ({ page }) => {
+test("places a vertical Power Rail from I and renames it on the canvas", async ({
+  page,
+}) => {
   await emulateDownloadOnlyBrowser(page);
   await page.goto("/editor");
   await awaitEditorReady(page);
@@ -436,16 +431,20 @@ test("places a named vertical Power Rail from I", async ({ page }) => {
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill("vdd");
   await dialog.getByTestId("insert-component-vdd").click();
-  await expect(dialog.locator("svg.insert-symbol-artwork")).toBeVisible();
-  await expect(dialog.getByLabel("Placement options")).toHaveCount(0);
-  await dialog.getByLabel("Power rail Net name").fill("AVDD");
-  await dialog.getByRole("button", { name: "Apply" }).click();
 
   const canvas = page.getByTestId("schematic-canvas");
   await canvas.hover({ position: { x: 260, y: 140 } });
   await expect(page.getByTestId("component-placement-preview")).toBeVisible();
   await canvas.click({ position: { x: 260, y: 140 } });
   await canvas.click({ position: { x: 260, y: 380 } });
+  await page.keyboard.press("Escape");
+
+  // The quick pick always lands the default VDD name; the label is the
+  // net-name authority, so editing it renames the rail to AVDD.
+  await page.getByTestId("annotation-hit-label-VDD1").dblclick();
+  const railEditor = page.getByRole("textbox", { name: "Canvas text editor" });
+  await railEditor.fill("AVDD");
+  await page.getByRole("button", { name: "Apply text changes" }).click();
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("component-input-plane")).toHaveCount(0);
   await expect(page.getByTestId("instance-count")).toHaveText("0");
@@ -522,8 +521,6 @@ test("places the VDD power-port device as the default VDD entry", async ({
     "insert-component-vdd",
   ]);
   await dialog.getByTestId("insert-component-vdd-port").click();
-  await expect(dialog.locator("svg.insert-symbol-artwork")).toBeVisible();
-  await dialog.getByRole("button", { name: "Apply" }).click();
 
   const canvas = page.getByTestId("schematic-canvas");
   await canvas.click({ position: { x: 300, y: 160 } });
@@ -766,8 +763,7 @@ test("carries a manual Value through placement and Q property editing", async ({
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill("resistor");
-  await dialog.getByLabel("Component value").fill("10k");
-  await dialog.getByRole("button", { name: "Apply" }).click();
+  await dialog.getByTestId("insert-component-resistor").click();
 
   const canvas = page.getByTestId("schematic-canvas");
   await canvas.click({ position: { x: 360, y: 230 } });
@@ -835,7 +831,8 @@ test("carries a manual Value through placement and Q property editing", async ({
   // toggle and editing starts only when the user clicks an input.
   await expect(page.getByTestId("selection-shelf")).toBeFocused();
   await expect(propertyValue).not.toBeFocused();
-  await expect(propertyValue).toHaveValue("10k");
+  // Quick placement leaves the value blank; it arrives through Q editing.
+  await expect(propertyValue).toHaveValue("");
   await page.keyboard.press("q");
   await expect(page.getByTestId("selection-shelf")).toHaveAttribute(
     "aria-expanded",
@@ -847,18 +844,18 @@ test("carries a manual Value through placement and Q property editing", async ({
     "true",
   );
   await expect(propertyValue).not.toBeFocused();
-  await expect(propertyValue).toHaveValue("10k");
+  await expect(propertyValue).toHaveValue("");
   await propertyValue.click();
   await expect(propertyValue).toBeFocused();
-  await propertyValue.fill("12k");
-  await expect(propertyValue).toHaveValue("12k");
+  await propertyValue.fill("10k");
+  await expect(propertyValue).toHaveValue("10k");
   await expect(page.getByTestId("revision")).toHaveText("2");
   await expect(
     page.getByRole("button", { name: "Apply component properties" }),
   ).toHaveCount(0);
   await page.getByRole("button", { name: "Discard changes" }).click();
   await expect(page.getByTestId("revision")).toHaveText("3");
-  await expect(propertyValue).toHaveValue("10k");
+  await expect(propertyValue).toHaveValue("");
   await expect(
     page.getByRole("button", { name: "Discard changes" }),
   ).toHaveCount(0);
@@ -950,7 +947,7 @@ test("keeps the workspace inside the viewport and exposes low-interference zoom 
     .toBeLessThan(canvasBefore?.width ?? 0);
 });
 
-test("keeps preview fixed while picking from the always-open catalog", async ({
+test("tiles the whole catalog into one flat quick-pick grid", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1100, height: 720 });
@@ -959,61 +956,56 @@ test("keeps preview fixed while picking from the always-open catalog", async ({
   await page.keyboard.press("i");
 
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
-  const artwork = dialog.locator(".insert-symbol-artwork");
-  const cancel = dialog.getByRole("button", { name: "Cancel" });
-  const apply = dialog.getByRole("button", { name: "Apply" });
-
-  const measure = () =>
-    dialog.evaluate((element) => {
-      const bounds = (target: Element) => {
-        const rect = target.getBoundingClientRect();
-        return {
-          top: rect.top,
-          bottom: rect.bottom,
-          width: rect.width,
-          height: rect.height,
-        };
-      };
-      const preview = element.querySelector(".insert-component-preview")!;
-      const artwork = element.querySelector(".insert-symbol-artwork")!;
-      const footer = element.querySelector(".insert-dialog-actions")!;
-      return {
-        dialog: bounds(element),
-        preview: bounds(preview),
-        artwork: bounds(artwork),
-        footer: bounds(footer),
-      };
-    });
-
-  const before = await measure();
-  await expect(cancel).toBeVisible();
-  await expect(apply).toBeVisible();
-  expect(before.footer.bottom).toBeLessThanOrEqual(before.dialog.bottom);
-  const options = dialog.locator(".insert-component-options");
-  await expect(options).toBeVisible();
+  const grid = dialog.locator(".insert-tile-grid");
+  await expect(grid).toBeVisible();
   expect(
-    await options.evaluate((element) => getComputedStyle(element).overflowY),
+    await grid.evaluate((element) => getComputedStyle(element).overflowY),
   ).toBe("auto");
 
-  // The catalog is permanently open: no collapse control exists, and picking
-  // an item keeps the list in place for the next pick.
-  await expect(
-    dialog.getByRole("button", { name: "Collapse component list" }),
-  ).toHaveCount(0);
+  // One glance covers the library: the grid is flat (no category headings),
+  // every tile carries its own artwork, and the grid packs several columns.
+  await expect(grid.locator("h3, h4")).toHaveCount(0);
+  const optionCount = await dialog.getByRole("option").count();
+  expect(optionCount).toBeGreaterThan(20);
+  expect(await grid.locator("svg.insert-symbol-artwork").count()).toBe(
+    optionCount,
+  );
+  const firstTop = await dialog
+    .getByRole("option")
+    .first()
+    .evaluate((element) => (element as HTMLElement).offsetTop);
+  const sameRow = await grid.evaluate(
+    (element, top) =>
+      Array.from(
+        element.querySelectorAll<HTMLElement>('[role="option"]'),
+      ).filter((option) => option.offsetTop === top).length,
+    firstTop,
+  );
+  expect(sameRow).toBeGreaterThan(3);
+
+  // There is no separate confirm step to fit in: the footer is a hint line,
+  // and it stays inside the dialog bounds.
+  await expect(dialog.getByRole("button", { name: "Apply" })).toHaveCount(0);
+  await expect(dialog.getByRole("button", { name: "Cancel" })).toHaveCount(0);
+  const bounds = await dialog.evaluate((element) => {
+    const footer = element.querySelector(".insert-dialog-actions")!;
+    return {
+      dialogBottom: element.getBoundingClientRect().bottom,
+      footerBottom: footer.getBoundingClientRect().bottom,
+    };
+  });
+  expect(bounds.footerBottom).toBeLessThanOrEqual(bounds.dialogBottom);
+
+  // Clicking a tile starts placement immediately.
   await dialog.getByTestId("insert-component-inductor").click();
-  await expect(options).toBeVisible();
-  await expect(dialog.getByTestId("insert-component-resistor")).toBeVisible();
-  const after = await measure();
-  expect(after.dialog.height).toBeCloseTo(before.dialog.height, 0);
-  expect(after.preview.width).toBeCloseTo(before.preview.width, 0);
-  expect(after.preview.height).toBeCloseTo(before.preview.height, 0);
-  expect(after.artwork.width).toBeCloseTo(before.artwork.width, 0);
-  expect(after.artwork.height).toBeCloseTo(before.artwork.height, 0);
-  expect(after.footer.top).toBeCloseTo(before.footer.top, 0);
-  expect(after.footer.bottom).toBeLessThanOrEqual(after.dialog.bottom);
+  await expect(dialog).toHaveCount(0);
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.hover({ position: { x: 360, y: 230 } });
+  await expect(page.getByTestId("component-placement-preview")).toBeVisible();
+  await page.keyboard.press("Escape");
 });
 
-test("places MOS parameters and orientation without a hidden-label suppressor", async ({
+test("sets MOS parameters and orientation through the ghost and Properties", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -1022,36 +1014,15 @@ test("places MOS parameters and orientation without a hidden-label suppressor", 
 
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill("nmos");
-  await expect(
-    dialog.getByLabel("Component w", { exact: true }),
-  ).toHaveAttribute("placeholder", "1u");
-  await dialog.getByLabel("Component w", { exact: true }).fill("2u");
-  await dialog.getByLabel("Component l", { exact: true }).fill("180n");
-  await dialog.getByLabel("Component m", { exact: true }).fill("4");
-  await dialog.getByLabel("Initial rotation").selectOption("90");
-  const dialogArtwork = dialog.locator(".insert-symbol-artwork");
-  await expect(dialogArtwork).toHaveAttribute("data-rotation", "90");
-  await expect(dialogArtwork.locator("g")).toHaveAttribute(
-    "transform",
-    "rotate(90)",
-  );
-  await dialog.getByLabel("Component preview").focus();
-  await page.keyboard.press("r");
-  await expect(dialog.getByLabel("Initial rotation")).toHaveValue("180");
-  await expect(dialogArtwork).toHaveAttribute("data-rotation", "180");
-  await dialog.getByLabel("Initial rotation").selectOption("90");
-  await dialog
-    .getByRole("checkbox", { name: "Reference", exact: true })
-    .uncheck();
-  await expect(dialog.locator(".insert-parameter-name").first()).toHaveText(
-    "W / m(Total channel width)",
-  );
-  await dialog.getByRole("button", { name: "Apply" }).click();
+  await dialog.getByTestId("insert-component-nmos").click();
 
+  // Orientation is a ghost decision now: R rotates the placement preview.
   const canvas = page.getByTestId("schematic-canvas");
   const box = await canvas.boundingBox();
   if (!box) throw new Error("Canvas is not measurable");
   await page.mouse.move(box.x + 360, box.y + 230);
+  await expect(page.getByTestId("component-placement-preview")).toBeVisible();
+  await page.keyboard.press("r");
   await expect(page.getByTestId("component-placement-preview")).toHaveAttribute(
     "transform",
     /rotate\(90\)/u,
@@ -1059,10 +1030,22 @@ test("places MOS parameters and orientation without a hidden-label suppressor", 
   await canvas.click({ position: { x: 360, y: 230 } });
   await page.keyboard.press("Escape");
 
+  // Parameters and label visibility are Properties decisions.
+  await page.getByTestId("hit-M1").click();
+  await page.keyboard.press("q");
+  await expect(page.getByLabel("Component w", { exact: true })).toHaveValue(
+    "1u",
+  );
+  await page.getByLabel("Component w", { exact: true }).fill("2u");
+  await page.getByLabel("Component l", { exact: true }).fill("180n");
+  await page.getByLabel("Component m", { exact: true }).fill("4");
+  await page.getByLabel("Component m", { exact: true }).press("Tab");
+  await page
+    .getByRole("checkbox", { name: "Reference", exact: true })
+    .uncheck();
   await expect(
     page.locator('[data-object-id="instance-label-M1"]'),
   ).toHaveCount(0);
-  await page.keyboard.press("q");
   await expect(page.getByLabel("Component w", { exact: true })).toHaveValue(
     "2u",
   );
@@ -1087,7 +1070,8 @@ test("keeps component placement active across independent canvas commits", async
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill("resistor");
-  await dialog.getByRole("button", { name: "Apply" }).click();
+  // Enter places the top match straight from the search field.
+  await page.keyboard.press("Enter");
 
   const canvas = page.getByTestId("schematic-canvas");
   const box = await canvas.boundingBox();
@@ -1476,8 +1460,7 @@ test("double-clicking a placed device opens Properties for editing", async ({
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill("resistor");
-  await dialog.getByLabel("Component value").fill("4.7k");
-  await dialog.getByRole("button", { name: "Apply" }).click();
+  await dialog.getByTestId("insert-component-resistor").click();
   const canvas = page.getByTestId("schematic-canvas");
   await canvas.click({ position: { x: 360, y: 230 } });
   await page.keyboard.press("Escape");
@@ -1494,7 +1477,6 @@ test("double-clicking a placed device opens Properties for editing", async ({
   );
   const propertyValue = page.getByLabel("Component value");
   await expect(propertyValue).toBeVisible();
-  await expect(propertyValue).toHaveValue("4.7k");
   await expect(propertyValue).toBeFocused();
 });
 

--- a/apps/editor/e2e/editor-fixtures.ts
+++ b/apps/editor/e2e/editor-fixtures.ts
@@ -70,8 +70,9 @@ export async function chooseComponent(
   await clickDrawTool(page, "insert");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill(symbolId);
+  // Clicking a tile starts placement immediately; the quick-pick grid has no
+  // separate Apply step.
   await dialog.getByTestId(`insert-component-${symbolId}`).click();
-  await dialog.getByRole("button", { name: "Apply" }).click();
 }
 
 export async function downloadBytes(

--- a/apps/editor/e2e/hierarchy.spec.ts
+++ b/apps/editor/e2e/hierarchy.spec.ts
@@ -133,7 +133,6 @@ test("manages Cell rename and lists callers", async ({ page }) => {
   await runCellCommand(page, "Place Cell");
   const insert = page.getByRole("dialog", { name: "Place Hierarchical Cell" });
   await insert.getByRole("option", { name: /ReusableStage/u }).click();
-  await insert.getByRole("button", { name: "Apply" }).click();
   await page
     .getByTestId("schematic-canvas")
     .click({ position: { x: 320, y: 180 } });
@@ -215,7 +214,6 @@ test("declares and places a Cell Pin on a new local Net", async ({ page }) => {
     name: "Place Hierarchical Cell",
   });
   await insertDialog.getByRole("option", { name: /ReusableStage/u }).click();
-  await insertDialog.getByRole("button", { name: "Apply" }).click();
   await canvas.click({ position: { x: 420, y: 180 } });
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("active-instance-count")).toHaveText("1");
@@ -532,7 +530,9 @@ test("places an existing Cell and blocks deleting its shared definition", async 
 
   await runCellCommand(page, "Place Cell");
   const dialog = page.getByRole("dialog", { name: "Place Hierarchical Cell" });
-  await expect(dialog.getByText("Cells", { exact: true })).toBeVisible();
+  await expect(
+    dialog.getByRole("option", { name: /ReusableStage/u }),
+  ).toBeVisible();
   await expect(dialog.getByTestId("insert-component-nmos")).toHaveCount(0);
   await page.keyboard.press("Escape");
   await page.keyboard.press("i");
@@ -545,7 +545,6 @@ test("places an existing Cell and blocks deleting its shared definition", async 
     name: "Place Hierarchical Cell",
   });
   await cellDialog.getByRole("option", { name: /ReusableStage/u }).click();
-  await cellDialog.getByRole("button", { name: "Apply" }).click();
 
   const canvas = page.getByTestId("schematic-canvas");
   await canvas.hover({ position: { x: 360, y: 230 } });

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -332,18 +332,22 @@ test("shows faithful symbol previews for the reviewed Razavi palette", async ({
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   const search = dialog.getByLabel("Component search");
-  const preview = dialog.locator("svg.insert-symbol-artwork");
-  // Browser coverage owns dialog-to-preview wiring. Catalogue completeness and
+  // Browser coverage owns tile-to-artwork wiring. Catalogue completeness and
   // every symbol's geometry are covered by the symbol contract and goldens.
   for (const symbolId of ["pmos", "resistor", "comparator-unmarked"]) {
     await search.fill(symbolId);
-    await dialog.getByTestId(`insert-component-${symbolId}`).click();
-    await expect(preview).toBeVisible();
+    await expect(
+      dialog
+        .getByTestId(`insert-component-${symbolId}`)
+        .locator("svg.insert-symbol-artwork"),
+    ).toBeVisible();
   }
   await search.fill("pmos");
-  await dialog.getByTestId("insert-component-pmos").click();
-  await expect(preview.locator("circle")).toHaveCount(0);
-  await expect(preview.locator("polygon")).toHaveCount(3);
+  const tileArtwork = dialog
+    .getByTestId("insert-component-pmos")
+    .locator("svg.insert-symbol-artwork");
+  await expect(tileArtwork.locator("circle")).toHaveCount(0);
+  await expect(tileArtwork.locator("polygon")).toHaveCount(3);
   await expect(dialog.getByTestId("insert-component-nmos3")).toHaveCount(0);
   await expect(dialog.getByTestId("insert-component-pmos3")).toHaveCount(0);
   await page.keyboard.press("Escape");
@@ -2456,21 +2460,18 @@ test("value display projects MOS W/L and passive values beside the reference", a
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill("nmos");
-  // A MOS arrives with its device defaults, so the Value toggle is usable
-  // without typing geometry first.
-  const valueToggle = dialog.getByRole("checkbox", {
-    name: "Value",
-    exact: true,
-  });
-  await expect(valueToggle).toBeEnabled();
-  await dialog.getByLabel("Component w", { exact: true }).fill("2u");
-  await dialog.getByLabel("Component l", { exact: true }).fill("180n");
-  await expect(valueToggle).toBeEnabled();
-  await valueToggle.check();
-  await dialog.getByRole("button", { name: "Apply" }).click();
+  await dialog.getByTestId("insert-component-nmos").click();
   const canvas = page.getByTestId("schematic-canvas");
   await canvas.click({ position: { x: 360, y: 240 } });
   await page.keyboard.press("Escape");
+
+  // Geometry and the Value display are Properties decisions after placement.
+  await page.getByTestId("hit-M1").click();
+  await openSelectionShelf(page);
+  await page.getByLabel("Component w", { exact: true }).fill("2u");
+  await page.getByLabel("Component l", { exact: true }).fill("180n");
+  await page.getByRole("checkbox", { name: "Value", exact: true }).check();
+  await canvas.click({ position: { x: 80, y: 80 } });
 
   const reference = page.locator('[data-object-id="instance-label-M1"]');
   const value = page.locator('[data-object-id="instance-value-M1"]');
@@ -2486,14 +2487,17 @@ test("value display projects MOS W/L and passive values beside the reference", a
   if (!referenceBox || !valueBox) throw new Error("Labels are not measurable");
   expect(valueBox.y).toBeGreaterThan(referenceBox.y);
 
-  // A passive value projects the same way from the insert dialog.
+  // A passive value projects the same way through Properties.
   await page.keyboard.press("i");
   await dialog.getByLabel("Component search").fill("resistor");
-  await dialog.getByLabel("Component value", { exact: true }).fill("33k");
-  await dialog.getByRole("checkbox", { name: "Value", exact: true }).check();
-  await dialog.getByRole("button", { name: "Apply" }).click();
+  await dialog.getByTestId("insert-component-resistor").click();
   await canvas.click({ position: { x: 560, y: 240 } });
   await page.keyboard.press("Escape");
+  await page.getByTestId("hit-R1").click();
+  await openSelectionShelf(page);
+  await page.getByLabel("Component value", { exact: true }).fill("33k");
+  await page.getByRole("checkbox", { name: "Value", exact: true }).check();
+  await canvas.click({ position: { x: 80, y: 80 } });
   await expect(
     page.locator('[data-object-id="instance-value-R1"]'),
   ).toContainText("33kΩ");
@@ -3674,7 +3678,6 @@ test("keeps component insertion and inspection from resizing the canvas", async 
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill("pmos");
   await dialog.getByTestId("insert-component-pmos").click();
-  await dialog.getByRole("button", { name: "Apply" }).click();
 
   await canvas.click({ position: { x: 420, y: 260 } });
 

--- a/apps/editor/src/features/component-insert/insert-component-dialog.test.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.test.tsx
@@ -5,7 +5,7 @@ import { builtInSymbols } from "@icm/symbols";
 import { InsertComponentDialog } from "./insert-component-dialog";
 
 describe("InsertComponentDialog", () => {
-  it("renders an expanded picker, device controls, and one authoritative preview", () => {
+  it("renders one flat quick-pick grid with a tile per candidate", () => {
     const markup = renderToStaticMarkup(
       <InsertComponentDialog
         open
@@ -21,35 +21,26 @@ describe("InsertComponentDialog", () => {
     expect(markup).toContain('role="combobox"');
     expect(markup).toContain('aria-label="Component search"');
     expect(markup).toContain('aria-expanded="true"');
-    // The catalog is permanently open: no collapse control exists and the
-    // listbox renders without any toggle interaction.
-    expect(markup).not.toContain("Collapse component list");
-    expect(markup).not.toContain("insert-picker-toggle");
     expect(markup).toContain('role="listbox"');
+    expect(markup).toContain('class="insert-tile-grid"');
+    // Every candidate is a tile with its artwork and name; the grid is flat,
+    // so no category headings section the quick pick.
     expect(markup).toContain('class="insert-symbol-artwork"');
-    expect(markup).toContain('aria-label="Component w"');
-    expect(markup).toContain('aria-label="Component l"');
-    expect(markup).toContain('aria-label="Component m"');
-    expect(markup).toContain('aria-label="Placement options"');
-    expect(markup).toContain('aria-label="Initial rotation"');
-    expect(markup).toContain('aria-label="Reference name"');
-    expect(markup).toContain(">Extended Devices</h3>");
-    expect(markup).toContain(">Annotations</h3>");
-    expect(markup).toContain(">High-voltage devices</h4>");
+    expect(markup).toContain('data-testid="insert-component-resistor"');
     expect(markup).toContain('data-testid="insert-component-ndmos"');
-    expect(markup).toContain('data-testid="insert-component-pdmos"');
     expect(markup).toContain('data-testid="insert-component-annotation-arrow"');
     expect(markup).toContain(
       'data-testid="insert-component-annotation-polarity-both"',
     );
-    expect(markup).toContain("W / m");
-    expect(markup).toContain("(Total channel width)");
-    expect(markup).toContain("(Finger count, so finger width is W / NF)");
-    // The default is Reference on, Value off and disabled until the device
-    // parameters carry a displayable projection.
-    expect(markup).toContain(">Reference</span>");
-    expect(markup).toContain(">Value</span>");
-    expect(markup).toContain('disabled=""');
+    expect(markup).not.toContain("<h3");
+    expect(markup).not.toContain("<h4");
+    // Per-device setup moved to post-placement Properties: the quick pick
+    // carries no parameter, reference, rotation, or rail-name fields.
+    expect(markup).not.toContain('aria-label="Component w"');
+    expect(markup).not.toContain('aria-label="Reference name"');
+    expect(markup).not.toContain('aria-label="Initial rotation"');
+    expect(markup).not.toContain('aria-label="Power rail Net name"');
+    expect(markup).not.toContain(">Apply</button>");
     expect(markup).not.toContain("library-component-");
   });
 
@@ -90,12 +81,10 @@ describe("InsertComponentDialog", () => {
       />,
     );
 
-    expect(markup).toContain(">Cells</h3>");
     expect(markup).toContain("Place Hierarchical Cell");
     expect(markup).toContain('aria-label="Cell search"');
     expect(markup).toContain('data-testid="insert-cell-document-amplifier"');
     expect(markup).not.toContain('data-testid="insert-component-nmos"');
     expect(markup).toContain(">Amplifier</span>");
-    expect(markup).toContain('aria-label="Reference name"');
   });
 });

--- a/apps/editor/src/features/component-insert/insert-component-dialog.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.tsx
@@ -1,24 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { displayableInstanceValue } from "@icm/derived";
 import type { SymbolDefinition } from "@icm/symbols";
 
-import {
-  componentParameters,
-  initialComponentParameterValues,
-} from "./component-parameters";
+import { initialComponentParameterValues } from "./component-parameters";
 import {
   annotationDrawingTool,
   annotationPolarity,
 } from "./annotation-preview-symbols";
-import {
-  componentCatalog,
-  libraryDescription,
-  libraryDisplayName,
-} from "./symbol-catalog";
+import { componentCatalog, libraryDisplayName } from "./symbol-catalog";
 import type { ComponentInsertRequest } from "./component-insert-request";
 import type { InsertScope } from "./insert-launch";
-import { DisplayToggle } from "./display-toggle";
 import { SymbolArtwork } from "./symbol-artwork";
 
 export type { ComponentInsertRequest } from "./component-insert-request";
@@ -56,6 +47,12 @@ interface InsertChoice {
   readonly masterName?: string;
 }
 
+/**
+ * The I picker is a one-glance speed surface: every candidate tiles into one
+ * flat grid and a click or Enter starts placement immediately. Per-device
+ * setup (parameters, reference text, value display, supply names) lives in
+ * the Properties panel after placement, not here.
+ */
 export function InsertComponentDialog({
   open,
   styleProfileId,
@@ -72,63 +69,21 @@ export function InsertComponentDialog({
   const dialogTitle = cellsOnly
     ? "Place Hierarchical Cell"
     : "Insert Component";
-  const initialChoices = useMemo<InsertChoice[]>(
-    () => [
-      ...(cellsOnly
-        ? []
-        : componentCatalog(styleProfileId, "", recentSymbolIds).flatMap(
-            (group) =>
-              group.symbols.map((symbol) => ({
-                key: symbol.id,
-                kind: "symbol" as const,
-                symbol,
-              })),
-          )),
-      ...cells.map((cell) => ({
-        key: `cell:${cell.childDocumentId}`,
-        kind: "cell" as const,
-        symbol: cell.symbol,
-        childDocumentId: cell.childDocumentId,
-        cellName: cell.cellName,
-      })),
-      ...(cellsOnly
-        ? []
-        : externalDefinitions.map((definition) => ({
-            key: `external:${definition.definitionId}`,
-            kind: "external-subcircuit" as const,
-            symbol: definition.symbol,
-            definitionId: definition.definitionId,
-            masterName: definition.masterName,
-          }))),
-    ],
-    [cellsOnly, cells, externalDefinitions, recentSymbolIds, styleProfileId],
-  );
   const [query, setQuery] = useState("");
-  const [selectedId, setSelectedId] = useState(
-    () => initialChoices[0]?.key ?? null,
-  );
-  const [parameterValues, setParameterValues] = useState<
-    Record<string, string>
-  >({});
-  const [initialRotation, setInitialRotation] = useState<0 | 90 | 180 | 270>(0);
-  const [showReference, setShowReference] = useState(true);
-  const [referenceText, setReferenceText] = useState("");
-  const [showValue, setShowValue] = useState(false);
-  const [railNetName, setRailNetName] = useState("VDD");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const groups = useMemo<
-    { category: string; subcategory?: string; choices: InsertChoice[] }[]
-  >(() => {
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  const choices = useMemo<InsertChoice[]>(() => {
+    const normalized = query.trim().toLowerCase();
     const cellChoices = cells
-      .filter((cell) => {
-        const normalized = query.trim().toLowerCase();
-        return (
+      .filter(
+        (cell) =>
           normalized.length === 0 ||
           `${cell.cellName} ${cell.symbol.id}`
             .toLowerCase()
-            .includes(normalized)
-        );
-      })
+            .includes(normalized),
+      )
       .map<InsertChoice>((cell) => ({
         key: `cell:${cell.childDocumentId}`,
         kind: "cell",
@@ -137,15 +92,13 @@ export function InsertComponentDialog({
         cellName: cell.cellName,
       }));
     const externalChoices = (cellsOnly ? [] : externalDefinitions)
-      .filter((definition) => {
-        const normalized = query.trim().toLowerCase();
-        return (
+      .filter(
+        (definition) =>
           normalized.length === 0 ||
           `${definition.masterName} ${definition.symbol.id}`
             .toLowerCase()
-            .includes(normalized)
-        );
-      })
+            .includes(normalized),
+      )
       .map<InsertChoice>((definition) => ({
         key: `external:${definition.definitionId}`,
         kind: "external-subcircuit",
@@ -153,27 +106,27 @@ export function InsertComponentDialog({
         definitionId: definition.definitionId,
         masterName: definition.masterName,
       }));
-    return [
-      ...(cellsOnly
-        ? []
-        : componentCatalog(styleProfileId, query, recentSymbolIds).map(
-            (group) => ({
-              category: group.category,
-              ...(group.subcategory ? { subcategory: group.subcategory } : {}),
-              choices: group.symbols.map<InsertChoice>((symbol) => ({
-                key: symbol.id,
-                kind: "symbol",
-                symbol,
-              })),
-            }),
-          )),
-      ...(cellChoices.length > 0
-        ? [{ category: "Cells", choices: cellChoices }]
-        : []),
-      ...(externalChoices.length > 0
-        ? [{ category: "External masters", choices: externalChoices }]
-        : []),
-    ];
+    // The catalog ranks recents within each category; the flat grid hoists
+    // them to the very front so the last few picks are always the first tiles.
+    const recentRank = new Map(
+      recentSymbolIds.map((symbolId, index) => [symbolId, index] as const),
+    );
+    const symbolChoices = cellsOnly
+      ? []
+      : componentCatalog(styleProfileId, query, recentSymbolIds)
+          .flatMap((group) =>
+            group.symbols.map<InsertChoice>((symbol) => ({
+              key: symbol.id,
+              kind: "symbol",
+              symbol,
+            })),
+          )
+          .sort(
+            (left, right) =>
+              (recentRank.get(left.symbol.id) ?? Number.POSITIVE_INFINITY) -
+              (recentRank.get(right.symbol.id) ?? Number.POSITIVE_INFINITY),
+          );
+    return [...symbolChoices, ...cellChoices, ...externalChoices];
   }, [
     cellsOnly,
     cells,
@@ -182,71 +135,17 @@ export function InsertComponentDialog({
     recentSymbolIds,
     styleProfileId,
   ]);
-  const choices = useMemo(
-    () => groups.flatMap((group) => group.choices),
-    [groups],
-  );
+
   const selected =
     choices.find((choice) => choice.key === selectedId) ?? choices[0] ?? null;
-  const selectedIsVddRail =
-    selected?.kind === "symbol" && selected.symbol.id === "vdd";
-  const selectedIsPort =
-    selected?.kind === "symbol" &&
-    (selected.symbol.id === "port" || selected.symbol.id === "port-filled");
-  const selectedDrawingTool =
-    selected?.kind === "symbol"
-      ? annotationDrawingTool(selected.symbol.id)
-      : undefined;
-  const selectedPolarity =
-    selected?.kind === "symbol"
-      ? annotationPolarity(selected.symbol.id)
-      : undefined;
-  const parameters = componentParameters(
-    selected?.kind === "symbol" ? selected.symbol.id : "",
-  );
-  const valueDisplay = displayableInstanceValue({
-    symbolId: selected?.kind === "symbol" ? selected.symbol.id : "",
-    netlist: {
-      parameters: Object.fromEntries(
-        Object.entries(parameterValues)
-          .map(([key, value]) => [key, value.trim()] as const)
-          .filter(([, value]) => value !== ""),
-      ),
-    },
-  });
-  const valueAvailable =
-    selected?.kind === "cell" || valueDisplay.kind === "displayable";
 
   useEffect(() => {
     if (!open) return;
     setQuery("");
-    setSelectedId(
-      initialSelectionId &&
-        initialChoices.some((choice) => choice.key === initialSelectionId)
-        ? initialSelectionId
-        : (initialChoices[0]?.key ?? null),
-    );
-    setInitialRotation(0);
-    setShowReference(true);
-    setReferenceText("");
-    setShowValue(false);
-    setRailNetName("VDD");
+    setSelectedId(initialSelectionId);
     const frame = requestAnimationFrame(() => inputRef.current?.focus());
     return () => cancelAnimationFrame(frame);
-  }, [initialChoices, initialSelectionId, open]);
-
-  useEffect(() => {
-    setParameterValues(
-      initialComponentParameterValues(
-        selected?.kind === "symbol" ? selected.symbol.id : "",
-      ),
-    );
-  }, [selected]);
-
-  useEffect(() => {
-    if (selected?.kind === "cell" || selected?.kind === "external-subcircuit")
-      setShowValue(true);
-  }, [selected?.kind]);
+  }, [initialSelectionId, open]);
 
   useEffect(() => {
     if (choices.length === 0) {
@@ -256,7 +155,29 @@ export function InsertComponentDialog({
     }
   }, [choices, selectedId]);
 
+  useEffect(() => {
+    if (!open || !selected) return;
+    gridRef.current
+      ?.querySelector(
+        `[id="insert-component-option-${CSS.escape(selected.key)}"]`,
+      )
+      ?.scrollIntoView({ block: "nearest" });
+  }, [open, selected]);
+
   if (!open) return null;
+
+  const gridColumns = (): number => {
+    const options =
+      gridRef.current?.querySelectorAll<HTMLElement>('[role="option"]');
+    if (!options || options.length === 0) return 1;
+    const firstTop = options[0]!.offsetTop;
+    let columns = 0;
+    for (const option of options) {
+      if (option.offsetTop !== firstTop) break;
+      columns += 1;
+    }
+    return Math.max(1, columns);
+  };
 
   const selectOffset = (offset: number): void => {
     if (choices.length === 0) return;
@@ -264,95 +185,82 @@ export function InsertComponentDialog({
       0,
       choices.findIndex((choice) => choice.key === selected?.key),
     );
-    const next = (index + offset + choices.length) % choices.length;
+    const next = Math.min(Math.max(index + offset, 0), choices.length - 1);
     setSelectedId(choices[next]!.key);
   };
 
-  // Selecting never folds the list away: the catalog stays in place so the
-  // next pick is one click, not an expand-then-click.
-  const selectChoice = (key: string): void => {
-    setSelectedId(key);
-    setQuery("");
-  };
-
-  const rotatePreview = (): void => {
-    if (selectedIsVddRail || selectedDrawingTool) return;
-    setInitialRotation(
-      (current) => ((current + 90) % 360) as 0 | 90 | 180 | 270,
-    );
-  };
-
-  const apply = (): void => {
-    if (!selected) return;
-    if (selectedIsVddRail) {
-      const netName = railNetName.trim();
-      if (!netName) return;
+  const applyChoice = (choice: InsertChoice | null): void => {
+    if (!choice) return;
+    const symbolId = choice.symbol.id;
+    if (choice.kind === "symbol" && symbolId === "vdd") {
       onApply({
         kind: "vdd-rail",
         symbolId: "vdd",
         symbolName: "Power Rail",
-        netName,
+        netName: "VDD",
       });
       return;
     }
-    if (selectedDrawingTool) {
+    const drawingTool =
+      choice.kind === "symbol" ? annotationDrawingTool(symbolId) : undefined;
+    if (drawingTool) {
       onApply({
         kind: "drawing-tool",
-        symbolId: selected.symbol.id,
-        symbolName: selected.symbol.name,
-        tool: selectedDrawingTool,
+        symbolId,
+        symbolName: choice.symbol.name,
+        tool: drawingTool,
       });
       return;
     }
-    if (selectedPolarity) {
+    const polarity =
+      choice.kind === "symbol" ? annotationPolarity(symbolId) : undefined;
+    if (polarity) {
       onApply({
         kind: "polarity-annotation",
-        symbolId: selected.symbol.id,
-        symbolName: selected.symbol.name,
-        polarity: selectedPolarity,
-        initialRotation,
+        symbolId,
+        symbolName: choice.symbol.name,
+        polarity,
+        initialRotation: 0,
       });
       return;
     }
-    if (selected.kind === "cell") {
-      const trimmedReference = referenceText.trim();
+    if (choice.kind === "cell") {
       onApply({
         kind: "cell",
-        symbolId: selected.symbol.id,
-        symbolName: selected.cellName ?? selected.symbol.name,
-        childDocumentId: selected.childDocumentId!,
-        cellName: selected.cellName ?? selected.symbol.name,
+        symbolId,
+        symbolName: choice.cellName ?? choice.symbol.name,
+        childDocumentId: choice.childDocumentId!,
+        cellName: choice.cellName ?? choice.symbol.name,
         parameters: {},
-        initialRotation,
-        showReference,
-        referenceText: trimmedReference === "" ? null : trimmedReference,
+        initialRotation: 0,
+        showReference: true,
+        referenceText: null,
         showValue: true,
       });
       return;
     }
-    if (selected.kind === "external-subcircuit") {
-      const trimmedReference = referenceText.trim();
+    if (choice.kind === "external-subcircuit") {
       onApply({
         kind: "external-subcircuit",
-        symbolId: selected.symbol.id,
-        symbolName: selected.masterName ?? selected.symbol.name,
-        definitionId: selected.definitionId!,
-        masterName: selected.masterName ?? selected.symbol.name,
+        symbolId,
+        symbolName: choice.masterName ?? choice.symbol.name,
+        definitionId: choice.definitionId!,
+        masterName: choice.masterName ?? choice.symbol.name,
         parameters: {},
-        initialRotation,
-        showReference,
-        referenceText: trimmedReference === "" ? null : trimmedReference,
+        initialRotation: 0,
+        showReference: true,
+        referenceText: null,
         showValue: true,
       });
       return;
     }
-    if (selectedIsPort) {
+    if (symbolId === "port" || symbolId === "port-filled") {
       onApply({
         kind: "symbol",
-        symbolId: selected.symbol.id,
-        symbolName: selected.symbol.name,
+        symbolId,
+        symbolName: choice.symbol.name,
         parameters: {},
-        initialRotation,
+        initialRotation: 0,
         showReference: false,
         referenceText: null,
         showValue: false,
@@ -360,21 +268,22 @@ export function InsertComponentDialog({
       });
       return;
     }
+    // Devices arrive with their catalog defaults (a MOS still lands as
+    // 1u/180n); everything is editable in Properties after placement.
     const parameters = Object.fromEntries(
-      Object.entries(parameterValues)
+      Object.entries(initialComponentParameterValues(symbolId))
         .map(([key, value]) => [key, value.trim()] as const)
         .filter(([, value]) => value !== ""),
     );
-    const trimmedReference = referenceText.trim();
     onApply({
       kind: "symbol",
-      symbolId: selected.symbol.id,
-      symbolName: selected.symbol.name,
+      symbolId,
+      symbolName: choice.symbol.name,
       parameters,
-      initialRotation,
-      showReference,
-      referenceText: trimmedReference === "" ? null : trimmedReference,
-      showValue: showValue && valueAvailable,
+      initialRotation: 0,
+      showReference: true,
+      referenceText: null,
+      showValue: false,
     });
   };
 
@@ -386,38 +295,30 @@ export function InsertComponentDialog({
         if (event.target === event.currentTarget) onCancel();
       }}
     >
-      <form
+      <div
         className="insert-component-dialog"
         role="dialog"
         aria-modal="true"
         aria-labelledby="insert-component-title"
-        onSubmit={(event) => {
-          event.preventDefault();
-          apply();
-        }}
         onKeyDown={(event) => {
-          const target = event.target as HTMLElement;
-          const isTextEntry = Boolean(
-            target.closest('input, textarea, [contenteditable="true"]'),
-          );
-          if (
-            event.key.toLowerCase() === "r" &&
-            !event.ctrlKey &&
-            !event.metaKey &&
-            !event.altKey &&
-            !isTextEntry
-          ) {
-            event.preventDefault();
-            rotatePreview();
-          } else if (event.key === "Escape") {
+          if (event.key === "Escape") {
             event.preventDefault();
             onCancel();
-          } else if (event.key === "ArrowDown") {
+          } else if (event.key === "Enter") {
+            event.preventDefault();
+            applyChoice(selected);
+          } else if (event.key === "ArrowRight") {
             event.preventDefault();
             selectOffset(1);
-          } else if (event.key === "ArrowUp") {
+          } else if (event.key === "ArrowLeft") {
             event.preventDefault();
             selectOffset(-1);
+          } else if (event.key === "ArrowDown") {
+            event.preventDefault();
+            selectOffset(gridColumns());
+          } else if (event.key === "ArrowUp") {
+            event.preventDefault();
+            selectOffset(-gridColumns());
           } else if (event.key === "Home") {
             event.preventDefault();
             setSelectedId(choices[0]?.key ?? null);
@@ -435,250 +336,75 @@ export function InsertComponentDialog({
           {cellsOnly ? null : <kbd>I</kbd>}
         </header>
 
-        <div className="insert-dialog-body">
-          <aside
-            className="insert-control-column"
-            aria-label={`${pickerNoun} setup`}
-          >
-            <section className="insert-component-picker">
-              <label className="insert-search-field">
-                <span>{pickerNoun}</span>
-                <div className="insert-picker-input-row">
-                  <input
-                    ref={inputRef}
-                    role="combobox"
-                    aria-label={`${pickerNoun} search`}
-                    aria-autocomplete="list"
-                    aria-expanded={true}
-                    aria-controls="insert-component-options"
-                    aria-activedescendant={
-                      selected
-                        ? `insert-component-option-${selected.key}`
-                        : undefined
-                    }
-                    value={query}
-                    placeholder={`Search ${pickerNoun.toLowerCase()}`}
-                    onChange={(event) => setQuery(event.currentTarget.value)}
-                  />
-                </div>
-              </label>
-              {
-                <div
-                  id="insert-component-options"
-                  className="insert-component-options"
-                  role="listbox"
-                  aria-label={`${pickerNoun} choices`}
-                >
-                  {groups.map((group) => (
-                    <section
-                      key={`${group.category}:${group.subcategory ?? ""}`}
-                      className="insert-option-group"
-                    >
-                      <h3>{group.category}</h3>
-                      {group.subcategory ? <h4>{group.subcategory}</h4> : null}
-                      {group.choices.map((choice) => (
-                        <button
-                          type="button"
-                          id={`insert-component-option-${choice.key}`}
-                          key={choice.key}
-                          role="option"
-                          aria-selected={choice.key === selected?.key}
-                          data-testid={
-                            choice.kind === "cell"
-                              ? `insert-cell-${choice.childDocumentId}`
-                              : `insert-component-${choice.symbol.id}`
-                          }
-                          onClick={() => selectChoice(choice.key)}
-                          onDoubleClick={() => {
-                            // The first click of the pair already committed
-                            // this selection; the second applies it.
-                            apply();
-                          }}
-                        >
-                          <span>
-                            {choice.cellName ??
-                              libraryDisplayName(
-                                choice.symbol.id,
-                                choice.symbol.name,
-                              )}
-                          </span>
-                          <small>
-                            {choice.kind === "cell" ? "Cell" : choice.symbol.id}
-                          </small>
-                        </button>
-                      ))}
-                    </section>
-                  ))}
-                  {choices.length === 0 ? (
-                    <p className="insert-no-results">
-                      No matching {pickerNoun.toLowerCase()}s
-                    </p>
-                  ) : null}
-                </div>
-              }
-            </section>
+        <input
+          ref={inputRef}
+          className="insert-quick-search"
+          role="combobox"
+          aria-label={`${pickerNoun} search`}
+          aria-autocomplete="list"
+          aria-expanded={true}
+          aria-controls="insert-component-options"
+          aria-activedescendant={
+            selected ? `insert-component-option-${selected.key}` : undefined
+          }
+          value={query}
+          placeholder={`Search ${pickerNoun.toLowerCase()}s`}
+          onChange={(event) => setQuery(event.currentTarget.value)}
+        />
 
-            {selectedIsVddRail ? (
-              <section
-                className="insert-placement-options"
-                aria-label="Power rail options"
+        <div
+          ref={gridRef}
+          id="insert-component-options"
+          className="insert-tile-grid"
+          role="listbox"
+          aria-label={`${pickerNoun} choices`}
+        >
+          {choices.map((choice) => {
+            const label =
+              choice.cellName ??
+              choice.masterName ??
+              libraryDisplayName(choice.symbol.id, choice.symbol.name);
+            return (
+              <button
+                type="button"
+                id={`insert-component-option-${choice.key}`}
+                key={choice.key}
+                role="option"
+                aria-selected={choice.key === selected?.key}
+                className="insert-tile"
+                title={
+                  choice.kind === "cell"
+                    ? `${label} · Cell`
+                    : `${label} · ${choice.symbol.id}`
+                }
+                data-testid={
+                  choice.kind === "cell"
+                    ? `insert-cell-${choice.childDocumentId}`
+                    : `insert-component-${choice.symbol.id}`
+                }
+                onClick={() => applyChoice(choice)}
               >
-                <label>
-                  <span>Net name</span>
-                  <input
-                    aria-label="Power rail Net name"
-                    value={railNetName}
-                    onChange={(event) =>
-                      setRailNetName(event.currentTarget.value)
-                    }
-                  />
-                </label>
-              </section>
-            ) : selectedDrawingTool ? (
-              <section
-                className="insert-placement-options"
-                aria-label="Drawing tool"
-              >
-                <p className="insert-cell-label-note">
-                  Starts the existing {selected!.symbol.name.toLowerCase()}{" "}
-                  tool. Click the canvas to draw; press Esc when finished.
-                </p>
-              </section>
-            ) : (
-              <section
-                className="insert-placement-options"
-                aria-label="Placement options"
-              >
-                <label className="insert-rotation-control">
-                  <span>Rotate</span>
-                  <select
-                    aria-label="Initial rotation"
-                    value={initialRotation}
-                    onChange={(event) =>
-                      setInitialRotation(
-                        Number(event.currentTarget.value) as 0 | 90 | 180 | 270,
-                      )
-                    }
-                  >
-                    <option value="0">0°</option>
-                    <option value="90">90°</option>
-                    <option value="180">180°</option>
-                    <option value="270">270°</option>
-                  </select>
-                </label>
-                {selectedPolarity ? (
-                  <p className="insert-cell-label-note">
-                    Place the annotation, then edit its center text directly on
-                    the canvas.
-                  </p>
-                ) : selectedIsPort ? (
-                  <p className="insert-cell-label-note">
-                    {libraryDescription(selected.symbol.id) ??
-                      "Names a net on this sheet."}{" "}
-                    Rename it on the canvas.
-                  </p>
-                ) : (
-                  <div className="insert-label-control">
-                    <DisplayToggle
-                      label="Reference"
-                      checked={showReference}
-                      onChange={setShowReference}
-                    />
-                    <input
-                      aria-label="Reference name"
-                      value={referenceText}
-                      disabled={!showReference}
-                      placeholder="Name (auto)"
-                      onChange={(event) =>
-                        setReferenceText(event.currentTarget.value)
-                      }
-                    />
-                    <DisplayToggle
-                      label="Value"
-                      checked={showValue}
-                      disabled={!valueAvailable}
-                      help={
-                        valueAvailable
-                          ? undefined
-                          : "Fill the device parameters first"
-                      }
-                      onChange={setShowValue}
-                    />
-                  </div>
-                )}
-              </section>
-            )}
-
-            {parameters.length > 0 ? (
-              <section
-                className="insert-control-section"
-                aria-label="Device parameters"
-              >
-                <h3>Device parameters</h3>
-                {parameters.map((parameter) => (
-                  <label key={parameter.key} title={parameter.help}>
-                    <span className="insert-parameter-name">
-                      {parameter.label}
-                      {parameter.unit ? ` / ${parameter.unit}` : ""}
-                      <em>({parameter.help})</em>
-                    </span>
-                    <input
-                      aria-label={`Component ${parameter.label.toLowerCase()}`}
-                      inputMode={parameter.inputMode}
-                      value={parameterValues[parameter.key] ?? ""}
-                      placeholder={parameter.placeholder}
-                      onChange={(event) => {
-                        const value = event.currentTarget.value;
-                        setParameterValues((current) => ({
-                          ...current,
-                          [parameter.key]: value,
-                        }));
-                      }}
-                    />
-                  </label>
-                ))}
-              </section>
-            ) : null}
-          </aside>
-
-          <section
-            className="insert-component-preview"
-            aria-label="Component preview"
-            aria-live="polite"
-            tabIndex={0}
-          >
-            {selected ? (
-              <>
                 <SymbolArtwork
-                  symbol={selected.symbol}
+                  symbol={choice.symbol}
                   className="insert-symbol-artwork"
-                  rotation={initialRotation}
                 />
-                <div>
-                  <h3>{selected.cellName ?? selected.symbol.name}</h3>
-                  <p>
-                    {selected.kind === "cell" ? "Cell" : selected.symbol.id}
-                  </p>
-                </div>
-              </>
-            ) : (
-              <p>Select a component to preview it.</p>
-            )}
-          </section>
+                <span>{label}</span>
+              </button>
+            );
+          })}
+          {choices.length === 0 ? (
+            <p className="insert-no-results">
+              No matching {pickerNoun.toLowerCase()}s
+            </p>
+          ) : null}
         </div>
 
         <footer className="insert-dialog-actions">
-          <small>Type to search · ↑↓ choose · Enter place · Esc cancel</small>
-          <div>
-            <button type="button" onClick={onCancel}>
-              Cancel
-            </button>
-            <button type="submit" className="primary" disabled={!selected}>
-              Apply
-            </button>
-          </div>
+          <small>
+            Type to filter · ←↑↓→ choose · Enter or click places · Esc closes
+          </small>
         </footer>
-      </form>
+      </div>
     </div>
   );
 }

--- a/apps/editor/src/styles/editor-dialogs.css
+++ b/apps/editor/src/styles/editor-dialogs.css
@@ -111,15 +111,14 @@
   gap: 0.5rem;
 }
 
-/* The Insert dialog is deliberately a compact setup surface: discovery and
-   parameters remain in the left column, while the right preview never reflows
-   when the component picker opens. */
+/* The Insert dialog is a one-glance speed picker: every candidate tiles into
+   one flat grid, and a click or Enter starts placement immediately. */
 .insert-component-dialog {
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
-  gap: 0.9rem;
-  width: min(54rem, calc(100vw - 2.5rem));
-  height: min(38rem, calc(100dvh - 2.5rem));
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  gap: 0.8rem;
+  width: min(46rem, calc(100vw - 2.5rem));
+  max-height: calc(100dvh - 2.5rem);
   padding: 1rem;
   overflow: hidden;
   border: 1px solid var(--icm-border-strong);
@@ -138,9 +137,7 @@
 }
 
 .insert-dialog-header p,
-.insert-dialog-header h2,
-.insert-component-preview h3,
-.insert-component-preview p {
+.insert-dialog-header h2 {
   margin: 0;
 }
 
@@ -167,15 +164,7 @@
   font-size: var(--icm-font-sm);
 }
 
-.insert-search-field {
-  display: grid;
-  gap: 0.35rem;
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-sm);
-  font-weight: 650;
-}
-
-.insert-search-field input {
+.insert-quick-search {
   width: 100%;
   min-height: 2.35rem;
   padding: 0.45rem 0.6rem;
@@ -187,90 +176,69 @@
   font-size: var(--icm-font-lg);
 }
 
-.insert-search-field input:focus {
+.insert-quick-search:focus {
   border-color: var(--icm-accent);
   background: var(--icm-surface);
   box-shadow: 0 0 0 3px var(--icm-accent-soft);
 }
 
-.insert-dialog-body {
+.insert-tile-grid {
   display: grid;
-  grid-template-columns: minmax(17rem, 0.85fr) minmax(24rem, 1.15fr);
+  grid-template-columns: repeat(auto-fill, minmax(6.4rem, 1fr));
+  align-content: start;
+  gap: 0.45rem;
   min-height: 0;
-  overflow: hidden;
-  border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-md);
-}
-
-.insert-component-options {
-  min-height: 0;
+  padding: 0.55rem;
   overflow-y: auto;
   overscroll-behavior: contain;
-  border-right: 1px solid var(--icm-border);
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-md);
   background: var(--icm-surface-muted);
   scrollbar-width: thin;
 }
 
-.insert-option-group h3 {
-  position: sticky;
-  z-index: 1;
-  top: 0;
-  margin: 0;
-  padding: 0.55rem 0.75rem 0.35rem;
-  color: var(--icm-text-muted);
-  background: rgb(248 250 252 / 95%);
-  font-size: var(--icm-font-xs);
-  letter-spacing: 0.075em;
-  text-transform: uppercase;
-  backdrop-filter: blur(8px);
-}
-
-.insert-option-group h4 {
-  margin: 0;
-  padding: 0.25rem 0.75rem 0.35rem;
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-xs);
-  font-weight: 600;
-}
-
-.insert-option-group button {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 0.75rem;
-  width: 100%;
-  min-height: 2.25rem;
-  padding: 0.45rem 0.75rem;
-  border: 0;
-  border-radius: 0;
-  background: transparent;
+.insert-tile {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.5rem 0.35rem 0.45rem;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-md);
+  background: var(--icm-surface);
   box-shadow: none;
-  text-align: left;
+  text-align: center;
 }
 
-.insert-option-group button:hover,
-.insert-option-group button[aria-selected="true"] {
+.insert-tile:hover,
+.insert-tile[aria-selected="true"] {
+  border-color: var(--icm-accent);
   color: var(--icm-accent);
   background: var(--icm-accent-soft);
 }
 
-.insert-option-group button[aria-selected="true"] {
-  box-shadow: inset 3px 0 0 var(--icm-accent);
+.insert-tile[aria-selected="true"] {
+  box-shadow: 0 0 0 2px var(--icm-accent-soft);
 }
 
-.insert-option-group button span {
+.insert-tile .insert-symbol-artwork {
+  width: 100%;
+  height: 3.4rem;
+  color: #111827;
+}
+
+.insert-tile span {
+  max-width: 100%;
   overflow: hidden;
-  font-size: var(--icm-font-md);
+  font-size: var(--icm-font-xs);
   font-weight: 600;
+  line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.insert-option-group button small {
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-xs);
-}
-
 .insert-no-results {
+  grid-column: 1 / -1;
   margin: 0;
   padding: 1.25rem;
   color: var(--icm-text-muted);
@@ -278,57 +246,9 @@
   text-align: center;
 }
 
-.insert-component-preview {
-  display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
-  gap: 0.75rem;
-  min-width: 0;
-  min-height: 0;
-  padding: 1.25rem;
-  overflow: hidden;
-  background:
-    radial-gradient(circle at 50% 40%, #fff 0, #fff 42%, transparent 72%),
-    linear-gradient(135deg, var(--icm-surface-muted), #fff);
-}
-
-.insert-symbol-artwork {
-  align-self: center;
-  justify-self: center;
-  width: min(100%, 18rem);
-  height: 14rem;
-  color: #111827;
-}
-
-.insert-component-preview h3 {
-  font-size: var(--icm-font-lg);
-}
-
-.insert-component-preview p,
-.insert-component-preview small {
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-sm);
-}
-
 .insert-dialog-actions > small {
   color: var(--icm-text-muted);
   font-size: var(--icm-font-sm);
-}
-
-.insert-dialog-actions > div {
-  display: flex;
-  gap: 0.5rem;
-}
-
-.insert-dialog-actions button {
-  min-width: 5.5rem;
-  min-height: 2.3rem;
-  padding-inline: 0.85rem;
-}
-
-.insert-dialog-actions .primary {
-  border-color: var(--icm-accent);
-  color: #fff;
-  background: var(--icm-accent);
 }
 
 /* Cell Manager is a compact master-detail workbench. Interface facts remain
@@ -779,26 +699,6 @@
   background: var(--icm-danger, #b42318);
 }
 
-.insert-cell-label-note {
-  margin: 0;
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-sm);
-}
-
-.insert-control-column {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  min-width: 0;
-  min-height: 0;
-  padding: 0.8rem;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  border-right: 1px solid var(--icm-border);
-  background: var(--icm-surface-muted);
-  scrollbar-width: thin;
-}
-
 /* Document style knobs: one settings row per knob, sharing the publish
    dialog's card so the two modals read as one family. */
 .style-dialog {
@@ -931,111 +831,6 @@
   white-space: pre;
 }
 
-.insert-component-picker,
-.insert-control-section {
-  padding: 0.65rem;
-  border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-md);
-  background: var(--icm-surface);
-}
-
-.insert-picker-input-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 2.4rem;
-  gap: 0.35rem;
-}
-
-.insert-picker-toggle {
-  padding: 0;
-  border-color: var(--icm-border-strong);
-  box-shadow: none;
-  font-size: var(--icm-font-lg);
-}
-
-.insert-component-options {
-  /* The catalog stays permanently open; give it real height so most
-     categories are visible without scrolling. */
-  max-height: min(26rem, 48vh);
-  margin-top: 0.55rem;
-  overflow-y: auto;
-  border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-sm);
-  background: var(--icm-surface-muted);
-}
-
-.insert-control-section {
-  display: grid;
-  gap: 0.45rem;
-}
-
-.insert-control-section h3 {
-  margin: 0;
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-xs);
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-}
-
-.insert-control-section label {
-  display: grid;
-  gap: 0.22rem;
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-sm);
-}
-
-.insert-control-section input {
-  min-width: 0;
-  min-height: var(--icm-control-h-lg);
-  padding: 0.4rem 0.5rem;
-  border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-sm);
-  color: var(--icm-text);
-  background: var(--icm-surface);
-  font: inherit;
-}
-
-.insert-control-section small {
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-xs);
-}
-
-.insert-placement-options {
-  display: grid;
-  grid-template-columns: 6.2rem minmax(0, 1fr);
-  align-items: end;
-  gap: 0.55rem;
-  padding: 0.55rem 0.65rem;
-  border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-md);
-  background: var(--icm-surface);
-}
-
-.insert-rotation-control {
-  display: grid;
-  gap: 0.22rem;
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-sm);
-}
-
-.insert-rotation-control select,
-.insert-label-control > input {
-  min-width: 0;
-  min-height: var(--icm-control-h-lg);
-  padding: 0.4rem 0.5rem;
-  border: 1px solid var(--icm-border);
-  border-radius: var(--icm-radius-sm);
-  color: var(--icm-text);
-  background: var(--icm-surface);
-  font: inherit;
-}
-
-.insert-label-control {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  align-items: end;
-  gap: 0.45rem;
-}
-
 /* One compact Reference/Value switch shared by the insert dialog, the
    component properties panel, and group selection. */
 .display-toggle-row {
@@ -1068,28 +863,7 @@
   cursor: help;
 }
 
-.insert-parameter-name {
-  color: var(--icm-text);
-  font-weight: 650;
-}
-
-.insert-parameter-name em {
-  margin-left: 0.25rem;
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-xs);
-  font-style: normal;
-  font-weight: 500;
-}
-
 @media (max-width: 860px) {
-  .insert-component-dialog {
-    width: min(40rem, calc(100vw - 2rem));
-  }
-
-  .insert-dialog-body {
-    grid-template-columns: minmax(12rem, 0.85fr) minmax(15rem, 1.15fr);
-  }
-
   .cell-manager-dialog {
     width: calc(100vw - 1rem);
     height: calc(100dvh - 1rem);

--- a/packages/model/src/schema.test.ts
+++ b/packages/model/src/schema.test.ts
@@ -479,6 +479,49 @@ describe("CircuitProject schema", () => {
     );
   });
 
+  it("accepts a rail label format override whose power claim is owned by the label itself", () => {
+    // A drawn power rail's name-claim owner is the label annotation, not the
+    // junction the label anchors to; the override check must find that claim.
+    const document = createEmptyProject("project-rail", "Rail").documents[0]!;
+    document.nets.push({ id: "net-power-vdd1", terminals: [] });
+    document.junctions.push({
+      id: "junction-vdd1-start",
+      netId: "net-power-vdd1",
+      position: { x: 0, y: 0 },
+    });
+    document.annotations.push({
+      id: "label-VDD1",
+      kind: "power-label",
+      binding: { kind: "net-name", netId: "net-power-vdd1" },
+      netId: "net-power-vdd1",
+      anchor: {
+        kind: "object",
+        objectId: "junction-vdd1-start",
+        localOffset: { x: 10, y: 10 },
+        fallbackPosition: { x: 10, y: 10 },
+      },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+      formatOverride: { runs: [{ kind: "text", value: "AVDD" }] },
+    });
+    document.connectivityEvidence.push({
+      id: "claim-rail-vdd1",
+      kind: "name-claim",
+      netId: "net-power-vdd1",
+      name: "AVDD",
+      owner: { kind: "power-marker", objectId: "label-VDD1" },
+      scope: "global",
+      powerDomain: "vdd",
+    });
+    expect(SchematicDocumentSchema.safeParse(document).success).toBe(true);
+
+    document.annotations.at(-1)!.formatOverride = {
+      runs: [{ kind: "text", value: "OTHER" }],
+    };
+    expect(SchematicDocumentSchema.safeParse(document).success).toBe(false);
+  });
+
   it("rejects every removed first-class Port shape", () => {
     const project = createEmptyProject("project-port", "Port contract");
     const document = project.documents[0]!;

--- a/packages/model/src/schema/document.ts
+++ b/packages/model/src/schema/document.ts
@@ -477,9 +477,13 @@ export const SchematicDocumentSchema = SchematicDocumentBaseSchema.superRefine(
             (binding.kind === "net-name" ? binding.netId : undefined) &&
           ((evidence.owner.kind === "net-label" &&
             evidence.owner.annotationId === annotation.id) ||
-            (annotation.anchor.kind === "object" &&
-              evidence.owner.kind === "power-marker" &&
-              evidence.owner.objectId === annotation.anchor.objectId)),
+            // A power-marker claim is owned by the marker instance for supply
+            // ports, but a drawn power rail's claim is owned by the label
+            // annotation itself — both spellings name this annotation's net.
+            (evidence.owner.kind === "power-marker" &&
+              ((annotation.anchor.kind === "object" &&
+                evidence.owner.objectId === annotation.anchor.objectId) ||
+                evidence.owner.objectId === annotation.id))),
       );
       const semanticContent =
         binding.kind === "cell-terminal-name"


### PR DESCRIPTION
Pressing I now opens a one-glance speed surface: every component tiles into one flat grid (recents hoisted to the front), a click or Enter starts placement immediately, and per-device setup lives where it already exists post-placement — parameters/reference/value in Q Properties, orientation via R on the placement ghost, supply names on the label. The preview pane, Apply step, and insert-time option fields are removed; the sidebar Library keeps its categorized view.

Also fixes a pre-existing model validator bug this exposed: a drawn power rail's name-claim is owned by its label annotation, but the format-override check only recognized power-marker claims owned by the label's anchor object — so renaming a rail on the canvas failed with "Transaction result failed Document validation". The validator now accepts both spellings (regression-tested), and the rail e2e covers place → rename-to-AVDD end to end.

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)