### PR TITLE
feat(editor): trackpad viewport controls, continuous cursor zoom, raw marquee

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -925,7 +925,18 @@ export function App({
       if (sceneCrashRequested()) {
         throw new Error("scene build crashed (test hook)");
       }
-      return buildSvgScene(renderedDocument, resolver, { bounds: viewBox });
+      // The scene contract validates integer grid bounds; the camera itself
+      // may sit between grid lines mid-gesture, so hand the builder an
+      // outward integer envelope of the viewport instead.
+      const sceneX = Math.floor(viewBox.x);
+      const sceneY = Math.floor(viewBox.y);
+      const sceneBounds = {
+        x: sceneX,
+        y: sceneY,
+        width: Math.max(1, Math.ceil(viewBox.x + viewBox.width) - sceneX),
+        height: Math.max(1, Math.ceil(viewBox.y + viewBox.height) - sceneY),
+      };
+      return buildSvgScene(renderedDocument, resolver, { bounds: sceneBounds });
     }, lastGoodSceneRef.current);
     if (!outcome.degraded) lastGoodSceneRef.current = outcome.scene;
     return outcome;
@@ -2765,7 +2776,6 @@ export function App({
       continue: continueCanvasGesture,
       finish: finishCanvasGesture,
       cancelDrag: () => canvasDragSessionRef.current?.cancel(),
-      onWheel: handleWheel,
       onDrop: handleDrop,
     },
     drafting: {
@@ -3783,6 +3793,7 @@ export function App({
         />
         <EditorCanvasSurface
           empty={canvasIsEmpty}
+          onWheel={handleWheel}
           className={[
             "schematic-canvas",
             tool === "wire" ? "wire-mode" : "",

--- a/apps/editor/src/canvas/canvas-gesture-controller.ts
+++ b/apps/editor/src/canvas/canvas-gesture-controller.ts
@@ -1,7 +1,4 @@
-import type {
-  PointerEvent as ReactPointerEvent,
-  WheelEvent as ReactWheelEvent,
-} from "react";
+import type { PointerEvent as ReactPointerEvent } from "react";
 
 import type { SchematicStyleProfile } from "@icm/derived";
 import type {
@@ -225,16 +222,46 @@ export function createCanvasGestureController({
     );
   };
 
-  const handleWheel = (event: ReactWheelEvent<SVGSVGElement>): void => {
-    if (event.ctrlKey || event.metaKey) return;
+  // Trackpad map: horizontal scroll pans, vertical scroll zooms at the
+  // cursor, pinch (ctrl/meta+wheel) zooms at the cursor, Shift+scroll pans
+  // both axes. Attached as a non-passive native listener so preventDefault
+  // actually stops browser page zoom and history-swipe navigation.
+  const handleWheel = (event: WheelEvent, element: SVGSVGElement): void => {
     event.preventDefault();
-    const bounds = event.currentTarget.getBoundingClientRect();
+    const bounds = element.getBoundingClientRect();
+    if (bounds.width <= 0 || bounds.height <= 0) return;
+    const unit =
+      event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? bounds.height : 1;
+    const deltaX = event.deltaX * unit;
+    const deltaY = event.deltaY * unit;
     const anchor = {
       x: (event.clientX - bounds.left) / bounds.width,
       y: (event.clientY - bounds.top) / bounds.height,
     };
-    const factor = event.deltaY < 0 ? 0.88 : 1.14;
-    setViewBox((current) => zoomCameraAtAnchor(current, factor, anchor));
+    if (event.ctrlKey || event.metaKey) {
+      const factor = Math.exp(deltaY * 0.01);
+      setViewBox((current) => zoomCameraAtAnchor(current, factor, anchor));
+      return;
+    }
+    if (event.shiftKey) {
+      setViewBox((current) => ({
+        ...current,
+        x: current.x + (deltaX * current.width) / bounds.width,
+        y: current.y + (deltaY * current.height) / bounds.height,
+      }));
+      return;
+    }
+    const factor = deltaY === 0 ? 1 : Math.exp(deltaY * 0.0012);
+    setViewBox((current) => {
+      const panned =
+        deltaX === 0
+          ? current
+          : {
+              ...current,
+              x: current.x + (deltaX * current.width) / bounds.width,
+            };
+      return factor === 1 ? panned : zoomCameraAtAnchor(panned, factor, anchor);
+    });
   };
 
   const begin = (event: ReactPointerEvent<SVGSVGElement>): void => {
@@ -262,7 +289,9 @@ export function createCanvasGestureController({
       return;
     }
     if (gesture === "zoom") {
-      const zoomStart = pointFromClient(
+      // Raw pointer: the framing rectangle tracks the cursor exactly
+      // instead of jumping in Document-grid steps.
+      const zoomStart = rawPointFromClient(
         event.clientX,
         event.clientY,
         event.currentTarget,
@@ -277,7 +306,8 @@ export function createCanvasGestureController({
       return;
     }
     if (gesture !== "select") return;
-    const point = pointFromClient(
+    // Raw pointer: the marquee must not snap to the grid.
+    const point = rawPointFromClient(
       event.clientX,
       event.clientY,
       event.currentTarget,
@@ -352,7 +382,14 @@ export function createCanvasGestureController({
       return;
     }
     if (boxPreview?.pointerId === event.pointerId) {
-      setBoxPreview({ ...boxPreview, end: point });
+      setBoxPreview({
+        ...boxPreview,
+        end: rawPointFromClient(
+          event.clientX,
+          event.clientY,
+          event.currentTarget,
+        ),
+      });
     }
     if (
       (tool === "arrow" ||

--- a/apps/editor/src/canvas/editor-canvas-event-handlers.ts
+++ b/apps/editor/src/canvas/editor-canvas-event-handlers.ts
@@ -2,7 +2,6 @@ import type {
   DragEvent as ReactDragEvent,
   MouseEvent as ReactMouseEvent,
   PointerEvent as ReactPointerEvent,
-  WheelEvent as ReactWheelEvent,
 } from "react";
 
 import type {
@@ -72,7 +71,6 @@ interface CanvasEventHandlerDependencies {
     continue: (event: CanvasPointerEvent) => void;
     finish: (event: CanvasPointerEvent) => void;
     cancelDrag: () => void;
-    onWheel: (event: ReactWheelEvent<SVGSVGElement>) => void;
     onDrop: (event: ReactDragEvent<SVGSVGElement>) => void;
   };
   drafting: {
@@ -142,7 +140,6 @@ export function createEditorCanvasEventHandlers({
     continue: continueCanvasGesture,
     finish: finishCanvasGesture,
     cancelDrag: cancelCanvasDrag,
-    onWheel,
     onDrop,
   },
   drafting: {
@@ -167,7 +164,6 @@ export function createEditorCanvasEventHandlers({
   report: setStatus,
 }: CanvasEventHandlerDependencies) {
   return {
-    onWheel,
     onClickCapture(event: CanvasMouseEvent) {
       const kind = interactionKind();
       if (kind === "moving-selection") {

--- a/apps/editor/src/canvas/editor-canvas-surface.tsx
+++ b/apps/editor/src/canvas/editor-canvas-surface.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import type { ComponentProps, SVGProps } from "react";
 
 import {
@@ -23,6 +24,12 @@ export interface EditorCanvasSurfaceProps {
   className: string;
   viewBox: string;
   eventHandlers: SVGProps<SVGSVGElement>;
+  /**
+   * Native wheel handler, attached non-passively. React's onWheel rides the
+   * passive root listener, where preventDefault cannot stop browser page
+   * zoom (pinch) or history-swipe navigation (horizontal scroll).
+   */
+  onWheel: (event: WheelEvent, element: SVGSVGElement) => void;
   grid: ComponentProps<typeof CanvasGridOverlay>;
   sceneInnerHtml: { __html: string };
   cellSymbolLayout: ComponentProps<typeof EditorCellSymbolLayoutOverlay> | null;
@@ -71,6 +78,7 @@ export function EditorCanvasSurface({
   className,
   viewBox,
   eventHandlers,
+  onWheel,
   grid,
   sceneInnerHtml,
   cellSymbolLayout,
@@ -85,6 +93,18 @@ export function EditorCanvasSurface({
   draftingHandles,
   interactionPreviews,
 }: EditorCanvasSurfaceProps) {
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const onWheelRef = useRef(onWheel);
+  useEffect(() => {
+    onWheelRef.current = onWheel;
+  });
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const listener = (event: WheelEvent) => onWheelRef.current(event, svg);
+    svg.addEventListener("wheel", listener, { passive: false });
+    return () => svg.removeEventListener("wheel", listener);
+  }, []);
   return (
     <section className="canvas-panel">
       {empty ? (
@@ -108,6 +128,7 @@ export function EditorCanvasSurface({
         </aside>
       ) : null}
       <svg
+        ref={svgRef}
         className={className}
         data-testid="schematic-canvas"
         role="img"

--- a/apps/editor/src/canvas/fit-view.test.ts
+++ b/apps/editor/src/canvas/fit-view.test.ts
@@ -22,13 +22,24 @@ describe("fitCameraToBounds", () => {
     ).toEqual({ x: -40, y: 20, width: 960, height: 640 });
   });
 
-  it("normalizes zoom, pan, and focus camera updates onto the grid", () => {
+  it("keeps camera updates continuous instead of snapping to the grid", () => {
+    // Snapping the camera made wheel zoom step and the cursor anchor
+    // drift; the viewport may sit between grid lines.
     expect(
       normalizeCameraRect(
         { x: 97.55, y: -43.2, width: 61.3, height: 16.7 },
         10,
       ),
-    ).toEqual({ x: 100, y: -40, width: 60, height: 20 });
+    ).toEqual({ x: 97.55, y: -43.2, width: 61.3, height: 16.7 });
+  });
+
+  it("rounds camera updates to a fine precision so float noise cannot accumulate", () => {
+    expect(
+      normalizeCameraRect(
+        { x: 29.999999999999996, y: 0.0001, width: 100.00049, height: 50 },
+        10,
+      ),
+    ).toEqual({ x: 30, y: 0, width: 100, height: 50 });
   });
 });
 
@@ -60,21 +71,24 @@ describe("zoomCameraAtAnchor", () => {
     });
   });
 
-  it("clamps zoomed extents to the camera limits", () => {
+  it("clamps zoomed extents to the camera limits without distorting aspect", () => {
     const shrunk = zoomCameraAtAnchor(
       { x: 0, y: 0, width: 100, height: 60 },
       0.5,
       { x: 0.5, y: 0.5 },
     );
-    expect(shrunk.width).toBe(CAMERA_ZOOM_LIMITS.minWidth);
+    // The tighter limit wins for both axes so aspect ratio is preserved:
+    // height hits minHeight (60 -> 80, scale 4/3) and width follows.
     expect(shrunk.height).toBe(CAMERA_ZOOM_LIMITS.minHeight);
+    expect(shrunk.width).toBeCloseTo((100 * 4) / 3, 10);
     const grown = zoomCameraAtAnchor(
       { x: 0, y: 0, width: 4000, height: 3000 },
       4,
       { x: 0.5, y: 0.5 },
     );
-    expect(grown.width).toBe(CAMERA_ZOOM_LIMITS.maxWidth);
+    // maxHeight (3000 -> 3500, scale 7/6) binds before maxWidth.
     expect(grown.height).toBe(CAMERA_ZOOM_LIMITS.maxHeight);
+    expect(grown.width).toBeCloseTo((4000 * 7) / 6, 10);
   });
 });
 

--- a/apps/editor/src/canvas/fit-view.ts
+++ b/apps/editor/src/canvas/fit-view.ts
@@ -37,21 +37,23 @@ function assertFinitePositiveRect(
 }
 
 /**
- * Quantizes an editor viewport to the current Document grid. Camera is
- * transient, but retaining the same grid contract prevents it from becoming a
- * covert float path into SVG rendering and pointer conversion.
+ * Sanitizes an editor viewport update. The camera is transient and stays
+ * continuous — quantizing it to the Document grid made wheel zoom step and
+ * the cursor anchor drift. Snapped pointer conversion still lands edits on
+ * the grid; only the viewport itself may sit between grid lines. Values are
+ * rounded to a fine fixed precision so float noise never accumulates.
  */
 export function normalizeCameraRect(
   rect: CameraRectInput,
   grid: number,
 ): GridRect {
   assertFinitePositiveRect(rect, grid, "Camera normalization");
-  const snap = (value: number) => Math.round(value / grid) * grid;
+  const precise = (value: number) => Math.round(value * 1000) / 1000;
   return {
-    x: snap(rect.x),
-    y: snap(rect.y),
-    width: Math.max(grid, snap(rect.width)),
-    height: Math.max(grid, snap(rect.height)),
+    x: precise(rect.x),
+    y: precise(rect.y),
+    width: Math.max(1, precise(rect.width)),
+    height: Math.max(1, precise(rect.height)),
   };
 }
 
@@ -162,8 +164,17 @@ export function fitCameraToVisibleBounds(
   const centreY = bounds.y + bounds.height / 2;
   const cameraX = centreX - (insets.left + visibleWidth / 2) / scale;
   const cameraY = centreY - (insets.top + visibleHeight / 2) / scale;
+  // Fit is a named landing point, not a gesture: it keeps the historical
+  // Document-grid camera (wheel zoom is the path that stays continuous),
+  // so a fresh fit always yields a grid-aligned integer camera.
+  const snap = (value: number) => Math.round(value / grid) * grid;
   return normalizeCameraRect(
-    { x: cameraX, y: cameraY, width: cameraWidth, height: cameraHeight },
+    {
+      x: snap(cameraX),
+      y: snap(cameraY),
+      width: Math.max(grid, snap(cameraWidth)),
+      height: Math.max(grid, snap(cameraHeight)),
+    },
     grid,
   );
 }
@@ -193,19 +204,25 @@ export function zoomCameraAtAnchor(
   anchor: { x: number; y: number },
   limits: CameraZoomLimits = CAMERA_ZOOM_LIMITS,
 ): GridRect {
-  const width = Math.max(
-    limits.minWidth,
-    Math.min(limits.maxWidth, Math.round(current.width * factor)),
+  // Clamp the scale once for both axes so hitting a limit never distorts
+  // the aspect ratio, and keep everything continuous: rounding here made
+  // the point under the cursor drift on every wheel step.
+  const scale = Math.max(
+    Math.min(
+      factor,
+      limits.maxWidth / current.width,
+      limits.maxHeight / current.height,
+    ),
+    limits.minWidth / current.width,
+    limits.minHeight / current.height,
   );
-  const height = Math.max(
-    limits.minHeight,
-    Math.min(limits.maxHeight, Math.round(current.height * factor)),
-  );
+  const width = current.width * scale;
+  const height = current.height * scale;
   const anchorX = current.x + anchor.x * current.width;
   const anchorY = current.y + anchor.y * current.height;
   return {
-    x: Math.round(anchorX - anchor.x * width),
-    y: Math.round(anchorY - anchor.y * height),
+    x: anchorX - anchor.x * width,
+    y: anchorY - anchor.y * height,
     width,
     height,
   };


### PR DESCRIPTION
Owner feedback batch (viewport): trackpad pan/zoom mapping, precise cursor-anchored zoom, unsnapped selection rectangle.

- **Trackpad map**: horizontal scroll pans; vertical scroll zooms at the cursor; pinch (ctrl/meta+wheel) zooms rather than triggering browser page zoom; Shift+scroll pans both axes. The wheel handler is a native `{ passive: false }` listener so `preventDefault` actually blocks page zoom and history-swipe.
- **Continuous zoom**: the camera rect is no longer quantized to the Document grid (that produced the stepped/jumpy zoom), zoom magnitude follows wheel delta exponentially, and the anchor math keeps the point under the cursor exactly fixed (verified: anchor world coordinate invariant to 3 decimals). Zoom limits clamp both axes with a single scale, so aspect ratio never distorts.
- **Marquee**: selection and zoom-frame rectangles use the raw pointer, not grid-snapped corners.

Validation: editor canvas suite 47/47, full editor unit suite green (one pre-existing flake in recovery-coordinator.test.ts fails on clean main too, unrelated), viewport e2e (marquee/frames/transform) 6/6, live behavior verified in-browser (zoom-in/pan/pinch all anchored correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)