### PR TITLE
fix(editor): the transfer-function field starts from the block's own formula

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -4046,6 +4046,9 @@ test("edits a formula-capable Signal Flow block with undo, redo, and Reset defau
   const minimumHeight = properties.getByLabel("Signal flow minimum height");
   await expect(minimumWidth).toHaveAttribute("placeholder", "Auto");
   await expect(minimumHeight).toHaveAttribute("placeholder", "Auto");
+  // A freshly placed block carries its own formula in the field, ready to
+  // be edited in place instead of retyped.
+  await expect(formula).toHaveValue(symbol.formulaPresentation!.defaultFormula);
 
   const formalScene = page.locator('[data-layer="formal"]');
   const renderedFormula = formalScene.locator(
@@ -4090,7 +4093,9 @@ test("edits a formula-capable Signal Flow block with undo, redo, and Reset defau
   await expect(frame).toHaveAttribute("height", "80");
 
   await properties.getByRole("button", { name: "Reset defaults" }).click();
-  await expect(formula).toHaveValue("");
+  // Reset restores the Symbol's own formula as editable text, not an empty
+  // box: the default is the starting point for the next edit.
+  await expect(formula).toHaveValue(symbol.formulaPresentation!.defaultFormula);
   await expect(coefficient).toHaveValue("");
   await expect(minimumWidth).toHaveValue("");
   await expect(minimumHeight).toHaveValue("");

--- a/apps/editor/src/features/properties/component-signal-flow-properties.test.tsx
+++ b/apps/editor/src/features/properties/component-signal-flow-properties.test.tsx
@@ -2,7 +2,11 @@ import { createEmptyDocument } from "@icm/model";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
+import type { SchematicDocument } from "@icm/model";
+
 import { ComponentSignalFlowProperties } from "./component-signal-flow-properties";
+
+type Instance = SchematicDocument["instances"][number];
 
 const presentation = {
   defaultFormula: "z^-1/(1-z^-1)",
@@ -54,5 +58,29 @@ describe("Signal Flow properties", () => {
     expect(markup).toContain('value="60"');
     expect(markup).toContain("Reset defaults");
     expect(markup).toContain("does not change SPICE");
+  });
+
+  it("pre-fills the Symbol's own formula so it can be edited in place", () => {
+    const instance: Instance = {
+      id: "B2",
+      symbolId: "custom-formula-block",
+      placement: null,
+    };
+    const markup = renderToStaticMarkup(
+      <ComponentSignalFlowProperties
+        instance={instance}
+        presentation={presentation}
+        revision={1}
+        onChange={vi.fn()}
+      />,
+    );
+
+    // Without an override the field carries the default as a real value,
+    // not only as placeholder text: the default is the starting point for
+    // editing rather than something the author has to retype.
+    const formulaInput =
+      /<input[^>]*aria-label="Signal flow formula"[^>]*>/u.exec(markup)?.[0];
+    expect(formulaInput).toBeDefined();
+    expect(formulaInput).toContain('value="z^-1/(1-z^-1)"');
   });
 });

--- a/apps/editor/src/features/properties/component-signal-flow-properties.tsx
+++ b/apps/editor/src/features/properties/component-signal-flow-properties.tsx
@@ -24,11 +24,16 @@ function normalizedParameters(
   bodyWidth: string,
   bodyHeight: string,
   supportsCoefficient: boolean,
+  defaultFormula: string,
 ): SignalFlowParameters | null {
   const next: SignalFlowParameters = {};
   const formulaValue = formula.trim();
   const coefficientValue = coefficient.trim();
-  if (formulaValue) next.formula = formulaValue;
+  // The field shows the Symbol's own formula so it can be edited in place;
+  // matching that default (or clearing the field) means "no override", not
+  // a stored copy of the default.
+  if (formulaValue && formulaValue !== defaultFormula)
+    next.formula = formulaValue;
   if (supportsCoefficient && coefficientValue)
     next.coefficient = coefficientValue;
   const width = normalizedDimension(bodyWidth, 20, 1000);
@@ -67,7 +72,7 @@ export function ComponentSignalFlowProperties({
   onChange: (parameters: SignalFlowParameters | null) => boolean;
 }) {
   const [formula, setFormula] = useState(
-    instance.signalFlowParameters?.formula ?? "",
+    instance.signalFlowParameters?.formula ?? presentation.defaultFormula,
   );
   const [coefficient, setCoefficient] = useState(
     instance.signalFlowParameters?.coefficient ?? "",
@@ -84,12 +89,19 @@ export function ComponentSignalFlowProperties({
 
   // A transaction, undo/redo, or another selection can replace the instance.
   useEffect(() => {
-    setFormula(instance.signalFlowParameters?.formula ?? "");
+    setFormula(
+      instance.signalFlowParameters?.formula ?? presentation.defaultFormula,
+    );
     setCoefficient(instance.signalFlowParameters?.coefficient ?? "");
     setBodyWidth(instance.signalFlowParameters?.bodyWidth?.toString() ?? "");
     setBodyHeight(instance.signalFlowParameters?.bodyHeight?.toString() ?? "");
     committedParameters.current = instance.signalFlowParameters;
-  }, [instance.id, instance.signalFlowParameters, revision]);
+  }, [
+    instance.id,
+    instance.signalFlowParameters,
+    presentation.defaultFormula,
+    revision,
+  ]);
 
   const commit = () => {
     const next = normalizedParameters(
@@ -98,10 +110,14 @@ export function ComponentSignalFlowProperties({
       bodyWidth,
       bodyHeight,
       presentation.supportsCoefficient,
+      presentation.defaultFormula,
     );
     if (sameParameters(committedParameters.current, next)) return;
     if (onChange(next)) {
       committedParameters.current = next ?? undefined;
+      // Show what the block actually renders: clearing the field falls back
+      // to the Symbol's own formula rather than leaving an empty box.
+      setFormula(next?.formula ?? presentation.defaultFormula);
       setBodyWidth(next?.bodyWidth?.toString() ?? "");
       setBodyHeight(next?.bodyHeight?.toString() ?? "");
     }
@@ -109,7 +125,7 @@ export function ComponentSignalFlowProperties({
   const resetDefaults = () => {
     if (committedParameters.current !== undefined && onChange(null)) {
       committedParameters.current = undefined;
-      setFormula("");
+      setFormula(presentation.defaultFormula);
       setCoefficient("");
       setBodyWidth("");
       setBodyHeight("");


### PR DESCRIPTION
Owner report: the Formula field on a Signal Flow block looked uneditable — "默认的 formula 应该是可以编辑的才对,应该直接可以在原来的基础上进行编辑".

The field was in fact editable, but the block's formula was only a **placeholder** over an empty input. Editing `1/s` therefore meant retyping the whole expression rather than adjusting what the canvas already showed. (Screenshot's grey `1/s` reads the same as the neighbouring `Optional` / `Auto` placeholders — that is exactly what it was.)

The Formula box now carries the effective formula as real text, so it can be edited in place. Matching the Symbol's own default — or clearing the box — still means "no override" rather than a stored copy of the default, so documents keep no redundant parameters; `Reset defaults` restores the default as editable text instead of an empty field. Coefficient (`Optional`) and Min width/height (`Auto`) keep their placeholders: those have no default to start from.

Validation: red-first unit test (the pre-fill assertion fails against the previous placeholder-only rendering); editor unit suite 685/685; the signal-flow e2e updated for the new Reset behaviour and green; live check on a placed integrator shows `value: "1/s"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)