### PR TITLE
Copy only explicitly selected wiring

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -1609,6 +1609,29 @@ test("connects copied multi-pin groups through a manually bent wire", async ({
   await expect(page.getByTestId("active-tool")).toHaveText("wire");
 });
 
+test("copies one explicitly selected transistor without its dangling Wire", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "nmos", { x: 320, y: 260 });
+  await clickDrawTool(page, "wire");
+  await page.getByTestId("terminal-M1-G").click();
+  await page
+    .getByTestId("schematic-canvas")
+    .dblclick({ position: { x: 160, y: 260 } });
+  await page.keyboard.press("Escape");
+  await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(1);
+
+  // Clicking only the Instance is an exact visual selection. The unselected
+  // dangling Route must remain on the original instead of entering the copy
+  // through electrical-closure expansion.
+  await page.getByTestId("hit-M1").click();
+  await copySelectionAt(page, { x: 560, y: 260 });
+
+  await expect(page.getByTestId("instance-count")).toHaveText("2");
+  await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(1);
+});
+
 test("moves a selected wire segment and deletes a connected component safely", async ({
   page,
 }) => {

--- a/apps/editor/src/features/clipboard/clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard.test.ts
@@ -263,6 +263,63 @@ describe("schematic clipboard", () => {
     expect(() => buildSvgScene(repeatedPreview, resolver)).not.toThrow();
   });
 
+  it("copies only an explicitly selected Instance when its dangling Wire is not selected", () => {
+    const document = createEmptyDocument("document-main", "Clipboard");
+    document.instances.push({
+      id: "M1",
+      symbolId: "nmos",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0,
+        mirror: "none",
+      },
+    });
+    document.nets.push({
+      id: "signal",
+      terminals: [{ instanceId: "M1", pinName: "G" }],
+    });
+    document.junctions.push({
+      id: "J1",
+      netId: "signal",
+      position: { x: 20, y: 100 },
+    });
+    document.routes.push(
+      createRoutePath({
+        id: "dangling",
+        netId: "signal",
+        start: { kind: "terminal", instanceId: "M1", pinName: "G" },
+        end: { kind: "junction", junctionId: "J1" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+
+    const instanceOnly = copySelection(document, ["M1"], [], {
+      routeIds: [],
+      junctionIds: [],
+      annotationIds: [],
+    });
+    expect(instanceOnly).toMatchObject({
+      instances: [{ id: "M1" }],
+      nets: [],
+      routes: [],
+      junctions: [],
+    });
+
+    const explicitSubgraph = copySelection(document, ["M1"], [], {
+      routeIds: ["dangling"],
+      junctionIds: ["J1"],
+      annotationIds: [],
+    });
+    expect(explicitSubgraph?.nets.map((net) => net.id)).toEqual(["signal"]);
+    expect(explicitSubgraph?.routes.map((route) => route.id)).toEqual([
+      "dangling",
+    ]);
+    expect(explicitSubgraph?.junctions.map((junction) => junction.id)).toEqual([
+      "J1",
+    ]);
+  });
+
   it("creates an isolated translated document for a copy-placement ghost", () => {
     const document = createEmptyDocument("document-main", "Preview");
     document.instances.push({

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -71,6 +71,13 @@ export interface PasteProposal {
   operationPlan: RoutingOperationPlan;
 }
 
+/** Electrical objects the person explicitly included in the visual selection. */
+export interface ExplicitCopyRoutingSelection {
+  routeIds: readonly string[];
+  junctionIds: readonly string[];
+  annotationIds: readonly string[];
+}
+
 /**
  * Compile the transient copy-placement commands into the same ordered
  * instance edits used by ordinary canvas rotation and reflection.  Keeping
@@ -525,6 +532,7 @@ export function copySelection(
   document: SchematicDocument,
   instanceIds: readonly string[],
   draftingIds: readonly string[] = [],
+  routingSelection?: ExplicitCopyRoutingSelection,
 ): SchematicClipboard | null {
   const selectedIds = new Set(instanceIds);
   const instances = document.instances.filter((instance) =>
@@ -537,12 +545,34 @@ export function copySelection(
   // A drawing-only selection is a complete copy: notes and callouts are
   // worth duplicating on their own, and requiring a part alongside them made
   // C look broken to anyone who had only selected a piece of text.
-  if (instances.length === 0 && draftingObjects.length === 0) return null;
-  const capture = captureRoutingCopyFragment(document, {
-    instanceIds,
-    routeIds: [],
-    junctionIds: [],
-  });
+  const hasExplicitRoutingSelection = Boolean(
+    routingSelection &&
+    (routingSelection.routeIds.length > 0 ||
+      routingSelection.junctionIds.length > 0 ||
+      routingSelection.annotationIds.length > 0),
+  );
+  if (
+    instances.length === 0 &&
+    draftingObjects.length === 0 &&
+    !hasExplicitRoutingSelection
+  ) {
+    return null;
+  }
+  const capture = captureRoutingCopyFragment(
+    document,
+    {
+      instanceIds,
+      routeIds: routingSelection?.routeIds ?? [],
+      junctionIds: routingSelection?.junctionIds ?? [],
+      annotationIds: routingSelection?.annotationIds ?? [],
+    },
+    {
+      // Supplying the visual routing selection is an explicit copy contract:
+      // only those Routes travel. Legacy/programmatic callers that omit it
+      // retain connected-subgraph capture.
+      includeImplicitInstanceRoutes: routingSelection === undefined,
+    },
+  );
   const netIds = new Set(capture.clonedNetIds);
   const internalNetIds = new Set(capture.internalNetIds);
   const routeIds = new Set(capture.affected.internalRoutes);

--- a/apps/editor/src/features/selection/use-selection-interaction.ts
+++ b/apps/editor/src/features/selection/use-selection-interaction.ts
@@ -1092,6 +1092,11 @@ export function useSelectionInteraction(
       options.document,
       options.selectedIds,
       options.visualSelection.draftingIds,
+      {
+        routeIds: options.visualSelection.routeIds,
+        junctionIds: options.visualSelection.junctionIds,
+        annotationIds: options.visualSelection.annotationIds,
+      },
     );
     if (!copied) {
       options.setStatus("Select something to copy");

--- a/packages/derived/src/routing-affected-closure.test.ts
+++ b/packages/derived/src/routing-affected-closure.test.ts
@@ -131,4 +131,45 @@ describe("routing affected closure", () => {
     expect(closure.electricalAnnotationIds).toEqual(["label"]);
     expect(closure.protectedObjectIds).toEqual(["label", "route"]);
   });
+
+  it("keeps an unselected dangling Route outside an explicit Instance selection", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.instances.push({
+      id: "M1",
+      symbolId: "nmos",
+      placement: null,
+    });
+    document.nets.push({
+      id: "signal",
+      terminals: [{ instanceId: "M1", pinName: "G" }],
+    });
+    document.junctions.push({
+      id: "J1",
+      netId: "signal",
+      position: { x: 0, y: 0 },
+    });
+    document.routes.push(
+      createRoutePath({
+        id: "dangling",
+        netId: "signal",
+        start: { kind: "terminal", instanceId: "M1", pinName: "G" },
+        end: { kind: "junction", junctionId: "J1" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+
+    expect(
+      deriveRoutingAffectedClosure(
+        document,
+        { instanceIds: ["M1"], routeIds: [], junctionIds: [] },
+        { includeImplicitInstanceRoutes: false },
+      ),
+    ).toMatchObject({
+      instances: ["M1"],
+      internalRoutes: [],
+      internalJunctions: [],
+      boundaryRoutes: ["dangling"],
+    });
+  });
 });

--- a/packages/derived/src/routing-affected-closure.ts
+++ b/packages/derived/src/routing-affected-closure.ts
@@ -21,6 +21,16 @@ export interface RoutingAffectedClosure {
   readonly protectedObjectIds: readonly string[];
 }
 
+export interface RoutingAffectedClosureOptions {
+  /**
+   * Expand selected Instances to Route components whose terminal endpoints
+   * are all selected. Move/delete use that connected-subgraph behavior. An
+   * explicit clipboard selection disables it so unselected Wire never enters
+   * a copy merely because it ends at a selected part.
+   */
+  readonly includeImplicitInstanceRoutes?: boolean;
+}
+
 function stable(values: Iterable<string>): string[] {
   return [...new Set(values)].sort((left, right) =>
     left.localeCompare(right, "en"),
@@ -61,6 +71,7 @@ function isInside(
 export function deriveRoutingAffectedClosure(
   document: SchematicDocument,
   seed: RoutingSelectionSeed,
+  options: RoutingAffectedClosureOptions = {},
 ): RoutingAffectedClosure {
   const knownInstances = new Set(document.instances.map((item) => item.id));
   const knownJunctions = new Set(document.junctions.map((item) => item.id));
@@ -69,7 +80,10 @@ export function deriveRoutingAffectedClosure(
     seed.instanceIds.filter((id) => knownInstances.has(id)),
   );
   const instanceIds = new Set(instances);
-  const internal = deriveInternalGroupSelection(document, instances);
+  const internal =
+    options.includeImplicitInstanceRoutes === false
+      ? { netIds: [], routeIds: [], junctionIds: [] }
+      : deriveInternalGroupSelection(document, instances);
   const internalRouteIds = new Set(internal.routeIds);
   const internalJunctionIds = new Set(internal.junctionIds);
 

--- a/packages/edit-engine/src/routing-copy-fragment.test.ts
+++ b/packages/edit-engine/src/routing-copy-fragment.test.ts
@@ -1,4 +1,4 @@
-import { createEmptyDocument } from "@icm/model";
+import { createEmptyDocument, createRoutePath } from "@icm/model";
 import { describe, expect, it } from "vitest";
 
 import { captureRoutingCopyFragment } from "./routing-copy-fragment.js";
@@ -44,5 +44,39 @@ describe("routing copy fragment", () => {
     });
     expect(capture.clonedNetIds).toEqual(["vdd"]);
     expect(capture.boundaryTerminalKeys).toEqual(["terminal:R1:1"]);
+  });
+
+  it("does not infer a dangling Route or ordinary Net for an explicit copy", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.instances.push({ id: "M1", symbolId: "nmos", placement: null });
+    document.nets.push({
+      id: "signal",
+      terminals: [{ instanceId: "M1", pinName: "G" }],
+    });
+    document.junctions.push({
+      id: "J1",
+      netId: "signal",
+      position: { x: 0, y: 0 },
+    });
+    document.routes.push(
+      createRoutePath({
+        id: "dangling",
+        netId: "signal",
+        start: { kind: "terminal", instanceId: "M1", pinName: "G" },
+        end: { kind: "junction", junctionId: "J1" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+
+    const capture = captureRoutingCopyFragment(
+      document,
+      { instanceIds: ["M1"], routeIds: [], junctionIds: [] },
+      { includeImplicitInstanceRoutes: false },
+    );
+    expect(capture.affected.internalRoutes).toEqual([]);
+    expect(capture.affected.internalJunctions).toEqual([]);
+    expect(capture.clonedNetIds).toEqual([]);
+    expect(capture.boundaryTerminalKeys).toEqual(["terminal:M1:G"]);
   });
 });

--- a/packages/edit-engine/src/routing-copy-fragment.ts
+++ b/packages/edit-engine/src/routing-copy-fragment.ts
@@ -14,6 +14,10 @@ export interface RoutingCopyCapture {
   readonly boundaryTerminalKeys: readonly string[];
 }
 
+export interface RoutingCopyCaptureOptions {
+  readonly includeImplicitInstanceRoutes?: boolean;
+}
+
 function stable(values: Iterable<string>): string[] {
   return [...new Set(values)].sort((left, right) =>
     left.localeCompare(right, "en"),
@@ -29,8 +33,9 @@ function stable(values: Iterable<string>): string[] {
 export function captureRoutingCopyFragment(
   document: SchematicDocument,
   seed: RoutingSelectionSeed,
+  options: RoutingCopyCaptureOptions = {},
 ): RoutingCopyCapture {
-  const affected = deriveRoutingAffectedClosure(document, seed);
+  const affected = deriveRoutingAffectedClosure(document, seed, options);
   const selectedInstances = new Set(affected.instances);
   const selectedAnnotations = new Set([
     ...(seed.annotationIds ?? []),
@@ -38,6 +43,7 @@ export function captureRoutingCopyFragment(
   ]);
   const internalNetIds = stable(
     document.nets.flatMap((net) =>
+      options.includeImplicitInstanceRoutes !== false &&
       net.terminals.length > 0 &&
       net.terminals.every((terminal) =>
         selectedInstances.has(terminal.instanceId),


### PR DESCRIPTION
## Summary
- make GUI copy follow the exact visual selection instead of expanding through connected wiring
- keep unselected dangling/self-connected Wire out of a transistor-only copy
- preserve routed-subgraph copying when the Route is explicitly selected by marquee
- retain connected-subgraph expansion for legacy programmatic callers and for move/delete

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- pnpm gate:full
- post-rebase focused unit, build, and GUI regression checks