### PR TITLE
fix(editor): attach every pin landing on one wire on placement and move snap

### DIFF
--- a/apps/editor/src/features/component-insert/placement-connectivity.test.ts
+++ b/apps/editor/src/features/component-insert/placement-connectivity.test.ts
@@ -1,4 +1,4 @@
-import { createRoutePath } from "@icm/model";
+import { createRoutePath, routeEnd, type RouteEndpoint } from "@icm/model";
 import { executeTransaction, planInstanceDeletion } from "@icm/edit-engine";
 import { resolveDocumentLogicalNets } from "@icm/derived";
 import { createEmptyDocument, transformPoint } from "@icm/model";
@@ -727,5 +727,163 @@ describe("naming a supply marker", () => {
       return logical.byBaseNetId.get(net.id)?.id;
     };
     expect(logicalIdOf("VDD1")).toBe(logicalIdOf("VDD2"));
+  });
+});
+
+describe("multi-pin placement onto one conductor", () => {
+  function verticalWireDocument() {
+    const document = createEmptyDocument("main", "Main");
+    document.nets.push({ id: "n1", terminals: [] });
+    document.junctions.push(
+      {
+        id: "J1",
+        netId: "n1",
+        position: { x: 100, y: 0 },
+        role: "route-anchor",
+      },
+      {
+        id: "J2",
+        netId: "n1",
+        position: { x: 100, y: 200 },
+        role: "route-anchor",
+      },
+    );
+    document.routes.push(
+      createRoutePath({
+        id: "R1",
+        netId: "n1",
+        start: { kind: "junction", junctionId: "J1" },
+        end: { kind: "junction", junctionId: "J2" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+    return document;
+  }
+
+  function endpointName(endpoint: RouteEndpoint): string {
+    return endpoint.kind === "junction"
+      ? endpoint.junctionId
+      : `${endpoint.instanceId}.${endpoint.pinName}`;
+  }
+
+  it("attaches both pins of a current source dropped onto one wire (feedback image 6/7)", () => {
+    const document = verticalWireDocument();
+    // current-source pins: "+" at (0,-20), "-" at (0,20). Placed at
+    // (100,100), both pins land on R1's interior: (100,80) and (100,120).
+    const source = {
+      id: "I1",
+      symbolId: "current-source",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0 as const,
+        mirror: "none" as const,
+      },
+    };
+    const proposal = proposePlacementContact(document, resolver, source, []);
+    expect(proposal.ambiguous).toBe(false);
+    expect(proposal.matched).toBe(true);
+    const committed = executeTransaction(
+      document,
+      transaction(0, [
+        { kind: "add_instance", instance: source },
+        ...proposal.edits,
+      ]),
+      context,
+    );
+    expect(committed.ok).toBe(true);
+    if (!committed.ok) return;
+    // The wire is cut into three series segments through the device:
+    // J1 -> "+", "+" -> "-", "-" -> J2.
+    expect(committed.document.routes).toHaveLength(3);
+    const spans = committed.document.routes.map(
+      (route) =>
+        `${endpointName(route.start)}->${endpointName(routeEnd(route))}`,
+    );
+    expect(new Set(spans)).toEqual(
+      new Set(["J1->I1.+", "I1.+->I1.-", "I1.-->J2"]),
+    );
+    // Both pins joined the wire's Net.
+    const net = committed.document.nets.find(
+      (candidate) => candidate.id === "n1",
+    )!;
+    expect(net.terminals).toEqual(
+      expect.arrayContaining([
+        { instanceId: "I1", pinName: "+" },
+        { instanceId: "I1", pinName: "-" },
+      ]),
+    );
+    // The series-insertion workflow: the middle segment between the pins is
+    // its own Route and can be deleted on its own.
+    const middle = committed.document.routes.find(
+      (route) =>
+        route.start.kind === "terminal" && routeEnd(route).kind === "terminal",
+    );
+    expect(middle).toBeDefined();
+  });
+
+  it("keeps rejecting one pin that touches two disconnected conductors", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.nets.push(
+      { id: "n1", terminals: [] },
+      { id: "n2", terminals: [] },
+    );
+    document.junctions.push(
+      {
+        id: "J1",
+        netId: "n1",
+        position: { x: 100, y: 0 },
+        role: "route-anchor",
+      },
+      {
+        id: "J2",
+        netId: "n1",
+        position: { x: 100, y: 200 },
+        role: "route-anchor",
+      },
+      {
+        id: "J3",
+        netId: "n2",
+        position: { x: 0, y: 80 },
+        role: "route-anchor",
+      },
+      {
+        id: "J4",
+        netId: "n2",
+        position: { x: 200, y: 80 },
+        role: "route-anchor",
+      },
+    );
+    document.routes.push(
+      createRoutePath({
+        id: "R1",
+        netId: "n1",
+        start: { kind: "junction", junctionId: "J1" },
+        end: { kind: "junction", junctionId: "J2" },
+        bends: [],
+        modes: ["manual"],
+      }),
+      createRoutePath({
+        id: "R2",
+        netId: "n2",
+        start: { kind: "junction", junctionId: "J3" },
+        end: { kind: "junction", junctionId: "J4" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+    // "+" pin lands at (100,80): the crossing of two disconnected conductors.
+    const source = {
+      id: "I1",
+      symbolId: "current-source",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0 as const,
+        mirror: "none" as const,
+      },
+    };
+    const proposal = proposePlacementContact(document, resolver, source, []);
+    expect(proposal).toMatchObject({ matched: false, ambiguous: true });
+    expect(proposal.edits).toHaveLength(0);
   });
 });

--- a/apps/editor/src/features/component-insert/placement-connectivity.ts
+++ b/apps/editor/src/features/component-insert/placement-connectivity.ts
@@ -3,6 +3,7 @@ import {
   planElectricalMarkerRename,
   planEnsurePowerNet,
   proposeEndpointRouteAttachment,
+  proposeEndpointsRouteAttachment,
   type SchematicEdit,
   type WireSource,
 } from "@icm/edit-engine";
@@ -138,6 +139,8 @@ function samePoint(
  * pin-to-pin, pin-to-Junction, or pin-to-Route contact. Grid coincidence alone
  * is deliberately insufficient. Multiple independent contacts commit
  * together; multiple disconnected conductors at one point remain ambiguous.
+ * Several pins landing on one conductor at distinct points are the
+ * series-insertion drop and attach together, cutting the Route at each pin.
  */
 export function proposePlacementContact(
   document: SchematicDocument,
@@ -197,11 +200,33 @@ export function proposePlacementContact(
   if (contacts.length === 0) {
     return { edits: [], matched: false, ambiguous: false };
   }
-  const routeIds = contacts.flatMap((contact) =>
-    contact.target.route ? [contact.target.route.routeId] : [],
-  );
-  if (new Set(routeIds).size !== routeIds.length) {
-    return { edits: [], matched: false, ambiguous: true };
+  // Several pins of one device may land on the SAME conductor — that is the
+  // series-insertion gesture, not an ambiguity. Group those contacts per
+  // Route and attach them together; only two pins claiming the exact same
+  // point remain ambiguous.
+  const routeContactGroups = new Map<
+    string,
+    Array<{
+      source: WireSource;
+      route: NonNullable<ElectricalContactTarget["route"]>;
+    }>
+  >();
+  for (const contact of contacts) {
+    const route = contact.target.route;
+    if (!route || contact.target.endpoint) continue;
+    routeContactGroups.set(route.routeId, [
+      ...(routeContactGroups.get(route.routeId) ?? []),
+      { source: contact.source, route },
+    ]);
+  }
+  for (const group of routeContactGroups.values()) {
+    const pointKeys = group.map(
+      (member) =>
+        `${member.source.connection.contactPoint.x},${member.source.connection.contactPoint.y}`,
+    );
+    if (new Set(pointKeys).size !== pointKeys.length) {
+      return { edits: [], matched: false, ambiguous: true };
+    }
   }
   const power =
     POWER_CONNECTION_BY_SYMBOL[
@@ -247,17 +272,34 @@ export function proposePlacementContact(
       }
       netId = target.endpoint.netId ?? newNetId;
     } else if (target.route) {
-      edits.push(
-        ...proposeEndpointRouteAttachment(
-          document,
-          source.endpoint,
-          null,
-          target.route.routeId,
-          source.connection.contactPoint,
-          target.route.segmentIndex,
-          `contact-${instance.id.toLowerCase()}-${source.endpoint.kind === "terminal" ? source.endpoint.pinName.toLowerCase() : "pin"}`,
-        ).edits,
-      );
+      const group = routeContactGroups.get(target.route.routeId) ?? [];
+      if (group[0]?.source === source) {
+        edits.push(
+          ...(group.length === 1
+            ? proposeEndpointRouteAttachment(
+                document,
+                source.endpoint,
+                null,
+                target.route.routeId,
+                source.connection.contactPoint,
+                target.route.segmentIndex,
+                `contact-${instance.id.toLowerCase()}-${source.endpoint.kind === "terminal" ? source.endpoint.pinName.toLowerCase() : "pin"}`,
+              )
+            : proposeEndpointsRouteAttachment(
+                document,
+                resolver,
+                target.route.routeId,
+                group.map((member) => ({
+                  endpoint: member.source.endpoint,
+                  endpointNetId: null,
+                  point: member.source.connection.contactPoint,
+                  segmentIndex: member.route.segmentIndex,
+                })),
+                `contact-${instance.id.toLowerCase()}`,
+              )
+          ).edits,
+        );
+      }
       if (power) powerNetId = target.route.netId;
       if (power) powerCandidateState = "existing";
       netId = target.route.netId;

--- a/apps/editor/src/features/selection/pin-attach-move.test.ts
+++ b/apps/editor/src/features/selection/pin-attach-move.test.ts
@@ -8,6 +8,7 @@ import { resolve } from "node:path";
 
 import {
   createRoutePath,
+  routeEnd,
   type RouteEndpoint,
   type SchematicDocument,
 } from "@icm/model";
@@ -227,5 +228,146 @@ describe("pin-onto-wire move snap float dust", () => {
     expect(statuses.some((s) => s.includes("Snapped pin endpoints"))).toBe(
       true,
     );
+  });
+});
+
+describe("two-pin device moved onto one wire", () => {
+  function runTwoPinMove() {
+    const seeded = routedDocument();
+    // A current source rotated 90° has horizontal pins: "+" (0,-20) maps to
+    // (+20,0), "-" (0,20) maps to (-20,0).
+    const added = executeTransaction(
+      seeded,
+      {
+        transactionId: "seed-current-source",
+        documentId: seeded.id,
+        expectedRevision: seeded.revision,
+        actor: { kind: "human", id: "test" },
+        edits: [
+          {
+            kind: "add_instance",
+            instance: {
+              id: "I1",
+              symbolId: "current-source",
+              placement: {
+                position: { x: 50, y: 180 },
+                rotation: 90,
+                mirror: "none",
+              },
+            },
+          },
+        ],
+      },
+      { symbolResolver: resolver },
+    );
+    if (!added.ok) throw new Error(`seed failed: ${added.error.message}`);
+    let document = added.document;
+    const statuses: string[] = [];
+    const results: ReturnType<typeof executeTransaction>[] = [];
+    const transactConnectivity = (
+      intent: RoutingOperationIntent,
+      edits: readonly SchematicEdit[],
+    ) => {
+      const proposal = createRoutingOperationPlan(document, {
+        intent,
+        edits,
+        diagnostics: [],
+      });
+      const gate = gateRoutingOperationPlan(document, proposal, {
+        symbolResolver: resolver,
+      });
+      if (!gate.ok) {
+        statuses.push(gate.message);
+        return null;
+      }
+      const result = executeTransaction(
+        document,
+        {
+          transactionId: "two-pin-move-commit",
+          documentId: document.id,
+          expectedRevision: document.revision,
+          actor: { kind: "human", id: "test" },
+          edits: [...gate.edits],
+        },
+        { symbolResolver: resolver },
+      );
+      results.push(result);
+      if (result.ok) document = result.document;
+      else statuses.push(`${result.error.code}: ${result.error.message}`);
+      return { ok: result.ok };
+    };
+    const controller = createSelectionMoveController({
+      document,
+      resolver,
+      visibleEndpoints: [],
+      routeGeometryRecords: [],
+      contactComponents: [],
+      transactConnectivity,
+      setStatus: (status) => statuses.push(status),
+      nextRoutingSuffix: () => 7,
+    });
+    const movePlan = planSelectionMove(document, {
+      instanceIds: ["I1"],
+      routeIds: [],
+      junctionIds: [],
+      annotationIds: [],
+      draftingIds: [],
+    });
+    const preview = {
+      instanceIds: movePlan.instanceIds,
+      primaryInstanceId: "I1",
+      originalPositions: { I1: { x: 50, y: 180 } },
+      pointerStart: { x: 500, y: 500 },
+      movePlan,
+    };
+    // Drop the device body onto route-h: pins land at (30,300) and (70,300),
+    // both strictly inside the wire span (0,300)-(110,300).
+    const position = { x: 500, y: 500 + 120 };
+    const tolerance = 7;
+    const resolved = controller.resolveInstanceMove(
+      preview,
+      position,
+      tolerance,
+      false,
+      undefined,
+      document,
+    );
+    controller.completeInstanceMove(
+      preview,
+      position,
+      tolerance,
+      false,
+      resolved.snap,
+      {
+        document,
+        prefixEdits: [],
+        resolvedMove: resolved,
+      },
+    );
+    return { document, resolved, statuses, results };
+  }
+
+  it("attaches both pins and cuts the wire into three series segments", () => {
+    const { document, resolved, results } = runTwoPinMove();
+    expect(resolved.snap.electricalMatch?.target.electrical?.kind).toBe(
+      "route",
+    );
+    expect(results.some((result) => result.ok)).toBe(true);
+    const net = document.nets.find((candidate) => candidate.id === "net-h")!;
+    expect(net.terminals).toEqual(
+      expect.arrayContaining([
+        { instanceId: "I1", pinName: "+" },
+        { instanceId: "I1", pinName: "-" },
+      ]),
+    );
+    // route-h + the two device terminals = three series segments.
+    expect(document.routes).toHaveLength(3);
+    const middle = document.routes.find(
+      (route) =>
+        route.start.kind === "terminal" &&
+        route.start.instanceId === "I1" &&
+        routeEnd(route).kind === "terminal",
+    );
+    expect(middle).toBeDefined();
   });
 });

--- a/apps/editor/src/features/selection/selection-move-controller.ts
+++ b/apps/editor/src/features/selection/selection-move-controller.ts
@@ -1,13 +1,15 @@
 import {
   planDirectEndpointConnection,
-  proposeEndpointRouteAttachment,
+  proposeEndpointsRouteAttachment,
   planRoutingTransform,
+  type EndpointRouteAttachmentRequest,
   type RoutingOperationIntent,
   type SchematicEdit,
   type WireSource,
 } from "@icm/edit-engine";
 import {
   deriveNetConnectivity,
+  findRouteSegmentsAtPoint,
   isMosBulkTerminal,
   isVisibleEndpoint,
   resolveDocumentRoutingGeometry,
@@ -54,6 +56,95 @@ import type {
 import type { SelectionMovePlan } from "./selection-move-plan";
 
 type TransactionResult = { ok: boolean };
+
+/**
+ * The pins the snapped move actually lands on the matched conductor.
+ *
+ * The snap match names one moving pin, but the drop-a-device-into-a-wire
+ * gesture lands every series pin of the device on the same Route; the
+ * explicit snap intent covers the whole device, so every visible pin of the
+ * matched instance whose contact lies on that Route attaches. Other selected
+ * instances and other conductors are untouched — a plain transform still
+ * never bonds. Falls back to the single matched endpoint when nothing beyond
+ * it qualifies, so degenerate matches keep their previous behavior.
+ */
+function routeAttachRequestsForMovedPins(
+  projected: SchematicDocument,
+  resolver: SymbolResolver,
+  moving: { endpoint: RouteEndpoint; netId: string | null },
+  target: { routeId: string; segmentIndex: number },
+): EndpointRouteAttachmentRequest[] {
+  const fallback = (): EndpointRouteAttachmentRequest[] => {
+    const connection = resolveEndpointConnection(
+      projected,
+      resolver,
+      moving.endpoint,
+    );
+    return connection
+      ? [
+          {
+            endpoint: moving.endpoint,
+            endpointNetId: moving.netId,
+            point: connection.contactPoint,
+            segmentIndex: target.segmentIndex,
+          },
+        ]
+      : [];
+  };
+  if (moving.endpoint.kind !== "terminal") return fallback();
+  const movingInstanceId = moving.endpoint.instanceId;
+  const instance = projected.instances.find(
+    (candidate) => candidate.id === movingInstanceId,
+  );
+  const resolved = instance
+    ? resolver.resolve(instance.symbolId, instance.symbolVariantId)
+    : null;
+  if (!instance || !resolved) return fallback();
+  const geometry = resolveDocumentRoutingGeometry(projected, resolver);
+  const requests: EndpointRouteAttachmentRequest[] = [];
+  for (const pin of resolved.definition.pins) {
+    if (resolved.variant?.hiddenPinNames.includes(pin.name)) continue;
+    if (pin.presentation.visibility === "implicit") continue;
+    const endpoint: RouteEndpoint = {
+      kind: "terminal",
+      instanceId: instance.id,
+      pinName: pin.name,
+    };
+    // A pin that already terminates a Route is attached; splitting at a
+    // Route end would only create degenerate geometry.
+    const alreadyAttached = projected.routes.some((route) =>
+      routeEndpoints(route).some(
+        (candidate) =>
+          candidate.kind === "terminal" &&
+          candidate.instanceId === instance.id &&
+          candidate.pinName === pin.name,
+      ),
+    );
+    if (alreadyAttached) continue;
+    const connection = resolveEndpointConnection(projected, resolver, endpoint);
+    if (!connection) continue;
+    const address = findRouteSegmentsAtPoint(
+      geometry,
+      connection.contactPoint,
+    ).find((candidate) => candidate.routeId === target.routeId);
+    if (!address) continue;
+    const netId =
+      projected.nets.find((net) =>
+        net.terminals.some(
+          (terminal) =>
+            terminal.instanceId === instance.id &&
+            terminal.pinName === pin.name,
+        ),
+      )?.id ?? null;
+    requests.push({
+      endpoint,
+      endpointNetId: netId,
+      point: connection.contactPoint,
+      segmentIndex: address.segmentIndex,
+    });
+  }
+  return requests.length > 0 ? requests : fallback();
+}
 
 export function createSelectionMoveController({
   document,
@@ -497,29 +588,26 @@ export function createSelectionMoveController({
       }
       // The snap target point is a float projection and can carry dust
       // (29.999999999999996) that the integer Point schema rejects, killing
-      // the whole move at release. The endpoint's own resolved contact point
+      // the whole move at release. Each endpoint's own resolved contact point
       // in the projected document is grid-exact by construction — attach
       // there, exactly like placement does.
-      const attachContact =
+      const attachRequests: readonly EndpointRouteAttachmentRequest[] =
         movingElectrical?.kind === "endpoint" &&
         targetElectrical?.kind === "route"
-          ? resolveEndpointConnection(
+          ? routeAttachRequestsForMovedPins(
               projected,
               resolver,
-              movingElectrical.endpoint,
+              movingElectrical,
+              targetElectrical,
             )
-          : null;
+          : [];
       const contactEdits: readonly SchematicEdit[] =
-        movingElectrical?.kind === "endpoint" &&
-        targetElectrical?.kind === "route" &&
-        attachContact
-          ? proposeEndpointRouteAttachment(
+        targetElectrical?.kind === "route" && attachRequests.length > 0
+          ? proposeEndpointsRouteAttachment(
               projected,
-              movingElectrical.endpoint,
-              movingElectrical.netId,
+              resolver,
               targetElectrical.routeId,
-              attachContact.contactPoint,
-              targetElectrical.segmentIndex,
+              attachRequests,
               `move-${nextRoutingSuffix()}`,
             ).edits
           : [];

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -5,6 +5,7 @@ import {
   isMosBulkTerminal,
   pointOnSegment,
   resolveEndpointConnection,
+  resolveRouteGeometry,
   segmentLength,
   type EndpointConnection,
   type EndpointRoutingGeometry,
@@ -142,6 +143,123 @@ export function proposeEndpointRouteAttachment(
     secondRouteId: routeIds[1],
   });
   return { netId: route.netId, routeIds, edits };
+}
+
+export interface EndpointRouteAttachmentRequest {
+  endpoint: RouteEndpoint;
+  endpointNetId: string | null;
+  point: Point;
+  segmentIndex: number;
+}
+
+export interface EndpointsRouteAttachmentProposal {
+  netId: string;
+  /** Final Route segments in start-to-end order after every attach. */
+  routeIds: readonly string[];
+  edits: SchematicEdit[];
+}
+
+/**
+ * Attach several real endpoints to one Route in one transaction.
+ *
+ * The device-into-wire gesture lands more than one pin on the same conductor,
+ * and each pin must become a real Route endpoint. Attaches are emitted
+ * far-to-near along the Route: every attach splits the current start-side
+ * piece, and the start side of a split retains its Route id and original leg
+ * identity, so each later edit can address the leg it computed against the
+ * original Route.
+ */
+export function proposeEndpointsRouteAttachment(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  routeId: string,
+  requests: readonly EndpointRouteAttachmentRequest[],
+  suffix: string,
+): EndpointsRouteAttachmentProposal {
+  if (requests.length === 0) {
+    throw new Error("Route attachment requires at least one endpoint");
+  }
+  if (requests.length === 1) {
+    const only = requests[0]!;
+    return proposeEndpointRouteAttachment(
+      document,
+      only.endpoint,
+      only.endpointNetId,
+      routeId,
+      only.point,
+      only.segmentIndex,
+      suffix,
+    );
+  }
+  const route = document.routes.find((candidate) => candidate.id === routeId);
+  if (!route) throw new Error(`Route not found: ${routeId}`);
+  const centerline = resolveRouteGeometry(
+    document,
+    resolver,
+    route,
+  )?.centerline;
+  if (!centerline) {
+    throw new Error(`Route has an unresolved endpoint: ${routeId}`);
+  }
+  const ordered = requests
+    .map((request) => {
+      const leg = route.legs[request.segmentIndex];
+      if (!leg) {
+        throw new Error(
+          `Route leg index is out of range: ${request.segmentIndex}`,
+        );
+      }
+      const offset = pathOffsetAtPoint(centerline, request.point);
+      if (offset === null) {
+        throw new Error(`Attachment point is not on Route ${routeId}`);
+      }
+      return { request, legId: leg.id, offset };
+    })
+    .sort((left, right) => right.offset - left.offset);
+  for (let index = 1; index < ordered.length; index += 1) {
+    if (ordered[index]!.offset === ordered[index - 1]!.offset) {
+      throw new Error("Two endpoints cannot attach at the same Route point");
+    }
+  }
+  const edits: SchematicEdit[] = [];
+  const mergedNetIds = new Set<string>();
+  for (const { request } of ordered) {
+    if (
+      request.endpointNetId &&
+      request.endpointNetId !== route.netId &&
+      !mergedNetIds.has(request.endpointNetId)
+    ) {
+      mergedNetIds.add(request.endpointNetId);
+      edits.push({
+        kind: "merge_nets",
+        targetNetId: route.netId,
+        sourceNetId: request.endpointNetId,
+      });
+    }
+  }
+  let currentRouteId = route.id;
+  const tailRouteIds: string[] = [];
+  ordered.forEach((entry, index) => {
+    const marker = `${suffix}-p${index + 1}`;
+    const firstRouteId = `${route.id}-a-${marker}`;
+    const secondRouteId = `${route.id}-b-${marker}`;
+    edits.push({
+      kind: "attach_endpoint_to_route",
+      endpoint: entry.request.endpoint,
+      routeId: currentRouteId,
+      point: entry.request.point,
+      legId: entry.legId,
+      firstRouteId,
+      secondRouteId,
+    });
+    tailRouteIds.push(secondRouteId);
+    currentRouteId = firstRouteId;
+  });
+  return {
+    netId: route.netId,
+    routeIds: [currentRouteId, ...tailRouteIds.reverse()],
+    edits,
+  };
 }
 
 export type WireIntentAnchor =


### PR DESCRIPTION
## Problem

User feedback comparing Cadence wire handling (feedback doc, images 6/7): drop a current source onto a wire and the wire is expected to be cut into three series segments through the device — enabling the standard series-insertion workflow of dropping a device on a wire and deleting the middle segment.

Today the gesture does worse than "not splitting": the device is left with **no electrical connection at all**.

- **Placement**: `proposePlacementContact` treated two pins landing on the *same* Route as ambiguous (`new Set(routeIds).size !== routeIds.length`) and emitted zero edits. The guard's own doc comment only defends ambiguity for *multiple disconnected conductors at one point*; one conductor at N distinct points was an unhandled case.
- **Move**: the snap flow handled exactly one `electricalMatch`, so at most one pin of the dragged device attached.

Single-pin attach already worked on both paths (`attach_endpoint_to_route` splits the Route at the pin terminal).

## Change

- **`@icm/edit-engine`**: new `proposeEndpointsRouteAttachment` planner — attach several endpoints to one Route in a single transaction. Attaches are emitted **far-to-near** along the Route: every attach splits the current start-side piece, and the start side of a split retains the planner-chosen route id and the original leg identity (ADR 0047 start-side retention), so each later edit can address the leg it computed against the original Route. A single request delegates to the existing single-attach planner, keeping id shapes unchanged.
- **Placement** (`placement-connectivity.ts`): pins of the placed instance landing on the same conductor at distinct points attach as one group, cutting the Route at each pin. Still ambiguous (unchanged): a pin touching two disconnected conductors at one point, and (new, explicit) two pins claiming the exact same point.
- **Move** (`selection-move-controller.ts`): when the snap's electrical match targets a Route, every visible pin of the matched instance that lands on that Route attaches — the explicit snap intent covers the whole device. Pins already terminating a Route are skipped; degenerate matches fall back to the previous single-endpoint behavior; other selected instances and other conductors are untouched, so plain transforms still never bond (`connectivity-and-routing.md` authoring rules hold).

No canonical-form work is included: no route merging, no normalization, no bend splitting. This is Step 0 from the wire-segmentation design assessment — the smallest change that removes the reported workflow pain.

## Validation

- Red-first at both layers (failing before the fix, for the right reason):
  - `placement-connectivity.test.ts` — "attaches both pins of a current source dropped onto one wire (feedback image 6/7)": asserts `J1 -> I1.+`, `I1.+ -> I1.-`, `I1.- -> J2` and both pins in the wire's Net; plus a guard test that one pin touching two disconnected conductors stays ambiguous.
  - `pin-attach-move.test.ts` — "attaches both pins and cuts the wire into three series segments": drives the real selection-move controller with the real snap.
- Full unit suite green (298 files / 1862 tests), `pnpm typecheck`, `pnpm format:check`, `pnpm test:impact -- --base origin/main`, full `pnpm ci:check` before merge.

Related to the wire-segmentation feedback assessment (canonical-form design work tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
