### PR TITLE
feat(editor): Cadence-style verb-first commands — press C/M/R/Delete, then click

### DIFF
--- a/apps/editor/e2e/verb-first.spec.ts
+++ b/apps/editor/e2e/verb-first.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { chooseComponent } from "./editor-fixtures";
+
+async function placeComponent(
+  page: Page,
+  symbolId: string,
+  position: { x: number; y: number },
+): Promise<void> {
+  await chooseComponent(page, symbolId);
+  await page.getByTestId("schematic-canvas").click({ position });
+  await page.keyboard.press("Escape");
+}
+
+function instances(page: Page) {
+  return page.locator('[data-canvas-hit-kind="instance"]');
+}
+
+test("C pressed first arms copy; the next click picks up a copy", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 300, y: 250 });
+  await expect(instances(page)).toHaveCount(1);
+
+  // Nothing selected: C arms the verb instead of complaining.
+  // Click empty canvas so nothing is selected before pressing the verb key.
+  await page.getByTestId("schematic-canvas").click({
+    position: { x: 150, y: 420 },
+  });
+  await page.keyboard.press("c");
+  await expect(page.getByTestId("status")).toContainText("Copy: click");
+
+  // Clicking the part starts copy placement with its ghost on the cursor.
+  const part = instances(page).first();
+  const box = (await part.boundingBox())!;
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+  await expect(page.getByTestId("status")).toContainText("Place copy");
+
+  // Clicking empty canvas commits the copy.
+  await page.getByTestId("schematic-canvas").click({
+    position: { x: 520, y: 250 },
+  });
+  await expect(instances(page)).toHaveCount(2);
+  await page.keyboard.press("Escape");
+});
+
+test("Delete pressed first enters a repeating delete mode until Escape", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 280, y: 220 });
+  await placeComponent(page, "resistor", { x: 460, y: 220 });
+  await expect(instances(page)).toHaveCount(2);
+
+  // Click empty canvas so nothing is selected before pressing the verb key.
+  await page.getByTestId("schematic-canvas").click({
+    position: { x: 150, y: 420 },
+  });
+  await page.keyboard.press("Delete");
+  await expect(page.getByTestId("status")).toContainText("Delete: click");
+
+  const first = (await instances(page).first().boundingBox())!;
+  await page.mouse.click(first.x + first.width / 2, first.y + first.height / 2);
+  await expect(instances(page)).toHaveCount(1);
+  await expect(page.getByTestId("status")).toContainText("click another");
+
+  const second = (await instances(page).first().boundingBox())!;
+  await page.mouse.click(
+    second.x + second.width / 2,
+    second.y + second.height / 2,
+  );
+  await expect(instances(page)).toHaveCount(0);
+
+  // Escape leaves the mode; later clicks stop deleting.
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("status")).toContainText("Cancelled");
+  await placeComponent(page, "resistor", { x: 360, y: 320 });
+  const third = (await instances(page).first().boundingBox())!;
+  await page.mouse.click(third.x + third.width / 2, third.y + third.height / 2);
+  await expect(instances(page)).toHaveCount(1);
+});
+
+test("M pressed first arms move; the next click picks the part up", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 300, y: 250 });
+
+  // Click empty canvas so nothing is selected before pressing the verb key.
+  await page.getByTestId("schematic-canvas").click({
+    position: { x: 150, y: 420 },
+  });
+  await page.keyboard.press("m");
+  await expect(page.getByTestId("status")).toContainText("Move: click");
+
+  const part = instances(page).first();
+  const before = (await part.boundingBox())!;
+  await page.mouse.click(
+    before.x + before.width / 2,
+    before.y + before.height / 2,
+  );
+  await expect(page.getByTestId("status")).toContainText("Move: move the");
+
+  // The part follows the pointer; a click places it.
+  await page.mouse.move(before.x + 160, before.y + before.height / 2);
+  await page.mouse.click(before.x + 160, before.y + before.height / 2);
+  const after = (await instances(page).first().boundingBox())!;
+  expect(after.x).toBeGreaterThan(before.x + 80);
+});
+
+test("Escape disarms rotate so later clicks stop turning parts", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 300, y: 250 });
+
+  // Click empty canvas so nothing is selected before pressing the verb key.
+  await page.getByTestId("schematic-canvas").click({
+    position: { x: 150, y: 420 },
+  });
+  await page.keyboard.press("r");
+  await expect(page.getByTestId("status")).toContainText("Rotate: click");
+
+  const part = instances(page).first();
+  const upright = (await part.boundingBox())!;
+  await page.mouse.click(
+    upright.x + upright.width / 2,
+    upright.y + upright.height / 2,
+  );
+  await expect(page.getByTestId("status")).toContainText("Rotated");
+  const turned = (await instances(page).first().boundingBox())!;
+  expect(turned.width).toBeGreaterThan(upright.width);
+
+  // Escape must actually stop the armed rotate (the historical gap).
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("status")).toContainText("Cancelled");
+  await page.mouse.click(
+    turned.x + turned.width / 2,
+    turned.y + turned.height / 2,
+  );
+  const settled = (await instances(page).first().boundingBox())!;
+  expect(Math.abs(settled.width - turned.width)).toBeLessThan(2);
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -257,6 +257,7 @@ import {
   useSelectionInteraction,
 } from "../features/selection/use-selection-interaction";
 import {
+  EMPTY_VISUAL_SELECTION,
   hasVisualSelection,
   pruneVisualSelection,
 } from "../features/selection/visual-selection";
