### PR TITLE
fix(edit-engine): a stretched wire meets both pins along their leads

### DIFF
--- a/packages/edit-engine/src/route-geometry-edit.ts
+++ b/packages/edit-engine/src/route-geometry-edit.ts
@@ -326,3 +326,71 @@ export function moveRouteSegment(
 }
 
 /** Adds an explicit orthogonal jog to the selected unprotected segment. */
+
+export type PinAxis = "horizontal" | "vertical" | null;
+
+/**
+ * The axis a pin's lead is drawn along, reported only when following it also
+ * carries the wire toward the other end. A pin whose lead points away from
+ * where the wire has to go needs an escape stub rather than a corner, which
+ * is beyond what a stretch may invent, so it reports no axis and leaves the
+ * heading to the fallback.
+ */
+export function usablePinAxis(
+  outward: Point | null,
+  self: Point,
+  other: Point,
+): PinAxis {
+  if (!outward) return null;
+  const toward =
+    (other.x - self.x) * outward.x + (other.y - self.y) * outward.y;
+  if (toward <= 0) return null;
+  if (outward.x !== 0 && outward.y === 0) return "horizontal";
+  if (outward.y !== 0 && outward.x === 0) return "vertical";
+  return null;
+}
+
+/**
+ * Bends that keep a stretched single segment meeting both pins along their
+ * own leads.
+ *
+ * A one-segment Route is adjacent to both endpoints at once, so it is the
+ * only shape where following the moved end can spoil the end that stayed
+ * put. A pin is drawn with its lead along the outward direction; a wire that
+ * arrives across that axis lands on the side of the symbol and runs over its
+ * artwork instead of meeting the lead. One corner can serve only one end, so
+ * pins whose axes are parallel get two corners and a crossbar between them.
+ * Either axis may be unusable — a Junction has no lead, and a lead pointing
+ * away from the other end cannot be followed — and then the usable one
+ * decides; with neither, the segment keeps its original heading.
+ */
+export function bridgeStretchedSegment(
+  from: Point,
+  to: Point,
+  fromAxis: PinAxis,
+  toAxis: PinAxis,
+  originallyVertical: boolean,
+  grid: number,
+): Point[] {
+  const snap = (value: number): number =>
+    grid > 0 ? Math.round(value / grid) * grid : value;
+  if (fromAxis === "vertical" && toAxis === "vertical") {
+    const crossbar = snap((from.y + to.y) / 2);
+    return [
+      { x: from.x, y: crossbar },
+      { x: to.x, y: crossbar },
+    ];
+  }
+  if (fromAxis === "horizontal" && toAxis === "horizontal") {
+    const crossbar = snap((from.x + to.x) / 2);
+    return [
+      { x: crossbar, y: from.y },
+      { x: crossbar, y: to.y },
+    ];
+  }
+  const leavesVertically =
+    fromAxis === "vertical" ||
+    toAxis === "horizontal" ||
+    (fromAxis === null && toAxis === null && originallyVertical);
+  return [leavesVertically ? { x: from.x, y: to.y } : { x: to.x, y: from.y }];
+}

--- a/packages/edit-engine/src/route-operations.ts
+++ b/packages/edit-engine/src/route-operations.ts
@@ -26,8 +26,11 @@ import {
   type ResolvedDocumentRoutingGeometry,
 } from "@icm/derived";
 import {
+  bridgeStretchedSegment,
   moveRouteSegment,
   normalizeRouteGeometry,
+  usablePinAxis,
+  type PinAxis,
   type RouteEditPath,
   type SegmentMode,
 } from "./route-geometry-edit.js";
