### PR TITLE
feat(editor): place actionable findings on the canvas as severity rings

### DIFF
--- a/apps/editor/e2e/diagnostics-surfacing.spec.ts
+++ b/apps/editor/e2e/diagnostics-surfacing.spec.ts
@@ -27,6 +27,9 @@ test("statusbar issues badge surfaces live findings and opens the workbench", as
   await expect(badge).toHaveAttribute("data-severity", "warning");
   await expect(badge).toContainText("warning");
 
+  // Warnings do not mark the canvas until the issues review is open.
+  await expect(page.locator(".diagnostic-marker")).toHaveCount(0);
+
   // The badge opens the dock with the issues section expanded.
   await badge.click();
   const issuesSection = page.locator(
@@ -36,7 +39,16 @@ test("statusbar issues badge surfaces live findings and opens the workbench", as
   const findings = page.getByTestId("project-diagnostics").locator("li button");
   await expect(findings.first()).toBeVisible();
 
+  // Review mode places a warning ring on each finding's pin.
+  const markers = page.locator(".diagnostic-marker");
+  await expect(markers).toHaveCount(2);
+  await expect(markers.first()).toHaveAttribute("data-severity", "warning");
+
   // A finding navigates: the status line reports the ERC jump.
   await findings.first().click();
   await expect(page.getByTestId("status")).toContainText("ERC");
+
+  // A marker ring navigates the same way from the canvas side.
+  await page.locator(".diagnostic-marker-hit").first().click();
+  await expect(page.getByTestId("status")).toContainText("ERC_UNCONNECTED_PIN");
 });

--- a/apps/editor/e2e/diagnostics-surfacing.spec.ts
+++ b/apps/editor/e2e/diagnostics-surfacing.spec.ts
@@ -48,7 +48,16 @@ test("statusbar issues badge surfaces live findings and opens the workbench", as
   await findings.first().click();
   await expect(page.getByTestId("status")).toContainText("ERC");
 
-  // A marker ring navigates the same way from the canvas side.
-  await page.locator(".diagnostic-marker-hit").first().click();
+  // A marker ring navigates the same way from the canvas side. The hit is
+  // the ring band only — the centre stays click-through for the pin — so
+  // aim for the top of the band (screen coordinates, ~15% down the box).
+  const ringBox = (await page
+    .locator(".diagnostic-marker-hit")
+    .first()
+    .boundingBox())!;
+  await page.mouse.click(
+    ringBox.x + ringBox.width / 2,
+    ringBox.y + ringBox.height * 0.15,
+  );
   await expect(page.getByTestId("status")).toContainText("ERC_UNCONNECTED_PIN");
 });

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -79,6 +79,7 @@ import {
 } from "../canvas/canvas-drag-session";
 import { startCanvasDragVisual } from "../canvas/canvas-drag-visual";
 import { createCanvasHitController } from "../canvas/canvas-hit-controller";
