### PR TITLE
feat(editor): say when a placed part came a grid short of a wire

### DIFF
--- a/apps/editor/e2e/placement-near-miss.spec.ts
+++ b/apps/editor/e2e/placement-near-miss.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+
+import { chooseComponent } from "./editor-fixtures.js";
+
+async function placeAt(
+  page: import("@playwright/test").Page,
+  x: number,
+  y: number,
+): Promise<string> {
+  await chooseComponent(page, "resistor");
+  await page.getByTestId("schematic-canvas").click({ position: { x, y } });
+  // Read before Escape: cancelling the still-armed tool overwrites the line.
+  const status = await page.getByTestId("status").innerText();
+  await page.keyboard.press("Escape");
+  return status;
+}
+
+test("the status line warns about a near miss and stays quiet otherwise", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  // Two resistors joined by a wire: that wire is what a later part can miss.
+  await placeAt(page, 260, 200);
+  await placeAt(page, 260, 420);
+  const ids = await page.evaluate(() =>
+    [...document.querySelectorAll('[data-object-id^="R"]')].map((node) =>
+      node.getAttribute("data-object-id"),
+    ),
+  );
+  await page.keyboard.press("w");
+  await page.getByTestId(`terminal-${ids[0]}-2`).click();
+  await page.getByTestId(`terminal-${ids[1]}-1`).click();
+  await page.keyboard.press("Escape");
+  await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(1);
+
+  const route = page.locator('[data-canvas-hit-kind="route"]').first();
+  const box = (await route.boundingBox())!;
+  const canvas = (await page.getByTestId("schematic-canvas").boundingBox())!;
+  // The wire runs vertically at this x. Place to its side at three distances.
+  const wireX = Math.round(box.x + box.width / 2 - canvas.x);
+  const midY = Math.round(box.y + box.height / 2 - canvas.y);
+
+  const onWire = await placeAt(page, wireX, midY);
+  const nearby = await placeAt(page, wireX + 10, midY);
+  const faraway = await placeAt(page, wireX + 180, midY);
+
+  // On the wire: the placement connects, so there is nothing to warn about.
+  expect(onWire).toContain("connected its contacted pin");
+  expect(onWire).not.toContain("not connected");
+  // One grid out: it looks joined and is not, so the line says so.
+  expect(nearby).toContain("is 1 grid from");
+  expect(nearby).toContain("not connected");
+  // Somewhere else entirely: silence, or the hint becomes noise.
+  expect(faraway).not.toContain("not connected");
+});

