### PR TITLE
Refine formula input palette

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -235,12 +235,58 @@ test("authors one validated formula through the canonical text editor", async ({
   expect(editorLayout.keyboardToggleDisplay).toBe("none");
   expect(editorLayout.virtualKeyboardVisible).toBe(false);
 
-  await page.getByRole("button", { name: "Insert Square root" }).click();
+  const formulaKeyboard = page.getByRole("toolbar", {
+    name: "Formula keyboard",
+  });
+  await expect(formulaKeyboard.getByRole("button")).toHaveCount(20);
+  const keyRowCount = await formulaKeyboard
+    .getByRole("button")
+    .evaluateAll(
+      (buttons) =>
+        new Set(
+          buttons.map((button) =>
+            Math.round(button.getBoundingClientRect().top),
+          ),
+        ).size,
+    );
+  expect(keyRowCount).toBe(2);
   await expect(
-    page.getByRole("textbox", { name: "Formula LaTeX source" }),
-  ).toHaveValue(/\\sqrt/u);
+    formulaKeyboard.getByRole("button", { name: "Insert Product" }),
+  ).toBeVisible();
+  await expect(
+    formulaKeyboard.getByRole("button", { name: "Insert Derivative" }),
+  ).toBeVisible();
+  await expect(
+    formulaKeyboard.getByRole("button", { name: "Insert Plus" }),
+  ).toHaveCount(0);
+  await expect(
+    formulaKeyboard.getByRole("button", { name: "Insert Equals" }),
+  ).toHaveCount(0);
 
   const source = page.getByRole("textbox", { name: "Formula LaTeX source" });
+  await page.locator('math-field[aria-label="Formula editor"]').click();
+  await page.keyboard.type("a+b-c=(d)");
+  await expect(source).toHaveValue(/a\+b-c=/u);
+  await expect(source).toHaveValue(/\\left\(d\\right\)/u);
+  await formulaKeyboard.getByRole("button", { name: "Insert Product" }).click();
+  await formulaKeyboard
+    .getByRole("button", { name: "Insert Derivative" })
+    .click();
+  await expect(source).toHaveValue(/\\prod/u);
+  await expect(source).toHaveValue(/\\mathrm\{d\}/u);
+
+  const moreSymbols = page.getByText("More symbols", { exact: true });
+  await expect(page.getByRole("toolbar", { name: "Greek" })).not.toBeVisible();
+  await moreSymbols.click();
+  await page.getByRole("button", { name: "Insert Omega", exact: true }).click();
+  await expect(
+    page.getByRole("textbox", { name: "Formula LaTeX source" }),
+  ).toHaveValue(/\\Omega/u);
+  await moreSymbols.click();
+
+  await page.getByRole("button", { name: "Insert Square root" }).click();
+  await expect(source).toHaveValue(/\\sqrt/u);
+
   await source.fill(String.raw`A_v=\frac{g_m}{1+s/\omega_p}`);
   await page.getByRole("button", { name: "Display" }).click();
   await page

--- a/apps/editor/src/features/text-editing/rich-text-editor.tsx
+++ b/apps/editor/src/features/text-editing/rich-text-editor.tsx
@@ -320,22 +320,100 @@ const FORMULA_KEYCAPS = [
   { label: "xⁿ", title: "Superscript", latex: "^{#0}" },
   { label: "a⁄b", title: "Fraction", latex: "\\frac{#0}{#0}" },
   { label: "√x", title: "Square root", latex: "\\sqrt{#0}" },
+  { label: "ⁿ√x", title: "Nth root", latex: "\\sqrt[#0]{#0}" },
   { label: "x̅", title: "Overbar", latex: "\\overline{#0}" },
+  { label: "x̂", title: "Hat", latex: "\\hat{#0}" },
+  { label: "x⃗", title: "Vector", latex: "\\vec{#0}" },
   { label: "|x|", title: "Absolute value", latex: "\\left|#0\\right|" },
-  { label: "∫", title: "Integral", latex: "\\int_{#0}^{#0}" },
+  { label: "{x}", title: "Braces", latex: "\\left\\{#0\\right\\}" },
+  {
+    label: "dy⁄dx",
+    title: "Derivative",
+    latex: "\\frac{\\mathrm{d}#0}{\\mathrm{d}#0}",
+  },
+  {
+    label: "∂y⁄∂x",
+    title: "Partial derivative",
+    latex: "\\frac{\\partial #0}{\\partial #0}",
+  },
   { label: "Σ", title: "Summation", latex: "\\sum_{#0}^{#0}" },
-  { label: "+", title: "Plus", latex: "+" },
-  { label: "−", title: "Minus", latex: "-" },
-  { label: "×", title: "Multiply", latex: "\\times" },
-  { label: "÷", title: "Divide", latex: "\\div" },
-  { label: "=", title: "Equals", latex: "=" },
-  { label: "(", title: "Open parenthesis", latex: "(" },
-  { label: ")", title: "Close parenthesis", latex: ")" },
-  { label: "π", title: "Pi", latex: "\\pi" },
-  { label: "ω", title: "Omega", latex: "\\omega" },
-  { label: "μ", title: "Mu", latex: "\\mu" },
-  { label: "Δ", title: "Delta", latex: "\\Delta" },
-  { label: "→", title: "Right arrow", latex: "\\rightarrow" },
+  { label: "Π", title: "Product", latex: "\\prod_{#0}^{#0}" },
+  { label: "∫", title: "Integral", latex: "\\int_{#0}^{#0}" },
+  { label: "∬", title: "Double integral", latex: "\\iint_{#0}" },
+  { label: "lim", title: "Limit", latex: "\\lim_{#0 \\to #0}" },
+  {
+    label: "[ ]₂×₂",
+    title: "Two by two matrix",
+    latex: "\\begin{bmatrix}#0&#0\\\\#0&#0\\end{bmatrix}",
+  },
+  {
+    label: "{⋯",
+    title: "Cases",
+    latex: "\\begin{cases}#0&#0\\\\#0&#0\\end{cases}",
+  },
+  { label: "∞", title: "Infinity", latex: "\\infty" },
+] as const;
+
+const FORMULA_MORE_GROUPS = [
+  {
+    title: "Greek",
+    items: [
+      ["α", "Alpha", "\\alpha"],
+      ["β", "Beta", "\\beta"],
+      ["γ", "Gamma", "\\gamma"],
+      ["δ", "Delta lowercase", "\\delta"],
+      ["ε", "Epsilon", "\\epsilon"],
+      ["θ", "Theta", "\\theta"],
+      ["λ", "Lambda", "\\lambda"],
+      ["μ", "Mu", "\\mu"],
+      ["π", "Pi", "\\pi"],
+      ["ρ", "Rho", "\\rho"],
+      ["σ", "Sigma lowercase", "\\sigma"],
+      ["τ", "Tau", "\\tau"],
+      ["φ", "Phi", "\\phi"],
+      ["ω", "Omega lowercase", "\\omega"],
+      ["Δ", "Delta", "\\Delta"],
+      ["Ω", "Omega", "\\Omega"],
+    ],
+  },
+  {
+    title: "Relations & operators",
+    items: [
+      ["±", "Plus or minus", "\\pm"],
+      ["∓", "Minus or plus", "\\mp"],
+      ["×", "Multiply", "\\times"],
+      ["÷", "Divide", "\\div"],
+      ["·", "Centered dot", "\\cdot"],
+      ["≠", "Not equal", "\\neq"],
+      ["≈", "Approximately equal", "\\approx"],
+      ["≤", "Less than or equal", "\\leq"],
+      ["≥", "Greater than or equal", "\\geq"],
+      ["∝", "Proportional to", "\\propto"],
+      ["∠", "Angle", "\\angle"],
+      ["∥", "Parallel", "\\parallel"],
+      ["⊥", "Perpendicular", "\\perp"],
+      ["→", "Right arrow", "\\rightarrow"],
+      ["↔", "Left right arrow", "\\leftrightarrow"],
+      ["⇒", "Implies", "\\Rightarrow"],
+    ],
+  },
+  {
+    title: "Functions & accents",
+    items: [
+      ["sin", "Sine", "\\sin(#0)"],
+      ["cos", "Cosine", "\\cos(#0)"],
+      ["tan", "Tangent", "\\tan(#0)"],
+      ["ln", "Natural logarithm", "\\ln(#0)"],
+      ["log", "Logarithm", "\\log_{#0}(#0)"],
+      ["exp", "Exponential", "\\exp(#0)"],
+      ["Re", "Real part", "\\operatorname{Re}(#0)"],
+      ["Im", "Imaginary part", "\\operatorname{Im}(#0)"],
+      ["ẋ", "Dot accent", "\\dot{#0}"],
+      ["ẍ", "Double dot accent", "\\ddot{#0}"],
+      ["x̃", "Tilde accent", "\\tilde{#0}"],
+      ["⟨x⟩", "Angle brackets", "\\left\\langle#0\\right\\rangle"],
+    ],
+  },
 ] as const;
 
 export function RichTextEditor({
@@ -785,6 +863,36 @@ export function RichTextEditor({
                 </button>
               ))}
             </div>
+            <details className="rich-text-formula-more">
+              <summary>More symbols</summary>
+              <div className="rich-text-formula-more-groups">
+                {FORMULA_MORE_GROUPS.map((group) => (
+                  <section key={group.title}>
+                    <h4>{group.title}</h4>
+                    <div
+                      className="rich-text-formula-more-grid"
+                      role="toolbar"
+                      aria-label={group.title}
+                    >
+                      {group.items.map(([label, title, latex]) => (
+                        <button
+                          key={title}
+                          type="button"
+                          aria-label={`Insert ${title}`}
+                          title={title}
+                          onPointerDown={(event) => event.preventDefault()}
+                          onClick={() =>
+                            formulaMathfieldRef.current?.insert(latex)
+                          }
+                        >
+                          {label}
+                        </button>
+                      ))}
+                    </div>
+                  </section>
+                ))}
+              </div>
+            </details>
             <label className="rich-text-formula-source">
               <span>LaTeX source</span>
               <textarea

--- a/apps/editor/src/styles/editor-canvas.css
+++ b/apps/editor/src/styles/editor-canvas.css
@@ -414,11 +414,11 @@
    from formal SVG/export, but uses the same RichText AST as formal rendering. */
 .rich-text-editor-shell {
   display: grid;
-  gap: 0.15rem;
+  gap: 0.35rem;
   box-sizing: border-box;
   width: 100%;
   min-width: 0;
-  padding: 0.2rem;
+  padding: 0.4rem;
   overflow: visible;
   border: 1px solid var(--icm-border-strong);
   border-radius: var(--icm-radius-md);
@@ -439,9 +439,9 @@
   box-sizing: border-box;
   width: 100%;
   max-width: 100%;
-  gap: 0.15rem;
-  min-height: 1.9rem;
-  padding: 0.15rem;
+  gap: 0.2rem;
+  min-height: 2.15rem;
+  padding: 0.25rem;
   border: 1px solid var(--icm-border);
   border-radius: var(--icm-radius-md);
   background: var(--icm-surface);
@@ -530,8 +530,8 @@
   box-sizing: border-box;
   max-width: 100%;
   overflow-y: visible;
-  min-height: 1.35rem;
-  padding: 0.1rem 0.25rem;
+  min-height: 2rem;
+  padding: 0.35rem 0.5rem;
   border: 1px solid var(--icm-accent);
   border-radius: 0.2rem;
   outline: 0;
@@ -706,6 +706,65 @@
 }
 
 .rich-text-formula-keyboard button:hover {
+  border-color: var(--icm-accent);
+  background: var(--icm-accent-tint);
+}
+
+.rich-text-formula-more {
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface-muted);
+}
+
+.rich-text-formula-more > summary {
+  padding: 0.35rem 0.45rem;
+  color: var(--icm-text-muted);
+  cursor: pointer;
+  font-size: var(--icm-font-xs);
+  font-weight: 600;
+  list-style-position: inside;
+}
+
+.rich-text-formula-more[open] > summary {
+  border-bottom: 1px solid var(--icm-border);
+}
+
+.rich-text-formula-more-groups {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.45rem;
+}
+
+.rich-text-formula-more-groups section {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.rich-text-formula-more-groups h4 {
+  margin: 0;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  font-weight: 600;
+}
+
+.rich-text-formula-more-grid {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(2rem, 1fr));
+  gap: 0.18rem;
+}
+
+.rich-text-formula-more-grid button {
+  min-width: 0;
+  min-height: 1.8rem;
+  padding: 0.15rem;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: #fff;
+  font-family: "DejaVu Sans", Arial, sans-serif;
+  font-size: var(--icm-font-sm);
+}
+
+.rich-text-formula-more-grid button:hover {
   border-color: var(--icm-accent);
   background: var(--icm-accent-tint);
 }

--- a/packages/math-typesetting/src/index.test.ts
+++ b/packages/math-typesetting/src/index.test.ts
@@ -19,6 +19,10 @@ const corpus = [
   String.raw`\frac{g_m r_o}{1+s/\omega_p}`,
   String.raw`A_v=-g_m(r_o\parallel R_D)`,
   String.raw`\Delta V=\frac{I}{C}\Delta t`,
+  String.raw`\frac{\mathrm{d}y}{\mathrm{d}x}`,
+  String.raw`\prod_{k=0}^{N-1}a_k`,
+  String.raw`\iint_{\Omega}f(x,y)\,\mathrm{d}x\,\mathrm{d}y`,
+  String.raw`\lim_{s\to0}H(s)`,
   String.raw`\begin{bmatrix}1 & 0 \\ 0 & 1\end{bmatrix}`,
   String.raw`\begin{cases}V_{OH},&x>0\\V_{OL},&x\leq0\end{cases}`,
 ];


### PR DESCRIPTION
## Summary
- give the rich-text editor more breathing room
- replace physical-keyboard characters in the two-row formula pad with structural templates such as derivatives, products, integrals, limits, matrices, and cases
- add a collapsed categorized palette for Greek symbols, relations, operators, functions, and accents
- protect physical-keyboard entry, two-row layout, expanded scrolling, and new formula families with regression coverage

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm build
- ICM_E2E_PORT=4181 pnpm gate:affected -- --base origin/main (1724 unit tests, 117 browser tests)
- focused drafting formula browser test
- manual visual inspection at 1280x720
