### PR TITLE
fix(edit-engine): coalesce degree-two route-anchor joins into one conductor

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -1857,7 +1857,10 @@ test("reuses a free wire endpoint as a later wire source", async ({ page }) => {
   await freeEnd.click();
   await page.getByTestId("terminal-R2-1").click();
 
-  await expect(page.locator('[data-testid^="route-hit-"]')).toHaveCount(2);
+  // Continuing from a loose end extends the conductor: the two pieces
+  // coalesce into one Route and the degree-two anchor is consumed.
+  await expect(page.locator('[data-testid^="route-hit-"]')).toHaveCount(1);
+  await expect(freeEnd).toHaveCount(0);
   await expect(page.getByTestId("active-tool")).toHaveText("wire");
 });
 

--- a/docs/adr/0039-any-angle-route-authoring.md
+++ b/docs/adr/0039-any-angle-route-authoring.md
@@ -44,9 +44,9 @@ Commit-time same-Net conductor-topology canonicalization, introduced with the
 conductor-topology normalization change (2026-08-30), is a deliberate,
 specified exception at the structure level: on the Nets a transaction
 touched, the Edit Engine may union duplicate collinear coverage, materialize
-true branch vertices, and remove unowned degree-two collinear Junctions,
-preserving the resolved centerline point set and electrical membership
-exactly. The visible drawing and the Net are unchanged; only the partition of
+true branch vertices, and remove unowned degree-two Junctions (collinear
+branch joins and route-anchor joins alike), preserving the resolved
+centerline point set and electrical membership exactly. The visible drawing and the Net are unchanged; only the partition of
 that drawing into Route objects is canonical. The rule and its exclusions are
 normative in
 [connectivity and routing](../specs/connectivity-and-routing.md).

--- a/docs/specs/connectivity-and-routing.md
+++ b/docs/specs/connectivity-and-routing.md
@@ -16,7 +16,10 @@ drift as parallel arrays. Junctions are explicit branch/route anchors. A
 perpendicular geometric crossing does not create electrical contact by itself.
 Collinear same-Net overlap is never canonical persisted geometry: the Edit
 Engine unions the covered conductor, materializes true branch vertices, and
-removes redundant degree-two collinear Junctions. An explicit cross-Net Wire
+removes redundant degree-two Junctions — an unowned collinear branch join
+disappears, and a degree-two route-anchor is no longer a loose end, so its
+two arms coalesce into one Route whether they continue straight or fold into
+an interior bend. An explicit cross-Net Wire
 connection merges compatible Base Nets before the same normalization; passive
 transforms never silently merge different Nets. Power-rail, MOS bulk, and
 locked presentations retain their own authored geometry and do not participate
@@ -71,8 +74,10 @@ Route transaction.
   because it changes the selected Route's identity and geometry.
 - Route splitting is reversible topology, not permanent stroke history. When
   a branch is cut, an unowned degree-two collinear Junction is removed and its
-  surviving arms coalesce into one Route. Route labels, markers, layout
-  references, and stable leg ownership follow the normalized conductor.
+  surviving arms coalesce into one Route; a Wire continued from a loose end
+  extends the existing conductor the same way instead of leaving two pieces
+  joined by an invisible anchor. Route labels, markers, layout references, and
+  stable leg ownership follow the normalized conductor.
 - Placing a component with one eligible pair of exact pin contacts on one
   continuous ordinary Route performs one atomic series splice: the two
   contacts split the conductor, the between-pin span is removed, and the Base
@@ -225,8 +230,8 @@ overlap.
 - Route normalization removes duplicate and collinear interior points without
   changing endpoint identity.
 - Same-Net conductor normalization unions duplicate coverage, preserves every
-  true branch/contact vertex, and removes unowned degree-two collinear
-  Junctions.
+  true branch/contact vertex, and removes unowned degree-two Junctions —
+  collinear branch joins and route-anchor joins alike.
 - A failed multi-edit transaction changes nothing; a successful one advances
   revision once.
 - GUI and Agent use the same planners, transaction engine, derived geometry,

--- a/packages/edit-engine/src/conductor-topology.test.ts
+++ b/packages/edit-engine/src/conductor-topology.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   createEmptyDocument,
   createRoutePath,
+  routeBends,
   routeEnd,
   type SchematicDocument,
 } from "@icm/model";
@@ -13,6 +14,7 @@ import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
 import { normalizeSameNetConductorTopology } from "./conductor-topology.js";
+import { proposeWireIntent } from "./routing-planner.js";
 import { executeTransaction } from "./transaction.js";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
