### PR TITLE
Fix DFF bounds and rotated pin labels

### DIFF
--- a/apps/editor/src/canvas/instance-geometry.test.ts
+++ b/apps/editor/src/canvas/instance-geometry.test.ts
@@ -43,4 +43,15 @@ describe("selection geometry", () => {
     expect(bounds!.width).toBeCloseTo(localBounds.height);
     expect(bounds!.height).toBeCloseTo(localBounds.width);
   });
+
+  it("uses the reviewed DFF artwork envelope instead of source-crop whitespace", () => {
+    const resolved = resolver.resolve("d-flip-flop");
+    expect(resolved).toBeDefined();
+    expect(visibleSymbolLocalBounds(resolved!)).toEqual({
+      x: -42,
+      y: -27,
+      width: 84,
+      height: 54,
+    });
+  });
 });

--- a/apps/editor/src/features/component-insert/symbol-artwork.test.tsx
+++ b/apps/editor/src/features/component-insert/symbol-artwork.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { requireRazaviCatalogSymbol } from "@icm/symbols";
 
 import { ComponentPlacementPreview } from "./component-placement-preview";
-import { SymbolArtwork } from "./symbol-artwork";
+import { renderSymbolPreviewPinNames, SymbolArtwork } from "./symbol-artwork";
 
 function expectDffPinNames(markup: string): void {
   expect(markup).toContain('data-pin-name="D"');
@@ -14,6 +14,14 @@ function expectDffPinNames(markup: string): void {
   expect(markup).toContain("text-decoration:overline");
   expect(markup).toContain("font-style:italic;font-weight:700");
   expect(markup).not.toContain(">QBAR</");
+}
+
+function pinNameY(markup: string, pinName: string): number {
+  const match = markup.match(
+    new RegExp(`data-pin-name="${pinName}"[^>]* y="([^"]+)"`, "u"),
+  );
+  if (!match?.[1]) throw new Error(`Missing ${pinName} pin-name y coordinate`);
+  return Number(match[1]);
 }
 
 describe("SymbolArtwork pin-name previews", () => {
@@ -46,4 +54,18 @@ describe("SymbolArtwork pin-name previews", () => {
       expect(markup).toContain('transform="translate(100 80)"');
     },
   );
+
+  it("keeps rotated DFF pin-name baselines symmetric inside opposite edges", () => {
+    const quarterTurn = renderSymbolPreviewPinNames(dff, [], 90);
+    expect(pinNameY(quarterTurn, "D")).toBeCloseTo(-13.916336);
+    expect(pinNameY(quarterTurn, "CK")).toBeCloseTo(-13.916336);
+    expect(pinNameY(quarterTurn, "Q")).toBeCloseTo(21.916336);
+    expect(pinNameY(quarterTurn, "QBAR")).toBeCloseTo(21.916336);
+
+    const threeQuarterTurn = renderSymbolPreviewPinNames(dff, [], 270);
+    expect(pinNameY(threeQuarterTurn, "D")).toBeCloseTo(21.916336);
+    expect(pinNameY(threeQuarterTurn, "CK")).toBeCloseTo(21.916336);
+    expect(pinNameY(threeQuarterTurn, "Q")).toBeCloseTo(-13.916336);
+    expect(pinNameY(threeQuarterTurn, "QBAR")).toBeCloseTo(-13.916336);
+  });
 });

--- a/apps/editor/src/features/component-insert/symbol-artwork.test.tsx
+++ b/apps/editor/src/features/component-insert/symbol-artwork.test.tsx
@@ -66,6 +66,8 @@ describe("SymbolArtwork pin-name previews", () => {
     expect(pinNameY(threeQuarterTurn, "D")).toBeCloseTo(21.916336);
     expect(pinNameY(threeQuarterTurn, "CK")).toBeCloseTo(21.916336);
     expect(pinNameY(threeQuarterTurn, "Q")).toBeCloseTo(-13.916336);
-    expect(pinNameY(threeQuarterTurn, "QBAR")).toBeCloseTo(-13.916336);
+    // Q-bar's overline faces the north body edge at 270 degrees, so its
+    // baseline needs one additional decoration clearance inside the body.
+    expect(pinNameY(threeQuarterTurn, "QBAR")).toBeCloseTo(-12.271536);
   });
 });

