### PR TITLE
feat(editor): mark a selected component by tracing its own lines

### DIFF
--- a/apps/editor/e2e/selection-visuals.spec.ts
+++ b/apps/editor/e2e/selection-visuals.spec.ts
@@ -12,7 +12,7 @@ async function placeComponent(
   await page.keyboard.press("Escape");
 }
 
-test("selection tints the device and marks carried wires as would-move", async ({
+test("selection traces the device and marks carried wires as would-move", async ({
   page,
 }) => {
   await page.goto("/editor");
@@ -34,14 +34,38 @@ test("selection tints the device and marks carried wires as would-move", async (
 
   await instances.nth(0).click();
   await expect(instances.nth(0)).toHaveClass(/hit-target selected/);
-  // The dashed bounding box is gone; the selection is a tinted body.
-  const dash = await instances
-    .nth(0)
-    .evaluate((element) => getComputedStyle(element).strokeDasharray);
-  expect(dash === "none" || dash === "").toBeTruthy();
+  // Nothing is drawn around the device: the hit rectangle carries the click,
+  // never the mark. Selection shows as a halo tracing the symbol's own lines.
+  const box = await instances.nth(0).evaluate((element) => {
+    const style = getComputedStyle(element);
+    return { fill: style.fill, stroke: style.stroke };
+  });
+  expect(box.fill).toBe("rgba(0, 0, 0, 0)");
+  expect(box.stroke).toBe("rgba(0, 0, 0, 0)");
+
+  const halo = page.getByTestId("selection-halo-selected");
+  await expect(halo).toBeAttached();
+  await expect(halo.locator(`[data-object-id="${ids[0]}"]`)).toBeAttached();
+  await expect(halo.locator(`[data-object-id="${ids[1]}"]`)).toHaveCount(0);
+
   // The attached wire would travel with a drag, so it carries the
   // would-move tint while staying unselected.
   await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveClass(
     /would-move|selected/,
   );
+});
+
+test("an instance label is not marked a second time beside its device", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 300, y: 220 });
+  const instance = page.locator('[data-canvas-hit-kind="instance"]').first();
+  await instance.click();
+
+  // The label rides along with the device it names, and the device's halo
+  // already says so. Boxing the label too would read as a second object
+  // having been selected.
+  const label = page.locator('[data-canvas-hit-kind="annotation"]').first();
+  await expect(label).toHaveClass(/hit-target annotation-text-hit$/);
 });

--- a/apps/editor/e2e/selection-visuals.spec.ts
+++ b/apps/editor/e2e/selection-visuals.spec.ts
@@ -55,17 +55,23 @@ test("selection traces the device and marks carried wires as would-move", async 
   );
 });
 