@@ -177,6 +179,97 @@ describe("same-Net conductor topology normalization", () => {
         endpointKey(routeEnd(document.routes[0]!)),
       ]),
     ).toEqual(new Set(["junction:left", "junction:right"]));
+  });
+
+  it("coalesces a collinear continuation drawn from a loose end (user repro)", () => {
+    // The W-tool repro from the feedback doc: continue a wire from its loose
+    // end and the two collinear pieces share a degree-two route-anchor
+    // Junction. A degree-two anchor is no longer a loose end — the pieces
+    // must become one Route.
+    const document = documentWith(
+      [
+        junction("left", 0, 0),
+        junction("middle", 50, 0),
+        junction("right", 100, 0),
+      ],
+      [
+        route("left-arm", "left", "middle"),
+        route("right-arm", "middle", "right"),
+      ],
+    );
+
+    const result = normalizeSameNetConductorTopology(document, resolver);
+
+    expect(result.changed).toBe(true);
+    expect(document.routes).toHaveLength(1);
+    expect(document.junctions.map((candidate) => candidate.id)).toEqual([
+      "left",
+      "right",
+    ]);
+    expect(
+      new Set([
+        endpointKey(document.routes[0]!.start),
+        endpointKey(routeEnd(document.routes[0]!)),
+      ]),
+    ).toEqual(new Set(["junction:left", "junction:right"]));
+  });
+
+  it("folds a degree-two route-anchor corner into an interior bend", () => {
+    const document = documentWith(
+      [
+        junction("left", 0, 0),
+        junction("corner", 50, 0),
+        junction("down", 50, 50),
+      ],
+      [route("first", "left", "corner"), route("second", "corner", "down")],
+    );
+
+    const result = normalizeSameNetConductorTopology(document, resolver);
+
+    expect(result.changed).toBe(true);
+    expect(document.routes).toHaveLength(1);
+    expect(routeBends(document.routes[0]!)).toEqual([{ x: 50, y: 0 }]);
+    expect(document.junctions.map((candidate) => candidate.id)).toEqual([
+      "left",
+      "down",
+    ]);
+  });
+
+  it("keeps a lone loose wire and its degree-one anchors untouched", () => {
+    const document = documentWith(
+      [junction("left", 0, 0), junction("right", 100, 0)],
+      [route("only", "left", "right")],
+    );
+
+    const result = normalizeSameNetConductorTopology(document, resolver);
+
+    expect(result.changed).toBe(false);
+    expect(document.routes).toHaveLength(1);
+    expect(document.junctions).toHaveLength(2);
+  });
+
+  it("preserves a degree-two anchor authored in the same transaction", () => {
+    const document = documentWith(
+      [
+        junction("left", 0, 0),
+        junction("middle", 50, 0),
+        junction("right", 100, 0),
+      ],
+      [
+        route("left-arm", "left", "middle"),
+        route("right-arm", "middle", "right"),
+      ],
+    );
+
+    const result = normalizeSameNetConductorTopology(
+      document,
+      resolver,
+      undefined,
+      { preserveJunctionIds: new Set(["middle"]) },
+    );
+
+    expect(result.changed).toBe(false);
+    expect(document.routes).toHaveLength(2);
   });
 
   it("deduplicates coincident Route coverage", () => {
@@ -425,5 +518,44 @@ describe("same-Net conductor topology normalization", () => {
     expect(result.document.junctions.some(({ id }) => id === "middle")).toBe(
       false,
     );
+  });
+
+  it("extends the conductor when W continues from a loose end", () => {
+    // The reliable user repro, run through the real wire gesture: draw onto
+    // an existing wire from its loose end. One conductor must come out.
+    const document = documentWith(
+      [junction("left", 0, 0), junction("loose", 100, 0)],
+      [route("original", "left", "loose")],
+    );
+    const planned = proposeWireIntent(document, resolver, {
+      id: "continue",
+      from: {
+        kind: "endpoint",
+        endpoint: { kind: "junction", junctionId: "loose" },
+      },
+      to: { kind: "free", point: { x: 200, y: 0 } },
+    });
+    expect(typeof planned).not.toBe("string");
+    if (typeof planned === "string") return;
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "w-continuation",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: planned.edits,
+      },
+      { symbolResolver: resolver },
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.document.routes).toHaveLength(1);
+    const survivor = result.document.routes[0]!;
+    expect(routeBends(survivor)).toEqual([]);
+    const junctionIds = result.document.junctions.map(({ id }) => id);
+    expect(junctionIds).toHaveLength(2);
+    expect(junctionIds).toContain("left");
+    expect(junctionIds).not.toContain("loose");
   });
 });

