### PR TITLE
fix(editor): group adjustable passives with extended devices

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -1367,6 +1367,11 @@ test("shows the complete foldable categorized Library, quick-places a device, an
   ).toHaveCount(5);
   await expect(
     page
+      .getByTestId("shapes-category-passives")
+      .locator('[data-testid^="shapes-chip-"]'),
+  ).toHaveCount(4);
+  await expect(
+    page
       .getByTestId("shapes-category-logic-gates")
       .locator('[data-testid^="shapes-chip-"]'),
   ).toHaveCount(10);
@@ -1376,7 +1381,16 @@ test("shows the complete foldable categorized Library, quick-places a device, an
   const extendedCategory = page.getByTestId("shapes-category-extended-devices");
   await expect(
     extendedCategory.locator('[data-testid^="shapes-chip-"]'),
-  ).toHaveCount(4);
+  ).toHaveCount(7);
+  await expect(
+    extendedCategory.getByTestId("shapes-chip-variable-resistor"),
+  ).toBeVisible();
+  await expect(
+    extendedCategory.getByTestId("shapes-chip-variable-capacitor"),
+  ).toBeVisible();
+  await expect(
+    extendedCategory.getByTestId("shapes-chip-variable-inductor"),
+  ).toBeVisible();
   await expect(extendedCategory.getByTestId("shapes-chip-diode")).toBeVisible();
   await expect(
     extendedCategory.getByTestId("shapes-chip-zener-diode"),

--- a/apps/editor/src/features/component-insert/symbol-catalog.test.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.test.ts
@@ -39,7 +39,9 @@ describe("component insertion catalog", () => {
       "resistor",
     ]);
     expect(symbolCategory("capacitor")).toBe("Passives");
-    expect(symbolCategory("variable-resistor")).toBe("Passives");
+    expect(symbolCategory("variable-resistor")).toBe("Extended Devices");
+    expect(symbolCategory("variable-capacitor")).toBe("Extended Devices");
+    expect(symbolCategory("variable-inductor")).toBe("Extended Devices");
     expect(symbolCategory("opamp")).toBe("Analog Blocks");
     expect(symbolCategory("comparator")).toBe("Analog Blocks");
     expect(symbolCategory("comparator-unmarked")).toBe("Analog Blocks");
@@ -90,11 +92,11 @@ describe("component insertion catalog", () => {
     ]);
   });
 
-  it("offers the two-terminal variable resistor as a searchable passive", () => {
-    const symbols = flattenComponentCatalog(
-      componentCatalog("razavi-textbook-v1", "variable resistor"),
-    );
+  it("offers the two-terminal variable resistor as a searchable extended device", () => {
+    const groups = componentCatalog("razavi-textbook-v1", "variable resistor");
+    const symbols = flattenComponentCatalog(groups);
 
+    expect(groups.map((group) => group.category)).toEqual(["Extended Devices"]);
     expect(symbols.map((symbol) => symbol.id)).toEqual(["variable-resistor"]);
     expect(symbols[0]?.pins.map((pin) => pin.name)).toEqual(["P1", "P2"]);
   });
@@ -126,12 +128,15 @@ describe("component insertion catalog", () => {
     ).toEqual([]);
   });
 
-  it("keeps diode and DMOS tiles in one undivided expanded library", () => {
+  it("keeps adjustable passives, diodes, and DMOS in one extended library", () => {
     const extended = componentCatalog("razavi-textbook-v1", "").find(
       (group) => group.category === "Extended Devices",
     );
 
     expect(extended?.symbols.map((symbol) => symbol.id)).toEqual([
+      "variable-resistor",
+      "variable-capacitor",
+      "variable-inductor",
       "diode",
       "zener-diode",
       "ndmos",
@@ -192,6 +197,9 @@ describe("reach order inside a category", () => {
     // and the supply Port from its Rail.
     expect(ids("Transistors")).toEqual(["nmos", "pmos", "npn", "pnp"]);
     expect(ids("Extended Devices")).toEqual([
+      "variable-resistor",
+      "variable-capacitor",
+      "variable-inductor",
       "diode",
       "zener-diode",
       "ndmos",

--- a/apps/editor/src/features/component-insert/symbol-catalog.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.ts
@@ -43,9 +43,17 @@ export interface ComponentCatalogGroup {
 
 export function symbolCategory(symbolId: string): string {
   if (isAnnotationPaletteSymbol(symbolId)) return ANNOTATION_CATEGORY;
-  // Keep the two diode tiles in the Extended Devices UI group, not at the
-  // front of the everyday transistor palette.
-  if (["diode", "zener-diode"].includes(symbolId)) {
+  // Keep diode and adjustable-passive tiles in Extended Devices,
+  // leaving the everyday transistor and passive groups compact.
+  if (
+    [
+      "variable-resistor",
+      "variable-capacitor",
+      "variable-inductor",
+      "diode",
+      "zener-diode",
+    ].includes(symbolId)
+  ) {
     return EXTENDED_DEVICE_CATEGORY;
   }
   const expanded = expandedDeviceCatalogEntry(symbolId);
@@ -54,15 +62,7 @@ export function symbolCategory(symbolId: string): string {
     return "Transistors";
   }
   if (
-    [
-      "resistor",
-      "variable-resistor",
-      "capacitor",
-      "variable-capacitor",
-      "inductor-compact",
-      "inductor",
-      "variable-inductor",
-    ].includes(symbolId)
+    ["resistor", "capacitor", "inductor-compact", "inductor"].includes(symbolId)
   ) {
     return "Passives";
   }
@@ -170,6 +170,9 @@ const SYMBOL_ORDER: readonly string[] = [
   "pmos",
   "npn",
   "pnp",
+  "variable-resistor",
+  "variable-capacitor",
+  "variable-inductor",
   "diode",
   "zener-diode",
   "ndmos",

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -33,7 +33,7 @@ describe("shapes quick-place", () => {
       groups.map((group) => [group.category, group.symbols.length]),
     ).toEqual([
       ["Transistors", 4],
-      ["Passives", 7],
+      ["Passives", 4],
       ["Power and Ports", 5],
       ["Sources", 3],
       ["Switches", 3],
@@ -41,7 +41,7 @@ describe("shapes quick-place", () => {
       ["Logic Gates", 10],
       ["Signal Flow", 5],
       ["Annotations", 7],
-      ["Extended Devices", 4],
+      ["Extended Devices", 7],
     ]);
     const categoryTestIds = [
       "transistors",


### PR DESCRIPTION
## Summary
- keep fixed resistor, capacitor, and inductors in Passives
- move variable resistor, capacitor, and inductor to Extended Devices
- keep the Insert dialog and Library panel on the same catalog grouping

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- 1717 unit tests passed
- 30 component-insert browser tests passed
- production build passed
- git diff --check