### PR TITLE
feat(editor): red warning spans for wires buried under symbol artwork

### DIFF
--- a/apps/editor/e2e/overlap-warning.spec.ts
+++ b/apps/editor/e2e/overlap-warning.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { chooseComponent } from "./editor-fixtures";
+
+async function placeComponent(
+  page: Page,
+  symbolId: string,
+  position: { x: number; y: number },
+): Promise<void> {
+  await chooseComponent(page, symbolId);
+  await page.getByTestId("schematic-canvas").click({ position });
+  await page.keyboard.press("Escape");
+}
+
+test("a component dragged over a wire paints a red warning on the covered span", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 200, y: 200 });
+  await placeComponent(page, "resistor", { x: 200, y: 460 });
+  await placeComponent(page, "resistor", { x: 500, y: 330 });
+  const instances = page.locator('[data-canvas-hit-kind="instance"]');
+  const ids = await instances.evaluateAll((elements) =>
+    elements.map((element) => element.getAttribute("data-canvas-hit-id")!),
+  );
+  await page.keyboard.press("w");
+  await page.getByTestId(`terminal-${ids[0]}-2`).click();
+  await page.getByTestId(`terminal-${ids[1]}-1`).click();
+  await page.keyboard.press("Escape");
+  await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(1);
+  await expect(page.getByTestId("wire-under-symbol-overlay")).toHaveCount(0);
+
+  // Drag the third resistor so its body sits on the vertical wire.
+  const third = page.getByTestId(`hit-${ids[2]}`);
+  const from = (await third.boundingBox())!;
+  const route = page.locator('[data-canvas-hit-kind="route"]').first();
+  const wire = (await route.boundingBox())!;
+  const targetX = wire.x + wire.width / 2;
+  const targetY = wire.y + wire.height / 2;
+  await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(targetX, targetY, { steps: 8 });
+  await page.mouse.up();
+
+  const overlay = page.getByTestId("wire-under-symbol-overlay");
+  await expect(overlay).toBeAttached();
+  const lines = overlay.locator(".wire-under-symbol-paint");
+  await expect(lines).not.toHaveCount(0);
+  expect(await lines.first().boundingBox()).not.toBeNull();
+
+  // Clicking the warned span still selects a wire (the warning itself is
+  // pointer-transparent; the route hit band lies underneath).
+  const hitLine = overlay.locator(".wire-under-symbol-hit").first();
+  const lineBox = (await hitLine.boundingBox())!;
+  await page.mouse.click(
+    lineBox.x + lineBox.width / 2,
+    lineBox.y + lineBox.height / 2,
+  );
+  await expect(page.getByTestId("status")).toContainText(
+    "Selected a wire buried under a symbol",
+  );
+  await expect(
+    page.locator('[data-canvas-hit-kind="route"].selected'),
+  ).not.toHaveCount(0);
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -105,6 +105,7 @@ import {
 } from "../features/component-insert/symbol-catalog";
 import { SymbolArtwork } from "../features/component-insert/symbol-artwork";
 import { CanvasContextMenu } from "../features/selection/canvas-context-menu";
