### PR TITLE
fix(editor): the account name sits on the header's centre line

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -475,6 +475,85 @@ test("clicking a byline filters the wall to that author, clearable", async ({
   await expect(page).not.toHaveURL(/author=/);
 });
 
+test("the account chip sits on the header line and ellipsizes a long name", async ({
+  page,
+}) => {
+  await page.route("**/api/auth/providers", (route) =>
+    route.fulfill({ json: { github: true, google: false, email: false } }),
+  );
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      json: {
+        user: {
+          id: "u1",
+          displayName: "Zhishuai Zhang",
+          email: "z@example.com",
+          provider: "github",
+          role: "user",
+          isAdmin: false,
+        },
+      },
+    }),
+  );
+  await page.route("**/api/gallery**", (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname === "/api/gallery/tags") {
+      return route.fulfill({ json: { tags: [] } });
+    }
+    if (url.pathname !== "/api/gallery") return route.fallback();
+    return route.fulfill({ json: { entries: [], nextCursor: null } });
+  });
+
+  await page.setViewportSize({ width: 760, height: 720 });
+  await page.goto("/");
+  const chip = page.getByTestId("account-name");
+  await expect(chip).toBeVisible();
+
+  // The name rides the same centre line as every other control in the row.
+  // Zeroed vertical padding is what puts it there: the chip opts out of the
+  // row's shared control rule so its ellipsis works, and that rule was also
+  // what kept its line box the full height of the control.
+  const centred = await chip.evaluate((element) => {
+    const box = element.getBoundingClientRect();
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    const text = range.getBoundingClientRect();
+    return text.top + text.height / 2 - (box.top + box.height / 2);
+  });
+  expect(Math.abs(centred)).toBeLessThanOrEqual(1);
+
+  const newCircuit = page.getByTestId("gallery-new-circuit");
+  const chipBox = (await chip.boundingBox())!;
+  const buttonBox = (await newCircuit.boundingBox())!;
+  expect(
+    Math.abs(
+      chipBox.y + chipBox.height / 2 - (buttonBox.y + buttonBox.height / 2),
+    ),
+  ).toBeLessThanOrEqual(1);
+
+  // An ordinary two-part name fits whole at this width.
+  expect(
+    await chip.evaluate(
+      (element) => element.scrollWidth <= element.clientWidth,
+    ),
+  ).toBe(true);
+
+  // A name that cannot fit ends in an ellipsis rather than a sliced letter,
+  // which only holds while the chip is not a flex container.
+  const overflowing = await chip.evaluate((element) => {
+    element.textContent = "A Considerably Longer Display Name";
+    const style = getComputedStyle(element);
+    return {
+      clipped: element.scrollWidth > element.clientWidth,
+      textOverflow: style.textOverflow,
+      display: style.display,
+    };
+  });
+  expect(overflowing.clipped).toBe(true);
+  expect(overflowing.textOverflow).toBe("ellipsis");
+  expect(overflowing.display).not.toContain("flex");
+});
+
 test("the tag row filters, collapses, and keeps a selection visible", async ({
   page,
 }) => {

--- a/apps/editor/src/gallery.css
+++ b/apps/editor/src/gallery.css
@@ -95,6 +95,12 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  /* The line box is the whole content box, so the name sits on the row's
+     centre line. The shared control rule this one opts out of also zeroed
+     these; with the 6px back, a 26px line inside a 14px content box pushed
+     the name 6px below every other control in the header. */
+  padding-top: 0;
+  padding-bottom: 0;
   line-height: calc(var(--icm-control-h) - 2px);
 }
 


### PR DESCRIPTION
Follow-up to #398, and a defect that PR introduced.

Taking the account chip out of the header row's shared control rule — so its `text-overflow: ellipsis` would work at all — also dropped what that rule zeroed: the vertical padding.

`.account-name` carries `padding: 6px 10px` of its own. Inside a `border-box` control 28px tall that leaves a content box of `28 − 12 − 2 = 14px`, while the line box is 26px. A 26px line in a 14px box renders low, so the name sat below every other control in the row.

Measured on the deployed page, with a probe in the real header:

```
box centre   21.5
text centre  27.5      → 6px low
```

The chip's own box was never crooked: its `top` and `height` matched the New Circuit button exactly. What was off was the text inside it.

Zeroing the vertical padding makes the line box the whole content box. Re-measured with the fix: offset `0`.

## The test

`gallery.spec.ts` now measures the name's centre against its own box **and** against the New Circuit button, and checks that an over-long name still ends in an ellipsis on a non-flex chip — the property #398 was protecting when it caused this.

Removing the two padding declarations makes that test fail with `Received: 6`, exactly the offset seen on production. A test that does not fail on the defect it is named for is not worth having, so this one was checked against the broken state before being kept.

## Verification

- Full `gallery.spec.ts`: 35 passed, single worker on a clean dev server
- 1766 unit tests pass. One failure, `apps/mcp-server/src/resources.test.ts`, is a generated-resource drift that fails identically on unmodified `main`
- Typecheck, Prettier — green

An earlier run of the same spec on this branch reported 6 and then 9 failures with a failure set that did not overlap main's, alongside `ResizeObserver loop` errors from the dev overlay. That was contention from several suites run back to back against one server; a fresh server at one worker is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)