### PR TITLE
Add canonical three-dot annotation

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -553,7 +553,7 @@ test("groups drafting tools and editable polarity labels under Annotations", asy
 
   const annotations = page.getByTestId("shapes-category-annotations");
   await expect(annotations).toBeVisible();
-  await expect(annotations.locator(".shapes-category-count")).toHaveText("7");
+  await expect(annotations.locator(".shapes-category-count")).toHaveText("8");
   // Drawing tools lead; the polarity label and the standalone sign texts
   // close the category. The one-sign-with-text variants no longer exist.
   expect(
@@ -570,6 +570,7 @@ test("groups drafting tools and editable polarity labels under Annotations", asy
     "shapes-chip-annotation-polarity-both",
     "shapes-chip-annotation-text-plus",
     "shapes-chip-annotation-text-minus",
+    "shapes-chip-annotation-ellipsis",
   ]);
 
   // The Library entries reuse the authoritative toolbar tools rather than
@@ -657,6 +658,31 @@ test("groups drafting tools and editable polarity labels under Annotations", asy
   expect(
     await armOf(loneMinus.locator('[data-role="polarity-negative"]')),
   ).toBe(await armOf(polarity.locator('[data-role="polarity-negative"]')));
+
+  // Three dots use the canonical DraftText path. That makes each dot exactly
+  // the current default font's period glyph and reuses the same generic text
+  // selection frame instead of a symbol-specific box.
+  await page.keyboard.press("i");
+  await dialog.getByLabel("Component search").fill("three dots");
+  await dialog.getByTestId("insert-component-annotation-ellipsis").click();
+  await canvas.hover({ position: { x: 700, y: 260 } });
+  await page.keyboard.press("r");
+  await canvas.click({ position: { x: 700, y: 260 } });
+  const ellipsis = canvas.locator('[data-kind="draft-text"]').filter({
+    hasText: "...",
+  });
+  await expect(ellipsis).toBeVisible();
+  await expect(ellipsis).toHaveText("...");
+  await expect(ellipsis).toHaveAttribute("transform", /rotate\(90\b/u);
+  await expect(
+    canvas.locator('[data-testid^="drafting-hit-text-"]'),
+  ).toHaveClass(/hit-target annotation-text-hit selected/u);
+  await expect
+    .poll(() => recoveryProjectTexts(page))
+    .toContain('"kind": "text"');
+  await expect
+    .poll(() => recoveryProjectTexts(page))
+    .toContain('"value": "..."');
 });
 
 test("places a vertical Power Rail from I and renames it on the canvas", async ({

--- a/apps/editor/src/features/component-insert/annotation-preview-symbols.test.ts
+++ b/apps/editor/src/features/component-insert/annotation-preview-symbols.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   annotationPolarity,
+  annotationTextPreset,
   isAnnotationPaletteSymbol,
   isBarePolaritySign,
 } from "./annotation-preview-symbols";
@@ -53,6 +54,9 @@ describe("polarity annotations", () => {
     expect(isBarePolaritySign("annotation-text-plus")).toBe(true);
     expect(isBarePolaritySign("annotation-polarity-both")).toBe(false);
     expect(isAnnotationPaletteSymbol("annotation-text-minus")).toBe(true);
+    expect(isAnnotationPaletteSymbol("annotation-ellipsis")).toBe(true);
+    expect(annotationPolarity("annotation-ellipsis")).toBeUndefined();
+    expect(annotationTextPreset("annotation-ellipsis")).toBe("...");
   });
 
   it("draws a lone sign at exactly the size the pair draws it", () => {

--- a/apps/editor/src/features/component-insert/annotation-preview-symbols.ts
+++ b/apps/editor/src/features/component-insert/annotation-preview-symbols.ts
@@ -24,6 +24,10 @@ const polarityBySymbolId = {
   "annotation-text-minus": "negative",
 } as const satisfies Readonly<Record<string, PolarityAnnotationKind>>;
 
+const textPresetBySymbolId = {
+  "annotation-ellipsis": "...",
+} as const satisfies Readonly<Record<string, string>>;
+
 export function annotationDrawingTool(
   symbolId: string,
 ): DrawingTool | undefined {
@@ -36,6 +40,10 @@ export function annotationPolarity(
   return polarityBySymbolId[symbolId as keyof typeof polarityBySymbolId];
 }
 
+export function annotationTextPreset(symbolId: string): string | undefined {
+  return textPresetBySymbolId[symbolId as keyof typeof textPresetBySymbolId];
+}
+
 /** True for a lone + or −: a polarity mark with no centre text to write. */
 export function isBarePolaritySign(symbolId: string): boolean {
   const polarity = annotationPolarity(symbolId);
@@ -44,7 +52,9 @@ export function isBarePolaritySign(symbolId: string): boolean {
 
 export function isAnnotationPaletteSymbol(symbolId: string): boolean {
   return Boolean(
-    annotationDrawingTool(symbolId) ?? annotationPolarity(symbolId),
+    annotationDrawingTool(symbolId) ??
+    annotationPolarity(symbolId) ??
+    annotationTextPreset(symbolId),
   );
 }
 
@@ -188,6 +198,23 @@ const annotationTextMinus = {
   primitives: minusStrokes(0),
 } satisfies SymbolDefinition;
 
+// Catalog-only artwork. Placement uses the canonical DraftText renderer with
+// content "...", so its dots and selection bounds are exactly those of the
+// current default label font rather than a second symbol geometry contract.
+const annotationEllipsis = {
+  ...shared,
+  id: "annotation-ellipsis",
+  name: "Three dots",
+  viewBox: { x: -12, y: -8, width: 24, height: 16 },
+  primitives: [-6, 0, 6].map((x) => ({
+    kind: "circle" as const,
+    center: { x, y: 0 },
+    radius: 1.25,
+    fill: "foreground" as const,
+    stroke: "none" as const,
+  })),
+} satisfies SymbolDefinition;
+
 /**
  * Editor-only catalog artwork. These definitions never enter the electrical
  * SymbolResolver: drawing entries activate an existing tool, while polarity
@@ -201,4 +228,5 @@ export const annotationPreviewSymbols: readonly SymbolDefinition[] = [
   annotationPolarityBoth,
   annotationTextPlus,
   annotationTextMinus,
+  annotationEllipsis,
 ];

--- a/apps/editor/src/features/component-insert/component-insert-request.ts
+++ b/apps/editor/src/features/component-insert/component-insert-request.ts
@@ -33,6 +33,14 @@ export interface PolarityAnnotationInsertRequest {
   initialRotation: 0 | 90 | 180 | 270;
 }
 
+export interface DraftTextAnnotationInsertRequest {
+  kind: "drafting-text";
+  symbolId: string;
+  symbolName: string;
+  text: string;
+  initialRotation: 0 | 90 | 180 | 270;
+}
+
 export interface CellInsertRequest {
   kind: "cell";
   symbolId: string;
@@ -65,4 +73,5 @@ export type ComponentInsertRequest =
   | ExternalSubcircuitInsertRequest
   | VddRailInsertRequest
   | DrawingToolInsertRequest
-  | PolarityAnnotationInsertRequest;
+  | PolarityAnnotationInsertRequest
+  | DraftTextAnnotationInsertRequest;

--- a/apps/editor/src/features/component-insert/insert-component-dialog.test.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.test.tsx
@@ -32,6 +32,9 @@ describe("InsertComponentDialog", () => {
     expect(markup).toContain(
       'data-testid="insert-component-annotation-polarity-both"',
     );
+    expect(markup).toContain(
+      'data-testid="insert-component-annotation-ellipsis"',
+    );
     expect(markup).not.toContain("<h3");
     expect(markup).not.toContain("<h4");
     // Library order: transistors lead, categories stay together, and the

--- a/apps/editor/src/features/component-insert/insert-component-dialog.tsx
+++ b/apps/editor/src/features/component-insert/insert-component-dialog.tsx
@@ -6,6 +6,7 @@ import { initialComponentParameterValues } from "./component-parameters";
 import {
   annotationDrawingTool,
   annotationPolarity,
+  annotationTextPreset,
 } from "./annotation-preview-symbols";
 import { componentCatalog, libraryDisplayName } from "./symbol-catalog";
 import type { ComponentInsertRequest } from "./component-insert-request";
@@ -264,6 +265,18 @@ export function InsertComponentDialog({
         symbolId,
         symbolName: choice.symbol.name,
         polarity,
+        initialRotation: 0,
+      });
+      return;
+    }
+    const textPreset =
+      choice.kind === "symbol" ? annotationTextPreset(symbolId) : undefined;
+    if (textPreset) {
+      onApply({
+        kind: "drafting-text",
+        symbolId,
+        symbolName: choice.symbol.name,
+        text: textPreset,
         initialRotation: 0,
       });
       return;

--- a/apps/editor/src/features/component-insert/symbol-catalog.test.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.test.ts
@@ -62,9 +62,10 @@ describe("component insertion catalog", () => {
     expect(symbolCategory("pdmos")).toBe("Extended Devices");
     expect(symbolCategory("annotation-arrow")).toBe("Annotations");
     expect(symbolCategory("annotation-polarity-both")).toBe("Annotations");
+    expect(symbolCategory("annotation-ellipsis")).toBe("Annotations");
   });
 
-  it("orders annotations as drawing tools, the polarity label, then signs", () => {
+  it("orders annotations as drawing tools, polarity marks, then three dots", () => {
     const groups = componentCatalog("razavi-textbook-v1", "");
     const annotations = groups.find(
       (group) => group.category === "Annotations",
@@ -78,6 +79,7 @@ describe("component insertion catalog", () => {
       "annotation-polarity-both",
       "annotation-text-plus",
       "annotation-text-minus",
+      "annotation-ellipsis",
     ]);
     expect(groups.at(-1)?.category).toBe("Extended Devices");
   });

--- a/apps/editor/src/features/component-insert/symbol-catalog.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.ts
@@ -210,7 +210,7 @@ const SYMBOL_ORDER: readonly string[] = [
   "discrete-time-integrator",
   "quantizer",
   // Annotations: drawing tools first (toolbar order), then the polarity
-  // label, and the standalone sign texts last.
+  // label, standalone signs, and fixed decorative marks last.
   "annotation-arrow",
   "annotation-line",
   "annotation-rectangle",
@@ -218,6 +218,7 @@ const SYMBOL_ORDER: readonly string[] = [
   "annotation-polarity-both",
   "annotation-text-plus",
   "annotation-text-minus",
+  "annotation-ellipsis",
 ];
 
 function symbolRank(symbolId: string): number {

--- a/apps/editor/src/features/component-insert/use-component-placement.ts
+++ b/apps/editor/src/features/component-insert/use-component-placement.ts
@@ -615,16 +615,14 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     position: Point,
     placementRequest: PendingComponentPlacement,
   ): void => {
-    if (
-      placementRequest.kind !== "drafting-text" ||
-      !placementRequest.polarity
-    ) {
-      return;
-    }
+    if (placementRequest.kind !== "drafting-text") return;
     // A lone + or − has no centre to write in, so it lands as the canonical
     // empty document — the same shape an emptied polarity label keeps.
-    const bare = placementRequest.polarity !== "both";
-    let id = options.nextId("polarity");
+    const bare =
+      Boolean(placementRequest.polarity) &&
+      placementRequest.polarity !== "both";
+    const preset = placementRequest.text;
+    let id = options.nextId(placementRequest.polarity ? "polarity" : "text");
     while (
       options.document.drafting?.objects.some((object) => object.id === id)
     ) {
@@ -638,7 +636,9 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       anchor: { kind: "free", position },
       content: bare
         ? { runs: [{ kind: "line-break" as const }] }
-        : defaultDraftTextDocument("V_x"),
+        : preset
+          ? { runs: [{ kind: "text" as const, value: preset }] }
+          : defaultDraftTextDocument("V_x"),
       alignment: "middle",
       rotation: options.componentPlacementRotation,
       typographyToken: "label",
@@ -651,6 +651,10 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     }
     options.cancelAllTransientInteraction();
     options.selectOnly("drafting", [object.id]);
+    if (preset) {
+      options.setStatus(`Added ${placementRequest.symbolId}`);
+      return;
+    }
     if (bare) {
       options.setStatus(`Added ${placementRequest.polarity} polarity mark`);
       return;
@@ -722,20 +726,32 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
             showValue: false,
             polarity: request.polarity,
           }
-        : request.kind === "symbol" &&
-            (request.symbolId === "port" || request.symbolId === "port-filled")
+        : request.kind === "drafting-text"
           ? {
-              kind: "cell-pin",
+              kind: "drafting-text",
               symbolId: request.symbolId,
               parameters: {},
               initialRotation: request.initialRotation,
               showReference: false,
               referenceText: null,
               showValue: false,
-              direction: request.portDirection ?? "passive",
-              ...(request.portName ? { portName: request.portName } : {}),
+              text: request.text,
             }
-          : request;
+          : request.kind === "symbol" &&
+              (request.symbolId === "port" ||
+                request.symbolId === "port-filled")
+            ? {
+                kind: "cell-pin",
+                symbolId: request.symbolId,
+                parameters: {},
+                initialRotation: request.initialRotation,
+                showReference: false,
+                referenceText: null,
+                showValue: false,
+                direction: request.portDirection ?? "passive",
+                ...(request.portName ? { portName: request.portName } : {}),
+              }
+            : request;
     options.beginComponentPlacement(pendingRequest);
     options.setStatus(
       request.kind === "polarity-annotation"

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -20,7 +20,7 @@ describe("shapes quick-place", () => {
       }),
     );
 
-    expect(symbols).toHaveLength(55);
+    expect(symbols).toHaveLength(56);
     expect(markup).toContain("All devices");
     expect(markup.match(/data-testid="shapes-chip-/g)).toHaveLength(
       symbols.length,
@@ -40,7 +40,7 @@ describe("shapes quick-place", () => {
       ["Analog Blocks", 6],
       ["Logic Gates", 10],
       ["Signal Flow", 6],
-      ["Annotations", 7],
+      ["Annotations", 8],
       ["Extended Devices", 7],
     ]);
     const categoryTestIds = [
@@ -157,6 +157,13 @@ describe("shapes quick-place", () => {
       symbolId: "annotation-text-minus",
       symbolName: "Minus sign",
       polarity: "negative",
+      initialRotation: 0,
+    });
+    expect(quickPlaceRequest("razavi", "annotation-ellipsis")).toEqual({
+      kind: "drafting-text",
+      symbolId: "annotation-ellipsis",
+      symbolName: "Three dots",
+      text: "...",
       initialRotation: 0,
     });
     expect(quickPlaceRequest("razavi", "annotation-polarity-positive")).toBe(

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -10,6 +10,7 @@ import { initialComponentParameterValues } from "../component-insert/component-p
 import {
   annotationDrawingTool,
   annotationPolarity,
+  annotationTextPreset,
 } from "../component-insert/annotation-preview-symbols";
 import {
   componentCatalog,
@@ -74,6 +75,7 @@ const COMPACT_LIBRARY_LABELS: Readonly<Record<string, string>> = {
   "annotation-polarity-both": "+ V −",
   "annotation-text-plus": "+",
   "annotation-text-minus": "−",
+  "annotation-ellipsis": "•••",
 };
 
 function libraryLabel(symbolId: string, symbolName: string): string {
@@ -108,6 +110,16 @@ export function quickPlaceRequest(
       symbolId,
       symbolName: symbol.name,
       polarity,
+      initialRotation: 0,
+    };
+  }
+  const textPreset = annotationTextPreset(symbolId);
+  if (textPreset) {
+    return {
+      kind: "drafting-text",
+      symbolId,
+      symbolName: symbol.name,
+      text: textPreset,
       initialRotation: 0,
     };
   }

--- a/apps/editor/src/interaction/interaction-state.ts
+++ b/apps/editor/src/interaction/interaction-state.ts
@@ -48,7 +48,8 @@ export interface PendingComponentPlacement {
   portName?: string;
   direction?: "input" | "output" | "inout" | "passive";
   polarity?: "both" | "positive" | "negative";
-  /** Fixed initial content for a preset drafting text ("+", "−"). */
+  /** Fixed initial content for a catalog drafting-text preset. */
+  text?: string;
   /** Existing unplaced Instance being returned from the Placement Tray. */
   instanceId?: string;
 }


### PR DESCRIPTION
Adds a Three dots entry under Annotations. Placement creates one DraftText object containing three canonical full stops, so the round-period font, default text metrics, rotation, persistence, and shared text/device selection frame are reused without separate symbol geometry. Validation: frozen install; gate preflight; gate affected on latest main (1773 unit tests, 31 component-insert browser tests, 117 editor browser tests).