### PR TITLE
fix(edit-engine): a drag repairs a non-45-degree slanted route leg

### DIFF
--- a/packages/edit-engine/src/route-geometry-edit.ts
+++ b/packages/edit-engine/src/route-geometry-edit.ts
@@ -232,13 +232,9 @@ export function moveRouteSegment(
   const to = points[segmentIndex + 1]!;
   const horizontal = from.y === to.y;
   const vertical = from.x === to.x;
+  const slanted = !horizontal && !vertical;
   const diagonal =
-    !horizontal &&
-    !vertical &&
-    Math.abs(to.x - from.x) === Math.abs(to.y - from.y);
-  if (!horizontal && !vertical && !diagonal) {
-    throw new Error("Route segment move requires octilinear geometry");
-  }
+    slanted && Math.abs(to.x - from.x) === Math.abs(to.y - from.y);
   const lastSegmentIndex = points.length - 2;
 
   // A diagonal segment has one perpendicular degree of freedom.  Express its
@@ -257,6 +253,33 @@ export function moveRouteSegment(
     if (!isOctilinear(normalized.points)) {
       throw new Error(
         "Diagonal segment move would make geometry non-octilinear",
+      );
+    }
+    return {
+      waypoints: normalized.points.slice(1, -1),
+      segmentModes: normalized.segmentModes,
+    };
+  }
+
+  // A slanted leg outside the 45-degree family should never survive an
+  // edit, so its drag both moves and repairs it: the leg is replaced by an
+  // orthogonal Z along its dominant axis through the dragged coordinate,
+  // with perpendicular jogs at the unmoved endpoints. Model geometry can
+  // hold such a leg (an imported or auto-laid-out file), and refusing the
+  // drag would leave no mouse-only way to fix it.
+  if (slanted) {
+    const axis: "x" | "y" =
+      Math.abs(to.y - from.y) > Math.abs(to.x - from.x) ? "x" : "y";
+    const coordinate = target[axis];
+    const shiftedFrom = { ...from, [axis]: coordinate };
+    const shiftedTo = { ...to, [axis]: coordinate };
+    const mode = modes[segmentIndex] ?? "manual";
+    points.splice(segmentIndex + 1, 0, shiftedFrom, shiftedTo);
+    modes.splice(segmentIndex, 1, mode, mode, mode);
+    const normalized = normalizeRouteGeometry(points, modes);
+    if (!isOctilinear(normalized.points)) {
+      throw new Error(
+        "Slanted segment move would make geometry non-octilinear",
       );
     }
     return {

--- a/packages/edit-engine/src/route-operations.ts
+++ b/packages/edit-engine/src/route-operations.ts
@@ -787,7 +787,12 @@ export function proposeWireSegmentDrag(
   const toPoint = selectedPolyline.points[segmentIndex + 1]!;
   const horizontal = fromPoint.y === toPoint.y;
   const vertical = fromPoint.x === toPoint.x;
-  const diagonal = !horizontal && !vertical;
+  const slanted = !horizontal && !vertical;
+  // Only an exact 45-degree leg keeps its perpendicular-offset drag; any
+  // other slant is repaired by the dominant-axis path below.
+  const diagonal =
+    slanted &&
+    Math.abs(toPoint.x - fromPoint.x) === Math.abs(toPoint.y - fromPoint.y);
   if (horizontal && vertical) {
     throw new Error(`Route ${routeId} segment is degenerate`);
   }
@@ -890,7 +895,15 @@ export function proposeWireSegmentDrag(
     };
   }
 
-  const axis: "x" | "y" = horizontal ? "y" : "x";
+  // A slanted (non-45) leg is dragged along its dominant axis: a nearly
+  // vertical leg moves horizontally like a vertical one, and the planned
+  // geometry lands orthogonal, so the drag repairs the slant it touches.
+  const axis: "x" | "y" =
+    horizontal ||
+    (slanted &&
+      Math.abs(toPoint.x - fromPoint.x) > Math.abs(toPoint.y - fromPoint.y))
+      ? "y"
+      : "x";
   const coordinate = target[axis];
   const movedJunctions = new Map<string, Point>();
   for (const anchorId of [leftAnchorId, rightAnchorId]) {

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -778,6 +778,121 @@ describe("routing Edit Engine", () => {
     ]);
   });
 
+  it("drags a junction-tapped slanted leg by its dominant axis and restores orthogonality", () => {
+    // The reported shelf circuit: a tap Junction on a horizontal net, and a
+    // nearly vertical leg (Δx = 40, Δy ≈ 130) dropping to a pin. Dragging
+    // that leg sideways must slide the Junction along its host wire, land
+    // the leg vertical at the target x, and dogleg into the unmoved pin —
+    // repairing the slant instead of refusing the drag.
+    const document = documentFixture();
+    document.junctions.push({
+      id: "junction-tap",
+      netId: "net-h",
+      position: { x: 300, y: 300 },
+    });
+    document.routes.push(
+      createRoutePath({
+        id: "route-host-a",
+        netId: "net-h",
+        start: terminal("A"),
+        end: { kind: "junction", junctionId: "junction-tap" },
+        bends: [],
+        modes: ["manual"],
+      }),
+      createRoutePath({
+        id: "route-host-b",
+        netId: "net-h",
+        start: { kind: "junction", junctionId: "junction-tap" },
+        end: terminal("B"),
+        bends: [],
+        modes: ["manual"],
+      }),
+      createRoutePath({
+        id: "route-slant",
+        netId: "net-h",
+        start: { kind: "junction", junctionId: "junction-tap" },
+        end: terminal("E"),
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+    const plan = proposeWireSegmentMove(document, resolver, "route-slant", 0, {
+      x: 260,
+      y: 370,
+    });
+    const moved = executeTransaction(
+      document,
+      transaction(document.id, 0, plan.edits),
+      context,
+    );
+    expect(moved.ok).toBe(true);
+    if (!moved.ok) return;
+    expect(
+      moved.document.junctions.find(
+        (junction) => junction.id === "junction-tap",
+      )?.position,
+    ).toEqual({ x: 260, y: 300 });
+    for (const route of moved.document.routes) {
+      expect(
+        resolveRouteGeometry(moved.document, resolver, route)?.centerline,
+      ).toSatisfy((points: Array<{ x: number; y: number }>) =>
+        isOrthogonal(points),
+      );
+    }
+  });
+
+  it("doglegs a slanted leg between two pins at the dragged coordinate", () => {
+    // Both endpoints hard (pins), horizontal-dominant slant: the connector
+    // must become orthogonal through the dragged y, with jogs at the
+    // unmoved pins.
+    const document = documentFixture();
+    document.routes.push(
+      createRoutePath({
+        id: "route-slant-2",
+        netId: "net-h",
+        start: terminal("A"),
+        end: terminal("E"),
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+    const before = resolveRouteGeometry(
+      document,
+      resolver,
+      document.routes.find((route) => route.id === "route-slant-2")!,
+    )!.centerline;
+    const slantIndex = before.findIndex(
+      (point, index) =>
+        index + 1 < before.length &&
+        point.x !== before[index + 1]!.x &&
+        point.y !== before[index + 1]!.y,
+    );
+    expect(slantIndex).toBeGreaterThanOrEqual(0);
+    const plan = proposeWireSegmentMove(
+      document,
+      resolver,
+      "route-slant-2",
+      slantIndex,
+      { x: 240, y: 360 },
+    );
+    const moved = executeTransaction(
+      document,
+      transaction(document.id, 0, plan.edits),
+      context,
+    );
+    expect(moved.ok).toBe(true);
+    if (!moved.ok) return;
+    const centerline = resolveRouteGeometry(
+      moved.document,
+      resolver,
+      moved.document.routes.find((route) => route.id === "route-slant-2")!,
+    )?.centerline;
+    expect(centerline).toSatisfy((points: Array<{ x: number; y: number }>) =>
+      isOrthogonal(points),
+    );
+    expect(centerline?.some((point) => point.y === 360)).toBe(true);
+  });
+
   it("authors every planned internal Route so group geometry is order-independent", () => {
     const document = documentFixture();
     const routed = executeTransaction(


### PR DESCRIPTION
## Summary

Owner feedback: a nearly vertical wire on a shelf circuit (tap Junction on a horizontal net dropping to an inverter pin) could not be dragged sideways at all. The drag machinery recognized horizontal, vertical, and exact 45° legs; any other slant fell through to `moveRouteSegment`, which threw `Route segment move requires octilinear geometry` — surfaced only as a transient status message, so the drag silently did nothing. Model geometry can hold such a leg (imported or auto-laid-out files), and refusing the drag left no mouse-only way to repair it.

A slanted (non-45°) leg is now dragged along its **dominant axis**, and the planned geometry lands **orthogonal** — the drag repairs the slant it touches:

- `proposeWireSegmentDrag` restricts the perpendicular-offset branch to exact 45° legs (its offset formula assumes unit slope) and routes other slants through the topology-aware axis path: an endpoint Junction slides along its host wire and incident routes stretch exactly like an orthogonal drag.
- `moveRouteSegment` replaces the slanted leg with an orthogonal Z along the dominant axis through the dragged coordinate, with perpendicular jogs at the unmoved endpoints; exact 45° legs keep their established octilinear behavior.

## Validation

- Routing suite grown to 48 cases: the junction-tapped slant (the reported topology) and a two-pin horizontal-dominant slant are both red before this change.
- Route-family suites green: 69 tests across routing, geometry-edit, leg-mutation, transform/deletion planners, and editor route-interaction geometry — rerun on this exact base.
- Interactive proof: imported a slanted-leg project, dragged the leg — it landed orthogonal at the target (`230,300 → 230,450 → 340,450`) with the Junction slid along its host wire.
- Prettier + repo typecheck; `Test-Impact: tests-updated` validated by `check-test-impact`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)