+import { buildDiagnosticMarkers } from "../canvas/diagnostic-markers";
 import {
   type RouteStretchPreview,
   useWireInteraction,
@@ -1285,6 +1286,27 @@ export function App({
     [document, resolver, visibleEndpoints],
   );
   const [issuesFocusToken, setIssuesFocusToken] = useState(0);
+  const [issuesSectionOpen, setIssuesSectionOpen] = useState(false);
+  const diagnosticMarkers = useMemo(
+    () =>
+      buildDiagnosticMarkers({
+        document,
+        resolver,
+        connectivityIndex: projectConnectivityIndex,
+        electricalDiagnostics,
+        visualDiagnostics,
+        reviewOpen: selectionOpen && issuesSectionOpen,
+      }),
+    [
+      document,
+      resolver,
+      projectConnectivityIndex,
+      electricalDiagnostics,
+      visualDiagnostics,
+      selectionOpen,
+      issuesSectionOpen,
+    ],
+  );
   const issueCounts = useMemo(() => {
     let errorCount = 0;
     let warningCount = 0;
@@ -4646,6 +4668,7 @@ export function App({
                 ?.name ?? documentId,
             onSelectDiagnostic: jumpToProjectDiagnostic,
             focusRequestToken: issuesFocusToken,
+            onOpenStateChange: setIssuesSectionOpen,
           }}
           netTrace={
             highlightedTrace && highlightedTrace.hops.length > 0
@@ -4774,6 +4797,10 @@ export function App({
               selectOnly("route", [routeId]);
               setStatus("Selected a wire buried under a symbol");
             },
+          }}
+          diagnosticMarkers={{
+            markers: diagnosticMarkers,
+            onSelectMarker: jumpToProjectDiagnostic,
           }}
           netLabelTether={netLabelTether}
           copyPreviewInnerHtml={copyPreviewInnerHtml}

--- a/apps/editor/src/canvas/diagnostic-markers.test.ts
+++ b/apps/editor/src/canvas/diagnostic-markers.test.ts
@@ -1,0 +1,131 @@
+import { buildProjectConnectivityIndex } from "@icm/derived";
+import type { Diagnostic, VisualDiagnostic } from "@icm/derived";
+import { createEmptyDocument, createEmptyProject } from "@icm/model";
+import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { buildDiagnosticMarkers } from "./diagnostic-markers";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+function fixture() {
+  const project = createEmptyProject("markers", "Markers", "doc-markers");
+  const document = project.documents[0]!;
+  document.nets.push({ id: "n1", terminals: [] });
+  document.junctions.push(
+    { id: "J1", netId: "n1", position: { x: 100, y: 40 }, role: "branch" },
+    { id: "J2", netId: "n1", position: { x: 200, y: 40 }, role: "branch" },
+  );
+  const connectivityIndex = buildProjectConnectivityIndex(project, resolver);
+  return { document, connectivityIndex };
+}
+
+function ercWarningAt(junctionId: string, documentId: string): Diagnostic {
+  return {
+    id: `erc:${junctionId}`,
+    domain: "erc",
+    code: "ERC_UNCONNECTED_PIN",
+    severity: "warning",
+    confidence: "high",
+    gateEligible: false,
+    message: `${junctionId} finding`,
+    primary: {
+      documentId,
+      hierarchyPath: [],
+      kind: "junction",
+      objectId: junctionId,
+      endpoint: { kind: "junction", junctionId },
+    },
+    related: [],
+    parameters: {},
+  };
+}
+
+const visualErrorAtJ1: VisualDiagnostic = {
+  code: "VISUAL_AMBIGUOUS_JUNCTION",
+  severity: "error",
+  category: "structural",
+  confidence: "high",
+  gateEligible: true,
+  message: "Junction J1 lies on unrelated route R9",
+  objectIds: ["J1", "R9"],
+  point: { x: 100, y: 40 },
+};
+
+const visualWarningNoPoint: VisualDiagnostic = {
+  code: "VISUAL_ROUTE_OVERLAP",
+  severity: "warning",
+  category: "observation",
+  confidence: "medium",
+  gateEligible: false,
+  message: "2 Routes share collinear geometry on Net n1",
+  objectIds: ["R1", "R2"],
+};
+
+describe("buildDiagnosticMarkers", () => {
+  it("keeps actionable error markers on outside review mode", () => {
+    const { document, connectivityIndex } = fixture();
+    const markers = buildDiagnosticMarkers({
+      document,
+      resolver,
+      connectivityIndex,
+      electricalDiagnostics: [],
+      visualDiagnostics: [visualErrorAtJ1],
+      reviewOpen: false,
+    });
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toMatchObject({
+      severity: "error",
+      point: { x: 100, y: 40 },
+      count: 1,
+    });
+    expect(markers[0]!.diagnostic.code).toBe("VISUAL_AMBIGUOUS_JUNCTION");
+  });
+
+  it("shows warnings only while the issues review is open", () => {
+    const { document, connectivityIndex } = fixture();
+    const inputs = {
+      document,
+      resolver,
+      connectivityIndex,
+      electricalDiagnostics: [ercWarningAt("J2", document.id)],
+      visualDiagnostics: [],
+    };
+    expect(
+      buildDiagnosticMarkers({ ...inputs, reviewOpen: false }),
+    ).toHaveLength(0);
+    const open = buildDiagnosticMarkers({ ...inputs, reviewOpen: true });
+    expect(open).toHaveLength(1);
+    expect(open[0]).toMatchObject({
+      severity: "warning",
+      point: { x: 200, y: 40 },
+    });
+  });
+
+  it("clusters findings at one point under the highest severity", () => {
+    const { document, connectivityIndex } = fixture();
+    const markers = buildDiagnosticMarkers({
+      document,
+      resolver,
+      connectivityIndex,
+      electricalDiagnostics: [ercWarningAt("J1", document.id)],
+      visualDiagnostics: [visualErrorAtJ1],
+      reviewOpen: true,
+    });
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toMatchObject({ severity: "error", count: 2 });
+  });
+
+  it("renders nothing for findings without a place on this document", () => {
+    const { document, connectivityIndex } = fixture();
+    const markers = buildDiagnosticMarkers({
+      document,
+      resolver,
+      connectivityIndex,
+      electricalDiagnostics: [ercWarningAt("J1", "some-other-document")],
+      visualDiagnostics: [visualWarningNoPoint],
+      reviewOpen: true,
+    });
+    expect(markers).toHaveLength(0);
+  });
+});

--- a/apps/editor/src/canvas/diagnostic-markers.ts
+++ b/apps/editor/src/canvas/diagnostic-markers.ts
@@ -1,0 +1,100 @@
+import {
+  adaptVisualDiagnostic,
+  diagnosticPresentationGroup,
+  resolveEndpointPoint,
+} from "@icm/derived";
+import type {
+  Diagnostic,
+  ProjectConnectivityIndex,
+  VisualDiagnostic,
+} from "@icm/derived";
+import type { Point, SchematicDocument } from "@icm/model";
+import type { SymbolResolver } from "@icm/symbols";
+
+export interface DiagnosticMarker {
+  key: string;
+  point: Point;
+  severity: "error" | "warning";
+  /** Findings sharing this point; the ring shows a numeral above one. */
+  count: number;
+  /** The highest-severity finding here — the click's navigation payload. */
+  diagnostic: Diagnostic;
+}
+
+interface MarkerEntry {
+  point: Point;
+  severity: "error" | "warning";
+  diagnostic: Diagnostic;
+}
+
+/**
+ * Place actionable findings on the canvas. Errors always earn a marker;
+ * warnings appear only while the issues review is open, and observations
+ * never render — the same presentation grouping the badge and workbench use.
+ * Findings without a resolvable point on this document simply stay off the
+ * map; the workbench remains the complete list.
+ */
+export function buildDiagnosticMarkers(input: {
+  document: SchematicDocument;
+  resolver: SymbolResolver;
+  connectivityIndex: ProjectConnectivityIndex;
+  electricalDiagnostics: readonly Diagnostic[];
+  visualDiagnostics: readonly VisualDiagnostic[];
+  reviewOpen: boolean;
+}): DiagnosticMarker[] {
+  const entries: MarkerEntry[] = [];
+  for (const diagnostic of input.electricalDiagnostics) {
+    if (diagnostic.primary.documentId !== input.document.id) continue;
+    if (diagnostic.severity !== "error" && diagnostic.severity !== "warning") {
+      continue;
+    }
+    if (diagnosticPresentationGroup(diagnostic) !== "actionable") continue;
+    const endpoint = diagnostic.primary.endpoint;
+    if (!endpoint) continue;
+    const point = resolveEndpointPoint(
+      input.document,
+      input.resolver,
+      endpoint,
+    );
+    if (!point) continue;
+    entries.push({ point, severity: diagnostic.severity, diagnostic });
+  }
+  for (const visual of input.visualDiagnostics) {
+    if (!visual.point) continue;
+    if (visual.severity !== "error" && visual.severity !== "warning") continue;
+    const diagnostic = adaptVisualDiagnostic(
+      visual,
+      input.document.id,
+      input.connectivityIndex,
+    );
+    if (diagnosticPresentationGroup(diagnostic) !== "actionable") continue;
+    entries.push({
+      point: { ...visual.point },
+      severity: visual.severity,
+      diagnostic,
+    });
+  }
+  const visible = entries.filter(
+    (entry) => entry.severity === "error" || input.reviewOpen,
+  );
+  const byPoint = new Map<string, MarkerEntry[]>();
+  for (const entry of visible) {
+    const key = `${entry.point.x},${entry.point.y}`;
+    byPoint.set(key, [...(byPoint.get(key) ?? []), entry]);
+  }
+  return [...byPoint.entries()]
+    .map(([key, group]) => {
+      const severity = group.some((entry) => entry.severity === "error")
+        ? ("error" as const)
+        : ("warning" as const);
+      const primary = group.find((entry) => entry.severity === severity)!;
+      return {
+        key,
+        point: { ...primary.point },
+        severity,
+        count: group.length,
+        diagnostic: primary.diagnostic,
+      };
+    })
+    .sort((left, right) => left.key.localeCompare(right.key, "en"));
+}

--- a/apps/editor/src/canvas/editor-canvas-overlays.test.tsx
+++ b/apps/editor/src/canvas/editor-canvas-overlays.test.tsx
@@ -1,0 +1,80 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { Diagnostic } from "@icm/derived";
+
+import { DiagnosticMarkersOverlay } from "./editor-canvas-overlays";
+
+const finding: Diagnostic = {
+  id: "visual:doc:VISUAL_AMBIGUOUS_JUNCTION:J1",
+  domain: "visual",
+  code: "VISUAL_AMBIGUOUS_JUNCTION",
+  severity: "error",
+  confidence: "high",
+  gateEligible: true,
+  message: "Junction J1 lies on unrelated route R9",
+  primary: {
+    documentId: "doc",
+    hierarchyPath: [],
+    kind: "junction",
+    objectId: "J1",
+  },
+  related: [],
+  parameters: {},
+};
+
+describe("DiagnosticMarkersOverlay", () => {
+  it("renders severity-colored rings at finding points", () => {
+    const markup = renderToStaticMarkup(
+      <DiagnosticMarkersOverlay
+        markers={[
+          {
+            key: "100,40",
+            point: { x: 100, y: 40 },
+            severity: "error",
+            count: 1,
+            diagnostic: finding,
+          },
+          {
+            key: "200,40",
+            point: { x: 200, y: 40 },
+            severity: "warning",
+            count: 1,
+            diagnostic: { ...finding, id: "erc:2", severity: "warning" },
+          },
+        ]}
+        onSelectMarker={vi.fn()}
+      />,
+    );
+    expect(markup).toContain('data-testid="diagnostic-markers"');
+    expect(markup).toContain('data-severity="error"');
+    expect(markup).toContain('data-severity="warning"');
+    expect(markup).toContain('class="diagnostic-marker-ring"');
+  });
+
+  it("adds a numeral only for clustered findings", () => {
+    const markup = renderToStaticMarkup(
+      <DiagnosticMarkersOverlay
+        markers={[
+          {
+            key: "100,40",
+            point: { x: 100, y: 40 },
+            severity: "error",
+            count: 3,
+            diagnostic: finding,
+          },
+        ]}
+        onSelectMarker={vi.fn()}
+      />,
+    );
+    expect(markup).toContain('class="diagnostic-marker-count"');
+    expect(markup).toContain(">3</text>");
+  });
+
+  it("renders nothing without markers", () => {
+    expect(
+      renderToStaticMarkup(
+        <DiagnosticMarkersOverlay markers={[]} onSelectMarker={vi.fn()} />,
+      ),
+    ).toBe("");
+  });
+});

--- a/apps/editor/src/canvas/editor-canvas-overlays.tsx
+++ b/apps/editor/src/canvas/editor-canvas-overlays.tsx
@@ -200,11 +200,25 @@ export function WireUnderSymbolOverlay({
   );
 }
 
+/** An annulus path: ring-band hit area whose centre stays click-through. */
+function ringBandPath(
+  cx: number,
+  cy: number,
+  outer: number,
+  inner: number,
+): string {
+  const circle = (r: number, sweep: 0 | 1) =>
+    `M ${cx - r},${cy} a ${r},${r} 0 1,${sweep} ${2 * r},0 a ${r},${r} 0 1,${sweep} ${-2 * r},0`;
+  return `${circle(outer, 0)} ${circle(inner, 1)}`;
+}
+
 /**
  * Actionable findings placed on the canvas: an open severity-colored ring
  * over a light halo, so the marker never occludes what it marks. Pointer-down
- * navigates through the same jump the workbench uses; the hit circle stops
- * propagation so markers never enter ordinary canvas hit ranking.
+ * on the ring band navigates through the same jump the workbench uses and
+ * stops propagation, so markers never enter ordinary canvas hit ranking —
+ * while the band's open centre keeps the pin or junction it rings directly
+ * clickable (and right-clickable).
  */
 export function DiagnosticMarkersOverlay({
   markers,
@@ -246,13 +260,13 @@ export function DiagnosticMarkersOverlay({
               {marker.count}
             </text>
           ) : null}
-          <circle
+          <path
             className="diagnostic-marker-hit"
             data-testid={`diagnostic-marker-${marker.key}`}
-            cx={marker.point.x}
-            cy={marker.point.y}
-            r={9}
+            d={ringBandPath(marker.point.x, marker.point.y, 8.5, 3)}
+            fillRule="evenodd"
             onPointerDown={(event) => {
+              if (event.button !== 0) return;
               event.stopPropagation();
               event.preventDefault();
               onSelectMarker(marker.diagnostic);

--- a/apps/editor/src/canvas/editor-canvas-overlays.tsx
+++ b/apps/editor/src/canvas/editor-canvas-overlays.tsx
@@ -4,11 +4,13 @@ import {
   type NetHighlight,
   type ResolvedRouteGeometry,
 } from "@icm/derived";
+import type { Diagnostic } from "@icm/derived";
 import type { GridRect, RouteBranch, SchematicDocument } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 
 import type { EditorTool } from "../interaction/interaction-state";
 import { serializePolylinePoints } from "./canvas-geometry";
+import type { DiagnosticMarker } from "./diagnostic-markers";
 
 export function CanvasGridOverlay({
   visible,
@@ -189,6 +191,71 @@ export function WireUnderSymbolOverlay({
               event.stopPropagation();
               event.preventDefault();
               onSelectRoute(warning.routeId);
+            }}
+            onClick={(event) => event.stopPropagation()}
+          />
+        </g>
+      ))}
+    </g>
+  );
+}
+
+/**
+ * Actionable findings placed on the canvas: an open severity-colored ring
+ * over a light halo, so the marker never occludes what it marks. Pointer-down
+ * navigates through the same jump the workbench uses; the hit circle stops
+ * propagation so markers never enter ordinary canvas hit ranking.
+ */
+export function DiagnosticMarkersOverlay({
+  markers,
+  onSelectMarker,
+}: {
+  markers: readonly DiagnosticMarker[];
+  onSelectMarker: (diagnostic: Diagnostic) => void;
+}) {
+  if (markers.length === 0) return null;
+  return (
+    <g data-testid="diagnostic-markers" className="diagnostic-markers">
+      {markers.map((marker) => (
+        <g
+          key={marker.key}
+          className="diagnostic-marker"
+          data-severity={marker.severity}
+        >
+          <circle
+            className="diagnostic-marker-halo"
+            pointerEvents="none"
+            cx={marker.point.x}
+            cy={marker.point.y}
+            r={6}
+          />
+          <circle
+            className="diagnostic-marker-ring"
+            pointerEvents="none"
+            cx={marker.point.x}
+            cy={marker.point.y}
+            r={6}
+          />
+          {marker.count > 1 ? (
+            <text
+              className="diagnostic-marker-count"
+              pointerEvents="none"
+              x={marker.point.x + 8}
+              y={marker.point.y - 6}
+            >
+              {marker.count}
+            </text>
+          ) : null}
+          <circle
+            className="diagnostic-marker-hit"
+            data-testid={`diagnostic-marker-${marker.key}`}
+            cx={marker.point.x}
+            cy={marker.point.y}
+            r={9}
+            onPointerDown={(event) => {
+              event.stopPropagation();
+              event.preventDefault();
+              onSelectMarker(marker.diagnostic);
             }}
             onClick={(event) => event.stopPropagation()}
           />

--- a/apps/editor/src/canvas/editor-canvas-surface.tsx
+++ b/apps/editor/src/canvas/editor-canvas-surface.tsx
@@ -6,6 +6,7 @@ import {
   CanvasGridOverlay,
   CanvasInputPlanes,
   NetHighlightOverlay,
+  DiagnosticMarkersOverlay,
   WireUnderSymbolOverlay,
   NetLabelTetherOverlay,
   type NetLabelTether,
@@ -52,6 +53,7 @@ export interface EditorCanvasSurfaceProps {
   cellSymbolLayout: ComponentProps<typeof EditorCellSymbolLayoutOverlay> | null;
   netHighlight: ComponentProps<typeof NetHighlightOverlay>;
   wireUnderSymbol: ComponentProps<typeof WireUnderSymbolOverlay>;
+  diagnosticMarkers: ComponentProps<typeof DiagnosticMarkersOverlay>;
   netLabelTether: NetLabelTether | null;
   copyPreviewInnerHtml: { __html: string } | null;
   copyPreviewTransform: string | undefined;
@@ -106,6 +108,7 @@ export function EditorCanvasSurface({
   cellSymbolLayout,
   netHighlight,
   wireUnderSymbol,
+  diagnosticMarkers,
   netLabelTether,
   copyPreviewInnerHtml,
   copyPreviewTransform,
@@ -232,6 +235,7 @@ export function EditorCanvasSurface({
           <EditorCanvasHitLayer {...selectionHitLayer} />
           <EditorDraftingHitTargets {...draftingHitTargets} />
           <WireUnderSymbolOverlay {...wireUnderSymbol} />
+          <DiagnosticMarkersOverlay {...diagnosticMarkers} />
           <EditorDraftingHandles {...draftingHandles} />
           <EditorInteractionPreviews {...interactionPreviews} />
         </g>

--- a/apps/editor/src/features/selection/selection-inspector-details.tsx
+++ b/apps/editor/src/features/selection/selection-inspector-details.tsx
@@ -141,6 +141,8 @@ export interface ProjectDiagnosticsSectionProps {
    * statusbar badge's click. The section stays user-collapsible afterwards.
    */
   focusRequestToken?: number;
+  /** Reports the section's expanded state — the canvas review-mode gate. */
+  onOpenStateChange?(open: boolean): void;
 }
 
 export interface NetTraceSectionProps {
@@ -248,6 +250,7 @@ export function ProjectDiagnosticsSection({
   documentLabel,
   onSelectDiagnostic,
   focusRequestToken = 0,
+  onOpenStateChange,
 }: ProjectDiagnosticsSectionProps) {
   const diagnostics = snapshot.diagnostics;
   const [severityFilter, setSeverityFilter] =
@@ -264,6 +267,9 @@ export function ProjectDiagnosticsSection({
   );
   const [handledFocusToken, setHandledFocusToken] = useState(focusRequestToken);
   const sectionRef = useRef<HTMLDetailsElement>(null);
+  useEffect(() => {
+    onOpenStateChange?.(sectionOpen);
+  }, [onOpenStateChange, sectionOpen]);
   useEffect(() => {
     if (focusRequestToken <= handledFocusToken) return;
     setHandledFocusToken(focusRequestToken);

--- a/apps/editor/src/styles/editor-canvas.css
+++ b/apps/editor/src/styles/editor-canvas.css
@@ -183,11 +183,14 @@
   fill: var(--icm-warning, #b54708);
 }
 
+/* Ring-band hit only (an annulus path): the marker's centre stays
+   click-through, so the pin or junction it rings remains directly clickable
+   (and right-clickable) — the marker never captures what it annotates. */
 .diagnostic-markers .diagnostic-marker-hit {
   fill: transparent;
   stroke: none;
   cursor: pointer;
-  pointer-events: all;
+  pointer-events: fill;
 }
 
 .hit-target.annotation-text-hit.would-move {

--- a/apps/editor/src/styles/editor-canvas.css
+++ b/apps/editor/src/styles/editor-canvas.css
@@ -141,6 +141,55 @@
   pointer-events: stroke;
 }
 
+/* Findings on the canvas: an open severity-colored ring over a light halo,
+   never occluding the artwork it marks. Geometry scales with the schematic
+   (like junction dots) while non-scaling-stroke keeps the line crisp, so
+   rings shrink and fade on zoom-out instead of clouding the drawing. */
+.diagnostic-markers .diagnostic-marker-halo {
+  fill: none;
+  stroke: var(--icm-surface, #fff);
+  stroke-width: 4.5;
+  vector-effect: non-scaling-stroke;
+  opacity: 0.85;
+}
+
+.diagnostic-markers .diagnostic-marker-ring {
+  fill: none;
+  stroke-width: 2;
+  vector-effect: non-scaling-stroke;
+}
+
+.diagnostic-marker[data-severity="error"] .diagnostic-marker-ring {
+  stroke: var(--icm-danger, #b42318);
+}
+
+.diagnostic-marker[data-severity="warning"] .diagnostic-marker-ring {
+  stroke: var(--icm-warning, #b54708);
+}
+
+.diagnostic-markers .diagnostic-marker-count {
+  font-size: 9px;
+  font-weight: 700;
+  paint-order: stroke;
+  stroke: var(--icm-surface, #fff);
+  stroke-width: 2.5;
+}
+
+.diagnostic-marker[data-severity="error"] .diagnostic-marker-count {
+  fill: var(--icm-danger, #b42318);
+}
+
+.diagnostic-marker[data-severity="warning"] .diagnostic-marker-count {
+  fill: var(--icm-warning, #b54708);
+}
+
+.diagnostic-markers .diagnostic-marker-hit {
+  fill: transparent;
+  stroke: none;
+  cursor: pointer;
+  pointer-events: all;
+}
+
 .hit-target.annotation-text-hit.would-move {
   fill: rgb(var(--icm-accent-rgb) / 7%);
   stroke: rgb(var(--icm-accent-rgb) / 28%);


### PR DESCRIPTION
Phase 2 of diagnostics surfacing (deferred by design in #437). The badge says **that** findings exist, the workbench says **which** — on a real-scale schematic the remaining cost is going from a list entry to the spot on the canvas. Findings already carry points and locators, so the canvas now shows them.

## Design (as checkpointed)

- **Marker**: an open severity-colored ring (error `--icm-danger`, warning `--icm-warning`) over a light halo at the finding's point. Outlines never occlude what they mark; the halo keeps them legible against dense artwork and per-wire colors. Geometry scales with the schematic while `vector-effect: non-scaling-stroke` keeps the line crisp — rings shrink and fade on zoom-out instead of forming a marker cloud.
- **Gating, no new control**: actionable **errors always on** (that severity means act, matching the badge's red); actionable **warnings only while the Issues section is expanded** (the workbench reports its open state — opening the list lights up the map); **observations never**. Same presentation grouping as the badge and workbench.
- **Clustering**: findings sharing a point collapse to one ring with a numeral, highest severity wins.
- **Click**: pointer-down runs the exact `jumpToProjectDiagnostic` navigation the workbench uses (select + status report). Deliberately **not** building scroll-workbench-to-finding — no per-item anchor exists and the two entry points stay symmetric.
- **No-place findings** (schema/spice domains, coordinate-less ERC) stay off the map; the workbench remains the complete list.

## Mechanics

Generalizes the pattern `WireUnderSymbolOverlay` established: paint elements + a stop-propagation hit circle, so markers never enter `rankCanvasHits`. Marker assembly is one memoized pure function ([diagnostic-markers.ts](apps/editor/src/canvas/diagnostic-markers.ts)) over the already-memoized `electricalDiagnostics` + `visualDiagnostics`; visual entries adapt through `adaptVisualDiagnostic`, so the click payload is the same envelope the workbench holds. Recomputes per committed revision only; new detectors (e.g. the terminal-park detector in flight) surface with zero coupling.

## Tests (red-first)

- Builder: always-on errors, review-gated warnings, cluster severity + count, no-place findings render nothing.
- Overlay statics: severity rings, cluster numeral, empty state.
- The diagnostics e2e now walks the canvas half: no markers before review → two warning rings after opening Issues → ring click navigates with the ERC report.

## Validation

Full unit suite 1932/1932, extended e2e green, typecheck, prettier, full `pnpm ci:check` under the gate-slot lock. Production verification includes the coordinator-requested **error-ring density check on a real broken published document (LTC3452)** before this is called done.

Related to #437, #432, and the wire-segmentation feedback assessment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
