### PR TITLE
Hide digital simulation in Cloudflare builds

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -34,6 +34,10 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @icm/editor... build
+        env:
+          # Timing simulation remains a localhost development surface until
+          # its interaction and presentation contracts are ready to publish.
+          VITE_ICM_TIMING_UI: disabled
       - run: pnpm dlx wrangler@4.120.1 deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -21,12 +21,8 @@ edit model.
   and child Cells.
 - **Projects and interchange:** save a private Cloud Project, import/export
   canonical `.icproj.json`, import structural `.cir`, `.sp`, and `.spi` files, and export
-  deterministic structural SPICE or Spectre.
-- **Digital timing simulation:** drive supported logic with a Digital Clock,
-  save Nets for observation, inspect and export deterministic waveforms, and
-  optionally place grouped waveform snapshots on the canvas. This bounded
-  digital layer does not supply analog simulation, PDKs, device models,
-  corners, or transistor-level analyses.
+  deterministic structural SPICE or Spectre. Analog Canvas does not supply
+  simulation, PDKs, device models, corners, stimuli, or analyses.
 - **Publication-ready output:** the web editor's SVG and PDF exports remain
   vector graphics; PNG is rendered at 3× raster scale.
 - **Community publishing:** signed-in users can publish selected circuits with

--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -190,12 +190,18 @@ describe("editor shell", () => {
     expect(markup).not.toContain("Approve Agent file import");
   });
 
