### PR TITLE
fix(gallery): publish quality checks are advisory, never a hard gate

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -1172,19 +1172,17 @@ test("an ordinary user sees blocking quality gates on an empty project", async (
     )
     .toEqual(toolbarStyleBeforeDialog);
 
-  // The empty canvas fails the content gate, evaluated locally.
+  // The empty canvas trips the content check — listed as advice, never as a
+  // hard gate: the checker has false positives and sketches are shareable.
   const gates = page.getByTestId("publish-gallery-gates");
   await expect(gates).toBeVisible();
-  await expect(gates).toContainText("Fix these before publishing");
+  await expect(gates).toContainText("publishing stays open");
   await expect(gates).toContainText("Too little content");
-  await expect(gates).toHaveCSS("border-top-color", "rgb(235, 87, 87)");
-  await expect(gates).toHaveCSS("background-color", "rgba(235, 87, 87, 0.08)");
   const tags = dialog.getByTestId("publish-tags");
   await expect(tags).toHaveCSS("display", "flex");
   await expect(tags).toHaveCSS("flex-direction", "column");
   await expect(dialog.getByLabel("Owner passphrase")).toHaveCount(0);
-  // The gates still hold, but the button says what actually happens next.
-  await expect(dialog.getByRole("button", { name: "Publish" })).toBeDisabled();
+  await expect(dialog.getByRole("button", { name: "Publish" })).toBeEnabled();
 });
 
 test("the publish dialog resolves internal Cell instances from the open Project", async ({

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.css
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.css
@@ -159,15 +159,6 @@
   padding-left: 1.1rem;
 }
 
-.publish-gallery-gates-blocking {
-  border-color: var(--icm-error);
-  background: rgb(235 87 87 / 8%);
-}
-
-.publish-gallery-gates-blocking p {
-  color: var(--icm-error);
-}
-
 .publish-gallery-note {
   margin: 0;
   color: var(--icm-text-muted, #667085);

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.test.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.test.tsx
@@ -86,7 +86,7 @@ describe("PublishGalleryDialog", () => {
     expect(markup).toContain("Publishing as Token Zhang");
   });
 
-  it("blocks an ordinary member on gate failures and lists them", () => {
+  it("keeps Publish open for an ordinary member and lists gate findings", () => {
     const markup = renderToStaticMarkup(
       createElement(PublishGalleryDialog, {
         defaultName: "Ring Oscillator",
@@ -108,13 +108,15 @@ describe("PublishGalleryDialog", () => {
         onClose: () => undefined,
       }),
     );
-    expect(markup).toContain("publish-gallery-gates-blocking");
-    expect(markup).toContain("Fix these before publishing:");
+    // Advisory, never a hard gate: the checker has false positives and a
+    // sketch is legitimate to share.
+    expect(markup).not.toContain("publish-gallery-gates-blocking");
+    expect(markup).toContain("publishing stays open");
     expect(markup).toContain("M1.g, R2.2");
-    expect(markup).toMatch(/disabled=""[^>]*>Publish</u);
+    expect(markup).not.toMatch(/disabled=""[^>]*>Publish</u);
   });
 
-  it("shows the same failures as informational for a moderator", () => {
+  it("shows the same advisory failures for a moderator", () => {
     const markup = renderToStaticMarkup(
       createElement(PublishGalleryDialog, {
         defaultName: "Ring Oscillator",
@@ -136,7 +138,7 @@ describe("PublishGalleryDialog", () => {
       }),
     );
     expect(markup).not.toContain("publish-gallery-gates-blocking");
-    expect(markup).toContain("informational for your role");
+    expect(markup).toContain("publishing stays open");
     expect(markup).not.toMatch(/disabled=""[^>]*>Publish</u);
   });
 });

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
@@ -57,8 +57,9 @@ export interface PublishGalleryDraft {
  * account publishes straight to the wall — no passphrase, no review queue.
  * The byline is the account's display name, which the server reads from the
  * session rather than from this form, so one account cannot publish under
- * another's name. Ordinary members still pass the quality gates (listed
- * live, blocking); moderators curate past them.
+ * another's name. Quality checks are advisory for every role: the list keeps
+ * publishers informed, but the checker has false positives and sharing a
+ * work-in-progress sketch is legitimate, so nothing here blocks Publish.
  */
 export function PublishGalleryDialog({
   defaultName,
@@ -74,10 +75,7 @@ export function PublishGalleryDialog({
   draft = null,
   onDraftChange,
 }: PublishGalleryDialogProps) {
-  const privileged = session?.isAdmin === true || session?.role === "moderator";
-  const ordinary = session !== null && !privileged;
   const signedOut = session === null;
-  const gatesBlock = ordinary && gateReport !== null && !gateReport.ok;
   const canUpdate = updateTarget !== null && publishUpdate !== undefined;
   const [mode, setMode] = useState<"update" | "new">(
     canUpdate ? "update" : "new",
@@ -332,18 +330,10 @@ export function PublishGalleryDialog({
             </div>
             {gateReport && gateReport.failures.length > 0 ? (
               <div
-                className={
-                  gatesBlock
-                    ? "publish-gallery-gates publish-gallery-gates-blocking"
-                    : "publish-gallery-gates"
-                }
+                className="publish-gallery-gates"
                 data-testid="publish-gallery-gates"
               >
-                <p>
-                  {gatesBlock
-                    ? "Fix these before publishing:"
-                    : "Quality checks (informational for your role):"}
-                </p>
+                <p>Quality checks — worth a look, publishing stays open:</p>
                 <ul>
                   {gateReport.failures.map((failure) => (
                     <li key={failure.code}>
@@ -377,7 +367,7 @@ export function PublishGalleryDialog({
             <button
               type="button"
               className="publish-gallery-primary"
-              disabled={busy || name.trim() === "" || gatesBlock}
+              disabled={busy || name.trim() === ""}
               onClick={() => void submit()}
             >
               {busy ? "Publishing…" : updating ? "Update entry" : "Publish"}


### PR DESCRIPTION
Ordinary members were hard-blocked from publishing whenever the quality checks failed (e.g. "Floating endpoints" false positives), while moderators saw the same findings as informational. Publishing is a sharing act and the checker misfires: the findings now render as advice for every role ("Quality checks — worth a look, publishing stays open"), the Publish button stays enabled, and only an empty circuit name still holds the form. The server never enforced these gates, so the API is unchanged.

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)