### PR TITLE
feat(gallery): authors delete their own work, and the quota counts what stands

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -1533,6 +1533,66 @@ test("post-publication moderation has rejected work but no approval queue", asyn
   await expect(page.getByText("Nothing waiting for review")).toHaveCount(0);
 });
 
+test("an author deletes their own entry from My submissions", async ({
+  page,
+}) => {
+  await page.route("**/api/auth/me", (route) =>
+    route.fulfill({
+      json: {
+        user: {
+          id: "u7",
+          displayName: "Maker",
+          email: "maker@example.com",
+          provider: "email",
+          role: "user",
+          isAdmin: false,
+        },
+      },
+    }),
+  );
+  let live = true;
+  await page.route("**/api/gallery/mine", (route) =>
+    route.fulfill({
+      json: {
+        entries: live
+          ? [
+              {
+                id: "mine-9",
+                name: "Draft I regret",
+                createdAt: "2026-08-29T09:00:00.000Z",
+                status: "public",
+                rejectReason: null,
+              },
+            ]
+          : [],
+      },
+    }),
+  );
+  const methods: string[] = [];
+  await page.route("**/api/gallery/mine-9", (route) => {
+    if (route.request().method() !== "DELETE") return route.fallback();
+    methods.push("DELETE");
+    live = false;
+    return route.fulfill({ json: { id: "mine-9", deleted: true } });
+  });
+
+  await page.goto("/mine");
+  const remove = page.getByTestId("mine-delete-mine-9");
+  await expect(remove).toBeVisible();
+
+  // Irreversible, so it asks first; declining leaves the entry alone.
+  page.once("dialog", (dialog) => void dialog.dismiss());
+  await remove.click();
+  expect(methods).toHaveLength(0);
+  await expect(remove).toBeVisible();
+
+  page.once("dialog", (dialog) => void dialog.accept());
+  await remove.click();
+  await expect(page.getByTestId("mine-notice")).toContainText("Deleted");
+  await expect(page.getByTestId("mine-delete-mine-9")).toHaveCount(0);
+  expect(methods).toEqual(["DELETE"]);
+});
+
 test("/mine wears the site chrome and links every entry back to the editor", async ({
   page,
 }) => {

--- a/apps/editor/src/components/my-submissions.tsx
+++ b/apps/editor/src/components/my-submissions.tsx
@@ -50,6 +50,26 @@ export async function loadMySubmissions(
 }
 
 /** Owner lifecycle action; the worker checks ownership per entry. */
+/**
+ * Remove one of your own entries for good. The daily publish quota counts the
+ * entries that still stand, so deleting hands the slot straight back — an
+ * author is not rationed on changing their mind.
+ */
+export async function deleteMyEntry(
+  id: string,
+  fetchLike: typeof fetch = fetch,
+): Promise<boolean> {
+  try {
+    const response = await fetchLike(`/api/gallery/${id}`, {
+      method: "DELETE",
+      credentials: "same-origin",
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
 export async function setMyEntryRecycled(
   id: string,
   action: "recycle" | "restore",
@@ -121,6 +141,27 @@ export function MySubmissions() {
     await reload();
   }
 
+  async function remove(entry: MineEntry): Promise<void> {
+    if (
+      !window.confirm(
+        `Delete "${entry.name}" permanently? This cannot be undone.`,
+      )
+    ) {
+      return;
+    }
+    setBusy(entry.id);
+    setNotice(null);
+    const ok = await deleteMyEntry(entry.id);
+    setBusy(null);
+    if (!ok) {
+      setNotice(`Could not delete "${entry.name}".`);
+      return;
+    }
+    setNotice(`Deleted "${entry.name}".`);
+    announceGalleryChange({ entryId: entry.id });
+    await reload();
+  }
+
   return (
     <main className="review-shell" data-testid="mine-page">
       <GalleryChrome subtitle="My submissions" />
@@ -180,6 +221,18 @@ export function MySubmissions() {
                       onClick={() => setHistoryFor(entry)}
                     >
                       Version history
+                    </button>
+                    {/* Withdrawing hides an entry and keeps it; deleting is
+                        the author saying they are done with it, and returns
+                        the day's publish slot. */}
+                    <button
+                      type="button"
+                      className="account-link mine-card-delete"
+                      data-testid={`mine-delete-${entry.id}`}
+                      disabled={busy === entry.id}
+                      onClick={() => void remove(entry)}
+                    >
+                      Delete
                     </button>
                     {entry.status === "recycled" && !entry.rejectReason ? (
                       <button

--- a/apps/editor/src/gallery.css
+++ b/apps/editor/src/gallery.css
@@ -1145,3 +1145,15 @@
 .gallery-tag-any {
   font-weight: 600;
 }
+
+/* Deleting is irreversible, so it reads as the weightier of the two author
+   actions without shouting from a closed menu. */
+.gallery-owner-danger-action {
+  color: var(--icm-error);
+}
+
+/* Deleting is irreversible, so it reads as the weightier action on the card
+   without shouting over Open and Version history. */
+.mine-card-delete {
+  color: var(--icm-error);
+}

--- a/worker/gallery-do.ts
+++ b/worker/gallery-do.ts
@@ -340,13 +340,13 @@ export class GalleryDO {
       ON gallery_likes(entry_id)
     `);
     this.sql.exec(`
-      CREATE TABLE IF NOT EXISTS gallery_submissions (
-        day TEXT NOT NULL,
-        submitter_hash TEXT NOT NULL,
-        count INTEGER NOT NULL,
-        PRIMARY KEY (day, submitter_hash)
-      ) WITHOUT ROWID
+      CREATE INDEX IF NOT EXISTS idx_gallery_entries_owner_created
+      ON gallery_entries(owner_user_id, created_at)
     `);
+    // The daily quota used to live in its own counter table, which survived
+    // deletion and so could not be given back. It now counts the entries
+    // themselves; the old table is dropped rather than left to accumulate.
+    this.sql.exec("DROP TABLE IF EXISTS gallery_submissions");
     this.sql.exec(`
       CREATE TABLE IF NOT EXISTS gallery_entry_versions (
         id TEXT PRIMARY KEY,
@@ -496,7 +496,7 @@ export class GalleryDO {
       case "reject":
         return this.reject(body);
       case "delete":
-        return this.delete(String(body.id));
+        return this.delete(String(body.id), body.requireRecycled !== false);
       case "recycled":
         return this.recycled();
       case "rejected":
@@ -618,31 +618,29 @@ export class GalleryDO {
     const entry = body.entry as EntryRow;
     const previewRevision = sha256Hex(entry.svg_text);
     const day = String(body.day);
-    const submitterHash = String(body.submitterHash);
     // The daily quota is anti-garbage protection for ordinary submitters;
     // admin and moderator sessions are exempt (they curate).
+    //
+    // It counts the account's own entries for the day rather than a separate
+    // tally, so deleting work gives the allowance back. That is deliberate:
+    // the quota exists to bound how much a stranger can dump on the wall at
+    // once, not to ration how many times someone may change their mind.
     const enforceLimit = body.enforceLimit !== false;
     const outcome = this.state.storage.transactionSync(() => {
       if (enforceLimit) {
-        const used =
-          this.sql
-            .exec<{
-              count: number;
-            }>(
-              "SELECT count FROM gallery_submissions WHERE day = ? AND submitter_hash = ?",
-              day,
-              submitterHash,
-            )
-            .toArray()[0]?.count ?? 0;
+        const used = this.sql
+          .exec<{
+            count: number;
+          }>(
+            `SELECT COUNT(*) AS count FROM gallery_entries
+             WHERE owner_user_id = ? AND substr(created_at, 1, 10) = ?`,
+            entry.owner_user_id ?? "",
+            day,
+          )
+          .one().count;
         if (used >= GALLERY_DAILY_SUBMISSION_LIMIT) {
           return { status: "rate-limited" as const };
         }
-        this.sql.exec(
-          `INSERT INTO gallery_submissions(day, submitter_hash, count) VALUES (?, ?, 1)
-           ON CONFLICT(day, submitter_hash) DO UPDATE SET count = count + 1`,
-          day,
-          submitterHash,
-        );
       }
       entry.id = this.freeEntryId();
       this.sql.exec(
@@ -1496,12 +1494,20 @@ export class GalleryDO {
     return Response.json({ id, status: "rejected" });
   }
 
-  private delete(id: string): Response {
+  /**
+   * Remove an entry and everything hanging off it.
+   *
+   * A curator deletes out of the recycle bin, so the two-step stands for
+   * them. An author deleting their own work has already decided, and asking
+   * them to withdraw first would only be ceremony, so that path passes
+   * `requireRecycled: false`.
+   */
+  private delete(id: string, requireRecycled: boolean): Response {
     const row = this.sql
       .exec<EntryRow>("SELECT * FROM gallery_entries WHERE id = ?", id)
       .toArray()[0];
     if (!row) return Response.json({ error: "not-found" }, { status: 404 });
-    if (row.status !== "recycled") {
+    if (requireRecycled && row.status !== "recycled") {
       return Response.json({ error: "not-recycled" }, { status: 409 });
     }
     this.state.storage.transactionSync(() => {

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -1129,25 +1129,28 @@ describe("gallery submissions", () => {
   it("rate-limits ordinary submitters per day; curators are exempt", async () => {
     const env = environment();
 
-    // Ordinary submissions (limit enforced) exhaust the day, without
-    // touching a different submitter.
-    async function submitDirect(hash: string): Promise<number> {
+    // The quota counts the account's own entries for the day, so it is
+    // driven through the real submission route rather than a synthetic key.
+    async function submitDirect(
+      ownerUserId: string,
+      day: string,
+    ): Promise<number> {
       const response = await env.GALLERY.getByName("gallery").fetch(
         "https://gallery/submit",
         {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({
-            day: "2026-08-22",
-            submitterHash: hash,
+            day,
             enforceLimit: true,
             entry: {
               id: crypto.randomUUID(),
               name: "Quota",
               author: "",
               description: "",
-              created_at: "2026-08-22T00:00:00.000Z",
+              created_at: `${day}T00:00:00.000Z`,
               schema_version: 21,
+              owner_user_id: ownerUserId,
               project_text: projectText(),
               svg_text: "<svg/>",
             },
@@ -1157,10 +1160,12 @@ describe("gallery submissions", () => {
       return response.status;
     }
     for (let index = 0; index < GALLERY_DAILY_SUBMISSION_LIMIT; index += 1) {
-      expect(await submitDirect("hash-a")).toBe(200);
+      expect(await submitDirect("account-a", "2026-08-22")).toBe(200);
     }
-    expect(await submitDirect("hash-a")).toBe(429);
-    expect(await submitDirect("hash-b")).toBe(200);
+    expect(await submitDirect("account-a", "2026-08-22")).toBe(429);
+    // A different account is untouched, and so is the same account tomorrow.
+    expect(await submitDirect("account-b", "2026-08-22")).toBe(200);
+    expect(await submitDirect("account-a", "2026-08-23")).toBe(200);
 
     // A curator is exempt: more than the limit, all accepted.
     const adminCookie = await adminOf(env);
@@ -1175,65 +1180,109 @@ describe("gallery submissions", () => {
 });
 
 describe("the daily publish quota", () => {
-  const countsByHash = (env: Harness): Map<string, number> =>
-    new Map(
-      env.gallerySql
-        .exec<{
-          submitter_hash: string;
-          count: number;
-        }>("SELECT submitter_hash, count FROM gallery_submissions")
-        .toArray()
-        .map((row) => [row.submitter_hash, row.count]),
-    );
+  const entryCount = (env: Harness): number =>
+    env.gallerySql
+      .exec<{ count: number }>("SELECT COUNT(*) AS count FROM gallery_entries")
+      .one().count;
 
-  it("counts per account, so one address does not spend everyone's allowance", async () => {
-    const env = environment();
-    const first = await signIn(env.authDurable, "first@example.com");
-    const second = await signIn(env.authDurable, "second@example.com");
-
-    // Two members behind one shared exit — a campus or an office.
-    await submitOne(env, "From first", { cookie: first, ip: "203.0.113.7" });
-    await submitOne(env, "From second", { cookie: second, ip: "203.0.113.7" });
-
-    const shared = countsByHash(env);
-    expect(shared.size).toBe(2);
-    expect([...shared.values()]).toEqual([1, 1]);
-
-    // One member from two addresses — switching networks is not a fresh
-    // allowance, which is what keying on the address used to permit.
-    await submitOne(env, "Roaming", { cookie: first, ip: "198.51.100.2" });
-    const roamed = countsByHash(env);
-    expect(roamed.size).toBe(2);
-    expect([...roamed.values()].sort()).toEqual([1, 2]);
-  });
-
-  it("refuses the submission past the limit and leaves the count where it was", async () => {
+  it("counts an account's own entries, so removing work returns the allowance", async () => {
     const env = environment();
     const cookie = await makerOf(env);
+    const first = await submitOne(env, "First", { cookie });
+    await submitOne(env, "Second", { cookie });
+    expect(entryCount(env)).toBe(2);
 
-    await submitOne(env, "First", { cookie });
-    const hash = [...countsByHash(env).keys()][0]!;
-    env.gallerySql.exec(
-      "UPDATE gallery_submissions SET count = ? WHERE submitter_hash = ?",
-      GALLERY_DAILY_SUBMISSION_LIMIT,
-      hash,
-    );
-
-    const refused = await route(
+    // Deleting is meant to give the slot back: the quota bounds what stands
+    // on the wall, not how many times someone may change their mind.
+    const removed = await route(
       env,
-      submissionRequest(
-        {
-          name: "One too many",
-          description: "d",
-          projectText: projectText("One too many"),
-        },
-        { cookie },
-      ),
+      new Request(`${ORIGIN}/api/gallery/${first}`, {
+        method: "DELETE",
+        headers: { Origin: ORIGIN, Cookie: cookie },
+      }),
     );
-    expect(refused.status).toBe(429);
-    expect((await refused.json()).error).toBe("rate-limited");
-    // A refused publish must not spend a slot of its own.
-    expect(countsByHash(env).get(hash)).toBe(GALLERY_DAILY_SUBMISSION_LIMIT);
+    expect(removed.status).toBe(200);
+    expect(entryCount(env)).toBe(1);
+  });
+
+  it("keeps one account's day separate from another's and from tomorrow", async () => {
+    const env = environment();
+    const mine = await makerOf(env);
+    const theirs = await signIn(env.authDurable, "other@example.com");
+    // Two members behind one shared exit no longer share an allowance: the
+    // quota keys on the account, not the address it arrived from.
+    await submitOne(env, "Mine", { cookie: mine, ip: "203.0.113.7" });
+    await submitOne(env, "Theirs", { cookie: theirs, ip: "203.0.113.7" });
+
+    const owners = env.gallerySql
+      .exec<{
+        owner_user_id: string | null;
+      }>("SELECT owner_user_id FROM gallery_entries")
+      .toArray()
+      .map((row) => row.owner_user_id);
+    expect(new Set(owners).size).toBe(2);
+  });
+
+  it("has no separate counter table left to drift from the entries", () => {
+    const env = environment();
+    const tables = env.gallerySql
+      .exec<{
+        name: string;
+      }>("SELECT name FROM sqlite_master WHERE type = 'table'")
+      .toArray()
+      .map((row) => row.name);
+    expect(tables).not.toContain("gallery_submissions");
+  });
+});
+
+describe("an author removes their own entry", () => {
+  it("deletes it outright, without withdrawing it first", async () => {
+    const env = environment();
+    const cookie = await makerOf(env);
+    const id = await submitOne(env, "Mine to remove", { cookie });
+
+    const removed = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}`, {
+        method: "DELETE",
+        headers: { Origin: ORIGIN, Cookie: cookie },
+      }),
+    );
+    expect(removed.status).toBe(200);
+    expect((await removed.json()).deleted).toBe(true);
+
+    const gone = await route(env, new Request(`${ORIGIN}/api/gallery/${id}`));
+    expect(gone.status).toBe(404);
+  });
+
+  it("refuses a stranger and an anonymous visitor", async () => {
+    const env = environment();
+    const owner = await makerOf(env);
+    const id = await submitOne(env, "Not yours", { cookie: owner });
+    const stranger = await signIn(env.authDurable, "stranger@example.com");
+
+    const byStranger = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}`, {
+        method: "DELETE",
+        headers: { Origin: ORIGIN, Cookie: stranger },
+      }),
+    );
+    expect(byStranger.status).toBe(401);
+
+    const anonymous = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}`, {
+        method: "DELETE",
+        headers: { Origin: ORIGIN },
+      }),
+    );
+    expect(anonymous.status).toBe(401);
+
+    // Still standing after both refusals.
+    expect(
+      (await route(env, new Request(`${ORIGIN}/api/gallery/${id}`))).status,
+    ).toBe(200);
   });
 });
 

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -120,26 +120,6 @@ async function entryManager(
   };
 }
 
-/**
- * The daily quota counts per account, not per address. Publishing already
- * requires signing in, so the account is the honest unit: one campus or office
- * exit used to spend one allowance between everyone behind it, and a submitter
- * could reset their own by changing networks.
- *
- * Still hashed, so the counter table holds no identifier of its own. The
- * prefix differs from the retired address-keyed one, so a stale row from the
- * old scheme can never be read as an account's count.
- */
-async function submitterHash(userId: string): Promise<string> {
-  const digest = await crypto.subtle.digest(
-    "SHA-256",
-    new TextEncoder().encode(`gallery-account:${userId}`),
-  );
-  return [...new Uint8Array(digest)]
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("");
-}
-
 function fieldText(value: unknown, maxLength: number): string | null {
   if (value === undefined || value === null) return "";
   if (typeof value !== "string") return null;
@@ -385,7 +365,6 @@ async function handleSubmission(
     previewRevision?: string;
   }>(env, "submit", {
     day: now.toISOString().slice(0, 10),
-    submitterHash: await submitterHash(user.id),
     enforceLimit: !privileged,
     entry: {
       // The id is drawn inside the Durable Object, which is the only place
@@ -920,11 +899,27 @@ export async function routeGalleryRequest(
     return Response.json(payload, { status });
   }
   if (segments.length === 1 && request.method === "DELETE") {
-    if (!(await isAdmin(request, env))) {
-      return Response.json({ error: "unauthorized" }, { status: 401 });
+    if (!sameOrigin(request)) {
+      return Response.json({ error: "forbidden" }, { status: 403 });
+    }
+    // An author owns their own work: removing it is theirs to do, not a
+    // favour to ask a curator for. The daily quota counts entries that still
+    // exist, so deleting gives the allowance back — that is the point.
+    const admin = await isAdmin(request, env);
+    if (!admin) {
+      const access = await entryManager(request, env, segments[0]!);
+      if (!access.found) {
+        return Response.json({ error: "not-found" }, { status: 404 });
+      }
+      if (!access.owner) {
+        return Response.json({ error: "unauthorized" }, { status: 401 });
+      }
     }
     const { status, payload } = await callGallery(env, "delete", {
       id: segments[0],
+      // The curator's bin keeps its withdraw-then-empty step; an author
+      // removing their own entry does it in one.
+      requireRecycled: admin,
     });
     return Response.json(payload, { status });
   }


### PR DESCRIPTION
## What

Lands the second stranded commit from the local `raise-publish-limit` branch (follows #418):

- **Authors delete their own gallery entries** — `DELETE /api/gallery/:id` now allows the entry's owner (one step, with a client confirm dialog in My submissions); admins keep the two-step recycle-then-empty flow; moderators unchanged. Non-admin deletes require same-origin and ownership (404 unknown id, 401 non-owner).
- **The daily quota counts what stands** — the `gallery_submissions` counter table is dropped (idempotent migration in the DO constructor, plus a new `gallery_entries(owner_user_id, created_at)` index); the quota now counts the account's surviving entries for the UTC day, so deleting work returns the slot by design.

Cherry-picked verbatim from `026882fb` (authored 14:24 today, never pushed); applies cleanly on top of #418.

## Validation

- `vitest run worker apps/editor/src/components` — 132 tests pass (the commit rewrites the quota tests around entry counting and adds owner-delete coverage; +60-line Playwright spec runs in CI)
- root `tsc -p tsconfig.check.json` clean, Prettier clean, `check-test-impact` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
