### PR TITLE
feat(editor): surface live findings through a statusbar issues badge

### DIFF
--- a/apps/editor/e2e/diagnostics-surfacing.spec.ts
+++ b/apps/editor/e2e/diagnostics-surfacing.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+import { chooseComponent } from "./editor-fixtures";
+
+/**
+ * Findings must reach the person drawing: the statusbar carries a persistent
+ * issues badge fed by the live diagnostic snapshot, and clicking it opens the
+ * properties dock with the issues section expanded, where each finding
+ * navigates to its object.
+ */
+test("statusbar issues badge surfaces live findings and opens the workbench", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+
+  // A fresh document rests at a quiet, still-clickable entry point.
+  const badge = page.getByTestId("statusbar-issues");
+  await expect(badge).toHaveAttribute("data-severity", "none");
+  await expect(badge).toHaveText("No issues");
+
+  // A placed component with open pins produces live actionable findings.
+  await chooseComponent(page, "resistor");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 400, y: 240 } });
+  await page.keyboard.press("Escape");
+  await expect(badge).toHaveAttribute("data-severity", "warning");
+  await expect(badge).toContainText("warning");
+
+  // The badge opens the dock with the issues section expanded.
+  await badge.click();
+  const issuesSection = page.locator(
+    'section[aria-label="Project diagnostics"] details',
+  );
+  await expect(issuesSection).toHaveAttribute("open", "");
+  const findings = page.getByTestId("project-diagnostics").locator("li button");
+  await expect(findings.first()).toBeVisible();
+
+  // A finding navigates: the status line reports the ERC jump.
+  await findings.first().click();
+  await expect(page.getByTestId("status")).toContainText("ERC");
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -24,6 +24,7 @@ import {
   annotationOwningInstanceId,
   deriveNetConnectivity,
   deriveRoutingAffectedClosure,
+  diagnosticPresentationGroup,
   resolveDraftingObjectGeometry,
   displayableInstanceValue,
   resolveMosBulkConnection,
@@ -1283,6 +1284,24 @@ export function App({
     () => buildSceneSnapTargetIndex(document, resolver, visibleEndpoints),
     [document, resolver, visibleEndpoints],
   );
+  const [issuesFocusToken, setIssuesFocusToken] = useState(0);
+  const issueCounts = useMemo(() => {
+    let errorCount = 0;
+    let warningCount = 0;
+    for (const diagnostic of liveDiagnosticSnapshot.diagnostics) {
+      if (diagnosticPresentationGroup(diagnostic) !== "actionable") continue;
+      if (diagnostic.severity === "error") errorCount += 1;
+      else if (diagnostic.severity === "warning") warningCount += 1;
+    }
+    return { errorCount, warningCount };
+  }, [liveDiagnosticSnapshot]);
+  const openIssuesPanel = (): void => {
+    // Narrow layouts have room for one side panel — same rule as the dock
+    // toggle, but this entry point always OPENS.
+    if (compactLayout) setCompactLibraryPanelOpen(false);
+    setSelectionOpen(true);
+    setIssuesFocusToken((token) => token + 1);
+  };
   const simulationPickHighlight = useMemo(
     () =>
       simulationPickNetsActive && simulationHoverNetId
@@ -4626,6 +4645,7 @@ export function App({
               project.documents.find((candidate) => candidate.id === documentId)
                 ?.name ?? documentId,
             onSelectDiagnostic: jumpToProjectDiagnostic,
+            focusRequestToken: issuesFocusToken,
           }}
           netTrace={
             highlightedTrace && highlightedTrace.hops.length > 0
@@ -5190,6 +5210,11 @@ export function App({
         wheelBehavior={wheelBehavior}
         onWheelBehaviorChange={setWheelBehavior}
         zoomPercent={zoomPercent}
+        issues={{
+          errorCount: issueCounts.errorCount,
+          warningCount: issueCounts.warningCount,
+          onOpen: openIssuesPanel,
+        }}
         onToggleWireOptions={() => setWireOptionsOpen((open) => !open)}
         onWireRoutingModeChange={setWireRoutingMode}
         onWireCornerOrderChange={setWireCornerOrder}

--- a/apps/editor/src/features/editor-shell/editor-statusbar.test.tsx
+++ b/apps/editor/src/features/editor-shell/editor-statusbar.test.tsx
@@ -38,4 +38,73 @@ describe("editor statusbar", () => {
     expect(markup).toContain('aria-label="Current zoom"');
     expect(markup).toContain('aria-label="Annotation grid"');
   });
+
+  function statusbarWithIssues(issues: {
+    errorCount: number;
+    warningCount: number;
+    onOpen(): void;
+  }) {
+    return renderToStaticMarkup(
+      <EditorStatusbar
+        status="Ready"
+        tool="pointer"
+        vddRailMode={false}
+        pendingSymbolId={null}
+        wireOptionsOpen={false}
+        wireRoutingMode="orthogonal"
+        wireCornerOrder="auto"
+        recoveryLabel={null}
+        gridDotsVisible
+        drawAngleMode="free"
+        wheelBehavior="auto"
+        onWheelBehaviorChange={vi.fn()}
+        onDrawAngleModeChange={vi.fn()}
+        annotationGrid={5}
+        zoomPercent={100}
+        issues={issues}
+        onToggleWireOptions={vi.fn()}
+        onWireRoutingModeChange={vi.fn()}
+        onWireCornerOrderChange={vi.fn()}
+        onToggleGridDots={vi.fn()}
+        onOpenAnalytics={vi.fn()}
+        onAnnotationGridChange={vi.fn()}
+        onZoomOut={vi.fn()}
+        onZoomIn={vi.fn()}
+        onFitView={vi.fn()}
+      />,
+    );
+  }
+
+  it("shows an error-severity issues badge with combined counts", () => {
+    const markup = statusbarWithIssues({
+      errorCount: 2,
+      warningCount: 1,
+      onOpen: vi.fn(),
+    });
+    expect(markup).toContain('data-testid="statusbar-issues"');
+    expect(markup).toContain('data-severity="error"');
+    expect(markup).toContain("2 errors, 1 warning");
+    expect(markup).toContain("Action required");
+  });
+
+  it("shows a warning-severity issues badge without errors", () => {
+    const markup = statusbarWithIssues({
+      errorCount: 0,
+      warningCount: 3,
+      onOpen: vi.fn(),
+    });
+    expect(markup).toContain('data-severity="warning"');
+    expect(markup).toContain("3 warnings");
+  });
+
+  it("keeps a quiet zero-state badge as the discoverable entry point", () => {
+    const markup = statusbarWithIssues({
+      errorCount: 0,
+      warningCount: 0,
+      onOpen: vi.fn(),
+    });
+    expect(markup).toContain('data-testid="statusbar-issues"');
+    expect(markup).toContain('data-severity="none"');
+    expect(markup).toContain("No issues");
+  });
 });

--- a/apps/editor/src/features/editor-shell/editor-statusbar.tsx
+++ b/apps/editor/src/features/editor-shell/editor-statusbar.tsx
@@ -15,6 +15,37 @@ function toolLabel(
   return tool.charAt(0).toUpperCase() + tool.slice(1);
 }
 
+function issuesBadge(issues: { errorCount: number; warningCount: number }): {
+  severity: "error" | "warning" | "none";
+  label: string;
+  title: string;
+} {
+  const plural = (count: number, noun: string) =>
+    `${count} ${noun}${count === 1 ? "" : "s"}`;
+  if (issues.errorCount > 0) {
+    return {
+      severity: "error",
+      label:
+        issues.warningCount > 0
+          ? `${plural(issues.errorCount, "error")}, ${plural(issues.warningCount, "warning")}`
+          : plural(issues.errorCount, "error"),
+      title: "Action required — open the issues list",
+    };
+  }
+  if (issues.warningCount > 0) {
+    return {
+      severity: "warning",
+      label: plural(issues.warningCount, "warning"),
+      title: "Review findings — open the issues list",
+    };
+  }
+  return {
+    severity: "none",
+    label: "No issues",
+    title: "Open the issues list",
+  };
+}
+
 export function EditorStatusbar({
   visitStats,
   status,
@@ -30,6 +61,7 @@ export function EditorStatusbar({
   drawAngleMode,
   wheelBehavior,
   zoomPercent,
+  issues,
   onToggleWireOptions,
   onWireRoutingModeChange,
   onWireCornerOrderChange,
@@ -56,6 +88,7 @@ export function EditorStatusbar({
   drawAngleMode: "free" | "45" | "orthogonal";
   wheelBehavior: "auto" | "zoom" | "pan";
   zoomPercent: number;
+  issues?: { errorCount: number; warningCount: number; onOpen: () => void };
   onToggleWireOptions: () => void;
   onWireRoutingModeChange: (mode: WireRoutingMode) => void;
   onWireCornerOrderChange: (order: WireCornerOrder) => void;
@@ -132,6 +165,24 @@ export function EditorStatusbar({
             {recoveryLabel}
           </output>
         ) : null}
+        {issues
+          ? (() => {
+              const badge = issuesBadge(issues);
+              return (
+                <button
+                  type="button"
+                  className="statusbar-issues"
+                  data-testid="statusbar-issues"
+                  data-severity={badge.severity}
+                  title={badge.title}
+                  aria-label={`${badge.label}. ${badge.title}`}
+                  onClick={issues.onOpen}
+                >
+                  {badge.label}
+                </button>
+              );
+            })()
+          : null}
       </div>
       {visitStats ? (
         <a

--- a/apps/editor/src/features/selection/selection-inspector-details.test.tsx
+++ b/apps/editor/src/features/selection/selection-inspector-details.test.tsx
@@ -139,6 +139,41 @@ describe("selection inspector details", () => {
     expect(markup).toContain("Issues (1)");
   });
 
+  it("expands the issues section when a focus request token arrives", () => {
+    const markup = renderToStaticMarkup(
+      <ProjectDiagnosticsSection
+        snapshot={{
+          source: "live",
+          projectId: "project-fixture",
+          documentRevisions: [{ documentId: "document-child", revision: 7 }],
+          diagnostics: [ercDiagnostic],
+        }}
+        documentLabel={() => "Main Cell"}
+        onSelectDiagnostic={() => undefined}
+        focusRequestToken={1}
+      />,
+    );
+    // A warning alone does not auto-open the section; the statusbar badge's
+    // focus request must.
+    expect(markup).toContain("<details open");
+  });
+
+  it("keeps a warning-only issues section collapsed without a focus request", () => {
+    const markup = renderToStaticMarkup(
+      <ProjectDiagnosticsSection
+        snapshot={{
+          source: "live",
+          projectId: "project-fixture",
+          documentRevisions: [{ documentId: "document-child", revision: 7 }],
+          diagnostics: [ercDiagnostic],
+        }}
+        documentLabel={() => "Main Cell"}
+        onSelectDiagnostic={() => undefined}
+      />,
+    );
+    expect(markup).not.toContain("<details open");
+  });
+
   it("renders concrete, navigable hierarchy Net hops", () => {
     const trace: HierarchyNetTrace = {
       primary: {

--- a/apps/editor/src/features/selection/selection-inspector-details.tsx
+++ b/apps/editor/src/features/selection/selection-inspector-details.tsx
@@ -11,7 +11,7 @@ import type {
   LiveDiagnosticSnapshot,
   VisualDiagnostic,
 } from "@icm/derived";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { SpiceDiagnostic } from "@icm/spice";
 
 import type { EditorTool } from "../../interaction/interaction-state";
@@ -136,6 +136,11 @@ export interface ProjectDiagnosticsSectionProps {
   snapshot: LiveDiagnosticSnapshot;
   documentLabel(documentId: string): string;
   onSelectDiagnostic(diagnostic: Diagnostic): void;
+  /**
+   * Increment to expand and reveal the issues section from outside — the
+   * statusbar badge's click. The section stays user-collapsible afterwards.
+   */
+  focusRequestToken?: number;
 }
 
 export interface NetTraceSectionProps {
@@ -242,11 +247,29 @@ export function ProjectDiagnosticsSection({
   snapshot,
   documentLabel,
   onSelectDiagnostic,
+  focusRequestToken = 0,
 }: ProjectDiagnosticsSectionProps) {
   const diagnostics = snapshot.diagnostics;
   const [severityFilter, setSeverityFilter] =
     useState<DiagnosticSeverityFilter>("all");
   const [showObservations, setShowObservations] = useState(false);
+  const [sectionOpen, setSectionOpen] = useState(
+    () =>
+      focusRequestToken > 0 ||
+      diagnostics.some(
+        (diagnostic) =>
+          diagnostic.severity === "error" &&
+          diagnosticPresentationGroup(diagnostic) === "actionable",
+      ),
+  );
+  const [handledFocusToken, setHandledFocusToken] = useState(focusRequestToken);
+  const sectionRef = useRef<HTMLDetailsElement>(null);
+  useEffect(() => {
+    if (focusRequestToken <= handledFocusToken) return;
+    setHandledFocusToken(focusRequestToken);
+    setSectionOpen(true);
+    sectionRef.current?.scrollIntoView({ block: "nearest" });
+  }, [focusRequestToken, handledFocusToken]);
   const observationCount = diagnostics.filter(
     (diagnostic) => diagnosticPresentationGroup(diagnostic) === "observation",
   ).length;
@@ -271,12 +294,23 @@ export function ProjectDiagnosticsSection({
   const hasBlockingIssue = availableDiagnostics.some(
     (diagnostic) => diagnostic.severity === "error",
   );
+  const previousBlockingRef = useRef(hasBlockingIssue);
+  useEffect(() => {
+    // Preserve the pre-existing behavior: a blocking issue APPEARING opens
+    // the section; the user can still collapse it afterwards.
+    if (hasBlockingIssue && !previousBlockingRef.current) setSectionOpen(true);
+    previousBlockingRef.current = hasBlockingIssue;
+  }, [hasBlockingIssue]);
   return (
     <section
       aria-label="Project diagnostics"
       className="diagnostics erc-diagnostics"
     >
-      <details open={hasBlockingIssue || undefined}>
+      <details
+        ref={sectionRef}
+        open={sectionOpen || undefined}
+        onToggle={(event) => setSectionOpen(event.currentTarget.open)}
+      >
         <summary>
           <h2>Issues ({availableDiagnostics.length})</h2>
           <span>{hasBlockingIssue ? "Action required" : "Review"}</span>

--- a/apps/editor/src/styles/editor-workspace.css
+++ b/apps/editor/src/styles/editor-workspace.css
@@ -535,6 +535,31 @@
   line-height: var(--icm-line-tight);
 }
 
+/* Persistent findings entry point. Same chip language as the tool label; the
+   severity recolors it, and the zero state stays quiet but clickable. */
+.statusbar-issues {
+  flex: 0 0 auto;
+  padding: 2px 8px;
+  border: 0;
+  border-radius: 999px;
+  color: var(--icm-text-muted);
+  background: var(--icm-surface-muted);
+  font-size: var(--icm-font-xs);
+  font-weight: 600;
+  line-height: var(--icm-line-tight);
+  cursor: pointer;
+}
+
+.statusbar-issues[data-severity="warning"] {
+  color: var(--icm-warning);
+  background: color-mix(in srgb, var(--icm-warning) 14%, transparent);
+}
+
+.statusbar-issues[data-severity="error"] {
+  color: var(--icm-danger, #b42318);
+  background: color-mix(in srgb, var(--icm-danger, #b42318) 12%, transparent);
+}
+
 /* The gallery panel shows circuits, not just their names, and the reader
    chooses how many fit per row. */
 .shapes-example-list {


### PR DESCRIPTION
Findings never reached the person drawing. The live diagnostic pipeline has been complete all along — `diagnoseProjectSnapshot` unifies every domain (schema/spice/erc/routing/visual) into locator-backed findings, memoized per committed revision, and `ProjectDiagnosticsSection` renders a full workbench (severity filters, observation toggle, click-to-navigate via `jumpToProjectDiagnostic`) — but the workbench lives inside the properties dock, and nothing anywhere says "there are findings". In the LTC3452 feedback session, seventeen findings including the exact net the user was debugging sat in a closed panel while they hunted by eye.

## Change (display layer only)

- **Statusbar issues badge** (`editor-statusbar.tsx`, left zone, chip idiom): fed by the *same* memoized snapshot — zero new computation, recomputes only per committed revision, so the #423–#426 derived-recomputation work is untouched. Counts use the workbench's own `diagnosticPresentationGroup`: actionable errors and warnings; observations stay out of the count exactly as the workbench hides them by default. States: ≥1 error → red, "N errors[, M warnings]", title "Action required"; warnings only → amber; zero → muted "No issues", kept visible and **clickable in every state** so the entry point stays discoverable.
- **Click → workbench**: opens the properties dock through the same narrow-layout one-panel rule as the dock toggle, and a `focusRequestToken` threaded App → dock → `ProjectDiagnosticsSection` expands and reveals the issues section. The section's `<details>` is now controlled-open: a badge request and a newly *appearing* blocking issue both expand it (the pre-existing auto-open behavior preserved as a transition), and the reader can still collapse it by hand.
- **Live behavior**: findings appear and resolve on each committed edit with no extra wiring; future detectors (e.g. the terminal-parked-on-foreign-route detector in flight) surface automatically because the badge reads the envelope, never the rules.

Out of scope, deliberately: on-canvas markers at finding points (phase 2 candidate — findings carry points), any change to diagnostic rules/severities/domains, the netlist preflight dialog and gallery publish flows.

## Tests (red-first)

- Statusbar: error-severity combined counts, warning-only, and quiet zero state (three red before implementation).
- Inspector: `focusRequestToken` expands the issues section (red); warning-only stays collapsed without a request (guard, green on both sides).
- New e2e `diagnostics-surfacing.spec.ts`: fresh document shows the quiet badge → placing a resistor raises warning findings on the badge live → clicking opens the dock with the section expanded → clicking the finding navigates with an ERC status report.

## Validation

Full unit suite 1922/1922, typecheck, prettier, `pnpm test:impact`, full `pnpm ci:check` (logged, explicit exit code) before merge. Production verification after deploy walks the same badge → workbench → navigate path.

Related to the wire-segmentation feedback assessment (diagnostics-reach gap), #432 and #433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
