### PR TITLE
feat(editor): redesign the unsaved-changes guard as a decision card

### DIFF
--- a/apps/editor/src/components/replace-guard-dialog.test.tsx
+++ b/apps/editor/src/components/replace-guard-dialog.test.tsx
@@ -15,7 +15,7 @@ describe("ReplaceGuardDialog", () => {
       />,
     );
     expect(html).toContain("Unsaved changes");
-    expect(html).toContain("your latest changes will not be saved");
+    expect(html).toContain("will drop your latest");
     expect(html).toContain("Cloud Projects (up to 3)");
     expect(html).toContain("Export Project File");
     expect(html).toContain(".icproj.json");

--- a/apps/editor/src/components/replace-guard-dialog.tsx
+++ b/apps/editor/src/components/replace-guard-dialog.tsx
@@ -12,7 +12,7 @@ export interface ReplaceGuardDialogProps {
 /**
  * Outgoing dirty-work protection. Recovery is a safety copy, not permission to
  * discard the foreground Project, so every dirty replacement pauses here.
- * Defaults to Cancel; Escape cancels. Cloud Save must succeed before the
+ * Defaults to Stay; Escape stays. Cloud Save must succeed before the
  * replacement is allowed to continue.
  */
 export function ReplaceGuardDialog({
@@ -35,7 +35,7 @@ export function ReplaceGuardDialog({
       }}
     >
       <section
-        className="help-dialog"
+        className="replace-guard-dialog"
         role="dialog"
         aria-modal="true"
         aria-labelledby="replace-guard-title"
@@ -46,42 +46,67 @@ export function ReplaceGuardDialog({
           }
         }}
       >
-        <header className="help-dialog-header">
-          <div>
+        <div className="replace-guard-lede">
+          <span className="replace-guard-glyph" aria-hidden="true">
+            <svg viewBox="0 0 20 20" width="20" height="20">
+              <path
+                d="M10 3.2 18 17H2Z"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinejoin="round"
+              />
+              <line
+                x1="10"
+                y1="8.4"
+                x2="10"
+                y2="12.2"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+              />
+              <circle cx="10" cy="14.6" r="0.9" fill="currentColor" />
+            </svg>
+          </span>
+          <div className="replace-guard-copy">
             <h2 id="replace-guard-title">Unsaved changes</h2>
+            <p>
+              Continuing to <strong>{intent}</strong> will drop your latest
+              edits.
+            </p>
+            <p className="replace-guard-hint">
+              Save keeps this Project in Cloud Projects (up to 3). Prefer a
+              file? <strong>File → Export Project File…</strong> downloads
+              <code>.icproj.json</code>.
+            </p>
           </div>
-        </header>
-        <div className="help-dialog-content">
-          <p>
-            If you continue to <strong>{intent}</strong>, your latest changes
-            will not be saved.
-          </p>
-          <p>
-            <strong>Save</strong> stores this Project in Cloud Projects (up to
-            3). <strong>File / Export Project File…</strong> downloads a local
-            <code>.icproj.json</code> file.
-          </p>
-          <div className="replace-guard-actions">
-            <button
-              type="button"
-              ref={cancelRef}
-              onClick={onCancel}
-              disabled={saving}
-            >
-              Stay
-            </button>
-            <button type="button" onClick={onSaveAndContinue} disabled={saving}>
-              {saving ? "Saving to Cloud…" : "Save to Cloud and continue"}
-            </button>
-            <button
-              type="button"
-              className="danger"
-              onClick={onDiscard}
-              disabled={saving}
-            >
-              Continue without saving
-            </button>
-          </div>
+        </div>
+        <div className="replace-guard-actions">
+          <button
+            type="button"
+            className="replace-guard-discard"
+            onClick={onDiscard}
+            disabled={saving}
+          >
+            Continue without saving
+          </button>
+          <button
+            type="button"
+            className="replace-guard-stay"
+            ref={cancelRef}
+            onClick={onCancel}
+            disabled={saving}
+          >
+            Stay
+          </button>
+          <button
+            type="button"
+            className="replace-guard-save"
+            onClick={onSaveAndContinue}
+            disabled={saving}
+          >
+            {saving ? "Saving to Cloud…" : "Save to Cloud and continue"}
+          </button>
         </div>
       </section>
     </div>

--- a/apps/editor/src/styles/editor-overlays.css
+++ b/apps/editor/src/styles/editor-overlays.css
@@ -66,10 +66,130 @@
   scroll-margin-top: 5.5rem;
 }
 
+/* The unsaved-changes guard: a compact decision card, not a document.
+   Hierarchy does the work — amber glyph names the stakes, the accent
+   button is the recommended way out, and the destructive path sits
+   apart on the left in quiet red. */
+.replace-guard-dialog {
+  width: min(37rem, 100%);
+  padding: 1.15rem 1.25rem 1rem;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-lg);
+  background: var(--icm-surface);
+  box-shadow: var(--icm-shadow-lg);
+}
+
+.replace-guard-lede {
+  display: flex;
+  gap: 0.85rem;
+  align-items: flex-start;
+}
+
+.replace-guard-glyph {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 2.35rem;
+  height: 2.35rem;
+  margin-top: 0.1rem;
+  border-radius: 999px;
+  background: #fef3c7;
+  color: #b45309;
+}
+
+.replace-guard-copy {
+  display: grid;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.replace-guard-copy h2 {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.3;
+}
+
+.replace-guard-copy p {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--icm-text);
+}
+
+.replace-guard-hint {
+  color: var(--icm-text-muted, #787066);
+  font-size: 12px;
+}
+
+.replace-guard-hint code {
+  font-size: 11px;
+  padding: 0 0.25em;
+}
+
 .replace-guard-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.6rem;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 1.1rem;
+}
+
+.replace-guard-actions button {
+  height: var(--icm-control-h);
+  padding: 0 0.85rem;
+  border-radius: var(--icm-radius-sm);
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.replace-guard-actions button:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.replace-guard-discard {
+  margin-right: auto;
+  border: 1px solid transparent;
+  background: transparent;
+  color: #b3261e;
+}
+
+.replace-guard-discard:hover:not(:disabled) {
+  background: rgb(179 38 30 / 8%);
+}
+
+.replace-guard-stay {
+  border: 1px solid var(--icm-border);
+  background: var(--icm-surface);
+  color: var(--icm-text);
+}
+
+.replace-guard-stay:hover:not(:disabled) {
+  background: var(--icm-surface-hover);
+}
+
+.replace-guard-save {
+  border: 1px solid var(--icm-accent);
+  background: var(--icm-accent);
+  color: #fff;
+  font-weight: 600;
+}
+
+.replace-guard-save:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+@media (max-width: 560px) {
+  .replace-guard-discard {
+    margin-right: 0;
+    order: 3;
+  }
+
+  .replace-guard-actions {
+    justify-content: flex-end;
+  }
 }
 
 .replace-guard-warning {


### PR DESCRIPTION
Owner report: the unsaved-changes prompt — the highest-frequency dialog in the app — looked like an unstyled document: three equal buttons with the destructive one reading as the default, cramped copy, no hierarchy.

Now a compact decision card:
- amber warning glyph + one-sentence consequence with the intent bolded;
- the Cloud-vs-file explainer drops to a muted footnote;
- action hierarchy carries the meaning: accent-filled **Save to Cloud and continue** (recommended), quiet **Stay** beside it — still the focused default, Escape still stays — and **Continue without saving** set apart on the left in restrained red; below 560px the row wraps with the destructive action last.

Button accessible names, `role="dialog"`, the title id, and the saving lockout are unchanged — every e2e that drives this guard keeps working (project-file guard spec green locally; dialog unit tests updated for the new copy, 2/2).

Verified live: triggered via File → New Project on a dirty document; one-row layout at desktop width, correct focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)