### PR TITLE
fix(editor): a wire on the body-box boundary is skimming, not buried

### DIFF
--- a/apps/editor/src/canvas/wire-under-symbol.test.ts
+++ b/apps/editor/src/canvas/wire-under-symbol.test.ts
@@ -1,5 +1,8 @@
 import { createEmptyDocument, createRoutePath } from "@icm/model";
-import { resolveDocumentRoutingGeometry } from "@icm/derived";
+import {
+  resolveDocumentRoutingGeometry,
+  resolveEndpointConnection,
+} from "@icm/derived";
 import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
@@ -276,5 +279,73 @@ describe("deriveWireUnderSymbolWarnings", () => {
         (warning) => warning.instanceId === "G1",
       ),
     ).toEqual([]);
+  });
+
+  function rotatedResistorFixture(wireX: (contact: { x: number }) => number) {
+    // A horizontal resistor (rotation 90). Its artwork is a path primitive,
+    // so the envelope falls back to the declaration viewBox, whose padding
+    // equals the body clearance: the deflated box edges land exactly on the
+    // pin contacts.
+    const document = createEmptyDocument("doc", "Corner");
+    document.instances.push({
+      id: "RX",
+      symbolId: "resistor",
+      placement: { position: { x: 300, y: 400 }, rotation: 90, mirror: "none" },
+      netlist: { reference: "RX", parameters: {} },
+    });
+    const contact = resolveEndpointConnection(document, resolver, {
+      kind: "terminal",
+      instanceId: "RX",
+      pinName: "1",
+    })!.contactPoint;
+    const x = wireX(contact);
+    document.nets.push({ id: "net-c", terminals: [] });
+    document.junctions.push(
+      { id: "J1", netId: "net-c", position: { x, y: 500 } },
+      { id: "J2", netId: "net-c", position: { x, y: 300 } },
+    );
+    document.routes.push(
+      createRoutePath({
+        id: "route-c",
+        netId: "net-c",
+        start: { kind: "junction", junctionId: "J1" },
+        end: { kind: "junction", junctionId: "J2" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+    const geometry = resolveDocumentRoutingGeometry(document, resolver);
+    const records = document.routes.flatMap((route) => {
+      const resolved = geometry.routes.get(route.id);
+      return resolved ? [{ route, geometry: resolved }] : [];
+    });
+    return { document, records };
+  }
+
+  it("stays quiet for a wire running exactly along the pin-contact edge", () => {
+    // The reported ground-to-resistor corner: a vertical wire at the left
+    // pin contact of a horizontal resistor lies exactly on the deflated box
+    // boundary. Zero penetration depth is skimming, not burial.
+    const { document, records } = rotatedResistorFixture(
+      (contact) => contact.x,
+    );
+    expect(
+      deriveWireUnderSymbolWarnings(document, resolver, records).filter(
+        (warning) => warning.instanceId === "RX",
+      ),
+    ).toEqual([]);
+  });
+
+  it("still flags a wire strictly inside the body box", () => {
+    // Six units inboard of the contact edge the same vertical wire crosses
+    // real artwork and keeps its warning.
+    const { document, records } = rotatedResistorFixture((contact) =>
+      contact.x < 300 ? contact.x + 6 : contact.x - 6,
+    );
+    expect(
+      deriveWireUnderSymbolWarnings(document, resolver, records).filter(
+        (warning) => warning.instanceId === "RX",
+      ),
+    ).not.toEqual([]);
   });
 });

--- a/apps/editor/src/canvas/wire-under-symbol.ts
+++ b/apps/editor/src/canvas/wire-under-symbol.ts
@@ -110,7 +110,13 @@ function clipSegmentToBox(
   to: { x: number; y: number },
   box: { x: number; y: number; width: number; height: number },
 ): { from: { x: number; y: number }; to: { x: number; y: number } } | null {
-  // Liang-Barsky parametric clip; works for any orientation.
+  // Liang-Barsky parametric clip; works for any orientation. The box is
+  // treated as OPEN along the axis a segment does not travel: a segment
+  // lying exactly on a boundary line has zero penetration depth and is a
+  // wire skimming the deflated envelope, not a buried one. Path-artwork
+  // symbols fall back to their declaration viewBox, whose padding often
+  // equals BODY_CLEARANCE, so the deflated edge lands exactly on the pin
+  // contacts — a wire cornering at a pin must stay quiet.
   const dx = to.x - from.x;
   const dy = to.y - from.y;
   let t0 = 0;
@@ -123,7 +129,7 @@ function clipSegmentToBox(
   ];
   for (const [p, q] of edges) {
     if (p === 0) {
-      if (q < 0) return null;
+      if (q <= 0) return null;
       continue;
     }
     const r = q / p;


### PR DESCRIPTION
## Summary

Owner feedback: the ground-to-resistor corner — a vertical wire rising to a horizontal resistor's pin contact — painted a red buried-wire span on the vertical segment; the same red appeared wherever a wire cornered at a pin contact of a path-artwork symbol.

**Root cause** (two facts composing):
1. Path-artwork symbols cannot be bounded from their ink, so `visibleSymbolLocalBounds` falls back to the declaration viewBox — whose padding often equals `BODY_CLEARANCE` (the resistor viewBox extends 4 units past its pin tips). After the 4-unit deflation the body-box edge lands **exactly on the pin contacts**.
2. The Liang-Barsky clip treated a segment lying exactly on a boundary line (`p === 0, q === 0`) as inside, so a wire touching the edge with **zero penetration depth** produced a full warning span.

**Fix**: the clip treats the box as open along the axis a segment does not travel (`q <= 0` rejects). Exact boundary contact is skimming — consistent with the feature's documented intent — while any strictly interior crossing keeps its warning.

## Validation

- Derivation unit suite extended to 11 cases: the pin-contact-edge case (faithful rotated-resistor reproduction) is red before / green after; the strictly-inside control stays red in both worlds.
- `overlap-warning.spec.ts` e2e green against a worktree dev server.
- The reported ground/resistor scene reproduced interactively: zero warning spans.
- Prettier + repo typecheck; `Test-Impact: tests-updated` validated by `check-test-impact`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)