--- a/apps/editor/src/features/component-insert/symbol-artwork.test.tsx
+++ b/apps/editor/src/features/component-insert/symbol-artwork.test.tsx
@@ -10,6 +10,8 @@ function expectDffPinNames(markup: string): void {
   expect(markup).toContain('data-pin-name="CK"');
   expect(markup).toContain('data-pin-name="Q"');
   expect(markup).toContain('data-pin-name="QBAR"');
+  expect(markup).toContain('data-text-run="overbar"');
+  expect(markup).toContain("text-decoration:overline");
   expect(markup).toContain("font-style:italic;font-weight:700");
   expect(markup).not.toContain(">QBAR</");
 }
@@ -25,20 +27,23 @@ describe("SymbolArtwork pin-name previews", () => {
     expectDffPinNames(markup);
   });
 
-  it("keeps visible pin names in a rotated placement preview", () => {
-    const markup = renderToStaticMarkup(
-      <svg>
-        <ComponentPlacementPreview
-          styleProfileId="razavi-textbook-v1"
-          symbolId={dff.id}
-          symbol={dff}
-          position={{ x: 100, y: 80 }}
-          rotation={90}
-        />
-      </svg>,
-    );
+  it.each([0, 90, 180, 270] as const)(
+    "keeps visible pin names and Q-bar upright at %d degrees",
+    (rotation) => {
+      const markup = renderToStaticMarkup(
+        <svg>
+          <ComponentPlacementPreview
+            styleProfileId="razavi-textbook-v1"
+            symbolId={dff.id}
+            symbol={dff}
+            position={{ x: 100, y: 80 }}
+            rotation={rotation}
+          />
+        </svg>,
+      );
 
-    expectDffPinNames(markup);
-    expect(markup).toContain('transform="translate(100 80)"');
-  });
+      expectDffPinNames(markup);
+      expect(markup).toContain('transform="translate(100 80)"');
+    },
+  );
 });

--- a/fixtures/visual-reference/razavi-reference-v1/d-flip-flop-vector-source.json
+++ b/fixtures/visual-reference/razavi-reference-v1/d-flip-flop-vector-source.json
@@ -281,6 +281,7 @@
         },
         {
           "kind": "line",
+          "part": "pin-name-overbar",
           "from": {
             "x": 13.687,
             "y": 4.24947
@@ -301,7 +302,7 @@
   },
   "derivation": {
     "pinExtension": "native leads extend collinearly to the existing x=+/-40 electrical anchors",
-    "semantics": "pin identity is reconstructed explicitly; only visual geometry comes from PDF vectors"
+    "semantics": "pin identity is reconstructed explicitly; the extracted Q-bar stroke is renderer-owned so it stays attached to the upright complementary-output label through rotation; only visual geometry comes from PDF vectors"
   },
   "rasterWitness": {
     "kind": "source-pdf-crop",

--- a/fixtures/visual-reference/razavi-reference-v1/manifest.json
+++ b/fixtures/visual-reference/razavi-reference-v1/manifest.json
@@ -363,7 +363,7 @@
         "figure": "16.23(a)"
       },
       "extractPath": "d-flip-flop-vector-source.json",
-      "extractSha256": "7c2a8ec481fb5145af3a6b1fd99c0f28430ea278694b446d54364e2ffe407a43",
+      "extractSha256": "e4998a1a3a55bf9ce223eab734ed9b3e68bc0a6d74470c8414e3657e317def78",
       "rasterPath": "d-flip-flop-reference.png",
       "rasterSha256": "b3a7caab14b71944766da26cac934902a96fa7a304b4963cbb43ac49fe97fa2e",
       "scope": [

--- a/packages/derived/src/visual.test.ts
+++ b/packages/derived/src/visual.test.ts
@@ -1,4 +1,4 @@
-import { createEmptyDocument } from "@icm/model";
+import { createEmptyDocument, createRoutePath } from "@icm/model";
 import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
@@ -154,5 +154,43 @@ describe("visual quality diagnostics", () => {
         (item) => item.code === "VISUAL_SYMBOL_OVERLAP",
       ),
     ).toBe(true);
+  });
+
+  it("does not treat a one-grid DFF pin escape as wire-through-symbol", () => {
+    const document = createEmptyDocument("doc", "DFF pin escape");
+    document.instances.push({
+      id: "U1",
+      symbolId: "d-flip-flop",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0,
+        mirror: "none",
+      },
+    });
+    document.nets.push({
+      id: "n-d",
+      terminals: [{ instanceId: "U1", pinName: "D" }],
+    });
+    document.junctions.push({
+      id: "j-d",
+      netId: "n-d",
+      position: { x: 50, y: 120 },
+    });
+    document.routes.push(
+      createRoutePath({
+        id: "route-d",
+        netId: "n-d",
+        start: { kind: "terminal", instanceId: "U1", pinName: "D" },
+        end: { kind: "junction", junctionId: "j-d" },
+        bends: [{ x: 50, y: 90 }],
+        modes: ["manual", "manual"],
+      }),
+    );
+
+    expect(
+      diagnoseVisualQuality(document, resolver).filter(
+        (item) => item.code === "VISUAL_WIRE_THROUGH_SYMBOL",
+      ),
+    ).toEqual([]);
   });
 });

