### PR TITLE
fix(editor): a Net highlight can always be cleared

### DIFF
--- a/apps/editor/e2e/net-highlight.spec.ts
+++ b/apps/editor/e2e/net-highlight.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { chooseComponent, clickCommand } from "./editor-fixtures";
+
+async function placeComponent(
+  page: Page,
+  symbolId: string,
+  position: { x: number; y: number },
+): Promise<void> {
+  await chooseComponent(page, symbolId);
+  await page.getByTestId("schematic-canvas").click({ position });
+  await page.keyboard.press("Escape");
+}
+
+async function instanceIds(page: Page): Promise<string[]> {
+  return page
+    .locator('[data-canvas-hit-kind="instance"]')
+    .evaluateAll((elements) =>
+      elements.map((element) => element.getAttribute("data-canvas-hit-id")!),
+    );
+}
+
+test("a Net highlight set from the Check Report can always be cleared", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 260, y: 200 });
+  await placeComponent(page, "resistor", { x: 260, y: 420 });
+  const ids = await instanceIds(page);
+
+  // An unnamed wire between two pins exports with a generated name, which the
+  // Check Report lists as a clickable GENERATED_NET_NAME finding.
+  await page.keyboard.press("w");
+  await page.getByTestId(`terminal-${ids[0]}-2`).click();
+  await page.getByTestId(`terminal-${ids[1]}-1`).click();
+  await page.keyboard.press("Escape");
+
+  await clickCommand(page, "Netlist", "Check Report…");
+  const preflight = page.getByRole("dialog", { name: "Check Report" });
+  await preflight
+    .getByRole("button", { name: /GENERATED_NET_NAME/ })
+    .first()
+    .click();
+  await expect(page.getByTestId("net-highlight-overlay")).toBeVisible();
+
+  // Close the report via its backdrop; the highlight persists on the canvas.
+  await page
+    .locator(".insert-dialog-backdrop")
+    .click({ position: { x: 5, y: 5 } });
+  await expect(preflight).toHaveCount(0);
+  await expect(page.getByTestId("net-highlight-overlay")).toBeVisible();
+
+  // The finding navigation selected the net's route, so H toggles the
+  // highlight off, back on, and off again.
+  await page.keyboard.press("h");
+  await expect(page.getByTestId("net-highlight-overlay")).toHaveCount(0);
+  await expect(page.getByTestId("status")).toHaveText(/Cleared Net highlight/);
+  await page.keyboard.press("h");
+  await expect(page.getByTestId("net-highlight-overlay")).toBeVisible();
+
+  // Escape clears it too, selection or not.
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("net-highlight-overlay")).toHaveCount(0);
+
+  // Even with the selection gone entirely, a lingering highlight stays
+  // clearable from the keyboard.
+  await page.keyboard.press("h");
+  await expect(page.getByTestId("net-highlight-overlay")).toBeVisible();
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 60, y: 60 } });
+  await page.keyboard.press("h");
+  await expect(page.getByTestId("net-highlight-overlay")).toHaveCount(0);
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -2095,6 +2095,7 @@ export function App({
     selectOnly,
     setSelectedEndpoint,
     setHighlightedNetOrigin,
+    highlightedNetOrigin,
     selectedHighlightNetId,
     selectedHighlightEndpoint,
     selectedHighlightIsActive,
@@ -2533,6 +2534,7 @@ export function App({
         selectedDrafting?.kind === "construction-line" ||
         selectedDrafting?.kind === "rectangle" ||
         selectedDrafting?.kind === "circle",
+      hasActiveNetHighlight: highlightedNetOrigin !== null,
     }),
     operations: {
       closeHelp,
@@ -2557,6 +2559,10 @@ export function App({
       clearDraftingSelection: () => {
         replaceSelectionKind("drafting", []);
         setStatus("Cleared drawing selection");
+      },
+      clearNetHighlight: () => {
+        setHighlightedNetOrigin(null);
+        setStatus("Cleared Net highlight");
       },
       cancelPassive: () => {
         setBoxPreview(null);
@@ -2734,6 +2740,7 @@ export function App({
         hasInspectableSelection,
         hasRouteSelection: Boolean(selectedRoute),
         hasHighlightableNet: selectedHighlightNetId !== null,
+        hasActiveNetHighlight: highlightedNetOrigin !== null,
         wireReadyToFinish: Boolean(wireSource && wirePreviewPoint),
         draftingReadyToFinish:
           (tool === "arrow" ||

--- a/apps/editor/src/commands/editor-command.test.ts
+++ b/apps/editor/src/commands/editor-command.test.ts
@@ -23,6 +23,7 @@ function fixture(overrides: Partial<EditorCommandContext> = {}) {
     helpOpen: false,
     canvasDragActive: false,
     hasClearableDraftingSelection: false,
+    hasActiveNetHighlight: false,
     ...overrides,
   };
   const operations: EditorCommandOperations = {
@@ -30,6 +31,7 @@ function fixture(overrides: Partial<EditorCommandContext> = {}) {
     cancelCanvasDrag: vi.fn(),
     cancelInteraction: vi.fn(),
     clearDraftingSelection: vi.fn(),
+    clearNetHighlight: vi.fn(),
     cancelPassive: vi.fn(),
     undo: vi.fn(),
     redo: vi.fn(),
@@ -84,6 +86,26 @@ describe("editor command router", () => {
     expect(interaction.operations.cancelInteraction).toHaveBeenCalledWith(
       "placing-vdd-rail",
     );
+  });
+
+  it("clears an active Net highlight on Escape once nothing else is pending", () => {
+    // Highlight alone: cancel is enabled and clears exactly the highlight.
+    const highlightOnly = fixture({ hasActiveNetHighlight: true });
+    expect(highlightOnly.router.state({ id: "editor.cancel" }).enabled).toBe(
+      true,
+    );
+    highlightOnly.router.execute({ id: "editor.cancel" });
+    expect(highlightOnly.operations.clearNetHighlight).toHaveBeenCalledOnce();
+    expect(highlightOnly.operations.cancelPassive).not.toHaveBeenCalled();
+
+    // A drafting selection still outranks the highlight in the Escape order.
+    const layered = fixture({
+      hasActiveNetHighlight: true,
+      hasClearableDraftingSelection: true,
+    });
+    layered.router.execute({ id: "editor.cancel" });
+    expect(layered.operations.clearDraftingSelection).toHaveBeenCalledOnce();
+    expect(layered.operations.clearNetHighlight).not.toHaveBeenCalled();
   });
 
   it("routes one Rotate command to the active domain", () => {

--- a/apps/editor/src/commands/editor-command.ts
+++ b/apps/editor/src/commands/editor-command.ts
@@ -52,6 +52,7 @@ export interface EditorCommandContext {
   helpOpen: boolean;
   canvasDragActive: boolean;
   hasClearableDraftingSelection: boolean;
+  hasActiveNetHighlight: boolean;
 }
 
 export interface EditorCommandOperations {
@@ -59,6 +60,7 @@ export interface EditorCommandOperations {
   cancelCanvasDrag(): void;
   cancelInteraction(interactionMode: InteractionMode): void;
   clearDraftingSelection(): void;
+  clearNetHighlight(): void;
   cancelPassive(): void;
   undo(): void;
   redo(): void;
@@ -168,7 +170,8 @@ export function createEditorCommandRouter(
           context.helpOpen ||
             context.canvasDragActive ||
             context.interactionMode !== "idle" ||
-            context.hasClearableDraftingSelection,
+            context.hasClearableDraftingSelection ||
+            context.hasActiveNetHighlight,
         );
       case "history.undo":
         return context.canUndo ? enabled() : disabled("Nothing to undo");
@@ -268,6 +271,8 @@ export function createEditorCommandRouter(
           options.operations.cancelInteraction(context.interactionMode);
         } else if (context.hasClearableDraftingSelection) {
           options.operations.clearDraftingSelection();
+        } else if (context.hasActiveNetHighlight) {
+          options.operations.clearNetHighlight();
         } else {
           options.operations.cancelPassive();
         }

--- a/apps/editor/src/features/hierarchy/editor-navigation-controller.test.ts
+++ b/apps/editor/src/features/hierarchy/editor-navigation-controller.test.ts
@@ -1,5 +1,5 @@
 import { buildProjectConnectivityIndex } from "@icm/derived";
-import { createEmptyProject } from "@icm/model";
+import { createEmptyProject, createRoutePath } from "@icm/model";
 import { builtInSymbols, createProjectSymbolResolver } from "@icm/symbols";
 import { describe, expect, it, vi } from "vitest";
 
@@ -33,6 +33,7 @@ function dependencies(
     selectOnly: vi.fn(),
     setSelectedEndpoint: vi.fn(),
     setHighlightedNetOrigin: vi.fn(),
+    highlightedNetOrigin: null,
     selectedHighlightNetId: "net-a",
     selectedHighlightEndpoint: undefined,
     selectedHighlightIsActive,
@@ -78,5 +79,64 @@ describe("editor navigation controller", () => {
     const clear = dependencies(true);
     createEditorNavigationController(clear).toggleHighlightedNet();
     expect(clear.setHighlightedNetOrigin).toHaveBeenCalledWith(null);
+  });
+
+  it("clears an active highlight even when nothing highlightable is selected", () => {
+    const stuck = {
+      ...dependencies(false),
+      selectedHighlightNetId: null,
+      highlightedNetOrigin: { netId: "net-x" },
+    };
+    createEditorNavigationController(stuck).toggleHighlightedNet();
+    expect(stuck.setHighlightedNetOrigin).toHaveBeenCalledWith(null);
+    expect(stuck.setStatus).toHaveBeenCalledWith("Cleared Net highlight net-x");
+  });
+
+  it("net navigation selects the net's route so the highlight stays togglable", () => {
+    const input = dependencies(false);
+    input.document.nets.push({ id: "net-1", terminals: [] });
+    input.document.junctions.push(
+      {
+        id: "j1",
+        netId: "net-1",
+        position: { x: 0, y: 0 },
+        role: "route-anchor",
+      },
+      {
+        id: "j2",
+        netId: "net-1",
+        position: { x: 40, y: 0 },
+        role: "route-anchor",
+      },
+    );
+    input.document.routes.push(
+      createRoutePath({
+        id: "route-1",
+        netId: "net-1",
+        start: { kind: "junction", junctionId: "j1" },
+        end: { kind: "junction", junctionId: "j2" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+    input.connectivityIndex = buildProjectConnectivityIndex(
+      input.project,
+      input.resolver,
+    );
+    createEditorNavigationController(input).navigateToLocator(
+      {
+        documentId: input.document.id,
+        hierarchyPath: [],
+        kind: "net",
+        objectId: "net-1",
+      },
+      "Preflight: floating net",
+    );
+    expect(input.setHighlightedNetOrigin).toHaveBeenCalledWith({
+      documentId: input.document.id,
+      netId: "net-1",
+      hierarchyPath: [],
+    });
+    expect(input.selectOnly).toHaveBeenCalledWith("route", ["route-1"]);
   });
 });

--- a/apps/editor/src/features/hierarchy/editor-navigation-controller.ts
+++ b/apps/editor/src/features/hierarchy/editor-navigation-controller.ts
@@ -71,6 +71,7 @@ export interface EditorNavigationControllerDependencies {
       endpoint?: RouteEndpoint;
     } | null,
   ) => void;
+  highlightedNetOrigin: { netId: string } | null;
   selectedHighlightNetId: string | null;
   selectedHighlightEndpoint: RouteEndpoint | undefined;
   selectedHighlightIsActive: boolean;
@@ -100,6 +101,7 @@ export function createEditorNavigationController({
   selectOnly,
   setSelectedEndpoint,
   setHighlightedNetOrigin,
+  highlightedNetOrigin,
   selectedHighlightNetId,
   selectedHighlightEndpoint,
   selectedHighlightIsActive,
@@ -272,14 +274,21 @@ export function createEditorNavigationController({
           : annotation?.anchor.fallbackPosition;
       if (position) focusPoint(position);
     } else if (locator.kind === "net") {
+      // Store the same resolved path that the document stack was set to:
+      // diagnostics carry an empty locator path, and a mismatched origin
+      // would keep the highlight from ever reading as active (so the first
+      // H press would re-highlight instead of clearing it).
       setHighlightedNetOrigin({
         documentId: opened.id,
         netId: locator.objectId,
-        hierarchyPath: locator.hierarchyPath,
+        hierarchyPath,
       });
       const route = opened.routes.find(
         (item) => item.netId === locator.objectId,
       );
+      // Give the highlight a selection like every other locator kind, so the
+      // H toggle and the dock's Highlight action stay reachable.
+      if (route) selectOnly("route", [route.id]);
       const centerline = route
         ? connectivityIndex.documents
             .get(opened.id)
@@ -415,6 +424,14 @@ export function createEditorNavigationController({
 
   const toggleHighlightedNet = (): void => {
     if (!selectedHighlightNetId) {
+      // No selection to highlight from — but an active highlight must still
+      // be clearable, or a highlight set by a diagnostic/agent with no
+      // surviving selection would be stuck on screen.
+      if (highlightedNetOrigin !== null) {
+        setHighlightedNetOrigin(null);
+        setStatus(`Cleared Net highlight ${highlightedNetOrigin.netId}`);
+        return;
+      }
       setStatus(
         "Select a wire, connected pin, or Net Label before highlighting a Net",
       );

--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -17,6 +17,7 @@ const baseContext: EditorShortcutContext = {
   hasInspectableSelection: false,
   hasRouteSelection: false,
   hasHighlightableNet: false,
+  hasActiveNetHighlight: false,
   wireReadyToFinish: false,
   draftingReadyToFinish: false,
   hasRemovableWireWaypoint: false,
@@ -202,6 +203,11 @@ describe("editor shortcut contract", () => {
     });
     expect(resolve("h")).toBeNull();
     expect(resolve("h", { hasHighlightableNet: true })).toEqual({
+      kind: "toggle-net-highlight",
+    });
+    // A showing highlight keeps H reachable with nothing selected, so a
+    // highlight set by a diagnostic can always be toggled off.
+    expect(resolve("h", { hasActiveNetHighlight: true })).toEqual({
       kind: "toggle-net-highlight",
     });
     expect(resolve("q")).toEqual(command({ id: "properties.open" }));

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -21,6 +21,8 @@ export interface EditorShortcutContext {
   hasInspectableSelection: boolean;
   hasRouteSelection: boolean;
   hasHighlightableNet: boolean;
+  /** A Net highlight is showing; H must stay reachable to clear it. */
+  hasActiveNetHighlight: boolean;
   wireReadyToFinish: boolean;
   draftingReadyToFinish: boolean;
   hasRemovableWireWaypoint: boolean;
@@ -307,7 +309,11 @@ export function resolveEditorShortcut(
       ? { kind: "edit-net-label" }
       : { kind: "net-label-selection-required" };
   }
-  if (plain && key === "h" && context.hasHighlightableNet) {
+  if (
+    plain &&
+    key === "h" &&
+    (context.hasHighlightableNet || context.hasActiveNetHighlight)
+  ) {
     return { kind: "toggle-net-highlight" };
   }
   if (plain && key === "k") {


### PR DESCRIPTION
## Summary

Owner feedback: **"Unable to clear the netlist highlight"**. Highlighting a Net from a Check Report finding stored `highlightedNetOrigin` without creating any selection, while every clear affordance was selection-gated: the H shortcut required `hasHighlightableNet`, the dock buttons need a route/net-label selection, and Escape never touched the highlight. The origin also stored the locator's raw `hierarchyPath` (empty for diagnostics), so even a manually selected same-net wire read as inactive and the first H press re-highlighted instead of clearing.

## Fix (four coordinated changes)

- Net-locator navigation stores the **resolved** hierarchy path (same as the document stack) and selects the net's route like every other locator branch.
- `toggleHighlightedNet` clears any active origin when nothing highlightable is selected.
- The H shortcut stays reachable while a highlight is showing (`hasActiveNetHighlight`).
- `editor.cancel` gains a clear-net-highlight step after drafting-selection clearing — Escape peels the highlight once nothing else is pending.

## Validation

- New unit tests: command router (Escape priority incl. highlight), shortcut contract, navigation controller (clear-without-selection; route selection on net navigation).
- New Playwright spec: Check Report → highlight → close dialog → H toggle off/on → Escape clear → clear with no selection.
- Full `tsconfig.check` typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)