### PR TITLE
fix(editor): stop straightening wires the person meant to offset

### DIFF
--- a/apps/editor/src/features/wiring/wire-canvas-snap.test.ts
+++ b/apps/editor/src/features/wiring/wire-canvas-snap.test.ts
@@ -130,7 +130,9 @@ describe("wire canvas snap", () => {
     expect(result.point).toEqual({ x: 0, y: 0 });
   });
 
-  it("holds a drifting leg to the axis it is really going", () => {
+  it("keeps a one-grid offset exactly where it was put", () => {
+    // Offsetting a wire a single grid is ordinary drawing, not a wobble to be
+    // corrected. An earlier axis hold straightened these away.
     const document = createEmptyDocument("document", "Document");
     document.presentation.grid = 10;
     const context = {
@@ -140,32 +142,15 @@ describe("wire canvas snap", () => {
       routeGeometryRecords: [],
       contactComponents: [],
       wireSource: source(),
-      // A corner already committed, two grid to the left of the source.
       wireWaypoints: [{ x: -20, y: 0 }],
       captureTolerance: 7,
     };
 
-    // Four grid down and one adrift: the hand wobbled, the wire did not turn.
-    // Left as a corner, the next click folded it back over the line just drawn.
     expect(
       resolveWireCanvasSnap(context, { x: -10, y: 40 }, false).point,
-    ).toEqual({ x: -20, y: 40 });
-
-    // Sideways drift on a mostly horizontal leg is held the same way.
+    ).toEqual({ x: -10, y: 40 });
     expect(
       resolveWireCanvasSnap(context, { x: 40, y: 10 }, false).point,
-    ).toEqual({ x: 40, y: 0 });
-
-    // Four grid off the axis is a step someone meant, even though it is the
-    // same fraction of the run as the one-grid wobble above. Distance off the
-    // line separates them; a ratio cannot.
-    expect(
-      resolveWireCanvasSnap(context, { x: -20 + 210, y: 40 }, false).point,
-    ).toEqual({ x: 190, y: 40 });
-
-    // And a plain diagonal still opens a corner.
-    expect(
-      resolveWireCanvasSnap(context, { x: 20, y: 40 }, false).point,
-    ).toEqual({ x: 20, y: 40 });
+    ).toEqual({ x: 40, y: 10 });
   });
 });

--- a/apps/editor/src/features/wiring/wire-canvas-snap.ts
+++ b/apps/editor/src/features/wiring/wire-canvas-snap.ts
@@ -39,34 +39,6 @@ export interface WireCanvasSnapResult {
 }
 
 /** Resolve one wire-canvas pointer to a grid, endpoint, or routed conductor. */
-/**
- * A wobble is a grid or two off the line, never four.
- *
- * A ratio cannot tell the two apart: a hand drifting one grid over five is
- * the same fraction as a deliberate four-grid step over twenty-one. What
- * separates them is how far off the axis the leg actually sits.
- */
-const AXIS_WOBBLE_GRIDS = 2;
-
-/**
- * Hold a free leg to a single axis.
- *
- * A hand that drifts a grid sideways while pulling a wire down turned the leg
- * into a corner, and at the next click the wire folded back over the line it
- * had just drawn. A leg that is going one way with a wobble is meant to be
- * going that way. A deliberate step off the axis still opens a corner — that
- * is what the corner-order modes are for.
- */
-function holdLegToOneAxis(from: Point, to: Point, grid: number): Point {
-  const alongX = Math.abs(to.x - from.x);
-  const alongY = Math.abs(to.y - from.y);
-  if (alongX === 0 || alongY === 0) return to;
-  const wobble = Math.max(grid, 1) * AXIS_WOBBLE_GRIDS;
-  if (alongY > alongX && alongX <= wobble) return { x: from.x, y: to.y };
-  if (alongX > alongY && alongY <= wobble) return { x: to.x, y: from.y };
-  return to;
-}
-
 export function resolveWireCanvasSnap(
   {
     document,
@@ -176,14 +148,8 @@ export function resolveWireCanvasSnap(
           (candidate) => candidate.anchor.id === contact.route!.id,
         )
       : undefined;
-  // Only a landing that hit nothing is free to be straightened; a leg aimed at
-  // a terminal, a junction, or a route has to reach it exactly.
-  const landing =
-    !endpoint && !route && !ambiguous && arrival
-      ? holdLegToOneAxis(arrival, snappedPoint, document.presentation.grid)
-      : snappedPoint;
   return {
-    point: landing,
+    point: snappedPoint,
     ...(ambiguous ? { ambiguous: true } : {}),
     ...(endpoint ? { endpoint } : {}),
     ...(route


### PR DESCRIPTION
The axis hold from #331 was wrong and comes out.

Offsetting a wire a single grid is ordinary drawing, not a wobble to be corrected — the repository owner does it often — and the hold was quietly eating those offsets.

**The fold it was meant to prevent is already gone without it.** Cancelling legs that double back is what removed the retrace and the hanging stub, and that stays. Measured with the hold removed:

```
left 2 (clicked), then down drifting one grid right
  100,100 → 90,100 → 90,150        no retrace over the line just drawn

left, then down past the corner and back up
  100,100 → 80,100 → 80,150        no stub

a deliberate one-grid offset
  100,100 → 110,100 → 110,200      kept exactly as placed
```

The test that pinned the hold is replaced by one pinning the opposite: a one-grid drift lands exactly where it was put, on either axis.

## What I got wrong

The original report ended with "let it only move one direction at a time", so I built the hold as well as the fold cancelling. Only the fold cancelling was needed; the hold was me acting on the suggested remedy rather than on the fault, and it broke a real drawing move to do it.

## Validation

- unit: 1572 pass.
- Playwright: 225 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)