### PR TITLE
fix(editor): Cmd+Z/Y/S/O reach history, save, and open on macOS

### DIFF
--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -54,21 +54,29 @@ function resolve(
 const command = (value: object) => ({ kind: "run-command", command: value });
 
 describe("editor shortcut contract", () => {
-  it("maps history and file chord shortcuts without stealing copy/paste chords", () => {
+  it("maps history and file chords on either command modifier without stealing copy/paste chords", () => {
     expect(resolve("u")).toEqual(command({ id: "history.undo" }));
     expect(resolve("u", {}, { shiftKey: true })).toEqual(
       command({ id: "history.redo" }),
     );
-    expect(resolve("z", {}, { ctrlKey: true })).toEqual(
-      command({ id: "history.undo" }),
-    );
-    expect(resolve("z", {}, { ctrlKey: true, shiftKey: true })).toEqual(
-      command({ id: "history.redo" }),
-    );
-    expect(resolve("s", {}, { ctrlKey: true })).toEqual({ kind: "save" });
-    expect(resolve("s", {}, { metaKey: true })).toBeNull();
-    expect(resolve("c", {}, { ctrlKey: true })).toBeNull();
-    expect(resolve("v", {}, { ctrlKey: true })).toBeNull();
+    // macOS presses Cmd where Windows presses Ctrl; a ctrl-only binding
+    // leaves these chords to the browser there (Save Page, Open File,
+    // history navigation), so meta is bound identically.
+    for (const modifiers of [{ ctrlKey: true }, { metaKey: true }]) {
+      expect(resolve("z", {}, modifiers)).toEqual(
+        command({ id: "history.undo" }),
+      );
+      expect(resolve("z", {}, { ...modifiers, shiftKey: true })).toEqual(
+        command({ id: "history.redo" }),
+      );
+      expect(resolve("y", {}, modifiers)).toEqual(
+        command({ id: "history.redo" }),
+      );
+      expect(resolve("s", {}, modifiers)).toEqual({ kind: "save" });
+      expect(resolve("o", {}, modifiers)).toEqual({ kind: "open" });
+      expect(resolve("c", {}, modifiers)).toBeNull();
+      expect(resolve("v", {}, modifiers)).toBeNull();
+    }
   });
 
   it("arbitrates browser refresh chords before blocking their defaults", () => {
@@ -396,6 +404,7 @@ describe("editor shortcut contract", () => {
       expect(resolve(value, { isTyping: true })).toBeNull();
     }
     expect(resolve("s", { isTyping: true }, { ctrlKey: true })).toBeNull();
+    expect(resolve("s", { isTyping: true }, { metaKey: true })).toBeNull();
   });
 
   it("keeps typing suppressed with the Properties dock open, and Q blocked while interacting", () => {

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -109,17 +109,20 @@ export function resolveEditorShortcut(
       command: { id: event.shiftKey ? "history.redo" : "history.undo" },
     };
   }
-  if (event.ctrlKey && key === "z") {
+  // History and file chords answer to both command modifiers: macOS presses
+  // Cmd where Windows presses Ctrl, and an unbound meta chord would fall
+  // through to the browser (Save Page, Open File, history navigation).
+  if (commandModifier && key === "z") {
     return {
       kind: "run-command",
       command: { id: event.shiftKey ? "history.redo" : "history.undo" },
     };
   }
-  if (event.ctrlKey && key === "y") {
+  if (commandModifier && key === "y") {
     return { kind: "run-command", command: { id: "history.redo" } };
   }
-  if (event.ctrlKey && key === "s") return { kind: "save" };
-  if (event.ctrlKey && key === "o") return { kind: "open" };
+  if (commandModifier && key === "s") return { kind: "save" };
+  if (commandModifier && key === "o") return { kind: "open" };
 
   if (event.key === "Escape") {
     return { kind: "run-command", command: { id: "editor.cancel" } };


### PR DESCRIPTION
## Problem

`resolveEditorShortcut` bound undo/redo/save/open to `ctrlKey` alone, so on macOS the native chords fell through to the browser: Cmd+Z did nothing, Cmd+Y opened browser history, Cmd+S offered *Save Page As*, and Cmd+O a local file picker over the live editor. Ctrl/Cmd+D, Ctrl/Cmd+R, Ctrl/Cmd+F, and #412's Select All already treat either modifier as the command modifier — these four chords were the remaining ctrl-only bindings.

## Decision (deliberate contract change)

The unit contract explicitly pinned **Meta+S as unbound** (`resolve("s", {}, { metaKey: true })` → `null`). That pin dates to the shortcut-centralization refactor, which froze the then-current App.tsx behavior rather than recording a macOS product decision, and no spec/ADR mandates ctrl-only chords. This PR deliberately reverses the pin to full meta parity:

- **Cmd+Z / Cmd+Shift+Z** → `history.undo` / `history.redo`
- **Cmd+Y** → `history.redo`
- **Cmd+S** → save, **Cmd+O** → open project
- Copy/paste chords stay unbound under **both** modifiers (now pinned for meta too)
- Typing suppression is unchanged: while a text field has focus these chords still resolve to `null` on every platform

Complementary to #412 (touches only the z/y/s/o hunks; no overlap with its Select All hunks).

## Validation

- `vitest run apps/editor/src/interaction apps/editor/src/commands` — 50 tests pass
- root `tsc -p tsconfig.check.json` clean, Prettier clean, `check-test-impact` passes
- Verified live on darwin against the dev server: real **Cmd+Z**, **Cmd+Shift+Z**, and **Cmd+Y** key events undo/redo an NMOS placement (revision counter advances, no browser default fires). Existing e2e specs press explicit `Control+…` chords, which remain bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)