### PR TITLE
fix(edit-engine): transform tail — seed forwarding, session staleness, fine anchors, shared derivation

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -435,7 +435,15 @@ export function App({
     controller: editorDocumentController,
     projectSessionId,
     synchronizeExternalCommit,
-  } = useDocumentController(preparedInitialProject, stageRecovery);
+  } = useDocumentController(preparedInitialProject, (project) => {
+    // A commit landing outside the active pointer session invalidates it:
+    // the session's completion would otherwise plan on the pointer-down
+    // document and stamp the live revision, silently reverting this commit
+    // (audit #8). The session's own commit runs after its cleanup, so this
+    // is a no-op for ordinary drags.
+    canvasDragSessionRef.current?.cancel();
+    stageRecovery(project);
+  });
   const agentSemanticIntentRef = useRef<
     (request: AgentHostSemanticIntentRequest) => AgentHostSemanticIntentResult
   >(() => ({

--- a/apps/editor/src/features/selection/annotation-fine-move.test.ts
+++ b/apps/editor/src/features/selection/annotation-fine-move.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Wire-transform audit batch 4, #11: moving a free annotation with the
+ * selection preserves its fine (sub-device-grid) placement — the grid
+ * discipline rides on the delta, exactly like the drafting branch.
+ */
+import { createEmptyDocument } from "@icm/model";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import type { SchematicEdit, RoutingOperationIntent } from "@icm/edit-engine";
+import { describe, expect, it } from "vitest";
+
+import { createSelectionMoveController } from "./selection-move-controller";
+import { planSelectionMove } from "./selection-move-plan";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+describe("free annotation fine placement (#11)", () => {
+  it("a grid-aligned group move keeps the annotation's fine offset", () => {
+    const document = createEmptyDocument("doc", "Fine");
+    document.nets.push({ id: "net-a", terminals: [] });
+    document.annotations.push({
+      id: "note",
+      kind: "route-marker",
+      markerKind: "current",
+      netId: "net-a",
+      // Legal under the 1-unit annotation pitch (schema 29).
+      anchor: { kind: "free", position: { x: 103, y: 57 } },
+      alignment: "middle",
+      rotation: 0,
+      locked: false,
+    });
+    const captured: SchematicEdit[][] = [];
+    const controller = createSelectionMoveController({
+      document,
+      resolver,
+      visibleEndpoints: [],
+      routeGeometryRecords: [],
+      contactComponents: [],
+      transactConnectivity: (
+        _intent: RoutingOperationIntent,
+        edits: readonly SchematicEdit[],
+      ) => {
+        captured.push([...edits]);
+        return { ok: true };
+      },
+      setStatus: () => {},
+      nextRoutingSuffix: () => 1,
+    });
+    const movePlan = planSelectionMove(document, {
+      instanceIds: [],
+      routeIds: [],
+      junctionIds: [],
+      annotationIds: ["note"],
+      draftingIds: [],
+    });
+    controller.completeVisualSelectionMove(movePlan, { x: 10, y: 0 });
+    const upsert = captured
+      .flat()
+      .find((edit) => edit.kind === "upsert_schematic_annotation");
+    expect(upsert).toBeDefined();
+    if (upsert?.kind !== "upsert_schematic_annotation") throw new Error("kind");
+    expect(upsert.annotation.anchor).toEqual({
+      kind: "free",
+      position: { x: 113, y: 57 },
+    });
+  });
+});

--- a/apps/editor/src/features/selection/selection-move-controller.ts
+++ b/apps/editor/src/features/selection/selection-move-controller.ts
@@ -14,6 +14,7 @@ import {
   resolveElectricalContactTargets,
   resolveEndpointConnection,
   type RoutedComponent,
+  deriveNetConnectivityContext,
 } from "@icm/derived";
 import {
   routeEndpoints,
@@ -91,12 +92,15 @@ export function createSelectionMoveController({
             ...annotation,
             anchor: {
               kind: "free" as const,
+              // Translation preserves the annotation's fine placement: the
+              // grid discipline rides on the delta, and the annotation pitch
+              // can be finer than the Document grid (drafting contract).
               position: snapGridPoint(
                 {
                   x: annotation.anchor.position.x + delta.x,
                   y: annotation.anchor.position.y + delta.y,
                 },
-                sourceDocument.presentation.grid,
+                1,
               ),
             },
           },
@@ -277,10 +281,23 @@ export function createSelectionMoveController({
         })()
       : routeGeometryRecords;
     const sourceContactComponents = projectedDocument
-      ? sourceDocument.nets.flatMap(
-          (net) =>
-            deriveNetConnectivity(sourceDocument, resolver, net).components,
-        )
+      ? (() => {
+          // One shared geometry+contacts pass; deriving them per net made
+          // every keyboard-Move pointer event quadratic in net count.
+          const connectivityContext = deriveNetConnectivityContext(
+            sourceDocument,
+            resolver,
+          );
+          return sourceDocument.nets.flatMap(
+            (net) =>
+              deriveNetConnectivity(
+                sourceDocument,
+                resolver,
+                net,
+                connectivityContext,
+              ).components,
+          );
+        })()
       : contactComponents;
     const rawDelta = {
       x: position.x - preview.pointerStart.x,

--- a/packages/derived/src/connectivity.test.ts
+++ b/packages/derived/src/connectivity.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Wire-transform audit batch 4, #17: the shared per-document connectivity
+ * context must be observationally identical to the per-net derivation —
+ * it exists purely to stop an all-nets sweep from re-deriving full-document
+ * contact evidence and routing geometry once per net.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { parseProject } from "@icm/project-protocol";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveNetConnectivity,
+  deriveNetConnectivityContext,
+} from "./connectivity.js";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+describe("shared connectivity context (#17)", () => {
+  it("context-shared derivation matches the per-net derivation exactly", () => {
+    const document = parseProject(
+      readFileSync(
+        resolve(
+          process.cwd(),
+          "fixtures/projects/phase-3-routing/project.icproj.json",
+        ),
+        "utf8",
+      ),
+    ).documents[0]!;
+    const context = deriveNetConnectivityContext(document, resolver);
+    expect(document.nets.length).toBeGreaterThan(0);
+    for (const net of document.nets) {
+      expect(deriveNetConnectivity(document, resolver, net, context)).toEqual(
+        deriveNetConnectivity(document, resolver, net),
+      );
+    }
+  });
+});

--- a/packages/derived/src/connectivity.ts
+++ b/packages/derived/src/connectivity.ts
@@ -9,6 +9,10 @@ import {
   resolveEndpointPoint,
 } from "./endpoint.js";
 import { deriveDocumentContactEvidence } from "./contact.js";
+import {
+  resolveDocumentRoutingGeometry,
+  type ResolvedDocumentRoutingGeometry,
+} from "./resolved-route-geometry.js";
 import { resolveNetLabelBindings } from "./net-label.js";
 import { resolveAnnotationText } from "./annotation-text.js";
 import { resolveDocumentLogicalNets } from "./logical-net.js";
@@ -67,10 +71,36 @@ class DisjointSet {
   }
 }
 
+/**
+ * Shared per-document context for connectivity derivation. Deriving it once
+ * and passing it through turns an all-nets sweep from quadratic (full
+ * contact evidence and label bindings re-derived per net) into one pass.
+ */
+export interface NetConnectivityContext {
+  routingGeometry: ResolvedDocumentRoutingGeometry;
+  contacts: ReturnType<typeof deriveDocumentContactEvidence>;
+}
+
+export function deriveNetConnectivityContext(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+): NetConnectivityContext {
+  const routingGeometry = resolveDocumentRoutingGeometry(document, resolver);
+  return {
+    routingGeometry,
+    contacts: deriveDocumentContactEvidence(
+      document,
+      resolver,
+      routingGeometry,
+    ),
+  };
+}
+
 export function deriveNetConnectivity(
   document: SchematicDocument,
   resolver: SymbolResolver,
   net: Net,
+  context?: NetConnectivityContext,
 ): VisibleNetConnectivity {
   const endpoints = netEndpoints(document, net).filter((endpoint) =>
     isVisibleEndpoint(document, resolver, endpoint),
@@ -97,7 +127,8 @@ export function deriveNetConnectivity(
     const to = endpointKey(routeEnd(route));
     if (nodes.has(from) && nodes.has(to)) sets.union(from, to);
   }
-  const contacts = deriveDocumentContactEvidence(document, resolver);
+  const contacts =
+    context?.contacts ?? deriveDocumentContactEvidence(document, resolver);
   for (const contact of contacts.contacts.filter(
     (candidate) => candidate.netId === net.id,
   )) {
@@ -109,7 +140,15 @@ export function deriveNetConnectivity(
     for (const key of keys.slice(1)) sets.union(first, key);
   }
   const labeledEndpoints = new Map<string, string[]>();
-  for (const binding of resolveNetLabelBindings(document, resolver, net.id)) {
+  const netLabelBindings = context
+    ? resolveNetLabelBindings(
+        document,
+        resolver,
+        net.id,
+        context.routingGeometry,
+      )
+    : resolveNetLabelBindings(document, resolver, net.id);
+  for (const binding of netLabelBindings) {
     const annotation = document.annotations.find(
       (candidate) => candidate.id === binding.annotationId,
     )!;
@@ -126,7 +165,7 @@ export function deriveNetConnectivity(
     if (annotation.kind !== "power-label" || annotation.netId !== net.id) {
       continue;
     }
-    const binding = resolveNetLabelBindings(document, resolver, net.id).find(
+    const binding = netLabelBindings.find(
       (candidate) => candidate.annotationId === annotation.id,
     );
     if (!binding) continue;

--- a/packages/edit-engine/src/route-operations.ts
+++ b/packages/edit-engine/src/route-operations.ts
@@ -1398,6 +1398,7 @@ export function proposeGroupRotation(
   instanceIds: readonly string[],
   deltaDegrees: 90 | -90 | 180,
   center?: Point,
+  additionalJunctionIds: readonly string[] = [],
 ): GroupRotationProposal {
   return proposeRigidBodyMove(
     document,
@@ -1412,6 +1413,7 @@ export function proposeGroupRotation(
       }),
     }),
     center,
+    additionalJunctionIds,
   );
 }
 
@@ -1430,6 +1432,7 @@ export function proposeGroupReflection(
   instanceIds: readonly string[],
   direction: ScreenFlip,
   center?: Point,
+  additionalJunctionIds: readonly string[] = [],
 ): GroupRotationProposal {
   const axis = direction === "left-right" ? "x" : "y";
   return proposeRigidBodyMove(
@@ -1441,6 +1444,7 @@ export function proposeGroupReflection(
       placement: (placement) => reflectOrientation(placement, direction),
     }),
     center,
+    additionalJunctionIds,
   );
 }
 
@@ -1455,6 +1459,12 @@ function proposeRigidBodyMove(
   instanceIds: readonly string[],
   transformFor: (pivot: Point) => RigidBodyTransform,
   center?: Point,
+  /**
+   * Explicitly selected Junctions that turn with the body even when the
+   * instance closure alone would not carry them — the translate path has
+   * always taken these; rotate and mirror dropped them (audit #7).
+   */
+  additionalJunctionIds: readonly string[] = [],
 ): GroupRotationProposal {
   const selected = new Set(instanceIds);
   const placed = document.instances.filter(
@@ -1503,6 +1513,11 @@ function proposeRigidBodyMove(
   ]);
   const internalNetIds = new Set(internalSelection.netIds);
   const turningJunctionIds = new Set(internalSelection.junctionIds);
+  for (const junctionId of additionalJunctionIds) {
+    if (document.junctions.some((junction) => junction.id === junctionId)) {
+      turningJunctionIds.add(junctionId);
+    }
+  }
   const routingGeometry = resolveDocumentRoutingGeometry(document, resolver);
   const movedDocument = structuredClone(document);
   for (const instance of movedDocument.instances) {

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -264,10 +264,18 @@ export function proposeGroupReflectionEdits(
   instanceIds: readonly string[],
   direction: ScreenFlip,
   center?: Point,
+  additionalJunctionIds: readonly string[] = [],
 ): GroupMoveEditProposal {
   return rigidBodyEdits(
     document,
-    proposeGroupReflection(document, resolver, instanceIds, direction, center),
+    proposeGroupReflection(
+      document,
+      resolver,
+      instanceIds,
+      direction,
+      center,
+      additionalJunctionIds,
+    ),
   );
 }
 
@@ -277,10 +285,18 @@ export function proposeGroupRotationEdits(
   instanceIds: readonly string[],
   deltaDegrees: 90 | -90 | 180,
   center?: Point,
+  additionalJunctionIds: readonly string[] = [],
 ): GroupMoveEditProposal {
   return rigidBodyEdits(
     document,
-    proposeGroupRotation(document, resolver, instanceIds, deltaDegrees, center),
+    proposeGroupRotation(
+      document,
+      resolver,
+      instanceIds,
+      deltaDegrees,
+      center,
+      additionalJunctionIds,
+    ),
   );
 }
 

--- a/packages/edit-engine/src/routing-transform-planner.ts
+++ b/packages/edit-engine/src/routing-transform-planner.ts
@@ -106,6 +106,7 @@ export function planRoutingTransform(
       affected.instances,
       delta,
       operation.center,
+      affected.internalJunctions,
     ).edits;
   } else {
     const direction: ScreenFlip =
@@ -116,6 +117,7 @@ export function planRoutingTransform(
       affected.instances,
       direction,
       operation.center,
+      affected.internalJunctions,
     ).edits;
   }
 

--- a/packages/edit-engine/src/transform-seed-forwarding.test.ts
+++ b/packages/edit-engine/src/transform-seed-forwarding.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Wire-transform audit batch 4, #7: rotate and mirror carry explicitly
+ * selected wires and junctions with the body, exactly like translate does.
+ */
+import { createEmptyDocument, createRoutePath } from "@icm/model";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { planRoutingTransform } from "./routing-transform-planner.js";
+import type { SchematicEdit } from "./edit-schema.js";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+function fixture() {
+  const document = createEmptyDocument("doc", "Seeds");
+  document.instances.push({
+    id: "R1",
+    symbolId: "resistor",
+    placement: { position: { x: 50, y: 50 }, rotation: 0, mirror: "none" },
+    netlist: { reference: "R1", parameters: {} },
+  });
+  document.nets.push({ id: "net-loose", terminals: [] });
+  document.junctions.push(
+    { id: "J1", netId: "net-loose", position: { x: 100, y: 0 } },
+    { id: "J2", netId: "net-loose", position: { x: 100, y: 40 } },
+  );
+  document.routes.push(
+    createRoutePath({
+      id: "wire-a",
+      netId: "net-loose",
+      start: { kind: "junction", junctionId: "J1" },
+      end: { kind: "junction", junctionId: "J2" },
+      bends: [],
+      modes: ["manual"],
+    }),
+  );
+  return document;
+}
+
+function junctionMoves(edits: readonly SchematicEdit[]): string[] {
+  return edits
+    .flatMap((edit) => (edit.kind === "move_junction" ? [edit.junctionId] : []))
+    .sort();
+}
+
+describe("rotate/mirror seed forwarding (#7)", () => {
+  const seed = {
+    instanceIds: ["R1"],
+    routeIds: ["wire-a"],
+    junctionIds: ["J1", "J2"],
+    annotationIds: [],
+  };
+
+  it("translate carries the selected junctions (control)", () => {
+    const plan = planRoutingTransform(fixture(), resolver, seed, {
+      kind: "translate",
+      delta: { x: 20, y: 0 },
+    });
+    expect(junctionMoves(plan.edits)).toEqual(["J1", "J2"]);
+  });
+
+  it("rotate carries the selected junctions and wire", () => {
+    const plan = planRoutingTransform(fixture(), resolver, seed, {
+      kind: "rotate",
+      degrees: 90,
+      center: { x: 50, y: 50 },
+    });
+    expect(junctionMoves(plan.edits)).toEqual(["J1", "J2"]);
+  });
+
+  it("mirror carries the selected junctions and wire", () => {
+    const plan = planRoutingTransform(fixture(), resolver, seed, {
+      kind: "mirror",
+      axis: "y",
+      center: { x: 50, y: 50 },
+    });
+    expect(junctionMoves(plan.edits)).toEqual(["J1", "J2"]);
+  });
+});


### PR DESCRIPTION
Wire-transform audit remediation, batch 4 of 4 — findings #7, #8, #11, #17. All four re-verified as still reproducing on current main before fixing (independent verification pass; #8 confirmed by code-trace with the keyboard-Move guard noted as the only prior mitigation).

- **#7**: `additionalJunctionIds` threads through `proposeGroupRotationEdits`/`proposeGroupReflectionEdits` → `proposeRigidBodyMove`, and `planRoutingTransform` forwards `affected.internalJunctions` in the rotate/mirror branches like translate always did. Regression: `transform-seed-forwarding.test.ts` (translate control + rotate + mirror).
- **#8**: the document controller's on-commit hook cancels the shared canvas drag session (`canvasDragSessionRef`), which all three pointer paths (wire stretch, instance move, visual-selection move) register into. A concurrent Agent commit mid-drag now aborts the drag instead of being silently reverted by a stale full-geometry commit stamped with the live revision. The session's own commit runs post-cleanup, so normal drags are no-ops.
- **#11**: `visualMoveEdits` translates free annotations on the 1-unit pitch (delta carries the grid discipline), matching the drafting branch; the (103,57)+(10,0) → (113,57) case is pinned.
- **#17**: `deriveNetConnectivityContext` derives routing geometry + document contact evidence once and threads them through `deriveNetConnectivity`; the keyboard-Move preview sweep uses it. Verified equivalent output on the phase-3 fixture; the verification benchmark measured ~440ms → ~1ms for a 40-net sweep.

Validation: engine+derived+editor sweep 1101/1101, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)