### PR TITLE
Fix Cloud Project menu overflow and unify Save

### DIFF
--- a/apps/editor/e2e/project-file.spec.ts
+++ b/apps/editor/e2e/project-file.spec.ts
@@ -91,7 +91,7 @@ test("Cloud Save updates one binding while local export stays interchange", asyn
   const fileMenu = await openMenu(page, "File");
   await expect(
     fileMenu.getByRole("button", { name: "Save as Cloud Copy…" }),
-  ).toBeDisabled();
+  ).toHaveCount(0);
   await fileMenu.getByRole("button", { name: "Save", exact: true }).click();
   await expect(page.getByTestId("status")).toContainText(
     "Saved New Circuit to Cloud",
@@ -107,8 +107,23 @@ test("Cloud Save updates one binding while local export stays interchange", asyn
   const reopenedMenu = await openMenu(page, "File");
   await expect(reopenedMenu.getByText("Cloud Projects (1/3)")).toBeVisible();
   await expect(
-    reopenedMenu.getByRole("button", { name: "Save as Cloud Copy…" }),
-  ).toBeEnabled();
+    reopenedMenu.getByRole("button", { name: "Save", exact: true }),
+  ).toHaveCount(1);
+  const cloudProjectButton = reopenedMenu.getByTestId("cloud-project-cloud-1");
+  const cloudProjectTime = cloudProjectButton.locator("time");
+  await expect(cloudProjectTime).toBeVisible();
+  expect(
+    await cloudProjectTime.evaluate(
+      (element) => getComputedStyle(element).overflow,
+    ),
+  ).toBe("hidden");
+  const buttonBounds = await cloudProjectButton.boundingBox();
+  const timeBounds = await cloudProjectTime.boundingBox();
+  expect(buttonBounds).not.toBeNull();
+  expect(timeBounds).not.toBeNull();
+  expect(timeBounds!.x + timeBounds!.width).toBeLessThanOrEqual(
+    buttonBounds!.x + buttonBounds!.width,
+  );
   await page.getByRole("link", { name: "Back to the gallery" }).click();
   await expect(page).toHaveURL(/\/$/u);
   await page.goto("/editor");

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -2781,7 +2781,6 @@ export function App({
           projectInputRef,
           onNewProject: createNewProject,
           onSave: () => void saveProjectToCloud(),
-          onSaveAsCopy: () => void saveProjectToCloud({ asCopy: true }),
           onRefreshCloudProjects: () => void reloadCloudProjects(),
           onOpenCloudProject: (summary) =>
             void openCloudProjectById(summary.id),

--- a/apps/editor/src/document/use-project-file-lifecycle.ts
+++ b/apps/editor/src/document/use-project-file-lifecycle.ts
@@ -179,18 +179,13 @@ export function useProjectFileLifecycle({
     return nextDocument;
   }
 
-  async function performProjectSaveToCloud(
-    options: { asCopy?: boolean } = {},
-  ): Promise<CloudProjectSaveOutcome> {
+  async function performProjectSaveToCloud(): Promise<CloudProjectSaveOutcome> {
     setPersistenceState("saving");
     recovery.stage(project, { unsavedAtSnapshot: true, cloudBinding });
     await recovery.flushNow();
     const savedCandidate = structuredClone(project);
     const savedCandidateToken = projectChangeToken(savedCandidate);
-    const outcome = await saveCloudProject(
-      savedCandidate,
-      options.asCopy ? null : cloudBinding,
-    );
+    const outcome = await saveCloudProject(savedCandidate, cloudBinding);
     if (outcome.status === "saved") {
       const nextBinding = {
         id: outcome.project.id,
@@ -246,12 +241,10 @@ export function useProjectFileLifecycle({
     return outcome;
   }
 
-  function saveProjectToCloud(
-    options: { asCopy?: boolean } = {},
-  ): Promise<CloudProjectSaveOutcome> {
+  function saveProjectToCloud(): Promise<CloudProjectSaveOutcome> {
     const inFlight = saveInFlightRef.current;
     if (inFlight) return inFlight;
-    const operation = performProjectSaveToCloud(options);
+    const operation = performProjectSaveToCloud();
     saveInFlightRef.current = operation;
     const clear = () => {
       if (saveInFlightRef.current === operation) saveInFlightRef.current = null;

--- a/apps/editor/src/features/editor-shell/file-command-menu.test.tsx
+++ b/apps/editor/src/features/editor-shell/file-command-menu.test.tsx
@@ -23,7 +23,6 @@ describe("FileCommandMenu", () => {
         projectInputRef={createRef<HTMLInputElement>()}
         onNewProject={vi.fn()}
         onSave={vi.fn()}
-        onSaveAsCopy={vi.fn()}
         onRefreshCloudProjects={vi.fn()}
         onOpenCloudProject={vi.fn()}
         onDeleteCloudProject={vi.fn()}
@@ -39,12 +38,10 @@ describe("FileCommandMenu", () => {
       />,
     );
 
-    expect(markup).toContain("Save as Cloud Copy…");
-    expect(markup).toContain(
-      'disabled="" title="Save this Project to Cloud before creating a copy"',
-    );
+    expect(markup).not.toContain("Save as Cloud Copy");
     expect(markup).toContain("Cloud Projects (1/3)");
     expect(markup).toContain("Saved Circuit");
+    expect(markup).toContain('class="cloud-project-time"');
     expect(markup).toContain("cloud-project-cloud-1");
     expect(markup).toContain("Import Project File…");
     expect(markup).toContain("Export Project File…");

--- a/apps/editor/src/features/editor-shell/file-command-menu.tsx
+++ b/apps/editor/src/features/editor-shell/file-command-menu.tsx
@@ -13,7 +13,6 @@ export interface FileCommandMenuProps {
   projectInputRef: RefObject<HTMLInputElement | null>;
   onNewProject: () => void;
   onSave: () => void;
-  onSaveAsCopy: () => void;
   onRefreshCloudProjects: () => void;
   onOpenCloudProject: (project: CloudProjectSummary) => void;
   onDeleteCloudProject: (project: CloudProjectSummary) => void;
@@ -38,7 +37,6 @@ export function FileCommandMenu({
   projectInputRef,
   onNewProject,
   onSave,
-  onSaveAsCopy,
   onRefreshCloudProjects,
   onRefresh,
   onImportProject,
@@ -66,18 +64,6 @@ export function FileCommandMenu({
         <button type="button" data-testid="save-cloud-project" onClick={onSave}>
           Save
         </button>
-        <button
-          type="button"
-          onClick={onSaveAsCopy}
-          disabled={activeCloudProjectId === null}
-          title={
-            activeCloudProjectId === null
-              ? "Save this Project to Cloud before creating a copy"
-              : "Create a separate Cloud Project"
-          }
-        >
-          Save as Cloud Copy…
-        </button>
         <span className="command-group-label">
           Cloud Projects ({cloudProjects.length}/{CLOUD_PROJECT_LIMIT})
         </span>
@@ -85,12 +71,19 @@ export function FileCommandMenu({
           <div className="cloud-project-command" key={project.id}>
             <button
               type="button"
+              className="cloud-project-open"
               data-testid={`cloud-project-${project.id}`}
               title={`Open revision ${project.revision}`}
               disabled={project.id === activeCloudProjectId}
               onClick={() => onOpenCloudProject(project)}
             >
-              {project.name} — {new Date(project.updatedAt).toLocaleString()}
+              <span className="cloud-project-name">{project.name}</span>
+              <time className="cloud-project-time" dateTime={project.updatedAt}>
+                {new Date(project.updatedAt).toLocaleString(undefined, {
+                  dateStyle: "short",
+                  timeStyle: "short",
+                })}
+              </time>
             </button>
             <button
               type="button"

--- a/apps/editor/src/styles/editor-chrome.css
+++ b/apps/editor/src/styles/editor-chrome.css
@@ -455,6 +455,33 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 2px;
+  width: min(22rem, calc(100vw - var(--icm-space-6)));
+  min-width: 0;
+  max-width: 100%;
+}
+
+.command-popover .cloud-project-open {
+  display: grid;
+  min-width: 0;
+  height: auto;
+  padding-block: 6px;
+  gap: 1px;
+  white-space: normal;
+}
+
+.cloud-project-name,
+.cloud-project-time {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cloud-project-time {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-sm);
+  font-weight: 400;
 }
 
 .command-popover .cloud-project-command > button:last-child {

--- a/docs/specs/persistence-and-recovery.md
+++ b/docs/specs/persistence-and-recovery.md
@@ -80,10 +80,10 @@ GET  /api/projects/:id             open one Project
 
 Repeated Save updates the same id and does not consume another account slot.
 The first Save of an unbound New/imported/recovered Project creates a Cloud
-Project. **Save as Cloud Copy** deliberately creates and binds a new id. The
-server retains no implicit save history and never evicts another Project to
-make room. A revision mismatch or capacity limit blocks only that explicit
-Save; editing and local recovery continue.
+Project. The editor exposes no second Save command that silently creates a
+duplicate Project. The server retains no implicit save history and never
+evicts another Project to make room. A revision mismatch or capacity limit
+blocks only that explicit Save; editing and local recovery continue.
 
 The editor session owns only the transient Cloud binding (`id` and acknowledged
 revision), the saved content baseline, and its recovery working-copy id. No
@@ -92,10 +92,11 @@ the binding and saved baseline. If edits occurred while the request was in
 flight, the submitted snapshot is saved but the newer live content remains
 dirty. Undo back to the acknowledged content becomes clean.
 
-**Import Project File**, **Export Project File**, and **Download Backup** are
-interchange operations. They never claim to be Save and never clear Cloud
-dirty state. Export/download does not remove recovery records; bounded
-retention and explicit user deletion remain their only removal paths.
+**Import Project File** and **Export Project File** are interchange operations.
+They never claim to be Save and never clear Cloud dirty state. A contextual
+backup download is offered only when recovery needs attention. Export/download
+does not remove recovery records; bounded retention and explicit user deletion
+remain their only removal paths.
 
 The editor persistence lifecycle is the single source of unsaved truth. A
 successful persistent edit marks it dirty; only an acknowledged Cloud Save of

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -57,8 +57,8 @@ palette-first manual authoring; no Project file needs to be opened first.
 
 **File / Save** (or `Ctrl+S`) saves the current content to one private Cloud
 Project. Repeated saves update that Project instead of creating snapshots. A
-new or imported drawing is unbound until its first Save; **Save as Cloud Copy**
-deliberately creates another Cloud Project. A dot beside the Project name means
+new or imported drawing is unbound until its first Save, which creates and
+binds its Cloud Project. A dot beside the Project name means
 the Cloud Project has unsaved changes. Browser Back, Refresh, and tab or window
 close then show the browser's standard leave warning; only an acknowledged
 Cloud Save of the current content clears it.


### PR DESCRIPTION
## Summary
- Bound Cloud Project rows and ellipsize the name and localized timestamp independently.
- Remove the duplicate Save as Cloud Copy command and its lifecycle branch.
- Keep one Save command: create when unbound, update the active Cloud Project afterward.
- Update persistence/user docs and browser coverage.

## Validation
- pnpm gate:preflight -- --base origin/main
- ICM_E2E_ISOLATED=1 pnpm gate:affected -- --base origin/main
  - 249 unit files / 1558 tests
  - project-file browser: 8/8
  - editor browser: 114/114
- git diff --check origin/main...HEAD