### PR TITLE
fix(editor): preserve Gallery drafting on import

### DIFF
--- a/apps/editor/src/features/clipboard/clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard.test.ts
@@ -914,6 +914,209 @@ describe("schematic clipboard", () => {
 });
 
 describe("copyWholeDocument", () => {
+  it("keeps standalone drafting geometry and its layout group", () => {
+    const document = createEmptyDocument("document-main", "Drafting scene");
+    document.drafting = {
+      objects: [
+        {
+          id: "scene-rectangle",
+          kind: "rectangle",
+          locked: false,
+          zIndex: 0,
+          anchor: { kind: "free", position: { x: 40, y: 30 } },
+          center: { x: 40, y: 30 },
+          width: 80,
+          height: 40,
+          rotation: 0,
+          lineStyle: "solid",
+        },
+        {
+          id: "scene-arrow",
+          kind: "arrow",
+          locked: false,
+          zIndex: 1,
+          anchor: { kind: "free", position: { x: 0, y: 0 } },
+          from: { kind: "free", position: { x: 0, y: 0 } },
+          to: { kind: "free", position: { x: 80, y: 0 } },
+        },
+        {
+          id: "scene-leader",
+          kind: "leader",
+          locked: false,
+          zIndex: 2,
+          anchor: { kind: "free", position: { x: 0, y: 20 } },
+          target: { kind: "free", position: { x: 80, y: 20 } },
+        },
+      ],
+    };
+    document.layoutGroups.push({
+      id: "scene-drafting-group",
+      kind: "custom",
+      objectIds: ["scene-rectangle", "scene-arrow", "scene-leader"],
+      locked: false,
+    });
+
+    const clipboard = copyWholeDocument(document);
+    expect(clipboard?.draftingObjects.map((object) => object.kind)).toEqual([
+      "rectangle",
+      "arrow",
+      "leader",
+    ]);
+    expect(clipboard?.draftingGroups).toEqual([document.layoutGroups[0]]);
+    expect(clipboardPlacementAnchor(clipboard!)).toEqual({ x: 40, y: 30 });
+
+    const target = createEmptyDocument("target", "Target");
+    const proposal = proposePaste(target, clipboard!, { x: 100, y: 50 }, 1);
+    const pastedObjects = proposal.edits.flatMap((edit) =>
+      edit.kind === "upsert_drafting_object" ? [edit.object] : [],
+    );
+    expect(pastedObjects).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "scene-rectangle-copy-1",
+          kind: "rectangle",
+          center: { x: 140, y: 80 },
+        }),
+        expect.objectContaining({
+          id: "scene-arrow-copy-1",
+          kind: "arrow",
+          from: { kind: "free", position: { x: 100, y: 50 } },
+          to: { kind: "free", position: { x: 180, y: 50 } },
+        }),
+        expect.objectContaining({
+          id: "scene-leader-copy-1",
+          kind: "leader",
+          anchor: { kind: "free", position: { x: 100, y: 70 } },
+          target: { kind: "free", position: { x: 180, y: 70 } },
+        }),
+      ]),
+    );
+    expect(
+      proposal.edits.find((edit) => edit.kind === "set_layout_group"),
+    ).toMatchObject({
+      group: {
+        objectIds: [
+          "scene-rectangle-copy-1",
+          "scene-arrow-copy-1",
+          "scene-leader-copy-1",
+        ],
+      },
+    });
+  });
+
+  it("retargets drafting anchors to copied Instances and Route legs", () => {
+    const document = createEmptyDocument("document-main", "Anchored drafting");
+    document.instances.push({
+      id: "R1",
+      symbolId: "resistor",
+      placement: {
+        position: { x: 20, y: 20 },
+        rotation: 0,
+        mirror: "none",
+      },
+    });
+    document.nets.push({ id: "net-guide", terminals: [] });
+    document.junctions.push(
+      {
+        id: "guide-start",
+        netId: "net-guide",
+        position: { x: 40, y: 40 },
+        role: "route-anchor",
+      },
+      {
+        id: "guide-end",
+        netId: "net-guide",
+        position: { x: 100, y: 40 },
+        role: "route-anchor",
+      },
+    );
+    const route = createRoutePath({
+      id: "guide-route",
+      netId: "net-guide",
+      start: { kind: "junction", junctionId: "guide-start" },
+      end: { kind: "junction", junctionId: "guide-end" },
+      bends: [],
+      modes: ["manual"],
+    });
+    document.routes.push(route);
+    document.drafting = {
+      objects: [
+        {
+          id: "anchored-arrow",
+          kind: "arrow",
+          locked: false,
+          zIndex: 0,
+          anchor: {
+            kind: "object",
+            objectId: "R1",
+            localOffset: { x: 0, y: 0 },
+            fallbackPosition: { x: 20, y: 20 },
+          },
+          from: {
+            kind: "object",
+            objectId: "R1",
+            localOffset: { x: 0, y: 0 },
+            fallbackPosition: { x: 20, y: 20 },
+          },
+          to: {
+            kind: "route",
+            routeId: route.id,
+            legId: route.legs[0]!.id,
+            t: 0.5,
+            normalOffset: 0,
+            direction: "forward",
+            orientation: "follow",
+            fallbackPosition: { x: 70, y: 40 },
+          },
+        },
+      ],
+    };
+
+    const clipboard = copyWholeDocument(document)!;
+    const proposal = proposePaste(
+      createEmptyDocument("target", "Target"),
+      clipboard,
+      { x: 100, y: 50 },
+      1,
+    );
+    const pastedRoute = proposal.edits.find(
+      (edit) => edit.kind === "set_route_path",
+    );
+    const pastedArrow = proposal.edits.find(
+      (edit) =>
+        edit.kind === "upsert_drafting_object" &&
+        edit.object.id === "anchored-arrow-copy-1",
+    );
+    expect(pastedRoute?.kind).toBe("set_route_path");
+    expect(pastedArrow).toMatchObject({
+      kind: "upsert_drafting_object",
+      object: {
+        anchor: {
+          kind: "object",
+          objectId: "R1-copy-1",
+          fallbackPosition: { x: 120, y: 70 },
+        },
+        from: {
+          kind: "object",
+          objectId: "R1-copy-1",
+          fallbackPosition: { x: 120, y: 70 },
+        },
+        to: {
+          kind: "route",
+          routeId:
+            pastedRoute?.kind === "set_route_path"
+              ? pastedRoute.route.id
+              : undefined,
+          legId:
+            pastedRoute?.kind === "set_route_path"
+              ? pastedRoute.route.legs[0]!.id
+              : undefined,
+          fallbackPosition: { x: 170, y: 90 },
+        },
+      },
+    });
+  });
+
   it("keeps a Power Rail that no device is wired to yet", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.nets.push({

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -26,6 +26,7 @@ import type {
   RouteBranch,
   RouteEndpoint,
   SchematicDocument,
+  VisualAnchor,
 } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 import {
@@ -590,9 +591,15 @@ export function clipboardPreviewDocument(
 export function copyWholeDocument(
   document: SchematicDocument,
 ): SchematicClipboard | null {
-  if (document.instances.length === 0 && document.routes.length === 0) {
+  const draftingObjects = document.drafting?.objects ?? [];
+  if (
+    document.instances.length === 0 &&
+    document.routes.length === 0 &&
+    draftingObjects.length === 0
+  ) {
     return null;
   }
+  const draftingIds = new Set(draftingObjects.map((object) => object.id));
   const netIds = new Set<string>([
     ...document.nets.flatMap((net) =>
       net.terminals.length > 0 ? [net.id] : [],
@@ -648,8 +655,12 @@ export function copyWholeDocument(
         ? evidence.memberNetIds.every((netId) => netIds.has(netId))
         : netIds.has(evidence.netId),
     ),
-    draftingObjects: [],
-    draftingGroups: [],
+    draftingObjects,
+    draftingGroups: document.layoutGroups.filter(
+      (group) =>
+        group.objectIds.length > 0 &&
+        group.objectIds.every((objectId) => draftingIds.has(objectId)),
+    ),
   });
 }
 
@@ -901,6 +912,63 @@ function movePoint(point: Point, offset: Point): Point {
   return { x: point.x + offset.x, y: point.y + offset.y };
 }
 
+function remapPastedVisualAnchor(
+  anchor: VisualAnchor,
+  objectIds: ReadonlyMap<string, string>,
+  routeIds: ReadonlyMap<string, string>,
+  legIds: ReadonlyMap<string, string>,
+  offset: Point,
+  translateFree = false,
+): VisualAnchor {
+  if (anchor.kind === "free") {
+    return translateFree
+      ? { ...anchor, position: movePoint(anchor.position, offset) }
+      : anchor;
+  }
+  if (anchor.kind === "object") {
+    return {
+      ...anchor,
+      objectId: objectIds.get(anchor.objectId) ?? anchor.objectId,
+      fallbackPosition: movePoint(anchor.fallbackPosition, offset),
+    };
+  }
+  return {
+    ...anchor,
+    routeId: routeIds.get(anchor.routeId) ?? anchor.routeId,
+    legId: legIds.get(anchor.legId) ?? anchor.legId,
+    fallbackPosition: movePoint(anchor.fallbackPosition, offset),
+  };
+}
+
+function remapPastedDraftingAnchors(
+  object: DraftingObject,
+  objectIds: ReadonlyMap<string, string>,
+  routeIds: ReadonlyMap<string, string>,
+  legIds: ReadonlyMap<string, string>,
+  offset: Point,
+): DraftingObject {
+  const clone = structuredClone(object);
+  const remap = (anchor: VisualAnchor): VisualAnchor =>
+    remapPastedVisualAnchor(anchor, objectIds, routeIds, legIds, offset);
+  clone.anchor = remap(clone.anchor);
+  if (clone.kind === "arrow") {
+    clone.from = remap(clone.from);
+    clone.to = remap(clone.to);
+  } else if (clone.kind === "leader" || clone.kind === "callout") {
+    // translateDraftingObject moves the primary anchor, while the leader tip
+    // is independent geometry and still needs the paste offset here.
+    clone.target = remapPastedVisualAnchor(
+      clone.target,
+      objectIds,
+      routeIds,
+      legIds,
+      offset,
+      true,
+    );
+  }
+  return clone;
+}
+
 function mapEndpoint(
   endpoint: RouteEndpoint,
   instanceIds: ReadonlyMap<string, string>,
@@ -1085,6 +1153,12 @@ export function proposePaste(
     ...routeIds,
     ...junctionIds,
   ]);
+  const draftingIds = new Map(
+    clipboard.draftingObjects.map((object) => [
+      object.id,
+      uniqueCopyId(object.id, sequence, occupied),
+    ]),
+  );
   const edits: SchematicEdit[] = clipboard.instances.map(
     (instance): SchematicEdit => ({
       kind: "add_instance",
@@ -1432,14 +1506,25 @@ export function proposePaste(
   });
   // Drafting objects carry no connectivity, so a copy is the object itself
   // under a fresh id, shifted by the same placement offset as everything else.
-  const draftingIds = new Map<string, string>();
+  const pastedAnchorObjectIds = new Map([...objectIds, ...draftingIds]);
+  const pastedLegIds = new Map(Object.entries(idRemap.legs));
   for (const object of clipboard.draftingObjects) {
-    const id = uniqueCopyId(object.id, sequence, occupied);
-    draftingIds.set(object.id, id);
+    const id = draftingIds.get(object.id)!;
+    const translated = translateDraftingObject(
+      object,
+      offset,
+      document.presentation.grid,
+    );
     edits.push({
       kind: "upsert_drafting_object",
       object: {
-        ...translateDraftingObject(object, offset, document.presentation.grid),
+        ...remapPastedDraftingAnchors(
+          translated,
+          pastedAnchorObjectIds,
+          routeIds,
+          pastedLegIds,
+          offset,
+        ),
         id,
       },
     });

--- a/apps/editor/src/features/editor-shell/gallery-example-commands.test.ts
+++ b/apps/editor/src/features/editor-shell/gallery-example-commands.test.ts
@@ -60,6 +60,39 @@ describe("Gallery and example commands", () => {
     expect(input.beginCopyPlacement).not.toHaveBeenCalled();
   });
 
+  it("starts placement for a drawing-only Gallery Project", () => {
+    const input = dependencies();
+    const imported = createEmptyProject("imported", "Drawing");
+    imported.documents[0]!.drafting = {
+      objects: [
+        {
+          id: "gallery-rectangle",
+          kind: "rectangle",
+          locked: false,
+          zIndex: 0,
+          anchor: { kind: "free", position: { x: 60, y: 40 } },
+          center: { x: 60, y: 40 },
+          width: 80,
+          height: 40,
+          rotation: 0,
+          lineStyle: "solid",
+        },
+      ],
+    };
+    const commands = createGalleryExampleCommands(input);
+
+    expect(commands.beginProjectImportPlacement(imported, "Drawing")).toBe(
+      true,
+    );
+    expect(input.beginCopyPlacement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        draftingObjects: imported.documents[0]!.drafting.objects,
+      }),
+      { x: 60, y: 40 },
+    );
+    expect(input.replaceActiveProject).not.toHaveBeenCalled();
+  });
+
   it("opens a Gallery Project and records the live entry context", async () => {
     const project = createEmptyProject("gallery-project", "Project fallback");
     const fetchImpl = vi.fn<typeof fetch>(async () =>


### PR DESCRIPTION
## Summary

- retain rectangles, arrows, leaders, and other drafting objects when inserting a single-Document Gallery entry as a copy
- allow drawing-only Gallery projects to enter placement and preserve wholly contained drafting groups
- remap copied drafting anchors to the cloned Instance, Route, Route leg, and drafting identities

## Validation

- pnpm build
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- 286 unit test files / 1773 tests passed
- pps/editor/e2e/manual-editor.spec.ts: 117 tests passed

Test-Impact: tests-updated