### PR TITLE
ci: three Playwright workers per browser shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Four shards, two Playwright workers each: eight browser workers.
+        # Four shards, three Playwright workers each on 4-vCPU runners:
+        # twelve browser workers.
         # The required-check names migrated with this split (ruleset updated
         # in the same change window).
         shard:
@@ -189,4 +190,4 @@ jobs:
           E2E_ARGS: ${{ needs.changes.outputs.e2e_args }}
         run: |
           read -r -a specs <<< "$E2E_ARGS"
-          pnpm ci:e2e --workers=2 --shard=${{ matrix.shard }} "${specs[@]}"
+          pnpm ci:e2e --workers=3 --shard=${{ matrix.shard }} "${specs[@]}"


### PR DESCRIPTION
The hosted runners have four vCPUs and a browser shard spends its whole life in test time (install ~7s and build ~6s are cached), so a third worker per shard should trim shard wall time from ~2.8min toward ~2min — about a minute off every CI leg, two per merge — without renaming any required check. This PR's own run doubles as the timing/stability measurement; if shards flake, revert is one line.

Test-Impact: no-test-change — CI parallelism only; the same spec set runs with one more worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)