### PR TITLE
fix(editor): move quick start to the upper right

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -259,7 +259,7 @@ test("refresh restores the circuit when the session started from a boot-target U
     .toBeNull();
 });
 
-test("keeps quick-start shortcuts in the corner until the first component is inserted", async ({
+test("keeps quick-start shortcuts in the upper-right corner until the first component is inserted", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -294,9 +294,39 @@ test("keeps quick-start shortcuts in the corner until the first component is ins
   expect(
     await quickStart.evaluate((element) => {
       const style = getComputedStyle(element);
-      return { top: style.top, left: style.left, transform: style.transform };
+      const bounds = element.getBoundingClientRect();
+      const canvasBounds = element.parentElement?.getBoundingClientRect();
+      if (!canvasBounds) throw new Error("Canvas panel is not measurable");
+      return {
+        top: style.top,
+        right: style.right,
+        rightGap: Math.round(canvasBounds.right - bounds.right),
+        transform: style.transform,
+      };
     }),
-  ).toEqual({ top: "12px", left: "12px", transform: "none" });
+  ).toEqual({
+    top: "12px",
+    right: "12px",
+    rightGap: 12,
+    transform: "none",
+  });
+
+  const initialViewport = page.viewportSize();
+  if (!initialViewport) throw new Error("Viewport is not measurable");
+  await page.setViewportSize({ width: 720, height: 720 });
+  const quickStartBox = await quickStart.boundingBox();
+  const canvasPanelBox = await page.locator(".canvas-panel").boundingBox();
+  const propertiesBox = await page
+    .getByRole("complementary", { name: "Properties" })
+    .boundingBox();
+  if (!quickStartBox || !canvasPanelBox || !propertiesBox) {
+    throw new Error("Narrow editor chrome is not measurable");
+  }
+  expect(
+    Math.round(propertiesBox.x - (quickStartBox.x + quickStartBox.width)),
+  ).toBe(12);
+  expect(quickStartBox.x).toBeGreaterThanOrEqual(canvasPanelBox.x + 11.5);
+  await page.setViewportSize(initialViewport);
 
   await page.keyboard.press("i");
   const dialog = page.getByRole("dialog", { name: "Insert Component" });

--- a/apps/editor/src/styles/editor-canvas-state.css
+++ b/apps/editor/src/styles/editor-canvas-state.css
@@ -42,7 +42,7 @@
   position: absolute;
   z-index: 3;
   top: var(--icm-space-3);
-  left: var(--icm-space-3);
+  right: var(--icm-space-3);
   display: grid;
   gap: var(--icm-space-2);
   width: max-content;
@@ -124,6 +124,13 @@
   font: inherit;
   font-size: var(--icm-font-xs);
   font-weight: 650;
+}
+
+@media (max-width: 860px) {
+  .canvas-shortcut-menu {
+    right: calc(var(--icm-props-collapsed) + var(--icm-space-3));
+    max-width: calc(100% - var(--icm-props-collapsed) - var(--icm-space-6));
+  }
 }
 
 .canvas-controls {


### PR DESCRIPTION
## Summary
- anchor the empty-canvas Quick Start card to the upper-right corner
- offset it from the floating Properties dock on narrow screens
- keep the card inside the usable canvas width at the narrow breakpoint

## Validation
- focused Quick Start browser test at desktop and 720px widths
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- 1717 unit tests passed
- 30 component-insert browser tests passed
- visual inspection at 1280px and 720px
- git diff --check