### PR TITLE
fix(editor): preserve label-only nets in Gallery placement

### DIFF
--- a/apps/editor/src/features/clipboard/clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard.test.ts
@@ -914,6 +914,70 @@ describe("schematic clipboard", () => {
 });
 
 describe("copyWholeDocument", () => {
+  it("materializes a label-only Net while placing a Gallery document", () => {
+    const source = createEmptyDocument("document-main", "Label-only Net");
+    source.instances.push({
+      id: "VDD1",
+      symbolId: "vdd-port",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0,
+        mirror: "none",
+      },
+      schematicReference: "VDD1",
+    });
+    source.nets.push({ id: "net-label-only", terminals: [] });
+    source.annotations.push({
+      id: "power-label-vdd1",
+      kind: "power-label",
+      binding: { kind: "net-name", netId: "net-label-only" },
+      anchor: {
+        kind: "object",
+        objectId: "VDD1",
+        localOffset: { x: 15, y: 10 },
+        fallbackPosition: { x: 115, y: 110 },
+      },
+      netId: "net-label-only",
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    });
+
+    const target = createEmptyDocument("target", "Target");
+    const clipboard = copyWholeDocument(source);
+    expect(clipboard).not.toBeNull();
+    const proposal = proposePaste(target, clipboard!, { x: 200, y: 50 }, 1);
+    expect(proposal.errors).toEqual([]);
+    const result = executeTransaction(
+      target,
+      {
+        transactionId: "paste-label-only-net",
+        documentId: target.id,
+        expectedRevision: target.revision,
+        actor: { kind: "human", id: "test" },
+        edits: proposal.edits,
+      },
+      { symbolResolver: resolver },
+    );
+
+    if (!result.ok) throw new Error(JSON.stringify(result, null, 2));
+    const copiedNet = result.document.nets.find(
+      (net) => net.id === proposal.idRemap.nets["net-label-only"],
+    );
+    expect(copiedNet).toEqual({
+      id: "net-label-only-copy-1",
+      terminals: [],
+    });
+    expect(result.document.annotations).toEqual([
+      expect.objectContaining({
+        id: "power-label-vdd1-copy-1",
+        netId: "net-label-only-copy-1",
+        binding: { kind: "net-name", netId: "net-label-only-copy-1" },
+      }),
+    ]);
+    expect(result.document.junctions).toEqual([]);
+  });
+
   it("keeps standalone drafting geometry and its layout group", () => {
     const document = createEmptyDocument("document-main", "Drafting scene");
     document.drafting = {

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -1147,6 +1147,41 @@ export function proposePaste(
       );
     }
   }
+  const junctionNetIds = new Set(
+    clipboard.junctions.map((junction) => junction.netId),
+  );
+  const annotationNetIds = new Set(
+    clipboard.annotations.flatMap((annotation) => [
+      ...(annotation.netId ? [annotation.netId] : []),
+      ...(annotation.binding?.kind === "net-name"
+        ? [annotation.binding.netId]
+        : []),
+    ]),
+  );
+  /**
+   * `connect_endpoints` and `add_junction` normally materialize each copied
+   * Base Net. A valid Document may also contain a label-only Net with neither
+   * terminals nor Junctions, though, and `upsert_schematic_annotation` quite
+   * correctly refuses to reference a Net that does not exist. The typed edit
+   * surface has no raw add-Net operation, so use an atomic, temporary
+   * label-anchor Junction to create the Net and remove it after the copied
+   * Annotation makes that empty Net reachable. Nothing synthetic survives in
+   * the pasted Document.
+   */
+  const annotationNetScaffoldIds = new Map(
+    clipboard.nets.flatMap((net) =>
+      net.terminals.length === 0 &&
+      !junctionNetIds.has(net.id) &&
+      annotationNetIds.has(net.id)
+        ? [
+            [
+              net.id,
+              uniqueCopyId("clipboard-net-anchor", sequence, occupied),
+            ] as const,
+          ]
+        : [],
+    ),
+  );
   const objectIds = new Map<string, string>([
     ...instanceIds,
     ...netIds,
@@ -1292,6 +1327,18 @@ export function proposePaste(
         },
       };
     }),
+  );
+  edits.push(
+    ...[...annotationNetScaffoldIds].map(
+      ([sourceNetId, junctionId]): SchematicEdit => ({
+        kind: "add_junction",
+        junctionId,
+        netId: netIds.get(sourceNetId)!,
+        position: { x: 0, y: 0 },
+        role: "label-anchor",
+        createNet: true,
+      }),
+    ),
   );
   const availableNetIds = new Set([
     ...document.nets.map((net) => net.id),
@@ -1445,6 +1492,14 @@ export function proposePaste(
         },
       };
     }),
+  );
+  edits.push(
+    ...[...annotationNetScaffoldIds.values()].map(
+      (junctionId): SchematicEdit => ({
+        kind: "remove_junction",
+        junctionId,
+      }),
+    ),
   );
   const clonedRoutesBySource = new Map(
     clipboard.routes.flatMap((source) => {


### PR DESCRIPTION
## Summary
- materialize label-only Base Nets during Gallery copy placement
- remove the temporary label anchor inside the same atomic transaction so no synthetic geometry remains
- add a regression for the LTC3452 failure shape: an empty Net referenced only by a power label

## Root cause
Direct Gallery open installs the persisted project wholesale. Insert-as-copy rebuilds it through typed clipboard edits. The clipboard correctly remapped the power label from net-power-vdd1 to a fresh ID, but no existing edit materialized a Net with zero terminals, Routes, or Junctions. Final Document validation therefore rejected the annotation's unknown Net and rolled back the whole placement.

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm test:local (307 files, 1934 tests)
- pnpm build
- pnpm test:e2e:local apps/editor/e2e/manual-editor.spec.ts (123 tests)
- the reported LTC3452 project passed the UI-equivalent routing gate and final transaction

Test-Impact: tests-updated