### PR TITLE
fix(editor): silent Apply dead-ends surface a status message

### DIFF
--- a/apps/editor/src/features/properties/property-edit-planner.test.ts
+++ b/apps/editor/src/features/properties/property-edit-planner.test.ts
@@ -103,6 +103,53 @@ describe("property edit planner", () => {
     );
   });
 
+  it("surfaces a rejected named-net plan on the status bar instead of failing silently", () => {
+    const input = routedFixture();
+    input.document.connectivityEvidence.push(
+      {
+        id: "claim-a",
+        kind: "name-claim",
+        netId: "net",
+        name: "vdd",
+        scope: "local",
+        powerDomain: "vdd",
+        owner: { kind: "explicit-net-property" },
+      },
+      {
+        id: "claim-b",
+        kind: "name-claim",
+        netId: "net",
+        name: "vdd",
+        scope: "local",
+        powerDomain: "ground",
+        owner: { kind: "explicit-net-property" },
+      },
+    );
+    const planner = createPropertyEditPlanner(input);
+    const edits = planner.netLabelEditsForRoute(
+      input.document.routes[0]!,
+      "vdd",
+    );
+    expect(edits).toBeNull();
+    expect(input.setStatus).toHaveBeenCalledWith(
+      "Cannot join named Nets with incompatible power roles",
+    );
+  });
+
+  it("reports an unresolved wire geometry instead of failing silently", () => {
+    const input = routedFixture();
+    input.routeGeometryRecords = [];
+    const planner = createPropertyEditPlanner(input);
+    const edits = planner.netLabelEditsForRoute(
+      input.document.routes[0]!,
+      "bias",
+    );
+    expect(edits).toBeNull();
+    expect(input.setStatus).toHaveBeenCalledWith(
+      "Net Label position could not be resolved for this wire",
+    );
+  });
+
   it("reports a stale Power Label binding without emitting edits", () => {
     const input = fixture();
     const annotation: Annotation = {

--- a/apps/editor/src/features/properties/property-edit-planner.ts
+++ b/apps/editor/src/features/properties/property-edit-planner.ts
@@ -76,7 +76,10 @@ export function createPropertyEditPlanner({
     },
   ): SchematicEdit[] | null => {
     const net = document.nets.find((candidate) => candidate.id === route.netId);
-    if (!net) return null;
+    if (!net) {
+      setStatus(`Wire references missing Net ${route.netId}`);
+      return null;
+    }
     const existingLabel = netLabelForRoute(route);
     const name = rawName.trim();
     if (!name) {
@@ -109,12 +112,21 @@ export function createPropertyEditPlanner({
         ),
       owner: { kind: "net-label", annotationId: labelId },
     });
-    if (!namedNetPlan.ok) return null;
+    // A rejected plan (name collision, power-domain conflict) must reach the
+    // status bar: this planner also backs the text editor's Apply, where a
+    // silent null leaves the edit box open with no visible reaction.
+    if (!namedNetPlan.ok) {
+      setStatus(namedNetPlan.message);
+      return null;
+    }
     const targetNetId = namedNetPlan.netId;
     const geometry = routeGeometryRecords.find(
       ({ route: candidate }) => candidate.id === route.id,
     )?.geometry;
-    if (!geometry) return null;
+    if (!geometry) {
+      setStatus("Net Label position could not be resolved for this wire");
+      return null;
+    }
     const segment = Math.max(
       0,
       Math.floor((geometry.centerline.length - 1) / 2),

--- a/apps/editor/src/features/properties/use-properties-editor.ts
+++ b/apps/editor/src/features/properties/use-properties-editor.ts
@@ -356,7 +356,13 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
       options.setStatus(plan.message);
       return;
     }
-    if (plan.kind === "unchanged") return;
+    if (plan.kind === "unchanged") {
+      // The draft can differ from the baseline (whitespace, a new row with a
+      // blank value) while producing no persisted change; without a message
+      // the still-visible Apply button reads as broken.
+      options.setStatus("No additional-parameter changes to apply");
+      return;
+    }
     if (!options.transact([plan.edit]).ok) return;
     const baseline = additionalParameterDraft
       .filter((entry) => entry.name.trim() && entry.value.trim())
@@ -739,6 +745,18 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
                 : presentationChanged || formatOverrideChanged
                   ? [presentationEdit]
                   : [];
+          if (
+            netLabelEdits === null &&
+            !boundRoute &&
+            annotationNetEdits === undefined
+          ) {
+            // No planner owns this label (not route-anchored, not a
+            // power-label): say so instead of leaving Apply visibly inert.
+            options.setStatus(
+              "This label cannot rename its Net — edit the name from a wire on that Net",
+            );
+            return;
+          }
           if (netLabelEdits && transactNamedNet(netLabelEdits)) {
             setTextEditing(null);
           }
@@ -796,7 +814,10 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
       }
     }
     const proposal = proposeTextEditingCommit(options.document, textEditing);
-    if (proposal.kind === "blocked") return;
+    if (proposal.kind === "blocked") {
+      options.setStatus("This text can no longer be edited");
+      return;
+    }
     if (proposal.kind === "delete" && textEditing.owner === "annotation") {
       const annotation = options.document.annotations.find(
         (candidate) => candidate.id === textEditing.id,
@@ -820,7 +841,10 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     ) {
       const content = proposal.edit.annotation.content ?? { runs: [] };
       const name = flattenRichText(content).trim();
-      if (!name) return;
+      if (!name) {
+        options.setStatus("Cell Pin name cannot be empty");
+        return;
+      }
       if (!options.commitCellPinAnnotation(proposal.edit.annotation, name))
         return;
       setTextEditing(null);


### PR DESCRIPTION
## Summary

Owner feedback: **"The property editing box does not accept Apply, it only takes Delete"** (Chrome/Firefox/Edge). The canvas text editor's Apply/Delete pair exposes the asymmetry: Delete transacts unconditionally, while several Apply paths returned without committing, without any message, and with the edit box left open.

## Fix — every silent dead-end now reports

- A rejected named-net plan (name collision, incompatible power roles) forwards the plan's message from `netLabelEditsForRoute` — exactly as the power-label sibling already did.
- A wire whose Net or resolved geometry is missing says so.
- A net-name label no planner owns (not route-anchored, not a power label) explains where to rename instead.
- A blocked text commit and an emptied Cell Pin name in the instance-label path get messages.
- Applying an unchanged additional-parameter draft (whitespace edit, or a new row with a blank value — the planner's delete-nothing case) reports "No additional-parameter changes to apply" instead of leaving a seemingly dead Apply button.

No new edits are committed on any of these paths; only the missing feedback is added.

## Validation

Two new planner unit tests pin the rejected-plan and missing-geometry messages; properties suite green; full `tsconfig.check` typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)