### PR TITLE
fix(editor): shelf thumbnails backfill and degrade gracefully

### DIFF
--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { TilePreview } from "./tile-preview";
 import "../styles/gallery-entry.css";
 
 import { renderDocumentSvg } from "@icm/render-svg";
@@ -722,16 +723,14 @@ export function GalleryFeed({
                           href={`/g/${entry.id}`}
                           data-testid={`gallery-tile-${entry.id}`}
                         >
-                          <span className="gallery-tile-preview">
-                            <img
-                              src={galleryPreviewUrl(
-                                entry.id,
-                                entry.previewRevision,
-                              )}
-                              alt={`Preview of ${entry.name}`}
-                              loading="lazy"
-                            />
-                          </span>
+                          <TilePreview
+                            key={`${entry.id}-${entry.previewRevision}`}
+                            src={galleryPreviewUrl(
+                              entry.id,
+                              entry.previewRevision,
+                            )}
+                            alt={`Preview of ${entry.name}`}
+                          />
                           <span className="gallery-tile-copy">
                             <span className="gallery-tile-name">
                               {entry.name}

--- a/apps/editor/src/components/shelf-wall.tsx
+++ b/apps/editor/src/components/shelf-wall.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { TilePreview } from "./tile-preview";
 
 import {
   CLOUD_PROJECT_LIMIT,
@@ -127,13 +128,11 @@ export function ShelfWall() {
                 href={shelfProjectHref(project.id)}
                 data-testid={`shelf-tile-${project.id}`}
               >
-                <span className="gallery-tile-preview">
-                  <img
-                    src={cloudProjectPreviewUrl(project.id, project.revision)}
-                    alt={`Preview of ${project.name}`}
-                    loading="lazy"
-                  />
-                </span>
+                <TilePreview
+                  key={`${project.id}-${project.revision}`}
+                  src={cloudProjectPreviewUrl(project.id, project.revision)}
+                  alt={`Preview of ${project.name}`}
+                />
                 <span className="gallery-tile-copy">
                   <span className="gallery-tile-name">{project.name}</span>
                   <span className="gallery-tile-meta">

--- a/apps/editor/src/components/tile-preview.test.tsx
+++ b/apps/editor/src/components/tile-preview.test.tsx
@@ -1,0 +1,16 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { TilePreview } from "./tile-preview";
+
+describe("TilePreview", () => {
+  it("renders the image markup with lazy loading", () => {
+    const html = renderToStaticMarkup(
+      <TilePreview src="/p.svg" alt="Preview of Amp" />,
+    );
+    expect(html).toContain('src="/p.svg"');
+    expect(html).toContain('alt="Preview of Amp"');
+    expect(html).toContain('loading="lazy"');
+    expect(html).not.toContain("gallery-tile-placeholder");
+  });
+});

--- a/apps/editor/src/components/tile-preview.tsx
+++ b/apps/editor/src/components/tile-preview.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+
+/**
+ * A gallery/shelf thumbnail that degrades gracefully: when the preview
+ * request fails (a shelf saved before previews existed and not yet
+ * backfilled, or a drawing the renderer cannot handle), the tile shows a
+ * quiet schematic placeholder instead of the browser's broken-image glyph.
+ */
+export function TilePreview({ src, alt }: { src: string; alt: string }) {
+  const [failed, setFailed] = useState(false);
+  return (
+    <span
+      className={
+        failed
+          ? "gallery-tile-preview gallery-tile-preview-missing"
+          : "gallery-tile-preview"
+      }
+    >
+      {failed ? (
+        <svg
+          className="gallery-tile-placeholder"
+          viewBox="0 0 96 64"
+          role="img"
+          aria-label={alt}
+        >
+          <path
+            d="M8 40h14l4-10 6 20 6-24 6 20 4-6h14"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <circle cx="70" cy="40" r="3" fill="currentColor" />
+          <path
+            d="M73 40h15"
+            stroke="currentColor"
+            strokeWidth="2.4"
+            strokeLinecap="round"
+          />
+        </svg>
+      ) : (
+        <img
+          src={src}
+          alt={alt}
+          loading="lazy"
+          onError={() => setFailed(true)}
+        />
+      )}
+    </span>
+  );
+}

--- a/apps/editor/src/gallery.css
+++ b/apps/editor/src/gallery.css
@@ -935,6 +935,21 @@
   padding: 10px;
 }
 
+/* Missing thumbnail: a quiet schematic squiggle on the muted surface,
+   never the browser's broken-image glyph. */
+.gallery-tile-preview-missing {
+  display: grid;
+  place-items: center;
+  aspect-ratio: 3 / 2;
+  color: var(--icm-border);
+  background: var(--icm-chrome-bg);
+}
+
+.gallery-tile-placeholder {
+  width: 40%;
+  max-width: 9rem;
+}
+
 .gallery-tile-preview img,
 .gallery-tile-preview svg {
   display: block;

--- a/worker/gallery-do.ts
+++ b/worker/gallery-do.ts
@@ -528,6 +528,13 @@ export class GalleryDO {
         return this.cloudProjectDelete(String(body.userId), String(body.id));
       case "cloud-project-preview":
         return this.cloudProjectPreview(String(body.userId), String(body.id));
+      case "cloud-project-preview-store":
+        return this.cloudProjectPreviewStore(
+          String(body.userId),
+          String(body.id),
+          Number(body.revision),
+          String(body.previewSvg),
+        );
       case "schema-backup":
         return this.schemaBackup();
       case "schema-converge":
@@ -1074,6 +1081,31 @@ export class GalleryDO {
       previewSvg: row.preview_svg,
       revision: row.revision,
     });
+  }
+
+  /**
+   * Lazy backfill for shelves saved before previews existed: store the
+   * rendered thumbnail only while the row still has none at the same
+   * revision, so a save racing this write always wins.
+   */
+  private cloudProjectPreviewStore(
+    userId: string,
+    id: string,
+    revision: number,
+    previewSvg: string,
+  ): Response {
+    if (!previewSvg || !Number.isInteger(revision)) {
+      return Response.json({ error: "invalid-fields" }, { status: 400 });
+    }
+    this.sql.exec(
+      `UPDATE cloud_projects SET preview_svg = ?
+        WHERE user_id = ? AND id = ? AND revision = ? AND preview_svg = ''`,
+      previewSvg,
+      userId,
+      id,
+      revision,
+    );
+    return Response.json({ ok: true });
   }
 
   private cloudProjectOpenPayload(userId: string, id: string) {

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -687,6 +687,38 @@ describe("private Cloud Projects", () => {
     expect(anonymous.status).toBe(401);
   });
 
+  it("backfills a thumbnail for a shelf saved before previews existed", async () => {
+    const env = environment();
+    const cookie = await makerOf(env);
+    const created = await route(env, saveRequest(cookie, "Legacy"));
+    const { project } = (await created.json()) as {
+      project: { id: string; revision: number };
+    };
+    // Simulate a row from before stored previews.
+    env.gallerySql.exec(
+      "UPDATE cloud_projects SET preview_svg = '' WHERE id = ?",
+      project.id,
+    );
+
+    const preview = await route(
+      env,
+      new Request(
+        `${ORIGIN}/api/projects/${project.id}/preview.svg?v=${project.revision}`,
+        { headers: cookieHeaders(cookie) },
+      ),
+    );
+    expect(preview.status).toBe(200);
+    expect(await preview.text()).toContain("<svg");
+    // And it sticks: the row now carries the rendered bytes.
+    const row = env.gallerySql
+      .exec<{ preview_svg: string }>(
+        "SELECT preview_svg FROM cloud_projects WHERE id = ?",
+        project.id,
+      )
+      .toArray()[0]!;
+    expect(row.preview_svg).toContain("<svg");
+  });
+
   it("updates one stable Project with optimistic revision checking", async () => {
     const env = environment();
     const cookie = await makerOf(env);

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -263,7 +263,46 @@ async function handleCloudProjectPreview(
     previewSvg?: string;
     revision?: number;
   }>(env, "cloud-project-preview", { userId: user.id, id: projectId });
-  if (status !== 200 || !payload.previewSvg) {
+  if (status !== 200) {
+    return Response.json(
+      { error: "not-found" },
+      { status: 404, headers: { "cache-control": "no-store" } },
+    );
+  }
+  if (!payload.previewSvg) {
+    // Shelves saved before previews existed have empty thumbnails; render
+    // one from the stored Project now and keep it for next time.
+    const opened = await callGallery<{
+      project?: { projectText?: string; revision?: number };
+    }>(env, "cloud-project-open", { userId: user.id, id: projectId });
+    const projectText = opened.payload.project?.projectText;
+    if (opened.status === 200 && typeof projectText === "string") {
+      try {
+        const project = parseProject(projectText);
+        const rendered = renderPreview(
+          project,
+          createProjectSymbolResolver(project, builtInSymbols),
+        );
+        if (rendered) {
+          payload.previewSvg = rendered;
+          const openedRevision = opened.payload.project?.revision;
+          if (typeof openedRevision === "number") {
+            payload.revision = openedRevision;
+          }
+          await callGallery(env, "cloud-project-preview-store", {
+            userId: user.id,
+            id: projectId,
+            revision: opened.payload.project?.revision,
+            previewSvg: rendered,
+          });
+        }
+      } catch {
+        // The renderer cannot draw this Project; the shelf shows its
+        // placeholder tile instead.
+      }
+    }
+  }
+  if (!payload.previewSvg) {
     return Response.json(
       { error: "not-found" },
       { status: 404, headers: { "cache-control": "no-store" } },


### PR DESCRIPTION
Owner report (screenshot): every My-shelf card showed the browser's broken-image glyph. Root cause: projects saved before stored previews existed carry `preview_svg = ''` (the migration default), so `/api/projects/:id/preview.svg` 404s.

- **Lazy backfill (worker)**: on an empty thumbnail the preview route opens the stored Project, renders the SVG, returns it, and persists it via a new `cloud-project-preview-store` DO op — guarded by revision and only-while-empty so a concurrent save always wins. Legacy shelves heal on first view. Regression test: save → wipe `preview_svg` → request → 200 `<svg>` and the row is repopulated (worker suite 49/49).
- **Graceful degradation (frontend)**: shared `TilePreview` swaps a failed image for a quiet schematic-squiggle placeholder on the muted surface (shelf + community walls), keeping the accessible name; no more broken-image icons even when a drawing genuinely cannot render.

Validation: worker + components + editor-shell suites 174/174, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)