### PR TITLE
feat(editor): Ctrl/Cmd+drag moves a part without its wires

### DIFF
--- a/apps/editor/e2e/detach-move.spec.ts
+++ b/apps/editor/e2e/detach-move.spec.ts
@@ -1,0 +1,131 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { chooseComponent } from "./editor-fixtures";
+
+async function placeComponent(
+  page: Page,
+  symbolId: string,
+  position: { x: number; y: number },
+): Promise<void> {
+  await chooseComponent(page, symbolId);
+  await page.getByTestId("schematic-canvas").click({ position });
+  await page.keyboard.press("Escape");
+}
+
+async function instanceIds(page: Page): Promise<string[]> {
+  return page
+    .locator('[data-canvas-hit-kind="instance"]')
+    .evaluateAll((elements) =>
+      elements.map((element) => element.getAttribute("data-canvas-hit-id")!),
+    );
+}
+
+function routePoints(page: Page) {
+  return page
+    .locator('[data-canvas-hit-kind="route"]')
+    .evaluateAll((elements) =>
+      elements.map((element) => element.getAttribute("points")),
+    );
+}
+
+const META = 4; // CDP Input modifier bitmask (Cmd; macOS turns Ctrl+left into a right press)
+
+/**
+ * Playwright's high-level mouse API cannot attach keyboard modifiers to
+ * pointer events, so the detach drag goes through the raw CDP input
+ * pipeline. Cmd stands in for Ctrl because macOS converts Ctrl+left-press
+ * into a right-button press before the page sees it.
+ */
+async function ctrlDrag(
+  page: Page,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+): Promise<void> {
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send("Input.dispatchMouseEvent", {
+    type: "mousePressed",
+    x: from.x,
+    y: from.y,
+    button: "left",
+    buttons: 1,
+    clickCount: 1,
+    modifiers: META,
+  });
+  const steps = 8;
+  for (let step = 1; step <= steps; step += 1) {
+    await cdp.send("Input.dispatchMouseEvent", {
+      type: "mouseMoved",
+      x: from.x + ((to.x - from.x) * step) / steps,
+      y: from.y + ((to.y - from.y) * step) / steps,
+      button: "left",
+      buttons: 1,
+      modifiers: META,
+    });
+  }
+  await cdp.send("Input.dispatchMouseEvent", {
+    type: "mouseReleased",
+    x: to.x,
+    y: to.y,
+    button: "left",
+    buttons: 0,
+    clickCount: 1,
+    modifiers: META,
+  });
+  await cdp.detach();
+}
+
+test("Ctrl+drag moves only the part; its wire stays exactly in place", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 300, y: 180 });
+  await placeComponent(page, "resistor", { x: 300, y: 400 });
+  const ids = await instanceIds(page);
+
+  await page.keyboard.press("w");
+  await page.getByTestId(`terminal-${ids[0]}-2`).click();
+  await page.getByTestId(`terminal-${ids[1]}-1`).click();
+  await page.keyboard.press("Escape");
+  await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(1);
+  // Deselect so the drag targets exactly the pointed-at part.
+  await page.getByTestId("schematic-canvas").click({
+    position: { x: 620, y: 420 },
+  });
+
+  const wireBefore = await routePoints(page);
+  const top = page.getByTestId(`hit-${ids[0]}`);
+  const before = (await top.boundingBox())!;
+  const center = {
+    x: before.x + before.width / 2,
+    y: before.y + before.height / 2,
+  };
+
+  await ctrlDrag(page, center, { x: center.x + 180, y: center.y });
+
+  // The part moved; the wire kept its exact geometry on the same net.
+  const after = (await top.boundingBox())!;
+  expect(after.x).toBeGreaterThan(before.x + 100);
+  const wireAfter = await routePoints(page);
+  expect(wireAfter).toEqual(wireBefore);
+  await expect(page.getByTestId("status")).toContainText("without its wires");
+});
+
+test("Ctrl+click without a drag still toggles selection", async ({ page }) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 300, y: 250 });
+  const ids = await instanceIds(page);
+  await page.getByTestId("schematic-canvas").click({
+    position: { x: 600, y: 420 },
+  });
+
+  const hit = page.getByTestId(`hit-${ids[0]}`);
+  const box = (await hit.boundingBox())!;
+  const center = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+  // A ctrl press-release without movement is the toggle-selection click.
+  await ctrlDrag(page, center, center);
+  await expect(hit).toHaveClass(/selected/);
+
+  // The part did not move.
+  const settled = (await hit.boundingBox())!;
+  expect(Math.abs(settled.x - box.x)).toBeLessThan(2);
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -4720,6 +4720,10 @@ export function App({
                 beginMoveFromSelection(event, instance.id);
               },
               onInstanceContextMenu: (instance, clientX, clientY) => {
+                // macOS fires contextmenu for Ctrl+left-press; while that
+                // press is driving a drag session (the Ctrl+drag detach
+                // move), the menu must not pop over it.
+                if (canvasDragSessionRef.current !== null) return;
                 openVisualContextMenu(
                   "instance",
                   instance.id,

--- a/apps/editor/src/features/selection/use-selection-interaction.ts
+++ b/apps/editor/src/features/selection/use-selection-interaction.ts
@@ -16,6 +16,7 @@ import {
   createRoutingOperationPlan,
   executeTransaction,
   gateRoutingOperationPlan,
+  planRoutedTerminalDetachment,
   planRoutingDeletion,
   planRoutingTransform,
   type RoutingOperationIntent,
@@ -40,6 +41,38 @@ import {
 } from "./selection-move-plan";
 
 type TransactionResult = { ok: boolean; revision: number };
+
+/**
+ * Preview projection of the detach edits: apply the planned Junction stubs
+ * and re-anchored routes to a document clone so the drag ghost shows the
+ * wires already staying put. The real edits still commit atomically as the
+ * move transaction's prefix.
+ */
+function projectDetachedDocument(
+  document: SchematicDocument,
+  edits: readonly SchematicEdit[],
+): SchematicDocument {
+  if (edits.length === 0) return document;
+  const next = structuredClone(document) as SchematicDocument & {
+    junctions: SchematicDocument["junctions"][number][];
+    routes: SchematicDocument["routes"][number][];
+  };
+  for (const edit of edits) {
+    if (edit.kind === "add_junction") {
+      next.junctions.push({
+        id: edit.junctionId,
+        netId: edit.netId,
+        position: edit.position,
+      });
+    } else if (edit.kind === "set_route_path") {
+      const index = next.routes.findIndex(
+        (candidate) => candidate.id === edit.route.id,
+      );
+      if (index >= 0) next.routes[index] = edit.route;
+    }
+  }
+  return next;
+}
 
 interface ResolvedInstanceMove {
   snap: SnapResult;
@@ -197,6 +230,8 @@ export function useSelectionInteraction(
   options: UseSelectionInteractionOptions,
 ) {
   const commandMoveSessionRef = useRef<CommandMoveSession | null>(null);
+  /** Uniquifies Junction ids minted by successive Ctrl+drag detach moves. */
+  const detachSequenceRef = useRef(0);
   const transactConnectivity = (
     intent: RoutingOperationIntent,
     edits: readonly SchematicEdit[],
@@ -646,25 +681,57 @@ export function useSelectionInteraction(
       event.shiftKey || event.ctrlKey || event.metaKey;
     options.suppressInstanceClickRef.current =
       hitTarget.getAttribute("data-canvas-hit-kind") === "instance";
-    if (hasSelectionModifier) {
+    // Ctrl-drag follows Virtuoso: the drag moves ONLY the part, leaving its
+    // wires exactly where they are (they re-anchor onto Junction stubs and
+    // stay on the Net, so the missing path shows as a flightline). Cmd
+    // serves the same role because macOS browsers convert Ctrl+left-press
+    // into a right-button press before the page ever sees it. A plain
+    // modifier-click without a drag keeps its toggle-selection meaning.
+    const detachDrag = (event.ctrlKey || event.metaKey) && !event.shiftKey;
+    if (hasSelectionModifier && !detachDrag) {
       selectInstance(instanceId, true);
       options.setStatus(`Selected ${instanceId}`);
       return;
     }
-    const movingSelection: VisualSelection = options.selectedIds.includes(
-      instanceId,
-    )
-      ? options.visualSelection
-      : {
-          instanceIds: [instanceId],
-          routeIds: [],
-          junctionIds: [],
-          annotationIds: [],
-          draftingIds: [],
-        };
+    let detachEdits: SchematicEdit[] = [];
+    let previewBaseDocument = options.document;
+    if (detachDrag) {
+      try {
+        detachSequenceRef.current += 1;
+        detachEdits = planRoutedTerminalDetachment(
+          options.document,
+          options.resolver,
+          new Set([instanceId]),
+          detachSequenceRef.current,
+        );
+      } catch (error) {
+        options.setStatus(
+          error instanceof Error ? error.message : "Detach move failed",
+        );
+        return;
+      }
+      previewBaseDocument = projectDetachedDocument(
+        options.document,
+        detachEdits,
+      );
+    }
+    const movingSelection: VisualSelection =
+      !detachDrag && options.selectedIds.includes(instanceId)
+        ? options.visualSelection
+        : {
+            instanceIds: [instanceId],
+            routeIds: [],
+            junctionIds: [],
+            annotationIds: [],
+            draftingIds: [],
+          };
     const movePlan = planSelectionMove(options.document, movingSelection);
     const movingIds = movePlan.instanceIds;
-    if (!options.selectedIds.includes(instanceId))
+    // A detach drag defers selection: a threshold-crossing drag selects the
+    // moved part on finish, while a mere modifier-click keeps its
+    // toggle-selection meaning (pre-selecting here would make that toggle
+    // deselect what it just selected).
+    if (!detachDrag && !options.selectedIds.includes(instanceId))
       selectInstance(instanceId, false);
     if (movingIds.length === 0) return;
     options.canvasDragSessionRef.current?.cancel();
@@ -717,7 +784,7 @@ export function useSelectionInteraction(
         lastSnap,
       );
       const document = projectInstanceMove(
-        options.document,
+        previewBaseDocument,
         resolved.moves,
         preview.movePlan,
       );
@@ -781,11 +848,28 @@ export function useSelectionInteraction(
             suppressSnap,
             projection.resolved.snap,
             {
-              document: options.document,
-              prefixEdits: [],
+              // The detached projection, so the commit's routing transform
+              // plans against the topology the prefix edits will create —
+              // otherwise it would re-stretch the wires the detach just
+              // anchored in place.
+              document: previewBaseDocument,
+              prefixEdits: detachEdits,
               resolvedMove: projection.resolved,
             },
           );
+          if (detachDrag) {
+            selectInstance(instanceId, false);
+          }
+          if (detachEdits.length > 0) {
+            options.setStatus(
+              `Moved ${instanceId} without its wires — reconnect via the flightlines`,
+            );
+          }
+        } else if (detachDrag) {
+          // The drag never crossed the threshold: keep the plain
+          // ctrl-click toggle-selection meaning.
+          selectInstance(instanceId, true);
+          options.setStatus(`Selected ${instanceId}`);
         }
       },
       onCancel: () => {

--- a/packages/edit-engine/src/instance-lifecycle.ts
+++ b/packages/edit-engine/src/instance-lifecycle.ts
@@ -82,7 +82,14 @@ function instancesById(
   return document.instances.filter((instance) => selected.has(instance.id));
 }
 
-function planRoutedTerminalDetachment(
+/**
+ * Re-anchors every routed wire leaving the selected instances onto a fresh
+ * Junction at its landing, leaving the wires' geometry untouched. Net
+ * membership is intentionally preserved: the terminals stay electrically
+ * connected and the missing physical path shows up as a flightline, so a
+ * detach-move (Ctrl+drag) cannot silently change connectivity.
+ */
+export function planRoutedTerminalDetachment(
   document: SchematicDocument,
   resolver: SymbolResolver,
   selected: ReadonlySet<string>,


### PR DESCRIPTION
## Summary

Owner feedback, matching Virtuoso's **"Ctrl + Drag — move object without connected nets"**: dragging with the modifier moves ONLY the part; every routed wire stays exactly where it was.

Semantics chosen deliberately for this editor's explicit-connectivity model: the wires re-anchor onto fresh **Junction stubs** at their old landings (`planRoutedTerminalDetachment`, now exported) while **Net membership is preserved** — the part remains electrically connected and the missing physical path shows as a flightline, so the gesture can never silently change connectivity (Virtuoso's Move creates silent opens; ours shows the debt).

## Mechanics

- **Cmd serves alongside Ctrl** because macOS browsers convert Ctrl+left-press into a right-button press before the page ever sees it — a plain Ctrl+drag cannot reach the page there. The instance context menu is suppressed while a drag session is active so macOS's synthetic contextmenu cannot pop over the gesture.
- The detach edits commit as the move transaction's **prefix**, and the commit-side routing transform plans against the **detached projection** — planning against the pre-detach document would re-stretch the wires the prefix just anchored (found red).
- The drag **preview** projects the detached document too, so wires visibly stay put during the drag, not only after it.
- A modifier-press that never crosses the drag threshold keeps its **toggle-selection** meaning; pre-selecting before the drag is skipped on the detach path precisely so that toggle does not immediately undo itself (found red). A threshold-crossing drag selects the moved part on finish.

## Validation

- New `detach-move.spec.ts` drives the gesture through the **raw CDP input pipeline** (Playwright's mouse API cannot attach modifiers to pointer events): the wire's polyline is byte-identical across the drag while the part moves; a no-drag modifier click still toggles selection. The drag case is red before this change (wires stretched).
- Selection + edit-engine unit suites and the manual-editor / verb-first e2e suites green (379 unit / 100 e2e); prettier + repo typecheck; rechecked on this base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)