### PR TITLE
refactor(derived): thread the contact point instead of re-resolving it

### DIFF
--- a/packages/derived/src/contact.ts
+++ b/packages/derived/src/contact.ts
@@ -203,13 +203,11 @@ function contactIncidents(
   resolver: SymbolResolver,
   netId: string,
   endpoints: readonly RouteEndpoint[],
+  point: Point,
   geometry: ResolvedDocumentRoutingGeometry,
 ): ContactIncident[] {
   const incidents: ContactIncident[] = [];
   const explicitEndpointKeys = new Set(endpoints.map(endpointKey));
-  const point = endpoints
-    .map((endpoint) => resolveEndpointPoint(document, resolver, endpoint))
-    .find((candidate) => candidate !== null);
   for (const route of document.routes) {
     if (route.netId !== netId) continue;
     const centerline = geometry.routes.get(route.id)?.centerline;
@@ -222,7 +220,7 @@ function contactIncidents(
     for (const direction of endpointDirections) {
       incidents.push({ kind: "route", objectId: route.id, direction });
     }
-    if (endpointDirections.length === 0 && point) {
+    if (endpointDirections.length === 0) {
       for (const direction of routeThroughDirections(centerline, point)) {
         incidents.push({ kind: "route", objectId: route.id, direction });
       }
@@ -284,6 +282,7 @@ function netContacts(
         resolver,
         net.id,
         endpoints,
+        point,
         geometry,
       );
       const directions = new Map<string, Point>();


### PR DESCRIPTION
Ultrareview of #343 flagged that `contactIncidents` re-derived the contact coordinate via `resolveEndpointPoint` over every endpoint although its only caller groups endpoints by exactly that point. The point is now a parameter, deleting N redundant terminal resolutions per contact per derivation.

Test-Impact: no-test-change — behavior-identical parameter threading; derived and render suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)