@@ -917,11 +918,16 @@ export function App({
     null,
   );
   /**
-   * R pressed with nothing selected: the next part pointed at is turned.
-   * The key means rotate whether or not something is selected yet, rather
-   * than meaning rotate sometimes and draw a rectangle the rest of the time.
+   * A verb key pressed with nothing selected arms that verb: the next
+   * object pointed at is the one acted on (Cadence-style verb-first).
+   * Rotate and Delete stay armed for repeated clicks; Copy and Move hand
+   * over to their own placement/move interactions on the first target.
    */
-  const [rotateArmed, setRotateArmed] = useState(false);
+  const [armedVerb, setArmedVerb] = useState<
+    "rotate" | "copy" | "move" | "delete" | null
+  >(null);
+  /** The click paired with an armed-verb pickup must not commit a placement. */
+  const suppressCommitClickRef = useRef(false);
   const [selectedEndpoint, setSelectedEndpoint] = useState<WireSource | null>(
     null,
   );
@@ -1767,32 +1773,83 @@ export function App({
     setStatus,
   });
 
-  /** Arm R so the next part pointed at is the one that turns. */
-  function armRotateOnNextPart(): void {
-    setRotateArmed(true);
-    setStatus("Rotate: click a part to turn it, Escape to stop");
+  /** Arm a verb so the next object pointed at is the one acted on. */
+  function armVerb(verb: "rotate" | "copy" | "move" | "delete"): void {
+    setArmedVerb(verb);
+    setStatus(
+      verb === "rotate"
+        ? "Rotate: click a part to turn it, Escape to stop"
+        : verb === "copy"
+          ? "Copy: click a part to pick up a copy · Esc cancels"
+          : verb === "move"
+            ? "Move: click a part to pick it up · Esc cancels"
+            : "Delete: click objects to delete them · Esc exits",
+    );
   }
 
-  /** Turn one part where it stands. Returns false when nothing was armed. */
-  function rotateArmedInstance(instanceId: string): boolean {
-    if (!rotateArmed) return false;
+  function disarmVerb(): void {
+    setArmedVerb(null);
+    setStatus("Cancelled");
+  }
+
+  /**
+   * Apply the armed verb to one part. Returns false when nothing was armed.
+   * Rotate and Delete remain armed for the next click; Copy and Move disarm
+   * because their own interactions (copy placement, command move) take over
+   * and own Esc from here.
+   */
+  function consumeArmedVerbOnInstance(instanceId: string): boolean {
+    if (armedVerb === null) return false;
     const instance = document.instances.find(
       (candidate) => candidate.id === instanceId,
     );
     if (!instance?.placement) return false;
-    const next = (instance.placement.rotation + 90) % 360;
-    const applied = transact([
-      {
-        kind: "rotate_instance",
-        instanceId,
-        rotation: next as 0 | 90 | 180 | 270,
-      },
-    ]);
-    if (applied.ok) {
-      setStatus(
-        `Rotated ${instanceId} to ${next}° — click another, Escape to stop`,
-      );
+    if (armedVerb === "rotate") {
+      const next = (instance.placement.rotation + 90) % 360;
+      const applied = transact([
+        {
+          kind: "rotate_instance",
+          instanceId,
+          rotation: next as 0 | 90 | 180 | 270,
+        },
+      ]);
+      if (applied.ok) {
+        setStatus(
+          `Rotated ${instanceId} to ${next}° — click another, Escape to stop`,
+        );
+      }
+      return true;
     }
+    if (armedVerb === "copy") {
+      setArmedVerb(null);
+      selectOnly("instance", [instanceId]);
+      suppressCommitClickRef.current = true;
+      beginCopyPlacementFromSelection([instanceId]);
+      return true;
+    }
+    if (armedVerb === "move") {
+      setArmedVerb(null);
+      selectOnly("instance", [instanceId]);
+      suppressCommitClickRef.current = true;
+      beginKeyboardSelectionMoveFromSelection({
+        ...EMPTY_VISUAL_SELECTION,
+        instanceIds: [instanceId],
+      });
+      return true;
+    }
+    deleteSelectionFromSelection({ instanceIds: [instanceId] });
+    setStatus(`Deleted ${instanceId} — click another, Esc exits`);
+    return true;
+  }
+
+  /** Armed Delete applied to a non-instance object; stays armed. */
+  function consumeArmedDeleteOnObject(
+    kind: "routeIds" | "junctionIds" | "annotationIds" | "draftingIds",
+    id: string,
+  ): boolean {
+    if (armedVerb !== "delete") return false;
+    deleteSelectionFromSelection({ [kind]: [id] });
+    setStatus(`Deleted ${id} — click another, Esc exits`);
     return true;
   }
   const {
@@ -2231,6 +2288,20 @@ export function App({
       selectEndpoint,
       endpointStatusLabel: (endpoint) => endpointTestId(endpoint.endpoint),
       setStatus,
+      consumeArmedVerb: (kind, id) => {
+        if (kind === "instance") return consumeArmedVerbOnInstance(id);
+        if (kind === "route") return consumeArmedDeleteOnObject("routeIds", id);
+        if (kind === "junction") {
+          return consumeArmedDeleteOnObject("junctionIds", id);
+        }
+        if (kind === "annotation") {
+          return consumeArmedDeleteOnObject("annotationIds", id);
+        }
+        if (kind === "drafting") {
+          return consumeArmedDeleteOnObject("draftingIds", id);
+        }
+        return false;
+      },
     },
   });
   const {
@@ -2557,7 +2628,7 @@ export function App({
     cancelInteraction();
     setBulkDrawInstanceId(null);
     setBoxPreview(null);
-    setRotateArmed(false);
+    setArmedVerb(null);
   }
 
   function selectEndpoint(candidate: WireSource): void {
@@ -2852,6 +2923,7 @@ export function App({
         selectedDrafting?.kind === "rectangle" ||
         selectedDrafting?.kind === "circle",
       hasActiveNetHighlight: highlightedNetOrigin !== null,
+      hasArmedVerb: armedVerb !== null,
     }),
     operations: {
       closeHelp,
@@ -2894,15 +2966,36 @@ export function App({
       },
       selectAll: selectAllObjects,
       clearSelection: clearEditorSelection,
-      deleteSelection: deleteSelectionFromSelection,
-      beginCopy: beginCopyPlacementFromSelection,
-      beginMove: beginKeyboardSelectionMoveFromSelection,
+      // Verb keys with nothing to act on arm the verb instead (Cadence
+      // style: command first, then click the target).
+      deleteSelection: () => {
+        if (hasVisualSelection(visualSelection) || selectedEndpoint !== null) {
+          deleteSelectionFromSelection();
+          return;
+        }
+        armVerb("delete");
+      },
+      beginCopy: () => {
+        if (hasVisualSelection(visualSelection)) {
+          beginCopyPlacementFromSelection();
+          return;
+        }
+        armVerb("copy");
+      },
+      beginMove: () => {
+        if (canBeginKeyboardSelectionMove()) {
+          beginKeyboardSelectionMoveFromSelection();
+          return;
+        }
+        armVerb("move");
+      },
       alignSelection,
       rotatePlacement: rotatePendingComponentFromHook,
       rotateCopy: rotatePendingCopy,
       rotateMove: rotateCommandMoveFromSelection,
       rotateSelection: rotateSelected,
-      armRotate: () => armRotateOnNextPart(),
+      armRotate: () => armVerb("rotate"),
+      disarmVerb,
       mirrorPlacement: mirrorPendingComponentFromHook,
       mirrorCopy: mirrorPendingCopy,
       mirrorMove: mirrorCommandMoveFromSelection,
@@ -3401,6 +3494,11 @@ export function App({
       },
     },
     report: setStatus,
+    consumePickupClick: () => {
+      if (!suppressCommitClickRef.current) return false;
+      suppressCommitClickRef.current = false;
+      return true;
+    },
   });
 
   return (
@@ -4606,11 +4704,16 @@ export function App({
                   event.preventDefault();
                   return;
                 }
-                // While R is armed the click turns the part rather than
-                // picking it up, so the gesture reads as "rotate that one".
-                if (rotateArmedInstance(instance.id)) {
+                // While a verb is armed the click acts on the pointed-at
+                // part (rotate it, copy it, pick it up, delete it) rather
+                // than picking it up for a plain drag.
+                if (
+                  event.button === 0 &&
+                  consumeArmedVerbOnInstance(instance.id)
+                ) {
                   event.stopPropagation();
                   event.preventDefault();
+                  suppressInstanceClick.current = true;
                   return;
                 }
                 beginMoveFromSelection(event, instance.id);
@@ -4633,6 +4736,14 @@ export function App({
                   if (route) toggleSimulationSavedNet(route.netId);
                   return;
                 }
+                if (
+                  event.button === 0 &&
+                  consumeArmedDeleteOnObject("routeIds", routeId)
+                ) {
+                  event.stopPropagation();
+                  event.preventDefault();
+                  return;
+                }
                 handleRoutePointerDown(event, routeId);
               },
               onAnnotationPointerDown: (event, annotation) => {
@@ -4640,6 +4751,14 @@ export function App({
                   event.stopPropagation();
                   event.preventDefault();
                   toggleSimulationSavedNet(annotation.netId);
+                  return;
+                }
+                if (
+                  event.button === 0 &&
+                  consumeArmedDeleteOnObject("annotationIds", annotation.id)
+                ) {
+                  event.stopPropagation();
+                  event.preventDefault();
                   return;
                 }
                 beginAnnotationDrag(event, annotation);
@@ -4683,6 +4802,15 @@ export function App({
                     toggleSimulationSavedNet(candidate.netId);
                   return;
                 }
+                if (
+                  candidate.endpoint.kind === "junction" &&
+                  consumeArmedDeleteOnObject(
+                    "junctionIds",
+                    candidate.endpoint.junctionId,
+                  )
+                ) {
+                  return;
+                }
                 selectEndpoint(candidate);
                 setStatus(`Selected ${endpointTestId(candidate.endpoint)}`);
               },
@@ -4719,6 +4847,14 @@ export function App({
             selectedDraftingId,
             supplementalDraftingIds: supplementalSelection.draftingIds,
             onPointerDown: (event, object, draggable) => {
+              if (
+                event.button === 0 &&
+                consumeArmedDeleteOnObject("draftingIds", object.id)
+              ) {
+                event.stopPropagation();
+                event.preventDefault();
+                return;
+              }
               const groupIds = draftingSelectionIds(object.id);
               if (draggable && groupIds.length > 1) {
                 if (event.shiftKey || event.ctrlKey || event.metaKey) {

--- a/apps/editor/src/canvas/canvas-hit-controller.ts
+++ b/apps/editor/src/canvas/canvas-hit-controller.ts
@@ -57,6 +57,11 @@ export interface CanvasHitControllerDependencies {
     selectEndpoint: (endpoint: WireSource) => void;
     endpointStatusLabel: (endpoint: WireSource) => string;
     setStatus: (status: string) => void;
+    /**
+     * Offer the press to an armed verb (rotate/copy/move/delete pressed
+     * before a target). Returns true when the verb consumed the hit.
+     */
+    consumeArmedVerb?: (kind: string, id: string) => boolean;
   };
 }
 
@@ -86,6 +91,7 @@ export function createCanvasHitController({
     selectEndpoint,
     endpointStatusLabel,
     setStatus,
+    consumeArmedVerb,
   },
 }: CanvasHitControllerDependencies) {
   const compositeSelectionOwnsHit = (
@@ -165,6 +171,10 @@ export function createCanvasHitController({
     const hitTarget = hit.element as SVGElement;
     event.preventDefault();
     event.stopPropagation();
+
+    // An armed verb (rotate/copy/move/delete pressed first) owns the click:
+    // the pointed-at object is acted on instead of picked up or selected.
+    if (consumeArmedVerb?.(hit.kind, hit.id)) return;
 
     if (
       !event.shiftKey &&

--- a/apps/editor/src/canvas/editor-canvas-event-handlers.ts
+++ b/apps/editor/src/canvas/editor-canvas-event-handlers.ts
@@ -110,6 +110,11 @@ interface CanvasEventHandlerDependencies {
     cancel: () => void;
   };
   report: (status: string) => void;
+  /**
+   * Read-and-clear flag for the click that belongs to an armed-verb pickup;
+   * true means this click already did its work on pointerdown.
+   */
+  consumePickupClick?: () => boolean;
 }
 
 /** DOM event boundary for the editor canvas; domain mutations stay injected. */
@@ -168,10 +173,22 @@ export function createEditorCanvasEventHandlers({
     cancel: cancelWire,
   },
   report: setStatus,
+  consumePickupClick,
 }: CanvasEventHandlerDependencies) {
   return {
     onClickCapture(event: CanvasMouseEvent) {
       const kind = interactionKind();
+      // The pointerdown that just picked something up (an armed Copy/Move
+      // verb consuming its target) must not also place it: its click would
+      // otherwise commit at the pickup point with zero displacement.
+      if (
+        (kind === "moving-selection" || kind === "copy-placement") &&
+        consumePickupClick?.()
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
       if (kind === "moving-selection") {
         if (event.detail === 1) {
           event.preventDefault();

--- a/apps/editor/src/commands/editor-command.test.ts
+++ b/apps/editor/src/commands/editor-command.test.ts
@@ -25,6 +25,7 @@ function fixture(overrides: Partial<EditorCommandContext> = {}) {
     canvasDragActive: false,
     hasClearableDraftingSelection: false,
     hasActiveNetHighlight: false,
+    hasArmedVerb: false,
     ...overrides,
   };
   const operations: EditorCommandOperations = {
@@ -47,6 +48,7 @@ function fixture(overrides: Partial<EditorCommandContext> = {}) {
     rotateMove: vi.fn(),
     rotateSelection: vi.fn(),
     armRotate: vi.fn(),
+    disarmVerb: vi.fn(),
     mirrorPlacement: vi.fn(),
     mirrorCopy: vi.fn(),
     mirrorMove: vi.fn(),
@@ -226,6 +228,7 @@ describe("editor command router", () => {
       canUndo: false,
       canRedo: false,
       hasDeletableSelection: false,
+      interactionMode: "wire",
     });
 
     expect(router.state({ id: "history.undo" }).enabled).toBe(false);
@@ -233,5 +236,28 @@ describe("editor command router", () => {
     expect(router.execute({ id: "history.redo" }).status).toBe("rejected");
     expect(router.execute({ id: "selection.delete" }).status).toBe("rejected");
     expect(operations.report).not.toHaveBeenCalled();
+  });
+
+  it("lets verb commands execute while idle with nothing selected so they can arm", () => {
+    // Cadence-style verb-first: with no selection, C / M / Delete reach their
+    // operations, whose owner arms the verb and waits for a target click.
+    const { router, operations } = fixture({
+      hasDeletableSelection: false,
+      hasMoveSelection: false,
+    });
+    expect(router.execute({ id: "selection.delete" }).status).toBe("executed");
+    expect(operations.deleteSelection).toHaveBeenCalled();
+    expect(router.execute({ id: "selection.move" }).status).toBe("executed");
+    expect(operations.beginMove).toHaveBeenCalled();
+    expect(router.execute({ id: "selection.copy" }).status).toBe("executed");
+    expect(operations.beginCopy).toHaveBeenCalled();
+  });
+
+  it("Escape disarms an armed verb before touching passive state", () => {
+    const { router, operations } = fixture({ hasArmedVerb: true });
+    expect(router.state({ id: "editor.cancel" }).enabled).toBe(true);
+    router.execute({ id: "editor.cancel" });
+    expect(operations.disarmVerb).toHaveBeenCalled();
+    expect(operations.cancelPassive).not.toHaveBeenCalled();
   });
 });

--- a/apps/editor/src/commands/editor-command.ts
+++ b/apps/editor/src/commands/editor-command.ts
@@ -56,6 +56,8 @@ export interface EditorCommandContext {
   canvasDragActive: boolean;
   hasClearableDraftingSelection: boolean;
   hasActiveNetHighlight: boolean;
+  /** A verb (rotate/copy/move/delete) is armed, waiting for a target click. */
+  hasArmedVerb: boolean;
 }
 
 export interface EditorCommandOperations {
@@ -79,6 +81,8 @@ export interface EditorCommandOperations {
   rotateSelection(deltaDegrees: 90 | -90): void;
   /** Wait for a part to be pointed at, then turn that one. */
   armRotate(): void;
+  /** Drop whatever verb is armed without acting on anything. */
+  disarmVerb(): void;
   mirrorPlacement(direction: ScreenFlip): void;
   mirrorCopy(direction: ScreenFlip): void;
   mirrorMove(direction: ScreenFlip): void;
@@ -174,6 +178,7 @@ export function createEditorCommandRouter(
           context.helpOpen ||
             context.canvasDragActive ||
             context.interactionMode !== "idle" ||
+            context.hasArmedVerb ||
             context.hasClearableDraftingSelection ||
             context.hasActiveNetHighlight,
         );
@@ -185,7 +190,10 @@ export function createEditorCommandRouter(
       case "selection.clear":
         return enabled();
       case "selection.delete":
-        return context.hasDeletableSelection
+        // With nothing selected while idle, Delete arms the verb (Cadence
+        // style): the next clicks delete what they point at.
+        return context.hasDeletableSelection ||
+          context.interactionMode === "idle"
           ? enabled()
           : disabled("Select an object before deleting it");
       case "selection.copy":
@@ -203,10 +211,9 @@ export function createEditorCommandRouter(
         ) {
           return disabled("Finish or cancel the active tool before moving");
         }
-        return context.hasMoveSelection ||
-          context.interactionMode === "moving-selection"
-          ? enabled(context.interactionMode === "moving-selection")
-          : disabled("Select objects before moving them");
+        // With nothing selected while idle, M arms the verb: the next click
+        // picks up the pointed-at part.
+        return enabled(context.interactionMode === "moving-selection");
       case "selection.align":
         if (context.interactionMode !== "idle") {
           return disabled("Finish or cancel the active tool before aligning");
@@ -280,6 +287,8 @@ export function createEditorCommandRouter(
           options.operations.cancelCanvasDrag();
         } else if (context.interactionMode !== "idle") {
           options.operations.cancelInteraction(context.interactionMode);
+        } else if (context.hasArmedVerb) {
+          options.operations.disarmVerb();
         } else if (context.hasClearableDraftingSelection) {
           options.operations.clearDraftingSelection();
         } else if (context.hasActiveNetHighlight) {

--- a/apps/editor/src/features/selection/use-selection-interaction.ts
+++ b/apps/editor/src/features/selection/use-selection-interaction.ts
@@ -322,16 +322,20 @@ export function useSelectionInteraction(
     return result.document;
   };
 
-  const beginKeyboardSelectionMove = (): void => {
+  const beginKeyboardSelectionMove = (
+    explicitSelection?: VisualSelection,
+  ): void => {
     if (commandMoveSessionRef.current) {
       options.setStatus(
         "Move is already active · click to place · Esc cancels",
       );
       return;
     }
+    // An explicit selection serves the armed Move verb: the pointed-at part
+    // is picked up directly, independent of the live selection state.
     const movePlan = planSelectionMove(
       options.document,
-      options.visualSelection,
+      explicitSelection ?? options.visualSelection,
     );
     if (movePlan.previewObjectIds.length === 0) {
       options.setStatus(
@@ -339,8 +343,11 @@ export function useSelectionInteraction(
       );
       return;
     }
-    const primaryInstanceId =
-      options.selectedIds.at(-1) ?? movePlan.instanceIds.at(0) ?? null;
+    const primaryInstanceId = explicitSelection
+      ? (explicitSelection.instanceIds.at(-1) ??
+        movePlan.instanceIds.at(0) ??
+        null)
+      : (options.selectedIds.at(-1) ?? movePlan.instanceIds.at(0) ?? null);
     const primary = primaryInstanceId
       ? options.document.instances.find((item) => item.id === primaryInstanceId)
       : undefined;
@@ -962,43 +969,66 @@ export function useSelectionInteraction(
     }
   };
 
-  const deleteSelection = (): void => {
-    const deletionSeed = {
-      instanceIds: [
-        ...new Set([
-          ...options.visualSelection.instanceIds,
-          ...options.selectedIds,
-        ]),
-      ],
-      routeIds: [
-        ...new Set([
-          ...options.visualSelection.routeIds,
-          ...(options.selectedRouteId ? [options.selectedRouteId] : []),
-        ]),
-      ],
-      junctionIds: [
-        ...new Set([
-          ...options.visualSelection.junctionIds,
-          ...(options.selectedEndpoint?.endpoint.kind === "junction"
-            ? [options.selectedEndpoint.endpoint.junctionId]
-            : []),
-        ]),
-      ],
-      annotationIds: [
-        ...new Set([
-          ...options.visualSelection.annotationIds,
-          ...(options.selectedAnnotationId
-            ? [options.selectedAnnotationId]
-            : []),
-        ]),
-      ],
-      draftingIds: [
-        ...new Set([
-          ...options.visualSelection.draftingIds,
-          ...(options.selectedDraftingId ? [options.selectedDraftingId] : []),
-        ]),
-      ],
-    };
+  const deleteSelection = (
+    explicitTarget?: Partial<
+      Record<
+        | "instanceIds"
+        | "routeIds"
+        | "junctionIds"
+        | "annotationIds"
+        | "draftingIds",
+        readonly string[]
+      >
+    >,
+  ): void => {
+    // An explicit target deletes exactly the pointed-at objects (the armed
+    // Delete verb), bypassing whatever the live selection happens to hold.
+    const deletionSeed = explicitTarget
+      ? {
+          instanceIds: [...(explicitTarget.instanceIds ?? [])],
+          routeIds: [...(explicitTarget.routeIds ?? [])],
+          junctionIds: [...(explicitTarget.junctionIds ?? [])],
+          annotationIds: [...(explicitTarget.annotationIds ?? [])],
+          draftingIds: [...(explicitTarget.draftingIds ?? [])],
+        }
+      : {
+          instanceIds: [
+            ...new Set([
+              ...options.visualSelection.instanceIds,
+              ...options.selectedIds,
+            ]),
+          ],
+          routeIds: [
+            ...new Set([
+              ...options.visualSelection.routeIds,
+              ...(options.selectedRouteId ? [options.selectedRouteId] : []),
+            ]),
+          ],
+          junctionIds: [
+            ...new Set([
+              ...options.visualSelection.junctionIds,
+              ...(options.selectedEndpoint?.endpoint.kind === "junction"
+                ? [options.selectedEndpoint.endpoint.junctionId]
+                : []),
+            ]),
+          ],
+          annotationIds: [
+            ...new Set([
+              ...options.visualSelection.annotationIds,
+              ...(options.selectedAnnotationId
+                ? [options.selectedAnnotationId]
+                : []),
+            ]),
+          ],
+          draftingIds: [
+            ...new Set([
+              ...options.visualSelection.draftingIds,
+              ...(options.selectedDraftingId
+                ? [options.selectedDraftingId]
+                : []),
+            ]),
+          ],
+        };
     const existingSelectionCounts = {
       instances: deletionSeed.instanceIds.filter((id) =>
         options.document.instances.some((item) => item.id === id),
@@ -1078,7 +1108,9 @@ export function useSelectionInteraction(
     }
   };
 
-  const beginCopyPlacement = (): void => {
+  const beginCopyPlacement = (
+    explicitInstanceIds?: readonly string[],
+  ): void => {
     const interactionKind = options.getInteractionState().kind;
     if (interactionKind === "copy-placement") {
       options.setStatus("Copy placement is already active · Esc cancels");
@@ -1088,16 +1120,24 @@ export function useSelectionInteraction(
       options.setStatus("Finish or cancel the active tool before copying");
       return;
     }
-    const copied = copySelection(
-      options.document,
-      options.selectedIds,
-      options.visualSelection.draftingIds,
-      {
-        routeIds: options.visualSelection.routeIds,
-        junctionIds: options.visualSelection.junctionIds,
-        annotationIds: options.visualSelection.annotationIds,
-      },
-    );
+    // Explicit ids serve the armed Copy verb: the pointed-at part is copied
+    // directly, independent of the (possibly stale) live selection state.
+    const copied = explicitInstanceIds
+      ? copySelection(options.document, explicitInstanceIds, [], {
+          routeIds: [],
+          junctionIds: [],
+          annotationIds: [],
+        })
+      : copySelection(
+          options.document,
+          options.selectedIds,
+          options.visualSelection.draftingIds,
+          {
+            routeIds: options.visualSelection.routeIds,
+            junctionIds: options.visualSelection.junctionIds,
+            annotationIds: options.visualSelection.annotationIds,
+          },
+        );
     if (!copied) {
       options.setStatus("Select something to copy");
       return;


### PR DESCRIPTION
## Summary

Owner feedback: in Cadence Virtuoso you press the command first (c, m, Delete) and then click targets; our editor required selecting first. Verified Virtuoso semantics before designing: commands are modal and repeat until Esc; with a selection they act immediately, with none they wait for a target (sources: [AnalogHub hotkeys](https://analoghub.ie/category/cadenceTricks/article/cadenceTricksHotkeys), Purdue/UVA/UMBC Composer tutorials).

One armed-verb mechanism generalizes the existing R-arming:

- **C / M / Delete pressed while idle with nothing selected arm their verb** (the command router lets verbs through when idle, so the Edit menu gains the same semantics); with a selection every key keeps its immediate behavior.
- The armed click acts on the pointed-at object through the canvas hit controller's single dispatch point: **Copy** picks up a ghost of the part (repeatable placement), **Move** attaches the part to the pointer and places on the next click, **Rotate** turns in place and stays armed, **Delete** removes it and stays armed — instances, routes, junctions, annotations, and drafting objects all deletable click-by-click until Esc.
- The click paired with a Copy/Move pickup is consumed (`consumePickupClick`) so it cannot instantly commit a zero-length placement — pickup and placement are separate clicks, as in Virtuoso.
- Fixes two latent gaps found on the way: **Escape never actually disarmed the armed R**, and element-level armed-rotate consumption had been **bypassed entirely** since the composite canvas-hit controller took over pointer dispatch — arming now lives on that dispatch path.

## Known-unrelated failure

`context-menu.spec.ts` › "drafting text shares device additive selection…" fails identically on the **unpatched base** in this environment (Ctrl+A select-all assertion). Tracked separately.

## Validation

- New `verb-first.spec.ts` e2e (C-then-click copy, repeating Delete mode, M-then-click pickup+place, Esc-disarms-R): red before, green after.
- Command-router unit suite extended (idle verbs execute to arm; Escape disarms before passive cancel): red before.
- 171 unit tests across commands/interaction/selection/canvas green; interaction-heavy e2e suites green except the pre-existing failure above.
- Prettier + repo typecheck; `Test-Impact: tests-updated` validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)