@@ -248,6 +251,12 @@ function stretchRouteEndpoint(
   side: "from" | "to",
   originalPoint: Point,
   movedPoint: Point,
+  /**
+   * The leads of the Route's two endpoints, in Route order. Supplied where the
+   * caller knows them so a stretched single segment can meet both pins along
+   * their own leads instead of arriving across one of them.
+   */
+  leads?: { from: PinAxis; to: PinAxis; grid: number },
 ): void {
   const segmentMode = side === "from" ? modes[0] : modes.at(-1);
   if (protectedMode(segmentMode)) {
@@ -274,6 +283,25 @@ function stretchRouteEndpoint(
       ? movedPoint.x === neighbor.x
       : movedPoint.y === neighbor.y;
     if (stillAligned) return;
+    const modeIndex = side === "from" ? 0 : modes.length - 1;
+    const mode = modes[modeIndex]!;
+    if (leads) {
+      const bends = bridgeStretchedSegment(
+        points[0]!,
+        points[1]!,
+        leads.from,
+        leads.to,
+        originallyVertical,
+        leads.grid,
+      );
+      points.splice(1, 0, ...bends);
+      modes.splice(
+        0,
+        1,
+        ...new Array<SegmentMode>(bends.length + 1).fill(mode),
+      );
+      return;
+    }
     const insertIndex = side === "from" ? 1 : points.length - 1;
     points.splice(
       insertIndex,
@@ -282,8 +310,6 @@ function stretchRouteEndpoint(
         ? { x: neighbor.x, y: movedPoint.y }
         : { x: movedPoint.x, y: neighbor.y },
     );
-    const modeIndex = side === "from" ? 0 : modes.length - 1;
-    const mode = modes[modeIndex]!;
     modes.splice(modeIndex, 1, mode, mode);
     return;
   }
@@ -443,6 +469,19 @@ function smoothedBoundaryProposal(
   } else {
     candidates.push([a, { x: b.x, y: a.y }, b]);
     candidates.push([a, { x: a.x, y: b.y }, b]);
+    // One corner can only align with one of the two leads. Where both pins
+    // point along the same axis, every single-corner shape has to arrive
+    // across one of them and lay the wire over that symbol, so the two-corner
+    // shapes are offered as well and scored on the same terms.
+    const grid = smoothing.movedDocument.presentation.grid;
+    const between = (left: number, right: number): number =>
+      grid > 0
+        ? Math.round((left + right) / 2 / grid) * grid
+        : (left + right) / 2;
+    const crossbarY = between(a.y, b.y);
+    const crossbarX = between(a.x, b.x);
+    candidates.push([a, { x: a.x, y: crossbarY }, { x: b.x, y: crossbarY }, b]);
+    candidates.push([a, { x: crossbarX, y: a.y }, { x: crossbarX, y: b.y }, b]);
   }
 
   const escapeAxis = (connection: EndpointConnection): "x" | "y" | null =>
@@ -976,6 +1015,32 @@ export function proposeGroupStretch(
   return proposeGroupMove(document, resolver, moves).routes;
 }
 
+/**
+ * Lead axes for a Route whose whole body is one segment, read from the
+ * post-move document so the pins are where the drag left them. Longer Routes
+ * already turn before each pin and need no bridge.
+ */
+function stretchedSegmentLeads(
+  movedDocument: SchematicDocument,
+  resolver: SymbolResolver,
+  route: SchematicDocument["routes"][number],
+  pointCount: number,
+): { from: PinAxis; to: PinAxis; grid: number } | undefined {
+  if (pointCount !== 2) return undefined;
+  const from = resolveEndpointConnection(movedDocument, resolver, route.start);
+  const to = resolveEndpointConnection(
+    movedDocument,
+    resolver,
+    routeEnd(route),
+  );
+  if (!from || !to) return undefined;
+  return {
+    from: usablePinAxis(from.outward, from.contactPoint, to.contactPoint),
+    to: usablePinAxis(to.outward, to.contactPoint, from.contactPoint),
+    grid: movedDocument.presentation.grid,
+  };
+}
+
 export function proposeGroupMove(
   document: SchematicDocument,
   resolver: SymbolResolver,
@@ -1091,19 +1156,35 @@ export function proposeGroupMove(
     if (!original) throw new Error(`Route ${route.id} has unresolved geometry`);
     const points = original.points.map((point) => ({ ...point }));
     const modes = [...original.segmentModes];
+    const leads = stretchedSegmentLeads(
+      movedDocument,
+      resolver,
+      route,
+      original.points.length,
+    );
     if (resolvedFromDelta) {
       const from = original.points[0]!;
-      stretchRouteEndpoint(route.id, points, modes, "from", from, {
-        x: from.x + resolvedFromDelta.x,
-        y: from.y + resolvedFromDelta.y,
-      });
+      stretchRouteEndpoint(
+        route.id,
+        points,
+        modes,
+        "from",
+        from,
+        { x: from.x + resolvedFromDelta.x, y: from.y + resolvedFromDelta.y },
+        leads,
+      );
     }
     if (toDelta) {
       const to = original.points.at(-1)!;
-      stretchRouteEndpoint(route.id, points, modes, "to", to, {
-        x: to.x + toDelta.x,
-        y: to.y + toDelta.y,
-      });
+      stretchRouteEndpoint(
+        route.id,
+        points,
+        modes,
+        "to",
+        to,
+        { x: to.x + toDelta.x, y: to.y + toDelta.y },
+        leads,
+      );
     }
     proposals.set(
       route.id,

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -1228,11 +1228,17 @@ describe("routing Edit Engine", () => {
     const plan = proposeGroupMoveEdits(routed.document, resolver, [
       { instanceId: "A", position: { x: 160, y: 320 } },
     ]);
+    // B holds an east/west lead like A, so a single corner would have to turn
+    // up out of A's lead or in across B's. The crossbar keeps both ends on
+    // their own leads and leaves B's contact point where it was.
     expect(plan.preview.routes).toEqual([
       {
         routeId: "route-h",
-        waypoints: [{ x: 170, y: 300 }],
-        segmentModes: ["manual", "manual"],
+        waypoints: [
+          { x: 310, y: 320 },
+          { x: 310, y: 300 },
+        ],
+        segmentModes: ["manual", "manual", "manual"],
       },
     ]);
     const moved = executeTransaction(
@@ -1250,7 +1256,8 @@ describe("routing Edit Engine", () => {
       )?.centerline,
     ).toEqual([
       { x: 170, y: 320 },
-      { x: 170, y: 300 },
+      { x: 310, y: 320 },
+      { x: 310, y: 300 },
       { x: 450, y: 300 },
     ]);
   });
@@ -1477,9 +1484,13 @@ describe("routing Edit Engine", () => {
         resolver,
         moved.document.routes.find((route) => route.id === "route-h")!,
       )?.centerline,
+      // A and B both carry east/west leads, so the stretched segment leaves A
+      // along its lead and arrives at B along B's rather than turning up into
+      // B's side, which would have laid the wire across the port artwork.
     ).toEqual([
       { x: 170, y: 320 },
-      { x: 450, y: 320 },
+      { x: 310, y: 320 },
+      { x: 310, y: 300 },
       { x: 450, y: 300 },
     ]);
     expect(
@@ -1511,7 +1522,8 @@ describe("routing Edit Engine", () => {
       )?.centerline,
     ).toEqual([
       { x: 160, y: 330 },
-      { x: 450, y: 330 },
+      { x: 310, y: 330 },
+      { x: 310, y: 300 },
       { x: 450, y: 300 },
     ]);
     expect(
@@ -1544,7 +1556,8 @@ describe("routing Edit Engine", () => {
       )?.centerline,
     ).toEqual([
       { x: 160, y: 310 },
-      { x: 450, y: 310 },
+      { x: 310, y: 310 },
+      { x: 310, y: 300 },
       { x: 450, y: 300 },
     ]);
     expect(

--- a/packages/edit-engine/src/transaction-route-follow.test.ts
+++ b/packages/edit-engine/src/transaction-route-follow.test.ts
@@ -1,0 +1,255 @@
+import { createEmptyDocument, createRoutePath } from "@icm/model";
+import type { Point, RouteEndpoint } from "@icm/model";
+import { resolveRouteGeometry } from "@icm/derived";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { proposeGroupMoveEdits } from "./routing-planner.js";
+import { executeTransaction } from "./transaction.js";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+const context = { symbolResolver: resolver };
+
+const terminal = (instanceId: string, pinName: string): RouteEndpoint => ({
+  kind: "terminal",
+  instanceId,
+  pinName,
+});
+
+function transaction(documentId: string, revision: number, edits: unknown[]) {
+  return {
+    transactionId: `follow-${revision}`,
+    documentId,
+    expectedRevision: revision,
+    actor: { kind: "human" as const, id: "follow-test" },
+    edits,
+  };
+}
+
+/**
+ * One resistor over one transistor over two grounds, the shape a bias branch
+ * takes: every wire here runs straight down a pin's own lead.
+ */
+function branchFixture() {
+  const document = createEmptyDocument("follow", "Follow");
+  const place = (id: string, symbolId: string, x: number, y: number) => ({
+    kind: "add_instance" as const,
+    instance: {
+      id,
+      symbolId,
+      placement: { position: { x, y }, rotation: 0, mirror: "none" as const },
+    },
+  });
+  const built = executeTransaction(
+    document,
+    transaction(document.id, 0, [
+      place("R2", "resistor", 400, 300),
+      place("Q3", "npn", 400, 420),
+      place("GB", "ground", 280, 470),
+      place("GE", "ground", 400, 520),
+    ]),
+    context,
+  );
+  if (!built.ok) throw new Error("fixture instances rejected");
+  const wired = executeTransaction(
+    built.document,
+    transaction(document.id, 1, [
+      {
+        kind: "connect_endpoints",
+        from: terminal("R2", "2"),
+        to: terminal("Q3", "C"),
+        newNetId: "n-collector",
+      },
+      {
+        kind: "connect_endpoints",
+        from: terminal("Q3", "B"),
+        to: terminal("GB", "0"),
+        newNetId: "n-base",
+      },
+      {
+        kind: "connect_endpoints",
+        from: terminal("Q3", "E"),
+        to: terminal("GE", "0"),
+        newNetId: "n-emitter",
+      },
+      {
+        kind: "set_route_path",
+        route: createRoutePath({
+          id: "w-collector",
+          netId: "n-collector",
+          start: terminal("R2", "2"),
+          end: terminal("Q3", "C"),
+          bends: [],
+          modes: ["manual"],
+        }),
+      },
+      {
+        kind: "set_route_path",
+        route: createRoutePath({
+          id: "w-base",
+          netId: "n-base",
+          start: terminal("Q3", "B"),
+          end: terminal("GB", "0"),
+          bends: [{ x: 280, y: 420 }],
+          modes: ["manual", "manual"],
+        }),
+      },
+      {
+        kind: "set_route_path",
+        route: createRoutePath({
+          id: "w-emitter",
+          netId: "n-emitter",
+          start: terminal("Q3", "E"),
+          end: terminal("GE", "0"),
+          bends: [],
+          modes: ["manual"],
+        }),
+      },
+    ]),
+    context,
+  );
+  if (!wired.ok) throw new Error("fixture wiring rejected");
+  return wired.document;
+}
+
+function centerline(
+  document: ReturnType<typeof branchFixture>,
+  routeId: string,
+): readonly Point[] {
+  const route = document.routes.find((candidate) => candidate.id === routeId)!;
+  return resolveRouteGeometry(document, resolver, route)!.centerline;
+}
+
+describe("Route follow after an instance moves", () => {
+  it("meets both pins along their leads when one segment is stretched", () => {
+    const document = branchFixture();
+    expect(centerline(document, "w-collector")).toEqual([
+      { x: 400, y: 320 },
+      { x: 400, y: 390 },
+    ]);
+
+    const moved = executeTransaction(
+      document,
+      transaction(document.id, 2, [
+        {
+          kind: "move_instance",
+          instanceId: "Q3",
+          position: { x: 520, y: 420 },
+        },
+      ]),
+      context,
+    );
+    expect(moved.ok).toBe(true);
+    if (!moved.ok) return;
+
+    // Both pins face along the vertical axis, so a single corner would have to
+    // sacrifice one of them and run the wire into the side of that symbol.
+    // Two corners leave the resistor downward and arrive at the collector from
+    // above, which is where its lead points.
+    expect(centerline(moved.document, "w-collector")).toEqual([
+      { x: 400, y: 320 },
+      { x: 400, y: 360 },
+      { x: 520, y: 360 },
+      { x: 520, y: 390 },
+    ]);
+    expect(centerline(moved.document, "w-emitter")).toEqual([
+      { x: 520, y: 450 },
+      { x: 520, y: 480 },
+      { x: 400, y: 480 },
+      { x: 400, y: 510 },
+    ]);
+  });
+
+  it("leaves a route that already turns before its far pin alone", () => {
+    const document = branchFixture();
+    const moved = executeTransaction(
+      document,
+      transaction(document.id, 2, [
+        {
+          kind: "move_instance",
+          instanceId: "Q3",
+          position: { x: 520, y: 420 },
+        },
+      ]),
+      context,
+    );
+    expect(moved.ok).toBe(true);
+    if (!moved.ok) return;
+    // The base wire already turns down into the ground, so following the base
+    // pin only stretches its own leg and the ground keeps its approach.
+    expect(centerline(moved.document, "w-base")).toEqual([
+      { x: 480, y: 420 },
+      { x: 280, y: 420 },
+      { x: 280, y: 460 },
+    ]);
+  });
+
+  it("keeps the original heading when a lead points away from the far end", () => {
+    const document = branchFixture();
+    // Moving the emitter ground above its own pin puts the transistor's
+    // south-facing lead on the wrong side of the target. A stretch may not
+    // invent an escape stub, so the segment keeps the heading it had.
+    const moved = executeTransaction(
+      document,
+      transaction(document.id, 2, [
+        {
+          kind: "move_instance",
+          instanceId: "GE",
+          position: { x: 300, y: 400 },
+        },
+      ]),
+      context,
+    );
+    expect(moved.ok).toBe(true);
+    if (!moved.ok) return;
+    const points = centerline(moved.document, "w-emitter");
+    expect(points[0]).toEqual({ x: 400, y: 450 });
+    expect(points.at(-1)).toEqual({ x: 300, y: 390 });
+    for (let index = 1; index < points.length; index += 1) {
+      const previous = points[index - 1]!;
+      const current = points[index]!;
+      expect(previous.x === current.x || previous.y === current.y).toBe(true);
+    }
+  });
+});
+
+describe("Route follow after a canvas drag", () => {
+  it("meets both pins along their leads through the group-move planner", () => {
+    const document = branchFixture();
+    // The canvas drag plans its own Route geometry rather than letting the
+    // transaction stretch it, so the rule has to hold on this path too.
+    const plan = proposeGroupMoveEdits(document, resolver, [
+      { instanceId: "Q3", position: { x: 520, y: 420 } },
+    ]);
+    const dragged = executeTransaction(
+      document,
+      {
+        transactionId: "drag-q3",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human" as const, id: "follow-test" },
+        edits: plan.edits,
+      },
+      context,
+    );
+    expect(dragged.ok).toBe(true);
+    if (!dragged.ok) return;
+    expect(centerline(dragged.document, "w-collector")).toEqual([
+      { x: 400, y: 320 },
+      { x: 400, y: 360 },
+      { x: 520, y: 360 },
+      { x: 520, y: 390 },
+    ]);
+    expect(centerline(dragged.document, "w-emitter")).toEqual([
+      { x: 520, y: 450 },
+      { x: 520, y: 480 },
+      { x: 400, y: 480 },
+      { x: 400, y: 510 },
+    ]);
+    expect(centerline(dragged.document, "w-base")).toEqual([
+      { x: 480, y: 420 },
+      { x: 280, y: 420 },
+      { x: 280, y: 460 },
+    ]);
+  });
+});

--- a/packages/edit-engine/src/transaction-route-follow.ts
+++ b/packages/edit-engine/src/transaction-route-follow.ts
@@ -13,7 +13,11 @@ import {
 import type { SymbolResolver } from "@icm/symbols";
 
 import type { SchematicEdit } from "./edit-schema.js";
-import { normalizeRouteGeometry } from "./route-geometry-edit.js";
+import {
+  bridgeStretchedSegment,
+  normalizeRouteGeometry,
+  usablePinAxis,
+} from "./route-geometry-edit.js";
 import { rebuildRoutePath } from "./route-leg-mutation.js";
 import { resolveRouteEditPath } from "./route-operations.js";
 import { pointOnSegment } from "./transaction-routing.js";
@@ -317,17 +321,25 @@ export function applyInstancesRouteFollow(
       newFrom.contactPoint.x !== newTo.contactPoint.x &&
       newFrom.contactPoint.y !== newTo.contactPoint.y
     ) {
-      const originallyVertical =
-        original.points[0]!.x === original.points[1]!.x;
-      points.splice(
-        1,
-        0,
-        originallyVertical
-          ? { x: newFrom.contactPoint.x, y: newTo.contactPoint.y }
-          : { x: newTo.contactPoint.x, y: newFrom.contactPoint.y },
+      const bends = bridgeStretchedSegment(
+        newFrom.contactPoint,
+        newTo.contactPoint,
+        usablePinAxis(
+          newFrom.outward,
+          newFrom.contactPoint,
+          newTo.contactPoint,
+        ),
+        usablePinAxis(newTo.outward, newTo.contactPoint, newFrom.contactPoint),
+        original.points[0]!.x === original.points[1]!.x,
+        draft.presentation.grid,
       );
       const mode = modes[0] ?? "manual";
-      modes.splice(0, 1, mode, mode);
+      points.splice(1, 0, ...bends);
+      modes.splice(
+        0,
+        1,
+        ...new Array<SegmentMode>(bends.length + 1).fill(mode),
+      );
     }
 
     const normalized = normalizeRouteGeometry(points, modes);


### PR DESCRIPTION
Dragging a part sideways left the attached wires running across the symbols they connect to. Reported from the canvas: selecting a transistor in a bias branch and moving it right put the collector wire through the transistor body and the emitter wire through the ground symbol.

## Cause

A wire whose whole body is one segment is adjacent to **both** of its endpoints, so following the moved end also decides the shape at the end that stayed put. Both stretch implementations resolved that conflict by sacrificing one end — and they disagreed about which:

| path | kept | sacrificed |
| --- | --- | --- |
| `applyInstancesRouteFollow` (transaction) | moved pin | far pin |
| `proposeGroupMove` (canvas drag) | far pin | moved pin |

A pin is drawn with a lead along its outward direction. A wire arriving across that axis lands on the side of the symbol and runs over its artwork.

## Fix

One corner can serve only one end, so pins whose leads share an axis get **two** corners and a crossbar between them. A lead that points away from the other end cannot be followed by a corner at all — that needs an escape stub, which a stretch may not invent — so it keeps the heading it had. Both paths call the same rule.

The drag planner's smoothing pass only generated one-corner candidates, so it kept replacing the corrected shape with a shape that crossed a lead; it now scores two-corner candidates on the same terms (body crossings still outweigh lead alignment).

Measured on a resistor/transistor/ground branch, dragging the transistor 120 right:

```
before  collector  (400,320) → (400,390) → (520,390)              across the collector lead
after   collector  (400,320) → (400,360) → (520,360) → (520,390)  down the lead

before  emitter    (520,450) → (400,450) → (400,510)              across the emitter lead
after   emitter    (520,450) → (520,480) → (400,480) → (400,510)  down the lead
```

A wire that already turns before its far pin is untouched.

## Verification

- 1636 unit tests, 248 Playwright specs, visual and export goldens, typecheck, Prettier — all green locally
- New `packages/edit-engine/src/transaction-route-follow.test.ts` covers both stretch paths, the untouched case, and the lead-points-away fallback
- Three existing expectations in `routing.test.ts` encoded the old shape; each is updated with a comment naming the lead that used to be crossed

🤖 Generated with [Claude Code](https://claude.com/claude-code)