### PR TITLE
feat(gallery): the filter box searches circuits, not just the tag row

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -623,21 +623,142 @@ test("the tag row filters, collapses, and keeps a selection visible", async ({
   await expect(page.getByTestId("gallery-tag-option-ldo")).toHaveCount(0);
 
   // Filtering reaches a tag the collapsed row does not show.
-  await page.getByTestId("gallery-tag-search").fill("ld");
+  await page.getByTestId("gallery-search").fill("ld");
   await expect(page.getByTestId("gallery-tag-option-ldo")).toBeVisible();
   await expect(page.getByTestId("gallery-tag-option-amplifier")).toHaveCount(0);
 
   // A selected tag survives clearing the filter and re-collapsing: the row
   // may never hide the reason the wall is filtered.
   await page.getByTestId("gallery-tag-option-ldo").click();
-  await page.getByTestId("gallery-tag-search").fill("");
+  await page.getByTestId("gallery-search").fill("");
   await expect(page.getByTestId("gallery-tag-option-ldo")).toBeVisible();
   await expect(page.getByTestId("gallery-tags-clear")).toContainText(
     "Clear 1 selected",
   );
 
-  await page.getByTestId("gallery-tag-search").fill("zzz");
-  await expect(page.getByTestId("gallery-tags-empty")).toBeVisible();
+  await page.getByTestId("gallery-search").fill("zzz");
+  await expect(page.getByTestId("gallery-search-empty")).toBeVisible();
+});
+
+test("the search box reaches authors, names, and descriptions", async ({
+  page,
+}) => {
+  const walled = [
+    {
+      id: "s1",
+      name: "Ring Oscillator",
+      author: "mei",
+      description: "Three-stage loop",
+      createdAt: "2026-08-21T10:00:00.000Z",
+      schemaVersion: 23,
+      tags: ["amplifier"],
+    },
+    {
+      id: "s2",
+      name: "Folded Cascode",
+      author: "arash",
+      description: "",
+      createdAt: "2026-08-20T10:00:00.000Z",
+      schemaVersion: 23,
+      tags: [],
+    },
+  ];
+  await page.route(galleryListUrl, (route) =>
+    route.fulfill({ json: { entries: walled, nextCursor: null, total: 2 } }),
+  );
+  await page.route("**/api/gallery/tags", (route) =>
+    route.fulfill({ json: { tags: [{ tag: "amplifier", count: 1 }] } }),
+  );
+  await page.route("**/api/gallery/*/preview.svg*", (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10" fill="#fff"/></svg>',
+    }),
+  );
+  await page.goto("/");
+
+  const box = page.getByTestId("gallery-search");
+  await expect(box).toHaveAttribute("placeholder", "Name, author, tag…");
+  await expect(box).toHaveAttribute("aria-label", "Search circuits");
+
+  await box.fill("mei");
+  await expect(page.getByTestId("gallery-tile-s1")).toBeVisible();
+  await expect(page.getByTestId("gallery-tile-s2")).toHaveCount(0);
+  await expect(page.getByTestId("gallery-count-panel")).toHaveText(
+    "2 circuits · 1 match",
+  );
+
+  await box.fill("cascode");
+  await expect(page.getByTestId("gallery-tile-s2")).toBeVisible();
+  await expect(page.getByTestId("gallery-tile-s1")).toHaveCount(0);
+
+  await box.fill("three-stage");
+  await expect(page.getByTestId("gallery-tile-s1")).toBeVisible();
+
+  await box.fill("zzz");
+  await expect(page.getByTestId("gallery-tile-s1")).toHaveCount(0);
+  await expect(page.getByTestId("gallery-search-empty")).toHaveText(
+    "No circuits match “zzz”.",
+  );
+  await expect(page.getByTestId("gallery-count-panel")).toHaveText(
+    "2 circuits · 0 matches",
+  );
+
+  await box.fill("");
+  await expect(page.getByTestId("gallery-tile-s1")).toBeVisible();
+  await expect(page.getByTestId("gallery-tile-s2")).toBeVisible();
+  await expect(page.getByTestId("gallery-count-panel")).toHaveText(
+    "2 circuits",
+  );
+});
+
+test("an unfinished feed says it is still searching, not that nothing matches", async ({
+  page,
+}) => {
+  await page.route(galleryListUrl, (route) => {
+    const url = new URL(route.request().url());
+    if (url.searchParams.get("cursor")) {
+      // Hold the tail of the feed open: the fetch never resolves, so the
+      // feed stays legitimately incomplete for the whole assertion window.
+      return;
+    }
+    return route.fulfill({
+      json: {
+        entries: [
+          {
+            id: "s1",
+            name: "Ring Oscillator",
+            author: "mei",
+            description: "",
+            createdAt: "2026-08-21T10:00:00.000Z",
+            schemaVersion: 23,
+          },
+        ],
+        nextCursor: "2026-08-20T00:00:00.000Z|older",
+        total: 40,
+      },
+    });
+  });
+  await page.route("**/api/gallery/tags", (route) =>
+    route.fulfill({ json: { tags: [] } }),
+  );
+  await page.route("**/api/gallery/*/preview.svg*", (route) =>
+    route.fulfill({
+      contentType: "image/svg+xml",
+      body: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10" fill="#fff"/></svg>',
+    }),
+  );
+  await page.goto("/");
+  await expect(page.getByTestId("gallery-tile-s1")).toBeVisible();
+
+  await page.getByTestId("gallery-search").fill("zzz");
+  await expect(page.getByTestId("gallery-search-pending")).toHaveText(
+    "No matches yet — searching older circuits…",
+  );
+  await expect(page.getByTestId("gallery-search-empty")).toHaveCount(0);
+  await expect(page.getByTestId("gallery-count-panel")).toHaveText(
+    "40 circuits · 0 matches so far",
+  );
 });
 
 test("the wall states how many circuits the gallery holds", async ({

--- a/apps/editor/src/components/gallery-feed.test.tsx
+++ b/apps/editor/src/components/gallery-feed.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import {
+  galleryEntryMatchesQuery,
   GalleryCountPanel,
   GalleryFeed,
   loadGalleryFeed,
@@ -72,6 +73,33 @@ describe("loadGalleryFeed", () => {
   });
 });
 
+describe("galleryEntryMatchesQuery", () => {
+  // The caller normalizes the query (trim + lowercase); fields match
+  // case-insensitively on their side.
+  const entry = {
+    name: "Ring Oscillator",
+    author: "Mei Chen",
+    description: "Three-stage loop",
+    tags: ["clocking"],
+  };
+  it("reaches name, author, description, and tags, case-insensitively", () => {
+    expect(galleryEntryMatchesQuery(entry, "ring")).toBe(true);
+    expect(galleryEntryMatchesQuery(entry, "mei")).toBe(true);
+    expect(galleryEntryMatchesQuery(entry, "three-stage")).toBe(true);
+    expect(galleryEntryMatchesQuery(entry, "clock")).toBe(true);
+    expect(galleryEntryMatchesQuery(entry, "zzz")).toBe(false);
+  });
+  it("treats an empty query as no filter and missing fields as absent", () => {
+    expect(galleryEntryMatchesQuery(entry, "")).toBe(true);
+    expect(
+      galleryEntryMatchesQuery(
+        { name: "R1", author: "", description: "" },
+        "clock",
+      ),
+    ).toBe(false);
+  });
+});
+
 describe("GalleryCountPanel", () => {
   it("shows the wall size, marks a filtered count, and hides an unknown one", () => {
     const render = (total: number | null, filtered = false) =>
@@ -81,10 +109,29 @@ describe("GalleryCountPanel", () => {
     expect(render(1280)).toContain(`${(1280).toLocaleString()} circuits`);
     expect(render(1)).toContain("1 circuit");
     expect(render(1)).not.toContain("circuits");
-    expect(render(3, true)).toContain("3 matching circuits");
-    expect(render(1, true)).toContain("1 matching circuit");
+    // "Filtered" names the state; "match" belongs to the text query alone.
+    expect(render(3, true)).toContain("3 filtered circuits");
+    expect(render(1, true)).toContain("1 filtered circuit");
     // No total (older API, still loading): say nothing rather than guess.
     expect(render(null)).toBe("");
+  });
+
+  it("adds a visible-match clause while a search narrows the wall", () => {
+    const render = (visible: number, settled: boolean) =>
+      renderToStaticMarkup(
+        createElement(GalleryCountPanel, {
+          total: 128,
+          filtered: false,
+          search: { visible, settled },
+        }),
+      );
+    // Mid-fetch the clause says it may still grow; settled it stops saying so.
+    expect(render(3, false)).toContain("128 circuits · 3 matches so far");
+    expect(render(3, true)).toContain("128 circuits · 3 matches");
+    expect(render(3, true)).not.toContain("so far");
+    expect(render(1, true)).toContain("· 1 match");
+    expect(render(1, true)).not.toContain("1 matches");
+    expect(render(0, false)).toContain("· 0 matches so far");
   });
 });
 

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -258,22 +258,48 @@ function HeartIcon({ filled }: { filled: boolean }) {
 }
 
 /**
+ * One search string against one circuit. The query arrives normalized
+ * (trimmed, lowercased); fields answer case-insensitively. A tag counts as
+ * content, so a query matching a tag matches the circuits that carry it.
+ */
+export function galleryEntryMatchesQuery(
+  entry: Pick<GalleryFeedEntry, "name" | "author" | "description" | "tags">,
+  normalizedQuery: string,
+): boolean {
+  if (!normalizedQuery) return true;
+  return [entry.name, entry.author, entry.description, ...(entry.tags ?? [])]
+    .filter((field): field is string => Boolean(field))
+    .some((field) => field.toLowerCase().includes(normalizedQuery));
+}
+
+/**
  * The wall's size, said only when the server has said it: a pre-totals API
- * or a still-loading feed renders nothing rather than a guess. With a
- * filter on, the same number means "matching", and the label says so.
+ * or a still-loading feed renders nothing rather than a guess. "Filtered"
+ * names the server-side narrowing; "match" belongs to the text query, whose
+ * clause counts VISIBLE tiles (true at every instant by construction) and
+ * says "so far" until the feed is exhausted.
  */
 export function GalleryCountPanel({
   total,
   filtered = false,
+  search = null,
 }: {
   total: number | null;
   filtered?: boolean;
+  search?: { visible: number; settled: boolean } | null;
 }) {
   if (total === null) return null;
   const noun = total === 1 ? "circuit" : "circuits";
+  const base = `${total.toLocaleString()} ${filtered ? `filtered ${noun}` : noun}`;
+  const clause = search
+    ? ` · ${search.visible} ${search.visible === 1 ? "match" : "matches"}${
+        search.settled ? "" : " so far"
+      }`
+    : "";
   return (
     <span className="gallery-count-panel" data-testid="gallery-count-panel">
-      {total.toLocaleString()} {filtered ? `matching ${noun}` : noun}
+      {base}
+      {clause}
     </span>
   );
 }
@@ -361,10 +387,9 @@ export function GalleryFeed({
       ? "shelf"
       : "gallery",
   );
-  // Twenty-odd tags wrapped to three rows and pushed the wall below the fold.
-  // A filter narrows the row to what the reader is looking for, and the rest
-  // stay one click away rather than always on screen.
-  const [tagQuery, setTagQuery] = useState("");
+  // One box, two levels: the query narrows the tag row to reachable chips,
+  // and filters the wall itself by name, author, description, and tags.
+  const [searchQuery, setSearchQuery] = useState("");
   const [showAllTags, setShowAllTags] = useState(false);
   const [isOwner, setIsOwner] = useState(false);
   const [ownerBusy, setOwnerBusy] = useState<string | null>(null);
@@ -660,10 +685,15 @@ export function GalleryFeed({
 
   const entries = state.entries;
 
-  const normalizedTagQuery = tagQuery.trim().toLowerCase();
-  const matchingTags = normalizedTagQuery
+  const normalizedSearchQuery = searchQuery.trim().toLowerCase();
+  const visibleEntries = normalizedSearchQuery
+    ? entries.filter((entry) =>
+        galleryEntryMatchesQuery(entry, normalizedSearchQuery),
+      )
+    : entries;
+  const matchingTags = normalizedSearchQuery
     ? tagOptions.filter((option) =>
-        option.tag.toLowerCase().includes(normalizedTagQuery),
+        option.tag.toLowerCase().includes(normalizedSearchQuery),
       )
     : tagOptions;
   const everyTagSelected =
@@ -673,7 +703,7 @@ export function GalleryFeed({
   // every tag on, the pressed "Any tag" control is that reason, and pinning
   // all of them open would undo the collapse entirely.
   const visibleTags =
-    showAllTags || normalizedTagQuery
+    showAllTags || normalizedSearchQuery
       ? matchingTags
       : matchingTags.filter(
           (option, index) =>
@@ -726,6 +756,15 @@ export function GalleryFeed({
           <GalleryCountPanel
             total={state.total}
             filtered={author !== null || selectedTags.length > 0}
+            search={
+              normalizedSearchQuery
+                ? {
+                    visible: visibleEntries.length,
+                    settled:
+                      state.nextCursor === null && state.status === "ready",
+                  }
+                : null
+            }
           />
         ) : null}
       </div>
@@ -733,42 +772,44 @@ export function GalleryFeed({
 
       {view === "gallery" ? (
         <>
-          {tagOptions.length > 0 ? (
+          {tagOptions.length > 0 || entries.length > 0 ? (
             <div className="gallery-tag-bar" data-testid="gallery-tag-bar">
               <input
                 className="gallery-tag-search"
-                data-testid="gallery-tag-search"
+                data-testid="gallery-search"
                 type="search"
-                value={tagQuery}
-                placeholder="Filter tags"
-                aria-label="Filter tags"
-                onChange={(event) => setTagQuery(event.currentTarget.value)}
+                value={searchQuery}
+                placeholder="Name, author, tag…"
+                aria-label="Search circuits"
+                onChange={(event) => setSearchQuery(event.currentTarget.value)}
               />
               {/* Tags select as a union, so turning every one on is not "no
                   filter" — it is "carrying at least one tag", which drops the
                   untagged circuits. The control is named for what it does, and
                   sits with the filter box so it is reachable without first
                   expanding the row. */}
-              <button
-                type="button"
-                className="gallery-tag-option gallery-tag-any"
-                data-testid="gallery-tags-any"
-                aria-pressed={everyTagSelected}
-                title={
-                  everyTagSelected
-                    ? "Stop filtering by tag"
-                    : "Show only circuits that carry at least one tag"
-                }
-                onClick={() => {
-                  const next = everyTagSelected
-                    ? []
-                    : tagOptions.map((option) => option.tag);
-                  setSelectedTags(next);
-                  syncQuery(author, next);
-                }}
-              >
-                Any tag
-              </button>
+              {tagOptions.length > 0 ? (
+                <button
+                  type="button"
+                  className="gallery-tag-option gallery-tag-any"
+                  data-testid="gallery-tags-any"
+                  aria-pressed={everyTagSelected}
+                  title={
+                    everyTagSelected
+                      ? "Stop filtering by tag"
+                      : "Show only circuits that carry at least one tag"
+                  }
+                  onClick={() => {
+                    const next = everyTagSelected
+                      ? []
+                      : tagOptions.map((option) => option.tag);
+                    setSelectedTags(next);
+                    syncQuery(author, next);
+                  }}
+                >
+                  Any tag
+                </button>
+              ) : null}
               {visibleTags.map(({ tag, count }) => (
                 <button
                   key={tag}
@@ -795,7 +836,7 @@ export function GalleryFeed({
                   Show {hiddenTagCount} more
                 </button>
               ) : null}
-              {showAllTags && !normalizedTagQuery ? (
+              {showAllTags && !normalizedSearchQuery ? (
                 <button
                   type="button"
                   className="gallery-tag-option gallery-tag-more"
@@ -804,14 +845,6 @@ export function GalleryFeed({
                 >
                   Show fewer
                 </button>
-              ) : null}
-              {normalizedTagQuery && matchingTags.length === 0 ? (
-                <span
-                  className="gallery-tag-empty"
-                  data-testid="gallery-tags-empty"
-                >
-                  No tag matches “{tagQuery.trim()}”
-                </span>
               ) : null}
               {selectedTags.length > 0 && !everyTagSelected ? (
                 <button
@@ -854,7 +887,7 @@ export function GalleryFeed({
               <Masonry
                 aria-label="Published circuits"
                 items={[
-                  ...entries.map((entry) => ({
+                  ...visibleEntries.map((entry) => ({
                     key: entry.id,
                     node: (
                       <div className="gallery-tile-wrap">
@@ -979,33 +1012,40 @@ export function GalleryFeed({
                     ),
                   })),
                   ...(entries.length === 0 && author === null
-                    ? bundledTiles().map((tile) => ({
-                        key: `bundled-${tile.id}`,
-                        node: (
-                          <a
-                            className="gallery-tile gallery-tile-bundled"
-                            href={`/editor?example=${tile.id}`}
-                            data-testid={`gallery-bundled-${tile.id}`}
-                          >
-                            <span
-                              className="gallery-tile-preview"
-                              // Server-free preview: our own renderer's escaped SVG output.
-                              dangerouslySetInnerHTML={{ __html: tile.svg }}
-                            />
-                            <span className="gallery-tile-copy">
-                              <span className="gallery-tile-kicker">
-                                Built-in example
+                    ? bundledTiles()
+                        .filter((tile) =>
+                          galleryEntryMatchesQuery(
+                            { ...tile, author: "", tags: [] },
+                            normalizedSearchQuery,
+                          ),
+                        )
+                        .map((tile) => ({
+                          key: `bundled-${tile.id}`,
+                          node: (
+                            <a
+                              className="gallery-tile gallery-tile-bundled"
+                              href={`/editor?example=${tile.id}`}
+                              data-testid={`gallery-bundled-${tile.id}`}
+                            >
+                              <span
+                                className="gallery-tile-preview"
+                                // Server-free preview: our own renderer's escaped SVG output.
+                                dangerouslySetInnerHTML={{ __html: tile.svg }}
+                              />
+                              <span className="gallery-tile-copy">
+                                <span className="gallery-tile-kicker">
+                                  Built-in example
+                                </span>
+                                <span className="gallery-tile-name">
+                                  {tile.name}
+                                </span>
+                                <span className="gallery-tile-description">
+                                  {tile.description}
+                                </span>
                               </span>
-                              <span className="gallery-tile-name">
-                                {tile.name}
-                              </span>
-                              <span className="gallery-tile-description">
-                                {tile.description}
-                              </span>
-                            </span>
-                          </a>
-                        ),
-                      }))
+                            </a>
+                          ),
+                        }))
                     : []),
                 ]}
               />
@@ -1016,6 +1056,30 @@ export function GalleryFeed({
                 >
                   No public circuits by {author} yet.
                 </p>
+              ) : null}
+              {/* Two empty states, because only one of them is a verdict:
+                  while the cursor chain is unexhausted the true sentence is
+                  "nothing in what has loaded", not "nothing". The sentinel
+                  below keeps pulling pages whenever the thin wall leaves it
+                  in view, so the pending state resolves itself. */}
+              {normalizedSearchQuery &&
+              visibleEntries.length === 0 &&
+              entries.length > 0 ? (
+                state.nextCursor !== null ? (
+                  <p
+                    className="gallery-status"
+                    data-testid="gallery-search-pending"
+                  >
+                    No matches yet — searching older circuits…
+                  </p>
+                ) : (
+                  <p
+                    className="gallery-status"
+                    data-testid="gallery-search-empty"
+                  >
+                    No circuits match “{searchQuery.trim()}”.
+                  </p>
+                )
               ) : null}
             </section>
           )}


### PR DESCRIPTION
## What

The box labelled "Filter tags" only narrowed the tag-chip row; circuits were reachable through it only indirectly. It now searches the wall itself: a circuit matches when its **name, author, description, or any tag** contains the query — case-insensitive, trimmed, one union with no precedence — composed as AND with the server-side chip/author filters. Chip-row narrowing is unchanged.

## Consequences owned as part of the feature

- **The label stopped being true, so it changed**: placeholder "Name, author, tag…", aria-label "Search circuits", testid `gallery-search`. The box also renders whenever the wall has entries, not only when tags exist.
- **Two empty states, because only one is a verdict**: an unexhausted feed says "No matches yet — searching older circuits…" (the scroll sentinel keeps pulling pages while visible, so this state resolves itself); only an exhausted feed says "No circuits match “q”." The e2e proves the distinction by holding a cursor fetch open so the feed is legitimately incomplete during the assertion.
- **The count panel stays truthful under search**: it gains a second clause counting *visible* tiles — instantaneously true by construction — with "so far" until the feed is exhausted: `128 circuits · 3 matches so far`. The server-filter label changes from "matching" to "filtered" so "match" belongs to the text query alone (the word only became ambiguous in this diff, so this diff renames it).
- Bundled dev-host tiles filter through the same matcher.

## Honest boundary

Matching is client-side over loaded pages by design at this scale; a server-side search param is the eventual answer if the gallery grows to thousands.

## Validation

Red observed before implementation at both layers (4 unit, 2 e2e), then green; full `gallery.spec.ts` 40/40 locally on an isolated port; typecheck and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)