### PR TITLE
feat(editor): exempt a connected single-pin lead ride from the buried-wire warning

### DIFF
--- a/apps/editor/src/canvas/wire-under-symbol.test.ts
+++ b/apps/editor/src/canvas/wire-under-symbol.test.ts
@@ -87,4 +87,194 @@ describe("deriveWireUnderSymbolWarnings", () => {
       warnings.filter((warning) => ["A", "B"].includes(warning.instanceId)),
     ).toEqual([]);
   });
+
+  function nmosFixture(
+    nmosAt: { x: number; y: number },
+    options: { gateOnNet?: boolean } = {},
+  ) {
+    const { document } = fixture({ x: 300, y: 200 });
+    document.instances.push({
+      id: "M1",
+      symbolId: "nmos",
+      placement: { position: nmosAt, rotation: 0, mirror: "none" },
+      netlist: { reference: "M1", parameters: {} },
+    });
+    if (options.gateOnNet !== false) {
+      document.nets[0]!.terminals.push({ instanceId: "M1", pinName: "G" });
+    }
+    const geometry = resolveDocumentRoutingGeometry(document, resolver);
+    const records = document.routes.flatMap((route) => {
+      const resolved = geometry.routes.get(route.id);
+      return resolved ? [{ route, geometry: resolved }] : [];
+    });
+    return { document, records };
+  }
+
+  it("exempts a wire riding the gate lead line straight through a MOS", () => {
+    // The bias-rail idiom: the y=400 run passes through M1's body exactly on
+    // the gate lead line (gate contact at x-20 of the placement), covering
+    // the contact of a gate terminal the Net declares. The span is that
+    // terminal's own connection and stays quiet.
+    const { document, records } = nmosFixture({ x: 300, y: 400 });
+    expect(
+      deriveWireUnderSymbolWarnings(document, resolver, records).filter(
+        (warning) => warning.instanceId === "M1",
+      ),
+    ).toEqual([]);
+  });
+
+  it("still flags a gate-line wire whose Net does not include the gate", () => {
+    // Same geometry, but M1's gate is not a terminal of the wire's Net: the
+    // component is merely parked on a foreign wire and looks connected
+    // without being so.
+    const { document, records } = nmosFixture(
+      { x: 300, y: 400 },
+      { gateOnNet: false },
+    );
+    expect(
+      deriveWireUnderSymbolWarnings(document, resolver, records).filter(
+        (warning) => warning.instanceId === "M1",
+      ),
+    ).not.toEqual([]);
+  });
+
+  it("still flags a wire crossing a MOS body off the lead lines", () => {
+    // Shifted 10 units, the same run crosses the body at local y=+10 where
+    // no pin lead runs horizontally.
+    const { document, records } = nmosFixture({ x: 300, y: 390 });
+    expect(
+      deriveWireUnderSymbolWarnings(document, resolver, records).filter(
+        (warning) => warning.instanceId === "M1",
+      ),
+    ).not.toEqual([]);
+  });
+
+  it("still flags a collinear span that never reaches the pin contact", () => {
+    // A stub starting inside the body on the gate line but east of the gate
+    // contact is buried, not connected.
+    const { document } = nmosFixture({ x: 300, y: 400 });
+    document.routes.length = 0;
+    document.junctions.push({
+      id: "J",
+      netId: "net-w",
+      position: { x: 305, y: 400 },
+    });
+    document.routes.push(
+      createRoutePath({
+        id: "route-stub",
+        netId: "net-w",
+        start: { kind: "junction", junctionId: "J" },
+        end: { kind: "terminal", instanceId: "B", pinName: "2" },
+        bends: [{ x: 500, y: 400 }],
+        modes: ["manual", "manual"],
+      }),
+    );
+    const geometry = resolveDocumentRoutingGeometry(document, resolver);
+    const records = document.routes.flatMap((route) => {
+      const resolved = geometry.routes.get(route.id);
+      return resolved ? [{ route, geometry: resolved }] : [];
+    });
+    const warnings = deriveWireUnderSymbolWarnings(document, resolver, records);
+    expect(
+      warnings.filter((warning) => warning.instanceId === "M1"),
+    ).not.toEqual([]);
+  });
+
+  function verticalFixture(middle: {
+    id: string;
+    symbolId: string;
+    pinNamesOnNet: readonly string[];
+  }) {
+    const document = createEmptyDocument("doc", "Axis");
+    document.instances.push(
+      {
+        id: "C",
+        symbolId: "resistor",
+        placement: {
+          position: { x: 300, y: 150 },
+          rotation: 0,
+          mirror: "none",
+        },
+        netlist: { reference: "C", parameters: {} },
+      },
+      {
+        id: "D",
+        symbolId: "resistor",
+        placement: {
+          position: { x: 300, y: 650 },
+          rotation: 0,
+          mirror: "none",
+        },
+        netlist: { reference: "D", parameters: {} },
+      },
+      {
+        id: middle.id,
+        symbolId: middle.symbolId,
+        placement: {
+          position: { x: 300, y: 400 },
+          rotation: 0,
+          mirror: "none",
+        },
+        netlist: { reference: middle.id, parameters: {} },
+      },
+    );
+    document.nets.push({
+      id: "net-v",
+      terminals: [
+        { instanceId: "C", pinName: "2" },
+        { instanceId: "D", pinName: "1" },
+        ...middle.pinNamesOnNet.map((pinName) => ({
+          instanceId: middle.id,
+          pinName,
+        })),
+      ],
+    });
+    document.routes.push(
+      createRoutePath({
+        id: "route-v",
+        netId: "net-v",
+        start: { kind: "terminal", instanceId: "C", pinName: "2" },
+        end: { kind: "terminal", instanceId: "D", pinName: "1" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+    const geometry = resolveDocumentRoutingGeometry(document, resolver);
+    const records = document.routes.flatMap((route) => {
+      const resolved = geometry.routes.get(route.id);
+      return resolved ? [{ route, geometry: resolved }] : [];
+    });
+    return { document, records };
+  }
+
+  it("flags a wire tunneling between both leads of a resistor even on its pin axis", () => {
+    // The x=300 run rides both of RX's pin leads, so the wire shorts through
+    // the component while looking like a series insertion. Declaring the
+    // bonded terminals does not quiet it: two ridden leads always warn.
+    const { document, records } = verticalFixture({
+      id: "RX",
+      symbolId: "resistor",
+      pinNamesOnNet: ["1", "2"],
+    });
+    expect(
+      deriveWireUnderSymbolWarnings(document, resolver, records).filter(
+        (warning) => warning.instanceId === "RX",
+      ),
+    ).not.toEqual([]);
+  });
+
+  it("exempts a vertical wire riding a ground port's single connected lead", () => {
+    // Ground has one pin ("0", north) whose lead the x=300 run rides; with
+    // the terminal on the Net this is the port's own connection.
+    const { document, records } = verticalFixture({
+      id: "G1",
+      symbolId: "ground",
+      pinNamesOnNet: ["0"],
+    });
+    expect(
+      deriveWireUnderSymbolWarnings(document, resolver, records).filter(
+        (warning) => warning.instanceId === "G1",
+      ),
+    ).toEqual([]);
+  });
 });

--- a/apps/editor/src/canvas/wire-under-symbol.ts
+++ b/apps/editor/src/canvas/wire-under-symbol.ts
@@ -1,4 +1,5 @@
 import type { SchematicDocument } from "@icm/model";
+import { resolveEndpointConnection } from "@icm/derived";
 import type { ResolvedRouteGeometry } from "@icm/derived";
 import type { SymbolResolver } from "@icm/symbols";
 
@@ -17,6 +18,92 @@ export interface WireUnderSymbolWarning {
  * wire crossing the artwork body is the drawing error being flagged.
  */
 const BODY_CLEARANCE = 4;
+
+const AXIS_EPSILON = 1e-6;
+
+interface PinLead {
+  pinName: string;
+  axis: "horizontal" | "vertical";
+  contact: { x: number; y: number };
+}
+
+/**
+ * Document-space lead lines of an instance's visible pins. A conductor that
+ * rides one of these lines is the pin's own connection continued across the
+ * body (the bias-rail-through-a-gate-row idiom), not a buried wire.
+ */
+function visiblePinLeads(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  instance: SchematicDocument["instances"][number],
+): PinLead[] {
+  const resolved = resolver.resolve(
+    instance.symbolId,
+    instance.symbolVariantId,
+  );
+  if (!resolved) return [];
+  return resolved.definition.pins.flatMap((pin) => {
+    if (pin.presentation.visibility === "implicit") return [];
+    if (resolved.variant?.hiddenPinNames.includes(pin.name)) return [];
+    const connection = resolveEndpointConnection(document, resolver, {
+      kind: "terminal",
+      instanceId: instance.id,
+      pinName: pin.name,
+    });
+    if (!connection?.outward) return [];
+    return [
+      {
+        pinName: pin.name,
+        axis:
+          connection.outward.x !== 0
+            ? ("horizontal" as const)
+            : ("vertical" as const),
+        contact: connection.contactPoint,
+      },
+    ];
+  });
+}
+
+/**
+ * Whether a conductor segment is one pin's own connection drawn the
+ * conventional way — a bias rail riding through a gate row. That holds only
+ * when the segment rides exactly ONE of the instance's pin lead lines
+ * (collinear with the lead and passing over its contact point) and the Net
+ * of the route lists that pin as a terminal. Riding two leads of the same
+ * instance means the wire tunnels between two of its terminals — a
+ * shorted-through component that looks like a series insertion — and a
+ * ridden pin the Net does not list is a component merely parked on a
+ * foreign wire; both keep their warning. The original (unclipped) segment
+ * is tested because contacts sit at the artwork edge, outside the deflated
+ * body box.
+ */
+function segmentIsSingleConnectedPinRide(
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  leads: readonly PinLead[],
+  netTerminalPinNames: ReadonlySet<string>,
+): boolean {
+  const horizontal = Math.abs(from.y - to.y) <= AXIS_EPSILON;
+  const vertical = Math.abs(from.x - to.x) <= AXIS_EPSILON;
+  const ridden = leads.filter((lead) => {
+    if (lead.axis === "horizontal" && horizontal) {
+      return (
+        Math.abs(from.y - lead.contact.y) <= AXIS_EPSILON &&
+        lead.contact.x >= Math.min(from.x, to.x) - AXIS_EPSILON &&
+        lead.contact.x <= Math.max(from.x, to.x) + AXIS_EPSILON
+      );
+    }
+    if (lead.axis === "vertical" && vertical) {
+      return (
+        Math.abs(from.x - lead.contact.x) <= AXIS_EPSILON &&
+        lead.contact.y >= Math.min(from.y, to.y) - AXIS_EPSILON &&
+        lead.contact.y <= Math.max(from.y, to.y) + AXIS_EPSILON
+      );
+    }
+    return false;
+  });
+  return ridden.length === 1 && netTerminalPinNames.has(ridden[0]!.pinName);
+}
 
 function clipSegmentToBox(
   from: { x: number; y: number },
@@ -57,7 +144,8 @@ function clipSegmentToBox(
 
 /**
  * Conductor spans buried under symbol artwork. Escape leads (a pin's own
- * derived stem) and bulk-dashed presentation are exempt; everything else
+ * derived stem), bulk-dashed presentation, and spans riding exactly one pin
+ * lead that the route's Net lists as a terminal are exempt; everything else
  * that crosses the deflated body box of any placed instance is reported so
  * the editor can paint a warning over the covered span.
  */
@@ -84,7 +172,13 @@ export function deriveWireUnderSymbolWarnings(
       height: box.height - BODY_CLEARANCE * 2,
     };
     return deflated.width > 0 && deflated.height > 0
-      ? [{ instanceId: instance.id, box: deflated }]
+      ? [
+          {
+            instanceId: instance.id,
+            box: deflated,
+            leads: visiblePinLeads(document, resolver, instance),
+          },
+        ]
       : [];
   });
   if (boxes.length === 0) return [];
@@ -92,11 +186,29 @@ export function deriveWireUnderSymbolWarnings(
   const warnings: WireUnderSymbolWarning[] = [];
   for (const { route, geometry } of records) {
     if (route.presentation === "bulk-dashed") continue;
+    const net = document.nets.find((candidate) => candidate.id === route.netId);
+    const netPinNamesByInstance = new Map<string, Set<string>>();
+    for (const terminal of net?.terminals ?? []) {
+      const names = netPinNamesByInstance.get(terminal.instanceId) ?? new Set();
+      names.add(terminal.pinName);
+      netPinNamesByInstance.set(terminal.instanceId, names);
+    }
+    const noPins: ReadonlySet<string> = new Set();
     for (const segment of geometry.segments) {
       if (segment.mode === "escape") continue;
-      for (const { instanceId, box } of boxes) {
+      for (const { instanceId, box, leads } of boxes) {
         const clipped = clipSegmentToBox(segment.from, segment.to, box);
         if (!clipped) continue;
+        if (
+          segmentIsSingleConnectedPinRide(
+            segment.from,
+            segment.to,
+            leads,
+            netPinNamesByInstance.get(instanceId) ?? noPins,
+          )
+        ) {
+          continue;
+        }
         warnings.push({
           routeId: route.id,
           instanceId,


### PR DESCRIPTION
## Summary

Owner feedback on the #360 buried-wire warning: a bias rail drawn straight through a MOS row exactly along the gate lead line (the `V_b` line through `M1`/`M2` in the reported screenshot) was painted red, although the drawing is the conventional schematic idiom and electrically exact.

The derivation now exempts a clipped span only when the conductor segment **rides exactly one** of the instance's visible pin lead lines — collinear with the lead axis and passing over its contact point — **and the route's Net lists that pin as a terminal**. Both boundaries are deliberate:

- A ridden pin the Net does not list is a component merely parked on a foreign wire — it looks connected without being so and keeps its warning. This preserves the original #360 drag-onto-wire contract (overlap-warning e2e stays green).
- Riding two leads of the same instance means the wire tunnels between two of its own terminals — a shorted-through component that reads as a series insertion — and warns even when both terminals are bonded.

## Validation

- Unit suite for the derivation extended to 9 cases: the gate-line exemption is red before the change; foreign-net, two-lead, off-axis, and collinear-but-not-reaching controls all stay red.
- `overlap-warning.spec.ts` e2e green against a worktree dev server (`ICM_E2E_PORT`).
- Interactive check: gate-riding rail quiet (0 spans), off-axis body crossing warns (2 spans).
- Prettier + repo typecheck; `Test-Impact: tests-updated` validated by `check-test-impact`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)