### PR TITLE
feat(editor): annotation grid pitch with 1-unit fine placement

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -216,8 +216,10 @@ test("snaps quick Text creation after a non-grid viewport zoom", async ({
   const textObject = project.documents[0].drafting.objects.find(
     (object: { kind: string }) => object.kind === "text",
   );
-  expect(textObject.anchor.position.x % 10).toBe(0);
-  expect(textObject.anchor.position.y % 10).toBe(0);
+  // Quick text rounds to the annotation pitch (default 5), never raw
+  // fractional viewport coordinates.
+  expect(textObject.anchor.position.x % 5).toBe(0);
+  expect(textObject.anchor.position.y % 5).toBe(0);
 });
 
 test("copies a selected text with C", async ({ page }) => {
@@ -710,7 +712,9 @@ test("O creates a selectable, styleable circle with one radial handle and no rot
   const circle = page.locator('[data-kind="draft-circle"]');
   await expect(circle).toHaveCount(1);
   await expect(circle).toHaveAttribute("fill", "none");
-  await expect(circle).toHaveAttribute("r", "80");
+  // The default 5-unit annotation pitch resolves this gesture half a grid
+  // finer than the old device-grid rounding did.
+  await expect(circle).toHaveAttribute("r", "85");
 
   const hit = page.getByTestId(/^drafting-hit-circle-/);
   await expect(hit).toHaveCSS("pointer-events", "stroke");
@@ -1155,4 +1159,83 @@ test("Properties sets precise size, stroke width, and color per shape", async ({
   await properties.getByRole("button", { name: "Auto" }).click();
   const stroke = await rectangle.getAttribute("stroke");
   expect(stroke).not.toBe("#cc2200");
+});
+
+test("annotation grid pitch frees drawings from the device grid", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await awaitEditorReady(page);
+
+  // Half-grid is the shipped default; the electrical grid is not offered.
+  const pitch = page.getByTestId("annotation-grid-select");
+  await expect(pitch).toHaveValue("5");
+  await pitch.selectOption("1");
+
+  // A drawn rectangle commits at 1-unit precision and survives validation.
+  await clickDrawTool(page, "rectangle");
+  const canvas = page.getByTestId("schematic-canvas");
+  const corners = [
+    { x: 301, y: 203 },
+    { x: 352, y: 247 },
+  ];
+  await canvas.click({ position: corners[0]! });
+  await canvas.click({ position: corners[1]! });
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("revision")).toHaveText("1");
+  // Reproduce the click-to-document mapping so the center assertion is exact.
+  const expectedCenter = await canvas.evaluate((element, points) => {
+    const svg = element as SVGSVGElement;
+    const bounds = svg.getBoundingClientRect();
+    const matrix = svg.getScreenCTM()!.inverse();
+    const toDocument = (point: { x: number; y: number }) => {
+      const client = new DOMPoint(bounds.left + point.x, bounds.top + point.y);
+      const local = client.matrixTransform(matrix);
+      return { x: Math.round(local.x), y: Math.round(local.y) };
+    };
+    const start = toDocument(points[0]!);
+    const end = toDocument(points[1]!);
+    return {
+      x: Math.round((start.x + end.x) / 2),
+      y: Math.round((start.y + end.y) / 2),
+    };
+  }, corners);
+
+  // A device stays on the Document grid no matter the annotation pitch.
+  await chooseComponent(page, "resistor");
+  await canvas.click({ position: { x: 363, y: 327 } });
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("hit-R1")).toBeVisible();
+
+  const saved = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(
+      "utf8",
+    ),
+  ) as {
+    schemaVersion: number;
+    documents: Array<{
+      instances: Array<{ placement?: { position: { x: number; y: number } } }>;
+      drafting?: {
+        objects: Array<{
+          kind: string;
+          anchor: { kind: string; position?: { x: number; y: number } };
+        }>;
+      };
+    }>;
+  };
+  expect(saved.schemaVersion).toBe(29);
+  const document = saved.documents[0]!;
+  const rectangle = document.drafting?.objects.find(
+    (object) => object.kind === "rectangle",
+  ) as { center?: { x: number; y: number } } | undefined;
+  // 1-unit pitch: the drawn center lands exactly where the clicks map, not
+  // on a device-grid multiple.
+  expect(rectangle?.center).toEqual(expectedCenter);
+  const placement = document.instances[0]!.placement!.position;
+  expect(placement.x % 10).toBe(0);
+  expect(placement.y % 10).toBe(0);
+
+  // The pitch choice is an editor preference that survives a reload.
+  await page.reload();
+  await expect(page.getByTestId("annotation-grid-select")).toHaveValue("1");
 });

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -446,6 +446,23 @@ export function App({
   const uniqueSuffixCounter = useRef(0);
   const [viewBox, setRawViewBox] = useState<GridRect>(DEFAULT_VIEWBOX);
   const [gridDotsVisible, setGridDotsVisible] = useState(true);
+  // Annotations and drafting place on their own pitch; the Document grid
+  // stays the electrical contract for devices, wires, and junctions.
+  const [annotationGrid, setAnnotationGridState] = useState<1 | 5 | 10>(() => {
+    if (typeof window === "undefined") return 5;
+    const stored = Number(
+      window.localStorage.getItem("icm.annotation-grid.v1"),
+    );
+    return stored === 1 || stored === 5 || stored === 10 ? stored : 5;
+  });
+  const setAnnotationGrid = (pitch: 1 | 5 | 10): void => {
+    setAnnotationGridState(pitch);
+    try {
+      window.localStorage.setItem("icm.annotation-grid.v1", String(pitch));
+    } catch {
+      // Storage may be unavailable; the choice still applies to this session.
+    }
+  };
   const setViewBox = (
     next: GridRect | CameraRectInput | ((current: GridRect) => CameraRectInput),
     grid = document.presentation.grid,
@@ -848,7 +865,15 @@ export function App({
   /** Show a placement ghost under the cursor without waiting for a move. */
   function seedComponentPreviewFromPointer(): void {
     const point = lastCanvasPointRef.current;
-    if (point) setComponentPreviewPoint(point);
+    if (!point) return;
+    const pitch =
+      pendingComponentPlacement?.kind === "drafting-text"
+        ? annotationGrid
+        : document.presentation.grid;
+    setComponentPreviewPoint({
+      x: snapCoordinate(point.x, pitch),
+      y: snapCoordinate(point.y, pitch),
+    });
   }
 
   function seedCopyPreviewFromPointer(): void {
@@ -1614,6 +1639,7 @@ export function App({
     reverseSelectedDrafting,
   } = createDraftingCommands({
     document,
+    annotationGrid,
     resolver,
     viewBox,
     selection: visualSelection,
@@ -1637,6 +1663,7 @@ export function App({
     finish: finishDraftingCreate,
   } = createDraftingCreateController({
     document,
+    annotationGrid,
     resolver,
     visibleEndpoints,
     routeGeometryRecords,
@@ -1662,6 +1689,7 @@ export function App({
     beginHandleDrag: beginDraftingHandleDrag,
   } = createDraftingDragController({
     document,
+    annotationGrid,
     resolver,
     visibleEndpoints,
     dragSessionRef: canvasDragSessionRef,
@@ -1698,6 +1726,7 @@ export function App({
   });
   const { beginDrag: beginAnnotationDrag } = createAnnotationDragController({
     document,
+    annotationGrid,
     resolver,
     routeGeometryRecords,
     dragSessionRef: canvasDragSessionRef,
@@ -1853,6 +1882,10 @@ export function App({
         pendingSymbolId && pendingComponentPlacement,
       ),
       componentSymbolPending: pendingSymbolId !== null,
+      placementGrid: () =>
+        pendingComponentPlacement?.kind === "drafting-text"
+          ? annotationGrid
+          : document.presentation.grid,
       setComponentPreviewPoint,
       vddRailMode,
       vddRailStart,
@@ -2701,10 +2734,16 @@ export function App({
       pendingComponentPlacement: Boolean(pendingComponentPlacement),
       vddRailMode,
       copyPlacementActive: copyPlacement !== null,
-      snapPlacementPoint: (point) => ({
-        x: snapCoordinate(point.x, document.presentation.grid),
-        y: snapCoordinate(point.y, document.presentation.grid),
-      }),
+      snapPlacementPoint: (point) => {
+        const pitch =
+          pendingComponentPlacement?.kind === "drafting-text"
+            ? annotationGrid
+            : document.presentation.grid;
+        return {
+          x: snapCoordinate(point.x, pitch),
+          y: snapCoordinate(point.y, pitch),
+        };
+      },
       commitCopyPlacement: commitCopyPlacementFromSelection,
       commitPendingPlacement: commitPendingPlacementAtFromHook,
       clearComponentPreview: () => setComponentPreviewPoint(null),
@@ -3961,6 +4000,8 @@ export function App({
         wireCornerOrder={wireCornerOrder}
         recoveryLabel={isDirtyWork() ? recoveryStateLabel(recoveryState) : null}
         gridDotsVisible={gridDotsVisible}
+        annotationGrid={annotationGrid}
+        onAnnotationGridChange={setAnnotationGrid}
         zoomPercent={zoomPercent}
         onToggleWireOptions={() => setWireOptionsOpen((open) => !open)}
         onWireRoutingModeChange={setWireRoutingMode}

--- a/apps/editor/src/canvas/canvas-gesture-controller.ts
+++ b/apps/editor/src/canvas/canvas-gesture-controller.ts
@@ -102,6 +102,8 @@ export interface CanvasGestureControllerDependencies {
   placement: {
     componentPlacementPending: boolean;
     componentSymbolPending: boolean;
+    /** Rounding pitch for the pending placement's ghost (annotation texts move finer than devices). */
+    placementGrid: () => number;
     setComponentPreviewPoint: (point: Point) => void;
     vddRailMode: boolean;
     vddRailStart: Point | null;
@@ -170,6 +172,7 @@ export function createCanvasGestureController({
   placement: {
     componentPlacementPending,
     componentSymbolPending,
+    placementGrid,
     setComponentPreviewPoint,
     vddRailMode,
     vddRailStart,
@@ -330,7 +333,15 @@ export function createCanvasGestureController({
       return;
     }
     if (componentSymbolPending) {
-      setComponentPreviewPoint(point);
+      const raw = rawPointFromClient(
+        event.clientX,
+        event.clientY,
+        event.currentTarget,
+      );
+      setComponentPreviewPoint({
+        x: snapCoordinate(raw.x, placementGrid()),
+        y: snapCoordinate(raw.y, placementGrid()),
+      });
       return;
     }
     if (interactionKind === "copy-placement") {
@@ -350,8 +361,10 @@ export function createCanvasGestureController({
         tool === "circle") &&
       draftingSource !== null
     ) {
+      // Raw pointer: the drafting snapper rounds by the annotation grid,
+      // which can be finer than the Document grid this handler's point uses.
       const snapped = snapDraftingPoint(
-        point,
+        rawPointFromClient(event.clientX, event.clientY, event.currentTarget),
         event.altKey,
         event.shiftKey,
         draftingSource,

--- a/apps/editor/src/canvas/editor-canvas-event-handlers.ts
+++ b/apps/editor/src/canvas/editor-canvas-event-handlers.ts
@@ -188,7 +188,12 @@ export function createEditorCanvasEventHandlers({
         event.stopPropagation();
         commitCopyPlacement(
           snapPlacementPoint(
-            pointFromClient(event.clientX, event.clientY, event.currentTarget),
+            pointFromClient(
+              event.clientX,
+              event.clientY,
+              event.currentTarget,
+              false,
+            ),
           ),
         );
         return;
@@ -199,7 +204,12 @@ export function createEditorCanvasEventHandlers({
       event.stopPropagation();
       commitPendingPlacement(
         snapPlacementPoint(
-          pointFromClient(event.clientX, event.clientY, event.currentTarget),
+          pointFromClient(
+            event.clientX,
+            event.clientY,
+            event.currentTarget,
+            false,
+          ),
         ),
       );
     },
@@ -256,7 +266,14 @@ export function createEditorCanvasEventHandlers({
         onBackground
       ) {
         handleDraftingCanvasClick(
-          pointFromClient(event.clientX, event.clientY, event.currentTarget),
+          // Raw pointer: the drafting controller rounds by the annotation
+          // grid, which can be finer than the Document grid.
+          pointFromClient(
+            event.clientX,
+            event.clientY,
+            event.currentTarget,
+            false,
+          ),
           event.altKey,
           event.shiftKey,
           logicalRadiusForPixels(event.currentTarget, snapCaptureRadiusPixels),

--- a/apps/editor/src/examples/common-source-amplifier.icproj.json
+++ b/apps/editor/src/examples/common-source-amplifier.icproj.json
@@ -1380,7 +1380,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 28,
+  "schemaVersion": 29,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/current-mirror-loaded-differential-pair.icproj.json
+++ b/apps/editor/src/examples/current-mirror-loaded-differential-pair.icproj.json
@@ -716,36 +716,28 @@
           {
             "direction": "passive",
             "id": "cell-terminal-p1",
-            "interfaceInstanceIds": [
-              "P1"
-            ],
+            "interfaceInstanceIds": ["P1"],
             "name": "Vin1",
             "netId": "net-contact-p1"
           },
           {
             "direction": "passive",
             "id": "cell-terminal-p2",
-            "interfaceInstanceIds": [
-              "P2"
-            ],
+            "interfaceInstanceIds": ["P2"],
             "name": "Vin2",
             "netId": "net-contact-p2"
           },
           {
             "direction": "passive",
             "id": "cell-terminal-p3",
-            "interfaceInstanceIds": [
-              "P3"
-            ],
+            "interfaceInstanceIds": ["P3"],
             "name": "Vout",
             "netId": "net-ui-8"
           },
           {
             "direction": "passive",
             "id": "cell-terminal-p4",
-            "interfaceInstanceIds": [
-              "P4"
-            ],
+            "interfaceInstanceIds": ["P4"],
             "name": "Vb",
             "netId": "net-contact-p4"
           }

--- a/apps/editor/src/examples/current-mirror-loaded-differential-pair.icproj.json
+++ b/apps/editor/src/examples/current-mirror-loaded-differential-pair.icproj.json
@@ -716,28 +716,36 @@
           {
             "direction": "passive",
             "id": "cell-terminal-p1",
-            "interfaceInstanceIds": ["P1"],
+            "interfaceInstanceIds": [
+              "P1"
+            ],
             "name": "Vin1",
             "netId": "net-contact-p1"
           },
           {
             "direction": "passive",
             "id": "cell-terminal-p2",
-            "interfaceInstanceIds": ["P2"],
+            "interfaceInstanceIds": [
+              "P2"
+            ],
             "name": "Vin2",
             "netId": "net-contact-p2"
           },
           {
             "direction": "passive",
             "id": "cell-terminal-p3",
-            "interfaceInstanceIds": ["P3"],
+            "interfaceInstanceIds": [
+              "P3"
+            ],
             "name": "Vout",
             "netId": "net-ui-8"
           },
           {
             "direction": "passive",
             "id": "cell-terminal-p4",
-            "interfaceInstanceIds": ["P4"],
+            "interfaceInstanceIds": [
+              "P4"
+            ],
             "name": "Vb",
             "netId": "net-contact-p4"
           }
@@ -1287,7 +1295,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 28,
+  "schemaVersion": 29,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/fully-differential-two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/fully-differential-two-stage-op-amp.icproj.json
@@ -1277,28 +1277,36 @@
           {
             "direction": "passive",
             "id": "cell-terminal-p1",
-            "interfaceInstanceIds": ["P1"],
+            "interfaceInstanceIds": [
+              "P1"
+            ],
             "name": "Vin+",
             "netId": "net-ui-34"
           },
           {
             "direction": "passive",
             "id": "cell-terminal-p2",
-            "interfaceInstanceIds": ["P2"],
+            "interfaceInstanceIds": [
+              "P2"
+            ],
             "name": "Vin-",
             "netId": "net-ui-35"
           },
           {
             "direction": "passive",
             "id": "cell-terminal-p3",
-            "interfaceInstanceIds": ["P3"],
+            "interfaceInstanceIds": [
+              "P3"
+            ],
             "name": "Vout1",
             "netId": "net-port-p3"
           },
           {
             "direction": "passive",
             "id": "cell-terminal-p4",
-            "interfaceInstanceIds": ["P4"],
+            "interfaceInstanceIds": [
+              "P4"
+            ],
             "name": "Vout2",
             "netId": "net-port-p4"
           }
@@ -2521,7 +2529,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 28,
+  "schemaVersion": 29,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/fully-differential-two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/fully-differential-two-stage-op-amp.icproj.json
@@ -1277,36 +1277,28 @@
           {
             "direction": "passive",
             "id": "cell-terminal-p1",
-            "interfaceInstanceIds": [
-              "P1"
-            ],
+            "interfaceInstanceIds": ["P1"],
             "name": "Vin+",
             "netId": "net-ui-34"
           },
           {
             "direction": "passive",
             "id": "cell-terminal-p2",
-            "interfaceInstanceIds": [
-              "P2"
-            ],
+            "interfaceInstanceIds": ["P2"],
             "name": "Vin-",
             "netId": "net-ui-35"
           },
           {
             "direction": "passive",
             "id": "cell-terminal-p3",
-            "interfaceInstanceIds": [
-              "P3"
-            ],
+            "interfaceInstanceIds": ["P3"],
             "name": "Vout1",
             "netId": "net-port-p3"
           },
           {
             "direction": "passive",
             "id": "cell-terminal-p4",
-            "interfaceInstanceIds": [
-              "P4"
-            ],
+            "interfaceInstanceIds": ["P4"],
             "name": "Vout2",
             "netId": "net-port-p4"
           }

--- a/apps/editor/src/examples/two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/two-stage-op-amp.icproj.json
@@ -454,14 +454,18 @@
           {
             "direction": "passive",
             "id": "cell-terminal-p12",
-            "interfaceInstanceIds": ["P12"],
+            "interfaceInstanceIds": [
+              "P12"
+            ],
             "name": "P1",
             "netId": "net-contact-p13"
           },
           {
             "direction": "passive",
             "id": "cell-terminal-p13",
-            "interfaceInstanceIds": ["P13"],
+            "interfaceInstanceIds": [
+              "P13"
+            ],
             "name": "P2",
             "netId": "net-contact-p13"
           }
@@ -801,7 +805,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 28,
+  "schemaVersion": 29,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/two-stage-op-amp.icproj.json
@@ -454,18 +454,14 @@
           {
             "direction": "passive",
             "id": "cell-terminal-p12",
-            "interfaceInstanceIds": [
-              "P12"
-            ],
+            "interfaceInstanceIds": ["P12"],
             "name": "P1",
             "netId": "net-contact-p13"
           },
           {
             "direction": "passive",
             "id": "cell-terminal-p13",
-            "interfaceInstanceIds": [
-              "P13"
-            ],
+            "interfaceInstanceIds": ["P13"],
             "name": "P2",
             "netId": "net-contact-p13"
           }

--- a/apps/editor/src/features/drafting/drafting-commands.test.ts
+++ b/apps/editor/src/features/drafting/drafting-commands.test.ts
@@ -12,6 +12,7 @@ describe("drafting commands", () => {
     const beginTextEditing = vi.fn();
     const commands = createDraftingCommands({
       document,
+      annotationGrid: 10,
       resolver: new InMemorySymbolResolver(builtInSymbols),
       viewBox: { x: 0, y: 0, width: 400, height: 300 },
       selection: {

--- a/apps/editor/src/features/drafting/drafting-commands.ts
+++ b/apps/editor/src/features/drafting/drafting-commands.ts
@@ -31,6 +31,7 @@ type TransactionResult = { ok: boolean };
 
 export function createDraftingCommands({
   document,
+  annotationGrid,
   resolver,
   viewBox,
   selection,
@@ -46,6 +47,8 @@ export function createDraftingCommands({
   selectAnnotation,
 }: {
   document: SchematicDocument;
+  /** Rounding pitch for drafting geometry edits and new plain text. */
+  annotationGrid: number;
   resolver: SymbolResolver;
   viewBox: GridRect;
   selection: VisualSelection;
@@ -164,7 +167,7 @@ export function createDraftingCommands({
       geometry,
       index,
       angleDegrees,
-      document.presentation.grid,
+      annotationGrid,
     );
     if (next) {
       transact([{ kind: "upsert_drafting_object", object: next }]);
@@ -191,7 +194,7 @@ export function createDraftingCommands({
       selectedDrafting,
       geometry,
       bearingDegrees,
-      document.presentation.grid,
+      annotationGrid,
     );
     if (next.kind === "attached-arrow") {
       setStatus(
@@ -225,7 +228,7 @@ export function createDraftingCommands({
         x: Math.round(viewBox.x + viewBox.width / 2),
         y: Math.round(viewBox.y + viewBox.height - 20),
       },
-      document.presentation.grid,
+      annotationGrid,
     );
     const object: DraftingText = {
       id,

--- a/apps/editor/src/features/drafting/drafting-create-controller.test.ts
+++ b/apps/editor/src/features/drafting/drafting-create-controller.test.ts
@@ -21,6 +21,7 @@ describe("drafting create controller", () => {
     const setTool = vi.fn();
     const controller = createDraftingCreateController({
       document: createEmptyDocument("cell", "Cell"),
+      annotationGrid: 10,
       resolver: new InMemorySymbolResolver(builtInSymbols),
       visibleEndpoints: [],
       routeGeometryRecords: [],
@@ -55,6 +56,7 @@ describe("drafting create controller", () => {
     const transact = vi.fn(() => ({ ok: true }));
     const controller = createDraftingCreateController({
       document: createEmptyDocument("cell", "Cell"),
+      annotationGrid: 10,
       resolver: new InMemorySymbolResolver(builtInSymbols),
       visibleEndpoints: [],
       routeGeometryRecords: [],

--- a/apps/editor/src/features/drafting/drafting-create-controller.ts
+++ b/apps/editor/src/features/drafting/drafting-create-controller.ts
@@ -40,6 +40,7 @@ export function constrainDraftingAngle(
 
 export function createDraftingCreateController({
   document,
+  annotationGrid,
   resolver,
   visibleEndpoints,
   routeGeometryRecords,
@@ -58,6 +59,8 @@ export function createDraftingCreateController({
   nextId,
 }: {
   document: SchematicDocument;
+  /** Rounding pitch for drawn objects; the Document grid stays electrical. */
+  annotationGrid: number;
   resolver: SymbolResolver;
   visibleEndpoints: readonly WireSource[];
   routeGeometryRecords: readonly RouteGeometryRecord[];
@@ -94,7 +97,7 @@ export function createDraftingCreateController({
       const constrained =
         shiftKey && origin ? constrainDraftingAngle(origin, point) : point;
       return {
-        point: snapGridPoint(constrained, document.presentation.grid),
+        point: snapGridPoint(constrained, annotationGrid),
         snap: null,
         guides: [],
       };
@@ -117,7 +120,7 @@ export function createDraftingCreateController({
         ...routeTargets,
       ],
       {
-        grid: document.presentation.grid,
+        grid: annotationGrid,
         tolerance,
         profile: SNAP_PROFILES.draftingHandle,
       },
@@ -130,7 +133,7 @@ export function createDraftingCreateController({
       (resolved.xMatch && resolved.xMatch.targetKind !== "grid") ||
       (resolved.yMatch && resolved.yMatch.targetKind !== "grid");
     if (shiftKey && origin) snapped = constrainDraftingAngle(origin, snapped);
-    const gridPoint = snapGridPoint(snapped, document.presentation.grid);
+    const gridPoint = snapGridPoint(snapped, annotationGrid);
     return {
       point: gridPoint,
       snap: hasObjectSnap ? gridPoint : null,
@@ -142,7 +145,7 @@ export function createDraftingCreateController({
     if (points.length < 2) return;
     const id = nextId("construction");
     const snappedPoints = points.map((point) =>
-      snapGridPoint(point, document.presentation.grid),
+      snapGridPoint(point, annotationGrid),
     );
     if (
       transact([
@@ -167,8 +170,8 @@ export function createDraftingCreateController({
 
   const commit = (active: DraftingTool, start: Point, end: Point): void => {
     const id = nextId(active === "construction-line" ? "construction" : active);
-    const snappedStart = snapGridPoint(start, document.presentation.grid);
-    const snappedEnd = snapGridPoint(end, document.presentation.grid);
+    const snappedStart = snapGridPoint(start, annotationGrid);
+    const snappedEnd = snapGridPoint(end, annotationGrid);
     if (active === "circle") {
       const radius = Math.round(
         Math.hypot(
@@ -211,7 +214,7 @@ export function createDraftingCreateController({
           x: Math.round((snappedStart.x + snappedEnd.x) / 2),
           y: Math.round((snappedStart.y + snappedEnd.y) / 2),
         },
-        document.presentation.grid,
+        annotationGrid,
       );
       if (
         transact([

--- a/apps/editor/src/features/drafting/drafting-drag-controller.ts
+++ b/apps/editor/src/features/drafting/drafting-drag-controller.ts
@@ -44,6 +44,7 @@ type TransactionResult = { ok: boolean };
 
 export function createDraftingDragController({
   document,
+  annotationGrid,
   resolver,
   visibleEndpoints,
   dragSessionRef,
@@ -62,6 +63,8 @@ export function createDraftingDragController({
   setStatus,
 }: {
   document: SchematicDocument;
+  /** Rounding pitch for dragged drafting objects. */
+  annotationGrid: number;
   resolver: SymbolResolver;
   visibleEndpoints: readonly import("@icm/edit-engine").WireSource[];
   dragSessionRef: MutableRefObject<CanvasDragSession | null>;
@@ -153,7 +156,7 @@ export function createDraftingDragController({
               movingAnchors,
               targetAnchors,
               primaryAnchorId: `drafting:${object.id}:origin`,
-              grid: document.presentation.grid,
+              grid: annotationGrid,
               tolerance,
               profile: SNAP_PROFILES.draftingMove,
             },
@@ -210,7 +213,7 @@ export function createDraftingDragController({
               object: translateDraftingObject(
                 latest,
                 { x: position.x - original.x, y: position.y - original.y },
-                document.presentation.grid,
+                annotationGrid,
               ),
             },
           ]);
@@ -268,7 +271,7 @@ export function createDraftingDragController({
             handle,
             snapped.point,
             originalGeometry,
-            document.presentation.grid,
+            annotationGrid,
           ),
         });
       },
@@ -290,7 +293,7 @@ export function createDraftingDragController({
               handle,
               point,
               originalGeometry,
-              document.presentation.grid,
+              annotationGrid,
             );
             if (next !== latest) {
               transact([{ kind: "upsert_drafting_object", object: next }]);

--- a/apps/editor/src/features/editor-shell/editor-statusbar.test.tsx
+++ b/apps/editor/src/features/editor-shell/editor-statusbar.test.tsx
@@ -16,12 +16,14 @@ describe("editor statusbar", () => {
         wireCornerOrder="horizontal-first"
         recoveryLabel="Saved locally"
         gridDotsVisible
+        annotationGrid={5}
         zoomPercent={100}
         onToggleWireOptions={vi.fn()}
         onWireRoutingModeChange={vi.fn()}
         onWireCornerOrderChange={vi.fn()}
         onToggleGridDots={vi.fn()}
         onOpenAnalytics={vi.fn()}
+        onAnnotationGridChange={vi.fn()}
         onZoomOut={vi.fn()}
         onZoomIn={vi.fn()}
         onFitView={vi.fn()}
@@ -30,5 +32,6 @@ describe("editor statusbar", () => {
     expect(markup).toContain('data-testid="wire-options"');
     expect(markup).toContain("Saved locally");
     expect(markup).toContain('aria-label="Current zoom"');
+    expect(markup).toContain('aria-label="Annotation grid"');
   });
 });

--- a/apps/editor/src/features/editor-shell/editor-statusbar.tsx
+++ b/apps/editor/src/features/editor-shell/editor-statusbar.tsx
@@ -26,12 +26,14 @@ export function EditorStatusbar({
   wireCornerOrder,
   recoveryLabel,
   gridDotsVisible,
+  annotationGrid,
   zoomPercent,
   onToggleWireOptions,
   onWireRoutingModeChange,
   onWireCornerOrderChange,
   onToggleGridDots,
   onOpenAnalytics,
+  onAnnotationGridChange,
   onZoomOut,
   onZoomIn,
   onFitView,
@@ -46,12 +48,14 @@ export function EditorStatusbar({
   wireCornerOrder: WireCornerOrder;
   recoveryLabel: string | null;
   gridDotsVisible: boolean;
+  annotationGrid: 1 | 5 | 10;
   zoomPercent: number;
   onToggleWireOptions: () => void;
   onWireRoutingModeChange: (mode: WireRoutingMode) => void;
   onWireCornerOrderChange: (order: WireCornerOrder) => void;
   onToggleGridDots: () => void;
   onOpenAnalytics: () => void;
+  onAnnotationGridChange: (pitch: 1 | 5 | 10) => void;
   onZoomOut: () => void;
   onZoomIn: () => void;
   onFitView: () => void;
@@ -159,6 +163,21 @@ export function EditorStatusbar({
         >
           <ToolIcon name="grid" />
         </button>
+        <select
+          aria-label="Annotation grid"
+          data-testid="annotation-grid-select"
+          title="Placement pitch for text and drawing annotations. Devices, wires, and junctions always stay on the 10-unit grid."
+          value={annotationGrid}
+          onChange={(event) =>
+            onAnnotationGridChange(
+              Number(event.currentTarget.value) as 1 | 5 | 10,
+            )
+          }
+        >
+          <option value="10">±10</option>
+          <option value="5">±5</option>
+          <option value="1">±1</option>
+        </select>
         <button
           type="button"
           aria-label="Zoom out"

--- a/apps/editor/src/features/text-editing/annotation-drag-controller.ts
+++ b/apps/editor/src/features/text-editing/annotation-drag-controller.ts
@@ -29,6 +29,7 @@ type TransactionResult = { ok: boolean };
 
 export function createAnnotationDragController({
   document,
+  annotationGrid,
   resolver,
   routeGeometryRecords,
   dragSessionRef,
@@ -41,6 +42,8 @@ export function createAnnotationDragController({
   setStatus,
 }: {
   document: SchematicDocument;
+  /** Rounding pitch for dragged labels. */
+  annotationGrid: number;
   resolver: SymbolResolver;
   routeGeometryRecords: readonly RouteGeometryRecord[];
   dragSessionRef: MutableRefObject<CanvasDragSession | null>;
@@ -131,12 +134,9 @@ export function createAnnotationDragController({
           {
             kind: "upsert_schematic_annotation",
             annotation: draggedAnnotationAtPosition(
-              { document, resolver, routeGeometryRecords },
+              { document, annotationGrid, resolver, routeGeometryRecords },
               latest,
-              snapGridPoint(
-                positionAt(client.x, client.y),
-                document.presentation.grid,
-              ),
+              snapGridPoint(positionAt(client.x, client.y), annotationGrid),
             ),
           },
         ]);

--- a/apps/editor/src/features/text-editing/annotation-drag-model.test.ts
+++ b/apps/editor/src/features/text-editing/annotation-drag-model.test.ts
@@ -13,6 +13,7 @@ function context(document: ReturnType<typeof createEmptyDocument>) {
   const routing = resolveDocumentRoutingGeometry(document, resolver);
   return {
     document,
+    annotationGrid: 10,
     resolver,
     routeGeometryRecords: document.routes.flatMap((route) => {
       const geometry = routing.routes.get(route.id);

--- a/apps/editor/src/features/text-editing/annotation-drag-model.ts
+++ b/apps/editor/src/features/text-editing/annotation-drag-model.ts
@@ -20,6 +20,8 @@ import {
 
 export interface AnnotationDragGeometryContext {
   document: SchematicDocument;
+  /** Rounding pitch for dragged labels; 1-unit precision is valid. */
+  annotationGrid: number;
   resolver: SymbolResolver;
   routeGeometryRecords: readonly {
     route: RouteBranch;
@@ -28,7 +30,12 @@ export interface AnnotationDragGeometryContext {
 }
 
 function constrainAnnotationPosition(
-  { document, resolver, routeGeometryRecords }: AnnotationDragGeometryContext,
+  {
+    document,
+    annotationGrid,
+    resolver,
+    routeGeometryRecords,
+  }: AnnotationDragGeometryContext,
   annotation: Annotation,
   candidate: DerivedPoint,
 ): Point {
@@ -67,7 +74,7 @@ function constrainAnnotationPosition(
             instance.placement.position.y + radius,
           ),
         },
-        document.presentation.grid,
+        annotationGrid,
       );
     }
   }
@@ -106,11 +113,11 @@ function constrainAnnotationPosition(
             closest.y + NET_LABEL_MAX_NORMAL_OFFSET,
           ),
         },
-        document.presentation.grid,
+        annotationGrid,
       );
     }
   }
-  return snapGridPoint(candidate, document.presentation.grid);
+  return snapGridPoint(candidate, annotationGrid);
 }
 
 /** Resolve the persisted annotation produced by one completed drag gesture. */

--- a/docs/adr/0046-independent-cell-pins-and-formal-port-projection.md
+++ b/docs/adr/0046-independent-cell-pins-and-formal-port-projection.md
@@ -18,7 +18,7 @@ which could not be seen from the schematic geometry.
 ## Decision
 
 Schema 25 introduced every visible Cell Pin as an independent authored
-declaration; the contract remains present in current Schema 28.
+declaration; the contract remains present in current Schema 29.
 Each declaration owns exactly one Port Instance, one stable terminal identity,
 one name, one direction, and one physical Base Net. Duplicate names are valid.
 Placement, rename, copy, direction editing, deletion, and Wire cutting never

--- a/docs/overall-product-plan.md
+++ b/docs/overall-product-plan.md
@@ -68,7 +68,7 @@ revision, lock, or transaction invariants.
   ordered hierarchy interface rather than another Net-label mechanism.
 - Routes describe visible geometry; they may stretch locally during movement
   without changing logical connectivity.
-- A Project's canonical content is schema-28 JSON. Explicit Save updates one
+- A Project's canonical content is schema-29 JSON. Explicit Save updates one
   stable private Cloud Project; `.icproj.json` is portable interchange, and
   browser recovery is an origin-local, non-authoritative copy.
 - Visual variants may change presentation but never remove electrical terminal

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -340,8 +340,8 @@ no electrical meaning.
 Open, demo load, restore, and human-approved staged import replace the entire
 Project through one replacement boundary; they are not Edit Engine
 transactions. Replacement cancels pending recovery for the outgoing Project
-and terminates its Agent session. A complete schema-27 Project may be upgraded
-at the read boundary and then enters the editor only as schema-28; migrated
+and terminates its Agent session. A complete schema-28 Project may be upgraded
+at the read boundary and then enters the editor only as schema-29; migrated
 files are marked as needing save.
 
 Selection, viewport, active tool, previews, Agent tokens, and approval UI are

--- a/docs/specs/persistence-and-recovery.md
+++ b/docs/specs/persistence-and-recovery.md
@@ -5,17 +5,17 @@ Status: `accepted`
 Primary owner: Worker Cloud Project storage, `packages/project-protocol`, and
 the editor document lifecycle
 
-Project content uses canonical schema-28 JSON. A private Cloud Project is the
+Project content uses canonical schema-29 JSON. A private Cloud Project is the
 formal saved resource; `.icproj.json` is portable import/export and backup.
 The current-only model in `packages/model` validates the normalized shape;
 `packages/project-protocol` owns parsing, rolling compatibility diagnostics,
 and canonical serialization. Persistence validates the complete current schema
-before import or Cloud Save. Schema 27 upgrades to 28 at ingestion; serialization
-always writes schema 28. Older schemas are rejected outside the rolling
+before import or Cloud Save. Schema 28 upgrades to 29 at ingestion; serialization
+always writes schema 29. Older schemas are rejected outside the rolling
 current-and-previous compatibility window.
 
 Recovery state is a non-authoritative browser safety copy. It may restore a
-complete schema-28 Project or a schema-27 record that validates after the
+complete schema-29 Project or a schema-28 record that validates after the
 bounded upgrade, associated with a recorded working-copy session.
 Corrupt, incompatible, or partial recovery data is discarded or retained as raw
 data without changing the live Project. User-saved Library examples are the

--- a/docs/specs/project-file-format.md
+++ b/docs/specs/project-file-format.md
@@ -2,15 +2,16 @@
 
 Status: `accepted`
 
-Current Project schema: `28`
+Current Project schema: `29`
 
 Primary owners: `packages/model` (current shape) and
 `packages/project-protocol` (file boundary)
 
 An `.icproj.json` file is canonical JSON for one complete `CircuitProject`.
 `@icm/project-protocol` exposes `parseProject`. It accepts schemas 27 and 28,
-adds the optional polarity-annotation intent when reading schema 27, supplies
-only schema 28 in memory, and writes only schema 28. Older project files are
+accepts schema 28 unchanged (schema 29 only relaxes annotation and drafting
+anchors to 1-unit precision), supplies only schema 29 in memory, and writes
+only schema 29. Older project files are
 rejected.
 
 ## Current authorities
@@ -62,8 +63,8 @@ rejected.
 ## Read and write
 
 ```text
-import text -> parse JSON -> require Project schema 27 or 28
--> converge to schema 28 -> strict schema-28 validation -> install unbound
+import text -> parse JSON -> require Project schema 28 or 29
+-> converge to schema 29 -> strict schema-29 validation -> install unbound
 export -> strict validation -> canonical key ordering -> Blob download
 ```
 
@@ -83,7 +84,7 @@ until the author explicitly renames or merges the Nets.
 Canonical serialization ends with one newline and is byte-stable across
 serialize/parse/serialize. The current corpus is listed in
 `fixtures/projects/compatibility-corpus.json`; its accepted entries must all be
-already canonical Project schema 28. The rejected corpus names expected
+already canonical Project schema 29. The rejected corpus names expected
 validation failures.
 
 Viewport, selection, undo history, canvas overlays, Agent credentials,

--- a/docs/specs/schematic-model.md
+++ b/docs/specs/schematic-model.md
@@ -5,7 +5,7 @@ Status: `accepted`
 Primary owner: `packages/model`
 
 The Project contains Documents; each Document owns revisioned electrical,
-geometric, and presentation facts. The current model is strict schema 28 and has
+geometric, and presentation facts. The current model is strict schema 29 and has
 no compatibility shape.
 
 ## Coordinate domains

--- a/docs/user/project-compatibility.md
+++ b/docs/user/project-compatibility.md
@@ -1,6 +1,6 @@
 # Project File Compatibility
 
-The released Project schema version is `28`. It retains schematic-only
+The released Project schema version is `29`. It retains schematic-only
 hierarchy integrity, a Project structural revision, stable formal Cell ports,
 and definition-level Cell symbol presentation. It also has one typed Instance
 netlist authority, formal Cell parameters, and Project-local external
@@ -14,14 +14,17 @@ Its bound annotation may persist same-text RichText formatting but cannot store
 a divergent alias. Equal Port Names remain independent in the saved drawing
 and are grouped only by the read-only formal interface projection. Drafting
 text may also carry one of three polarity-label forms while its editable RichText
-content remains independent from the fixed vector marks. A canonical v28 file
-can be opened, saved, reopened, and saved again without byte drift.
+content remains independent from the fixed vector marks. Annotations and
+drafting objects position at 1-unit integer precision, while Instance
+placements, route bends, and Junctions stay aligned to the Document grid. A
+canonical v29 file can be opened, saved, reopened, and saved again without
+byte drift.
 
-Schema v27 is accepted through a bounded upgrade to v28. The new polarity
-field is optional, so the upgrade preserves all existing circuit and drafting
-content and stamps the current version. The next save writes v28. The original
-file is never overwritten silently. Schema v26 and older, and versions newer
-than v28, are rejected by the interactive project-file boundary.
+Schema v28 is accepted through a bounded upgrade to v29. The change is a
+validation relaxation only, so the upgrade preserves all existing circuit and
+drafting content and stamps the current version. The next save writes v29. The
+original file is never overwritten silently. Schema v27 and older, and versions
+newer than v29, are rejected by the interactive project-file boundary.
 
 The canonical-current corpus at
 [`fixtures/projects/compatibility-corpus.json`](../../fixtures/projects/compatibility-corpus.json)
@@ -33,7 +36,7 @@ Retired fields such as first-class
 
 An incompatible Project is rejected before it can replace the current browser
 Project. Conversion, when needed, is an explicit external operation that must
-produce and validate a complete v28 candidate before a human chooses to load it.
+produce and validate a complete v29 candidate before a human chooses to load it.
 
 The editor never silently merges duplicate canonical Ground (`0`) or VDD Nets.
 Duplicate folded Net names are invalid and remain diagnostics until the author

--- a/fixtures/projects/instance-value-display/project.icproj.json
+++ b/fixtures/projects/instance-value-display/project.icproj.json
@@ -1048,7 +1048,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "instance-value-display",
   "name": "Instance Value Display",
-  "schemaVersion": 28,
+  "schemaVersion": 29,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/minimal/project.icproj.json
+++ b/fixtures/projects/minimal/project.icproj.json
@@ -32,7 +32,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-minimal",
   "name": "Minimal Project",
-  "schemaVersion": 28,
+  "schemaVersion": 29,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-1-manual/project.icproj.json
+++ b/fixtures/projects/phase-1-manual/project.icproj.json
@@ -59,7 +59,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-1-manual",
   "name": "Phase 1 Manual Editor",
-  "schemaVersion": 28,
+  "schemaVersion": 29,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-3-routing/project.icproj.json
+++ b/fixtures/projects/phase-3-routing/project.icproj.json
@@ -191,7 +191,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-routing",
   "name": "Phase 3 Routing Demo",
-  "schemaVersion": 28,
+  "schemaVersion": 29,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-5-dense-analog/project.icproj.json
+++ b/fixtures/projects/phase-5-dense-analog/project.icproj.json
@@ -428,7 +428,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-5-dense-analog",
   "name": "Current Differential Stage",
-  "schemaVersion": 28,
+  "schemaVersion": 29,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/rejected-missing-top/project.icproj.json
+++ b/fixtures/projects/rejected-missing-top/project.icproj.json
@@ -32,7 +32,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-rejected",
   "name": "Rejected",
-  "schemaVersion": 28,
+  "schemaVersion": 29,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/packages/edit-engine/src/drafting-transform.ts
+++ b/packages/edit-engine/src/drafting-transform.ts
@@ -12,9 +12,12 @@ import type { DraftingObject, GridPoint, VisualAnchor } from "@icm/model";
 function translatePoint(
   point: GridPoint,
   delta: GridPoint,
-  grid: number,
+  _grid: number,
 ): GridPoint {
-  return snapGridPoint({ x: point.x + delta.x, y: point.y + delta.y }, grid);
+  // Translation preserves an object's relative fine placement: annotation
+  // pitch can be finer than the Document grid, so only integer precision is
+  // restored here — the delta itself carries the grid discipline.
+  return snapGridPoint({ x: point.x + delta.x, y: point.y + delta.y }, 1);
 }
 
 function translateFreeAnchor<T extends VisualAnchor>(

--- a/packages/edit-engine/src/transaction-preflight.ts
+++ b/packages/edit-engine/src/transaction-preflight.ts
@@ -134,15 +134,23 @@ export function gridAlignmentDiagnostics(
   edit: SchematicEdit,
   grid: number,
 ): EditDiagnostic[] {
+  // Annotations and drafting objects position at 1-unit precision (schema
+  // 29); the Document grid remains the hard contract for electrical edits so
+  // pins, wires, and junctions always coincide.
+  const pitch =
+    edit.kind === "upsert_schematic_annotation" ||
+    edit.kind === "upsert_drafting_object"
+      ? 1
+      : grid;
   return gridPointsOfEdit(edit).flatMap(({ point, path }) =>
     (["x", "y"] as const).flatMap((axis) =>
-      point[axis] % grid === 0
+      point[axis] % pitch === 0
         ? []
         : [
             {
               code: "GRID_ALIGNMENT",
               severity: "error" as const,
-              message: `Document page coordinates must align to grid ${grid}`,
+              message: `Document page coordinates must align to grid ${pitch}`,
               path: [...path, axis],
             },
           ],

--- a/packages/model/src/schema.test.ts
+++ b/packages/model/src/schema.test.ts
@@ -185,25 +185,35 @@ describe("CircuitProject schema", () => {
     expect(SchematicDocumentSchema.safeParse(document).success).toBe(false);
   });
 
-  it("rejects a persisted page point that is not aligned to its Document grid", () => {
+  it("holds electrical objects to the Document grid while annotations position freely", () => {
     const document = createEmptyProject("project-grid", "Grid").documents[0]!;
+    // Schema 29: drafting and annotation anchors are 1-unit precise.
     document.drafting!.objects.push({
-      id: "draft-off-grid",
+      id: "draft-fine",
       kind: "text",
       locked: false,
       zIndex: 0,
-      anchor: { kind: "free", position: { x: 15, y: 20 } },
-      content: { runs: [{ kind: "text", value: "off grid" }] },
+      anchor: { kind: "free", position: { x: 15, y: 21 } },
+      content: { runs: [{ kind: "text", value: "fine placed" }] },
       alignment: "start",
       rotation: 0,
     });
+    expect(SchematicDocumentSchema.safeParse(document).success).toBe(true);
 
+    // The electrical grid contract is unchanged: an off-grid Instance
+    // placement still fails Document validation.
+    document.instances.push({
+      id: "R1",
+      symbolId: "resistor",
+      schematicReference: "R1",
+      placement: { position: { x: 15, y: 20 }, rotation: 0, mirror: "none" },
+    });
     const result = SchematicDocumentSchema.safeParse(document);
     expect(result.success).toBe(false);
     if (result.success) return;
     expect(result.error.issues).toContainEqual(
       expect.objectContaining({
-        path: ["drafting", "objects", 0, "anchor", "position", "x"],
+        path: ["instances", 0, "placement", "position", "x"],
       }),
     );
   });

--- a/packages/model/src/schema/common.ts
+++ b/packages/model/src/schema/common.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-export const CURRENT_PROJECT_SCHEMA_VERSION = 28;
+export const CURRENT_PROJECT_SCHEMA_VERSION = 29;
 
 export const StableIdSchema = z.string().min(1).max(256);
 /** A persisted Document page point before its Document-grid relation is known. */

--- a/packages/model/src/schema/document.ts
+++ b/packages/model/src/schema/document.ts
@@ -13,7 +13,7 @@ import {
   NoConnectSchema,
 } from "./connectivity.js";
 import { JunctionSchema, RouteBranchSchema } from "./routing.js";
-import { AnnotationSchema, VisualAnchorSchema } from "./annotations.js";
+import { AnnotationSchema } from "./annotations.js";
 import { DraftingLayerSchema } from "./drafting.js";
 import { flattenRichText } from "../rich-text.js";
 import { semanticTextDocument } from "../semantic-text.js";
@@ -23,7 +23,7 @@ import {
   MosBulkDefaultsSchema,
   PresentationIntentSchema,
 } from "./presentation.js";
-import type { DraftingObject, GridPoint, VisualAnchor } from "./types.js";
+import type { GridPoint } from "./types.js";
 import { reportDuplicateIds } from "./validation.js";
 export const SourceBindingSchema = z.strictObject({
   cellName: z.string().min(1),
@@ -90,123 +90,6 @@ function reportGridPoint(
       message: `Document page coordinates must align to grid ${grid}`,
       path: [...path, axis],
     });
-  }
-}
-
-function reportVisualAnchorGridAlignment(
-  anchor: VisualAnchor,
-  grid: number,
-  path: ReadonlyArray<string | number>,
-  context: z.RefinementCtx,
-): void {
-  switch (anchor.kind) {
-    case "free":
-      reportGridPoint(anchor.position, grid, [...path, "position"], context);
-      return;
-    case "object":
-      reportGridPoint(
-        anchor.localOffset,
-        grid,
-        [...path, "localOffset"],
-        context,
-      );
-      reportGridPoint(
-        anchor.fallbackPosition,
-        grid,
-        [...path, "fallbackPosition"],
-        context,
-      );
-      return;
-    case "route":
-      // `t` and normalOffset are parametric scalars, not page coordinates.
-      reportGridPoint(
-        anchor.fallbackPosition,
-        grid,
-        [...path, "fallbackPosition"],
-        context,
-      );
-  }
-}
-
-function reportDraftingObjectGridAlignment(
-  object: DraftingObject,
-  grid: number,
-  path: ReadonlyArray<string | number>,
-  context: z.RefinementCtx,
-): void {
-  reportVisualAnchorGridAlignment(
-    object.anchor,
-    grid,
-    [...path, "anchor"],
-    context,
-  );
-  switch (object.kind) {
-    case "text":
-    case "floating-symbol":
-      return;
-    case "arrow":
-      reportVisualAnchorGridAlignment(
-        object.from,
-        grid,
-        [...path, "from"],
-        context,
-      );
-      reportVisualAnchorGridAlignment(
-        object.to,
-        grid,
-        [...path, "to"],
-        context,
-      );
-      object.waypoints?.forEach((point, index) =>
-        reportGridPoint(point, grid, [...path, "waypoints", index], context),
-      );
-      object.curveControls?.forEach((point, index) => {
-        if (point) {
-          reportGridPoint(
-            point,
-            grid,
-            [...path, "curveControls", index],
-            context,
-          );
-        }
-      });
-      return;
-    case "leader":
-      reportVisualAnchorGridAlignment(
-        object.target,
-        grid,
-        [...path, "target"],
-        context,
-      );
-      return;
-    case "callout":
-      reportVisualAnchorGridAlignment(
-        object.target,
-        grid,
-        [...path, "target"],
-        context,
-      );
-      return;
-    case "construction-line":
-      object.points.forEach((point, index) =>
-        reportGridPoint(point, grid, [...path, "points", index], context),
-      );
-      object.curveControls?.forEach((point, index) => {
-        if (point) {
-          reportGridPoint(
-            point,
-            grid,
-            [...path, "curveControls", index],
-            context,
-          );
-        }
-      });
-      return;
-    case "rectangle":
-      reportGridPoint(object.center, grid, [...path, "center"], context);
-      return;
-    case "circle":
-      reportGridPoint(object.center, grid, [...path, "center"], context);
   }
 }
 
@@ -564,22 +447,11 @@ export const SchematicDocumentSchema = SchematicDocumentBaseSchema.superRefine(
         context,
       ),
     );
-    document.annotations.forEach((annotation, index) =>
-      reportVisualAnchorGridAlignment(
-        annotation.anchor,
-        grid,
-        ["annotations", index, "anchor"],
-        context,
-      ),
-    );
-    document.drafting?.objects.forEach((object, index) =>
-      reportDraftingObjectGridAlignment(
-        object,
-        grid,
-        ["drafting", "objects", index],
-        context,
-      ),
-    );
+    // Schema 29: annotations and drafting objects position at 1-unit
+    // precision (their point schemas already enforce integers). The Document
+    // grid remains the hard electrical contract above — instance placements,
+    // route bends, and junctions stay grid-aligned so pins and wires always
+    // coincide.
 
     const instanceIds = new Set(
       document.instances.map((instance) => instance.id),

--- a/packages/project-protocol/src/load.ts
+++ b/packages/project-protocol/src/load.ts
@@ -12,7 +12,7 @@ import {
 } from "./diagnostics.js";
 import {
   ProjectMigrationError,
-  upgradeSchema27To28,
+  upgradeSchema28To29,
 } from "./previous-to-current.js";
 import { PREVIOUS_PROJECT_SCHEMA_VERSION } from "./version.js";
 
@@ -108,7 +108,7 @@ export function tryParseProjectWithMetadata(
   try {
     current =
       sourceSchemaVersion === PREVIOUS_PROJECT_SCHEMA_VERSION
-        ? upgradeSchema27To28(parsed)
+        ? upgradeSchema28To29(parsed)
         : parsed;
   } catch (error) {
     if (error instanceof ProjectMigrationError) {

--- a/packages/project-protocol/src/persistence.test.ts
+++ b/packages/project-protocol/src/persistence.test.ts
@@ -180,8 +180,8 @@ describe("Project persistence", () => {
     );
     expect(migrated).toMatchObject({
       sourceSchemaVersion: 28,
-      migrated: false,
-      project: { schemaVersion: 28 },
+      migrated: true,
+      project: { schemaVersion: 29 },
     });
     const migratedDocument = migrated.project.documents[0]!;
     expect(migratedDocument.netlist?.terminals).toMatchObject([
@@ -327,8 +327,8 @@ describe("Project persistence", () => {
     );
     expect(parsed).toMatchObject({
       sourceSchemaVersion: 28,
-      migrated: false,
-      project: { schemaVersion: 28 },
+      migrated: true,
+      project: { schemaVersion: 29 },
     });
     const route = parsed.project.documents[0]!.routes[0]!;
     const annotation = parsed.project.documents[0]!.annotations[0]!;
@@ -346,10 +346,10 @@ describe("Project persistence", () => {
 
   it("rejects schemas outside the current-and-previous window", () => {
     const project = createEmptyProject("project-test", "Test Project");
-    for (const schemaVersion of [23, 24, 25, 29, 99]) {
+    for (const schemaVersion of [23, 24, 25, 30, 99]) {
       expect(() =>
         parseProject(JSON.stringify({ ...project, schemaVersion })),
-      ).toThrow(/must be 27 or 28/);
+      ).toThrow(/must be 28 or 29/);
     }
   });
 });

--- a/packages/project-protocol/src/previous-to-current.ts
+++ b/packages/project-protocol/src/previous-to-current.ts
@@ -34,3 +34,11 @@ export type {
   Schema27To28MigrationReport,
   Schema27To28MigrationResult,
 } from "./transforms/polarity-drafting.js";
+export {
+  upgradeSchema28To29,
+  upgradeSchema28To29WithReport,
+} from "./transforms/annotation-grid.js";
+export type {
+  Schema28To29MigrationReport,
+  Schema28To29MigrationResult,
+} from "./transforms/annotation-grid.js";

--- a/packages/project-protocol/src/protocol.test.ts
+++ b/packages/project-protocol/src/protocol.test.ts
@@ -16,21 +16,21 @@ describe("Project protocol boundary", () => {
     });
   });
 
-  it("upgrades the previous schema to schema 28", () => {
+  it("upgrades the previous schema to schema 29", () => {
     const current = JSON.parse(
       serializeProject(createEmptyProject("protocol-project", "Protocol")),
     ) as Record<string, unknown>;
     const result = tryParseProjectWithMetadata(
       JSON.stringify({
         ...current,
-        schemaVersion: 27,
+        schemaVersion: 28,
       }),
     );
     expect(result).toMatchObject({
       ok: true,
-      sourceSchemaVersion: 27,
+      sourceSchemaVersion: 28,
       migrated: true,
-      project: { schemaVersion: 28, structureRevision: 0 },
+      project: { schemaVersion: 29, structureRevision: 0 },
     });
   });
 

--- a/packages/project-protocol/src/transforms/annotation-grid.ts
+++ b/packages/project-protocol/src/transforms/annotation-grid.ts
@@ -1,0 +1,32 @@
+import { CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
+
+export interface Schema28To29MigrationReport {
+  /**
+   * Schema 29 relaxes annotation and drafting anchors from Document-grid
+   * alignment to 1-unit integer precision; existing data is unchanged.
+   */
+  readonly changed: false;
+}
+
+export interface Schema28To29MigrationResult {
+  readonly project: Record<string, unknown>;
+  readonly report: Schema28To29MigrationReport;
+}
+
+/**
+ * Upgrade schema 28 to 29. The change is a validation relaxation only, so
+ * every valid schema-28 project is already valid schema-29 data.
+ */
+export function upgradeSchema28To29WithReport(
+  raw: Record<string, unknown>,
+): Schema28To29MigrationResult {
+  const project = structuredClone(raw);
+  project.schemaVersion = CURRENT_PROJECT_SCHEMA_VERSION;
+  return { project, report: { changed: false } };
+}
+
+export function upgradeSchema28To29(
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  return upgradeSchema28To29WithReport(raw).project;
+}

--- a/packages/project-protocol/src/transforms/polarity-drafting.ts
+++ b/packages/project-protocol/src/transforms/polarity-drafting.ts
@@ -1,5 +1,3 @@
-import { CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
-
 export interface Schema27To28MigrationReport {
   /** Schema 28 adds optional polarity intent; existing projects are unchanged. */
   readonly changed: false;
@@ -18,7 +16,7 @@ export function upgradeSchema27To28WithReport(
   raw: Record<string, unknown>,
 ): Schema27To28MigrationResult {
   const project = structuredClone(raw);
-  project.schemaVersion = CURRENT_PROJECT_SCHEMA_VERSION;
+  project.schemaVersion = 28;
   return { project, report: { changed: false } };
 }
 

--- a/packages/project-protocol/src/version.ts
+++ b/packages/project-protocol/src/version.ts
@@ -2,4 +2,4 @@
  * The rolling compatibility window is deliberately explicit. Advancing the
  * current schema replaces this adapter instead of extending a migration chain.
  */
-export const PREVIOUS_PROJECT_SCHEMA_VERSION = 27;
+export const PREVIOUS_PROJECT_SCHEMA_VERSION = 28;

--- a/worker/gallery-do.ts
+++ b/worker/gallery-do.ts
@@ -22,7 +22,8 @@ import {
   upgradeSchema24To25,
   upgradeSchema25To26,
   upgradeSchema26To27,
-  upgradeSchema27To28WithReport,
+  upgradeSchema27To28,
+  upgradeSchema28To29WithReport,
 } from "@icm/project-protocol";
 import { renderDocumentSvg } from "@icm/render-svg";
 import {
@@ -1275,7 +1276,7 @@ export class GalleryDO {
     const migrationReports: Array<{
       table: string;
       id: string;
-      report: ReturnType<typeof upgradeSchema27To28WithReport>["report"];
+      report: ReturnType<typeof upgradeSchema28To29WithReport>["report"];
     }> = [];
     for (const source of sources) {
       const versions: Record<string, number> = {};
@@ -1298,9 +1299,12 @@ export class GalleryDO {
           if (lifted.schemaVersion === 26) {
             lifted = upgradeSchema26To27(lifted);
           }
+          if (lifted.schemaVersion === 27) {
+            lifted = upgradeSchema27To28(lifted);
+          }
           const migration =
-            lifted.schemaVersion === 27
-              ? upgradeSchema27To28WithReport(lifted)
+            lifted.schemaVersion === 28
+              ? upgradeSchema28To29WithReport(lifted)
               : null;
           lifted = migration?.project ?? lifted;
           const project = parseProject(JSON.stringify(lifted));


### PR DESCRIPTION
Adds the layered-grid design: the Document grid (10) stays the hard electrical contract, while annotations and drafting objects gain their own placement pitch.

**Schema 29** relaxes annotation/drafting anchors from Document-grid alignment to 1-unit integer precision — validation relaxation only, identity 28→29 upgrade, retained 27→28 now stamps literal 28, worker converge chain extended, fixtures re-canonicalized at v29, and the seven protocol docs updated. Instance placements, route bends, and junctions still validate against the Document grid in both the model schema and the edit-engine preflight; engine-side drafting translation no longer re-snaps to the coarse grid, so grid-multiple group moves preserve fine offsets.

**Editor**: a statusbar "Annotation grid" control — ±10 / ±5 / ±1, default ±5, persisted per browser — governs drawing-tool clicks and hover previews, drafting drags and handle resizes, label drags, quick Text, and preset ± sign placement. Ghost previews and commits share one mapping. Devices, wires, junctions, copy placement, and power rails ignore the setting and keep the 10-unit grid.

Validated with the full unit suite (1572) and the full local browser suite (244), including a new e2e that maps clicks through the SVG CTM and asserts exact 1-unit landing plus the device-grid invariant.

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)