### PR TITLE
fix(editor): a physical mouse wheel zooms even when its deltas look small

### DIFF
--- a/apps/editor/src/canvas/canvas-gesture-controller.test.ts
+++ b/apps/editor/src/canvas/canvas-gesture-controller.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { wheelEventLooksLikeTrackpad } from "./canvas-gesture-controller";
+import {
+  wheelEventIsMouseDetent,
+  wheelEventLooksLikeTrackpad,
+} from "./canvas-gesture-controller";
 
 describe("wheelEventLooksLikeTrackpad", () => {
   it("classifies wheel sources by delta shape", () => {
@@ -20,6 +23,51 @@ describe("wheelEventLooksLikeTrackpad", () => {
     ).toBe(true);
     expect(
       wheelEventLooksLikeTrackpad({ deltaMode: 0, deltaX: 0, deltaY: 8 }),
+    ).toBe(true);
+  });
+
+  it("reads a detent-quantized wheelDeltaY as a mouse despite small deltas", () => {
+    // macOS scroll acceleration shrinks a slow mouse detent's deltaY under
+    // the small-step threshold, but Chromium/WebKit still stamp the detent
+    // as wheelDeltaY = n*120 without the trackpad's 3:1 pixel ratio.
+    expect(
+      wheelEventLooksLikeTrackpad({
+        deltaMode: 0,
+        deltaX: 0,
+        deltaY: 4,
+        wheelDeltaY: -120,
+      }),
+    ).toBe(false);
+    expect(
+      wheelEventIsMouseDetent({
+        deltaMode: 0,
+        deltaX: 0,
+        deltaY: 16,
+        wheelDeltaY: -240,
+      }),
+    ).toBe(true);
+    // A trackpad step that happens to land on 120 keeps the 3:1 ratio and
+    // is not claimed as a detent.
+    expect(
+      wheelEventIsMouseDetent({
+        deltaMode: 0,
+        deltaX: 0,
+        deltaY: 40,
+        wheelDeltaY: -120,
+      }),
+    ).toBe(false);
+    // A horizontal component is trackpad evidence regardless of quantizing.
+    expect(
+      wheelEventLooksLikeTrackpad({
+        deltaMode: 0,
+        deltaX: 4,
+        deltaY: 40,
+        wheelDeltaY: -120,
+      }),
+    ).toBe(true);
+    // Firefox never exposes wheelDeltaY; the small-step reading holds.
+    expect(
+      wheelEventLooksLikeTrackpad({ deltaMode: 0, deltaX: 0, deltaY: 4 }),
     ).toBe(true);
   });
 });

--- a/apps/editor/src/canvas/canvas-gesture-controller.ts
+++ b/apps/editor/src/canvas/canvas-gesture-controller.ts
@@ -146,13 +146,38 @@ export interface CanvasGestureControllerDependencies {
  * mouse wheel reports line/page mode or large integer vertical detents.
  * Heuristic by necessity — the DOM never names the device.
  */
-export function wheelEventLooksLikeTrackpad(event: {
+interface WheelSourceShape {
   deltaMode: number;
   deltaX: number;
   deltaY: number;
-}): boolean {
+  /** Non-standard, Chromium/WebKit only; absent on Firefox. */
+  wheelDeltaY?: number;
+}
+
+/**
+ * Chromium and WebKit stamp a physical wheel detent as wheelDeltaY = n*120
+ * regardless of pointer-acceleration, while macOS acceleration can shrink
+ * the same detent's deltaY below the small-step threshold — which made a
+ * slowly turned mouse wheel read as a trackpad and pan instead of zoom. A
+ * trackpad event keeps wheelDeltaY = -3 * deltaY, so a detent-quantized
+ * value that breaks that ratio is a mouse wheel — decisively enough to
+ * override even recent trackpad evidence.
+ */
+export function wheelEventIsMouseDetent(event: WheelSourceShape): boolean {
+  const wheelDeltaY = event.wheelDeltaY;
+  return (
+    event.deltaX === 0 &&
+    typeof wheelDeltaY === "number" &&
+    wheelDeltaY !== 0 &&
+    wheelDeltaY % 120 === 0 &&
+    Math.abs(wheelDeltaY) !== 3 * Math.abs(event.deltaY)
+  );
+}
+
+export function wheelEventLooksLikeTrackpad(event: WheelSourceShape): boolean {
   if (event.deltaMode !== 0) return false;
   if (event.deltaX !== 0) return true;
+  if (wheelEventIsMouseDetent(event)) return false;
   if (!Number.isInteger(event.deltaY)) return true;
   return Math.abs(event.deltaY) > 0 && Math.abs(event.deltaY) < 40;
 }
@@ -289,9 +314,12 @@ export function createCanvasGestureController({
       lastTrackpadWheelAt = event.timeStamp;
     }
     // Momentum tails of a trackpad flick can degrade into clean integer
-    // steps, so recent trackpad evidence keeps the pan interpretation.
+    // steps, so recent trackpad evidence keeps the pan interpretation — but
+    // a detent-quantized mouse wheel must zoom even inside that window: the
+    // mouse's only axis always earns the zoom.
     const trackpad =
       event.deltaMode === 0 &&
+      !wheelEventIsMouseDetent(event) &&
       event.timeStamp - lastTrackpadWheelAt < TRACKPAD_EVIDENCE_WINDOW_MS;
     if (!trackpad) {
       if (event.shiftKey) {


### PR DESCRIPTION
## Summary

Owner feedback (urgent): vertical mouse-wheel scrolling panned the canvas instead of zooming. macOS pointer acceleration shrinks a slowly turned wheel detent's `deltaY` below the trackpad small-step threshold (`|deltaY| < 40`), so the source heuristic read the mouse as a trackpad and panned — and each such event refreshed the 1.5 s trackpad-evidence window, locking the misreading in.

Chromium and WebKit stamp a physical detent as `wheelDeltaY = n×120` regardless of acceleration, while trackpad events keep `wheelDeltaY = -3 × deltaY`. A detent-quantized value that breaks that ratio is now read as a mouse wheel (`wheelEventIsMouseDetent`) — it never counts as trackpad evidence and zooms **even inside the evidence window**: the mouse's only axis always earns the zoom. Firefox exposes no `wheelDeltaY` and already separates devices by `deltaMode`; trackpad panning is unchanged, including steps whose `wheelDeltaY` lands on 120 with the 3:1 ratio intact.

## Validation

- Heuristic unit suite extended; the detent-despite-small-delta case is red before this change, and ratio-preserving 120 steps / horizontal components / Firefox-shaped events keep their prior readings.
- Interactive proof with synthetic events carrying real device signatures: a detent zooms at the cursor immediately after a trackpad pan; a 3:1 step still pans.
- Prettier + repo typecheck; `Test-Impact: tests-updated` validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)