### PR TITLE
fix(editor): Properties drops controls the Symbol can never honour

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -2683,6 +2683,37 @@ test("L edits a selected route Net Label without opening Properties", async ({
   ).toHaveCount(0);
 });
 
+test("Properties offers no dead label controls for a schematic-only block", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "adder", { x: 300, y: 200 });
+  await placeComponent(page, "resistor", { x: 520, y: 200 });
+  await openSelectionShelf(page);
+  const properties = page.getByRole("complementary", { name: "Properties" });
+  const labelField = properties.getByLabel("Component schematic label");
+  const parametersCard = properties.getByLabel(
+    "Component parameters and display",
+  );
+
+  // A summing junction hides its designator on the canvas, so the panel
+  // offers neither the label field nor the display toggles that could
+  // never change the drawing. Identity facts and Appearance remain.
+  await page.locator('[data-canvas-hit-kind="instance"]').first().click();
+  await expect(properties.getByText("Symbol")).toBeVisible();
+  await expect(labelField).toHaveCount(0);
+  await expect(parametersCard).toHaveCount(0);
+  await expect(properties.getByText("Line / foreground")).toBeVisible();
+
+  // An ordinary device keeps both.
+  await page.getByTestId("hit-R1").click();
+  await expect(labelField).toHaveCount(1);
+  await expect(parametersCard).toHaveCount(1);
+  await expect(properties.getByLabel("Component display toggles")).toHaveCount(
+    1,
+  );
+});
+
 test("Properties toggles reference label visibility for one or many components", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -1480,6 +1480,14 @@ export function App({
   };
   // Formula capability is owned by the resolved SymbolDefinition, never by a
   // symbol-id allowlist or any electrical/netlist descriptor.
+  // A Symbol that hides its label never draws a reference: the label field
+  // and the Reference toggle would be edits the drawing cannot show.
+  const selectedLabelRenderable = selectedInstance
+    ? resolver.resolve(
+        selectedInstance.symbolId,
+        selectedInstance.symbolVariantId,
+      )?.definition.labelVisibility !== "hidden"
+    : true;
   const selectedSignalFlowPresentation = selectedInstance
     ? resolver.resolve(
         selectedInstance.symbolId,
@@ -4110,6 +4118,7 @@ export function App({
                     revision: document.revision,
                     cellName: document.netlist?.name ?? document.name,
                     formalTerminalSelected: Boolean(selectedFormalTerminal),
+                    schematicLabelEditable: selectedLabelRenderable,
                     portNet: selectedPortNet
                       ? {
                           id: selectedPortNet.id,
@@ -4203,6 +4212,7 @@ export function App({
                       selectedInstanceValue !== null &&
                       selectedInstanceValue.visible !== false,
                     valueAvailable: selectedInstanceValueAvailable,
+                    referenceLabelRenderable: selectedLabelRenderable,
                     additionalParameters: additionalParameterDraft,
                     additionalParametersChanged:
                       additionalParameterDraftChanges,

--- a/apps/editor/src/features/properties/component-electrical-properties.test.tsx
+++ b/apps/editor/src/features/properties/component-electrical-properties.test.tsx
@@ -37,6 +37,7 @@ describe("component electrical properties", () => {
         referenceVisible
         valueVisible
         valueAvailable
+        referenceLabelRenderable
         additionalParameters={[
           { id: "extra", originalName: "ad", name: "ad", value: "1p" },
         ]}
@@ -55,5 +56,73 @@ describe("component electrical properties", () => {
     expect(markup).toContain('aria-label="Additional parameter name 1"');
     expect(markup).toContain("Apply parameters");
     expect(markup).not.toContain("Component compatibility field");
+  });
+
+  it("says nothing at all for a Symbol that has neither parameters nor a drawable label", () => {
+    const document = createEmptyDocument("cell", "Cell");
+    const instance: (typeof document.instances)[number] = {
+      id: "X2",
+      symbolId: "adder",
+      placement: null,
+    };
+    const markup = renderToStaticMarkup(
+      <ComponentElectricalProperties
+        instance={instance}
+        parameters={[]}
+        parameterValues={{}}
+        firstInputRef={createRef<HTMLInputElement>()}
+        referenceVisible={false}
+        valueVisible={false}
+        valueAvailable={false}
+        referenceLabelRenderable={false}
+        additionalParameters={[]}
+        additionalParametersChanged={false}
+        onParameterChange={vi.fn()}
+        onReferenceVisibilityChange={vi.fn()}
+        onValueVisibilityChange={vi.fn()}
+        onAdditionalParameterChange={vi.fn()}
+        onAdditionalParameterRemove={vi.fn()}
+        onAdditionalParameterAdd={vi.fn()}
+        onAdditionalParametersApply={vi.fn()}
+        onAdditionalParametersCancel={vi.fn()}
+      />,
+    );
+    // A summing junction draws no reference and carries no value: the card
+    // would hold two controls that cannot change anything.
+    expect(markup).toBe("");
+  });
+
+  it("keeps the Value toggle alone when only the reference is undrawable", () => {
+    const document = createEmptyDocument("cell", "Cell");
+    const instance: (typeof document.instances)[number] = {
+      id: "GND1",
+      symbolId: "ground",
+      placement: null,
+      netlist: { reference: "GND1", parameters: {} },
+    };
+    const markup = renderToStaticMarkup(
+      <ComponentElectricalProperties
+        instance={instance}
+        parameters={[]}
+        parameterValues={{}}
+        firstInputRef={createRef<HTMLInputElement>()}
+        referenceVisible={false}
+        valueVisible={false}
+        valueAvailable
+        referenceLabelRenderable={false}
+        additionalParameters={[]}
+        additionalParametersChanged={false}
+        onParameterChange={vi.fn()}
+        onReferenceVisibilityChange={vi.fn()}
+        onValueVisibilityChange={vi.fn()}
+        onAdditionalParameterChange={vi.fn()}
+        onAdditionalParameterRemove={vi.fn()}
+        onAdditionalParameterAdd={vi.fn()}
+        onAdditionalParametersApply={vi.fn()}
+        onAdditionalParametersCancel={vi.fn()}
+      />,
+    );
+    expect(markup).toContain("Value");
+    expect(markup).not.toContain(">Reference<");
   });
 });

--- a/apps/editor/src/features/properties/component-electrical-properties.tsx
+++ b/apps/editor/src/features/properties/component-electrical-properties.tsx
@@ -17,6 +17,7 @@ export function ComponentElectricalProperties({
   referenceVisible,
   valueVisible,
   valueAvailable,
+  referenceLabelRenderable,
   additionalParameters,
   additionalParametersChanged,
   onParameterChange,
@@ -35,6 +36,12 @@ export function ComponentElectricalProperties({
   referenceVisible: boolean;
   valueVisible: boolean;
   valueAvailable: boolean;
+  /**
+   * Whether this Symbol can draw a reference label at all. A Symbol that
+   * declares `labelVisibility: "hidden"` — a summing junction, a 1/s block,
+   * Ground — never shows one, so the toggle cannot do anything.
+   */
+  referenceLabelRenderable: boolean;
   additionalParameters: readonly AdditionalParameterDraft[];
   additionalParametersChanged: boolean;
   onParameterChange: (key: string, value: string) => void;
@@ -53,6 +60,14 @@ export function ComponentElectricalProperties({
   const primaryParameters = parameters.filter(
     (parameter) => !parameter.compatibilityOnly,
   );
+  // A toggle that cannot change the drawing is not an option, it is a dead
+  // control: schematic-only glyphs neither draw a reference nor carry a
+  // value, and a Symbol with no parameters and no netlist has nothing left
+  // for this card to say.
+  const displayable = referenceLabelRenderable || valueAvailable;
+  if (primaryParameters.length === 0 && !displayable && !instance.netlist) {
+    return null;
+  }
   return (
     <div
       className="property-card property-electrical-section"
@@ -85,33 +100,37 @@ export function ComponentElectricalProperties({
           Finger width {fingerWidth} · W = FW × NF
         </p>
       ) : null}
-      <div className="property-display-card">
-        <div className="property-section-heading">Display</div>
-        <div
-          className="display-toggle-row"
-          aria-label="Component display toggles"
-        >
-          <DisplayToggle
-            label={
-              instance.symbolId === "port" ||
-              instance.symbolId === "port-filled"
-                ? "Port label"
-                : "Reference"
-            }
-            checked={referenceVisible}
-            onChange={onReferenceVisibilityChange}
-          />
-          <DisplayToggle
-            label="Value"
-            checked={valueVisible}
-            disabled={!valueAvailable}
-            help={
-              valueAvailable ? undefined : "Set the device parameters first"
-            }
-            onChange={onValueVisibilityChange}
-          />
+      {displayable ? (
+        <div className="property-display-card">
+          <div className="property-section-heading">Display</div>
+          <div
+            className="display-toggle-row"
+            aria-label="Component display toggles"
+          >
+            {referenceLabelRenderable ? (
+              <DisplayToggle
+                label={
+                  instance.symbolId === "port" ||
+                  instance.symbolId === "port-filled"
+                    ? "Port label"
+                    : "Reference"
+                }
+                checked={referenceVisible}
+                onChange={onReferenceVisibilityChange}
+              />
+            ) : null}
+            <DisplayToggle
+              label="Value"
+              checked={valueVisible}
+              disabled={!valueAvailable}
+              help={
+                valueAvailable ? undefined : "Set the device parameters first"
+              }
+              onChange={onValueVisibilityChange}
+            />
+          </div>
         </div>
-      </div>
+      ) : null}
       {instance.netlist ? (
         <details className="property-details property-details-inline">
           <summary>

--- a/apps/editor/src/features/properties/component-identity-properties.test.tsx
+++ b/apps/editor/src/features/properties/component-identity-properties.test.tsx
@@ -39,6 +39,7 @@ describe("component identity properties", () => {
         revision={0}
         cellName="Cell"
         formalTerminalSelected={false}
+        schematicLabelEditable
         portNet={{ id: "net", logicalName: "VDD", supply: true }}
         targetDescription={null}
         capacitorPlateRows={null}
@@ -56,5 +57,35 @@ describe("component identity properties", () => {
     );
     expect(markup).toContain('aria-label="Supply name"');
     expect(markup).toContain("sky130_fd_pr__nfet_01v8");
+  });
+
+  it("offers no schematic label field when the Symbol never draws one", () => {
+    const document = createEmptyDocument("cell", "Cell");
+    const instance: (typeof document.instances)[number] = {
+      id: "X2",
+      symbolId: "adder",
+      placement: null,
+    };
+    const markup = renderToStaticMarkup(
+      <ComponentIdentityProperties
+        instance={instance}
+        revision={1}
+        cellName="Main"
+        formalTerminalSelected={false}
+        schematicLabelEditable={false}
+        portNet={null}
+        targetDescription={null}
+        capacitorPlateRows={null}
+        modelTarget={null}
+        onMarkerNameChange={vi.fn()}
+        onSchematicNameChange={vi.fn()}
+        onReferenceChange={vi.fn()}
+        onModelTargetChange={vi.fn()}
+      />,
+    );
+    // The Symbol and Cell stay: they answer "what am I looking at". The
+    // label input does not, because the drawing can never show its text.
+    expect(markup).toContain("Symbol");
+    expect(markup).not.toContain("Schematic label");
   });
 });

--- a/apps/editor/src/features/properties/component-identity-properties.tsx
+++ b/apps/editor/src/features/properties/component-identity-properties.tsx
@@ -37,6 +37,7 @@ export function ComponentIdentityProperties({
   revision,
   cellName,
   formalTerminalSelected,
+  schematicLabelEditable,
   portNet,
   targetDescription,
   capacitorPlateRows,
@@ -50,6 +51,12 @@ export function ComponentIdentityProperties({
   revision: number;
   cellName: string;
   formalTerminalSelected: boolean;
+  /**
+   * Whether a schematic label can appear on this Symbol at all. A Symbol
+   * that declares `labelVisibility: "hidden"` never draws one, so offering
+   * the field would invite an edit the drawing cannot show.
+   */
+  schematicLabelEditable: boolean;
   portNet: { id: string; logicalName: string; supply: boolean } | null;
   targetDescription: string | null;
   capacitorPlateRows: readonly CapacitorPlatePropertyRow[] | null;
@@ -84,7 +91,7 @@ export function ComponentIdentityProperties({
                 />
               </dd>
             </div>
-          ) : !formalTerminalSelected ? (
+          ) : !formalTerminalSelected && schematicLabelEditable ? (
             <div>
               <dt>Schematic label</dt>
               <dd>


### PR DESCRIPTION
Owner report on a summing junction's Properties panel: "信号流图部分不应该有这种 identity 吧？…还有什么 display label 之类的，这根本就没有任何意义，我们好像特地把这个东西给删掉过的".

Correct — and the controls were not merely redundant, they were dead. #386 gave the five signal-flow blocks `labelVisibility: "hidden"`, so `defaultInstanceLabel` returns null for them. The panel had not followed:

- **Schematic label field** — typing in it changed nothing the drawing could show (the `X2` itself comes from the `"X"` fallback prefix for a Symbol with no reference policy; adder/integrator/quantizer have no device descriptor at all).
- **Reference toggle** — produced zero edits and the status "No reference labels are available for this selection", then reverted to unchecked.
- **Value toggle** — already permanently disabled, since there are no parameters.

So the Parameters card's entire content was two controls that could not act.

The panel now asks the Symbol what it can show, rather than hard-coding symbol ids (same shape as the transfer-function card keying off `formulaPresentation`):

- no drawable label ⇒ no Schematic label field, no Reference toggle;
- no parameters, no drawable label, and no netlist ⇒ no Parameters card at all;
- Identity facts (Symbol, Cell), Appearance, and the transfer-function card are untouched.

Ground and the supply Port share `labelVisibility: "hidden"` and lose the same dead controls; `port` / `port-filled` are `shown`, so their "Port label" toggle is unaffected.

Validation: three red-first unit tests (all fail against the previous rendering), editor unit suite 688/688, new e2e pinning an adder (no field, no card, Appearance present) against a resistor (both present), full manual-editor spec 119/119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)