### PR TITLE
feat(gallery): the tab band's right side says how big the wall is

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -640,6 +640,42 @@ test("the tag row filters, collapses, and keeps a selection visible", async ({
   await expect(page.getByTestId("gallery-tags-empty")).toBeVisible();
 });
 
+test("the wall states how many circuits the gallery holds", async ({
+  page,
+}) => {
+  await page.route(galleryListUrl, (route) =>
+    route.fulfill({ json: { entries: [ENTRY], nextCursor: null, total: 128 } }),
+  );
+  await page.route(`**/api/gallery/${ENTRY.id}/preview.svg*`, (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10" fill="#fff"/></svg>',
+    }),
+  );
+  await page.route("**/api/gallery/tags", (route) =>
+    route.fulfill({ json: { tags: [] } }),
+  );
+  await page.goto("/");
+  await expect(page.getByTestId("gallery-count-panel")).toHaveText(
+    "128 circuits",
+  );
+  // The shelf states its own count; the community total stays off it.
+  await page.getByTestId("gallery-view-shelf").click();
+  await expect(page.getByTestId("gallery-count-panel")).toHaveCount(0);
+});
+
+test("an API without totals hides the count rather than guessing", async ({
+  page,
+}) => {
+  await mockGallery(page, [ENTRY]);
+  await page.route("**/api/gallery/tags", (route) =>
+    route.fulfill({ json: { tags: [] } }),
+  );
+  await page.goto("/");
+  await expect(page.getByTestId(`gallery-tile-${ENTRY.id}`)).toBeVisible();
+  await expect(page.getByTestId("gallery-count-panel")).toHaveCount(0);
+});
+
 test("Any tag selects every tag as one union and takes it back", async ({
   page,
 }) => {

--- a/apps/editor/src/components/gallery-feed.test.tsx
+++ b/apps/editor/src/components/gallery-feed.test.tsx
@@ -2,7 +2,11 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import { GalleryFeed, loadGalleryFeed } from "./gallery-feed";
+import {
+  GalleryCountPanel,
+  GalleryFeed,
+  loadGalleryFeed,
+} from "./gallery-feed";
 
 function fetchReturning(payload: unknown, ok = true): typeof fetch {
   return (async () =>
@@ -49,12 +53,38 @@ describe("loadGalleryFeed", () => {
     ]);
   });
 
+  it("passes the server's total through and tolerates its absence", async () => {
+    const withTotal = await loadGalleryFeed(
+      fetchReturning({ entries: [], nextCursor: null, total: 42 }),
+    );
+    expect(withTotal?.total).toBe(42);
+    // An older worker without totals must read as "unknown", never as zero.
+    const withoutTotal = await loadGalleryFeed(fetchReturning({ entries: [] }));
+    expect(withoutTotal?.total).toBeNull();
+  });
+
   it("degrades to null on errors and non-OK responses", async () => {
     expect(await loadGalleryFeed(fetchReturning({}, false))).toBeNull();
     const throwing = (async () => {
       throw new Error("offline");
     }) as unknown as typeof fetch;
     expect(await loadGalleryFeed(throwing)).toBeNull();
+  });
+});
+
+describe("GalleryCountPanel", () => {
+  it("shows the wall size, marks a filtered count, and hides an unknown one", () => {
+    const render = (total: number | null, filtered = false) =>
+      renderToStaticMarkup(
+        createElement(GalleryCountPanel, { total, filtered }),
+      );
+    expect(render(1280)).toContain(`${(1280).toLocaleString()} circuits`);
+    expect(render(1)).toContain("1 circuit");
+    expect(render(1)).not.toContain("circuits");
+    expect(render(3, true)).toContain("3 matching circuits");
+    expect(render(1, true)).toContain("1 matching circuit");
+    // No total (older API, still loading): say nothing rather than guess.
+    expect(render(null)).toBe("");
   });
 });
 

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -39,12 +39,15 @@ export interface GalleryFeedEntry {
 export interface GalleryFeedPage {
   entries: GalleryFeedEntry[];
   nextCursor: string | null;
+  /** Whole filtered wall's size; null while a pre-totals API answers. */
+  total: number | null;
 }
 
 export interface GalleryFeedState {
   status: "loading" | "ready" | "unavailable";
   entries: GalleryFeedEntry[];
   nextCursor: string | null;
+  total: number | null;
 }
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
@@ -254,6 +257,27 @@ function HeartIcon({ filled }: { filled: boolean }) {
   );
 }
 
