### PR TITLE
Flatten the Extended Devices library

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -1229,6 +1229,7 @@ test("shows the complete foldable categorized Library, quick-places a device, an
 }) => {
   await page.setViewportSize({ width: 1024, height: 720 });
   await page.goto("/editor");
+  await awaitEditorReady(page);
   const panel = page.getByTestId("shapes-library-panel");
   const canvas = page.getByTestId("schematic-canvas");
   const libraryChips = panel.locator('[data-testid^="shapes-chip-"]');
@@ -1242,9 +1243,9 @@ test("shows the complete foldable categorized Library, quick-places a device, an
   const transistorChips = transistorCategory.locator(
     '[data-testid^="shapes-chip-"]',
   );
-  // NMOS, PMOS, NPN, PNP, and the ordinary and Zener diodes that belong with
-  // their semiconductor family.
-  await expect(transistorChips).toHaveCount(6);
+  // Keep the everyday transistor palette compact; the two diode tiles live
+  // in Extended Devices below.
+  await expect(transistorChips).toHaveCount(4);
   const transistorGrid = transistorCategory.locator(".shapes-grid");
   // Tiles keep a fixed square size; a wider panel fits more of them per row
   // instead of stretching each tile.
@@ -1268,7 +1269,7 @@ test("shows the complete foldable categorized Library, quick-places a device, an
           ),
         ).size,
     ),
