### PR TITLE
fix(export): preserve rich text in vector PDF

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { expect, test } from "@playwright/test";
 import type { Locator, Page } from "@playwright/test";
 import { resolve } from "node:path";
+import { inflateSync } from "node:zlib";
 import { createEmptyProject } from "@icm/model";
 
 import { createRoutingDemoProject } from "../src/demos/routing-demo.js";
@@ -16,6 +17,64 @@ import {
   readRecoveryRecords,
   recoveryProjectTexts,
 } from "./editor-fixtures.js";
+
+interface PdfTextRun {
+  fontSize: number;
+  text: string;
+  x: number;
+  y: number;
+}
+
+function pdfTextRuns(pdf: Buffer): PdfTextRun[] {
+  const streamStartMarker = Buffer.from("stream\n", "ascii");
+  const streamEndMarker = Buffer.from("\nendstream", "ascii");
+  const dictionaryStartMarker = Buffer.from("<<", "ascii");
+  const streams: string[] = [];
+  let cursor = 0;
+  while (cursor < pdf.length) {
+    const streamStart = pdf.indexOf(streamStartMarker, cursor);
+    if (streamStart < 0) break;
+    const streamEnd = pdf.indexOf(
+      streamEndMarker,
+      streamStart + streamStartMarker.length,
+    );
+    if (streamEnd < 0) break;
+    const dictionaryStart = pdf.lastIndexOf(dictionaryStartMarker, streamStart);
+    const dictionary = pdf
+      .subarray(dictionaryStart, streamStart)
+      .toString("ascii");
+    const bytes = pdf.subarray(
+      streamStart + streamStartMarker.length,
+      streamEnd,
+    );
+    if (dictionary.includes("/FlateDecode")) {
+      streams.push(inflateSync(bytes).toString("latin1"));
+    }
+    cursor = streamEnd + streamEndMarker.length;
+  }
+
+  const runs: PdfTextRun[] = [];
+  const textBlock = /BT\s+([\s\S]*?)\s+ET/gu;
+  const font = /\/F\d+\s+([\d.]+)\s+Tf/u;
+  const matrix =
+    /[-\d.]+\s+[-\d.]+\s+[-\d.]+\s+[-\d.]+\s+([-\d.]+)\s+([-\d.]+)\s+Tm/u;
+  const text = /\(([^)]*)\)\s+Tj/u;
+  for (const stream of streams) {
+    for (const block of stream.matchAll(textBlock)) {
+      const fontMatch = font.exec(block[1]!);
+      const matrixMatch = matrix.exec(block[1]!);
+      const textMatch = text.exec(block[1]!);
+      if (!fontMatch || !matrixMatch || !textMatch) continue;
+      runs.push({
+        fontSize: Number(fontMatch[1]),
+        x: Number(matrixMatch[1]),
+        y: Number(matrixMatch[2]),
+        text: textMatch[1]!,
+      });
+    }
+  }
+  return runs;
+}
 
 function markRoutingDemoNetsImported(
   project: ReturnType<typeof createRoutingDemoProject>,
@@ -3564,9 +3623,8 @@ test("requires warning review before exporting generated NoConnect nodes", async
 test("exports one formal visual scene as Project, SVG, PNG, and PDF", async ({
   page,
 }) => {
-  await page.goto("/editor");
-  await placeComponent(page, "resistor", { x: 420, y: 240 });
-  await page.keyboard.press("Escape");
+  await page.goto("/editor?example=common-source-amplifier");
+  await awaitEditorReady(page);
 
   const projectBytes = await downloadBytes(
     page,
@@ -3578,6 +3636,8 @@ test("exports one formal visual scene as Project, SVG, PNG, and PDF", async ({
     "utf8",
   );
   expect(svg).toContain('data-layer="formal"');
+  expect(svg).toContain('data-text-run="subscript"');
+  expect(svg).toContain("baseline-shift=");
   expect(svg).not.toMatch(/selection|route-hit|editor-overlay/u);
 
   const png = await downloadBytes(page, "File", "Export PNG");
@@ -3589,6 +3649,33 @@ test("exports one formal visual scene as Project, SVG, PNG, and PDF", async ({
   // retain the formal SVG as PDF paths/text, so it cannot contain an image XObject.
   expect(pdfText).not.toContain("/Subtype /Image");
   expect(pdfText).toContain("/Type /Font");
+
+  const textRuns = pdfTextRuns(pdf);
+  for (const [baseText, scriptText] of [
+    ["I", "out"],
+    ["C", "GS"],
+    ["C", "GD"],
+    ["M", "1"],
+    ["R", "D"],
+    ["R", "S"],
+    ["V", "in"],
+    ["V", "DD"],
+  ]) {
+    const scriptIndex = textRuns.findIndex(
+      (run, index) =>
+        index > 0 &&
+        run.text.trim() === scriptText &&
+        textRuns[index - 1]!.text === baseText,
+    );
+    expect(scriptIndex, `${baseText}_${scriptText} is present`).toBeGreaterThan(
+      0,
+    );
+    const base = textRuns[scriptIndex - 1]!;
+    const script = textRuns[scriptIndex]!;
+    expect(script.fontSize).toBeCloseTo(base.fontSize * 0.76, 2);
+    expect(script.x).toBeGreaterThan(base.x);
+    expect(script.y).toBeGreaterThan(base.y);
+  }
 });
 
 test("exports structural SPICE and Spectre netlists while exposing instance authoring", async ({

--- a/docs/specs/export.md
+++ b/docs/specs/export.md
@@ -27,6 +27,14 @@ and text; it never embeds the page-cover PNG used by the PNG artifact. The
 original SVG is unchanged. Export filenames are normalized and all three
 formats use the same base name.
 
+The browser converter operates on a temporary SVG clone. Before conversion it
+must expand renderer constructs that `svg2pdf.js` does not implement directly:
+percentage `tspan` font sizes become computed pixel sizes, `baseline-shift`
+becomes an equivalent explicit baseline displacement, empty fraction-reset
+spans are carried to the following visible run, and text decorations are
+materialized as vector strokes. This compatibility pass must not rewrite the
+downloaded canonical SVG or flatten PDF text into a page image.
+
 Node/headless export retains a high-resolution raster-PDF fallback for release
 tooling because the browser vector converter requires a live DOM. It is not the
 interactive editor's user-facing PDF path.
@@ -40,7 +48,9 @@ fallback.
 - parse the SVG viewBox and reject invalid bounds;
 - check PNG signature and dimensions against viewBox times scale;
 - reopen browser PDF, check one page and page bounds, assert it contains no
-  page-cover image XObject, and visually compare it with the SVG fixture;
+  page-cover image XObject, assert representative rich-text runs retain their
+  nonzero scaled fonts and displaced baselines, and visually compare a rendered
+  PDF page with the SVG fixture;
 - assert formal SVG has no editor-only layers.
 
 ## Agent File Resource

--- a/packages/exporters/src/browser.ts
+++ b/packages/exporters/src/browser.ts
@@ -2,6 +2,7 @@ import { jsPDF } from "jspdf";
 
 import type { FormalExportSource, RasterExport } from "./index.js";
 import { DEFAULT_EXPORT_SCALE, EXPORT_VERSION } from "./index.js";
+import { normalizeFormalSvgForSvg2Pdf } from "./svg2pdf-compat.js";
 
 function loadImage(url: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
@@ -68,9 +69,10 @@ function formalSvgElement(source: FormalExportSource): {
   const host = document.createElement("div");
   host.setAttribute("aria-hidden", "true");
   host.style.cssText =
-    "position:fixed;left:-100000px;top:0;visibility:hidden;pointer-events:none;";
+    "position:fixed;left:-100000px;top:0;pointer-events:none;";
   host.append(svg);
   document.body.append(host);
+  normalizeFormalSvgForSvg2Pdf(svg);
   return { host, svg };
 }
 

--- a/packages/exporters/src/svg2pdf-compat.ts
+++ b/packages/exporters/src/svg2pdf-compat.ts
@@ -1,0 +1,178 @@
+const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
+
+function renderedTextNode(root: Node): Text | undefined {
+  if (root.nodeType === Node.TEXT_NODE) {
+    const text = root as Text;
+    return text.data.trim().length > 0 ? text : undefined;
+  }
+  for (const child of root.childNodes) {
+    const match = renderedTextNode(child);
+    if (match) return match;
+  }
+  return undefined;
+}
+
+function nextNodeAfterSubtree(node: Node, boundary: Node): Node | undefined {
+  let cursor: Node | null = node;
+  while (cursor && cursor !== boundary) {
+    if (cursor.nextSibling) return cursor.nextSibling;
+    cursor = cursor.parentNode;
+  }
+  return undefined;
+}
+
+function nextRenderedTextNode(
+  node: Node,
+  boundary: SVGTextElement,
+): Text | undefined {
+  let cursor: Node = node;
+  while (true) {
+    const candidate = nextNodeAfterSubtree(cursor, boundary);
+    if (!candidate) return undefined;
+    const match = renderedTextNode(candidate);
+    if (match) return match;
+    cursor = candidate;
+  }
+}
+
+function cssLengthInPixels(value: string | null, element: Element): number {
+  if (!value) return 0;
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed)) return 0;
+  const fontSize = Number.parseFloat(getComputedStyle(element).fontSize) || 16;
+  if (value.trim().endsWith("em")) return parsed * fontSize;
+  if (value.trim().endsWith("%")) return (parsed / 100) * fontSize;
+  return parsed;
+}
+
+function relativePositionCarrier(text: Text): SVGTSpanElement {
+  const parent = text.parentElement;
+  if (parent instanceof SVGTSpanElement && renderedTextNode(parent) === text) {
+    return parent;
+  }
+  const wrapper = document.createElementNS(SVG_NAMESPACE, "tspan");
+  text.before(wrapper);
+  wrapper.append(text);
+  return wrapper;
+}
+
+function addRelativePosition(
+  text: Text,
+  attribute: "dx" | "dy",
+  delta: number,
+): void {
+  if (Math.abs(delta) < 1e-9) return;
+  const carrier = relativePositionCarrier(text);
+  const current = cssLengthInPixels(carrier.getAttribute(attribute), carrier);
+  carrier.setAttribute(attribute, `${current + delta}px`);
+}
+
+function materializeTextDecorations(svg: SVGSVGElement): void {
+  for (const span of svg.querySelectorAll<SVGTSpanElement>(
+    'tspan[data-text-run="overbar"][style*="text-decoration:overline"]',
+  )) {
+    const text = span.closest<SVGTextElement>("text");
+    if (!text?.parentElement) continue;
+    const bounds = span.getBBox();
+    const style = getComputedStyle(span);
+    const fontSize = Number.parseFloat(style.fontSize) || 16;
+    const line = document.createElementNS(SVG_NAMESPACE, "line");
+    line.setAttribute("data-text-decoration", "overbar");
+    line.setAttribute("x1", String(bounds.x));
+    line.setAttribute("x2", String(bounds.x + bounds.width));
+    line.setAttribute("y1", String(bounds.y - fontSize * 0.08));
+    line.setAttribute("y2", String(bounds.y - fontSize * 0.08));
+    line.setAttribute("stroke", style.fill || "#111111");
+    line.setAttribute("stroke-width", String(Math.max(1, fontSize * 0.06)));
+    const transform = text.getAttribute("transform");
+    if (transform) line.setAttribute("transform", transform);
+    text.after(line);
+    span.style.textDecoration = "none";
+  }
+
+  // jsPDF's Base-14 font mapping turns U+2212 into an underscore. Formal
+  // polarity marks have fixed geometry, so preserve the SVG mark as a path.
+  for (const minus of svg.querySelectorAll<SVGTextElement>(
+    'text[data-role="polarity-negative"]',
+  )) {
+    const x = Number(minus.getAttribute("x"));
+    const y = Number(minus.getAttribute("y"));
+    const style = getComputedStyle(minus);
+    const fontSize = Number.parseFloat(style.fontSize) || 16;
+    if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+    const line = document.createElementNS(SVG_NAMESPACE, "line");
+    line.setAttribute("data-role", "polarity-negative");
+    line.setAttribute("x1", String(x - fontSize * 0.3));
+    line.setAttribute("x2", String(x + fontSize * 0.3));
+    line.setAttribute("y1", String(y - fontSize * 0.3));
+    line.setAttribute("y2", String(y - fontSize * 0.3));
+    line.setAttribute("stroke", style.fill || "#111111");
+    line.setAttribute("stroke-width", String(Math.max(1, fontSize * 0.08)));
+    minus.replaceWith(line);
+  }
+}
+
+/**
+ * Expand renderer constructs that svg2pdf does not implement. This mutates
+ * only the temporary, live-DOM clone used for PDF conversion; canonical SVG
+ * bytes remain unchanged.
+ */
+export function normalizeFormalSvgForSvg2Pdf(svg: SVGSVGElement): void {
+  materializeTextDecorations(svg);
+
+  // svg2pdf accepts px/em font sizes but resolves percentages to zero. Capture
+  // the browser-computed size before translating baseline offsets.
+  for (const span of svg.querySelectorAll<SVGTSpanElement>(
+    'tspan[font-size$="%"]',
+  )) {
+    const fontSize = Number.parseFloat(getComputedStyle(span).fontSize);
+    if (!Number.isFinite(fontSize) || fontSize <= 0) {
+      throw new Error("Vector PDF could not resolve a rich-text font size");
+    }
+    span.setAttribute("font-size", `${fontSize}px`);
+  }
+
+  for (const script of svg.querySelectorAll<SVGTSpanElement>(
+    "tspan[baseline-shift]",
+  )) {
+    const text = script.closest<SVGTextElement>("text");
+    const first = renderedTextNode(script);
+    if (!text || !first) continue;
+    const shift = cssLengthInPixels(
+      script.getAttribute("baseline-shift"),
+      script,
+    );
+    // SVG baseline-shift raises positive values; SVG dy lowers them.
+    addRelativePosition(first, "dy", -shift);
+    const next = nextRenderedTextNode(script, text);
+    if (next) addRelativePosition(next, "dy", shift);
+    script.removeAttribute("baseline-shift");
+  }
+
+  const emptyPositioningSpans = [
+    ...svg.querySelectorAll<SVGTSpanElement>("tspan[dx], tspan[dy]"),
+  ].filter((span) => !renderedTextNode(span));
+  for (const reset of emptyPositioningSpans) {
+    const text = reset.closest<SVGTextElement>("text");
+    if (text) {
+      const next = nextRenderedTextNode(reset, text);
+      if (next) {
+        addRelativePosition(
+          next,
+          "dx",
+          cssLengthInPixels(reset.getAttribute("dx"), reset),
+        );
+        addRelativePosition(
+          next,
+          "dy",
+          cssLengthInPixels(reset.getAttribute("dy"), reset),
+        );
+      }
+    }
+    reset.remove();
+  }
+
+  if (svg.querySelector('tspan[font-size$="%"], tspan[baseline-shift]')) {
+    throw new Error("Vector PDF contains unsupported rich-text positioning");
+  }
+}


### PR DESCRIPTION
## Summary
- translate unsupported percentage tspan sizing and baseline shifts only in the temporary PDF SVG clone
- preserve rich-text scripts, fraction resets, overbars, and formal polarity marks as vector output
- validate real PDF content runs so invisible zero-sized subscripts cannot regress

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- pnpm ci:check (1572 unit tests and 244 browser tests passed before the latest clean rebase)
- isolated PDF export E2E passed again on the latest origin/main
- Poppler-rendered PDF visually compared with the canonical SVG

Test-Impact: tests-updated