### PR TITLE
feat(editor): tag-driven quick pick, diode with semiconductors, junk-free prompts

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -24,10 +24,32 @@ test("blocks destructive browser refresh shortcuts and uses the stronger grid", 
     "fill",
     "rgb(196, 199, 201)",
   );
+  // A blank circuit has nothing to protect: the editor does not intercept
+  // the refresh shortcut (a real browser would reload here; synthetic keys
+  // cannot drive the browser accelerator, so assert the guard stays silent).
+  await awaitEditorReady(page);
+  await page.keyboard.press("Control+r");
+  await expect(page.getByTestId("status")).not.toHaveText(
+    "Refresh blocked to protect the current circuit",
+  );
+
+  // With meaningful content (three objects) the guard takes over. Clear the
+  // selection first: Ctrl+R on a mirrorable selection means mirror, not
+  // refresh.
+  for (const x of [220, 320, 420]) {
+    await chooseComponent(page, "resistor");
+    await page
+      .getByTestId("schematic-canvas")
+      .click({ position: { x, y: 220 } });
+    await page.keyboard.press("Escape");
+  }
+  await page.keyboard.press("Escape");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 60, y: 60 } });
   await page.evaluate(() => {
     document.body.dataset.refreshGuard = "alive";
   });
-
   await page.keyboard.press("Control+r");
   await expect(page.getByTestId("status")).toHaveText(
     "Refresh blocked to protect the current circuit",
@@ -322,6 +344,15 @@ test("category chips multi-select which kinds the quick pick shows", async ({
   await dialog.getByLabel("Component search").fill("nmos");
   await expect(dialog.getByTestId("insert-component-resistor")).toHaveCount(0);
   await expect(dialog.getByTestId("insert-component-nmos")).toBeVisible();
+
+  // Clear all starts from zero: nothing shows until kinds are picked back.
+  await dialog.getByLabel("Component search").fill("");
+  await dialog.getByTestId("insert-category-clear").click();
+  await expect(dialog.getByRole("option")).toHaveCount(0);
+  await expect(dialog.getByText("No matching components")).toBeVisible();
+  await dialog.getByTestId("insert-category-logic-gates").click();
+  await expect(dialog.getByTestId("insert-component-and-gate")).toBeVisible();
+  await expect(dialog.getByTestId("insert-component-nmos")).toHaveCount(0);
 
   // Reopening resets to everything shown.
   await page.keyboard.press("Escape");
@@ -1165,7 +1196,8 @@ test("shows the complete foldable categorized Library, quick-places a device, an
   const transistorChips = transistorCategory.locator(
     '[data-testid^="shapes-chip-"]',
   );
-  await expect(transistorChips).toHaveCount(4);
+  // NMOS, PMOS, NPN, PNP, and the diode that belongs with them.
+  await expect(transistorChips).toHaveCount(5);
   const transistorGrid = transistorCategory.locator(".shapes-grid");
   // Tiles keep a fixed square size; a wider panel fits more of them per row
   // instead of stretching each tile.

--- a/apps/editor/e2e/recovery-dialog.spec.ts
+++ b/apps/editor/e2e/recovery-dialog.spec.ts
@@ -84,6 +84,8 @@ test("startup recovery is visible after reload and restore forks a working copy"
   page,
 }) => {
   await page.goto("/editor");
+  // One lone component is below the meaningful-content threshold: the
+  // reload must stay banner-free.
   await chooseComponent(page, "resistor");
   await page
     .getByTestId("schematic-canvas")
@@ -93,16 +95,32 @@ test("startup recovery is visible after reload and restore forks a working copy"
   await expect
     .poll(() => recoveryProjectTexts(page))
     .toContain('"revision": 1');
-
   await page.reload();
   const banner = page.getByTestId("startup-recovery-banner");
+  await expect(page.getByTestId("schematic-canvas")).toBeVisible();
+  await expect(banner).toHaveCount(0);
+
+  // Three objects clear the threshold and the banner offers the restore.
+  for (const x of [360, 470, 580]) {
+    await chooseComponent(page, "resistor");
+    await page
+      .getByTestId("schematic-canvas")
+      .click({ position: { x, y: 330 } });
+    await page.keyboard.press("Escape");
+  }
+  await expect(page.getByTestId("revision")).toHaveText("3");
+  await expect
+    .poll(() => recoveryProjectTexts(page))
+    .toContain('"revision": 3');
+
+  await page.reload();
   await expect(banner).toBeVisible();
   await expect(banner).toContainText("New Circuit");
   await banner.getByRole("button", { name: "Restore" }).click();
   await expect(banner).toBeHidden();
-  await expect(page.getByTestId("revision")).toHaveText("1");
+  await expect(page.getByTestId("revision")).toHaveText("3");
   await expect(page.getByTestId("status")).toContainText(
-    "Restored recovery revision 1",
+    "Restored recovery revision 3",
   );
 });
 

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -170,6 +170,7 @@ import {
 import { useDocumentController } from "../document/document-controller";
 import { useProjectFileLifecycle } from "../document/use-project-file-lifecycle";
 import { useUnsavedWorkGuard } from "../document/use-unsaved-work-guard";
+import { projectHasMeaningfulContent } from "../document/project-content";
 import {
   draftingDragOrigin,
   translateDraftingObject,
@@ -669,7 +670,9 @@ export function App({
       return nextDocument;
     },
   });
-  const allowNextBrowserUnload = useUnsavedWorkGuard(isDirtyWork());
+  const allowNextBrowserUnload = useUnsavedWorkGuard(
+    isDirtyWork() && projectHasMeaningfulContent(project),
+  );
   const startupCloudRestoreAttemptedRef = useRef(false);
   const hasExplicitBootTarget =
     initialGalleryEntryId !== null ||
@@ -2594,6 +2597,7 @@ export function App({
       const currentInteraction = getCurrentInteractionState();
       const shortcut = resolveEditorShortcut(event, {
         isTyping: isTypingTarget(event.target),
+        hasAuthoredContent: projectHasMeaningfulContent(project),
         interactionMode: currentInteraction.kind,
         hasRoutedMarkerSelection: Boolean(
           selectedAnnotation && isRoutedMarker(selectedAnnotation),

--- a/apps/editor/src/document/project-content.test.ts
+++ b/apps/editor/src/document/project-content.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { createEmptyProject } from "@icm/model";
+
+import {
+  authoredObjectCount,
+  projectHasMeaningfulContent,
+  projectTextHasMeaningfulContent,
+} from "./project-content";
+
+const textObject = (id: string) => ({
+  id,
+  kind: "text" as const,
+  locked: false,
+  zIndex: 0,
+  anchor: { kind: "free" as const, position: { x: 10, y: 10 } },
+  content: { runs: [{ kind: "text" as const, value: id }] },
+  alignment: "start" as const,
+  rotation: 0 as const,
+});
+
+describe("meaningful content threshold", () => {
+  it("prompts only at three or more authored objects", () => {
+    const project = createEmptyProject("project-blank", "Blank");
+    expect(authoredObjectCount(project)).toBe(0);
+    expect(projectHasMeaningfulContent(project)).toBe(false);
+
+    const sketch = structuredClone(project);
+    sketch.documents[0]!.drafting!.objects.push(
+      textObject("note-1"),
+      textObject("note-2"),
+    );
+    expect(projectHasMeaningfulContent(sketch)).toBe(false);
+
+    sketch.documents[0]!.drafting!.objects.push(textObject("note-3"));
+    expect(projectHasMeaningfulContent(sketch)).toBe(true);
+
+    // Emptying the circuit back out drops the protection again.
+    sketch.documents[0]!.drafting!.objects.length = 0;
+    expect(projectHasMeaningfulContent(sketch)).toBe(false);
+  });
+
+  it("evaluates serialized snapshots tolerantly", () => {
+    expect(projectTextHasMeaningfulContent("not json")).toBe(false);
+    const project = createEmptyProject("project-snap", "Snap");
+    project.documents[0]!.drafting!.objects.push(
+      textObject("a"),
+      textObject("b"),
+      textObject("c"),
+    );
+    expect(projectTextHasMeaningfulContent(JSON.stringify(project))).toBe(true);
+  });
+});

--- a/apps/editor/src/document/project-content.ts
+++ b/apps/editor/src/document/project-content.ts
@@ -1,0 +1,49 @@
+/**
+ * How many authored objects make a circuit worth protecting. Below this the
+ * user is sketching throwaways: no leave prompt, no blocked refresh, no
+ * startup recovery banner.
+ */
+export const MEANINGFUL_CONTENT_MIN_OBJECTS = 3;
+
+interface CountableDocument {
+  readonly instances?: readonly unknown[];
+  readonly routes?: readonly unknown[];
+  readonly drafting?: { readonly objects?: readonly unknown[] } | undefined;
+}
+
+interface CountableProject {
+  readonly documents?: readonly CountableDocument[];
+}
+
+/**
+ * Count user-authored objects: placed devices, drawn wires, and drafting
+ * objects. Junctions and annotations ride along with these, so counting them
+ * too would inflate one resistor into several "objects".
+ */
+export function authoredObjectCount(project: CountableProject): number {
+  return (project.documents ?? []).reduce(
+    (total, document) =>
+      total +
+      (document.instances?.length ?? 0) +
+      (document.routes?.length ?? 0) +
+      (document.drafting?.objects?.length ?? 0),
+    0,
+  );
+}
+
+export function projectHasMeaningfulContent(
+  project: CountableProject,
+): boolean {
+  return authoredObjectCount(project) >= MEANINGFUL_CONTENT_MIN_OBJECTS;
+}
+
+/** The same threshold for a serialized snapshot, tolerant of bad text. */
+export function projectTextHasMeaningfulContent(projectText: string): boolean {
+  try {
+    return projectHasMeaningfulContent(
+      JSON.parse(projectText) as CountableProject,
+    );
+  } catch {
+    return false;
+  }
+}

--- a/apps/editor/src/document/recovery-coordinator.ts
+++ b/apps/editor/src/document/recovery-coordinator.ts
@@ -19,6 +19,7 @@
 // session's records. Storage failures only change coordinator state and user
 // messaging, never Project content.
 
+import { projectTextHasMeaningfulContent } from "./project-content";
 import { useEffect, useRef, useState } from "react";
 
 import { serializeProject } from "@icm/project-protocol";
@@ -60,6 +61,8 @@ export interface RecoveryGenerationSummary {
   revision: number | null;
   /** `null` means the field predates this additive recovery metadata. */
   unsavedAtSnapshot: boolean | null;
+  /** Whether the snapshot clears the meaningful-content threshold. */
+  meaningfulContent: boolean;
 }
 
 export interface RecoveryStageOptions {
@@ -179,6 +182,9 @@ function summarizeGeneration(
     revision:
       review.status === "valid" ? (readTopRevision(record) ?? null) : null,
     unsavedAtSnapshot: record.unsavedAtSnapshot ?? null,
+    meaningfulContent:
+      review.status === "valid" &&
+      projectTextHasMeaningfulContent(record.projectText),
   };
 }
 

--- a/apps/editor/src/document/use-project-file-lifecycle.ts
+++ b/apps/editor/src/document/use-project-file-lifecycle.ts
@@ -634,7 +634,10 @@ export function useProjectFileLifecycle({
             session.workingCopyId === recovery.workingCopyId &&
             session.latest?.review === "valid" &&
             session.latest.unsavedAtSnapshot === true &&
-            session.latest.recordId !== dismissedStartupRecoveryRecordId,
+            session.latest.recordId !== dismissedStartupRecoveryRecordId &&
+            // Tiny sketches are not worth a banner; the manual Recover menu
+            // still lists every snapshot.
+            session.latest.meaningfulContent,
         ) ?? null)
       : null;
   const canRestoreStartupCloudProject =

--- a/apps/editor/src/features/component-insert/insert-component-dialog.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.tsx
@@ -174,6 +174,13 @@ export function InsertComponentDialog({
     return () => cancelAnimationFrame(frame);
   }, [initialSelectionId, open]);
 
+  const clearAllCategories = (): void => {
+    // Start from zero: hide everything, then chips turn kinds back on one by
+    // one.
+    setHiddenCategories(new Set(availableCategories));
+    inputRef.current?.focus();
+  };
+
   const toggleCategory = (category: string): void => {
     setHiddenCategories((current) => {
       const next = new Set(current);
@@ -407,6 +414,15 @@ export function InsertComponentDialog({
             role="group"
             aria-label={`${pickerNoun} categories`}
           >
+            <button
+              type="button"
+              className="insert-category-chip insert-category-clear"
+              data-testid="insert-category-clear"
+              title="Hide every category, then pick the ones to show"
+              onClick={clearAllCategories}
+            >
+              Clear all
+            </button>
             {availableCategories.map((category) => (
               <button
                 type="button"

--- a/apps/editor/src/features/component-insert/symbol-catalog.test.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.test.ts
@@ -50,7 +50,7 @@ describe("component insertion catalog", () => {
     expect(symbolCategory("xor-gate")).toBe("Logic Gates");
     expect(symbolCategory("xnor-gate")).toBe("Logic Gates");
     expect(symbolCategory("npn")).toBe("Transistors");
-    expect(symbolCategory("diode")).toBe("Passives");
+    expect(symbolCategory("diode")).toBe("Transistors");
     expect(symbolCategory("ideal-switch")).toBe("Switches");
     expect(symbolCategory("closed-switch")).toBe("Switches");
     expect(symbolCategory("ndmos")).toBe("Extended Devices");

--- a/apps/editor/src/features/component-insert/symbol-catalog.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.ts
@@ -49,7 +49,8 @@ export function symbolCategory(symbolId: string): string {
   if (isAnnotationPaletteSymbol(symbolId)) return ANNOTATION_CATEGORY;
   const expanded = expandedDeviceCatalogEntry(symbolId);
   if (expanded) return expanded.category;
-  if (["nmos", "pmos", "npn", "pnp"].includes(symbolId)) {
+  // The diode sits with its semiconductor family, not the passives.
+  if (["nmos", "pmos", "npn", "pnp", "diode"].includes(symbolId)) {
     return "Transistors";
   }
   if (
@@ -61,7 +62,6 @@ export function symbolCategory(symbolId: string): string {
       "inductor-compact",
       "inductor",
       "variable-inductor",
-      "diode",
     ].includes(symbolId)
   ) {
     return "Passives";
@@ -156,6 +156,9 @@ export function paletteSymbols(_styleProfileId: string): SymbolDefinition[] {
 const SYMBOL_ORDER: readonly string[] = [
   "nmos",
   "pmos",
+  "npn",
+  "pnp",
+  "diode",
   "ndmos",
   "pdmos",
   "vdd-port",

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -32,8 +32,8 @@ describe("shapes quick-place", () => {
     expect(
       groups.map((group) => [group.category, group.symbols.length]),
     ).toEqual([
-      ["Transistors", 4],
-      ["Passives", 8],
+      ["Transistors", 5],
+      ["Passives", 7],
       ["Power and Ports", 5],
       ["Sources", 2],
       ["Switches", 2],

--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -8,6 +8,7 @@ import type {
 
 const baseContext: EditorShortcutContext = {
   isTyping: false,
+  hasAuthoredContent: true,
   interactionMode: "idle",
   hasRoutedMarkerSelection: false,
   canRotate: false,
@@ -396,5 +397,47 @@ describe("editor shortcut contract", () => {
     expect(
       resolve("q", { propertiesOpen: true, interactionMode: "drawing" }),
     ).toEqual({ kind: "blocked-interaction-command", command: "Properties" });
+  });
+});
+
+describe("blank-circuit refresh", () => {
+  it("lets the browser refresh when nothing is authored", () => {
+    const empty = { ...baseContext, hasAuthoredContent: false };
+    expect(
+      resolveEditorShortcut(
+        {
+          key: "F5",
+          ctrlKey: false,
+          metaKey: false,
+          altKey: false,
+          shiftKey: false,
+        },
+        empty,
+      ),
+    ).toBeNull();
+    expect(
+      resolveEditorShortcut(
+        {
+          key: "r",
+          ctrlKey: true,
+          metaKey: false,
+          altKey: false,
+          shiftKey: false,
+        },
+        empty,
+      ),
+    ).toBeNull();
+    expect(
+      resolveEditorShortcut(
+        {
+          key: "F5",
+          ctrlKey: false,
+          metaKey: false,
+          altKey: false,
+          shiftKey: false,
+        },
+        baseContext,
+      ),
+    ).toEqual({ kind: "block-browser-refresh" });
   });
 });

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -11,6 +11,8 @@ export interface EditorShortcutKey {
 
 export interface EditorShortcutContext {
   isTyping: boolean;
+  /** Blank circuits let the browser refresh; there is nothing to protect. */
+  hasAuthoredContent: boolean;
   interactionMode: InteractionMode;
   hasRoutedMarkerSelection: boolean;
   canRotate: boolean;
@@ -73,18 +75,25 @@ export function resolveEditorShortcut(
   ) {
     return { kind: "toggle-wire-options" };
   }
-  if (event.key === "F5") return { kind: "block-browser-refresh" };
+  if (event.key === "F5") {
+    return context.hasAuthoredContent
+      ? { kind: "block-browser-refresh" }
+      : null;
+  }
   if (commandModifier && key === "r") {
-    if (context.isTyping) return { kind: "block-browser-refresh" };
+    if (context.isTyping) {
+      return context.hasAuthoredContent
+        ? { kind: "block-browser-refresh" }
+        : null;
+    }
     if (context.canMirror)
       return {
         kind: "run-command",
         command: { id: "transform.mirror", direction: "top-bottom" },
       };
-    if (context.interactionMode !== "idle") {
-      return { kind: "block-browser-refresh" };
-    }
-    return { kind: "block-browser-refresh" };
+    return context.hasAuthoredContent
+      ? { kind: "block-browser-refresh" }
+      : null;
   }
   if (commandModifier && key === "d") {
     if (context.isTyping) return { kind: "block-browser-bookmark" };


### PR DESCRIPTION
Three requests in one pass:

1. **Clear all tags** — the I picker's chip row gains a "Clear all" button that hides every category, so kinds toggle back on one by one: a true start-from-zero multi-select. Search stays: typing a name + Enter is the fastest placement path, and it composes with the tag filter rather than competing with it.
2. **Diode belongs with the semiconductors** — moved from Passives to the transistor group in both the Library sidebar and the quick pick (NMOS, PMOS, NPN, PNP, Diode).
3. **No prompts for junk circuits** — a meaningful-content threshold (≥3 authored objects: devices, wires, drawings) now gates the browser leave prompt, the Ctrl+R/F5 refresh block, and the startup "Unsaved work was recovered" banner. Blank circuits and circuits emptied back out refresh and close silently. The manual Recover menu still lists every snapshot and the header's unsaved dot keeps showing the plain dirty state.

Validated with the full unit suite (1575) and the full browser suite (246), including new coverage for the threshold boundary (2 objects silent, 3 objects protected) and the clear-all flow.

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)