-  ).toBe(Math.ceil(6 / columns));
+  ).toBe(Math.ceil(4 / columns));
   expect(
     await transistorGrid.evaluate((element) => {
       const gridBounds = element.getBoundingClientRect();
@@ -1372,11 +1373,15 @@ test("shows the complete foldable categorized Library, quick-places a device, an
   await expect(page.getByTestId("shapes-chip-buffer")).toBeAttached();
   await expect(page.getByTestId("shapes-chip-delay-cell")).toBeAttached();
   await expect(page.getByTestId("shapes-chip-d-flip-flop")).toBeAttached();
+  const extendedCategory = page.getByTestId("shapes-category-extended-devices");
   await expect(
-    page
-      .getByTestId("shapes-category-extended-devices")
-      .getByText("High-voltage devices", { exact: true }),
+    extendedCategory.locator('[data-testid^="shapes-chip-"]'),
+  ).toHaveCount(4);
+  await expect(extendedCategory.getByTestId("shapes-chip-diode")).toBeVisible();
+  await expect(
+    extendedCategory.getByTestId("shapes-chip-zener-diode"),
   ).toBeVisible();
+  await expect(extendedCategory).not.toContainText("High-voltage devices");
   await expect(
     panel.getByRole("button", { name: "Place Independent Voltage Source" }),
   ).toBeAttached();
@@ -1521,6 +1526,7 @@ test("keeps a usable canvas while toggling Library at the narrow breakpoint", as
 }) => {
   await page.setViewportSize({ width: 720, height: 720 });
   await page.goto("/editor");
+  await awaitEditorReady(page);
 
   const chrome = page.locator(".app-chrome-main");
   // The analytics readout lives in the statusbar now; the top bar ends

--- a/apps/editor/src/features/component-insert/symbol-catalog.test.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.test.ts
@@ -7,7 +7,6 @@ import {
   libraryDescription,
   libraryDisplayName,
   symbolCategory,
-  symbolSubcategory,
 } from "./symbol-catalog";
 
 describe("component insertion catalog", () => {
@@ -52,15 +51,14 @@ describe("component insertion catalog", () => {
     expect(symbolCategory("xor-gate")).toBe("Logic Gates");
     expect(symbolCategory("xnor-gate")).toBe("Logic Gates");
     expect(symbolCategory("npn")).toBe("Transistors");
-    expect(symbolCategory("diode")).toBe("Transistors");
-    expect(symbolCategory("zener-diode")).toBe("Transistors");
+    expect(symbolCategory("diode")).toBe("Extended Devices");
+    expect(symbolCategory("zener-diode")).toBe("Extended Devices");
     expect(symbolCategory("ideal-switch")).toBe("Switches");
     expect(symbolCategory("closed-switch")).toBe("Switches");
     expect(symbolCategory("ndmos")).toBe("Extended Devices");
     expect(symbolCategory("pdmos")).toBe("Extended Devices");
     expect(symbolCategory("annotation-arrow")).toBe("Annotations");
     expect(symbolCategory("annotation-polarity-both")).toBe("Annotations");
-    expect(symbolSubcategory("ndmos")).toBe("High-voltage devices");
   });
 
   it("orders annotations as drawing tools, the polarity label, then signs", () => {
@@ -128,17 +126,18 @@ describe("component insertion catalog", () => {
     ).toEqual([]);
   });
 
-  it("offers N- and P-channel DMOS in the high-voltage expanded library", () => {
-    const groups = componentCatalog("razavi-textbook-v1", "dmos");
-    expect(groups).toHaveLength(1);
-    expect(groups[0]).toMatchObject({
-      category: "Extended Devices",
-      subcategory: "High-voltage devices",
-    });
-    expect(groups[0]?.symbols.map((symbol) => symbol.id)).toEqual([
+  it("keeps diode and DMOS tiles in one undivided expanded library", () => {
+    const extended = componentCatalog("razavi-textbook-v1", "").find(
+      (group) => group.category === "Extended Devices",
+    );
+
+    expect(extended?.symbols.map((symbol) => symbol.id)).toEqual([
+      "diode",
+      "zener-diode",
       "ndmos",
       "pdmos",
     ]);
+    expect(extended).not.toHaveProperty("subcategory");
   });
 
   it("describes the filled Cell Pin as an independent authoring object", () => {
@@ -191,7 +190,13 @@ describe("reach order inside a category", () => {
 
     // Alphabetical order separated NMOS from PMOS with a bipolar between them,
     // and the supply Port from its Rail.
-    expect(ids("Transistors").slice(0, 2)).toEqual(["nmos", "pmos"]);
+    expect(ids("Transistors")).toEqual(["nmos", "pmos", "npn", "pnp"]);
+    expect(ids("Extended Devices")).toEqual([
+      "diode",
+      "zener-diode",
+      "ndmos",
+      "pdmos",
+    ]);
     const power = ids("Power and Ports");
     expect(power.indexOf("vdd-port")).toBeLessThan(power.indexOf("vdd"));
   });

--- a/apps/editor/src/features/component-insert/symbol-catalog.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.ts
@@ -2,7 +2,6 @@ import {
   expandedDeviceCatalogEntry,
   expandedDeviceSymbols,
   EXTENDED_DEVICE_CATEGORY,
-  HIGH_VOLTAGE_DEVICE_SUBCATEGORY,
   razaviProductSymbols,
 } from "@icm/symbols";
 import type { SymbolDefinition } from "@icm/symbols";
@@ -22,7 +21,6 @@ import { TIMING_UI_ENABLED } from "../simulation/timing-ui";
  */
 interface CatalogSection {
   readonly category: string;
-  readonly subcategory?: string;
 }
 
 const CATALOG_SECTIONS: readonly CatalogSection[] = [
@@ -35,26 +33,24 @@ const CATALOG_SECTIONS: readonly CatalogSection[] = [
   { category: "Logic Gates" },
   { category: "Signal Flow" },
   { category: ANNOTATION_CATEGORY },
-  {
-    category: EXTENDED_DEVICE_CATEGORY,
-    subcategory: HIGH_VOLTAGE_DEVICE_SUBCATEGORY,
-  },
+  { category: EXTENDED_DEVICE_CATEGORY },
 ];
 
 export interface ComponentCatalogGroup {
   category: string;
-  subcategory?: string;
   symbols: SymbolDefinition[];
 }
 
 export function symbolCategory(symbolId: string): string {
   if (isAnnotationPaletteSymbol(symbolId)) return ANNOTATION_CATEGORY;
+  // Keep the two diode tiles in the Extended Devices UI group, not at the
+  // front of the everyday transistor palette.
+  if (["diode", "zener-diode"].includes(symbolId)) {
+    return EXTENDED_DEVICE_CATEGORY;
+  }
   const expanded = expandedDeviceCatalogEntry(symbolId);
   if (expanded) return expanded.category;
-  // The diode sits with its semiconductor family, not the passives.
-  if (
-    ["nmos", "pmos", "npn", "pnp", "diode", "zener-diode"].includes(symbolId)
-  ) {
+  if (["nmos", "pmos", "npn", "pnp"].includes(symbolId)) {
     return "Transistors";
   }
   if (
@@ -120,10 +116,6 @@ export function symbolCategory(symbolId: string): string {
     return "Switches";
   }
   return "Power and Ports";
-}
-
-export function symbolSubcategory(symbolId: string): string | undefined {
-  return expandedDeviceCatalogEntry(symbolId)?.subcategory;
 }
 
 /**
@@ -237,14 +229,9 @@ export function componentCatalog(
       return left.name.localeCompare(right.name);
     });
 
-  return CATALOG_SECTIONS.map(({ category, ...location }) => ({
+  return CATALOG_SECTIONS.map(({ category }) => ({
     category,
-    ...location,
-    symbols: symbols.filter(
-      (symbol) =>
-        symbolCategory(symbol.id) === category &&
-        symbolSubcategory(symbol.id) === location.subcategory,
-    ),
+    symbols: symbols.filter((symbol) => symbolCategory(symbol.id) === category),
   })).filter((group) => group.symbols.length > 0);
 }
 

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -32,7 +32,7 @@ describe("shapes quick-place", () => {
     expect(
       groups.map((group) => [group.category, group.symbols.length]),
     ).toEqual([
-      ["Transistors", 6],
+      ["Transistors", 4],
       ["Passives", 7],
       ["Power and Ports", 5],
       ["Sources", 3],
@@ -41,7 +41,7 @@ describe("shapes quick-place", () => {
       ["Logic Gates", 10],
       ["Signal Flow", 5],
       ["Annotations", 7],
-      ["Extended Devices", 2],
+      ["Extended Devices", 4],
     ]);
     const categoryTestIds = [
       "transistors",
@@ -80,9 +80,7 @@ describe("shapes quick-place", () => {
     expect(markup).toContain('aria-label="Place Comparator (unmarked)"');
     expect(markup).toContain('aria-label="Place N-channel DMOS"');
     expect(markup).toContain('aria-label="Place P-channel DMOS"');
-    expect(markup).toContain(
-      '<div class="shapes-subcategory-label">High-voltage devices</div>',
-    );
+    expect(markup).not.toContain("High-voltage devices");
     expect(markup).toContain(">V Src</span>");
     expect(markup).toContain(">Pulse Src</span>");
     expect(markup).toContain(">Cap</span>");

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -220,11 +220,6 @@ export function ShapesPanel({
                       {group.symbols.length}
                     </span>
                   </summary>
-                  {group.subcategory ? (
-                    <div className="shapes-subcategory-label">
-                      {group.subcategory}
-                    </div>
-                  ) : null}
                   <div className="shapes-grid">
                     {group.symbols.map((symbol) => (
                       <button

--- a/apps/editor/src/styles/editor-workspace.css
+++ b/apps/editor/src/styles/editor-workspace.css
@@ -339,8 +339,7 @@
   white-space: nowrap;
 }
 
-.shapes-category:not([open]) > .shapes-grid,
-.shapes-category:not([open]) > .shapes-subcategory-label {
+.shapes-category:not([open]) > .shapes-grid {
   display: none;
 }
 
@@ -350,14 +349,6 @@
   font-size: 10px;
   font-variant-numeric: tabular-nums;
   line-height: 1;
-}
-
-.shapes-subcategory-label {
-  padding: 0 2px 1px 12px;
-  color: var(--icm-text-muted);
-  font-size: 10px;
-  font-weight: 600;
-  line-height: var(--icm-line-tight);
 }
 
 /* Fixed-size tiles rather than fractional columns: dragging the panel wider


### PR DESCRIPTION
## Summary

- move Diode and Zener Diode from Transistors to the final Extended Devices group
- show Diode, Zener, NDMOS, and PDMOS as one continuous list
- remove the High-voltage devices subheading and its unused UI styling
- stabilize the touched browser scenarios by waiting for the editor to finish loading

## Validation

- `pnpm gate:preflight -- --base origin/main`
- 1,704 workspace unit tests passed
- 29/30 component-insert browser tests passed in the affected run; the remaining pre-existing Loading editor startup timeout passed on focused retry after adding the standard editor-ready wait
- focused catalog/Shapes Panel tests and production build passed