### PR TITLE
feat(editor): three-part annotation signs and a survivable polarity center

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -344,15 +344,23 @@ test("groups drafting tools and editable polarity labels under Annotations", asy
   const annotations = page.getByTestId("shapes-category-annotations");
   await expect(annotations).toBeVisible();
   await expect(annotations.locator(".shapes-category-count")).toHaveText("7");
-  await expect(
-    annotations.getByTestId("shapes-chip-annotation-polarity-both"),
-  ).toBeVisible();
-  await expect(
-    annotations.getByTestId("shapes-chip-annotation-polarity-positive"),
-  ).toBeVisible();
-  await expect(
-    annotations.getByTestId("shapes-chip-annotation-polarity-negative"),
-  ).toBeVisible();
+  // Drawing tools lead; the polarity label and the standalone sign texts
+  // close the category. The one-sign-with-text variants no longer exist.
+  expect(
+    await annotations
+      .locator(".shapes-chip")
+      .evaluateAll((chips) =>
+        chips.map((chip) => chip.getAttribute("data-testid")),
+      ),
+  ).toEqual([
+    "shapes-chip-annotation-arrow",
+    "shapes-chip-annotation-line",
+    "shapes-chip-annotation-rectangle",
+    "shapes-chip-annotation-circle",
+    "shapes-chip-annotation-polarity-both",
+    "shapes-chip-annotation-text-plus",
+    "shapes-chip-annotation-text-minus",
+  ]);
 
   // The Library entries reuse the authoritative toolbar tools rather than
   // creating fixed-size decorative symbols.
@@ -397,28 +405,36 @@ test("groups drafting tools and editable polarity labels under Annotations", asy
     .poll(() => recoveryProjectTexts(page))
     .toContain('"polarity": "both"');
 
-  // The full Insert picker exposes the same semantic entry; clicking its tile
-  // starts annotation placement directly.
-  await page.keyboard.press("i");
-  const dialog = page.getByRole("dialog", { name: "Insert Component" });
-  await dialog.getByLabel("Component search").fill("negative polarity");
-  await dialog
-    .getByTestId("insert-component-annotation-polarity-negative")
-    .click();
-  await canvas.hover({ position: { x: 600, y: 260 } });
-  await canvas.click({ position: { x: 600, y: 260 } });
+  // Deleting the center text keeps the polarity object: the + / − marks are
+  // the component and the text is one removable part of it.
+  await page.getByTestId("drafting-hit-polarity-1").dblclick();
   await expect(editor).toBeVisible();
-  await editor.fill("VDS");
+  await editor.press("ControlOrMeta+a");
+  await editor.press("Delete");
   await page.getByRole("button", { name: "Apply text changes" }).click();
-
-  const negative = canvas.locator('[data-polarity="negative"]');
-  await expect(negative).toBeVisible();
-  await expect(negative.locator('[data-role="polarity-negative"]')).toHaveCount(
+  await expect(polarity).toBeVisible();
+  await expect(
+    polarity.locator('[data-role^="polarity-positive"]'),
+  ).toHaveCount(2);
+  await expect(polarity.locator('[data-role="polarity-negative"]')).toHaveCount(
     1,
   );
-  await expect(
-    negative.locator('[data-role^="polarity-positive"]'),
-  ).toHaveCount(0);
+  await expect(polarity.locator("text")).not.toContainText("VGS");
+
+  // The standalone signs place directly from the Insert picker as ordinary
+  // texts — no editor popup, editable and stylable later like any text.
+  await page.keyboard.press("i");
+  const dialog = page.getByRole("dialog", { name: "Insert Component" });
+  await dialog.getByLabel("Component search").fill("minus");
+  await dialog.getByTestId("insert-component-annotation-text-minus").click();
+  await canvas.hover({ position: { x: 600, y: 260 } });
+  await canvas.click({ position: { x: 600, y: 260 } });
+  await expect(editor).toHaveCount(0);
+  const minusText = canvas.locator(
+    '[data-kind="draft-text"]:not([data-polarity])',
+  );
+  await expect(minusText).toBeVisible();
+  await expect(minusText).toContainText("−");
 });
 
 test("places a vertical Power Rail from I and renames it on the canvas", async ({

--- a/apps/editor/src/features/component-insert/annotation-preview-symbols.ts
+++ b/apps/editor/src/features/component-insert/annotation-preview-symbols.ts
@@ -15,9 +15,14 @@ const drawingToolBySymbolId = {
 
 const polarityBySymbolId = {
   "annotation-polarity-both": "both",
-  "annotation-polarity-positive": "positive",
-  "annotation-polarity-negative": "negative",
 } as const satisfies Readonly<Record<string, PolarityAnnotationKind>>;
+
+// Standalone signs are ordinary DraftText objects with a fixed initial
+// content — sizable and colorable like any text, no polarity machinery.
+const presetTextBySymbolId = {
+  "annotation-text-plus": "+",
+  "annotation-text-minus": "−",
+} as const satisfies Readonly<Record<string, string>>;
 
 export function annotationDrawingTool(
   symbolId: string,
@@ -31,9 +36,15 @@ export function annotationPolarity(
   return polarityBySymbolId[symbolId as keyof typeof polarityBySymbolId];
 }
 
+export function annotationPresetText(symbolId: string): string | undefined {
+  return presetTextBySymbolId[symbolId as keyof typeof presetTextBySymbolId];
+}
+
 export function isAnnotationPaletteSymbol(symbolId: string): boolean {
   return Boolean(
-    annotationDrawingTool(symbolId) ?? annotationPolarity(symbolId),
+    annotationDrawingTool(symbolId) ??
+    annotationPolarity(symbolId) ??
+    annotationPresetText(symbolId),
   );
 }
 
@@ -161,26 +172,29 @@ const annotationPolarityBoth = {
   primitives: [...plusStrokes(-18), ...textStrokes(0), ...minusStrokes(18)],
 } satisfies SymbolDefinition;
 
-const annotationPolarityPositive = {
+const annotationTextPlus = {
   ...shared,
-  id: "annotation-polarity-positive",
-  name: "Positive polarity (+ / text)",
-  viewBox: { x: -14, y: -20, width: 28, height: 40 },
-  primitives: [...plusStrokes(-11), ...textStrokes(7)],
+  id: "annotation-text-plus",
+  name: "Plus sign",
+  viewBox: { x: -12, y: -12, width: 24, height: 24 },
+  primitives: [
+    { kind: "line", from: { x: -6, y: 0 }, to: { x: 6, y: 0 } },
+    { kind: "line", from: { x: 0, y: -6 }, to: { x: 0, y: 6 } },
+  ],
 } satisfies SymbolDefinition;
 
-const annotationPolarityNegative = {
+const annotationTextMinus = {
   ...shared,
-  id: "annotation-polarity-negative",
-  name: "Negative polarity (text / −)",
-  viewBox: { x: -14, y: -20, width: 28, height: 40 },
-  primitives: [...textStrokes(-7), ...minusStrokes(11)],
+  id: "annotation-text-minus",
+  name: "Minus sign",
+  viewBox: { x: -12, y: -12, width: 24, height: 24 },
+  primitives: [{ kind: "line", from: { x: -6, y: 0 }, to: { x: 6, y: 0 } }],
 } satisfies SymbolDefinition;
 
 /**
  * Editor-only catalog artwork. These definitions never enter the electrical
  * SymbolResolver: drawing entries activate an existing tool, while polarity
- * entries create editable DraftText objects.
+ * and sign entries create editable DraftText objects.
  */
 export const annotationPreviewSymbols: readonly SymbolDefinition[] = [
   annotationArrow,
@@ -188,6 +202,6 @@ export const annotationPreviewSymbols: readonly SymbolDefinition[] = [
   annotationRectangle,
   annotationCircle,
   annotationPolarityBoth,
-  annotationPolarityPositive,
-  annotationPolarityNegative,
+  annotationTextPlus,
+  annotationTextMinus,
 ];

--- a/apps/editor/src/features/component-insert/component-insert-request.ts
+++ b/apps/editor/src/features/component-insert/component-insert-request.ts
@@ -33,6 +33,18 @@ export interface PolarityAnnotationInsertRequest {
   initialRotation: 0 | 90 | 180 | 270;
 }
 
+/**
+ * A drafting text placed with its content already decided — the standalone
+ * "+" and "−" signs. Ordinary text afterwards: independently movable,
+ * editable, and stylable like any other DraftText.
+ */
+export interface PresetTextInsertRequest {
+  kind: "preset-text";
+  symbolId: string;
+  symbolName: string;
+  text: string;
+}
+
 export interface CellInsertRequest {
   kind: "cell";
   symbolId: string;
@@ -65,4 +77,5 @@ export type ComponentInsertRequest =
   | ExternalSubcircuitInsertRequest
   | VddRailInsertRequest
   | DrawingToolInsertRequest
-  | PolarityAnnotationInsertRequest;
+  | PolarityAnnotationInsertRequest
+  | PresetTextInsertRequest;

--- a/apps/editor/src/features/component-insert/insert-component-dialog.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.tsx
@@ -6,6 +6,7 @@ import { initialComponentParameterValues } from "./component-parameters";
 import {
   annotationDrawingTool,
   annotationPolarity,
+  annotationPresetText,
 } from "./annotation-preview-symbols";
 import { componentCatalog, libraryDisplayName } from "./symbol-catalog";
 import type { ComponentInsertRequest } from "./component-insert-request";
@@ -221,6 +222,17 @@ export function InsertComponentDialog({
         symbolName: choice.symbol.name,
         polarity,
         initialRotation: 0,
+      });
+      return;
+    }
+    const presetText =
+      choice.kind === "symbol" ? annotationPresetText(symbolId) : undefined;
+    if (presetText) {
+      onApply({
+        kind: "preset-text",
+        symbolId,
+        symbolName: choice.symbol.name,
+        text: presetText,
       });
       return;
     }

--- a/apps/editor/src/features/component-insert/symbol-catalog.test.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.test.ts
@@ -60,7 +60,7 @@ describe("component insertion catalog", () => {
     expect(symbolSubcategory("ndmos")).toBe("High-voltage devices");
   });
 
-  it("offers drawing tools and editable polarity labels as annotations", () => {
+  it("orders annotations as drawing tools, the polarity label, then signs", () => {
     const groups = componentCatalog("razavi-textbook-v1", "");
     const annotations = groups.find(
       (group) => group.category === "Annotations",
@@ -68,12 +68,12 @@ describe("component insertion catalog", () => {
 
     expect(annotations?.symbols.map((symbol) => symbol.id)).toEqual([
       "annotation-arrow",
-      "annotation-circle",
       "annotation-line",
-      "annotation-polarity-negative",
-      "annotation-polarity-both",
-      "annotation-polarity-positive",
       "annotation-rectangle",
+      "annotation-circle",
+      "annotation-polarity-both",
+      "annotation-text-plus",
+      "annotation-text-minus",
     ]);
     expect(groups.at(-1)?.category).toBe("Extended Devices");
   });

--- a/apps/editor/src/features/component-insert/symbol-catalog.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.ts
@@ -155,6 +155,15 @@ const SYMBOL_ORDER: readonly string[] = [
   "vdd-port",
   "vdd",
   "ground",
+  // Annotations: drawing tools first (toolbar order), then the polarity
+  // label, and the standalone sign texts last.
+  "annotation-arrow",
+  "annotation-line",
+  "annotation-rectangle",
+  "annotation-circle",
+  "annotation-polarity-both",
+  "annotation-text-plus",
+  "annotation-text-minus",
 ];
 
 function symbolRank(symbolId: string): number {

--- a/apps/editor/src/features/component-insert/use-component-placement.ts
+++ b/apps/editor/src/features/component-insert/use-component-placement.ts
@@ -603,13 +603,13 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     );
   };
 
-  const placePolarityAnnotation = (
+  const placeDraftingTextAnnotation = (
     position: Point,
     placementRequest: PendingComponentPlacement,
   ): void => {
     if (
       placementRequest.kind !== "drafting-text" ||
-      !placementRequest.polarity
+      (!placementRequest.polarity && !placementRequest.presetText)
     ) {
       return;
     }
@@ -625,19 +625,29 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       locked: false,
       zIndex: 0,
       anchor: { kind: "free", position },
-      content: defaultDraftTextDocument("V_x"),
+      content: defaultDraftTextDocument(placementRequest.presetText ?? "V_x"),
       alignment: "middle",
       rotation: options.componentPlacementRotation,
       typographyToken: "label",
-      polarity: placementRequest.polarity,
+      ...(placementRequest.polarity
+        ? { polarity: placementRequest.polarity }
+        : {}),
     };
     if (!options.transact([{ kind: "upsert_drafting_object", object }]).ok) {
       return;
     }
     options.cancelAllTransientInteraction();
     options.selectOnly("drafting", [object.id]);
-    options.beginDraftingTextEditing(object);
-    options.setStatus(`Added ${placementRequest.polarity} polarity annotation`);
+    if (placementRequest.polarity) {
+      // Polarity labels open for center-text editing right away; a preset
+      // sign is already its final content and stays placed as-is.
+      options.beginDraftingTextEditing(object);
+      options.setStatus(
+        `Added ${placementRequest.polarity} polarity annotation`,
+      );
+    } else {
+      options.setStatus(`Added ${placementRequest.presetText} text`);
+    }
   };
 
   const openInsertPicker = ({
@@ -702,25 +712,39 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
             showValue: false,
             polarity: request.polarity,
           }
-        : request.kind === "symbol" &&
-            (request.symbolId === "port" || request.symbolId === "port-filled")
+        : request.kind === "preset-text"
           ? {
-              kind: "cell-pin",
+              kind: "drafting-text",
               symbolId: request.symbolId,
               parameters: {},
-              initialRotation: request.initialRotation,
+              initialRotation: 0,
               showReference: false,
               referenceText: null,
               showValue: false,
-              direction: request.portDirection ?? "passive",
-              ...(request.portName ? { portName: request.portName } : {}),
+              presetText: request.text,
             }
-          : request;
+          : request.kind === "symbol" &&
+              (request.symbolId === "port" ||
+                request.symbolId === "port-filled")
+            ? {
+                kind: "cell-pin",
+                symbolId: request.symbolId,
+                parameters: {},
+                initialRotation: request.initialRotation,
+                showReference: false,
+                referenceText: null,
+                showValue: false,
+                direction: request.portDirection ?? "passive",
+                ...(request.portName ? { portName: request.portName } : {}),
+              }
+            : request;
     options.beginComponentPlacement(pendingRequest);
     options.setStatus(
       request.kind === "polarity-annotation"
         ? `Place ${request.symbolName} on the canvas · R rotates · Esc cancels`
-        : `Place ${request.symbolName} on the canvas · R rotates · Shift+R / Ctrl+R mirrors · Esc cancels`,
+        : request.kind === "preset-text"
+          ? `Place ${request.symbolName} on the canvas · Esc cancels`
+          : `Place ${request.symbolName} on the canvas · R rotates · Shift+R / Ctrl+R mirrors · Esc cancels`,
     );
   };
 
@@ -783,7 +807,7 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     }
     if (!options.pendingSymbolId || !options.pendingComponentPlacement) return;
     if (options.pendingComponentPlacement.kind === "drafting-text") {
-      placePolarityAnnotation(point, options.pendingComponentPlacement);
+      placeDraftingTextAnnotation(point, options.pendingComponentPlacement);
     } else if (options.pendingComponentPlacement.kind === "retained-instance") {
       const instanceId = options.pendingComponentPlacement.instanceId;
       if (instanceId) placeRetainedInstance(instanceId, point);

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -134,12 +134,26 @@ describe("shapes quick-place", () => {
       polarity: "both",
       initialRotation: 0,
     });
-    expect(
-      quickPlaceRequest("razavi", "annotation-polarity-positive"),
-    ).toMatchObject({ kind: "polarity-annotation", polarity: "positive" });
-    expect(
-      quickPlaceRequest("razavi", "annotation-polarity-negative"),
-    ).toMatchObject({ kind: "polarity-annotation", polarity: "negative" });
+    // Standalone signs are preset texts, not polarity variants; the single
+    // sign-with-text forms left the palette entirely.
+    expect(quickPlaceRequest("razavi", "annotation-text-plus")).toEqual({
+      kind: "preset-text",
+      symbolId: "annotation-text-plus",
+      symbolName: "Plus sign",
+      text: "+",
+    });
+    expect(quickPlaceRequest("razavi", "annotation-text-minus")).toEqual({
+      kind: "preset-text",
+      symbolId: "annotation-text-minus",
+      symbolName: "Minus sign",
+      text: "−",
+    });
+    expect(quickPlaceRequest("razavi", "annotation-polarity-positive")).toBe(
+      null,
+    );
+    expect(quickPlaceRequest("razavi", "annotation-polarity-negative")).toBe(
+      null,
+    );
   });
 
   it("quick-places high-voltage DMOS with MOS parameters", () => {

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -10,6 +10,7 @@ import { initialComponentParameterValues } from "../component-insert/component-p
 import {
   annotationDrawingTool,
   annotationPolarity,
+  annotationPresetText,
 } from "../component-insert/annotation-preview-symbols";
 import {
   componentCatalog,
@@ -62,8 +63,8 @@ const COMPACT_LIBRARY_LABELS: Readonly<Record<string, string>> = {
   "annotation-rectangle": "Rect",
   "annotation-circle": "Circle",
   "annotation-polarity-both": "+ V −",
-  "annotation-polarity-positive": "+ V",
-  "annotation-polarity-negative": "V −",
+  "annotation-text-plus": "+",
+  "annotation-text-minus": "−",
 };
 
 function libraryLabel(symbolId: string, symbolName: string): string {
@@ -99,6 +100,15 @@ export function quickPlaceRequest(
       symbolName: symbol.name,
       polarity,
       initialRotation: 0,
+    };
+  }
+  const presetText = annotationPresetText(symbolId);
+  if (presetText) {
+    return {
+      kind: "preset-text",
+      symbolId,
+      symbolName: symbol.name,
+      text: presetText,
     };
   }
   if (symbolId === "vdd") {

--- a/apps/editor/src/features/text-editing/text-editing.test.ts
+++ b/apps/editor/src/features/text-editing/text-editing.test.ts
@@ -169,6 +169,31 @@ describe("unified text editing", () => {
     ).toEqual({ kind: "blocked" });
   });
 
+  it("keeps an emptied polarity label alive as its bare marks", () => {
+    const object = { ...draftingText(), polarity: "both" as const };
+    const document = {
+      ...createEmptyDocument("text", "Text"),
+      drafting: { objects: [object] },
+    };
+    const session = createTextEditingSession({ owner: "drafting", object });
+    const blank = updateTextEditingSession(session, {
+      content: { runs: [{ kind: "text", value: "   " }] },
+    });
+    // The + / − marks are the component; clearing the center text updates the
+    // object to the canonical empty document instead of deleting it.
+    expect(proposeTextEditingCommit(document, blank)).toMatchObject({
+      kind: "update",
+      edit: {
+        kind: "upsert_drafting_object",
+        object: {
+          id: "drafting-1",
+          polarity: "both",
+          content: { runs: [{ kind: "line-break" }] },
+        },
+      },
+    });
+  });
+
   it("creates deletion edits from the session owner", () => {
     const session = createTextEditingSession({
       owner: "annotation",

--- a/apps/editor/src/features/text-editing/text-editing.ts
+++ b/apps/editor/src/features/text-editing/text-editing.ts
@@ -106,7 +106,18 @@ export function proposeTextEditingCommit(
   session: TextEditingSession,
 ): TextEditingCommitProposal {
   const plainText = flattenRichText(session.content).trim();
-  if (!plainText) {
+  const emptied = !plainText;
+  const emptyTarget = emptied
+    ? resolveTextEditingTarget(document, session)
+    : null;
+  // A polarity label survives with its center text removed: the + / − marks
+  // are the object, and the text is one deletable part of it. Every other
+  // text object is gone once its content is.
+  const polarityKeepsObject =
+    emptyTarget?.owner === "drafting" &&
+    emptyTarget.object.kind === "text" &&
+    Boolean(emptyTarget.object.polarity);
+  if (emptied && !polarityKeepsObject) {
     return {
       kind: "delete",
       edit: textDeletionEdit(session),
@@ -145,7 +156,11 @@ export function proposeTextEditingCommit(
   const object = target.object;
   const next = {
     ...object,
-    content: session.content,
+    // An emptied polarity center persists as the canonical empty document —
+    // a lone line break — because bare text runs must carry characters.
+    content: emptied
+      ? { runs: [{ kind: "line-break" as const }] }
+      : session.content,
     alignment: session.alignment,
     styleOverride: {
       ...object.styleOverride,

--- a/apps/editor/src/interaction/interaction-state.ts
+++ b/apps/editor/src/interaction/interaction-state.ts
@@ -48,6 +48,8 @@ export interface PendingComponentPlacement {
   portName?: string;
   direction?: "input" | "output" | "inout" | "passive";
   polarity?: "both" | "positive" | "negative";
+  /** Fixed initial content for a preset drafting text ("+", "−"). */
+  presetText?: string;
   /** Existing unplaced Instance being returned from the Placement Tray. */
   instanceId?: string;
 }


### PR DESCRIPTION
The Annotations palette reorders to drawing tools first (Arrow, Line, Rect, Circle) with the sign components last, restructured into three parts:

1. **"+ V −"** — the full polarity label. Its center text is now deletable while the + / − marks survive as the component (previously emptying the text deleted the whole object).
2. **"+"** — a standalone plus sign.
3. **"−"** — a standalone minus sign.

The standalone signs are ordinary DraftText objects with preset content: they place directly with no editor popup and are independently movable, editable, sizable, and colorable like any text. The single-sign-with-text variants ("+ V", "V −") left the palette; legacy documents containing them still load and render unchanged.

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)