### PR TITLE
feat(editor): device context menu, edge alignment, toolbar undo/redo

### DIFF
--- a/apps/editor/e2e/context-menu.spec.ts
+++ b/apps/editor/e2e/context-menu.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { chooseComponent } from "./editor-fixtures";
+
+async function placeComponent(
+  page: Page,
+  symbolId: string,
+  position: { x: number; y: number },
+): Promise<void> {
+  await chooseComponent(page, symbolId);
+  await page.getByTestId("schematic-canvas").click({ position });
+  await page.keyboard.press("Escape");
+}
+
+test("right-click on a device offers same-shape variant swap tiles", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "inductor", { x: 360, y: 240 });
+  const instance = page.locator('[data-canvas-hit-kind="instance"]').first();
+  await instance.click({ button: "right" });
+  const menu = page.getByTestId("canvas-context-menu");
+  await expect(menu).toBeVisible();
+  await expect(menu).toContainText("Swap device");
+  await expect(page.getByTestId("context-swap-resistor")).toBeVisible();
+  await expect(page.getByTestId("context-swap-capacitor")).toBeVisible();
+
+  await page.getByTestId("context-swap-resistor").click();
+  await expect(menu).toHaveCount(0);
+  await expect(page.getByTestId("status")).toContainText("Swapped to");
+  await instance.click({ button: "right" });
+  // The device is now a resistor, so the tiles offer the inductor back.
+  await expect(page.getByTestId("context-swap-inductor")).toBeVisible();
+  await expect(page.getByTestId("context-swap-resistor")).toHaveCount(0);
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("canvas-context-menu")).toHaveCount(0);
+});
+
+test("right-click on a multi-selection aligns bbox edges", async ({ page }) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 300, y: 220 });
+  await placeComponent(page, "resistor", { x: 420, y: 300 });
+  const instances = page.locator('[data-canvas-hit-kind="instance"]');
+  await expect(instances).toHaveCount(2);
+  await instances.nth(0).click();
+  await instances.nth(1).click({ modifiers: ["Shift"] });
+
+  await instances.nth(1).click({ button: "right" });
+  const menu = page.getByTestId("canvas-context-menu");
+  await expect(menu).toContainText("Align");
+  await page.getByTestId("context-align-left").click();
+  await expect(page.getByTestId("status")).toContainText(
+    "Aligned 2 selected instances",
+  );
+  const boxes = await instances.evaluateAll((elements) =>
+    elements.map((element) => element.getAttribute("x")),
+  );
+  expect(boxes[0]).toBe(boxes[1]);
+});
+
+test("toolbar undo and redo buttons follow history state", async ({ page }) => {
+  await page.goto("/editor");
+  const undo = page.getByTestId("draw-tool-undo");
+  const redo = page.getByTestId("draw-tool-redo");
+  await expect(undo).toBeDisabled();
+  await expect(redo).toBeDisabled();
+
+  await placeComponent(page, "resistor", { x: 360, y: 240 });
+  await expect(undo).toBeEnabled();
+  await undo.click();
+  await expect(page.locator('[data-canvas-hit-kind="instance"]')).toHaveCount(
+    0,
+  );
+  await expect(redo).toBeEnabled();
+  await redo.click();
+  await expect(page.locator('[data-canvas-hit-kind="instance"]')).toHaveCount(
+    1,
+  );
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -98,7 +98,13 @@ import {
   fullInsertLaunch,
 } from "../features/component-insert/insert-launch";
 import { useComponentPlacement } from "../features/component-insert/use-component-placement";
-import { findPaletteSymbol } from "../features/component-insert/symbol-catalog";
+import {
+  componentCatalog,
+  findPaletteSymbol,
+  symbolCategory,
+} from "../features/component-insert/symbol-catalog";
+import { SymbolArtwork } from "../features/component-insert/symbol-artwork";
+import { CanvasContextMenu } from "../features/selection/canvas-context-menu";
 import { createPlacementTrayCommands } from "../features/component-insert/placement-tray-commands";
 import { componentTargetDescription } from "../features/properties/component-identity-properties";
 import {
@@ -486,6 +492,10 @@ export function App({
   );
   const [importReviewOpen, setImportReviewOpen] = useState(false);
   const [cellManagerOpen, setCellManagerOpen] = useState(false);
+  const [canvasContextMenu, setCanvasContextMenu] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
   const [pendingCellReset, setPendingCellReset] = useState<{
     plan: CellResetPlan;
     command: string;
@@ -1186,6 +1196,68 @@ export function App({
     },
     commitCellPinAnnotation: editCellTerminalAnnotation,
   });
+  const deviceVariantCandidates = useMemo(() => {
+    if (!canvasContextMenu || selectedIds.length !== 1 || !selectedInstance) {
+      return [];
+    }
+    const resolved = resolver.resolve(
+      selectedInstance.symbolId,
+      selectedInstance.symbolVariantId,
+    );
+    if (!resolved) return [];
+    const pinCount = resolved.definition.pins.length;
+    const category = symbolCategory(selectedInstance.symbolId);
+    return componentCatalog(document.presentation.styleProfileId, "")
+      .flatMap((group) => group.symbols)
+      .filter(
+        (symbol) =>
+          symbol.id !== selectedInstance.symbolId &&
+          symbol.pins.length === pinCount &&
+          symbolCategory(symbol.id) === category,
+      )
+      .slice(0, 8)
+      .map((symbol) => ({ symbolId: symbol.id, name: symbol.name }));
+  }, [
+    canvasContextMenu,
+    selectedIds,
+    selectedInstance,
+    resolver,
+    document.presentation.styleProfileId,
+  ]);
+  const swapSelectedInstanceSymbol = (symbolId: string): void => {
+    if (!selectedInstance) return;
+    const resolved = resolver.resolve(
+      selectedInstance.symbolId,
+      selectedInstance.symbolVariantId,
+    );
+    const target = findPaletteSymbol(
+      document.presentation.styleProfileId,
+      symbolId,
+    );
+    if (!resolved || !target) return;
+    // Map pins positionally so nets follow the swap even when the
+    // replacement names its pins differently (A/Y vs 1/2).
+    const oldPins = resolved.definition.pins.map((pin) => pin.name);
+    const newPins = target.pins.map((pin) => pin.name);
+    const pinMap = Object.fromEntries(
+      oldPins.flatMap((name, index) => {
+        const next = newPins[index];
+        return next && next !== name ? [[name, next] as const] : [];
+      }),
+    );
+    const result = transactDocument([
+      {
+        kind: "set_instance_symbol",
+        instanceId: selectedInstance.id,
+        symbolId,
+        symbolVariantId: null,
+        ...(Object.keys(pinMap).length > 0 ? { pinMap } : {}),
+      },
+    ]);
+    setStatus(
+      result.ok ? `Swapped to ${target.name}` : "Could not swap the device",
+    );
+  };
   const selectedInstanceLabel = selectedInstance
     ? instanceLabelAnnotationFor(document, selectedInstance.id)
     : undefined;
@@ -1393,6 +1465,7 @@ export function App({
     rotate: rotateSelected,
     mirror: mirrorSelected,
     align: alignSelectedInstances,
+    alignEdge: alignEdgeSelected,
   } = createSelectionTransformController({
     document,
     resolver,
@@ -2953,6 +3026,14 @@ export function App({
           libraryPanelOpen: visibleLibraryPanelOpen,
           tool,
           documentSettingsOpen,
+          undo: {
+            enabled: editorCommands.state({ id: "history.undo" }).enabled,
+            execute: () => editorCommands.execute({ id: "history.undo" }),
+          },
+          redo: {
+            enabled: editorCommands.state({ id: "history.redo" }).enabled,
+            execute: () => editorCommands.execute({ id: "history.redo" }),
+          },
           onToggleExamples: toggleExamplesPanel,
           onToggleLibrary: toggleLibraryPanel,
           onInsert: () =>
@@ -3923,6 +4004,12 @@ export function App({
                 }
                 beginMoveFromSelection(event, instance.id);
               },
+              onInstanceContextMenu: (instance, clientX, clientY) => {
+                if (!selectedIds.includes(instance.id)) {
+                  selectInstanceFromSelection(instance.id, false);
+                }
+                setCanvasContextMenu({ x: clientX, y: clientY });
+              },
               onRoutePointerDown: handleRoutePointerDown,
               onAnnotationPointerDown: beginAnnotationDrag,
               onAnnotationEdit: beginAnnotationTextEditing,
@@ -4017,6 +4104,55 @@ export function App({
               : {}),
           }}
         />
+        {canvasContextMenu ? (
+          <CanvasContextMenu
+            position={canvasContextMenu}
+            variants={deviceVariantCandidates}
+            renderVariantArtwork={(symbolId) => {
+              const symbol = findPaletteSymbol(
+                document.presentation.styleProfileId,
+                symbolId,
+              );
+              return symbol ? (
+                <SymbolArtwork
+                  symbol={symbol}
+                  className="context-variant-art"
+                />
+              ) : null;
+            }}
+            onSwapVariant={swapSelectedInstanceSymbol}
+            alignmentEnabled={selectedIds.length > 1}
+            onAlign={alignEdgeSelected}
+            actions={[
+              {
+                label: "Rotate (R)",
+                enabled: editorCommands.state({ id: "transform.rotate" })
+                  .enabled,
+                execute: () =>
+                  editorCommands.execute({ id: "transform.rotate" }),
+              },
+              {
+                label: "Mirror left/right (Shift+R)",
+                enabled: editorCommands.state({
+                  id: "transform.mirror",
+                  direction: "left-right",
+                }).enabled,
+                execute: () =>
+                  editorCommands.execute({
+                    id: "transform.mirror",
+                    direction: "left-right",
+                  }),
+              },
+              {
+                label: "Delete",
+                enabled: hasVisualSelection(visualSelection),
+                execute: () =>
+                  editorCommands.execute({ id: "selection.delete" }),
+              },
+            ]}
+            onClose={() => setCanvasContextMenu(null)}
+          />
+        ) : null}
       </div>
       {timingUiEnabled ? (
         <TimingSimulationPanel

--- a/apps/editor/src/canvas/canvas-gesture-controller.ts
+++ b/apps/editor/src/canvas/canvas-gesture-controller.ts
@@ -238,6 +238,16 @@ export function createCanvasGestureController({
   };
 
   const begin = (event: ReactPointerEvent<SVGSVGElement>): void => {
+    // Right-press on a device opens its context menu: starting the frame
+    // gesture here would capture the pointer and swallow the contextmenu
+    // event, so the frame only starts on canvas background.
+    if (
+      event.button === 2 &&
+      (event.target as Element).getAttribute?.("data-canvas-hit-kind") ===
+        "instance"
+    ) {
+      return;
+    }
     const gesture = classifyCanvasGestureStart({
       button: event.button,
       altKey: event.altKey,

--- a/apps/editor/src/canvas/editor-canvas-hit-layer.test.tsx
+++ b/apps/editor/src/canvas/editor-canvas-hit-layer.test.tsx
@@ -45,6 +45,7 @@ function emptySelectionProps(document = createEmptyDocument("cell", "Cell")) {
     onInstanceClick: vi.fn(),
     onInstanceOpen: vi.fn(),
     onInstancePointerDown: vi.fn(),
+    onInstanceContextMenu: vi.fn(),
     onRoutePointerDown: vi.fn(),
     onAnnotationPointerDown: vi.fn(),
     onAnnotationEdit: vi.fn(),

--- a/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
+++ b/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
@@ -46,6 +46,11 @@ interface SelectionHitTargetProps {
     event: ReactPointerEvent<SVGRectElement>,
     instance: Instance,
   ) => void;
+  onInstanceContextMenu: (
+    instance: Instance,
+    clientX: number,
+    clientY: number,
+  ) => void;
   onRoutePointerDown: (
     event: ReactPointerEvent<SVGPolylineElement>,
     routeId: string,
@@ -110,6 +115,7 @@ function SelectionHitTargets({
   onInstanceClick,
   onInstanceOpen,
   onInstancePointerDown,
+  onInstanceContextMenu,
   onRoutePointerDown,
   onAnnotationPointerDown,
   onAnnotationEdit,
@@ -145,6 +151,11 @@ function SelectionHitTargets({
                 onInstanceOpen(instance);
               }}
               onPointerDown={(event) => onInstancePointerDown(event, instance)}
+              onContextMenu={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                onInstanceContextMenu(instance, event.clientX, event.clientY);
+              }}
               pointerEvents={tool === "wire" ? "none" : undefined}
             />
           );

--- a/apps/editor/src/features/editor-shell/drawing-toolbar.test.tsx
+++ b/apps/editor/src/features/editor-shell/drawing-toolbar.test.tsx
@@ -11,6 +11,8 @@ describe("DrawingToolbar", () => {
         libraryPanelOpen
         tool="wire"
         documentSettingsOpen
+        undo={{ enabled: true, execute: vi.fn() }}
+        redo={{ enabled: true, execute: vi.fn() }}
         onToggleExamples={vi.fn()}
         onToggleLibrary={vi.fn()}
         onInsert={vi.fn()}

--- a/apps/editor/src/features/editor-shell/drawing-toolbar.tsx
+++ b/apps/editor/src/features/editor-shell/drawing-toolbar.tsx
@@ -1,11 +1,18 @@
 import type { EditorTool } from "../../interaction/interaction-state";
 import { ToolIcon } from "./tool-icon";
 
+interface ToolbarCommand {
+  enabled: boolean;
+  execute: () => void;
+}
+
 export interface DrawingToolbarProps {
   leftPanelMode: "examples" | "library";
   libraryPanelOpen: boolean;
   tool: EditorTool;
   documentSettingsOpen: boolean;
+  undo: ToolbarCommand;
+  redo: ToolbarCommand;
   onToggleExamples: () => void;
   onToggleLibrary: () => void;
   onInsert: () => void;
@@ -19,6 +26,8 @@ export function DrawingToolbar({
   libraryPanelOpen,
   tool,
   documentSettingsOpen,
+  undo,
+  redo,
   onToggleExamples,
   onToggleLibrary,
   onInsert,
@@ -64,6 +73,29 @@ export function DrawingToolbar({
       >
         <ToolIcon name="library" />
         <span>Library</span>
+      </button>
+      <span className="draw-toolbar-divider" aria-hidden="true" />
+      <button
+        type="button"
+        className="draw-tool"
+        data-testid="draw-tool-undo"
+        title="Undo (Ctrl+Z)"
+        onClick={undo.execute}
+        disabled={!undo.enabled}
+      >
+        <ToolIcon name="undo" />
+        <span>Undo</span>
+      </button>
+      <button
+        type="button"
+        className="draw-tool"
+        data-testid="draw-tool-redo"
+        title="Redo (Ctrl+Shift+Z)"
+        onClick={redo.execute}
+        disabled={!redo.enabled}
+      >
+        <ToolIcon name="redo" />
+        <span>Redo</span>
       </button>
       <span className="draw-toolbar-divider" aria-hidden="true" />
       <button

--- a/apps/editor/src/features/selection/align-instances.test.ts
+++ b/apps/editor/src/features/selection/align-instances.test.ts
@@ -1,0 +1,91 @@
+import { createEmptyDocument } from "@icm/model";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { proposeEdgeAlignmentEdits } from "./align-instances";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+function fixture() {
+  const document = createEmptyDocument("doc", "Align");
+  document.instances.push(
+    {
+      id: "R1",
+      symbolId: "resistor",
+      placement: { position: { x: 100, y: 100 }, rotation: 0, mirror: "none" },
+      netlist: { reference: "R1", parameters: {} },
+    },
+    {
+      id: "R2",
+      symbolId: "resistor",
+      placement: { position: { x: 240, y: 180 }, rotation: 0, mirror: "none" },
+      netlist: { reference: "R2", parameters: {} },
+    },
+    {
+      id: "R3",
+      symbolId: "resistor",
+      placement: { position: { x: 300, y: 140 }, rotation: 0, mirror: "none" },
+      netlist: { reference: "R3", parameters: {} },
+    },
+  );
+  return document;
+}
+
+describe("proposeEdgeAlignmentEdits", () => {
+  it("aligns identical symbols exactly on the shared edge", () => {
+    const document = fixture();
+    const edits = proposeEdgeAlignmentEdits(
+      document,
+      resolver,
+      ["R1", "R2", "R3"],
+      "left",
+    );
+    // Identical symbols share bbox metrics, so aligning the left edge is
+    // exactly equalizing x; R1 already sits at the minimum.
+    expect(edits).toEqual([
+      { kind: "move_instance", instanceId: "R2", position: { x: 100, y: 180 } },
+      { kind: "move_instance", instanceId: "R3", position: { x: 100, y: 140 } },
+    ]);
+  });
+
+  it("aligns tops moving only along y", () => {
+    const document = fixture();
+    const edits = proposeEdgeAlignmentEdits(
+      document,
+      resolver,
+      ["R1", "R2", "R3"],
+      "top",
+    );
+    expect(edits).toEqual([
+      { kind: "move_instance", instanceId: "R2", position: { x: 240, y: 100 } },
+      { kind: "move_instance", instanceId: "R3", position: { x: 300, y: 100 } },
+    ]);
+  });
+
+  it("centers on the average and keeps every move on the grid", () => {
+    const document = fixture();
+    const edits = proposeEdgeAlignmentEdits(
+      document,
+      resolver,
+      ["R1", "R2", "R3"],
+      "v-center",
+    );
+    // Average center y = (100+180+140)/3 = 140.
+    expect(edits).toEqual([
+      { kind: "move_instance", instanceId: "R1", position: { x: 100, y: 140 } },
+      { kind: "move_instance", instanceId: "R2", position: { x: 240, y: 140 } },
+    ]);
+    for (const edit of edits) {
+      if (edit.kind !== "move_instance") continue;
+      expect(edit.position.x % document.presentation.grid).toBe(0);
+      expect(edit.position.y % document.presentation.grid).toBe(0);
+    }
+  });
+
+  it("returns nothing for fewer than two placed instances", () => {
+    const document = fixture();
+    expect(
+      proposeEdgeAlignmentEdits(document, resolver, ["R1"], "left"),
+    ).toEqual([]);
+  });
+});

--- a/apps/editor/src/features/selection/align-instances.ts
+++ b/apps/editor/src/features/selection/align-instances.ts
@@ -1,0 +1,91 @@
+import type { SchematicDocument } from "@icm/model";
+import type { SchematicEdit } from "@icm/edit-engine";
+import type { SymbolResolver } from "@icm/symbols";
+
+import { instanceHitBox } from "../wiring/route-interaction-geometry";
+
+export type EdgeAlignmentMode =
+  "left" | "h-center" | "right" | "top" | "v-center" | "bottom";
+
+export const EDGE_ALIGNMENT_MODES: readonly {
+  mode: EdgeAlignmentMode;
+  label: string;
+}[] = [
+  { mode: "left", label: "Align left" },
+  { mode: "h-center", label: "Align horizontal center" },
+  { mode: "right", label: "Align right" },
+  { mode: "top", label: "Align top" },
+  { mode: "v-center", label: "Align vertical center" },
+  { mode: "bottom", label: "Align bottom" },
+];
+
+/**
+ * Bounding-box edge alignment as per-instance moves. `align_instances`
+ * equalizes placement anchors, which only aligns edges for identically
+ * sized symbols; edges need a per-instance delta, and expressing each as
+ * a `move_instance` keeps the engine's route-follow and direct-contact
+ * reconciliation on the exact same path an ordinary drag uses. Deltas are
+ * rounded to the Document grid so pins stay on grid.
+ */
+export function proposeEdgeAlignmentEdits(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  instanceIds: readonly string[],
+  mode: EdgeAlignmentMode,
+): SchematicEdit[] {
+  const grid = document.presentation.grid;
+  const boxed = instanceIds.flatMap((instanceId) => {
+    const instance = document.instances.find(
+      (candidate) => candidate.id === instanceId,
+    );
+    if (!instance?.placement) return [];
+    const box = instanceHitBox(instance, resolver);
+    return box ? [{ instance, box }] : [];
+  });
+  if (boxed.length < 2) return [];
+
+  const measure = (box: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }) => {
+    switch (mode) {
+      case "left":
+        return box.x;
+      case "h-center":
+        return box.x + box.width / 2;
+      case "right":
+        return box.x + box.width;
+      case "top":
+        return box.y;
+      case "v-center":
+        return box.y + box.height / 2;
+      case "bottom":
+        return box.y + box.height;
+    }
+  };
+  const measures = boxed.map(({ box }) => measure(box));
+  const target =
+    mode === "left" || mode === "top"
+      ? Math.min(...measures)
+      : mode === "right" || mode === "bottom"
+        ? Math.max(...measures)
+        : measures.reduce((sum, value) => sum + value, 0) / measures.length;
+  const horizontal = mode === "left" || mode === "h-center" || mode === "right";
+
+  return boxed.flatMap(({ instance, box }): SchematicEdit[] => {
+    const delta = Math.round((target - measure(box)) / grid) * grid;
+    if (delta === 0) return [];
+    const position = instance.placement!.position;
+    return [
+      {
+        kind: "move_instance",
+        instanceId: instance.id,
+        position: horizontal
+          ? { x: position.x + delta, y: position.y }
+          : { x: position.x, y: position.y + delta },
+      },
+    ];
+  });
+}

--- a/apps/editor/src/features/selection/canvas-context-menu.tsx
+++ b/apps/editor/src/features/selection/canvas-context-menu.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
+
+import {
+  EDGE_ALIGNMENT_MODES,
+  type EdgeAlignmentMode,
+} from "./align-instances";
+
+export interface ContextMenuAction {
+  label: string;
+  enabled: boolean;
+  execute: () => void;
+}
+
+export interface ContextMenuVariant {
+  symbolId: string;
+  name: string;
+}
+
+export interface CanvasContextMenuProps {
+  position: { x: number; y: number };
+  /** Same-shape symbols the single selected device can swap into. */
+  variants: readonly ContextMenuVariant[];
+  renderVariantArtwork: (symbolId: string) => ReactNode;
+  onSwapVariant: (symbolId: string) => void;
+  /** Enabled when two or more instances are selected. */
+  alignmentEnabled: boolean;
+  onAlign: (mode: EdgeAlignmentMode) => void;
+  actions: readonly ContextMenuAction[];
+  onClose: () => void;
+}
+
+/**
+ * Right-click menu for devices: variant swap tiles, bbox-edge alignment,
+ * and the everyday transform commands. Rendered as a fixed overlay at the
+ * pointer, dismissed by backdrop click or Escape.
+ */
+export function CanvasContextMenu({
+  position,
+  variants,
+  renderVariantArtwork,
+  onSwapVariant,
+  alignmentEnabled,
+  onAlign,
+  actions,
+  onClose,
+}: CanvasContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const [placed, setPlaced] = useState(position);
+
+  useLayoutEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) return;
+    const bounds = menu.getBoundingClientRect();
+    setPlaced({
+      x: Math.max(
+        4,
+        Math.min(position.x, window.innerWidth - bounds.width - 4),
+      ),
+      y: Math.max(
+        4,
+        Math.min(position.y, window.innerHeight - bounds.height - 4),
+      ),
+    });
+  }, [position]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  return (
+    <div
+      className="canvas-context-menu-backdrop"
+      data-testid="canvas-context-menu-backdrop"
+      onPointerDown={onClose}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+    >
+      <div
+        ref={menuRef}
+        className="canvas-context-menu"
+        data-testid="canvas-context-menu"
+        role="menu"
+        style={{ left: placed.x, top: placed.y }}
+        onPointerDown={(event) => event.stopPropagation()}
+        onContextMenu={(event) => event.preventDefault()}
+      >
+        {variants.length > 0 ? (
+          <div className="context-menu-section">
+            <div className="context-menu-heading">Swap device</div>
+            <div className="context-menu-variants" role="group">
+              {variants.map((variant) => (
+                <button
+                  key={variant.symbolId}
+                  type="button"
+                  role="menuitem"
+                  className="context-menu-variant"
+                  title={variant.name}
+                  data-testid={`context-swap-${variant.symbolId}`}
+                  onClick={() => {
+                    onSwapVariant(variant.symbolId);
+                    onClose();
+                  }}
+                >
+                  {renderVariantArtwork(variant.symbolId)}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : null}
+        {alignmentEnabled ? (
+          <div className="context-menu-section">
+            <div className="context-menu-heading">Align</div>
+            {EDGE_ALIGNMENT_MODES.map(({ mode, label }) => (
+              <button
+                key={mode}
+                type="button"
+                role="menuitem"
+                className="context-menu-item"
+                data-testid={`context-align-${mode}`}
+                onClick={() => {
+                  onAlign(mode);
+                  onClose();
+                }}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        ) : null}
+        {actions.length > 0 ? (
+          <div className="context-menu-section">
+            {actions.map((action) => (
+              <button
+                key={action.label}
+                type="button"
+                role="menuitem"
+                className="context-menu-item"
+                disabled={!action.enabled}
+                onClick={() => {
+                  action.execute();
+                  onClose();
+                }}
+              >
+                {action.label}
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/editor/src/features/selection/selection-transform-controller.ts
+++ b/apps/editor/src/features/selection/selection-transform-controller.ts
@@ -4,6 +4,10 @@ import type { SchematicDocument } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 
 import { rotateDraftingObject } from "../drafting/drafting-manipulation";
+import {
+  proposeEdgeAlignmentEdits,
+  type EdgeAlignmentMode,
+} from "./align-instances";
 import type { ScreenFlip } from "../../interaction/shortcut-orientation";
 import type { VisualSelection } from "./visual-selection";
 
@@ -105,6 +109,25 @@ export function createSelectionTransformController({
       );
   };
 
+  const alignEdge = (mode: EdgeAlignmentMode): void => {
+    if (selectedInstanceIds.length < 2) {
+      setStatus("Select at least two instances to align");
+      return;
+    }
+    const edits = proposeEdgeAlignmentEdits(
+      document,
+      resolver,
+      selectedInstanceIds,
+      mode,
+    );
+    if (edits.length === 0) {
+      setStatus("Selection is already aligned");
+      return;
+    }
+    if (transact(edits).ok)
+      setStatus(`Aligned ${selectedInstanceIds.length} selected instances`);
+  };
+
   const align = (): void => {
     if (selectedInstanceIds.length < 2) {
       setStatus("Select at least two instances to align");
@@ -122,5 +145,5 @@ export function createSelectionTransformController({
       setStatus(`Aligned ${selectedInstanceIds.length} selected instances`);
   };
 
-  return { rotate, mirror, align };
+  return { rotate, mirror, align, alignEdge };
 }

--- a/apps/editor/src/styles/editor-context-menu.css
+++ b/apps/editor/src/styles/editor-context-menu.css
@@ -1,0 +1,90 @@
+.canvas-context-menu-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+}
+
+.canvas-context-menu {
+  position: fixed;
+  min-width: 180px;
+  max-width: 280px;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: var(--icm-surface);
+  border: 1px solid var(--icm-border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgb(0 0 0 / 14%);
+}
+
+.canvas-context-menu .context-menu-section {
+  display: flex;
+  flex-direction: column;
+}
+
+.canvas-context-menu .context-menu-section + .context-menu-section {
+  border-top: 1px solid var(--icm-border);
+  padding-top: 4px;
+  margin-top: 2px;
+}
+
+.canvas-context-menu .context-menu-heading {
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--icm-muted);
+  padding: 2px 8px 4px;
+}
+
+.canvas-context-menu .context-menu-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 6px 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.canvas-context-menu .context-menu-item:hover:not(:disabled) {
+  background: var(--icm-hover);
+}
+
+.canvas-context-menu .context-menu-item:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.canvas-context-menu .context-menu-variants {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 0 4px 2px;
+}
+
+.canvas-context-menu .context-menu-variant {
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border: 1px solid var(--icm-border);
+  border-radius: 6px;
+  background: var(--icm-surface);
+  cursor: pointer;
+}
+
+.canvas-context-menu .context-menu-variant:hover {
+  border-color: var(--icm-accent);
+  background: var(--icm-hover);
+}
+
+.canvas-context-menu .context-menu-variant svg {
+  max-width: 100%;
+  max-height: 100%;
+}

--- a/apps/editor/src/styles/editor-entry.css
+++ b/apps/editor/src/styles/editor-entry.css
@@ -13,5 +13,6 @@
 @import "./editor-agent.css";
 @import "./editor-simulation.css";
 @import "./editor-accessibility.css";
+@import "./editor-context-menu.css";
 @import "../features/editor-shell/publish-gallery-dialog.css";
 @import "../components/version-history-dialog.css";


### PR DESCRIPTION
Owner feedback batch (chrome), items: undo/redo toolbar buttons; right-click device variants; right-click alignment dropdown.

- **Device context menu**: right-click a device → menu at the pointer. Single device: same-category same-pin-count swap tiles drawn with real symbol artwork (e.g. inductor → resistor/capacitor); swap emits `set_instance_symbol` with a positional pin map so differently named pins keep their nets. Multi-selection: six bbox-edge alignment ops (left / h-center / right / top / v-center / bottom) as per-instance `move_instance` edits rounded to the grid — routes follow exactly like a drag. Rotate / mirror / delete included.
- **Gesture fix**: right-press on a device no longer starts the frame gesture (pointer capture was swallowing `contextmenu`); framing still works from canvas background (regression e2e green).
- **Toolbar undo/redo** with live enable/disable from history state.

Validation: typecheck clean; editor unit suite 611/611 (new align proposal tests); new e2e `context-menu.spec.ts` 3/3 (variant swap round-trip, bbox align, toolbar undo/redo); `manual-editor` frame/viewport e2e 2/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)