### PR TITLE
fix(editor): leave guards stand down once an equally safe copy exists

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -73,6 +73,34 @@ test("blocks destructive browser refresh shortcuts and uses the stronger grid", 
     "data-refresh-guard",
     "alive",
   );
+  await page.keyboard.press("Escape");
+
+  // Once an equally safe copy exists — here the exported Project file, the
+  // same stamp a gallery publish leaves — the guards stand down: refresh is
+  // no longer intercepted and File > New Project proceeds without the
+  // unsaved-changes dialog.
+  const download = page.waitForEvent("download");
+  await clickCommand(page, "File", "Export Project File…");
+  await download;
+  await page
+    .getByTestId("status")
+    .click({ trial: true })
+    .catch(() => {});
+  await page.keyboard.press("Escape");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 60, y: 60 } });
+  await page.keyboard.press("Control+r");
+  await expect(page.getByTestId("status")).not.toHaveText(
+    "Refresh blocked to protect the current circuit",
+  );
+  await clickCommand(page, "File", "New Project");
+  await expect(
+    page.getByRole("dialog", { name: "Unsaved changes" }),
+  ).toHaveCount(0);
+  await expect(page.locator('[data-canvas-hit-kind="instance"]')).toHaveCount(
+    0,
+  );
 });
 
 test("mirrors component and copy placement previews before their commits", async ({

--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -763,10 +763,8 @@ test("drafting content and anchor survive save and reopen", async ({
     mimeType: "application/json",
     buffer: projectBytes,
   });
-  await page
-    .getByRole("dialog", { name: "Unsaved changes" })
-    .getByRole("button", { name: "Continue without saving" })
-    .click();
+  // One drafting object sits under the guard's meaningful-content
+  // threshold, so the replacement proceeds without a prompt.
   await expect(page.getByTestId("status")).toContainText(
     "Opened saved-drafting.icproj.json",
   );

--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -1671,11 +1671,13 @@ test("the Examples panel guards dirty work before opening an entry", async ({
   );
 
   await page.goto("/editor");
-  await chooseComponent(page, "resistor");
-  await page
-    .getByTestId("schematic-canvas")
-    .click({ position: { x: 360, y: 230 } });
-  await page.keyboard.press("Escape");
+  for (const x of [300, 380, 460]) {
+    await chooseComponent(page, "resistor");
+    await page
+      .getByTestId("schematic-canvas")
+      .click({ position: { x, y: 230 } });
+    await page.keyboard.press("Escape");
+  }
   await expect(page.getByTestId("hit-R1")).toHaveCount(1);
   await page.getByTestId("examples-toggle").click();
   const panel = page.getByTestId("examples-panel");

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -4130,8 +4130,10 @@ test("retains recovery across export but honors explicit discard on replacement"
   page,
 }) => {
   await page.goto("/editor");
-  await placeComponent(page, "resistor", { x: 360, y: 220 });
-  await expect(page.getByTestId("revision")).toHaveText("1");
+  for (const x of [280, 360, 440]) {
+    await placeComponent(page, "resistor", { x, y: 220 });
+  }
+  await expect(page.getByTestId("revision")).toHaveText("3");
 
   // Saving downloads the formal Project but never clears the browser
   // recovery copies; waiting past the debounce proves they survive.
@@ -4139,16 +4141,18 @@ test("retains recovery across export but honors explicit discard on replacement"
   await page.waitForTimeout(500);
   await expect
     .poll(() => recoveryProjectTexts(page))
-    .toContain('"revision": 1');
+    .toContain('"revision": 3');
 
-  await placeComponent(page, "resistor", { x: 500, y: 220 });
-  await expect(page.getByTestId("revision")).toHaveText("2");
-  // Let the debounced recovery write for revision 2 settle before replacing;
+  // A fresh edit invalidates the export's safe stamp, so the replacement
+  // below prompts again.
+  await placeComponent(page, "resistor", { x: 520, y: 220 });
+  await expect(page.getByTestId("revision")).toHaveText("4");
+  // Let the debounced recovery write for revision 4 settle before replacing;
   // a replacement inside the window intentionally drops only the pending
   // write (stale-write protection), never the stored one.
   await expect
     .poll(() => recoveryProjectTexts(page))
-    .toContain('"revision": 2');
+    .toContain('"revision": 4');
   await page
     .getByTestId("project-file")
     .setInputFiles(

--- a/apps/editor/e2e/project-file.spec.ts
+++ b/apps/editor/e2e/project-file.spec.ts
@@ -147,11 +147,14 @@ test("Gallery navigation uses the replacement decision without a second browser 
   page,
 }) => {
   await page.goto("/editor");
-  await chooseComponent(page, "resistor");
-  await page
-    .getByTestId("schematic-canvas")
-    .click({ position: { x: 360, y: 230 } });
-  await page.keyboard.press("Escape");
+  // The guard protects meaningful drawings: three authored objects.
+  for (const x of [300, 380, 460]) {
+    await chooseComponent(page, "resistor");
+    await page
+      .getByTestId("schematic-canvas")
+      .click({ position: { x, y: 230 } });
+    await page.keyboard.press("Escape");
+  }
   await page.getByRole("link", { name: "Back to the gallery" }).click();
   const guard = page.getByRole("dialog", {
     name: "Unsaved changes",
@@ -230,11 +233,14 @@ test("replacement guard offers cancel, discard, and Cloud Save", async ({
     });
   });
   await page.goto("/editor");
-  await chooseComponent(page, "resistor");
-  await page
-    .getByTestId("schematic-canvas")
-    .click({ position: { x: 360, y: 230 } });
-  await page.keyboard.press("Escape");
+  // The guard protects meaningful drawings: three authored objects.
+  for (const x of [300, 380, 460]) {
+    await chooseComponent(page, "resistor");
+    await page
+      .getByTestId("schematic-canvas")
+      .click({ position: { x, y: 230 } });
+    await page.keyboard.press("Escape");
+  }
 
   const input = page.getByTestId("project-file");
   const replacement = resolve(
@@ -264,11 +270,14 @@ test("discarding a dirty replacement does not leave a second project stack", asy
   page,
 }) => {
   await page.goto("/editor");
-  await chooseComponent(page, "resistor");
-  await page
-    .getByTestId("schematic-canvas")
-    .click({ position: { x: 360, y: 230 } });
-  await page.keyboard.press("Escape");
+  // The guard protects meaningful drawings: three authored objects.
+  for (const x of [300, 380, 460]) {
+    await chooseComponent(page, "resistor");
+    await page
+      .getByTestId("schematic-canvas")
+      .click({ position: { x, y: 230 } });
+    await page.keyboard.press("Escape");
+  }
   let fileMenu = await openMenu(page, "File");
   await fileMenu.getByRole("button", { name: "New Project" }).click();
   const dialog = page.getByRole("dialog", {
@@ -297,11 +306,15 @@ test("reverts to the last acknowledged Cloud revision", async ({ page }) => {
   await fileMenu.getByRole("button", { name: "Save", exact: true }).click();
   await expect(page.getByTestId("project-unsaved-indicator")).toHaveCount(0);
 
-  await chooseComponent(page, "resistor");
-  await page
-    .getByTestId("schematic-canvas")
-    .click({ position: { x: 500, y: 230 } });
-  await page.keyboard.press("Escape");
+  // Two more parts push the drawing over the guard's meaningful-content
+  // threshold while staying unsaved.
+  for (const x of [500, 560]) {
+    await chooseComponent(page, "resistor");
+    await page
+      .getByTestId("schematic-canvas")
+      .click({ position: { x, y: 230 } });
+    await page.keyboard.press("Escape");
+  }
   fileMenu = await openMenu(page, "File");
   await fileMenu.getByRole("button", { name: "Revert to Last Saved" }).click();
   await page
@@ -310,6 +323,7 @@ test("reverts to the last acknowledged Cloud revision", async ({ page }) => {
     .click();
   await expect(page.getByTestId("hit-R1")).toHaveCount(1);
   await expect(page.getByTestId("hit-R2")).toHaveCount(0);
+  await expect(page.getByTestId("hit-R3")).toHaveCount(0);
 });
 
 test("the circuit name drives Cloud Save and portable export", async ({

--- a/apps/editor/e2e/project-file.spec.ts
+++ b/apps/editor/e2e/project-file.spec.ts
@@ -252,7 +252,7 @@ test("replacement guard offers cancel, discard, and Cloud Save", async ({
     name: "Unsaved changes",
   });
   await dialog.getByRole("button", { name: "Stay" }).click();
-  await expect(page.getByTestId("revision")).toHaveText("1");
+  await expect(page.getByTestId("revision")).toHaveText("3");
 
   await input.evaluate((element) => ((element as HTMLInputElement).value = ""));
   await input.setInputFiles(replacement);

--- a/apps/editor/e2e/recovery-dialog.spec.ts
+++ b/apps/editor/e2e/recovery-dialog.spec.ts
@@ -128,14 +128,17 @@ test("a damaged latest copy restores the previous generation", async ({
   page,
 }) => {
   await page.goto("/editor");
-  await chooseComponent(page, "resistor");
-  await page
-    .getByTestId("schematic-canvas")
-    .click({ position: { x: 360, y: 230 } });
-  await page.keyboard.press("Escape");
+  // Three authored objects: enough for the replacement guard to engage.
+  for (const x of [300, 380, 460]) {
+    await chooseComponent(page, "resistor");
+    await page
+      .getByTestId("schematic-canvas")
+      .click({ position: { x, y: 230 } });
+    await page.keyboard.press("Escape");
+  }
   await expect
     .poll(() => recoveryProjectTexts(page))
-    .toContain('"revision": 1');
+    .toContain('"revision": 3');
 
   // Place one more edit so a valid previous generation exists, then corrupt
   // the latest record's Project text in place.

--- a/apps/editor/e2e/recovery-dialog.spec.ts
+++ b/apps/editor/e2e/recovery-dialog.spec.ts
@@ -128,17 +128,14 @@ test("a damaged latest copy restores the previous generation", async ({
   page,
 }) => {
   await page.goto("/editor");
-  // Three authored objects: enough for the replacement guard to engage.
-  for (const x of [300, 380, 460]) {
-    await chooseComponent(page, "resistor");
-    await page
-      .getByTestId("schematic-canvas")
-      .click({ position: { x, y: 230 } });
-    await page.keyboard.press("Escape");
-  }
+  await chooseComponent(page, "resistor");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 360, y: 230 } });
+  await page.keyboard.press("Escape");
   await expect
     .poll(() => recoveryProjectTexts(page))
-    .toContain('"revision": 3');
+    .toContain('"revision": 1');
 
   // Place one more edit so a valid previous generation exists, then corrupt
   // the latest record's Project text in place.
@@ -240,14 +237,17 @@ test("explicit discard removes outgoing recovery and hides a clean replacement",
   page,
 }) => {
   await page.goto("/editor");
-  await chooseComponent(page, "resistor");
-  await page
-    .getByTestId("schematic-canvas")
-    .click({ position: { x: 360, y: 230 } });
-  await page.keyboard.press("Escape");
+  // Three authored objects: enough for the replacement guard to engage.
+  for (const x of [300, 380, 460]) {
+    await chooseComponent(page, "resistor");
+    await page
+      .getByTestId("schematic-canvas")
+      .click({ position: { x, y: 230 } });
+    await page.keyboard.press("Escape");
+  }
   await expect
     .poll(() => recoveryProjectTexts(page))
-    .toContain('"revision": 1');
+    .toContain('"revision": 3');
   await page
     .getByTestId("project-file")
     .setInputFiles(

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -191,7 +191,6 @@ import {
 import { useDocumentController } from "../document/document-controller";
 import { useProjectFileLifecycle } from "../document/use-project-file-lifecycle";
 import { useUnsavedWorkGuard } from "../document/use-unsaved-work-guard";
-import { projectHasMeaningfulContent } from "../document/project-content";
 import {
   draftingDragOrigin,
   translateDraftingObject,
@@ -678,6 +677,8 @@ export function App({
     restoreAfterRefresh,
     setRecoveryDialogOpen,
     isDirtyWork,
+    hasUnsafeWork,
+    noteProjectSnapshotSafe,
     replaceActiveProject,
     saveProjectToCloud,
     exportProjectFile,
@@ -736,9 +737,7 @@ export function App({
       return nextDocument;
     },
   });
-  const allowNextBrowserUnload = useUnsavedWorkGuard(
-    isDirtyWork() && projectHasMeaningfulContent(project),
-  );
+  const allowNextBrowserUnload = useUnsavedWorkGuard(hasUnsafeWork());
   const startupCloudRestoreAttemptedRef = useRef(false);
   const hasExplicitBootTarget =
     initialGalleryEntryId !== null ||
@@ -3020,7 +3019,7 @@ export function App({
       const currentInteraction = getCurrentInteractionState();
       const shortcut = resolveEditorShortcut(event, {
         isTyping: isTypingTarget(event.target),
-        hasAuthoredContent: projectHasMeaningfulContent(project),
+        hasUnsavedWork: hasUnsafeWork(),
         interactionMode: currentInteraction.kind,
         hasRoutedMarkerSelection: Boolean(
           selectedAnnotation && isRoutedMarker(selectedAnnotation),
@@ -3805,6 +3804,9 @@ export function App({
                     }
                   : {}),
                 onPublished: ({ id, name, updated, previewRevision }) => {
+                  // The gallery now holds these exact bytes: leaving or
+                  // refreshing loses nothing until the next edit.
+                  noteProjectSnapshotSafe();
                   void primeGalleryPreview(id, previewRevision);
                   announceGalleryChange({
                     entryId: id,

--- a/apps/editor/src/document/use-project-file-lifecycle.ts
+++ b/apps/editor/src/document/use-project-file-lifecycle.ts
@@ -20,6 +20,7 @@ import {
   stageProjectFile,
 } from "./project-file-service";
 import { projectChangeToken } from "./project-session-lifecycle";
+import { projectHasMeaningfulContent } from "./project-content";
 import {
   CLOUD_PROJECT_LIMIT,
   openCloudProject,
@@ -113,6 +114,8 @@ export function useProjectFileLifecycle({
   const saveInFlightRef = useRef<Promise<CloudProjectSaveOutcome> | null>(null);
   const liveProjectRef = useRef(project);
   liveProjectRef.current = project;
+  /** Change token of the last snapshot published or exported; see hasUnsafeWork. */
+  const safeSnapshotTokenRef = useRef<string | null>(null);
   const [persistenceState, setPersistenceState] =
     useState<PersistenceState>("unbound");
   const [cloudBinding, setCloudBinding] = useState<CloudProjectBinding | null>(
@@ -144,6 +147,28 @@ export function useProjectFileLifecycle({
     );
   }
 
+  /**
+   * The one predicate every leave/replace/refresh guard shares: there is
+   * meaningful drawing, the persistence state says it has not reached the
+   * Cloud, AND no equally safe copy of exactly these bytes exists anywhere
+   * else. Publishing to the gallery or exporting the Project file stamps
+   * the current snapshot safe — the drawing is recoverable from there, so
+   * prompting again would be crying wolf.
+   */
+  function hasUnsafeWork(): boolean {
+    if (!isDirtyWork()) return false;
+    const live = liveProjectRef.current;
+    if (!projectHasMeaningfulContent(live)) return false;
+    return (
+      safeSnapshotTokenRef.current === null ||
+      projectChangeToken(live) !== safeSnapshotTokenRef.current
+    );
+  }
+
+  function noteProjectSnapshotSafe(): void {
+    safeSnapshotTokenRef.current = projectChangeToken(liveProjectRef.current);
+  }
+
   function replaceActiveProject(
     nextProject: CircuitProject,
     nextViewBox: GridRect = defaultViewBox,
@@ -157,6 +182,7 @@ export function useProjectFileLifecycle({
       recovery.noteFormalFileHint(options.formalFileHint);
     }
     const prepared = materializeRazaviProjectBulkConnections(nextProject);
+    safeSnapshotTokenRef.current = null;
     const nextDocument = installProject(prepared.project, nextViewBox);
     const nextPersistenceState =
       options.persistenceState ??
@@ -262,6 +288,8 @@ export function useProjectFileLifecycle({
       setStatus(`Export failed: ${outcome.message}`);
       return;
     }
+    // The bytes now live in a local file: leaving no longer loses them.
+    noteProjectSnapshotSafe();
     recovery.noteFormalFileHint({
       name: outcome.fileName,
       lastDownloadRequestedAt: new Date().toISOString(),
@@ -292,7 +320,7 @@ export function useProjectFileLifecycle({
     intent: string,
     perform: () => void | Promise<void>,
   ): Promise<void> {
-    if (!isDirtyWork()) {
+    if (!hasUnsafeWork()) {
       await perform();
       return;
     }
@@ -663,6 +691,8 @@ export function useProjectFileLifecycle({
     restoreAfterRefresh,
     setRecoveryDialogOpen,
     isDirtyWork,
+    hasUnsafeWork,
+    noteProjectSnapshotSafe,
     replaceActiveProject,
     saveProjectToCloud,
     exportProjectFile,

--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -8,7 +8,7 @@ import type {
 
 const baseContext: EditorShortcutContext = {
   isTyping: false,
-  hasAuthoredContent: true,
+  hasUnsavedWork: true,
   interactionMode: "idle",
   hasRoutedMarkerSelection: false,
   canRotate: false,
@@ -408,7 +408,7 @@ describe("editor shortcut contract", () => {
 
 describe("blank-circuit refresh", () => {
   it("lets the browser refresh when nothing is authored", () => {
-    const empty = { ...baseContext, hasAuthoredContent: false };
+    const empty = { ...baseContext, hasUnsavedWork: false };
     expect(
       resolveEditorShortcut(
         {

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -12,7 +12,7 @@ export interface EditorShortcutKey {
 export interface EditorShortcutContext {
   isTyping: boolean;
   /** Blank circuits let the browser refresh; there is nothing to protect. */
-  hasAuthoredContent: boolean;
+  hasUnsavedWork: boolean;
   interactionMode: InteractionMode;
   hasRoutedMarkerSelection: boolean;
   canRotate: boolean;
@@ -78,24 +78,18 @@ export function resolveEditorShortcut(
     return { kind: "toggle-wire-options" };
   }
   if (event.key === "F5") {
-    return context.hasAuthoredContent
-      ? { kind: "block-browser-refresh" }
-      : null;
+    return context.hasUnsavedWork ? { kind: "block-browser-refresh" } : null;
   }
   if (commandModifier && key === "r") {
     if (context.isTyping) {
-      return context.hasAuthoredContent
-        ? { kind: "block-browser-refresh" }
-        : null;
+      return context.hasUnsavedWork ? { kind: "block-browser-refresh" } : null;
     }
     if (context.canMirror)
       return {
         kind: "run-command",
         command: { id: "transform.mirror", direction: "top-bottom" },
       };
-    return context.hasAuthoredContent
-      ? { kind: "block-browser-refresh" }
-      : null;
+    return context.hasUnsavedWork ? { kind: "block-browser-refresh" } : null;
   }
   if (commandModifier && key === "d") {
     if (context.isTyping) return { kind: "block-browser-bookmark" };


### PR DESCRIPTION
Owner report: "publish 之后或者 save 之后,退出或者刷新的时候还是会跳 unsaved changes … 如果 published 或者 saved,然后没有新的修改,或者最开始整个都是空的,就不应该跳".

Root cause: the three guard surfaces disagreed —
- **beforeunload**: dirty-state based (correct after Save, wrong after Publish);
- **Ctrl+R / F5 interception**: content-existence based only — blocked refresh even on a freshly saved circuit;
- **in-app replace guard** (File → New, open, gallery nav): dirty-based but without the meaningful-content exemption;
- **Publish** never marked anything saved.

Now one predicate (`hasUnsafeWork`) drives all three: meaningful content (≥3 authored objects) that persistence calls unsaved **and** whose exact bytes exist nowhere safe. A successful gallery publish or Project-file export stamps the live snapshot's change token as safe (any later edit invalidates it; project replacement resets it); Cloud Save already flips state clean.

Coverage: shortcut-layer rename `hasAuthoredContent` → `hasUnsavedWork` with tests updated; extended the refresh-guard e2e — blocked while unsaved, then after an export (same stamp a publish leaves) Ctrl+R passes and File → New proceeds with no dialog. Editor suite 672/672; project-file + recovery guard e2e 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)