+/**
+ * The wall's size, said only when the server has said it: a pre-totals API
+ * or a still-loading feed renders nothing rather than a guess. With a
+ * filter on, the same number means "matching", and the label says so.
+ */
+export function GalleryCountPanel({
+  total,
+  filtered = false,
+}: {
+  total: number | null;
+  filtered?: boolean;
+}) {
+  if (total === null) return null;
+  const noun = total === 1 ? "circuit" : "circuits";
+  return (
+    <span className="gallery-count-panel" data-testid="gallery-count-panel">
+      {total.toLocaleString()} {filtered ? `matching ${noun}` : noun}
+    </span>
+  );
+}
+
 function savedAtLabel(createdAt: string): string {
   const parsed = new Date(createdAt);
   return Number.isNaN(parsed.getTime())
@@ -305,11 +329,13 @@ export async function loadGalleryFeed(
     const payload = (await response.json()) as {
       entries?: GalleryFeedEntry[];
       nextCursor?: unknown;
+      total?: unknown;
     };
     return {
       entries: payload.entries ?? [],
       nextCursor:
         typeof payload.nextCursor === "string" ? payload.nextCursor : null,
+      total: typeof payload.total === "number" ? payload.total : null,
     };
   } catch {
     return null;
@@ -395,6 +421,7 @@ export function GalleryFeed({
     status: "loading",
     entries: [],
     nextCursor: null,
+    total: null,
   });
   const loadingMoreRef = useRef(false);
   const firstPageLoadingRef = useRef(true);
@@ -478,6 +505,7 @@ export function GalleryFeed({
         status: "loading",
         entries: [],
         nextCursor: null,
+        total: null,
       });
     }
     void loadGalleryFeed(fetch, { author, tags: selectedTags }).then((page) => {
@@ -492,6 +520,7 @@ export function GalleryFeed({
           status: "unavailable",
           entries: [],
           nextCursor: null,
+          total: null,
         });
       }
     });
@@ -528,6 +557,7 @@ export function GalleryFeed({
                 ...previous,
                 entries: [...previous.entries, ...page.entries],
                 nextCursor: page.nextCursor,
+                total: page.total ?? previous.total,
               }
             : previous,
         );
