### PR TITLE
Simplify unsaved navigation prompts

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -570,8 +570,8 @@ test("drafting content and anchor survive save and reopen", async ({
     buffer: projectBytes,
   });
   await page
-    .getByRole("dialog", { name: "Protect the current Project" })
-    .getByRole("button", { name: "Discard and continue" })
+    .getByRole("dialog", { name: "Unsaved changes" })
+    .getByRole("button", { name: "Continue without saving" })
     .click();
   await expect(page.getByTestId("status")).toContainText(
     "Opened saved-drafting.icproj.json",

--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -1690,14 +1690,14 @@ test("the Examples panel guards dirty work before opening an entry", async ({
 
   await card.click();
   const dialog = page.getByRole("dialog", {
-    name: "Protect the current Project",
+    name: "Unsaved changes",
   });
   await expect(dialog).toBeVisible();
-  await dialog.getByRole("button", { name: "Cancel (keep editing)" }).click();
+  await dialog.getByRole("button", { name: "Stay" }).click();
   await expect(page.getByTestId("hit-R1")).toHaveCount(1);
 
   await card.click();
-  await dialog.getByRole("button", { name: "Discard and continue" }).click();
+  await dialog.getByRole("button", { name: "Continue without saving" }).click();
   await expect(page.getByTestId("status")).toContainText(
     `Opened gallery circuit: ${ENTRY.name}`,
   );

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3761,8 +3761,8 @@ test("retains recovery across export but honors explicit discard on replacement"
       ),
     );
   await page
-    .getByRole("dialog", { name: "Protect the current Project" })
-    .getByRole("button", { name: "Discard and continue" })
+    .getByRole("dialog", { name: "Unsaved changes" })
+    .getByRole("button", { name: "Continue without saving" })
     .click();
   await expect(page.getByTestId("active-document-name")).toHaveText(
     "Manual Editor Demo",

--- a/apps/editor/e2e/project-file.spec.ts
+++ b/apps/editor/e2e/project-file.spec.ts
@@ -151,14 +151,14 @@ test("Gallery navigation uses the replacement decision without a second browser 
   await page.keyboard.press("Escape");
   await page.getByRole("link", { name: "Back to the gallery" }).click();
   const guard = page.getByRole("dialog", {
-    name: "Protect the current Project",
+    name: "Unsaved changes",
   });
   await expect(guard).toBeVisible();
-  await guard.getByRole("button", { name: "Cancel (keep editing)" }).click();
+  await guard.getByRole("button", { name: "Stay" }).click();
   await expect(page).toHaveURL(/\/editor/u);
 
   await page.getByRole("link", { name: "Back to the gallery" }).click();
-  await guard.getByRole("button", { name: "Discard and continue" }).click();
+  await guard.getByRole("button", { name: "Continue without saving" }).click();
   await expect(page).toHaveURL(/\/$/u);
   await page.goto("/editor");
   await expect(page.getByTestId("startup-recovery-banner")).toHaveCount(0);
@@ -240,14 +240,16 @@ test("replacement guard offers cancel, discard, and Cloud Save", async ({
   );
   await input.setInputFiles(replacement);
   const dialog = page.getByRole("dialog", {
-    name: "Protect the current Project",
+    name: "Unsaved changes",
   });
-  await dialog.getByRole("button", { name: "Cancel (keep editing)" }).click();
+  await dialog.getByRole("button", { name: "Stay" }).click();
   await expect(page.getByTestId("revision")).toHaveText("1");
 
   await input.evaluate((element) => ((element as HTMLInputElement).value = ""));
   await input.setInputFiles(replacement);
-  await dialog.getByRole("button", { name: "Save and continue" }).click();
+  await dialog
+    .getByRole("button", { name: "Save to Cloud and continue" })
+    .click();
   await expect(dialog).toBeHidden();
   expect(cloud.stored()?.projectText).toContain("resistor");
   await expect(page.getByTestId("active-document-name")).toHaveText(
@@ -267,9 +269,9 @@ test("discarding a dirty replacement does not leave a second project stack", asy
   let fileMenu = await openMenu(page, "File");
   await fileMenu.getByRole("button", { name: "New Project" }).click();
   const dialog = page.getByRole("dialog", {
-    name: "Protect the current Project",
+    name: "Unsaved changes",
   });
-  await dialog.getByRole("button", { name: "Discard and continue" }).click();
+  await dialog.getByRole("button", { name: "Continue without saving" }).click();
   await expect(page.getByTestId("canvas-empty-state")).toBeVisible();
   fileMenu = await openMenu(page, "File");
   await expect(
@@ -300,8 +302,8 @@ test("reverts to the last acknowledged Cloud revision", async ({ page }) => {
   fileMenu = await openMenu(page, "File");
   await fileMenu.getByRole("button", { name: "Revert to Last Saved" }).click();
   await page
-    .getByRole("dialog", { name: "Protect the current Project" })
-    .getByRole("button", { name: "Discard and continue" })
+    .getByRole("dialog", { name: "Unsaved changes" })
+    .getByRole("button", { name: "Continue without saving" })
     .click();
   await expect(page.getByTestId("hit-R1")).toHaveCount(1);
   await expect(page.getByTestId("hit-R2")).toHaveCount(0);

--- a/apps/editor/e2e/recovery-dialog.spec.ts
+++ b/apps/editor/e2e/recovery-dialog.spec.ts
@@ -236,8 +236,8 @@ test("explicit discard removes outgoing recovery and hides a clean replacement",
       ),
     );
   await page
-    .getByRole("dialog", { name: "Protect the current Project" })
-    .getByRole("button", { name: "Discard and continue" })
+    .getByRole("dialog", { name: "Unsaved changes" })
+    .getByRole("button", { name: "Continue without saving" })
     .click();
   await expect(page.getByTestId("active-document-name")).toHaveText(
     "Manual Editor Demo",

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -3012,7 +3012,6 @@ export function App({
             ? {
                 intent: replaceGuard.intent,
                 saving: replaceGuardSaving,
-                recoveryProtected: replaceGuard.recoveryProtected,
                 onCancel: cancelReplaceGuard,
                 onSaveAndContinue: saveAndContinueReplaceGuard,
                 onDiscard: confirmReplaceGuard,
@@ -3974,6 +3973,12 @@ export function App({
             return !visible;
           })
         }
+        onOpenAnalytics={() => {
+          void guardDirtyReplacement("Open Analytics", () => {
+            allowNextBrowserUnload();
+            window.location.assign("/analytics");
+          });
+        }}
         onZoomOut={() => zoomViewAtCenter(1.2)}
         onZoomIn={() => zoomViewAtCenter(0.84)}
         onFitView={() => editorCommands.execute({ id: "view.fit" })}

--- a/apps/editor/src/components/replace-guard-dialog.test.tsx
+++ b/apps/editor/src/components/replace-guard-dialog.test.tsx
@@ -4,39 +4,38 @@ import { describe, expect, it, vi } from "vitest";
 import { ReplaceGuardDialog } from "./replace-guard-dialog";
 
 describe("ReplaceGuardDialog", () => {
-  it("offers save, discard, and cancellation without treating recovery as a save", () => {
+  it("states the consequence and distinguishes Cloud Save from file export", () => {
     const html = renderToStaticMarkup(
       <ReplaceGuardDialog
         intent="Open OTA.icproj.json"
         saving={false}
-        recoveryProtected={true}
         onCancel={vi.fn()}
         onSaveAndContinue={vi.fn()}
         onDiscard={vi.fn()}
       />,
     );
-    expect(html).toContain("Save and continue");
-    expect(html).toContain("Discard and continue");
-    expect(html).toContain("Discard removes this working copy");
-    expect(html).toContain("Cancel (keep editing)");
-    expect(html).toContain("Cloud Project is the formal saved copy");
-    expect(html).not.toContain("authoritative copy");
-    expect(html).not.toContain("Download current Project");
+    expect(html).toContain("Unsaved changes");
+    expect(html).toContain("your latest changes will not be saved");
+    expect(html).toContain("Cloud Projects (up to 3)");
+    expect(html).toContain("Export Project File");
+    expect(html).toContain(".icproj.json");
+    expect(html).toContain("Save to Cloud and continue");
+    expect(html).toContain("Continue without saving");
+    expect(html).toContain("Stay");
+    expect(html).not.toContain("Browser recovery");
   });
 
-  it("warns when the outgoing recovery copy could not be confirmed", () => {
+  it("disables every decision while Cloud Save is in progress", () => {
     const html = renderToStaticMarkup(
       <ReplaceGuardDialog
         intent="Create a new Project"
         saving={true}
-        recoveryProtected={false}
         onCancel={vi.fn()}
         onSaveAndContinue={vi.fn()}
         onDiscard={vi.fn()}
       />,
     );
-    expect(html).toContain("could not be confirmed");
-    expect(html).toContain("Saving…");
+    expect(html).toContain("Saving to Cloud…");
     expect(html).toContain("disabled");
   });
 });

--- a/apps/editor/src/components/replace-guard-dialog.tsx
+++ b/apps/editor/src/components/replace-guard-dialog.tsx
@@ -4,7 +4,6 @@ export interface ReplaceGuardDialogProps {
   /** What is about to replace the dirty work, e.g. "Open amp.icproj.json". */
   intent: string;
   saving: boolean;
-  recoveryProtected: boolean;
   onCancel(): void;
   onSaveAndContinue(): void;
   onDiscard(): void;
@@ -19,7 +18,6 @@ export interface ReplaceGuardDialogProps {
 export function ReplaceGuardDialog({
   intent,
   saving,
-  recoveryProtected,
   onCancel,
   onSaveAndContinue,
   onDiscard,
@@ -50,28 +48,19 @@ export function ReplaceGuardDialog({
       >
         <header className="help-dialog-header">
           <div>
-            <p className="help-kicker">Unsaved changes</p>
-            <h2 id="replace-guard-title">Protect the current Project</h2>
+            <h2 id="replace-guard-title">Unsaved changes</h2>
           </div>
         </header>
         <div className="help-dialog-content">
           <p>
-            The current Project has unsaved changes. Browser recovery is only a
-            safety copy. Choose what happens before <strong>{intent}</strong>{" "}
-            continues.
+            If you continue to <strong>{intent}</strong>, your latest changes
+            will not be saved.
           </p>
-          {recoveryProtected ? (
-            <p>
-              A temporary recovery copy is available while you decide. Choosing
-              Discard removes this working copy before continuing.
-            </p>
-          ) : null}
-          {!recoveryProtected ? (
-            <p className="replace-guard-warning" role="alert">
-              A current browser recovery copy could not be confirmed. Saving is
-              strongly recommended before continuing.
-            </p>
-          ) : null}
+          <p>
+            <strong>Save</strong> stores this Project in Cloud Projects (up to
+            3). <strong>File / Export Project File…</strong> downloads a local
+            <code>.icproj.json</code> file.
+          </p>
           <div className="replace-guard-actions">
             <button
               type="button"
@@ -79,10 +68,10 @@ export function ReplaceGuardDialog({
               onClick={onCancel}
               disabled={saving}
             >
-              Cancel (keep editing)
+              Stay
             </button>
             <button type="button" onClick={onSaveAndContinue} disabled={saving}>
-              {saving ? "Saving…" : "Save and continue"}
+              {saving ? "Saving to Cloud…" : "Save to Cloud and continue"}
             </button>
             <button
               type="button"
@@ -90,14 +79,9 @@ export function ReplaceGuardDialog({
               onClick={onDiscard}
               disabled={saving}
             >
-              Discard and continue
+              Continue without saving
             </button>
           </div>
-          <p>
-            Cloud Project is the formal saved copy. Browser recovery and local
-            exports remain safety and interchange copies; neither is a hidden
-            project history.
-          </p>
         </div>
       </section>
     </div>

--- a/apps/editor/src/document/use-project-file-lifecycle.ts
+++ b/apps/editor/src/document/use-project-file-lifecycle.ts
@@ -47,7 +47,6 @@ export type PersistenceState =
 interface ReplaceGuardState {
   intent: string;
   perform: () => void | Promise<void>;
-  recoveryProtected: boolean;
 }
 
 export interface ReplaceProjectOptions {
@@ -294,11 +293,10 @@ export function useProjectFileLifecycle({
       return;
     }
     recovery.stage(project, { unsavedAtSnapshot: true, cloudBinding });
-    const recoveryState = await recovery.flushNow();
+    await recovery.flushNow();
     setReplaceGuard({
       intent,
       perform,
-      recoveryProtected: recoveryState === "stored",
     });
   }
 

--- a/apps/editor/src/features/editor-shell/editor-statusbar.test.tsx
+++ b/apps/editor/src/features/editor-shell/editor-statusbar.test.tsx
@@ -21,6 +21,7 @@ describe("editor statusbar", () => {
         onWireRoutingModeChange={vi.fn()}
         onWireCornerOrderChange={vi.fn()}
         onToggleGridDots={vi.fn()}
+        onOpenAnalytics={vi.fn()}
         onZoomOut={vi.fn()}
         onZoomIn={vi.fn()}
         onFitView={vi.fn()}

--- a/apps/editor/src/features/editor-shell/editor-statusbar.tsx
+++ b/apps/editor/src/features/editor-shell/editor-statusbar.tsx
@@ -31,6 +31,7 @@ export function EditorStatusbar({
   onWireRoutingModeChange,
   onWireCornerOrderChange,
   onToggleGridDots,
+  onOpenAnalytics,
   onZoomOut,
   onZoomIn,
   onFitView,
@@ -50,6 +51,7 @@ export function EditorStatusbar({
   onWireRoutingModeChange: (mode: WireRoutingMode) => void;
   onWireCornerOrderChange: (order: WireCornerOrder) => void;
   onToggleGridDots: () => void;
+  onOpenAnalytics: () => void;
   onZoomOut: () => void;
   onZoomIn: () => void;
   onFitView: () => void;
@@ -125,6 +127,19 @@ export function EditorStatusbar({
           href="/analytics"
           data-testid="statusbar-analytics"
           title="Open visitor analytics"
+          onClick={(event) => {
+            if (
+              event.button !== 0 ||
+              event.metaKey ||
+              event.ctrlKey ||
+              event.shiftKey ||
+              event.altKey
+            ) {
+              return;
+            }
+            event.preventDefault();
+            onOpenAnalytics();
+          }}
         >
           {visitStats.uv.toLocaleString()} visitors ·{" "}
           {visitStats.pv.toLocaleString()} views

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -353,9 +353,17 @@ lifecycle that controls Save. While that marker is present, browser Back,
 Refresh, and tab/window close use the browser-native leave confirmation;
 ordinary in-app navigation, selection, zoom, and panel changes do not affect
 it. New, Open, Revert, recovery restore, and approved staged replacement use
-one application dialog with Save and continue, Discard and continue, and
-Cancel. A startup recovery offer is a non-modal overlay and never silently
+one concise application dialog with Stay, Save to Cloud and continue, and
+Continue without saving. The dialog states the destination and distinguishes
+Cloud Save (at most three private Cloud Projects) from local Project-file
+export without exposing browser-recovery internals. A startup recovery offer is
+a non-modal overlay and never silently
 replaces the active Project.
+
+Same-site destinations owned by the product, including Gallery and Analytics,
+enter through this application replacement guard. Their anchors retain normal
+link behavior for modified clicks, but an ordinary primary click must not fall
+through to a second native `beforeunload` prompt.
 
 ## Agent semantic control
 

--- a/docs/specs/persistence-and-recovery.md
+++ b/docs/specs/persistence-and-recovery.md
@@ -112,7 +112,8 @@ read bytes, JSON/schema validation, approved-symbol validation, Project
 preparation — before the live Project changes. Invalid input leaves the
 Project, selection, history, recovery, and file state untouched. Before
 replacing dirty work the editor first attempts and flushes a recovery write,
-then offers **Save and continue**, **Discard and continue**, or **Cancel**,
+then offers **Save to Cloud and continue**, **Continue without saving**, or
+**Stay**,
 defaulting to Cancel. Cloud Save failure leaves the foreground
 Project and dialog in place. Recovery failure is shown in the same dialog as
 elevated risk but never grants permission to discard.

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -69,9 +69,12 @@ If Cloud is unavailable, continue editing normally and use **Export Project
 File…** when you want a portable copy. A direct **Download Backup** action is
 shown contextually if browser recovery itself cannot protect current work.
 
-New, Open, Revert, and the same-tab trip to Gallery ask whether to **Save and
-continue**, **Discard and continue**, or **Cancel** when the current Project is
-dirty. Discard means discard: that working copy is removed before the action
+New, Open, Revert, and the same-tab trip to Gallery ask whether to **Save to
+Cloud and continue**, **Continue without saving**, or **Stay** when the current
+Project is dirty. The prompt also identifies where each explicit save goes:
+Cloud Save updates one of at most three private Cloud Projects, while **Export
+Project File…** downloads a local `.icproj.json` file. Continue without saving
+means discard: that working copy is removed before the action
 continues. If a newer
 unsaved recovery copy is found on a later start, a small banner offers
 **Restore**, **Download backup**, or **Ignore**. The same copies remain


### PR DESCRIPTION
## Summary
- replace the recovery-heavy unsaved dialog with a concise consequence and storage explanation
- identify Cloud Save as one of three private Cloud Projects and Project-file export as a local .icproj.json download
- use Stay, Save to Cloud and continue, and Continue without saving as the three decisions
- remove recoveryProtected from the dialog contract while retaining background recovery and exceptional failure banners
- route ordinary Analytics clicks through the same application-owned guard as Gallery, avoiding a duplicate native beforeunload prompt

## Validation
- pnpm gate:preflight -- --base origin/main
- ICM_E2E_ISOLATED=1 pnpm gate:affected -- --base origin/main
  - 251 unit files / 1567 tests
  - project-file browser: 8/8
  - Gallery browser: 32/32
  - editor browser: 115/115
- in-app browser visual inspection at 127.0.0.1:5174
- git diff --check origin/main...HEAD