### PR TITLE
fix(editor): a refused routing operation says which rule refused it

### DIFF
--- a/apps/editor/src/app/editor-transaction-commands.ts
+++ b/apps/editor/src/app/editor-transaction-commands.ts
@@ -150,7 +150,15 @@ export function createEditorTransactionCommands({
       ...(resolver ? { symbolResolver: resolver } : {}),
     });
     if (!gate.ok) {
-      setStatus(gate.message);
+      // Say which rule refused, the way applyResult does for direct edits:
+      // the headline alone ("Transaction result failed Document validation")
+      // names no field and leaves nothing to report or fix.
+      const detail = gate.diagnostics[0]?.message;
+      setStatus(
+        detail && detail !== gate.message
+          ? `${gate.message} — ${detail}`
+          : gate.message,
+      );
       return null;
     }
     return transact([...gate.edits], options);

--- a/packages/edit-engine/src/routing-operation-plan.test.ts
+++ b/packages/edit-engine/src/routing-operation-plan.test.ts
@@ -68,12 +68,14 @@ describe("RoutingOperationPlan", () => {
     ).toEqual({
       ok: false,
       message: "Routing operation is stale",
+      diagnostics: [],
     });
     expect(
       gateRoutingOperationPlan({ ...document, id: "child" }, plan),
     ).toEqual({
       ok: false,
       message: "Routing operation targets another Cell",
+      diagnostics: [],
     });
   });
 
@@ -94,5 +96,32 @@ describe("RoutingOperationPlan", () => {
       ok: false,
       diagnostics: [{ code: "ELECTRICAL_EFFECT_MISMATCH" }],
     });
+  });
+
+  it("hands the refusal's reason to the caller, not just its headline", () => {
+    // A schema refusal names the field it rejected. The gate is the last
+    // place that knows, so a caller reporting only the headline leaves the
+    // person with "Transaction result failed Document validation" and
+    // nothing to act on or report.
+    const document = createEmptyDocument("main", "Main");
+    document.nets.push({ id: "net-a", terminals: [] });
+    const plan = createRoutingOperationPlan(document, {
+      intent: "transform",
+      edits: [
+        {
+          kind: "add_junction",
+          junctionId: "J-off-grid",
+          netId: "net-a",
+          // The Document grid is 10: an off-grid Junction is refused.
+          position: { x: 3, y: 7 },
+        },
+      ],
+      diagnostics: [],
+    });
+    const gate = gateRoutingOperationPlan(document, plan);
+    expect(gate.ok).toBe(false);
+    if (gate.ok) return;
+    expect(gate.diagnostics.length).toBeGreaterThan(0);
+    expect(gate.diagnostics[0]?.message).toBeTruthy();
   });
 });

--- a/packages/edit-engine/src/routing-operation-plan.ts
+++ b/packages/edit-engine/src/routing-operation-plan.ts
@@ -377,7 +377,17 @@ export type RoutingOperationGate =
       readonly edits: readonly SchematicEdit[];
       readonly evaluated: EvaluatedRoutingOperation;
     }
-  | { readonly ok: false; readonly message: string };
+  | {
+      readonly ok: false;
+      readonly message: string;
+      /**
+       * Why it failed, in the terms the schema or planner used. The gate is
+       * the last place that knows; dropping it here left a person staring
+       * at "Transaction result failed Document validation" with nothing to
+       * act on and nothing to report.
+       */
+      readonly diagnostics: readonly EditDiagnostic[];
+    };
 
 /** Evaluate once before a UI commit; the returned edits are the evaluated plan. */
 export function gateRoutingOperationPlan(
@@ -392,7 +402,11 @@ export function gateRoutingOperationPlan(
         edits: evaluation.value.plan.edits,
         evaluated: evaluation.value,
       }
-    : { ok: false, message: evaluation.message };
+    : {
+        ok: false,
+        message: evaluation.message,
+        diagnostics: evaluation.diagnostics,
+      };
 }
 
 export function evaluateRoutingOperationPlan(


### PR DESCRIPTION
From triaging issue #394: a user hit "Transaction result failed Document validation" while placing an nmos and had nothing further to report — the screenshot shows the whole message.

The reason was not missing, it was discarded. `executeTransaction` returns diagnostics naming the rejected field, `evaluateRoutingOperationPlan` carries them, and then `gateRoutingOperationPlan` returned `{ ok: false, message }` and dropped them on the floor; `transactConnectivity` showed that bare headline. Direct edits already append the diagnostic (`applyResult`), so the connectivity path was the odd one out.

The gate now carries `diagnostics`, and the connectivity commit appends the first message. Which operations get refused is unchanged — a refusal is simply legible now, both for the person editing and for the next bug report.

This does not by itself fix #394: I could not reproduce the underlying validation failure across ~22 placement scenarios (blank sheet, both fixtures, after supply placement/delete/undo, and MOS-on-MOS pin contacts for every pin). With this landed, the next report will name the field.

Validation: edit-engine + editor unit suites 1025/1025, including a new test that a schema refusal reaches the caller with its diagnostics; typecheck and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)