### PR TITLE
fix(editor): clipboard rigid bodies and net-label anchors survive edits

### DIFF
--- a/apps/editor/src/features/clipboard/clipboard-audit.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard-audit.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Wire-transform audit batch 3, clipboard trio: explicit route selections
+ * copy without dragging foreign terminals along (#5), orienting a clipboard
+ * turns drafting objects with the rigid body (#12), and a junction-only
+ * copy pastes into a fresh net instead of an undefined netId (#16).
+ */
+import { createEmptyDocument, createRoutePath } from "@icm/model";
+import { executeTransaction } from "@icm/edit-engine";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import {
+  copySelection,
+  orientClipboard,
+  proposePaste,
+  type SchematicClipboard,
+} from "./clipboard";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+// net-n1 spans P1.P -- r-a -- j1 -- r-b -- P2.P; the copy takes P1 + r-a + j1.
+function fixture() {
+  const document = createEmptyDocument("document-main", "Clipboard");
+  document.instances.push(
+    {
+      id: "P1",
+      symbolId: "port",
+      placement: { position: { x: 140, y: 300 }, rotation: 0, mirror: "none" },
+    },
+    {
+      id: "P2",
+      symbolId: "port",
+      placement: { position: { x: 460, y: 300 }, rotation: 0, mirror: "x" },
+    },
+  );
+  document.nets.push({
+    id: "net-n1",
+    terminals: [
+      { instanceId: "P1", pinName: "P" },
+      { instanceId: "P2", pinName: "P" },
+    ],
+  });
+  document.netlist = {
+    name: "cell",
+    formalParameters: [],
+    terminals: [
+      {
+        id: "cell-terminal-p1",
+        name: "T1",
+        netId: "net-n1",
+        direction: "passive",
+        interfaceInstanceIds: ["P1"],
+      },
+      {
+        id: "cell-terminal-p2",
+        name: "T2",
+        netId: "net-n1",
+        direction: "passive",
+        interfaceInstanceIds: ["P2"],
+      },
+    ],
+  };
+  document.junctions.push({
+    id: "j1",
+    netId: "net-n1",
+    position: { x: 300, y: 300 },
+  });
+  document.routes.push(
+    createRoutePath({
+      id: "r-a",
+      netId: "net-n1",
+      start: { kind: "terminal", instanceId: "P1", pinName: "P" },
+      end: { kind: "junction", junctionId: "j1" },
+      bends: [],
+      modes: ["manual"],
+    }),
+    createRoutePath({
+      id: "r-b",
+      netId: "net-n1",
+      start: { kind: "junction", junctionId: "j1" },
+      end: { kind: "terminal", instanceId: "P2", pinName: "P" },
+      bends: [],
+      modes: ["manual"],
+    }),
+  );
+  return document;
+}
+
+function paste(
+  document: ReturnType<typeof fixture>,
+  clipboard: SchematicClipboard,
+) {
+  const proposal = proposePaste(document, clipboard, { x: 0, y: 200 }, 1);
+  return executeTransaction(
+    document,
+    {
+      transactionId: "clipboard-audit-paste",
+      documentId: document.id,
+      expectedRevision: document.revision,
+      actor: { kind: "human", id: "test" },
+      edits: proposal.edits,
+    },
+    { symbolResolver: resolver },
+  );
+}
+
+describe("clipboard audit batch", () => {
+  it("explicit route selection copies without foreign terminals (#5)", () => {
+    const document = fixture();
+    const clipboard = copySelection(document, ["P1"], [], {
+      routeIds: ["r-a"],
+      junctionIds: ["j1"],
+      annotationIds: [],
+    });
+    expect(clipboard).not.toBeNull();
+    expect(
+      clipboard!.nets.flatMap((net) => net.terminals).map((t) => t.instanceId),
+    ).not.toContain("P2");
+    const result = paste(document, clipboard!);
+    if (!result.ok) throw new Error(`paste rejected: ${result.error.message}`);
+    expect(
+      result.document.instances.filter((i) => i.id.startsWith("P1")),
+    ).toHaveLength(2);
+  });
+
+  it("junction-only copy pastes into a fresh net (#16)", () => {
+    const document = fixture();
+    const clipboard = copySelection(document, [], [], {
+      routeIds: [],
+      junctionIds: ["j1"],
+      annotationIds: [],
+    });
+    expect(clipboard).not.toBeNull();
+    const proposal = proposePaste(document, clipboard!, { x: 0, y: 200 }, 1);
+    const junctionEdit = proposal.edits.find(
+      (edit) => edit.kind === "add_junction",
+    );
+    expect(
+      junctionEdit?.kind === "add_junction" ? junctionEdit.netId : undefined,
+    ).toBeDefined();
+    const result = paste(document, clipboard!);
+    if (!result.ok) throw new Error(`paste rejected: ${result.error.message}`);
+    expect(result.document.junctions).toHaveLength(2);
+  });
+
+  it("rotating the clipboard turns drafting objects with the rigid body (#12)", () => {
+    const clipboard: SchematicClipboard = {
+      instances: [
+        {
+          id: "R1",
+          symbolId: "resistor",
+          placement: {
+            position: { x: 100, y: 100 },
+            rotation: 0,
+            mirror: "none",
+          },
+        },
+      ],
+      cellTerminals: [],
+      nets: [],
+      routes: [],
+      junctions: [],
+      annotations: [],
+      noConnects: [],
+      connectivityEvidence: [],
+      draftingObjects: [
+        {
+          id: "rect-1",
+          kind: "rectangle",
+          locked: false,
+          zIndex: 0,
+          anchor: { kind: "free", position: { x: 200, y: 100 } },
+          center: { x: 200, y: 100 },
+          width: 40,
+          height: 20,
+          rotation: 0,
+          lineStyle: "solid",
+        },
+        {
+          id: "line-1",
+          kind: "construction-line",
+          locked: false,
+          zIndex: 0,
+          anchor: { kind: "free", position: { x: 100, y: 140 } },
+          points: [
+            { x: 100, y: 140 },
+            { x: 200, y: 140 },
+          ],
+          lineStyle: "dashed",
+        },
+      ],
+    };
+    const rotated = orientClipboard(clipboard, [
+      { kind: "rotate", deltaDegrees: 90 },
+    ]);
+    // The instance anchors the body; the rectangle orbits it: (200,100) ->
+    // (100,200), and its own rotation follows the quarter turn.
+    expect(rotated.instances[0]!.placement!.position).toEqual({
+      x: 100,
+      y: 100,
+    });
+    const rectangle = rotated.draftingObjects.find((o) => o.id === "rect-1")!;
+    expect(rectangle.kind === "rectangle" ? rectangle.center : null).toEqual({
+      x: 100,
+      y: 200,
+    });
+    expect(rectangle.kind === "rectangle" ? rectangle.rotation : null).toBe(90);
+    const line = rotated.draftingObjects.find((o) => o.id === "line-1")!;
+    expect(line.kind === "construction-line" ? line.points : null).toEqual([
+      { x: 60, y: 100 },
+      { x: 60, y: 200 },
+    ]);
+  });
+});

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -200,6 +200,112 @@ export function orientClipboard(
       }
       return clone;
     }),
+    // Drafting objects are part of the same rigid body: their anchors and
+    // kind-specific geometry orbit the anchor exactly like routes and
+    // junctions do, or a rotated paste tears the group apart.
+    draftingObjects: clipboard.draftingObjects.map((object) => {
+      const clone = structuredClone(object);
+      const mapAnchor = (anchor: typeof clone.anchor): typeof clone.anchor => {
+        if (anchor.kind === "free") {
+          return { ...anchor, position: mapPoint(anchor.position) };
+        }
+        if (anchor.kind === "object") {
+          return {
+            ...anchor,
+            localOffset: mapVector(anchor.localOffset),
+            fallbackPosition: mapPoint(anchor.fallbackPosition),
+          };
+        }
+        return {
+          ...anchor,
+          fallbackPosition: mapPoint(anchor.fallbackPosition),
+        };
+      };
+      const mappedAngle = (degrees: number): number => {
+        const radians = (degrees * Math.PI) / 180;
+        const turned = mapVector({
+          x: Math.cos(radians),
+          y: Math.sin(radians),
+        });
+        const next = (Math.atan2(turned.y, turned.x) * 180) / Math.PI;
+        const normalized = ((next % 360) + 360) % 360;
+        // Quarter turns and mirrors keep the angle exact in real math; only
+        // strip the trig float dust, never a genuinely fractional angle.
+        return Math.abs(normalized - Math.round(normalized)) < 1e-9
+          ? Math.round(normalized) % 360
+          : normalized;
+      };
+      const quarterTurns = operations.reduce(
+        (total, operation) =>
+          operation.kind === "rotate"
+            ? (((total + operation.deltaDegrees / 90) % 4) + 4) % 4
+            : total,
+        0,
+      );
+      const turnedRotation = (
+        rotation: 0 | 90 | 180 | 270,
+      ): 0 | 90 | 180 | 270 =>
+        (((rotation / 90 + quarterTurns) % 4) * 90) as 0 | 90 | 180 | 270;
+      clone.anchor = mapAnchor(clone.anchor);
+      switch (clone.kind) {
+        case "text": {
+          clone.rotation = turnedRotation(clone.rotation);
+          if (flipsWorldX && clone.alignment !== "middle") {
+            clone.alignment = clone.alignment === "start" ? "end" : "start";
+          }
+          break;
+        }
+        case "callout": {
+          clone.rotation = turnedRotation(clone.rotation);
+          clone.target = mapAnchor(clone.target);
+          if (flipsWorldX && clone.alignment !== "middle") {
+            clone.alignment = clone.alignment === "start" ? "end" : "start";
+          }
+          break;
+        }
+        case "leader": {
+          clone.target = mapAnchor(clone.target);
+          break;
+        }
+        case "arrow": {
+          clone.from = mapAnchor(clone.from);
+          clone.to = mapAnchor(clone.to);
+          if (clone.waypoints) clone.waypoints = clone.waypoints.map(mapPoint);
+          if (clone.curveControls) {
+            clone.curveControls = clone.curveControls.map((control) =>
+              control ? mapPoint(control) : control,
+            );
+          }
+          break;
+        }
+        case "construction-line": {
+          clone.points = clone.points.map(mapPoint);
+          if (clone.curveControls) {
+            clone.curveControls = clone.curveControls.map((control) =>
+              control ? mapPoint(control) : control,
+            );
+          }
+          break;
+        }
+        case "rectangle": {
+          clone.center = mapPoint(clone.center);
+          clone.rotation = mappedAngle(clone.rotation);
+          break;
+        }
+        case "circle": {
+          clone.center = mapPoint(clone.center);
+          break;
+        }
+        case "floating-symbol": {
+          clone.transform = applyOrientationOperations(
+            clone.transform,
+            operations,
+          );
+          break;
+        }
+      }
+      return clone;
+    }),
   };
 }
 
