### PR TITLE
feat(editor): persistent draw-angle mode for arrow and line tools

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -185,7 +185,10 @@ import {
   translateDraftingObject,
 } from "../features/drafting/drafting-manipulation";
 import { createDraftingCommands } from "../features/drafting/drafting-commands";
-import { createDraftingCreateController } from "../features/drafting/drafting-create-controller";
+import {
+  createDraftingCreateController,
+  type DrawAngleMode,
+} from "../features/drafting/drafting-create-controller";
 import {
   createDraftingDragController,
   type DraftingHandlePreview,
@@ -472,6 +475,19 @@ export function App({
     setAnnotationGridState(pitch);
     try {
       window.localStorage.setItem("icm.annotation-grid.v1", String(pitch));
+    } catch {
+      // Storage may be unavailable; the choice still applies to this session.
+    }
+  };
+  const [drawAngleMode, setDrawAngleModeState] = useState<DrawAngleMode>(() => {
+    if (typeof window === "undefined") return "free";
+    const stored = window.localStorage.getItem("icm.draw-angle.v1");
+    return stored === "45" || stored === "orthogonal" ? stored : "free";
+  });
+  const setDrawAngleMode = (mode: DrawAngleMode): void => {
+    setDrawAngleModeState(mode);
+    try {
+      window.localStorage.setItem("icm.draw-angle.v1", mode);
     } catch {
       // Storage may be unavailable; the choice still applies to this session.
     }
@@ -1746,6 +1762,7 @@ export function App({
   } = createDraftingCreateController({
     document,
     annotationGrid,
+    angleMode: drawAngleMode,
     resolver,
     visibleEndpoints,
     routeGeometryRecords,
@@ -4201,6 +4218,8 @@ export function App({
         gridDotsVisible={gridDotsVisible}
         annotationGrid={annotationGrid}
         onAnnotationGridChange={setAnnotationGrid}
+        drawAngleMode={drawAngleMode}
+        onDrawAngleModeChange={setDrawAngleMode}
         zoomPercent={zoomPercent}
         onToggleWireOptions={() => setWireOptionsOpen((open) => !open)}
         onWireRoutingModeChange={setWireRoutingMode}

--- a/apps/editor/src/features/drafting/drafting-create-controller.test.ts
+++ b/apps/editor/src/features/drafting/drafting-create-controller.test.ts
@@ -15,12 +15,58 @@ describe("drafting create controller", () => {
     });
   });
 
+  it("applies the persistent draw-angle mode without Shift", () => {
+    const base = {
+      document: createEmptyDocument("cell", "Cell"),
+      annotationGrid: 1,
+      resolver: new InMemorySymbolResolver(builtInSymbols),
+      visibleEndpoints: [],
+      routeGeometryRecords: [],
+      tool: "construction-line" as const,
+      source: { x: 0, y: 0 },
+      hover: null,
+      waypoints: [],
+      setSource: vi.fn(),
+      setHover: vi.fn(),
+      setWaypoints: vi.fn(),
+      setSnapPoint: vi.fn(),
+      clear: vi.fn(),
+      setTool: vi.fn(),
+      transact: vi.fn(() => ({ ok: true })),
+      setStatus: vi.fn(),
+      nextId: () => "line-1",
+    };
+    const at = (angleMode: "free" | "45" | "orthogonal") =>
+      createDraftingCreateController({ ...base, angleMode }).snapPoint(
+        { x: 40, y: 9 },
+        true,
+        false,
+        { x: 0, y: 0 },
+      ).point;
+    // Free keeps the raw direction; 45 locks to the diagonal family;
+    // orthogonal locks to the nearest axis.
+    expect(at("free")).toEqual({ x: 40, y: 9 });
+    expect(at("orthogonal")).toEqual({ x: 41, y: 0 });
+    const diag = at("45");
+    expect(diag.y).toBe(0);
+    // Shift still forces the 45-degree family even in free mode.
+    expect(
+      createDraftingCreateController({ ...base, angleMode: "free" }).snapPoint(
+        { x: 30, y: 28 },
+        true,
+        true,
+        { x: 0, y: 0 },
+      ).point,
+    ).toEqual({ x: 29, y: 29 });
+  });
+
   it("finishes an arrow through one transaction and clears the session", () => {
     const transact = vi.fn(() => ({ ok: true }));
     const clear = vi.fn();
     const setTool = vi.fn();
     const controller = createDraftingCreateController({
       document: createEmptyDocument("cell", "Cell"),
+      angleMode: "free",
       annotationGrid: 10,
       resolver: new InMemorySymbolResolver(builtInSymbols),
       visibleEndpoints: [],
@@ -56,6 +102,7 @@ describe("drafting create controller", () => {
     const transact = vi.fn(() => ({ ok: true }));
     const controller = createDraftingCreateController({
       document: createEmptyDocument("cell", "Cell"),
+      angleMode: "free",
       annotationGrid: 10,
       resolver: new InMemorySymbolResolver(builtInSymbols),
       visibleEndpoints: [],

--- a/apps/editor/src/features/drafting/drafting-create-controller.ts
+++ b/apps/editor/src/features/drafting/drafting-create-controller.ts
@@ -23,14 +23,17 @@ type DraftingTool = Extract<
   "arrow" | "construction-line" | "rectangle" | "circle"
 >;
 
+export type DrawAngleMode = "free" | "45" | "orthogonal";
+
 export function constrainDraftingAngle(
   origin: Point,
   target: DerivedPoint,
+  step: number = Math.PI / 4,
 ): DerivedPoint {
   const dx = target.x - origin.x;
   const dy = target.y - origin.y;
   const angle = Math.atan2(dy, dx);
-  const locked = Math.round(angle / (Math.PI / 4)) * (Math.PI / 4);
+  const locked = Math.round(angle / step) * step;
   const length = Math.hypot(dx, dy);
   return {
     x: Math.round(origin.x + Math.cos(locked) * length),
@@ -41,6 +44,7 @@ export function constrainDraftingAngle(
 export function createDraftingCreateController({
   document,
   annotationGrid,
+  angleMode,
   resolver,
   visibleEndpoints,
   routeGeometryRecords,
@@ -61,6 +65,8 @@ export function createDraftingCreateController({
   document: SchematicDocument;
   /** Rounding pitch for drawn objects; the Document grid stays electrical. */
   annotationGrid: number;
+  /** Persistent draw-angle lock for arrows and lines; Shift still forces the 45-degree family. */
+  angleMode: DrawAngleMode;
   resolver: SymbolResolver;
   visibleEndpoints: readonly WireSource[];
   routeGeometryRecords: readonly RouteGeometryRecord[];
@@ -93,9 +99,18 @@ export function createDraftingCreateController({
     origin?: Point,
     tolerance = document.presentation.grid,
   ): { point: Point; snap: Point | null; guides: SnapGuideLine[] } => {
+    const angleStep = shiftKey
+      ? Math.PI / 4
+      : angleMode === "orthogonal"
+        ? Math.PI / 2
+        : angleMode === "45"
+          ? Math.PI / 4
+          : null;
     if (altKey) {
       const constrained =
-        shiftKey && origin ? constrainDraftingAngle(origin, point) : point;
+        angleStep && origin
+          ? constrainDraftingAngle(origin, point, angleStep)
+          : point;
       return {
         point: snapGridPoint(constrained, annotationGrid),
         snap: null,
@@ -132,7 +147,8 @@ export function createDraftingCreateController({
     const hasObjectSnap =
       (resolved.xMatch && resolved.xMatch.targetKind !== "grid") ||
       (resolved.yMatch && resolved.yMatch.targetKind !== "grid");
-    if (shiftKey && origin) snapped = constrainDraftingAngle(origin, snapped);
+    if (angleStep && origin)
+      snapped = constrainDraftingAngle(origin, snapped, angleStep);
     const gridPoint = snapGridPoint(snapped, annotationGrid);
     return {
       point: gridPoint,

--- a/apps/editor/src/features/editor-shell/editor-statusbar.test.tsx
+++ b/apps/editor/src/features/editor-shell/editor-statusbar.test.tsx
@@ -16,6 +16,8 @@ describe("editor statusbar", () => {
         wireCornerOrder="horizontal-first"
         recoveryLabel="Saved locally"
         gridDotsVisible
+        drawAngleMode="free"
+        onDrawAngleModeChange={vi.fn()}
         annotationGrid={5}
         zoomPercent={100}
         onToggleWireOptions={vi.fn()}

--- a/apps/editor/src/features/editor-shell/editor-statusbar.tsx
+++ b/apps/editor/src/features/editor-shell/editor-statusbar.tsx
@@ -27,6 +27,7 @@ export function EditorStatusbar({
   recoveryLabel,
   gridDotsVisible,
   annotationGrid,
+  drawAngleMode,
   zoomPercent,
   onToggleWireOptions,
   onWireRoutingModeChange,
@@ -34,6 +35,7 @@ export function EditorStatusbar({
   onToggleGridDots,
   onOpenAnalytics,
   onAnnotationGridChange,
+  onDrawAngleModeChange,
   onZoomOut,
   onZoomIn,
   onFitView,
@@ -49,6 +51,7 @@ export function EditorStatusbar({
   recoveryLabel: string | null;
   gridDotsVisible: boolean;
   annotationGrid: 1 | 5 | 10;
+  drawAngleMode: "free" | "45" | "orthogonal";
   zoomPercent: number;
   onToggleWireOptions: () => void;
   onWireRoutingModeChange: (mode: WireRoutingMode) => void;
@@ -56,6 +59,7 @@ export function EditorStatusbar({
   onToggleGridDots: () => void;
   onOpenAnalytics: () => void;
   onAnnotationGridChange: (pitch: 1 | 5 | 10) => void;
+  onDrawAngleModeChange: (mode: "free" | "45" | "orthogonal") => void;
   onZoomOut: () => void;
   onZoomIn: () => void;
   onFitView: () => void;
@@ -177,6 +181,21 @@ export function EditorStatusbar({
           <option value="10">±10</option>
           <option value="5">±5</option>
           <option value="1">±1</option>
+        </select>
+        <select
+          aria-label="Draw angle"
+          data-testid="draw-angle-select"
+          title="Angle lock for the Arrow and Line tools. Shift while drawing always locks to the 45-degree family; wires stay orthogonal."
+          value={drawAngleMode}
+          onChange={(event) =>
+            onDrawAngleModeChange(
+              event.currentTarget.value as "free" | "45" | "orthogonal",
+            )
+          }
+        >
+          <option value="free">Free</option>
+          <option value="45">45°</option>
+          <option value="orthogonal">Ortho</option>
         </select>
         <button
           type="button"


### PR DESCRIPTION
Owner feedback: "add a tool button or menu where you can change the snap style (orthogonal, 45 degrees, free)".

Statusbar select (next to the annotation-grid pitch): **Free / 45° / Ortho**, persisted in localStorage, applied by the Arrow and construction-Line tools' snap pipeline. Shift while drawing still temporarily forces the 45° family in any mode. Wires keep the orthogonal model contract.

Validation: typecheck clean, drafting + editor-shell suites 74/74 (new mode test covers all three modes and the Shift override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)