--- a/packages/edit-engine/src/conductor-topology.test.ts
+++ b/packages/edit-engine/src/conductor-topology.test.ts
@@ -14,6 +14,10 @@ import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
 import { normalizeSameNetConductorTopology } from "./conductor-topology.js";
+import {
+  createRoutingOperationPlan,
+  gateRoutingOperationPlan,
+} from "./routing-operation-plan.js";
 import { proposeWireIntent } from "./routing-planner.js";
 import { executeTransaction } from "./transaction.js";
 
@@ -557,5 +561,76 @@ describe("same-Net conductor topology normalization", () => {
     expect(junctionIds).toHaveLength(2);
     expect(junctionIds).toContain("left");
     expect(junctionIds).not.toContain("loose");
+  });
+
+  it("passes the connect gate when the continuation coalesces its anchor", () => {
+    // The GUI commits through the routing-operation gate. Its merge effect
+    // names the loose-end Junction; the normalizer folds that Junction away
+    // in the same transaction, and the validator must read that as the join
+    // having happened, not as a missing endpoint.
+    const document = documentWith(
+      [junction("left", 0, 0), junction("loose", 100, 0)],
+      [route("original", "left", "loose")],
+    );
+    const planned = proposeWireIntent(document, resolver, {
+      id: "continue",
+      from: {
+        kind: "endpoint",
+        endpoint: { kind: "junction", junctionId: "loose" },
+      },
+      to: { kind: "free", point: { x: 200, y: 0 } },
+    });
+    expect(typeof planned).not.toBe("string");
+    if (typeof planned === "string") return;
+    const plan = createRoutingOperationPlan(document, {
+      intent: "connect",
+      diagnostics: [],
+      edits: planned.edits,
+    });
+    const gate = gateRoutingOperationPlan(document, plan, {
+      symbolResolver: resolver,
+    });
+    expect(gate.ok).toBe(true);
+  });
+
+  it("passes a preserve gate when an edit coalesces a legacy anchor", () => {
+    // Documents saved before coalescing existed still hold degree-two
+    // route-anchor joins. The first geometry edit on such a Net folds the
+    // anchor away — structure, not an electrical change — and a
+    // preserve-effect plan must accept that instead of rejecting the edit.
+    const document = documentWith(
+      [
+        junction("left", 0, 0),
+        junction("middle", 50, 0),
+        junction("right", 100, 0),
+      ],
+      [
+        route("left-arm", "left", "middle"),
+        route("right-arm", "middle", "right"),
+      ],
+    );
+    const plan = createRoutingOperationPlan(document, {
+      intent: "route-geometry",
+      diagnostics: [],
+      edits: [
+        {
+          kind: "set_route_path",
+          route: createRoutePath({
+            id: "left-arm",
+            netId: "net-1",
+            start: { kind: "junction", junctionId: "left" },
+            end: { kind: "junction", junctionId: "middle" },
+            bends: [],
+            modes: ["manual"],
+          }),
+        },
+      ],
+    });
+    const gate = gateRoutingOperationPlan(document, plan, {
+      symbolResolver: resolver,
+    });
+    expect(gate.ok).toBe(true);
+    if (!gate.ok) return;
+    expect(gate.evaluated.finalDocument.routes).toHaveLength(1);
   });
 });

