### PR TITLE
perf(editor): reduce commit and undo recomputation

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -19,6 +19,7 @@ import {
   type WireSource,
 } from "@icm/edit-engine";
 import {
+  buildProjectConnectivityIndex,
   computeNetHighlight,
   deriveNetConnectivity,
   deriveRoutingAffectedClosure,
@@ -472,6 +473,10 @@ export function App({
     canvasDragSessionRef.current?.cancel();
     stageRecovery(project);
   });
+  const projectConnectivityIndex = useMemo(
+    () => buildProjectConnectivityIndex(project, resolver),
+    [project, resolver],
+  );
   const agentSemanticIntentRef = useRef<
     (request: AgentHostSemanticIntentRequest) => AgentHostSemanticIntentResult
   >(() => ({
@@ -1093,11 +1098,28 @@ export function App({
       // camera-independent; rebuilding it during pan/zoom repeats all route,
       // symbol, text, and drafting derivation without changing one visible
       // object.
-      return buildSvgScene(renderedDocument, resolver);
+      const documentConnectivity =
+        renderedDocument === document
+          ? projectConnectivityIndex.documents.get(document.id)
+          : undefined;
+      return buildSvgScene(renderedDocument, resolver, {
+        ...(documentConnectivity
+          ? {
+              routingGeometry: documentConnectivity.routingGeometry,
+              contactEvidence: documentConnectivity.contactEvidence,
+            }
+          : {}),
+      });
     }, lastGoodSceneRef.current);
     if (!outcome.degraded) lastGoodSceneRef.current = outcome.scene;
     return outcome;
-  }, [formulaArtifactRevision, renderedDocument, resolver]);
+  }, [
+    document,
+    formulaArtifactRevision,
+    projectConnectivityIndex,
+    renderedDocument,
+    resolver,
+  ]);
   const scene = sceneState.scene;
   useEffect(() => {
     if (sceneState.degraded) {
@@ -1200,7 +1222,6 @@ export function App({
     selectedEndpoint,
   });
   const {
-    projectConnectivityIndex,
     logicalNets,
     routeGeometryRecords,
     netlistAnalysis,
@@ -1223,6 +1244,7 @@ export function App({
     project,
     document,
     resolver,
+    projectConnectivityIndex,
     documentStack,
     highlightedNetOrigin,
     selectedHighlightNetId,

--- a/apps/editor/src/app/use-editor-derived-model.ts
+++ b/apps/editor/src/app/use-editor-derived-model.ts
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 
 import {
-  buildProjectConnectivityIndex,
   buildProjectSearchIndex,
   deriveCrossings,
   diagnoseProjectSnapshot,
@@ -13,7 +12,11 @@ import {
   resolveEndpointConnection,
   traceHierarchyNet,
 } from "@icm/derived";
-import type { Flightline, HierarchyFrame } from "@icm/derived";
+import type {
+  Flightline,
+  HierarchyFrame,
+  ProjectConnectivityIndex,
+} from "@icm/derived";
 import type { WireSource } from "@icm/edit-engine";
 import { analyzeDesignNetlist } from "@icm/netlist";
 import type {
@@ -42,6 +45,7 @@ interface UseEditorDerivedModelOptions {
   project: CircuitProject;
   document: SchematicDocument;
   resolver: SymbolResolver;
+  projectConnectivityIndex: ProjectConnectivityIndex;
   documentStack: readonly HierarchyFrame[];
   highlightedNetOrigin: HighlightedNetOrigin | null;
   selectedHighlightNetId: string | null;
@@ -204,6 +208,7 @@ export function useEditorDerivedModel({
   project,
   document,
   resolver,
+  projectConnectivityIndex,
   documentStack,
   highlightedNetOrigin,
   selectedHighlightNetId,
@@ -213,10 +218,6 @@ export function useEditorDerivedModel({
   wireSource,
   bulkDrawInstanceId,
 }: UseEditorDerivedModelOptions) {
-  const projectConnectivityIndex = useMemo(
-    () => buildProjectConnectivityIndex(project, resolver),
-    [project, resolver],
-  );
   const documentConnectivity = projectConnectivityIndex.documents.get(
     document.id,
   );
@@ -332,8 +333,16 @@ export function useEditorDerivedModel({
     [document, documentConnectivity, resolver],
   );
   const visualDiagnostics = useMemo(
-    () => diagnoseVisualQuality(document, resolver),
-    [document, resolver],
+    () =>
+      diagnoseVisualQuality(document, resolver, {
+        ...(documentConnectivity
+          ? {
+              routingGeometry: documentConnectivity.routingGeometry,
+              contactEvidence: documentConnectivity.contactEvidence,
+            }
+          : {}),
+      }),
+    [document, documentConnectivity, resolver],
   );
   const visualDiagnosticSummary = useMemo(
     () => summarizeVisualDiagnostics(visualDiagnostics),

--- a/packages/derived/src/connectivity-index.test.ts
+++ b/packages/derived/src/connectivity-index.test.ts
@@ -93,6 +93,12 @@ describe("Project Connectivity Index logical aliases", () => {
         evidence: "BIAS",
       },
     ]);
+    const documentIndex = buildProjectConnectivityIndex(
+      project,
+      resolver,
+    ).documents.get(document.id)!;
+    expect(documentIndex.contactEvidence.contacts).toHaveLength(4);
+    expect(documentIndex.contactEvidence.byEndpointKey.size).toBe(4);
   });
 
   it("aggregates evidence-equivalent Base Nets under every Base-Net lookup", () => {

--- a/packages/derived/src/connectivity-index.ts
+++ b/packages/derived/src/connectivity-index.ts
@@ -20,6 +20,7 @@ import { directObjectLocator, type ObjectLocator } from "./object-locator.js";
 import type { ResolvedNetLabelBinding } from "./net-label.js";
 import { resolveAnnotationText } from "./annotation-text.js";
 import type { ResolvedDocumentRoutingGeometry } from "./resolved-route-geometry.js";
+import type { DocumentContactEvidence } from "./contact.js";
 import { resolveDocumentLogicalNets } from "./logical-net.js";
 
 /**
@@ -68,6 +69,7 @@ export interface DocumentConnectivityIndex {
   /** Total lookup from every Base Net id to its Logical Net record. */
   logicalNetByBaseNetId: ReadonlyMap<string, NetConnectivityRecord>;
   routingGeometry: ResolvedDocumentRoutingGeometry;
+  contactEvidence: DocumentContactEvidence;
 }
 
 export interface HierarchyEdge {
@@ -254,6 +256,7 @@ function buildDocumentIndex(
     logicalNets,
     logicalNetByBaseNetId,
     routingGeometry: connectivityContext.routingGeometry,
+    contactEvidence: connectivityContext.contacts,
   };
   documentIndexCache.set(document, {
     revision: document.revision,

--- a/packages/derived/src/diagnostics/diagnostic.ts
+++ b/packages/derived/src/diagnostics/diagnostic.ts
@@ -168,11 +168,19 @@ export function diagnoseProject(
   resolver: SymbolResolver,
   index = buildProjectConnectivityIndex(project, resolver),
 ): readonly Diagnostic[] {
-  const visual = project.documents.flatMap((document) =>
-    diagnoseVisualQuality(document, resolver).map((diagnostic) =>
+  const visual = project.documents.flatMap((document) => {
+    const documentIndex = index.documents.get(document.id);
+    return diagnoseVisualQuality(document, resolver, {
+      ...(documentIndex
+        ? {
+            routingGeometry: documentIndex.routingGeometry,
+            contactEvidence: documentIndex.contactEvidence,
+          }
+        : {}),
+    }).map((diagnostic) =>
       adaptVisualDiagnostic(diagnostic, document.id, index),
-    ),
-  );
+    );
+  });
   return mergeDiagnostics(runErcChecks(project, index, resolver), visual);
 }
 

--- a/packages/derived/src/route-query.test.ts
+++ b/packages/derived/src/route-query.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveRouteTap } from "./route-query.js";
+import { createEmptyDocument, createRoutePath } from "@icm/model";
+import { InMemorySymbolResolver } from "@icm/symbols";
+
+import { deriveCrossings, resolveRouteTap } from "./route-query.js";
 import type { ResolvedRouteGeometry } from "./resolved-route-geometry.js";
 
 function geometry(
@@ -49,6 +52,74 @@ function geometry(
 }
 
 describe("route queries", () => {
+  it("finds crossings and overlaps while excluding a shared explicit endpoint", () => {
+    const document = createEmptyDocument("crossings", "Crossings");
+    const junctions = [
+      ["J1", "net-a", 0, 0],
+      ["J2", "net-a", 100, 0],
+      ["J3", "net-b", 50, -50],
+      ["J4", "net-b", 50, 50],
+      ["J5", "net-c", 20, 0],
+      ["J6", "net-c", 80, 0],
+      ["J7", "net-a", 100, 50],
+    ] as const;
+    document.nets.push(
+      ...["net-a", "net-b", "net-c"].map((id) => ({
+        id,
+        terminals: [],
+      })),
+    );
+    document.junctions.push(
+      ...junctions.map(([id, netId, x, y]) => ({
+        id,
+        netId,
+        position: { x, y },
+      })),
+    );
+    const route = (id: string, netId: string, start: string, end: string) =>
+      createRoutePath({
+        id,
+        netId,
+        start: { kind: "junction", junctionId: start },
+        end: { kind: "junction", junctionId: end },
+        bends: [],
+        modes: ["manual"],
+      });
+    document.routes.push(
+      route("route-a", "net-a", "J1", "J2"),
+      route("route-b", "net-b", "J3", "J4"),
+      route("route-c", "net-c", "J5", "J6"),
+      route("route-d", "net-a", "J2", "J7"),
+    );
+
+    expect(deriveCrossings(document, new InMemorySymbolResolver([]))).toEqual([
+      {
+        routeAId: "route-a",
+        routeBId: "route-b",
+        netAId: "net-a",
+        netBId: "net-b",
+        point: { x: 50, y: 0 },
+        kind: "crossing",
+      },
+      {
+        routeAId: "route-a",
+        routeBId: "route-c",
+        netAId: "net-a",
+        netBId: "net-c",
+        point: { x: 20, y: 0 },
+        kind: "overlap",
+      },
+      {
+        routeAId: "route-b",
+        routeBId: "route-c",
+        netAId: "net-b",
+        netBId: "net-c",
+        point: { x: 50, y: 0 },
+        kind: "crossing",
+      },
+    ]);
+  });
+
   it("prefers an in-tolerance interior vertex over a closer segment projection", () => {
     expect(
       resolveRouteTap(

--- a/packages/derived/src/route-query.ts
+++ b/packages/derived/src/route-query.ts
@@ -38,6 +38,16 @@ export interface Crossing {
   kind: "crossing" | "overlap";
 }
 
+interface CrossingSegmentCandidate {
+  route: RouteBranch;
+  routeOrder: number;
+  segment: ResolvedRouteSegment;
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+}
+
 export function projectPointToRouteSegment(
   point: Point,
   segment: ResolvedRouteSegment,
@@ -162,44 +172,76 @@ export function deriveCrossings(
   const routes = [...document.routes].sort((left, right) =>
     left.id.localeCompare(right.id, "en"),
   );
+  const routeOrder = new Map(
+    routes.map((route, index) => [route.id, index] as const),
+  );
+  const candidates: CrossingSegmentCandidate[] = routes
+    .flatMap((route) => {
+      const geometry = routingGeometry.routes.get(route.id);
+      return (geometry?.segments ?? []).map((segment) => ({
+        route,
+        routeOrder: routeOrder.get(route.id)!,
+        segment,
+        minX: Math.min(segment.from.x, segment.to.x),
+        maxX: Math.max(segment.from.x, segment.to.x),
+        minY: Math.min(segment.from.y, segment.to.y),
+        maxY: Math.max(segment.from.y, segment.to.y),
+      }));
+    })
+    .sort(
+      (left, right) =>
+        left.minX - right.minX ||
+        left.maxX - right.maxX ||
+        left.minY - right.minY ||
+        left.routeOrder - right.routeOrder ||
+        left.segment.address.segmentIndex - right.segment.address.segmentIndex,
+    );
   const result: Crossing[] = [];
-  for (let leftIndex = 0; leftIndex < routes.length; leftIndex += 1) {
+  const sharedPointByRoutePair = new Map<string, Point | null>();
+  for (let leftIndex = 0; leftIndex < candidates.length; leftIndex += 1) {
+    const left = candidates[leftIndex]!;
     for (
       let rightIndex = leftIndex + 1;
-      rightIndex < routes.length;
+      rightIndex < candidates.length;
       rightIndex += 1
     ) {
-      const left = routes[leftIndex]!;
-      const right = routes[rightIndex]!;
-      const leftGeometry = routingGeometry.routes.get(left.id);
-      const rightGeometry = routingGeometry.routes.get(right.id);
-      if (!leftGeometry || !rightGeometry) continue;
-      const shared = sharedExplicitEndpoint(left, right);
-      const sharedPoint = shared
-        ? resolveEndpointPoint(document, resolver, shared)
-        : null;
-      for (const leftSegment of leftGeometry.segments) {
-        for (const rightSegment of rightGeometry.segments) {
-          const intersection = intersectSegments(
-            leftSegment.from,
-            leftSegment.to,
-            rightSegment.from,
-            rightSegment.to,
-          );
-          if (!intersection) continue;
-          if (sharedPoint && samePoint(sharedPoint, intersection.point)) {
-            continue;
-          }
-          result.push({
-            routeAId: left.id,
-            routeBId: right.id,
-            netAId: left.netId,
-            netBId: right.netId,
-            point: intersection.point,
-            kind: intersection.kind,
-          });
-        }
+      const right = candidates[rightIndex]!;
+      if (right.minX > left.maxX) break;
+      if (
+        left.route.id === right.route.id ||
+        right.minY > left.maxY ||
+        right.maxY < left.minY
+      ) {
+        continue;
       }
+      const intersection = intersectSegments(
+        left.segment.from,
+        left.segment.to,
+        right.segment.from,
+        right.segment.to,
+      );
+      if (!intersection) continue;
+      const routeA =
+        left.routeOrder < right.routeOrder ? left.route : right.route;
+      const routeB = routeA === left.route ? right.route : left.route;
+      const pairKey = `${routeA.id}\0${routeB.id}`;
+      let sharedPoint = sharedPointByRoutePair.get(pairKey);
+      if (sharedPoint === undefined) {
+        const shared = sharedExplicitEndpoint(routeA, routeB);
+        sharedPoint = shared
+          ? resolveEndpointPoint(document, resolver, shared)
+          : null;
+        sharedPointByRoutePair.set(pairKey, sharedPoint);
+      }
+      if (sharedPoint && samePoint(sharedPoint, intersection.point)) continue;
+      result.push({
+        routeAId: routeA.id,
+        routeBId: routeB.id,
+        netAId: routeA.netId,
+        netBId: routeB.netId,
+        point: intersection.point,
+        kind: intersection.kind,
+      });
     }
   }
   return result.sort(

--- a/packages/derived/src/visual.ts
+++ b/packages/derived/src/visual.ts
@@ -18,7 +18,10 @@ import {
   type ResolvedDocumentRoutingGeometry,
 } from "./resolved-route-geometry.js";
 import { resolveDocumentStyleProfile } from "./style-profile.js";
-import { deriveDocumentContactEvidence } from "./contact.js";
+import {
+  deriveDocumentContactEvidence,
+  type DocumentContactEvidence,
+} from "./contact.js";
 import { resolveAnnotationPresentation } from "./annotation-presentation.js";
 import { resolveAnnotationText } from "./annotation-text.js";
 import { pointOnSegment } from "./segment-geometry.js";
@@ -39,6 +42,10 @@ export interface VisualDiagnostic {
 export interface VisualDiagnosticOptions {
   minimumSegmentLength?: number;
   pageBounds?: Rect;
+  /** Revision-scoped routing read model supplied by a shared caller. */
+  routingGeometry?: ResolvedDocumentRoutingGeometry;
+  /** Contact evidence paired with `routingGeometry`; never persisted. */
+  contactEvidence?: DocumentContactEvidence;
 }
 
 interface CachedVisualDiagnostics {
@@ -89,11 +96,26 @@ function overlappingClusters<T extends { id: string; bounds: Rect }>(
     const rightRoot = find(right);
     if (leftRoot !== rightRoot) parents[rightRoot] = leftRoot;
   };
-  for (let left = 0; left < items.length; left += 1) {
-    for (let right = left + 1; right < items.length; right += 1) {
-      if (overlaps(items[left]!, items[right]!)) {
-        join(left, right);
-      }
+  const byLeftEdge = items
+    .map((_, index) => index)
+    .sort(
+      (left, right) =>
+        items[left]!.bounds.x - items[right]!.bounds.x || left - right,
+    );
+  for (let leftOrder = 0; leftOrder < byLeftEdge.length; leftOrder += 1) {
+    const left = byLeftEdge[leftOrder]!;
+    const leftItem = items[left]!;
+    const leftRight = leftItem.bounds.x + leftItem.bounds.width;
+    for (
+      let rightOrder = leftOrder + 1;
+      rightOrder < byLeftEdge.length;
+      rightOrder += 1
+    ) {
+      const right = byLeftEdge[rightOrder]!;
+      const rightItem = items[right]!;
+      if (rightItem.bounds.x >= leftRight) break;
+      if (!rectanglesOverlap(leftItem.bounds, rightItem.bounds)) continue;
+      if (overlaps(leftItem, rightItem)) join(left, right);
     }
   }
   const groups = new Map<number, T[]>();
@@ -398,6 +420,7 @@ function pushRoutingQualityMetrics(
   resolver: SymbolResolver,
   boundsById: Map<string, Rect>,
   routingGeometry: ResolvedDocumentRoutingGeometry,
+  contactEvidence: DocumentContactEvidence,
 ): void {
   const routeCenterlines = document.routes
     .map((route) => ({
@@ -412,12 +435,6 @@ function pushRoutingQualityMetrics(
         centerline: readonly Point[];
       } => entry.centerline !== undefined,
     );
-  const contactEvidence = deriveDocumentContactEvidence(
-    document,
-    resolver,
-    routingGeometry,
-  );
-
   // 1. Wire-through-symbol: a Route segment passes through an instance
   //    silhouette that is not one of its terminal endpoints.
   for (const { route, centerline } of routeCenterlines) {
@@ -611,7 +628,18 @@ export function diagnoseVisualQuality(
     options.minimumSegmentLength ?? document.presentation.grid;
   const bounds = instanceBounds(document, resolver);
   const boundsById = new Map(bounds.map((item) => [item.id, item.bounds]));
-  const routingGeometry = resolveDocumentRoutingGeometry(document, resolver);
+  const routingGeometry =
+    options.routingGeometry ??
+    resolveDocumentRoutingGeometry(document, resolver);
+  if (
+    routingGeometry.documentId !== document.id ||
+    routingGeometry.documentRevision !== document.revision
+  ) {
+    throw new Error("Visual diagnostics received stale routing geometry");
+  }
+  const contactEvidence =
+    options.contactEvidence ??
+    deriveDocumentContactEvidence(document, resolver, routingGeometry);
 
   for (const instance of document.instances) {
     if (!instance.placement) {
@@ -807,6 +835,7 @@ export function diagnoseVisualQuality(
     resolver,
     boundsById,
     routingGeometry,
+    contactEvidence,
   );
   const ordered = diagnostics.sort((left, right) =>
     `${left.code}\0${left.objectIds.join("\0")}`.localeCompare(

--- a/packages/edit-engine/src/direct-contact-lifecycle.test.ts
+++ b/packages/edit-engine/src/direct-contact-lifecycle.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it } from "vitest";
 
 import { executeTransaction } from "./transaction.js";
 import { DocumentHistory } from "./history.js";
+import { transformMaySeparateDirectContact } from "./transaction-direct-contact.js";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 const context = { symbolResolver: resolver };
@@ -77,6 +78,33 @@ function transaction(
 }
 
 describe("direct-contact transform lifecycle", () => {
+  it("uses coincident visible endpoints as the conservative transform guard", () => {
+    const contact = fixture();
+    expect(
+      transformMaySeparateDirectContact(
+        contact,
+        resolver,
+        new Set(["A"]),
+        new Set(),
+      ),
+    ).toBe(true);
+
+    const separate = fixture();
+    separate.instances.find((instance) => instance.id === "A")!.placement = {
+      position: { x: 100, y: 300 },
+      rotation: 0,
+      mirror: "none",
+    };
+    expect(
+      transformMaySeparateDirectContact(
+        separate,
+        resolver,
+        new Set(["A"]),
+        new Set(),
+      ),
+    ).toBe(false);
+  });
+
   it("materializes an ordinary Route when one endpoint moves away", () => {
     const document = fixture();
     const result = executeTransaction(

--- a/packages/edit-engine/src/physical-contact-license.test.ts
+++ b/packages/edit-engine/src/physical-contact-license.test.ts
@@ -7,7 +7,9 @@ import { parseProject } from "@icm/project-protocol";
 import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
-import { executeTransaction } from "./transaction.js";
+import { EditTransactionSchema, executeTransaction } from "./transaction.js";
+import { physicalContactLicenseForTransaction } from "./transaction-connectivity.js";
+import { nextPhysicalContactOperation } from "./transaction-connectivity-normalizer.js";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 const context = { symbolResolver: resolver };
@@ -147,6 +149,30 @@ function junctionNetIds(document: SchematicDocument): Record<string, string> {
 }
 
 describe("physical contact license", () => {
+  it("does no whole-Document contact search without an explicit license", () => {
+    const document = fixture({
+      keepInstances: ["A", "B"],
+      parkedJunctionX: 250,
+    });
+    const move = transaction(document, [
+      {
+        kind: "move_instance",
+        instanceId: "A",
+        position: { x: 160, y: 300 },
+      },
+    ]);
+    const license = physicalContactLicenseForTransaction(
+      EditTransactionSchema.parse(move),
+    );
+
+    expect(license.objectIds.size).toBe(0);
+    expect(license.endpointKeys.size).toBe(0);
+    expect(license.routePoints.size).toBe(0);
+    expect(
+      nextPhysicalContactOperation(document, resolver, license),
+    ).toBeNull();
+  });
+
   it("keeps a typed attach from bonding the rest of the conductor, regardless of split ID reuse", () => {
     const endpoint: RouteEndpoint = {
       kind: "terminal",

--- a/packages/edit-engine/src/transaction-connectivity-normalizer.ts
+++ b/packages/edit-engine/src/transaction-connectivity-normalizer.ts
@@ -86,6 +86,17 @@ export function nextPhysicalContactOperation(
   license: PhysicalContactLicense,
   suppressedEndpointKeys: ReadonlySet<string> = new Set(),
 ): PhysicalContactOperation | null {
+  // A transaction without an explicit physical-contact license cannot
+  // normalize any contact. Most geometry and presentation edits are in this
+  // category; avoid resolving every visible endpoint and comparing the whole
+  // Document only to reject every candidate below.
+  if (
+    license.objectIds.size === 0 &&
+    license.endpointKeys.size === 0 &&
+    license.routePoints.size === 0
+  ) {
+    return null;
+  }
   const endpointLicensed = (endpoint: RouteEndpoint): boolean =>
     license.objectIds.has(endpointObjectId(endpoint)) ||
     license.endpointKeys.has(endpointKey(endpoint));
@@ -101,29 +112,40 @@ export function nextPhysicalContactOperation(
     return point ? [{ endpoint, point }] : [];
   });
 
-  for (let leftIndex = 0; leftIndex < positioned.length; leftIndex += 1) {
-    const left = positioned[leftIndex]!;
-    for (
-      let rightIndex = leftIndex + 1;
-      rightIndex < positioned.length;
-      rightIndex += 1
-    ) {
-      const right = positioned[rightIndex]!;
-      if (!samePoint(left.point, right.point)) continue;
-      if (
-        !endpointLicensed(left.endpoint) &&
-        !endpointLicensed(right.endpoint)
+  const positionedByPoint = new Map<string, typeof positioned>();
+  for (const entry of positioned) {
+    const key = physicalContactPointKey(entry.point);
+    const entries = positionedByPoint.get(key) ?? [];
+    entries.push(entry);
+    positionedByPoint.set(key, entries);
+  }
+  for (const coincident of positionedByPoint.values()) {
+    if (!coincident.some(({ endpoint }) => endpointLicensed(endpoint))) {
+      continue;
+    }
+    for (let leftIndex = 0; leftIndex < coincident.length; leftIndex += 1) {
+      const left = coincident[leftIndex]!;
+      for (
+        let rightIndex = leftIndex + 1;
+        rightIndex < coincident.length;
+        rightIndex += 1
       ) {
-        continue;
+        const right = coincident[rightIndex]!;
+        if (
+          !endpointLicensed(left.endpoint) &&
+          !endpointLicensed(right.endpoint)
+        ) {
+          continue;
+        }
+        const leftOwner = endpointOwnerNetId(document, left.endpoint);
+        const rightOwner = endpointOwnerNetId(document, right.endpoint);
+        if (leftOwner !== null && leftOwner === rightOwner) continue;
+        return {
+          kind: "connect-endpoints",
+          left: left.endpoint,
+          right: right.endpoint,
+        };
       }
-      const leftOwner = endpointOwnerNetId(document, left.endpoint);
-      const rightOwner = endpointOwnerNetId(document, right.endpoint);
-      if (leftOwner !== null && leftOwner === rightOwner) continue;
-      return {
-        kind: "connect-endpoints",
-        left: left.endpoint,
-        right: right.endpoint,
-      };
     }
   }
 

--- a/packages/edit-engine/src/transaction-direct-contact.ts
+++ b/packages/edit-engine/src/transaction-direct-contact.ts
@@ -3,8 +3,11 @@ import type { RouteEndpoint, SchematicDocument } from "@icm/model";
 import {
   deriveDirectContactDelta,
   endpointKey,
+  isVisibleEndpoint,
   isMosBulkTerminal,
+  netEndpoints,
   resolveEndpointConnection,
+  resolveEndpointPoint,
 } from "@icm/derived";
 import type { SymbolResolver } from "@icm/symbols";
 
@@ -17,6 +20,50 @@ import {
 export interface DirectContactReconciliation {
   geometryChanged: boolean;
   changedRouteIds: readonly string[];
+}
+
+/**
+ * Cheap conservative guard for transform transactions. A lost direct contact
+ * must have contained a moved endpoint at a coordinate shared by at least one
+ * other visible endpoint before the transform. Returning true may do extra
+ * work; returning false proves the full contact-delta derivation unnecessary.
+ */
+export function transformMaySeparateDirectContact(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  instanceIds: ReadonlySet<string>,
+  junctionIds: ReadonlySet<string>,
+): boolean {
+  for (const net of document.nets) {
+    const positions = new Map<
+      string,
+      { count: number; containsTransformedEndpoint: boolean }
+    >();
+    for (const endpoint of netEndpoints(document, net)) {
+      if (!isVisibleEndpoint(document, resolver, endpoint)) continue;
+      const point = resolveEndpointPoint(document, resolver, endpoint);
+      if (!point) continue;
+      const key = `${point.x},${point.y}`;
+      const current = positions.get(key) ?? {
+        count: 0,
+        containsTransformedEndpoint: false,
+      };
+      current.count += 1;
+      current.containsTransformedEndpoint ||=
+        (endpoint.kind === "terminal" &&
+          instanceIds.has(endpoint.instanceId)) ||
+        (endpoint.kind === "junction" && junctionIds.has(endpoint.junctionId));
+      positions.set(key, current);
+    }
+    if (
+      [...positions.values()].some(
+        (entry) => entry.count > 1 && entry.containsTransformedEndpoint,
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function endpointsSharePhysicalComponent(

--- a/packages/edit-engine/src/transaction-route-annotations.ts
+++ b/packages/edit-engine/src/transaction-route-annotations.ts
@@ -153,8 +153,10 @@ function closestRouteAnchor(
 export function captureNetLabelRouteAnchors(
   document: SchematicDocument,
   resolver: SymbolResolver,
+  routeIds?: ReadonlySet<string>,
 ): NetLabelRouteAnchor[] {
   const polylines = document.routes.flatMap((route) => {
+    if (routeIds && !routeIds.has(route.id)) return [];
     const polyline = resolveRouteEditPath(document, resolver, route);
     return polyline ? [{ route, polyline }] : [];
   });
@@ -242,10 +244,12 @@ function arcFractionAt(
 export function captureRouteMarkerAnchors(
   document: SchematicDocument,
   resolver: SymbolResolver,
+  routeIds?: ReadonlySet<string>,
 ): RouteMarkerAnchor[] {
   return document.annotations.flatMap((annotation) => {
     const attachment = routeMarkerAttachment(annotation);
     if (!attachment) return [];
+    if (routeIds && !routeIds.has(attachment.routeId)) return [];
     const route = document.routes.find(
       (candidate) => candidate.id === attachment.routeId,
     );

--- a/packages/edit-engine/src/transaction-routing.ts
+++ b/packages/edit-engine/src/transaction-routing.ts
@@ -208,6 +208,7 @@ export function validateRoute(
   document: SchematicDocument,
   route: RouteBranch,
   resolver: SymbolResolver,
+  resolvedPath?: ReturnType<typeof resolveRouteEditPath>,
 ): string | null {
   const net = document.nets.find((candidate) => candidate.id === route.netId);
   if (!net) return `Route net does not exist: ${route.netId}`;
@@ -224,7 +225,10 @@ export function validateRoute(
   if (!endpointBelongsToNet(document, net, end)) {
     return `Route to endpoint is not a member of ${route.netId}`;
   }
-  const polyline = resolveRouteEditPath(document, resolver, route);
+  const polyline =
+    resolvedPath === undefined
+      ? resolveRouteEditPath(document, resolver, route)
+      : resolvedPath;
   if (!polyline) return `Route ${route.id} has an unresolved endpoint`;
   // Segment heading is geometry, not topology (ADR 0028), and ADR 0039 grants
   // the arbitrary-angle policy that ADR 0028 anticipated. Validation therefore

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -1,4 +1,4 @@
-import { SchematicDocumentSchema } from "@icm/model";
+import { routeEnd, SchematicDocumentSchema } from "@icm/model";
 import type { SchematicDocument } from "@icm/model";
 import {
   endpointKey,
@@ -25,7 +25,10 @@ import {
   applyInstancesRouteFollow,
   splitRoute,
 } from "./transaction-route-follow.js";
-import { reconcileTransformDirectContacts } from "./transaction-direct-contact.js";
+import {
+  reconcileTransformDirectContacts,
+  transformMaySeparateDirectContact,
+} from "./transaction-direct-contact.js";
 import { nextPhysicalContactOperation } from "./transaction-connectivity-normalizer.js";
 import { applyCellResetEdit } from "./transaction-cell-reset.js";
 import { applyCellInterfaceEdit } from "./transaction-cell-interface.js";
@@ -115,9 +118,6 @@ export function executeTransaction(
 
   const proposedRevision = document.revision + 1;
   const draft = structuredClone(document);
-  const originalNetContractIssueKeys = new Set(
-    validateLogicalNetContract(document).map(logicalNetContractIssueKey),
-  );
   const explicitlyAuthoredRouteIds = new Set(
     transaction.edits.flatMap((edit) =>
       edit.kind === "set_route_path" || edit.kind === "route_orthogonal"
@@ -137,25 +137,6 @@ export function executeTransaction(
       deferInto: deferredNetPruneIds,
     });
   const resolver = context.symbolResolver;
-  const originalRouteStates = new Map(
-    resolver
-      ? document.routes.map((route) => [
-          route.id,
-          {
-            points:
-              resolveRouteEditPath(document, resolver, route)?.points ?? null,
-            error: validateRoute(document, route, resolver),
-          },
-        ])
-      : [],
-  );
-  const originalNetLabelAnchors = resolver
-    ? captureNetLabelRouteAnchors(document, resolver)
-    : [];
-  const originalRouteMarkerAnchors = resolver
-    ? captureRouteMarkerAnchors(document, resolver)
-    : [];
-  const changedRouteIds = new Set<string>();
   const transformedInstanceIds = new Set(
     transaction.edits.flatMap((edit) =>
       edit.kind === "move_instance" ||
@@ -176,6 +157,59 @@ export function executeTransaction(
             : [],
     ),
   );
+  const routeValidationIds = transaction.edits.every((edit) =>
+    [
+      "noop",
+      "move_instance",
+      "rotate_instance",
+      "mirror_instance",
+      "align_instances",
+      "set_instance_signal_flow_parameters",
+    ].includes(edit.kind),
+  )
+    ? new Set(
+        document.routes.flatMap((route) =>
+          [route.start, routeEnd(route)].some(
+            (endpoint) =>
+              endpoint.kind === "terminal" &&
+              transformedInstanceIds.has(endpoint.instanceId),
+          )
+            ? [route.id]
+            : [],
+        ),
+      )
+    : undefined;
+  const originalRouteStates = new Map(
+    resolver
+      ? document.routes
+          .filter(
+            (route) =>
+              routeValidationIds === undefined ||
+              routeValidationIds.has(route.id),
+          )
+          .map((route) => {
+            const resolvedPath = resolveRouteEditPath(
+              document,
+              resolver,
+              route,
+            );
+            return [
+              route.id,
+              {
+                points: resolvedPath?.points ?? null,
+                error: validateRoute(document, route, resolver, resolvedPath),
+              },
+            ];
+          })
+      : [],
+  );
+  const originalNetLabelAnchors = resolver
+    ? captureNetLabelRouteAnchors(document, resolver, routeValidationIds)
+    : [];
+  const originalRouteMarkerAnchors = resolver
+    ? captureRouteMarkerAnchors(document, resolver, routeValidationIds)
+    : [];
+  const changedRouteIds = new Set<string>();
   let geometryChanged = false;
   let connectivityChanged = false;
 
@@ -515,16 +549,30 @@ export function executeTransaction(
         edit.kind === "set_instance_symbol",
     )
   ) {
-    const directContact = reconcileTransformDirectContacts(
-      document,
-      draft,
-      resolver,
-      transaction.transactionId,
-      changedObjectIds,
+    const movedJunctionIds = new Set(
+      transaction.edits.flatMap((edit) =>
+        edit.kind === "move_junction" ? [edit.junctionId] : [],
+      ),
     );
-    geometryChanged ||= directContact.geometryChanged;
-    for (const routeId of directContact.changedRouteIds) {
-      changedRouteIds.add(routeId);
+    if (
+      transformMaySeparateDirectContact(
+        document,
+        resolver,
+        transformedInstanceIds,
+        movedJunctionIds,
+      )
+    ) {
+      const directContact = reconcileTransformDirectContacts(
+        document,
+        draft,
+        resolver,
+        transaction.transactionId,
+        changedObjectIds,
+      );
+      geometryChanged ||= directContact.geometryChanged;
+      for (const routeId of directContact.changedRouteIds) {
+        changedRouteIds.add(routeId);
+      }
     }
   }
 
@@ -807,10 +855,17 @@ export function executeTransaction(
     draft.nets.length !== netCountBeforeDeferredPrune ||
     draft.connectivityEvidence.length !== evidenceCountBeforeDeferredPrune;
 
-  const introducedNetContractIssue = validateLogicalNetContract(draft).find(
-    (issue) =>
-      !originalNetContractIssueKeys.has(logicalNetContractIssueKey(issue)),
-  );
+  const originalNetContractIssueKeys = connectivityChanged
+    ? new Set(
+        validateLogicalNetContract(document).map(logicalNetContractIssueKey),
+      )
+    : new Set<string>();
+  const introducedNetContractIssue = connectivityChanged
+    ? validateLogicalNetContract(draft).find(
+        (issue) =>
+          !originalNetContractIssueKeys.has(logicalNetContractIssueKey(issue)),
+      )
+    : undefined;
   if (introducedNetContractIssue) {
     const message =
       introducedNetContractIssue.code === "CONFLICTING_LOGICAL_NET_SCOPE"
@@ -829,11 +884,18 @@ export function executeTransaction(
   }
 
   if (resolver) {
-    for (const route of draft.routes) {
-      const routeError = validateRoute(draft, route, resolver);
+    const routesToValidate =
+      routeValidationIds === undefined
+        ? draft.routes
+        : draft.routes.filter(
+            (route) =>
+              routeValidationIds.has(route.id) || changedRouteIds.has(route.id),
+          );
+    for (const route of routesToValidate) {
       const original = originalRouteStates.get(route.id);
-      const resolvedPoints =
-        resolveRouteEditPath(draft, resolver, route)?.points ?? null;
+      const resolvedPath = resolveRouteEditPath(draft, resolver, route);
+      const routeError = validateRoute(draft, route, resolver, resolvedPath);
+      const resolvedPoints = resolvedPath?.points ?? null;
       const resolvedGeometryChanged =
         original === undefined ||
         !sameResolvedRoutePoints(original.points, resolvedPoints);

--- a/packages/render-svg/src/render.test.ts
+++ b/packages/render-svg/src/render.test.ts
@@ -1,4 +1,8 @@
-import { createEmptyDocument } from "@icm/model";
+import { createEmptyDocument, createRoutePath } from "@icm/model";
+import {
+  deriveDocumentContactEvidence,
+  resolveDocumentRoutingGeometry,
+} from "@icm/derived";
 import { InMemorySymbolResolver } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
@@ -43,6 +47,41 @@ const definition = {
 };
 
 describe("render svg", () => {
+  it("renders identically from one shared routing read model", () => {
+    const doc = createEmptyDocument("shared", "Shared read model");
+    doc.nets.push({ id: "net", terminals: [] });
+    doc.junctions.push(
+      { id: "J1", netId: "net", position: { x: 0, y: 0 } },
+      { id: "J2", netId: "net", position: { x: 40, y: 0 } },
+    );
+    doc.routes.push(
+      createRoutePath({
+        id: "route",
+        netId: "net",
+        start: { kind: "junction", junctionId: "J1" },
+        end: { kind: "junction", junctionId: "J2" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+    const resolver = new InMemorySymbolResolver([]);
+    const routingGeometry = resolveDocumentRoutingGeometry(doc, resolver);
+    const contactEvidence = deriveDocumentContactEvidence(
+      doc,
+      resolver,
+      routingGeometry,
+    );
+
+    expect(
+      buildSvgScene(doc, resolver, { routingGeometry, contactEvidence }),
+    ).toEqual(buildSvgScene(doc, resolver));
+
+    doc.revision += 1;
+    expect(() => buildSvgScene(doc, resolver, { routingGeometry })).toThrow(
+      "SVG renderer received stale routing geometry",
+    );
+  });
+
   it("renders signal-flow-frame, 12pt formula, fraction line, dynamic leads, and keeps pin names", () => {
     const doc = createEmptyDocument("main", "Main");
     doc.instances.push({

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -28,6 +28,7 @@ import {
 import { flattenRichText } from "@icm/model";
 import type {
   EndpointJoin,
+  DocumentContactEvidence,
   ResolvedDocumentRoutingGeometry,
   ResolvedDraftingGeometry,
   SchematicStyleProfile,
@@ -70,6 +71,10 @@ export interface SvgRenderOptions {
   bounds?: GridRect;
   margin?: number;
   title?: string;
+  /** Revision-scoped routing read model supplied by a shared caller. */
+  routingGeometry?: ResolvedDocumentRoutingGeometry;
+  /** Contact evidence paired with `routingGeometry`; never persisted. */
+  contactEvidence?: DocumentContactEvidence;
 }
 
 export interface SvgScene {
@@ -669,7 +674,15 @@ export function buildSvgScene(
   if (!Number.isInteger(margin) || margin < 0) {
     throw new Error("SVG margin must be a non-negative integer");
   }
-  const routingGeometry = resolveDocumentRoutingGeometry(document, resolver);
+  const routingGeometry =
+    options.routingGeometry ??
+    resolveDocumentRoutingGeometry(document, resolver);
+  if (
+    routingGeometry.documentId !== document.id ||
+    routingGeometry.documentRevision !== document.revision
+  ) {
+    throw new Error("SVG renderer received stale routing geometry");
+  }
   const logicalNets = resolveDocumentLogicalNets(document);
   const powerRailNetIds = new Set(
     document.routes.flatMap((route) => {
@@ -726,11 +739,9 @@ export function buildSvgScene(
     routingGeometry.endpointJoins,
     profile,
   );
-  const contactEvidence = deriveDocumentContactEvidence(
-    document,
-    resolver,
-    routingGeometry,
-  );
+  const contactEvidence =
+    options.contactEvidence ??
+    deriveDocumentContactEvidence(document, resolver, routingGeometry);
   const junctions = contactEvidence.contacts
     .filter((contact) => {
       if (


### PR DESCRIPTION
## Summary
- share one revision-scoped routing/contact read model across renderer, diagnostics, and editor consumers
- narrow transform transaction validation and skip provably irrelevant contact normalization work
- replace all-pairs crossing and overlap scans with exact broad-phase sweeps

## Measured result
On the supplied 206-Net / 416-Route project, committed instance moves improve from about 0.60 s to about 0.38–0.41 s, Undo from about 0.32 s to about 0.26 s, crossing derivation from about 100 ms to 2–3 ms, and transaction work from about 216 ms to about 100 ms. Pan/zoom behavior is unchanged.

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main (1847 unit, 14 hierarchy browser, 120 editor browser)
- pnpm ci:check (production build/release/performance/goldens/smoke and 286 browser tests)

Test-Impact: tests-updated