### PR TITLE
fix(editor): Cmd+A selects all on macOS instead of falling to the browser

### DIFF
--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -252,8 +252,13 @@ describe("editor shortcut contract", () => {
     expect(resolve("e", {}, { shiftKey: true })).toBeNull();
   });
 
-  it("gives Ctrl+A selection precedence over the plain Arrow shortcut", () => {
+  it("gives Ctrl+A and Cmd+A selection precedence over the plain Arrow shortcut", () => {
     expect(resolve("a", {}, { ctrlKey: true })).toEqual(
+      command({ id: "selection.select-all" }),
+    );
+    // macOS sends Cmd+A for select-all; leaving meta unbound hands the chord
+    // to the browser's DOM selection and the schematic selection never moves.
+    expect(resolve("a", {}, { metaKey: true })).toEqual(
       command({ id: "selection.select-all" }),
     );
   });
@@ -341,6 +346,12 @@ describe("editor shortcut contract", () => {
       command({ id: "tool.activate", tool: "wire" }),
     );
     expect(resolve("f", active)).toEqual(command({ id: "view.fit" }));
+    for (const modifiers of [{ ctrlKey: true }, { metaKey: true }]) {
+      expect(resolve("a", active, modifiers)).toEqual({
+        kind: "blocked-interaction-command",
+        command: "Select All",
+      });
+    }
   });
 
   it("does not rotate a stale selection underneath another active tool", () => {

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -126,7 +126,7 @@ export function resolveEditorShortcut(
   }
 
   if (interactionActive) {
-    if (event.ctrlKey && key === "a") {
+    if (commandModifier && key === "a") {
       return { kind: "blocked-interaction-command", command: "Select All" };
     }
     if (plain && key === "c") {
@@ -230,7 +230,9 @@ export function resolveEditorShortcut(
     return command ? { kind: "blocked-interaction-command", command } : null;
   }
 
-  if (event.ctrlKey && key === "a") {
+  // Select All answers to both command modifiers: macOS presses Cmd+A, and
+  // an unbound meta chord would fall through to the browser's DOM selection.
+  if (commandModifier && key === "a") {
     return { kind: "run-command", command: { id: "selection.select-all" } };
   }
 


### PR DESCRIPTION
## Problem

`context-menu.spec.ts` › *drafting text shares device additive selection and context alignment* fails deterministically on macOS at the `ControlOrMeta+A` select-all assertion, while CI stays green. The pre-existing failure is also noted in #409's commit message as environment-local.

## Diagnosis

Playwright's `ControlOrMeta` is **Meta on darwin, Control on Linux**. `resolveEditorShortcut` bound Select All to `event.ctrlKey` alone, so on macOS Cmd+A resolved to `null`, `App.tsx` never called `preventDefault`, the browser performed its native DOM select-all, and the schematic selection never changed. Verified with an isolated probe on the unpatched base: after clearing the placement selection, **Meta+A is a no-op while Control+A selects all** — and the full text-apply flow passes with Control+A, so the spec's focus/tool-state assumptions were never the problem. Select-all was broken on macOS; the spec is correct and unchanged.

## Fix

Select All now matches `commandModifier` (ctrl **or** meta) — exactly how Ctrl+D/Cmd+D deselection already behaves — in both the idle mapping and the interaction-active "Select All is unavailable" block. Typing targets are unaffected: the `isTyping` guard returns before either branch, so text fields keep the browser's native chord (the other `ControlOrMeta+A` presses in e2e all target textboxes).

## Validation

- Unit: two new contract assertions (idle Meta+A → `selection.select-all`; blocked Meta+A during an active interaction) — red before the fix, green after; `apps/editor/src/interaction` + `src/commands` suites pass (50/50).
- E2E on a worktree dev server (macOS, system Chrome): the failing test reproduced red on the unmodified base, and the full `context-menu.spec.ts` passes 5/5 after the fix, spec untouched.
- Root typecheck clean; Prettier clean; `check-test-impact` passes against `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)