### PR TITLE
Add visitor analytics to Gallery header

### DIFF
--- a/apps/editor/src/components/gallery-chrome.tsx
+++ b/apps/editor/src/components/gallery-chrome.tsx
@@ -6,7 +6,13 @@ import { AccountMenu } from "./account";
  * as a bare paragraph without navigation. Markup mirrors the feed's
  * original header exactly (test ids included).
  */
-export function GalleryChrome({ subtitle }: { subtitle: string }) {
+export function GalleryChrome({
+  subtitle,
+  visitStats,
+}: {
+  subtitle: string;
+  visitStats?: { pv: number; uv: number } | null | undefined;
+}) {
   return (
     <header className="gallery-chrome">
       <div className="app-brand">
@@ -24,25 +30,38 @@ export function GalleryChrome({ subtitle }: { subtitle: string }) {
           <p>{subtitle}</p>
         </div>
       </div>
-      <div className="tokenzhang-credit">
-        <span className="tokenzhang-credit-kicker">Presented by</span>
-        <a
-          className="tokenzhang-link"
-          href="https://tokenzhang.com"
-          target="_blank"
-          rel="noreferrer"
-          aria-label="TokenZhang"
-          title="TokenZhang"
-        >
-          <img
-            className="tokenzhang-link-icon"
-            src="/tokenzhang-favicon.png"
-            alt=""
-            width={16}
-            height={16}
-          />
-          <span className="tokenzhang-link-label">TokenZhang</span>
-        </a>
+      <div className="gallery-credit-group">
+        <div className="tokenzhang-credit">
+          <span className="tokenzhang-credit-kicker">Presented by</span>
+          <a
+            className="tokenzhang-link"
+            href="https://tokenzhang.com"
+            target="_blank"
+            rel="noreferrer"
+            aria-label="TokenZhang"
+            title="TokenZhang"
+          >
+            <img
+              className="tokenzhang-link-icon"
+              src="/tokenzhang-favicon.png"
+              alt=""
+              width={16}
+              height={16}
+            />
+            <span className="tokenzhang-link-label">TokenZhang</span>
+          </a>
+        </div>
+        {visitStats ? (
+          <a
+            className="analytics-link gallery-analytics-link"
+            href="/analytics"
+            data-testid="gallery-analytics"
+            title="Open visitor analytics"
+          >
+            {visitStats.uv.toLocaleString()} visitors ·{" "}
+            {visitStats.pv.toLocaleString()} views
+          </a>
+        ) : null}
       </div>
       <nav className="gallery-actions">
         <AccountMenu />

--- a/apps/editor/src/components/gallery-feed.test.tsx
+++ b/apps/editor/src/components/gallery-feed.test.tsx
@@ -60,7 +60,9 @@ describe("loadGalleryFeed", () => {
 
 describe("GalleryFeed", () => {
   it("renders the landing chrome and editor entry point", () => {
-    const markup = renderToStaticMarkup(createElement(GalleryFeed));
+    const markup = renderToStaticMarkup(
+      createElement(GalleryFeed, { visitStats: { pv: 42, uv: 17 } }),
+    );
     expect(markup).toContain('data-testid="gallery-feed"');
     expect(markup).toContain("Analog Canvas");
     expect(markup).toContain('data-testid="gallery-new-circuit"');
@@ -68,6 +70,14 @@ describe("GalleryFeed", () => {
     expect(markup).toContain("Presented by");
     expect(markup).toContain('href="https://tokenzhang.com"');
     expect(markup).toContain('src="/tokenzhang-favicon.png"');
+    expect(markup).toContain('class="gallery-credit-group"');
+    expect(markup).toContain('data-testid="gallery-analytics"');
+    expect(markup).toContain('href="/analytics"');
+    expect(markup).toContain("17 visitors");
+    expect(markup).toContain("42 views");
+    expect(markup.indexOf("Presented by")).toBeLessThan(
+      markup.indexOf('data-testid="gallery-analytics"'),
+    );
     expect(markup).toContain('data-testid="gallery-loading"');
   });
 });

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -314,7 +314,11 @@ export async function loadGalleryFeed(
  * the community gallery is empty or unreachable (development hosts have no
  * worker), so the landing page is never blank.
  */
-export function GalleryFeed() {
+export function GalleryFeed({
+  visitStats,
+}: {
+  visitStats?: { pv: number; uv: number } | null | undefined;
+}) {
   const [isOwner, setIsOwner] = useState(false);
   const [ownerBusy, setOwnerBusy] = useState<string | null>(null);
   const [ownerNotice, setOwnerNotice] = useState<string | null>(null);
@@ -606,7 +610,7 @@ export function GalleryFeed() {
 
   return (
     <main className="gallery-shell" data-testid="gallery-feed">
-      <GalleryChrome subtitle="Community gallery" />
+      <GalleryChrome subtitle="Community gallery" visitStats={visitStats} />
 
       {tagOptions.length > 0 ? (
         <div className="gallery-tag-bar" data-testid="gallery-tag-bar">

--- a/apps/editor/src/main.tsx
+++ b/apps/editor/src/main.tsx
@@ -172,7 +172,7 @@ function Root() {
       <Suspense
         fallback={<div className="analytics-loading">Loading gallery…</div>}
       >
-        <GalleryFeed />
+        <GalleryFeed visitStats={stats} />
       </Suspense>
     );
   }

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -323,7 +323,7 @@ body {
   margin-left: auto;
 }
 
-/* Owner credit: centered on the gallery bar; stacked after Help in the editor. */
+/* Owner credit: paired with analytics at gallery center; after Help in editor. */
 .tokenzhang-credit {
   display: inline-flex;
   align-items: center;
@@ -331,11 +331,15 @@ body {
   white-space: nowrap;
 }
 
-.gallery-chrome .tokenzhang-credit {
+.gallery-credit-group {
   position: absolute;
   left: 50%;
   top: 50%;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--icm-space-3);
   transform: translate(-50%, -50%);
+  white-space: nowrap;
 }
 
 /* One line, even if long: "Presented by [Z] TokenZhang" never wraps. */
@@ -393,11 +397,9 @@ body {
   }
 }
 
-/* The gallery header centers the credit absolutely, and a signed-in
-   account chip makes the right side wide, so the "Provided by" kicker
-   collides well above half width. The kicker goes first, then the label
-   (icon+tooltip remain), and once even the icon would collide the credit
-   yields entirely. */
+/* The gallery header centers credit plus analytics as one unit. A signed-in
+   account chip makes the right side wide, so text yields progressively before
+   the whole centered group does. */
 @media (max-width: 1400px) {
   .gallery-chrome .tokenzhang-credit-kicker {
     display: none;
@@ -411,7 +413,7 @@ body {
 }
 
 @media (max-width: 860px) {
-  .gallery-chrome .tokenzhang-credit {
+  .gallery-credit-group {
     display: none;
   }
 }


### PR DESCRIPTION
## Summary\n- reuse the public visitor totals in the Gallery header\n- keep the Canvas readout in the bottom status bar\n- center the owner credit and analytics link as one side-by-side group\n\n## Validation\n- pnpm gate:preflight -- --base origin/main\n- ICM_E2E_ISOLATED=1 ICM_E2E_PORT=4193 pnpm gate:affected -- --base origin/main