### PR TITLE
fix(symbols): DFQ's output sits on the body centre line

### DIFF
--- a/packages/symbols/assets/razavi-v1/catalog.json
+++ b/packages/symbols/assets/razavi-v1/catalog.json
@@ -239,7 +239,7 @@
       "automaticMappings": [],
       "manualOnlyReason": "Behavioral logic symbol; structural SPICE realization requires an explicit subcircuit or PDK mapping.",
       "assetPath": "d-flip-flop-q.symbol.json",
-      "assetHash": "66b2a796af3409f0ec55fe56be57d8a52997f07a6fe0bac472fdb025bbe8e979",
+      "assetHash": "ca7d19af2d62a52d470c0cf0102b66c283bdaae28b4be129852b112ecd00fd8c",
       "visualAuthority": {
         "kind": "razavi-reference-v1",
         "referenceManifestPath": "fixtures/visual-reference/razavi-reference-v1/manifest.json",

--- a/packages/symbols/assets/razavi-v1/d-flip-flop-q.symbol.json
+++ b/packages/symbols/assets/razavi-v1/d-flip-flop-q.symbol.json
@@ -46,7 +46,7 @@
       "role": "output",
       "at": {
         "x": 40,
-        "y": -10
+        "y": 0
       },
       "direction": "east",
       "presentation": {
@@ -105,11 +105,11 @@
       "kind": "line",
       "from": {
         "x": 25.000855,
-        "y": -10
+        "y": 0
       },
       "to": {
         "x": 40,
-        "y": -10
+        "y": 0
       },
       "style": {
         "strokeRole": "normal",

--- a/packages/symbols/src/razavi-catalog.generated.ts
+++ b/packages/symbols/src/razavi-catalog.generated.ts
@@ -294,7 +294,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       "Behavioral logic symbol; structural SPICE realization requires an explicit subcircuit or PDK mapping.",
     assetPath: "d-flip-flop-q.symbol.json",
     assetHash:
-      "66b2a796af3409f0ec55fe56be57d8a52997f07a6fe0bac472fdb025bbe8e979",
+      "ca7d19af2d62a52d470c0cf0102b66c283bdaae28b4be129852b112ecd00fd8c",
     visualAuthority: {
       kind: "razavi-reference-v1",
       referenceManifestPath:
@@ -2720,7 +2720,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         role: "output",
         at: {
           x: 40,
-          y: -10,
+          y: 0,
         },
         direction: "east",
         presentation: {
@@ -2779,11 +2779,11 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         kind: "line",
         from: {
           x: 25.000855,
-          y: -10,
+          y: 0,
         },
         to: {
           x: 40,
-          y: -10,
+          y: 0,
         },
         style: {
           strokeRole: "normal",

--- a/packages/symbols/src/razavi-catalog.test.ts
+++ b/packages/symbols/src/razavi-catalog.test.ts
@@ -324,6 +324,41 @@ describe("Razavi symbol catalog", () => {
     ).toBe(false);
   });
 
+  it("puts the Q-only flip-flop's output on the body centre line", () => {
+    const dff = requireRazaviCatalogSymbol("d-flip-flop");
+    const q = requireRazaviCatalogSymbol("d-flip-flop-q");
+
+    expect(q.pins.map((pin) => pin.name)).toEqual(["D", "CK", "Q"]);
+    // With no complement to pair with, an output left at the pair's height
+    // reads as lopsided and hangs its name beside an empty corner. The body
+    // spans -25..25, so the centre line is y = 0.
+    expect(q.pins.map((pin) => pin.at)).toEqual([
+      { x: -40, y: -10 },
+      { x: -40, y: 10 },
+      { x: 40, y: 0 },
+    ]);
+    const outputLead = q.primitives.find(
+      (primitive) => primitive.kind === "line" && primitive.to.x === 40,
+    );
+    expect(outputLead).toMatchObject({
+      from: { y: 0 },
+      to: { x: 40, y: 0 },
+    });
+
+    // Deriving the sibling must not reshape the reviewed part it came from.
+    expect(dff.pins.map((pin) => pin.at)).toEqual([
+      { x: -40, y: -10 },
+      { x: -40, y: 10 },
+      { x: 40, y: -10 },
+      { x: 40, y: 10 },
+    ]);
+    // Same body, one fewer wire: the two must read as the same block.
+    expect(q.viewBox).toEqual(dff.viewBox);
+    expect(q.primitives.find((primitive) => primitive.kind === "path")).toEqual(
+      dff.primitives.find((primitive) => primitive.kind === "path"),
+    );
+  });
+
   it("keeps the page-331 Delay Cell proportions and source glyph outlines", () => {
     const delayCell = requireRazaviCatalogSymbol("delay-cell");
     expect(delayCell.pins.map((pin) => pin.name)).toEqual(["A", "Y"]);

--- a/scripts/generate-razavi-buffer-dff-assets.mjs
+++ b/scripts/generate-razavi-buffer-dff-assets.mjs
@@ -84,9 +84,12 @@ dff.viewBox = { x: -42, y: -27, width: 84, height: 54 };
 const qOnly = structuredClone(dff);
 qOnly.id = Q_ONLY_ID;
 qOnly.name = "D Flip-Flop (Q)";
-const complement = dff.pins.find((pin) => pin.role === "output-complement");
+// Work on the clone's own objects throughout. Filtering the source's arrays
+// would share its pins and primitives with the sibling, and the edits below
+// would then reach back and reshape the reviewed flip-flop itself.
+const complement = qOnly.pins.find((pin) => pin.role === "output-complement");
 if (!complement) fail("d-flip-flop lost its complementary output pin");
-qOnly.pins = dff.pins.filter((pin) => pin !== complement);
+qOnly.pins = qOnly.pins.filter((pin) => pin !== complement);
 // Drop the lead that ran to the pin that no longer exists. Matching on the
 // endpoint keeps this correct if the body is ever re-extracted at different
 // coordinates; matching on an index would not.
@@ -95,13 +98,30 @@ const touchesComplement = (primitive) =>
   [primitive.from, primitive.to].some(
     (point) => point.x === complement.at.x && point.y === complement.at.y,
   );
-const leadCount = dff.primitives.filter(touchesComplement).length;
+const leadCount = qOnly.primitives.filter(touchesComplement).length;
 if (leadCount !== 1) {
   fail(`expected one complementary lead to remove, found ${leadCount}`);
 }
-qOnly.primitives = dff.primitives.filter(
+qOnly.primitives = qOnly.primitives.filter(
   (primitive) => !touchesComplement(primitive),
 );
+// With only one output left, keeping it where the pair used to sit leaves the
+// body lopsided and the Q label riding high against an empty corner. Razavi
+// draws the single-output flip-flop with Q on the body's centre line, so the
+// pin and its lead move there and the name follows the pin.
+const output = qOnly.pins.find((pin) => pin.role === "output");
+if (!output) fail("d-flip-flop-q lost its output pin");
+const outputLead = qOnly.primitives.find(
+  (primitive) =>
+    primitive.kind === "line" &&
+    [primitive.from, primitive.to].some(
+      (point) => point.x === output.at.x && point.y === output.at.y,
+    ),
+);
+if (!outputLead) fail("d-flip-flop-q lost the lead to its output");
+outputLead.from.y = 0;
+outputLead.to.y = 0;
+output.at = { ...output.at, y: 0 };
 // The body is unchanged, so the frame stays identical to its source: the two
 // parts must read as the same block with one fewer wire, not as two drawings.
 definitions.set(Q_ONLY_ID, qOnly);


### PR DESCRIPTION
Follow-up to #429, from the reference figure: with only one output, `Q` belongs on the body's centre line, not at the height the pair used to share. Left where it was, the body reads as lopsided and the `Q` label hangs beside an empty corner.

The body spans `-25..25`, so the pin, its lead, and therefore its name move to `y = 0`.

## A real defect this uncovered

Writing it surfaced a bug in the derivation itself. It built the sibling like this:

```js
qOnly.pins = dff.pins.filter(...)          // source's pin OBJECTS
qOnly.primitives = dff.primitives.filter(...)
```

`structuredClone` had deep-copied the definition, but filtering the *source's* arrays put the source's own objects back into the clone. While the derivation only ever removed things that was harmless. The moment it mutated one — moving the output — it reshaped the reviewed four-pin `d-flip-flop` too.

The filters now run over the clone's own arrays. `keeps the PDF-derived Buffer seams and generic DFF pin contract` is what caught it, by failing on the source symbol rather than the new one.

## Test

`puts the Q-only flip-flop's output on the body centre line` pins three things:

- the three pins and the centred output lead
- **that the source is unchanged** — the assertion that would have caught the aliasing
- that both parts keep one identical body path and viewBox, so the pair reads as the same block with one fewer wire

## Verification

- `pnpm ci:static` clean, including every generated-artifact drift gate
- 1883 unit tests pass
- Visual and export goldens match
- Placed both in a running editor and looked at them: DFF's outputs paired, DFQ's single output centred

Generated artifacts regenerated in the documented order; none hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)