### PR TITLE
feat(editor): bond pin-on-pin drops, RTL textboxes, wiring e2e coverage

### DIFF
--- a/apps/editor/e2e/wiring-semantics.spec.ts
+++ b/apps/editor/e2e/wiring-semantics.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { chooseComponent } from "./editor-fixtures";
+
+async function placeComponent(
+  page: Page,
+  symbolId: string,
+  position: { x: number; y: number },
+): Promise<void> {
+  await chooseComponent(page, symbolId);
+  await page.getByTestId("schematic-canvas").click({ position });
+  await page.keyboard.press("Escape");
+}
+
+async function instanceIds(page: Page): Promise<string[]> {
+  return page
+    .locator('[data-canvas-hit-kind="instance"]')
+    .evaluateAll((elements) =>
+      elements.map((element) => element.getAttribute("data-canvas-hit-id")!),
+    );
+}
+
+test("wire can start from any interior point of an existing net", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 260, y: 200 });
+  await placeComponent(page, "resistor", { x: 260, y: 420 });
+  await placeComponent(page, "resistor", { x: 460, y: 310 });
+  const ids = await instanceIds(page);
+
+  // Vertical wire between the first two resistors.
+  await page.keyboard.press("w");
+  await page.getByTestId(`terminal-${ids[0]}-2`).click();
+  await page.getByTestId(`terminal-${ids[1]}-1`).click();
+  await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(1);
+
+  // Start the next wire from the MIDDLE of that wire, not from a pin, and
+  // land it on the third resistor's pin.
+  const route = page.locator('[data-canvas-hit-kind="route"]').first();
+  const box = (await route.boundingBox())!;
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+  await page.getByTestId(`terminal-${ids[2]}-1`).click();
+  await page.keyboard.press("Escape");
+
+  // The tap split the original wire and added the branch: three routes, one
+  // junction dot at the tee.
+  await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(3);
+  await expect(page.locator('g[data-layer="junctions"] circle')).toHaveCount(1);
+});
+
+test("clicking a junction dot selects it and Delete disconnects the tap", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 260, y: 200 });
+  await placeComponent(page, "resistor", { x: 260, y: 420 });
+  await placeComponent(page, "resistor", { x: 460, y: 310 });
+  const ids = await instanceIds(page);
+  await page.keyboard.press("w");
+  await page.getByTestId(`terminal-${ids[0]}-2`).click();
+  await page.getByTestId(`terminal-${ids[1]}-1`).click();
+  const route = page.locator('[data-canvas-hit-kind="route"]').first();
+  const box = (await route.boundingBox())!;
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+  await page.getByTestId(`terminal-${ids[2]}-1`).click();
+  await page.keyboard.press("Escape");
+  const dot = page.locator('g[data-layer="junctions"] circle');
+  await expect(dot).toHaveCount(1);
+
+  // Click exactly on the visible dot: the junction's hit circle sits on the
+  // same contact point, so the dot is clickable.
+  const dotBox = (await dot.boundingBox())!;
+  await page.mouse.click(
+    dotBox.x + dotBox.width / 2,
+    dotBox.y + dotBox.height / 2,
+  );
+  await page.keyboard.press("Delete");
+
+  // The tap is gone: the branch to the third resistor is disconnected and
+  // the dot disappears.
+  await expect(page.locator('g[data-layer="junctions"] circle')).toHaveCount(0);
+  await expect(page.locator('[data-canvas-hit-kind="route"]')).not.toHaveCount(
+    3,
+  );
+});

