### PR TITLE
feat(symbols): house-authored primitives, and a real SPICE switch

### DIFF
--- a/apps/editor/src/features/component-insert/symbol-catalog.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.ts
@@ -112,7 +112,11 @@ export function symbolCategory(symbolId: string): string {
   ) {
     return "Sources";
   }
-  if (["ideal-switch", "closed-switch"].includes(symbolId)) {
+  if (
+    ["ideal-switch", "closed-switch", "voltage-controlled-switch"].includes(
+      symbolId,
+    )
+  ) {
     return "Switches";
   }
   return "Power and Ports";

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -20,7 +20,7 @@ describe("shapes quick-place", () => {
       }),
     );
 
-    expect(symbols).toHaveLength(53);
+    expect(symbols).toHaveLength(54);
     expect(markup).toContain("All devices");
     expect(markup.match(/data-testid="shapes-chip-/g)).toHaveLength(
       symbols.length,
@@ -36,7 +36,7 @@ describe("shapes quick-place", () => {
       ["Passives", 7],
       ["Power and Ports", 5],
       ["Sources", 3],
-      ["Switches", 2],
+      ["Switches", 3],
       ["Analog Blocks", 6],
       ["Logic Gates", 10],
       ["Signal Flow", 5],

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -29,6 +29,9 @@ const COMPACT_LIBRARY_LABELS: Readonly<Record<string, string>> = {
   "current-source": "I Src",
   "d-flip-flop": "DFF",
   "ideal-switch": "Open",
+  // "Voltage-Controlled Switch" overflows the tile; the SPICE letter is what
+  // a reader is looking for anyway.
+  "voltage-controlled-switch": "S Switch",
   inductor: "Ind L",
   "inductor-compact": "Ind",
   ndmos: "NDMOS",

--- a/docs/specs/razavi-visual-contract.md
+++ b/docs/specs/razavi-visual-contract.md
@@ -2,7 +2,7 @@
 
 Status: `accepted`
 
-Version: `1.1`
+Version: `1.2`
 
 Owners: `fixtures/visual-reference`, `packages/symbols`, `packages/derived`,
 `packages/render-svg`, `scripts`
@@ -14,13 +14,37 @@ construction, product exposure, reference registration, and pixel-fidelity
 comparison. Generic Symbol DSL, electrical model, routing, and export contracts
 remain in their owning specifications and are not duplicated here.
 
+## Scope
+
+Every catalog entry declares its `provenance`:
+
+- `razavi-reference-v1` — drawn from the reviewed textbook authority. Every
+  rule in this contract applies, and the entry must pin its evidence.
+- `house` — drawn here, for a primitive the textbook does not contain. It
+  carries no visual authority and claims none.
+
+`razavi-reference-v1` is the default and stays the rule for anything the
+textbook covers. A `house` entry exists so a primitive the reference simply
+never drew — a four-terminal voltage-controlled switch, say — can be placed
+at all, instead of being unreachable because a book about analog design had
+no figure for it.
+
+The line is deliberate and narrow. A `house` entry may not stand in for a
+component the reference does cover, and may not be introduced to avoid the
+work of pinning evidence for one that it does. Naming the provenance in the
+catalog is what keeps the distinction checkable rather than remembered: a
+reader can see at a glance which artwork answers to the textbook and which
+answers to us.
+
 ## Authority and evidence
 
+The rules in this section govern `razavi-reference-v1` entries.
+
 `fixtures/visual-reference/razavi-reference-v1/manifest.json` and the evidence
-it hash-pins are the sole visual authority. They control component geometry,
-stroke hierarchy, node and interface-symbol treatment, arrows, typography,
-annotations, and visual acceptance. Supplemental rasters and PDF vector
-extracts are scoped evidence inside the same authority, not competing
+it hash-pins are the sole visual authority for them. They control component
+geometry, stroke hierarchy, node and interface-symbol treatment, arrows,
+typography, annotations, and visual acceptance. Supplemental rasters and PDF
+vector extracts are scoped evidence inside the same authority, not competing
 authorities.
 
 Existing raster targets remain raster-owned. A `pdf-vector-extract` entry is
@@ -34,7 +58,10 @@ derived artwork must never serve as the raster witness.
 
 VSS, decoded master IR, historical generators, and the
 current candidate rendering are not visual evidence. If the authority lacks a
-component or feature, it remains unreviewed; do not infer it from those sources.
+component or feature, it remains unreviewed; do not infer it from those
+sources, and never widen an evidence file to cover geometry the source does
+not contain. A primitive the textbook never drew is a `house` entry, drawn
+openly as ours, rather than a Razavi entry with invented evidence.
 
 PDF extraction, Symbol generation, and raster comparison are separate tools:
 

--- a/packages/devices/src/descriptors/index.ts
+++ b/packages/devices/src/descriptors/index.ts
@@ -15,6 +15,7 @@ export { resistorDevice } from "./resistor.js";
 export { variableCapacitorDevice } from "./variable-capacitor.js";
 export { variableInductorDevice } from "./variable-inductor.js";
 export { variableResistorDevice } from "./variable-resistor.js";
+export { voltageControlledSwitchDevice } from "./voltage-controlled-switch.js";
 export { vddPortDevice } from "./vdd-port.js";
 export { voltageSourceDevice } from "./voltage-source.js";
 export { zenerDiodeDevice } from "./zener-diode.js";

--- a/packages/devices/src/descriptors/voltage-controlled-switch.ts
+++ b/packages/devices/src/descriptors/voltage-controlled-switch.ts
@@ -1,0 +1,28 @@
+import type { DeviceDescriptor } from "../contract.js";
+
+/**
+ * The SPICE voltage-controlled switch, `S<ref> n+ n- nc+ nc- MODEL`.
+ *
+ * The two switched nodes come first, then the two control nodes, then the
+ * model card that says when it closes — the same order the simulator reads,
+ * so pin order needs no translation on the way out.
+ *
+ * It is a device of its own rather than netlist behaviour added to the
+ * textbook two-terminal switch, which has no control terminals to emit and
+ * whose artwork answers to the reviewed visual reference.
+ */
+export const voltageControlledSwitchDevice = {
+  id: "voltage-controlled-switch",
+  symbolId: "voltage-controlled-switch",
+  deviceClass: "switch",
+  referencePrefix: "S",
+  pinOrder: ["P", "N", "CP", "CN"],
+  targetPolicy: "required-model",
+  parameters: [],
+  dialects: ["spice", "spectre"],
+  capabilities: {
+    supportsModel: true,
+    supportsBulkBinding: false,
+    supportsValueAnnotation: false,
+  },
+} satisfies DeviceDescriptor;

--- a/packages/devices/src/registry.ts
+++ b/packages/devices/src/registry.ts
@@ -18,6 +18,7 @@ import {
   variableInductorDevice,
   variableResistorDevice,
   vddPortDevice,
+  voltageControlledSwitchDevice,
   voltageSourceDevice,
   zenerDiodeDevice,
 } from "./descriptors/index.js";
@@ -64,6 +65,7 @@ export const deviceRegistry = defineDeviceRegistry([
   voltageSourceDevice,
   pulseVoltageSourceDevice,
   currentSourceDevice,
+  voltageControlledSwitchDevice,
   groundDevice,
   vddPortDevice,
 ]);

--- a/packages/model/src/schema/instance.ts
+++ b/packages/model/src/schema/instance.ts
@@ -55,6 +55,9 @@ export const NetlistDeviceClassSchema = z.enum([
   "bjt",
   "voltage-source",
   "current-source",
+  // A voltage-controlled switch: `S<ref> n+ n- nc+ nc- MODEL` — two switched
+  // nodes, two control nodes, and a required model card.
+  "switch",
   "net-marker",
 ]);
 export const InstanceNetlistBindingSchema = z.discriminatedUnion("kind", [

--- a/packages/netlist/src/current-contract.test.ts
+++ b/packages/netlist/src/current-contract.test.ts
@@ -710,3 +710,44 @@ describe("current formal cell interface", () => {
     });
   });
 });
+
+describe("voltage-controlled switch", () => {
+  it("extracts and prints the four-node S card the simulator reads", () => {
+    const project = createEmptyProject("project", "Project");
+    const document = project.documents[0]!;
+    document.instances.push({
+      id: "S1",
+      symbolId: "voltage-controlled-switch",
+      placement: null,
+      netlist: {
+        reference: "S1",
+        binding: { kind: "model", deviceClass: "switch", name: "SW_RLY" },
+        parameters: {},
+      },
+    });
+    // Two switched nodes then two control nodes, in the descriptor's pin
+    // order, which is the order SPICE reads them.
+    const wire = (netId: string, name: string, pinName: string) => {
+      document.nets.push({
+        id: netId,
+        terminals: [{ instanceId: "S1", pinName }],
+      });
+      claimNet(document, netId, name);
+    };
+    wire("net-a", "vout", "P");
+    wire("net-b", "0", "N");
+    wire("net-c", "vctrl", "CP");
+    wire("net-d", "vcm", "CN");
+
+    const analysis = analyzeDesignNetlist(project);
+    expect(
+      analysis.diagnostics.filter(
+        (diagnostic) => diagnostic.severity === "error",
+      ),
+    ).toEqual([]);
+    expect(analysis.ir).not.toBeNull();
+    expect(printSpiceNetlist(analysis.ir!)).toContain(
+      "S1 vout 0 vctrl vcm SW_RLY",
+    );
+  });
+});

--- a/packages/netlist/src/printers.test.ts
+++ b/packages/netlist/src/printers.test.ts
@@ -166,6 +166,19 @@ describe("design netlist printers", () => {
     );
   });
 
+  it("prints a voltage-controlled switch as its four-node S card", () => {
+    const ir = structuralIr();
+    ir.cells[1]!.instances.push(
+      device("s1", "S1", "switch", ["vout", "0", "vctrl", "0"], "SW_RLY", []),
+    );
+
+    // The card a simulator reads: two switched nodes, two control nodes, then
+    // the model. Node order is the descriptor's pin order, so nothing is
+    // reordered on the way out.
+    expect(printSpiceNetlist(ir)).toContain("S1 vout 0 vctrl 0 SW_RLY");
+    expect(printSpectreNetlist(ir)).toContain("S1 (vout 0 vctrl 0) SW_RLY");
+  });
+
   it("wraps long SPICE instance records with continuation lines", () => {
     const ir = structuralIr();
     ir.cells[1]!.instances[0]!.parameters = Array.from(

--- a/packages/netlist/src/printers.ts
+++ b/packages/netlist/src/printers.ts
@@ -106,6 +106,9 @@ function spiceInstance(instance: DesignNetlistInstance): string[] {
     case "mos":
     case "diode":
     case "bjt":
+    // `S<ref> n+ n- nc+ nc- MODEL`: nodes then the model card, the same shape
+    // as every other model-bearing primitive.
+    case "switch":
       tokens = [
         instance.reference,
         ...nodes,
@@ -211,6 +214,7 @@ function spectreInstance(instance: DesignNetlistInstance): string {
     case "mos":
     case "diode":
     case "bjt":
+    case "switch":
     case "hierarchical":
       master = instance.target!;
       values = assignments(instance.parameters);

--- a/packages/symbols/assets/razavi-v1/catalog.json
+++ b/packages/symbols/assets/razavi-v1/catalog.json
@@ -1057,6 +1057,19 @@
       }
     },
     {
+      "symbolId": "voltage-controlled-switch",
+      "name": "Voltage-Controlled Switch",
+      "category": "switch",
+      "reviewStatus": "reviewed",
+      "provenance": "house",
+      "houseReason": "The reference draws a two-terminal switch and no control terminals, while a SPICE switch is S<ref> n+ n- nc+ nc- MODEL. Drawn here rather than by widening the two-terminal evidence with geometry the source does not contain.",
+      "pinOrder": ["P", "N", "CP", "CN"],
+      "palette": true,
+      "automaticMappings": ["spice:S"],
+      "assetPath": "voltage-controlled-switch.symbol.json",
+      "assetHash": "017dca36a916932614666b12f91785e8edf7848c1751cc30157ecdae94200db0"
+    },
+    {
       "symbolId": "voltage-source",
       "name": "Independent Voltage Source",
       "category": "source",

--- a/packages/symbols/assets/razavi-v1/voltage-controlled-switch.symbol.json
+++ b/packages/symbols/assets/razavi-v1/voltage-controlled-switch.symbol.json
@@ -1,0 +1,226 @@
+{
+  "schemaVersion": 1,
+  "id": "voltage-controlled-switch",
+  "name": "Voltage-Controlled Switch",
+  "viewBox": {
+    "x": -34,
+    "y": -27,
+    "width": 68,
+    "height": 55
+  },
+  "pins": [
+    {
+      "name": "P",
+      "role": "passive",
+      "at": {
+        "x": -30,
+        "y": -10
+      },
+      "direction": "west",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 10
+      }
+    },
+    {
+      "name": "N",
+      "role": "passive",
+      "at": {
+        "x": 30,
+        "y": -10
+      },
+      "direction": "east",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 10
+      }
+    },
+    {
+      "name": "CP",
+      "role": "passive",
+      "at": {
+        "x": -30,
+        "y": 20
+      },
+      "direction": "west",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 10
+      }
+    },
+    {
+      "name": "CN",
+      "role": "passive",
+      "at": {
+        "x": 30,
+        "y": 20
+      },
+      "direction": "east",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 10
+      }
+    }
+  ],
+  "primitives": [
+    {
+      "kind": "line",
+      "from": {
+        "x": -30,
+        "y": -10
+      },
+      "to": {
+        "x": -13,
+        "y": -10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "circle",
+      "center": {
+        "x": -10,
+        "y": -10
+      },
+      "radius": 3,
+      "fill": "none",
+      "stroke": "foreground",
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -7,
+        "y": -12.4
+      },
+      "to": {
+        "x": 6.4,
+        "y": -22.8
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "circle",
+      "center": {
+        "x": 11,
+        "y": -10
+      },
+      "radius": 3,
+      "fill": "none",
+      "stroke": "foreground",
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 14,
+        "y": -10
+      },
+      "to": {
+        "x": 30,
+        "y": -10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -30,
+        "y": 20
+      },
+      "to": {
+        "x": -4,
+        "y": 20
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 4,
+        "y": 20
+      },
+      "to": {
+        "x": 30,
+        "y": 20
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 0,
+        "y": 16
+      },
+      "to": {
+        "x": 0,
+        "y": 12
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 0,
+        "y": 8
+      },
+      "to": {
+        "x": 0,
+        "y": 4
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 0,
+        "y": 0
+      },
+      "to": {
+        "x": 0,
+        "y": -4
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    }
+  ],
+  "variants": []
+}

--- a/packages/symbols/src/builtins.test.ts
+++ b/packages/symbols/src/builtins.test.ts
@@ -47,6 +47,7 @@ const PRODUCT_IDS = [
   "vdd-port",
   "voltage-amplifier",
   "pulse-voltage-source",
+  "voltage-controlled-switch",
   "voltage-source",
   "xnor-gate",
   "xor-gate",

--- a/packages/symbols/src/razavi-catalog.generated.ts
+++ b/packages/symbols/src/razavi-catalog.generated.ts
@@ -1265,6 +1265,21 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
     },
   },
   {
+    symbolId: "voltage-controlled-switch",
+    name: "Voltage-Controlled Switch",
+    category: "switch",
+    reviewStatus: "reviewed",
+    provenance: "house",
+    houseReason:
+      "The reference draws a two-terminal switch and no control terminals, while a SPICE switch is S<ref> n+ n- nc+ nc- MODEL. Drawn here rather than by widening the two-terminal evidence with geometry the source does not contain.",
+    pinOrder: ["P", "N", "CP", "CN"],
+    palette: true,
+    automaticMappings: ["spice:S"],
+    assetPath: "voltage-controlled-switch.symbol.json",
+    assetHash:
+      "017dca36a916932614666b12f91785e8edf7848c1751cc30157ecdae94200db0",
+  },
+  {
     symbolId: "voltage-source",
     name: "Independent Voltage Source",
     category: "source",
@@ -7443,6 +7458,232 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         to: {
           x: 0,
           y: 20,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+    ],
+    variants: [],
+  },
+  {
+    schemaVersion: 1,
+    id: "voltage-controlled-switch",
+    name: "Voltage-Controlled Switch",
+    viewBox: {
+      x: -34,
+      y: -27,
+      width: 68,
+      height: 55,
+    },
+    pins: [
+      {
+        name: "P",
+        role: "passive",
+        at: {
+          x: -30,
+          y: -10,
+        },
+        direction: "west",
+        presentation: {
+          visibility: "visible",
+          leadLength: 10,
+        },
+      },
+      {
+        name: "N",
+        role: "passive",
+        at: {
+          x: 30,
+          y: -10,
+        },
+        direction: "east",
+        presentation: {
+          visibility: "visible",
+          leadLength: 10,
+        },
+      },
+      {
+        name: "CP",
+        role: "passive",
+        at: {
+          x: -30,
+          y: 20,
+        },
+        direction: "west",
+        presentation: {
+          visibility: "visible",
+          leadLength: 10,
+        },
+      },
+      {
+        name: "CN",
+        role: "passive",
+        at: {
+          x: 30,
+          y: 20,
+        },
+        direction: "east",
+        presentation: {
+          visibility: "visible",
+          leadLength: 10,
+        },
+      },
+    ],
+    primitives: [
+      {
+        kind: "line",
+        from: {
+          x: -30,
+          y: -10,
+        },
+        to: {
+          x: -13,
+          y: -10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "circle",
+        center: {
+          x: -10,
+          y: -10,
+        },
+        radius: 3,
+        fill: "none",
+        stroke: "foreground",
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -7,
+          y: -12.4,
+        },
+        to: {
+          x: 6.4,
+          y: -22.8,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "circle",
+        center: {
+          x: 11,
+          y: -10,
+        },
+        radius: 3,
+        fill: "none",
+        stroke: "foreground",
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 14,
+          y: -10,
+        },
+        to: {
+          x: 30,
+          y: -10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -30,
+          y: 20,
+        },
+        to: {
+          x: -4,
+          y: 20,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 4,
+          y: 20,
+        },
+        to: {
+          x: 30,
+          y: 20,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 0,
+          y: 16,
+        },
+        to: {
+          x: 0,
+          y: 12,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 0,
+          y: 8,
+        },
+        to: {
+          x: 0,
+          y: 4,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 0,
+          y: 0,
+        },
+        to: {
+          x: 0,
+          y: -4,
         },
         style: {
           strokeRole: "normal",

--- a/packages/symbols/src/razavi-catalog.test.ts
+++ b/packages/symbols/src/razavi-catalog.test.ts
@@ -132,7 +132,9 @@ describe("Razavi symbol catalog", () => {
       razaviSymbolCatalogEntries.map((entry) => [
         entry.symbolId,
         entry.reviewStatus,
-        entry.visualAuthority.kind,
+        // A house primitive has no visual authority and reports its
+        // provenance instead, so the table shows what each entry answers to.
+        entry.visualAuthority?.kind ?? entry.provenance,
       ]),
     ).toEqual([
       ["and-gate", "reviewed", "razavi-reference-v1"],
@@ -182,6 +184,7 @@ describe("Razavi symbol catalog", () => {
       ["vdd-port", "reviewed", "razavi-reference-v1"],
       ["voltage-amplifier", "reviewed", "razavi-reference-v1"],
       ["pulse-voltage-source", "reviewed", "razavi-reference-v1"],
+      ["voltage-controlled-switch", "reviewed", "house"],
       ["voltage-source", "reviewed", "razavi-reference-v1"],
       ["xnor-gate", "reviewed", "razavi-reference-v1"],
       ["xor-gate", "reviewed", "razavi-reference-v1"],
@@ -498,7 +501,7 @@ describe("Razavi symbol catalog", () => {
   });
 
   it("uses reviewed catalog objects as the sole built-in product library", () => {
-    expect(razaviCatalogSymbols).toHaveLength(47);
+    expect(razaviCatalogSymbols).toHaveLength(48);
     for (const catalogSymbol of razaviProductSymbols) {
       expect(
         builtInSymbols.find((symbol) => symbol.id === catalogSymbol.id),
@@ -549,6 +552,7 @@ describe("Razavi symbol catalog", () => {
       "vdd-port",
       "voltage-amplifier",
       "pulse-voltage-source",
+      "voltage-controlled-switch",
       "voltage-source",
       "xnor-gate",
       "xor-gate",

--- a/packages/symbols/src/razavi-catalog.ts
+++ b/packages/symbols/src/razavi-catalog.ts
@@ -11,7 +11,18 @@ export interface RazaviSymbolCatalogEntry {
   name: string;
   category: string;
   reviewStatus: "reviewed" | "provisional";
-  visualAuthority: {
+  /**
+   * Where the artwork comes from. `razavi-reference-v1` answers to the
+   * reviewed textbook authority and pins its evidence; `house` is drawn here
+   * for a primitive the textbook never contained, and says so rather than
+   * borrowing an authority it does not have. Absent means Razavi, which is
+   * what every reviewed entry is.
+   */
+  provenance?: "razavi-reference-v1" | "house";
+  /** Required on a house entry: why the reference does not cover it. */
+  houseReason?: string;
+  /** Present exactly when the provenance is `razavi-reference-v1`. */
+  visualAuthority?: {
     kind: "razavi-reference-v1";
     referenceManifestPath: string;
     referencePaths: string[];
@@ -81,10 +92,11 @@ const entriesById = new Map(
 export function isRazaviLibraryCatalogEntry(
   entry: RazaviSymbolCatalogEntry,
 ): boolean {
-  return (
-    entry.reviewStatus === "reviewed" &&
-    entry.visualAuthority.kind === "razavi-reference-v1"
-  );
+  if (entry.reviewStatus !== "reviewed") return false;
+  // A house primitive resolves and draws like any other reviewed entry; what
+  // it does not do is claim the reference's authority for its geometry.
+  if (entry.provenance === "house") return entry.visualAuthority === undefined;
+  return entry.visualAuthority?.kind === "razavi-reference-v1";
 }
 
 /** Browsable: the subset a person picks from. */

--- a/scripts/generate-razavi-symbol-catalog.mjs
+++ b/scripts/generate-razavi-symbol-catalog.mjs
@@ -128,35 +128,57 @@ for (const entry of catalog.entries) {
   ) {
     fail(`${entry.symbolId} is unreachable and lacks a manual-only reason`);
   }
-  if (entry.visualAuthority.kind !== "razavi-reference-v1") {
-    fail(`invalid visual authority for ${entry.symbolId}`);
+  const provenance = entry.provenance ?? "razavi-reference-v1";
+  if (provenance !== "razavi-reference-v1" && provenance !== "house") {
+    fail(`invalid provenance for ${entry.symbolId}`);
   }
-  const manifestPath = resolve(
-    root,
-    entry.visualAuthority.referenceManifestPath,
-  );
-  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
-  if (
-    manifest.id !== "razavi-reference-v1" ||
-    manifest.visualAuthority !== "sole"
-  ) {
-    fail(`invalid Razavi Reference authority for ${entry.symbolId}`);
-  }
-  if (entry.visualAuthority.referencePaths.length === 0) {
-    fail(`missing Razavi Reference path for ${entry.symbolId}`);
-  }
-  for (const referencePath of entry.visualAuthority.referencePaths) {
-    if (
-      !referencePath.startsWith(
-        "fixtures/visual-reference/razavi-reference-v1/",
-      )
-    ) {
-      fail(`reference path escapes Razavi authority for ${entry.symbolId}`);
+  if (provenance === "house") {
+    // Drawn here, for a primitive the reference never contained. It must not
+    // borrow the authority it does not have, and it must say why it exists.
+    if (entry.visualAuthority) {
+      fail(`house entry ${entry.symbolId} must not claim visual authority`);
     }
-    await readFile(resolve(root, referencePath));
-  }
-  if (entry.visualAuthority.calibrationPath) {
-    await readFile(resolve(root, entry.visualAuthority.calibrationPath));
+    if (!entry.houseReason) {
+      fail(
+        `house entry ${entry.symbolId} must state why the reference lacks it`,
+      );
+    }
+  } else {
+    if (entry.houseReason) {
+      fail(
+        `${entry.symbolId} states a house reason but claims Razavi authority`,
+      );
+    }
+    if (entry.visualAuthority?.kind !== "razavi-reference-v1") {
+      fail(`invalid visual authority for ${entry.symbolId}`);
+    }
+    const manifestPath = resolve(
+      root,
+      entry.visualAuthority.referenceManifestPath,
+    );
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    if (
+      manifest.id !== "razavi-reference-v1" ||
+      manifest.visualAuthority !== "sole"
+    ) {
+      fail(`invalid Razavi Reference authority for ${entry.symbolId}`);
+    }
+    if (entry.visualAuthority.referencePaths.length === 0) {
+      fail(`missing Razavi Reference path for ${entry.symbolId}`);
+    }
+    for (const referencePath of entry.visualAuthority.referencePaths) {
+      if (
+        !referencePath.startsWith(
+          "fixtures/visual-reference/razavi-reference-v1/",
+        )
+      ) {
+        fail(`reference path escapes Razavi authority for ${entry.symbolId}`);
+      }
+      await readFile(resolve(root, referencePath));
+    }
+    if (entry.visualAuthority.calibrationPath) {
+      await readFile(resolve(root, entry.visualAuthority.calibrationPath));
+    }
   }
   if (assetPaths.has(entry.assetPath)) {
     fail(`duplicate asset path ${entry.assetPath}`);


### PR DESCRIPTION
> 我觉得是允许自制原语符号的，不一定要 Razavi 的那个
> 理想开关也是应该有 netlist 的

## The impasse, and why it was real

The switch on the canvas could not be netlisted **at all**. The symbol library admitted only entries traceable to the reviewed Razavi textbook, and that textbook draws a **two-terminal** switch. A SPICE switch is:

```
S1 vout 0 vctrl vcm SW_RLY      ← four nodes and a model card
```

The catalog had already recorded the impasse in a string and left the component unreachable:

> `manualOnlyReason: "Two-terminal Razavi switch; SPICE S has a four-terminal control contract."`

Adding control pins to the existing drawing would have meant **widening an evidence file with geometry the source PDF does not contain** — the one thing the contract exists to prevent.

## The contract now scopes itself

`docs/specs/razavi-visual-contract.md` → **v1.2**. Every catalog entry declares a `provenance`:

| | authority | evidence |
| --- | --- | --- |
| `razavi-reference-v1` *(default)* | the reviewed textbook | must be pinned, every existing rule applies |
| `house` | **none, and claims none** | must state why the reference lacks it |

The line is narrow on purpose: a house entry **may not** stand in for a component the reference does cover, nor exist to dodge the work of pinning evidence for one that it does. The generator enforces **both** directions — a house entry carrying `visualAuthority` fails, and so does a Razavi entry carrying a `houseReason`.

Declaring artwork as ours is the honest version of the wish that would otherwise have been granted by faking evidence.

## The switch, on that footing

- **Symbol** — four terminals `P N CP CN`, drawn in the same lead/contact/blade idiom as the reviewed two-terminal switch, control pair below with a broken line to the blade. Pins on the 10-grid.
- **Device class** `switch`, **descriptor** with prefix `S` and pin order `P N CP CN` — the order SPICE reads, so nothing is reordered on the way out.
- **Both printers** emit it like every other model-bearing primitive.

## Validation

- Full unit suite: **1656 passed** (2 new: the printer's S card in both dialects, and an end-to-end extract)
- Full Playwright suite: **246 passed**
- Every static gate: catalog drift, agent-kit catalog, MCP distribution, references, markdown links, Prettier, typecheck
- Driven in the running editor: places under **Switches**, takes designator **S1**, four terminals resolve at `P/N` and `CP/CN`

End to end, an instance with a model binding extracts and prints as `S1 vout 0 vctrl vcm SW_RLY` — matching the cards in the benchmark decks.

Two catalog roll-call tests changed for a reason worth naming: the calibration list is Razavi-only by definition, so the house entry is deliberately **not** added to it, while the identity table now reports `visualAuthority?.kind ?? provenance` so each row shows what it answers to.

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)