### PR TITLE
feat(editor): wrap a rectangle's label inside its box

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -1064,6 +1064,47 @@ test("drawing Properties unlocks a protected drawing and Delete overrides its lo
   await expect(drawing).toHaveCount(0);
 });
 
+test("a label too long for its box wraps inside it", async ({ page }) => {
+  await page.goto("/editor");
+  await awaitEditorReady(page);
+  await clickDrawTool(page, "rectangle");
+  await clickCreate(page, { x: 220, y: 220 }, { x: 380, y: 320 });
+  await expect(page.getByTestId("revision")).toHaveText("1");
+
+  const hit = page.getByTestId(/^drafting-hit-rectangle-/);
+  const box = await hit.first().boundingBox();
+  if (!box) throw new Error("rectangle is not measurable");
+  await page.mouse.dblclick(box.x + box.width / 2, box.y + box.height / 2);
+  await expect(
+    page.getByRole("textbox", { name: "Canvas text editor" }),
+  ).toBeVisible();
+  await page.keyboard.type("A very long bias network label indeed");
+  await page.keyboard.press("Escape");
+
+  const label = page.locator('[data-kind="draft-text"]');
+  await expect(label).toHaveCount(1);
+  // Several drawn lines, not one line running out past both edges.
+  expect(
+    await label.locator('[data-text-run="line-break"]').count(),
+  ).toBeGreaterThan(0);
+
+  // And it stays inside the box it belongs to.
+  const fits = await page.evaluate(() => {
+    const polygon = document.querySelector(
+      '[data-kind="draft-rectangle"]',
+    ) as SVGPolygonElement | null;
+    const text = document.querySelector(
+      '[data-kind="draft-text"]',
+    ) as SVGTextElement | null;
+    if (!polygon || !text) return null;
+    const rect = polygon.getBBox();
+    const drawn = text.getBBox();
+    return { rectWidth: rect.width, textWidth: drawn.width };
+  });
+  if (!fits) throw new Error("label geometry is not measurable");
+  expect(fits.textWidth).toBeLessThanOrEqual(fits.rectWidth);
+});
+
 test("double-click inside a rectangle writes a centered, anchored label", async ({
   page,
 }) => {

--- a/packages/derived/src/drafting-geometry.test.ts
+++ b/packages/derived/src/drafting-geometry.test.ts
@@ -3,7 +3,16 @@ import type { DraftingObject, SchematicDocument } from "@icm/model";
 import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
-import { resolveDraftingObjectGeometry } from "./drafting-geometry.js";
+import {
+  draftTextLayoutContent,
+  resolveDraftingObjectGeometry,
+} from "./drafting-geometry.js";
+import { richTextMetrics } from "./rich-text-layout.js";
+import { resolveDocumentStyleProfile } from "./style-profile.js";
+
+/** The metrics a label lays out with, so a test measures what the app does. */
+const labelMetrics = (document: SchematicDocument) =>
+  richTextMetrics(resolveDocumentStyleProfile(document.presentation), "label");
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
@@ -105,6 +114,66 @@ describe("object-anchored drafting text on rectangles", () => {
     // Bounds stay centered on the resolved anchor.
     expect(geometry.bounds.x + geometry.bounds.width / 2).toBeCloseTo(100);
     expect(geometry.bounds.y + geometry.bounds.height / 2).toBeCloseTo(60);
+  });
+
+  it("wraps a long label inside its box instead of running past the edges", () => {
+    const label = anchoredLabel("label-1", "box-1", { x: 0, y: 0 });
+    label.content = {
+      runs: [{ kind: "text", value: "A very long bias network label indeed" }],
+    };
+    const document = documentWith([
+      rectangle("box-1", { x: 100, y: 60 }, 120, 80),
+      label,
+    ]);
+    const geometry = resolveDraftingObjectGeometry(
+      document,
+      resolver,
+      document.drafting!.objects[1]!,
+    );
+    if (geometry.kind !== "text") throw new Error("expected text geometry");
+
+    // The label is inside a box, so it wraps to that box rather than spilling
+    // out both sides of it.
+    expect(geometry.bounds.width).toBeLessThanOrEqual(120);
+    const laidOut = draftTextLayoutContent(
+      document,
+      label,
+      labelMetrics(document),
+    );
+    expect(
+      laidOut.runs.filter((run) => run.kind === "line-break").length,
+    ).toBeGreaterThan(0);
+    // Wrapping is a layout act, not an edit: every word survives, in order.
+    const words = laidOut.runs
+      .map((run) => (run.kind === "text" ? run.value : " "))
+      .join("")
+      .split(/\s+/u)
+      .filter(Boolean);
+    expect(words.join(" ")).toBe("A very long bias network label indeed");
+    // The stored content is untouched; only the laid-out copy carries breaks.
+    expect(label.content.runs).toHaveLength(1);
+  });
+
+  it("leaves a label that already fits on one line", () => {
+    const document = documentWith([
+      rectangle("box-1", { x: 100, y: 60 }, 120, 80),
+      anchoredLabel("label-1", "box-1", { x: 0, y: 0 }),
+    ]);
+    const geometry = resolveDraftingObjectGeometry(
+      document,
+      resolver,
+      document.drafting!.objects[1]!,
+    );
+    if (geometry.kind !== "text") throw new Error("expected text geometry");
+    const laidOut = draftTextLayoutContent(
+      document,
+      document.drafting!.objects[1] as Extract<
+        DraftingObject,
+        { kind: "text" }
+      >,
+      labelMetrics(document),
+    );
+    expect(laidOut.runs.some((run) => run.kind === "line-break")).toBe(false);
   });
 
   it("keeps the resolved center in sync with a moved rectangle", () => {

--- a/packages/derived/src/drafting-geometry.ts
+++ b/packages/derived/src/drafting-geometry.ts
@@ -16,6 +16,7 @@ import {
 import {
   measureRichTextDocument,
   richTextMetrics,
+  wrapRichTextDocument,
 } from "./rich-text-layout.js";
 import { resolveDocumentStyleProfile } from "./style-profile.js";
 
@@ -123,6 +124,35 @@ export type ResolvedDraftingGeometry =
     };
 
 const STROKE_PADDING = 6;
+/** Breathing room between a boxed label and the rectangle's own stroke. */
+const RECT_LABEL_PADDING = 6;
+
+/**
+ * The content a drafting text actually lays out.
+ *
+ * A label anchored to a rectangle is a label *inside a box*, so it wraps to
+ * that box instead of running out past its edges. Every other text keeps the
+ * author's own lines exactly. The SVG renderer calls this too: one wrapped
+ * document for both is what keeps the selection box on the text it frames,
+ * rather than two implementations agreeing by luck.
+ */
+export function draftTextLayoutContent(
+  document: SchematicDocument,
+  object: Extract<DraftingObject, { kind: "text" }>,
+  metrics: Parameters<typeof measureRichTextDocument>[1],
+): RichTextDocument {
+  if (object.anchor.kind !== "object") return object.content;
+  const anchorId = object.anchor.objectId;
+  const target = document.drafting?.objects.find(
+    (candidate) => candidate.id === anchorId,
+  );
+  if (target?.kind !== "rectangle") return object.content;
+  return wrapRichTextDocument(
+    object.content,
+    metrics,
+    target.width - RECT_LABEL_PADDING * 2,
+  );
+}
 const TEXT_PADDING_X = 6;
 const TEXT_PADDING_Y = 8;
 const ARROWHEAD_PADDING = 12;
@@ -244,20 +274,16 @@ function resolveText(
     object.typographyToken,
     object.styleOverride?.sizeScale,
   );
+  const content = draftTextLayoutContent(document, object, metrics);
   const polarity = object.polarity
-    ? resolvePolarityTextGeometry(
-        position,
-        object.polarity,
-        object.content,
-        metrics,
-      )
+    ? resolvePolarityTextGeometry(position, object.polarity, content, metrics)
     : null;
   const textPosition = polarity?.textPosition ?? position;
   const unrotatedTextBounds = textBounds(
     textPosition,
     object.alignment,
     0,
-    object.content,
+    content,
     metrics,
   );
   const unrotatedBounds = polarity

--- a/packages/derived/src/rich-text-layout.ts
+++ b/packages/derived/src/rich-text-layout.ts
@@ -128,6 +128,138 @@ export function measureRichTextDocument(
   };
 }
 
+/**
+ * Break a document's lines so none is wider than `maxWidth`.
+ *
+ * The result is an ordinary RichTextDocument with `line-break` runs inserted,
+ * which is why this is the whole of the feature: every consumer — measurement,
+ * bounds, the SVG renderer, export — already lays out explicit line breaks, so
+ * a wrapped document draws and measures the same everywhere by construction
+ * rather than by two implementations agreeing.
+ *
+ * Wrapping is by word. A single word wider than the box overflows rather than
+ * being cut mid-glyph, because a broken identifier reads as a different one.
+ * A script stack is indivisible, so `V` never comes apart from its subscript,
+ * while an ordinary styling span is descended into and reopened on each line —
+ * the house text style wraps a whole sentence in one italic span, so a wrapper
+ * that only split bare text runs would never break anything a person typed.
+ * Authored breaks are kept as they are.
+ */
+export function wrapRichTextDocument(
+  document: RichTextDocument,
+  metrics: RichTextMetrics,
+  maxWidth: number,
+): RichTextDocument {
+  if (!Number.isFinite(maxWidth) || maxWidth <= 0) return document;
+  const lines = wrapRunsIntoLines(document.runs, metrics, maxWidth, {
+    width: 0,
+  });
+  const runs: RichTextRun[] = [];
+  lines.forEach((line, index) => {
+    if (index > 0) runs.push({ kind: "line-break" });
+    runs.push(...line);
+  });
+  return { ...document, runs };
+}
+
+/** A line never ends in the space that pushed it over; that space is the break. */
+function trimLineEnd(line: RichTextRun[]): void {
+  const last = line.at(-1);
+  if (last?.kind !== "text") return;
+  const trimmed = last.value.replace(/\s+$/u, "");
+  if (trimmed) last.value = trimmed;
+  else line.pop();
+}
+
+function wrapRunsIntoLines(
+  runs: RichTextRun[],
+  metrics: RichTextMetrics,
+  maxWidth: number,
+  state: { width: number },
+): RichTextRun[][] {
+  const lines: RichTextRun[][] = [[]];
+  const breakLine = (): void => {
+    trimLineEnd(lines.at(-1)!);
+    lines.push([]);
+    state.width = 0;
+  };
+  const place = (run: RichTextRun, width: number): void => {
+    const line = lines.at(-1)!;
+    const last = line.at(-1);
+    if (run.kind === "text" && last?.kind === "text") last.value += run.value;
+    else line.push(run);
+    state.width += width;
+  };
+  const widthOf = (run: RichTextRun): number =>
+    measureRun(run, metrics)[0]?.width ?? 0;
+
+  for (let index = 0; index < runs.length; index += 1) {
+    const run = runs[index]!;
+    if (run.kind === "line-break") {
+      lines.push([]);
+      state.width = 0;
+      continue;
+    }
+    const next = runs[index + 1];
+    if (
+      next &&
+      isScriptRun(run) &&
+      isScriptRun(next) &&
+      run.style !== next.style
+    ) {
+      const width = measureScriptStack(run, next, metrics)[0]?.width ?? 0;
+      if (state.width > 0 && state.width + width > maxWidth) breakLine();
+      place(run, width);
+      place(next, 0);
+      index += 1;
+      continue;
+    }
+    if (run.kind === "text") {
+      // Keep the separators so a rebuilt line reads exactly as authored.
+      for (const piece of run.value.split(/(\s+)/u)) {
+        if (!piece) continue;
+        const width = widthOf({ kind: "text", value: piece });
+        if (/^\s+$/u.test(piece)) {
+          if (state.width === 0) continue;
+          if (state.width + width > maxWidth) {
+            breakLine();
+            continue;
+          }
+        } else if (state.width > 0 && state.width + width > maxWidth) {
+          breakLine();
+        }
+        place({ kind: "text", value: piece }, width);
+      }
+      continue;
+    }
+    if (
+      run.kind === "span" &&
+      run.style !== "subscript" &&
+      run.style !== "superscript"
+    ) {
+      // Styling only: wrap the children, then reopen the same span per line.
+      const childLines = wrapRunsIntoLines(
+        run.children,
+        metrics,
+        maxWidth,
+        state,
+      );
+      childLines.forEach((children, childIndex) => {
+        if (childIndex > 0) {
+          trimLineEnd(lines.at(-1)!);
+          lines.push([]);
+        }
+        if (children.length > 0) lines.at(-1)!.push({ ...run, children });
+      });
+      continue;
+    }
+    const width = widthOf(run);
+    if (state.width > 0 && state.width + width > maxWidth) breakLine();
+    place(run, width);
+  }
+  return lines;
+}
+
 function measureRuns(runs: RichTextRun[], metrics: RichTextMetrics): Line[] {
   const baseHeight = metrics.fontSize * metrics.lineHeight;
   const lines: Line[] = [{ width: 0, height: baseHeight }];

--- a/packages/derived/src/rich-text-wrap.test.ts
+++ b/packages/derived/src/rich-text-wrap.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import type { RichTextDocument } from "@icm/model";
+
+import {
+  measureRichTextDocument,
+  richTextMetrics,
+  wrapRichTextDocument,
+} from "./rich-text-layout.js";
+import { resolveSchematicStyleProfile } from "./style-profile.js";
+
+const metrics = richTextMetrics(
+  resolveSchematicStyleProfile("razavi-textbook-v1"),
+  "label",
+);
+
+const text = (value: string): RichTextDocument => ({
+  runs: [{ kind: "text", value }],
+});
+
+/** The rebuilt lines, so a test reads what a person would see. */
+function lines(document: RichTextDocument): string[] {
+  const out: string[] = [""];
+  for (const run of document.runs) {
+    if (run.kind === "line-break") out.push("");
+    else if (run.kind === "text") out[out.length - 1] += run.value;
+  }
+  return out;
+}
+
+describe("wrapRichTextDocument", () => {
+  it("breaks a long label into lines that fit the box", () => {
+    const wrapped = wrapRichTextDocument(
+      text("A very long bias network label indeed"),
+      metrics,
+      110,
+    );
+    expect(lines(wrapped).length).toBeGreaterThan(1);
+    expect(measureRichTextDocument(wrapped, metrics).width).toBeLessThanOrEqual(
+      110,
+    );
+    // Every word survives, in order: wrapping is a layout act, not an edit.
+    expect(lines(wrapped).join(" ")).toBe(
+      "A very long bias network label indeed",
+    );
+  });
+
+  it("leaves a label that already fits exactly as it was", () => {
+    const document = text("Bias");
+    expect(wrapRichTextDocument(document, metrics, 400)).toEqual(document);
+  });
+
+  it("keeps a word wider than the box whole rather than cutting it", () => {
+    // A broken identifier reads as a different identifier.
+    const wrapped = wrapRichTextDocument(
+      text("supercalifragilistic"),
+      metrics,
+      20,
+    );
+    expect(lines(wrapped)).toEqual(["supercalifragilistic"]);
+  });
+
+  it("never separates a subscript from what it belongs to", () => {
+    const document: RichTextDocument = {
+      runs: [
+        { kind: "text", value: "bias current " },
+        {
+          kind: "span",
+          style: "italic",
+          children: [{ kind: "text", value: "V" }],
+        },
+        {
+          kind: "span",
+          style: "subscript",
+          children: [{ kind: "text", value: "out" }],
+        },
+      ],
+    };
+    const wrapped = wrapRichTextDocument(document, metrics, 60);
+    const breakAt = wrapped.runs.findIndex((run) => run.kind === "line-break");
+    const stackAt = wrapped.runs.findIndex(
+      (run) => run.kind === "span" && run.style === "subscript",
+    );
+    expect(breakAt).toBeGreaterThanOrEqual(0);
+    // The break lands before the pair, never between its two halves.
+    expect(wrapped.runs[stackAt - 1]).toMatchObject({ style: "italic" });
+  });
+
+  it("keeps authored breaks and does not indent a wrapped line", () => {
+    const document: RichTextDocument = {
+      runs: [
+        { kind: "text", value: "first" },
+        { kind: "line-break" },
+        { kind: "text", value: "second line that must wrap somewhere" },
+      ],
+    };
+    const wrapped = wrapRichTextDocument(document, metrics, 90);
+    const rebuilt = lines(wrapped);
+    expect(rebuilt[0]).toBe("first");
+    expect(rebuilt.length).toBeGreaterThan(2);
+    expect(rebuilt.every((line) => !/^\s/u.test(line))).toBe(true);
+  });
+});

--- a/packages/render-svg/src/drafting-render.test.ts
+++ b/packages/render-svg/src/drafting-render.test.ts
@@ -1,6 +1,9 @@
 import { createEmptyDocument } from "@icm/model";
 import type { RichTextRun } from "@icm/model";
-import { resolveSchematicStyleProfile } from "@icm/derived";
+import {
+  resolveDraftingObjectGeometry,
+  resolveSchematicStyleProfile,
+} from "@icm/derived";
 import {
   ANALOG_CANVAS_MATH_PROFILE_ID,
   prepareFormula,
@@ -698,9 +701,33 @@ describe("object-anchored drafting text centering", () => {
     );
     const fontSize = profile.typography.annotationFontSize;
     const lineStep = fontSize * profile.typography.lineHeight;
+    // Count the lines actually drawn rather than the ones authored: a label
+    // inside a box also wraps to it, and the centering rule is about however
+    // many lines end up there.
+    const lines = (svg.match(/data-text-run="line-break"/gu) ?? []).length + 1;
+    expect(lines).toBeGreaterThan(1);
     expect(textBaselineY(svg, "label-1")).toBeCloseTo(
-      60 - lineStep / 2 + CENTERED_CAP_BASELINE_RATIO * fontSize,
+      60 -
+        ((lines - 1) * lineStep) / 2 +
+        CENTERED_CAP_BASELINE_RATIO * fontSize,
     );
+  });
+
+  it("wraps a boxed label and draws exactly the lines it measured", () => {
+    const document = labelDocument(
+      [{ kind: "text", value: "A very long bias network label indeed" }],
+      "object",
+    );
+    const svg = renderDocumentSvg(document, resolver);
+    const lines = (svg.match(/data-text-run="line-break"/gu) ?? []).length + 1;
+    expect(lines).toBeGreaterThan(1);
+
+    // The drawn lines are the ones the geometry measured its bounds from, so
+    // a selection box cannot come away from the text it frames.
+    const label = document.drafting!.objects[1]!;
+    const geometry = resolveDraftingObjectGeometry(document, resolver, label);
+    if (geometry.kind !== "text") throw new Error("expected text geometry");
+    expect(geometry.bounds.width).toBeLessThanOrEqual(80);
   });
 
   it("keeps free text on its first-line baseline unchanged", () => {

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -19,6 +19,8 @@ import {
   resolveAnnotationText,
   resolveDocumentStyleProfile,
   resolveDocumentLogicalNets,
+  draftTextLayoutContent,
+  richTextMetrics,
   resolveRouteAttachment,
   razaviTextbookProfile,
 } from "@icm/derived";
@@ -936,6 +938,7 @@ function renderDraftingLayer(
       switch (object.kind) {
         case "text":
           return renderDraftText(
+            document,
             object,
             geometry as Extract<ResolvedDraftingGeometry, { kind: "text" }>,
             profile,
@@ -997,6 +1000,7 @@ function renderDraftingLayer(
 }
 
 function renderDraftText(
+  document: SchematicDocument,
   object: Extract<DraftingObject, { kind: "text" }>,
   geometry: Extract<ResolvedDraftingGeometry, { kind: "text" }>,
   profile: SchematicStyleProfile,
@@ -1006,33 +1010,36 @@ function renderDraftText(
   const fontSize =
     typographyFontSize(object.typographyToken ?? "body", profile) *
     (object.styleOverride?.sizeScale ?? 1);
+  // The same function the geometry measured with, on the same inputs: a label
+  // inside a box arrives wrapped to that box, and the drawn lines cannot
+  // disagree with the bounds that framed them.
+  const content = draftTextLayoutContent(
+    document,
+    object,
+    richTextMetrics(
+      profile,
+      object.typographyToken,
+      object.styleOverride?.sizeScale,
+    ),
+  );
   // Object-anchored drafting text (e.g. a rectangle's centered label) paints
   // its uniform line grid centered on the resolved anchor position. Free and
   // route-anchored text keep the first-line-baseline placement unchanged.
   const baselineY =
     object.anchor.kind === "object" || object.polarity
-      ? centeredFirstBaselineY(
-          object.content,
-          textPosition.y,
-          fontSize,
-          profile,
-        )
+      ? centeredFirstBaselineY(content, textPosition.y, fontSize, profile)
       : textPosition.y;
   const weight = object.styleOverride?.weight === "bold" ? "bold" : "normal";
   const italic = object.styleOverride?.italic === true ? "italic" : "normal";
-  const positioned = renderPositionedOverbarScriptDocument(
-    object.content,
-    profile,
-    {
-      x: textPosition.x,
-      y: baselineY,
-      fontSize,
-      alignment: object.alignment,
-      defaultBold: weight === "bold",
-      defaultItalic: italic === "italic",
-    },
-  );
-  const formula = renderFormulaDocument(object.content, profile, {
+  const positioned = renderPositionedOverbarScriptDocument(content, profile, {
+    x: textPosition.x,
+    y: baselineY,
+    fontSize,
+    alignment: object.alignment,
+    defaultBold: weight === "bold",
+    defaultItalic: italic === "italic",
+  });
+  const formula = renderFormulaDocument(content, profile, {
     x: textPosition.x,
     baselineY,
     fontSize,
@@ -1055,7 +1062,7 @@ function renderDraftText(
       ? formula
       : positioned
         ? `<text x="${textPosition.x}" y="${baselineY}" text-anchor="start" font-size="${fontSize}" font-weight="${weight}" font-style="${italic}" fill="${color}">${positioned.tspans}</text>${positioned.decorations}`
-        : `<text x="${textPosition.x}" y="${baselineY}" text-anchor="${object.alignment}" font-size="${fontSize}" font-weight="${weight}" font-style="${italic}" fill="${color}">${renderRichTextDocument(object.content, profile, { lineOriginX: textPosition.x, fontSize })}</text>`;
+        : `<text x="${textPosition.x}" y="${baselineY}" text-anchor="${object.alignment}" font-size="${fontSize}" font-weight="${weight}" font-style="${italic}" fill="${color}">${renderRichTextDocument(content, profile, { lineOriginX: textPosition.x, fontSize })}</text>`;
     return `<g data-object-id="${object.id}" data-kind="draft-text" data-polarity="${object.polarity}"${unresolved} transform="rotate(${rotation} ${position.x} ${position.y})">${markers}${text}</g>`;
   }
   // P1: the renderer consumes geometry.rotation (the single rotation truth),
@@ -1067,11 +1074,11 @@ function renderDraftText(
   if (positioned) {
     return `<g transform="rotate(${rotation} ${position.x} ${position.y})"><text data-object-id="${object.id}" data-kind="draft-text"${unresolved} x="${textPosition.x}" y="${baselineY}" text-anchor="start" font-size="${fontSize}" font-weight="${weight}" font-style="${italic}">${positioned.tspans}</text>${positioned.decorations}</g>`;
   }
-  const content = renderRichTextDocument(object.content, profile, {
+  const markup = renderRichTextDocument(content, profile, {
     lineOriginX: textPosition.x,
     fontSize,
   });
-  return `<text data-object-id="${object.id}" data-kind="draft-text"${unresolved} x="${textPosition.x}" y="${baselineY}" text-anchor="${object.alignment}" transform="rotate(${rotation} ${position.x} ${position.y})" font-size="${fontSize}" font-weight="${weight}" font-style="${italic}">${content}</text>`;
+  return `<text data-object-id="${object.id}" data-kind="draft-text"${unresolved} x="${textPosition.x}" y="${baselineY}" text-anchor="${object.alignment}" transform="rotate(${rotation} ${position.x} ${position.y})" font-size="${fontSize}" font-weight="${weight}" font-style="${italic}">${markup}</text>`;
 }
 
 /** Glyph cap height is ~0.7 em; dropping the baseline by 0.35 em sits the


### PR DESCRIPTION
> 矩形框里的文字…换行

## What it did before

A label longer than its rectangle ran straight out past **both** edges as a single line — measured, not guessed: a 36-character label in a 120-wide box rendered one `<text>` with bounds **348 wide**.

Nothing wrapped it, because the layout only ever broke where the author had pressed Shift+Enter.

## Wrapping as a layout act, not an edit

`wrapRichTextDocument` returns an ordinary document with `line-break` runs inserted at word boundaries. The **stored content is never touched**, so resizing the box reflows and re-editing shows what was typed.

That shape is the whole reason the change is small: every consumer already lays out explicit breaks, so measurement, bounds, the SVG renderer, and export all follow with **no changes of their own**.

## Two details the wrapper has to get right

- **It descends into ordinary styling spans** and reopens them per line. The house text style wraps a whole sentence in one italic span, so a wrapper that only split bare `text` runs would never break anything a person actually typed — this is exactly what my first attempt got wrong, and the probe caught it: 0 breaks on real content while the unit test passed on synthetic runs.
- **A script stack stays indivisible**, so a subscript never comes away from what it belongs to.

A word wider than the box overflows rather than being cut, because a broken identifier reads as a different identifier.

## One function, two callers

The geometry and the renderer call the same exported `draftTextLayoutContent` on the same inputs rather than each wrapping for itself — that is what keeps the selection box on the text it frames.

The laid-out content deliberately does **not** travel on the resolved geometry. I tried that first; it fails the Agent snapshot's strict schema, and rightly so — `resolvedGeometry` is a published contract and layout detail is not part of it. The renderer takes the document instead.

## Validation

- Full unit suite: **1687 passed** (5 wrapper cases + 2 geometry cases + 1 render case)
- Full Playwright suite: **230 passed**, including a new one that types a long label into a rectangle in the real browser and asserts the drawn text is no wider than the box
- Typecheck, Prettier, markdown links

One existing assertion changed: the multi-line centering test hard-coded "2 lines" for a label that, at 14 characters in an 80-wide box, genuinely does not fit on one. It now counts the lines actually drawn, so it tests the centering **rule** rather than a number that only held before wrapping existed.

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)