--- a/apps/editor/src/features/component-insert/placement-near-miss.test.ts
+++ b/apps/editor/src/features/component-insert/placement-near-miss.test.ts
@@ -1,0 +1,154 @@
+import { createEmptyDocument, createRoutePath } from "@icm/model";
+import type { Instance, SchematicDocument } from "@icm/model";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import {
+  describePlacementNearMiss,
+  findPlacementNearMisses,
+} from "./placement-near-miss";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+/**
+ * One horizontal wire at y = 300, running x = 200..400, on a 10-unit grid.
+ * A resistor's pins sit 20 above and below its position.
+ */
+function documentWithWire(): SchematicDocument {
+  const document = createEmptyDocument("near-miss", "Near miss");
+  document.presentation.grid = 10;
+  document.nets.push({ id: "net-vdd", terminals: [] });
+  document.junctions.push(
+    { id: "J1", netId: "net-vdd", position: { x: 200, y: 300 } },
+    { id: "J2", netId: "net-vdd", position: { x: 400, y: 300 } },
+  );
+  document.routes.push(
+    createRoutePath({
+      id: "w1",
+      netId: "net-vdd",
+      start: { kind: "junction", junctionId: "J1" },
+      end: { kind: "junction", junctionId: "J2" },
+      bends: [],
+      modes: ["manual"],
+    }),
+  );
+  return document;
+}
+
+/** Resistor pin 1 sits 20 above the body centre, pin 2 sits 20 below. */
+function resistorAt(x: number, y: number): Instance {
+  return {
+    id: "R3",
+    symbolId: "resistor",
+    placement: { position: { x, y }, rotation: 0, mirror: "none" },
+  } as Instance;
+}
+
+describe("placement near misses", () => {
+  it("reports a pin one grid short of a wire", () => {
+    const document = documentWithWire();
+    // Pin 1 lands at y = 310 — one grid below the wire at 300.
+    const misses = findPlacementNearMisses(
+      document,
+      resolver,
+      resistorAt(300, 330),
+    );
+    expect(misses).toEqual([
+      { pinName: "1", netId: "net-vdd", netLabel: "a wire", gridsAway: 1 },
+    ]);
+    expect(describePlacementNearMiss(misses, "R3")).toBe(
+      "R3 pin 1 is 1 grid from a wire — not connected",
+    );
+  });
+
+  it("says nothing when the part is simply somewhere else", () => {
+    const document = documentWithWire();
+    const misses = findPlacementNearMisses(
+      document,
+      resolver,
+      resistorAt(300, 500),
+    );
+    expect(misses).toEqual([]);
+    expect(describePlacementNearMiss(misses, "R3")).toBeNull();
+  });
+
+  it("says nothing when the pin is on the wire, because that connects", () => {
+    const document = documentWithWire();
+    // Pin 1 lands exactly on y = 300: contact, which placement already handles.
+    const misses = findPlacementNearMisses(
+      document,
+      resolver,
+      resistorAt(300, 320),
+    );
+    expect(misses.some((miss) => miss.pinName === "1")).toBe(false);
+  });
+
+  it("measures to the nearest drawn point, not the infinite line", () => {
+    const document = documentWithWire();
+    // Well beyond the wire's right end at x = 400, level with it. The
+    // perpendicular distance to the line would be zero; to the segment it is
+    // far, and a part out here has nothing to do with that wire.
+    const misses = findPlacementNearMisses(
+      document,
+      resolver,
+      resistorAt(900, 320),
+    );
+    expect(misses).toEqual([]);
+  });
+
+  it("ignores a pin resting off the grid, which is a different mistake", () => {
+    const document = documentWithWire();
+    // Pin 1 at y = 305 — half a square out, so "one grid short" is not what
+    // happened and saying so would misdescribe it.
+    const misses = findPlacementNearMisses(
+      document,
+      resolver,
+      resistorAt(300, 325),
+    );
+    expect(misses).toEqual([]);
+  });
+
+  it("names the nearest wire when a pin is two grids out", () => {
+    const document = documentWithWire();
+    const misses = findPlacementNearMisses(
+      document,
+      resolver,
+      resistorAt(300, 340),
+    );
+    expect(misses).toEqual([
+      { pinName: "1", netId: "net-vdd", netLabel: "a wire", gridsAway: 2 },
+    ]);
+    expect(describePlacementNearMiss(misses, "R3")).toBe(
+      "R3 pin 1 is 2 grids from a wire — not connected",
+    );
+  });
+
+  it("says a named net's name rather than its generated id", () => {
+    const document = documentWithWire();
+    document.connectivityEvidence.push({
+      id: "claim-vdd",
+      kind: "name-claim",
+      netId: "net-vdd",
+      name: "VDD",
+      scope: "global",
+      owner: { kind: "explicit-net-property" },
+    });
+    const misses = findPlacementNearMisses(
+      document,
+      resolver,
+      resistorAt(300, 330),
+    );
+    expect(misses[0]?.netLabel).toBe("VDD");
+    expect(describePlacementNearMiss(misses, "R3")).toBe(
+      "R3 pin 1 is 1 grid from VDD — not connected",
+    );
+  });
+
+  it("stays quiet in a drawing with no wires at all", () => {
+    const document = createEmptyDocument("bare", "Bare");
+    document.presentation.grid = 10;
+    expect(
+      findPlacementNearMisses(document, resolver, resistorAt(300, 330)),
+    ).toEqual([]);
+  });
+});

