### PR TITLE
docs(hierarchy): retire rectangle Cell shortcut language

### DIFF
--- a/apps/editor/src/components/editor-help-dialog.test.tsx
+++ b/apps/editor/src/components/editor-help-dialog.test.tsx
@@ -59,5 +59,7 @@ describe("EditorHelpDialog", () => {
     expect(markup).toContain("Select a hierarchical block");
     expect(markup).not.toContain("Select a rectangle");
     expect(markup).not.toContain("convert it into a hierarchical block");
+    expect(markup).toContain("Cell and <strong>Place Cell</strong>");
+    expect(markup).toContain("Up</strong> or <kbd>Shift+E</kbd>");
   });
 });

--- a/apps/editor/src/components/editor-help-dialog.test.tsx
+++ b/apps/editor/src/components/editor-help-dialog.test.tsx
@@ -62,4 +62,24 @@ describe("EditorHelpDialog", () => {
     expect(markup).toContain("Cell and <strong>Place Cell</strong>");
     expect(markup).toContain("Up</strong> or <kbd>Shift+E</kbd>");
   });
+
+  it("keeps prose separated from inline emphasis and shortcut keys", () => {
+    const markup = renderToStaticMarkup(
+      <EditorHelpDialog closeButtonRef={{ current: null }} onClose={vi.fn()} />,
+    );
+
+    for (const boundary of [
+      "files. Use <strong>File / Save Project</strong>",
+      "File / Refresh app</strong> when",
+      "tool from <strong>Draw</strong>",
+      "the left <strong>Library</strong>",
+      "Wire (or <kbd>W</kbd>)",
+      "Delete</kbd> or <kbd>Backspace</kbd>",
+      "places it and <kbd>Esc</kbd>",
+      "Cell and <strong>Place Cell</strong>",
+      "Up</strong> or <kbd>Shift+E</kbd>",
+    ]) {
+      expect(markup).toContain(boundary);
+    }
+  });
 });

--- a/apps/editor/src/components/editor-help-dialog.test.tsx
+++ b/apps/editor/src/components/editor-help-dialog.test.tsx
@@ -48,4 +48,16 @@ describe("EditorHelpDialog", () => {
     expect(shortcuts).not.toContain("File and history");
     expect(shortcuts).not.toContain("Select all placed components");
   });
+
+  it("describes explicit Cell authoring without a rectangle conversion", () => {
+    const markup = renderToStaticMarkup(
+      <EditorHelpDialog closeButtonRef={{ current: null }} onClose={vi.fn()} />,
+    );
+
+    expect(markup).toContain("Manage Cells…");
+    expect(markup).toContain("Place Cell");
+    expect(markup).toContain("Select a hierarchical block");
+    expect(markup).not.toContain("Select a rectangle");
+    expect(markup).not.toContain("convert it into a hierarchical block");
+  });
 });

