### PR TITLE
fix(editor): outline shapes stay selected through additive and member presses

### DIFF
--- a/apps/editor/e2e/context-menu.spec.ts
+++ b/apps/editor/e2e/context-menu.spec.ts
@@ -96,6 +96,55 @@ test("drafting text shares device additive selection and context alignment", asy
   );
 });
 
+test("drafting shapes join device selection from either order", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 300, y: 220 });
+  await clickDrawTool(page, "rectangle");
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.click({ position: { x: 420, y: 180 } });
+  await canvas.click({ position: { x: 540, y: 280 } });
+  await page.keyboard.press("Escape");
+
+  const instance = page.locator('[data-canvas-hit-kind="instance"]').first();
+  const rectangle = page.getByTestId(/^drafting-hit-rectangle-/);
+
+  // Shape first, then Shift+device — the order that used to drop the shape:
+  // the outside-press deselect ran before the additive click could compose.
+  await canvas.click({ position: { x: 480, y: 180 } });
+  await expect(rectangle).toHaveClass(/selected/);
+  await instance.click({ modifiers: ["Shift"] });
+  await expect(instance).toHaveClass(/selected/);
+  await expect(rectangle).toHaveClass(/selected/);
+
+  // Right-clicking the DEVICE member must not shed the shape either: the
+  // press acts on the pair, so the shared command surface opens over both.
+  // (Shapes do not participate in edge alignment — that boundary is #384's,
+  // not this test's — so the mixed menu is asserted, not an Align action.)
+  await instance.click({ button: "right" });
+  const menu = page.getByTestId("canvas-context-menu");
+  await expect(menu).toBeVisible();
+  await expect(menu).not.toContainText("Swap device");
+  await expect(menu.getByRole("menuitem", { name: "Delete" })).toBeEnabled();
+  await expect(rectangle).toHaveClass(/selected/);
+  await expect(instance).toHaveClass(/selected/);
+  await page.keyboard.press("Escape");
+  await expect(menu).toHaveCount(0);
+
+  // A plain press on empty canvas keeps its meaning: the shape deselects.
+  await canvas.click({ position: { x: 640, y: 400 } });
+  await expect(rectangle).not.toHaveClass(/selected/);
+
+  // The reverse order composes too. A shape is a stroke-only hit, so the
+  // additive click aims at its edge, not the locator's center.
+  await instance.click();
+  await expect(instance).toHaveClass(/selected/);
+  await canvas.click({ position: { x: 480, y: 180 }, modifiers: ["Shift"] });
+  await expect(instance).toHaveClass(/selected/);
+  await expect(rectangle).toHaveClass(/selected/);
+});
+
 test("device annotation shares device additive selection and context menu", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -3497,6 +3497,25 @@ export function App({
     selection: {
       commitCommandMove: commitCommandMoveFromSelection,
       clearDraftingSelection: () => replaceSelectionKind("drafting", []),
+      pressActsOnSelection: (target) => {
+        const hitElement = target.closest("[data-canvas-hit-kind]");
+        const kind = hitElement?.getAttribute("data-canvas-hit-kind");
+        const id = hitElement?.getAttribute("data-canvas-hit-id");
+        if (!kind || !id) return false;
+        if (kind === "drafting") {
+          return visualSelection.draftingIds.includes(id);
+        }
+        if (
+          kind === "instance" ||
+          kind === "instance-label" ||
+          kind === "annotation" ||
+          kind === "route" ||
+          kind === "junction"
+        ) {
+          return compositeSelectionOwnsHit(kind, id);
+        }
+        return false;
+      },
       handleCanvasHitPointerDown: (event) => {
         if (!simulationPickNetsActive) handleCanvasHitPointerDown(event);
       },

--- a/apps/editor/src/canvas/editor-canvas-event-handlers.ts
+++ b/apps/editor/src/canvas/editor-canvas-event-handlers.ts
@@ -52,6 +52,12 @@ interface CanvasEventHandlerDependencies {
       canvas: SVGSVGElement,
     ) => void;
     clearDraftingSelection: () => void;
+    /**
+     * Whether the pressed element belongs to the current selection, so the
+     * press is about to act on that selection (drag it as one body, open its
+     * context menu) rather than replace it.
+     */
+    pressActsOnSelection: (target: Element) => boolean;
     handleCanvasHitPointerDown: (event: CanvasPointerEvent) => void;
   };
   placement: {
@@ -129,6 +135,7 @@ export function createEditorCanvasEventHandlers({
   selection: {
     commitCommandMove,
     clearDraftingSelection,
+    pressActsOnSelection,
     handleCanvasHitPointerDown,
   },
   placement: {
@@ -261,18 +268,27 @@ export function createEditorCanvasEventHandlers({
         event.stopPropagation();
         return;
       }
+      // Outline shapes are stroke-only hits, so a press "inside" one lands on
+      // the canvas; this deselect gives them plain-click-outside dismissal.
+      // It must stand down for an additive press (the click is composing a
+      // selection, not replacing one) and for a press on any member of the
+      // current selection (the press is about to drag it or open its menu).
       if (
         selectedDrafting &&
         (selectedDrafting.kind === "arrow" ||
           selectedDrafting.kind === "construction-line" ||
           selectedDrafting.kind === "rectangle" ||
           selectedDrafting.kind === "circle") &&
+        !event.shiftKey &&
+        !event.ctrlKey &&
+        !event.metaKey &&
         !target.closest(
           `[data-testid="drafting-hit-${selectedDrafting.id}"]`,
         ) &&
         !target.closest(
           `[data-testid="drafting-handles-${selectedDrafting.id}"]`,
-        )
+        ) &&
+        !pressActsOnSelection(target)
       ) {
         clearDraftingSelection();
       }


### PR DESCRIPTION
## Feedback addressed

> I cant select rectangle with other items at the same time.

## Root cause

A capture-phase handler deselected any selected outline shape (arrow, construction line, rectangle, circle) on **every** pointer press outside the shape's own hit target — with no regard for modifiers or for what the press was about to do. Shift-clicking a device while a rectangle was selected therefore cleared the rectangle first, and the device's additive click composed into an empty set: the pair could never be assembled in that order. Drafting **text** is not in the handler's kind list, which is why the existing mixed-selection spec (text + device) always passed. The same premature clear also shed the shape from right-clicks and plain drags on a fellow selection member — a composed group lost its shape exactly when it was acted on.

## Fix

The outside-press deselect keeps its purpose (outline shapes are stroke-only hits, so a press "inside" one lands on the canvas and a plain click should dismiss the shape), but now stands down in two cases:

- the press carries a selection modifier (Shift/Ctrl/Cmd) — it is composing a selection, not replacing one;
- the pressed element belongs to the current selection — it is about to drag the group or open its context menu (membership reuses the hit controller's `compositeSelectionOwnsHit`).

Out of scope, unchanged: shapes still do not participate in edge alignment (#384's deliberate boundary). The new spec asserts the mixed context menu, both composition orders, and pins the plain-outside-click dismissal.

## Validation

New e2e red before the fix (shape-first composition dropped the shape at the exact reported step), green after; context-menu 6/6, drafting + selection-visuals + verb-first + detach-move 43/43, editor unit suite 712/712, typecheck and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)