--- a/apps/editor/src/features/component-insert/placement-near-miss.ts
+++ b/apps/editor/src/features/component-insert/placement-near-miss.ts
@@ -1,0 +1,120 @@
+import {
+  resolveDocumentLogicalNets,
+  resolveDocumentRoutingGeometry,
+} from "@icm/derived";
+import { transformPoint } from "@icm/model";
+import type { Instance, Point, SchematicDocument } from "@icm/model";
+import type { SymbolResolver } from "@icm/symbols";
+
+/**
+ * A pin that came close to a wire without touching it.
+ *
+ * Placement connects only on exact contact — geometry never guesses a
+ * connection (a Crossing is not a Junction). That rule is right, and it is
+ * also silent: a part dropped one grid short of a wire looks connected at a
+ * glance and behaves as if it is not. This reports the near miss so the
+ * editor can say so, and changes nothing about what actually connects.
+ */
+export interface PlacementNearMiss {
+  pinName: string;
+  netId: string;
+  /**
+   * What to call the wire out loud. A named net says its name; an unnamed one
+   * has only a generated id, which tells a reader nothing, so it stays "a
+   * wire" rather than putting `net-split-d0a1fbbd…` in front of a person.
+   */
+  netLabel: string;
+  /** Whole grid squares between the pin and the wire, 1 or 2. */
+  gridsAway: number;
+}
+
+/** How far off still counts as "you probably meant to touch this". */
+const NEAR_MISS_MAX_GRIDS = 2;
+
+function distanceToSegment(point: Point, from: Point, to: Point): number {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const lengthSquared = dx * dx + dy * dy;
+  if (lengthSquared === 0)
+    return Math.hypot(point.x - from.x, point.y - from.y);
+  // Project onto the segment and clamp, so a pin beside a wire's middle and a
+  // pin past its end are both measured to the nearest point actually drawn.
+  const t = Math.max(
+    0,
+    Math.min(
+      1,
+      ((point.x - from.x) * dx + (point.y - from.y) * dy) / lengthSquared,
+    ),
+  );
+  return Math.hypot(point.x - (from.x + t * dx), point.y - (from.y + t * dy));
+}
+
+/**
+ * Pins of a just-placed Instance that sit within a couple of grid squares of
+ * a wire they did not connect to, nearest first.
+ *
+ * Contact itself is not re-derived here: the caller already knows whether the
+ * placement connected, and a pin that touched a wire is at distance zero and
+ * is excluded by the lower bound.
+ */
+export function findPlacementNearMisses(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  instance: Instance,
+): readonly PlacementNearMiss[] {
+  const grid = document.presentation.grid;
+  if (grid <= 0 || !instance.placement) return [];
+  const resolved = resolver.resolve(
+    instance.symbolId,
+    instance.symbolVariantId,
+  );
+  if (!resolved) return [];
+  const geometry = resolveDocumentRoutingGeometry(document, resolver);
+  const logicalNets = resolveDocumentLogicalNets(document);
+
+  const misses: PlacementNearMiss[] = [];
+  for (const pin of resolved.definition.pins) {
+    const at = transformPoint(
+      pin.at,
+      instance.placement.position,
+      instance.placement,
+    );
+    let nearest: { netId: string; distance: number } | null = null;
+    for (const route of geometry.routes.values()) {
+      for (const segment of route.segments) {
+        const distance = distanceToSegment(at, segment.from, segment.to);
+        if (nearest === null || distance < nearest.distance) {
+          nearest = { netId: route.netId, distance };
+        }
+      }
+    }
+    if (!nearest) continue;
+    // Zero is contact, which the placement already handled; beyond the bound
+    // the part was simply put somewhere else and saying anything is noise.
+    if (nearest.distance <= 0) continue;
+    const gridsAway = nearest.distance / grid;
+    if (gridsAway > NEAR_MISS_MAX_GRIDS) continue;
+    // Only whole-grid gaps read as "one square short". A pin resting mid-square
+    // is off the grid entirely, which is a different mistake.
+    if (!Number.isInteger(gridsAway)) continue;
+    misses.push({
+      pinName: pin.name,
+      netId: nearest.netId,
+      netLabel: logicalNets.byBaseNetId.get(nearest.netId)?.name ?? "a wire",
+      gridsAway,
+    });
+  }
+  return misses.sort((left, right) => left.gridsAway - right.gridsAway);
+}
+
+/** The sentence the status bar shows, or null when nothing came close. */
+export function describePlacementNearMiss(
+  misses: readonly PlacementNearMiss[],
+  instanceId: string,
+): string | null {
+  const nearest = misses[0];
+  if (!nearest) return null;
+  const squares =
+    nearest.gridsAway === 1 ? "1 grid" : `${nearest.gridsAway} grids`;
+  return `${instanceId} pin ${nearest.pinName} is ${squares} from ${nearest.netLabel} — not connected`;
+}

