### PR TITLE
fix(editor): contain and resize formula authoring

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -195,6 +195,50 @@ test("authors one validated formula through the canonical text editor", async ({
     page.locator('math-field[aria-label="Formula editor"]'),
   ).toBeVisible();
 
+  const editorLayout = await page
+    .getByTestId("canvas-text-editor")
+    .evaluate((element) => {
+      const shell = element.querySelector<HTMLElement>(
+        ".rich-text-editor-shell",
+      );
+      const formulaScroll = element.querySelector<HTMLElement>(
+        '[data-testid="formula-scroll-region"]',
+      );
+      const mathfield = element.querySelector<HTMLElement>("math-field");
+      const keyboardToggle = mathfield?.shadowRoot?.querySelector<HTMLElement>(
+        '[part="virtual-keyboard-toggle"]',
+      );
+      return {
+        frameHeight: Number(element.getAttribute("height")),
+        shellHeight: shell?.offsetHeight ?? 0,
+        shellScrollHeight: shell?.scrollHeight ?? 0,
+        shellOverflowY: shell ? getComputedStyle(shell).overflowY : "",
+        formulaOverflowY: formulaScroll
+          ? getComputedStyle(formulaScroll).overflowY
+          : "",
+        keyboardToggleDisplay: keyboardToggle
+          ? getComputedStyle(keyboardToggle).display
+          : "none",
+        virtualKeyboardVisible: window.mathVirtualKeyboard?.visible === true,
+      };
+    });
+  expect(editorLayout.frameHeight).toBeGreaterThanOrEqual(
+    editorLayout.shellScrollHeight,
+  );
+  expect(editorLayout.shellHeight).toBeGreaterThanOrEqual(
+    editorLayout.shellScrollHeight,
+  );
+  expect(editorLayout.shellOverflowY).not.toBe("auto");
+  expect(editorLayout.shellOverflowY).not.toBe("scroll");
+  expect(editorLayout.formulaOverflowY).toBe("auto");
+  expect(editorLayout.keyboardToggleDisplay).toBe("none");
+  expect(editorLayout.virtualKeyboardVisible).toBe(false);
+
+  await page.getByRole("button", { name: "Insert Square root" }).click();
+  await expect(
+    page.getByRole("textbox", { name: "Formula LaTeX source" }),
+  ).toHaveValue(/\\sqrt/u);
+
   const source = page.getByRole("textbox", { name: "Formula LaTeX source" });
   await source.fill(String.raw`A_v=\frac{g_m}{1+s/\omega_p}`);
   await page.getByRole("button", { name: "Display" }).click();

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -4630,14 +4630,29 @@ test("keeps a long right-aligned Port label readable while editing", async ({
   await editable.click();
   await page.keyboard.type("VinputDifferentialPositive");
 
-  // The overlay is a foreignObject, so anything past its frame is clipped
-  // away silently rather than scrolled to.
-  const overflow = await editable.evaluate((element) => ({
-    hidden: element.scrollHeight - element.clientHeight,
-    scrollable: getComputedStyle(element).overflowY,
-  }));
-  expect(overflow.hidden).toBeLessThanOrEqual(0);
-  expect(overflow.scrollable).toBe("auto");
+  // The outer foreignObject follows the editor's measured height. The text
+  // stays fully visible without turning the main editing surface into a
+  // nested vertical scroller.
+  const layout = await page
+    .getByTestId("canvas-text-editor")
+    .evaluate((element) => {
+      const editable = element.querySelector<HTMLElement>(
+        ".rich-text-editable",
+      );
+      const shell = element.querySelector<HTMLElement>(
+        ".rich-text-editor-shell",
+      );
+      return {
+        hidden: (editable?.scrollHeight ?? 0) - (editable?.clientHeight ?? 0),
+        editableOverflowY: editable ? getComputedStyle(editable).overflowY : "",
+        frameHeight: Number(element.getAttribute("height")),
+        shellScrollHeight: shell?.scrollHeight ?? 0,
+      };
+    });
+  expect(layout.hidden).toBeLessThanOrEqual(0);
+  expect(layout.editableOverflowY).not.toBe("auto");
+  expect(layout.editableOverflowY).not.toBe("scroll");
+  expect(layout.frameHeight).toBeGreaterThanOrEqual(layout.shellScrollHeight);
 });
 
 test("turns a marquee selection as one body, not three parts in place", async ({

--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.test.ts
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.test.ts
@@ -82,6 +82,18 @@ describe("canvas text editor frame", () => {
     expect(frame.layoutHeight).toBeGreaterThan(54 + oneLine * 2);
   });
 
+  it("expands to the editor's measured content height", () => {
+    const frame = resolveCanvasTextEditorFrame(
+      target,
+      camera(960, 640),
+      1,
+      1,
+      312,
+    );
+    expect(frame.layoutHeight).toBe(312);
+    expect(frame.height).toBe(312);
+  });
+
   it("clamps the frame to all four viewport edges", () => {
     const view = camera(960, 640);
     const topLeft = resolveCanvasTextEditorFrame(

--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
@@ -1,4 +1,10 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 import type { DerivedRect, GridRect } from "@icm/model";
 
@@ -57,6 +63,7 @@ export function resolveCanvasTextEditorFrame(
   viewBox: GridRect,
   sizeScale: number,
   pixelsPerUnit?: number | null,
+  preferredLayoutHeight?: number | null,
 ): CanvasTextEditorFrame {
   const width = viewBox.width * EDITOR_VIEW_FRACTION;
   // Laying the panel out at true screen pixels is what lets its type be set
@@ -73,7 +80,11 @@ export function resolveCanvasTextEditorFrame(
   // committed bounds imply. Anything past that scrolls rather than being
   // clipped away by the foreignObject.
   const lineHeight = 15.116 * sizeScale * 1.2;
-  const layoutHeight = Math.max(EDITOR_LAYOUT_MIN_HEIGHT, 54 + lineHeight * 3);
+  const layoutHeight = Math.max(
+    EDITOR_LAYOUT_MIN_HEIGHT,
+    54 + lineHeight * 3,
+    preferredLayoutHeight ?? 0,
+  );
   const height = layoutHeight * scale;
   const viewportInset = 8;
   const targetGap = 8;
@@ -116,6 +127,19 @@ export function CanvasTextEditorOverlay({
     width: number;
     height: number;
   } | null>(null);
+  const [measuredLayoutHeight, setMeasuredLayoutHeight] = useState<
+    number | null
+  >(null);
+
+  useEffect(() => {
+    setMeasuredLayoutHeight(null);
+  }, [session.id, session.owner]);
+
+  const handleLayoutHeightChange = useCallback((height: number): void => {
+    setMeasuredLayoutHeight((current) =>
+      current !== null && Math.abs(current - height) < 1 ? current : height,
+    );
+  }, []);
 
   // How many screen pixels one Document unit covers. The panel is laid out in
   // those pixels so its type can be set against the rest of the chrome, and
@@ -146,6 +170,7 @@ export function CanvasTextEditorOverlay({
           canvasSize.height / viewBox.height,
         )
       : null,
+    measuredLayoutHeight,
   );
 
   return (
@@ -187,6 +212,7 @@ export function CanvasTextEditorOverlay({
           onAlignmentChange={(alignment) => onUpdate({ alignment })}
           onCommit={onCommit}
           onDelete={onDelete}
+          onLayoutHeightChange={handleLayoutHeightChange}
           {...(onReverseCurrentArrow ? { onReverseCurrentArrow } : {})}
         />
       </foreignObject>

--- a/apps/editor/src/features/text-editing/rich-text-editor.tsx
+++ b/apps/editor/src/features/text-editing/rich-text-editor.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useRef, useState } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 import {
   flattenRichText,
@@ -30,6 +37,7 @@ export interface RichTextEditorProps {
   onCommit(): void;
   onDelete(): void;
   onReverseCurrentArrow?(): void;
+  onLayoutHeightChange?(height: number): void;
 }
 
 function escapeHtml(value: string): string {
@@ -215,21 +223,45 @@ function editableDocument(element: HTMLElement): RichTextDocument {
   return normalizeRichText(document);
 }
 
-function FormulaMathfield({
-  value,
-  onChange,
-}: {
-  value: string;
-  onChange(value: string): void;
-}) {
+interface FormulaMathfieldHandle {
+  insert(latex: string): void;
+}
+
+const FormulaMathfield = forwardRef<
+  FormulaMathfieldHandle,
+  {
+    value: string;
+    onChange(value: string): void;
+  }
+>(function FormulaMathfield({ value, onChange }, ref) {
   const hostRef = useRef<HTMLDivElement>(null);
   const fieldRef = useRef<import("mathlive").MathfieldElement | null>(null);
   const changeRef = useRef(onChange);
+  const valueRef = useRef(value);
   changeRef.current = onChange;
+  valueRef.current = value;
+
+  useImperativeHandle(ref, () => ({
+    insert(latex: string): void {
+      const field = fieldRef.current;
+      if (!field) return;
+      field.insert(latex, {
+        format: "latex",
+        selectionMode: "placeholder",
+        focus: true,
+        feedback: false,
+      });
+      changeRef.current(field.value);
+    },
+  }));
 
   useEffect(() => {
     let disposed = false;
     let field: import("mathlive").MathfieldElement | undefined;
+    let keyboard: Window["mathVirtualKeyboard"] | undefined;
+    const suppressVirtualKeyboard = (event: Event): void => {
+      event.preventDefault();
+    };
     const mount = async () => {
       const [{ MathfieldElement }] = await Promise.all([
         import("mathlive"),
@@ -240,13 +272,25 @@ function FormulaMathfield({
       // MathLive's fallback loader, whose module-relative `/fonts` guess does
       // not exist in a bundled application.
       MathfieldElement.fontsDirectory = null;
+      MathfieldElement.soundsDirectory = null;
       field = new MathfieldElement();
-      field.value = value;
+      field.value = valueRef.current;
       field.setAttribute("aria-label", "Formula editor");
+      // The stock virtual keyboard is appended to the page, outside this SVG
+      // foreignObject. Keep physical-keyboard input and provide a local,
+      // product-styled formula structure palette instead.
       field.setAttribute("math-virtual-keyboard-policy", "manual");
+      field.popoverPolicy = "off";
+      field.environmentPopoverPolicy = "off";
       field.addEventListener("input", () => changeRef.current(field!.value));
       hostRef.current.replaceChildren(field);
       fieldRef.current = field;
+      keyboard = window.mathVirtualKeyboard;
+      if (keyboard.visible) keyboard.hide({ animate: false });
+      keyboard.addEventListener(
+        "before-virtual-keyboard-toggle",
+        suppressVirtualKeyboard,
+      );
       field.focus();
     };
     void mount();
@@ -254,6 +298,11 @@ function FormulaMathfield({
       disposed = true;
       fieldRef.current = null;
       field?.remove();
+      keyboard?.removeEventListener(
+        "before-virtual-keyboard-toggle",
+        suppressVirtualKeyboard,
+      );
+      if (keyboard?.visible) keyboard.hide({ animate: false });
     };
   }, []);
 
@@ -264,7 +313,30 @@ function FormulaMathfield({
   }, [value]);
 
   return <div className="rich-text-formula-mathfield" ref={hostRef} />;
-}
+});
+
+const FORMULA_KEYCAPS = [
+  { label: "xₙ", title: "Subscript", latex: "_{#0}" },
+  { label: "xⁿ", title: "Superscript", latex: "^{#0}" },
+  { label: "a⁄b", title: "Fraction", latex: "\\frac{#0}{#0}" },
+  { label: "√x", title: "Square root", latex: "\\sqrt{#0}" },
+  { label: "x̅", title: "Overbar", latex: "\\overline{#0}" },
+  { label: "|x|", title: "Absolute value", latex: "\\left|#0\\right|" },
+  { label: "∫", title: "Integral", latex: "\\int_{#0}^{#0}" },
+  { label: "Σ", title: "Summation", latex: "\\sum_{#0}^{#0}" },
+  { label: "+", title: "Plus", latex: "+" },
+  { label: "−", title: "Minus", latex: "-" },
+  { label: "×", title: "Multiply", latex: "\\times" },
+  { label: "÷", title: "Divide", latex: "\\div" },
+  { label: "=", title: "Equals", latex: "=" },
+  { label: "(", title: "Open parenthesis", latex: "(" },
+  { label: ")", title: "Close parenthesis", latex: ")" },
+  { label: "π", title: "Pi", latex: "\\pi" },
+  { label: "ω", title: "Omega", latex: "\\omega" },
+  { label: "μ", title: "Mu", latex: "\\mu" },
+  { label: "Δ", title: "Delta", latex: "\\Delta" },
+  { label: "→", title: "Right arrow", latex: "\\rightarrow" },
+] as const;
 
 export function RichTextEditor({
   targetKey,
@@ -280,9 +352,12 @@ export function RichTextEditor({
   onCommit,
   onDelete,
   onReverseCurrentArrow,
+  onLayoutHeightChange,
 }: RichTextEditorProps) {
+  const shellRef = useRef<HTMLDivElement>(null);
   const editableRef = useRef<HTMLDivElement>(null);
   const sourceInputRef = useRef<HTMLInputElement>(null);
+  const formulaMathfieldRef = useRef<FormulaMathfieldHandle>(null);
   const selectionRangeRef = useRef<Range | null>(null);
   const existingFormula = soleRichTextMathRun(content);
   const [formulaOpen, setFormulaOpen] = useState(false);
@@ -293,6 +368,19 @@ export function RichTextEditor({
     existingFormula?.display ?? "inline",
   );
   const [formulaError, setFormulaError] = useState<string | null>(null);
+
+  useLayoutEffect(() => {
+    const shell = shellRef.current;
+    if (!shell || !onLayoutHeightChange) return;
+    const report = (): void => {
+      onLayoutHeightChange(Math.ceil(shell.offsetHeight));
+    };
+    report();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(report);
+    observer.observe(shell);
+    return () => observer.disconnect();
+  }, [onLayoutHeightChange, targetKey]);
 
   useEffect(() => {
     if (sourceOnly && sourceInputRef.current) {
@@ -417,7 +505,7 @@ export function RichTextEditor({
     if (disabled) return;
     const selection = window.getSelection()?.toString().trim();
     const formula = soleRichTextMathRun(content);
-    setFormulaDraft(formula?.latex ?? selection ?? "V_{OUT}");
+    setFormulaDraft(formula?.latex ?? (selection || "V_{OUT}"));
     setFormulaDisplay(formula?.display ?? "inline");
     setFormulaError(null);
     setFormulaOpen(true);
@@ -448,6 +536,7 @@ export function RichTextEditor({
 
   return (
     <div
+      ref={shellRef}
       className="rich-text-editor-shell"
       onPointerDown={(event) => event.stopPropagation()}
     >
@@ -651,43 +740,90 @@ export function RichTextEditor({
           role="dialog"
           aria-label="Formula"
         >
-          <FormulaMathfield value={formulaDraft} onChange={setFormulaDraft} />
-          {formulaError ? (
-            <div className="rich-text-formula-error" role="alert">
-              {formulaError}
+          <div className="rich-text-formula-header">
+            <div>
+              <strong>Formula</strong>
+              <span>LaTeX with live preview</span>
             </div>
-          ) : null}
-          <div className="rich-text-formula-source">
-            <label>
-              LaTeX
+            <button
+              type="button"
+              aria-label="Close formula editor"
+              onClick={() => setFormulaOpen(false)}
+            >
+              ×
+            </button>
+          </div>
+          <div
+            className="rich-text-formula-scroll-region"
+            data-testid="formula-scroll-region"
+          >
+            <section className="rich-text-formula-preview">
+              <span>Preview</span>
+              <FormulaMathfield
+                ref={formulaMathfieldRef}
+                value={formulaDraft}
+                onChange={setFormulaDraft}
+              />
+            </section>
+            <div
+              className="rich-text-formula-keyboard"
+              role="toolbar"
+              aria-label="Formula keyboard"
+            >
+              {FORMULA_KEYCAPS.map((item) => (
+                <button
+                  key={item.title}
+                  type="button"
+                  aria-label={`Insert ${item.title}`}
+                  title={item.title}
+                  onPointerDown={(event) => event.preventDefault()}
+                  onClick={() =>
+                    formulaMathfieldRef.current?.insert(item.latex)
+                  }
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+            <label className="rich-text-formula-source">
+              <span>LaTeX source</span>
               <textarea
                 value={formulaDraft}
                 aria-label="Formula LaTeX source"
                 spellCheck={false}
+                rows={3}
                 onChange={(event) => setFormulaDraft(event.target.value)}
               />
             </label>
+            {formulaError ? (
+              <div className="rich-text-formula-error" role="alert">
+                {formulaError}
+              </div>
+            ) : null}
           </div>
           <div className="rich-text-formula-actions">
+            <div className="rich-text-formula-display-toggle">
+              <button
+                type="button"
+                aria-pressed={formulaDisplay === "inline"}
+                onClick={() => setFormulaDisplay("inline")}
+              >
+                Inline
+              </button>
+              <button
+                type="button"
+                aria-pressed={formulaDisplay === "block"}
+                onClick={() => setFormulaDisplay("block")}
+              >
+                Display
+              </button>
+            </div>
             <button
+              className="rich-text-formula-primary-action"
               type="button"
-              aria-pressed={formulaDisplay === "inline"}
-              onClick={() => setFormulaDisplay("inline")}
+              onClick={() => void applyFormula()}
             >
-              Inline
-            </button>
-            <button
-              type="button"
-              aria-pressed={formulaDisplay === "block"}
-              onClick={() => setFormulaDisplay("block")}
-            >
-              Display
-            </button>
-            <button type="button" onClick={() => void applyFormula()}>
               Insert
-            </button>
-            <button type="button" onClick={() => setFormulaOpen(false)}>
-              Cancel
             </button>
           </div>
         </div>

--- a/apps/editor/src/styles/editor-canvas.css
+++ b/apps/editor/src/styles/editor-canvas.css
@@ -376,10 +376,9 @@
   gap: 0.15rem;
   box-sizing: border-box;
   width: 100%;
-  height: 100%;
   min-width: 0;
   padding: 0.2rem;
-  overflow: hidden;
+  overflow: visible;
   border: 1px solid var(--icm-border-strong);
   border-radius: var(--icm-radius-md);
   color: var(--icm-text);
@@ -489,10 +488,7 @@
 .rich-text-editable {
   box-sizing: border-box;
   max-width: 100%;
-  /* The overlay is a foreignObject, which clips silently. Text that still
-     overflows the frame must stay reachable by scrolling. */
-  max-height: 100%;
-  overflow-y: auto;
+  overflow-y: visible;
   min-height: 1.35rem;
   padding: 0.1rem 0.25rem;
   border: 1px solid var(--icm-accent);
@@ -553,23 +549,78 @@
 
 .rich-text-formula-popover {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 0.2rem 0.35rem;
-  padding: 0.25rem;
-  overflow: auto;
+  gap: 0;
+  min-width: 0;
+  overflow: hidden;
   border: 1px solid var(--icm-border-strong);
-  border-radius: var(--icm-radius-sm);
-  background: #fff;
+  border-radius: var(--icm-radius-md);
+  background: var(--icm-surface);
   box-shadow: var(--icm-shadow-md);
+}
+
+.rich-text-formula-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.45rem 0.55rem;
+  border-bottom: 1px solid var(--icm-border);
+  background: var(--icm-surface-muted);
+}
+
+.rich-text-formula-header > div {
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+}
+
+.rich-text-formula-header strong {
+  font-size: var(--icm-font-sm);
+}
+
+.rich-text-formula-header span,
+.rich-text-formula-preview > span,
+.rich-text-formula-source > span {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+
+.rich-text-formula-header button {
+  width: 1.65rem;
+  height: 1.65rem;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  font-size: 1.15rem;
+  line-height: 1;
+}
+
+.rich-text-formula-header button:hover {
+  background: var(--icm-accent-tint);
+}
+
+.rich-text-formula-scroll-region {
+  display: grid;
+  gap: 0.45rem;
+  max-height: min(20rem, 48vh);
+  min-height: 0;
+  padding: 0.5rem 0.55rem;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+
+.rich-text-formula-preview {
+  display: grid;
+  gap: 0.2rem;
 }
 
 .rich-text-formula-mathfield {
   min-width: 0;
-  grid-column: 1 / -1;
 }
 
 .rich-text-formula-error {
-  grid-column: 1 / -1;
   color: var(--icm-danger, #b42318);
   font-size: var(--icm-font-xs);
 }
@@ -578,38 +629,97 @@
   box-sizing: border-box;
   width: 100%;
   min-height: 2.2rem;
+  padding: 0.2rem 0.35rem;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
+  outline: 0;
+  background: #fff;
   font-size: 1.05rem;
 }
 
-.rich-text-formula-source label {
+.rich-text-formula-mathfield math-field:focus-within {
+  border-color: var(--icm-accent);
+  box-shadow: 0 0 0 2px rgb(var(--icm-accent-rgb) / 20%);
+}
+
+.rich-text-formula-mathfield math-field::part(virtual-keyboard-toggle),
+.rich-text-formula-mathfield math-field::part(menu-toggle) {
+  display: none;
+}
+
+.rich-text-formula-keyboard {
   display: grid;
-  grid-template-columns: auto minmax(10rem, 1fr);
-  align-items: center;
-  gap: 0.25rem;
-  color: var(--icm-text-muted);
-  font-size: var(--icm-font-xs);
+  grid-template-columns: repeat(10, minmax(1.8rem, 1fr));
+  gap: 0.18rem;
+}
+
+.rich-text-formula-keyboard button {
+  min-width: 0;
+  min-height: 1.8rem;
+  padding: 0.15rem;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface-muted);
+  font-family: "DejaVu Sans", Arial, sans-serif;
+  font-size: var(--icm-font-sm);
+}
+
+.rich-text-formula-keyboard button:hover {
+  border-color: var(--icm-accent);
+  background: var(--icm-accent-tint);
+}
+
+.rich-text-formula-source {
+  display: grid;
+  gap: 0.2rem;
 }
 
 .rich-text-formula-source textarea {
   box-sizing: border-box;
   width: 100%;
-  min-height: 2rem;
-  resize: vertical;
+  min-height: 3.7rem;
+  max-height: 7rem;
+  padding: 0.35rem 0.45rem;
+  resize: none;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-sm);
+  background: #fff;
   font-family: "Google Sans Code Variable", monospace;
+  font-size: var(--icm-font-xs);
+  line-height: 1.35;
 }
 
 .rich-text-formula-actions {
   display: flex;
   align-items: center;
-  gap: 0.15rem;
+  justify-content: space-between;
+  gap: 0.4rem;
+  padding: 0.4rem 0.55rem;
+  border-top: 1px solid var(--icm-border);
+  background: var(--icm-surface-muted);
+}
+
+.rich-text-formula-display-toggle {
+  display: inline-flex;
+  padding: 0.1rem;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: #fff;
+}
+
+.rich-text-formula-display-toggle button {
+  border: 0;
+  background: transparent;
 }
 
 .rich-text-formula-actions button[aria-pressed="true"] {
   color: #fff;
+  background: var(--icm-accent);
+}
+
+.rich-text-formula-primary-action {
+  color: #fff;
+  border-color: var(--icm-accent);
   background: var(--icm-accent);
 }
 


### PR DESCRIPTION
## Summary
- replace MathLive's page-level black virtual keyboard with an in-panel, product-styled formula keyboard
- resize the SVG text editor frame from measured content so the main editor no longer scrolls vertically
- keep only the formula content region scrollable and polish the preview/source/action hierarchy
- synchronize lazy MathLive initialization with the current formula draft

## Validation
- `pnpm gate:preflight -- --base origin/main`
- `pnpm gate:affected -- --base origin/main` (1676 unit tests, 117 browser tests)
- isolated formula E2E: 2/2
- `pnpm build`