### PR TITLE
fix(derived): let a selected wire carry its connection point

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -4672,6 +4672,135 @@ test("Fit View keeps the drawing clear of the Properties dock", async ({
   for (const right of rights) expect(right).toBeLessThanOrEqual(dockBox.x);
 });
 
+test("carries the connection point when a column and its wire move", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+
+  // Two columns sharing one bus, as a differential pair is drawn.
+  for (const [x, y] of [
+    [240, 200],
+    [560, 200],
+    [240, 440],
+    [560, 440],
+  ] as const) {
+    await placeComponent(page, "nmos", { x, y });
+  }
+  const ids = await page
+    .locator('[data-layer="symbols"] [data-object-id]')
+    .evaluateAll((elements) =>
+      elements.map((element) => element.getAttribute("data-object-id")),
+    );
+  for (const [top, bottom] of [
+    [ids[0], ids[2]],
+    [ids[1], ids[3]],
+  ] as const) {
+    await clickDrawTool(page, "wire");
+    await page.getByTestId(`terminal-${top}-D`).click();
+    await page.getByTestId(`terminal-${bottom}-D`).click();
+    await page.keyboard.press("Escape");
+  }
+  const columnMids = await page
+    .locator('[data-layer="routes"] polyline')
+    .evaluateAll((elements) =>
+      elements
+        .map((element) => element.getBoundingClientRect())
+        .map((rect) => ({
+          x: rect.x + rect.width / 2,
+          y: rect.y + rect.height / 2,
+        })),
+    );
+  await clickDrawTool(page, "wire");
+  await page.mouse.click(columnMids[0]!.x, columnMids[0]!.y);
+  await page.mouse.dblclick(columnMids[1]!.x, columnMids[1]!.y);
+  await page.keyboard.press("Escape");
+
+  const scene = () =>
+    page.evaluate(() => ({
+      dots: [
+        ...document.querySelectorAll('[data-layer="junctions"] circle'),
+      ].map((circle) => Math.round(Number(circle.getAttribute("cx")))),
+      bends: [
+        ...document.querySelectorAll('[data-layer="routes"] polyline'),
+      ].map((line) => (line as unknown as SVGPolylineElement).points.length),
+    }));
+
+  const before = await scene();
+  expect(before.dots).toHaveLength(2);
+  // Every wire is a straight run to start with.
+  expect(before.bends.every((count) => count === 2)).toBe(true);
+  const rightJunction = Math.max(...before.dots);
+
+  const box = (await canvas.boundingBox())!;
+  await page.mouse.move(box.x + 480, box.y + 140);
+  await page.mouse.down();
+  await page.mouse.move(box.x + 700, box.y + 520, { steps: 12 });
+  await page.mouse.up();
+  await expect(page.getByTestId("status")).toContainText("Selected");
+
+  await page.mouse.move(box.x + 560, box.y + 200);
+  await page.mouse.down();
+  await page.mouse.move(box.x + 680, box.y + 200, { steps: 12 });
+  await page.mouse.up();
+
+  const after = await scene();
+  // The connection point travels with the column it belongs to. Pinning it
+  // left the selected wires bending back to a point that stayed behind.
+  expect(Math.max(...after.dots)).toBeGreaterThan(rightJunction);
+  expect(Math.min(...after.dots)).toBe(Math.min(...before.dots));
+  // The bus stretches; nothing in the selection deforms into a dogleg.
+  expect(after.bends.filter((count) => count > 2)).toHaveLength(0);
+});
+
+test("leaves the connection point alone when only a part moves", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await placeComponent(page, "nmos", { x: 300, y: 200 });
+  await placeComponent(page, "nmos", { x: 300, y: 440 });
+  const ids = await page
+    .locator('[data-layer="symbols"] [data-object-id]')
+    .evaluateAll((elements) =>
+      elements.map((element) => element.getAttribute("data-object-id")),
+    );
+  await clickDrawTool(page, "wire");
+  await page.getByTestId(`terminal-${ids[0]}-D`).click();
+  await page.getByTestId(`terminal-${ids[1]}-D`).click();
+  await page.keyboard.press("Escape");
+  const wire = (await page
+    .locator('[data-layer="routes"] polyline')
+    .first()
+    .boundingBox())!;
+  await clickDrawTool(page, "wire");
+  await page.mouse.click(wire.x + wire.width / 2, wire.y + wire.height / 2);
+  await page.mouse.dblclick(
+    wire.x + wire.width / 2 - 200,
+    wire.y + wire.height / 2,
+  );
+  await page.keyboard.press("Escape");
+
+  const dotX = () =>
+    page
+      .locator('[data-layer="junctions"] circle')
+      .first()
+      .evaluate((circle) => Math.round(Number(circle.getAttribute("cx"))));
+  const before = await dotX();
+
+  // One part, no wire: its own lead stretches rather than dragging the
+  // connection point — and with it the rest of the net — along.
+  await canvas.click({ position: { x: 300, y: 200 } });
+  await page.mouse.move(0, 0);
+  const box = (await canvas.boundingBox())!;
+  await page.mouse.move(box.x + 300, box.y + 200);
+  await page.mouse.down();
+  await page.mouse.move(box.x + 420, box.y + 200, { steps: 10 });
+  await page.mouse.up();
+
+  expect(await dotX()).toBe(before);
+});
+
 test("drags a marquee selection that holds no instance", async ({ page }) => {
   await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");

--- a/packages/derived/src/routing-affected-closure.ts
+++ b/packages/derived/src/routing-affected-closure.ts
@@ -77,22 +77,30 @@ export function deriveRoutingAffectedClosure(
     if (knownJunctions.has(junctionId)) internalJunctionIds.add(junctionId);
   }
 
-  // A selected isolated Wire owns both degree-one route-anchor Junctions.
-  // Other selected Routes remain physical geometry, not an implicit request
-  // to absorb their external electrical neighbourhood into the selection.
+  // A Route the person selected travels with the selection, and the Junctions
+  // on its ends travel with it.
+  //
+  // What pins a Route is a terminal it cannot take along: a Terminal endpoint
+  // belongs to an Instance, so a Route reaching an unselected Instance has to
+  // stay attached and stretch. A Junction endpoint pins nothing — it is an
+  // anchor, free to move, and the unselected Routes meeting it stretch to
+  // follow. Requiring every endpoint to be inside instead stranded the
+  // Junction where two columns share a bus: the selected wires grew doglegs
+  // bending back to a connection point that stayed behind.
   for (const routeId of seed.routeIds) {
     if (!knownRoutes.has(routeId) || internalRouteIds.has(routeId)) continue;
     const route = document.routes.find((item) => item.id === routeId)!;
-    const end = routeEnd(route);
-    if (
-      route.start.kind === "junction" &&
-      end.kind === "junction" &&
-      junctionDegree(document, route.start.junctionId) === 1 &&
-      junctionDegree(document, end.junctionId) === 1
-    ) {
-      internalRouteIds.add(route.id);
-      internalJunctionIds.add(route.start.junctionId);
-      internalJunctionIds.add(end.junctionId);
+    const ends = [route.start, routeEnd(route)];
+    const heldByUnselectedInstance = ends.some(
+      (endpoint) =>
+        endpoint.kind === "terminal" && !instanceIds.has(endpoint.instanceId),
+    );
+    if (heldByUnselectedInstance) continue;
+    internalRouteIds.add(route.id);
+    for (const endpoint of ends) {
+      if (endpoint.kind === "junction") {
+        internalJunctionIds.add(endpoint.junctionId);
+      }
     }
   }
 


### PR DESCRIPTION
Dragging a column and its wire left the connection point behind. Reproduced in the running editor — two columns sharing one bus, marquee the right column, drag it right:

```
before   junctions 220,320 · 560,320
         right column  560,190→560,320 | 560,320→560,450     straight
         bus           220,320 → 560,320

after    junctions 220,320 · 560,320                          the right one did not move
         right column  690,190→560,190→560,320                doglegs bending back to it
                       560,320→560,450→690,450
         transistors moved to 660
```

The selection deformed instead of the surroundings, which is the one thing a group move must not do.

## Why

A Route the person selected was only taken as internal when **both** its ends were degree-one anchors:

```ts
route.start.kind === "junction" && end.kind === "junction" &&
junctionDegree(start) === 1 && junctionDegree(end) === 1
```

Anything meeting a shared Junction fails that, so the Junction stayed pinned and the selected wires stretched around it.

## The rule that replaces it

What pins a Route is a terminal it cannot take along. A **Terminal** endpoint belongs to an Instance, so a Route reaching an unselected Instance has to stay attached and stretch. A **Junction** endpoint pins nothing — it is an anchor, free to travel, and the unselected Routes meeting it stretch to follow.

After the change, the same drag gives straight wires, a junction that travelled with its column, and a bus stretched from `220,320` to `690,320`.

Selecting parts alone is unchanged: their leads are boundary Routes, so the Junction is still an anchor and moving one part stretches its own lead rather than dragging the whole net.

## Validation

- unit: 1564 pass.
- Playwright: 228 pass. Two new specs cover both directions — a column plus its wire carries the connection point and no wire in the selection gains a bend, and a part moved on its own leaves the connection point exactly where it was. The first fails before this change with the geometry above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)