--- a/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
+++ b/apps/editor/src/features/editor-shell/publish-gallery-dialog.tsx
@@ -205,6 +205,7 @@ export function PublishGalleryDialog({
               <div className="publish-gallery-mode" data-testid="publish-mode">
                 <label>
                   <input
+                    dir="auto"
                     type="radio"
                     name="publish-mode"
                     checked={mode === "update"}
@@ -217,6 +218,7 @@ export function PublishGalleryDialog({
                 </label>
                 <label>
                   <input
+                    dir="auto"
                     type="radio"
                     name="publish-mode"
                     checked={mode === "new"}
@@ -243,6 +245,7 @@ export function PublishGalleryDialog({
               <label>
                 Circuit name
                 <input
+                  dir="auto"
                   aria-label="Circuit name"
                   value={name}
                   maxLength={120}
@@ -256,6 +259,7 @@ export function PublishGalleryDialog({
                   <span className="publish-gallery-optional">optional</span>
                 </span>
                 <textarea
+                  dir="auto"
                   aria-label="Description"
                   value={description}
                   maxLength={300}
@@ -290,6 +294,7 @@ export function PublishGalleryDialog({
                   </div>
                 ) : null}
                 <input
+                  dir="auto"
                   aria-label="Add tag"
                   placeholder="Type a tag and press Enter"
                   value={tagDraft}

--- a/apps/editor/src/features/properties/component-identity-properties.tsx
+++ b/apps/editor/src/features/properties/component-identity-properties.tsx
@@ -72,6 +72,7 @@ export function ComponentIdentityProperties({
               <dt>{portNet.supply ? "Supply" : "Net name"}</dt>
               <dd>
                 <input
+                  dir="auto"
                   key={`${portNet.id}-${revision}-net-port-name`}
                   aria-label={
                     portNet.supply ? "Supply name" : "Supply Net name"
@@ -88,6 +89,7 @@ export function ComponentIdentityProperties({
               <dt>Schematic label</dt>
               <dd>
                 <input
+                  dir="auto"
                   key={`${instance.id}-${revision}-schematic-label`}
                   aria-label="Component schematic label"
                   defaultValue={flattenRichText(
@@ -111,6 +113,7 @@ export function ComponentIdentityProperties({
               <dt>Netlist reference</dt>
               <dd>
                 <input
+                  dir="auto"
                   key={`${instance.id}-${revision}-netlist-reference`}
                   aria-label="Component netlist reference"
                   defaultValue={instance.netlist.reference}
@@ -166,6 +169,7 @@ export function ComponentIdentityProperties({
           <label>
             Model
             <input
+              dir="auto"
               key={`${instance.id}-${revision}-model-target`}
               aria-label="Component model target"
               list={modelTarget.listId}

--- a/apps/editor/src/features/search/project-search-dialog.tsx
+++ b/apps/editor/src/features/search/project-search-dialog.tsx
@@ -47,6 +47,7 @@ export function ProjectSearchDialog({
           </button>
         </header>
         <input
+          dir="auto"
           ref={inputRef}
           data-testid="project-search-input"
           aria-label="Search project"

--- a/apps/editor/src/features/selection/pin-bond-move.test.ts
+++ b/apps/editor/src/features/selection/pin-bond-move.test.ts
@@ -1,0 +1,221 @@
+/**
+ * A pin dropped exactly onto a foreign pin bonds the two endpoints through
+ * the direct-contact planner (merge + connect), the same explicit gesture
+ * as placing a component against one. Owner feedback: two elements that
+ * abut via terminals are connected; moving one later grows the wire back
+ * (that half lives in the engine's direct-contact lifecycle).
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import type { RouteEndpoint, SchematicDocument } from "@icm/model";
+import { parseProject } from "@icm/project-protocol";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import {
+  createRoutingOperationPlan,
+  executeTransaction,
+  gateRoutingOperationPlan,
+  type RoutingOperationIntent,
+  type SchematicEdit,
+} from "@icm/edit-engine";
+import { describe, expect, it } from "vitest";
+
+import { createSelectionMoveController } from "./selection-move-controller";
+import { planSelectionMove } from "./selection-move-plan";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+function fixtureDocument(): SchematicDocument {
+  const document = parseProject(
+    readFileSync(
+      resolve(
+        process.cwd(),
+        "fixtures/projects/phase-3-routing/project.icproj.json",
+      ),
+      "utf8",
+    ),
+  ).documents[0]!;
+  // C: pin contact at (0,200) — the bond target on net-v.
+  document.instances.find((i) => i.id === "C")!.placement = {
+    position: { x: -10, y: 200 },
+    rotation: 0,
+    mirror: "none",
+  };
+  // E: rotation 270 puts its pin contact at (pos.x, pos.y-10).
+  document.instances.find((i) => i.id === "E")!.placement = {
+    position: { x: 30, y: 400 },
+    rotation: 270,
+    mirror: "none",
+  };
+  // RX: an unowned two-pin device; pin "1" contact at (pos.x, pos.y-20).
+  document.instances.push({
+    id: "RX",
+    symbolId: "resistor",
+    placement: { position: { x: 100, y: 420 }, rotation: 0, mirror: "none" },
+    netlist: { reference: "RX", parameters: {} },
+  });
+  return document;
+}
+
+function runMove(options: {
+  instanceId: string;
+  origin: { x: number; y: number };
+  pinStart: { x: number; y: number };
+  target: { x: number; y: number };
+}) {
+  const document = fixtureDocument();
+  const statuses: string[] = [];
+  const transactions: {
+    intent: RoutingOperationIntent;
+    edits: readonly SchematicEdit[];
+    result?: ReturnType<typeof executeTransaction>;
+  }[] = [];
+  const transactConnectivity = (
+    intent: RoutingOperationIntent,
+    edits: readonly SchematicEdit[],
+  ) => {
+    const record: (typeof transactions)[number] = { intent, edits };
+    transactions.push(record);
+    const proposal = createRoutingOperationPlan(document, {
+      intent,
+      edits,
+      diagnostics: [],
+    });
+    const gate = gateRoutingOperationPlan(document, proposal, {
+      symbolResolver: resolver,
+    });
+    if (!gate.ok) {
+      statuses.push(gate.message);
+      return null;
+    }
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "bond-commit",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: [...gate.edits],
+      },
+      { symbolResolver: resolver },
+    );
+    record.result = result;
+    if (!result.ok)
+      statuses.push(`${result.error.code}: ${result.error.message}`);
+    return { ok: result.ok };
+  };
+  const controller = createSelectionMoveController({
+    document,
+    resolver,
+    visibleEndpoints: [],
+    routeGeometryRecords: [],
+    contactComponents: [],
+    transactConnectivity,
+    setStatus: (status) => statuses.push(status),
+    nextRoutingSuffix: () => 1,
+  });
+  const movePlan = planSelectionMove(document, {
+    instanceIds: [options.instanceId],
+    routeIds: [],
+    junctionIds: [],
+    annotationIds: [],
+    draftingIds: [],
+  });
+  const preview = {
+    instanceIds: movePlan.instanceIds,
+    primaryInstanceId: options.instanceId,
+    originalPositions: { [options.instanceId]: options.origin },
+    pointerStart: { x: 500, y: 500 },
+    movePlan,
+  };
+  // Land the moving pin exactly on the target contact.
+  const position = {
+    x: 500 + (options.target.x - options.pinStart.x),
+    y: 500 + (options.target.y - options.pinStart.y),
+  };
+  const resolved = controller.resolveInstanceMove(
+    preview,
+    position,
+    7,
+    false,
+    undefined,
+    document,
+  );
+  controller.completeInstanceMove(preview, position, 7, false, resolved.snap, {
+    document,
+    prefixEdits: [],
+    resolvedMove: resolved,
+  });
+  return { resolved, statuses, transactions };
+}
+
+const netOf = (
+  document: SchematicDocument,
+  endpoint: Extract<RouteEndpoint, { kind: "terminal" }>,
+): string | null =>
+  document.nets.find((net) =>
+    net.terminals.some(
+      (candidate) =>
+        candidate.instanceId === endpoint.instanceId &&
+        candidate.pinName === endpoint.pinName,
+    ),
+  )?.id ?? null;
+
+describe("pin-onto-pin move bond", () => {
+  it("bonds an unowned pin dropped on a foreign pin into its net", () => {
+    const { resolved, statuses, transactions } = runMove({
+      instanceId: "RX",
+      origin: { x: 100, y: 420 },
+      pinStart: { x: 100, y: 400 },
+      target: { x: 0, y: 200 },
+    });
+    expect(resolved.snap.electricalMatch?.target.electrical?.kind).toBe(
+      "endpoint",
+    );
+    const edits = transactions.flatMap((t) => t.edits);
+    expect(edits.some((edit) => edit.kind === "connect_endpoints")).toBe(true);
+    const committed = transactions.find((t) => t.result?.ok);
+    expect(committed).toBeDefined();
+    const after = committed!.result!;
+    if (!after.ok) throw new Error("expected ok");
+    expect(
+      netOf(after.document, {
+        kind: "terminal",
+        instanceId: "RX",
+        pinName: "1",
+      }),
+    ).toBe(
+      netOf(after.document, {
+        kind: "terminal",
+        instanceId: "C",
+        pinName: "P",
+      }),
+    );
+    expect(statuses.some((s) => s.includes("Snapped pin endpoints"))).toBe(
+      true,
+    );
+  });
+
+  it("keeps two differently named nets apart and says why", () => {
+    // E rides net-h (HORIZONTAL); C rides net-v (VERTICAL). The planner
+    // refuses the silent merge, the move itself still commits, and the
+    // status names the conflict instead of claiming a connection.
+    const { statuses, transactions } = runMove({
+      instanceId: "E",
+      origin: { x: 30, y: 400 },
+      pinStart: { x: 30, y: 390 },
+      target: { x: 0, y: 200 },
+    });
+    const edits = transactions.flatMap((t) => t.edits);
+    expect(edits.some((edit) => edit.kind === "connect_endpoints")).toBe(false);
+    expect(transactions.some((t) => t.result?.ok)).toBe(true);
+    expect(
+      statuses.some((s) =>
+        s.includes("Moved without connecting: Cannot directly connect"),
+      ),
+    ).toBe(true);
+    expect(statuses.some((s) => s.includes("Snapped pin endpoints"))).toBe(
+      false,
+    );
+  });
+});

--- a/apps/editor/src/features/selection/selection-move-controller.ts
+++ b/apps/editor/src/features/selection/selection-move-controller.ts
@@ -1,4 +1,5 @@
 import {
+  planDirectEndpointConnection,
   proposeEndpointRouteAttachment,
   planRoutingTransform,
   type RoutingOperationIntent,
@@ -498,6 +499,29 @@ export function createSelectionMoveController({
               `move-${nextRoutingSuffix()}`,
             ).edits
           : [];
+      // A pin dropped exactly on a foreign pin (or junction) is the same
+      // explicit gesture as placing a component against one: bond the two
+      // endpoints through the direct-contact planner. Incompatible nets
+      // (conflicting names or power domains) fall back to a plain move.
+      let directContactRejection: string | null = null;
+      const directEdits: readonly SchematicEdit[] = (() => {
+        if (
+          movingElectrical?.kind !== "endpoint" ||
+          targetElectrical?.kind !== "endpoint"
+        ) {
+          return [];
+        }
+        const plan = planDirectEndpointConnection(projected, {
+          from: movingElectrical.endpoint,
+          to: targetElectrical.endpoint,
+          newNetId: `net-move-${nextRoutingSuffix()}`,
+        });
+        if (!plan.ok) {
+          directContactRejection = plan.message;
+          return [];
+        }
+        return plan.edits;
+      })();
       const result = transactConnectivity(
         targetElectrical?.kind === "route"
           ? "attach-to-route"
@@ -509,10 +533,13 @@ export function createSelectionMoveController({
           ...groupMove.edits,
           ...visualMoveEdits(preview.movePlan, delta, sourceDocument),
           ...contactEdits,
+          ...directEdits,
         ],
       );
-      if (result?.ok && electricalMatch) {
+      if (result?.ok && (contactEdits.length > 0 || directEdits.length > 0)) {
         setStatus("Snapped pin endpoints and connected them without a wire");
+      } else if (result?.ok && directContactRejection) {
+        setStatus(`Moved without connecting: ${directContactRejection}`);
       } else if (result?.ok && prefixEdits.length > 0) {
         setStatus("Moved and transformed selection");
       }

--- a/apps/editor/src/features/text-editing/rich-text-editor.tsx
+++ b/apps/editor/src/features/text-editing/rich-text-editor.tsx
@@ -525,6 +525,7 @@ export function RichTextEditor({
           ref={sourceInputRef}
           className="rich-text-editable rich-text-source-input"
           type="text"
+          dir="auto"
           value={flattenRichText(content)}
           disabled={disabled}
           aria-label="Canvas text editor"
@@ -547,6 +548,8 @@ export function RichTextEditor({
           contentEditable={!disabled}
           suppressContentEditableWarning
           role="textbox"
+          // Follow the content's script: RTL text edits right-to-left.
+          dir="auto"
           aria-label="Canvas text editor"
           aria-multiline="true"
           style={{


### PR DESCRIPTION
Owner feedback batch (wiring): abutting terminals connect; RTL textboxes; wire-from-net-point and dot-delete verified.

- **Pin-on-pin bond**: dropping a pin exactly on a foreign pin emits the direct-contact planner's `merge_nets` + `connect_endpoints` — explicit typed edits, not silent transform bonding, mirroring the component-placement path. Two differently named nets refuse the merge, the move still commits, and the status says why (regression test for both directions). Moving the device away later materializes the wire (engine direct-contact lifecycle).
- **RTL**: `dir="auto"` on the canvas rich-text editor, source input, identity fields, search, and publish dialog inputs.
- **E2E**: `wiring-semantics.spec.ts` locks in mid-route wire starts (split + tee dot) and junction-dot click → Delete → tap disconnected — both already worked but had no coverage.

Validation: typecheck clean, editor+engine suites 905/905 (incl. 2 new bond tests), new e2e 2/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)