### PR TITLE
Protect unsaved work through the recovery lifecycle

### DIFF
--- a/apps/editor/e2e/project-file.spec.ts
+++ b/apps/editor/e2e/project-file.spec.ts
@@ -15,6 +15,34 @@ test.beforeEach(async ({ page }) => {
   await emulateDownloadOnlyBrowser(page);
 });
 
+test("marks unsaved work and uses the native browser leave prompt only while dirty", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await expect(page.getByTestId("project-unsaved-indicator")).toHaveCount(0);
+
+  await chooseComponent(page, "resistor");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 360, y: 230 } });
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("project-unsaved-indicator")).toBeVisible();
+
+  const leaveAttempt = page
+    .getByRole("link", { name: "Back to the gallery" })
+    .click();
+  const dialog = await page.waitForEvent("dialog");
+  expect(dialog.type()).toBe("beforeunload");
+  await dialog.dismiss();
+  await leaveAttempt;
+  await expect(page).toHaveURL(/\/editor/);
+
+  await downloadBytes(page, "File", "Save Project");
+  await expect(page.getByTestId("project-unsaved-indicator")).toHaveCount(0);
+  await page.getByRole("link", { name: "Back to the gallery" }).click();
+  await expect(page).toHaveURL(/\/$/);
+});
+
 test("downloads the canonical Project when File System Access is unavailable", async ({
   page,
 }) => {
@@ -366,7 +394,9 @@ test("protects dirty work before opening a replacement", async ({ page }) => {
   await expect(dialog).toBeHidden();
 });
 
-test("offers a download from the replacement guard", async ({ page }) => {
+test("saves through the replacement guard before continuing", async ({
+  page,
+}) => {
   await page.addInitScript(() => {
     Object.defineProperty(window, "indexedDB", {
       configurable: false,
@@ -397,16 +427,15 @@ test("offers a download from the replacement guard", async ({ page }) => {
   await expect(dialog).toBeVisible();
 
   const downloadPromise = page.waitForEvent("download");
-  await dialog
-    .getByRole("button", { name: "Download current Project" })
-    .click();
+  await dialog.getByRole("button", { name: "Save and continue" }).click();
   const download = await downloadPromise;
   expect(download.suggestedFilename()).toContain(".icproj.json");
-  // The dialog stays open so the user can still cancel or replace.
-  await expect(dialog).toBeVisible();
-  await dialog.getByRole("button", { name: "Cancel (keep editing)" }).click();
+  // A requested browser download is the download-only browser's truthful save
+  // outcome, so the staged replacement can now continue.
   await expect(dialog).toBeHidden();
-  await expect(page.getByTestId("revision")).toHaveText("1");
+  await expect(page.getByTestId("active-document-name")).toHaveText(
+    "Manual Editor Demo",
+  );
 });
 
 test("creates a fresh Project and returns to the previous Project", async ({

--- a/apps/editor/e2e/recovery-dialog.spec.ts
+++ b/apps/editor/e2e/recovery-dialog.spec.ts
@@ -84,7 +84,7 @@ test.beforeEach(async ({ page }) => {
   await emulateDownloadOnlyBrowser(page);
 });
 
-test("recovery stays reachable after reload and restore forks a working copy", async ({
+test("startup recovery is visible after reload and restore forks a working copy", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -99,15 +99,11 @@ test("recovery stays reachable after reload and restore forks a working copy", a
     .toContain('"revision": 1');
 
   await page.reload();
-  // No startup notice covers the canvas; recovery is reachable on demand.
-  await expect(page.getByTestId("recovery-banner")).toHaveCount(0);
-  await clickCommand(page, "File", "Recover recent work…");
-
-  const dialog = page.getByRole("dialog", { name: "Recover recent work" });
-  await expect(dialog).toBeVisible();
-  await expect(dialog.getByTestId("recovery-session-card")).toHaveCount(1);
-  await dialog.getByRole("button", { name: "Restore" }).click();
-  await expect(dialog).toBeHidden();
+  const banner = page.getByTestId("startup-recovery-banner");
+  await expect(banner).toBeVisible();
+  await expect(banner).toContainText("New Circuit");
+  await banner.getByRole("button", { name: "Restore" }).click();
+  await expect(banner).toBeHidden();
   await expect(page.getByTestId("revision")).toHaveText("1");
   await expect(page.getByTestId("status")).toContainText(
     "Restored recovery revision 1",
@@ -289,7 +285,7 @@ test("dialog closes with Escape and keeps focus labels", async ({ page }) => {
   await expect(dialog).toBeHidden();
 });
 
-test("storage failure shows a persistent warning with a direct download", async ({
+test("storage failure offers a direct download and clears the dirty warning afterward", async ({
   page,
 }) => {
   await page.addInitScript(() => {
@@ -318,6 +314,8 @@ test("storage failure shows a persistent warning with a direct download", async 
   await warning.getByRole("button", { name: "Download Project" }).click();
   const download = await downloadPromise;
   expect(download.suggestedFilename()).toContain(".icproj.json");
-  // The warning stays until dismissed; the editor never crashes.
-  await expect(warning).toBeVisible();
+  // The canonical backup marks the foreground file lifecycle clean, so the
+  // recovery failure no longer needs to interrupt the user.
+  await expect(warning).toBeHidden();
+  await expect(page.getByTestId("project-unsaved-indicator")).toHaveCount(0);
 });

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -169,6 +169,7 @@ import {
 } from "../examples/library-examples";
 import { useDocumentController } from "../document/document-controller";
 import { useProjectFileLifecycle } from "../document/use-project-file-lifecycle";
+import { useUnsavedWorkGuard } from "../document/use-unsaved-work-guard";
 import {
   draftingDragOrigin,
   translateDraftingObject,
@@ -209,7 +210,6 @@ import {
   razaviMosPresentationEdits,
 } from "../presentation/razavi-presentation";
 import { useRecoveryCoordinator } from "../document/recovery-coordinator";
-import { requestProjectDownload } from "../document/project-file-service";
 import { useSelectionController } from "../features/selection/selection-controller";
 import { deriveSelectionInspectionModel } from "../features/selection/selection-inspection-model";
 import { usePropertiesEditor } from "../features/properties/use-properties-editor";
@@ -559,16 +559,20 @@ export function App({
     formalProjectBaseline,
     previousProject,
     replaceGuard,
+    replaceGuardSaving,
     recoveryDialogOpen,
+    startupRecovery,
     setRecoveryDialogOpen,
     isDirtyWork,
     replaceActiveProject,
     saveProjectFile,
+    downloadCurrentProjectBackup,
     reportExport,
     guardDirtyReplacement,
     cancelReplaceGuard,
     confirmReplaceGuard,
-    downloadCurrentProjectFromGuard,
+    saveAndContinueReplaceGuard,
+    dismissStartupRecovery,
     createNewProject,
     restorePreviousProject,
     revertToFormalProjectBaseline,
@@ -612,6 +616,7 @@ export function App({
       return nextDocument;
     },
   });
+  const allowNextBrowserUnload = useUnsavedWorkGuard(isDirtyWork());
   const agentSession = useAgentSession({
     enabled: publicAgentUiEnabled,
     project,
@@ -2696,6 +2701,7 @@ export function App({
       <EditorAppChrome
         projectName={project.name}
         projectNameDraft={projectNameDraft}
+        hasUnsavedWork={isDirtyWork()}
         documentName={document.name}
         onProjectNameDraftChange={setProjectNameDraft}
         onProjectNameCommit={commitProjectName}
@@ -2710,7 +2716,10 @@ export function App({
           onSaveProject: (pickLocation) =>
             void saveProjectFile({ pickLocation }),
           onOpenShelfSlot: (slot) => void openShelvedCircuit(slot),
-          onRefresh: refreshApp,
+          onRefresh: () => {
+            allowNextBrowserUnload();
+            refreshApp();
+          },
           onOpenProject: (file) => void openProjectFile(file),
           onImportSpice: (files) => void importSpiceFiles(files),
           onExportSvg: exportSvg,
@@ -2875,18 +2884,33 @@ export function App({
           (recoveryState === "quota-exceeded" ||
             recoveryState === "unavailable" ||
             recoveryState === "failed") &&
+          isDirtyWork() &&
           !recoveryFailureDismissed
             ? {
                 state: recoveryState,
-                onDownload: () => {
-                  const outcome = requestProjectDownload(project);
-                  setStatus(
-                    outcome.status === "download-requested"
-                      ? `Download requested: ${outcome.fileName}`
-                      : `Download failed: ${outcome.message}`,
+                onDownload: downloadCurrentProjectBackup,
+                onDismiss: () => setRecoveryFailureDismissed(true),
+              }
+            : null
+        }
+        recoveryAvailable={
+          startupRecovery?.latest
+            ? {
+                projectName: startupRecovery.projectName,
+                updatedAt: startupRecovery.latest.updatedAt,
+                onRestore: () => {
+                  dismissStartupRecovery();
+                  restoreRecoverySession(
+                    startupRecovery.workingCopyId,
+                    "latest",
                   );
                 },
-                onDismiss: () => setRecoveryFailureDismissed(true),
+                onDownload: () =>
+                  downloadRecoveryBackup(
+                    startupRecovery.workingCopyId,
+                    "latest",
+                  ),
+                onDismiss: dismissStartupRecovery,
               }
             : null
         }
@@ -2905,9 +2929,11 @@ export function App({
           replaceGuard !== null
             ? {
                 intent: replaceGuard.intent,
+                saving: replaceGuardSaving,
+                recoveryProtected: replaceGuard.recoveryProtected,
                 onCancel: cancelReplaceGuard,
-                onConfirm: confirmReplaceGuard,
-                onDownload: downloadCurrentProjectFromGuard,
+                onSaveAndContinue: saveAndContinueReplaceGuard,
+                onDiscard: confirmReplaceGuard,
               }
             : null
         }
@@ -3852,7 +3878,7 @@ export function App({
         wireOptionsOpen={wireOptionsOpen}
         wireRoutingMode={wireRoutingMode}
         wireCornerOrder={wireCornerOrder}
-        recoveryLabel={recoveryStateLabel(recoveryState)}
+        recoveryLabel={isDirtyWork() ? recoveryStateLabel(recoveryState) : null}
         gridDotsVisible={gridDotsVisible}
         zoomPercent={zoomPercent}
         onToggleWireOptions={() => setWireOptionsOpen((open) => !open)}

--- a/apps/editor/src/app/editor-app-chrome.tsx
+++ b/apps/editor/src/app/editor-app-chrome.tsx
@@ -21,6 +21,7 @@ interface ResetAction {
 export interface EditorAppChromeProps {
   projectName: string;
   projectNameDraft: string | null;
+  hasUnsavedWork: boolean;
   documentName: string;
   onProjectNameDraftChange: (value: string) => void;
   onProjectNameCommit: () => void;
@@ -57,6 +58,7 @@ export interface EditorAppChromeProps {
 export function EditorAppChrome({
   projectName,
   projectNameDraft,
+  hasUnsavedWork,
   documentName,
   onProjectNameDraftChange,
   onProjectNameCommit,
@@ -119,6 +121,16 @@ export function EditorAppChrome({
                   if (event.key === "Escape") onProjectNameCancel();
                 }}
               />{" "}
+              {hasUnsavedWork ? (
+                <span
+                  className="project-unsaved-indicator"
+                  data-testid="project-unsaved-indicator"
+                  aria-label="Unsaved changes"
+                  title="Unsaved changes"
+                >
+                  ●
+                </span>
+              ) : null}{" "}
               / <span data-testid="active-document-name">{documentName}</span>
             </p>
           </div>

--- a/apps/editor/src/app/editor-dialog-layer.tsx
+++ b/apps/editor/src/app/editor-dialog-layer.tsx
@@ -3,7 +3,10 @@ import { Suspense, type ComponentProps } from "react";
 import type { AgentFileCandidateSummary } from "@icm/agent-adapter";
 import type { CellResetPlan } from "@icm/edit-engine";
 
-import { RecoveryFailureBanner } from "../components/recovery-banners";
+import {
+  RecoveryAvailableBanner,
+  RecoveryFailureBanner,
+} from "../components/recovery-banners";
 import {
   LazyCellManagerDialog,
   LazyConnectAgentPanel,
@@ -21,6 +24,7 @@ import {
 export interface EditorDialogLayerProps {
   help: ComponentProps<typeof LazyEditorHelpDialog> | null;
   recoveryFailure: ComponentProps<typeof RecoveryFailureBanner> | null;
+  recoveryAvailable: ComponentProps<typeof RecoveryAvailableBanner> | null;
   recentRecovery: ComponentProps<typeof LazyRecentRecoveryDialog> | null;
   replaceGuard: ComponentProps<typeof LazyReplaceGuardDialog> | null;
   search: ComponentProps<typeof LazyProjectSearchDialog> | null;
@@ -48,6 +52,7 @@ export interface EditorDialogLayerProps {
 export function EditorDialogLayer({
   help,
   recoveryFailure,
+  recoveryAvailable,
   recentRecovery,
   replaceGuard,
   search,
@@ -67,6 +72,9 @@ export function EditorDialogLayer({
         {help ? <LazyEditorHelpDialog {...help} /> : null}
         {recoveryFailure ? (
           <RecoveryFailureBanner {...recoveryFailure} />
+        ) : null}
+        {recoveryAvailable ? (
+          <RecoveryAvailableBanner {...recoveryAvailable} />
         ) : null}
         {recentRecovery ? (
           <LazyRecentRecoveryDialog {...recentRecovery} />

--- a/apps/editor/src/components/recovery-banners.test.tsx
+++ b/apps/editor/src/components/recovery-banners.test.tsx
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  RecoveryAvailableBanner,
+  recoveryStateLabel,
+} from "./recovery-banners";
+
+describe("recovery banners", () => {
+  it("keeps normal recovery writes silent and exposes only failures", () => {
+    expect(recoveryStateLabel("idle")).toBeNull();
+    expect(recoveryStateLabel("pending")).toBeNull();
+    expect(recoveryStateLabel("stored")).toBeNull();
+    expect(recoveryStateLabel("failed")).toContain("failed");
+  });
+
+  it("offers non-modal restore, backup, and ignore actions", () => {
+    const html = renderToStaticMarkup(
+      <RecoveryAvailableBanner
+        projectName="OTA"
+        updatedAt="2026-08-28T08:30:00.000Z"
+        onRestore={vi.fn()}
+        onDownload={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(html).toContain("startup-recovery-banner");
+    expect(html).toContain("OTA");
+    expect(html).toContain("Restore");
+    expect(html).toContain("Download backup");
+    expect(html).toContain("Ignore");
+    expect(html).not.toContain('role="dialog"');
+  });
+});

--- a/apps/editor/src/components/recovery-banners.tsx
+++ b/apps/editor/src/components/recovery-banners.tsx
@@ -6,6 +6,14 @@ export interface RecoveryFailureBannerProps {
   onDismiss(): void;
 }
 
+export interface RecoveryAvailableBannerProps {
+  projectName: string;
+  updatedAt: string;
+  onRestore(): void;
+  onDownload(): void;
+  onDismiss(): void;
+}
+
 function failureMessage(state: RecoveryState): string {
   switch (state) {
     case "quota-exceeded":
@@ -48,15 +56,47 @@ export function RecoveryFailureBanner({
   );
 }
 
+/** Non-modal startup offer for a newer, explicitly unsaved working copy. */
+export function RecoveryAvailableBanner({
+  projectName,
+  updatedAt,
+  onRestore,
+  onDownload,
+  onDismiss,
+}: RecoveryAvailableBannerProps) {
+  return (
+    <aside
+      className="recovery-banner"
+      data-testid="startup-recovery-banner"
+      aria-label="Unsaved recovery available"
+    >
+      <p>
+        Unsaved work for <strong>{projectName}</strong> was recovered from{" "}
+        <time dateTime={updatedAt}>{new Date(updatedAt).toLocaleString()}</time>
+        .
+      </p>
+      <div className="recovery-banner-actions">
+        <button type="button" onClick={onRestore}>
+          Restore
+        </button>
+        <button type="button" onClick={onDownload}>
+          Download backup
+        </button>
+        <button type="button" onClick={onDismiss}>
+          Ignore
+        </button>
+      </div>
+    </aside>
+  );
+}
+
 /** Concise statusbar label derived from coordinator recovery state. */
 export function recoveryStateLabel(state: RecoveryState): string | null {
   switch (state) {
     case "idle":
-      return null;
     case "pending":
-      return "Saving recovery…";
     case "stored":
-      return "Recovery saved";
+      return null;
     case "quota-exceeded":
       return "Recovery full — download now";
     case "unavailable":

--- a/apps/editor/src/components/replace-guard-dialog.test.tsx
+++ b/apps/editor/src/components/replace-guard-dialog.test.tsx
@@ -1,0 +1,39 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { ReplaceGuardDialog } from "./replace-guard-dialog";
+
+describe("ReplaceGuardDialog", () => {
+  it("offers save, discard, and cancellation without treating recovery as a save", () => {
+    const html = renderToStaticMarkup(
+      <ReplaceGuardDialog
+        intent="Open OTA.icproj.json"
+        saving={false}
+        recoveryProtected={true}
+        onCancel={vi.fn()}
+        onSaveAndContinue={vi.fn()}
+        onDiscard={vi.fn()}
+      />,
+    );
+    expect(html).toContain("Save and continue");
+    expect(html).toContain("Discard and continue");
+    expect(html).toContain("Cancel (keep editing)");
+    expect(html).not.toContain("Download current Project");
+  });
+
+  it("warns when the outgoing recovery copy could not be confirmed", () => {
+    const html = renderToStaticMarkup(
+      <ReplaceGuardDialog
+        intent="Create a new Project"
+        saving={true}
+        recoveryProtected={false}
+        onCancel={vi.fn()}
+        onSaveAndContinue={vi.fn()}
+        onDiscard={vi.fn()}
+      />,
+    );
+    expect(html).toContain("could not be confirmed");
+    expect(html).toContain("Saving…");
+    expect(html).toContain("disabled");
+  });
+});

--- a/apps/editor/src/components/replace-guard-dialog.tsx
+++ b/apps/editor/src/components/replace-guard-dialog.tsx
@@ -3,22 +3,26 @@ import { useEffect, useRef } from "react";
 export interface ReplaceGuardDialogProps {
   /** What is about to replace the dirty work, e.g. "Open amp.icproj.json". */
   intent: string;
+  saving: boolean;
+  recoveryProtected: boolean;
   onCancel(): void;
-  onConfirm(): void;
-  onDownload(): void;
+  onSaveAndContinue(): void;
+  onDiscard(): void;
 }
 
 /**
  * Outgoing dirty-work protection. Recovery is a safety copy, not permission to
  * discard the foreground Project, so every dirty replacement pauses here.
- * Defaults to Cancel; Escape cancels; the download action keeps the dialog open
- * so the user can still decide.
+ * Defaults to Cancel; Escape cancels. Save must succeed (or request a browser
+ * download) before the replacement is allowed to continue.
  */
 export function ReplaceGuardDialog({
   intent,
+  saving,
+  recoveryProtected,
   onCancel,
-  onConfirm,
-  onDownload,
+  onSaveAndContinue,
+  onDiscard,
 }: ReplaceGuardDialogProps) {
   const cancelRef = useRef<HTMLButtonElement | null>(null);
   useEffect(() => {
@@ -29,7 +33,7 @@ export function ReplaceGuardDialog({
     <div
       className="help-backdrop"
       onPointerDown={(event) => {
-        if (event.target === event.currentTarget) onCancel();
+        if (!saving && event.target === event.currentTarget) onCancel();
       }}
     >
       <section
@@ -38,7 +42,7 @@ export function ReplaceGuardDialog({
         aria-modal="true"
         aria-labelledby="replace-guard-title"
         onKeyDown={(event) => {
-          if (event.key === "Escape") {
+          if (!saving && event.key === "Escape") {
             event.preventDefault();
             onCancel();
           }
@@ -46,7 +50,7 @@ export function ReplaceGuardDialog({
       >
         <header className="help-dialog-header">
           <div>
-            <p className="help-kicker">Unsaved work</p>
+            <p className="help-kicker">Unsaved changes</p>
             <h2 id="replace-guard-title">Protect the current Project</h2>
           </div>
         </header>
@@ -56,14 +60,30 @@ export function ReplaceGuardDialog({
             safety copy. Choose what happens before <strong>{intent}</strong>{" "}
             continues.
           </p>
+          {!recoveryProtected ? (
+            <p className="replace-guard-warning" role="alert">
+              A current browser recovery copy could not be confirmed. Saving is
+              strongly recommended before continuing.
+            </p>
+          ) : null}
           <div className="replace-guard-actions">
-            <button type="button" ref={cancelRef} onClick={onCancel}>
+            <button
+              type="button"
+              ref={cancelRef}
+              onClick={onCancel}
+              disabled={saving}
+            >
               Cancel (keep editing)
             </button>
-            <button type="button" onClick={onDownload}>
-              Download current Project
+            <button type="button" onClick={onSaveAndContinue} disabled={saving}>
+              {saving ? "Saving…" : "Save and continue"}
             </button>
-            <button type="button" onClick={onConfirm}>
+            <button
+              type="button"
+              className="danger"
+              onClick={onDiscard}
+              disabled={saving}
+            >
               Discard and continue
             </button>
           </div>

--- a/apps/editor/src/document/browser-recovery-contract.test.ts
+++ b/apps/editor/src/document/browser-recovery-contract.test.ts
@@ -89,6 +89,16 @@ describe("finalizeBrowserRecoveryRecord", () => {
       ).formalFileHint,
     ).toEqual({ name: "amp.icproj.json" });
   });
+
+  it("preserves additive unsaved-state metadata without requiring it", () => {
+    expect(
+      finalizeBrowserRecoveryRecord(draft()).unsavedAtSnapshot,
+    ).toBeUndefined();
+    expect(
+      finalizeBrowserRecoveryRecord(draft({ unsavedAtSnapshot: true }))
+        .unsavedAtSnapshot,
+    ).toBe(true);
+  });
 });
 
 describe("decodeBrowserRecoveryRecord", () => {
@@ -152,6 +162,9 @@ describe("decodeBrowserRecoveryRecord", () => {
         ...record,
         documentRevisions: { "document-main": -1 },
       }),
+    ).toMatchObject({ status: "corrupt" });
+    expect(
+      decodeBrowserRecoveryRecord({ ...record, unsavedAtSnapshot: "yes" }),
     ).toMatchObject({ status: "corrupt" });
     expect(
       decodeBrowserRecoveryRecord({
@@ -298,6 +311,30 @@ describe("rotateBrowserRecoverySession", () => {
     expect(rotation.status).toBe("unchanged");
     if (rotation.status === "unchanged") {
       expect(rotation.session.latest?.recordId).toBe("record-1");
+    }
+  });
+
+  it("updates save metadata in place without rotating identical content", () => {
+    const first = finalizeBrowserRecoveryRecord(
+      draft({ recordId: "record-1", unsavedAtSnapshot: true }),
+    );
+    const saved = finalizeBrowserRecoveryRecord(
+      draft({
+        recordId: "record-2",
+        updatedAt: "2026-08-14T10:05:00.000Z",
+        unsavedAtSnapshot: false,
+        formalFileHint: { name: "amp.icproj.json" },
+      }),
+    );
+    const rotation = rotateBrowserRecoverySession(
+      session("working-copy-a", { latest: first }),
+      saved,
+    );
+    expect(rotation.status).toBe("updated");
+    if (rotation.status === "updated") {
+      expect(rotation.session.latest?.recordId).toBe("record-2");
+      expect(rotation.session.latest?.unsavedAtSnapshot).toBe(false);
+      expect(rotation.session.previous).toBeNull();
     }
   });
 

--- a/apps/editor/src/document/browser-recovery-contract.ts
+++ b/apps/editor/src/document/browser-recovery-contract.ts
@@ -71,6 +71,8 @@ export interface BrowserRecoveryRecordV2 {
   /** UTF-8 byte length of `projectText`; always recomputed, never trusted. */
   byteLength: number;
   projectText: string;
+  /** Whether this snapshot represents work not confirmed in a formal file. */
+  unsavedAtSnapshot?: boolean;
   formalFileHint?: BrowserRecoveryFormalFileHint;
 }
 
@@ -87,6 +89,7 @@ export interface BrowserRecoveryRecordDraft {
   source: BrowserRecoverySource;
   updatedAt: string;
   projectText: string;
+  unsavedAtSnapshot?: boolean;
   formalFileHint?: BrowserRecoveryFormalFileHint;
 }
 
@@ -124,6 +127,9 @@ export function finalizeBrowserRecoveryRecord(
     updatedAt: draft.updatedAt,
     byteLength: browserRecoveryByteLength(draft.projectText),
     projectText: draft.projectText,
+    ...(draft.unsavedAtSnapshot === undefined
+      ? {}
+      : { unsavedAtSnapshot: draft.unsavedAtSnapshot }),
     ...(draft.formalFileHint === undefined
       ? {}
       : { formalFileHint: draft.formalFileHint }),
@@ -233,6 +239,12 @@ export function decodeBrowserRecoveryRecord(
       }
     }
   }
+  if (
+    raw.unsavedAtSnapshot !== undefined &&
+    typeof raw.unsavedAtSnapshot !== "boolean"
+  ) {
+    return corrupt("unsavedAtSnapshot is not a boolean");
+  }
 
   const projectText = raw.projectText as string;
   const record: BrowserRecoveryRecordV2 = {
@@ -249,6 +261,9 @@ export function decodeBrowserRecoveryRecord(
     updatedAt: raw.updatedAt as string,
     byteLength: browserRecoveryByteLength(projectText),
     projectText,
+    ...(raw.unsavedAtSnapshot === undefined
+      ? {}
+      : { unsavedAtSnapshot: raw.unsavedAtSnapshot as boolean }),
     ...(raw.formalFileHint === undefined
       ? {}
       : {
@@ -352,6 +367,7 @@ export interface BrowserRecoverySession {
 
 export type BrowserRecoveryRotation =
   | { status: "unchanged"; session: BrowserRecoverySession }
+  | { status: "updated"; session: BrowserRecoverySession }
   | { status: "rotated"; session: BrowserRecoverySession }
   | {
       status: "rejected-too-large";
@@ -381,7 +397,25 @@ export function rotateBrowserRecoverySession(
     session.latest !== null &&
     session.latest.projectText === candidate.projectText
   ) {
-    return { status: "unchanged", session };
+    const sameHint =
+      session.latest.formalFileHint?.name === candidate.formalFileHint?.name &&
+      session.latest.formalFileHint?.lastConfirmedWriteAt ===
+        candidate.formalFileHint?.lastConfirmedWriteAt &&
+      session.latest.formalFileHint?.lastDownloadRequestedAt ===
+        candidate.formalFileHint?.lastDownloadRequestedAt;
+    if (
+      session.latest.unsavedAtSnapshot === candidate.unsavedAtSnapshot &&
+      sameHint
+    ) {
+      return { status: "unchanged", session };
+    }
+    return {
+      status: "updated",
+      session: {
+        ...session,
+        latest: candidate,
+      },
+    };
   }
   return {
     status: "rotated",

--- a/apps/editor/src/document/browser-recovery-store.ts
+++ b/apps/editor/src/document/browser-recovery-store.ts
@@ -331,7 +331,7 @@ export function createBrowserRecoveryStore(
         generation: "latest",
       };
       try {
-        let rotated = false;
+        let written = false;
         let deletedRecordIds: string[] = [];
         await runMutation(async (objectStore, stored) => {
           const sessions = buildSessions(stored);
@@ -355,11 +355,12 @@ export function createBrowserRecoveryStore(
           await deleteStoredRecords(objectStore, stored, (record) =>
             plannedIds.has(record.recordId),
           );
-          if (rotation.status === "rotated") {
-            rotated = true;
+          if (rotation.status === "rotated" || rotation.status === "updated") {
+            written = true;
             // A previous generation dropped by retention must not be
             // re-written into its new slot.
-            const previousCandidate = rotation.session.previous;
+            const previousCandidate =
+              rotation.status === "rotated" ? rotation.session.previous : null;
             const previous =
               previousCandidate !== null &&
               !plannedIds.has(previousCandidate.recordId)
@@ -382,7 +383,7 @@ export function createBrowserRecoveryStore(
           }
           deletedRecordIds = plan.deleteRecordIds;
         });
-        if (!rotated) return { status: "unchanged" };
+        if (!written) return { status: "unchanged" };
         return {
           status: "stored",
           record: asLatest,

--- a/apps/editor/src/document/recovery-coordinator.test.ts
+++ b/apps/editor/src/document/recovery-coordinator.test.ts
@@ -133,6 +133,7 @@ describe("createRecoveryCoordinator", () => {
       serializeProject(projectA),
     );
     expect(read.sessions[0]?.latest?.source).toBe("new");
+    expect(read.sessions[0]?.latest?.unsavedAtSnapshot).toBe(true);
   });
 
   it("coalesces a burst of commits into the newest Project", async () => {
@@ -162,6 +163,17 @@ describe("createRecoveryCoordinator", () => {
     expect(read.sessions[0]?.latest?.projectText).toBe(
       serializeProject(projectA),
     );
+  });
+
+  it("marks identical content clean without consuming the previous generation", async () => {
+    const harness = createHarness();
+    harness.coordinator.stage(projectA);
+    await harness.coordinator.flushNow();
+    harness.coordinator.stage(projectA, { unsavedAtSnapshot: false });
+    await harness.coordinator.flushNow();
+    const read = await harness.coordinator.store.readAll();
+    expect(read.sessions[0]?.previous).toBeNull();
+    expect(read.sessions[0]?.latest?.unsavedAtSnapshot).toBe(false);
   });
 
   it("rotates previous generations across separate writes", async () => {
@@ -328,6 +340,7 @@ describe("createRecoveryCoordinator", () => {
     expect(byName).toEqual(["Alpha", "Beta"]);
     expect(harness.sessions[0]?.latest?.review).toBe("valid");
     expect(harness.sessions[0]?.latest?.revision).not.toBeNull();
+    expect(harness.sessions[0]?.latest?.unsavedAtSnapshot).toBe(true);
   });
 
   it("classifies corrupt and unsupported-schema generations in summaries", async () => {

--- a/apps/editor/src/document/recovery-coordinator.ts
+++ b/apps/editor/src/document/recovery-coordinator.ts
@@ -57,6 +57,13 @@ export interface RecoveryGenerationSummary {
   review: "valid" | "corrupt" | "unsupported-schema";
   /** Top-document revision at the time of the snapshot, when known. */
   revision: number | null;
+  /** `null` means the field predates this additive recovery metadata. */
+  unsavedAtSnapshot: boolean | null;
+}
+
+export interface RecoveryStageOptions {
+  /** Defaults to true because normal staging follows a committed edit. */
+  unsavedAtSnapshot?: boolean;
 }
 
 export interface RecoverySessionSummary {
@@ -103,7 +110,7 @@ export interface RecoveryCoordinator {
   readonly state: RecoveryState;
   readonly sessions: RecoverySessionSummary[];
   /** Schedule a debounced recovery write for a successfully committed Project. */
-  stage(project: CircuitProject): void;
+  stage(project: CircuitProject, options?: RecoveryStageOptions): void;
   /** Drop a pending write without storing it (replacement boundary). */
   cancelPending(): void;
   /** Flush any pending write and wait for the write chain to settle. */
@@ -169,6 +176,7 @@ function summarizeGeneration(
         : "unsupported-schema",
     revision:
       review.status === "valid" ? (readTopRevision(record) ?? null) : null,
+    unsavedAtSnapshot: record.unsavedAtSnapshot ?? null,
   };
 }
 
@@ -217,12 +225,17 @@ export function createRecoveryCoordinator(
   // never race two write transactions against the same session.
   let writeChain: Promise<void> = Promise.resolve();
 
-  function enqueueWrite(project: CircuitProject): void {
+  interface RecoveryCandidate {
+    project: CircuitProject;
+    unsavedAtSnapshot: boolean;
+  }
+
+  function enqueueWrite(candidate: RecoveryCandidate): void {
     publishState("pending");
     writeChain = writeChain.then(async () => {
       let record: BrowserRecoveryRecordV2;
       try {
-        record = buildRecord(project);
+        record = buildRecord(candidate);
       } catch (error) {
         publishState("failed");
         events.onNotice?.(
@@ -254,7 +267,8 @@ export function createRecoveryCoordinator(
     });
   }
 
-  function buildRecord(project: CircuitProject): BrowserRecoveryRecordV2 {
+  function buildRecord(candidate: RecoveryCandidate): BrowserRecoveryRecordV2 {
+    const { project } = candidate;
     recordCounter += 1;
     const documentRevisions: Record<string, number> = {};
     for (const document of project.documents) {
@@ -272,11 +286,12 @@ export function createRecoveryCoordinator(
       source: currentSource,
       updatedAt: now(),
       projectText: serializeProject(project),
+      unsavedAtSnapshot: candidate.unsavedAtSnapshot,
       ...(formalFileHint === undefined ? {} : { formalFileHint }),
     });
   }
 
-  const scheduler = createRecoveryScheduler<CircuitProject>({
+  const scheduler = createRecoveryScheduler<RecoveryCandidate>({
     delayMs: options.delayMs ?? RECOVERY_WRITE_DELAY_MS,
     write: enqueueWrite,
     ...(options.setTimeout === undefined
@@ -302,8 +317,11 @@ export function createRecoveryCoordinator(
       return sessions;
     },
 
-    stage(project: CircuitProject): void {
-      scheduler.schedule(project);
+    stage(project: CircuitProject, options: RecoveryStageOptions = {}): void {
+      scheduler.schedule({
+        project,
+        unsavedAtSnapshot: options.unsavedAtSnapshot ?? true,
+      });
     },
 
     cancelPending(): void {
@@ -423,7 +441,7 @@ export interface UseRecoveryCoordinatorResult {
   /** True once startup discovery (after any migration) has settled. */
   ready: boolean;
   workingCopyId: string;
-  stage: (project: CircuitProject) => void;
+  stage: (project: CircuitProject, options?: RecoveryStageOptions) => void;
   cancelPending: () => void;
   flushNow: () => Promise<RecoveryState>;
   beginWorkingCopy: (source: BrowserRecoverySource) => string;
@@ -508,7 +526,7 @@ export function useRecoveryCoordinator(
     sessions,
     ready,
     workingCopyId: currentWorkingCopyId,
-    stage: (project) => coordinator.stage(project),
+    stage: (project, stageOptions) => coordinator.stage(project, stageOptions),
     cancelPending: () => coordinator.cancelPending(),
     flushNow: () => coordinator.flushNow(),
     beginWorkingCopy: (source) => {

--- a/apps/editor/src/document/use-project-file-lifecycle.ts
+++ b/apps/editor/src/document/use-project-file-lifecycle.ts
@@ -23,6 +23,7 @@ import {
 } from "./project-file-service";
 import type {
   ProjectFileState,
+  ProjectSaveOutcome,
   ProjectSaveTarget,
 } from "./project-file-service";
 import { projectChangeToken } from "./project-session-lifecycle";
@@ -46,6 +47,7 @@ interface PreviousProjectSnapshot extends FormalProjectBaseline {
 interface ReplaceGuardState {
   intent: string;
   perform: () => void | Promise<void>;
+  recoveryProtected: boolean;
 }
 
 export interface ReplaceProjectOptions {
@@ -115,7 +117,12 @@ export function useProjectFileLifecycle({
   const [replaceGuard, setReplaceGuard] = useState<ReplaceGuardState | null>(
     null,
   );
+  const [replaceGuardSaving, setReplaceGuardSaving] = useState(false);
   const [recoveryDialogOpen, setRecoveryDialogOpen] = useState(false);
+  const [
+    dismissedStartupRecoveryRecordId,
+    setDismissedStartupRecoveryRecordId,
+  ] = useState<string | null>(null);
 
   function isDirtyWork(): boolean {
     return fileState === "dirty" || fileState === "write-failed";
@@ -149,18 +156,25 @@ export function useProjectFileLifecycle({
     const prepared = materializeRazaviProjectBulkConnections(nextProject);
     const nextDocument = installProject(prepared.project, nextViewBox);
     saveTargetRef.current = null;
-    setFileState(
+    const nextFileState =
       options.fileState ??
-        (options.source === "opened-file" ? "opened" : "new"),
-    );
+      (options.source === "opened-file"
+        ? "opened"
+        : options.source === "spice-import" || options.source === "recovered"
+          ? "dirty"
+          : "new");
+    setFileState(nextFileState);
     setFormalProjectBaseline(options.formalBaseline ?? null);
-    recovery.stage(prepared.project);
+    recovery.stage(prepared.project, {
+      unsavedAtSnapshot:
+        nextFileState === "dirty" || nextFileState === "write-failed",
+    });
     return nextDocument;
   }
 
   async function saveProjectFile(
     options: { pickLocation?: boolean } = {},
-  ): Promise<void> {
+  ): Promise<ProjectSaveOutcome> {
     const outcome = await saveProjectArtifact(
       project,
       {},
@@ -176,9 +190,11 @@ export function useProjectFileLifecycle({
         name: outcome.fileName,
         lastConfirmedWriteAt: outcome.at,
       });
+      recovery.stage(project, { unsavedAtSnapshot: false });
+      await recovery.flushNow();
       setFileState("write-confirmed");
       setStatus(`Saved ${outcome.fileName} (write confirmed)`);
-      return;
+      return outcome;
     }
     if (outcome.status === "download-requested") {
       setFormalProjectBaseline({
@@ -189,32 +205,35 @@ export function useProjectFileLifecycle({
         name: outcome.fileName,
         lastDownloadRequestedAt: new Date().toISOString(),
       });
+      recovery.stage(project, { unsavedAtSnapshot: false });
+      await recovery.flushNow();
       setFileState("download-requested");
       setStatus(`Download requested: ${outcome.fileName}`);
-      return;
+      return outcome;
     }
     if (outcome.status === "picker-cancelled") {
       setStatus("Save cancelled");
-      return;
+      return outcome;
     }
     if (outcome.status === "permission-denied") {
       setStatus(
         `Save location unavailable and download failed: ${outcome.message}`,
       );
-      return;
+      return outcome;
     }
     if (outcome.status === "write-failed") {
       setFileState("write-failed");
       setStatus(
         `Save failed at ${outcome.stage}: ${outcome.message} — recovery kept; download the Project instead`,
       );
-      return;
+      return outcome;
     }
     if (outcome.status === "target-unavailable") {
       setStatus("Save location is no longer available — choose one again");
-      return;
+      return outcome;
     }
     setStatus(`Project could not be serialized: ${outcome.message}`);
+    return outcome;
   }
 
   async function reportExport(message: string): Promise<void> {
@@ -230,12 +249,33 @@ export function useProjectFileLifecycle({
           name: outcome.fileName,
           lastConfirmedWriteAt: outcome.at,
         });
+        recovery.stage(project, { unsavedAtSnapshot: false });
+        await recovery.flushNow();
         setFileState("write-confirmed");
         setStatus(`${message} — also saved ${outcome.fileName}`);
         return;
       }
     }
     setStatus(`${message} — the Project file still has unsaved changes`);
+  }
+
+  function downloadCurrentProjectBackup(): void {
+    const outcome = requestProjectDownload(project);
+    if (outcome.status !== "download-requested") {
+      setStatus(`Download failed: ${outcome.message}`);
+      return;
+    }
+    setFormalProjectBaseline({
+      project: structuredClone(project),
+      viewBox: { ...viewBox },
+    });
+    recovery.noteFormalFileHint({
+      name: outcome.fileName,
+      lastDownloadRequestedAt: new Date().toISOString(),
+    });
+    recovery.stage(project, { unsavedAtSnapshot: false });
+    setFileState("download-requested");
+    setStatus(`Download requested: ${outcome.fileName}`);
   }
 
   async function guardDirtyReplacement(
@@ -246,30 +286,43 @@ export function useProjectFileLifecycle({
       await perform();
       return;
     }
-    recovery.stage(project);
-    await recovery.flushNow();
-    setReplaceGuard({ intent, perform });
+    recovery.stage(project, { unsavedAtSnapshot: true });
+    const recoveryState = await recovery.flushNow();
+    setReplaceGuard({
+      intent,
+      perform,
+      recoveryProtected: recoveryState === "stored",
+    });
   }
 
   function cancelReplaceGuard(): void {
+    if (replaceGuardSaving) return;
     setReplaceGuard(null);
   }
 
   function confirmReplaceGuard(): void {
+    if (replaceGuardSaving) return;
     const guard = replaceGuard;
     if (!guard) return;
     setReplaceGuard(null);
     void guard.perform();
   }
 
-  function downloadCurrentProjectFromGuard(): void {
-    const outcome = requestProjectDownload(project);
-    if (outcome.status === "download-requested") {
-      setFileState("download-requested");
-      setStatus(`Download requested: ${outcome.fileName}`);
-    } else {
-      setStatus(`Download failed: ${outcome.message}`);
-    }
+  function saveAndContinueReplaceGuard(): void {
+    const guard = replaceGuard;
+    if (!guard || replaceGuardSaving) return;
+    setReplaceGuardSaving(true);
+    void (async () => {
+      const outcome = await saveProjectFile();
+      if (
+        outcome.status === "write-confirmed" ||
+        outcome.status === "download-requested"
+      ) {
+        setReplaceGuard(null);
+        await guard.perform();
+      }
+      setReplaceGuardSaving(false);
+    })();
   }
 
   function createNewProject(): void {
@@ -359,7 +412,7 @@ export function useProjectFileLifecycle({
           const recoveredDocument = replaceActiveProject(
             read.project,
             defaultViewBox,
-            { source: "recovered" },
+            { source: "recovered", fileState: "dirty" },
           );
           setRecoveryDialogOpen(false);
           await recovery.discover();
@@ -413,7 +466,7 @@ export function useProjectFileLifecycle({
 
   function refreshApp(): void {
     void (async () => {
-      recovery.stage(project);
+      recovery.stage(project, { unsavedAtSnapshot: isDirtyWork() });
       await recovery.flushNow();
       window.sessionStorage.setItem(REFRESH_RESTORE_STORAGE_KEY, "true");
       window.location.reload();
@@ -442,8 +495,8 @@ export function useProjectFileLifecycle({
           project: structuredClone(staged.project),
           viewBox: { ...defaultViewBox },
         },
+        fileState: staged.migrated ? "dirty" : "opened",
       });
-      if (staged.migrated) setFileState("dirty");
       setStatus(
         staged.migrated
           ? `Opened and upgraded ${staged.fileName} from schema ${staged.sourceSchemaVersion} to schema ${staged.project.schemaVersion} — save the Project to keep the upgrade`
@@ -511,6 +564,8 @@ export function useProjectFileLifecycle({
           source: "recovered",
           keepWorkingCopy: true,
           rememberPrevious: false,
+          fileState:
+            read.record.unsavedAtSnapshot === false ? "opened" : "dirty",
         },
       );
       setStatus(`Restored recovery revision ${restoredDocument.revision}`);
@@ -538,21 +593,39 @@ export function useProjectFileLifecycle({
     }
   }, [currentProjectChangeToken, projectSessionId]);
 
+  const startupRecovery =
+    !restoreAfterRefresh && !isDirtyWork()
+      ? (recovery.sessions.find(
+          (session) =>
+            session.workingCopyId === recovery.workingCopyId &&
+            session.latest?.review === "valid" &&
+            session.latest.unsavedAtSnapshot === true &&
+            session.latest.recordId !== dismissedStartupRecoveryRecordId,
+        ) ?? null)
+      : null;
+
   return {
     fileState,
     formalProjectBaseline,
     previousProject,
     replaceGuard,
+    replaceGuardSaving,
     recoveryDialogOpen,
+    startupRecovery,
     setRecoveryDialogOpen,
     isDirtyWork,
     replaceActiveProject,
     saveProjectFile,
+    downloadCurrentProjectBackup,
     reportExport,
     guardDirtyReplacement,
     cancelReplaceGuard,
     confirmReplaceGuard,
-    downloadCurrentProjectFromGuard,
+    saveAndContinueReplaceGuard,
+    dismissStartupRecovery: () =>
+      setDismissedStartupRecoveryRecordId(
+        startupRecovery?.latest?.recordId ?? null,
+      ),
     createNewProject,
     restorePreviousProject,
     revertToFormalProjectBaseline,

--- a/apps/editor/src/document/use-unsaved-work-guard.test.ts
+++ b/apps/editor/src/document/use-unsaved-work-guard.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  installUnsavedWorkGuard,
+  type BeforeUnloadTarget,
+} from "./use-unsaved-work-guard";
+
+describe("installUnsavedWorkGuard", () => {
+  it("asks the browser to protect dirty work and removes the exact listener", () => {
+    let listener: ((event: BeforeUnloadEvent) => void) | null = null;
+    const target: BeforeUnloadTarget = {
+      addEventListener: vi.fn((_type, next) => {
+        listener = next;
+      }),
+      removeEventListener: vi.fn(),
+    };
+    const installed = installUnsavedWorkGuard(target);
+    const preventDefault = vi.fn();
+    const event = {
+      preventDefault,
+      returnValue: false,
+    } as unknown as BeforeUnloadEvent;
+
+    expect(listener).not.toBeNull();
+    (listener as unknown as (event: BeforeUnloadEvent) => void)(event);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(event.returnValue).toBe(true);
+
+    installed.dispose();
+    expect(target.removeEventListener).toHaveBeenCalledWith(
+      "beforeunload",
+      listener,
+    );
+  });
+
+  it("allows exactly one application-controlled unload", () => {
+    let listener: ((event: BeforeUnloadEvent) => void) | null = null;
+    const target: BeforeUnloadTarget = {
+      addEventListener: vi.fn((_type, next) => {
+        listener = next;
+      }),
+      removeEventListener: vi.fn(),
+    };
+    const installed = installUnsavedWorkGuard(target);
+    const preventDefault = vi.fn();
+    const event = {
+      preventDefault,
+      returnValue: false,
+    } as unknown as BeforeUnloadEvent;
+
+    installed.allowNextUnload();
+    (listener as unknown as (event: BeforeUnloadEvent) => void)(event);
+    expect(preventDefault).not.toHaveBeenCalled();
+
+    (listener as unknown as (event: BeforeUnloadEvent) => void)(event);
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/editor/src/document/use-unsaved-work-guard.ts
+++ b/apps/editor/src/document/use-unsaved-work-guard.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export interface BeforeUnloadTarget {
+  addEventListener(
+    type: "beforeunload",
+    listener: (event: BeforeUnloadEvent) => void,
+  ): void;
+  removeEventListener(
+    type: "beforeunload",
+    listener: (event: BeforeUnloadEvent) => void,
+  ): void;
+}
+
+/**
+ * Install the browser-owned leave prompt. This deliberately does not save,
+ * flush recovery, or manipulate history: those are separate lifecycle
+ * responsibilities and unload is not a reliable asynchronous work boundary.
+ */
+export interface InstalledUnsavedWorkGuard {
+  /** Allow one application-controlled unload, then resume normal protection. */
+  allowNextUnload(): void;
+  dispose(): void;
+}
+
+export function installUnsavedWorkGuard(
+  target: BeforeUnloadTarget,
+): InstalledUnsavedWorkGuard {
+  let allowNextUnload = false;
+  const onBeforeUnload = (event: BeforeUnloadEvent): void => {
+    if (allowNextUnload) {
+      allowNextUnload = false;
+      return;
+    }
+    event.preventDefault();
+    // Legacy Chromium/Edge still consult this field. Browsers choose the
+    // visible copy; the application never supplies custom prompt text.
+    event.returnValue = true;
+  };
+  target.addEventListener("beforeunload", onBeforeUnload);
+  return {
+    allowNextUnload: () => {
+      allowNextUnload = true;
+    },
+    dispose: () => target.removeEventListener("beforeunload", onBeforeUnload),
+  };
+}
+
+/** Register the native browser prompt only while formal work is unsaved. */
+export function useUnsavedWorkGuard(isDirty: boolean): () => void {
+  const installedRef = useRef<InstalledUnsavedWorkGuard | null>(null);
+  useEffect(() => {
+    if (!isDirty || typeof window === "undefined") return;
+    const installed = installUnsavedWorkGuard(window);
+    installedRef.current = installed;
+    return () => {
+      installed.dispose();
+      if (installedRef.current === installed) installedRef.current = null;
+    };
+  }, [isDirty]);
+  return useCallback(() => installedRef.current?.allowNextUnload(), []);
+}

--- a/apps/editor/src/styles/editor-chrome.css
+++ b/apps/editor/src/styles/editor-chrome.css
@@ -813,6 +813,12 @@
   outline: 0;
 }
 
+.project-unsaved-indicator {
+  color: var(--icm-accent);
+  font-size: 0.62rem;
+  vertical-align: middle;
+}
+
 @media (max-width: 1100px) {
   .app-brand-copy h1 {
     font-size: var(--icm-font-md);

--- a/apps/editor/src/styles/editor-overlays.css
+++ b/apps/editor/src/styles/editor-overlays.css
@@ -72,6 +72,12 @@
   gap: 0.6rem;
 }
 
+.replace-guard-warning {
+  padding: var(--icm-space-2) var(--icm-space-3);
+  border-left: 3px solid #b45309;
+  background: #fef3c7;
+}
+
 /* Recovery banners float over the canvas so they never resize it. */
 .recovery-banner {
   position: fixed;

--- a/docs/release/browser-recovery-v2.md
+++ b/docs/release/browser-recovery-v2.md
@@ -24,9 +24,15 @@ lives in [`docs/specs/persistence-and-recovery.md`](../specs/persistence-and-rec
   and reports `Download requested`, because browsers do not confirm durable
   download completion. Saving or downloading never deletes safety copies.
 - Opening, importing, or accepting an Agent replacement of a Project with
-  unsaved changes first confirms a recovery write; if storage fails, the
-  editor offers Download current Project / Replace anyway / Cancel, defaulting
-  to Cancel. A rejected file keeps its diagnostic code and path.
+  unsaved changes first flushes a recovery write, then offers Save and continue
+  / Discard and continue / Cancel, defaulting to Cancel. Save failure or
+  cancellation keeps the foreground Project in place. A rejected file keeps
+  its diagnostic code and path.
+- A small dot marks dirty work. Browser Back, Refresh, and tab/window close use
+  the native leave confirmation only while dirty. After an unexpected exit, a
+  non-modal startup banner offers an explicitly unsaved latest recovery copy;
+  older records without save-state metadata remain available from the File
+  menu without triggering the banner.
 - Storage failures (quota, unavailable) show a persistent warning with a
   direct download action; they never change or crash the live Project.
 - The legacy `icm.recovery.v1` localStorage slot migrates into IndexedDB on

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -345,6 +345,15 @@ Selection, viewport, active tool, previews, Agent tokens, and approval UI are
 transient and never enter Project JSON. Recovery is scheduled only after a
 successful transaction or explicit replacement and stores no bearer token.
 
+The Project-name area shows a small unsaved marker derived from the same file
+lifecycle that controls Save. While that marker is present, browser Back,
+Refresh, and tab/window close use the browser-native leave confirmation;
+ordinary in-app navigation, selection, zoom, and panel changes do not affect
+it. New, Open, Revert, recovery restore, and approved staged replacement use
+one application dialog with Save and continue, Discard and continue, and
+Cancel. A startup recovery offer is a non-modal overlay and never silently
+replaces the active Project.
+
 ## Agent semantic control
 
 API 2.0 may advertise optional `semanticControl` for transient review focus:

--- a/docs/specs/persistence-and-recovery.md
+++ b/docs/specs/persistence-and-recovery.md
@@ -35,7 +35,8 @@ limits live in `apps/editor/src/document/browser-recovery-contract.ts`:
 - at most 2 retained working-copy sessions, the active one always kept and the
   oldest inactive session pruned first;
 - at most `latest` and `previous` per session; identical Project text does not
-  consume a new generation;
+  consume a new generation. Save-state and formal-file metadata may update the
+  latest envelope in place without rotating its Project text into `previous`;
 - one record's Project text is at most 4 MB (UTF-8, recomputed on read);
 - all owned records total at most 12 MB.
 
@@ -44,7 +45,12 @@ separate from the Project schema and never enters `.icproj.json`. Stored input
 is decoded structurally before its Project text is parsed, and a record whose
 Project text carries an unsupported schema version classifies as
 `unsupported-schema`, keeps its raw bytes downloadable, and is never deleted as
-corrupt. Envelope identity fields must agree with the parsed Project.
+corrupt. Envelope identity fields must agree with the parsed Project. The
+optional `unsavedAtSnapshot` envelope field records whether the snapshot was
+ahead of the formal save baseline. Records written before this additive field
+remain valid but have unknown save state and therefore do not trigger an
+automatic startup offer. This metadata is browser lifecycle state, never part
+of Project JSON.
 
 A rejected write (oversized, quota exceeded, storage unavailable, or failed)
 must leave every previous record readable. Storage or quota failure is visible
@@ -70,14 +76,32 @@ recovery records; bounded retention and explicit user deletion are the only
 removal paths. File handles stay transient runtime capabilities and are never
 serialized into Project JSON or recovery records.
 
+The editor file lifecycle is the single source of unsaved truth. A successful
+persistent edit marks it dirty; a confirmed file write or requested canonical
+download marks it clean; selection, view, and panel changes do neither. While
+dirty, and only while dirty, the editor registers the browser-native
+`beforeunload` guard for Back, Refresh, and tab/window close. The application
+does not synthesize history entries, customize the browser-owned warning, or
+depend on unload-time asynchronous storage as its only protection.
+
 Opening or replacing a Project stages and validates the complete candidate —
 read bytes, JSON/schema validation, approved-symbol validation, Project
 preparation — before the live Project changes. Invalid input leaves the
 Project, selection, history, recovery, and file state untouched. Before
-replacing dirty work the editor first confirms a recovery write; if recovery
-fails it offers download, replace-anyway, and cancel, defaulting to cancel.
+replacing dirty work the editor first attempts and flushes a recovery write,
+then offers **Save and continue**, **Discard and continue**, or **Cancel**,
+defaulting to Cancel. Save cancellation or failure leaves the foreground
+Project and dialog in place. Recovery failure is shown in the same dialog as
+elevated risk but never grants permission to discard.
 A successful replacement retains the outgoing Project in recent recovery and
 seeds the incoming Project's own working-copy identity.
+
+On startup, the current tab's latest valid recovery record is offered
+non-modally only when it explicitly says `unsavedAtSnapshot: true`, the
+foreground Project is still clean, and the load is not the editor's explicit
+refresh-restore path. The offer provides Restore, Download backup, and Ignore.
+Normal pending/stored recovery writes stay silent; only failures are promoted
+while the foreground work is dirty.
 
 Agent File Resource staging stores a bounded candidate separately from the
 browser Project. Inspecting or requesting approval does not mutate the live

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -59,8 +59,17 @@ palette-first manual authoring; no Project file needs to be opened first.
 file. In browsers without an explicitly authorised file handle, this is a
 download; keep the downloaded file as your authoritative Project. Edits also
 stage an origin-local recovery copy. A recovery copy is not a formal save and
-can be lost if browser site data is cleared. On a later start the File menu
-offers recovery choices; recovery never silently replaces a formal file.
+can be lost if browser site data is cleared. A dot beside the Project name
+means the formal Project has unsaved changes. Browser Back, Refresh, and tab or
+window close then show the browser's standard leave warning; after a successful
+save or requested download, they do not.
+
+New, Open, and Revert ask whether to **Save and continue**, **Discard and
+continue**, or **Cancel** when the current Project is dirty. If a newer
+unsaved recovery copy is found on a later start, a small banner offers
+**Restore**, **Download backup**, or **Ignore**. The same copies remain
+available through **File / Recover recent work…**; recovery never silently
+replaces a formal file.
 
 Use **File / Open Project** to validate and reopen a formal Project file.
 Opening an invalid or future-version file leaves the current Document


### PR DESCRIPTION
Summary: use the existing file lifecycle as the sole dirty-work truth; register the native browser leave guard only while dirty; add backward-compatible recovery save-state metadata and a non-modal startup restore offer; replace dirty-project replacement controls with Save and continue, Discard, or Cancel; keep routine recovery writes silent. Boundaries: no Project schema, Edit Engine, Net/Port, Cloud snapshot, or Agent API changes; IndexedDB remains the only recovery store. Validation: gate preflight and affected passed (1574 unit tests, 16 project-file browser tests, 114 manual-editor browser tests), recovery-dialog and explicit-refresh browser checks passed, build and diff checks passed.