### PR TITLE
fix(editor): scope dialog chunk failures; bound reference renumbering

### DIFF
--- a/apps/editor/e2e/runtime-crash-safety.spec.ts
+++ b/apps/editor/e2e/runtime-crash-safety.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { chooseComponent } from "./editor-fixtures.js";
+import { chooseComponent, clickCommand } from "./editor-fixtures.js";
 
 test("a render crash shows the recovery screen instead of a blank page", async ({
   page,
@@ -36,6 +36,47 @@ test("a render crash shows the recovery screen instead of a blank page", async (
   // Reloading brings the editor back without the transient crash flag.
   await crashScreen.getByRole("button", { name: "Reload editor" }).click();
   await expect(page.getByTestId("schematic-canvas")).toBeVisible();
+});
+
+test("a failed dialog chunk degrades to a scoped notice, not the crash screen", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await chooseComponent(page, "resistor");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 360, y: 230 } });
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("hit-R1")).toBeVisible();
+
+  // A tab that survives a redeploy asks for chunk names the server no longer
+  // has. Aborting the request reproduces the same rejected dynamic import.
+  await page.route("**/instance-table-dialog*", (route) => route.abort());
+  await clickCommand(page, "Netlist", "Instance Table…");
+
+  const fallback = page.getByTestId("dialog-chunk-load-fallback");
+  await expect(fallback).toBeVisible();
+  await expect(fallback).toContainText("This dialog could not be loaded");
+  await expect(page.getByTestId("editor-crash-screen")).toHaveCount(0);
+
+  // Closing the notice hands the intact editor back.
+  await fallback.getByRole("button", { name: "Close" }).click();
+  await expect(fallback).toHaveCount(0);
+  await expect(page.getByTestId("hit-R1")).toBeVisible();
+
+  // Refreshing from the notice restores the circuit automatically.
+  await clickCommand(page, "Netlist", "Instance Table…");
+  const navigated = page.waitForEvent("framenavigated");
+  await page.unroute("**/instance-table-dialog*");
+  await page
+    .getByTestId("dialog-chunk-load-fallback")
+    .getByRole("button", { name: "Refresh app" })
+    .click();
+  await navigated;
+  await expect(page.getByTestId("hit-R1")).toBeVisible();
+  await expect(page.getByTestId("status")).toHaveText(
+    "Restored recovery revision 1",
+  );
 });
 
 test("a scene build failure degrades to the last good view and recovers", async ({

--- a/apps/editor/src/app/lazy-editor-dialogs.ts
+++ b/apps/editor/src/app/lazy-editor-dialogs.ts
@@ -1,72 +1,97 @@
-import { lazy } from "react";
+import { lazy, type ComponentType } from "react";
 
-export const LazyCellManagerDialog = lazy(() =>
+import { createChunkLoadFallback } from "../components/chunk-load-fallback";
+
+/**
+ * A rejected dynamic import would otherwise re-throw through Suspense into
+ * the root error boundary and unmount the whole editor — the classic failure
+ * is a tab that survived a redeploy asking for chunk names that no longer
+ * exist. Resolving to a scoped fallback keeps the schematic alive and offers
+ * the refresh (with automatic restore) that actually fixes it.
+ */
+function lazyChunk<Component extends ComponentType<any>>(
+  variant: "dialog" | "inline",
+  load: () => Promise<{ default: Component }>,
+) {
+  return lazy(() =>
+    load().catch((error: unknown) => {
+      console.error("Editor dialog chunk failed to load:", error);
+      // The fallback ignores unknown props, so standing in for the real
+      // component is safe even though the prop types differ.
+      return {
+        default: createChunkLoadFallback(variant, error),
+      } as unknown as { default: Component };
+    }),
+  );
+}
+
+export const LazyCellManagerDialog = lazyChunk("dialog", () =>
   import("../features/hierarchy/cell-manager-dialog").then((module) => ({
     default: module.CellManagerDialog,
   })),
 );
 
-export const LazyNetlistPreflightDialog = lazy(() =>
+export const LazyNetlistPreflightDialog = lazyChunk("dialog", () =>
   import("../features/netlist-export/netlist-preflight-dialog").then(
     (module) => ({ default: module.NetlistPreflightDialog }),
   ),
 );
 
-export const LazyPublishGalleryDialog = lazy(() =>
+export const LazyPublishGalleryDialog = lazyChunk("dialog", () =>
   import("../features/editor-shell/publish-gallery-dialog").then((module) => ({
     default: module.PublishGalleryDialog,
   })),
 );
 
-export const LazyVersionHistoryDialog = lazy(() =>
+export const LazyVersionHistoryDialog = lazyChunk("dialog", () =>
   import("../components/version-history-dialog").then((module) => ({
     default: module.VersionHistoryDialog,
   })),
 );
 
-export const LazyEditorHelpDialog = lazy(() =>
+export const LazyEditorHelpDialog = lazyChunk("dialog", () =>
   import("../components/editor-help-dialog").then((module) => ({
     default: module.EditorHelpDialog,
   })),
 );
 
-export const LazyReplaceGuardDialog = lazy(() =>
+export const LazyReplaceGuardDialog = lazyChunk("dialog", () =>
   import("../components/replace-guard-dialog").then((module) => ({
     default: module.ReplaceGuardDialog,
   })),
 );
 
-export const LazyRecentRecoveryDialog = lazy(() =>
+export const LazyRecentRecoveryDialog = lazyChunk("dialog", () =>
   import("../components/recent-recovery-dialog").then((module) => ({
     default: module.RecentRecoveryDialog,
   })),
 );
 
-export const LazyProjectSearchDialog = lazy(() =>
+export const LazyProjectSearchDialog = lazyChunk("dialog", () =>
   import("../features/search/project-search-dialog").then((module) => ({
     default: module.ProjectSearchDialog,
   })),
 );
 
-export const LazyInstanceTableDialog = lazy(() =>
+export const LazyInstanceTableDialog = lazyChunk("dialog", () =>
   import("../features/properties/instance-table-dialog").then((module) => ({
     default: module.InstanceTableDialog,
   })),
 );
 
-export const LazyInsertComponentDialog = lazy(() =>
+export const LazyInsertComponentDialog = lazyChunk("dialog", () =>
   import("../features/component-insert/insert-component-dialog").then(
     (module) => ({ default: module.InsertComponentDialog }),
   ),
 );
 
-export const LazyConnectAgentPanel = lazy(() =>
+export const LazyConnectAgentPanel = lazyChunk("dialog", () =>
   import("../agent/connect-agent-panel").then((module) => ({
     default: module.ConnectAgentPanel,
   })),
 );
 
-export const LazyAgentPropertiesSection = lazy(() =>
+export const LazyAgentPropertiesSection = lazyChunk("inline", () =>
   import("../agent/connect-agent-panel").then((module) => ({
     default: module.AgentPropertiesSection,
   })),

--- a/apps/editor/src/components/chunk-load-fallback.tsx
+++ b/apps/editor/src/components/chunk-load-fallback.tsx
@@ -1,0 +1,108 @@
+import type { ComponentType } from "react";
+
+import { REFRESH_RESTORE_STORAGE_KEY } from "../document/use-project-file-lifecycle";
+
+export interface ChunkLoadFallbackProps {
+  onClose?: () => void;
+  onCancel?: () => void;
+}
+
+function refreshWithRestore(): void {
+  try {
+    // The recovery coordinator flushes on pagehide, so the snapshot survives
+    // this reload; the flag lets the refreshed page restore it automatically.
+    window.sessionStorage.setItem(REFRESH_RESTORE_STORAGE_KEY, "true");
+  } catch {
+    // Without sessionStorage the reload still recovers via the manual banner.
+  }
+  window.location.reload();
+}
+
+/**
+ * Stands in for a lazily loaded dialog or panel whose chunk failed to load —
+ * typically a tab that stayed open across a redeploy (its content-hashed
+ * chunk names no longer exist on the server) or an offline PWA opening a
+ * surface it never cached. The failure must stay scoped to the dialog: the
+ * schematic keeps running, and the remedy is a refresh that restores the
+ * current work, not the whole-editor crash screen.
+ */
+export function createChunkLoadFallback(
+  variant: "dialog" | "inline",
+  error: unknown,
+): ComponentType<ChunkLoadFallbackProps> {
+  const detail = error instanceof Error ? error.message : String(error);
+  if (variant === "inline") {
+    return function ChunkLoadFallbackSection() {
+      return (
+        <section
+          className="chunk-load-fallback-inline"
+          role="alert"
+          data-testid="section-chunk-load-fallback"
+        >
+          <p>
+            This panel could not be loaded — the app has likely been updated
+            since this tab opened. Refresh to load the new version; your current
+            circuit is restored automatically.
+          </p>
+          <button type="button" onClick={refreshWithRestore}>
+            Refresh app
+          </button>
+        </section>
+      );
+    };
+  }
+  return function ChunkLoadFallbackDialog({
+    onClose,
+    onCancel,
+  }: ChunkLoadFallbackProps) {
+    const close = onClose ?? onCancel;
+    return (
+      <div
+        className="insert-dialog-backdrop"
+        role="presentation"
+        onPointerDown={(event) => {
+          if (event.target === event.currentTarget) close?.();
+        }}
+      >
+        <section
+          className="editor-action-dialog"
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby="chunk-load-fallback-title"
+          data-testid="dialog-chunk-load-fallback"
+        >
+          <header className="editor-action-dialog-header">
+            <p>Dialog unavailable</p>
+            <h2 id="chunk-load-fallback-title">
+              This dialog could not be loaded
+            </h2>
+          </header>
+          <div className="editor-action-dialog-body">
+            <p>
+              The app has likely been updated since this tab opened, or the
+              browser is offline. Your circuit is unaffected. Refresh to load
+              the new version — your current work is restored automatically.
+            </p>
+            <p>
+              <code>{detail}</code>
+            </p>
+          </div>
+          <footer className="editor-action-dialog-actions">
+            {close ? (
+              <button type="button" onClick={() => close()}>
+                Close
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="primary"
+              onClick={refreshWithRestore}
+            >
+              Refresh app
+            </button>
+          </footer>
+        </section>
+      </div>
+    );
+  };
+}

--- a/apps/editor/src/document/use-project-file-lifecycle.ts
+++ b/apps/editor/src/document/use-project-file-lifecycle.ts
@@ -34,7 +34,7 @@ import {
   rememberRecentCloudProject,
 } from "./cloud-project-session";
 
-const REFRESH_RESTORE_STORAGE_KEY = "icm.restore-after-refresh.v1";
+export const REFRESH_RESTORE_STORAGE_KEY = "icm.restore-after-refresh.v1";
 
 export interface SavedProjectBaseline {
   project: CircuitProject;
@@ -95,15 +95,19 @@ export function useProjectFileLifecycle({
   setStatus,
   onCloudProjectSaved,
 }: UseProjectFileLifecycleOptions) {
-  const [restoreAfterRefresh] = useState(() => {
-    if (typeof window === "undefined") return false;
-    const requested =
-      window.sessionStorage.getItem(REFRESH_RESTORE_STORAGE_KEY) === "true";
-    if (requested) {
+  // Read-only initializer: consuming the one-shot flag here would be a render
+  // side effect, and a discarded render (StrictMode's double pass, a Suspense
+  // retry) would eat the flag before the committed render sees it.
+  const [restoreAfterRefresh] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.sessionStorage.getItem(REFRESH_RESTORE_STORAGE_KEY) === "true",
+  );
+  useEffect(() => {
+    if (restoreAfterRefresh) {
       window.sessionStorage.removeItem(REFRESH_RESTORE_STORAGE_KEY);
     }
-    return requested;
-  });
+  }, [restoreAfterRefresh]);
   const [startupCloudProjectId] = useState(readRecentCloudProjectId);
   const refreshRestoreAttemptedRef = useRef(false);
   const saveInFlightRef = useRef<Promise<CloudProjectSaveOutcome> | null>(null);
@@ -656,6 +660,7 @@ export function useProjectFileLifecycle({
     startupRecovery,
     startupCloudProjectId,
     canRestoreStartupCloudProject,
+    restoreAfterRefresh,
     setRecoveryDialogOpen,
     isDirtyWork,
     replaceActiveProject,

--- a/packages/edit-engine/src/reference-batch-planner.test.ts
+++ b/packages/edit-engine/src/reference-batch-planner.test.ts
@@ -89,4 +89,40 @@ describe("planReferenceRenumber", () => {
       },
     ]);
   });
+
+  it("terminates at the safe-integer suffix boundary instead of looping", () => {
+    // M9007199254740991 = M{2^53 - 1}: the next float increment no-ops, which
+    // previously pinned nextAvailableReference in an endless render-time scan.
+    const project = createEmptyProject("project", "Project");
+    project.documents[0]!.instances.push(
+      nmos("M1", "M9007199254740991"),
+      nmos("M2", "MX"),
+      nmos("M3", "MY"),
+    );
+
+    const preview = planReferenceRenumber(
+      project,
+      [
+        { documentId: project.topDocumentId, instanceId: "M1" },
+        { documentId: project.topDocumentId, instanceId: "M2" },
+        { documentId: project.topDocumentId, instanceId: "M3" },
+      ],
+      { policy: "fill-gaps" },
+    );
+
+    // The boundary reference is preserved; the invalid ones renumber from the
+    // low end because the unsafe successor is never used as a start.
+    expect(preview.preserved).toEqual([
+      {
+        documentId: project.topDocumentId,
+        instanceId: "M1",
+        reference: "M9007199254740991",
+      },
+    ]);
+    expect(preview.reassigned.map((entry) => entry.reference)).toEqual([
+      "M1",
+      "M2",
+    ]);
+    expect(preview.skipped).toEqual([]);
+  });
 });

--- a/packages/edit-engine/src/reference-batch-planner.ts
+++ b/packages/edit-engine/src/reference-batch-planner.ts
@@ -56,9 +56,14 @@ function nextAvailableReference(
   policy: Extract<ReferencePolicy, { kind: "required" }>,
   occupied: ReadonlySet<string>,
   startAt: number,
-): string {
+): string | null {
   let suffix = Math.max(1, startAt);
-  while (occupied.has(folded(`${policy.prefix}${suffix}`))) suffix += 1;
+  while (occupied.has(folded(`${policy.prefix}${suffix}`))) {
+    suffix += 1;
+    // Past 2^53 the float increment no-ops, so the same occupied candidate
+    // would repeat forever. Runs during render — it must terminate.
+    if (!Number.isSafeInteger(suffix)) return null;
+  }
   return `${policy.prefix}${suffix}`;
 }
 
@@ -142,10 +147,19 @@ export function planReferenceRenumber(
         const reference = validCurrent
           ? current
           : nextAvailableReference(policy, occupied, nextSuffix);
+        if (reference === null) {
+          skipped.push({
+            ...target,
+            reason: "Reference numbering space is exhausted",
+          });
+          continue;
+        }
         occupied.add(folded(reference));
         retained.add(folded(reference));
         const suffix = referenceSuffixForPolicy(reference, policy);
-        if (suffix !== null) nextSuffix = suffix + 1;
+        if (suffix !== null && Number.isSafeInteger(suffix + 1)) {
+          nextSuffix = suffix + 1;
+        }
         if (reference === current) {
           preserved.push({ ...target, reference });
           continue;


### PR DESCRIPTION
## Summary

Owner feedback: **"Instance Table brings an unexpected error (occasionally)"**. Two confirmed causes, both reproduced.

**1. Unhandled lazy-chunk rejection unmounts the whole editor.** Every dialog loads via `React.lazy` with no rejection handling. A tab open across a redeploy requests content-hashed chunk names the server no longer has (the Worker's SPA fallback answers `index.html`, so the import rejects); an offline PWA hits the same for never-cached dialogs. The rejection re-threw through Suspense into the root error boundary → full crash screen. Reproduced by aborting the dialog chunk request.

Dialog imports now resolve to a scoped fallback on failure: the schematic keeps running; the notice offers Close and a Refresh that sets the existing restore-after-refresh handshake, so the circuit comes back automatically. (`REFRESH_RESTORE_STORAGE_KEY` export is shared with the refresh-restore PR — identical file content, either lands first.)

**2. Render-phase infinite loop in `planReferenceRenumber`.** The Instance Table runs the planner on every render; a reference at the safe-integer boundary (`M9007199254740991`) pinned `nextAvailableReference` forever — past 2^53 the float increment no-ops, so the same occupied candidate repeated and froze the tab. The scan now stops at the boundary, and an unsafe successor never becomes the next start.

## Validation

- New Playwright regression: aborted chunk → scoped notice (no crash screen), editor alive, Refresh restores revision 1.
- New planner unit test at the 2^53−1 boundary — times out on the previous code.
- Full `tsconfig.check` typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)