### PR TITLE
fix(editor): the middle button cycles the wire corner instead of committing

### DIFF
--- a/apps/editor/e2e/wiring-semantics.spec.ts
+++ b/apps/editor/e2e/wiring-semantics.spec.ts
@@ -84,3 +84,36 @@ test("clicking a junction dot selects it and Delete disconnects the tap", async 
     3,
   );
 });
+
+test("middle click cycles the wire corner and never commits the wire", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 260, y: 200 });
+  await placeComponent(page, "resistor", { x: 460, y: 420 });
+  const ids = await instanceIds(page);
+  await page.keyboard.press("w");
+  await page.getByTestId(`terminal-${ids[0]}-2`).click();
+
+  // Drafting toward the second pin: middle over bare canvas cycles the
+  // corner shape instead of placing a point.
+  await page.mouse.move(360, 320);
+  await page.mouse.down({ button: "middle" });
+  await page.mouse.up({ button: "middle" });
+  await expect(page.getByTestId("status")).toContainText("Wire corner:");
+  await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(0);
+
+  // Middle directly over the destination endpoint's snap circle is the
+  // reported hazard: it must cycle again, not commit the wire.
+  const destination = page.getByTestId(`terminal-${ids[1]}-1`);
+  const box = (await destination.boundingBox())!;
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down({ button: "middle" });
+  await page.mouse.up({ button: "middle" });
+  await expect(page.getByTestId("status")).toContainText("Wire corner:");
+  await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(0);
+
+  // The primary button still commits.
+  await destination.click();
+  await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(1);
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -4684,6 +4684,14 @@ export function App({
                     toggleSimulationSavedNet(candidate.netId);
                   return;
                 }
+                // Middle press over an endpoint cycles the wire corner just
+                // like over bare canvas; it must never commit the wire.
+                if (event.button === 1 && tool === "wire") {
+                  event.stopPropagation();
+                  event.preventDefault();
+                  cycleWireCornerShape();
+                  return;
+                }
                 handleWireEndpoint(event, candidate);
               },
               onNetPointerEnter: (netId) => {

--- a/apps/editor/src/features/wiring/use-wire-canvas-controller.ts
+++ b/apps/editor/src/features/wiring/use-wire-canvas-controller.ts
@@ -310,6 +310,17 @@ export function useWireCanvasController({
       return;
     }
     if (tool !== "pointer") {
+      // The middle button never places or taps: while the wire tool is up it
+      // cycles the corner shape (matching the canvas-background gesture), and
+      // other buttons leave the conductor untouched so right-click keeps
+      // cancelling through the context-menu path.
+      if (event.button === 1 && tool === "wire") {
+        event.stopPropagation();
+        event.preventDefault();
+        cycleWireCornerShape();
+        return;
+      }
+      if (event.button !== 0) return;
       handleWireRoutePointerDown(event, routeId, hitTarget);
       return;
     }

--- a/apps/editor/src/features/wiring/use-wire-interaction.ts
+++ b/apps/editor/src/features/wiring/use-wire-interaction.ts
@@ -260,6 +260,10 @@ export function useWireInteraction(capabilities: UseWireInteractionOptions) {
     event: ReactPointerEvent<SVGCircleElement>,
     candidate: WireSource,
   ): void => {
+    // Only the primary button starts or commits on an endpoint. A middle
+    // press bubbles to the canvas gesture (corner cycling) unless the caller
+    // intercepted it; right-click keeps cancelling via the context menu.
+    if (event.button !== 0) return;
     event.stopPropagation();
     if (event.altKey) {
       options.setStatus("Snap suppressed while Alt is held");
@@ -685,6 +689,7 @@ export function useWireInteraction(capabilities: UseWireInteractionOptions) {
     routeId: string,
     hitTarget: SVGElement = event.currentTarget,
   ): void => {
+    if (event.button !== 0) return;
     event.stopPropagation();
     if (event.altKey) {
       options.setStatus("Snap suppressed while Alt is held");


### PR DESCRIPTION
## Summary

Owner feedback (urgent): while drafting a wire, pressing the middle button was expected to cycle the corner shape (vertical-first / horizontal-first / diagonal / auto) but **committed the connection** instead.

The canvas-background gesture already implemented the cycle (a middle click with no drag). It never fired because the wire overlay's hit targets — endpoint snap circles and route conductors — handle pointerdown **without any button filter** and `stopPropagation`, so a middle press over them (where the cursor usually is mid-draft, thanks to snapping) started or committed the wire before the gesture layer could see it.

Every wire hit target now routes buttons deliberately:
- primary button keeps its start/commit behavior;
- middle button cycles the corner shape from anywhere — bare canvas, an endpoint circle, or a conductor — and never places a point;
- other buttons fall through untouched, so right-click keeps cancelling via the context-menu path.

## Validation

- New wiring e2e drafts a wire, middle-clicks over bare canvas **and directly over the destination pin's snap circle** (the reported hazard): both must cycle with zero committed routes, and the following primary click still commits. The spec is red before this change (the middle press committed the wire).
- Full wiring-semantics e2e suite green against a worktree dev server.
- Prettier + repo typecheck; `Test-Impact: tests-updated` validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)