### PR TITLE
fix(edit-engine): scope physical-contact bonding and transform gates

### DIFF
--- a/apps/editor/src/features/selection/pin-attach-move.test.ts
+++ b/apps/editor/src/features/selection/pin-attach-move.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Regression: pin-onto-wire move snap must commit even when the snap
+ * projection carries float dust. The attach edit takes the endpoint's own
+ * grid-exact contact point, never the raw projection (audit finding #3).
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  createRoutePath,
+  type RouteEndpoint,
+  type SchematicDocument,
+} from "@icm/model";
+import { parseProject } from "@icm/project-protocol";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import {
+  createRoutingOperationPlan,
+  executeTransaction,
+  gateRoutingOperationPlan,
+  type RoutingOperationIntent,
+  type SchematicEdit,
+} from "@icm/edit-engine";
+import { resolveEndpointConnection } from "@icm/derived";
+import { describe, expect, it } from "vitest";
+
+import { createSelectionMoveController } from "./selection-move-controller";
+import { planSelectionMove } from "./selection-move-plan";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+const terminal = (instanceId: string): RouteEndpoint => ({
+  kind: "terminal",
+  instanceId,
+  pinName: "P",
+});
+
+function fixtureDocument(): SchematicDocument {
+  const document = parseProject(
+    readFileSync(
+      resolve(
+        process.cwd(),
+        "fixtures/projects/phase-3-routing/project.icproj.json",
+      ),
+      "utf8",
+    ),
+  ).documents[0]!;
+  // Reposition ports so route-h spans exactly (0,300) -> (110,300):
+  // port pin "P" is at local (10,0); A mirror none -> contact (pos.x+10, y),
+  // B mirror x -> contact (pos.x-10, y).
+  document.instances.find((i) => i.id === "A")!.placement = {
+    position: { x: -10, y: 300 },
+    rotation: 0,
+    mirror: "none",
+  };
+  document.instances.find((i) => i.id === "B")!.placement = {
+    position: { x: 120, y: 300 },
+    rotation: 0,
+    mirror: "x",
+  };
+  // E: rotation 270 puts its pin contact at (pos.x, pos.y-10), outward north.
+  document.instances.find((i) => i.id === "E")!.placement = {
+    position: { x: 30, y: 400 },
+    rotation: 270,
+    mirror: "none",
+  };
+  return document;
+}
+
+function routedDocument(): SchematicDocument {
+  const document = fixtureDocument();
+  const result = executeTransaction(
+    document,
+    {
+      transactionId: "seed-route-h",
+      documentId: document.id,
+      expectedRevision: 0,
+      actor: { kind: "human", id: "test" },
+      edits: [
+        {
+          kind: "set_route_path",
+          route: createRoutePath({
+            id: "route-h",
+            netId: "net-h",
+            start: terminal("A"),
+            end: terminal("B"),
+            bends: [],
+            modes: ["manual"],
+          }),
+        },
+      ],
+    },
+    { symbolResolver: resolver },
+  );
+  if (!result.ok) throw new Error(`seed failed: ${result.error.message}`);
+  return result.document;
+}
+
+function runMove(targetX: number) {
+  const document = routedDocument();
+  const statuses: string[] = [];
+  const transactions: {
+    intent: RoutingOperationIntent;
+    edits: readonly SchematicEdit[];
+    gateMessage?: string;
+    result?: ReturnType<typeof executeTransaction>;
+  }[] = [];
+  const transactConnectivity = (
+    intent: RoutingOperationIntent,
+    edits: readonly SchematicEdit[],
+  ) => {
+    const record: (typeof transactions)[number] = { intent, edits };
+    transactions.push(record);
+    const proposal = createRoutingOperationPlan(document, {
+      intent,
+      edits,
+      diagnostics: [],
+    });
+    const gate = gateRoutingOperationPlan(document, proposal, {
+      symbolResolver: resolver,
+    });
+    if (!gate.ok) {
+      record.gateMessage = gate.message;
+      statuses.push(gate.message);
+      return null;
+    }
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "move-commit",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: [...gate.edits],
+      },
+      { symbolResolver: resolver },
+    );
+    record.result = result;
+    if (!result.ok)
+      statuses.push(`${result.error.code}: ${result.error.message}`);
+    return { ok: result.ok };
+  };
+  const controller = createSelectionMoveController({
+    document,
+    resolver,
+    visibleEndpoints: [],
+    routeGeometryRecords: [],
+    contactComponents: [],
+    transactConnectivity,
+    setStatus: (status) => statuses.push(status),
+    nextRoutingSuffix: () => 1,
+  });
+  const movePlan = planSelectionMove(document, {
+    instanceIds: ["E"],
+    routeIds: [],
+    junctionIds: [],
+    annotationIds: [],
+    draftingIds: [],
+  });
+  const preview = {
+    instanceIds: movePlan.instanceIds,
+    primaryInstanceId: "E",
+    originalPositions: { E: { x: 30, y: 400 } },
+    pointerStart: { x: 500, y: 500 },
+    movePlan,
+  };
+  // Raw pointer lands so the moved pin contact is exactly (targetX, 294.3):
+  // pin contact starts at (30, 390); rawDelta = (targetX-30, -95.7).
+  const position = { x: 500 + (targetX - 30), y: 500 - 95.7 };
+  const tolerance = 7;
+  const resolved = controller.resolveInstanceMove(
+    preview,
+    position,
+    tolerance,
+    false,
+    undefined,
+    document,
+  );
+  controller.completeInstanceMove(
+    preview,
+    position,
+    tolerance,
+    false,
+    resolved.snap,
+    {
+      document,
+      prefixEdits: [],
+      resolvedMove: resolved,
+    },
+  );
+  return { document, resolved, statuses, transactions };
+}
+
+describe("pin-onto-wire move snap float dust", () => {
+  it("dusty lattice point: the attach uses the pin's exact contact and commits", () => {
+    const { resolved, statuses, transactions } = runMove(30);
+    // The electrical route match engages on a float-dusted projection...
+    expect(resolved.snap.electricalMatch?.target.electrical?.kind).toBe(
+      "route",
+    );
+    const targetPoint = resolved.snap.electricalMatch!.target.point;
+    expect(targetPoint.y).toBe(300);
+    expect(Math.abs(targetPoint.x - 30)).toBeLessThan(1e-9);
+    // ...but the committed attach point is the endpoint's grid-exact contact,
+    // and the whole move applies instead of dying on the integer schema.
+    const attach = transactions
+      .flatMap((t) => t.edits)
+      .find((edit) => edit.kind === "attach_endpoint_to_route");
+    expect(attach).toBeDefined();
+    expect((attach as { point: { x: number; y: number } }).point).toEqual({
+      x: 30,
+      y: 300,
+    });
+    expect(transactions.some((t) => t.result?.ok)).toBe(true);
+    expect(statuses.some((s) => s.includes("Snapped pin endpoints"))).toBe(
+      true,
+    );
+  });
+
+  it("clean lattice point: identical gesture commits and splits the route", () => {
+    const { resolved, statuses, transactions } = runMove(40);
+    expect(resolved.snap.electricalMatch?.target.electrical?.kind).toBe(
+      "route",
+    );
+    expect(resolved.snap.electricalMatch!.target.point.x).toBe(40);
+    const applied = transactions.some((t) => t.result?.ok);
+    expect(applied).toBe(true);
+    expect(statuses.some((s) => s.includes("Snapped pin endpoints"))).toBe(
+      true,
+    );
+  });
+});

