### PR TITLE
fix(editor): Refresh app restores the circuit on boot-target URLs

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -225,6 +225,40 @@ test("refreshes explicitly only after flushing and automatically restoring recov
     .toBeNull();
 });
 
+test("refresh restores the circuit when the session started from a boot-target URL", async ({
+  page,
+}) => {
+  // location.reload() keeps the entry URL, so the ?new=1 boot target re-runs
+  // on the refreshed page. It must yield to the pending restore instead of
+  // forking a fresh working copy that orphans the flushed snapshot.
+  await page.goto("/editor?new=1");
+  await expect(page.getByTestId("status")).toHaveText("Created a new Project");
+  await chooseComponent(page, "resistor");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 360, y: 230 } });
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("hit-R1")).toBeVisible();
+  await expect(page.getByTestId("revision")).toHaveText("1");
+
+  const navigated = page.waitForEvent("framenavigated");
+  await clickCommand(page, "File", "Refresh app");
+  await navigated;
+
+  await expect(page.getByTestId("hit-R1")).toBeVisible();
+  await expect(page.getByTestId("revision")).toHaveText("1");
+  await expect(page.getByTestId("status")).toHaveText(
+    "Restored recovery revision 1",
+  );
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        sessionStorage.getItem("icm.restore-after-refresh.v1"),
+      ),
+    )
+    .toBeNull();
+});
+
 test("keeps quick-start shortcuts in the corner until the first component is inserted", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -644,6 +644,7 @@ export function App({
     startupRecovery,
     startupCloudProjectId,
     canRestoreStartupCloudProject,
+    restoreAfterRefresh,
     setRecoveryDialogOpen,
     isDirtyWork,
     replaceActiveProject,
@@ -2196,6 +2197,11 @@ export function App({
   useEffect(() => {
     if (bootTargetHandled.current) return;
     bootTargetHandled.current = true;
+    // "Refresh app" reloads the same URL on purpose: the pending restore owns
+    // this boot. Re-running the URL's boot target here would fork the
+    // working-copy identity and orphan the snapshot the restore is about to
+    // read.
+    if (restoreAfterRefresh) return;
     const exampleId = new URLSearchParams(window.location.search).get(
       "example",
     );
@@ -2220,7 +2226,7 @@ export function App({
         setStatus(`Opened example: ${example.name}`);
       }
     }
-  }, [initialGalleryEntryId]);
+  }, [initialGalleryEntryId, restoreAfterRefresh]);
 
   function resetInteractionState(): void {
     exitCellSymbolLayout();

--- a/apps/editor/src/document/use-project-file-lifecycle.ts
+++ b/apps/editor/src/document/use-project-file-lifecycle.ts
@@ -34,7 +34,7 @@ import {
   rememberRecentCloudProject,
 } from "./cloud-project-session";
 
-const REFRESH_RESTORE_STORAGE_KEY = "icm.restore-after-refresh.v1";
+export const REFRESH_RESTORE_STORAGE_KEY = "icm.restore-after-refresh.v1";
 
 export interface SavedProjectBaseline {
   project: CircuitProject;
@@ -95,15 +95,19 @@ export function useProjectFileLifecycle({
   setStatus,
   onCloudProjectSaved,
 }: UseProjectFileLifecycleOptions) {
-  const [restoreAfterRefresh] = useState(() => {
-    if (typeof window === "undefined") return false;
-    const requested =
-      window.sessionStorage.getItem(REFRESH_RESTORE_STORAGE_KEY) === "true";
-    if (requested) {
+  // Read-only initializer: consuming the one-shot flag here would be a render
+  // side effect, and a discarded render (StrictMode's double pass, a Suspense
+  // retry) would eat the flag before the committed render sees it.
+  const [restoreAfterRefresh] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.sessionStorage.getItem(REFRESH_RESTORE_STORAGE_KEY) === "true",
+  );
+  useEffect(() => {
+    if (restoreAfterRefresh) {
       window.sessionStorage.removeItem(REFRESH_RESTORE_STORAGE_KEY);
     }
-    return requested;
-  });
+  }, [restoreAfterRefresh]);
   const [startupCloudProjectId] = useState(readRecentCloudProjectId);
   const refreshRestoreAttemptedRef = useRef(false);
   const saveInFlightRef = useRef<Promise<CloudProjectSaveOutcome> | null>(null);
@@ -656,6 +660,7 @@ export function useProjectFileLifecycle({
     startupRecovery,
     startupCloudProjectId,
     canRestoreStartupCloudProject,
+    restoreAfterRefresh,
     setRecoveryDialogOpen,
     isDirtyWork,
     replaceActiveProject,


### PR DESCRIPTION
## Summary

Owner feedback: **"Refresh app clears the circuit forever"**. Two compounding defects:

1. `location.reload()` keeps the entry URL, so a session started from `?new=1`, `?example=<id>`, or `/g/<id>` re-ran its boot target after the refresh. `replaceActiveProject` forked a fresh working-copy identity, orphaning the snapshot `refreshApp` had just flushed — the restore effect then found nothing under the new identity. With `BROWSER_RECOVERY_MAX_SESSIONS = 2`, one more fork evicts the orphan permanently.
2. The one-shot restore flag was consumed (`removeItem`) inside a `useState` initializer — a render side effect that a discarded render (StrictMode double pass, Suspense retry) could eat.

## Fix

- The boot effect yields to a pending refresh restore (`restoreAfterRefresh` now exposed by the lifecycle hook).
- The flag read is a pure initializer; consumption moved to an effect.
- `REFRESH_RESTORE_STORAGE_KEY` is exported for the dialog chunk-load fallback PR that reuses the restore handshake (identical file content there — either PR lands cleanly first).

## Validation

- New Playwright regression: boot-target URL → place component → File / Refresh app → circuit restored. **Fails on the previous code, passes now.**
- Existing bare-`/editor` refresh spec still green; full `tsconfig.check` typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)