### PR TITLE
fix(edit-engine): a symbol swap reconciles the contacts its pins leave

### DIFF
--- a/packages/edit-engine/src/direct-contact-lifecycle.test.ts
+++ b/packages/edit-engine/src/direct-contact-lifecycle.test.ts
@@ -811,6 +811,22 @@ describe("signal-flow resize direct contacts", () => {
     return document;
   }
 
+  it("materializes a Route when a symbol swap moves the pin away", () => {
+    // Swapping to a narrower block moves the output pin inward; the
+    // abutting Cell Pin stays put, so the contact needs a conductor.
+    const document = abutting();
+    const result = executeTransaction(
+      document,
+      transaction(document, [
+        { kind: "set_instance_symbol", instanceId: "SF", symbolId: "buffer" },
+      ]),
+      context,
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.document.routes).toHaveLength(1);
+    expect(result.document.routes[0]!.netId).toBe("net-sf");
+  });
+
   it("materializes a Route when a wider body pulls the contact apart", () => {
     const document = abutting();
     const result = executeTransaction(

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -167,9 +167,11 @@ export function executeTransaction(
           edit.kind === "align_instances"
           ? edit.instanceIds
           : // Signal Flow parameters resize the body, which carries the
-            // pins with it: the incident Routes have to re-derive their
-            // leads exactly as they do for a move.
-            edit.kind === "set_instance_signal_flow_parameters"
+            // pins with it, and a symbol swap replaces the pin geometry
+            // outright: the incident Routes have to re-derive their leads
+            // exactly as they do for a move.
+            edit.kind === "set_instance_signal_flow_parameters" ||
+              edit.kind === "set_instance_symbol"
             ? [edit.instanceId]
             : [],
     ),
@@ -509,7 +511,8 @@ export function executeTransaction(
         // moves, and a Signal Flow resize that carries the pins outward.
         edit.kind === "align_instances" ||
         edit.kind === "move_junction" ||
-        edit.kind === "set_instance_signal_flow_parameters",
+        edit.kind === "set_instance_signal_flow_parameters" ||
+        edit.kind === "set_instance_symbol",
     )
   ) {
     const directContact = reconcileTransformDirectContacts(


### PR DESCRIPTION
Found while reviewing #388: `set_instance_symbol` belongs to the same pin-moving family as move/rotate/mirror/align, but sat in neither the route-follow set nor the direct-contact reconcile gate.

Replacing an Instance's Symbol replaces its pin geometry. Swapping a block whose output pin sits 40 units out for one whose pin sits 20 units out moves that pin, so a zero-length direct contact at that pin survives in the model while disappearing from the drawing — two pins 20 units apart, on one Net, with no conductor between them. That is the invisible-connectivity failure the transform lifecycle exists to prevent (audit finding #2's class, a sibling of the `align_instances` / `move_junction` gaps fixed in #350 and the Signal Flow resize fixed in #388).

The right-click device swap shipped in #355 makes this reachable in two clicks, which is how it surfaced.

The swap now materializes the bridging Route exactly as a move does, and incident Routes re-derive their leads against the new pin geometry.

Validation: engine suite 324/324 with a red-first regression (integrator → buffer swap on an abutting Cell Pin now yields one bridging Route on the shared Net); typecheck and prettier clean; full unit suite and the context-menu swap e2e were green on the pre-rebase branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)