### PR TITLE
Add one-click bug reporting

### DIFF
--- a/apps/editor/e2e/runtime-crash-safety.spec.ts
+++ b/apps/editor/e2e/runtime-crash-safety.spec.ts
@@ -21,6 +21,17 @@ test("a render crash shows the recovery screen instead of a blank page", async (
     "The editor hit an unexpected problem",
   );
   await expect(crashScreen).toContainText("render crashed (test hook)");
+  const bugReportLink = crashScreen.getByTestId("crash-report-bug");
+  await expect(bugReportLink).toBeVisible();
+  await expect(bugReportLink).toHaveAttribute(
+    "href",
+    /^https:\/\/github\.com\/cascode-ai\/analog-canvas\/issues\/new\?/u,
+  );
+  const bugReportHref = await bugReportLink.getAttribute("href");
+  expect(bugReportHref).not.toBeNull();
+  const bugReportBody = new URL(bugReportHref ?? "").searchParams.get("body");
+  expect(bugReportBody).not.toContain("render crashed");
+  expect(bugReportBody).not.toContain("test hook");
 
   // Reloading brings the editor back without the transient crash flag.
   await crashScreen.getByRole("button", { name: "Reload editor" }).click();

--- a/apps/editor/src/analytics.css
+++ b/apps/editor/src/analytics.css
@@ -131,6 +131,10 @@ html.light .analytics-shell {
   align-items: center;
 }
 
+.analytics-top-bar-right {
+  gap: 0.8rem;
+}
+
 .analytics-theme-switch {
   width: 2.7rem;
   height: 2.7rem;
@@ -211,6 +215,21 @@ html.light .analytics-shell {
 
 .analytics-home:hover {
   color: var(--analytics-ink);
+}
+
+.analytics-bug-report {
+  height: auto;
+  padding: 0.35rem 0.2rem;
+  border: 0;
+  color: var(--analytics-ink-soft);
+  background: transparent;
+  font-size: 0.9rem;
+}
+
+.analytics-bug-report:hover {
+  border-color: transparent;
+  color: var(--analytics-ink);
+  background: transparent;
 }
 
 .analytics-error {

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -157,6 +157,8 @@ describe("editor shell", () => {
     expect(markup).toContain('aria-haspopup="dialog"');
     // About folded into Help: one entry, not two saying the same thing.
     expect(markup).not.toContain(">About</button>");
+    expect(markup).toContain('data-testid="editor-report-bug"');
+    expect(markup).toContain("Report bug");
     expect(markup).toContain(">Help</button>");
     expect(markup).toContain('class="app-chrome-actions"');
     expect(markup).toContain("Presented by");

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -2902,6 +2902,7 @@ export function App({
       {renderCrashRequested() ? <RenderCrashProbe /> : null}
       <EditorAppChrome
         projectName={project.name}
+        projectSchemaVersion={project.schemaVersion}
         projectNameDraft={projectNameDraft}
         hasUnsavedWork={isDirtyWork()}
         documentName={document.name}

--- a/apps/editor/src/app/editor-app-chrome.tsx
+++ b/apps/editor/src/app/editor-app-chrome.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps, RefObject } from "react";
 
+import { BugReportLink } from "../components/bug-report-link";
 import { DrawingToolbar } from "../features/editor-shell/drawing-toolbar";
 import { EditorTestTelemetry } from "../features/editor-shell/editor-test-telemetry";
 import { FileCommandMenu } from "../features/editor-shell/file-command-menu";
@@ -20,6 +21,7 @@ interface ResetAction {
 
 export interface EditorAppChromeProps {
   projectName: string;
+  projectSchemaVersion: number;
   projectNameDraft: string | null;
   hasUnsavedWork: boolean;
   documentName: string;
@@ -57,6 +59,7 @@ export interface EditorAppChromeProps {
 /** Persistent command chrome above the document workspace. */
 export function EditorAppChrome({
   projectName,
+  projectSchemaVersion,
   projectNameDraft,
   hasUnsavedWork,
   documentName,
@@ -288,6 +291,11 @@ export function EditorAppChrome({
           </div>
         </nav>
         <div className="app-chrome-actions">
+          <BugReportLink
+            testId="editor-report-bug"
+            surface="Editor"
+            projectSchemaVersion={projectSchemaVersion}
+          />
           <button
             type="button"
             className="menubar-help"

--- a/apps/editor/src/components/analytics-page.tsx
+++ b/apps/editor/src/components/analytics-page.tsx
@@ -6,6 +6,7 @@ import {
   WORLD_BOUNDS,
   type FeatureCollection,
 } from "../lib/world-map";
+import { BugReportLink } from "./bug-report-link";
 
 type DayRow = { date: string; pv: number; uv: number };
 type BreakdownRow = { pv?: number; uv?: number; count?: number };
@@ -208,6 +209,11 @@ export function AnalyticsPage() {
           </button>
         </div>
         <div className="analytics-top-bar-right">
+          <BugReportLink
+            className="analytics-bug-report"
+            testId="analytics-report-bug"
+            surface="Analytics"
+          />
           <a className="analytics-home" href="/">
             ← Back to editor
           </a>

--- a/apps/editor/src/components/bug-report-link.test.tsx
+++ b/apps/editor/src/components/bug-report-link.test.tsx
@@ -1,0 +1,89 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  browserSummary,
+  BugReportLink,
+  buildBugReportUrl,
+  type BugReportEnvironment,
+} from "./bug-report-link";
+
+const environment: BugReportEnvironment = {
+  pathname: "/editor?project=private-project#private-fragment-value",
+  browser: "Chrome 140",
+  viewport: "1440 × 900 @ 2×",
+  mode: "browser tab",
+  reportedAt: "2026-08-28T08:30:00.000Z",
+};
+
+describe("bug report link", () => {
+  it("opens a structured public GitHub issue without private URL parts", () => {
+    const url = new URL(
+      buildBugReportUrl(environment, {
+        surface: "Editor",
+        projectSchemaVersion: 29,
+      }),
+    );
+    const body = url.searchParams.get("body") ?? "";
+
+    expect(url.origin).toBe("https://github.com");
+    expect(url.pathname).toBe("/cascode-ai/analog-canvas/issues/new");
+    expect(url.searchParams.get("labels")).toBe("bug");
+    expect(url.searchParams.get("title")).toBe("[Bug] ");
+    expect(body).toContain("## What happened?");
+    expect(body).toContain("## Steps to reproduce");
+    expect(body).toContain("- Surface: `Editor`");
+    expect(body).toContain("- Page: `/editor`");
+    expect(body).toContain("- Browser: `Chrome 140`");
+    expect(body).toContain("- Project schema: `29`");
+    expect(body).toContain("This GitHub Issue will be public");
+    expect(body).not.toContain("private-project");
+    expect(body).not.toContain("private-fragment-value");
+  });
+
+  it("reduces user agents to a browser family and major version", () => {
+    expect(
+      browserSummary(
+        "Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/140.0.0.0 Safari/537.36",
+      ),
+    ).toBe("Chrome 140");
+    expect(
+      browserSummary(
+        "Mozilla/5.0 AppleWebKit/605.1.15 Version/18.5 Safari/605.1.15",
+      ),
+    ).toBe("Safari 18");
+  });
+
+  it("redacts Gallery entry ids that may identify a private submission", () => {
+    const url = new URL(
+      buildBugReportUrl(
+        {
+          ...environment,
+          pathname: "/g/private-entry-id?owner_token=secret",
+        },
+        { surface: "Gallery entry" },
+      ),
+    );
+    const body = url.searchParams.get("body") ?? "";
+
+    expect(body).toContain("- Page: `/g/:id`");
+    expect(body).not.toContain("private-entry-id");
+    expect(body).not.toContain("owner_token");
+  });
+
+  it("keeps the current page open while GitHub receives the final confirmation", () => {
+    const markup = renderToStaticMarkup(
+      <BugReportLink
+        testId="report-bug"
+        surface="Community gallery"
+        environment={environment}
+      />,
+    );
+
+    expect(markup).toContain('data-testid="report-bug"');
+    expect(markup).toContain('target="_blank"');
+    expect(markup).toContain('rel="noopener noreferrer"');
+    expect(markup).toContain("Report bug");
+    expect(markup).toContain("publicly on GitHub");
+  });
+});

--- a/apps/editor/src/components/bug-report-link.tsx
+++ b/apps/editor/src/components/bug-report-link.tsx
@@ -1,0 +1,160 @@
+const NEW_BUG_ISSUE_URL =
+  "https://github.com/cascode-ai/analog-canvas/issues/new";
+
+export interface BugReportEnvironment {
+  pathname: string;
+  browser: string;
+  viewport: string;
+  mode: "browser tab" | "installed app" | "unknown";
+  reportedAt: string;
+}
+
+export interface BugReportDetails {
+  surface: string;
+  projectSchemaVersion?: number | undefined;
+}
+
+function inlineCode(value: string, maxLength = 240): string {
+  return value
+    .replace(/[\r\n]+/gu, " ")
+    .replaceAll("`", "'")
+    .trim()
+    .slice(0, maxLength);
+}
+
+function pathnameWithoutPrivateParts(pathname: string): string {
+  const staticPathname = pathname.split(/[?#]/u, 1)[0] || "/";
+  // Gallery entry ids can identify rejected, recycled, or otherwise private
+  // submissions linked from /mine. The route is useful; the id is not.
+  const redactedPathname = /^\/g\/[^/]+\/?$/u.test(staticPathname)
+    ? "/g/:id"
+    : staticPathname;
+  return inlineCode(redactedPathname, 160);
+}
+
+/** Keep only a coarse browser family and major version, not the full UA. */
+export function browserSummary(userAgent: string): string {
+  for (const [pattern, name] of [
+    [/Edg\/(\d+)/u, "Edge"],
+    [/OPR\/(\d+)/u, "Opera"],
+    [/CriOS\/(\d+)/u, "Chrome iOS"],
+    [/Chrome\/(\d+)/u, "Chrome"],
+    [/FxiOS\/(\d+)/u, "Firefox iOS"],
+    [/Firefox\/(\d+)/u, "Firefox"],
+    [/Version\/(\d+).+Safari\//u, "Safari"],
+  ] as const) {
+    const match = pattern.exec(userAgent);
+    if (match?.[1]) return `${name} ${match[1]}`;
+  }
+  return "Other / unknown";
+}
+
+export function currentBugReportEnvironment(): BugReportEnvironment {
+  if (typeof window === "undefined") {
+    return {
+      pathname: "/",
+      browser: "Unknown",
+      viewport: "Unknown",
+      mode: "unknown",
+      reportedAt: new Date().toISOString(),
+    };
+  }
+  const standalone = window.matchMedia?.("(display-mode: standalone)").matches;
+  return {
+    // Path only: query strings and hashes can carry private Project/session data.
+    pathname: window.location.pathname,
+    browser:
+      typeof navigator === "undefined"
+        ? "Unknown"
+        : browserSummary(navigator.userAgent),
+    viewport: `${window.innerWidth} × ${window.innerHeight} @ ${window.devicePixelRatio || 1}×`,
+    mode: standalone ? "installed app" : "browser tab",
+    reportedAt: new Date().toISOString(),
+  };
+}
+
+export function buildBugReportUrl(
+  environment: BugReportEnvironment,
+  details: BugReportDetails,
+): string {
+  const schemaLine =
+    details.projectSchemaVersion === undefined
+      ? []
+      : [`- Project schema: \`${details.projectSchemaVersion}\``];
+  const body = [
+    "## What happened?",
+    "",
+    "<!-- Describe the problem. This GitHub Issue will be public: do not include private circuit content, PDK/model files, secrets, access links, or tokens. -->",
+    "",
+    "## Steps to reproduce",
+    "",
+    "1. ",
+    "2. ",
+    "3. ",
+    "",
+    "## Expected behavior",
+    "",
+    "<!-- What should have happened instead? -->",
+    "",
+    "## Environment",
+    "",
+    `- Surface: \`${inlineCode(details.surface, 80)}\``,
+    `- Page: \`${pathnameWithoutPrivateParts(environment.pathname)}\``,
+    `- Browser: \`${inlineCode(environment.browser, 80)}\``,
+    `- Viewport: \`${inlineCode(environment.viewport, 80)}\``,
+    `- Mode: \`${environment.mode}\``,
+    ...schemaLine,
+    `- Report prepared: \`${inlineCode(environment.reportedAt, 40)}\``,
+    "",
+    "## Additional context",
+    "",
+    "<!-- Add screenshots only if they contain no private circuit or account data. -->",
+  ].join("\n");
+  const params = new URLSearchParams({
+    labels: "bug",
+    title: "[Bug] ",
+    body,
+  });
+  return `${NEW_BUG_ISSUE_URL}?${params.toString()}`;
+}
+
+export function BugReportLink({
+  className,
+  testId,
+  surface,
+  projectSchemaVersion,
+  environment,
+}: {
+  className?: string | undefined;
+  testId: string;
+  surface: string;
+  projectSchemaVersion?: number | undefined;
+  /** Deterministic override for tests; production always reads the current page. */
+  environment?: BugReportEnvironment | undefined;
+}) {
+  const reportUrl = () =>
+    buildBugReportUrl(environment ?? currentBugReportEnvironment(), {
+      surface,
+      projectSchemaVersion,
+    });
+  return (
+    <a
+      className={["bug-report-link", className].filter(Boolean).join(" ")}
+      href={reportUrl()}
+      target="_blank"
+      rel="noopener noreferrer"
+      data-testid={testId}
+      aria-label="Report a bug publicly on GitHub (opens in a new tab)"
+      title="Open a prefilled public GitHub issue in a new tab"
+      onClick={(event) => {
+        // Refresh timestamp, route, and viewport for long-lived editor tabs.
+        event.currentTarget.href = reportUrl();
+      }}
+    >
+      <span className="bug-report-mark" aria-hidden="true">
+        !
+      </span>
+      <span className="bug-report-label">Report bug</span>
+    </a>
+  );
+}

--- a/apps/editor/src/components/editor-error-boundary.test.tsx
+++ b/apps/editor/src/components/editor-error-boundary.test.tsx
@@ -14,6 +14,8 @@ describe("EditorCrashScreen", () => {
     expect(html).toContain("The editor hit an unexpected problem");
     expect(html).toContain("boom in scene build");
     expect(html).toContain("Reload editor");
+    expect(html).toContain('data-testid="crash-report-bug"');
+    expect(html).toContain("Report bug");
     expect(html).toContain("Recover Local Work");
   });
 });

--- a/apps/editor/src/components/editor-error-boundary.tsx
+++ b/apps/editor/src/components/editor-error-boundary.tsx
@@ -1,6 +1,8 @@
 import { Component } from "react";
 import type { ErrorInfo, ReactNode } from "react";
 
+import { BugReportLink } from "./bug-report-link";
+
 export interface EditorErrorBoundaryProps {
   children: ReactNode;
 }
@@ -72,9 +74,15 @@ export function EditorCrashScreen({
         <p>
           <code>{message}</code>
         </p>
-        <button type="button" onClick={onReload}>
-          Reload editor
-        </button>
+        <div className="editor-crash-actions">
+          <button type="button" onClick={onReload}>
+            Reload editor
+          </button>
+          <BugReportLink
+            testId="crash-report-bug"
+            surface="Unexpected problem screen"
+          />
+        </div>
         <p className="editor-crash-note">
           After reloading, use File / Recover Local Work… if your latest changes
           are missing.

--- a/apps/editor/src/components/gallery-chrome.tsx
+++ b/apps/editor/src/components/gallery-chrome.tsx
@@ -1,4 +1,5 @@
 import { AccountMenu } from "./account";
+import { BugReportLink } from "./bug-report-link";
 
 /**
  * The one gallery site header, shared by the feed and every gallery
@@ -65,6 +66,7 @@ export function GalleryChrome({
       </div>
       <nav className="gallery-actions">
         <AccountMenu />
+        <BugReportLink testId="gallery-report-bug" surface={subtitle} />
         <a
           className="gallery-open-editor"
           href="/editor?new=1"

--- a/apps/editor/src/components/gallery-feed.test.tsx
+++ b/apps/editor/src/components/gallery-feed.test.tsx
@@ -66,6 +66,8 @@ describe("GalleryFeed", () => {
     expect(markup).toContain('data-testid="gallery-feed"');
     expect(markup).toContain("Analog Canvas");
     expect(markup).toContain('data-testid="gallery-new-circuit"');
+    expect(markup).toContain('data-testid="gallery-report-bug"');
+    expect(markup).toContain("Report bug");
     expect(markup).toContain('href="/editor"');
     expect(markup).toContain("Presented by");
     expect(markup).toContain('href="https://tokenzhang.com"');

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -323,6 +323,46 @@ body {
   margin-left: auto;
 }
 
+/* One public support path across Gallery, Editor, Analytics, and crash UI. */
+.bug-report-link {
+  box-sizing: border-box;
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  gap: var(--icm-space-1);
+  height: var(--icm-control-h);
+  padding: 0 10px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  color: var(--icm-text-muted);
+  background: transparent;
+  font-size: var(--icm-font-md);
+  font-weight: 500;
+  line-height: var(--icm-line-tight);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.bug-report-link:hover {
+  border-color: var(--icm-border-hover);
+  color: var(--icm-text);
+  background: var(--icm-surface-hover);
+}
+
+.bug-report-mark {
+  display: inline-grid;
+  width: 1rem;
+  height: 1rem;
+  place-items: center;
+  border: 1px solid currentcolor;
+  border-radius: 999px;
+  color: var(--icm-error);
+  font-size: 0.7rem;
+  font-weight: 750;
+  line-height: 1;
+}
+
 /* Owner credit: paired with analytics at gallery center; after Help in editor. */
 .tokenzhang-credit {
   display: inline-flex;
@@ -395,6 +435,15 @@ body {
   .publish-label-long {
     display: none;
   }
+
+  .app-chrome-actions .bug-report-label {
+    display: none;
+  }
+
+  .app-chrome-actions .bug-report-link {
+    width: var(--icm-control-h);
+    padding: 0;
+  }
 }
 
 /* The gallery header centers credit plus analytics as one unit. A signed-in
@@ -415,6 +464,17 @@ body {
 @media (max-width: 860px) {
   .gallery-credit-group {
     display: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .gallery-actions .bug-report-label {
+    display: none;
+  }
+
+  .gallery-actions .bug-report-link {
+    width: var(--icm-control-h);
+    padding: 0;
   }
 }
 

--- a/apps/editor/src/styles/editor-chrome.css
+++ b/apps/editor/src/styles/editor-chrome.css
@@ -815,6 +815,16 @@
   overflow-wrap: anywhere;
 }
 
+.editor-crash-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--icm-space-2);
+}
+
+.editor-crash-actions > * {
+  min-height: var(--icm-control-h-lg);
+}
+
 .editor-crash-note {
   color: #5f6b7a;
   font-size: var(--icm-font-sm);


### PR DESCRIPTION
## Summary

- add a shared Report bug entry to Gallery, Editor, Analytics, and the crash screen
- open a prefilled public GitHub issue for user review instead of granting the site Issue write access
- include bounded diagnostics while redacting query strings, fragments, Gallery ids, project content, credentials, and crash details
- keep compact headers responsive and accessible

## Validation

- `pnpm gate:preflight -- --base origin/main`
- `ICM_E2E_PORT=4175 ICM_E2E_ISOLATED=1 pnpm gate:affected -- --base origin/main`
- focused privacy and crash-screen tests after final hardening