### PR TITLE
fix(editor): thin electrical targets outrank the symbol bounding box

### DIFF
--- a/apps/editor/e2e/thin-target-hit.spec.ts
+++ b/apps/editor/e2e/thin-target-hit.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+
+import { chooseComponent, clickDrawTool } from "./editor-fixtures";
+
+/**
+ * A deliberate click on visible wire must select the wire even where the
+ * symbol's blank hit rectangle overlaps it; the symbol body itself stays
+ * selectable, and a second click cycles between overlapped candidates.
+ */
+test("clicking wire beside a symbol body selects the wire, not the box", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await chooseComponent(page, "resistor");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 300, y: 220 } });
+  await page.keyboard.press("Escape");
+
+  // Wire from the resistor's bottom pin outward; its first stretch runs
+  // through the symbol's hit rectangle.
+  await clickDrawTool(page, "wire");
+  await page.getByTestId("terminal-R1-2").click();
+  await page
+    .getByTestId("schematic-canvas")
+    .dblclick({ position: { x: 300, y: 360 } });
+  await page.keyboard.press("Escape");
+
+  const route = page.locator('[data-canvas-hit-kind="route"]').first();
+  const routeBox = (await route.boundingBox())!;
+  const instanceBox = (await page.getByTestId("hit-R1").boundingBox())!;
+  // A point on the wire inside the symbol's hit rectangle.
+  const x = routeBox.x + routeBox.width / 2;
+  const y = Math.min(
+    instanceBox.y + instanceBox.height - 4,
+    routeBox.y + routeBox.height - 4,
+  );
+  expect(y).toBeGreaterThan(instanceBox.y);
+
+  await page.mouse.click(x, y);
+  await expect(page.getByTestId("status")).toContainText("Selected route");
+
+  // The body away from the wire still selects the symbol.
+  await page.keyboard.press("Escape");
+  await page.mouse.click(
+    instanceBox.x + instanceBox.width - 6,
+    instanceBox.y + instanceBox.height / 2,
+  );
+  await expect(page.getByTestId("hit-R1")).toHaveClass(/selected/);
+});

--- a/apps/editor/src/canvas/canvas-hit-resolver.test.ts
+++ b/apps/editor/src/canvas/canvas-hit-resolver.test.ts
@@ -57,4 +57,52 @@ describe("resolveCanvasHit", () => {
       element: first,
     });
   });
+
+  it("lets a deliberate click on visible wire beat the symbol bounding box", () => {
+    // A route hit means the pointer is on the wire's thin stroke; an instance
+    // hit only means it is inside the symbol's blank bounding box. The thin
+    // target wins in either paint order.
+    const route = element("route", "route-1");
+    const instance = element("instance", "M1");
+    expect(resolveCanvasHit([instance, route])).toMatchObject({
+      kind: "route",
+      id: "route-1",
+    });
+    expect(resolveCanvasHit([route, instance])).toMatchObject({
+      kind: "route",
+      id: "route-1",
+    });
+  });
+
+  it("lets a junction dot beat the symbol bounding box the same way", () => {
+    const junction = element("junction", "J1");
+    const instance = element("instance", "M1");
+    expect(resolveCanvasHit([instance, junction])).toMatchObject({
+      kind: "junction",
+      id: "J1",
+    });
+  });
+
+  it("keeps the symbol selectable beside wires and sticky while selected", () => {
+    // Away from any wire the instance is the only candidate.
+    const aloneInstance = element("instance", "M1");
+    expect(resolveCanvasHit([aloneInstance])).toMatchObject({
+      kind: "instance",
+      id: "M1",
+    });
+    // Under a wire the second click still cycles to the symbol.
+    const route = element("route", "route-1");
+    const instance = element("instance", "M1");
+    expect(resolveCanvasHit([instance, route], 1)).toMatchObject({
+      kind: "instance",
+      id: "M1",
+    });
+    // An already-selected symbol stays sticky across crossing wires, so a
+    // drag that starts over a wire pixel keeps moving the symbol.
+    const selectedInstance = element("instance", "M1", true);
+    expect(resolveCanvasHit([selectedInstance, route])).toMatchObject({
+      kind: "instance",
+      id: "M1",
+    });
+  });
 });

--- a/apps/editor/src/canvas/canvas-hit-resolver.ts
+++ b/apps/editor/src/canvas/canvas-hit-resolver.ts
@@ -14,11 +14,17 @@ export interface CanvasHit {
   element: Element;
 }
 
+// Thin electrical targets outrank the symbol's blank bounding box: a route
+// or junction hit means the pointer is on the wire stroke or the dot itself,
+// while an instance hit only means it is somewhere inside the hit rectangle.
+// A deliberate click on visible wire beside or under a body therefore selects
+// the wire; the symbol stays one cycle-click away, and a selected symbol's
+// stickiness bonus keeps drags over crossing wires on the symbol.
 const KIND_PRIORITY: Record<CanvasHitKind, number> = {
   handle: 70,
+  route: 62,
+  junction: 61,
   instance: 60,
-  route: 55,
-  junction: 50,
   annotation: 45,
   "instance-label": 44,
   drafting: 40,


### PR DESCRIPTION
Clicking visible wire beside or under a symbol body selected the symbol instead: `rankCanvasHits` scored `instance > route > junction`, and the instance hit target is the symbol's blank **bounding rectangle**, so anywhere the rectangle overlapped a wire the wire lost. A short segment next to a pin — the exact shape every series insertion leaves behind — was nearly unclickable at normal zoom. The #432 production verification ran into this directly (the between-pins sliver), and the coordinator scoped the generic fix.

## Change (interaction layer only)

Thin targets outrank the box: a route or junction hit means the pointer is on the wire stroke or the dot itself; an instance hit only means somewhere inside the rectangle. Priorities become `handle 70 > route 62 > junction 61 > instance 60 > …` — one table edit in [canvas-hit-resolver.ts](apps/editor/src/canvas/canvas-hit-resolver.ts).

Deliberately unchanged:

- What is selectable, and all selection semantics — only which overlapped candidate wins the first click.
- The symbol body away from wires selects exactly as before (no route candidate present).
- The existing **cycle click** still reaches the symbol when a wire crosses it (second click on the same spot).
- The **selected-candidate bonus** keeps an already-selected symbol sticky above routes, so a drag that starts over a crossing wire keeps moving the symbol.

## Tests (red-first)

- Resolver units: wire beats the box in both paint orders; junction dot beats the box; guards for the lone symbol, the cycle click, and selected-symbol stickiness. Three failed before the change.
- New e2e [thin-target-hit.spec.ts](apps/editor/e2e/thin-target-hit.spec.ts): wires a resistor pin outward, clicks the wire **inside the symbol's hit rectangle** → the wire selects; clicks the body away from the wire → the symbol selects.
- Adjacent selection/wiring e2e specs pass unchanged.

## Validation

Full unit suite 1925/1925, targeted e2e green, typecheck, prettier, `pnpm test:impact`, full `pnpm ci:check` (logged, explicit exit code) before merge. Production verification after deploy repeats the wire-inside-the-box click live.

Related to #432 (where the ergonomic was first hit) and the wire-segmentation feedback assessment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
