### PR TITLE
fix(derived): a parked endpoint on a conductor's interior gets its dot

### DIFF
--- a/packages/derived/src/contact.test.ts
+++ b/packages/derived/src/contact.test.ts
@@ -111,6 +111,23 @@ describe("contactRequiresJunctionDot", () => {
     expect(dotAt(document, { x: 0, y: 0 })).toBe(false);
   });
 
+  it("dots a parked endpoint riding another conductor's interior", () => {
+    // The branch ends ON the through wire without the model splitting it —
+    // the through arms still count, so the visual T carries its dot.
+    const teed = documentWith([
+      { id: "through", from: { x: -60, y: 0 }, to: { x: 60, y: 0 } },
+      { id: "branch", from: { x: 0, y: 60 }, to: { x: 0, y: 0 } },
+    ]);
+    expect(dotAt(teed, { x: 0, y: 0 })).toBe(true);
+
+    // A collinear park is one continuous line, not a branch: no dot.
+    const inline = documentWith([
+      { id: "through", from: { x: -60, y: 0 }, to: { x: 60, y: 0 } },
+      { id: "tail", from: { x: -120, y: 0 }, to: { x: 0, y: 0 } },
+    ]);
+    expect(dotAt(inline, { x: 0, y: 0 })).toBe(false);
+  });
+
   it("dots a three-way route branch", () => {
     const document = documentWith([
       { id: "left", from: { x: -60, y: 0 }, to: { x: 0, y: 0 } },

--- a/packages/derived/src/contact.ts
+++ b/packages/derived/src/contact.ts
@@ -129,6 +129,53 @@ function inverseAxisDirection(direction: Point): Point {
   };
 }
 
+/**
+ * Directions of a same-Net conductor whose interior runs through `point`.
+ * A route the model never split still reads as one continuous wire under a
+ * parked endpoint, so the visual branch needs its two through arms counted.
+ * Pure crossings stay out: with no endpoint at the point there is no contact
+ * to attach these directions to.
+ */
+function routeThroughDirections(
+  centerline: readonly Point[],
+  point: Point,
+): Point[] {
+  for (let index = 1; index < centerline.length - 1; index += 1) {
+    const vertex = centerline[index]!;
+    if (vertex.x === point.x && vertex.y === point.y) {
+      return [
+        {
+          x: Math.sign(centerline[index - 1]!.x - point.x),
+          y: Math.sign(centerline[index - 1]!.y - point.y),
+        },
+        {
+          x: Math.sign(centerline[index + 1]!.x - point.x),
+          y: Math.sign(centerline[index + 1]!.y - point.y),
+        },
+      ];
+    }
+  }
+  for (let index = 0; index < centerline.length - 1; index += 1) {
+    const from = centerline[index]!;
+    const to = centerline[index + 1]!;
+    const cross =
+      (to.x - from.x) * (point.y - from.y) -
+      (to.y - from.y) * (point.x - from.x);
+    if (cross !== 0) continue;
+    const dot =
+      (point.x - from.x) * (to.x - from.x) +
+      (point.y - from.y) * (to.y - from.y);
+    const length =
+      (to.x - from.x) * (to.x - from.x) + (to.y - from.y) * (to.y - from.y);
+    if (dot <= 0 || dot >= length) continue;
+    return [
+      { x: Math.sign(from.x - point.x), y: Math.sign(from.y - point.y) },
+      { x: Math.sign(to.x - point.x), y: Math.sign(to.y - point.y) },
+    ];
+  }
+  return [];
+}
+
 function routeEndpointDirections(
   route: SchematicDocument["routes"][number],
   centerline: readonly Point[],
@@ -160,16 +207,25 @@ function contactIncidents(
 ): ContactIncident[] {
   const incidents: ContactIncident[] = [];
   const explicitEndpointKeys = new Set(endpoints.map(endpointKey));
+  const point = endpoints
+    .map((endpoint) => resolveEndpointPoint(document, resolver, endpoint))
+    .find((candidate) => candidate !== null);
   for (const route of document.routes) {
     if (route.netId !== netId) continue;
     const centerline = geometry.routes.get(route.id)?.centerline;
     if (!centerline) continue;
-    for (const direction of routeEndpointDirections(
+    const endpointDirections = routeEndpointDirections(
       route,
       centerline,
       explicitEndpointKeys,
-    )) {
+    );
+    for (const direction of endpointDirections) {
       incidents.push({ kind: "route", objectId: route.id, direction });
+    }
+    if (endpointDirections.length === 0 && point) {
+      for (const direction of routeThroughDirections(centerline, point)) {
+        incidents.push({ kind: "route", objectId: route.id, direction });
+      }
     }
   }
   for (const endpoint of endpoints) {


### PR DESCRIPTION
**Why a visible T could render dotless:** junction dots are derived per contact from "≥3 distinct visible directions". A contact only collects arms from routes whose own endpoints sit at that point — so when a same-Net route ends ON another route's mid-segment or bend and the through route was never split (agent-authored paths, imported guidance, endpoints dragged onto same-Net conductors — movement is deliberately inert), the through conductor contributed zero arms and the T lost its dot. That is the current-mirror node in the report.

**Fix:** contacts now also count a same-Net through conductor's two directions when a Net endpoint rides its interior. Pure crossings have no endpoint there, so no contact forms and they stay dotless (the "a Crossing is not a Junction" invariant is untouched); collinear parks read as one continuous line and stay dotless; cross-Net stacking is unaffected because contacts are per-Net.

Validated: new derived regression tests (T-on-interior dots, collinear park dotless), 1576 unit tests, visual/export goldens byte-stable, 144 junction-heavy e2e green.

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)