@@ -607,13 +713,13 @@ export function copySelection(
       .filter((net) => netIds.has(net.id))
       .map((net) => ({
         ...net,
-        // Owner-retained boundary Nets become a new physical Base Net around
-        // the copied owner. Ordinary boundary terminals remain disconnected.
-        terminals: internalNetIds.has(net.id)
-          ? net.terminals
-          : net.terminals.filter((terminal) =>
-              selectedIds.has(terminal.instanceId),
-            ),
+        // Only terminals whose instance is actually copied travel: an
+        // explicitly selected Route promotes its whole net to internal, but
+        // that net can still land on instances outside the copy, and their
+        // terminals would map to nothing at paste time.
+        terminals: net.terminals.filter((terminal) =>
+          selectedIds.has(terminal.instanceId),
+        ),
       })),
     routes: document.routes.filter((route) => routeIds.has(route.id)),
     junctions: document.junctions.filter((junction) =>
@@ -936,6 +1042,17 @@ export function proposePaste(
   for (const net of clipboard.nets) {
     netIds.set(net.id, uniqueCopyId(net.id, sequence, occupied));
   }
+  for (const junction of clipboard.junctions) {
+    // A junction can arrive without its net (a junction-only marquee copy
+    // clones no internal Route, so the net is never cloned): the paste
+    // creates a fresh net for it instead of emitting an undefined netId.
+    if (!netIds.has(junction.netId)) {
+      netIds.set(
+        junction.netId,
+        uniqueCopyId(junction.netId, sequence, occupied),
+      );
+    }
+  }
   const objectIds = new Map<string, string>([
     ...instanceIds,
     ...netIds,
@@ -1001,11 +1118,18 @@ export function proposePaste(
   }
 
   for (const net of clipboard.nets) {
-    const mappedTerminals = net.terminals.map((terminal): RouteEndpoint => ({
-      kind: "terminal",
-      instanceId: instanceIds.get(terminal.instanceId)!,
-      pinName: terminal.pinName,
-    }));
+    const mappedTerminals = net.terminals.flatMap(
+      (terminal): RouteEndpoint[] => {
+        const instanceId = instanceIds.get(terminal.instanceId);
+        if (!instanceId) {
+          // Legacy clipboards could carry terminals of uncopied instances;
+          // surface a plan-time error instead of a raw schema rejection.
+          errors.push(`Unknown terminal instance: ${terminal.instanceId}`);
+          return [];
+        }
+        return [{ kind: "terminal", instanceId, pinName: terminal.pinName }];
+      },
+    );
     const netId = netIds.get(net.id)!;
     if (mappedTerminals[0]) {
       edits.push({

--- a/packages/edit-engine/src/netlabel-follow.test.ts
+++ b/packages/edit-engine/src/netlabel-follow.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Wire-transform audit batch 3, net-label pair: a rigid translation keeps
+ * the persisted anchor byte-for-byte (#10), and splitting a labelled wire
+ * retargets the label onto the right half instead of rejecting (#13).
+ */
+import { createEmptyDocument, createRoutePath } from "@icm/model";
+import type { SchematicDocument } from "@icm/model";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { executeTransaction } from "./transaction.js";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+function fixture(): SchematicDocument {
+  const document = createEmptyDocument("document-follow", "Follow");
+  document.instances.push(
+    {
+      id: "P1",
+      symbolId: "port",
+      placement: { position: { x: 140, y: 300 }, rotation: 0, mirror: "none" },
+    },
+    {
+      id: "P2",
+      symbolId: "port",
+      placement: { position: { x: 460, y: 300 }, rotation: 0, mirror: "x" },
+    },
+  );
+  document.nets.push({
+    id: "net-h",
+    terminals: [
+      { instanceId: "P1", pinName: "P" },
+      { instanceId: "P2", pinName: "P" },
+    ],
+  });
+  document.netlist = {
+    name: "cell",
+    formalParameters: [],
+    terminals: [
+      {
+        id: "cell-terminal-p1",
+        name: "T1",
+        netId: "net-h",
+        direction: "passive",
+        interfaceInstanceIds: ["P1"],
+      },
+      {
+        id: "cell-terminal-p2",
+        name: "T2",
+        netId: "net-h",
+        direction: "passive",
+        interfaceInstanceIds: ["P2"],
+      },
+    ],
+  };
+  const route = createRoutePath({
+    id: "r1",
+    netId: "net-h",
+    start: { kind: "terminal", instanceId: "P1", pinName: "P" },
+    end: { kind: "terminal", instanceId: "P2", pinName: "P" },
+    bends: [],
+    modes: ["manual"],
+  });
+  document.routes.push(route);
+  document.annotations.push({
+    id: "nl-1",
+    kind: "net-label",
+    binding: { kind: "net-name", netId: "net-h" },
+    netId: "net-h",
+    anchor: {
+      kind: "route",
+      routeId: "r1",
+      legId: route.legs[0]!.id,
+      t: 0.3,
+      normalOffset: -8,
+      direction: "forward",
+      orientation: "follow",
+      // The exact point (240,292) as the editor persists it: snapped.
+      fallbackPosition: { x: 240, y: 290 },
+    },
+    alignment: "middle",
+    rotation: 0,
+    locked: false,
+  });
+  return document;
+}
+
+function anchorOf(document: SchematicDocument) {
+  const anchor = document.annotations.find((a) => a.id === "nl-1")!.anchor;
+  if (anchor.kind !== "route") throw new Error("route anchor expected");
+  return anchor;
+}
+
+describe("net-label anchors under routing transactions", () => {
+  it("a rigid translation preserves t and normalOffset byte-for-byte (#10)", () => {
+    let document = fixture();
+    // Three consecutive rigid +20x translations: the anchor must not creep.
+    for (let step = 1; step <= 3; step += 1) {
+      const result = executeTransaction(
+        document,
+        {
+          transactionId: `follow-${step}`,
+          documentId: document.id,
+          expectedRevision: document.revision,
+          actor: { kind: "human", id: "test" },
+          edits: [
+            {
+              kind: "move_instance",
+              instanceId: "P1",
+              position: { x: 140 + step * 20, y: 300 },
+            },
+            {
+              kind: "move_instance",
+              instanceId: "P2",
+              position: { x: 460 + step * 20, y: 300 },
+            },
+          ],
+        },
+        { symbolResolver: resolver },
+      );
+      if (!result.ok) throw new Error(result.error.message);
+      document = result.document;
+      const anchor = anchorOf(document);
+      expect(anchor.t).toBe(0.3);
+      expect(anchor.normalOffset).toBe(-8);
+    }
+  });
+
+  it("splitting a labelled route retargets the label onto the right half (#13)", () => {
+    const document = fixture();
+    const route = document.routes[0]!;
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "split-label",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: [
+          {
+            kind: "add_junction",
+            junctionId: "j-split",
+            netId: "net-h",
+            position: { x: 300, y: 300 },
+            split: {
+              routeId: "r1",
+              firstRouteId: "r1-first",
+              secondRouteId: "r1-second",
+              legId: route.legs[0]!.id,
+            },
+          },
+        ],
+      },
+      { symbolResolver: resolver },
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    const anchor = anchorOf(result.document);
+    // Label conductor point was at x = 150 + 0.3 * 300 = 240 — the first
+    // half (150..300) owns it.
+    expect(anchor.routeId).toBe("r1-first");
+    expect(anchor.normalOffset).toBe(-8);
+    const half = result.document.routes.find((r) => r.id === "r1-first")!;
+    expect(half.legs.some((leg) => leg.id === anchor.legId)).toBe(true);
+  });
+});

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -1325,7 +1325,10 @@ describe("routing Edit Engine", () => {
         (annotation) => annotation.id === "net-label-route-h",
       ),
     ).toMatchObject({
-      anchor: { fallbackPosition: { x: 300, y: 330 } },
+      // Conductor lands on y=340; the persisted -8 normal offset survives
+      // verbatim (the old 330 expectation encoded the coarse-grid snap the
+      // follow no longer applies).
+      anchor: { fallbackPosition: { x: 300, y: 332 } },
       rotation: 0,
     });
     expect(reshaped.diff.changedObjectIds).toEqual(

--- a/packages/edit-engine/src/transaction-route-annotation-follow.ts
+++ b/packages/edit-engine/src/transaction-route-annotation-follow.ts
@@ -60,10 +60,13 @@ export function followNetLabelsOnChangedRoutes(
       ...annotation.anchor,
       legId: route.legs[attachment.segmentIndex]!.id,
       t: attachment.t,
-      normalOffset: Math.round(offset.x * normal.x + offset.y * normal.y),
+      // The captured offset is the persisted truth; rounding a re-derived
+      // projection drifted the label toward the coarse grid on every
+      // transaction. The fallback rounds on the 1-unit annotation pitch.
+      normalOffset: captured.normalOffset,
       fallbackPosition: snapPointToDocumentGrid(
         { x: anchor.x + offset.x, y: anchor.y + offset.y },
-        draft.presentation.grid,
+        1,
       ),
     };
     changedObjectIds.add(annotation.id);
@@ -134,7 +137,7 @@ export function followRouteMarkersOnChangedRoutes(
         x: from.x + (to.x - from.x) * attachment.t,
         y: from.y + (to.y - from.y) * attachment.t,
       },
-      draft.presentation.grid,
+      1,
     );
     if (annotation.anchor.kind === "route") {
       annotation.anchor = {
@@ -190,7 +193,7 @@ export function remapRouteMarkersAfterSplit(
         x: from.x + (to.x - from.x) * t,
         y: from.y + (to.y - from.y) * t,
       },
-      draft.presentation.grid,
+      1,
     );
     if (annotation.anchor.kind === "route") {
       annotation.anchor = {
@@ -201,6 +204,108 @@ export function remapRouteMarkersAfterSplit(
         fallbackPosition: position,
       };
     }
+    changedObjectIds.add(annotation.id);
+  }
+}
+
+/**
+ * Retarget net-label route anchors onto the split products. Splitting hands
+ * both halves fresh identities (or reuses one), so a label anchored to the
+ * original Route would otherwise fail final validation and make a labelled
+ * wire untappable. The captured conductor point picks the half; the
+ * persisted normal offset survives verbatim.
+ */
+export function remapNetLabelsAfterSplit(
+  draft: SchematicDocument,
+  resolver: SymbolResolver,
+  anchors: readonly NetLabelRouteAnchor[],
+  splitRouteIds: readonly string[],
+  changedObjectIds: Set<string>,
+): void {
+  for (const captured of anchors) {
+    const annotation = draft.annotations.find(
+      (candidate) => candidate.id === captured.annotationId,
+    );
+    if (
+      !annotation ||
+      (annotation.kind !== "net-label" && annotation.kind !== "power-label") ||
+      annotation.anchor.kind !== "route"
+    ) {
+      continue;
+    }
+    const closest = splitRouteIds
+      .flatMap((routeId) => {
+        const route = draft.routes.find(
+          (candidate) => candidate.id === routeId,
+        );
+        const polyline = route
+          ? resolveRouteEditPath(draft, resolver, route)
+          : null;
+        if (!route || !polyline) return [];
+        const lengths = polyline.points.slice(0, -1).map((from, index) => {
+          const to = polyline.points[index + 1]!;
+          return Math.hypot(to.x - from.x, to.y - from.y);
+        });
+        let best: {
+          segmentIndex: number;
+          t: number;
+          distanceSquared: number;
+        } | null = null;
+        for (const [segmentIndex, length] of lengths.entries()) {
+          if (length === 0) continue;
+          const from = polyline.points[segmentIndex]!;
+          const to = polyline.points[segmentIndex + 1]!;
+          const dx = to.x - from.x;
+          const dy = to.y - from.y;
+          const t = Math.max(
+            0,
+            Math.min(
+              1,
+              ((captured.position.x - from.x) * dx +
+                (captured.position.y - from.y) * dy) /
+                (length * length),
+            ),
+          );
+          const px = from.x + dx * t;
+          const py = from.y + dy * t;
+          const distanceSquared =
+            (captured.position.x - px) ** 2 + (captured.position.y - py) ** 2;
+          if (!best || distanceSquared < best.distanceSquared) {
+            best = { segmentIndex, t, distanceSquared };
+          }
+        }
+        return best ? [{ route, polyline, best }] : [];
+      })
+      .sort(
+        (left, right) =>
+          left.best.distanceSquared - right.best.distanceSquared ||
+          left.route.id.localeCompare(right.route.id, "en"),
+      )[0];
+    if (!closest) continue;
+    const from = closest.polyline.points[closest.best.segmentIndex]!;
+    const to = closest.polyline.points[closest.best.segmentIndex + 1]!;
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const length = Math.hypot(dx, dy);
+    if (length === 0) continue;
+    const normal = { x: -dy / length, y: dx / length };
+    const anchorPoint = {
+      x: from.x + dx * closest.best.t,
+      y: from.y + dy * closest.best.t,
+    };
+    annotation.anchor = {
+      ...annotation.anchor,
+      routeId: closest.route.id,
+      legId: closest.route.legs[closest.best.segmentIndex]!.id,
+      t: closest.best.t,
+      fallbackPosition: snapPointToDocumentGrid(
+        {
+          x: anchorPoint.x + normal.x * captured.normalOffset,
+          y: anchorPoint.y + normal.y * captured.normalOffset,
+        },
+        1,
+      ),
+    };
     changedObjectIds.add(annotation.id);
   }
 }

--- a/packages/edit-engine/src/transaction-route-annotations.ts
+++ b/packages/edit-engine/src/transaction-route-annotations.ts
@@ -11,6 +11,8 @@ export interface NetLabelRouteAnchor {
   t: number;
   normalOffset: number;
   arcFraction: number;
+  /** Conductor point of the anchor at capture time (world coordinates). */
+  position: Point;
 }
 
 export interface RouteMarkerAnchor {
@@ -96,7 +98,10 @@ function closestRouteAnchor(
   points: readonly Point[],
   position: Point,
 ):
-  | (Omit<NetLabelRouteAnchor, "annotationId" | "routeId" | "segmentCount"> & {
+  | (Omit<
+      NetLabelRouteAnchor,
+      "annotationId" | "routeId" | "segmentCount" | "position"
+    > & {
       distanceSquared: number;
     })
   | null {
@@ -161,33 +166,77 @@ export function captureNetLabelRouteAnchors(
     ) {
       return [];
     }
-    const closest = polylines
-      .filter(({ route }) => route.id === annotationAnchor.routeId)
-      .flatMap(({ route, polyline }) => {
-        const anchor = closestRouteAnchor(
-          polyline.points,
-          annotationAnchor.fallbackPosition,
-        );
-        return anchor
-          ? [
-              {
-                ...anchor,
-                annotationId: annotation.id,
-                routeId: route.id,
-                segmentCount: polyline.points.length - 1,
-              },
-            ]
-          : [];
-      })
-      .sort(
-        (left, right) =>
-          left.distanceSquared - right.distanceSquared ||
-          left.routeId.localeCompare(right.routeId, "en"),
-      )[0];
-    if (!closest) return [];
-    const { distanceSquared: _distanceSquared, ...anchor } = closest;
-    return [anchor];
+    const entry = polylines.find(
+      ({ route }) => route.id === annotationAnchor.routeId,
+    );
+    if (!entry) return [];
+    // Persisted-first: the stored legId/t/normalOffset are the anchor's
+    // source of truth. Re-projecting from the grid-snapped fallbackPosition
+    // quantized the anchor a little further on every routing transaction.
+    const legIndex = entry.route.legs.findIndex(
+      (leg) => leg.id === annotationAnchor.legId,
+    );
+    if (legIndex >= 0 && legIndex < entry.polyline.points.length - 1) {
+      const from = entry.polyline.points[legIndex]!;
+      const to = entry.polyline.points[legIndex + 1]!;
+      return [
+        {
+          annotationId: annotation.id,
+          routeId: entry.route.id,
+          segmentIndex: legIndex,
+          segmentCount: entry.polyline.points.length - 1,
+          t: annotationAnchor.t,
+          normalOffset: annotationAnchor.normalOffset,
+          arcFraction: arcFractionAt(
+            entry.polyline.points,
+            legIndex,
+            annotationAnchor.t,
+          ),
+          position: {
+            x: from.x + (to.x - from.x) * annotationAnchor.t,
+            y: from.y + (to.y - from.y) * annotationAnchor.t,
+          },
+        },
+      ];
+    }
+    const anchor = closestRouteAnchor(
+      entry.polyline.points,
+      annotationAnchor.fallbackPosition,
+    );
+    if (!anchor) return [];
+    const { distanceSquared: _distanceSquared, ...rest } = anchor;
+    const from = entry.polyline.points[rest.segmentIndex]!;
+    const to = entry.polyline.points[rest.segmentIndex + 1]!;
+    return [
+      {
+        ...rest,
+        annotationId: annotation.id,
+        routeId: entry.route.id,
+        segmentCount: entry.polyline.points.length - 1,
+        position: {
+          x: from.x + (to.x - from.x) * rest.t,
+          y: from.y + (to.y - from.y) * rest.t,
+        },
+      },
+    ];
   });
+}
+
+function arcFractionAt(
+  points: readonly Point[],
+  segmentIndex: number,
+  t: number,
+): number {
+  const lengths = points.slice(0, -1).map((from, index) => {
+    const to = points[index + 1]!;
+    return Math.hypot(to.x - from.x, to.y - from.y);
+  });
+  const total = lengths.reduce((sum, length) => sum + length, 0);
+  if (total === 0) return 0;
+  const before = lengths
+    .slice(0, segmentIndex)
+    .reduce((sum, length) => sum + length, 0);
+  return (before + (lengths[segmentIndex] ?? 0) * t) / total;
 }
 
 export function captureRouteMarkerAnchors(

--- a/packages/edit-engine/src/transaction-route-topology.ts
+++ b/packages/edit-engine/src/transaction-route-topology.ts
@@ -21,8 +21,14 @@ import {
   retargetMosBulkDefaultsAfterSplit,
   retargetOwnerEvidenceAfterSplit,
 } from "./transaction-connectivity.js";
-import { captureRouteMarkerAnchors } from "./transaction-route-annotations.js";
-import { remapRouteMarkersAfterSplit } from "./transaction-route-annotation-follow.js";
+import {
+  captureNetLabelRouteAnchors,
+  captureRouteMarkerAnchors,
+} from "./transaction-route-annotations.js";
+import {
+  remapNetLabelsAfterSplit,
+  remapRouteMarkersAfterSplit,
+} from "./transaction-route-annotation-follow.js";
 import { splitRoute } from "./transaction-route-follow.js";
 import {
   addEndpointToNet,
@@ -139,6 +145,10 @@ export function applyRouteTopologyEdit(
           draft,
           resolver,
         ).filter((anchor) => anchor.routeId === route.id);
+        const splitNetLabelAnchors = captureNetLabelRouteAnchors(
+          draft,
+          resolver,
+        ).filter((anchor) => anchor.routeId === route.id);
         const splitIndex = route.legs.findIndex(
           (leg) => leg.id === edit.split!.legId,
         );
@@ -176,6 +186,13 @@ export function applyRouteTopologyEdit(
           draft,
           resolver,
           splitMarkerAnchors,
+          [split.first.id, split.second.id],
+          changedObjectIds,
+        );
+        remapNetLabelsAfterSplit(
+          draft,
+          resolver,
+          splitNetLabelAnchors,
           [split.first.id, split.second.id],
           changedObjectIds,
         );
@@ -243,6 +260,10 @@ export function applyRouteTopologyEdit(
       const markerAnchors = captureRouteMarkerAnchors(draft, resolver).filter(
         (anchor) => anchor.routeId === route.id,
       );
+      const netLabelAnchors = captureNetLabelRouteAnchors(
+        draft,
+        resolver,
+      ).filter((anchor) => anchor.routeId === route.id);
       const splitIndex = route.legs.findIndex((leg) => leg.id === edit.legId);
       if (splitIndex < 0) {
         return rejectAt(
@@ -279,6 +300,13 @@ export function applyRouteTopologyEdit(
         draft,
         resolver,
         markerAnchors,
+        [split.first.id, split.second.id],
+        changedObjectIds,
+      );
+      remapNetLabelsAfterSplit(
+        draft,
+        resolver,
+        netLabelAnchors,
         [split.first.id, split.second.id],
         changedObjectIds,
       );

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -11,6 +11,7 @@ import {
   followNetLabelsOnChangedRoutes,
   followRouteMarkersOnChangedRoutes,
   remapRouteMarkersAfterSplit,
+  remapNetLabelsAfterSplit,
 } from "./transaction-route-annotation-follow.js";
 import {
   captureNetLabelRouteAnchors,
@@ -652,6 +653,10 @@ export function executeTransaction(
       const markerAnchors = captureRouteMarkerAnchors(draft, resolver).filter(
         (anchor) => anchor.routeId === route.id,
       );
+      const netLabelAnchors = captureNetLabelRouteAnchors(
+        draft,
+        resolver,
+      ).filter((anchor) => anchor.routeId === route.id);
       const seed = `${route.id}:${endpointKey(operation.endpoint)}:${operation.point.x},${operation.point.y}`;
       // Keep the original ID on the from-side so selection, drag state, and
       // callers holding a revision-local Route address remain valid after an
@@ -709,6 +714,13 @@ export function executeTransaction(
         draft,
         resolver,
         markerAnchors,
+        [split.first.id, split.second.id],
+        changedObjectIds,
+      );
+      remapNetLabelsAfterSplit(
+        draft,
+        resolver,
+        netLabelAnchors,
         [split.first.id, split.second.id],
         changedObjectIds,
       );


### PR DESCRIPTION
Wire-transform audit remediation, batch 3 of 4 — findings #5, #10, #12, #13, #16 (clipboard trio + net-label pair). All five re-verified as still reproducing on current main before fixing (independent verification pass with executable repros); regression tests in `clipboard-audit.test.ts` (3) and `netlabel-follow.test.ts` (2).

**Clipboard**
- **#5**: explicit route selection no longer drags terminals of uncopied instances into the clipboard (the #344 regression that made such selections unpastable); a plan-time "Unknown terminal instance" error replaces the raw schema rejection for legacy clipboards.
- **#12**: `orientClipboard` now transforms drafting objects with the rigid body — anchors, arrow/leader/callout targets, waypoints, curve controls, construction-line points, rectangle centers/angles (float-exact), floating-symbol orientations. Rotated pastes stay one body.
- **#16**: junction-only copies mint a fresh net at paste (previously `add_junction` with `netId: undefined` poisoned the whole paste).

**Net labels**
- **#10**: anchor capture is persisted-first (legId/t/normalOffset), so rigid translations keep the anchor byte-for-byte across repeated transactions instead of creeping toward the 10-grid (the -8 → -10 drift); fallback positions round on the 1-unit annotation pitch (markers too). One existing expectation updated — it had encoded the quantization bug (330 vs the true 332).
- **#13**: all three route-split sites (add_junction split, typed attach, contact normalizer) retarget net-label anchors onto the owning split product — a labelled wire can now be tapped instead of failing INVALID_RESULT.

Validation: engine+derived+editor sweep 1092/1092, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)