+import { deriveWireUnderSymbolWarnings } from "../canvas/wire-under-symbol";
 import { createPlacementTrayCommands } from "../features/component-insert/placement-tray-commands";
 import { componentTargetDescription } from "../features/properties/component-identity-properties";
 import {
@@ -1291,6 +1292,11 @@ export function App({
       : false;
   });
   const styleProfile = resolveDocumentStyleProfile(document.presentation);
+  const wireUnderSymbolWarnings = useMemo(
+    () =>
+      deriveWireUnderSymbolWarnings(document, resolver, routeGeometryRecords),
+    [document, resolver, routeGeometryRecords],
+  );
   const {
     createRouteAnchor,
     beginRouteStretch,
@@ -3905,6 +3911,13 @@ export function App({
             document,
             resolver,
             routeGeometryRecords,
+          }}
+          wireUnderSymbol={{
+            warnings: wireUnderSymbolWarnings,
+            onSelectRoute: (routeId) => {
+              selectOnly("route", [routeId]);
+              setStatus("Selected a wire buried under a symbol");
+            },
           }}
           copyPreviewInnerHtml={copyPreviewInnerHtml}
           inputPlanes={{

--- a/apps/editor/src/canvas/canvas-hit-controller.ts
+++ b/apps/editor/src/canvas/canvas-hit-controller.ts
@@ -141,9 +141,14 @@ export function createCanvasHitController({
     }
     // Handles outrank the scene even when another hit surface is above their
     // SVG element, such as a power-rail endpoint under its Junction circle.
+    // The buried-wire warning span joins them: it exists precisely because
+    // the symbol's hit box sits over the wire, so the span must win the
+    // point or the wire underneath could never be picked.
     const handleAtPoint = event.currentTarget.ownerDocument
       .elementsFromPoint(event.clientX, event.clientY)
-      .some((element) => element.closest(".draft-handle, .route-handle"));
+      .some((element) =>
+        element.closest(".draft-handle, .route-handle, .wire-under-symbol-hit"),
+      );
     if (handleAtPoint) return;
     const hit = resolveCanvasHitAtPoint(
       event.currentTarget.ownerDocument,

--- a/apps/editor/src/canvas/editor-canvas-overlays.tsx
+++ b/apps/editor/src/canvas/editor-canvas-overlays.tsx
@@ -147,3 +147,53 @@ export function NetHighlightOverlay({
     </g>
   );
 }
+
+import type { WireUnderSymbolWarning } from "./wire-under-symbol";
+
+/**
+ * Red spans over wires buried under symbol artwork. The symbol's own hit
+ * box sits above the wire there, so each span carries its own click
+ * target that selects the buried Route for deletion.
+ */
+export function WireUnderSymbolOverlay({
+  warnings,
+  onSelectRoute,
+}: {
+  warnings: readonly WireUnderSymbolWarning[];
+  onSelectRoute: (routeId: string) => void;
+}) {
+  if (warnings.length === 0) return null;
+  return (
+    <g
+      data-testid="wire-under-symbol-overlay"
+      className="wire-under-symbol-overlay"
+    >
+      {warnings.map((warning, index) => (
+        <g key={`${warning.routeId}:${warning.instanceId}:${index}`}>
+          <line
+            className="wire-under-symbol-paint"
+            pointerEvents="none"
+            x1={warning.from.x}
+            y1={warning.from.y}
+            x2={warning.to.x}
+            y2={warning.to.y}
+          />
+          <line
+            className="wire-under-symbol-hit"
+            data-testid={`wire-under-symbol-hit-${warning.routeId}`}
+            x1={warning.from.x}
+            y1={warning.from.y}
+            x2={warning.to.x}
+            y2={warning.to.y}
+            onPointerDown={(event) => {
+              event.stopPropagation();
+              event.preventDefault();
+              onSelectRoute(warning.routeId);
+            }}
+            onClick={(event) => event.stopPropagation()}
+          />
+        </g>
+      ))}
+    </g>
+  );
+}

--- a/apps/editor/src/canvas/editor-canvas-surface.tsx
+++ b/apps/editor/src/canvas/editor-canvas-surface.tsx
@@ -4,6 +4,7 @@ import {
   CanvasGridOverlay,
   CanvasInputPlanes,
   NetHighlightOverlay,
+  WireUnderSymbolOverlay,
 } from "./editor-canvas-overlays";
 import { EditorCanvasHitLayer } from "./editor-canvas-hit-layer";
 import { EditorCellSymbolLayoutOverlay } from "./editor-cell-symbol-layout-overlay";
@@ -27,6 +28,7 @@ export interface EditorCanvasSurfaceProps {
   sceneInnerHtml: { __html: string };
   cellSymbolLayout: ComponentProps<typeof EditorCellSymbolLayoutOverlay> | null;
   netHighlight: ComponentProps<typeof NetHighlightOverlay>;
+  wireUnderSymbol: ComponentProps<typeof WireUnderSymbolOverlay>;
   copyPreviewInnerHtml: { __html: string } | null;
   inputPlanes: ComponentProps<typeof CanvasInputPlanes>;
   placementPreview: ComponentProps<typeof EditorPlacementPreview>;
@@ -75,6 +77,7 @@ export function EditorCanvasSurface({
   sceneInnerHtml,
   cellSymbolLayout,
   netHighlight,
+  wireUnderSymbol,
   copyPreviewInnerHtml,
   inputPlanes,
   placementPreview,
@@ -135,6 +138,7 @@ export function EditorCanvasSurface({
           <EditorRouteHandles {...routeHandles} />
           <EditorCanvasHitLayer {...selectionHitLayer} />
           <EditorDraftingHitTargets {...draftingHitTargets} />
+          <WireUnderSymbolOverlay {...wireUnderSymbol} />
           <EditorDraftingHandles {...draftingHandles} />
           <EditorInteractionPreviews {...interactionPreviews} />
         </g>

--- a/apps/editor/src/canvas/wire-under-symbol.test.ts
+++ b/apps/editor/src/canvas/wire-under-symbol.test.ts
@@ -1,0 +1,90 @@
+import { createEmptyDocument, createRoutePath } from "@icm/model";
+import { resolveDocumentRoutingGeometry } from "@icm/derived";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { deriveWireUnderSymbolWarnings } from "./wire-under-symbol";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+function fixture(resistorAt: { x: number; y: number }) {
+  const document = createEmptyDocument("doc", "Overlap");
+  document.instances.push(
+    {
+      id: "A",
+      symbolId: "resistor",
+      placement: { position: { x: 100, y: 300 }, rotation: 0, mirror: "none" },
+      netlist: { reference: "A", parameters: {} },
+    },
+    {
+      id: "B",
+      symbolId: "resistor",
+      placement: { position: { x: 500, y: 300 }, rotation: 0, mirror: "none" },
+      netlist: { reference: "B", parameters: {} },
+    },
+    {
+      id: "RX",
+      symbolId: "resistor",
+      placement: { position: resistorAt, rotation: 0, mirror: "none" },
+      netlist: { reference: "RX", parameters: {} },
+    },
+  );
+  document.nets.push({
+    id: "net-w",
+    terminals: [
+      { instanceId: "A", pinName: "2" },
+      { instanceId: "B", pinName: "2" },
+    ],
+  });
+  document.routes.push(
+    createRoutePath({
+      id: "route-w",
+      netId: "net-w",
+      start: { kind: "terminal", instanceId: "A", pinName: "2" },
+      end: { kind: "terminal", instanceId: "B", pinName: "2" },
+      bends: [
+        { x: 100, y: 400 },
+        { x: 500, y: 400 },
+      ],
+      modes: ["manual", "manual", "manual"],
+    }),
+  );
+  const geometry = resolveDocumentRoutingGeometry(document, resolver);
+  const records = document.routes.flatMap((route) => {
+    const resolved = geometry.routes.get(route.id);
+    return resolved ? [{ route, geometry: resolved }] : [];
+  });
+  return { document, records };
+}
+
+describe("deriveWireUnderSymbolWarnings", () => {
+  it("flags the span a symbol body covers", () => {
+    // RX parked so its body straddles the horizontal run at y=400.
+    const { document, records } = fixture({ x: 300, y: 400 });
+    const warnings = deriveWireUnderSymbolWarnings(document, resolver, records);
+    const hit = warnings.filter((warning) => warning.instanceId === "RX");
+    expect(hit.length).toBeGreaterThan(0);
+    expect(hit[0]!.routeId).toBe("route-w");
+    expect(hit[0]!.from.y).toBe(400);
+    expect(hit[0]!.to.y).toBe(400);
+  });
+
+  it("does not flag wires that stay clear of symbol bodies", () => {
+    const { document, records } = fixture({ x: 300, y: 200 });
+    expect(
+      deriveWireUnderSymbolWarnings(document, resolver, records).filter(
+        (warning) => warning.instanceId === "RX",
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not flag a pin's own stem skimming the outline", () => {
+    // Endpoint resistors A and B connect to the route legitimately; their
+    // own connection stems must not be reported.
+    const { document, records } = fixture({ x: 300, y: 200 });
+    const warnings = deriveWireUnderSymbolWarnings(document, resolver, records);
+    expect(
+      warnings.filter((warning) => ["A", "B"].includes(warning.instanceId)),
+    ).toEqual([]);
+  });
+});

--- a/apps/editor/src/canvas/wire-under-symbol.ts
+++ b/apps/editor/src/canvas/wire-under-symbol.ts
@@ -1,0 +1,110 @@
+import type { SchematicDocument } from "@icm/model";
+import type { ResolvedRouteGeometry } from "@icm/derived";
+import type { SymbolResolver } from "@icm/symbols";
+
+import { instanceVisibleHitBox } from "./instance-geometry";
+
+export interface WireUnderSymbolWarning {
+  routeId: string;
+  instanceId: string;
+  from: { x: number; y: number };
+  to: { x: number; y: number };
+}
+
+/**
+ * How far inside a symbol's hit box a conductor must reach before it counts
+ * as buried. Pin stems and wires skimming the outline are legitimate; a
+ * wire crossing the artwork body is the drawing error being flagged.
+ */
+const BODY_CLEARANCE = 4;
+
+function clipSegmentToBox(
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  box: { x: number; y: number; width: number; height: number },
+): { from: { x: number; y: number }; to: { x: number; y: number } } | null {
+  // Liang-Barsky parametric clip; works for any orientation.
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  let t0 = 0;
+  let t1 = 1;
+  const edges: readonly [number, number][] = [
+    [-dx, from.x - box.x],
+    [dx, box.x + box.width - from.x],
+    [-dy, from.y - box.y],
+    [dy, box.y + box.height - from.y],
+  ];
+  for (const [p, q] of edges) {
+    if (p === 0) {
+      if (q < 0) return null;
+      continue;
+    }
+    const r = q / p;
+    if (p < 0) {
+      if (r > t1) return null;
+      if (r > t0) t0 = r;
+    } else {
+      if (r < t0) return null;
+      if (r < t1) t1 = r;
+    }
+  }
+  if (t1 - t0 <= 1e-9) return null;
+  return {
+    from: { x: from.x + dx * t0, y: from.y + dy * t0 },
+    to: { x: from.x + dx * t1, y: from.y + dy * t1 },
+  };
+}
+
+/**
+ * Conductor spans buried under symbol artwork. Escape leads (a pin's own
+ * derived stem) and bulk-dashed presentation are exempt; everything else
+ * that crosses the deflated body box of any placed instance is reported so
+ * the editor can paint a warning over the covered span.
+ */
+export function deriveWireUnderSymbolWarnings(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  records: readonly {
+    route: SchematicDocument["routes"][number];
+    geometry: ResolvedRouteGeometry;
+  }[],
+): WireUnderSymbolWarning[] {
+  const boxes = document.instances.flatMap((instance) => {
+    if (!instance.placement) return [];
+    const resolved = resolver.resolve(
+      instance.symbolId,
+      instance.symbolVariantId,
+    );
+    const box = resolved ? instanceVisibleHitBox(instance, resolved) : null;
+    if (!box) return [];
+    const deflated = {
+      x: box.x + BODY_CLEARANCE,
+      y: box.y + BODY_CLEARANCE,
+      width: box.width - BODY_CLEARANCE * 2,
+      height: box.height - BODY_CLEARANCE * 2,
+    };
+    return deflated.width > 0 && deflated.height > 0
+      ? [{ instanceId: instance.id, box: deflated }]
+      : [];
+  });
+  if (boxes.length === 0) return [];
+
+  const warnings: WireUnderSymbolWarning[] = [];
+  for (const { route, geometry } of records) {
+    if (route.presentation === "bulk-dashed") continue;
+    for (const segment of geometry.segments) {
+      if (segment.mode === "escape") continue;
+      for (const { instanceId, box } of boxes) {
+        const clipped = clipSegmentToBox(segment.from, segment.to, box);
+        if (!clipped) continue;
+        warnings.push({
+          routeId: route.id,
+          instanceId,
+          from: clipped.from,
+          to: clipped.to,
+        });
+      }
+    }
+  }
+  return warnings;
+}

--- a/apps/editor/src/styles/editor-canvas.css
+++ b/apps/editor/src/styles/editor-canvas.css
@@ -88,6 +88,23 @@
   cursor: move;
 }
 
+.wire-under-symbol-overlay .wire-under-symbol-paint {
+  stroke: #d3212c;
+  stroke-width: 2.5;
+  stroke-dasharray: 5 3;
+  stroke-linecap: round;
+  vector-effect: non-scaling-stroke;
+  opacity: 0.9;
+}
+
+.wire-under-symbol-overlay .wire-under-symbol-hit {
+  stroke: transparent;
+  stroke-width: 10;
+  cursor: pointer;
+  vector-effect: non-scaling-stroke;
+  pointer-events: stroke;
+}
+
 .flightline {
   stroke: var(--icm-text-muted);
   stroke-width: 1;


### PR DESCRIPTION
Owner feedback: "wires that are behind components should draw a red warning line on top of the component, that the user can select and delete".

- `deriveWireUnderSymbolWarnings` (pure, editor-side): Liang-Barsky clip of every non-escape route segment against each placed instance's deflated visible hit box (4-unit clearance exempts pin stems and edge skims; bulk-dashed exempt). Unit-tested for hit, clear, and own-stem cases.
- Overlay paints dashed red spans above the hit layer; each span has a fat transparent pointer target that selects the buried route (status: "Selected a wire buried under a symbol") — then Delete removes it. The canvas hit controller's point-based resolution now yields to the warning span like it does for handles, since the symbol's own hit box otherwise owns every click there.
- Formal render/export untouched — editing aid only.

Validation: typecheck clean, editor suite 617/617 (3 new unit tests), e2e `overlap-warning.spec.ts` (drag a resistor onto a wire → red span appears → click selects the buried wire) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)