### PR TITLE
fix(editor): draw a lone polarity sign the same size as the pair

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -489,8 +489,10 @@ test("groups drafting tools and editable polarity labels under Annotations", asy
   );
   await expect(polarity.locator("text")).not.toContainText("VGS");
 
-  // The standalone signs place directly from the Insert picker as ordinary
-  // texts — no editor popup, editable and stylable later like any text.
+  // A standalone sign places directly from the Insert picker with no editor
+  // popup, and lands as the same mark the pair draws rather than as a font's
+  // glyph for the character — otherwise the two are different sizes side by
+  // side.
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });
   await dialog.getByLabel("Component search").fill("minus");
@@ -498,11 +500,21 @@ test("groups drafting tools and editable polarity labels under Annotations", asy
   await canvas.hover({ position: { x: 600, y: 260 } });
   await canvas.click({ position: { x: 600, y: 260 } });
   await expect(editor).toHaveCount(0);
-  const minusText = canvas.locator(
-    '[data-kind="draft-text"]:not([data-polarity])',
-  );
-  await expect(minusText).toBeVisible();
-  await expect(minusText).toContainText("−");
+  const loneMinus = canvas.locator('[data-polarity="negative"]');
+  await expect(loneMinus).toBeVisible();
+  await expect(
+    loneMinus.locator('[data-role="polarity-negative"]'),
+  ).toHaveCount(1);
+  // Its arm is the pair's arm, measured rather than eyeballed.
+  const armOf = (locator: ReturnType<typeof canvas.locator>) =>
+    locator.evaluate((line) =>
+      Math.abs(
+        Number(line.getAttribute("x2")) - Number(line.getAttribute("x1")),
+      ),
+    );
+  expect(
+    await armOf(loneMinus.locator('[data-role="polarity-negative"]')),
+  ).toBe(await armOf(polarity.locator('[data-role="polarity-negative"]')));
 });
 
 test("places a vertical Power Rail from I and renames it on the canvas", async ({

--- a/apps/editor/src/features/component-insert/annotation-preview-symbols.test.ts
+++ b/apps/editor/src/features/component-insert/annotation-preview-symbols.test.ts
@@ -1,0 +1,93 @@
+import { resolveDraftingObjectGeometry } from "@icm/derived";
+import { createEmptyDocument, defaultDraftTextDocument } from "@icm/model";
+import type { DraftingObject } from "@icm/model";
+import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import {
+  annotationPolarity,
+  isAnnotationPaletteSymbol,
+  isBarePolaritySign,
+} from "./annotation-preview-symbols";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+/** The + and − strokes a drafting object actually commits to the canvas. */
+function polarityMarks(
+  polarity: "both" | "positive" | "negative",
+  content: DraftingObject extends never
+    ? never
+    : ReturnType<typeof defaultDraftTextDocument>,
+) {
+  const document = createEmptyDocument("main", "Main");
+  const object = {
+    id: "mark",
+    kind: "text" as const,
+    locked: false,
+    zIndex: 0,
+    anchor: { kind: "free" as const, position: { x: 0, y: 0 } },
+    content,
+    alignment: "middle" as const,
+    rotation: 0 as const,
+    typographyToken: "label" as const,
+    polarity,
+  };
+  document.drafting = { objects: [object] };
+  const geometry = resolveDraftingObjectGeometry(document, resolver, object);
+  if (geometry.kind !== "text") throw new Error("expected text geometry");
+  return geometry.polarityLines;
+}
+
+/** Arm half-length, which is what "the same size" means for these marks. */
+function armSpan(line: { from: { x: number }; to: { x: number } }): number {
+  return Math.abs(line.to.x - line.from.x);
+}
+
+const emptyCentre = { runs: [{ kind: "line-break" as const }] };
+
+describe("polarity annotations", () => {
+  it("treats a lone sign as a polarity mark, not as text", () => {
+    expect(annotationPolarity("annotation-polarity-both")).toBe("both");
+    expect(annotationPolarity("annotation-text-plus")).toBe("positive");
+    expect(annotationPolarity("annotation-text-minus")).toBe("negative");
+    expect(isBarePolaritySign("annotation-text-plus")).toBe(true);
+    expect(isBarePolaritySign("annotation-polarity-both")).toBe(false);
+    expect(isAnnotationPaletteSymbol("annotation-text-minus")).toBe(true);
+  });
+
+  it("draws a lone sign at exactly the size the pair draws it", () => {
+    const pair = polarityMarks("both", defaultDraftTextDocument("V_x"));
+    const lonePlus = polarityMarks("positive", emptyCentre);
+    const loneMinus = polarityMarks("negative", emptyCentre);
+
+    const pairPlus = pair.find((line) => line.role === "positive-horizontal")!;
+    const pairMinus = pair.find((line) => line.role === "negative")!;
+    const solePlus = lonePlus.find(
+      (line) => line.role === "positive-horizontal",
+    )!;
+    const soleMinus = loneMinus.find((line) => line.role === "negative")!;
+
+    // The whole point: a sign standing on its own is the same mark as the
+    // one the pair brackets a name with. Drawn as a font glyph it never was.
+    expect(armSpan(solePlus)).toBe(armSpan(pairPlus));
+    expect(armSpan(soleMinus)).toBe(armSpan(pairMinus));
+    // And the plus stays square — arms of equal length, not a glyph's shape.
+    const soleVertical = lonePlus.find(
+      (line) => line.role === "positive-vertical",
+    )!;
+    expect(Math.abs(soleVertical.to.y - soleVertical.from.y)).toBeCloseTo(
+      armSpan(solePlus),
+      10,
+    );
+  });
+
+  it("puts a lone sign on the spot, with no second mark beside it", () => {
+    expect(polarityMarks("positive", emptyCentre).map((l) => l.role)).toEqual([
+      "positive-horizontal",
+      "positive-vertical",
+    ]);
+    expect(polarityMarks("negative", emptyCentre).map((l) => l.role)).toEqual([
+      "negative",
+    ]);
+  });
+});

--- a/apps/editor/src/features/component-insert/annotation-preview-symbols.ts
+++ b/apps/editor/src/features/component-insert/annotation-preview-symbols.ts
@@ -13,16 +13,16 @@ const drawingToolBySymbolId = {
   "annotation-circle": "circle",
 } as const satisfies Readonly<Record<string, DrawingTool>>;
 
+// A standalone sign is the same mark as the one the pair draws, so it goes
+// through the same polarity machinery. Drawn as a text glyph instead, it
+// came out a different size beside the pair — a glyph is a font's drawing of
+// a plus, while the mark is two strokes measured from the type size, and no
+// amount of tuning makes those two agree.
 const polarityBySymbolId = {
   "annotation-polarity-both": "both",
+  "annotation-text-plus": "positive",
+  "annotation-text-minus": "negative",
 } as const satisfies Readonly<Record<string, PolarityAnnotationKind>>;
-
-// Standalone signs are ordinary DraftText objects with a fixed initial
-// content — sizable and colorable like any text, no polarity machinery.
-const presetTextBySymbolId = {
-  "annotation-text-plus": "+",
-  "annotation-text-minus": "−",
-} as const satisfies Readonly<Record<string, string>>;
 
 export function annotationDrawingTool(
   symbolId: string,
@@ -36,15 +36,15 @@ export function annotationPolarity(
   return polarityBySymbolId[symbolId as keyof typeof polarityBySymbolId];
 }
 
-export function annotationPresetText(symbolId: string): string | undefined {
-  return presetTextBySymbolId[symbolId as keyof typeof presetTextBySymbolId];
+/** True for a lone + or −: a polarity mark with no centre text to write. */
+export function isBarePolaritySign(symbolId: string): boolean {
+  const polarity = annotationPolarity(symbolId);
+  return polarity === "positive" || polarity === "negative";
 }
 
 export function isAnnotationPaletteSymbol(symbolId: string): boolean {
   return Boolean(
-    annotationDrawingTool(symbolId) ??
-    annotationPolarity(symbolId) ??
-    annotationPresetText(symbolId),
+    annotationDrawingTool(symbolId) ?? annotationPolarity(symbolId),
   );
 }
 
@@ -177,10 +177,7 @@ const annotationTextPlus = {
   id: "annotation-text-plus",
   name: "Plus sign",
   viewBox: { x: -12, y: -12, width: 24, height: 24 },
-  primitives: [
-    { kind: "line", from: { x: -6, y: 0 }, to: { x: 6, y: 0 } },
-    { kind: "line", from: { x: 0, y: -6 }, to: { x: 0, y: 6 } },
-  ],
+  primitives: plusStrokes(0),
 } satisfies SymbolDefinition;
 
 const annotationTextMinus = {
@@ -188,7 +185,7 @@ const annotationTextMinus = {
   id: "annotation-text-minus",
   name: "Minus sign",
   viewBox: { x: -12, y: -12, width: 24, height: 24 },
-  primitives: [{ kind: "line", from: { x: -6, y: 0 }, to: { x: 6, y: 0 } }],
+  primitives: minusStrokes(0),
 } satisfies SymbolDefinition;
 
 /**

--- a/apps/editor/src/features/component-insert/component-insert-request.ts
+++ b/apps/editor/src/features/component-insert/component-insert-request.ts
@@ -33,18 +33,6 @@ export interface PolarityAnnotationInsertRequest {
   initialRotation: 0 | 90 | 180 | 270;
 }
 
-/**
- * A drafting text placed with its content already decided — the standalone
- * "+" and "−" signs. Ordinary text afterwards: independently movable,
- * editable, and stylable like any other DraftText.
- */
-export interface PresetTextInsertRequest {
-  kind: "preset-text";
-  symbolId: string;
-  symbolName: string;
-  text: string;
-}
-
 export interface CellInsertRequest {
   kind: "cell";
   symbolId: string;
@@ -77,5 +65,4 @@ export type ComponentInsertRequest =
   | ExternalSubcircuitInsertRequest
   | VddRailInsertRequest
   | DrawingToolInsertRequest
-  | PolarityAnnotationInsertRequest
-  | PresetTextInsertRequest;
+  | PolarityAnnotationInsertRequest;

--- a/apps/editor/src/features/component-insert/component-placement-preview.tsx
+++ b/apps/editor/src/features/component-insert/component-placement-preview.tsx
@@ -3,7 +3,6 @@ import { renderSymbolDefinitionBody } from "@icm/render-svg";
 import type { SymbolDefinition } from "@icm/symbols";
 
 import { defaultRazaviSymbolVariantId } from "../../presentation/razavi-presentation";
-import { annotationPresetText } from "./annotation-preview-symbols";
 import { findPaletteSymbol } from "./symbol-catalog";
 import { renderSymbolPreviewPinNames } from "./symbol-artwork";
 
@@ -26,31 +25,6 @@ export function ComponentPlacementPreview({
 }: ComponentPlacementPreviewProps) {
   const definition = symbol ?? findPaletteSymbol(styleProfileId, symbolId);
   if (!definition) return null;
-  const presetText = annotationPresetText(symbolId);
-  if (presetText) {
-    // WYSIWYG: a preset sign lands as an ordinary drafting text, so its ghost
-    // is that exact glyph — same font, size, and baseline-at-cursor placement
-    // the drafting renderer commits — not the palette's vector sketch.
-    return (
-      <g
-        data-testid="component-placement-preview"
-        className="component-placement-preview"
-        transform={`translate(${position.x} ${position.y}) rotate(${rotation})`}
-      >
-        <text
-          x={0}
-          y={0}
-          textAnchor="middle"
-          fill="currentColor"
-          stroke="none"
-          fontSize={razaviTextbookProfile.typography.annotationFontSize}
-          style={{ fontFamily: razaviTextbookProfile.typography.fontFamily }}
-        >
-          {presetText}
-        </text>
-      </g>
-    );
-  }
   const variantId = defaultRazaviSymbolVariantId(definition.id);
   const variant = definition.variants.find(
     (candidate) => candidate.id === variantId,

--- a/apps/editor/src/features/component-insert/insert-component-dialog.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.tsx
@@ -6,7 +6,6 @@ import { initialComponentParameterValues } from "./component-parameters";
 import {
   annotationDrawingTool,
   annotationPolarity,
-  annotationPresetText,
 } from "./annotation-preview-symbols";
 import { componentCatalog, libraryDisplayName } from "./symbol-catalog";
 import type { ComponentInsertRequest } from "./component-insert-request";
@@ -266,17 +265,6 @@ export function InsertComponentDialog({
         symbolName: choice.symbol.name,
         polarity,
         initialRotation: 0,
-      });
-      return;
-    }
-    const presetText =
-      choice.kind === "symbol" ? annotationPresetText(symbolId) : undefined;
-    if (presetText) {
-      onApply({
-        kind: "preset-text",
-        symbolId,
-        symbolName: choice.symbol.name,
-        text: presetText,
       });
       return;
     }

--- a/apps/editor/src/features/component-insert/use-component-placement.ts
+++ b/apps/editor/src/features/component-insert/use-component-placement.ts
@@ -609,10 +609,13 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
   ): void => {
     if (
       placementRequest.kind !== "drafting-text" ||
-      (!placementRequest.polarity && !placementRequest.presetText)
+      !placementRequest.polarity
     ) {
       return;
     }
+    // A lone + or − has no centre to write in, so it lands as the canonical
+    // empty document — the same shape an emptied polarity label keeps.
+    const bare = placementRequest.polarity !== "both";
     let id = options.nextId("polarity");
     while (
       options.document.drafting?.objects.some((object) => object.id === id)
@@ -625,7 +628,9 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       locked: false,
       zIndex: 0,
       anchor: { kind: "free", position },
-      content: defaultDraftTextDocument(placementRequest.presetText ?? "V_x"),
+      content: bare
+        ? { runs: [{ kind: "line-break" as const }] }
+        : defaultDraftTextDocument("V_x"),
       alignment: "middle",
       rotation: options.componentPlacementRotation,
       typographyToken: "label",
@@ -638,16 +643,13 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     }
     options.cancelAllTransientInteraction();
     options.selectOnly("drafting", [object.id]);
-    if (placementRequest.polarity) {
-      // Polarity labels open for center-text editing right away; a preset
-      // sign is already its final content and stays placed as-is.
-      options.beginDraftingTextEditing(object);
-      options.setStatus(
-        `Added ${placementRequest.polarity} polarity annotation`,
-      );
-    } else {
-      options.setStatus(`Added ${placementRequest.presetText} text`);
+    if (bare) {
+      options.setStatus(`Added ${placementRequest.polarity} polarity mark`);
+      return;
     }
+    // A pair brackets a name, so it opens for that name straight away.
+    options.beginDraftingTextEditing(object);
+    options.setStatus(`Added ${placementRequest.polarity} polarity annotation`);
   };
 
   const openInsertPicker = ({
@@ -712,39 +714,25 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
             showValue: false,
             polarity: request.polarity,
           }
-        : request.kind === "preset-text"
+        : request.kind === "symbol" &&
+            (request.symbolId === "port" || request.symbolId === "port-filled")
           ? {
-              kind: "drafting-text",
+              kind: "cell-pin",
               symbolId: request.symbolId,
               parameters: {},
-              initialRotation: 0,
+              initialRotation: request.initialRotation,
               showReference: false,
               referenceText: null,
               showValue: false,
-              presetText: request.text,
+              direction: request.portDirection ?? "passive",
+              ...(request.portName ? { portName: request.portName } : {}),
             }
-          : request.kind === "symbol" &&
-              (request.symbolId === "port" ||
-                request.symbolId === "port-filled")
-            ? {
-                kind: "cell-pin",
-                symbolId: request.symbolId,
-                parameters: {},
-                initialRotation: request.initialRotation,
-                showReference: false,
-                referenceText: null,
-                showValue: false,
-                direction: request.portDirection ?? "passive",
-                ...(request.portName ? { portName: request.portName } : {}),
-              }
-            : request;
+          : request;
     options.beginComponentPlacement(pendingRequest);
     options.setStatus(
       request.kind === "polarity-annotation"
         ? `Place ${request.symbolName} on the canvas · R rotates · Esc cancels`
-        : request.kind === "preset-text"
-          ? `Place ${request.symbolName} on the canvas · Esc cancels`
-          : `Place ${request.symbolName} on the canvas · R rotates · Shift+R / Ctrl+R mirrors · Esc cancels`,
+        : `Place ${request.symbolName} on the canvas · R rotates · Shift+R / Ctrl+R mirrors · Esc cancels`,
     );
   };
 

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -137,19 +137,23 @@ describe("shapes quick-place", () => {
       polarity: "both",
       initialRotation: 0,
     });
-    // Standalone signs are preset texts, not polarity variants; the single
-    // sign-with-text forms left the palette entirely.
+    // A standalone sign is the same mark the pair draws, so it goes through
+    // the same polarity placement; as a preset text glyph it came out a
+    // different size beside the pair. The sign-with-text forms left the
+    // palette entirely.
     expect(quickPlaceRequest("razavi", "annotation-text-plus")).toEqual({
-      kind: "preset-text",
+      kind: "polarity-annotation",
       symbolId: "annotation-text-plus",
       symbolName: "Plus sign",
-      text: "+",
+      polarity: "positive",
+      initialRotation: 0,
     });
     expect(quickPlaceRequest("razavi", "annotation-text-minus")).toEqual({
-      kind: "preset-text",
+      kind: "polarity-annotation",
       symbolId: "annotation-text-minus",
       symbolName: "Minus sign",
-      text: "−",
+      polarity: "negative",
+      initialRotation: 0,
     });
     expect(quickPlaceRequest("razavi", "annotation-polarity-positive")).toBe(
       null,

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -10,7 +10,6 @@ import { initialComponentParameterValues } from "../component-insert/component-p
 import {
   annotationDrawingTool,
   annotationPolarity,
-  annotationPresetText,
 } from "../component-insert/annotation-preview-symbols";
 import {
   componentCatalog,
@@ -106,15 +105,6 @@ export function quickPlaceRequest(
       symbolName: symbol.name,
       polarity,
       initialRotation: 0,
-    };
-  }
-  const presetText = annotationPresetText(symbolId);
-  if (presetText) {
-    return {
-      kind: "preset-text",
-      symbolId,
-      symbolName: symbol.name,
-      text: presetText,
     };
   }
   if (symbolId === "vdd") {

--- a/apps/editor/src/interaction/interaction-state.ts
+++ b/apps/editor/src/interaction/interaction-state.ts
@@ -49,7 +49,6 @@ export interface PendingComponentPlacement {
   direction?: "input" | "output" | "inout" | "passive";
   polarity?: "both" | "positive" | "negative";
   /** Fixed initial content for a preset drafting text ("+", "−"). */
-  presetText?: string;
   /** Existing unplaced Instance being returned from the Placement Tray. */
   instanceId?: string;
 }


### PR DESCRIPTION
> 这个符号的单独的时候，大小和那个组合元件不一样

## Why they could never match

Two different machineries drew them:

| | how it was drawn | result |
| --- | --- | --- |
| the pair's `+` / `−` | two **strokes**, half-arm `fontSize * 0.23`, annotation stroke weight | span **6.95**, stroke **1.6** |
| a standalone `+` | an ordinary DraftText whose content was `"+"` | whatever **the font** draws for that character |

A glyph's width and stroke are the typeface's business, so no amount of tuning would have made the two agree — and the mismatch is exactly what the screenshot shows.

## The fix was already half-built

`PolarityAnnotationKind` already had `positive` and `negative`, and an emptied polarity centre was already supported as the canonical empty document (`text-editing.ts`: *"An emptied polarity centre persists as the canonical empty document"*). The standalone signs simply never used any of it.

A lone sign now lands as **a polarity mark with no centre**, which is what it actually is. It measures identically to the pair's mark *by construction*, not by tuning.

Placing one no longer opens the text editor — there is no centre to write in — while the pair still opens for the name it brackets.

## Cleanup that follows

The whole `preset-text` placement path existed only for these two palette entries, so it retires with them: the request type, the branch in the insert dialog, the branch in the shapes panel, the ghost's special case, and the `presetText` field on the pending placement. The palette chips now draw `plusStrokes` / `minusStrokes`, the same helpers the pair's chip uses, so the chip shows the shape you get.

## Validation

- Full unit suite: **1635 passed** (3 new, asserting the two arm spans are equal and that a lone sign emits exactly its own mark)
- Driven in the running editor: pair `positive-horizontal` span **6.9534** @ stroke 1.6, lone `+` span **6.9534** @ stroke 1.6 — identical
- Typecheck, Prettier

Two expectations asserted the retired behaviour and now assert the new one, each with the reason recorded beside it: the shapes-panel request shape, and the Annotations e2e, which previously required the sign to be a draft text with no polarity containing the character. That e2e now measures the lone mark's arm against the pair's — the property the report was actually about.

A correction on my first pass of this PR: I reported the two annotation specs as passing before pushing. They were run before the change reached the dev server, and the Annotations case does fail against the old expectation — CI caught it. The assertion is updated and re-run.

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)