### PR TITLE
perf(derived): share document connectivity work

### DIFF
--- a/docs/specs/performance.md
+++ b/docs/specs/performance.md
@@ -12,7 +12,9 @@ The release benchmark uses a deterministic generated Project with 500 placed
 two-terminal instances and 499 logical nets. It measures canonical save,
 formal SVG render, a bounded Agent summary query, and one atomic Edit Engine
 transaction. SPICE import is measured against the checked ngspice baseline
-corpus.
+corpus. A second deterministic workload with 200 Nets, 200 Routes, 400
+Junctions, and 200 route-bound Net Labels protects the document connectivity
+index from accidental per-Net full-document rescans.
 
 ## CI-safe budgets
 
@@ -23,6 +25,7 @@ corpus.
 | Formal SVG render                            | 2,000 ms |
 | Bounded Agent summary query                  | 1,000 ms |
 | One-instance Edit Engine transaction         | 1,000 ms |
+| Build multi-Net document connectivity index  | 1,000 ms |
 | ngspice baseline import                      | 2,000 ms |
 
 These are release regression ceilings, not UI latency claims. The benchmark

--- a/packages/derived/src/connectivity-index.test.ts
+++ b/packages/derived/src/connectivity-index.test.ts
@@ -1,4 +1,8 @@
-import { createEmptyDocument, createEmptyProject } from "@icm/model";
+import {
+  createEmptyDocument,
+  createEmptyProject,
+  createRoutePath,
+} from "@icm/model";
 import {
   createProjectSymbolResolver,
   hierarchicalSymbolId,
@@ -13,6 +17,84 @@ import { computeNetHighlight } from "./net-highlight.js";
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
 describe("Project Connectivity Index logical aliases", () => {
+  it("retains label virtual edges while sharing document connectivity work", () => {
+    const project = createEmptyProject("project-labels", "Labels");
+    const document = project.documents[0]!;
+    document.nets.push({ id: "net-bias", terminals: [] });
+    document.junctions.push(
+      { id: "J1", netId: "net-bias", position: { x: 0, y: 0 } },
+      { id: "J2", netId: "net-bias", position: { x: 40, y: 0 } },
+      { id: "J3", netId: "net-bias", position: { x: 100, y: 0 } },
+      { id: "J4", netId: "net-bias", position: { x: 140, y: 0 } },
+    );
+    const routes = [
+      createRoutePath({
+        id: "route-a",
+        netId: "net-bias",
+        start: { kind: "junction", junctionId: "J1" },
+        end: { kind: "junction", junctionId: "J2" },
+        bends: [],
+        modes: ["manual"],
+      }),
+      createRoutePath({
+        id: "route-b",
+        netId: "net-bias",
+        start: { kind: "junction", junctionId: "J3" },
+        end: { kind: "junction", junctionId: "J4" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    ];
+    document.routes.push(...routes);
+    for (const [id, route] of [
+      ["label-z", routes[0]!],
+      ["label-a", routes[1]!],
+    ] as const) {
+      document.annotations.push({
+        id,
+        kind: "net-label",
+        binding: { kind: "net-name", netId: "net-bias" },
+        netId: "net-bias",
+        anchor: {
+          kind: "route",
+          routeId: route.id,
+          legId: route.legs[0]!.id,
+          t: 0.5,
+          normalOffset: 10,
+          direction: "forward",
+          orientation: "horizontal",
+          fallbackPosition: { x: 20, y: -10 },
+        },
+        alignment: "middle",
+        rotation: 0,
+        locked: false,
+      });
+      document.connectivityEvidence.push({
+        id: `claim-${id}`,
+        kind: "name-claim",
+        netId: "net-bias",
+        name: "BIAS",
+        owner: { kind: "net-label", annotationId: id },
+        scope: "local",
+      });
+    }
+
+    const record = buildProjectConnectivityIndex(project, resolver)
+      .documents.get(document.id)
+      ?.logicalNetByBaseNetId.get("net-bias");
+    expect(record?.routedComponents).toHaveLength(1);
+    expect(record?.routes).toEqual(["route-a", "route-b"]);
+    expect(record?.junctions).toEqual(["J1", "J2", "J3", "J4"]);
+    expect(record?.virtualEdges).toEqual([
+      {
+        kind: "net-label",
+        from: { kind: "junction", junctionId: "J1" },
+        to: { kind: "junction", junctionId: "J3" },
+        evidence: "BIAS",
+      },
+    ]);
+  });
+
   it("aggregates evidence-equivalent Base Nets under every Base-Net lookup", () => {
     const project = createEmptyProject("project", "Project");
     const document = project.documents[0]!;

--- a/packages/derived/src/connectivity-index.ts
+++ b/packages/derived/src/connectivity-index.ts
@@ -10,17 +10,16 @@ import type { SymbolResolver } from "@icm/symbols";
 import {
   deriveImportedRoutingGuidance,
   deriveNetConnectivity,
+  deriveNetConnectivityContext,
+  type NetConnectivityContext,
   type RoutedComponent,
 } from "./connectivity.js";
 import type { RoutingGuide } from "./routing-guidance.js";
 import { endpointKey, isVisibleEndpoint, netEndpoints } from "./endpoint.js";
 import { directObjectLocator, type ObjectLocator } from "./object-locator.js";
-import { resolveNetLabelBindings } from "./net-label.js";
+import type { ResolvedNetLabelBinding } from "./net-label.js";
 import { resolveAnnotationText } from "./annotation-text.js";
-import {
-  resolveDocumentRoutingGeometry,
-  type ResolvedDocumentRoutingGeometry,
-} from "./resolved-route-geometry.js";
+import type { ResolvedDocumentRoutingGeometry } from "./resolved-route-geometry.js";
 import { resolveDocumentLogicalNets } from "./logical-net.js";
 
 /**
@@ -193,6 +192,20 @@ function buildDocumentIndex(
     }
   }
 
+  const connectivityContext = deriveNetConnectivityContext(document, resolver);
+  const routesByNetId = new Map<string, SchematicDocument["routes"]>();
+  for (const route of document.routes) {
+    const routes = routesByNetId.get(route.netId) ?? [];
+    routes.push(route);
+    routesByNetId.set(route.netId, routes);
+  }
+  const junctionsByNetId = new Map<string, SchematicDocument["junctions"]>();
+  for (const junction of document.junctions) {
+    const junctions = junctionsByNetId.get(junction.netId) ?? [];
+    junctions.push(junction);
+    junctionsByNetId.set(junction.netId, junctions);
+  }
+
   const baseRecords = new Map<string, NetConnectivityRecord>();
   for (const net of document.nets) {
     baseRecords.set(
@@ -202,6 +215,9 @@ function buildDocumentIndex(
         resolver,
         net,
         routingGuidanceByNet.get(net.id) ?? [],
+        connectivityContext,
+        routesByNetId.get(net.id) ?? [],
+        junctionsByNetId.get(net.id) ?? [],
       ),
     );
   }
@@ -232,13 +248,12 @@ function buildDocumentIndex(
     }
   }
 
-  const routingGeometry = resolveDocumentRoutingGeometry(document, resolver);
   const index = {
     documentId: document.id,
     endpointToBaseNetId,
     logicalNets,
     logicalNetByBaseNetId,
-    routingGeometry,
+    routingGeometry: connectivityContext.routingGeometry,
   };
   documentIndexCache.set(document, {
     revision: document.revision,
@@ -277,6 +292,9 @@ function buildNetRecord(
   resolver: SymbolResolver,
   net: Net,
   routingGuidance: readonly RoutingGuide[],
+  connectivityContext: NetConnectivityContext,
+  routesForNet: SchematicDocument["routes"],
+  junctionsForNet: SchematicDocument["junctions"],
 ): NetConnectivityRecord {
   const logicalEndpoints: EndpointRef[] = [
     ...net.terminals.map((terminal) =>
@@ -292,19 +310,22 @@ function buildNetRecord(
     document,
     resolver,
     net,
+    connectivityContext,
   ).components;
 
-  const routes = document.routes
-    .filter((route) => route.netId === net.id)
+  const routes = routesForNet
     .map((route) => route.id)
     .sort((a, b) => a.localeCompare(b, "en"));
 
-  const junctions = document.junctions
-    .filter((junction) => junction.netId === net.id)
+  const junctions = junctionsForNet
     .map((junction) => junction.id)
     .sort((a, b) => a.localeCompare(b, "en"));
 
-  const virtualEdges = deriveLabelVirtualEdges(document, resolver, net);
+  const virtualEdges = deriveLabelVirtualEdges(
+    document,
+    net,
+    connectivityContext.netLabelBindingsByNetId.get(net.id) ?? [],
+  );
 
   return {
     netId: net.id,
@@ -327,14 +348,14 @@ function buildNetRecord(
  */
 function deriveLabelVirtualEdges(
   document: SchematicDocument,
-  resolver: SymbolResolver,
   net: Net,
+  bindings: readonly ResolvedNetLabelBinding[],
 ): VirtualConnectivityEdge[] {
   const groups = new Map<
     string,
     { kind: VirtualConnectivityEdge["kind"]; endpoints: EndpointRef[] }
   >();
-  for (const binding of resolveNetLabelBindings(document, resolver, net.id)) {
+  for (const binding of bindings) {
     const annotation = document.annotations.find(
       (candidate) => candidate.id === binding.annotationId,
     )!;
@@ -353,7 +374,7 @@ function deriveLabelVirtualEdges(
     if (annotation.kind !== "power-label" || annotation.netId !== net.id) {
       continue;
     }
-    const binding = resolveNetLabelBindings(document, resolver, net.id).find(
+    const binding = bindings.find(
       (candidate) => candidate.annotationId === annotation.id,
     );
     if (!binding) continue;

--- a/packages/derived/src/connectivity.test.ts
+++ b/packages/derived/src/connectivity.test.ts
@@ -7,6 +7,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
+import { createEmptyDocument, createRoutePath } from "@icm/model";
 import { parseProject } from "@icm/project-protocol";
 import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
@@ -36,5 +37,77 @@ describe("shared connectivity context (#17)", () => {
         deriveNetConnectivity(document, resolver, net),
       );
     }
+  });
+
+  it("pre-resolves and orders net-label bindings without changing connectivity", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.nets.push({ id: "net-bias", terminals: [] });
+    document.junctions.push(
+      { id: "J1", netId: "net-bias", position: { x: 0, y: 0 } },
+      { id: "J2", netId: "net-bias", position: { x: 40, y: 0 } },
+      { id: "J3", netId: "net-bias", position: { x: 100, y: 0 } },
+      { id: "J4", netId: "net-bias", position: { x: 140, y: 0 } },
+    );
+    const routes = [
+      createRoutePath({
+        id: "route-a",
+        netId: "net-bias",
+        start: { kind: "junction", junctionId: "J1" },
+        end: { kind: "junction", junctionId: "J2" },
+        bends: [],
+        modes: ["manual"],
+      }),
+      createRoutePath({
+        id: "route-b",
+        netId: "net-bias",
+        start: { kind: "junction", junctionId: "J3" },
+        end: { kind: "junction", junctionId: "J4" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    ];
+    document.routes.push(...routes);
+    for (const [id, route] of [
+      ["label-z", routes[0]!],
+      ["label-a", routes[1]!],
+    ] as const) {
+      document.annotations.push({
+        id,
+        kind: "net-label",
+        binding: { kind: "net-name", netId: "net-bias" },
+        netId: "net-bias",
+        anchor: {
+          kind: "route",
+          routeId: route.id,
+          legId: route.legs[0]!.id,
+          t: 0.5,
+          normalOffset: 10,
+          direction: "forward",
+          orientation: "horizontal",
+          fallbackPosition: { x: 20, y: -10 },
+        },
+        alignment: "middle",
+        rotation: 0,
+        locked: false,
+      });
+      document.connectivityEvidence.push({
+        id: `claim-${id}`,
+        kind: "name-claim",
+        netId: "net-bias",
+        name: "BIAS",
+        owner: { kind: "net-label", annotationId: id },
+        scope: "local",
+      });
+    }
+
+    const context = deriveNetConnectivityContext(document, resolver);
+    expect(
+      context.netLabelBindingsByNetId
+        .get("net-bias")
+        ?.map((binding) => binding.annotationId),
+    ).toEqual(["label-a", "label-z"]);
+    expect(
+      deriveNetConnectivity(document, resolver, document.nets[0]!, context),
+    ).toEqual(deriveNetConnectivity(document, resolver, document.nets[0]!));
   });
 });

--- a/packages/derived/src/connectivity.ts
+++ b/packages/derived/src/connectivity.ts
@@ -13,7 +13,11 @@ import {
   resolveDocumentRoutingGeometry,
   type ResolvedDocumentRoutingGeometry,
 } from "./resolved-route-geometry.js";
-import { resolveNetLabelBindings } from "./net-label.js";
+import {
+  resolveNetLabelBinding,
+  resolveNetLabelBindings,
+  type ResolvedNetLabelBinding,
+} from "./net-label.js";
 import { resolveAnnotationText } from "./annotation-text.js";
 import { resolveDocumentLogicalNets } from "./logical-net.js";
 import {
@@ -79,6 +83,10 @@ class DisjointSet {
 export interface NetConnectivityContext {
   routingGeometry: ResolvedDocumentRoutingGeometry;
   contacts: ReturnType<typeof deriveDocumentContactEvidence>;
+  netLabelBindingsByNetId: ReadonlyMap<
+    string,
+    readonly ResolvedNetLabelBinding[]
+  >;
 }
 
 export function deriveNetConnectivityContext(
@@ -86,6 +94,24 @@ export function deriveNetConnectivityContext(
   resolver: SymbolResolver,
 ): NetConnectivityContext {
   const routingGeometry = resolveDocumentRoutingGeometry(document, resolver);
+  const netLabelBindingsByNetId = new Map<string, ResolvedNetLabelBinding[]>();
+  for (const annotation of document.annotations) {
+    const binding = resolveNetLabelBinding(
+      document,
+      resolver,
+      annotation,
+      routingGeometry,
+    );
+    if (!binding) continue;
+    const bindings = netLabelBindingsByNetId.get(binding.netId) ?? [];
+    bindings.push(binding);
+    netLabelBindingsByNetId.set(binding.netId, bindings);
+  }
+  for (const bindings of netLabelBindingsByNetId.values()) {
+    bindings.sort((left, right) =>
+      left.annotationId.localeCompare(right.annotationId, "en"),
+    );
+  }
   return {
     routingGeometry,
     contacts: deriveDocumentContactEvidence(
@@ -93,6 +119,7 @@ export function deriveNetConnectivityContext(
       resolver,
       routingGeometry,
     ),
+    netLabelBindingsByNetId,
   };
 }
 
@@ -141,12 +168,7 @@ export function deriveNetConnectivity(
   }
   const labeledEndpoints = new Map<string, string[]>();
   const netLabelBindings = context
-    ? resolveNetLabelBindings(
-        document,
-        resolver,
-        net.id,
-        context.routingGeometry,
-      )
+    ? (context.netLabelBindingsByNetId.get(net.id) ?? [])
     : resolveNetLabelBindings(document, resolver, net.id);
   for (const binding of netLabelBindings) {
     const annotation = document.annotations.find(

--- a/scripts/performance-baseline.mjs
+++ b/scripts/performance-baseline.mjs
@@ -4,9 +4,11 @@ import { resolve } from "node:path";
 import { performance } from "node:perf_hooks";
 
 import { createAgentCircuitService } from "../packages/agent-adapter/dist/index.js";
+import { buildProjectConnectivityIndex } from "../packages/derived/dist/index.js";
 import {
   CircuitProjectSchema,
   createEmptyProject,
+  createRoutePath,
 } from "../packages/model/dist/index.js";
 import {
   saveProject,
@@ -26,6 +28,7 @@ const budgets = {
   renderSvg: 2000,
   agentSnapshot: 1000,
   editTransaction: 1000,
+  connectivityIndex: 1000,
   spiceImport: 2000,
   atomicSave: 1000,
 };
@@ -68,6 +71,62 @@ const project = generated.result;
 let document = project.documents[0];
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
+const connectivityProject = createEmptyProject(
+  "connectivity-performance",
+  "Connectivity Performance",
+);
+const connectivityDocument = connectivityProject.documents[0];
+for (let index = 0; index < 200; index += 1) {
+  const netId = `net-${index}`;
+  const leftJunctionId = `J${index}-left`;
+  const rightJunctionId = `J${index}-right`;
+  const y = index * 20;
+  connectivityDocument.nets.push({ id: netId, terminals: [] });
+  connectivityDocument.junctions.push(
+    { id: leftJunctionId, netId, position: { x: 0, y } },
+    { id: rightJunctionId, netId, position: { x: 40, y } },
+  );
+  const route = createRoutePath({
+    id: `route-${index}`,
+    netId,
+    start: { kind: "junction", junctionId: leftJunctionId },
+    end: { kind: "junction", junctionId: rightJunctionId },
+    bends: [],
+    modes: ["manual"],
+  });
+  connectivityDocument.routes.push(route);
+  const annotationId = `label-${index}`;
+  connectivityDocument.annotations.push({
+    id: annotationId,
+    kind: "net-label",
+    binding: { kind: "net-name", netId },
+    netId,
+    anchor: {
+      kind: "route",
+      routeId: route.id,
+      legId: route.legs[0].id,
+      t: 0.5,
+      normalOffset: 10,
+      direction: "forward",
+      orientation: "horizontal",
+      fallbackPosition: { x: 20, y: y - 10 },
+    },
+    alignment: "middle",
+    rotation: 0,
+    locked: false,
+  });
+  connectivityDocument.connectivityEvidence.push({
+    id: `claim-${index}`,
+    kind: "name-claim",
+    netId,
+    name: `NET_${index}`,
+    owner: { kind: "net-label", annotationId },
+    scope: "local",
+  });
+}
+const validatedConnectivityProject =
+  CircuitProjectSchema.parse(connectivityProject);
+
 const serialized = await measure(() => serializeProject(project));
 const rendered = await measure(() =>
   renderDocumentSvg(document, resolver, { title: project.name }),
@@ -109,6 +168,9 @@ const edit = await measure(() =>
     ],
   }),
 );
+const connectivityIndex = await measure(() =>
+  buildProjectConnectivityIndex(validatedConnectivityProject, resolver),
+);
 const sourcePath = resolve("fixtures/spice-baseline/core.cir");
 const modelPath = resolve("fixtures/spice-baseline/models.lib");
 const imported = await measure(async () =>
@@ -135,6 +197,7 @@ const measurements = {
   renderSvg: rendered.milliseconds,
   agentSnapshot: snapshot.milliseconds,
   editTransaction: edit.milliseconds,
+  connectivityIndex: connectivityIndex.milliseconds,
   spiceImport: imported.milliseconds,
   atomicSave: saved.milliseconds,
 };
@@ -152,6 +215,12 @@ const report = {
     instances: 500,
     serializedBytes: Buffer.byteLength(serialized.result),
     svgBytes: Buffer.byteLength(rendered.result),
+  },
+  connectivityFixture: {
+    nets: connectivityDocument.nets.length,
+    routes: connectivityDocument.routes.length,
+    junctions: connectivityDocument.junctions.length,
+    annotations: connectivityDocument.annotations.length,
   },
   measurements: Object.fromEntries(
     Object.entries(measurements).map(([name, value]) => [


### PR DESCRIPTION
## Summary
- build routing geometry, contact evidence, and Net Label bindings once per Document connectivity index
- pre-group Route and Junction membership before individual Net records
- add label-aware semantic parity tests and a 200-Net release performance budget

## Measured result
- supplied 206-Net Project: cold index median 8,897 ms -> 69.522 ms (~128x)
- canonicalized pre/post connectivity-index SHA-256 values are identical
- release workload: 200 Nets / 200 Routes / 400 Junctions / 200 labels in ~323 ms under a 1,000 ms ceiling

## Validation
- focused derived tests: 5 passed
- workspace typecheck
- gate:affected: 1,843 tests passed
- gate:full: build, release/performance smoke, and 286 browser tests passed
- post-commit gate:preflight passed

Test-Impact: tests-updated