### PR TITLE
fix(math): accept MathLive differential source

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -305,7 +305,8 @@ test("authors one validated formula through the canonical text editor", async ({
   await page.getByRole("button", { name: "Insert Square root" }).click();
   await expect(source).toHaveValue(/\\sqrt/u);
 
-  await source.fill(String.raw`A_v=\frac{g_m}{1+s/\omega_p}`);
+  const normalizedDifferential = String.raw`\int_0^1\frac{1}{\sqrt{1+\cos^2x}}\differentialD x`;
+  await source.fill(normalizedDifferential);
   await page.getByRole("button", { name: "Display" }).click();
   await page
     .getByRole("dialog", { name: "Formula" })
@@ -313,7 +314,7 @@ test("authors one validated formula through the canonical text editor", async ({
     .click();
   await expect(
     page.getByTestId("canvas-text-editor").locator("[data-rich-text-math]"),
-  ).toHaveAttribute("data-latex", String.raw`A_v=\frac{g_m}{1+s/\omega_p}`);
+  ).toHaveAttribute("data-latex", normalizedDifferential);
   await page.getByRole("button", { name: "Apply text changes" }).click();
 
   const formula = page.locator(
@@ -335,7 +336,7 @@ test("authors one validated formula through the canonical text editor", async ({
     runs: [
       {
         kind: "math",
-        latex: String.raw`A_v=\frac{g_m}{1+s/\omega_p}`,
+        latex: normalizedDifferential,
         display: "block",
       },
     ],

--- a/docs/specs/visual-language.md
+++ b/docs/specs/visual-language.md
@@ -80,8 +80,11 @@ not another text object type. Its persisted facts are bounded LaTeX source and
 `inline`/`block` display intent. The `analog-canvas-math-v1` profile supports
 the reviewed base, AMS, and cases command sets and rejects external resources,
 HTML/style injection, package loading, and dynamic command definitions. The
-typesetter emits standalone path-only SVG with deterministic width, height,
-baseline, and source identity. Formula SVG is embedded into the same formal
+formal profile recognizes MathLive's `\differentialD` source as an upright
+differential operator, so source produced by the editor preview remains valid
+without rewriting the persisted LaTeX. The typesetter emits standalone
+path-only SVG with deterministic width, height, baseline, and source identity.
+Formula SVG is embedded into the same formal
 scene used by canvas, SVG, PNG, and vector PDF; it is never rasterized or
 persisted.
 

--- a/packages/math-typesetting/src/index.test.ts
+++ b/packages/math-typesetting/src/index.test.ts
@@ -20,6 +20,7 @@ const corpus = [
   String.raw`A_v=-g_m(r_o\parallel R_D)`,
   String.raw`\Delta V=\frac{I}{C}\Delta t`,
   String.raw`\frac{\mathrm{d}y}{\mathrm{d}x}`,
+  String.raw`\int_0^1\frac{1}{\sqrt{1+\cos^2x}}\differentialD x`,
   String.raw`\prod_{k=0}^{N-1}a_k`,
   String.raw`\iint_{\Omega}f(x,y)\,\mathrm{d}x\,\mathrm{d}y`,
   String.raw`\lim_{s\to0}H(s)`,

--- a/packages/math-typesetting/src/index.ts
+++ b/packages/math-typesetting/src/index.ts
@@ -3,6 +3,7 @@ import { RegisterHTMLHandler } from "@mathjax/src/js/handlers/html.js";
 import { TeX } from "@mathjax/src/js/input/tex.js";
 import "@mathjax/src/js/input/tex/ams/AmsConfiguration.js";
 import "@mathjax/src/js/input/tex/cases/CasesConfiguration.js";
+import "@mathjax/src/js/input/tex/configmacros/ConfigMacrosConfiguration.js";
 import { mathjax } from "@mathjax/src/js/mathjax.js";
 import { SVG } from "@mathjax/src/js/output/svg.js";
 import {
@@ -98,7 +99,12 @@ export interface FormulaTypesetter {
 export function createFormulaTypesetter(): FormulaTypesetter {
   const adaptor = liteAdaptor();
   RegisterHTMLHandler(adaptor);
-  const input = new TeX({ packages: ["base", "ams", "cases"] });
+  const input = new TeX({
+    packages: ["base", "ams", "cases", "configmacros"],
+    macros: {
+      differentialD: String.raw`\mathrm{d}`,
+    },
+  });
   const output = new SVG({ fontCache: "none" });
   const document = mathjax.document("", {
     InputJax: input,


### PR DESCRIPTION
## Summary
- register MathLive's \differentialD command in the formal MathJax profile
- preserve MathLive-normalized LaTeX through Insert, Project persistence, and export
- cover the exact integral from the editor with renderer and browser regression tests

## Validation
- pnpm test:local packages/math-typesetting/src/index.test.ts`n- pnpm typecheck`n- ICM_E2E_PORT=4183 pnpm test:e2e:local apps/editor/e2e/drafting.spec.ts --grep authors one validated formula`n- pnpm gate:preflight -- --base origin/main`n- pnpm gate:affected -- --base origin/main (1724 tests)