### PR TITLE
feat(editor): Mac trackpad — two-finger scroll pans every direction

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -2173,6 +2173,7 @@ export function App({
     fitView,
     zoomViewAtCenter,
     handleWheel,
+    zoomAtClientPoint,
     beginCanvasGesture,
     continueCanvasGesture,
     finishCanvasGesture,
@@ -4316,6 +4317,7 @@ export function App({
         <EditorCanvasSurface
           empty={canvasIsEmpty}
           onWheel={handleWheel}
+          onPinch={zoomAtClientPoint}
           className={[
             "schematic-canvas",
             tool === "wire" ? "wire-mode" : "",

--- a/apps/editor/src/canvas/canvas-gesture-controller.ts
+++ b/apps/editor/src/canvas/canvas-gesture-controller.ts
@@ -226,10 +226,27 @@ export function createCanvasGestureController({
     );
   };
 
-  // Trackpad map: horizontal scroll pans, vertical scroll zooms at the
-  // cursor, pinch (ctrl/meta+wheel) zooms at the cursor, Shift+scroll pans
-  // both axes. Attached as a non-passive native listener so preventDefault
-  // actually stops browser page zoom and history-swipe navigation.
+  /** Cursor-anchored zoom shared by wheel, pinch, and Safari gestures. */
+  const zoomAtClientPoint = (
+    factor: number,
+    clientX: number,
+    clientY: number,
+    element: SVGSVGElement,
+  ): void => {
+    const bounds = element.getBoundingClientRect();
+    if (bounds.width <= 0 || bounds.height <= 0) return;
+    const anchor = {
+      x: (clientX - bounds.left) / bounds.width,
+      y: (clientY - bounds.top) / bounds.height,
+    };
+    setViewBox((current) => zoomCameraAtAnchor(current, factor, anchor));
+  };
+
+  // Trackpad map: two-finger scroll pans in every direction; pinch (which
+  // browsers deliver as ctrl+wheel) and Cmd+scroll zoom at the cursor;
+  // Shift turns a mouse's vertical-only wheel into horizontal panning.
+  // Attached as a non-passive native listener so preventDefault actually
+  // stops browser page zoom and history-swipe navigation.
   const handleWheel = (event: WheelEvent, element: SVGSVGElement): void => {
     event.preventDefault();
     const bounds = element.getBoundingClientRect();
@@ -238,34 +255,23 @@ export function createCanvasGestureController({
       event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? bounds.height : 1;
     const deltaX = event.deltaX * unit;
     const deltaY = event.deltaY * unit;
-    const anchor = {
-      x: (event.clientX - bounds.left) / bounds.width,
-      y: (event.clientY - bounds.top) / bounds.height,
-    };
     if (event.ctrlKey || event.metaKey) {
-      const factor = Math.exp(deltaY * 0.01);
-      setViewBox((current) => zoomCameraAtAnchor(current, factor, anchor));
+      zoomAtClientPoint(
+        Math.exp(deltaY * 0.01),
+        event.clientX,
+        event.clientY,
+        element,
+      );
       return;
     }
-    if (event.shiftKey) {
-      setViewBox((current) => ({
-        ...current,
-        x: current.x + (deltaX * current.width) / bounds.width,
-        y: current.y + (deltaY * current.height) / bounds.height,
-      }));
-      return;
-    }
-    const factor = deltaY === 0 ? 1 : Math.exp(deltaY * 0.0012);
-    setViewBox((current) => {
-      const panned =
-        deltaX === 0
-          ? current
-          : {
-              ...current,
-              x: current.x + (deltaX * current.width) / bounds.width,
-            };
-      return factor === 1 ? panned : zoomCameraAtAnchor(panned, factor, anchor);
-    });
+    const panX = event.shiftKey && deltaX === 0 ? deltaY : deltaX;
+    const panY = event.shiftKey && deltaX === 0 ? 0 : deltaY;
+    if (panX === 0 && panY === 0) return;
+    setViewBox((current) => ({
+      ...current,
+      x: current.x + (panX * current.width) / bounds.width,
+      y: current.y + (panY * current.height) / bounds.height,
+    }));
   };
 
   const begin = (event: ReactPointerEvent<SVGSVGElement>): void => {
@@ -502,6 +508,7 @@ export function createCanvasGestureController({
     fitView,
     zoomViewAtCenter,
     handleWheel,
+    zoomAtClientPoint,
     beginCanvasGesture: begin,
     continueCanvasGesture: continueGesture,
     finishCanvasGesture: finish,

--- a/apps/editor/src/canvas/editor-canvas-surface.tsx
+++ b/apps/editor/src/canvas/editor-canvas-surface.tsx
@@ -33,6 +33,17 @@ export interface EditorCanvasSurfaceProps {
    * zoom (pinch) or history-swipe navigation (horizontal scroll).
    */
   onWheel: (event: WheelEvent, element: SVGSVGElement) => void;
+  /**
+   * Cursor-anchored zoom for Safari's proprietary trackpad gesture events
+   * (gesturestart/gesturechange), which Safari fires INSTEAD of ctrl+wheel
+   * for pinches. factor < 1 zooms in.
+   */
+  onPinch: (
+    factor: number,
+    clientX: number,
+    clientY: number,
+    element: SVGSVGElement,
+  ) => void;
   grid: ComponentProps<typeof CanvasGridOverlay>;
   sceneInnerHtml: { __html: string };
   cellSymbolLayout: ComponentProps<typeof EditorCellSymbolLayoutOverlay> | null;
@@ -84,6 +95,7 @@ export function EditorCanvasSurface({
   viewBox,
   eventHandlers,
   onWheel,
+  onPinch,
   grid,
   sceneInnerHtml,
   cellSymbolLayout,
@@ -102,8 +114,10 @@ export function EditorCanvasSurface({
 }: EditorCanvasSurfaceProps) {
   const svgRef = useRef<SVGSVGElement | null>(null);
   const onWheelRef = useRef(onWheel);
+  const onPinchRef = useRef(onPinch);
   useEffect(() => {
     onWheelRef.current = onWheel;
+    onPinchRef.current = onPinch;
   });
   useEffect(() => {
     const svg = svgRef.current;
@@ -124,7 +138,37 @@ export function EditorCanvasSurface({
       onWheelRef.current(event, svg);
     };
     svg.addEventListener("wheel", listener, { passive: false });
-    return () => svg.removeEventListener("wheel", listener);
+    // Safari delivers trackpad pinches through its own gesture events (no
+    // ctrl+wheel); track the running scale and hand ratios to the shared
+    // cursor-anchored zoom. Other browsers simply never fire these.
+    type SafariGestureEvent = Event & {
+      scale?: number;
+      clientX: number;
+      clientY: number;
+    };
+    let lastScale = 1;
+    const gestureStart = (event: Event) => {
+      event.preventDefault();
+      lastScale = (event as SafariGestureEvent).scale ?? 1;
+    };
+    const gestureChange = (event: Event) => {
+      event.preventDefault();
+      const gesture = event as SafariGestureEvent;
+      if (!gesture.scale || gesture.scale <= 0 || lastScale <= 0) return;
+      const factor = lastScale / gesture.scale;
+      lastScale = gesture.scale;
+      onPinchRef.current(factor, gesture.clientX, gesture.clientY, svg);
+    };
+    const gestureEnd = (event: Event) => event.preventDefault();
+    svg.addEventListener("gesturestart", gestureStart, { passive: false });
+    svg.addEventListener("gesturechange", gestureChange, { passive: false });
+    svg.addEventListener("gestureend", gestureEnd, { passive: false });
+    return () => {
+      svg.removeEventListener("wheel", listener);
+      svg.removeEventListener("gesturestart", gestureStart);
+      svg.removeEventListener("gesturechange", gestureChange);
+      svg.removeEventListener("gestureend", gestureEnd);
+    };
   }, []);
   return (
     <section className="canvas-panel">


### PR DESCRIPTION
Owner follow-up: "现在触摸板左滑、右滑是左右移动,但是上下滑是放大缩小,我认为应该都是上下左右滑动比较好" + "对于mac触摸板的支持需要增强".

- **Two-finger scroll pans in every direction** (was: horizontal pan, vertical zoom). Diagonal scrolls pan both axes in one motion.
- **Zoom stays on pinch**: browsers deliver trackpad pinch as ctrl+wheel (already handled); Cmd+scroll also zooms; and **Safari's proprietary `gesturestart`/`gesturechange` events** — which Safari fires *instead of* ctrl+wheel — now drive the same cursor-anchored zoom through a shared `zoomAtClientPoint`. All gesture listeners are non-passive so page zoom and history-swipe stay suppressed.
- Shift still maps a mouse's vertical-only wheel to horizontal panning.

Verified live: diagonal scroll pans both axes with exact px→doc conversion; ctrl+wheel zooms at the cursor; a Safari gesture with scale 1.25 divides the viewport width by exactly 1.25 anchored at the pointer. Canvas suite 54/54; viewport/marquee/fit e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)