### PR TITLE
fix(editor): gallery chrome stops crushing at half-screen widths

### DIFF
--- a/apps/editor/src/gallery.css
+++ b/apps/editor/src/gallery.css
@@ -81,6 +81,20 @@
 
 .account-name {
   font-weight: 600;
+  /* The chip is one line always: a long display name ellipsizes instead
+     of wrapping inside the fixed-height control (inline-block, not the
+     shared inline-flex, so text-overflow can apply). */
+  display: inline-block;
+  max-width: 11rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: calc(var(--icm-control-h) - 2px);
+}
+
+.account-signout,
+.account-owner-badge {
+  white-space: nowrap;
 }
 
 .account-rename-input {
@@ -584,6 +598,7 @@
   font-size: 13px;
   font-weight: 600;
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .gallery-open-editor:hover {

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -467,7 +467,14 @@ body {
   }
 }
 
-@media (max-width: 640px) {
+/* Below the credit group's exit the actions still crowd the brand: the
+   subtitle yields (the tab bar right underneath names the page), the bug
+   link goes icon-only, and the account chip tightens. */
+@media (max-width: 900px) {
+  .gallery-chrome .app-brand-copy {
+    display: none;
+  }
+
   .gallery-actions .bug-report-label {
     display: none;
   }
@@ -475,6 +482,26 @@ body {
   .gallery-actions .bug-report-link {
     width: var(--icm-control-h);
     padding: 0;
+  }
+
+  .gallery-actions .account-name {
+    max-width: 8rem;
+  }
+}
+
+/* Narrower still, stop squeezing one row: the chrome wraps into brand and
+   action rows with breathing room. */
+@media (max-width: 620px) {
+  .gallery-chrome {
+    flex-wrap: wrap;
+    height: auto;
+    padding-top: 6px;
+    padding-bottom: 6px;
+    row-gap: 6px;
+  }
+
+  .gallery-actions .account-name {
+    max-width: 6.5rem;
   }
 }
 


### PR DESCRIPTION
Owner report (screenshot): at half-screen width the gallery header crushed — the signed-in account name wrapped to two lines inside its fixed-height chip, "New Circuit" broke across lines, and everything squeezed.

- Account chip / OWNER badge / sign-out / New Circuit are single-line everywhere; long display names ellipsize (`inline-block` + `text-overflow` so it works despite the shared inline-flex control rule).
- ≤900px: subtitle hides (the tab bar directly below names the page), the bug link goes icon-only (previously only ≤640px), the chip tightens to 8rem.
- ≤620px: the chrome wraps into brand + action rows with row-gap instead of squeezing one line; chip tightens to 6.5rem.

Verified in-browser at 734, 600, and 420 CSS px with an injected signed-in-shaped chip: one 44px bar (no intra-control wrap) down to 600, clean at 420. CSS-only; browser suites in CI cover the gallery specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)