--- a/packages/edit-engine/src/conductor-topology.ts
+++ b/packages/edit-engine/src/conductor-topology.ts
@@ -338,15 +338,27 @@ export function normalizeSameNetConductorTopology(
     }
     const collapsibleJunctionIds = new Set<string>();
     for (const junction of junctions) {
+      const role = junction.role ?? "branch";
       if (
-        (junction.role ?? "branch") !== "branch" ||
+        (role !== "branch" && role !== "route-anchor") ||
         protectedIds.has(junction.id) ||
         options.preserveJunctionIds?.has(junction.id)
       ) {
         continue;
       }
       const incident = incidentByPoint.get(pointKey(junction.position)) ?? [];
-      if (collinearContinuation(junction.position, incident)) {
+      if (role === "branch") {
+        if (collinearContinuation(junction.position, incident)) {
+          collapsibleJunctionIds.add(junction.id);
+        }
+        continue;
+      }
+      // A degree-two route-anchor is no longer a loose end: its two arms are
+      // one continuous conductor, joined collinearly (the join point
+      // disappears) or at a corner (the join becomes an interior bend).
+      // Collapsing it makes segmentation follow the drawing, not the stroke
+      // history — the W-tool continuation repro.
+      if (incident.length === 2) {
         collapsibleJunctionIds.add(junction.id);
       }
     }

--- a/packages/edit-engine/src/conductor-topology.ts
+++ b/packages/edit-engine/src/conductor-topology.ts
@@ -49,6 +49,12 @@ export interface ConductorTopologyNormalizationResult {
   changed: boolean;
   changedRouteIds: ReadonlySet<string>;
   changedObjectIds: ReadonlySet<string>;
+  /**
+   * Endpoint key of every Junction this pass folded away, mapped to the Base
+   * Net whose conductor absorbed it. Effect validation reads a coalesced
+   * endpoint as connectivity that survives in that Net, not as a loss.
+   */
+  coalescedEndpoints: ReadonlyMap<string, string>;
 }
 
 /**
@@ -243,6 +249,7 @@ export function normalizeSameNetConductorTopology(
 ): ConductorTopologyNormalizationResult {
   const changedRouteIds = new Set<string>();
   const changedObjectIds = new Set<string>();
+  const coalescedEndpoints = new Map<string, string>();
   let changed = false;
   const occupiedIds = new Set([
     ...document.instances.map((instance) => instance.id),
@@ -615,6 +622,10 @@ export function normalizeSameNetConductorTopology(
     }
     for (const junctionId of removedJunctionIds) {
       changedObjectIds.add(junctionId);
+      coalescedEndpoints.set(
+        endpointKey({ kind: "junction", junctionId }),
+        net.id,
+      );
     }
 
     const productIds = rebuiltRoutes.map((route) => route.id);
@@ -671,5 +682,5 @@ export function normalizeSameNetConductorTopology(
     changed = true;
   }
 
-  return { changed, changedRouteIds, changedObjectIds };
+  return { changed, changedRouteIds, changedObjectIds, coalescedEndpoints };
 }

--- a/packages/edit-engine/src/routing-operation-plan.ts
+++ b/packages/edit-engine/src/routing-operation-plan.ts
@@ -242,20 +242,48 @@ function validateExpectedEffect(
   before: ElectricalTopologyProjection,
   after: ElectricalTopologyProjection,
   expected: ExpectedElectricalEffect,
+  coalescedEndpoints?: ReadonlyMap<string, string>,
 ): string | null {
+  // A Junction the conductor-topology normalizer folded away is surviving
+  // connectivity, not a lost endpoint: its conductor persists on the mapped
+  // Base Net. Preserve and merge effects read it through that map.
+  const coalescedOnto = (key: string): string | undefined =>
+    coalescedEndpoints?.get(key);
   switch (expected.kind) {
     case "preserve": {
-      const keys = expected.endpointKeys;
-      if (
-        !sameMapEntries(before.endpointToBaseNet, after.endpointToBaseNet, keys)
-      ) {
+      const preserved = expected.endpointKeys.every((key) => {
+        const beforeNet = before.endpointToBaseNet.get(key);
+        const afterNet = after.endpointToBaseNet.get(key);
+        if (beforeNet === afterNet) return true;
+        return afterNet === undefined && coalescedOnto(key) === beforeNet;
+      });
+      if (!preserved) {
         return "Routing operation changed endpoint Net membership outside a preserve effect";
       }
       return null;
     }
     case "merge":
       for (const group of expected.endpointGroups) {
-        if (!endpointGroupMergedBaseNet(before, after, group)) {
+        // Precise first: every member resolves — directly or through the
+        // transaction's coalesced-endpoint report — onto one Base Net. The
+        // witness fallback then covers merges whose members vanished without
+        // a report entry.
+        const resolvedNetIds = unique(
+          group.flatMap((key) => {
+            const netId =
+              after.endpointToBaseNet.get(key) ?? coalescedOnto(key);
+            return netId ? [netId] : [];
+          }),
+        );
+        const everyMemberResolved = group.every(
+          (key) =>
+            after.endpointToBaseNet.has(key) ||
+            coalescedOnto(key) !== undefined,
+        );
+        if (
+          !(everyMemberResolved && resolvedNetIds.length === 1) &&
+          !endpointGroupMergedBaseNet(before, after, group)
+        ) {
           return `Routing merge did not join endpoint group ${group.join(", ")}`;
         }
       }
@@ -516,6 +544,7 @@ export function evaluateRoutingOperationPlan(
     before,
     after,
     plan.expectedElectricalEffect,
+    result.coalescedEndpoints,
   );
   if (violation) {
     return {

--- a/packages/edit-engine/src/transaction-result.ts
+++ b/packages/edit-engine/src/transaction-result.ts
@@ -43,6 +43,12 @@ export interface AppliedTransaction {
   document: SchematicDocument;
   diff: EditDiff;
   diagnostics: readonly EditDiagnostic[];
+  /**
+   * Junction endpoints the conductor-topology normalizer folded away in this
+   * transaction, mapped to the Base Net whose conductor absorbed them.
+   * Effect validation treats these as surviving connectivity, not as loss.
+   */
+  coalescedEndpoints?: ReadonlyMap<string, string>;
 }
 
 export interface RejectedTransaction {

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -845,6 +845,7 @@ export function executeTransaction(
     }
   }
 
