### PR TITLE
fix(gallery): the publish API stops enforcing quality gates

### DIFF
--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -1099,26 +1099,20 @@ describe("gallery submissions", () => {
 });
 
 describe("direct publishing (the review queue is retired)", () => {
-  it("keeps the gates blocking for a member and open for a curator", async () => {
+  it("publishes for every role: quality checks are advisory, never a gate", async () => {
     const env = environment();
     const cookie = await makerOf(env);
 
-    const gated = await route(
+    // An ordinary member publishes even when the quality checks would flag
+    // the project; the checker has false positives and sharing is the point.
+    const member = await route(
       env,
       submissionRequest(
         { name: "Empty", projectText: projectText("Empty") },
         { cookie },
       ),
     );
-    expect(gated.status).toBe(422);
-    const payload = (await gated.json()) as {
-      error: string;
-      failures: { code: string }[];
-    };
-    expect(payload.error).toBe("quality-gate");
-    expect(payload.failures.map((failure) => failure.code)).toContain(
-      "empty-project",
-    );
+    expect(member.status).toBe(201);
 
     // A curator curates: the same empty project goes straight up.
     const adminCookie = await adminOf(env);
@@ -1732,8 +1726,9 @@ describe("gallery owner editing", () => {
     // The detail response names the owner so the editor can offer updates.
     expect(typeof detail.ownerUserId).toBe("string");
 
-    // An empty replacement still fails the gates for the ordinary owner.
-    const gated = await route(
+    // Quality checks are advisory on updates too: an ordinary owner may
+    // replace the entry with a sparse sketch.
+    const sparse = await route(
       env,
       new Request(`${ORIGIN}/api/gallery/${id}`, {
         method: "PUT",
@@ -1745,7 +1740,7 @@ describe("gallery owner editing", () => {
         body: JSON.stringify({ name: "Empty", projectText: projectText() }),
       }),
     );
-    expect(gated.status).toBe(422);
+    expect(sparse.status).toBe(200);
   });
 });
 

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -1,7 +1,6 @@
 // Public Gallery HTTP policy and rendering. Durable storage lives in
 // gallery-do.ts; this module only authenticates and maps API requests.
 
-import { evaluateSubmissionGates } from "@icm/derived";
 import { analyzeDesignNetlist } from "@icm/netlist";
 import { parseProject, serializeProject } from "@icm/project-protocol";
 import { renderDocumentSvg } from "@icm/render-svg";
@@ -278,15 +277,6 @@ async function handleSubmission(
     return Response.json({ error: "invalid-project" }, { status: 400 });
   }
   const projectResolver = createProjectSymbolResolver(project, builtInSymbols);
-  if (!privileged) {
-    const report = evaluateSubmissionGates(project, projectResolver);
-    if (!report.ok) {
-      return Response.json(
-        { error: "quality-gate", failures: report.failures },
-        { status: 422 },
-      );
-    }
-  }
   project.name = name;
   const now = new Date();
   const { status, payload } = await callGallery<{
@@ -398,15 +388,6 @@ async function handleEntryUpdate(
     return Response.json({ error: "invalid-project" }, { status: 400 });
   }
   const projectResolver = createProjectSymbolResolver(project, builtInSymbols);
-  if (!privileged) {
-    const report = evaluateSubmissionGates(project, projectResolver);
-    if (!report.ok) {
-      return Response.json(
-        { error: "quality-gate", failures: report.failures },
-        { status: 422 },
-      );
-    }
-  }
   project.name = name;
   const nextStatus = existing.payload.status ?? "public";
   const netlistable = analyzeDesignNetlist(project).ir ? 1 : 0;


### PR DESCRIPTION
Follow-up to #341: the dialog shows quality findings as advice and enables Publish, but the worker still returned 422 quality-gate for ordinary members on both publish (POST) and update (PUT), so the click failed with "The submission did not pass the quality gates". Both server enforcement blocks are removed. Structural validity still holds — the project must parse, fit the size cap, and the session must own the entry — and the advisory list in the dialog is unchanged.

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)