### PR TITLE
feat(editor): moving a two-pin device onto a wire splices it in series

### DIFF
--- a/apps/editor/e2e/overlap-warning.spec.ts
+++ b/apps/editor/e2e/overlap-warning.spec.ts
@@ -12,9 +12,15 @@ async function placeComponent(
   await page.keyboard.press("Escape");
 }
 
-test("a component dragged over a wire paints a red warning on the covered span", async ({
-  page,
-}) => {
+/**
+ * Three resistors; the first two joined by one vertical wire. Returns the
+ * instance ids and the wire's bounding box, with the third resistor left
+ * unwired at (500, 330) as the drag subject.
+ */
+async function wiredPairWithSpare(page: Page): Promise<{
+  ids: string[];
+  wire: { x: number; y: number; width: number; height: number };
+}> {
   await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 200, y: 200 });
   await placeComponent(page, "resistor", { x: 200, y: 460 });
@@ -29,12 +35,24 @@ test("a component dragged over a wire paints a red warning on the covered span",
   await page.keyboard.press("Escape");
   await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(1);
   await expect(page.getByTestId("wire-under-symbol-overlay")).toHaveCount(0);
-
-  // Drag the third resistor so its body sits on the vertical wire.
-  const third = page.getByTestId(`hit-${ids[2]}`);
-  const from = (await third.boundingBox())!;
   const route = page.locator('[data-canvas-hit-kind="route"]').first();
   const wire = (await route.boundingBox())!;
+  return { ids, wire };
+}
+
+test("a component dragged over a wire paints a red warning on the covered span", async ({
+  page,
+}) => {
+  const { ids, wire } = await wiredPairWithSpare(page);
+
+  // Turn the third resistor sideways first: its body then lies across the
+  // vertical wire while both pins sit far off the conductor, so the drop
+  // buries the wire without acquiring contacts. (A pin-exact drop is the
+  // series-insertion gesture and no longer leaves a buried span.)
+  const third = page.getByTestId(`hit-${ids[2]}`);
+  await third.click();
+  await page.keyboard.press("r");
+  const from = (await third.boundingBox())!;
   const targetX = wire.x + wire.width / 2;
   const targetY = wire.y + wire.height / 2;
   await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
@@ -62,4 +80,29 @@ test("a component dragged over a wire paints a red warning on the covered span",
   await expect(
     page.locator('[data-canvas-hit-kind="route"].selected'),
   ).not.toHaveCount(0);
+});
+
+test("a pin-exact drop onto the wire splices in series instead of warning", async ({
+  page,
+}) => {
+  const { ids, wire } = await wiredPairWithSpare(page);
+
+  // Same drag, but the resistor stays vertical: both pins land on the
+  // conductor at distinct points, which is the series-insertion gesture.
+  // The covered span is cut away, so there is nothing to warn about.
+  const third = page.getByTestId(`hit-${ids[2]}`);
+  const from = (await third.boundingBox())!;
+  const targetX = wire.x + wire.width / 2;
+  const targetY = wire.y + wire.height / 2;
+  await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(targetX, targetY, { steps: 8 });
+  await page.mouse.up();
+
+  await expect(page.getByTestId("status")).toContainText(
+    "Inserted the moved component in series",
+  );
+  // One wire became two conductors, one per side of the device.
+  await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(2);
+  await expect(page.getByTestId("wire-under-symbol-overlay")).toHaveCount(0);
 });

--- a/apps/editor/src/features/component-insert/placement-connectivity.ts
+++ b/apps/editor/src/features/component-insert/placement-connectivity.ts
@@ -1,4 +1,5 @@
 import {
+  isEligibleSeriesInsertionPinPair,
   planDirectEndpointConnection,
   planElectricalMarkerRename,
   planEnsurePowerNet,
@@ -143,20 +144,12 @@ function isEligibleSeriesInsertionPair(
   visibleSources: readonly WireSource[],
   contactedSources: readonly WireSource[],
 ): boolean {
-  if (contactedSources.length !== 2) return false;
-  if (visibleSources.length === 2) return true;
-  const configuredPair = deviceDescriptor(
-    instance.symbolId,
-  )?.seriesInsertionPinPair;
-  if (!configuredPair) return false;
-  const contactedKeys = new Set(
+  return isEligibleSeriesInsertionPinPair(
     contactedSources.map(({ endpoint }) =>
       endpoint.kind === "terminal" ? endpoint.pinName : "",
     ),
-  );
-  return (
-    contactedKeys.size === 2 &&
-    configuredPair.every((pinName) => contactedKeys.has(pinName))
+    visibleSources.length,
+    deviceDescriptor(instance.symbolId)?.seriesInsertionPinPair,
   );
 }
 

--- a/apps/editor/src/features/selection/pin-attach-move.test.ts
+++ b/apps/editor/src/features/selection/pin-attach-move.test.ts
@@ -18,6 +18,7 @@ import {
   createRoutingOperationPlan,
   executeTransaction,
   gateRoutingOperationPlan,
+  type ExpectedElectricalEffect,
   type RoutingOperationIntent,
   type SchematicEdit,
 } from "@icm/edit-engine";
@@ -108,6 +109,7 @@ function runMove(targetX: number) {
   const transactConnectivity = (
     intent: RoutingOperationIntent,
     edits: readonly SchematicEdit[],
+    options: { expectedElectricalEffect?: ExpectedElectricalEffect } = {},
   ) => {
     const record: (typeof transactions)[number] = { intent, edits };
     transactions.push(record);
@@ -115,6 +117,9 @@ function runMove(targetX: number) {
       intent,
       edits,
       diagnostics: [],
+      ...(options.expectedElectricalEffect
+        ? { expectedElectricalEffect: options.expectedElectricalEffect }
+        : {}),
     });
     const gate = gateRoutingOperationPlan(document, proposal, {
       symbolResolver: resolver,
@@ -232,7 +237,7 @@ describe("pin-onto-wire move snap float dust", () => {
 });
 
 describe("two-pin device moved onto one wire", () => {
-  function runTwoPinMove() {
+  function runTwoPinMove({ prewirePlus = false } = {}) {
     const seeded = routedDocument();
     // A current source rotated 90° has horizontal pins: "+" (0,-20) maps to
     // (+20,0), "-" (0,20) maps to (-20,0).
@@ -262,16 +267,80 @@ describe("two-pin device moved onto one wire", () => {
     );
     if (!added.ok) throw new Error(`seed failed: ${added.error.message}`);
     let document = added.document;
+    if (prewirePlus) {
+      // The control case wires "+" away to E before the drop: a pin that
+      // already terminates a Route is not a new contact, so the gesture
+      // must stay an ordinary attachment. E already belongs to net-h in the
+      // fixture, so the bond joins that Net and the stub route rides on it.
+      const connected = executeTransaction(
+        document,
+        {
+          transactionId: "seed-stub-wire",
+          documentId: document.id,
+          expectedRevision: document.revision,
+          actor: { kind: "human", id: "test" },
+          edits: [
+            {
+              kind: "connect_endpoints",
+              from: { kind: "terminal", instanceId: "I1", pinName: "+" },
+              to: terminal("E"),
+            },
+          ],
+        },
+        { symbolResolver: resolver },
+      );
+      if (!connected.ok) {
+        throw new Error(`stub bond failed: ${connected.error.message}`);
+      }
+      const wired = executeTransaction(
+        connected.document,
+        {
+          transactionId: "seed-stub-route",
+          documentId: connected.document.id,
+          expectedRevision: connected.document.revision,
+          actor: { kind: "human", id: "test" },
+          edits: [
+            {
+              kind: "set_route_path",
+              route: createRoutePath({
+                id: "route-stub",
+                netId: "net-h",
+                start: { kind: "terminal", instanceId: "I1", pinName: "+" },
+                end: terminal("E"),
+                bends: [
+                  { x: 200, y: 180 },
+                  { x: 200, y: 390 },
+                ],
+                modes: ["manual", "manual", "manual"],
+              }),
+            },
+          ],
+        },
+        { symbolResolver: resolver },
+      );
+      if (!wired.ok) {
+        throw new Error(`stub route failed: ${wired.error.message}`);
+      }
+      document = wired.document;
+    }
     const statuses: string[] = [];
     const results: ReturnType<typeof executeTransaction>[] = [];
+    const transactions: {
+      intent: RoutingOperationIntent;
+      edits: readonly SchematicEdit[];
+    }[] = [];
     const transactConnectivity = (
       intent: RoutingOperationIntent,
       edits: readonly SchematicEdit[],
+      options: { expectedElectricalEffect?: ExpectedElectricalEffect } = {},
     ) => {
       const proposal = createRoutingOperationPlan(document, {
         intent,
         edits,
         diagnostics: [],
+        ...(options.expectedElectricalEffect
+          ? { expectedElectricalEffect: options.expectedElectricalEffect }
+          : {}),
       });
       const gate = gateRoutingOperationPlan(document, proposal, {
         symbolResolver: resolver,
@@ -292,8 +361,10 @@ describe("two-pin device moved onto one wire", () => {
         { symbolResolver: resolver },
       );
       results.push(result);
-      if (result.ok) document = result.document;
-      else statuses.push(`${result.error.code}: ${result.error.message}`);
+      if (result.ok) {
+        document = result.document;
+        transactions.push({ intent, edits: [...gate.edits] });
+      } else statuses.push(`${result.error.code}: ${result.error.message}`);
       return { ok: result.ok };
     };
     const controller = createSelectionMoveController({
@@ -344,30 +415,68 @@ describe("two-pin device moved onto one wire", () => {
         resolvedMove: resolved,
       },
     );
-    return { document, resolved, statuses, results };
+    return { document, resolved, statuses, results, transactions };
   }
 
-  it("attaches both pins and cuts the wire into three series segments", () => {
+  it("splices the device into the wire instead of shorting it", () => {
     const { document, resolved, results } = runTwoPinMove();
     expect(resolved.snap.electricalMatch?.target.electrical?.kind).toBe(
       "route",
     );
     expect(results.some((result) => result.ok)).toBe(true);
-    const net = document.nets.find((candidate) => candidate.id === "net-h")!;
-    expect(net.terminals).toEqual(
+    // Series insertion: the span between the pins is gone, leaving one
+    // conductor on each side of the device instead of a wire through it.
+    expect(document.routes).toHaveLength(2);
+    const netOf = (pinName: string) =>
+      document.nets.find((net) =>
+        net.terminals.some(
+          (terminal) =>
+            terminal.instanceId === "I1" && terminal.pinName === pinName,
+        ),
+      );
+    const plusNet = netOf("+");
+    const minusNet = netOf("-");
+    expect(plusNet).toBeDefined();
+    expect(minusNet).toBeDefined();
+    // Two Base Nets: the pins are not shorted by the wire they landed on.
+    expect(plusNet!.id).not.toBe(minusNet!.id);
+    const throughDevice = document.routes.find((route) => {
+      const end = routeEnd(route);
+      return (
+        route.start.kind === "terminal" &&
+        route.start.instanceId === "I1" &&
+        end.kind === "terminal" &&
+        end.instanceId === "I1"
+      );
+    });
+    expect(throughDevice).toBeUndefined();
+  });
+
+  it("keeps the ordinary attachment when one pin is already wired", () => {
+    const { document, results, transactions } = runTwoPinMove({
+      prewirePlus: true,
+    });
+    expect(results.some((result) => result.ok)).toBe(true);
+    // Not a series drop: only "-" is a new contact, so nothing is cut.
+    expect(
+      transactions
+        .flatMap(({ edits }) => edits)
+        .some((edit) => edit.kind === "cut_connection"),
+    ).toBe(false);
+    // Route counts belong to commit-time canonicalization; the contract here
+    // is electrical: everything stays one conductor family on one Net.
+    const netH = document.nets.find((candidate) => candidate.id === "net-h")!;
+    expect(netH.terminals).toEqual(
       expect.arrayContaining([
+        { instanceId: "A", pinName: "P" },
+        { instanceId: "B", pinName: "P" },
         { instanceId: "I1", pinName: "+" },
         { instanceId: "I1", pinName: "-" },
       ]),
     );
-    // route-h + the two device terminals = three series segments.
-    expect(document.routes).toHaveLength(3);
-    const middle = document.routes.find(
-      (route) =>
-        route.start.kind === "terminal" &&
-        route.start.instanceId === "I1" &&
-        routeEnd(route).kind === "terminal",
+    // No partition happened: everything still shares one Base Net.
+    expect(document.routes.every((route) => route.netId === "net-h")).toBe(
+      true,
     );
-    expect(middle).toBeDefined();
   });
 });

--- a/apps/editor/src/features/selection/selection-move-controller.ts
+++ b/apps/editor/src/features/selection/selection-move-controller.ts
@@ -1,12 +1,17 @@
 import {
+  isEligibleSeriesInsertionPinPair,
   planDirectEndpointConnection,
+  planSeriesInstanceSplice,
   proposeEndpointsRouteAttachment,
   planRoutingTransform,
   type EndpointRouteAttachmentRequest,
+  type ExpectedElectricalEffect,
   type RoutingOperationIntent,
   type SchematicEdit,
+  type SeriesSplicePlan,
   type WireSource,
 } from "@icm/edit-engine";
+import { deviceDescriptor } from "@icm/devices";
 import {
   deriveNetConnectivity,
   findRouteSegmentsAtPoint,
@@ -166,6 +171,7 @@ export function createSelectionMoveController({
   transactConnectivity: (
     intent: RoutingOperationIntent,
     edits: readonly SchematicEdit[],
+    options?: { expectedElectricalEffect?: ExpectedElectricalEffect },
   ) => TransactionResult | null;
   setStatus: (status: string) => void;
   nextRoutingSuffix: () => number;
@@ -601,8 +607,75 @@ export function createSelectionMoveController({
               targetElectrical,
             )
           : [];
-      const contactEdits: readonly SchematicEdit[] =
-        targetElectrical?.kind === "route" && attachRequests.length > 0
+      // A two-pin drop onto one wire is the series-insertion gesture, exactly
+      // as it is when placing (#432): the wire is cut between the pins
+      // instead of left shorting the device. Eligibility is the placement
+      // rule verbatim — a whole-device two-pin interface, or the device
+      // descriptor's declared pair (#435) — and anything else, including a
+      // pair the splice preconditions refuse, keeps the plain attachment.
+      const seriesSplice: Extract<SeriesSplicePlan, { ok: true }> | null =
+        (() => {
+          if (targetElectrical?.kind !== "route") return null;
+          if (attachRequests.length !== 2) return null;
+          const [first, second] = attachRequests as [
+            EndpointRouteAttachmentRequest,
+            EndpointRouteAttachmentRequest,
+          ];
+          if (
+            first.endpoint.kind !== "terminal" ||
+            second.endpoint.kind !== "terminal" ||
+            first.endpoint.instanceId !== second.endpoint.instanceId ||
+            (first.point.x === second.point.x &&
+              first.point.y === second.point.y)
+          ) {
+            return null;
+          }
+          const instance = projected.instances.find(
+            (candidate) =>
+              candidate.id ===
+              (first.endpoint as { instanceId: string }).instanceId,
+          );
+          const resolvedSymbol = instance
+            ? resolver.resolve(instance.symbolId, instance.symbolVariantId)
+            : null;
+          if (!instance || !resolvedSymbol) return null;
+          const visiblePinCount = resolvedSymbol.definition.pins.filter(
+            (pin) =>
+              !resolvedSymbol.variant?.hiddenPinNames.includes(pin.name) &&
+              pin.presentation.visibility !== "implicit",
+          ).length;
+          if (
+            !isEligibleSeriesInsertionPinPair(
+              [first.endpoint.pinName, second.endpoint.pinName],
+              visiblePinCount,
+              deviceDescriptor(instance.symbolId)?.seriesInsertionPinPair,
+            )
+          ) {
+            return null;
+          }
+          const plan = planSeriesInstanceSplice(
+            projected,
+            resolver,
+            targetElectrical.routeId,
+            [
+              {
+                endpoint: first.endpoint,
+                point: first.point,
+                segmentIndex: first.segmentIndex,
+              },
+              {
+                endpoint: second.endpoint,
+                point: second.point,
+                segmentIndex: second.segmentIndex,
+              },
+            ],
+            `move-splice-${nextRoutingSuffix()}`,
+          );
+          return plan.ok ? plan : null;
+        })();
+      const contactEdits: readonly SchematicEdit[] = seriesSplice
+        ? seriesSplice.edits
+        : targetElectrical?.kind === "route" && attachRequests.length > 0
           ? proposeEndpointsRouteAttachment(
               projected,
               resolver,
@@ -647,8 +720,16 @@ export function createSelectionMoveController({
           ...contactEdits,
           ...directEdits,
         ],
+        seriesSplice
+          ? { expectedElectricalEffect: seriesSplice.expectedElectricalEffect }
+          : undefined,
       );
-      if (result?.ok && (contactEdits.length > 0 || directEdits.length > 0)) {
+      if (result?.ok && seriesSplice) {
+        setStatus("Inserted the moved component in series into the wire");
+      } else if (
+        result?.ok &&
+        (contactEdits.length > 0 || directEdits.length > 0)
+      ) {
         setStatus("Snapped pin endpoints and connected them without a wire");
       } else if (result?.ok && directContactRejection) {
         setStatus(`Moved without connecting: ${directContactRejection}`);

--- a/packages/edit-engine/src/series-splice-planner.ts
+++ b/packages/edit-engine/src/series-splice-planner.ts
@@ -25,6 +25,29 @@ export interface SeriesSpliceContact {
   segmentIndex: number;
 }
 
+/**
+ * Whether exactly-two same-conductor pin contacts form the series-insertion
+ * gesture. A device whose whole visible interface is two pins qualifies
+ * outright; a multi-pin device qualifies only through its descriptor's
+ * declared series-insertion pin pair (D–S, C–E), matched by pin name. One
+ * definition serves every gesture that can drop a device onto a wire —
+ * placing and moving must agree on what "insertable" means.
+ */
+export function isEligibleSeriesInsertionPinPair(
+  contactedPinNames: readonly string[],
+  visiblePinCount: number,
+  seriesInsertionPinPair: readonly string[] | undefined,
+): boolean {
+  if (contactedPinNames.length !== 2) return false;
+  if (visiblePinCount === 2) return true;
+  if (!seriesInsertionPinPair) return false;
+  const contactedKeys = new Set(contactedPinNames);
+  return (
+    contactedKeys.size === 2 &&
+    seriesInsertionPinPair.every((pinName) => contactedKeys.has(pinName))
+  );
+}
+
 export type SeriesSplicePlan =
   | {
       ok: true;


### PR DESCRIPTION
## What

Placing a device onto a wire has spliced it in series since #432; **moving** the same device onto the same wire still bulk-attached both pins to the unbroken conductor — the wire shorted the component, and the old move test pinned that as intended. The two gestures now agree.

When the move snap lands on a route and the new-contact set is exactly two terminals of one moved instance at distinct points, `completeInstanceMove` calls `planSeriesInstanceSplice` and declares its partition effect through the routing-operation gate (ADR 0048) — the same planner, eligibility, and effect declaration placement uses.

## Shared eligibility, by construction

`isEligibleSeriesInsertionPinPair` is promoted from placement-connectivity into the edit-engine planner module (whole-device two-pin interface, or the descriptor's declared D–S / C–E pair per #435); placement now delegates to it, so the gestures cannot drift apart again. Everything ineligible — more pins, an already-wired pin, or an eligible-shaped pair the splice preconditions refuse (power rail, locked leg, blocking annotation) — keeps the existing bulk attachment byte-for-byte.

## Tests, red first and gate-level

The old "three series segments" move test asserted the shorting outcome; it is rewritten to the splice contract (two conductors, two Base Nets, no route through the device) and was observed red for the right reason (3 routes) before the controller change. A control test pins the wired-pin case to bulk attachment with nothing cut. Both harnesses run the full `createRoutingOperationPlan → gateRoutingOperationPlan → executeTransaction` chain and forward `expectedElectricalEffect`, so the splice passing is itself proof the gate accepted the declared partition — a direct-`executeTransaction` test would have bypassed exactly the check that matters.

## Validation

pin-attach-move 4/4; editor + edit-engine unit suites 1087/1087; e2e manual-editor + detach-move + wiring-semantics 128/128 (including both #432/#435 placement-splice regressions); typecheck and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)