### PR TITLE
Enable timing tools only in local development

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -34,6 +34,10 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @icm/editor... build
+        env:
+          # Timing simulation remains a localhost development surface until
+          # its interaction and presentation contracts are ready to publish.
+          VITE_ICM_TIMING_UI: disabled
       - run: pnpm dlx wrangler@4.120.1 deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -89,15 +89,31 @@ function markRoutingDemoNetsImported(
   }
 }
 
-test("keeps digital timing controls out of the editor GUI", async ({
+test("exposes local timing tools and opens the saved-node picker", async ({
   page,
 }) => {
   await page.goto("/editor");
 
-  await expect(page.getByRole("button", { name: "Timing" })).toHaveCount(0);
   await expect(
     page.getByLabel("Place Pulse Voltage Source", { exact: true }),
-  ).toHaveCount(0);
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Timing" }).click();
+
+  const picker = page.locator("details.timing-node-picker");
+  await picker.locator("summary").click();
+  const menu = picker.locator(".timing-node-picker-menu");
+  await expect(menu).toBeVisible();
+  await expect(menu).toContainText("No Nets in this Cell.");
+
+  const menuReceivesPointerEvents = await menu.evaluate((element) => {
+    const bounds = element.getBoundingClientRect();
+    const hit = document.elementFromPoint(
+      bounds.left + bounds.width / 2,
+      bounds.top + bounds.height / 2,
+    );
+    return hit !== null && element.contains(hit);
+  });
+  expect(menuReceivesPointerEvents).toBe(true);
 });
 
 test("opens netlist preflight and navigates its canonical finding", async ({

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -18,6 +18,7 @@
     "@icm/netlist": "workspace:*",
     "@icm/project-protocol": "workspace:*",
     "@icm/render-svg": "workspace:*",
+    "@icm/simulation": "workspace:*",
     "@icm/spice": "workspace:*",
     "@icm/symbols": "workspace:*",
     "react": "19.2.8",

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -188,6 +188,21 @@ describe("editor shell", () => {
     expect(markup).not.toContain("Approve Agent file import");
   });
 
+  it("keeps the timing surface behind its deployment flag", () => {
+    const project = createEmptyProject("timing-flag", "Timing Flag");
+    const localMarkup = renderToStaticMarkup(
+      <App project={project} timingUiEnabled />,
+    );
+    const productionMarkup = renderToStaticMarkup(
+      <App project={project} timingUiEnabled={false} />,
+    );
+
+    expect(localMarkup).toContain('data-testid="timing-simulation-panel"');
+    expect(productionMarkup).not.toContain(
+      'data-testid="timing-simulation-panel"',
+    );
+  });
+
   it("links to first-party visitor analytics without crowding editor commands", () => {
     const project = createEmptyProject("analytics-entry", "Analytics Entry");
     const markup = renderToStaticMarkup(

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -89,6 +89,9 @@ import {
   type SpiceImportReport,
 } from "../features/editor-shell/editor-file-commands";
 import { EditorStatusbar } from "../features/editor-shell/editor-statusbar";
+import { TimingSimulationPanel } from "../features/simulation/timing-simulation-panel";
+import { TIMING_UI_ENABLED } from "../features/simulation/timing-ui";
+import { waveformDraftingObjects } from "../features/simulation/timing-waveform";
 import { useCellSymbolLayout } from "../features/hierarchy/use-cell-symbol-layout";
 import {
   cellInsertLaunch,
@@ -283,6 +286,8 @@ export interface AppProps {
   visitStats?: { pv: number; uv: number } | null;
   /** Test/staging seam; production defaults to a human-only editor. */
   publicAgentUiEnabled?: boolean;
+  /** Test/staging seam; production Cloudflare builds keep timing tools hidden. */
+  timingUiEnabled?: boolean;
   /** `/g/<id>` deep link: load this gallery entry after boot. */
   initialGalleryEntryId?: string | null;
 }
@@ -291,6 +296,7 @@ export function App({
   project: initialProject,
   visitStats,
   publicAgentUiEnabled = PUBLIC_AGENT_UI_ENABLED,
+  timingUiEnabled = TIMING_UI_ENABLED,
   initialGalleryEntryId = null,
 }: AppProps) {
   const [preparedInitialProject] = useState(
@@ -3993,6 +3999,40 @@ export function App({
           }}
         />
       </div>
+      {timingUiEnabled ? (
+        <TimingSimulationPanel
+          key={document.id}
+          document={document}
+          onStatus={setStatus}
+          onPlaceOnCanvas={(result) => {
+            const grid = document.presentation.grid;
+            const origin = {
+              x: snapCoordinate(viewBox.x + viewBox.width * 0.08, grid),
+              y: snapCoordinate(viewBox.y + viewBox.height * 0.08, grid),
+            };
+            const objects = waveformDraftingObjects(
+              result,
+              origin,
+              grid,
+              (prefix) => {
+                uniqueSuffixCounter.current += 1;
+                return `${prefix}-${uniqueSuffixCounter.current}`;
+              },
+            );
+            const placed = transact(
+              objects.map((object) => ({
+                kind: "upsert_drafting_object" as const,
+                object,
+              })),
+            );
+            if (placed.ok) {
+              setStatus(
+                `Placed a static vector timing snapshot with ${result.traces.length} trace${result.traces.length === 1 ? "" : "s"}`,
+              );
+            }
+          }}
+        />
+      ) : null}
       <EditorStatusbar
         visitStats={visitStats}
         status={status}

--- a/apps/editor/src/features/component-insert/symbol-catalog.test.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.test.ts
@@ -98,13 +98,29 @@ describe("component insertion catalog", () => {
     expect(symbols[0]?.pins.map((pin) => pin.name)).toEqual(["P1", "P2"]);
   });
 
-  it("keeps the Pulse Source out of the editor palette", () => {
+  it("offers Pulse Source locally but can remove it with the production flag", () => {
     expect(
       findPaletteSymbol("razavi-textbook-v1", "pulse-voltage-source"),
-    ).toBeUndefined();
+    )?.toMatchObject({
+      id: "pulse-voltage-source",
+      pins: [{ name: "+" }, { name: "-" }],
+    });
     expect(
       flattenComponentCatalog(
         componentCatalog("razavi-textbook-v1", "pulse voltage source"),
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPaletteSymbol("razavi-textbook-v1", "pulse-voltage-source", false),
+    ).toBeUndefined();
+    expect(
+      flattenComponentCatalog(
+        componentCatalog(
+          "razavi-textbook-v1",
+          "pulse voltage source",
+          [],
+          false,
+        ),
       ),
     ).toEqual([]);
   });

--- a/apps/editor/src/features/component-insert/symbol-catalog.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.ts
@@ -13,6 +13,7 @@ import {
   isAnnotationPaletteSymbol,
 } from "./annotation-preview-symbols";
 import { vddRailPreviewSymbol } from "./vdd-rail-preview-symbol";
+import { TIMING_UI_ENABLED } from "../simulation/timing-ui";
 
 /**
  * Reach order rather than taxonomy order: the devices placed most often in a
@@ -129,8 +130,6 @@ const LIBRARY_DESCRIPTIONS: Readonly<Record<string, string>> = {
   "port-filled": "An independent Cell Pin with a solid appearance",
 };
 
-const HIDDEN_PALETTE_SYMBOL_IDS = new Set(["pulse-voltage-source"]);
-
 export function libraryDisplayName(symbolId: string, fallback: string): string {
   return LIBRARY_DISPLAY_NAMES[symbolId] ?? fallback;
 }
@@ -139,13 +138,19 @@ export function libraryDescription(symbolId: string): string | undefined {
   return LIBRARY_DESCRIPTIONS[symbolId];
 }
 
-export function paletteSymbols(_styleProfileId: string): SymbolDefinition[] {
-  return [
+export function paletteSymbols(
+  _styleProfileId: string,
+  timingUiEnabled = TIMING_UI_ENABLED,
+): SymbolDefinition[] {
+  const symbols = [
     vddRailPreviewSymbol,
     ...razaviProductSymbols,
     ...annotationPreviewSymbols,
     ...expandedDeviceSymbols,
-  ].filter((symbol) => !HIDDEN_PALETTE_SYMBOL_IDS.has(symbol.id));
+  ];
+  return timingUiEnabled
+    ? symbols
+    : symbols.filter((symbol) => symbol.id !== "pulse-voltage-source");
 }
 
 /**
@@ -188,12 +193,13 @@ export function componentCatalog(
   styleProfileId: string,
   query: string,
   recentSymbolIds: readonly string[] = [],
+  timingUiEnabled = TIMING_UI_ENABLED,
 ): ComponentCatalogGroup[] {
   const normalizedQuery = query.trim().toLowerCase();
   const recentRank = new Map(
     recentSymbolIds.map((symbolId, index) => [symbolId, index]),
   );
-  const symbols = paletteSymbols(styleProfileId)
+  const symbols = paletteSymbols(styleProfileId, timingUiEnabled)
     .filter(
       (symbol) =>
         normalizedQuery.length === 0 ||
@@ -223,8 +229,9 @@ export function componentCatalog(
 export function findPaletteSymbol(
   styleProfileId: string,
   symbolId: string,
+  timingUiEnabled = TIMING_UI_ENABLED,
 ): SymbolDefinition | undefined {
-  return paletteSymbols(styleProfileId).find(
+  return paletteSymbols(styleProfileId, timingUiEnabled).find(
     (symbol) => symbol.id === symbolId,
   );
 }

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -20,7 +20,7 @@ describe("shapes quick-place", () => {
       }),
     );
 
-    expect(symbols).toHaveLength(46);
+    expect(symbols).toHaveLength(47);
     expect(markup).toContain("All devices");
     expect(markup.match(/data-testid="shapes-chip-/g)).toHaveLength(
       symbols.length,
@@ -35,7 +35,7 @@ describe("shapes quick-place", () => {
       ["Transistors", 5],
       ["Passives", 7],
       ["Power and Ports", 5],
-      ["Sources", 2],
+      ["Sources", 3],
       ["Switches", 2],
       ["Analog Blocks", 6],
       ["Logic Gates", 10],
@@ -67,7 +67,7 @@ describe("shapes quick-place", () => {
     expect(markup.match(/class="shapes-category" open=""/g)).toHaveLength(9);
     expect(markup.match(/class="shapes-category-header"/g)).toHaveLength(9);
     expect(markup).toContain('aria-label="Place Independent Voltage Source"');
-    expect(markup).not.toContain('aria-label="Place Pulse Voltage Source"');
+    expect(markup).toContain('aria-label="Place Pulse Voltage Source"');
     expect(markup).toContain('title="Place Capacitor"');
     expect(markup).toContain('aria-label="Place Variable Resistor"');
     expect(markup).toContain('aria-label="Place Inverter"');
@@ -82,6 +82,7 @@ describe("shapes quick-place", () => {
       '<div class="shapes-subcategory-label">High-voltage devices</div>',
     );
     expect(markup).toContain(">V Src</span>");
+    expect(markup).toContain(">Pulse Src</span>");
     expect(markup).toContain(">Cap</span>");
     expect(markup).toContain(">Var Res</span>");
     expect(markup).toContain(">Inv</span>");

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -50,6 +50,7 @@ const COMPACT_LIBRARY_LABELS: Readonly<Record<string, string>> = {
   pdmos: "PDMOS",
   port: "Pin",
   "port-filled": "Pin \u2022",
+  "pulse-voltage-source": "Pulse Src",
   resistor: "Res",
   "variable-capacitor": "Var Cap",
   "variable-inductor": "Var Ind",

--- a/apps/editor/src/features/simulation/timing-simulation-panel.test.tsx
+++ b/apps/editor/src/features/simulation/timing-simulation-panel.test.tsx
@@ -1,0 +1,40 @@
+import { createEmptyDocument } from "@icm/model";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { TimingSimulationPanel } from "./timing-simulation-panel";
+
+describe("TimingSimulationPanel", () => {
+  it("starts as a zero-layout collapsed launcher", () => {
+    const markup = renderToStaticMarkup(
+      <TimingSimulationPanel
+        document={createEmptyDocument("main", "Main")}
+        onPlaceOnCanvas={() => undefined}
+        onStatus={() => undefined}
+      />,
+    );
+    expect(markup).toContain('class="timing-panel collapsed"');
+    expect(markup).toContain("Timing");
+    expect(markup).not.toContain("Simulation stop time");
+  });
+
+  it("exposes saved-node selection, run, export, and optional canvas placement", () => {
+    const document = createEmptyDocument("main", "Clock divider");
+    document.nets.push({ id: "clock", terminals: [] });
+    const markup = renderToStaticMarkup(
+      <TimingSimulationPanel
+        document={document}
+        defaultOpen
+        onPlaceOnCanvas={() => undefined}
+        onStatus={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain('data-testid="timing-simulation-panel"');
+    expect(markup).toContain("Saved nodes (0)");
+    expect(markup).toContain("Export SVG");
+    expect(markup).toContain("Export PNG");
+    expect(markup).toContain("Place on Canvas");
+    expect(markup).toContain("Temporary results");
+  });
+});

--- a/apps/editor/src/features/simulation/timing-simulation-panel.tsx
+++ b/apps/editor/src/features/simulation/timing-simulation-panel.tsx
@@ -1,0 +1,253 @@
+import { useMemo, useState } from "react";
+
+import { resolveDocumentLogicalNets } from "@icm/derived";
+import type { SchematicDocument } from "@icm/model";
+import {
+  simulateDigitalDocument,
+  type DigitalSimulationResult,
+} from "@icm/simulation";
+
+import { parseSimulationTimePs, timingWaveformSvg } from "./timing-waveform";
+
+export interface TimingSimulationPanelProps {
+  document: SchematicDocument;
+  defaultOpen?: boolean;
+  onPlaceOnCanvas: (result: DigitalSimulationResult) => void;
+  onStatus: (message: string) => void;
+}
+
+function download(blob: Blob, fileName: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = globalThis.document.createElement("a");
+  anchor.href = url;
+  anchor.download = fileName;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+function safeFileStem(value: string): string {
+  return value.trim().replace(/[^A-Za-z0-9._-]+/gu, "-") || "timing";
+}
+
+function exportPng(svg: string, fileName: string): void {
+  const source = new Blob([svg], { type: "image/svg+xml;charset=utf-8" });
+  const url = URL.createObjectURL(source);
+  const image = new Image();
+  image.onload = () => {
+    const canvas = globalThis.document.createElement("canvas");
+    canvas.width = image.naturalWidth * 2;
+    canvas.height = image.naturalHeight * 2;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      URL.revokeObjectURL(url);
+      return;
+    }
+    context.scale(2, 2);
+    context.drawImage(image, 0, 0);
+    canvas.toBlob((blob) => {
+      URL.revokeObjectURL(url);
+      if (blob) download(blob, fileName);
+    }, "image/png");
+  };
+  image.onerror = () => URL.revokeObjectURL(url);
+  image.src = url;
+}
+
+export function TimingSimulationPanel({
+  document,
+  defaultOpen = false,
+  onPlaceOnCanvas,
+  onStatus,
+}: TimingSimulationPanelProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  const [stopTime, setStopTime] = useState("40ns");
+  const [savedNetIds, setSavedNetIds] = useState<Set<string>>(() => new Set());
+  const [result, setResult] = useState<DigitalSimulationResult | null>(null);
+  const logicalNets = useMemo(
+    () => resolveDocumentLogicalNets(document).groups,
+    [document],
+  );
+  const waveformSvg = result ? timingWaveformSvg(result) : null;
+  const stale =
+    result !== null && result.documentRevision !== document.revision;
+
+  const toggleSavedNet = (netId: string): void => {
+    setSavedNetIds((current) => {
+      const next = new Set(current);
+      if (next.has(netId)) next.delete(netId);
+      else next.add(netId);
+      return next;
+    });
+  };
+  const run = (): void => {
+    const stopTimePs = parseSimulationTimePs(stopTime);
+    if (!stopTimePs) {
+      onStatus(
+        "Simulation stop time must include a supported unit, for example 40ns",
+      );
+      return;
+    }
+    if (savedNetIds.size === 0) {
+      onStatus("Save at least one Net before running the timing simulation");
+      return;
+    }
+    const next = simulateDigitalDocument({
+      document,
+      profile: { stopTimePs, savedNetIds: [...savedNetIds] },
+    });
+    setResult(next);
+    onStatus(
+      next.completed
+        ? `Digital simulation completed with ${next.traces.length} saved Net${next.traces.length === 1 ? "" : "s"}`
+        : "Digital simulation stopped with errors; inspect the waveform panel diagnostics",
+    );
+  };
+  const fileStem = `${safeFileStem(document.name)}-timing`;
+
+  return (
+    <section
+      className={open ? "timing-panel" : "timing-panel collapsed"}
+      aria-label="Digital timing simulation"
+      data-testid="timing-simulation-panel"
+    >
+      <header className="timing-panel-header">
+        <button
+          type="button"
+          className="timing-panel-toggle"
+          aria-expanded={open}
+          onClick={() => setOpen((current) => !current)}
+        >
+          <span aria-hidden="true">{open ? "▾" : "▸"}</span> Timing
+        </button>
+        {result ? (
+          <span
+            className={stale ? "timing-run-state stale" : "timing-run-state"}
+          >
+            {stale
+              ? "Circuit changed · run again"
+              : result.completed
+                ? "Complete"
+                : "Errors"}
+          </span>
+        ) : (
+          <span className="timing-run-state">Temporary results</span>
+        )}
+        {open ? (
+          <div className="timing-panel-actions">
+            <details className="timing-node-picker">
+              <summary>Saved nodes ({savedNetIds.size})</summary>
+              <div className="timing-node-picker-menu">
+                <div className="timing-node-picker-actions">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setSavedNetIds(
+                        new Set(logicalNets.map((net) => net.baseNetIds[0]!)),
+                      )
+                    }
+                  >
+                    All
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setSavedNetIds(new Set())}
+                  >
+                    Clear
+                  </button>
+                </div>
+                {logicalNets.length === 0 ? (
+                  <p>No Nets in this Cell.</p>
+                ) : (
+                  logicalNets.map((net) => {
+                    const baseNetId = net.baseNetIds[0]!;
+                    return (
+                      <label key={net.id}>
+                        <input
+                          type="checkbox"
+                          checked={savedNetIds.has(baseNetId)}
+                          onChange={() => toggleSavedNet(baseNetId)}
+                        />
+                        <span>{net.name ?? net.id}</span>
+                        <code>{baseNetId}</code>
+                      </label>
+                    );
+                  })
+                )}
+              </div>
+            </details>
+            <label className="timing-stop-time">
+              Stop
+              <input
+                value={stopTime}
+                aria-label="Simulation stop time"
+                onChange={(event) => setStopTime(event.currentTarget.value)}
+              />
+            </label>
+            <button type="button" className="primary" onClick={run}>
+              Run
+            </button>
+            <button
+              type="button"
+              disabled={!waveformSvg}
+              onClick={() =>
+                waveformSvg &&
+                download(
+                  new Blob([waveformSvg], {
+                    type: "image/svg+xml;charset=utf-8",
+                  }),
+                  `${fileStem}.svg`,
+                )
+              }
+            >
+              Export SVG
+            </button>
+            <button
+              type="button"
+              disabled={!waveformSvg}
+              onClick={() =>
+                waveformSvg && exportPng(waveformSvg, `${fileStem}.png`)
+              }
+            >
+              Export PNG
+            </button>
+            <button
+              type="button"
+              disabled={!result || result.traces.length === 0 || stale}
+              onClick={() => result && onPlaceOnCanvas(result)}
+            >
+              Place on Canvas
+            </button>
+          </div>
+        ) : null}
+      </header>
+      {open ? (
+        <div className="timing-panel-body">
+          {waveformSvg ? (
+            <div
+              className="timing-waveform-preview"
+              data-testid="timing-waveform-preview"
+              dangerouslySetInnerHTML={{ __html: waveformSvg }}
+            />
+          ) : (
+            <div className="timing-panel-empty">
+              Save the Nets you want to observe, then run the digital
+              simulation.
+            </div>
+          )}
+          {result && result.diagnostics.length > 0 ? (
+            <details className="timing-diagnostics">
+              <summary>{result.diagnostics.length} diagnostics</summary>
+              <ul>
+                {result.diagnostics.map((diagnostic, index) => (
+                  <li key={`${diagnostic.code}-${index}`}>
+                    <strong>{diagnostic.code}</strong> {diagnostic.message}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/editor/src/features/simulation/timing-ui.test.ts
+++ b/apps/editor/src/features/simulation/timing-ui.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveTimingUiEnabled } from "./timing-ui";
+
+describe("resolveTimingUiEnabled", () => {
+  it("shows timing tools during local development and hides them in production", () => {
+    expect(resolveTimingUiEnabled({ production: false })).toBe(true);
+    expect(resolveTimingUiEnabled({ production: true })).toBe(false);
+  });
+
+  it("supports an explicit staging or local override", () => {
+    expect(
+      resolveTimingUiEnabled({ production: true, configured: "enabled" }),
+    ).toBe(true);
+    expect(
+      resolveTimingUiEnabled({ production: false, configured: "disabled" }),
+    ).toBe(false);
+  });
+});

--- a/apps/editor/src/features/simulation/timing-ui.ts
+++ b/apps/editor/src/features/simulation/timing-ui.ts
@@ -1,0 +1,21 @@
+/**
+ * Controls the experimental human-facing digital timing tools.
+ *
+ * The deterministic simulation package and persisted circuit contracts never
+ * depend on this flag. Local development enables the UI by default, while a
+ * production build (including Cloudflare) keeps it hidden unless a staging
+ * build explicitly opts in.
+ */
+export function resolveTimingUiEnabled(input: {
+  production: boolean;
+  configured?: string;
+}): boolean {
+  if (input.configured === "enabled") return true;
+  if (input.configured === "disabled") return false;
+  return !input.production;
+}
+
+export const TIMING_UI_ENABLED = resolveTimingUiEnabled({
+  production: import.meta.env.PROD,
+  configured: import.meta.env.VITE_ICM_TIMING_UI,
+});

--- a/apps/editor/src/features/simulation/timing-waveform.test.ts
+++ b/apps/editor/src/features/simulation/timing-waveform.test.ts
@@ -1,0 +1,83 @@
+import { DraftingObjectSchema } from "@icm/model";
+import type { DigitalSimulationResult } from "@icm/simulation";
+import { describe, expect, it } from "vitest";
+
+import {
+  parseSimulationTimePs,
+  timingWaveformSvg,
+  traceStepPoints,
+  waveformDraftingObjects,
+} from "./timing-waveform";
+
+const result: DigitalSimulationResult = {
+  documentId: "main",
+  documentRevision: 4,
+  stopTimePs: 20_000,
+  completed: true,
+  diagnostics: [],
+  traces: [
+    {
+      netId: "clock",
+      baseNetIds: ["clock"],
+      name: "CK",
+      transitions: [
+        { timePs: 0, value: "0" },
+        { timePs: 5_000, value: "1" },
+        { timePs: 10_000, value: "0" },
+      ],
+    },
+  ],
+};
+
+describe("timing waveform presentation", () => {
+  it("parses explicit simulation time units into integer picoseconds", () => {
+    expect(parseSimulationTimePs("40ns")).toBe(40_000);
+    expect(parseSimulationTimePs("1.5 us")).toBe(1_500_000);
+    expect(parseSimulationTimePs("0ns")).toBeNull();
+    expect(parseSimulationTimePs("40")).toBeNull();
+  });
+
+  it("builds square-step points without interpolating digital edges", () => {
+    expect(
+      traceStepPoints(result.traces[0]!, 20_000, 100, 400, 20, 20),
+    ).toEqual([
+      { x: 100, y: 40 },
+      { x: 200, y: 40 },
+      { x: 200, y: 20 },
+      { x: 300, y: 20 },
+      { x: 300, y: 40 },
+      { x: 500, y: 40 },
+    ]);
+  });
+
+  it("exports a self-contained Razavi-style SVG with guides and time axis", () => {
+    const svg = timingWaveformSvg(result);
+    expect(svg).toContain('aria-label="Digital timing waveform"');
+    expect(svg).toContain("stroke-dasharray:5 5");
+    expect(svg).toContain(">CK</text>");
+    expect(svg).toContain(">20 ns</text>");
+    expect(svg).toContain('marker-end="url(#time-arrow)"');
+  });
+
+  it("converts a temporary run into valid editable vector drafting objects", () => {
+    let suffix = 0;
+    const objects = waveformDraftingObjects(
+      result,
+      { x: 20, y: 30 },
+      10,
+      (prefix) => `${prefix}-${++suffix}`,
+    );
+    expect(objects.map((object) => object.kind)).toEqual([
+      "text",
+      "text",
+      "construction-line",
+      "construction-line",
+      "construction-line",
+      "arrow",
+      "text",
+    ]);
+    for (const object of objects) {
+      expect(DraftingObjectSchema.parse(object)).toEqual(object);
+    }
+  });
+});

--- a/apps/editor/src/features/simulation/timing-waveform.ts
+++ b/apps/editor/src/features/simulation/timing-waveform.ts
@@ -1,0 +1,232 @@
+import { snapGridPoint, type DraftingObject, type GridPoint } from "@icm/model";
+import type {
+  DigitalSimulationResult,
+  DigitalTrace,
+  LogicValue,
+} from "@icm/simulation";
+
+const TIME_SCALE_PS: Readonly<Record<string, number>> = {
+  ps: 1,
+  ns: 1_000,
+  us: 1_000_000,
+  ms: 1_000_000_000,
+  s: 1_000_000_000_000,
+};
+
+export function parseSimulationTimePs(raw: string): number | null {
+  const match = /^([+]?(?:\d+(?:\.\d*)?|\.\d+))\s*(ps|ns|us|ms|s)$/iu.exec(
+    raw.trim(),
+  );
+  if (!match) return null;
+  const value = Number(match[1]) * TIME_SCALE_PS[match[2]!.toLowerCase()]!;
+  const rounded = Math.round(value);
+  return Number.isSafeInteger(rounded) && rounded > 0 ? rounded : null;
+}
+
+export function formatSimulationTime(timePs: number): string {
+  for (const [unit, scale] of [
+    ["s", 1_000_000_000_000],
+    ["ms", 1_000_000_000],
+    ["µs", 1_000_000],
+    ["ns", 1_000],
+  ] as const) {
+    if (timePs >= scale && timePs % scale === 0) {
+      return `${timePs / scale} ${unit}`;
+    }
+  }
+  return `${timePs} ps`;
+}
+
+function valueY(value: LogicValue, top: number, amplitude: number): number {
+  if (value === "1") return top;
+  if (value === "0") return top + amplitude;
+  return top + amplitude / 2;
+}
+
+export function traceStepPoints(
+  trace: DigitalTrace,
+  stopTimePs: number,
+  left: number,
+  width: number,
+  top: number,
+  amplitude: number,
+): Array<{ x: number; y: number }> {
+  const x = (timePs: number) => left + (timePs / stopTimePs) * width;
+  const transitions = trace.transitions;
+  if (transitions.length === 0) return [];
+  const points = [
+    { x: left, y: valueY(transitions[0]!.value, top, amplitude) },
+  ];
+  let previousValue = transitions[0]!.value;
+  for (const transition of transitions.slice(1)) {
+    points.push({
+      x: x(transition.timePs),
+      y: valueY(previousValue, top, amplitude),
+    });
+    points.push({
+      x: x(transition.timePs),
+      y: valueY(transition.value, top, amplitude),
+    });
+    previousValue = transition.value;
+  }
+  points.push({
+    x: left + width,
+    y: valueY(previousValue, top, amplitude),
+  });
+  return points;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function guideTimes(result: DigitalSimulationResult): number[] {
+  return [
+    ...new Set(
+      result.traces.flatMap((trace) =>
+        trace.transitions
+          .map((transition) => transition.timePs)
+          .filter((timePs) => timePs > 0 && timePs < result.stopTimePs),
+      ),
+    ),
+  ]
+    .sort((left, right) => left - right)
+    .slice(0, 24);
+}
+
+export function timingWaveformSvg(result: DigitalSimulationResult): string {
+  const width = 900;
+  const labelWidth = 120;
+  const plotLeft = 140;
+  const plotWidth = 700;
+  const rowHeight = 54;
+  const traceAmplitude = 24;
+  const topPadding = 28;
+  const axisY = topPadding + result.traces.length * rowHeight + 18;
+  const height = axisY + 40;
+  const guides = guideTimes(result)
+    .map((timePs) => {
+      const x = plotLeft + (timePs / result.stopTimePs) * plotWidth;
+      return `<line class="guide" x1="${x}" y1="${topPadding - 8}" x2="${x}" y2="${axisY - 8}" />`;
+    })
+    .join("");
+  const traces = result.traces
+    .map((trace, index) => {
+      const top = topPadding + index * rowHeight;
+      const points = traceStepPoints(
+        trace,
+        result.stopTimePs,
+        plotLeft,
+        plotWidth,
+        top,
+        traceAmplitude,
+      )
+        .map((point) => `${point.x},${point.y}`)
+        .join(" ");
+      return `<text class="label" x="${labelWidth}" y="${top + 18}" text-anchor="end">${escapeXml(trace.name)}</text><polyline class="trace" points="${points}" />`;
+    })
+    .join("");
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-label="Digital timing waveform"><defs><marker id="time-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="#111"/></marker></defs><rect width="100%" height="100%" fill="#fff"/><style>.trace{fill:none;stroke:#111;stroke-width:3;stroke-linejoin:miter;stroke-linecap:square}.guide{stroke:#666;stroke-width:1.2;stroke-dasharray:5 5}.label,.time-label{fill:#111;font-family:Georgia,'Times New Roman',serif;font-size:18px;font-style:italic;font-weight:600}.time-label{font-size:15px;font-weight:400}</style>${guides}${traces}<line x1="${plotLeft - 12}" y1="${axisY}" x2="${plotLeft + plotWidth + 16}" y2="${axisY}" stroke="#111" stroke-width="2" marker-end="url(#time-arrow)"/><text class="time-label" x="${plotLeft + plotWidth}" y="${axisY + 28}" text-anchor="end">${escapeXml(formatSimulationTime(result.stopTimePs))}</text><text class="label" x="${plotLeft + plotWidth + 28}" y="${axisY + 8}">t</text></svg>`;
+}
+
+function free(position: GridPoint) {
+  return { kind: "free" as const, position };
+}
+
+export function waveformDraftingObjects(
+  result: DigitalSimulationResult,
+  origin: GridPoint,
+  grid: number,
+  nextId: (prefix: string) => string,
+): DraftingObject[] {
+  const objects: DraftingObject[] = [];
+  const labelX = origin.x;
+  const plotLeft = origin.x + 100;
+  const plotWidth = 400;
+  const rowHeight = 50;
+  const amplitude = 20;
+  const topPadding = 40;
+  const snap = (point: { x: number; y: number }) => snapGridPoint(point, grid);
+  const addText = (
+    value: string,
+    position: GridPoint,
+    token: "caption" | "label",
+  ) => {
+    objects.push({
+      id: nextId("waveform-text"),
+      kind: "text",
+      locked: false,
+      zIndex: 0,
+      anchor: free(position),
+      content: { runs: [{ kind: "text", value }] },
+      alignment: "start",
+      rotation: 0,
+      typographyToken: token,
+    });
+  };
+
+  addText(
+    `Digital timing · ${formatSimulationTime(result.stopTimePs)}`,
+    snap({ x: labelX, y: origin.y }),
+    "caption",
+  );
+  result.traces.forEach((trace, index) => {
+    const top = origin.y + topPadding + index * rowHeight;
+    const points = traceStepPoints(
+      trace,
+      result.stopTimePs,
+      plotLeft,
+      plotWidth,
+      top,
+      amplitude,
+    ).map(snap);
+    addText(trace.name, snap({ x: labelX, y: top + amplitude }), "label");
+    if (points.length >= 2) {
+      objects.push({
+        id: nextId("waveform-trace"),
+        kind: "construction-line",
+        locked: false,
+        zIndex: 0,
+        anchor: free(points[0]!),
+        points,
+        lineStyle: "solid",
+        styleOverride: { strokeScale: 1.5 },
+      });
+    }
+  });
+
+  const axisY = origin.y + topPadding + result.traces.length * rowHeight + 10;
+  for (const timePs of guideTimes(result).slice(0, 12)) {
+    const x = plotLeft + (timePs / result.stopTimePs) * plotWidth;
+    const from = snap({ x, y: origin.y + topPadding - 10 });
+    const to = snap({ x, y: axisY - 10 });
+    objects.push({
+      id: nextId("waveform-guide"),
+      kind: "construction-line",
+      locked: false,
+      zIndex: 0,
+      anchor: free(from),
+      points: [from, to],
+      lineStyle: "dashed",
+      styleOverride: { strokeScale: 0.75 },
+    });
+  }
+  const axisStart = snap({ x: plotLeft - 10, y: axisY });
+  const axisEnd = snap({ x: plotLeft + plotWidth + 20, y: axisY });
+  objects.push({
+    id: nextId("waveform-time-axis"),
+    kind: "arrow",
+    locked: false,
+    zIndex: 0,
+    anchor: free(axisStart),
+    from: free(axisStart),
+    to: free(axisEnd),
+    styleOverride: { arrowHead: "filled", strokeScale: 1.25 },
+  });
+  addText("t", snap({ x: axisEnd.x + 10, y: axisEnd.y + 10 }), "label");
+  return objects;
+}

--- a/apps/editor/src/styles/editor-entry.css
+++ b/apps/editor/src/styles/editor-entry.css
@@ -11,6 +11,7 @@
 @import "./editor-dialogs.css";
 @import "./editor-canvas-state.css";
 @import "./editor-agent.css";
+@import "./editor-simulation.css";
 @import "./editor-accessibility.css";
 @import "../features/editor-shell/publish-gallery-dialog.css";
 @import "../components/version-history-dialog.css";

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -1,0 +1,219 @@
+/* Local-development digital timing controls and Razavi-style traces. */
+
+.timing-panel {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 190px;
+  max-height: min(34dvh, 310px);
+  border-top: 1px solid var(--icm-border-strong);
+  background: var(--icm-surface);
+  /* The saved-node picker opens above the header into the canvas area. */
+  overflow: visible;
+}
+
+.timing-panel.collapsed {
+  display: block;
+  min-height: 0;
+  height: 0;
+  border-top: 0;
+  overflow: visible;
+}
+
+.timing-panel.collapsed .timing-panel-header {
+  position: fixed;
+  right: calc(var(--icm-props-collapsed) + var(--icm-space-2));
+  bottom: var(--icm-statusbar-h);
+  z-index: 19;
+  width: auto;
+  min-height: 30px;
+  padding: 2px var(--icm-space-2);
+  border: 1px solid var(--icm-border-strong);
+  border-bottom: 0;
+  border-radius: var(--icm-radius-sm) var(--icm-radius-sm) 0 0;
+  box-shadow: var(--icm-shadow-sm);
+}
+
+.timing-panel.collapsed .timing-run-state {
+  display: none;
+}
+
+.timing-panel-header {
+  display: flex;
+  align-items: center;
+  gap: var(--icm-space-2);
+  min-height: 34px;
+  padding: 3px var(--icm-space-3);
+  border-bottom: 1px solid var(--icm-border);
+  background: var(--icm-surface-muted);
+}
+
+.timing-panel-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 78px;
+  border-color: transparent;
+  background: transparent;
+  font-weight: 650;
+}
+
+.timing-run-state {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  white-space: nowrap;
+}
+
+.timing-run-state.stale {
+  color: var(--icm-warning);
+}
+
+.timing-panel-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--icm-space-1);
+  min-width: 0;
+  margin-left: auto;
+}
+
+.timing-panel-actions button,
+.timing-node-picker > summary,
+.timing-stop-time input {
+  min-height: 26px;
+  padding: 3px 8px;
+  font-size: var(--icm-font-sm);
+}
+
+.timing-panel-actions .primary {
+  border-color: var(--icm-accent);
+  color: #fff;
+  background: var(--icm-accent);
+}
+
+.timing-stop-time {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+
+.timing-stop-time input {
+  width: 72px;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-sm);
+  color: var(--icm-text);
+  background: var(--icm-surface);
+}
+
+.timing-node-picker {
+  position: relative;
+}
+
+.timing-node-picker > summary {
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface);
+  cursor: pointer;
+  list-style: none;
+  white-space: nowrap;
+}
+
+.timing-node-picker-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 7px);
+  z-index: 30;
+  display: grid;
+  gap: 4px;
+  width: min(380px, 72vw);
+  max-height: 310px;
+  padding: var(--icm-space-2);
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-md);
+  background: var(--icm-surface);
+  box-shadow: var(--icm-shadow-md);
+  overflow: auto;
+}
+
+.timing-node-picker-menu label {
+  display: grid;
+  grid-template-columns: auto minmax(90px, 1fr) minmax(80px, auto);
+  align-items: center;
+  gap: var(--icm-space-2);
+  padding: 4px;
+  border-radius: var(--icm-radius-sm);
+}
+
+.timing-node-picker-menu label:hover {
+  background: var(--icm-surface-hover);
+}
+
+.timing-node-picker-menu code {
+  color: var(--icm-text-muted);
+  font: 10px/1.2 var(--font-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.timing-node-picker-actions {
+  display: flex;
+  gap: var(--icm-space-1);
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--icm-border);
+}
+
+.timing-panel-body {
+  display: flex;
+  min-height: 0;
+  overflow: auto;
+}
+
+.timing-waveform-preview {
+  flex: 1 1 auto;
+  min-width: 620px;
+  padding: 8px 16px;
+  background: #fff;
+}
+
+.timing-waveform-preview svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 130px;
+}
+
+.timing-panel-empty {
+  display: grid;
+  flex: 1;
+  place-items: center;
+  min-height: 130px;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-sm);
+}
+
+.timing-diagnostics {
+  flex: 0 0 min(310px, 30vw);
+  padding: var(--icm-space-2);
+  border-left: 1px solid var(--icm-border);
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  overflow: auto;
+}
+
+.timing-diagnostics ul {
+  margin: 8px 0;
+  padding-left: 20px;
+}
+
+@media (max-width: 920px) {
+  .timing-panel-actions button:not(.primary),
+  .timing-run-state {
+    display: none;
+  }
+
+  .timing-panel {
+    max-height: 28dvh;
+  }
+}

--- a/docs/adr/0049-deterministic-digital-timing-simulation.md
+++ b/docs/adr/0049-deterministic-digital-timing-simulation.md
@@ -30,10 +30,12 @@ terminal must connect to Ground; its positive terminal drives the logical Net.
 
 Saved nodes are observation selections in the run profile, not electrical
 probes. Simulation results remain derived data and are not stored in Project
-JSON. This delivery deliberately exposes no timing-simulation controls,
-waveform presentation, export, or canvas-placement workflow in the editor GUI.
-The Pulse Source remains a resolvable symbol and device contract for project
-compatibility and programmatic use, but it is hidden from the editor palette.
+JSON. The local development editor exposes timing controls, waveform
+presentation and export, optional canvas placement, and Pulse Source authoring
+behind `VITE_ICM_TIMING_UI`. The default is enabled for local development and
+disabled for production; the Cloudflare workflow also sets `disabled`
+explicitly. The simulation layer and project compatibility never depend on
+this presentation flag.
 
 Razavi Figure 20.54 governs presentation only: stacked square traces, signal
 labels, dashed timing guides, and a horizontal time axis. It cannot establish
@@ -44,8 +46,8 @@ logic values, event ordering, or clock semantics.
 - Identical Document/profile inputs produce identical traces.
 - The simulation layer can grow without making the editor or netlist exporter
   its execution engine.
-- Existing projects containing Pulse Sources remain loadable even though new
-  Pulse Sources cannot be authored through the editor palette.
+- Existing projects containing Pulse Sources remain loadable in every build;
+  the local development palette also supports authoring new Pulse Sources.
 - An unused DFF `QBAR` output may remain unconnected; `D`, `CK`, and `Q` remain
   required for the supported rising-edge behavior.
 - Gate delay, setup/hold timing, metastability, hierarchy, and analog threshold
@@ -57,5 +59,5 @@ logic values, event ordering, or clock semantics.
   optional `QBAR`, and logical-Net equivalence.
 - Device and netlist tests cover the two-terminal Pulse Source defaults and
   SPICE/Spectre `PULSE` output.
-- Editor catalog tests verify that Pulse Source and simulation controls are not
-  exposed through the GUI.
+- Editor and browser tests cover the local timing controls and Pulse Source;
+  flag tests and the deployment workflow protect the production-hidden state.

--- a/packages/simulation/README.md
+++ b/packages/simulation/README.md
@@ -11,10 +11,11 @@ The first supported set is:
 - four-state `0`, `1`, `X`, and `Z` driver resolution.
 
 Simulation time is an integer number of picoseconds. Saved Net IDs select
-traces to return; they do not change circuit connectivity. The simulation
-package and Pulse Source contracts remain available to code and project
-compatibility, but this delivery does not expose simulation controls or Pulse
-Source authoring in the editor GUI.
+traces to return; they do not change circuit connectivity. Browser run results
+are intentionally temporary. The local development editor exposes the timing
+panel, waveform export, optional canvas placement, and Pulse Source authoring;
+Cloudflare production builds explicitly keep that experimental UI hidden.
+The simulation package and project compatibility do not depend on the UI flag.
 
 This package does not model analog thresholds, propagation delay, setup/hold
 windows, metastability, or transistor-level behavior.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       "@icm/render-svg":
         specifier: workspace:*
         version: link:../../packages/render-svg
+      "@icm/simulation":
+        specifier: workspace:*
+        version: link:../../packages/simulation
       "@icm/spice":
         specifier: workspace:*
         version: link:../../packages/spice
@@ -304,6 +307,15 @@ importers:
         specifier: workspace:*
         version: link:../symbols
 
+  packages/simulation:
+    dependencies:
+      "@icm/derived":
+        specifier: workspace:*
+        version: link:../derived
+      "@icm/model":
+        specifier: workspace:*
+        version: link:../model
+
   packages/spice:
     dependencies:
       "@icm/model":
@@ -315,15 +327,6 @@ importers:
       zod:
         specifier: 4.4.3
         version: 4.4.3
-
-  packages/simulation:
-    dependencies:
-      "@icm/derived":
-        specifier: workspace:*
-        version: link:../derived
-      "@icm/model":
-        specifier: workspace:*
-        version: link:../model
 
   packages/symbols:
     dependencies:


### PR DESCRIPTION
## Summary
- restore the local Timing panel, saved-Net selection, waveform export, and optional canvas placement
- expose Pulse Source authoring during localhost development
- keep the simulation and project contracts independent of UI visibility
- default production builds to hidden and explicitly disable the UI in the Cloudflare deployment workflow

## Validation
- 255 test files / 1588 unit and integration tests passed
- 247 browser tests passed on an isolated server
- full build, release, performance, golden, PWA, production smoke, and MCP smoke checks passed
- browser-verified localhost visible and disabled production preview hidden

Unrelated local untracked file \probe-conflicts.mjs\ remains excluded.