### PR TITLE
fix(editor): the wheel is read from evidence, and the person can decide

### DIFF
--- a/apps/editor/e2e/wheel-behavior.spec.ts
+++ b/apps/editor/e2e/wheel-behavior.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { awaitEditorReady } from "./editor-fixtures";
+
+/** Dispatch one wheel event with a chosen device signature. */
+async function wheel(
+  page: Page,
+  signature: { deltaY: number; deltaX?: number; wheelDeltaY?: number },
+): Promise<void> {
+  await page.getByTestId("schematic-canvas").evaluate((element, init) => {
+    const bounds = element.getBoundingClientRect();
+    const event = new WheelEvent("wheel", {
+      clientX: bounds.left + bounds.width * 0.3,
+      clientY: bounds.top + bounds.height * 0.3,
+      deltaX: init.deltaX ?? 0,
+      deltaY: init.deltaY,
+      bubbles: true,
+      cancelable: true,
+    });
+    if (init.wheelDeltaY !== undefined) {
+      Object.defineProperty(event, "wheelDeltaY", { value: init.wheelDeltaY });
+    }
+    element.dispatchEvent(event);
+  }, signature);
+}
+
+const width = async (page: Page): Promise<number> =>
+  Number(
+    (await page.getByTestId("schematic-canvas").getAttribute("viewBox"))!.split(
+      " ",
+    )[2],
+  );
+
+test("a wheel zooms and a trackpad pans, and the setting overrides both", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await awaitEditorReady(page);
+  const setting = page.getByLabel("Scroll wheel");
+  await expect(setting).toHaveValue("auto");
+
+  // A detent-quantized signature zooms even though its deltaY is tiny —
+  // the case that made a slowly turned mouse wheel pan. Scrolling up
+  // zooms in, so the camera narrows.
+  const beforeWheel = await width(page);
+  await wheel(page, { deltaY: -4, wheelDeltaY: 120 });
+  await expect.poll(() => width(page)).toBeLessThan(beforeWheel);
+
+  // The trackpad's 3:1 ratio pans instead, leaving the zoom untouched.
+  const afterWheel = await width(page);
+  await wheel(page, { deltaY: 40, wheelDeltaY: -120 });
+  await expect.poll(() => width(page)).toBe(afterWheel);
+
+  // An explicit choice wins over any evidence: the same trackpad
+  // signature now zooms.
+  await setting.selectOption("zoom");
+  await wheel(page, { deltaY: -40, wheelDeltaY: 120 });
+  await expect.poll(() => width(page)).toBeLessThan(afterWheel);
+
+  // And a mouse detent pans once the person says the device is a surface.
+  await setting.selectOption("pan");
+  const beforePan = await width(page);
+  await wheel(page, { deltaY: -4, wheelDeltaY: 120 });
+  await expect.poll(() => width(page)).toBe(beforePan);
+
+  // The choice survives a reload.
+  await page.reload();
+  await awaitEditorReady(page);
+  await expect(page.getByLabel("Scroll wheel")).toHaveValue("pan");
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -82,7 +82,10 @@ import {
 } from "../features/wiring/use-wire-interaction";
 import { closestPointOnSegment } from "../canvas/canvas-geometry";
 import type { BoxPreview, PanPreview } from "../canvas/canvas-gesture-model";
-import { createCanvasGestureController } from "../canvas/canvas-gesture-controller";
+import {
+  createCanvasGestureController,
+  type WheelBehavior,
+} from "../canvas/canvas-gesture-controller";
 import { createEditorCanvasEventHandlers } from "../canvas/editor-canvas-event-handlers";
 import {
   canvasPointFromClient,
@@ -522,6 +525,21 @@ export function App({
     const stored = window.localStorage.getItem("icm.draw-angle.v1");
     return stored === "45" || stored === "orthogonal" ? stored : "free";
   });
+  const [wheelBehavior, setWheelBehaviorState] = useState<WheelBehavior>(() => {
+    if (typeof window === "undefined") return "auto";
+    const stored = window.localStorage.getItem("icm.wheel-behavior.v1");
+    return stored === "zoom" || stored === "pan" ? stored : "auto";
+  });
+  const wheelBehaviorRef = useRef(wheelBehavior);
+  wheelBehaviorRef.current = wheelBehavior;
+  const setWheelBehavior = (behavior: WheelBehavior): void => {
+    setWheelBehaviorState(behavior);
+    try {
+      window.localStorage.setItem("icm.wheel-behavior.v1", behavior);
+    } catch {
+      // Storage may be unavailable; the choice still applies to this session.
+    }
+  };
   const setDrawAngleMode = (mode: DrawAngleMode): void => {
     setDrawAngleModeState(mode);
     try {
@@ -2324,6 +2342,7 @@ export function App({
       rawPointFromClient: (clientX, clientY, svg) =>
         pointFromClient(clientX, clientY, svg, false),
       logicalRadiusForPixels,
+      wheelBehavior: () => wheelBehaviorRef.current,
     },
     gestureSession: {
       boxPreview,
@@ -5030,6 +5049,8 @@ export function App({
         onAnnotationGridChange={setAnnotationGrid}
         drawAngleMode={drawAngleMode}
         onDrawAngleModeChange={setDrawAngleMode}
+        wheelBehavior={wheelBehavior}
+        onWheelBehaviorChange={setWheelBehavior}
         zoomPercent={zoomPercent}
         onToggleWireOptions={() => setWireOptionsOpen((open) => !open)}
         onWireRoutingModeChange={setWireRoutingMode}

--- a/apps/editor/src/canvas/canvas-gesture-controller.test.ts
+++ b/apps/editor/src/canvas/canvas-gesture-controller.test.ts
@@ -1,73 +1,87 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  wheelEventIsMouseDetent,
-  wheelEventLooksLikeTrackpad,
-} from "./canvas-gesture-controller";
+import { classifyWheelSource } from "./canvas-gesture-controller";
 
-describe("wheelEventLooksLikeTrackpad", () => {
-  it("classifies wheel sources by delta shape", () => {
-    // Discrete mouse detents: integer verticals, no horizontal component.
-    expect(
-      wheelEventLooksLikeTrackpad({ deltaMode: 0, deltaX: 0, deltaY: 120 }),
-    ).toBe(false);
-    expect(
-      wheelEventLooksLikeTrackpad({ deltaMode: 1, deltaX: 0, deltaY: 3 }),
-    ).toBe(false);
-    // Trackpads: horizontal component, fractional, or gentle steps.
-    expect(
-      wheelEventLooksLikeTrackpad({ deltaMode: 0, deltaX: 4, deltaY: 12 }),
-    ).toBe(true);
-    expect(
-      wheelEventLooksLikeTrackpad({ deltaMode: 0, deltaX: 0, deltaY: 33.4 }),
-    ).toBe(true);
-    expect(
-      wheelEventLooksLikeTrackpad({ deltaMode: 0, deltaX: 0, deltaY: 8 }),
-    ).toBe(true);
+/**
+ * Signatures taken from what each engine actually reports. The point of
+ * these cases is that no verdict rests on the size of a delta: a slowly
+ * turned or high-resolution wheel emits exactly the small values a
+ * trackpad does, which is why "unknown" is a permitted answer.
+ */
+describe("classifyWheelSource", () => {
+  it("reads line and page modes as a wheel", () => {
+    // Firefox reports a mouse wheel in lines, a trackpad in pixels.
+    expect(classifyWheelSource({ deltaMode: 1, deltaX: 0, deltaY: 3 })).toBe(
+      "mouse",
+    );
+    expect(classifyWheelSource({ deltaMode: 2, deltaX: 0, deltaY: 1 })).toBe(
+      "mouse",
+    );
   });
 
-  it("reads a detent-quantized wheelDeltaY as a mouse despite small deltas", () => {
-    // macOS scroll acceleration shrinks a slow mouse detent's deltaY under
-    // the small-step threshold, but Chromium/WebKit still stamp the detent
-    // as wheelDeltaY = n*120 without the trackpad's 3:1 pixel ratio.
+  it("reads a detent-quantized wheelDeltaY as a wheel however small its deltaY", () => {
+    // Chromium/WebKit stamp a detent as a multiple of 120 even when macOS
+    // acceleration shrinks the normalized deltaY to a handful of pixels.
     expect(
-      wheelEventLooksLikeTrackpad({
+      classifyWheelSource({
         deltaMode: 0,
         deltaX: 0,
         deltaY: 4,
         wheelDeltaY: -120,
       }),
-    ).toBe(false);
+    ).toBe("mouse");
     expect(
-      wheelEventIsMouseDetent({
+      classifyWheelSource({
         deltaMode: 0,
         deltaX: 0,
-        deltaY: 16,
+        deltaY: 100,
         wheelDeltaY: -240,
       }),
-    ).toBe(true);
-    // A trackpad step that happens to land on 120 keeps the 3:1 ratio and
-    // is not claimed as a detent.
+    ).toBe("mouse");
+  });
+
+  it("reads the trackpad's fixed 3:1 ratio as a surface", () => {
+    // A precise surface keeps wheelDeltaY = -3 * deltaY, including where
+    // the product happens to land on a multiple of 120.
     expect(
-      wheelEventIsMouseDetent({
+      classifyWheelSource({
         deltaMode: 0,
         deltaX: 0,
         deltaY: 40,
         wheelDeltaY: -120,
       }),
-    ).toBe(false);
-    // A horizontal component is trackpad evidence regardless of quantizing.
+    ).toBe("trackpad");
     expect(
-      wheelEventLooksLikeTrackpad({
+      classifyWheelSource({
         deltaMode: 0,
-        deltaX: 4,
-        deltaY: 40,
-        wheelDeltaY: -120,
+        deltaX: 0,
+        deltaY: 7,
+        wheelDeltaY: -21,
       }),
-    ).toBe(true);
-    // Firefox never exposes wheelDeltaY; the small-step reading holds.
-    expect(
-      wheelEventLooksLikeTrackpad({ deltaMode: 0, deltaX: 0, deltaY: 4 }),
-    ).toBe(true);
+    ).toBe("trackpad");
+  });
+
+  it("reads two axes or sub-pixel precision as a surface", () => {
+    expect(classifyWheelSource({ deltaMode: 0, deltaX: 4, deltaY: 12 })).toBe(
+      "trackpad",
+    );
+    expect(classifyWheelSource({ deltaMode: 0, deltaX: 0, deltaY: 33.4 })).toBe(
+      "trackpad",
+    );
+  });
+
+  it("admits it cannot tell when the engine offers no evidence", () => {
+    // Firefox exposes no wheelDeltaY, so a plain vertical integer scroll
+    // carries nothing that separates a high-resolution wheel from a
+    // trackpad. Guessing "trackpad" here is what made a mouse pan.
+    expect(classifyWheelSource({ deltaMode: 0, deltaX: 0, deltaY: 8 })).toBe(
+      "unknown",
+    );
+    expect(classifyWheelSource({ deltaMode: 0, deltaX: 0, deltaY: 120 })).toBe(
+      "unknown",
+    );
+    expect(classifyWheelSource({ deltaMode: 0, deltaX: 0, deltaY: 0 })).toBe(
+      "unknown",
+    );
   });
 });

--- a/apps/editor/src/canvas/canvas-gesture-controller.ts
+++ b/apps/editor/src/canvas/canvas-gesture-controller.ts
@@ -70,6 +70,8 @@ export interface CanvasGestureControllerDependencies {
       svg: SVGSVGElement,
     ) => DerivedPoint;
     logicalRadiusForPixels: (svg: SVGSVGElement, pixels: number) => number;
+    /** Live read: the person can change it between two wheel events. */
+    wheelBehavior: () => WheelBehavior;
   };
   gestureSession: {
     boxPreview: BoxPreview | null;
@@ -155,31 +157,42 @@ interface WheelSourceShape {
 }
 
 /**
- * Chromium and WebKit stamp a physical wheel detent as wheelDeltaY = n*120
- * regardless of pointer-acceleration, while macOS acceleration can shrink
- * the same detent's deltaY below the small-step threshold — which made a
- * slowly turned mouse wheel read as a trackpad and pan instead of zoom. A
- * trackpad event keeps wheelDeltaY = -3 * deltaY, so a detent-quantized
- * value that breaks that ratio is a mouse wheel — decisively enough to
- * override even recent trackpad evidence.
+ * What a wheel event proves about the device that produced it.
+ *
+ * The DOM never names the device, so this reports evidence rather than a
+ * guess: "unknown" is a real answer, and the caller decides what a
+ * device-less event should do. Nothing here infers a source from how large
+ * a delta happens to be — a high-resolution or slowly turned wheel emits
+ * exactly the small values a trackpad does.
  */
-export function wheelEventIsMouseDetent(event: WheelSourceShape): boolean {
-  const wheelDeltaY = event.wheelDeltaY;
-  return (
-    event.deltaX === 0 &&
-    typeof wheelDeltaY === "number" &&
-    wheelDeltaY !== 0 &&
-    wheelDeltaY % 120 === 0 &&
-    Math.abs(wheelDeltaY) !== 3 * Math.abs(event.deltaY)
-  );
-}
+export type WheelSource = "mouse" | "trackpad" | "unknown";
 
-export function wheelEventLooksLikeTrackpad(event: WheelSourceShape): boolean {
-  if (event.deltaMode !== 0) return false;
-  if (event.deltaX !== 0) return true;
-  if (wheelEventIsMouseDetent(event)) return false;
-  if (!Number.isInteger(event.deltaY)) return true;
-  return Math.abs(event.deltaY) > 0 && Math.abs(event.deltaY) < 40;
+/**
+ * How the wheel should be read. "auto" trusts the evidence above; the two
+ * explicit values exist because no evidence is available in every browser,
+ * and a person who knows their own device should never be at the mercy of
+ * a guess.
+ */
+export type WheelBehavior = "auto" | "zoom" | "pan";
+
+export function classifyWheelSource(event: WheelSourceShape): WheelSource {
+  // Firefox and older engines report a wheel in lines or pages; a precise
+  // surface always reports pixels.
+  if (event.deltaMode !== 0) return "mouse";
+  // Chromium and WebKit carry the raw platform value alongside the
+  // normalized one. A precise surface keeps the fixed 3:1 pixel ratio,
+  // while a physical detent is quantized to multiples of 120 and breaks
+  // that ratio however much pointer acceleration shrinks its deltaY.
+  const wheelDeltaY = event.wheelDeltaY;
+  if (typeof wheelDeltaY === "number" && wheelDeltaY !== 0) {
+    if (Math.abs(wheelDeltaY) === 3 * Math.abs(event.deltaY)) return "trackpad";
+    if (wheelDeltaY % 120 === 0) return "mouse";
+  }
+  // Two axes at once is a surface, not a wheel.
+  if (event.deltaX !== 0) return "trackpad";
+  // Sub-pixel precision comes from momentum, which a detent cannot produce.
+  if (!Number.isInteger(event.deltaY)) return "trackpad";
+  return "unknown";
 }
 
 const TRACKPAD_EVIDENCE_WINDOW_MS = 1500;
@@ -196,6 +209,7 @@ export function createCanvasGestureController({
     pointFromClient,
     rawPointFromClient,
     logicalRadiusForPixels,
+    wheelBehavior,
   },
   gestureSession: {
     boxPreview,
@@ -310,17 +324,19 @@ export function createCanvasGestureController({
       );
       return;
     }
-    if (wheelEventLooksLikeTrackpad(event)) {
-      lastTrackpadWheelAt = event.timeStamp;
-    }
-    // Momentum tails of a trackpad flick can degrade into clean integer
-    // steps, so recent trackpad evidence keeps the pan interpretation — but
-    // a detent-quantized mouse wheel must zoom even inside that window: the
-    // mouse's only axis always earns the zoom.
+    const source = classifyWheelSource(event);
+    if (source === "trackpad") lastTrackpadWheelAt = event.timeStamp;
+    if (source === "mouse") lastTrackpadWheelAt = Number.NEGATIVE_INFINITY;
+    // An explicit preference is the whole answer; "auto" reads the evidence
+    // and, where a browser offers none, keeps the momentum tail of a recent
+    // trackpad gesture panning before falling back to the wheel's zoom.
     const trackpad =
-      event.deltaMode === 0 &&
-      !wheelEventIsMouseDetent(event) &&
-      event.timeStamp - lastTrackpadWheelAt < TRACKPAD_EVIDENCE_WINDOW_MS;
+      wheelBehavior() === "pan" ||
+      (wheelBehavior() === "auto" &&
+        (source === "trackpad" ||
+          (source === "unknown" &&
+            event.timeStamp - lastTrackpadWheelAt <
+              TRACKPAD_EVIDENCE_WINDOW_MS)));
     if (!trackpad) {
       if (event.shiftKey) {
         if (deltaY === 0) return;

--- a/apps/editor/src/features/editor-shell/editor-statusbar.test.tsx
+++ b/apps/editor/src/features/editor-shell/editor-statusbar.test.tsx
@@ -17,6 +17,8 @@ describe("editor statusbar", () => {
         recoveryLabel="Saved locally"
         gridDotsVisible
         drawAngleMode="free"
+        wheelBehavior="auto"
+        onWheelBehaviorChange={vi.fn()}
         onDrawAngleModeChange={vi.fn()}
         annotationGrid={5}
         zoomPercent={100}

--- a/apps/editor/src/features/editor-shell/editor-statusbar.tsx
+++ b/apps/editor/src/features/editor-shell/editor-statusbar.tsx
@@ -28,6 +28,7 @@ export function EditorStatusbar({
   gridDotsVisible,
   annotationGrid,
   drawAngleMode,
+  wheelBehavior,
   zoomPercent,
   onToggleWireOptions,
   onWireRoutingModeChange,
@@ -36,6 +37,7 @@ export function EditorStatusbar({
   onOpenAnalytics,
   onAnnotationGridChange,
   onDrawAngleModeChange,
+  onWheelBehaviorChange,
   onZoomOut,
   onZoomIn,
   onFitView,
@@ -52,6 +54,7 @@ export function EditorStatusbar({
   gridDotsVisible: boolean;
   annotationGrid: 1 | 5 | 10;
   drawAngleMode: "free" | "45" | "orthogonal";
+  wheelBehavior: "auto" | "zoom" | "pan";
   zoomPercent: number;
   onToggleWireOptions: () => void;
   onWireRoutingModeChange: (mode: WireRoutingMode) => void;
@@ -60,6 +63,7 @@ export function EditorStatusbar({
   onOpenAnalytics: () => void;
   onAnnotationGridChange: (pitch: 1 | 5 | 10) => void;
   onDrawAngleModeChange: (mode: "free" | "45" | "orthogonal") => void;
+  onWheelBehaviorChange: (behavior: "auto" | "zoom" | "pan") => void;
   onZoomOut: () => void;
   onZoomIn: () => void;
   onFitView: () => void;
@@ -196,6 +200,21 @@ export function EditorStatusbar({
           <option value="free">Free</option>
           <option value="45">45°</option>
           <option value="orthogonal">Ortho</option>
+        </select>
+        <select
+          aria-label="Scroll wheel"
+          data-testid="wheel-behavior-select"
+          title="What a plain scroll does. Auto reads the device from the event: a mouse wheel zooms, a trackpad pans. Pick one explicitly if your device is read wrongly. Pinch and Cmd+scroll always zoom."
+          value={wheelBehavior}
+          onChange={(event) =>
+            onWheelBehaviorChange(
+              event.currentTarget.value as "auto" | "zoom" | "pan",
+            )
+          }
+        >
+          <option value="auto">Scroll: Auto</option>
+          <option value="zoom">Scroll: Zoom</option>
+          <option value="pan">Scroll: Pan</option>
         </select>
         <button
           type="button"


### PR DESCRIPTION
Owner pushback on my earlier heuristic: "'小步长=触摸板' 这个肯定不能这么搞吧，这个应该仔细搞吧？把事情给搞对吧？" — correct, and the fix is two-part.

**The guess is gone.** The classifier ended with "pixel mode + small integer deltaY ⇒ trackpad". A high-resolution or slowly turned mouse wheel emits exactly those values, and **Firefox exposes no `wheelDeltaY`**, so every event it produces fell through to that line — the guess decided the behaviour outright there. #406 had already patched one symptom (the detent ratio check) but left the guess as the fallback.

Classification now reports evidence, with "unknown" as a permitted verdict:

| evidence | verdict | why |
|---|---|---|
| `deltaMode` is line/page | mouse | Firefox and older engines report a wheel in lines; a precise surface always reports pixels |
| `\|wheelDeltaY\| === 3·\|deltaY\|` | trackpad | a precise surface keeps the fixed 3:1 pixel ratio |
| `wheelDeltaY % 120 === 0` (ratio broken) | mouse | a detent stays quantized however much acceleration shrinks its deltaY |
| `deltaX ≠ 0` | trackpad | two axes at once is a surface |
| `deltaY` not an integer | trackpad | sub-pixel precision comes from momentum |
| otherwise | **unknown** | nothing is inferred from magnitude |

`unknown` no longer means trackpad: it zooms — the wheel's historical behaviour, and the failure mode the owner reported — unless positive trackpad evidence arrived inside the 1.5s momentum window, which covers a flick's tail. Positive mouse evidence clears that window immediately.

**And no heuristic decides alone.** The status bar gains a persisted `Scroll: Auto / Zoom / Pan`. Anyone whose device is read wrongly in any browser settles it once. Pinch and Cmd+scroll zoom under every setting; Shift+wheel still pans horizontally.

Validation: classifier unit tests rewritten around real device signatures rather than magnitudes (line mode, Chromium detent with deltaY 4, the 3:1 ratio including the ambiguous 40/−120 case, two-axis, sub-pixel, and three genuinely undecidable events); new e2e drives all four paths — auto/detent zooms, auto/trackpad pans, explicit Zoom overrides a trackpad signature, explicit Pan overrides a detent, and the choice survives reload. Editor unit suite 694/694 (three consecutive runs), e2e manual-editor + drafting + component-insert 167/167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)