### PR TITLE
fix(gallery): withdrawing to the bin returns the day's slot at once

### DIFF
--- a/worker/gallery-do.ts
+++ b/worker/gallery-do.ts
@@ -622,9 +622,22 @@ export class GalleryDO {
     // admin and moderator sessions are exempt (they curate).
     //
     // It counts the account's own entries for the day rather than a separate
-    // tally, so deleting work gives the allowance back. That is deliberate:
-    // the quota exists to bound how much a stranger can dump on the wall at
-    // once, not to ration how many times someone may change their mind.
+    // tally, so taking work down gives the allowance back. That is
+    // deliberate: the quota exists to bound how much a stranger can dump on
+    // the wall at once, not to ration how many times someone may change
+    // their mind.
+    //
+    // Withdrawing to the recycle bin therefore counts as taking it down, the
+    // same as deleting. The entry has left the wall; making the author wait
+    // for a curator to empty the bin would ration the second thought rather
+    // than the dumping. Restoring it publishes it again, and the slot is
+    // spent again with it.
+    //
+    // 'recycled' is the whole exemption, and 'rejected' is deliberately not
+    // in it: a rejection is the wall's owner turning work away, not the
+    // author changing their mind. Refunding it would mean the harder a
+    // curator works the more that account may publish, which points the
+    // quota away from the submitter it exists to bound.
     const enforceLimit = body.enforceLimit !== false;
     const outcome = this.state.storage.transactionSync(() => {
       if (enforceLimit) {
@@ -633,7 +646,8 @@ export class GalleryDO {
             count: number;
           }>(
             `SELECT COUNT(*) AS count FROM gallery_entries
-             WHERE owner_user_id = ? AND substr(created_at, 1, 10) = ?`,
+             WHERE owner_user_id = ? AND substr(created_at, 1, 10) = ?
+               AND status <> 'recycled'`,
             entry.owner_user_id ?? "",
             day,
           )

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -1205,6 +1205,131 @@ describe("the daily publish quota", () => {
     expect(entryCount(env)).toBe(1);
   });
 
+  /**
+   * Spend the day's whole allowance for one member, leaving them holding a
+   * public entry of their own that the lifecycle routes can act on.
+   *
+   * The filler entries go straight to the Durable Object: the quota is
+   * counted there, and a hundred trips through the full route would only
+   * re-test rendering.
+   */
+  async function dayAtTheLimit(env: Harness): Promise<{
+    cookie: string;
+    owner: string;
+    day: string;
+    mine: string;
+  }> {
+    const cookie = await makerOf(env);
+    const mine = await submitOne(env, "Second thoughts", { cookie });
+    const seed = env.gallerySql
+      .exec<{
+        owner_user_id: string;
+        created_at: string;
+      }>(
+        "SELECT owner_user_id, created_at FROM gallery_entries WHERE id = ?",
+        mine,
+      )
+      .one();
+    const owner = seed.owner_user_id;
+    const day = seed.created_at.slice(0, 10);
+    for (let index = 1; index < GALLERY_DAILY_SUBMISSION_LIMIT; index += 1) {
+      expect(await submitDirect(env, owner, day)).toBe(200);
+    }
+    expect(await submitDirect(env, owner, day)).toBe(429);
+    return { cookie, owner, day, mine };
+  }
+
+  async function submitDirect(
+    env: Harness,
+    ownerUserId: string,
+    day: string,
+  ): Promise<number> {
+    const response = await env.GALLERY.getByName("gallery").fetch(
+      "https://gallery/submit",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          day,
+          enforceLimit: true,
+          entry: {
+            id: "",
+            name: "Quota",
+            author: "",
+            description: "",
+            created_at: `${day}T00:00:00.000Z`,
+            schema_version: CURRENT_PROJECT_SCHEMA_VERSION,
+            owner_user_id: ownerUserId,
+            project_text: projectText(),
+            svg_text: "<svg/>",
+          },
+        }),
+      },
+    );
+    return response.status;
+  }
+
+  function lifecycle(
+    env: Harness,
+    id: string,
+    action: "recycle" | "restore",
+    cookie: string,
+  ) {
+    return route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/${action}`, {
+        method: "POST",
+        headers: { Origin: ORIGIN, Cookie: cookie },
+      }),
+    );
+  }
+
+  it("returns the allowance the moment work is withdrawn to the bin", async () => {
+    const env = environment();
+    const { cookie, owner, day, mine } = await dayAtTheLimit(env);
+
+    // Withdrawing is changing your mind, not publishing again. The entry
+    // stops standing on the wall, so it stops spending the day's allowance
+    // — waiting for a curator to empty the bin would ration the second
+    // thought, which is the one thing this quota is not for.
+    expect((await lifecycle(env, mine, "recycle", cookie)).status).toBe(200);
+    expect(await submitDirect(env, owner, day)).toBe(200);
+  });
+
+  it("spends the allowance again when the author restores from the bin", async () => {
+    const env = environment();
+    const { cookie, owner, day, mine } = await dayAtTheLimit(env);
+    expect((await lifecycle(env, mine, "recycle", cookie)).status).toBe(200);
+
+    // Coming back out of the bin is publishing it again, so the slot the
+    // withdrawal released is spent once more and the day is full.
+    expect((await lifecycle(env, mine, "restore", cookie)).status).toBe(200);
+    expect(await submitDirect(env, owner, day)).toBe(429);
+  });
+
+  it("keeps spending it when a curator rejects the work", async () => {
+    const env = environment();
+    const { owner, day, mine } = await dayAtTheLimit(env);
+
+    // A rejection is the wall's owner turning work away, not the author
+    // changing their mind, so it earns no refund. Refunding it would mean
+    // the harder a curator works the more that account may publish.
+    const rejected = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${mine}/reject`, {
+        method: "POST",
+        headers: {
+          Origin: ORIGIN,
+          Cookie: await adminOf(env),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ reason: "Not a circuit." }),
+      }),
+    );
+    expect(rejected.status).toBe(200);
+    expect(await submitDirect(env, owner, day)).toBe(429);
+  });
+
   it("keeps one account's day separate from another's and from tomorrow", async () => {
     const env = environment();
     const mine = await makerOf(env);


### PR DESCRIPTION
## The implementation contradicted its own documented intent

The daily publish quota counts every entry an account created that day, whatever became of it:

```sql
SELECT COUNT(*) AS count FROM gallery_entries
 WHERE owner_user_id = ? AND substr(created_at, 1, 10) = ?
```

No status filter. So an entry the author has withdrawn — off the wall, sitting in the recycle bin — kept spending its slot until a curator got around to emptying the bin, while a hard delete freed one instantly.

The strongest argument against that is already in the file, in the comment directly above the query:

> the quota exists to bound how much a stranger can dump on the wall at once, not to ration how many times someone may change their mind

Holding the slot for a withdrawn entry rations precisely the second thought that sentence protects, and makes the author wait on someone else's queue to get it back. This is not a policy change — it restores the policy the file already states.

## The change

One clause: `AND status <> 'recycled'`. The comment above it now spells out the withdrawal rule so the next reader does not have to re-derive it.

**Restoring from the bin needed no code.** `setStatus` leaves `created_at` untouched, so returning an entry to `'public'` puts it back in the count for its own day and spends the slot again by construction.

**Rejected entries keep counting — settled policy, not an oversight.** `status <> 'recycled'` is a deliberately narrow filter, and it reads as a suspicious one to anyone arriving without the argument, so both the code comment and a test now pin it. A rejection is the wall's owner turning work away, not the author changing their mind, so the comment's "changing their mind" rationale does not reach it. Refunding it would mean the harder a curator works the more that account may publish — the quota would point away from the very submitter it exists to bound. A mistaken rejection is already a curator-side fix: an owner cannot restore an Owner rejection ([gallery.ts:889](../blob/main/worker/gallery.ts#L889)), and the curator who restores it restores the slot with it.

`GALLERY_DAILY_SUBMISSION_LIMIT` (100) and the curator-exempt path are untouched.

## Tests

Three cases beside the existing delete-frees-the-slot test, all driving the real routes with real cookies:

- **withdraw** — fill the day to exactly 100, confirm 429, `POST /<id>/recycle`, confirm a fresh submit is 200.
- **restore** — same fill and withdraw, then `POST /<id>/restore`, confirm 429.
- **reject** — same fill, then a curator `POST /<id>/reject`, confirm it stays 429.

Red before green: the withdraw test failed with `expected 429 to be 200` before the fix.

The other two pass before the fix as well as after, so a green from them proves nothing on its own and neither was taken on faith. Each was mutation-checked against the specific wrong edit it exists to catch: breaking restore to leave the status `'recycled'` fails the restore test (`expected 200 to be 429`), and widening the clause to `status NOT IN ('recycled', 'rejected')` — the exact "helpful fix" a future reader might make — fails the reject test (`expected 200 to be 429`). Both mutations were reverted and the reverts verified in the diff.

## Notes

- `status <> 'recycled'` is safe against SQL three-valued logic: the column is `status TEXT NOT NULL`, so a NULL status — which `<>` would silently drop from the count — cannot arise.
- `'pending'` no longer exists at submit time; the constructor migrates it to `'public'` ([gallery-do.ts:470](../blob/main/worker/gallery-do.ts#L470)).
- Second-order effect, following from the policy rather than this implementation: withdraw-then-republish now cycles without limit, and each cycle leaves a recycled row until a curator empties the bin — delete-then-republish never did, since delete removes the row. The standing wall stays bounded at 100/account/day as intended; stored rows do not. If that matters, the lever is recycle-bin retention, not the quota.

## Verification

`pnpm test:local worker/` — 98/98 green. `pnpm typecheck` clean. Prettier reports both files unchanged. `pnpm test:impact -- --base main` passes. Full `pnpm ci:check` run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)