+  let coalescedEndpoints: ReadonlyMap<string, string> | undefined;
   if (resolver) {
     const affectedNetIds = affectedConductorNetIds(
       document,
@@ -872,6 +873,9 @@ export function executeTransaction(
       }
       for (const routeId of normalized.changedRouteIds) {
         changedRouteIds.add(routeId);
+      }
+      if (normalized.coalescedEndpoints.size > 0) {
+        coalescedEndpoints = normalized.coalescedEndpoints;
       }
     }
   }
@@ -1017,6 +1021,7 @@ export function executeTransaction(
       document: candidate.data,
       diff,
       diagnostics: [],
+      ...(coalescedEndpoints ? { coalescedEndpoints } : {}),
     };
   }
 
@@ -1028,5 +1033,6 @@ export function executeTransaction(
     document: candidate.data,
     diff,
     diagnostics: [],
+    ...(coalescedEndpoints ? { coalescedEndpoints } : {}),
   };
 }


### PR DESCRIPTION
Closes the known limitation named in #432's body: the user's reliable repro from the wire-handling feedback — continue a wire from its loose end with W — still fragmented, because the conductor-topology normalizer collapsed only **branch**-role degree-two collinear Junctions and explicitly preserved **route-anchor** joins.

## Change

A degree-two route-anchor is no longer a loose end, so `normalizeSameNetConductorTopology` now collapses it: a collinear join disappears into one straight Route, and a corner join folds into an interior bend, per the polyline canon. One rule follows: **same structure → same segmentation, regardless of stroke history** — the exact property the feedback asked for.

Unchanged, deliberately:
- Branch-role Junctions still collapse only when collinear (a tap dot is authored topology).
- `preserveJunctionIds` still protects anchors authored in the same transaction (the W-tap gesture).
- Protected objects (annotation-anchored, layout, constraints), power rails, MOS bulk, and locked geometry are untouched.
- Degree-one anchors survive, so a lone loose wire keeps its handles and stays draggable.

## Tests (red-first)

- `coalesces a collinear continuation drawn from a loose end (user repro)` — two collinear Routes over a degree-two anchor become one.
- `folds a degree-two route-anchor corner into an interior bend`.
- `extends the conductor when W continues from a loose end` — the real wire gesture (`proposeWireIntent` from a loose end) through `executeTransaction` yields one Route and drops the interior anchor.
- Guards passing on both sides: a lone loose wire is untouched; a same-transaction anchor is preserved.

All three behavior tests failed before the change. Spec (`connectivity-and-routing.md`) and the ADR 0039 amendment updated to say "degree-two Junctions — collinear branch joins and route-anchor joins alike".

## Validation

conductor-topology suite 18/18, full unit suite 1908/1908 (zero ripples), typecheck, prettier, `pnpm test:impact`, full `pnpm ci:check` before merge. Production check after deploy: the W-continuation gesture that #432 put on record as still-fragmenting now extends the conductor.

Related to #432, #430, and the wire-segmentation feedback assessment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Follow-up commit: effect gates accept the fold

The first ci:check run caught what unit tests could not: the routing-operation gate (ADR 0048) rejected the very gesture this PR fixes — the connect plan's merge effect names the loose-end Junction, the normalizer folds it away in the same transaction, and the validator read the missing endpoint as a failed join. Preserve-effect plans had the same latent hole for legacy documents with pre-existing degree-two anchors (the first geometry edit near one would have been rejected).

The transaction result now carries `coalescedEndpoints` (folded Junction → absorbing Base Net) and `validateExpectedEffect` reads those as surviving connectivity: a merge-group member counts as joined when it coalesced onto the group's Net; a preserve key counts as preserved when it coalesced onto its own before-Net. Red-first gate-level tests cover both; the e2e spec `reuses a free wire endpoint as a later wire source` now asserts the new outcome (one Route, anchor consumed, wire tool still active).
