### PR TITLE
Make component names and wire ends directly editable

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -1140,8 +1140,9 @@ test("carries a manual Value through placement and Q property editing", async ({
   const schematicLabel = page.getByLabel("Component schematic label");
   await expect(schematicLabel).toHaveValue("R1");
   await schematicLabel.fill("Input resistor");
-  await schematicLabel.press("Tab");
+  await schematicLabel.press("Enter");
   await expect(page.getByTestId("revision")).toHaveText("5");
+  await expect(schematicLabel).toHaveValue("Input resistor");
   await page
     .locator("summary")
     .filter({ hasText: "Advanced parameters" })

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -1232,6 +1232,59 @@ test("authors components and connectivity manually from an empty canvas", async 
   await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(0);
 });
 
+test("resizes a loose Wire from either endpoint without redrawing it", async ({
+  page,
+}) => {
+  const project = createEmptyProject("loose-wire-resize", "Loose Wire Resize");
+  const document = project.documents[0]!;
+  document.nets.push({ id: "net-loose", terminals: [] });
+  document.junctions.push(
+    {
+      id: "junction-loose-start",
+      netId: "net-loose",
+      position: { x: 200, y: 240 },
+      role: "route-anchor",
+    },
+    {
+      id: "junction-loose-end",
+      netId: "net-loose",
+      position: { x: 440, y: 240 },
+      role: "route-anchor",
+    },
+  );
+  document.routes.push(
+    createRoutePath({
+      id: "route-loose",
+      netId: "net-loose",
+      start: { kind: "junction", junctionId: "junction-loose-start" },
+      end: { kind: "junction", junctionId: "junction-loose-end" },
+      bends: [],
+      modes: ["manual"],
+    }),
+  );
+
+  await page.goto("/editor");
+  await page.getByTestId("project-file").setInputFiles({
+    name: "loose-wire-resize.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(project)),
+  });
+  await clickRoute(page, "route-loose");
+
+  const before = await readRoutePoints(page, "route-loose");
+  await dragBy(page.getByTestId("route-endpoint-handle-route-loose-end"), {
+    x: 80,
+    y: 0,
+  });
+  await expect(page.getByTestId("status")).toContainText(
+    "Resized wire route-loose",
+  );
+  const after = await readRoutePoints(page, "route-loose");
+  expect(after[0]).toEqual(before[0]);
+  expect(after.at(-1)!.x).toBeGreaterThan(before.at(-1)!.x);
+  expect(after.at(-1)!.y).toBe(before.at(-1)!.y);
+});
+
 test("connects one MOS Gate to Drain without false contact ambiguity", async ({
   page,
 }) => {
@@ -3062,12 +3115,20 @@ test("property edits commit on blank click and Escape instead of vanishing", asy
   await expect(page.getByLabel("Component value")).toHaveValue("47k");
 });
 
-test("canvas text editor commits on Escape and on an outside click", async ({
+test("canvas text editor cancels explicitly and commits on Escape or outside click", async ({
   page,
 }) => {
   await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 420, y: 280 });
   const rendered = page.locator('[data-object-id="instance-label-R1"]');
+
+  await page.getByTestId("annotation-hit-instance-label-R1").dblclick();
+  await page.keyboard.press("Control+a");
+  await page.keyboard.type("RA");
+  await page.getByRole("button", { name: "Cancel text changes" }).click();
+  await expect(rendered).toContainText("R1");
+  await expect(page.getByTestId("canvas-text-editor")).toHaveCount(0);
+  await expect(page.getByTestId("revision")).toHaveText("1");
 
   await page.getByTestId("annotation-hit-instance-label-R1").dblclick();
   await page.keyboard.press("Control+a");

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -3038,7 +3038,8 @@ export function App({
       if (event.key === "Escape" && textEditing) {
         event.preventDefault();
         // Escape commits the session; emptying the text still deletes the
-        // annotation, matching the Apply button.
+        // annotation, matching the Apply button. Explicit cancellation stays
+        // available through the editor's Cancel action.
         commitTextEditing();
         return;
       }
@@ -4666,7 +4667,7 @@ export function App({
                   `Endpoint actions: ${endpointTestId(candidate.endpoint)}`,
                 );
               },
-              onPowerRailStretch: beginRouteStretch,
+              onRouteStretch: beginRouteStretch,
               onJunctionSelect: (candidate) => {
                 if (simulationPickNetsActive) {
                   if (candidate.netId)
@@ -4791,6 +4792,10 @@ export function App({
             textEditingLocked,
             onTextUpdate: updateTextEditing,
             onTextCommit: commitTextEditing,
+            onTextCancel: () => {
+              clearTextEditing();
+              setStatus("Cancelled text changes");
+            },
             onTextDelete: deleteTextEditing,
             ...(editingAnnotation &&
             isRoutedMarker(editingAnnotation) &&

--- a/apps/editor/src/canvas/editor-canvas-hit-layer.test.tsx
+++ b/apps/editor/src/canvas/editor-canvas-hit-layer.test.tsx
@@ -22,7 +22,7 @@ function emptyEndpointProps(document = createEmptyDocument("cell", "Cell")) {
     supplementalJunctionIds: [],
     endpointLabel: vi.fn(),
     onEndpointActions: vi.fn(),
-    onPowerRailStretch: vi.fn(),
+    onRouteStretch: vi.fn(),
     onJunctionSelect: vi.fn(),
     onWireEndpoint: vi.fn(),
   };

--- a/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
+++ b/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
@@ -7,7 +7,12 @@ import {
   type ResolvedRouteGeometry,
 } from "@icm/derived";
 import type { WireSource } from "@icm/edit-engine";
-import type { Annotation, RouteBranch, SchematicDocument } from "@icm/model";
+import {
+  routeEnd,
+  type Annotation,
+  type RouteBranch,
+  type SchematicDocument,
+} from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 
 import {
@@ -21,7 +26,11 @@ import { serializePolylinePoints } from "./canvas-geometry";
 type Instance = SchematicDocument["instances"][number];
 type Route = SchematicDocument["routes"][number];
 type StyleProfile = ReturnType<typeof resolveDocumentStyleProfile>;
-type StretchIntent = "resize-power-rail-start" | "resize-power-rail-end";
+type StretchIntent =
+  | "resize-power-rail-start"
+  | "resize-power-rail-end"
+  | "resize-route-start"
+  | "resize-route-end";
 type RouteGeometryRecord = {
   route: RouteBranch;
   geometry: ResolvedRouteGeometry;
@@ -85,7 +94,7 @@ interface EndpointHitTargetProps {
   supplementalJunctionIds: readonly string[];
   endpointLabel: (endpoint: WireSource["endpoint"]) => string;
   onEndpointActions: (endpoint: WireSource) => void;
-  onPowerRailStretch: (
+  onRouteStretch: (
     event: ReactPointerEvent<SVGCircleElement>,
     routeId: string,
     segmentIndex: number,
@@ -281,12 +290,23 @@ function EndpointHitTargets({
   supplementalJunctionIds,
   endpointLabel,
   onEndpointActions,
-  onPowerRailStretch,
+  onRouteStretch,
   onJunctionSelect,
   onWireEndpoint,
   onNetPointerEnter,
   onNetPointerLeave,
 }: EndpointHitTargetProps) {
+  const selectedRouteEnd = selectedRoute ? routeEnd(selectedRoute) : null;
+  const selectedRouteStartJunctionId =
+    selectedRoute?.presentation !== "power-rail" &&
+    selectedRoute?.start.kind === "junction"
+      ? selectedRoute.start.junctionId
+      : null;
+  const selectedRouteEndJunctionId =
+    selectedRoute?.presentation !== "power-rail" &&
+    selectedRouteEnd?.kind === "junction"
+      ? selectedRouteEnd.junctionId
+      : null;
   const powerRailEnds =
     selectedRoute?.presentation === "power-rail"
       ? (derivePowerRailComponent(document, selectedRoute.id)
@@ -309,6 +329,14 @@ function EndpointHitTargets({
             (junction) => junction.id === candidateJunctionId,
           )
         : -1;
+    const selectedRouteEndSide =
+      candidateJunctionId !== null &&
+      candidateJunctionId === selectedRouteStartJunctionId
+        ? "start"
+        : candidateJunctionId !== null &&
+            candidateJunctionId === selectedRouteEndJunctionId
+          ? "end"
+          : null;
     const label = endpointLabel(candidate.endpoint);
     return (
       <circle
@@ -340,13 +368,30 @@ function EndpointHitTargets({
         }}
         onPointerDown={(event) => {
           if (tool === "pointer" && selectedRoute && powerRailEndIndex >= 0) {
-            onPowerRailStretch(
+            onRouteStretch(
               event,
               selectedRoute.id,
               selectedRouteSegmentIndex ?? 0,
               powerRailEndIndex === 0
                 ? "resize-power-rail-start"
                 : "resize-power-rail-end",
+            );
+            return;
+          }
+          if (
+            tool === "pointer" &&
+            selectedRoute &&
+            selectedRouteEndSide !== null
+          ) {
+            onRouteStretch(
+              event,
+              selectedRoute.id,
+              selectedRouteEndSide === "start"
+                ? 0
+                : selectedRoute.legs.length - 1,
+              selectedRouteEndSide === "start"
+                ? "resize-route-start"
+                : "resize-route-end",
             );
             return;
           }

--- a/apps/editor/src/canvas/editor-route-handles.test.tsx
+++ b/apps/editor/src/canvas/editor-route-handles.test.tsx
@@ -58,6 +58,10 @@ describe("editor route handles", () => {
     );
 
     expect(markup).toContain('data-testid="route-handle-route-1"');
+    expect(markup).toContain(
+      'data-testid="route-endpoint-handle-route-1-start"',
+    );
+    expect(markup).toContain('data-testid="route-endpoint-handle-route-1-end"');
     expect(markup).toContain('cx="50"');
     expect(markup).toContain('cy="20.5"');
   });

--- a/apps/editor/src/canvas/editor-route-handles.tsx
+++ b/apps/editor/src/canvas/editor-route-handles.tsx
@@ -4,7 +4,7 @@ import {
   derivePowerRailComponent,
   type ResolvedRouteGeometry,
 } from "@icm/derived";
-import type { RouteBranch, SchematicDocument } from "@icm/model";
+import { routeEnd, type RouteBranch, type SchematicDocument } from "@icm/model";
 
 import type { RouteStretchPreview } from "../features/wiring/use-wire-interaction";
 import { looseRouteAnchorIds } from "../features/wiring/route-interaction-geometry";
@@ -65,6 +65,22 @@ export function EditorRouteHandles({
             ? left.position.y - right.position.y
             : left.position.x - right.position.x,
         );
+      const ordinaryRouteEnds = powerRail
+        ? []
+        : ([route.start, routeEnd(route)] as const).flatMap(
+            (endpoint, index) =>
+              endpoint.kind === "junction"
+                ? [
+                    {
+                      side: index === 0 ? ("start" as const) : ("end" as const),
+                      point:
+                        index === 0
+                          ? geometry.centerline[0]!
+                          : geometry.centerline.at(-1)!,
+                    },
+                  ]
+                : [],
+          );
       const routeCenter = centerOfBounds(polylineBounds(geometry.centerline));
       const preview =
         routeStretchPreview?.routeId === route.id
@@ -129,6 +145,28 @@ export function EditorRouteHandles({
                   index === 0
                     ? "resize-power-rail-start"
                     : "resize-power-rail-end",
+                )
+              }
+              pointerEvents={pointerEvents}
+            />
+          ))}
+          {ordinaryRouteEnds.map(({ side, point }) => (
+            <circle
+              key={`route-endpoint-handle-${route.id}-${side}`}
+              data-testid={`route-endpoint-handle-${route.id}-${side}`}
+              data-canvas-hit-kind="handle"
+              data-canvas-hit-id={`route-endpoint-handle-${route.id}-${side}`}
+              aria-label={`Resize wire ${side}`}
+              className="route-handle route-endpoint-handle"
+              cx={point.x}
+              cy={point.y}
+              r="5"
+              onPointerDown={(event) =>
+                onHandlePointerDown(
+                  event,
+                  route.id,
+                  side === "start" ? 0 : geometry.centerline.length - 2,
+                  side === "start" ? "resize-route-start" : "resize-route-end",
                 )
               }
               pointerEvents={pointerEvents}

--- a/apps/editor/src/canvas/editor-transient-preview-overlays.test.tsx
+++ b/apps/editor/src/canvas/editor-transient-preview-overlays.test.tsx
@@ -54,6 +54,7 @@ describe("editor transient preview overlays", () => {
           textEditingLocked={false}
           onTextUpdate={vi.fn()}
           onTextCommit={vi.fn()}
+          onTextCancel={vi.fn()}
           onTextDelete={vi.fn()}
         />
       </svg>,

--- a/apps/editor/src/canvas/editor-transient-preview-overlays.tsx
+++ b/apps/editor/src/canvas/editor-transient-preview-overlays.tsx
@@ -87,6 +87,7 @@ export function EditorInteractionPreviews({
   textEditingLocked,
   onTextUpdate,
   onTextCommit,
+  onTextCancel,
   onTextDelete,
   onReverseCurrentArrow,
 }: {
@@ -104,6 +105,7 @@ export function EditorInteractionPreviews({
   textEditingLocked: boolean;
   onTextUpdate: CanvasTextEditorOverlayProps["onUpdate"];
   onTextCommit: () => void;
+  onTextCancel: () => void;
   onTextDelete: () => void;
   onReverseCurrentArrow?: () => void;
 }) {
@@ -151,6 +153,7 @@ export function EditorInteractionPreviews({
           disabled={textEditingLocked}
           onUpdate={onTextUpdate}
           onCommit={onTextCommit}
+          onCancel={onTextCancel}
           onDelete={onTextDelete}
           {...(onReverseCurrentArrow ? { onReverseCurrentArrow } : {})}
         />

--- a/apps/editor/src/features/properties/component-identity-properties.tsx
+++ b/apps/editor/src/features/properties/component-identity-properties.tsx
@@ -1,3 +1,5 @@
+import type { FocusEvent, KeyboardEvent } from "react";
+
 import { defaultDraftTextDocument, flattenRichText } from "@icm/model";
 import type { SchematicDocument } from "@icm/model";
 
@@ -10,6 +12,34 @@ export interface ComponentModelTargetView {
   suggestions: readonly string[];
   listId?: string;
   externalSubcircuit: boolean;
+}
+
+function commitIdentityInput(
+  event: FocusEvent<HTMLInputElement>,
+  savedValue: string,
+  commit: (value: string) => boolean | void,
+): void {
+  if (commit(event.currentTarget.value) === false) {
+    event.currentTarget.value = savedValue;
+  }
+}
+
+function handleIdentityInputKeyDown(
+  event: KeyboardEvent<HTMLInputElement>,
+  savedValue: string,
+): void {
+  if (event.key === "Enter") {
+    event.preventDefault();
+    event.stopPropagation();
+    event.currentTarget.blur();
+    return;
+  }
+  if (event.key === "Escape") {
+    event.preventDefault();
+    event.stopPropagation();
+    event.currentTarget.value = savedValue;
+    event.currentTarget.blur();
+  }
 }
 
 export function componentTargetDescription(
@@ -55,10 +85,17 @@ export function ComponentIdentityProperties({
   capacitorPlateRows: readonly CapacitorPlatePropertyRow[] | null;
   modelTarget: ComponentModelTargetView | null;
   onMarkerNameChange: (value: string) => void;
-  onSchematicNameChange: (value: string) => void;
-  onReferenceChange: (value: string) => void;
+  onSchematicNameChange: (value: string) => boolean | void;
+  onReferenceChange: (value: string) => boolean | void;
   onModelTargetChange: (value: string) => void;
 }) {
+  const schematicLabel = flattenRichText(
+    instance.schematicName ??
+      defaultDraftTextDocument(
+        instance.schematicReference ?? instance.netlist?.reference ?? "",
+      ),
+  );
+  const netlistReference = instance.netlist?.reference ?? "";
   return (
     <>
       <div
@@ -92,17 +129,17 @@ export function ComponentIdentityProperties({
                   dir="auto"
                   key={`${instance.id}-${revision}-schematic-label`}
                   aria-label="Component schematic label"
-                  defaultValue={flattenRichText(
-                    instance.schematicName ??
-                      defaultDraftTextDocument(
-                        instance.schematicReference ??
-                          instance.netlist?.reference ??
-                          "",
-                      ),
-                  )}
+                  defaultValue={schematicLabel}
                   placeholder="Schematic label"
                   onBlur={(event) =>
-                    onSchematicNameChange(event.currentTarget.value)
+                    commitIdentityInput(
+                      event,
+                      schematicLabel,
+                      onSchematicNameChange,
+                    )
+                  }
+                  onKeyDown={(event) =>
+                    handleIdentityInputKeyDown(event, schematicLabel)
                   }
                 />
               </dd>
@@ -116,9 +153,16 @@ export function ComponentIdentityProperties({
                   dir="auto"
                   key={`${instance.id}-${revision}-netlist-reference`}
                   aria-label="Component netlist reference"
-                  defaultValue={instance.netlist.reference}
+                  defaultValue={netlistReference}
                   onBlur={(event) =>
-                    onReferenceChange(event.currentTarget.value)
+                    commitIdentityInput(
+                      event,
+                      netlistReference,
+                      onReferenceChange,
+                    )
+                  }
+                  onKeyDown={(event) =>
+                    handleIdentityInputKeyDown(event, netlistReference)
                   }
                 />
               </dd>

--- a/apps/editor/src/features/properties/selection-property-commands.ts
+++ b/apps/editor/src/features/properties/selection-property-commands.ts
@@ -179,14 +179,14 @@ export function createSelectionPropertyCommands({
     }
   };
 
-  const updateSelectedSchematicName = (value: string): void => {
-    if (!selectedInstance) return;
+  const updateSelectedSchematicName = (value: string): boolean => {
+    if (!selectedInstance) return false;
     const content = defaultDraftTextDocument(value.trim());
     if (
       JSON.stringify(selectedInstance.schematicName ?? null) ===
       JSON.stringify(content)
     ) {
-      return;
+      return true;
     }
     if (
       transact([
@@ -198,17 +198,19 @@ export function createSelectionPropertyCommands({
       ]).ok
     ) {
       setStatus(`Renamed schematic label to ${value.trim()}`);
+      return true;
     }
+    return false;
   };
 
-  const updateSelectedReference = (value: string): void => {
-    if (!selectedInstance?.netlist) return;
+  const updateSelectedReference = (value: string): boolean => {
+    if (!selectedInstance?.netlist) return false;
     const reference = value.trim();
     if (!reference) {
       setStatus("Netlist reference cannot be empty");
-      return;
+      return false;
     }
-    if (reference === selectedInstance.netlist.reference) return;
+    if (reference === selectedInstance.netlist.reference) return true;
     if (
       transact([
         {
@@ -219,7 +221,9 @@ export function createSelectionPropertyCommands({
       ]).ok
     ) {
       setStatus(`Set netlist reference to ${reference}`);
+      return true;
     }
+    return false;
   };
 
   const deleteSelectedAnnotation = (): void => {

--- a/apps/editor/src/features/simulation/timing-simulation-panel.tsx
+++ b/apps/editor/src/features/simulation/timing-simulation-panel.tsx
@@ -345,6 +345,7 @@ export function TimingSimulationPanel({
                 });
                 setLabelEditor(null);
               }}
+              onCancel={() => setLabelEditor(null)}
               onDelete={() => {
                 const { baseNetId } = labelEditor;
                 setNetAliases((current) => {

--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
@@ -22,6 +22,7 @@ export interface CanvasTextEditorOverlayProps {
   disabled: boolean;
   onUpdate(change: TextEditingUpdate): void;
   onCommit(): void;
+  onCancel(): void;
   onDelete(): void;
   onReverseCurrentArrow?(): void;
 }
@@ -119,6 +120,7 @@ export function CanvasTextEditorOverlay({
   disabled,
   onUpdate,
   onCommit,
+  onCancel,
   onDelete,
   onReverseCurrentArrow,
 }: CanvasTextEditorOverlayProps) {
@@ -211,6 +213,7 @@ export function CanvasTextEditorOverlay({
           onSizeChange={(sizeScale) => onUpdate({ sizeScale })}
           onAlignmentChange={(alignment) => onUpdate({ alignment })}
           onCommit={onCommit}
+          onCancel={onCancel}
           onDelete={onDelete}
           onLayoutHeightChange={handleLayoutHeightChange}
           {...(onReverseCurrentArrow ? { onReverseCurrentArrow } : {})}

--- a/apps/editor/src/features/text-editing/rich-text-editor.tsx
+++ b/apps/editor/src/features/text-editing/rich-text-editor.tsx
@@ -37,6 +37,7 @@ export interface RichTextEditorProps {
   onSizeChange(sizeScale: number): void;
   onAlignmentChange(alignment: "start" | "middle" | "end"): void;
   onCommit(): void;
+  onCancel(): void;
   onDelete(): void;
   onReverseCurrentArrow?(): void;
   onLayoutHeightChange?(height: number): void;
@@ -432,6 +433,7 @@ export function RichTextEditor({
   onSizeChange,
   onAlignmentChange,
   onCommit,
+  onCancel,
   onDelete,
   onReverseCurrentArrow,
   onLayoutHeightChange,
@@ -807,6 +809,14 @@ export function RichTextEditor({
         </button>
         <button
           type="button"
+          aria-label="Cancel text changes"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={onCancel}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
           aria-label={`${deleteLabel} text`}
           disabled={disabled}
           onMouseDown={(event) => event.preventDefault()}
@@ -999,7 +1009,6 @@ export function RichTextEditor({
           onKeyDown={(event) => {
             if (event.key === "Escape") {
               event.preventDefault();
-              // Escape saves the session, matching click-away and Enter.
               onCommit();
             } else if (event.key === "Enter" && event.shiftKey && multiline) {
               // Enter finishes the text everywhere; a deliberate modifier is

--- a/apps/editor/src/features/wiring/use-wire-interaction.ts
+++ b/apps/editor/src/features/wiring/use-wire-interaction.ts
@@ -14,6 +14,7 @@ import {
   proposeLooseRouteTranslation,
   proposePowerRailEndpointResize,
   proposePowerRailTranslation,
+  proposeRouteEndpointMove,
   proposeWireSegmentMove,
   proposeWireCommitThroughContacts,
   type SchematicEdit,
@@ -62,7 +63,9 @@ export interface RouteStretchPreview {
     | "move-loose-route"
     | "move-power-rail"
     | "resize-power-rail-start"
-    | "resize-power-rail-end";
+    | "resize-power-rail-end"
+    | "resize-route-start"
+    | "resize-route-end";
   start: Point;
   point: Point;
 }
@@ -490,6 +493,24 @@ export function useWireInteraction(capabilities: UseWireInteractionOptions) {
         );
         if (result.ok)
           options.setStatus(`Resized Power Rail ${record.route.id}`);
+      } else if (
+        preview.intent === "resize-route-start" ||
+        preview.intent === "resize-route-end"
+      ) {
+        const proposal = proposeRouteEndpointMove(
+          options.document,
+          options.resolver,
+          record.route.id,
+          preview.intent === "resize-route-start" ? "start" : "end",
+          {
+            x: snapCoordinate(point.x, options.document.presentation.grid),
+            y: snapCoordinate(point.y, options.document.presentation.grid),
+          },
+        );
+        const result = transactProposal(
+          proposalFor("route-geometry", proposal.edits),
+        );
+        if (result.ok) options.setStatus(`Resized wire ${record.route.id}`);
       } else {
         const grid = options.document.presentation.grid;
         const planAt = (at: Point) =>
@@ -554,16 +575,41 @@ export function useWireInteraction(capabilities: UseWireInteractionOptions) {
       intent === "resize-power-rail-end"
         ? derivePowerRailComponent(options.document, routeId)
         : null;
+    const routeEndpoint =
+      intent === "resize-route-start"
+        ? record.route.start
+        : intent === "resize-route-end"
+          ? routeEnd(record.route)
+          : null;
+    const routeEndpointJunctionId =
+      routeEndpoint?.kind === "junction" ? routeEndpoint.junctionId : null;
+    const routeEndpointRouteIds = routeEndpointJunctionId
+      ? options.document.routes
+          .filter((candidate) => {
+            const end = routeEnd(candidate);
+            return (
+              (candidate.start.kind === "junction" &&
+                candidate.start.junctionId === routeEndpointJunctionId) ||
+              (end.kind === "junction" &&
+                end.junctionId === routeEndpointJunctionId)
+            );
+          })
+          .map((candidate) => candidate.id)
+      : [];
     const anchorIds =
       intent === "move-loose-route"
         ? (looseRouteAnchorIds(options.document, record.route) ?? [])
-        : (powerRail?.junctionIds ?? []);
+        : routeEndpointJunctionId
+          ? [routeEndpointJunctionId]
+          : (powerRail?.junctionIds ?? []);
     const translatedRouteIds =
       intent === "move-power-rail" ||
       intent === "resize-power-rail-start" ||
       intent === "resize-power-rail-end"
         ? (powerRail?.routeIds ?? [routeId])
-        : [routeId];
+        : routeEndpointRouteIds.length > 0
+          ? routeEndpointRouteIds
+          : [routeId];
     let visual: ReturnType<typeof startCanvasDragVisual> | null = null;
     const dragVisual = () =>
       (visual ??= startCanvasDragVisual(svg, [
@@ -594,19 +640,31 @@ export function useWireInteraction(capabilities: UseWireInteractionOptions) {
         }
         if (
           intent === "resize-power-rail-start" ||
-          intent === "resize-power-rail-end"
+          intent === "resize-power-rail-end" ||
+          intent === "resize-route-start" ||
+          intent === "resize-route-end"
         ) {
           try {
-            const plan = proposePowerRailEndpointResize(
-              options.document,
-              options.resolver,
-              routeId,
-              intent === "resize-power-rail-start" ? "start" : "end",
-              {
-                x: snapCoordinate(point.x, options.document.presentation.grid),
-                y: snapCoordinate(point.y, options.document.presentation.grid),
-              },
-            );
+            const snapped = {
+              x: snapCoordinate(point.x, options.document.presentation.grid),
+              y: snapCoordinate(point.y, options.document.presentation.grid),
+            };
+            const plan =
+              intent === "resize-route-start" || intent === "resize-route-end"
+                ? proposeRouteEndpointMove(
+                    options.document,
+                    options.resolver,
+                    routeId,
+                    intent === "resize-route-start" ? "start" : "end",
+                    snapped,
+                  )
+                : proposePowerRailEndpointResize(
+                    options.document,
+                    options.resolver,
+                    routeId,
+                    intent === "resize-power-rail-start" ? "start" : "end",
+                    snapped,
+                  );
             const movedJunctions = new Map(
               plan.preview?.junctions.map((junction) => [
                 junction.junctionId,
@@ -636,7 +694,7 @@ export function useWireInteraction(capabilities: UseWireInteractionOptions) {
               ]);
             }
           } catch {
-            // Keep the last valid rail preview; commit reports the error.
+            // Keep the last valid endpoint preview; commit reports the error.
           }
           return;
         }

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -493,6 +493,48 @@ export function proposeLooseRouteTranslation(
 }
 
 /**
+ * Move one grid-backed Route endpoint through the same Junction translation
+ * contract used by segment, group, and rail edits. Terminal endpoints remain
+ * electrically anchored to their symbols; callers must disconnect them before
+ * they can become free geometry.
+ */
+export function proposeRouteEndpointMove(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  routeId: string,
+  side: "start" | "end",
+  point: Point,
+): RouteEditPlan {
+  const route = document.routes.find((candidate) => candidate.id === routeId);
+  if (!route) throw new Error(`Route not found: ${routeId}`);
+  const endpoint = side === "start" ? route.start : routeEnd(route);
+  if (endpoint.kind !== "junction") {
+    throw new Error("A terminal-connected wire end is electrically anchored");
+  }
+  const junction = document.junctions.find(
+    (candidate) => candidate.id === endpoint.junctionId,
+  );
+  if (!junction) throw new Error(`Junction not found: ${endpoint.junctionId}`);
+  if (junction.position.x === point.x && junction.position.y === point.y) {
+    return { routeId, edits: [] };
+  }
+  const proposal = proposeJunctionGroupTranslation(document, resolver, [
+    { junctionId: junction.id, position: point },
+  ]);
+  return {
+    routeId,
+    preview: proposal,
+    edits: [
+      ...proposal.junctions.map((move): SchematicEdit => ({
+        kind: "move_junction",
+        ...move,
+      })),
+      ...routeEdits(document, proposal.routes),
+    ],
+  };
+}
+
+/**
  * Translate every fragment and Junction belonging to one visually continuous
  * VDD rail. Ordinary branch wires are not translated wholesale: they are
  * reshaped around the moved rail Junction instead.

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -34,6 +34,7 @@ import {
   proposeLooseRouteTranslation,
   proposePowerRailEndpointResize,
   proposePowerRailTranslation,
+  proposeRouteEndpointMove,
   proposeWireIntent,
   proposeVisualRouteDeletion,
   proposeWireSegmentMove,
@@ -674,6 +675,68 @@ describe("routing Edit Engine", () => {
       context,
     );
     expect(moved.ok).toBe(true);
+  });
+
+  it("resizes a Junction-backed Route end through the shared Junction planner", () => {
+    const document = createEmptyDocument("route-resize", "Route resize");
+    document.nets.push({ id: "net-1", terminals: [] });
+    document.junctions.push(
+      {
+        id: "j1",
+        netId: "net-1",
+        position: { x: 0, y: 20 },
+        role: "route-anchor",
+      },
+      {
+        id: "j2",
+        netId: "net-1",
+        position: { x: 100, y: 20 },
+        role: "route-anchor",
+      },
+    );
+    document.routes.push(
+      createRoutePath({
+        id: "route-1",
+        netId: "net-1",
+        start: { kind: "junction", junctionId: "j1" },
+        end: { kind: "junction", junctionId: "j2" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+
+    const plan = proposeRouteEndpointMove(
+      document,
+      resolver,
+      "route-1",
+      "end",
+      { x: 140, y: 20 },
+    );
+    expect(plan.edits).toEqual([
+      {
+        kind: "move_junction",
+        junctionId: "j2",
+        position: { x: 140, y: 20 },
+      },
+      expect.objectContaining({ kind: "set_route_path" }),
+    ]);
+    const resized = executeTransaction(
+      document,
+      transaction(document.id, 0, plan.edits),
+      context,
+    );
+    expect(resized.ok).toBe(true);
+    if (!resized.ok) return;
+    expect(
+      resolveRouteGeometry(
+        resized.document,
+        resolver,
+        resized.document.routes[0]!,
+      )?.centerline,
+    ).toEqual([
+      { x: 0, y: 20 },
+      { x: 140, y: 20 },
+    ]);
   });
 
   it("moves a three-way Junction with its dragged segment", () => {


### PR DESCRIPTION
## Summary
- make component identity fields commit reliably on Enter or blur and restore rejected values
- add an explicit cancel path for canvas rich-text editing without changing established Escape-to-commit behavior
- resize Junction-backed Wire endpoints through the shared Junction translation planner

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- pnpm gate:full -- --base origin/main (1801 unit tests, 272 browser tests, build/release/performance smoke)