--- a/packages/render-svg/src/current-contract.test.ts
+++ b/packages/render-svg/src/current-contract.test.ts
@@ -215,6 +215,8 @@ describe("current rendering contract", () => {
     );
 
     expect(svg).toContain('data-pin-name="QBAR"');
+    expect(svg).toContain('data-text-run="overbar"');
+    expect(svg).toContain("text-decoration:overline");
     expect(svg).toContain(">Q</tspan>");
     expect(svg).not.toContain(">QBAR</text>");
     expect(svg).toContain("font-style:italic;font-weight:700");

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -367,9 +367,17 @@ export function renderVisiblePinNames(
         !definition.hierarchicalBlock && outward.y !== 0
           ? pinFontSize * 0.3
           : 0;
+      // An overbar extends above the glyph box reported for the label. When a
+      // complemented output is on a north-facing edge, that decoration faces
+      // the body border, so reserve its own cap-height clearance instead of
+      // treating Q and Q-bar as having identical ink bounds.
+      const outwardOverbarInset =
+        pin.role === "output-complement" && outward.y < 0
+          ? pinFontSize * 0.16
+          : 0;
       const y =
         anchor.y -
-        outward.y * (distance + verticalInkInset) +
+        outward.y * (distance + verticalInkInset + outwardOverbarInset) +
         4 -
         outward.y * hierarchyVerticalInset;
       const alignment =

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -355,9 +355,21 @@ export function renderVisiblePinNames(
         definition.hierarchicalBlock && outward.y !== 0
           ? hierarchyVerticalPinNameInset
           : 0;
+      // SVG text y is a baseline, not an ink edge. Keep the established
+      // baseline correction, then move non-hierarchical north/south labels
+      // inward by a font-relative cap-height margin. This keeps both rows of
+      // a quarter-turned DFF clear of the body without pretending symmetric
+      // baselines have symmetric glyph bounds.
+      const pinFontSize =
+        schematicTextFontSize("pin-name", profile) *
+        (pin.presentation.textSizeScale ?? 1);
+      const verticalInkInset =
+        !definition.hierarchicalBlock && outward.y !== 0
+          ? pinFontSize * 0.3
+          : 0;
       const y =
         anchor.y -
-        outward.y * distance +
+        outward.y * (distance + verticalInkInset) +
         4 -
         outward.y * hierarchyVerticalInset;
       const alignment =

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -368,23 +368,33 @@ export function renderVisiblePinNames(
         pin.presentation.textSizeScale,
       );
       const displayName = pin.presentation.displayName ?? pin.name;
-      const content = definition.hierarchicalBlock
+      const mathSymbolRuns: RichTextRun[] = [
+        {
+          kind: "span",
+          style: "italic",
+          children: [
+            {
+              kind: "span",
+              style: "bold",
+              children: [{ kind: "text", value: displayName }],
+            },
+          ],
+        },
+      ];
+      const content: RichTextDocument = definition.hierarchicalBlock
         ? semanticTextDocument(displayName, "formal-port")
         : pin.presentation.textStyle === "math-symbol"
           ? {
-              runs: [
-                {
-                  kind: "span" as const,
-                  style: "italic" as const,
-                  children: [
-                    {
-                      kind: "span" as const,
-                      style: "bold" as const,
-                      children: [{ kind: "text" as const, value: displayName }],
-                    },
-                  ],
-                },
-              ],
+              runs:
+                pin.role === "output-complement"
+                  ? [
+                      {
+                        kind: "span",
+                        style: "overbar",
+                        children: mathSymbolRuns,
+                      },
+                    ]
+                  : mathSymbolRuns,
             }
           : { runs: [{ kind: "text" as const, value: displayName }] };
       const colorStyle = foregroundOverride

--- a/packages/symbols/assets/razavi-v1/catalog.json
+++ b/packages/symbols/assets/razavi-v1/catalog.json
@@ -211,7 +211,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Behavioral logic symbol; structural SPICE realization requires an explicit subcircuit or PDK mapping.",
       "assetPath": "d-flip-flop.symbol.json",
-      "assetHash": "2a3739a35bda4502424bd1b319604a6f93de5e25217b93549aa12c2b32342bb2",
+      "assetHash": "e39f752861f8f344b462b432a7ce0bbc58fa4174e5977377249390c5a015b629",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
@@ -226,7 +226,7 @@
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",
         "referencePath": "fixtures/visual-reference/razavi-reference-v1/d-flip-flop-vector-source.json",
         "converterPath": "scripts/generate-razavi-buffer-dff-assets.mjs",
-        "converterVersion": 2
+        "converterVersion": 3
       }
     },
     {

--- a/packages/symbols/assets/razavi-v1/d-flip-flop.symbol.json
+++ b/packages/symbols/assets/razavi-v1/d-flip-flop.symbol.json
@@ -3,10 +3,10 @@
   "id": "d-flip-flop",
   "name": "D Flip-Flop",
   "viewBox": {
-    "x": -55,
-    "y": -30,
-    "width": 110,
-    "height": 60
+    "x": -42,
+    "y": -27,
+    "width": 84,
+    "height": 54
   },
   "pins": [
     {
@@ -143,22 +143,6 @@
       "to": {
         "x": 40,
         "y": 10
-      },
-      "style": {
-        "strokeRole": "normal",
-        "lineCap": "butt",
-        "lineJoin": "miter"
-      }
-    },
-    {
-      "kind": "line",
-      "from": {
-        "x": 13.687,
-        "y": 4.24947
-      },
-      "to": {
-        "x": 22.354168,
-        "y": 4.24947
       },
       "style": {
         "strokeRole": "normal",

--- a/packages/symbols/src/razavi-catalog.generated.ts
+++ b/packages/symbols/src/razavi-catalog.generated.ts
@@ -260,7 +260,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Behavioral logic symbol; structural SPICE realization requires an explicit subcircuit or PDK mapping.",
     assetPath: "d-flip-flop.symbol.json",
     assetHash:
-      "2a3739a35bda4502424bd1b319604a6f93de5e25217b93549aa12c2b32342bb2",
+      "e39f752861f8f344b462b432a7ce0bbc58fa4174e5977377249390c5a015b629",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -279,7 +279,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       referencePath:
         "fixtures/visual-reference/razavi-reference-v1/d-flip-flop-vector-source.json",
       converterPath: "scripts/generate-razavi-buffer-dff-assets.mjs",
-      converterVersion: 2,
+      converterVersion: 3,
     },
   },
   {
@@ -2457,10 +2457,10 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
     id: "d-flip-flop",
     name: "D Flip-Flop",
     viewBox: {
-      x: -55,
-      y: -30,
-      width: 110,
-      height: 60,
+      x: -42,
+      y: -27,
+      width: 84,
+      height: 54,
     },
     pins: [
       {
@@ -2597,22 +2597,6 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         to: {
           x: 40,
           y: 10,
-        },
-        style: {
-          strokeRole: "normal",
-          lineCap: "butt",
-          lineJoin: "miter",
-        },
-      },
-      {
-        kind: "line",
-        from: {
-          x: 13.687,
-          y: 4.24947,
-        },
-        to: {
-          x: 22.354168,
-          y: 4.24947,
         },
         style: {
           strokeRole: "normal",

--- a/packages/symbols/src/razavi-catalog.test.ts
+++ b/packages/symbols/src/razavi-catalog.test.ts
@@ -283,8 +283,8 @@ describe("Razavi symbol catalog", () => {
     });
     expect(
       dff.primitives.filter((primitive) => primitive.kind === "line"),
-    ).toHaveLength(5);
-    expect(dff.viewBox).toEqual({ x: -55, y: -30, width: 110, height: 60 });
+    ).toHaveLength(4);
+    expect(dff.viewBox).toEqual({ x: -42, y: -27, width: 84, height: 54 });
     expect(dff.pins.map((pin) => pin.at)).toEqual([
       { x: -40, y: -10 },
       { x: -40, y: 10 },
@@ -298,11 +298,9 @@ describe("Razavi symbol catalog", () => {
       kind: "path",
       data: "M -25.000855 -25.0 L 25.000855 -25.0 L 25.000855 25.0 L -25.000855 25.0 Z",
     });
-    expect(dff.primitives.at(-1)).toMatchObject({
-      kind: "line",
-      from: { x: 13.687, y: 4.24947 },
-      to: { x: 22.354168, y: 4.24947 },
-    });
+    expect(
+      dff.primitives.some((primitive) => primitive.part === "pin-name-overbar"),
+    ).toBe(false);
   });
 
   it("keeps the page-331 Delay Cell proportions and source glyph outlines", () => {

--- a/scripts/generate-razavi-buffer-dff-assets.mjs
+++ b/scripts/generate-razavi-buffer-dff-assets.mjs
@@ -55,6 +55,20 @@ for (const definition of definitions.values()) {
   normalizeLogicPortLeads(definition);
 }
 
+const dff = definitions.get("d-flip-flop");
+if (!dff) fail("missing normalized d-flip-flop definition");
+// Pin names remain upright in world space while Symbol primitives rotate with
+// the body. The PDF's Q-bar therefore belongs to the complementary pin label,
+// not the rotating artwork. Remove only the evidence-tagged source stroke;
+// renderVisiblePinNames recreates it from the output-complement role.
+dff.primitives = dff.primitives.filter(
+  (primitive) => primitive.part !== "pin-name-overbar",
+);
+// The source crop carries generous whitespace. Runtime selection and visual
+// diagnostics fall back to viewBox for path-backed symbols, so retain only
+// stroke-safe clearance around the +/-40 pins and +/-25 body.
+dff.viewBox = { x: -42, y: -27, width: 84, height: 54 };
+
 const assetSources = new Map();
 for (const symbolId of symbolIds) {
   assetSources.set(
@@ -117,7 +131,7 @@ for (const symbolId of symbolIds) {
       "fixtures/visual-reference/razavi-reference-v1/manifest.json",
     referencePath: `fixtures/visual-reference/razavi-reference-v1/${symbolId}-vector-source.json`,
     converterPath: "scripts/generate-razavi-buffer-dff-assets.mjs",
-    converterVersion: 2,
+    converterVersion: symbolId === "d-flip-flop" ? 3 : 2,
   };
 }
 const catalogSource = normalize(


### PR DESCRIPTION
## Summary
- tighten the Razavi DFF interaction bounds without changing its electrical pins
- keep D, CK, Q, and Q-bar upright and inside the body through quarter turns
- reserve explicit decoration clearance so the Q-bar overline does not overlap the body edge

## Validation
- pnpm install --frozen-lockfile
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- pnpm gate:full -- --base origin/main
- 1745 unit tests and 261 browser tests passed
- build, release verification, performance, visual/export goldens, and smoke passed