### PR TITLE
Fix series-splice placement and reconnect lifecycle

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -1241,6 +1241,37 @@ test("authors components and connectivity manually from an empty canvas", async 
   await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(0);
 });
 
+test("splices a two-terminal device into one wire and reconnects its halves after deletion", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 420, y: 180 });
+  await placeComponent(page, "resistor", { x: 420, y: 460 });
+
+  await clickDrawTool(page, "wire");
+  await page.getByTestId("terminal-R1-2").click();
+  await page.getByTestId("terminal-R2-1").click();
+  await page.keyboard.press("Escape");
+  await expect(page.locator('[data-testid^="route-hit-"]')).toHaveCount(1);
+
+  await placeComponent(page, "resistor", { x: 420, y: 320 });
+  await expect(page.getByTestId("hit-R3")).toBeVisible();
+  await expect(page.locator('[data-testid^="route-hit-"]')).toHaveCount(2);
+
+  await page.keyboard.press("Delete");
+  await expect(page.getByTestId("hit-R3")).toHaveCount(0);
+  await expect(page.locator('[data-testid^="route-hit-"]')).toHaveCount(2);
+  const openEnds = page.locator('[data-testid^="junction-"]');
+  await expect(openEnds).toHaveCount(2);
+
+  await clickDrawTool(page, "wire");
+  await openEnds.nth(0).click();
+  await openEnds.nth(1).click();
+  await expect(page.getByTestId("status")).toContainText("Committed route");
+  await page.keyboard.press("Escape");
+  await expect(page.locator('[data-testid^="route-hit-"]')).toHaveCount(1);
+});
+
 test("resizes a loose Wire from either endpoint without redrawing it", async ({
   page,
 }) => {

--- a/apps/editor/src/app/editor-transaction-commands.ts
+++ b/apps/editor/src/app/editor-transaction-commands.ts
@@ -8,6 +8,7 @@ import type {
   ProjectTransaction,
   ProjectTransactionResult,
   SchematicEdit,
+  ExpectedElectricalEffect,
   RoutingOperationIntent,
 } from "@icm/edit-engine";
 import type { CircuitProject, SchematicDocument } from "@icm/model";
@@ -18,6 +19,10 @@ import type { InteractionMode } from "../interaction/interaction-state";
 interface TransactionOptions {
   completesWireSession?: boolean;
   preserveInteraction?: boolean;
+}
+
+interface ConnectivityTransactionOptions extends TransactionOptions {
+  expectedElectricalEffect?: ExpectedElectricalEffect;
 }
 
 export interface EditorTransactionCommandDependencies {
@@ -139,12 +144,15 @@ export function createEditorTransactionCommands({
   const transactConnectivity = (
     intent: RoutingOperationIntent,
     edits: readonly SchematicEdit[],
-    options: TransactionOptions = {},
+    options: ConnectivityTransactionOptions = {},
   ): EditTransactionResult | null => {
     const proposal = createRoutingOperationPlan(document, {
       intent,
       edits,
       diagnostics: [],
+      ...(options.expectedElectricalEffect
+        ? { expectedElectricalEffect: options.expectedElectricalEffect }
+        : {}),
     });
     const gate = gateRoutingOperationPlan(document, proposal, {
       ...(resolver ? { symbolResolver: resolver } : {}),

--- a/apps/editor/src/features/component-insert/placement-connectivity.test.ts
+++ b/apps/editor/src/features/component-insert/placement-connectivity.test.ts
@@ -1,5 +1,10 @@
 import { createRoutePath, routeEnd, type RouteEndpoint } from "@icm/model";
-import { executeTransaction, planInstanceDeletion } from "@icm/edit-engine";
+import {
+  createRoutingOperationPlan,
+  executeTransaction,
+  gateRoutingOperationPlan,
+  planInstanceDeletion,
+} from "@icm/edit-engine";
 import { resolveDocumentLogicalNets } from "@icm/derived";
 import { createEmptyDocument, transformPoint } from "@icm/model";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
@@ -84,6 +89,19 @@ describe("component placement electrical contacts", () => {
     const proposal = proposePlacementContact(document, resolver, resistor, []);
 
     expect(proposal).toMatchObject({ matched: true, ambiguous: false });
+    expect(proposal.expectedElectricalEffect).toMatchObject({
+      kind: "partition",
+      sourceBaseNetIds: ["net-signal"],
+    });
+    const operation = createRoutingOperationPlan(document, {
+      intent: "connect",
+      edits: [{ kind: "add_instance", instance: resistor }, ...proposal.edits],
+      diagnostics: [],
+      expectedElectricalEffect: proposal.expectedElectricalEffect!,
+    });
+    expect(gateRoutingOperationPlan(document, operation, context).ok).toBe(
+      true,
+    );
     const result = executeTransaction(
       document,
       transaction(document.revision, [

--- a/apps/editor/src/features/component-insert/placement-connectivity.ts
+++ b/apps/editor/src/features/component-insert/placement-connectivity.ts
@@ -5,6 +5,7 @@ import {
   planSeriesInstanceSplice,
   proposeEndpointRouteAttachment,
   proposeEndpointsRouteAttachment,
+  type ExpectedElectricalEffect,
   type SchematicEdit,
   type WireSource,
 } from "@icm/edit-engine";
@@ -56,6 +57,7 @@ export interface PlacementContactProposal {
   powerNetId?: string;
   powerEndpoint?: RouteEndpoint;
   netId?: string;
+  expectedElectricalEffect?: ExpectedElectricalEffect;
 }
 
 function standalonePowerNetId(
@@ -269,6 +271,7 @@ export function proposePlacementContact(
           edits: splice.edits,
           matched: true,
           ambiguous: false,
+          expectedElectricalEffect: splice.expectedElectricalEffect,
         }
       : {
           edits: [],

--- a/apps/editor/src/features/component-insert/use-component-placement.ts
+++ b/apps/editor/src/features/component-insert/use-component-placement.ts
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import type {
+  ExpectedElectricalEffect,
   RoutingOperationIntent,
   ProjectStructureEdit,
   SchematicEdit,
@@ -89,7 +90,10 @@ export interface UseComponentPlacementOptions {
   transactConnectivity: (
     intent: RoutingOperationIntent,
     edits: readonly SchematicEdit[],
-    options?: { preserveInteraction?: boolean },
+    options?: {
+      preserveInteraction?: boolean;
+      expectedElectricalEffect?: ExpectedElectricalEffect;
+    },
   ) => TransactionResult | null;
   transactProject: (
     transactionId: string,
@@ -273,6 +277,9 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     const committed = Boolean(
       options.transactConnectivity("connect", placementEdits, {
         preserveInteraction: true,
+        ...(contact.expectedElectricalEffect
+          ? { expectedElectricalEffect: contact.expectedElectricalEffect }
+          : {}),
       })?.ok,
     );
     if (!committed) return;

--- a/packages/edit-engine/src/routing-operation-plan.test.ts
+++ b/packages/edit-engine/src/routing-operation-plan.test.ts
@@ -1,4 +1,5 @@
-import { createEmptyDocument } from "@icm/model";
+import { createEmptyDocument, createRoutePath } from "@icm/model";
+import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -6,6 +7,9 @@ import {
   evaluateRoutingOperationPlan,
   gateRoutingOperationPlan,
 } from "./routing-operation-plan.js";
+import { proposeWireIntent } from "./routing-planner.js";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
 
 function twoNetDocument() {
   const document = createEmptyDocument("main", "Main");
@@ -52,6 +56,67 @@ describe("RoutingOperationPlan", () => {
       ok: true,
       edits: plan.edits,
     });
+  });
+
+  it("accepts a merge after canonicalization retires its temporary Junction endpoints", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.nets.push(
+      { id: "net-left", terminals: [] },
+      { id: "net-right", terminals: [] },
+    );
+    document.junctions.push(
+      { id: "left-outer", netId: "net-left", position: { x: 0, y: 0 } },
+      { id: "left-open", netId: "net-left", position: { x: 40, y: 0 } },
+      { id: "right-open", netId: "net-right", position: { x: 60, y: 0 } },
+      { id: "right-outer", netId: "net-right", position: { x: 100, y: 0 } },
+    );
+    document.routes.push(
+      createRoutePath({
+        id: "left",
+        netId: "net-left",
+        start: { kind: "junction", junctionId: "left-outer" },
+        end: { kind: "junction", junctionId: "left-open" },
+        bends: [],
+        modes: ["manual"],
+      }),
+      createRoutePath({
+        id: "right",
+        netId: "net-right",
+        start: { kind: "junction", junctionId: "right-open" },
+        end: { kind: "junction", junctionId: "right-outer" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+    const wire = proposeWireIntent(document, resolver, {
+      id: "reconnect",
+      from: {
+        kind: "endpoint",
+        endpoint: { kind: "junction", junctionId: "left-open" },
+      },
+      to: {
+        kind: "endpoint",
+        endpoint: { kind: "junction", junctionId: "right-open" },
+      },
+    });
+    expect(typeof wire).not.toBe("string");
+    if (typeof wire === "string") return;
+    const plan = createRoutingOperationPlan(document, {
+      intent: "connect",
+      diagnostics: [],
+      edits: wire.edits,
+    });
+
+    const gate = gateRoutingOperationPlan(document, plan, {
+      symbolResolver: resolver,
+    });
+    expect(gate.ok).toBe(true);
+    if (!gate.ok) return;
+    expect(gate.evaluated.finalDocument.nets).toHaveLength(1);
+    expect(gate.evaluated.finalDocument.routes).toHaveLength(1);
+    expect(
+      gate.evaluated.finalDocument.junctions.map((junction) => junction.id),
+    ).toEqual(["left-outer", "right-outer"]);
   });
 
   it("rejects stale and cross-Cell plans before evaluation", () => {

--- a/packages/edit-engine/src/routing-operation-plan.ts
+++ b/packages/edit-engine/src/routing-operation-plan.ts
@@ -186,6 +186,56 @@ function sameMapEntries(
   return keys.every((key) => before.get(key) === after.get(key));
 }
 
+/**
+ * A successful conductor merge may immediately canonicalize away the exact
+ * degree-two Junctions named by the Wire gesture. In that case the original
+ * endpoint identities are no longer valid witnesses even though their two
+ * source conductors now share one Base Net. Fall back to surviving endpoints
+ * from each source Base Net so effect validation follows electrical identity,
+ * not temporary segmentation anchors.
+ */
+function endpointGroupMergedBaseNet(
+  before: ElectricalTopologyProjection,
+  after: ElectricalTopologyProjection,
+  endpointKeys: readonly string[],
+): string | null {
+  const directNetIds = unique(
+    endpointKeys.flatMap((key) => {
+      const netId = after.endpointToBaseNet.get(key);
+      return netId ? [netId] : [];
+    }),
+  );
+  if (
+    directNetIds.length === 1 &&
+    endpointKeys.every((key) => after.endpointToBaseNet.has(key))
+  ) {
+    return directNetIds[0]!;
+  }
+
+  const sourceBaseNetIds = unique(
+    endpointKeys.flatMap((key) => {
+      const netId = before.endpointToBaseNet.get(key);
+      return netId ? [netId] : [];
+    }),
+  );
+  if (sourceBaseNetIds.length === 0) return null;
+
+  const survivingNetIds: string[] = [];
+  for (const sourceBaseNetId of sourceBaseNetIds) {
+    const witnesses = unique(
+      [...before.endpointToBaseNet.entries()].flatMap(([key, netId]) => {
+        if (netId !== sourceBaseNetId) return [];
+        const survivingNetId = after.endpointToBaseNet.get(key);
+        return survivingNetId ? [survivingNetId] : [];
+      }),
+    );
+    if (witnesses.length === 0) return null;
+    survivingNetIds.push(...witnesses);
+  }
+  const merged = unique(survivingNetIds);
+  return merged.length === 1 ? merged[0]! : null;
+}
+
 function validateExpectedEffect(
   beforeDocument: SchematicDocument,
   afterDocument: SchematicDocument,
@@ -205,16 +255,7 @@ function validateExpectedEffect(
     }
     case "merge":
       for (const group of expected.endpointGroups) {
-        const netIds = unique(
-          group.flatMap((key) => {
-            const netId = after.endpointToBaseNet.get(key);
-            return netId ? [netId] : [];
-          }),
-        );
-        if (
-          netIds.length !== 1 ||
-          group.some((key) => !after.endpointToBaseNet.has(key))
-        ) {
+        if (!endpointGroupMergedBaseNet(before, after, group)) {
           return `Routing merge did not join endpoint group ${group.join(", ")}`;
         }
       }

--- a/packages/edit-engine/src/series-splice-planner.test.ts
+++ b/packages/edit-engine/src/series-splice-planner.test.ts
@@ -66,6 +66,11 @@ describe("series component splice", () => {
 
     expect(plan.ok).toBe(true);
     if (!plan.ok) return;
+    expect(plan.expectedElectricalEffect).toEqual({
+      kind: "partition",
+      sourceBaseNetIds: ["net-1"],
+      cutRouteIds: [plan.removedSpanRouteId],
+    });
     const result = executeTransaction(
       document,
       {

--- a/packages/edit-engine/src/series-splice-planner.ts
+++ b/packages/edit-engine/src/series-splice-planner.ts
@@ -16,6 +16,7 @@ import type { SymbolResolver } from "@icm/symbols";
 import type { SchematicEdit } from "./edit-schema.js";
 import { resolveRouteEditPath } from "./route-operations.js";
 import { proposeEndpointRouteAttachment } from "./routing-planner.js";
+import type { ExpectedElectricalEffect } from "./routing-operation-plan.js";
 import { executeTransaction } from "./transaction.js";
 
 export interface SeriesSpliceContact {
@@ -29,6 +30,7 @@ export type SeriesSplicePlan =
       ok: true;
       routeId: string;
       removedSpanRouteId: string;
+      expectedElectricalEffect: ExpectedElectricalEffect;
       edits: readonly SchematicEdit[];
     }
   | { ok: false; message: string };
@@ -215,6 +217,11 @@ export function planSeriesInstanceSplice(
     ok: true,
     routeId,
     removedSpanRouteId: removedSpan.id,
+    expectedElectricalEffect: {
+      kind: "partition",
+      sourceBaseNetIds: [route.netId],
+      cutRouteIds: [removedSpan.id],
+    },
     edits: [
       ...first.edits,
       ...second.edits,


### PR DESCRIPTION
## Summary
- pass the series-splice planner's explicit partition effect through the GUI routing-operation gate
- validate a conductor merge through surviving Base-Net endpoints when canonicalization retires temporary Junction identities
- cover the complete GUI lifecycle: place a two-terminal device onto one Wire, cut the middle span, delete the device, then reconnect and canonicalize both halves

## Root cause
PR #432 tested the splice through direct transaction execution, while the GUI submits through the routing-operation effect gate. The GUI classified the composite splice as a preserving connect, so the legitimate Net partition was rejected. After deletion, reconnecting the two halves did merge their Nets, but canonicalization retired the two degree-two Junction endpoints before effect validation, so the validator incorrectly rejected the successful merge.

## Validation
- pnpm install --frozen-lockfile
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- pnpm gate:full
- 1904/1904 unit tests
- 290/290 complete browser tests
- build, release, performance, visual/export golden, PWA, production and MCP smoke checks

Test-Impact: tests-updated