### PR TITLE
fix(edit-engine): leg-mode semantics across the stretch family

### DIFF
--- a/packages/edit-engine/src/route-geometry-edit.ts
+++ b/packages/edit-engine/src/route-geometry-edit.ts
@@ -279,7 +279,11 @@ export function moveRouteSegment(
           { x: target.x, y: points[1]!.y },
           points[1]!,
         ];
-    const mode = modes[0] ?? "manual";
+    // Dragging a derived escape lead authors real wire geometry: the moved
+    // leg leaves the pin axis and the new endpoint stubs arrive across it,
+    // so nothing here may stay "escape" or commit validation rejects it.
+    const sourceMode = modes[0] ?? "manual";
+    const mode = sourceMode === "escape" ? "manual" : sourceMode;
     const normalized = normalizeRouteGeometry(moved, [mode, mode, mode]);
     return {
       waypoints: normalized.points.slice(1, -1),
@@ -296,7 +300,8 @@ export function moveRouteSegment(
       points[1]!.x = target.x;
       points.splice(1, 0, { x: target.x, y: fixedEndpoint.y });
     }
-    modes.splice(0, 1, modes[0]!, modes[0]!);
+    const stubMode = modes[0] === "escape" ? "manual" : modes[0]!;
+    modes.splice(0, 1, stubMode, stubMode);
   } else if (segmentIndex === lastSegmentIndex) {
     const fixedEndpoint = points.at(-1)!;
     if (horizontal) {
@@ -306,7 +311,9 @@ export function moveRouteSegment(
       points[segmentIndex]!.x = target.x;
       points.splice(-1, 0, { x: target.x, y: fixedEndpoint.y });
     }
-    modes.splice(segmentIndex, 1, modes[segmentIndex]!, modes[segmentIndex]!);
+    const stubMode =
+      modes[segmentIndex] === "escape" ? "manual" : modes[segmentIndex]!;
+    modes.splice(segmentIndex, 1, stubMode, stubMode);
   } else if (horizontal) {
     points[segmentIndex]!.y = target.y;
     points[segmentIndex + 1]!.y = target.y;

--- a/packages/edit-engine/src/route-operations.ts
+++ b/packages/edit-engine/src/route-operations.ts
@@ -1,3 +1,4 @@
+import { cancelDoubledBackLegs } from "./routing-planner.js";
 import {
   reflectOrientation,
   routeBends,
@@ -219,9 +220,14 @@ function routeEditPathFromGeometry(
   };
 }
 
-/** Every stored step must advance; heading itself is unconstrained. */
+/**
+ * Every stored step must advance; heading itself is unconstrained. Fewer
+ * than two points is a collapsed conductor, not a Route — the vacuous
+ * "every segment" reading let a fully collapsed stretch slip past this
+ * guard and die later inside the Route factory with an internal message.
+ */
 function isSegmentGeometryUsable(points: readonly Point[]): boolean {
-  return polylineSatisfiesConstraint(points, "any-angle");
+  return points.length >= 2 && polylineSatisfiesConstraint(points, "any-angle");
 }
 
 function normalizeProposal(
@@ -229,7 +235,18 @@ function normalizeProposal(
   points: readonly Point[],
   modes: readonly SegmentMode[],
 ): RouteStretchProposal {
-  const normalized = normalizeRouteGeometry(points, modes);
+  let normalized = normalizeRouteGeometry(points, modes);
+  // A stretch can slide a bend back over its neighbor, leaving a leg that
+  // retraces the previous one. The shared normalizer deliberately keeps
+  // anti-parallel collinear steps (crossing detection needs them), so the
+  // stretch family cancels them here — except across protected legs, whose
+  // geometry must survive byte-for-byte.
+  if (!normalized.segmentModes.some(protectedMode)) {
+    normalized = cancelDoubledBackLegs(
+      normalized.points,
+      normalized.segmentModes,
+    );
+  }
   // Any heading is legal geometry (ADR 0039); only a degenerate segment is
   // not, and normalizeRouteGeometry already removes zero-length steps.
   if (!isSegmentGeometryUsable(normalized.points)) {
@@ -242,6 +259,27 @@ function normalizeProposal(
     waypoints: normalized.points.slice(1, -1),
     segmentModes: normalized.segmentModes,
   };
+}
+
+/**
+ * A rail must stay one straight axis-aligned conductor; a boundary stretch
+ * that would bend it fails here with a named plan-time error instead of a
+ * raw geometry rejection at commit.
+ */
+function assertPowerRailStaysStraight(
+  route: SchematicDocument["routes"][number],
+  first: Point,
+  last: Point,
+  waypoints: readonly Point[],
+): void {
+  if (route.presentation !== "power-rail") return;
+  const straight =
+    waypoints.length === 0 && (first.x === last.x || first.y === last.y);
+  if (!straight) {
+    throw new Error(
+      `Power rail ${route.id} would bend; move the whole rail or detach the tap first`,
+    );
+  }
 }
 
 function stretchRouteEndpoint(
@@ -275,6 +313,29 @@ function stretchRouteEndpoint(
   // generic branch below only handles an existing diagonal or future heading.
   if (originallyVertical || originallyHorizontal) {
     if (points.length > 2) {
+      const alignedMove = originallyVertical
+        ? movedPoint.x === neighbor.x
+        : movedPoint.y === neighbor.y;
+      const secondModeIndex = side === "from" ? 1 : modes.length - 2;
+      // Sliding the neighbor rewrites the SECOND leg. When that leg is
+      // locked or trunk it must survive byte-for-byte, so the moved
+      // endpoint elbows back through the original endpoint instead and
+      // the whole established path stays untouched.
+      if (!alignedMove && protectedMode(modes[secondModeIndex])) {
+        const corner = originallyVertical
+          ? { x: movedPoint.x, y: originalPoint.y }
+          : { x: originalPoint.x, y: movedPoint.y };
+        const inserted =
+          side === "from"
+            ? [corner, { ...originalPoint }]
+            : [{ ...originalPoint }, corner];
+        const insertIndex = side === "from" ? 1 : points.length - 1;
+        points.splice(insertIndex, 0, ...inserted);
+        const modeIndex = side === "from" ? 0 : modes.length - 1;
+        const mode = modes[modeIndex]!;
+        modes.splice(modeIndex, 1, mode, mode, mode);
+        return;
+      }
       if (originallyVertical) neighbor.x = movedPoint.x;
       else neighbor.y = movedPoint.y;
       return;
@@ -439,11 +500,14 @@ function smoothedBoundaryProposal(
   stretched: RouteStretchProposal,
   smoothing: BoundarySmoothing,
   resolver: SymbolResolver,
+  /**
+   * Bend count of the stretched path BEFORE fold-back cancellation. A
+   * cancelled double-back still means the stretch degraded the shape, so
+   * the complexity trigger reads the raw count.
+   */
+  stretchedRawBendCount: number = stretched.waypoints.length,
 ): RouteStretchProposal {
-  if (
-    route.presentation === "power-rail" ||
-    route.presentation === "bulk-dashed"
-  ) {
+  if (route.presentation === "power-rail") {
     return stretched;
   }
   if (stretched.segmentModes.some((mode) => protectedMode(mode))) {
@@ -543,22 +607,50 @@ function smoothedBoundaryProposal(
     ...stretched.waypoints,
     best.points.at(-1)!,
   ];
+  // A rigid turn re-aims the pins but the stretch kept the old leg axes:
+  // an escape end leg that no longer leaves its pin outward can never pass
+  // commit validation, so a stale lead forces the rebuild.
+  const escapeLegStale = (
+    mode: SegmentMode | undefined,
+    anchor: Point,
+    next: Point | undefined,
+    outward: Point | null,
+  ): boolean => {
+    if (mode !== "escape" || !outward || !next) return false;
+    const dir = { x: next.x - anchor.x, y: next.y - anchor.y };
+    return dir.x * outward.x + dir.y * outward.y <= 0;
+  };
+  const escapeStale =
+    escapeLegStale(
+      stretched.segmentModes[0],
+      stretchedFull[0]!,
+      stretchedFull[1],
+      from.outward,
+    ) ||
+    escapeLegStale(
+      stretched.segmentModes.at(-1),
+      stretchedFull.at(-1)!,
+      stretchedFull.at(-2),
+      to.outward,
+    );
   const stretchedCrossings = bodyCrossings(
     stretchedFull,
     smoothing.movedBodies,
   );
-  const grewComplexity = stretched.waypoints.length > originalBendCount;
+  const grewComplexity = stretchedRawBendCount > originalBendCount;
   // A wrap-around stretch shows up as sheer length: substantially longer
   // than the minimal landing-to-landing path means the old shape has gone
   // stale for the new positions.
   const lengthDegraded =
     pathLength(stretchedFull) > pathLength(best.points) * 1.5 + 20;
   const rebuild =
-    best.crossings <= stretchedCrossings &&
-    ((grewComplexity && fresh.waypoints.length < stretched.waypoints.length) ||
-      best.crossings < stretchedCrossings ||
-      lengthDegraded) &&
-    fresh.waypoints.length <= Math.max(stretched.waypoints.length, 1);
+    escapeStale ||
+    (best.crossings <= stretchedCrossings &&
+      ((grewComplexity &&
+        fresh.waypoints.length < stretched.waypoints.length) ||
+        best.crossings < stretchedCrossings ||
+        lengthDegraded) &&
+      fresh.waypoints.length <= Math.max(stretched.waypoints.length, 1));
   return rebuild ? fresh : stretched;
 }
 
@@ -999,6 +1091,7 @@ export function proposeLocalStretch(
         normalizeProposal(route.id, points, modes),
         smoothing,
         resolver,
+        normalizeRouteGeometry(points, modes).points.length - 2,
       ),
     );
   }
@@ -1186,16 +1279,21 @@ export function proposeGroupMove(
         leads,
       );
     }
-    proposals.set(
-      route.id,
-      smoothedBoundaryProposal(
-        route,
-        original.points.length - 2,
-        normalizeProposal(route.id, points, modes),
-        smoothing,
-        resolver,
-      ),
+    const stretchedProposal = smoothedBoundaryProposal(
+      route,
+      original.points.length - 2,
+      normalizeProposal(route.id, points, modes),
+      smoothing,
+      resolver,
+      normalizeRouteGeometry(points, modes).points.length - 2,
     );
+    assertPowerRailStaysStraight(
+      route,
+      points[0]!,
+      points.at(-1)!,
+      stretchedProposal.waypoints,
+    );
+    proposals.set(route.id, stretchedProposal);
   }
   const internalRouteIds = internalSelection.routeIds;
   const internallyMovedObjectIds = new Set<string>([
@@ -1478,16 +1576,21 @@ function proposeRigidBodyMove(
         transform.point(to),
       );
     }
-    proposals.set(
-      route.id,
-      smoothedBoundaryProposal(
-        route,
-        original.points.length - 2,
-        normalizeProposal(route.id, points, modes),
-        smoothing,
-        resolver,
-      ),
+    const stretchedProposal = smoothedBoundaryProposal(
+      route,
+      original.points.length - 2,
+      normalizeProposal(route.id, points, modes),
+      smoothing,
+      resolver,
+      normalizeRouteGeometry(points, modes).points.length - 2,
     );
+    assertPowerRailStaysStraight(
+      route,
+      points[0]!,
+      points.at(-1)!,
+      stretchedProposal.waypoints,
+    );
+    proposals.set(route.id, stretchedProposal);
   }
 
   const turnedObjectIds = new Set<string>([

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -862,7 +862,7 @@ function appendOctilinear(
  * need. Only the authored path wants the wider reading, so it is folded in
  * here rather than in the shared normalizer.
  */
-function cancelDoubledBackLegs(
+export function cancelDoubledBackLegs(
   points: readonly Point[],
   modes: readonly SegmentMode[],
 ): { points: Point[]; segmentModes: SegmentMode[] } {

--- a/packages/edit-engine/src/stretch-mode-semantics.test.ts
+++ b/packages/edit-engine/src/stretch-mode-semantics.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Wire-transform audit, batch 2: leg-mode semantics in the stretch family.
+ * Protected second legs survive byte-for-byte, fold-back residue cancels,
+ * escape leads re-derive under rigid transforms, and degenerate collapse
+ * fails with the contract's own message.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { createRoutePath, routeEnd } from "@icm/model";
+import type { Point, SchematicDocument, SegmentMode } from "@icm/model";
+import { parseProject } from "@icm/project-protocol";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import {
+  proposeGroupMove,
+  proposeJunctionGroupTranslation,
+  proposeWireSegmentDrag,
+} from "./route-operations.js";
+import { executeTransaction } from "./transaction.js";
+import { planRoutingTransform } from "./routing-transform-planner.js";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+function baseDocument(): SchematicDocument {
+  const document = parseProject(
+    readFileSync(
+      resolve(
+        process.cwd(),
+        "fixtures/projects/phase-3-routing/project.icproj.json",
+      ),
+      "utf8",
+    ),
+  ).documents[0]!;
+  document.instances = document.instances.filter((instance) =>
+    ["A", "B"].includes(instance.id),
+  );
+  document.nets = [
+    {
+      id: "net-1",
+      terminals: [
+        { instanceId: "A", pinName: "P" },
+        { instanceId: "B", pinName: "P" },
+      ],
+    },
+  ];
+  document.netlist!.terminals = ["A", "B"].map((instanceId) => ({
+    id: `cell-terminal-${instanceId.toLowerCase()}`,
+    name: instanceId,
+    netId: "net-1",
+    direction: "passive" as const,
+    interfaceInstanceIds: [instanceId],
+  }));
+  document.connectivityEvidence = [];
+  document.junctions = [];
+  document.routes = [];
+  return document;
+}
+
+function seedRoute(
+  document: SchematicDocument,
+  options: {
+    id?: string;
+    bends: Point[];
+    modes: SegmentMode[];
+    start?: { kind: "junction"; junctionId: string };
+    end?: { kind: "junction"; junctionId: string };
+    presentation?: "power-rail" | "bulk-dashed";
+  },
+): void {
+  const route = createRoutePath({
+    id: options.id ?? "route-x",
+    netId: "net-1",
+    start: options.start ?? { kind: "terminal", instanceId: "A", pinName: "P" },
+    end: options.end ?? { kind: "terminal", instanceId: "B", pinName: "P" },
+    bends: options.bends,
+    modes: options.modes,
+  });
+  if (options.presentation) route.presentation = options.presentation;
+  document.routes.push(route);
+}
+
+function legSpans(points: readonly Point[]): [Point, Point][] {
+  return points.slice(1).map((point, index) => [points[index]!, point]);
+}
+
+describe("protected second legs (finding #6)", () => {
+  // A at (-10,300): pin (0,300). Route drops to y=200 then runs locked to
+  // B's pin at (100,200) (B at (110,200), mirror x).
+  function lockedFixture(): SchematicDocument {
+    const document = baseDocument();
+    document.instances.find((i) => i.id === "A")!.placement = {
+      position: { x: -10, y: 300 },
+      rotation: 0,
+      mirror: "none",
+    };
+    document.instances.find((i) => i.id === "B")!.placement = {
+      position: { x: 110, y: 200 },
+      rotation: 0,
+      mirror: "x",
+    };
+    seedRoute(document, {
+      bends: [{ x: 0, y: 200 }],
+      modes: ["manual", "locked"],
+    });
+    return document;
+  }
+
+  it("moving the far endpoint never rewrites the locked second leg", () => {
+    for (const dx of [50, 100, 150]) {
+      const document = lockedFixture();
+      const proposal = proposeGroupMove(document, resolver, [
+        { instanceId: "A", position: { x: -10 + dx, y: 300 } },
+      ]);
+      const stretched = proposal.routes.find((r) => r.routeId === "route-x")!;
+      const full = [
+        { x: dx, y: 300 },
+        ...stretched.waypoints,
+        { x: 100, y: 200 },
+      ];
+      // The locked leg (0,200)->(100,200) must survive byte-for-byte as one
+      // of the final legs, and it must still be marked locked.
+      const spans = legSpans(full);
+      const lockedIndex = spans.findIndex(
+        ([from, to]) =>
+          from.x === 0 && from.y === 200 && to.x === 100 && to.y === 200,
+      );
+      expect(lockedIndex, `dx=${dx} locked leg vanished`).toBeGreaterThan(-1);
+      expect(stretched.segmentModes[lockedIndex]).toBe("locked");
+    }
+  });
+
+  it("trunk second legs get the same protection", () => {
+    const document = lockedFixture();
+    const route = document.routes[0]!;
+    route.legs = route.legs.map((leg) =>
+      leg.mode === "locked" ? { ...leg, mode: "trunk" } : leg,
+    );
+    const proposal = proposeGroupMove(document, resolver, [
+      { instanceId: "A", position: { x: 40, y: 300 } },
+    ]);
+    const stretched = proposal.routes.find((r) => r.routeId === "route-x")!;
+    const full = [
+      { x: 50, y: 300 },
+      ...stretched.waypoints,
+      { x: 100, y: 200 },
+    ];
+    const spans = legSpans(full);
+    expect(
+      spans.some(
+        ([from, to]) =>
+          from.x === 0 && from.y === 200 && to.x === 100 && to.y === 200,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("fold-back residue (finding #9)", () => {
+  it("junction translation cancels a self-reversing collinear remnant", () => {
+    const document = baseDocument();
+    document.instances = [];
+    document.nets = [{ id: "net-1", terminals: [] }];
+    document.netlist!.terminals = [];
+    document.junctions = [
+      { id: "J1", netId: "net-1", position: { x: 30, y: 50 } },
+      { id: "J2", netId: "net-1", position: { x: 60, y: 40 } },
+    ];
+    // Persisted fold: J1 (30,50) -> (30,20) -> (30,40) -> J2 (60,40); the
+    // first two legs retrace the x=30 line.
+    seedRoute(document, {
+      bends: [
+        { x: 30, y: 20 },
+        { x: 30, y: 40 },
+      ],
+      modes: ["manual", "manual", "manual"],
+      start: { kind: "junction", junctionId: "J1" },
+      end: { kind: "junction", junctionId: "J2" },
+    });
+    const proposal = proposeJunctionGroupTranslation(document, resolver, [
+      { junctionId: "J1", position: { x: 30, y: 60 } },
+    ]);
+    const stretched = proposal.routes.find((r) => r.routeId === "route-x")!;
+    const full = [{ x: 30, y: 60 }, ...stretched.waypoints, { x: 60, y: 40 }];
+    const spans = legSpans(full);
+    for (let index = 1; index < spans.length; index += 1) {
+      const [aFrom, aTo] = spans[index - 1]!;
+      const [bFrom, bTo] = spans[index]!;
+      const before = { x: aTo.x - aFrom.x, y: aTo.y - aFrom.y };
+      const after = { x: bTo.x - bFrom.x, y: bTo.y - bFrom.y };
+      const collinear = before.x * after.y - before.y * after.x === 0;
+      const reverses = before.x * after.x + before.y * after.y < 0;
+      expect(collinear && reverses, "fold-back survived the stretch").toBe(
+        false,
+      );
+    }
+  });
+});
+
+describe("degenerate collapse (finding #15)", () => {
+  it("a fully collapsed stretch fails with the contract message, not factory internals", () => {
+    const document = baseDocument();
+    document.instances = [];
+    document.nets = [{ id: "net-1", terminals: [] }];
+    document.netlist!.terminals = [];
+    document.junctions = [
+      { id: "J1", netId: "net-1", position: { x: 0, y: 0 } },
+      { id: "J2", netId: "net-1", position: { x: 40, y: 0 } },
+    ];
+    seedRoute(document, {
+      bends: [],
+      modes: ["manual"],
+      start: { kind: "junction", junctionId: "J1" },
+      end: { kind: "junction", junctionId: "J2" },
+    });
+    // Collapse the whole route onto one point: both junctions to (40,0).
+    expect(() =>
+      proposeJunctionGroupTranslation(document, resolver, [
+        { junctionId: "J1", position: { x: 40, y: 0 } },
+      ]),
+    ).toThrow(/degenerate/u);
+  });
+});
+
+describe("escape stubs from segment drags (finding #14)", () => {
+  it("dragging a single escape leg emits manual stubs that commit", () => {
+    const document = baseDocument();
+    document.instances.find((i) => i.id === "A")!.placement = {
+      position: { x: -10, y: 300 },
+      rotation: 0,
+      mirror: "none",
+    };
+    document.instances.find((i) => i.id === "B")!.placement = {
+      position: { x: 110, y: 300 },
+      rotation: 0,
+      mirror: "x",
+    };
+    // Agent-drawn direct connection: one straight escape leg pin to pin.
+    seedRoute(document, { bends: [], modes: ["escape"] });
+    const drag = proposeWireSegmentDrag(document, resolver, "route-x", 0, {
+      x: 50,
+      y: 260,
+    });
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "drag-escape",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: [
+          {
+            kind: "set_route_path",
+            route: {
+              ...document.routes[0]!,
+              ...createRoutePath({
+                id: "route-x",
+                netId: "net-1",
+                start: document.routes[0]!.start,
+                end: routeEnd(document.routes[0]!),
+                bends: drag.routes[0]!.waypoints,
+                modes: drag.routes[0]!.segmentModes,
+              }),
+            },
+          },
+        ],
+      },
+      { symbolResolver: resolver },
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    const route = result.document.routes.find((r) => r.id === "route-x")!;
+    expect(route.legs.length).toBeGreaterThan(1);
+  });
+});
+
+describe("escape leads under rigid transforms (finding #4)", () => {
+  function escapeFixture(presentation?: "bulk-dashed"): SchematicDocument {
+    const document = baseDocument();
+    document.instances.find((i) => i.id === "A")!.placement = {
+      position: { x: -10, y: 300 },
+      rotation: 0,
+      mirror: "none",
+    };
+    document.instances.find((i) => i.id === "B")!.placement = {
+      position: { x: 210, y: 300 },
+      rotation: 0,
+      mirror: "x",
+    };
+    // Escape-led boundary wire A.P (0,300) -> (40,300) -> (160,300) -> (200,300).
+    seedRoute(document, {
+      bends: [
+        { x: 40, y: 300 },
+        { x: 160, y: 300 },
+      ],
+      modes: ["escape", "manual", "escape"],
+      ...(presentation ? { presentation } : {}),
+    });
+    return document;
+  }
+
+  for (const [label, presentation] of [
+    ["plain", undefined],
+    ["bulk-dashed", "bulk-dashed"],
+  ] as const) {
+    it(`rotating one endpoint of an escape-led ${label} wire commits`, () => {
+      const document = escapeFixture(presentation);
+      const plan = planRoutingTransform(
+        document,
+        resolver,
+        {
+          instanceIds: ["A"],
+          routeIds: [],
+          junctionIds: [],
+          annotationIds: [],
+        },
+        { kind: "rotate", degrees: 90 },
+      );
+      const blocking = plan.diagnostics.find((d) => d.severity === "error");
+      expect(blocking?.message ?? "").toBe("");
+      const result = executeTransaction(
+        document,
+        {
+          transactionId: "rotate-escape",
+          documentId: document.id,
+          expectedRevision: document.revision,
+          actor: { kind: "human", id: "test" },
+          edits: [...plan.edits],
+        },
+        { symbolResolver: resolver },
+      );
+      if (!result.ok) throw new Error(result.error.message);
+      expect(result.document.routes).toHaveLength(1);
+    });
+  }
+});
+
+describe("power-rail boundary stretch (finding #18)", () => {
+  it("bending a rail-presentation branch fails with a named plan error", () => {
+    const document = baseDocument();
+    document.instances.find((i) => i.id === "A")!.placement = {
+      position: { x: -10, y: 300 },
+      rotation: 0,
+      mirror: "none",
+    };
+    document.instances.find((i) => i.id === "B")!.placement = {
+      position: { x: 110, y: 300 },
+      rotation: 0,
+      mirror: "x",
+    };
+    seedRoute(document, {
+      bends: [],
+      modes: ["manual"],
+      presentation: "power-rail",
+    });
+    // Vertical translate of one end would bend the rail.
+    expect(() =>
+      proposeGroupMove(document, resolver, [
+        { instanceId: "A", position: { x: -10, y: 200 } },
+      ]),
+    ).toThrow(/[Pp]ower rail/u);
+  });
+});


### PR DESCRIPTION
Wire-transform audit remediation, batch 2 of 4 — findings #4, #6, #9, #14, #15, #18 (mode-aware stretch family). All six re-verified as still reproducing before fixing; every fix landed with a red-first regression test in `stretch-mode-semantics.test.ts` (8 tests).

- **#6 protected second legs**: sliding a bend into a locked/trunk leg rewrote it (shorten/delete/reverse). The stretch now elbows through the original endpoint, keeping protected geometry byte-for-byte (locked and trunk covered).
- **#9 fold-back residue**: stretch proposals cancel self-reversing collinear remnants (reuses the wire-authoring canceller; protected legs exempt). The boundary-smoothing complexity trigger reads the pre-cancellation bend count, so the wrapped-far-move rebuild heuristic is unchanged (integration test stays green).
- **#4 escape leads under rotate/mirror**: a stale escape lead that no longer leaves its pin outward forces the landing-to-landing rebuild, and bulk-dashed routes are no longer exempt — escape-led agent wires and MOS bulk wires rotate/mirror instead of failing commit validation.
- **#14 escape segment drags**: dragging an escape leg demotes it and its new stubs to manual — agent-drawn direct wires become draggable.
- **#15 degenerate collapse**: `isSegmentGeometryUsable` rejects <2 points, so a full collapse fails with the contract's own message (previously it silently produced a degenerate proposal).
- **#18 power-rail boundary**: a stretch that would bend a rail branch fails with a named plan-time error.

Validation: engine suite 303/303, engine+derived+editor sweep 1091/1092 (one unrelated flake passing in isolation), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)