### PR TITLE
Fix transistor series insertion by exact pin pairs

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -1272,6 +1272,28 @@ test("splices a two-terminal device into one wire and reconnects its halves afte
   await expect(page.locator('[data-testid^="route-hit-"]')).toHaveCount(1);
 });
 
+test("splices a transistor into a wire only through its declared D/S pin pair", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 420, y: 180 });
+  await placeComponent(page, "resistor", { x: 420, y: 460 });
+
+  await clickDrawTool(page, "wire");
+  await page.getByTestId("terminal-R1-2").click();
+  await page.getByTestId("terminal-R2-1").click();
+  await page.keyboard.press("Escape");
+  await expect(page.locator('[data-testid^="route-hit-"]')).toHaveCount(1);
+
+  // The canonical NMOS D/S pins are 10 units to the right of its placement
+  // origin. Its body overlaps the wire as well, but the exact pin pair—not
+  // the visual bounds—is what authorizes the splice.
+  await placeComponent(page, "nmos", { x: 410, y: 320 });
+  await expect(page.getByTestId("hit-M1")).toBeVisible();
+  await expect(page.locator('[data-testid^="route-hit-"]')).toHaveCount(2);
+  await expect(page.getByTestId("terminal-M1-G")).toBeVisible();
+});
+
 test("resizes a loose Wire from either endpoint without redrawing it", async ({
   page,
 }) => {

--- a/apps/editor/src/features/component-insert/placement-connectivity.test.ts
+++ b/apps/editor/src/features/component-insert/placement-connectivity.test.ts
@@ -851,6 +851,125 @@ describe("multi-pin placement onto one conductor", () => {
       : `${endpoint.instanceId}.${endpoint.pinName}`;
   }
 
+  it.each([
+    {
+      symbolId: "nmos",
+      id: "M1",
+      position: { x: 90, y: 100 },
+      rotation: 0 as const,
+      mirror: "none" as const,
+      pair: ["D", "S"],
+      controlPin: "G",
+    },
+    {
+      symbolId: "pmos",
+      id: "M2",
+      position: { x: 110, y: 100 },
+      rotation: 0 as const,
+      mirror: "x" as const,
+      pair: ["D", "S"],
+      controlPin: "G",
+    },
+    {
+      symbolId: "npn",
+      id: "Q1",
+      position: { x: 100, y: 100 },
+      rotation: 0 as const,
+      mirror: "none" as const,
+      pair: ["C", "E"],
+      controlPin: "B",
+    },
+    {
+      symbolId: "pnp",
+      id: "Q2",
+      position: { x: 100, y: 100 },
+      rotation: 180 as const,
+      mirror: "none" as const,
+      pair: ["C", "E"],
+      controlPin: "B",
+    },
+  ])(
+    "splices $symbolId by its declared current-path pins while leaving the control pin open",
+    ({ symbolId, id, position, rotation, mirror, pair, controlPin }) => {
+      const document = verticalWireDocument();
+      const transistor = {
+        id,
+        symbolId,
+        placement: {
+          position,
+          rotation,
+          mirror,
+        },
+      };
+
+      const proposal = proposePlacementContact(
+        document,
+        resolver,
+        transistor,
+        [],
+      );
+
+      expect(proposal).toMatchObject({
+        matched: true,
+        ambiguous: false,
+        expectedElectricalEffect: {
+          kind: "partition",
+          sourceBaseNetIds: ["n1"],
+        },
+      });
+      const committed = executeTransaction(
+        document,
+        transaction(0, [
+          { kind: "add_instance", instance: transistor },
+          ...proposal.edits,
+        ]),
+        context,
+      );
+      expect(committed.ok).toBe(true);
+      if (!committed.ok) return;
+      expect(committed.document.routes).toHaveLength(2);
+      const pinNetIds = pair.map(
+        (pinName) =>
+          committed.document.nets.find((net) =>
+            net.terminals.some(
+              (terminal) =>
+                terminal.instanceId === id && terminal.pinName === pinName,
+            ),
+          )?.id,
+      );
+      expect(pinNetIds[0]).toBeTruthy();
+      expect(pinNetIds[1]).toBeTruthy();
+      expect(pinNetIds[0]).not.toBe(pinNetIds[1]);
+      expect(
+        committed.document.nets.some((net) =>
+          net.terminals.some(
+            (terminal) =>
+              terminal.instanceId === id && terminal.pinName === controlPin,
+          ),
+        ),
+      ).toBe(false);
+    },
+  );
+
+  it("does not splice a transistor whose body overlaps a Route without two exact pin contacts", () => {
+    const document = verticalWireDocument();
+    const transistor = {
+      id: "M1",
+      symbolId: "nmos",
+      placement: {
+        // The Route passes through the Symbol body at x=100, while D/S are at
+        // x=110 and G is at x=80. Bounds overlap must not create topology.
+        position: { x: 100, y: 100 },
+        rotation: 0 as const,
+        mirror: "none" as const,
+      },
+    };
+
+    expect(proposePlacementContact(document, resolver, transistor, [])).toEqual(
+      { edits: [], matched: false, ambiguous: false },
+    );
+  });
+
   it("splices a current source dropped onto one wire into series (feedback image 6/7)", () => {
     const document = verticalWireDocument();
     // current-source pins: "+" at (0,-20), "-" at (0,20). Placed at

--- a/apps/editor/src/features/component-insert/placement-connectivity.ts
+++ b/apps/editor/src/features/component-insert/placement-connectivity.ts
@@ -9,6 +9,7 @@ import {
   type SchematicEdit,
   type WireSource,
 } from "@icm/edit-engine";
+import { deviceDescriptor } from "@icm/devices";
 import {
   findRouteSegmentsAtPoint,
   resolveEndpointConnection,
@@ -137,6 +138,28 @@ function samePoint(
   return left.x === right.x && left.y === right.y;
 }
 
+function isEligibleSeriesInsertionPair(
+  instance: Instance,
+  visibleSources: readonly WireSource[],
+  contactedSources: readonly WireSource[],
+): boolean {
+  if (contactedSources.length !== 2) return false;
+  if (visibleSources.length === 2) return true;
+  const configuredPair = deviceDescriptor(
+    instance.symbolId,
+  )?.seriesInsertionPinPair;
+  if (!configuredPair) return false;
+  const contactedKeys = new Set(
+    contactedSources.map(({ endpoint }) =>
+      endpoint.kind === "terminal" ? endpoint.pinName : "",
+    ),
+  );
+  return (
+    contactedKeys.size === 2 &&
+    configuredPair.every((pinName) => contactedKeys.has(pinName))
+  );
+}
+
 /**
  * A component may acquire electrical connectivity only from an exact visible
  * pin-to-pin, pin-to-Junction, or pin-to-Route contact. Grid coincidence alone
@@ -204,12 +227,12 @@ export function proposePlacementContact(
   if (contacts.length === 0) {
     return { edits: [], matched: false, ambiguous: false };
   }
-  // Several pins of one device may land on the SAME conductor — that is the
-  // series-insertion gesture, not an ambiguity. An eligible two-terminal
-  // component with both pins on one continuous ordinary Route performs the
-  // atomic series splice; any other same-conductor multi-contact attaches
-  // every pin, cutting the Route at each contact. Only two pins claiming the
-  // exact same point remain ambiguous.
+  // Several pins of one device may land on the SAME conductor. Exactly two
+  // contacts form a series-insertion gesture only when the whole visible
+  // device is two-terminal or its Device descriptor names that pair. This is
+  // based on exact resolved pin contacts, never on symbol bounds. Any other
+  // same-conductor multi-contact remains an ordinary attachment; two pins
+  // claiming the exact same point remain ambiguous.
   const routeContactGroups = new Map<
     string,
     Array<{
@@ -234,11 +257,19 @@ export function proposePlacementContact(
       return { edits: [], matched: false, ambiguous: true };
     }
   }
-  const spliceGroup =
-    sources.length === 2 &&
-    contacts.length === 2 &&
+  const onlyRouteContactGroup =
     routeContactGroups.size === 1
       ? [...routeContactGroups.values()][0]
+      : undefined;
+  const spliceGroup =
+    contacts.length === 2 &&
+    onlyRouteContactGroup?.length === 2 &&
+    isEligibleSeriesInsertionPair(
+      instance,
+      sources,
+      onlyRouteContactGroup.map((member) => member.source),
+    )
+      ? onlyRouteContactGroup
       : undefined;
   if (spliceGroup && spliceGroup.length === 2) {
     const projected = structuredClone(document);

--- a/docs/specs/connectivity-and-routing.md
+++ b/docs/specs/connectivity-and-routing.md
@@ -73,12 +73,17 @@ Route transaction.
   a branch is cut, an unowned degree-two collinear Junction is removed and its
   surviving arms coalesce into one Route. Route labels, markers, layout
   references, and stable leg ownership follow the normalized conductor.
-- Placing an eligible two-terminal component with both pins on one continuous
-  ordinary Route performs one atomic series splice: the two contacts split the
-  conductor, the between-pin span is removed, and the Base Net partitions so
-  the two pins cannot remain shorted. One contacted pin remains an ordinary
-  endpoint-to-Route attachment; power rails, MOS bulk leads, locked geometry,
-  and ambiguous multi-pin contacts reject rather than guessing.
+- Placing a component with one eligible pair of exact pin contacts on one
+  continuous ordinary Route performs one atomic series splice: the two
+  contacts split the conductor, the between-pin span is removed, and the Base
+  Net partitions so the two pins cannot remain shorted. Every visible
+  two-terminal device is eligible; a multi-pin device must declare its stable
+  series-insertion pair in the Device descriptor (D/S for MOS, C/E for BJT),
+  so symbol bounds and incidental pin proximity never decide electrical
+  topology. One contacted pin remains an ordinary endpoint-to-Route
+  attachment; power rails, MOS bulk leads, locked geometry, and undeclared or
+  ambiguous multi-pin pairs never cut the conductor. Their exact contacts may
+  still use ordinary attachment semantics; visual overlap alone does nothing.
 - Moving a connected Instance stretches the attached Route while preserving
   endpoint identity.
 - `remove_route_geometry` removes presentation geometry only. The ordinary

--- a/packages/devices/src/contract.ts
+++ b/packages/devices/src/contract.ts
@@ -58,6 +58,13 @@ export interface DeviceDescriptor {
   readonly mosBulkClass?: MosBulkClass;
   readonly referencePrefix: string | null;
   readonly pinOrder: readonly string[];
+  /**
+   * The two stable terminals that may replace a conductor span when both
+   * exact pin contacts land on one ordinary Route. Multi-pin devices must
+   * declare this explicitly so placement never guesses from symbol bounds or
+   * from whichever two pins happen to be near a wire.
+   */
+  readonly seriesInsertionPinPair?: readonly [string, string];
   /** Optional fixed semantics for canonical pins; pin order remains electrical authority. */
   readonly pinSemantics?: readonly DevicePinSemantic[];
   readonly targetPolicy: DeviceNetlistTargetPolicy;

--- a/packages/devices/src/descriptors/nmos.ts
+++ b/packages/devices/src/descriptors/nmos.ts
@@ -7,6 +7,7 @@ export const nmosDevice = {
   mosBulkClass: "nmos",
   referencePrefix: "M",
   pinOrder: ["D", "G", "S", "B"],
+  seriesInsertionPinPair: ["D", "S"],
   targetPolicy: "required-model",
   parameters: [
     {

--- a/packages/devices/src/descriptors/npn.ts
+++ b/packages/devices/src/descriptors/npn.ts
@@ -6,6 +6,7 @@ export const npnDevice = {
   deviceClass: "bjt",
   referencePrefix: "Q",
   pinOrder: ["C", "B", "E"],
+  seriesInsertionPinPair: ["C", "E"],
   targetPolicy: "required-model",
   parameters: [],
   dialects: ["spice", "spectre"],

--- a/packages/devices/src/descriptors/pmos.ts
+++ b/packages/devices/src/descriptors/pmos.ts
@@ -7,6 +7,7 @@ export const pmosDevice = {
   mosBulkClass: "pmos",
   referencePrefix: "M",
   pinOrder: ["D", "G", "S", "B"],
+  seriesInsertionPinPair: ["D", "S"],
   targetPolicy: "required-model",
   parameters: [
     {

--- a/packages/devices/src/descriptors/pnp.ts
+++ b/packages/devices/src/descriptors/pnp.ts
@@ -6,6 +6,7 @@ export const pnpDevice = {
   deviceClass: "bjt",
   referencePrefix: "Q",
   pinOrder: ["C", "B", "E"],
+  seriesInsertionPinPair: ["C", "E"],
   targetPolicy: "required-model",
   parameters: [],
   dialects: ["spice", "spectre"],

--- a/packages/devices/src/registry.test.ts
+++ b/packages/devices/src/registry.test.ts
@@ -20,6 +20,7 @@ describe("built-in device registry", () => {
       mosBulkClass: "nmos",
       referencePrefix: "M",
       pinOrder: ["D", "G", "S", "B"],
+      seriesInsertionPinPair: ["D", "S"],
       targetPolicy: "required-model",
       parameters: [
         // W is the total width; NF divides it into fingers, so the panel can
@@ -60,6 +61,8 @@ describe("built-in device registry", () => {
       pinOrder: ["D", "G", "S", "B"],
       targetPolicy: "required-model",
     });
+    expect(deviceDescriptor("npn")?.seriesInsertionPinPair).toEqual(["C", "E"]);
+    expect(deviceDescriptor("pnp")?.seriesInsertionPinPair).toEqual(["C", "E"]);
   });
 
   it("models adjustable passives as ordinary primitives of their base class", () => {
@@ -196,6 +199,32 @@ describe("built-in device registry", () => {
       expect.arrayContaining([
         expect.objectContaining({
           message: "Only MOS devices may support bulk binding",
+        }),
+      ]),
+    );
+  });
+
+  it("rejects invalid series-insertion pin-pair declarations", () => {
+    const nmos = deviceDescriptor("nmos");
+    expect(nmos).toBeDefined();
+    if (!nmos) return;
+    expect(
+      validateDeviceDescriptors([
+        { ...nmos, seriesInsertionPinPair: ["D", "D"] },
+        {
+          ...nmos,
+          id: "unknown-series-pin",
+          symbolId: "unknown-series-pin",
+          seriesInsertionPinPair: ["D", "X"],
+        },
+      ]),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: "Series insertion pin pair must contain two distinct pins",
+        }),
+        expect.objectContaining({
+          message: "Series insertion references unknown pin: X",
         }),
       ]),
     );

--- a/packages/devices/src/validation.ts
+++ b/packages/devices/src/validation.ts
@@ -51,6 +51,23 @@ export function validateDeviceDescriptors(
       }
       pinNames.add(pinName);
     }
+    if (descriptor.seriesInsertionPinPair) {
+      const [first, second] = descriptor.seriesInsertionPinPair;
+      if (first === second) {
+        issues.push({
+          deviceId: descriptor.id,
+          message: "Series insertion pin pair must contain two distinct pins",
+        });
+      }
+      for (const pinName of descriptor.seriesInsertionPinPair) {
+        if (!pinNames.has(pinName)) {
+          issues.push({
+            deviceId: descriptor.id,
+            message: `Series insertion references unknown pin: ${pinName}`,
+          });
+        }
+      }
+    }
     const semanticPins = new Set<string>();
     const semanticRoles = new Set<string>();
     for (const semantic of descriptor.pinSemantics ?? []) {


### PR DESCRIPTION
## Summary
- declare stable series-insertion terminal pairs in multi-pin device descriptors
- splice NMOS/PMOS through D-S and NPN/PNP through C-E only when both resolved pin contacts land on one ordinary Route
- keep Gate/Base independent and make pure symbol-bound overlap electrically inert
- document and validate the descriptor contract

## Validation
- pnpm gate:affected -- --base origin/main
- pnpm ci:check
- focused transistor series-splice browser regression
- 1910 unit tests and 291 browser tests passed

Test-Impact: tests-updated