### PR TITLE
feat(editor): quick pick reads in Library order with category multi-select

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -289,11 +289,49 @@ test("keeps quick-start shortcuts in the corner until the first component is ins
   await page.keyboard.press("i");
   const reopened = page.getByRole("dialog", { name: "Insert Component" });
   await expect(reopened.locator(".insert-tile-grid")).toBeVisible();
-  // Recent picks float to the front of the flat grid.
+  // The grid reads in Library order — transistors first — not recency, even
+  // though a resistor was just placed.
   await expect(reopened.getByRole("option").first()).toHaveAttribute(
     "data-testid",
-    "insert-component-resistor",
+    "insert-component-nmos",
   );
+});
+
+test("category chips multi-select which kinds the quick pick shows", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await awaitEditorReady(page);
+  await page.keyboard.press("i");
+  const dialog = page.getByRole("dialog", { name: "Insert Component" });
+  await expect(dialog.getByTestId("insert-component-nmos")).toBeVisible();
+
+  // Hiding one category removes only its tiles.
+  await dialog.getByTestId("insert-category-transistors").click();
+  await expect(dialog.getByTestId("insert-component-nmos")).toHaveCount(0);
+  await expect(dialog.getByTestId("insert-component-resistor")).toBeVisible();
+
+  // The filter is a free multi-select, not a single choice.
+  await dialog.getByTestId("insert-category-passives").click();
+  await expect(dialog.getByTestId("insert-component-resistor")).toHaveCount(0);
+  await expect(dialog.getByTestId("insert-component-and-gate")).toBeVisible();
+
+  // Toggling back restores the tiles, and typing still filters afterwards.
+  await dialog.getByTestId("insert-category-transistors").click();
+  await expect(dialog.getByTestId("insert-component-nmos")).toBeVisible();
+  await dialog.getByLabel("Component search").fill("nmos");
+  await expect(dialog.getByTestId("insert-component-resistor")).toHaveCount(0);
+  await expect(dialog.getByTestId("insert-component-nmos")).toBeVisible();
+
+  // Reopening resets to everything shown.
+  await page.keyboard.press("Escape");
+  await expect(dialog).toHaveCount(0);
+  await page.keyboard.press("i");
+  await expect(dialog.getByTestId("insert-category-passives")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await expect(dialog.getByTestId("insert-component-resistor")).toBeVisible();
 });
 
 test("groups and places high-voltage DMOS from Extended Devices", async ({

--- a/apps/editor/src/features/component-insert/insert-component-dialog.test.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.test.tsx
@@ -34,6 +34,19 @@ describe("InsertComponentDialog", () => {
     );
     expect(markup).not.toContain("<h3");
     expect(markup).not.toContain("<h4");
+    // Library order: transistors lead, categories stay together, and the
+    // category filter chips render in the same order, all shown by default.
+    const nmos = markup.indexOf('data-testid="insert-component-nmos"');
+    const resistor = markup.indexOf('data-testid="insert-component-resistor"');
+    const arrow = markup.indexOf(
+      'data-testid="insert-component-annotation-arrow"',
+    );
+    expect(nmos).toBeGreaterThan(-1);
+    expect(nmos).toBeLessThan(resistor);
+    expect(resistor).toBeLessThan(arrow);
+    expect(markup).toContain('data-testid="insert-category-transistors"');
+    expect(markup).toContain('data-testid="insert-category-annotations"');
+    expect(markup).not.toContain('aria-pressed="false"');
     // Per-device setup moved to post-placement Properties: the quick pick
     // carries no parameter, reference, rotation, or rail-name fields.
     expect(markup).not.toContain('aria-label="Component w"');

--- a/apps/editor/src/features/component-insert/insert-component-dialog.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.tsx
@@ -42,22 +42,30 @@ interface InsertChoice {
   readonly key: string;
   readonly kind: "symbol" | "cell" | "external-subcircuit";
   readonly symbol: SymbolDefinition;
+  readonly category: string;
   readonly childDocumentId?: string;
   readonly cellName?: string;
   readonly definitionId?: string;
   readonly masterName?: string;
 }
 
+const CELLS_CATEGORY = "Cells";
+const EXTERNAL_CATEGORY = "External masters";
+
+function categorySlug(category: string): string {
+  return category.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+}
+
 /**
  * The I picker is a one-glance speed surface: every candidate tiles into one
- * flat grid and a click or Enter starts placement immediately. Per-device
- * setup (parameters, reference text, value display, supply names) lives in
- * the Properties panel after placement, not here.
+ * flat grid in the Library's category order and a click or Enter starts
+ * placement immediately. Per-device setup (parameters, reference text, value
+ * display, supply names) lives in the Properties panel after placement, not
+ * here.
  */
 export function InsertComponentDialog({
   open,
   styleProfileId,
-  recentSymbolIds,
   cells,
   externalDefinitions = [],
   scope = "all",
@@ -72,8 +80,28 @@ export function InsertComponentDialog({
     : "Insert Component";
   const [query, setQuery] = useState("");
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [hiddenCategories, setHiddenCategories] = useState<ReadonlySet<string>>(
+    new Set(),
+  );
   const inputRef = useRef<HTMLInputElement>(null);
   const gridRef = useRef<HTMLDivElement>(null);
+
+  // The filter row lists every category the full catalog offers, in the same
+  // order the Library sidebar uses, independent of the current search text.
+  const availableCategories = useMemo<string[]>(() => {
+    const categories = cellsOnly
+      ? []
+      : componentCatalog(styleProfileId, "", []).map((group) => group.category);
+    return [
+      ...categories.filter(
+        (category, index) => categories.indexOf(category) === index,
+      ),
+      ...(cells.length > 0 ? [CELLS_CATEGORY] : []),
+      ...(!cellsOnly && externalDefinitions.length > 0
+        ? [EXTERNAL_CATEGORY]
+        : []),
+    ];
+  }, [cells.length, cellsOnly, externalDefinitions.length, styleProfileId]);
 
   const choices = useMemo<InsertChoice[]>(() => {
     const normalized = query.trim().toLowerCase();
@@ -89,6 +117,7 @@ export function InsertComponentDialog({
         key: `cell:${cell.childDocumentId}`,
         kind: "cell",
         symbol: cell.symbol,
+        category: CELLS_CATEGORY,
         childDocumentId: cell.childDocumentId,
         cellName: cell.cellName,
       }));
@@ -104,36 +133,31 @@ export function InsertComponentDialog({
         key: `external:${definition.definitionId}`,
         kind: "external-subcircuit",
         symbol: definition.symbol,
+        category: EXTERNAL_CATEGORY,
         definitionId: definition.definitionId,
         masterName: definition.masterName,
       }));
-    // The catalog ranks recents within each category; the flat grid hoists
-    // them to the very front so the last few picks are always the first tiles.
-    const recentRank = new Map(
-      recentSymbolIds.map((symbolId, index) => [symbolId, index] as const),
-    );
+    // Library order, not recency: the grid reads exactly like the sidebar —
+    // transistors first, categories together — so positions stay learnable.
     const symbolChoices = cellsOnly
       ? []
-      : componentCatalog(styleProfileId, query, recentSymbolIds)
-          .flatMap((group) =>
-            group.symbols.map<InsertChoice>((symbol) => ({
-              key: symbol.id,
-              kind: "symbol",
-              symbol,
-            })),
-          )
-          .sort(
-            (left, right) =>
-              (recentRank.get(left.symbol.id) ?? Number.POSITIVE_INFINITY) -
-              (recentRank.get(right.symbol.id) ?? Number.POSITIVE_INFINITY),
-          );
-    return [...symbolChoices, ...cellChoices, ...externalChoices];
+      : componentCatalog(styleProfileId, query, []).flatMap((group) =>
+          group.symbols.map<InsertChoice>((symbol) => ({
+            key: symbol.id,
+            kind: "symbol",
+            symbol,
+            category: group.category,
+          })),
+        );
+    return [...symbolChoices, ...cellChoices, ...externalChoices].filter(
+      (choice) => !hiddenCategories.has(choice.category),
+    );
   }, [
     cellsOnly,
     cells,
     externalDefinitions,
+    hiddenCategories,
     query,
-    recentSymbolIds,
     styleProfileId,
   ]);
 
@@ -144,9 +168,22 @@ export function InsertComponentDialog({
     if (!open) return;
     setQuery("");
     setSelectedId(initialSelectionId);
+    // A quick pick always reopens showing everything.
+    setHiddenCategories(new Set());
     const frame = requestAnimationFrame(() => inputRef.current?.focus());
     return () => cancelAnimationFrame(frame);
   }, [initialSelectionId, open]);
+
+  const toggleCategory = (category: string): void => {
+    setHiddenCategories((current) => {
+      const next = new Set(current);
+      if (next.has(category)) next.delete(category);
+      else next.add(category);
+      return next;
+    });
+    // Typing keeps working right after a toggle.
+    inputRef.current?.focus();
+  };
 
   useEffect(() => {
     if (choices.length === 0) {
@@ -363,6 +400,32 @@ export function InsertComponentDialog({
           placeholder={`Search ${pickerNoun.toLowerCase()}s`}
           onChange={(event) => setQuery(event.currentTarget.value)}
         />
+
+        {availableCategories.length > 1 ? (
+          <div
+            className="insert-category-filter"
+            role="group"
+            aria-label={`${pickerNoun} categories`}
+          >
+            {availableCategories.map((category) => (
+              <button
+                type="button"
+                key={category}
+                className="insert-category-chip"
+                aria-pressed={!hiddenCategories.has(category)}
+                data-testid={`insert-category-${categorySlug(category)}`}
+                title={
+                  hiddenCategories.has(category)
+                    ? `Show ${category}`
+                    : `Hide ${category}`
+                }
+                onClick={() => toggleCategory(category)}
+              >
+                {category}
+              </button>
+            ))}
+          </div>
+        ) : null}
 
         <div
           ref={gridRef}

--- a/apps/editor/src/styles/editor-dialogs.css
+++ b/apps/editor/src/styles/editor-dialogs.css
@@ -114,8 +114,8 @@
 /* The Insert dialog is a one-glance speed picker: every candidate tiles into
    one flat grid, and a click or Enter starts placement immediately. */
 .insert-component-dialog {
-  display: grid;
-  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  display: flex;
+  flex-direction: column;
   gap: 0.8rem;
   width: min(46rem, calc(100vw - 2.5rem));
   max-height: calc(100dvh - 2.5rem);
@@ -182,7 +182,32 @@
   box-shadow: 0 0 0 3px var(--icm-accent-soft);
 }
 
+.insert-category-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.insert-category-chip {
+  min-height: 0;
+  padding: 0.22rem 0.6rem;
+  border: 1px solid var(--icm-border);
+  border-radius: 999px;
+  color: var(--icm-text-muted);
+  background: var(--icm-surface-muted);
+  box-shadow: none;
+  font-size: var(--icm-font-xs);
+  font-weight: 600;
+}
+
+.insert-category-chip[aria-pressed="true"] {
+  border-color: var(--icm-accent);
+  color: var(--icm-accent);
+  background: var(--icm-accent-soft);
+}
+
 .insert-tile-grid {
+  flex: 1 1 auto;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(6.4rem, 1fr));
   align-content: start;


### PR DESCRIPTION
The I grid now tiles in exactly the sidebar Library's order — transistors first, categories together — instead of hoisting recent picks to the front (which had put Variable Resistor in the first slot), so positions stay learnable. A chip row under the search box multi-selects which categories show: every chip toggles independently, all are on by default, reopening resets to everything, and search composes with the filter.

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)