-test("an instance label is not marked a second time beside its device", async ({
+test("an instance label is not tinted a second time beside its device", async ({
   page,
 }) => {
   await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 300, y: 220 });
   const instance = page.locator('[data-canvas-hit-kind="instance"]').first();
+  const label = page.locator('[data-canvas-hit-kind="annotation"]').first();
   await instance.click();
 
-  // The label rides along with the device it names, and the device's halo
-  // already says so. Boxing the label too would read as a second object
-  // having been selected.
-  const label = page.locator('[data-canvas-hit-kind="annotation"]').first();
+  // The label rides along with the device it names, and the halo already says
+  // so. A would-move box on the label repeated that next to a device wearing
+  // no box at all.
   await expect(label).toHaveClass(/hit-target annotation-text-hit$/);
+
+  // Selecting the label in its own right is a different thing to say, and it
+  // still marks itself: answering a deliberate click with nothing would be
+  // worse than the tint this test removes.
+  await label.click({ modifiers: ["Shift"], force: true });
+  await expect(label).toHaveClass(/selected/);
 });

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -4578,6 +4578,13 @@ export function App({
           eventHandlers={canvasEventHandlers}
           grid={{ visible: gridDotsVisible, viewBox }}
           sceneInnerHtml={sceneInnerHtml}
+          selectionHalo={{
+            document,
+            resolver,
+            styleProfile,
+            selectedInstanceIds: selectedIds,
+            wouldMoveIds,
+          }}
           cellSymbolLayout={
             selectedCellSymbolLayout
               ? {

--- a/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
+++ b/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
@@ -236,11 +236,13 @@ function SelectionHitTargets({
           const selected =
             selectedAnnotationId === annotation.id ||
             supplementalAnnotationIds.includes(annotation.id);
-          // An instance label belongs to its component rather than standing
-          // beside it. Once the component carries a halo the label is already
-          // spoken for, and a second mark on the label would read as a
-          // separate object having been selected.
-          const ownerMarked =
+          // An instance label belongs to the component it names rather than
+          // standing beside it, so it needs no would-move tint of its own once
+          // that component carries a halo — the tint only repeated what the
+          // halo already said, as a box next to a device that had none.
+          // A label the person selected in its own right still marks itself:
+          // suppressing that would answer a deliberate click with nothing.
+          const carriedByMarkedOwner =
             annotation.kind === "instance-label" &&
             annotation.anchor.kind === "object" &&
             (selectedInstanceIds.includes(annotation.anchor.objectId) ||
@@ -253,13 +255,11 @@ function SelectionHitTargets({
               data-canvas-hit-id={annotation.id}
               data-drag-object-id={annotation.id}
               className={
-                ownerMarked
-                  ? "hit-target annotation-text-hit"
-                  : selected
-                    ? "hit-target annotation-text-hit selected"
-                    : wouldMoveIds.has(annotation.id)
-                      ? "hit-target annotation-text-hit would-move"
-                      : "hit-target annotation-text-hit"
+                selected
+                  ? "hit-target annotation-text-hit selected"
+                  : wouldMoveIds.has(annotation.id) && !carriedByMarkedOwner
+                    ? "hit-target annotation-text-hit would-move"
+                    : "hit-target annotation-text-hit"
               }
               {...hitBox}
               onClick={(event) => event.stopPropagation()}

--- a/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
+++ b/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
@@ -236,6 +236,15 @@ function SelectionHitTargets({
           const selected =
             selectedAnnotationId === annotation.id ||
             supplementalAnnotationIds.includes(annotation.id);
+          // An instance label belongs to its component rather than standing
+          // beside it. Once the component carries a halo the label is already
+          // spoken for, and a second mark on the label would read as a
+          // separate object having been selected.
+          const ownerMarked =
+            annotation.kind === "instance-label" &&
+            annotation.anchor.kind === "object" &&
+            (selectedInstanceIds.includes(annotation.anchor.objectId) ||
+              wouldMoveIds.has(annotation.anchor.objectId));
           return (
             <rect
               key={`annotation-hit-${annotation.id}`}
@@ -244,11 +253,13 @@ function SelectionHitTargets({
               data-canvas-hit-id={annotation.id}
               data-drag-object-id={annotation.id}
               className={
-                selected
-                  ? "hit-target annotation-text-hit selected"
-                  : wouldMoveIds.has(annotation.id)
-                    ? "hit-target annotation-text-hit would-move"
-                    : "hit-target annotation-text-hit"
+                ownerMarked
+                  ? "hit-target annotation-text-hit"
+                  : selected
+                    ? "hit-target annotation-text-hit selected"
+                    : wouldMoveIds.has(annotation.id)
+                      ? "hit-target annotation-text-hit would-move"
+                      : "hit-target annotation-text-hit"
               }
               {...hitBox}
               onClick={(event) => event.stopPropagation()}

--- a/apps/editor/src/canvas/editor-canvas-surface.tsx
+++ b/apps/editor/src/canvas/editor-canvas-surface.tsx
@@ -13,6 +13,7 @@ import {
 import { EditorCanvasHitLayer } from "./editor-canvas-hit-layer";
 import { EditorCellSymbolLayoutOverlay } from "./editor-cell-symbol-layout-overlay";
 import { EditorRouteHandles } from "./editor-route-handles";
+import { EditorSelectionHalo } from "./editor-selection-halo";
 import {
   EditorDraftingHandles,
   EditorDraftingHitTargets,
@@ -47,6 +48,7 @@ export interface EditorCanvasSurfaceProps {
   ) => void;
   grid: ComponentProps<typeof CanvasGridOverlay>;
   sceneInnerHtml: { __html: string };
+  selectionHalo: ComponentProps<typeof EditorSelectionHalo>;
   cellSymbolLayout: ComponentProps<typeof EditorCellSymbolLayoutOverlay> | null;
   netHighlight: ComponentProps<typeof NetHighlightOverlay>;
   wireUnderSymbol: ComponentProps<typeof WireUnderSymbolOverlay>;
@@ -99,6 +101,7 @@ export function EditorCanvasSurface({
   onPinch,
   grid,
   sceneInnerHtml,
+  selectionHalo,
   cellSymbolLayout,
   netHighlight,
   wireUnderSymbol,
@@ -204,6 +207,7 @@ export function EditorCanvasSurface({
       >
         <style>{schematicRoundPeriodFontFaceCss}</style>
         <CanvasGridOverlay {...grid} />
+        <EditorSelectionHalo {...selectionHalo} />
         <g dangerouslySetInnerHTML={sceneInnerHtml} />
         {cellSymbolLayout ? (
           <EditorCellSymbolLayoutOverlay {...cellSymbolLayout} />

--- a/apps/editor/src/canvas/editor-selection-halo.test.tsx
+++ b/apps/editor/src/canvas/editor-selection-halo.test.tsx
@@ -1,0 +1,80 @@
+import { resolveDocumentStyleProfile } from "@icm/derived";
+import { createEmptyDocument } from "@icm/model";
+import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { EditorSelectionHalo } from "./editor-selection-halo";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+function twoResistors() {
+  const document = createEmptyDocument("cell", "Cell");
+  document.instances.push(
+    {
+      id: "inst-1",
+      symbolId: "resistor",
+      placement: { position: { x: 100, y: 100 }, rotation: 0, mirror: "none" },
+      netlist: { reference: "R1", parameters: {} },
+    },
+    {
+      id: "inst-2",
+      symbolId: "resistor",
+      placement: { position: { x: 300, y: 100 }, rotation: 0, mirror: "none" },
+      netlist: { reference: "R2", parameters: {} },
+    },
+  );
+  return document;
+}
+
+function render(
+  selectedInstanceIds: readonly string[],
+  wouldMoveIds: ReadonlySet<string> = new Set(),
+) {
+  const document = twoResistors();
+  return renderToStaticMarkup(
+    <EditorSelectionHalo
+      document={document}
+      resolver={resolver}
+      styleProfile={resolveDocumentStyleProfile(document.presentation)}
+      selectedInstanceIds={selectedInstanceIds}
+      wouldMoveIds={wouldMoveIds}
+    />,
+  );
+}
+
+describe("editor selection halo", () => {
+  it("traces the selected component rather than boxing it", () => {
+    const markup = render(["inst-1"]);
+    expect(markup).toContain('class="selection-halo"');
+    expect(markup).toContain('data-object-id="inst-1"');
+    expect(markup).not.toContain('data-object-id="inst-2"');
+  });
+
+  it("draws nothing at all when the selection holds no component", () => {
+    expect(render([])).toBe("");
+  });
+
+  /**
+   * Both bodies painting the same instance would stack their stroke alpha and
+   * read as a third, brighter state that means nothing.
+   */
+  it("keeps a selected component out of the would-move body", () => {
+    const markup = render(["inst-1"], new Set(["inst-1", "inst-2"]));
+    const wouldMove = markup.slice(
+      markup.indexOf("selection-halo-body--would-move"),
+      markup.indexOf("selection-halo-body--selected"),
+    );
+    expect(wouldMove).toContain('data-object-id="inst-2"');
+    expect(wouldMove).not.toContain('data-object-id="inst-1"');
+  });
+
+  it("ignores would-move members that are not components", () => {
+    const markup = render([], new Set(["route-7", "junction-3"]));
+    expect(markup).toBe("");
+  });
+
+  it("stays out of the way of every pointer gesture", () => {
+    expect(render(["inst-1"])).toContain('aria-hidden="true"');
+  });
+});

--- a/apps/editor/src/canvas/editor-selection-halo.tsx
+++ b/apps/editor/src/canvas/editor-selection-halo.tsx
@@ -1,0 +1,87 @@
+import { useMemo } from "react";
+
+import type { resolveDocumentStyleProfile } from "@icm/derived";
+import type { SchematicDocument } from "@icm/model";
+import { renderInstanceOutlineGeometry } from "@icm/render-svg";
+import type { SymbolResolver } from "@icm/symbols";
+
+type StyleProfile = ReturnType<typeof resolveDocumentStyleProfile>;
+
+export interface EditorSelectionHaloProps {
+  document: SchematicDocument;
+  resolver: SymbolResolver;
+  styleProfile: StyleProfile;
+  selectedInstanceIds: readonly string[];
+  /**
+   * Everything a drag on the selection would carry. Non-instance members are
+   * ignored here; routes and junctions mark themselves in their own layers.
+   */
+  wouldMoveIds: ReadonlySet<string>;
+}
+
+/**
+ * A selected component is marked by tracing its own artwork, never by boxing
+ * it. The halo is a second copy of the symbol geometry painted underneath the
+ * scene with a thick accent stroke, so every line of the component reads as
+ * lit while the component itself is drawn on top exactly as before —
+ * including a per-instance colour override, which a recolour would have
+ * destroyed and this leaves untouched.
+ *
+ * A box would also claim an extent the drawing does not occupy: an
+ * axis-aligned box around a rotated device, or around a symbol that is mostly
+ * whitespace, is far larger than the lines it contains, and in a dense
+ * schematic it overlaps neighbours that are not selected.
+ */
+export function EditorSelectionHalo({
+  document,
+  resolver,
+  styleProfile,
+  selectedInstanceIds,
+  wouldMoveIds,
+}: EditorSelectionHaloProps) {
+  const selected = useMemo(
+    () =>
+      renderInstanceOutlineGeometry(
+        document,
+        resolver,
+        selectedInstanceIds,
+        styleProfile,
+      ),
+    [document, resolver, selectedInstanceIds, styleProfile],
+  );
+  // Painting a selected instance twice would double the stroke alpha and read
+  // as a third state, so the trailing body covers only the rest.
+  const wouldMove = useMemo(
+    () =>
+      renderInstanceOutlineGeometry(
+        document,
+        resolver,
+        [...wouldMoveIds].filter((id) => !selectedInstanceIds.includes(id)),
+        styleProfile,
+      ),
+    [document, resolver, selectedInstanceIds, styleProfile, wouldMoveIds],
+  );
+  if (selected === "" && wouldMove === "") return null;
+  return (
+    <g
+      data-layer="selection-halo"
+      className="selection-halo"
+      aria-hidden="true"
+    >
+      {wouldMove === "" ? null : (
+        <g
+          data-testid="selection-halo-would-move"
+          className="selection-halo-body selection-halo-body--would-move"
+          dangerouslySetInnerHTML={{ __html: wouldMove }}
+        />
+      )}
+      {selected === "" ? null : (
+        <g
+          data-testid="selection-halo-selected"
+          className="selection-halo-body selection-halo-body--selected"
+          dangerouslySetInnerHTML={{ __html: selected }}
+        />
+      )}
+    </g>
+  );
+}

--- a/apps/editor/src/styles/editor-canvas.css
+++ b/apps/editor/src/styles/editor-canvas.css
@@ -84,13 +84,44 @@
   color: var(--icm-text-muted);
 }
 
-/* Selection highlights the device itself rather than boxing it: a soft
-   accent wash plus a solid outline. would-move marks everything a drag on
-   the selection would carry, so the whole moving body reads at a glance. */
+/* Selection traces the component's own lines instead of boxing it: the halo
+   layer paints a copy of the symbol artwork beneath the scene, so the hit
+   rectangle stays invisible and carries nothing but the cursor. Annotation
+   text has no artwork to trace and keeps the wash. would-move marks
+   everything a drag on the selection would carry, so the whole moving body
+   reads at a glance. */
 .hit-target.selected {
+  cursor: move;
+}
+
+.hit-target.annotation-text-hit.selected {
   fill: rgb(var(--icm-accent-rgb) / 13%);
   stroke: rgb(var(--icm-accent-rgb) / 60%);
-  cursor: move;
+}
+
+/* A thick accent stroke under every line of the component. The halo is drawn
+   below the scene, so a per-instance colour override still shows through on
+   top unchanged — a highlight that recoloured the strokes would have erased
+   the colour the person deliberately set.
+   non-scaling-stroke keeps the halo a constant width on screen. A halo that
+   scaled with the drawing would swell when zoomed in and thin away to nothing
+   when zoomed out, which is exactly when a whole-schematic view needs it. */
+.selection-halo {
+  pointer-events: none;
+}
+
+.selection-halo * {
+  fill: none;
+  stroke: rgb(var(--icm-accent-rgb) / 42%);
+  stroke-width: 7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.selection-halo-body--would-move * {
+  stroke: rgb(var(--icm-accent-rgb) / 18%);
+  stroke-width: 6;
 }
 
 .wire-under-symbol-overlay .wire-under-symbol-paint {
@@ -110,7 +141,7 @@
   pointer-events: stroke;
 }
 
-.hit-target.would-move {
+.hit-target.annotation-text-hit.would-move {
   fill: rgb(var(--icm-accent-rgb) / 7%);
   stroke: rgb(var(--icm-accent-rgb) / 28%);
 }

--- a/packages/render-svg/src/instance-outline-geometry.test.ts
+++ b/packages/render-svg/src/instance-outline-geometry.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { createEmptyDocument } from "@icm/model";
+import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
+
+import { renderInstanceOutlineGeometry } from "./render.js";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+function documentWithTwoResistors() {
+  const document = createEmptyDocument("doc-1", "Test");
+  document.instances.push(
+    {
+      id: "inst-1",
+      symbolId: "resistor",
+      placement: { position: { x: 100, y: 100 }, rotation: 0, mirror: "none" },
+      netlist: { reference: "R1", parameters: {} },
+    },
+    {
+      id: "inst-2",
+      symbolId: "resistor",
+      placement: { position: { x: 300, y: 100 }, rotation: 90, mirror: "none" },
+      netlist: { reference: "R2", parameters: {} },
+    },
+  );
+  return document;
+}
+
+describe("renderInstanceOutlineGeometry", () => {
+  it("emits artwork for the named instances only", () => {
+    const markup = renderInstanceOutlineGeometry(
+      documentWithTwoResistors(),
+      resolver,
+      ["inst-1"],
+    );
+    expect(markup).toContain('data-object-id="inst-1"');
+    expect(markup).not.toContain('data-object-id="inst-2"');
+  });
+
+  it("places the outline on the instance, orientation included", () => {
+    const markup = renderInstanceOutlineGeometry(
+      documentWithTwoResistors(),
+      resolver,
+      ["inst-2"],
+    );
+    expect(markup).toContain('transform="translate(300 100) rotate(90)"');
+  });
+
+  /**
+   * The halo exists so that marking a component does not repaint it. If the
+   * outline carried the instance's own colour the layer beneath would tint
+   * the mark to whatever the person chose, and the mark would vanish
+   * entirely on a component coloured like the accent.
+   */
+  it("carries no colour of the instance's own", () => {
+    const document = documentWithTwoResistors();
+    document.instances[0]!.styleOverride = { foreground: "#FF0000" };
+    const markup = renderInstanceOutlineGeometry(document, resolver, [
+      "inst-1",
+    ]);
+    expect(markup).not.toContain("#FF0000");
+  });
+
+  it("traces artwork only, never text", () => {
+    const markup = renderInstanceOutlineGeometry(
+      documentWithTwoResistors(),
+      resolver,
+      ["inst-1", "inst-2"],
+    );
+    expect(markup).not.toContain("<text");
+  });
+
+  it("skips an instance that is not placed", () => {
+    const document = documentWithTwoResistors();
+    document.instances[1]!.placement = null;
+    expect(
+      renderInstanceOutlineGeometry(document, resolver, ["inst-1", "inst-2"]),
+    ).not.toContain('data-object-id="inst-2"');
+  });
+
+  it("is empty when nothing is named", () => {
+    expect(
+      renderInstanceOutlineGeometry(documentWithTwoResistors(), resolver, []),
+    ).toBe("");
+  });
+});

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -310,6 +310,48 @@ function instanceTransform(
   return `translate(${placement.position.x} ${placement.position.y}) rotate(${placement.rotation})${mirror}`;
 }
 
+/**
+ * The symbol artwork of the named instances as bare geometry: no colour of
+ * our choosing, no pin names, no formula text.
+ *
+ * A caller that wants to mark a component by tracing the component's own
+ * lines — rather than by drawing a box around it — paints this layer beneath
+ * the scene and styles it entirely in CSS. Leaving the markup unstyled is the
+ * point: the copy in the scene above keeps whatever colour the instance
+ * overrides to, so marking a component never repaints it.
+ */
+export function renderInstanceOutlineGeometry(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  instanceIds: readonly string[],
+  profile: SchematicStyleProfile = razaviTextbookProfile,
+): string {
+  const wanted = new Set(instanceIds);
+  return document.instances
+    .filter(
+      (instance) => wanted.has(instance.id) && instance.placement !== null,
+    )
+    .map((instance) => {
+      const resolved = resolver.resolve(
+        instance.symbolId,
+        instance.symbolVariantId,
+      );
+      // Decoration must not take the canvas down: the scene is the layer
+      // that decides what an unresolved symbol means.
+      if (!resolved) return "";
+      const primitives = renderSymbolDefinitionBody(
+        resolved.definition,
+        resolved.variant?.hiddenPrimitiveParts,
+        resolved.variant?.additionalPrimitives,
+        profile,
+        undefined,
+        instance.signalFlowParameters,
+      );
+      return `<g data-object-id="${escapeXml(instance.id)}"><g transform="${instanceTransform(instance)}">${primitives}</g></g>`;
+    })
+    .join("");
+}
+
 function transformedDirection(
   direction: "north" | "east" | "south" | "west",
   placement: NonNullable<SchematicDocument["instances"][number]["placement"]>,


### PR DESCRIPTION
## What changed

Selecting a component drew a tinted rectangle over its hit box. It now draws a **halo** that traces the symbol's own artwork.

| before | after |
|---|---|
| axis-aligned box over the hit rectangle | accent stroke following every line of the symbol |

## Why not just recolour the strokes?

Because a component carries a **per-instance colour override** (`Appearance → Line / foreground`). Repainting its strokes to the accent would erase the colour the person deliberately set, and a component already coloured like the accent would show no mark at all.

The halo is painted *beneath* the scene instead, so the override is drawn on top unchanged. `packages/render-svg/src/instance-outline-geometry.test.ts` pins this: the outline markup for an instance overridden to `#FF0000` contains no `#FF0000`.

## Why a box was wrong here

- `instanceHitBox` is an axis-aligned padded rectangle. Around a rotated device, or a symbol that is mostly whitespace, it is far larger than the lines it contains, and in a dense schematic it overlaps neighbours that are not selected.
- Wires already marked themselves along their own path (`.route-hit.selected`). Components were the one thing still boxed — and the CSS comment at `editor-canvas.css:87` already *claimed* it highlighted "the device itself rather than boxing it". The style was just attached to the hit rectangle.
- The hit rectangle stays as the click target and is now fully transparent, which decouples *where you can click* from *what is selected*.

`vector-effect: non-scaling-stroke` keeps the halo constant on screen. A halo that scaled with the drawing would swell when zoomed in and vanish when zoomed out, which is when a whole-schematic view needs it most.

## Instance labels

An instance label no longer boxes itself beside a marked device — it rides along with the component that names it, and the halo already says so. Annotation text selected on its own keeps the wash, having no artwork to trace.

## Layering

`renderInstanceOutlineGeometry` is neutral: it emits the named instances' artwork as bare geometry with no colour, no widths of its own, and no text. All selection semantics and styling stay in the editor. It is not part of `formalBody`, so exports are untouched.

## Verification

- `packages/render-svg/src/instance-outline-geometry.test.ts` — 6 new tests (named instances only, orientation, no instance colour, no text, unplaced skipped, empty)
- `apps/editor/src/canvas/editor-selection-halo.test.tsx` — 5 new tests (traces not boxes, empty selection, would-move excludes selected, non-instance ids ignored, aria-hidden)
- `apps/editor/e2e/selection-visuals.spec.ts` — rewritten to assert the hit rectangle is transparent and the halo carries the selected instance; plus a new spec for the label
- Full unit suite: **1814 passed**
- Playwright `selection-visuals`, `component-insert`, `drafting`, `manual-editor`: **185 passed**
- Verified in the running editor: single select, marquee multi-select, and that the hit rectangle computes to `rgba(0, 0, 0, 0)` for fill and stroke

I could not drive the colour picker through synthetic events in the headless browser, so the colour-override claim is covered by the unit test rather than a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)