--- a/apps/editor/src/features/selection/selection-move-controller.ts
+++ b/apps/editor/src/features/selection/selection-move-controller.ts
@@ -470,15 +470,30 @@ export function createSelectionMoveController({
         );
         if (instance?.placement) instance.placement.position = move.position;
       }
-      const contactEdits: readonly SchematicEdit[] =
+      // The snap target point is a float projection and can carry dust
+      // (29.999999999999996) that the integer Point schema rejects, killing
+      // the whole move at release. The endpoint's own resolved contact point
+      // in the projected document is grid-exact by construction — attach
+      // there, exactly like placement does.
+      const attachContact =
         movingElectrical?.kind === "endpoint" &&
         targetElectrical?.kind === "route"
+          ? resolveEndpointConnection(
+              projected,
+              resolver,
+              movingElectrical.endpoint,
+            )
+          : null;
+      const contactEdits: readonly SchematicEdit[] =
+        movingElectrical?.kind === "endpoint" &&
+        targetElectrical?.kind === "route" &&
+        attachContact
           ? proposeEndpointRouteAttachment(
               projected,
               movingElectrical.endpoint,
               movingElectrical.netId,
               targetElectrical.routeId,
-              electricalMatch!.target.point,
+              attachContact.contactPoint,
               targetElectrical.segmentIndex,
               `move-${nextRoutingSuffix()}`,
             ).edits

