### PR TITLE
fix(editor): the gallery header holds a name, and the tag row holds one line

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -475,6 +475,92 @@ test("clicking a byline filters the wall to that author, clearable", async ({
   await expect(page).not.toHaveURL(/author=/);
 });
 
+test("the tag row filters, collapses, and keeps a selection visible", async ({
+  page,
+}) => {
+  // Enough tags that the row would wrap over several lines unfiltered, which
+  // is what pushed the wall itself below the fold.
+  const tags = [
+    "amplifier",
+    "oscillator",
+    "comparator",
+    "dcdc",
+    "power",
+    "differential",
+    "ota",
+    "pll",
+    "vtc",
+    "adc",
+    "bandgap",
+    "cmfb",
+    "current mirror",
+    "ldo",
+  ];
+  await page.route("**/api/gallery**", (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname === "/api/gallery/tags") {
+      return route.fulfill({
+        json: { tags: tags.map((tag, index) => ({ tag, count: index + 1 })) },
+      });
+    }
+    if (url.pathname !== "/api/gallery") return route.fallback();
+    return route.fulfill({
+      json: {
+        entries: [
+          {
+            id: "t-one",
+            name: "Circuit",
+            author: "tz",
+            description: "",
+            createdAt: "2026-08-22T10:00:00.000Z",
+            schemaVersion: 23,
+            tags: ["ldo"],
+          },
+        ],
+        nextCursor: null,
+      },
+    });
+  });
+  await page.route("**/api/gallery/*/preview.svg", (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"><rect width="10" height="6" fill="#fff"/></svg>',
+    }),
+  );
+
+  await page.goto("/");
+  const bar = page.getByTestId("gallery-tag-bar");
+  await expect(page.getByTestId("gallery-tag-option-amplifier")).toBeVisible();
+
+  // Collapsed: the tail is offered rather than shown.
+  const collapsed = await bar.getByRole("button").count();
+  await expect(page.getByTestId("gallery-tags-show-all")).toBeVisible();
+  await expect(page.getByTestId("gallery-tag-option-ldo")).toHaveCount(0);
+
+  await page.getByTestId("gallery-tags-show-all").click();
+  await expect(page.getByTestId("gallery-tag-option-ldo")).toBeVisible();
+  expect(await bar.getByRole("button").count()).toBeGreaterThan(collapsed);
+  await page.getByTestId("gallery-tags-show-fewer").click();
+  await expect(page.getByTestId("gallery-tag-option-ldo")).toHaveCount(0);
+
+  // Filtering reaches a tag the collapsed row does not show.
+  await page.getByTestId("gallery-tag-search").fill("ld");
+  await expect(page.getByTestId("gallery-tag-option-ldo")).toBeVisible();
+  await expect(page.getByTestId("gallery-tag-option-amplifier")).toHaveCount(0);
+
+  // A selected tag survives clearing the filter and re-collapsing: the row
+  // may never hide the reason the wall is filtered.
+  await page.getByTestId("gallery-tag-option-ldo").click();
+  await page.getByTestId("gallery-tag-search").fill("");
+  await expect(page.getByTestId("gallery-tag-option-ldo")).toBeVisible();
+  await expect(page.getByTestId("gallery-tags-clear")).toContainText(
+    "Clear 1 selected",
+  );
+
+  await page.getByTestId("gallery-tag-search").fill("zzz");
+  await expect(page.getByTestId("gallery-tags-empty")).toBeVisible();
+});
+
 test("the tag menu multi-selects and tile tags join the selection", async ({
   page,
 }) => {

--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -561,6 +561,73 @@ test("the tag row filters, collapses, and keeps a selection visible", async ({
   await expect(page.getByTestId("gallery-tags-empty")).toBeVisible();
 });
 
+test("Any tag selects every tag as one union and takes it back", async ({
+  page,
+}) => {
+  const listQueries: string[] = [];
+  const tags = ["amplifier", "adc", "pll"];
+  await page.route("**/api/gallery**", (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname === "/api/gallery/tags") {
+      return route.fulfill({
+        json: { tags: tags.map((tag, i) => ({ tag, count: i + 1 })) },
+      });
+    }
+    if (url.pathname !== "/api/gallery") return route.fallback();
+    const selected = (url.searchParams.get("tags") ?? "")
+      .split(",")
+      .filter(Boolean);
+    listQueries.push(selected.join(","));
+    const all = [
+      { id: "t-amp", tags: ["amplifier"] },
+      { id: "t-pll", tags: ["pll"] },
+      // Untagged work is exactly what "Any tag" leaves out, which is why the
+      // control is not called "select all".
+      { id: "t-bare", tags: [] as string[] },
+    ];
+    const entries = all
+      .filter(
+        (entry) =>
+          selected.length === 0 ||
+          entry.tags.some((tag) => selected.includes(tag)),
+      )
+      .map((entry) => ({
+        id: entry.id,
+        name: `Circuit ${entry.id}`,
+        author: "tz",
+        description: "",
+        createdAt: "2026-08-22T10:00:00.000Z",
+        schemaVersion: 23,
+        tags: entry.tags,
+      }));
+    return route.fulfill({ json: { entries, nextCursor: null } });
+  });
+  await page.route("**/api/gallery/*/preview.svg", (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"><rect width="10" height="6" fill="#fff"/></svg>',
+    }),
+  );
+
+  await page.goto("/");
+  await expect(page.getByTestId("gallery-tile-t-bare")).toBeVisible();
+  const any = page.getByTestId("gallery-tags-any");
+  await expect(any).toHaveAttribute("aria-pressed", "false");
+
+  await any.click();
+  await expect(any).toHaveAttribute("aria-pressed", "true");
+  // Every tag rides in the query as one union, and the untagged circuit goes.
+  await expect(page.getByTestId("gallery-tile-t-amp")).toBeVisible();
+  await expect(page.getByTestId("gallery-tile-t-bare")).toHaveCount(0);
+  expect(listQueries).toContain("amplifier,adc,pll");
+  // With everything on there is nothing partial left to clear.
+  await expect(page.getByTestId("gallery-tags-clear")).toHaveCount(0);
+
+  await any.click();
+  await expect(any).toHaveAttribute("aria-pressed", "false");
+  await expect(page.getByTestId("gallery-tile-t-bare")).toBeVisible();
+});
+
 test("the tag menu multi-selects and tile tags join the selection", async ({
   page,
 }) => {

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -48,6 +48,12 @@ export interface GalleryFeedState {
 }
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
+/**
+ * How many tags the bar shows before it offers the rest. One row at a typical
+ * desktop width; the wall is what the reader came for, so the tags stay a
+ * header rather than becoming the page.
+ */
+const COLLAPSED_TAG_COUNT = 10;
 const OWNER_REJECT_REASONS = [
   "too ugly",
   "circuit incorrect",
@@ -329,6 +335,11 @@ export function GalleryFeed({
       ? "shelf"
       : "gallery",
   );
+  // Twenty-odd tags wrapped to three rows and pushed the wall below the fold.
+  // A filter narrows the row to what the reader is looking for, and the rest
+  // stay one click away rather than always on screen.
+  const [tagQuery, setTagQuery] = useState("");
+  const [showAllTags, setShowAllTags] = useState(false);
   const [isOwner, setIsOwner] = useState(false);
   const [ownerBusy, setOwnerBusy] = useState<string | null>(null);
   const [ownerNotice, setOwnerNotice] = useState<string | null>(null);
@@ -618,6 +629,23 @@ export function GalleryFeed({
 
   const entries = state.entries;
 
+  const normalizedTagQuery = tagQuery.trim().toLowerCase();
+  const matchingTags = normalizedTagQuery
+    ? tagOptions.filter((option) =>
+        option.tag.toLowerCase().includes(normalizedTagQuery),
+      )
+    : tagOptions;
+  // A selected tag always stays visible, so collapsing or filtering can never
+  // hide the reason the wall is showing what it is.
+  const visibleTags =
+    showAllTags || normalizedTagQuery
+      ? matchingTags
+      : matchingTags.filter(
+          (option, index) =>
+            index < COLLAPSED_TAG_COUNT || selectedTags.includes(option.tag),
+        );
+  const hiddenTagCount = matchingTags.length - visibleTags.length;
+
   return (
     <main className="gallery-shell" data-testid="gallery-feed">
       <GalleryChrome
@@ -657,7 +685,16 @@ export function GalleryFeed({
         <>
           {tagOptions.length > 0 ? (
             <div className="gallery-tag-bar" data-testid="gallery-tag-bar">
-              {tagOptions.map(({ tag, count }) => (
+              <input
+                className="gallery-tag-search"
+                data-testid="gallery-tag-search"
+                type="search"
+                value={tagQuery}
+                placeholder="Filter tags"
+                aria-label="Filter tags"
+                onChange={(event) => setTagQuery(event.currentTarget.value)}
+              />
+              {visibleTags.map(({ tag, count }) => (
                 <button
                   key={tag}
                   type="button"
@@ -673,6 +710,34 @@ export function GalleryFeed({
                   {tag} <span>{count}</span>
                 </button>
               ))}
+              {hiddenTagCount > 0 ? (
+                <button
+                  type="button"
+                  className="gallery-tag-option gallery-tag-more"
+                  data-testid="gallery-tags-show-all"
+                  onClick={() => setShowAllTags(true)}
+                >
+                  Show {hiddenTagCount} more
+                </button>
+              ) : null}
+              {showAllTags && !normalizedTagQuery ? (
+                <button
+                  type="button"
+                  className="gallery-tag-option gallery-tag-more"
+                  data-testid="gallery-tags-show-fewer"
+                  onClick={() => setShowAllTags(false)}
+                >
+                  Show fewer
+                </button>
+              ) : null}
+              {normalizedTagQuery && matchingTags.length === 0 ? (
+                <span
+                  className="gallery-tag-empty"
+                  data-testid="gallery-tags-empty"
+                >
+                  No tag matches “{tagQuery.trim()}”
+                </span>
+              ) : null}
               {selectedTags.length > 0 ? (
                 <button
                   type="button"
@@ -683,7 +748,7 @@ export function GalleryFeed({
                     syncQuery(author, []);
                   }}
                 >
-                  Clear tags
+                  Clear {selectedTags.length} selected
                 </button>
               ) : null}
             </div>

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -635,14 +635,19 @@ export function GalleryFeed({
         option.tag.toLowerCase().includes(normalizedTagQuery),
       )
     : tagOptions;
-  // A selected tag always stays visible, so collapsing or filtering can never
-  // hide the reason the wall is showing what it is.
+  const everyTagSelected =
+    tagOptions.length > 0 && selectedTags.length === tagOptions.length;
+  // A selected tag stays visible while the collapsed row would otherwise hide
+  // it, so collapsing can never conceal the reason the wall is filtered. With
+  // every tag on, the pressed "Any tag" control is that reason, and pinning
+  // all of them open would undo the collapse entirely.
   const visibleTags =
     showAllTags || normalizedTagQuery
       ? matchingTags
       : matchingTags.filter(
           (option, index) =>
-            index < COLLAPSED_TAG_COUNT || selectedTags.includes(option.tag),
+            index < COLLAPSED_TAG_COUNT ||
+            (!everyTagSelected && selectedTags.includes(option.tag)),
         );
   const hiddenTagCount = matchingTags.length - visibleTags.length;
 
@@ -694,6 +699,31 @@ export function GalleryFeed({
                 aria-label="Filter tags"
                 onChange={(event) => setTagQuery(event.currentTarget.value)}
               />
+              {/* Tags select as a union, so turning every one on is not "no
+                  filter" — it is "carrying at least one tag", which drops the
+                  untagged circuits. The control is named for what it does, and
+                  sits with the filter box so it is reachable without first
+                  expanding the row. */}
+              <button
+                type="button"
+                className="gallery-tag-option gallery-tag-any"
+                data-testid="gallery-tags-any"
+                aria-pressed={everyTagSelected}
+                title={
+                  everyTagSelected
+                    ? "Stop filtering by tag"
+                    : "Show only circuits that carry at least one tag"
+                }
+                onClick={() => {
+                  const next = everyTagSelected
+                    ? []
+                    : tagOptions.map((option) => option.tag);
+                  setSelectedTags(next);
+                  syncQuery(author, next);
+                }}
+              >
+                Any tag
+              </button>
               {visibleTags.map(({ tag, count }) => (
                 <button
                   key={tag}
@@ -738,7 +768,7 @@ export function GalleryFeed({
                   No tag matches “{tagQuery.trim()}”
                 </span>
               ) : null}
-              {selectedTags.length > 0 ? (
+              {selectedTags.length > 0 && !everyTagSelected ? (
                 <button
                   type="button"
                   className="gallery-tag-option gallery-tag-clear"

--- a/apps/editor/src/gallery.css
+++ b/apps/editor/src/gallery.css
@@ -1133,3 +1133,9 @@
   color: var(--icm-text-muted);
   font-size: 12px;
 }
+
+/* "Any tag" is a filter, not a reset: pressed, it means the wall is showing
+   only circuits that carry at least one tag. */
+.gallery-tag-any {
+  font-weight: 600;
+}

--- a/apps/editor/src/gallery.css
+++ b/apps/editor/src/gallery.css
@@ -39,7 +39,6 @@
 
 .gallery-actions .account-owner-badge,
 .gallery-actions .account-link,
-.gallery-actions .account-name,
 .gallery-actions .account-signout,
 .gallery-actions .account-signin summary,
 .gallery-open-editor {
@@ -81,11 +80,18 @@
 
 .account-name {
   font-weight: 600;
-  /* The chip is one line always: a long display name ellipsizes instead
-     of wrapping inside the fixed-height control (inline-block, not the
-     shared inline-flex, so text-overflow can apply). */
+  /* The chip is one line always: a long display name ellipsizes instead of
+     wrapping inside the fixed-height control. It stays inline-block on
+     purpose — text-overflow does nothing on a flex container, so the header
+     row's shared inline-flex rule deliberately skips this one control, and a
+     name that outgrows the chip would otherwise be cut mid-letter. */
   display: inline-block;
-  max-width: 11rem;
+  box-sizing: border-box;
+  height: var(--icm-control-h);
+  /* A flex item will not shrink below its content without this, which is how
+     the chip ended up narrower than its own max-width and clipped anyway. */
+  min-width: 0;
+  max-width: 14rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1096,4 +1102,34 @@
 .shelf-tile-delete:disabled {
   opacity: 0.5;
   cursor: default;
+}
+
+/* The tag row is a header, not the page: a filter narrows it, and the tail
+   stays one click away instead of wrapping over three rows. */
+.gallery-tag-search {
+  flex: 0 0 auto;
+  width: 9rem;
+  padding: 5px 12px;
+  border: 1px solid var(--icm-border);
+  border-radius: 999px;
+  background: var(--icm-surface);
+  color: var(--icm-text);
+  font: inherit;
+  font-size: 12px;
+}
+
+.gallery-tag-search:focus-visible {
+  outline: 2px solid var(--icm-accent);
+  outline-offset: 1px;
+}
+
+.gallery-tag-more {
+  font-weight: 600;
+  color: var(--icm-accent);
+}
+
+.gallery-tag-empty {
+  align-self: center;
+  color: var(--icm-text-muted);
+  font-size: 12px;
 }

--- a/apps/editor/src/styles.css
+++ b/apps/editor/src/styles.css
@@ -485,7 +485,10 @@ body {
   }
 
   .gallery-actions .account-name {
-    max-width: 8rem;
+    /* Wide enough for an ordinary two-part display name; the header still
+       holds one row at this width. Anything longer ellipsizes, which only
+       works because the chip stays out of the row's shared flex rule. */
+    max-width: 10rem;
   }
 }
 


### PR DESCRIPTION
Reported from the gallery: the header still reads badly. Two separate things.

## A display name was cut mid-letter

`Zhishuai Zhang` lost its last letter with no ellipsis at mid widths.

The chip already carries `text-overflow: ellipsis`, and the comment on it already says it must stay `inline-block` for that to work — but the header row's shared `inline-flex` rule matched it with higher specificity, and **text-overflow does nothing on a flex container**, so the name was hard-clipped instead. Measured before the fix at a 730px viewport: content 117px in an 83px box, `display: flex`, ellipsis inert.

- the shared row rule no longer claims this control
- `min-width: 0`, because a flex item is otherwise squeezed below its own `max-width`
- the ≤900px cap goes 8rem → 10rem, which fits an ordinary two-part name; the header still holds one 44px row at 730px, measured with an extra chip in the row

Longer names now ellipsize rather than being sliced.

## The tag row was three lines and pushed the wall below the fold

It now shows ten tags behind a filter box and offers the rest ("Show 12 more" / "Show fewer"). A selected tag stays pinned open while the row is collapsed, so collapsing can never hide why the wall is filtered.

## "Any tag"

The original request was an enable-all control. Tags select as a **union**, so turning every one on is not "no filter" — it means "carrying at least one tag", which drops untagged circuits. Naming it "select all" would promise the opposite of what it does, so it is called `Any tag` and its title says so. Pressed it selects everything; pressed again it clears. The partial Clear names its count and steps aside when everything is on.

Two things the first draft of that control got wrong, both found by looking at the rendered row rather than the code: with every tag on, the pinning rule expanded the row straight back to three lines (with all of them on, the pressed control *is* the reason, so pinning no longer applies), and the button sat at the end of the row behind "Show 12 more" instead of beside the filter box.

## Verification

- 1760 unit tests across 283 files; typecheck; Prettier — green
- Full Playwright suite: 263 passed. Three failures, none in this area, each checked against unmodified `main`: `context-menu.spec.ts:61` and `recovery-hardening.spec.ts:72` fail there too; `drafting.spec.ts:357` passes on main and passed 3/3 on re-run here, so it is flaky
- Two new browser tests cover filtering, collapse/expand, a selected tag surviving both, and that `Any tag` drops an untagged circuit — the property that separates it from "select all"
- Before/after captured at a 760px viewport, the width the report came from

🤖 Generated with [Claude Code](https://claude.com/claude-code)