--- a/apps/editor/src/features/component-insert/use-component-placement.ts
+++ b/apps/editor/src/features/component-insert/use-component-placement.ts
@@ -63,6 +63,10 @@ import type { PendingComponentPlacement } from "../../interaction/interaction-st
 import type { DrawingTool } from "../../interaction/interaction-state";
 
 type TransactionResult = { ok: boolean; revision: number };
+import {
+  describePlacementNearMiss,
+  findPlacementNearMisses,
+} from "./placement-near-miss";
 
 function nextCellPinName(document: SchematicDocument): string {
   const occupiedNames = new Set(
@@ -293,12 +297,27 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
       "hidden"
         ? symbolId
         : `${id} (${symbolId})`;
+    // Nothing connected, but something was close: a part dropped a square
+    // short of a wire looks joined and is not. Say so once, in the line the
+    // person is already reading. It reports; it never connects.
+    const nearMiss = contact.matched
+      ? null
+      : describePlacementNearMiss(
+          findPlacementNearMisses(
+            projectedDocument,
+            options.resolver,
+            instance,
+          ),
+          id,
+        );
     options.setStatus(
       contact.ambiguous
         ? `Added ${named}; overlapping pins are ambiguous, wire explicitly · click to place another · Esc exits`
         : contact.matched
           ? `Added ${named} and connected its contacted pin · click to place another · Esc exits`
-          : `Added ${named} · click to place another · Esc exits`,
+          : nearMiss
+            ? `Added ${named} · ${nearMiss} · click to place another · Esc exits`
+            : `Added ${named} · click to place another · Esc exits`,
     );
   };
 


### PR DESCRIPTION
Placement connects only on exact contact, and it is right not to guess — a Crossing is not a Junction. But it is also **silent**: a part dropped one grid short of a wire looks joined at a glance and behaves as if it is not, and nothing tells the person which of the two happened.

Placing a part now reports the near miss in the line they are already reading:

```
Added R4 (resistor) · R4 pin 1 is 1 grid from VDD — not connected · click to place another · Esc exits
```

**It reports only.** Snap semantics are untouched, nothing is connected automatically, and the sentence appears only where no contact was made.

## Where the bounds come from

- **Two grid squares.** Further out, the part was simply put somewhere else and the hint is noise.
- **Whole squares only.** A pin resting mid-square is off the grid entirely — a different mistake, which "one grid short" would misdescribe.
- **Distance to the nearest point actually drawn**, not to the infinite line. A part far past a wire's end is not reported against it.
- **An unnamed net says "a wire."** Putting `net-split-d0a1fbbd5a12b60b` in front of a reader tells them nothing; a named net says its name.

That last one came out of running it: the first version printed the generated id.

## Verification

Measured in a running editor, all three cases from one wire:

| placement | status line |
| --- | --- |
| on the wire | `…and connected its contacted pin` — no hint |
| **one grid out** | `R4 pin 1 is 1 grid from a wire — not connected` |
| far away | `Added R5 …` — silent |

- 1930 unit tests pass; 8 new ones cover each bound, including the named-net case
- `apps/editor/e2e/placement-near-miss.spec.ts` drives the three cases through the real editor
- The spec was checked against the broken state: disabling the hint makes it fail on the near-miss case, so it holds the thing it is named for
- `pnpm ci:static` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)