--- a/packages/edit-engine/src/direct-contact-lifecycle.test.ts
+++ b/packages/edit-engine/src/direct-contact-lifecycle.test.ts
@@ -110,6 +110,35 @@ describe("direct-contact transform lifecycle", () => {
     );
   });
 
+  it("materializes a Route when alignment pulls a direct contact apart", () => {
+    // align_instances rewrites placements exactly like move_instance, so the
+    // direct-contact reconcile gate must run for it too (audit finding #2).
+    // Aligning both bodies to x=200 moves the mirrored pins in opposite
+    // directions: A.P lands at (210,300), B.P at (190,300).
+    const document = fixture();
+    const result = executeTransaction(
+      document,
+      transaction(document, [
+        {
+          kind: "align_instances",
+          instanceIds: ["A", "B"],
+          axis: "x",
+          coordinate: 200,
+        },
+      ]),
+      context,
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.document.routes).toHaveLength(1);
+    const route = result.document.routes[0]!;
+    expect(route.netId).toBe("net-contact");
+    expect(
+      new Set([endpointKey(route.start), endpointKey(routeEnd(route))]),
+    ).toEqual(
+      new Set([endpointKey(terminal("A")), endpointKey(terminal("B"))]),
+    );
+  });
+
   it("keeps a jointly moved direct contact route-free", () => {
     const document = fixture();
     const result = executeTransaction(

--- a/packages/edit-engine/src/physical-contact-license.test.ts
+++ b/packages/edit-engine/src/physical-contact-license.test.ts
@@ -1,0 +1,255 @@
+import { createRoutePath } from "@icm/model";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import type { RouteEndpoint, SchematicDocument } from "@icm/model";
+import { parseProject } from "@icm/project-protocol";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { executeTransaction } from "./transaction.js";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+const context = { symbolResolver: resolver };
+
+function transaction(
+  document: SchematicDocument,
+  edits: unknown[],
+  suffix = "edit",
+) {
+  return {
+    transactionId: `contact-license-${suffix}-${document.revision}`,
+    documentId: document.id,
+    expectedRevision: document.revision,
+    actor: { kind: "human" as const, id: "contact-license-test" },
+    edits,
+  };
+}
+
+/**
+ * A conductor on net-1 from A.P (150,300) to B.P (450,300), with a foreign
+ * Junction J2 (net-2) parked on its interior — visually coincident but
+ * electrically separate, exactly like a Crossing. Every test then runs a
+ * licensed contact elsewhere on the conductor and asserts J2 stays foreign.
+ */
+function fixture(options: {
+  keepInstances: readonly string[];
+  parkedJunctionX: number;
+}): SchematicDocument {
+  const document = parseProject(
+    readFileSync(
+      resolve(
+        process.cwd(),
+        "fixtures/projects/phase-3-routing/project.icproj.json",
+      ),
+      "utf8",
+    ),
+  ).documents[0]!;
+  document.instances = document.instances.filter((instance) =>
+    options.keepInstances.includes(instance.id),
+  );
+  const wireMembers = options.keepInstances.filter((id) =>
+    ["A", "B", "E"].includes(id),
+  );
+  document.nets = [
+    {
+      id: "net-1",
+      terminals: wireMembers.map((instanceId) => ({
+        instanceId,
+        pinName: "P",
+      })),
+    },
+    { id: "net-2", terminals: [] },
+  ];
+  document.junctions = [
+    {
+      id: "J2",
+      netId: "net-2",
+      position: { x: options.parkedJunctionX, y: 300 },
+    },
+  ];
+  document.netlist!.terminals = options.keepInstances
+    .filter((id) => id !== "RX")
+    .map((instanceId) => ({
+      id: `cell-terminal-${instanceId.toLowerCase()}`,
+      name: instanceId,
+      netId: instanceId === "D" ? "net-3" : "net-1",
+      direction: "passive" as const,
+      interfaceInstanceIds: [instanceId],
+    }));
+  if (options.keepInstances.includes("D")) {
+    document.nets.push({
+      id: "net-3",
+      terminals: [{ instanceId: "D", pinName: "P" }],
+    });
+    document.instances.find((instance) => instance.id === "D")!.placement = {
+      position: { x: 240, y: 340 },
+      rotation: 0,
+      mirror: "none",
+    };
+  }
+  if (options.keepInstances.includes("E")) {
+    document.instances.find((instance) => instance.id === "E")!.placement = {
+      position: { x: 250, y: 310 },
+      rotation: 270,
+      mirror: "none",
+    };
+  }
+  document.connectivityEvidence = [];
+  const seeded = executeTransaction(
+    document,
+    transaction(
+      document,
+      [
+        {
+          kind: "set_route_path",
+          route: createRoutePath({
+            id: "route-h",
+            netId: "net-1",
+            start: { kind: "terminal", instanceId: "A", pinName: "P" },
+            end: { kind: "terminal", instanceId: "B", pinName: "P" },
+            bends: [],
+            modes: ["manual"],
+          }),
+        },
+      ],
+      "seed",
+    ),
+    context,
+  );
+  if (!seeded.ok) throw new Error(seeded.error.message);
+  return seeded.document;
+}
+
+function attachEdit(
+  document: SchematicDocument,
+  endpoint: RouteEndpoint,
+  firstRouteId: string,
+): unknown {
+  const route = document.routes.find(
+    (candidate) => candidate.id === "route-h",
+  )!;
+  return {
+    kind: "attach_endpoint_to_route",
+    endpoint,
+    routeId: "route-h",
+    point: { x: 250, y: 300 },
+    legId: route.legs[0]!.id,
+    firstRouteId,
+    secondRouteId: "route-h-b",
+  };
+}
+
+function junctionNetIds(document: SchematicDocument): Record<string, string> {
+  return Object.fromEntries(
+    document.junctions.map((junction) => [junction.id, junction.netId]),
+  );
+}
+
+describe("physical contact license", () => {
+  it("keeps a typed attach from bonding the rest of the conductor, regardless of split ID reuse", () => {
+    const endpoint: RouteEndpoint = {
+      kind: "terminal",
+      instanceId: "E",
+      pinName: "P",
+    };
+    // Same attach twice: once with a fresh first-half ID, once reusing the
+    // original Route ID for the first half. The parked foreign Junction sits
+    // on the first half either way; which ID string the caller picked must
+    // not change the electrical outcome (audit finding #1).
+    for (const firstRouteId of ["route-h-a", "route-h"]) {
+      const document = fixture({
+        keepInstances: ["A", "B", "E"],
+        parkedJunctionX: 200,
+      });
+      const result = executeTransaction(
+        document,
+        transaction(
+          document,
+          [attachEdit(document, endpoint, firstRouteId)],
+          firstRouteId,
+        ),
+        context,
+      );
+      if (!result.ok) throw new Error(result.error.message);
+      expect(junctionNetIds(result.document)).toEqual({ J2: "net-2" });
+      expect(result.document.nets.map((net) => net.id).sort()).toEqual([
+        "net-1",
+        "net-2",
+      ]);
+    }
+  });
+
+  it("does not license the split products of a Junction-forced split", () => {
+    // Adding J1 on the interior licenses J1 alone; the split it forces must
+    // not open the conductor's far half to the parked foreign Junction J2.
+    const document = fixture({
+      keepInstances: ["A", "B"],
+      parkedJunctionX: 350,
+    });
+    const result = executeTransaction(
+      document,
+      transaction(document, [
+        {
+          kind: "add_junction",
+          junctionId: "J1",
+          netId: "net-1",
+          position: { x: 250, y: 300 },
+        },
+      ]),
+      context,
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    expect(junctionNetIds(result.document)).toEqual({
+      J1: "net-1",
+      J2: "net-2",
+    });
+    expect(result.document.nets.map((net) => net.id).sort()).toEqual([
+      "net-1",
+      "net-2",
+    ]);
+  });
+
+  it("licenses only the attached pin, not the instance's other pins", () => {
+    // RX pin 1 attaches at (250,300); RX pin 2 is parked exactly on port D's
+    // pin at (250,340). The attach names pin 1 only, so pin 2 must stay off
+    // D's net.
+    const document = fixture({
+      keepInstances: ["A", "B", "D"],
+      parkedJunctionX: 200,
+    });
+    document.instances.push({
+      id: "RX",
+      symbolId: "resistor",
+      placement: {
+        position: { x: 250, y: 320 },
+        rotation: 0,
+        mirror: "none",
+      },
+    });
+    const result = executeTransaction(
+      document,
+      transaction(document, [
+        attachEdit(
+          document,
+          { kind: "terminal", instanceId: "RX", pinName: "1" },
+          "route-h-a",
+        ),
+      ]),
+      context,
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    const netOf = (pinName: string) =>
+      result.document.nets.find((net) =>
+        net.terminals.some(
+          (candidate) =>
+            candidate.instanceId === "RX" && candidate.pinName === pinName,
+        ),
+      )?.id ?? null;
+    expect(netOf("1")).toBe("net-1");
+    expect(netOf("2")).toBeNull();
+    expect(
+      result.document.nets.find((net) => net.id === "net-3")!.terminals,
+    ).toEqual([{ instanceId: "D", pinName: "P" }]);
+  });
+});

--- a/packages/edit-engine/src/transaction-connectivity-normalizer.ts
+++ b/packages/edit-engine/src/transaction-connectivity-normalizer.ts
@@ -9,6 +9,10 @@ import {
 } from "@icm/derived";
 import type { SymbolResolver } from "@icm/symbols";
 
+import {
+  physicalContactPointKey,
+  type PhysicalContactLicense,
+} from "./transaction-connectivity.js";
 import { endpointOwnerNetId } from "./transaction-routing.js";
 
 export type PhysicalContactOperation =
@@ -71,17 +75,20 @@ function visibleEndpoints(
  * The transaction applies it and asks again, so route splits and Net merges
  * are always evaluated against fresh geometry instead of stale segment IDs.
  *
- * Only contacts incident to an object changed by the transaction are
- * normalized. Route-interior crossings are deliberately absent. This module
- * handles direct endpoint contacts and explicit Junction-on-route contacts;
- * snapped pin-to-route attachment remains a typed gesture intent.
+ * Only contacts the transaction licensed are normalized. Route-interior
+ * crossings are deliberately absent. This module handles direct endpoint
+ * contacts and explicit Junction-on-route contacts; snapped pin-to-route
+ * attachment remains a typed gesture intent.
  */
 export function nextPhysicalContactOperation(
   document: SchematicDocument,
   resolver: SymbolResolver,
-  changedObjectIds: ReadonlySet<string>,
+  license: PhysicalContactLicense,
   suppressedEndpointKeys: ReadonlySet<string> = new Set(),
 ): PhysicalContactOperation | null {
+  const endpointLicensed = (endpoint: RouteEndpoint): boolean =>
+    license.objectIds.has(endpointObjectId(endpoint)) ||
+    license.endpointKeys.has(endpointKey(endpoint));
   const endpoints = visibleEndpoints(document, resolver).filter(
     (endpoint) => !suppressedEndpointKeys.has(endpointKey(endpoint)),
   );
@@ -104,8 +111,8 @@ export function nextPhysicalContactOperation(
       const right = positioned[rightIndex]!;
       if (!samePoint(left.point, right.point)) continue;
       if (
-        !changedObjectIds.has(endpointObjectId(left.endpoint)) &&
-        !changedObjectIds.has(endpointObjectId(right.endpoint))
+        !endpointLicensed(left.endpoint) &&
+        !endpointLicensed(right.endpoint)
       ) {
         continue;
       }
@@ -128,7 +135,7 @@ export function nextPhysicalContactOperation(
     // by contrast, are explicit topology objects: a Junction on a conductor
     // is unambiguously a physical contact and is normalized here.
     if (endpoint.kind !== "junction") continue;
-    const endpointChanged = changedObjectIds.has(endpointObjectId(endpoint));
+    const junctionLicensed = endpointLicensed(endpoint);
     for (const address of findRouteSegmentsAtPoint(geometry, point)) {
       const route = document.routes.find(
         (candidate) => candidate.id === address.routeId,
@@ -146,7 +153,14 @@ export function nextPhysicalContactOperation(
       // that lead can short pins inside the symbol and destabilize the Route
       // whenever the symbol moves.
       if (segment.mode === "escape") continue;
-      if (!endpointChanged && !changedObjectIds.has(route.id)) continue;
+      // A wholesale license (introduced conductor) bonds anywhere along the
+      // Route; a typed attach only bonds at the exact point it named.
+      const routeLicensed =
+        license.objectIds.has(route.id) ||
+        license.routePoints
+          .get(route.id)
+          ?.has(physicalContactPointKey(point)) === true;
+      if (!junctionLicensed && !routeLicensed) continue;
       if (
         routeEndpoints(route).some(
           (candidate) => endpointKey(candidate) === endpointKey(endpoint),

--- a/packages/edit-engine/src/transaction-connectivity.ts
+++ b/packages/edit-engine/src/transaction-connectivity.ts
@@ -280,8 +280,7 @@ export function uniquePhysicalContactId(
 }
 
 /**
- * Objects whose exact endpoint contacts this transaction may normalize
- * into electrical connections.
+ * The contacts this transaction may normalize into electrical connections.
  *
  * Only geometry the transaction INTRODUCES bonds: a placed instance, an
  * explicit Junction, a drawn power rail, a typed attach. Moving,
@@ -290,34 +289,72 @@ export function uniquePhysicalContactId(
  * rejected by a merge it never asked for). A transform that parks pins
  * on foreign conductors leaves them visually coincident but electrically
  * separate, exactly like a Crossing.
+ *
+ * The license is deliberately tiered: introduced objects bond at every
+ * contact they make, but a typed attach names one endpoint and one exact
+ * conductor point, and bonds nothing beyond them — the instance's other
+ * pins and the rest of the conductor stay inert.
  */
-export function physicalContactObjectIdsForTransaction(
+export type PhysicalContactLicense = {
+  /** Objects the transaction introduces; every contact they make bonds. */
+  readonly objectIds: Set<string>;
+  /** Endpoints a typed attach names; only that pin or Junction bonds. */
+  readonly endpointKeys: Set<string>;
+  /** Exact conductor points a typed attach names, keyed by Route ID. */
+  readonly routePoints: Map<string, Set<string>>;
+};
+
+export function physicalContactPointKey(point: Point): string {
+  return `${point.x},${point.y}`;
+}
+
+function addLicensedRoutePoint(
+  license: PhysicalContactLicense,
+  routeId: string,
+  point: Point,
+): void {
+  const points = license.routePoints.get(routeId) ?? new Set<string>();
+  points.add(physicalContactPointKey(point));
+  license.routePoints.set(routeId, points);
+}
+
+export function physicalContactLicenseForTransaction(
   transaction: EditTransaction,
-): Set<string> {
-  const result = new Set<string>();
+): PhysicalContactLicense {
+  const result: PhysicalContactLicense = {
+    objectIds: new Set(),
+    endpointKeys: new Set(),
+    routePoints: new Map(),
+  };
   for (const edit of transaction.edits) {
     switch (edit.kind) {
       case "add_instance":
-        result.add(edit.instance.id);
+        result.objectIds.add(edit.instance.id);
         break;
       case "place_instance":
-        result.add(edit.instanceId);
+        result.objectIds.add(edit.instanceId);
         break;
       case "add_junction":
-        result.add(edit.junctionId);
+        result.objectIds.add(edit.junctionId);
         break;
       case "attach_endpoint_to_route":
-        result.add(
-          edit.endpoint.kind === "terminal"
-            ? edit.endpoint.instanceId
-            : edit.endpoint.junctionId,
-        );
-        result.add(edit.routeId);
+        result.endpointKeys.add(endpointKey(edit.endpoint));
+        // The attach splits the conductor at the named point; whether a
+        // caller reuses the original Route ID for a split product must not
+        // change what bonds, so the point is licensed under every ID the
+        // edit can leave it on.
+        for (const routeId of [
+          edit.routeId,
+          edit.firstRouteId,
+          edit.secondRouteId,
+        ]) {
+          addLicensedRoutePoint(result, routeId, edit.point);
+        }
         break;
       case "add_power_rail":
-        result.add(edit.routeId);
-        result.add(edit.startJunctionId);
-        result.add(edit.endJunctionId);
+        result.objectIds.add(edit.routeId);
+        result.objectIds.add(edit.startJunctionId);
+        result.objectIds.add(edit.endJunctionId);
         break;
     }
   }

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -39,7 +39,7 @@ import { applyRouteTopologyEdit } from "./transaction-route-topology.js";
 import { applyPresentationLayoutEdit } from "./transaction-presentation-layout.js";
 import {
   mergeBaseNets,
-  physicalContactObjectIdsForTransaction,
+  physicalContactLicenseForTransaction,
   preferredPhysicalMergeTarget,
   pruneUnreachableLocalNet,
   reconcileMaterializedMosBulkBindings,
@@ -160,7 +160,11 @@ export function executeTransaction(
       edit.kind === "rotate_instance" ||
       edit.kind === "mirror_instance"
         ? [edit.instanceId]
-        : [],
+        : // Alignment rewrites placements exactly like a move; leaving it out
+          // of the follow set let aligned instances shear their routes.
+          edit.kind === "align_instances"
+          ? edit.instanceIds
+          : [],
     ),
   );
   let geometryChanged = false;
@@ -481,7 +485,12 @@ export function executeTransaction(
       (edit) =>
         edit.kind === "move_instance" ||
         edit.kind === "rotate_instance" ||
-        edit.kind === "mirror_instance",
+        edit.kind === "mirror_instance" ||
+        // Any edit that rewrites a placement or junction position can pull a
+        // zero-length direct contact apart; alignment and junction moves were
+        // missing here, leaving invisible connectivity behind.
+        edit.kind === "align_instances" ||
+        edit.kind === "move_junction",
     )
   ) {
     const directContact = reconcileTransformDirectContacts(
@@ -501,8 +510,8 @@ export function executeTransaction(
     // Keep geometry incidence separate from the broader transaction diff.
     // Net merges retarget many Routes for bookkeeping, but that must not turn
     // an otherwise local edit into a whole-document geometry repair.
-    const physicalContactObjectIds =
-      physicalContactObjectIdsForTransaction(transaction);
+    const physicalContactLicense =
+      physicalContactLicenseForTransaction(transaction);
     const suppressedPhysicalEndpointKeys = new Set(
       transaction.edits.flatMap((edit) =>
         edit.kind === "disconnect_endpoint" ? [endpointKey(edit.endpoint)] : [],
@@ -522,7 +531,7 @@ export function executeTransaction(
       const operation = nextPhysicalContactOperation(
         draft,
         resolver,
-        physicalContactObjectIds,
+        physicalContactLicense,
         suppressedPhysicalEndpointKeys,
       );
       if (!operation) break;
@@ -708,8 +717,25 @@ export function executeTransaction(
         changedObjectIds.add(routeId);
         changedRouteIds.add(routeId);
       }
-      physicalContactObjectIds.add(split.first.id);
-      physicalContactObjectIds.add(split.second.id);
+      // Split products inherit only the license the split consumed: a
+      // conductor this transaction introduced stays licensed end to end,
+      // and a typed attach point stays licensed wherever it now lies — but
+      // a split forced by a licensed Junction must not open the rest of
+      // the conductor to unrelated parked geometry.
+      if (physicalContactLicense.objectIds.has(route.id)) {
+        physicalContactLicense.objectIds.add(split.first.id);
+        physicalContactLicense.objectIds.add(split.second.id);
+      }
+      const licensedPoints = physicalContactLicense.routePoints.get(route.id);
+      if (licensedPoints) {
+        for (const productId of [split.first.id, split.second.id]) {
+          const points =
+            physicalContactLicense.routePoints.get(productId) ??
+            new Set<string>();
+          for (const point of licensedPoints) points.add(point);
+          physicalContactLicense.routePoints.set(productId, points);
+        }
+      }
       changedObjectIds.add(route.netId);
       connectivityChanged = true;
       geometryChanged = true;


### PR DESCRIPTION
Batch 1 of the wire-transform audit remediation (findings #1–#3).

- **#3 float-dust attach**: selection-move commits now use the resolved endpoint contact point rather than the raw projected match point, so commits can't be rejected by the integer Point schema after long drags. Regression: `pin-attach-move.test.ts`.
- **#2 transform whitelists**: `align_instances` joins the route-follow set and (with `move_junction`) the direct-contact reconcile gate. Alignment no longer shears routes or leaves invisible zero-length connectivity. Regression: `direct-contact-lifecycle.test.ts`.
- **#1 bond accounting**: the physical-contact permission set becomes a tiered license — whole-object only for geometry the transaction introduces; typed attaches license exactly the named endpoint and conductor point; split products no longer inherit blanket permission. Parked foreign geometry stays separate, and Route-ID spelling can no longer change electrical outcome. Regression: `physical-contact-license.test.ts` (all three fail against the old semantics).

Validation: typecheck clean, full unit suite 1638/1638, manual-editor e2e 111/111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)