### PR TITLE
test(editor): settle recovery-coordinator tests on the write chain, not wall-clock

### DIFF
--- a/apps/editor/src/document/recovery-coordinator.test.ts
+++ b/apps/editor/src/document/recovery-coordinator.test.ts
@@ -90,9 +90,13 @@ function createHarness(
     storage,
     fire: timers.fire,
     settle: async () => {
-      // fake-indexeddb settles requests across real macrotasks; a short
-      // real-timer wait lets the full write chain finish.
-      await new Promise((resolve) => globalThis.setTimeout(resolve, 25));
+      // Await the serial write chain (and with it the fake-indexeddb
+      // transaction) through the coordinator's own settling point instead of
+      // racing a wall-clock wait. Every settle site runs after `fire()` or a
+      // cancel, so the scheduler holds no candidate and the flush half of
+      // `flushNow()` is a no-op — were a supposedly dropped candidate still
+      // pending, it would be written and fail the test's readAll assertions.
+      await coordinator.flushNow();
     },
   };
 }


### PR DESCRIPTION
## Summary

`recovery-coordinator.test.ts` was flaky (~1 in 2 under machine load): the harness's `settle()` waited a fixed **25 ms of real time** for the coordinator's IndexedDB write chain, so "stages a debounced write and publishes pending then stored" — and occasionally a neighboring `settle()` caller — failed with `expected 'pending' to be 'stored'` whenever the chain lost that race. Shrinking the window to 1 ms reproduces the failure on demand, confirming the mechanism.

`settle()` now awaits `coordinator.flushNow()`, the coordinator's designed settling point: the store resolves `writeRecord` only on the IndexedDB transaction's `oncomplete`, and `flushNow` awaits the serial write chain, so no wall-clock window remains anywhere in the file.

## Not weakened

- The debounced-trigger path is still proven by the injected fake timers and the explicit `"pending"` assertion after `fire()`; timer-arming semantics keep their primary layer in `recovery-scheduler.test.ts`.
- Every `settle()` site runs after `fire()` or a cancel, so the flush half of `flushNow()` is a no-op when the code under test is correct — and it *strengthens* the `cancelPending`/`beginWorkingCopy` tests: a supposedly dropped candidate still pending would now be written and fail their `readAll` assertions.

## Validation

- Target file 7/7 green: 5 idle runs + 2 under 12-way CPU load
- `prettier --check` on the file; `tsc -p tsconfig.check.json --noEmit`
- `Test-Impact: tests-updated` (test-only diff; `check-test-impact` passes against origin/main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)