--- a/apps/editor/src/components/editor-help-dialog.tsx
+++ b/apps/editor/src/components/editor-help-dialog.tsx
@@ -114,24 +114,24 @@ export function EditorHelpDialog({
             <p>
               Use <strong>File / Open Project</strong> to continue an exported
               project, or <strong>File / Import SPICE</strong> to create
-              editable Documents from SPICE source files. Use
+              editable Documents from SPICE source files. Use{" "}
               <strong>File / Save Project</strong> to download an editable
               project file; use <strong>File / Export</strong> for SVG, PNG, or
               PDF drawings. Because raw browser refresh shortcuts are blocked to
-              protect unsaved work, use <strong>File / Refresh app</strong>
-              when you deliberately want to reload; it saves and restores the
-              current recovery snapshot.
+              protect unsaved work, use <strong>File / Refresh app</strong> when
+              you deliberately want to reload; it saves and restores the current
+              recovery snapshot.
             </p>
             <h3>Place, select, and connect</h3>
             <p>
-              Select a symbol in the left Library, or a drawing tool from
+              Select a symbol in the left Library, or a drawing tool from{" "}
               <strong>Draw</strong>, then click the canvas to place or draw. On
-              compact screens, Library starts folded; use the left
+              compact screens, Library starts folded; use the left{" "}
               <strong>Library</strong> button to open its single-column list.
               Selecting an object opens Properties on the right; it overlays the
-              canvas and closes Library while compact. Choose Wire (or
+              canvas and closes Library while compact. Choose Wire (or{" "}
               <kbd>W</kbd>), click a terminal to start, click to add bends, then
-              press <kbd>Enter</kbd> to finish. <kbd>Delete</kbd> or
+              press <kbd>Enter</kbd> to finish. <kbd>Delete</kbd> or{" "}
               <kbd>Backspace</kbd> removes the selection, or removes the latest
               wire bend while drawing.
             </p>
@@ -164,8 +164,8 @@ export function EditorHelpDialog({
               top/bottom. <kbd>M</kbd> makes the current selection follow the
               pointer; click to place it, or press <kbd>Esc</kbd> to cancel.{" "}
               <kbd>F</kbd> always fits the circuit in view. <kbd>C</kbd> starts
-              a mouse-following copy; click places it and
-              <kbd>Esc</kbd> cancels.
+              a mouse-following copy; click places it and <kbd>Esc</kbd>{" "}
+              cancels.
             </p>
           </section>
           <section id="help-shortcuts" className="help-shortcuts">

--- a/apps/editor/src/components/editor-help-dialog.tsx
+++ b/apps/editor/src/components/editor-help-dialog.tsx
@@ -147,10 +147,10 @@ export function EditorHelpDialog({
             </p>
             <h3>Hierarchical Cells</h3>
             <p>
-              Use <strong>Manage Cells…</strong> to create a reusable Cell and
+              Use <strong>Manage Cells…</strong> to create a reusable Cell and{" "}
               <strong>Place Cell</strong> to add an instance to the canvas.
               Select a hierarchical block and press <kbd>E</kbd>, or
-              double-click it, to enter it. Use <strong>Up</strong> or
+              double-click it, to enter it. Use <strong>Up</strong> or{" "}
               <kbd>Shift+E</kbd> to return to the parent Cell.
             </p>
             <h3>View and drawing tools</h3>

--- a/apps/editor/src/components/editor-help-dialog.tsx
+++ b/apps/editor/src/components/editor-help-dialog.tsx
@@ -147,9 +147,9 @@ export function EditorHelpDialog({
             </p>
             <h3>Hierarchical Cells</h3>
             <p>
-              Select a rectangle and press <kbd>E</kbd> to convert it into a
-              hierarchical block and enter its new child Cell. Select an
-              existing hierarchical block and press <kbd>E</kbd>, or
+              Use <strong>Manage Cells…</strong> to create a reusable Cell and
+              <strong>Place Cell</strong> to add an instance to the canvas.
+              Select a hierarchical block and press <kbd>E</kbd>, or
               double-click it, to enter it. Use <strong>Up</strong> or
               <kbd>Shift+E</kbd> to return to the parent Cell.
             </p>

--- a/docs/adr/0025-schematic-hierarchy-and-formal-ports.md
+++ b/docs/adr/0025-schematic-hierarchy-and-formal-ports.md
@@ -118,10 +118,10 @@ edits or maintain a parallel hierarchy model.
 
 ### Formal blocks use the Instance/Symbol path
 
-The Rectangle drawing tool remains drafting-only. A hierarchy creation gesture
-may use rectangle geometry as transient input, but the committed result is a
+The Rectangle drawing tool remains drafting-only. Hierarchy is created through
+explicit Cell definitions and placement; a committed result is always a
 subcircuit Instance rendered and selected through the existing hierarchical
-Symbol path. No persisted DraftRectangle is an intermediate hierarchy state.
+Symbol path. There is no rectangle-based hierarchy creation state.
 
 Hierarchy navigation carries concrete Instance frames. A child definition
 opened without a caller path has no guessed parent; callers are selected

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -43,9 +43,9 @@ only the selected Cell Pin; a matching name never attaches markers, merges
 Nets, or synchronizes directions. The bound name is edited in place and its
 Razavi RichText projection retains conventional subscripts.
 
-Rectangle-to-Cell is likewise a convenience
-gesture that commits an ordinary hierarchical Instance; rectangles remain
-visual-only drafting objects.
+Reusable hierarchy is authored through **New Cell** and **Place Cell**. **Enter
+Cell** opens only a selected hierarchical Instance; it never changes a
+drafting object.
 
 There is no separate Cell Interface authoring surface. A child Cell Pin shows
 only its object-anchored terminal-name annotation in the normal Reference slot;

--- a/docs/user/schematic-hierarchy.md
+++ b/docs/user/schematic-hierarchy.md
@@ -10,16 +10,16 @@ each caller with **Jump to caller**. A referenced Cell's delete control is
 disabled; delete its caller Instances normally before deleting the now
 unreferenced definition.
 
-Use **New Cell** in the Cell Manager to create a module without first drawing
-a rectangle. **Cell → Place Cell** opens the normal Insert dialog with a
-searchable **Cells** section. Select a definition, then place its ordinary
-hierarchical Instance on the canvas using the same grid preview, `R` rotation,
-mirror shortcuts, and `Esc` cancellation as a library component. The commit
-keeps the `Xn` reference as internal netlist identity and shows only the Cell
-name at the normal instance-label position. **Enter Cell** opens the child of a selected hierarchical
-Instance. **Up** follows the actual parent Instance path; **Top** returns to
-the root. Opening a shared Cell from the selector has no caller context when
-more than one path reaches it, which is reported in the status bar.
+Use **New Cell** in the Cell Manager to create a module. **Cell → Place Cell**
+opens the normal Insert dialog with a searchable **Cells** section. Select a
+definition, then place its ordinary hierarchical Instance on the canvas using
+the same grid preview, `R` rotation, mirror shortcuts, and `Esc` cancellation
+as a library component. The commit keeps the `Xn` reference as internal
+netlist identity and shows only the Cell name at the normal instance-label
+position. **Enter Cell** opens the child of a selected hierarchical Instance.
+**Up** follows the actual parent Instance path; **Top** returns to the root.
+Opening a shared Cell from the selector has no caller context when more than
+one path reaches it, which is reported in the status bar.
 
 The top Cell is the Project export root and is not instantiated as a symbol,
 but it is still emitted as a reusable structural subcircuit. **Port** and


### PR DESCRIPTION
## Summary
- remove obsolete rectangle-to-Cell guidance from Help and hierarchy docs
- correct Help inline-label spacing across the handbook
- add rendering regression coverage for hierarchy wording and inline whitespace

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- local browser Help rendering inspection