-  it("always exposes Digital Simulation while keeping its window closed", () => {
-    const project = createEmptyProject("digital-simulation", "Simulation");
-    const markup = renderToStaticMarkup(<App project={project} />);
+  it("keeps the timing surface behind its deployment flag", () => {
+    const project = createEmptyProject("timing-flag", "Timing Flag");
+    const localMarkup = renderToStaticMarkup(
+      <App project={project} timingUiEnabled />,
+    );
+    const productionMarkup = renderToStaticMarkup(
+      <App project={project} timingUiEnabled={false} />,
+    );
 
-    expect(markup).toContain('title="Digital Simulation"');
-    expect(markup).not.toContain('data-testid="timing-simulation-panel"');
+    expect(localMarkup).toContain('title="Digital Simulation"');
+    expect(productionMarkup).not.toContain('title="Digital Simulation"');
+    expect(localMarkup).not.toContain('data-testid="timing-simulation-panel"');
   });
 
   it("links to first-party visitor analytics without crowding editor commands", () => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -98,6 +98,7 @@ import {
 } from "../features/editor-shell/editor-file-commands";
 import { EditorStatusbar } from "../features/editor-shell/editor-statusbar";
 import { TimingSimulationPanel } from "../features/simulation/timing-simulation-panel";
+import { TIMING_UI_ENABLED } from "../features/simulation/timing-ui";
 import { updateComponentParameterValues } from "../features/component-insert/component-parameters";
 import {
   waveformDraftingObjects,
@@ -321,6 +322,8 @@ export interface AppProps {
   visitStats?: { pv: number; uv: number } | null;
   /** Test/staging seam; production defaults to a human-only editor. */
   publicAgentUiEnabled?: boolean;
+  /** Test/staging seam; production Cloudflare builds keep timing tools hidden. */
+  timingUiEnabled?: boolean;
   /** `/g/<id>` deep link: load this gallery entry after boot. */
   initialGalleryEntryId?: string | null;
 }
@@ -329,6 +332,7 @@ export function App({
   project: initialProject,
   visitStats,
   publicAgentUiEnabled = PUBLIC_AGENT_UI_ENABLED,
+  timingUiEnabled = TIMING_UI_ENABLED,
   initialGalleryEntryId = null,
 }: AppProps) {
   const [preparedInitialProject] = useState(
@@ -3550,15 +3554,19 @@ export function App({
             setDocumentSettingsOpen((open) => !open);
             setSelectionOpen(true);
           },
-          simulation: {
-            open: simulationWindowOpen,
-            onToggle: () => {
-              setSimulationWindowOpen((open) => {
-                if (open) setSimulationPickMode(false);
-                return !open;
-              });
-            },
-          },
+          ...(timingUiEnabled
+            ? {
+                simulation: {
+                  open: simulationWindowOpen,
+                  onToggle: () => {
+                    setSimulationWindowOpen((open) => {
+                      if (open) setSimulationPickMode(false);
+                      return !open;
+                    });
+                  },
+                },
+              }
+            : {}),
         }}
         hierarchyToolbar={{
           documents: project.documents,
@@ -4773,22 +4781,24 @@ export function App({
           />
         ) : null}
       </div>
-      <TimingSimulationPanel
-        key={document.id}
-        document={document}
-        open={simulationWindowOpen}
-        savedNetIds={simulationSavedNetIds}
-        pickNetsActive={simulationPickNetsActive}
-        onOpenChange={(open) => {
-          setSimulationWindowOpen(open);
-          if (!open) setSimulationPickMode(false);
-        }}
-        onPickNetsChange={setSimulationPickMode}
-        onToggleSavedNet={toggleSimulationSavedNet}
-        onSetSavedNets={(netIds) => setSimulationSavedNetIds(new Set(netIds))}
-        onStatus={setStatus}
-        onPlaceOnCanvas={beginWaveformPlacement}
-      />
+      {timingUiEnabled ? (
+        <TimingSimulationPanel
+          key={document.id}
+          document={document}
+          open={simulationWindowOpen}
+          savedNetIds={simulationSavedNetIds}
+          pickNetsActive={simulationPickNetsActive}
+          onOpenChange={(open) => {
+            setSimulationWindowOpen(open);
+            if (!open) setSimulationPickMode(false);
+          }}
+          onPickNetsChange={setSimulationPickMode}
+          onToggleSavedNet={toggleSimulationSavedNet}
+          onSetSavedNets={(netIds) => setSimulationSavedNetIds(new Set(netIds))}
+          onStatus={setStatus}
+          onPlaceOnCanvas={beginWaveformPlacement}
+        />
+      ) : null}
       <EditorStatusbar
         visitStats={visitStats}
         status={status}

--- a/apps/editor/src/features/component-insert/symbol-catalog.test.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.test.ts
@@ -101,7 +101,7 @@ describe("component insertion catalog", () => {
     expect(symbols[0]?.pins.map((pin) => pin.name)).toEqual(["P1", "P2"]);
   });
 
-  it("offers Digital Clock as a searchable built-in source", () => {
+  it("offers Digital Clock locally but can remove it with the production flag", () => {
     expect(
       findPaletteSymbol("razavi-textbook-v1", "pulse-voltage-source"),
     )?.toMatchObject({
@@ -113,6 +113,14 @@ describe("component insertion catalog", () => {
         componentCatalog("razavi-textbook-v1", "digital clock"),
       ),
     ).toHaveLength(1);
+    expect(
+      findPaletteSymbol("razavi-textbook-v1", "pulse-voltage-source", false),
+    ).toBeUndefined();
+    expect(
+      flattenComponentCatalog(
+        componentCatalog("razavi-textbook-v1", "digital clock", [], false),
+      ),
+    ).toEqual([]);
   });
 
   it("keeps adjustable passives, diodes, and DMOS in one extended library", () => {

--- a/apps/editor/src/features/component-insert/symbol-catalog.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.ts
@@ -12,6 +12,7 @@ import {
   isAnnotationPaletteSymbol,
 } from "./annotation-preview-symbols";
 import { vddRailPreviewSymbol } from "./vdd-rail-preview-symbol";
+import { TIMING_UI_ENABLED } from "../simulation/timing-ui";
 
 /**
  * Reach order rather than taxonomy order: the devices placed most often in a
@@ -144,13 +145,19 @@ export function libraryDescription(symbolId: string): string | undefined {
   return LIBRARY_DESCRIPTIONS[symbolId];
 }
 
-export function paletteSymbols(_styleProfileId: string): SymbolDefinition[] {
-  return [
+export function paletteSymbols(
+  _styleProfileId: string,
+  timingUiEnabled = TIMING_UI_ENABLED,
+): SymbolDefinition[] {
+  const symbols = [
     vddRailPreviewSymbol,
     ...razaviProductSymbols,
     ...annotationPreviewSymbols,
     ...expandedDeviceSymbols,
   ];
+  return timingUiEnabled
+    ? symbols
+    : symbols.filter((symbol) => symbol.id !== "pulse-voltage-source");
 }
 
 /**
@@ -220,12 +227,13 @@ export function componentCatalog(
   styleProfileId: string,
   query: string,
   recentSymbolIds: readonly string[] = [],
+  timingUiEnabled = TIMING_UI_ENABLED,
 ): ComponentCatalogGroup[] {
   const normalizedQuery = query.trim().toLowerCase();
   const recentRank = new Map(
     recentSymbolIds.map((symbolId, index) => [symbolId, index]),
   );
-  const symbols = paletteSymbols(styleProfileId)
+  const symbols = paletteSymbols(styleProfileId, timingUiEnabled)
     .filter(
       (symbol) =>
         normalizedQuery.length === 0 ||
@@ -250,8 +258,9 @@ export function componentCatalog(
 export function findPaletteSymbol(
   styleProfileId: string,
   symbolId: string,
+  timingUiEnabled = TIMING_UI_ENABLED,
 ): SymbolDefinition | undefined {
-  return paletteSymbols(styleProfileId).find(
+  return paletteSymbols(styleProfileId, timingUiEnabled).find(
     (symbol) => symbol.id === symbolId,
   );
 }

--- a/apps/editor/src/features/simulation/timing-ui.test.ts
+++ b/apps/editor/src/features/simulation/timing-ui.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveTimingUiEnabled } from "./timing-ui";
+
+describe("resolveTimingUiEnabled", () => {
+  it("shows timing tools during local development and hides them in production", () => {
+    expect(resolveTimingUiEnabled({ production: false })).toBe(true);
+    expect(resolveTimingUiEnabled({ production: true })).toBe(false);
+  });
+
+  it("supports an explicit staging or local override", () => {
+    expect(
+      resolveTimingUiEnabled({ production: true, configured: "enabled" }),
+    ).toBe(true);
+    expect(
+      resolveTimingUiEnabled({ production: false, configured: "disabled" }),
+    ).toBe(false);
+  });
+});

--- a/apps/editor/src/features/simulation/timing-ui.ts
+++ b/apps/editor/src/features/simulation/timing-ui.ts
@@ -1,0 +1,21 @@
+/**
+ * Controls the experimental human-facing digital timing tools.
+ *
+ * The deterministic simulation package and persisted circuit contracts never
+ * depend on this flag. Local development enables the UI by default, while a
+ * production build (including Cloudflare) keeps it hidden unless a staging
+ * build explicitly opts in.
+ */
+export function resolveTimingUiEnabled(input: {
+  production: boolean;
+  configured?: string;
+}): boolean {
+  if (input.configured === "enabled") return true;
+  if (input.configured === "disabled") return false;
+  return !input.production;
+}
+
+export const TIMING_UI_ENABLED = resolveTimingUiEnabled({
+  production: import.meta.env.PROD,
+  configured: import.meta.env.VITE_ICM_TIMING_UI,
+});

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -1,4 +1,4 @@
-/* Digital Simulation tool window and waveform viewer. */
+/* Local-development Digital Simulation tool window and waveform viewer. */
 
 .digital-simulation-window {
   position: fixed;

--- a/docs/adr/0049-deterministic-digital-timing-simulation.md
+++ b/docs/adr/0049-deterministic-digital-timing-simulation.md
@@ -4,9 +4,6 @@ Status: `accepted`
 
 Date: `2026-08-28`
 
-Amended: `2026-08-29` to publish the accepted interaction in every editor
-build after its release gates passed.
-
 Owners: `packages/simulation`, `packages/devices`, `packages/netlist`
 
 ## Context
@@ -33,11 +30,12 @@ terminal must connect to Ground; its positive terminal drives the logical Net.
 
 Saved nodes are observation selections in the run profile, not electrical
 probes. Simulation results remain derived data and are not stored in Project
-JSON. Every editor build exposes Digital Clock authoring and one Digital
-Simulation window containing timing controls, saved-Net selection, waveform
-presentation and export, and optional canvas placement. Production and local
-builds use the same interaction path; there is no deployment-specific timing
-UI flag.
+JSON. The local development editor exposes timing controls, waveform
+presentation and export, optional canvas placement, and Pulse Source authoring
+behind `VITE_ICM_TIMING_UI`. The default is enabled for local development and
+disabled for production; the Cloudflare workflow also sets `disabled`
+explicitly. The simulation layer and project compatibility never depend on
+this presentation flag.
 
 Razavi Figure 20.54 governs presentation only: stacked square traces, signal
 labels, dashed timing guides, and a horizontal time axis. It cannot establish
@@ -49,7 +47,7 @@ logic values, event ordering, or clock semantics.
 - The simulation layer can grow without making the editor or netlist exporter
   its execution engine.
 - Existing projects containing Pulse Sources remain loadable in every build;
-  every editor palette supports authoring new Digital Clocks.
+  the local development palette also supports authoring new Pulse Sources.
 - An unused DFF `QBAR` output may remain unconnected; `D`, `CK`, and `Q` remain
   required for the supported rising-edge behavior.
 - Gate delay, setup/hold timing, metastability, hierarchy, and analog threshold
@@ -61,5 +59,5 @@ logic values, event ordering, or clock semantics.
   optional `QBAR`, and logical-Net equivalence.
 - Device and netlist tests cover the two-terminal Pulse Source defaults and
   SPICE/Spectre `PULSE` output.
-- Editor and browser tests cover the shared timing controls, Digital Clock,
-  waveform export, and optional canvas placement used by every deployment.
+- Editor and browser tests cover the local timing controls and Pulse Source;
+  flag tests and the deployment workflow protect the production-hidden state.

--- a/docs/overall-product-plan.md
+++ b/docs/overall-product-plan.md
@@ -3,8 +3,7 @@
 Analog Canvas is a local-first schematic editor. A human edits a circuit in the
 browser, while an authorized Agent may inspect and modify the same live Project
 through typed, revision-checked requests. The product is an editor and a
-structural circuit tool with a bounded deterministic digital timing layer; it
-is not an analog or transistor-level simulator, version-control service, or
+structural circuit tool; it is not a simulator, version-control service, or
 general browser-automation service.
 
 ## Product boundary
@@ -30,7 +29,6 @@ The authoritative sources are deliberately separate:
 | Visual construction and acceptance   | Razavi reference manifest and [visual contract](specs/razavi-visual-contract.md) |
 | SPICE import                         | `@icm/spice` transient Circuit IR                                                |
 | Design-netlist export                | `@icm/netlist` transient DesignNetlistIR                                         |
-| Digital timing execution             | `@icm/simulation` over current Document and run profile                          |
 | Browser Agent session                | accepted [web-session spec](specs/web-agent-session.md)                          |
 
 ## System shape
@@ -44,7 +42,6 @@ human UI / authorized Agent
             ▼
        Project and Document model
         ├─ derived connectivity and diagnostics
-        ├─ derived digital timing traces
         ├─ SVG/PNG/PDF formal export
         ├─ structural SPICE/Spectre export
         └─ explicit Cloud Save / portable Project interchange

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -53,23 +53,6 @@ palette-first manual authoring; no Project file needs to be opened first.
 - Use `Ctrl`+mouse wheel to zoom around the cursor and middle-button drag to
   pan. View changes do not increment the Document revision.
 
-## Simulate digital timing
-
-Place a two-terminal **Digital Clock**, connect its negative terminal to
-Ground, and set its Period, Duty cycle, and Initial level in Properties. The
-first simulation block supports Buffer, inverter, two-input AND/OR/NAND/NOR/
-XOR/XNOR gates, and rising-edge D flip-flops in addition to the clock source.
-Unsupported devices are reported instead of receiving guessed behavior.
-
-Choose **Simulation** in the top toolbar to open the single Digital Simulation
-window. Use **Pick Nets** and click anywhere along a connected wire, Net label,
-or port to add an observed Net; `Esc` ends picking. A saved Net's waveform name
-can be edited without changing its electrical name. Set the duration and run
-the simulation to inspect the stacked traces. The same window can export SVG
-or PNG, or start **Place on Canvas** to create a grouped, scalable waveform
-snapshot. Run results remain temporary unless exported or placed; they are not
-stored as simulation data in the Project file.
-
 ## Save and recover
 
 **File / Save** (or `Ctrl+S`) saves the current content to one private Cloud

--- a/packages/simulation/README.md
+++ b/packages/simulation/README.md
@@ -12,9 +12,10 @@ The first supported set is:
 
 Simulation time is an integer number of picoseconds. Saved Net IDs select
 traces to return; they do not change circuit connectivity. Browser run results
-are intentionally temporary. Every editor build exposes Digital Clock
-authoring and one Digital Simulation window for setup, saved Nets, waveform
-viewing and export, and optional canvas placement.
+are intentionally temporary. The local development editor exposes the timing
+panel, waveform export, optional canvas placement, and Digital Clock authoring;
+Cloudflare production builds explicitly keep that experimental UI hidden.
+The simulation package and project compatibility do not depend on the UI flag.
 
 This package does not model analog thresholds, propagation delay, setup/hold
 windows, metastability, or transistor-level behavior.


### PR DESCRIPTION
## Summary
- hide the Digital Simulation toolbar/window in Cloudflare production builds
- remove Digital Clock from production authoring surfaces while keeping existing project compatibility and the simulation engine intact
- keep Digital Simulation enabled by default for localhost and development builds
- restore production-hidden documentation and regression coverage

## Validation
- pnpm test:local apps/editor/src/features/simulation/timing-ui.test.ts apps/editor/src/app/App.test.tsx apps/editor/src/app/symbol-catalog.test.ts
- focused Digital Simulation Playwright test
- Cloudflare-equivalent production build with VITE_ICM_TIMING_UI=disabled
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- pnpm gate:full -- --base origin/main (1764 unit tests and 264 Playwright tests passed)

Test-Impact: tests-updated