@@ -567,6 +597,7 @@ export function GalleryFeed({
       entries: previous.entries.filter(
         (candidate) => candidate.id !== entry.id,
       ),
+      total: previous.total === null ? null : previous.total - 1,
     }));
     const removedTags = new Set(entry.tags ?? []);
     if (removedTags.size > 0) {
@@ -658,31 +689,45 @@ export function GalleryFeed({
         visitStats={visitStats}
       />
 
-      <div className="gallery-view-tabs" role="tablist" aria-label="Circuits">
-        {(
-          [
-            ["gallery", "Community gallery"],
-            ["shelf", "My shelf"],
-          ] as const
-        ).map(([id, label]) => (
-          <button
-            key={id}
-            type="button"
-            role="tab"
-            className="gallery-view-tab"
-            data-testid={`gallery-view-${id}`}
-            aria-selected={view === id}
-            onClick={() => {
-              setView(id);
-              const next = new URL(window.location.href);
-              if (id === "shelf") next.searchParams.set("view", "shelf");
-              else next.searchParams.delete("view");
-              window.history.replaceState(null, "", next);
-            }}
-          >
-            {label}
-          </button>
-        ))}
+      <div className="gallery-view-tabs">
+        <div
+          className="gallery-view-tablist"
+          role="tablist"
+          aria-label="Circuits"
+        >
+          {(
+            [
+              ["gallery", "Community gallery"],
+              ["shelf", "My shelf"],
+            ] as const
+          ).map(([id, label]) => (
+            <button
+              key={id}
+              type="button"
+              role="tab"
+              className="gallery-view-tab"
+              data-testid={`gallery-view-${id}`}
+              aria-selected={view === id}
+              onClick={() => {
+                setView(id);
+                const next = new URL(window.location.href);
+                if (id === "shelf") next.searchParams.set("view", "shelf");
+                else next.searchParams.delete("view");
+                window.history.replaceState(null, "", next);
+              }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        {/* The shelf states its own count ("N of 20 saved"); this one
+            describes the community wall and leaves with it. */}
+        {view === "gallery" ? (
+          <GalleryCountPanel
+            total={state.total}
+            filtered={author !== null || selectedTags.length > 0}
+          />
+        ) : null}
       </div>
       {view === "shelf" ? <ShelfWall /> : null}
 

--- a/apps/editor/src/gallery.css
+++ b/apps/editor/src/gallery.css
@@ -1048,9 +1048,26 @@
 /* The two walls: everyone's circuits, and your own private shelf. */
 .gallery-view-tabs {
   display: flex;
+  align-items: flex-end;
   gap: 6px;
   padding: 14px 22px 0;
   border-bottom: 1px solid var(--icm-border);
+}
+
+.gallery-view-tablist {
+  display: flex;
+  gap: 6px;
+}
+
+/* The band's spare right side carries the wall's one number. Muted like
+   .shelf-count: a fact about the wall, not a control. */
+.gallery-count-panel {
+  margin-left: auto;
+  align-self: center;
+  padding-bottom: 6px;
+  color: var(--icm-text-muted);
+  font-size: 0.85rem;
+  white-space: nowrap;
 }
 
 .gallery-view-tab {

--- a/worker/gallery-do.ts
+++ b/worker/gallery-do.ts
@@ -694,6 +694,17 @@ export class GalleryDO {
       conditions.push(`(${tags.map(() => "tags LIKE ?").join(" OR ")})`);
       for (const tag of tags) bindings.push(`%,${tag},%`);
     }
+    // The whole filtered wall's size, not the page's: counted before the
+    // cursor narrows the query, so every page carries the same total.
+    const total = Number(
+      this.sql
+        .exec<{ total: number }>(
+          `SELECT COUNT(*) AS total FROM gallery_entries
+           WHERE ${conditions.join(" AND ")}`,
+          ...bindings,
+        )
+        .toArray()[0]!.total,
+    );
     // The viewer id leads the bindings because its sub-select comes first.
     const viewerId = typeof body.viewerId === "string" ? body.viewerId : "";
     if (cursor) {
@@ -718,7 +729,7 @@ export class GalleryDO {
       rows.length > limit && page.length > 0
         ? `${page.at(-1)!.created_at}|${page.at(-1)!.id}`
         : null;
-    return Response.json({ entries: page.map(summaryOf), nextCursor });
+    return Response.json({ entries: page.map(summaryOf), nextCursor, total });
   }
 
   /**

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -379,6 +379,7 @@ describe("newest-first gallery feed", () => {
   ): Promise<{
     entries: { id: string; createdAt: string }[];
     nextCursor: string | null;
+    total: number;
   }> {
     const params = new URLSearchParams({ limit: "3" });
     if (cursor) params.set("cursor", cursor);
@@ -389,6 +390,7 @@ describe("newest-first gallery feed", () => {
     const payload = (await response.json()) as {
       entries: { id: string; createdAt: string }[];
       nextCursor: string | null;
+      total: number;
     };
     return payload;
   }
@@ -423,12 +425,50 @@ describe("newest-first gallery feed", () => {
   it("stops when the newest-first cursor chain is exhausted", async () => {
     const env = environment();
     const empty = await galleryPage(env);
-    expect(empty).toEqual({ entries: [], nextCursor: null });
+    expect(empty).toEqual({ entries: [], nextCursor: null, total: 0 });
 
     await wallOf(env, 2);
     const full = await galleryPage(env);
     expect(full.entries).toHaveLength(2);
     expect(full.nextCursor).toBeNull();
+  });
+
+  it("carries the whole wall's total on every page and counts the filtered set", async () => {
+    const env = environment();
+    const cookie = await adminOf(env);
+    for (let index = 0; index < 4; index += 1) {
+      await submitOne(env, `Plain ${index}`, { cookie });
+    }
+    for (let index = 0; index < 3; index += 1) {
+      const response = await route(
+        env,
+        submissionRequest(
+          {
+            name: `Tagged ${index}`,
+            description: "d",
+            tags: ["ldo"],
+            projectText: projectText(`Tagged ${index}`),
+          },
+          { cookie },
+        ),
+      );
+      expect(response.status).toBe(201);
+    }
+
+    // The client renders one page at a time; the total is the whole wall's
+    // size and must not shrink to the page or drift between pages.
+    const first = await galleryPage(env);
+    expect(first.entries).toHaveLength(3);
+    expect(first.total).toBe(7);
+    const second = await galleryPage(env, first.nextCursor!);
+    expect(second.total).toBe(7);
+
+    // With a filter on, the total counts the filtered set, not the gallery.
+    const filtered = (await (
+      await route(env, new Request(`${ORIGIN}/api/gallery?tags=ldo`))
+    ).json()) as { entries: unknown[]; total: number };
+    expect(filtered.entries).toHaveLength(3);
+    expect(filtered.total).toBe(3);
   });
 
   it("returns the same newest-first order on every read", async () => {


### PR DESCRIPTION
## What

The Community Gallery's view-tab band now carries a right-aligned count of the whole wall — the owner's requested total-circuits panel, in the empty space on the band's right.

## Why the count comes from the worker

The feed is keyset-paginated (30/page + scroll sentinel), so `entries.length` only counts scrolled-in pages and gets more wrong as the gallery fills. The DO list response now carries `total`: one `COUNT(*)` under the same status/author/tags conditions, taken before the cursor narrows the query, so every page repeats the same number. `routeGalleryRequest` forwards the payload verbatim — no route change, no new endpoint.

## Honesty rules

- Community view only: the shelf already states its own "N of 20 saved" from a non-paginated load.
- With an author or tag filter active the label reads "N matching circuits" — the number never silently changes meaning.
- A pre-totals API (deploy skew) or still-loading feed renders nothing rather than a guess; owner withdraw/reject decrements in place.
- ARIA: the tablist role moves to an inner wrapper so the count is not a child of `role=tablist`.

## Validation

Red-before/green-after at three layers: worker totals (paging keeps the total; `?tags=` counts the filtered set), `loadGalleryFeed` passthrough + `GalleryCountPanel` table, and two e2e tests (panel text from a mocked total; hidden on the shelf and on a total-less API). Full `gallery.spec.ts` 38/38 locally on an isolated port; typecheck and Prettier clean.

Merged ≠ live for `worker/`: the "Deploy Cloudflare" run for the merge commit will be watched before this is reported online; until then production hides the panel by the null path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)