### PR TITLE
perf: reduce committed scene and undo history overhead

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -1090,7 +1090,7 @@ export function App({
       releaseFormulaArtifacts();
     };
   }, [renderedDocument]);
-  const sceneState = useMemo(() => {
+  const committedSceneState = useMemo(() => {
     const outcome = buildSceneSafely(() => {
       if (sceneCrashRequested()) {
         throw new Error("scene build crashed (test hook)");
@@ -1099,11 +1099,10 @@ export function App({
       // camera-independent; rebuilding it during pan/zoom repeats all route,
       // symbol, text, and drafting derivation without changing one visible
       // object.
-      const documentConnectivity =
-        renderedDocument === document
-          ? projectConnectivityIndex.documents.get(document.id)
-          : undefined;
-      return buildSvgScene(renderedDocument, resolver, {
+      const documentConnectivity = projectConnectivityIndex.documents.get(
+        document.id,
+      );
+      return buildSvgScene(document, resolver, {
         ...(documentConnectivity
           ? {
               routingGeometry: documentConnectivity.routingGeometry,
@@ -1114,13 +1113,18 @@ export function App({
     }, lastGoodSceneRef.current);
     if (!outcome.degraded) lastGoodSceneRef.current = outcome.scene;
     return outcome;
-  }, [
-    document,
-    formulaArtifactRevision,
-    projectConnectivityIndex,
-    renderedDocument,
-    resolver,
-  ]);
+  }, [document, formulaArtifactRevision, projectConnectivityIndex, resolver]);
+  const sceneState = useMemo(() => {
+    if (renderedDocument === document) return committedSceneState;
+    const outcome = buildSceneSafely(() => {
+      if (sceneCrashRequested()) {
+        throw new Error("scene build crashed (test hook)");
+      }
+      return buildSvgScene(renderedDocument, resolver);
+    }, lastGoodSceneRef.current);
+    if (!outcome.degraded) lastGoodSceneRef.current = outcome.scene;
+    return outcome;
+  }, [committedSceneState, document, renderedDocument, resolver]);
   const scene = sceneState.scene;
   useEffect(() => {
     if (sceneState.degraded) {
@@ -2094,16 +2098,13 @@ export function App({
     (count, candidate) => count + candidate.instances.length,
     0,
   );
-  const contentScene = useMemo(() => {
-    try {
-      return buildSvgScene(document, resolver);
-    } catch {
-      // Fit view falls back to the default framing when the bounds scene
-      // cannot be built; the canvas itself renders through the guarded
-      // formal-scene pipeline above.
-      return null;
-    }
-  }, [document, resolver]);
+  // Fit and auto-fit describe committed content, never a transient move,
+  // handle, copy, or waveform preview. The committed formal scene already
+  // measured those exact bounds, so keep that single successful derivation
+  // instead of rebuilding the complete SVG solely to read its viewBox.
+  const contentSceneBounds = committedSceneState.degraded
+    ? null
+    : committedSceneState.scene.viewBox;
   const zoomPercent = Math.round((DEFAULT_VIEWBOX.width / viewBox.width) * 100);
   const canvasIsEmpty =
     document.instances.every((instance) => instance.placement === null) &&
@@ -2370,7 +2371,7 @@ export function App({
     model: { document, resolver, routeGeometryRecords, styleProfile },
     viewport: {
       defaultViewBox: DEFAULT_VIEWBOX,
-      contentBounds: contentScene?.viewBox,
+      contentBounds: contentSceneBounds,
       viewBox,
       setViewBox,
       pointFromClient: (clientX, clientY, svg) =>
@@ -2452,7 +2453,7 @@ export function App({
       pendingAutoFitRef.current = true;
     }
   }, [projectSessionId]);
-  const autoFitBounds = contentScene?.viewBox ?? null;
+  const autoFitBounds = contentSceneBounds;
   const autoFitHasContent = authoredObjectCount(project) > 0;
   useEffect(() => {
     if (!pendingAutoFitRef.current || !autoFitBounds) return;

--- a/apps/editor/src/app/scene-reuse.test.tsx
+++ b/apps/editor/src/app/scene-reuse.test.tsx
@@ -1,0 +1,20 @@
+import { createEmptyProject } from "@icm/model";
+import * as renderSvg from "@icm/render-svg";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { App } from "./App";
+
+describe("editor scene reuse", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("uses the committed formal scene bounds without a second SVG build", () => {
+    const build = vi.spyOn(renderSvg, "buildSvgScene");
+
+    renderToStaticMarkup(
+      <App project={createEmptyProject("scene-reuse", "Scene reuse")} />,
+    );
+
+    expect(build).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/edit-engine/src/document-structural-sharing.ts
+++ b/packages/edit-engine/src/document-structural-sharing.ts
@@ -1,0 +1,79 @@
+import type { SchematicDocument } from "@icm/model";
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stableId(value: unknown): string | undefined {
+  if (!isRecord(value)) return undefined;
+  return typeof value.id === "string" ? value.id : undefined;
+}
+
+function shareArray(before: unknown[], after: unknown[]): unknown[] {
+  const beforeById = new Map<string, unknown>();
+  for (const value of before) {
+    const id = stableId(value);
+    if (id !== undefined) beforeById.set(id, value);
+  }
+
+  const shared = after.map((value, index) => {
+    const id = stableId(value);
+    const candidate =
+      id === undefined ? before[index] : (beforeById.get(id) ?? before[index]);
+    return shareJsonStructure(candidate, value);
+  });
+
+  if (
+    shared.length === before.length &&
+    shared.every((value, index) => value === before[index])
+  ) {
+    return before;
+  }
+  return shared;
+}
+
+function shareRecord(before: JsonRecord, after: JsonRecord): JsonRecord {
+  const beforeKeys = Object.keys(before);
+  const afterKeys = Object.keys(after);
+  const shared: JsonRecord = {};
+  let unchanged = beforeKeys.length === afterKeys.length;
+
+  for (const key of afterKeys) {
+    const value = shareJsonStructure(before[key], after[key]);
+    shared[key] = value;
+    if (!Object.hasOwn(before, key) || value !== before[key]) {
+      unchanged = false;
+    }
+  }
+
+  return unchanged ? before : shared;
+}
+
+/**
+ * Reuses references from a previous JSON-compatible model tree wherever the
+ * next tree contains exactly the same value. Arrays of model objects are
+ * matched by stable id so an insertion or reorder does not forfeit sharing.
+ *
+ * The edit engine calls this only after the next document has passed the model
+ * schema. It is a storage optimization: the returned tree is value-equivalent
+ * to `after` and changed nodes never reuse their previous object.
+ */
+function shareJsonStructure(before: unknown, after: unknown): unknown {
+  if (Object.is(before, after)) return before;
+  if (Array.isArray(before) && Array.isArray(after)) {
+    return shareArray(before, after);
+  }
+  if (isRecord(before) && isRecord(after)) {
+    return shareRecord(before, after);
+  }
+  return after;
+}
+
+export function shareEqualDocumentStructure(
+  before: SchematicDocument,
+  after: SchematicDocument,
+): SchematicDocument {
+  return shareJsonStructure(before, after) as SchematicDocument;
+}

--- a/packages/edit-engine/src/history.test.ts
+++ b/packages/edit-engine/src/history.test.ts
@@ -18,6 +18,34 @@ function historyFixture() {
   return new DocumentHistory(document);
 }
 
+function structuralSharingFixture() {
+  const document = createEmptyDocument("document-main", "Main");
+  document.instances.push(
+    {
+      id: "R1",
+      symbolId: "resistor",
+      placement: null,
+      netlist: {
+        reference: "R1",
+        binding: { kind: "primitive", deviceClass: "resistor" },
+        parameters: { value: "1k" },
+      },
+    },
+    {
+      id: "R2",
+      symbolId: "resistor",
+      placement: null,
+      netlist: {
+        reference: "R2",
+        binding: { kind: "primitive", deviceClass: "resistor" },
+        parameters: { value: "2k" },
+      },
+    },
+  );
+  document.nets.push({ id: "net-signal", terminals: [] });
+  return new DocumentHistory(document);
+}
+
 function transaction(revision: number, edits: unknown[], dryRun = false) {
   return {
     transactionId: `transaction-${revision}-${String((edits[0] as { kind?: string }).kind)}`,
@@ -30,6 +58,79 @@ function transaction(revision: number, edits: unknown[], dryRun = false) {
 }
 
 describe("DocumentHistory", () => {
+  it("shares unchanged model structure without sharing changed objects", () => {
+    const history = structuralSharingFixture();
+    const before = history.document;
+    const beforeR1 = before.instances[0]!;
+    const beforeR2 = before.instances[1]!;
+    const beforeR1Netlist = beforeR1.netlist!;
+
+    const result = history.transact(
+      transaction(0, [
+        {
+          kind: "place_instance",
+          instanceId: "R1",
+          placement: {
+            position: { x: 50, y: 40 },
+            rotation: 0,
+            mirror: "none",
+          },
+        },
+      ]),
+    );
+
+    expect(result).toMatchObject({ ok: true, applied: true, revision: 1 });
+    if (!result.ok) throw new Error("Expected transaction to succeed");
+    expect(result.document).toBe(history.document);
+    expect(history.document).not.toBe(before);
+    expect(history.document.instances).not.toBe(before.instances);
+    expect(history.document.instances[0]).not.toBe(beforeR1);
+    expect(history.document.instances[0]?.netlist).toBe(beforeR1Netlist);
+    expect(history.document.instances[1]).toBe(beforeR2);
+    expect(history.document.nets).toBe(before.nets);
+    expect(history.document.presentation).toBe(before.presentation);
+  });
+
+  it("reuses the exact target state objects across undo and redo", () => {
+    const history = structuralSharingFixture();
+    const initial = history.document;
+    const initialR1 = initial.instances[0]!;
+    const initialR2 = initial.instances[1]!;
+
+    const placed = history.transact(
+      transaction(0, [
+        {
+          kind: "place_instance",
+          instanceId: "R1",
+          placement: {
+            position: { x: 50, y: 40 },
+            rotation: 0,
+            mirror: "none",
+          },
+        },
+      ]),
+    );
+    if (!placed.ok) throw new Error("Expected transaction to succeed");
+    const placedR1 = placed.document.instances[0]!;
+
+    const undone = history.transact(transaction(1, [{ kind: "undo" }]));
+    expect(undone).toMatchObject({ ok: true, applied: true, revision: 2 });
+    if (!undone.ok) throw new Error("Expected undo to succeed");
+    expect(undone.document.instances[0]).toBe(initialR1);
+    expect(undone.document.instances[1]).toBe(initialR2);
+    expect(undone.document.instances[0]?.placement).toBeNull();
+
+    const redone = history.transact(transaction(2, [{ kind: "redo" }]));
+    expect(redone).toMatchObject({ ok: true, applied: true, revision: 3 });
+    if (!redone.ok) throw new Error("Expected redo to succeed");
+    expect(redone.document.instances[0]).toBe(placedR1);
+    expect(redone.document.instances[1]).toBe(initialR2);
+    expect(redone.document.instances[0]?.placement?.position).toEqual({
+      x: 50,
+      y: 40,
+    });
+  });
+
   it("clears every authored collection atomically and restores it with undo", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.sourceBinding = {

--- a/packages/edit-engine/src/history.ts
+++ b/packages/edit-engine/src/history.ts
@@ -1,6 +1,7 @@
 import { SchematicDocumentSchema } from "@icm/model";
 import type { SchematicDocument } from "@icm/model";
 
+import { shareEqualDocumentStructure } from "./document-structural-sharing.js";
 import {
   EditTransactionSchema,
   executeTransaction,
@@ -105,12 +106,14 @@ export class DocumentHistory {
       const before = this.#document;
       const result = executeTransaction(before, transaction, this.#context);
       if (result.ok && result.applied) {
+        const document = shareEqualDocumentStructure(before, result.document);
         this.#undoStack.push(before);
         if (this.#undoStack.length > this.#historyLimit) {
           this.#undoStack.shift();
         }
         this.#redoStack.length = 0;
-        this.#document = result.document;
+        this.#document = document;
+        return { ...result, document };
       }
       return result;
     }
@@ -149,10 +152,11 @@ export class DocumentHistory {
     }
 
     const proposedRevision = this.#document.revision + 1;
-    const restored = SchematicDocumentSchema.parse({
+    const parsedRestored = SchematicDocumentSchema.parse({
       ...structuredClone(target),
       revision: proposedRevision,
     });
+    const restored = shareEqualDocumentStructure(target, parsedRestored);
     const diff: EditDiff = {
       documentId: this.#document.id,
       fromRevision: this.#document.revision,


### PR DESCRIPTION
## Summary
- reuse the committed scene viewBox instead of rebuilding the same SVG scene for content bounds
- keep transient drag previews isolated from Fit/AutoFit bounds
- structurally share value-equal document subtrees across full Undo/Redo snapshots
- preserve transaction, revision, history depth, and rendering behavior

## Measured impact
- 64-edit history heap growth on the 400 KB large-project fixture: about 61.96 MB to 2.77 MB
- median edit latency remains about 19.35 ms
- removes the duplicate committed scene build previously measured around 142 ms on the large fixture

## Validation
- gate:preflight
- gate:affected: 1852 unit, 14 hierarchy browser, 120 manual-editor browser tests
- gate:full: static, 1852 unit, production build/release/goldens/smoke/performance, 286 browser tests