### PR TITLE
Keep formula scrolling inside the text editor

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -278,6 +278,24 @@ test("authors one validated formula through the canonical text editor", async ({
   const moreSymbols = page.getByText("More symbols", { exact: true });
   await expect(page.getByRole("toolbar", { name: "Greek" })).not.toBeVisible();
   await moreSymbols.click();
+  const formulaScroll = page.getByTestId("formula-scroll-region");
+  const canvasViewBoxBeforeFormulaScroll = await page
+    .getByTestId("schematic-canvas")
+    .getAttribute("viewBox");
+  const scrollExtent = await formulaScroll.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+  }));
+  expect(scrollExtent.scrollHeight).toBeGreaterThan(scrollExtent.clientHeight);
+  await formulaScroll.hover();
+  await page.mouse.wheel(0, 240);
+  await expect
+    .poll(() => formulaScroll.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(0);
+  await expect(page.getByTestId("schematic-canvas")).toHaveAttribute(
+    "viewBox",
+    canvasViewBoxBeforeFormulaScroll!,
+  );
   await page.getByRole("button", { name: "Insert Omega", exact: true }).click();
   await expect(
     page.getByRole("textbox", { name: "Formula LaTeX source" }),

--- a/apps/editor/src/canvas/editor-canvas-surface.tsx
+++ b/apps/editor/src/canvas/editor-canvas-surface.tsx
@@ -108,7 +108,21 @@ export function EditorCanvasSurface({
   useEffect(() => {
     const svg = svgRef.current;
     if (!svg) return;
-    const listener = (event: WheelEvent) => onWheelRef.current(event, svg);
+    const listener = (event: WheelEvent) => {
+      // The editor lives inside this SVG through a foreignObject, but it owns
+      // ordinary document scrolling. React's delegated onWheel handler runs
+      // too late to protect it from this non-passive native canvas listener,
+      // which otherwise prevents the default scroll and zooms the camera.
+      const targetsTextEditor = event
+        .composedPath()
+        .some(
+          (target) =>
+            target instanceof Element &&
+            target.matches('[data-testid="canvas-text-editor"]'),
+        );
+      if (targetsTextEditor) return;
+      onWheelRef.current(event, svg);
+    };
     svg.addEventListener("wheel", listener, { passive: false });
     return () => svg.removeEventListener("wheel", listener);
   }, []);


### PR DESCRIPTION
Fix the native SVG wheel boundary so wheel input originating inside the canvas rich-text editor is left to the editor instead of zooming the schematic. Add a browser regression proving the expanded formula region scrolls while the canvas viewBox remains unchanged. Local validation: typecheck, build, 1724 unit tests, 117 editor browser tests, focused formula wheel test, and in-app interaction inspection.