### PR TITLE
feat(derived): flag a terminal resting on a foreign Net's route

### DIFF
--- a/packages/derived/src/visual.test.ts
+++ b/packages/derived/src/visual.test.ts
@@ -231,3 +231,106 @@ describe("visual quality diagnostics", () => {
     ).toEqual([]);
   });
 });
+
+describe("terminal-on-foreign-route exclusions", () => {
+  function documentWithRestingPin() {
+    const document = createEmptyDocument("rest", "Resting pin");
+    document.instances.push({
+      id: "R1",
+      symbolId: "resistor",
+      placement: { position: { x: 60, y: 40 }, rotation: 0, mirror: "none" },
+    });
+    return document;
+  }
+  const foreignHits = (document: Parameters<typeof diagnoseVisualQuality>[0]) =>
+    diagnoseVisualQuality(document, resolver).filter(
+      (item) => item.code === "VISUAL_TERMINAL_ON_FOREIGN_ROUTE",
+    );
+
+  it("stays quiet for a pin legally attached to the route it touches", () => {
+    const document = documentWithRestingPin();
+    document.nets.push({
+      id: "n",
+      terminals: [{ instanceId: "R1", pinName: "2" }],
+    });
+    document.junctions.push({
+      id: "J1",
+      netId: "n",
+      position: { x: 60, y: 140 },
+      role: "route-anchor",
+    });
+    document.routes.push(
+      createRoutePath({
+        id: "own-wire",
+        netId: "n",
+        start: { kind: "terminal", instanceId: "R1", pinName: "2" },
+        end: { kind: "junction", junctionId: "J1" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+    expect(foreignHits(document)).toEqual([]);
+  });
+
+  it("stays quiet for a NoConnect-marked pin resting on a foreign wire", () => {
+    const document = documentWithRestingPin();
+    document.noConnects.push({
+      id: "nc1",
+      endpoint: { kind: "terminal", instanceId: "R1", pinName: "2" },
+    });
+    document.nets.push({ id: "netA", terminals: [] });
+    document.junctions.push(
+      {
+        id: "J1",
+        netId: "netA",
+        position: { x: 0, y: 60 },
+        role: "route-anchor",
+      },
+      {
+        id: "J2",
+        netId: "netA",
+        position: { x: 200, y: 60 },
+        role: "route-anchor",
+      },
+    );
+    document.routes.push(
+      createRoutePath({
+        id: "wireA",
+        netId: "netA",
+        start: { kind: "junction", junctionId: "J1" },
+        end: { kind: "junction", junctionId: "J2" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+    expect(foreignHits(document)).toEqual([]);
+  });
+
+  it("stays quiet for a pin resting on another route of its own Net", () => {
+    const document = documentWithRestingPin();
+    document.nets.push({
+      id: "n",
+      terminals: [{ instanceId: "R1", pinName: "2" }],
+    });
+    document.junctions.push(
+      { id: "J1", netId: "n", position: { x: 0, y: 60 }, role: "route-anchor" },
+      {
+        id: "J2",
+        netId: "n",
+        position: { x: 200, y: 60 },
+        role: "route-anchor",
+      },
+    );
+    document.routes.push(
+      createRoutePath({
+        id: "same-net-wire",
+        netId: "n",
+        start: { kind: "junction", junctionId: "J1" },
+        end: { kind: "junction", junctionId: "J2" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+    expect(foreignHits(document)).toEqual([]);
+  });
+});

--- a/packages/derived/src/visual.ts
+++ b/packages/derived/src/visual.ts
@@ -782,6 +782,73 @@ export function diagnoseVisualQuality(
     }
   }
 
+  // The terminal twin of the ambiguous-junction rule: a visible pin whose
+  // contact point rests on a Net it does not belong to reads as connected
+  // while the model says otherwise. A rest on the pin's own Net is the
+  // ordinary contact idiom, and a NoConnect marker is the author stating
+  // the rest is deliberate; both stay quiet.
+  const terminalNetIds = new Map<string, string>();
+  for (const net of document.nets) {
+    for (const terminal of net.terminals) {
+      terminalNetIds.set(`${terminal.instanceId}\0${terminal.pinName}`, net.id);
+    }
+  }
+  const noConnectKeys = new Set(
+    document.noConnects.map(
+      (noConnect) =>
+        `${noConnect.endpoint.instanceId}\0${noConnect.endpoint.pinName}`,
+    ),
+  );
+  for (const instance of document.instances) {
+    if (!instance.placement) continue;
+    const resolved = resolver.resolve(
+      instance.symbolId,
+      instance.symbolVariantId,
+    );
+    if (!resolved) continue;
+    for (const pin of resolved.definition.pins) {
+      if (pin.presentation.visibility === "implicit") continue;
+      if (resolved.variant?.hiddenPinNames.includes(pin.name)) continue;
+      const key = `${instance.id}\0${pin.name}`;
+      if (noConnectKeys.has(key)) continue;
+      const terminalNetId = terminalNetIds.get(key);
+      const contactPoint = resolveEndpointPoint(document, resolver, {
+        kind: "terminal",
+        instanceId: instance.id,
+        pinName: pin.name,
+      });
+      if (!contactPoint) continue;
+      for (const route of document.routes) {
+        if (route.netId === terminalNetId) continue;
+        const centerline = routingGeometry.routes.get(route.id)?.centerline;
+        if (
+          centerline
+            ?.slice(1)
+            .some((to, index) =>
+              pointOnSegment(contactPoint, centerline[index]!, to),
+            )
+        ) {
+          diagnostics.push({
+            code: "VISUAL_TERMINAL_ON_FOREIGN_ROUTE",
+            severity: "error",
+            category: "structural",
+            confidence: "high",
+            gateEligible: true,
+            message: `Terminal ${instance.id}:${pin.name} lies on unrelated route ${route.id}`,
+            objectIds: [instance.id, route.id],
+            point: contactPoint,
+            parameters: {
+              instanceId: instance.id,
+              pinName: pin.name,
+              ...(terminalNetId === undefined ? {} : { terminalNetId }),
+              routeNetId: route.netId,
+            },
+          });
+        }
+      }
+    }
+  }
+
   for (const constraint of document.constraints) {
     if (constraintViolation(document, constraint, boundsById)) {
       const violationBounds = enclosingBounds(

--- a/packages/derived/src/visual.ts
+++ b/packages/derived/src/visual.ts
@@ -786,7 +786,11 @@ export function diagnoseVisualQuality(
   // contact point rests on a Net it does not belong to reads as connected
   // while the model says otherwise. A rest on the pin's own Net is the
   // ordinary contact idiom, and a NoConnect marker is the author stating
-  // the rest is deliberate; both stay quiet.
+  // the rest is deliberate; both stay quiet. Graded warning and kept out of
+  // the submission gate: a production-corpus sweep found the rest idiom in
+  // 8 published abbreviated schematics (floating pins parked on power
+  // rails), and the gallery contract welcomes abbreviated drawings — the
+  // finding is evidence for the author, not a wall in front of them.
   const terminalNetIds = new Map<string, string>();
   for (const net of document.nets) {
     for (const terminal of net.terminals) {
@@ -830,10 +834,10 @@ export function diagnoseVisualQuality(
         ) {
           diagnostics.push({
             code: "VISUAL_TERMINAL_ON_FOREIGN_ROUTE",
-            severity: "error",
+            severity: "warning",
             category: "structural",
             confidence: "high",
-            gateEligible: true,
+            gateEligible: false,
             message: `Terminal ${instance.id}:${pin.name} lies on unrelated route ${route.id}`,
             objectIds: [instance.id, route.id],
             point: contactPoint,

--- a/packages/edit-engine/src/transform-terminal-foreign-rest.test.ts
+++ b/packages/edit-engine/src/transform-terminal-foreign-rest.test.ts
@@ -77,10 +77,10 @@ describe("terminal resting on a foreign Net after a real transform", () => {
     );
     expect(hits).toHaveLength(1);
     expect(hits[0]).toMatchObject({
-      severity: "error",
+      severity: "warning",
       category: "structural",
       confidence: "high",
-      gateEligible: true,
+      gateEligible: false,
       objectIds: ["R1", "wireA"],
       point: { x: 60, y: 100 },
       parameters: {

--- a/packages/edit-engine/src/transform-terminal-foreign-rest.test.ts
+++ b/packages/edit-engine/src/transform-terminal-foreign-rest.test.ts
@@ -1,0 +1,94 @@
+import { diagnoseVisualQuality } from "@icm/derived";
+import { createEmptyDocument, createRoutePath } from "@icm/model";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { gateRoutingOperationPlan } from "./routing-operation-plan.js";
+import { planRoutingTransform } from "./routing-transform-planner.js";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+describe("terminal resting on a foreign Net after a real transform", () => {
+  it("flags the moved pin that lands on another Net's wire", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.nets.push({ id: "netA", terminals: [] });
+    document.nets.push({
+      id: "netB",
+      terminals: [{ instanceId: "R1", pinName: "2" }],
+    });
+    document.junctions.push(
+      {
+        id: "J1",
+        netId: "netA",
+        position: { x: 0, y: 100 },
+        role: "route-anchor",
+      },
+      {
+        id: "J2",
+        netId: "netA",
+        position: { x: 200, y: 100 },
+        role: "route-anchor",
+      },
+    );
+    document.routes.push(
+      createRoutePath({
+        id: "wireA",
+        netId: "netA",
+        start: { kind: "junction", junctionId: "J1" },
+        end: { kind: "junction", junctionId: "J2" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+    document.instances.push({
+      id: "R1",
+      symbolId: "resistor",
+      placement: { position: { x: 60, y: 40 }, rotation: 0, mirror: "none" },
+    });
+
+    const before = diagnoseVisualQuality(document, resolver);
+    expect(
+      before.filter(
+        (diagnostic) => diagnostic.code === "VISUAL_TERMINAL_ON_FOREIGN_ROUTE",
+      ),
+    ).toEqual([]);
+
+    // The real pipeline: plan the translate, run it through the routing
+    // gate, and diagnose the document the gate would commit. Pin "2" sits at
+    // (60, 60); the move parks it at (60, 100), on netA's wire.
+    const plan = planRoutingTransform(
+      document,
+      resolver,
+      { instanceIds: ["R1"], routeIds: [], junctionIds: [] },
+      { kind: "translate", delta: { x: 0, y: 40 } },
+    );
+    const gated = gateRoutingOperationPlan(document, plan, {
+      symbolResolver: resolver,
+    });
+    expect(gated.ok).toBe(true);
+    if (!gated.ok) return;
+
+    const after = diagnoseVisualQuality(
+      gated.evaluated.finalDocument,
+      resolver,
+    );
+    const hits = after.filter(
+      (diagnostic) => diagnostic.code === "VISUAL_TERMINAL_ON_FOREIGN_ROUTE",
+    );
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toMatchObject({
+      severity: "error",
+      category: "structural",
+      confidence: "high",
+      gateEligible: true,
+      objectIds: ["R1", "wireA"],
+      point: { x: 60, y: 100 },
+      parameters: {
+        instanceId: "R1",
+        pinName: "2",
+        terminalNetId: "netB",
+        routeNetId: "netA",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## What

`VISUAL_TERMINAL_ON_FOREIGN_ROUTE` — the terminal twin of `VISUAL_AMBIGUOUS_JUNCTION`: a visible pin whose contact point rests on a route of a Net it does not belong to reads as connected while the model says otherwise. Endpoint-inclusive segment containment, matching the junction rule. Exclusions: rests on the pin's own Net (the ordinary contact idiom), NoConnect-marked pins, hidden/implicit pins.

Graded **warning / structural / high, gateEligible false** — evidence for the author (surfaced live by the statusbar issues badge, #437), not a submission wall. See below for why.

## Red seed through the real pipeline

`packages/edit-engine/src/transform-terminal-foreign-rest.test.ts`: planRoutingTransform → gateRoutingOperationPlan → final document. Two facts it pins: the routing gate **accepts** a move that parks netB's pin on netA's wire (geometry-legal, no connection claimed), and before this rule the moved document diagnosed clean. Red first, green after; three exclusion tests in `visual.test.ts`.

## Corpus evidence (why warning, not gate)

Production gallery sweep, 119 works, 0 load failures: **11 hits in 8 works**, all geometric true positives, all in `netlistable=false` abbreviated schematics — 7/11 are floating pins parked on power rails (e.g. a ring oscillator's three resistors resting on the VDD rail). Canary dissection: in LTC3452 (recently normalized to near-clean), PMOS **M8's drain — member of no Net — rests exactly on the gate-bias line** (net of M6:G/M7:G/M8:G/Q3:C): drawn as a diode connection, electrically open. The rule found the one remaining lie in a clean document.

The gallery contract explicitly welcomes abbreviated drawings ("netlistable is a mark of extra completeness and never a gate"), so a gateEligible error would block future updates of all 8 published works. Upgrading to a gate later is a one-line change once the corpus is reviewed.

## Validation

- 711 tests across derived / edit-engine / agent-adapter / worker; root typecheck; Prettier; `check-test-impact`
- Full `pnpm ci:check` green on this branch (295/295 Playwright specs) under the machine gate-lock protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)
