### PR TITLE
test(edit-engine): red-line corpus over real gallery documents

### DIFF
--- a/fixtures/gallery-redline/2rmm2vb45f.icproj.json
+++ b/fixtures/gallery-redline/2rmm2vb45f.icproj.json
@@ -1,0 +1,5466 @@
+{
+  "documents": [
+    {
+      "annotations": [
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 120,
+              "y": 40
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -40,
+              "y": -20
+            },
+            "objectId": "XDP"
+          },
+          "binding": {
+            "instanceId": "XDP",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-XDP",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 130,
+              "y": 180
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -30,
+              "y": 30
+            },
+            "objectId": "XDN"
+          },
+          "binding": {
+            "instanceId": "XDN",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-XDN",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 280,
+              "y": 70
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "XSP"
+          },
+          "binding": {
+            "instanceId": "XSP",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-XSP",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 300,
+              "y": 170
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 40,
+              "y": 20
+            },
+            "objectId": "XSN"
+          },
+          "binding": {
+            "instanceId": "XSN",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-XSN",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 80,
+              "y": 120
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 10
+            },
+            "objectId": "cell-pin-97faf2cad5ec4598"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "cell-terminal-97faf2cad5ec4598"
+          },
+          "id": "instance-label-cell-pin-97faf2cad5ec4598",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 190,
+              "y": 70
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -10,
+              "y": -20
+            },
+            "objectId": "cell-pin-ff0aa142d476d8f2"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "cell-terminal-ff0aa142d476d8f2"
+          },
+          "id": "instance-label-cell-pin-ff0aa142d476d8f2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 320,
+              "y": 100
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": -10
+            },
+            "objectId": "cell-pin-8c4904af6a487d0c"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "cell-terminal-8c4904af6a487d0c"
+          },
+          "id": "instance-label-cell-pin-8c4904af6a487d0c",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 230,
+              "y": 230
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 20
+            },
+            "objectId": "cell-pin-617ad296817b00f2"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "cell-terminal-617ad296817b00f2"
+          },
+          "id": "instance-label-cell-pin-617ad296817b00f2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 230,
+              "y": -20
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": -20
+            },
+            "objectId": "cell-pin-a409bdc6ff5ca70d"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "cell-terminal-a409bdc6ff5ca70d"
+          },
+          "id": "instance-label-cell-pin-a409bdc6ff5ca70d",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        }
+      ],
+      "connectivityEvidence": [
+        {
+          "id": "connectivity-evidence-1e6f9972f85cb8bb",
+          "kind": "name-claim",
+          "name": "bit",
+          "netId": "net-29fcd9625212ec13",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-71764211b8d53092",
+          "kind": "spice-source",
+          "netId": "net-29fcd9625212ec13",
+          "sourceNetId": "net-29fcd9625212ec13"
+        },
+        {
+          "id": "connectivity-evidence-7f6c278617dc2b5c",
+          "kind": "name-claim",
+          "name": "nbit",
+          "netId": "net-75049abbe4dfc20a",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-d02a891bfb82d1f2",
+          "kind": "spice-source",
+          "netId": "net-75049abbe4dfc20a",
+          "sourceNetId": "net-75049abbe4dfc20a"
+        },
+        {
+          "id": "connectivity-evidence-6424d025f0acd521",
+          "kind": "name-claim",
+          "name": "bot",
+          "netId": "net-29e8dd62520249d5",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-f5c3c9c20a0a1f56",
+          "kind": "spice-source",
+          "netId": "net-29e8dd62520249d5",
+          "sourceNetId": "net-29e8dd62520249d5"
+        },
+        {
+          "id": "connectivity-evidence-5c921fd0f76a1e02",
+          "kind": "name-claim",
+          "name": "vdd",
+          "netId": "net-d7602f62b45329ba",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-d7d7cc6e137cbd2a",
+          "kind": "spice-source",
+          "netId": "net-d7602f62b45329ba",
+          "sourceNetId": "net-d7602f62b45329ba"
+        },
+        {
+          "id": "connectivity-evidence-1b21d8dcec3168de",
+          "kind": "spice-source",
+          "netId": "net-split-894a4365344669d4",
+          "sourceNetId": "net-d7191a62b4170368"
+        }
+      ],
+      "constraints": [],
+      "id": "document-82822626bf0850db",
+      "instances": [
+        {
+          "id": "XDP",
+          "importProvenance": {
+            "kind": "opaque",
+            "name": "sky130_fd_pr__pfet_01v8",
+            "sourceTarget": "external-subcircuit:sky130_fd_pr__pfet_01v8",
+            "status": "resolved",
+            "symbolMappingRegistryId": "sky130-pfet-four-terminal",
+            "terminalMapping": [
+              {
+                "pinName": "D",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "G",
+                "sourcePosition": 1
+              },
+              {
+                "pinName": "S",
+                "sourcePosition": 2
+              },
+              {
+                "pinName": "B",
+                "sourcePosition": 3
+              }
+            ]
+          },
+          "mosBulkBinding": {
+            "netId": "net-d7602f62b45329ba",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "binding": {
+              "definitionId": "external-subcircuit-27f716b14d59fc10",
+              "kind": "external-subcircuit"
+            },
+            "parameters": {
+              "l": "0.15",
+              "nf": "1",
+              "w": "1.2"
+            },
+            "reference": "XDP"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 160,
+              "y": 60
+            },
+            "rotation": 0
+          },
+          "schematicReference": "XDP",
+          "sourceRef": {
+            "end": {
+              "column": 63,
+              "line": 4,
+              "offset": 248
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 4,
+              "offset": 186
+            }
+          },
+          "symbolId": "pmos"
+        },
+        {
+          "id": "XDN",
+          "importProvenance": {
+            "kind": "opaque",
+            "name": "sky130_fd_pr__nfet_01v8",
+            "sourceTarget": "external-subcircuit:sky130_fd_pr__nfet_01v8",
+            "status": "resolved",
+            "symbolMappingRegistryId": "sky130-nfet-four-terminal",
+            "terminalMapping": [
+              {
+                "pinName": "D",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "G",
+                "sourcePosition": 1
+              },
+              {
+                "pinName": "S",
+                "sourcePosition": 2
+              },
+              {
+                "pinName": "B",
+                "sourcePosition": 3
+              }
+            ]
+          },
+          "netlist": {
+            "binding": {
+              "definitionId": "external-subcircuit-e5ee3d17d0c7c89a",
+              "kind": "external-subcircuit"
+            },
+            "parameters": {
+              "l": "0.15",
+              "nf": "1",
+              "w": "0.6"
+            },
+            "reference": "XDN"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 160,
+              "y": 150
+            },
+            "rotation": 0
+          },
+          "schematicReference": "XDN",
+          "sourceRef": {
+            "end": {
+              "column": 63,
+              "line": 5,
+              "offset": 311
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 5,
+              "offset": 249
+            }
+          },
+          "symbolId": "nmos"
+        },
+        {
+          "id": "XSP",
+          "importProvenance": {
+            "kind": "opaque",
+            "name": "sky130_fd_pr__pfet_01v8",
+            "sourceTarget": "external-subcircuit:sky130_fd_pr__pfet_01v8",
+            "status": "resolved",
+            "symbolMappingRegistryId": "sky130-pfet-four-terminal",
+            "terminalMapping": [
+              {
+                "pinName": "D",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "G",
+                "sourcePosition": 1
+              },
+              {
+                "pinName": "S",
+                "sourcePosition": 2
+              },
+              {
+                "pinName": "B",
+                "sourcePosition": 3
+              }
+            ]
+          },
+          "mosBulkBinding": {
+            "netId": "net-d7602f62b45329ba",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "binding": {
+              "definitionId": "external-subcircuit-27f716b14d59fc10",
+              "kind": "external-subcircuit"
+            },
+            "parameters": {
+              "l": "0.15",
+              "nf": "2",
+              "w": "4"
+            },
+            "reference": "XSP"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 260,
+              "y": 60
+            },
+            "rotation": 0
+          },
+          "schematicReference": "XSP",
+          "sourceRef": {
+            "end": {
+              "column": 61,
+              "line": 6,
+              "offset": 372
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 6,
+              "offset": 312
+            }
+          },
+          "symbolId": "pmos"
+        },
+        {
+          "id": "XSN",
+          "importProvenance": {
+            "kind": "opaque",
+            "name": "sky130_fd_pr__nfet_01v8",
+            "sourceTarget": "external-subcircuit:sky130_fd_pr__nfet_01v8",
+            "status": "resolved",
+            "symbolMappingRegistryId": "sky130-nfet-four-terminal",
+            "terminalMapping": [
+              {
+                "pinName": "D",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "G",
+                "sourcePosition": 1
+              },
+              {
+                "pinName": "S",
+                "sourcePosition": 2
+              },
+              {
+                "pinName": "B",
+                "sourcePosition": 3
+              }
+            ]
+          },
+          "netlist": {
+            "binding": {
+              "definitionId": "external-subcircuit-e5ee3d17d0c7c89a",
+              "kind": "external-subcircuit"
+            },
+            "parameters": {
+              "l": "0.15",
+              "nf": "1",
+              "w": "2"
+            },
+            "reference": "XSN"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 260,
+              "y": 150
+            },
+            "rotation": 0
+          },
+          "schematicReference": "XSN",
+          "sourceRef": {
+            "end": {
+              "column": 61,
+              "line": 7,
+              "offset": 433
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 7,
+              "offset": 373
+            }
+          },
+          "symbolId": "nmos"
+        },
+        {
+          "id": "cell-pin-97faf2cad5ec4598",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 100,
+              "y": 110
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "cell-pin-ff0aa142d476d8f2",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 200,
+              "y": 90
+            },
+            "rotation": 90
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "cell-pin-8c4904af6a487d0c",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 300,
+              "y": 110
+            },
+            "rotation": 180
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "cell-pin-617ad296817b00f2",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 220,
+              "y": 210
+            },
+            "rotation": 270
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "cell-pin-a409bdc6ff5ca70d",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 220,
+              "y": 0
+            },
+            "rotation": 90
+          },
+          "symbolId": "port"
+        }
+      ],
+      "junctions": [
+        {
+          "id": "junction-ui-8",
+          "netId": "net-75049abbe4dfc20a",
+          "position": {
+            "x": 170,
+            "y": 110
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-9",
+          "netId": "net-75049abbe4dfc20a",
+          "position": {
+            "x": 230,
+            "y": 110
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-11",
+          "netId": "net-75049abbe4dfc20a",
+          "position": {
+            "x": 200,
+            "y": 110
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-14",
+          "netId": "net-29e8dd62520249d5",
+          "position": {
+            "x": 270,
+            "y": 110
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-16",
+          "netId": "net-29fcd9625212ec13",
+          "position": {
+            "x": 130,
+            "y": 110
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-19",
+          "netId": "net-d7602f62b45329ba",
+          "position": {
+            "x": 220,
+            "y": 20
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-23",
+          "netId": "net-split-894a4365344669d4",
+          "position": {
+            "x": 220,
+            "y": 180
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-111",
+          "netId": "net-split-894a4365344669d4",
+          "position": {
+            "x": 180,
+            "y": 180
+          },
+          "role": "branch"
+        }
+      ],
+      "layoutGroups": [],
+      "mosBulkDefaults": {
+        "pmosNetId": "net-d7602f62b45329ba"
+      },
+      "name": "scdac_unit",
+      "netlist": {
+        "formalParameters": [],
+        "name": "scdac_unit",
+        "terminals": [
+          {
+            "direction": "passive",
+            "id": "cell-terminal-97faf2cad5ec4598",
+            "interfaceInstanceIds": [
+              "cell-pin-97faf2cad5ec4598"
+            ],
+            "name": "bit",
+            "netId": "net-29fcd9625212ec13"
+          },
+          {
+            "direction": "passive",
+            "id": "cell-terminal-ff0aa142d476d8f2",
+            "interfaceInstanceIds": [
+              "cell-pin-ff0aa142d476d8f2"
+            ],
+            "name": "nbit",
+            "netId": "net-75049abbe4dfc20a"
+          },
+          {
+            "direction": "passive",
+            "id": "cell-terminal-8c4904af6a487d0c",
+            "interfaceInstanceIds": [
+              "cell-pin-8c4904af6a487d0c"
+            ],
+            "name": "bot",
+            "netId": "net-29e8dd62520249d5"
+          },
+          {
+            "direction": "passive",
+            "id": "cell-terminal-617ad296817b00f2",
+            "interfaceInstanceIds": [
+              "cell-pin-617ad296817b00f2"
+            ],
+            "name": "vss",
+            "netId": "net-split-894a4365344669d4"
+          },
+          {
+            "direction": "passive",
+            "id": "cell-terminal-a409bdc6ff5ca70d",
+            "interfaceInstanceIds": [
+              "cell-pin-a409bdc6ff5ca70d"
+            ],
+            "name": "vdd",
+            "netId": "net-d7602f62b45329ba"
+          }
+        ]
+      },
+      "nets": [
+        {
+          "id": "net-29fcd9625212ec13",
+          "terminals": [
+            {
+              "instanceId": "XDP",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "XDN",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "cell-pin-97faf2cad5ec4598",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-75049abbe4dfc20a",
+          "terminals": [
+            {
+              "instanceId": "XDP",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "XDN",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "XSP",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "XSN",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "cell-pin-ff0aa142d476d8f2",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-29e8dd62520249d5",
+          "terminals": [
+            {
+              "instanceId": "XSP",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "XSN",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "cell-pin-8c4904af6a487d0c",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-d7602f62b45329ba",
+          "terminals": [
+            {
+              "instanceId": "XDP",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "XDP",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "XSP",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "XSP",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "cell-pin-a409bdc6ff5ca70d",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-split-894a4365344669d4",
+          "terminals": [
+            {
+              "instanceId": "cell-pin-617ad296817b00f2",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "XDN",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "XSN",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "XDN",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "XSN",
+              "pinName": "B"
+            }
+          ]
+        }
+      ],
+      "noConnects": [],
+      "presentation": {
+        "cellSymbol": {
+          "minimumBodySize": {
+            "height": 100,
+            "width": 100
+          },
+          "pinPlacements": [
+            {
+              "offset": 20,
+              "side": "east",
+              "terminalId": "cell-terminal-ff0aa142d476d8f2"
+            },
+            {
+              "offset": -20,
+              "side": "east",
+              "terminalId": "cell-terminal-617ad296817b00f2"
+            },
+            {
+              "offset": 30,
+              "side": "west",
+              "terminalId": "cell-terminal-a409bdc6ff5ca70d"
+            },
+            {
+              "offset": -30,
+              "side": "west",
+              "terminalId": "cell-terminal-8c4904af6a487d0c"
+            }
+          ]
+        },
+        "compactness": "normal",
+        "grid": 10,
+        "styleProfileId": "razavi-textbook-v1"
+      },
+      "revision": 82,
+      "routes": [
+        {
+          "id": "route-ui-1-a-16",
+          "legs": [
+            {
+              "id": "route-leg-f5ec1fcc1cefc956",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-f5ec1fcc1cefc956",
+                "kind": "bend",
+                "position": {
+                  "x": 130,
+                  "y": 60
+                }
+              }
+            },
+            {
+              "id": "route-leg-f5ec20cc1cefcb09",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-16",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-29fcd9625212ec13",
+          "start": {
+            "instanceId": "XDP",
+            "kind": "terminal",
+            "pinName": "G"
+          }
+        },
+        {
+          "id": "route-ui-1-b-16",
+          "legs": [
+            {
+              "id": "route-leg-59ae47838ab4f899",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-59ae47838ab4f899",
+                "kind": "bend",
+                "position": {
+                  "x": 130,
+                  "y": 150
+                }
+              }
+            },
+            {
+              "id": "route-leg-59ae46838ab4f6e6",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XDN",
+                  "kind": "terminal",
+                  "pinName": "G"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-29fcd9625212ec13",
+          "start": {
+            "junctionId": "junction-ui-16",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-2-a-9",
+          "legs": [
+            {
+              "id": "route-leg-9e4df7649118ba7e",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-9e4df7649118ba7e",
+                "kind": "bend",
+                "position": {
+                  "x": 230,
+                  "y": 60
+                }
+              }
+            },
+            {
+              "id": "route-leg-9e4df8649118bc31",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-9",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-75049abbe4dfc20a",
+          "start": {
+            "instanceId": "XSP",
+            "kind": "terminal",
+            "pinName": "G"
+          }
+        },
+        {
+          "id": "route-ui-2-b-9",
+          "legs": [
+            {
+              "id": "route-leg-f42d9aa16d8f5c77",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-f42d9aa16d8f5c77",
+                "kind": "bend",
+                "position": {
+                  "x": 230,
+                  "y": 150
+                }
+              }
+            },
+            {
+              "id": "route-leg-f42d99a16d8f5ac4",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XSN",
+                  "kind": "terminal",
+                  "pinName": "G"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-75049abbe4dfc20a",
+          "start": {
+            "junctionId": "junction-ui-9",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-6-a-14",
+          "legs": [
+            {
+              "id": "route-leg-02a65e574cbd14f7",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-14",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-29e8dd62520249d5",
+          "start": {
+            "instanceId": "XSP",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-6-b-14",
+          "legs": [
+            {
+              "id": "route-leg-0807884f368428a4",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XSN",
+                  "kind": "terminal",
+                  "pinName": "D"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-29e8dd62520249d5",
+          "start": {
+            "junctionId": "junction-ui-14",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-7-a-8",
+          "legs": [
+            {
+              "id": "route-leg-eff82a7c00ebecd2",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-8",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-75049abbe4dfc20a",
+          "start": {
+            "instanceId": "XDP",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-7-b-8",
+          "legs": [
+            {
+              "id": "route-leg-09231429a082fe3b",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XDN",
+                  "kind": "terminal",
+                  "pinName": "D"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-75049abbe4dfc20a",
+          "start": {
+            "junctionId": "junction-ui-8",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-10-a-11",
+          "legs": [
+            {
+              "id": "route-leg-aee77c7af76ac77a",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-11",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-75049abbe4dfc20a",
+          "start": {
+            "junctionId": "junction-ui-8",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-10-b-11",
+          "legs": [
+            {
+              "id": "route-leg-4fbafbe41815f469",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-9",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-75049abbe4dfc20a",
+          "start": {
+            "junctionId": "junction-ui-11",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-12",
+          "legs": [
+            {
+              "id": "route-leg-45feb7b4fda98d1a",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-11",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-75049abbe4dfc20a",
+          "start": {
+            "instanceId": "cell-pin-ff0aa142d476d8f2",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "route-ui-15",
+          "legs": [
+            {
+              "id": "route-leg-6e8cc5c78f885417",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "cell-pin-8c4904af6a487d0c",
+                  "kind": "terminal",
+                  "pinName": "P"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-29e8dd62520249d5",
+          "start": {
+            "junctionId": "junction-ui-14",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-17",
+          "legs": [
+            {
+              "id": "route-leg-56b8e59fb979bb35",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-16",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-29fcd9625212ec13",
+          "start": {
+            "instanceId": "cell-pin-97faf2cad5ec4598",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "route-ui-18-a-19",
+          "legs": [
+            {
+              "id": "route-leg-b45ffa461f0e5f2a",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-b45ffa461f0e5f2a",
+                "kind": "bend",
+                "position": {
+                  "x": 170,
+                  "y": 20
+                }
+              }
+            },
+            {
+              "id": "route-leg-b45ffb461f0e60dd",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-19",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-d7602f62b45329ba",
+          "start": {
+            "instanceId": "XDP",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-ui-18-b-19",
+          "legs": [
+            {
+              "id": "route-leg-395312eddce3d259",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-395312eddce3d259",
+                "kind": "bend",
+                "position": {
+                  "x": 270,
+                  "y": 20
+                }
+              }
+            },
+            {
+              "id": "route-leg-395311eddce3d0a6",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XSP",
+                  "kind": "terminal",
+                  "pinName": "S"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-d7602f62b45329ba",
+          "start": {
+            "junctionId": "junction-ui-19",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-20",
+          "legs": [
+            {
+              "id": "route-leg-8d47b73400233dbf",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-19",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-d7602f62b45329ba",
+          "start": {
+            "instanceId": "cell-pin-a409bdc6ff5ca70d",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "route-ui-22-a-23-a-111",
+          "legs": [
+            {
+              "id": "route-leg-4d9babeee9c3b67b",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-4d9babeee9c3b67b",
+                "kind": "bend",
+                "position": {
+                  "x": 170,
+                  "y": 180
+                }
+              }
+            },
+            {
+              "id": "route-leg-4d9baaeee9c3b4c8",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-111",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-894a4365344669d4",
+          "start": {
+            "instanceId": "XDN",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-ui-22-a-23-b-111",
+          "legs": [
+            {
+              "id": "route-leg-943539b45324b11a",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-23",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-894a4365344669d4",
+          "start": {
+            "junctionId": "junction-ui-111",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-22-b-23",
+          "legs": [
+            {
+              "id": "route-leg-b0edd4bbcaa76893",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-b0edd4bbcaa76893",
+                "kind": "bend",
+                "position": {
+                  "x": 270,
+                  "y": 180
+                }
+              }
+            },
+            {
+              "id": "route-leg-b0edd3bbcaa766e0",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XSN",
+                  "kind": "terminal",
+                  "pinName": "S"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-894a4365344669d4",
+          "start": {
+            "junctionId": "junction-ui-23",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-112",
+          "legs": [
+            {
+              "id": "route-leg-7c43db2e001cb54a",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-23",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-894a4365344669d4",
+          "start": {
+            "instanceId": "cell-pin-617ad296817b00f2",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "route-ui-113",
+          "legs": [
+            {
+              "id": "route-leg-9440b9247de6b049",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-9440b9247de6b049",
+                "kind": "bend",
+                "position": {
+                  "x": 180,
+                  "y": 150
+                }
+              }
+            },
+            {
+              "id": "route-leg-9440b8247de6ae96",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-9440b8247de6ae96",
+                "kind": "bend",
+                "position": {
+                  "x": 180,
+                  "y": 170
+                }
+              }
+            },
+            {
+              "id": "route-leg-9440b7247de6ace3",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XDN",
+                  "kind": "terminal",
+                  "pinName": "S"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-894a4365344669d4",
+          "presentation": "bulk-dashed",
+          "start": {
+            "instanceId": "XDN",
+            "kind": "terminal",
+            "pinName": "B"
+          }
+        },
+        {
+          "id": "route-ui-114",
+          "legs": [
+            {
+              "id": "route-leg-5f1c035c5fcaad68",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-5f1c035c5fcaad68",
+                "kind": "bend",
+                "position": {
+                  "x": 280,
+                  "y": 150
+                }
+              }
+            },
+            {
+              "id": "route-leg-5f1c045c5fcaaf1b",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-5f1c045c5fcaaf1b",
+                "kind": "bend",
+                "position": {
+                  "x": 280,
+                  "y": 170
+                }
+              }
+            },
+            {
+              "id": "route-leg-5f1c055c5fcab0ce",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XSN",
+                  "kind": "terminal",
+                  "pinName": "S"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-894a4365344669d4",
+          "presentation": "bulk-dashed",
+          "start": {
+            "instanceId": "XSN",
+            "kind": "terminal",
+            "pinName": "B"
+          }
+        }
+      ],
+      "sourceBinding": {
+        "cellName": "scdac_unit",
+        "sourceRef": {
+          "end": {
+            "column": 17,
+            "line": 8,
+            "offset": 450
+          },
+          "fileId": "source-648e50f6f6cd02ee",
+          "start": {
+            "column": 1,
+            "line": 3,
+            "offset": 146
+          }
+        }
+      },
+      "sourceStatus": "connectivity-modified"
+    },
+    {
+      "annotations": [
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 280,
+              "y": 290
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 0,
+              "y": 10
+            },
+            "objectId": "XU0"
+          },
+          "binding": {
+            "instanceId": "XU0",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-XU0",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 440,
+              "y": 280
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 0,
+              "y": 0
+            },
+            "objectId": "XU1"
+          },
+          "binding": {
+            "instanceId": "XU1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-XU1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 600,
+              "y": 290
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 0,
+              "y": 10
+            },
+            "objectId": "XU2"
+          },
+          "binding": {
+            "instanceId": "XU2",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-XU2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 750,
+              "y": 290
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 0,
+              "y": 10
+            },
+            "objectId": "XU3"
+          },
+          "binding": {
+            "instanceId": "XU3",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-XU3",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 890,
+              "y": 290
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 10
+            },
+            "objectId": "XU4"
+          },
+          "binding": {
+            "instanceId": "XU4",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-XU4",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 1020,
+              "y": 290
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 0,
+              "y": 10
+            },
+            "objectId": "XU5"
+          },
+          "binding": {
+            "instanceId": "XU5",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-XU5",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 1130,
+              "y": 180
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": -10
+            },
+            "objectId": "XRESET"
+          },
+          "binding": {
+            "instanceId": "XRESET",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-XRESET",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 470,
+              "y": 300
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "C0"
+          },
+          "binding": {
+            "instanceId": "C0",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-C0",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 640,
+              "y": 240
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "C1"
+          },
+          "binding": {
+            "instanceId": "C1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-C1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 830,
+              "y": 240
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "C2"
+          },
+          "binding": {
+            "instanceId": "C2",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-C2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 100,
+              "y": 360
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "C3"
+          },
+          "binding": {
+            "instanceId": "C3",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-C3",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 280,
+              "y": 360
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "C4"
+          },
+          "binding": {
+            "instanceId": "C4",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-C4",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 460,
+              "y": 360
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "C5"
+          },
+          "binding": {
+            "instanceId": "C5",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-C5",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 1230,
+              "y": 140
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "CDUMMY"
+          },
+          "binding": {
+            "instanceId": "CDUMMY",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-CDUMMY",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 110,
+              "y": 370
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 10
+            },
+            "objectId": "cell-pin-8d2d35d48ff5f9ed"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "cell-terminal-8d2d35d48ff5f9ed"
+          },
+          "id": "instance-label-cell-pin-8d2d35d48ff5f9ed",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 1060,
+              "y": 180
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": -10
+            },
+            "objectId": "cell-pin-a2a67d4f33b799c7"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "cell-terminal-a2a67d4f33b799c7"
+          },
+          "formatOverride": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "R"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "kind": "text",
+                    "value": "eset"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-cell-pin-a2a67d4f33b799c7",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 300,
+              "y": 200
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": -10
+            },
+            "objectId": "cell-pin-f3b64e14efff21be"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "cell-terminal-f3b64e14efff21be"
+          },
+          "id": "instance-label-cell-pin-f3b64e14efff21be",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 460,
+              "y": 200
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": -10
+            },
+            "objectId": "cell-pin-47376c4eca117570"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "cell-terminal-47376c4eca117570"
+          },
+          "id": "instance-label-cell-pin-47376c4eca117570",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 620,
+              "y": 200
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": -10
+            },
+            "objectId": "cell-pin-92d3b5ac7c8ee706"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "cell-terminal-92d3b5ac7c8ee706"
+          },
+          "id": "instance-label-cell-pin-92d3b5ac7c8ee706",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 770,
+              "y": 200
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": -10
+            },
+            "objectId": "cell-pin-ab6266f82f28dfdc"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "cell-terminal-ab6266f82f28dfdc"
+          },
+          "id": "instance-label-cell-pin-ab6266f82f28dfdc",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 900,
+              "y": 200
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": -10
+            },
+            "objectId": "cell-pin-6e2af21c7a63f9d6"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "cell-terminal-6e2af21c7a63f9d6"
+          },
+          "id": "instance-label-cell-pin-6e2af21c7a63f9d6",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 1040,
+              "y": 200
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": -10
+            },
+            "objectId": "cell-pin-fdb36ad3f48af9f8"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "cell-terminal-fdb36ad3f48af9f8"
+          },
+          "id": "instance-label-cell-pin-fdb36ad3f48af9f8",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 110,
+              "y": 180
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 10
+            },
+            "objectId": "cell-pin-c0d84c7e757d32bf"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "cell-terminal-c0d84c7e757d32bf"
+          },
+          "id": "instance-label-cell-pin-c0d84c7e757d32bf",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 110,
+              "y": 100
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 10
+            },
+            "objectId": "cell-pin-e9e91f330164cbe3"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "cell-terminal-e9e91f330164cbe3"
+          },
+          "id": "instance-label-cell-pin-e9e91f330164cbe3",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        }
+      ],
+      "connectivityEvidence": [
+        {
+          "id": "connectivity-evidence-3e39609101284864",
+          "kind": "name-claim",
+          "name": "vss",
+          "netId": "net-split-37570a4f779d22b7",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-92458337e10dc9a8",
+          "kind": "spice-source",
+          "netId": "net-split-37570a4f779d22b7",
+          "sourceNetId": "net-82ef833d9b98cf34"
+        },
+        {
+          "id": "connectivity-evidence-c57cba86aff44f8d",
+          "kind": "name-claim",
+          "name": "reset",
+          "netId": "net-b778eaaff63d68d5",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-4ccd2a01c5925790",
+          "kind": "spice-source",
+          "netId": "net-b778eaaff63d68d5",
+          "sourceNetId": "net-b778eaaff63d68d5"
+        },
+        {
+          "id": "connectivity-evidence-d2a4316a05ecd2ad",
+          "kind": "name-claim",
+          "name": "b0",
+          "netId": "net-b9d1505a12d36a23",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-96373bb3e1a70acc",
+          "kind": "spice-source",
+          "netId": "net-b9d1505a12d36a23",
+          "sourceNetId": "net-b9d1505a12d36a23"
+        },
+        {
+          "id": "connectivity-evidence-5b967be82c170162",
+          "kind": "name-claim",
+          "name": "b1",
+          "netId": "net-b9d14f5a12d36870",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-e4475a3be242e724",
+          "kind": "spice-source",
+          "netId": "net-b9d14f5a12d36870",
+          "sourceNetId": "net-b9d14f5a12d36870"
+        },
+        {
+          "id": "connectivity-evidence-b8f54bc5b89ed444",
+          "kind": "name-claim",
+          "name": "b2",
+          "netId": "net-b9d1525a12d36d89",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-ffe79b398627c3dc",
+          "kind": "spice-source",
+          "netId": "net-b9d1525a12d36d89",
+          "sourceNetId": "net-b9d1525a12d36d89"
+        },
+        {
+          "id": "connectivity-evidence-07c3213c6c14f289",
+          "kind": "name-claim",
+          "name": "b3",
+          "netId": "net-b9d1515a12d36bd6",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-fb4b76e09de94e50",
+          "kind": "spice-source",
+          "netId": "net-b9d1515a12d36bd6",
+          "sourceNetId": "net-b9d1515a12d36bd6"
+        },
+        {
+          "id": "connectivity-evidence-45e61a275fca9c13",
+          "kind": "name-claim",
+          "name": "b4",
+          "netId": "net-b9d1545a12d370ef",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-b6aabd48a2bb1f24",
+          "kind": "spice-source",
+          "netId": "net-b9d1545a12d370ef",
+          "sourceNetId": "net-b9d1545a12d370ef"
+        },
+        {
+          "id": "connectivity-evidence-39027b43ea1f55a9",
+          "kind": "name-claim",
+          "name": "b5",
+          "netId": "net-b9d1535a12d36f3c",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-c402f880ff0f5958",
+          "kind": "spice-source",
+          "netId": "net-b9d1535a12d36f3c",
+          "sourceNetId": "net-b9d1535a12d36f3c"
+        },
+        {
+          "id": "connectivity-evidence-64b12a5fda6dc0e3",
+          "kind": "name-claim",
+          "name": "vdd",
+          "netId": "net-split-47cc1a54ff6091e2",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-2a23b5aca9b64860",
+          "kind": "spice-source",
+          "netId": "net-split-47cc1a54ff6091e2",
+          "sourceNetId": "net-82ae603d9b60fcc6"
+        },
+        {
+          "id": "connectivity-evidence-4de9c5e3ae1e0993",
+          "kind": "name-claim",
+          "name": "vout",
+          "netId": "net-split-802ce8f2c4115a8a",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-26807951afa1dce4",
+          "kind": "spice-source",
+          "netId": "net-split-802ce8f2c4115a8a",
+          "sourceNetId": "net-5d241e46ea1603fd"
+        },
+        {
+          "id": "connectivity-evidence-edb4c347cfc87c18",
+          "kind": "name-claim",
+          "name": "nb0",
+          "netId": "net-544c083e1298c65c",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-feb1d59ed6a44864",
+          "kind": "spice-source",
+          "netId": "net-544c083e1298c65c",
+          "sourceNetId": "net-544c083e1298c65c"
+        },
+        {
+          "id": "connectivity-evidence-9983e368b7f99a12",
+          "kind": "name-claim",
+          "name": "bot0",
+          "netId": "net-2363ccedceb2b67c",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-dbc42f6ec1093588",
+          "kind": "spice-source",
+          "netId": "net-2363ccedceb2b67c",
+          "sourceNetId": "net-2363ccedceb2b67c"
+        },
+        {
+          "id": "connectivity-evidence-2a12499f171a6070",
+          "kind": "name-claim",
+          "name": "nb1",
+          "netId": "net-544c093e1298c80f",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-eb6cf100fc828784",
+          "kind": "spice-source",
+          "netId": "net-544c093e1298c80f",
+          "sourceNetId": "net-544c093e1298c80f"
+        },
+        {
+          "id": "connectivity-evidence-cd2ccd1ed74a57b6",
+          "kind": "name-claim",
+          "name": "bot1",
+          "netId": "net-2363cdedceb2b82f",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-918989a4a1f6c7dc",
+          "kind": "spice-source",
+          "netId": "net-2363cdedceb2b82f",
+          "sourceNetId": "net-2363cdedceb2b82f"
+        },
+        {
+          "id": "connectivity-evidence-a07466d3f9a454c1",
+          "kind": "name-claim",
+          "name": "nb2",
+          "netId": "net-544c0a3e1298c9c2",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-099282a6d3a88180",
+          "kind": "spice-source",
+          "netId": "net-544c0a3e1298c9c2",
+          "sourceNetId": "net-544c0a3e1298c9c2"
+        },
+        {
+          "id": "connectivity-evidence-0df49f4dca6fc78a",
+          "kind": "name-claim",
+          "name": "bot2",
+          "netId": "net-2363ceedceb2b9e2",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-d092a0f252a314e4",
+          "kind": "spice-source",
+          "netId": "net-2363ceedceb2b9e2",
+          "sourceNetId": "net-2363ceedceb2b9e2"
+        },
+        {
+          "id": "connectivity-evidence-7942050a23a1a933",
+          "kind": "name-claim",
+          "name": "nb3",
+          "netId": "net-544c0b3e1298cb75",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-34a6583bde0333d8",
+          "kind": "spice-source",
+          "netId": "net-544c0b3e1298cb75",
+          "sourceNetId": "net-544c0b3e1298cb75"
+        },
+        {
+          "id": "connectivity-evidence-3e0597c5cb7ce44e",
+          "kind": "name-claim",
+          "name": "bot3",
+          "netId": "net-2363cfedceb2bb95",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-e9d44e187c91f9e0",
+          "kind": "spice-source",
+          "netId": "net-2363cfedceb2bb95",
+          "sourceNetId": "net-2363cfedceb2bb95"
+        },
+        {
+          "id": "connectivity-evidence-5fc884685564215c",
+          "kind": "name-claim",
+          "name": "nb4",
+          "netId": "net-544c043e1298bf90",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-17fac1bd01dff52c",
+          "kind": "spice-source",
+          "netId": "net-544c043e1298bf90",
+          "sourceNetId": "net-544c043e1298bf90"
+        },
+        {
+          "id": "connectivity-evidence-deb5fb4cf80f4e80",
+          "kind": "name-claim",
+          "name": "bot4",
+          "netId": "net-2363c8edceb2afb0",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-df7ce0f3d93ef364",
+          "kind": "spice-source",
+          "netId": "net-2363c8edceb2afb0",
+          "sourceNetId": "net-2363c8edceb2afb0"
+        },
+        {
+          "id": "connectivity-evidence-15cddc47ed2b4fb0",
+          "kind": "name-claim",
+          "name": "nb5",
+          "netId": "net-544c053e1298c143",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-5e3a4fa2f372c8bc",
+          "kind": "spice-source",
+          "netId": "net-544c053e1298c143",
+          "sourceNetId": "net-544c053e1298c143"
+        },
+        {
+          "id": "connectivity-evidence-9bc27519eaac5f53",
+          "kind": "name-claim",
+          "name": "bot5",
+          "netId": "net-2363c9edceb2b163",
+          "owner": {
+            "kind": "explicit-net-property"
+          },
+          "scope": "local"
+        },
+        {
+          "id": "connectivity-evidence-472b51864b9d2a28",
+          "kind": "spice-source",
+          "netId": "net-2363c9edceb2b163",
+          "sourceNetId": "net-2363c9edceb2b163"
+        }
+      ],
+      "constraints": [],
+      "id": "document-fb815c3c3f719ef7",
+      "instances": [
+        {
+          "id": "XU0",
+          "importProvenance": {
+            "kind": "subcircuit",
+            "name": "scdac_unit",
+            "sourceTarget": "subcircuit:scdac_unit",
+            "status": "resolved",
+            "terminalMapping": [
+              {
+                "pinName": "bit",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "nbit",
+                "sourcePosition": 1
+              },
+              {
+                "pinName": "bot",
+                "sourcePosition": 2
+              },
+              {
+                "pinName": "vss",
+                "sourcePosition": 3
+              },
+              {
+                "pinName": "vdd",
+                "sourcePosition": 4
+              }
+            ]
+          },
+          "netlist": {
+            "binding": {
+              "childDocumentId": "document-82822626bf0850db",
+              "kind": "subcircuit"
+            },
+            "parameters": {},
+            "reference": "XU0"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 280,
+              "y": 280
+            },
+            "rotation": 90
+          },
+          "schematicReference": "XU0",
+          "sourceRef": {
+            "end": {
+              "column": 35,
+              "line": 11,
+              "offset": 559
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 11,
+              "offset": 525
+            }
+          },
+          "symbolId": "hierarchical-symbol-82822626bf0850db"
+        },
+        {
+          "id": "XU1",
+          "importProvenance": {
+            "kind": "subcircuit",
+            "name": "scdac_unit",
+            "sourceTarget": "subcircuit:scdac_unit",
+            "status": "resolved",
+            "terminalMapping": [
+              {
+                "pinName": "bit",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "nbit",
+                "sourcePosition": 1
+              },
+              {
+                "pinName": "bot",
+                "sourcePosition": 2
+              },
+              {
+                "pinName": "vss",
+                "sourcePosition": 3
+              },
+              {
+                "pinName": "vdd",
+                "sourcePosition": 4
+              }
+            ]
+          },
+          "netlist": {
+            "binding": {
+              "childDocumentId": "document-82822626bf0850db",
+              "kind": "subcircuit"
+            },
+            "parameters": {},
+            "reference": "XU1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 440,
+              "y": 280
+            },
+            "rotation": 90
+          },
+          "schematicReference": "XU1",
+          "sourceRef": {
+            "end": {
+              "column": 35,
+              "line": 12,
+              "offset": 594
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 12,
+              "offset": 560
+            }
+          },
+          "symbolId": "hierarchical-symbol-82822626bf0850db"
+        },
+        {
+          "id": "XU2",
+          "importProvenance": {
+            "kind": "subcircuit",
+            "name": "scdac_unit",
+            "sourceTarget": "subcircuit:scdac_unit",
+            "status": "resolved",
+            "terminalMapping": [
+              {
+                "pinName": "bit",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "nbit",
+                "sourcePosition": 1
+              },
+              {
+                "pinName": "bot",
+                "sourcePosition": 2
+              },
+              {
+                "pinName": "vss",
+                "sourcePosition": 3
+              },
+              {
+                "pinName": "vdd",
+                "sourcePosition": 4
+              }
+            ]
+          },
+          "netlist": {
+            "binding": {
+              "childDocumentId": "document-82822626bf0850db",
+              "kind": "subcircuit"
+            },
+            "parameters": {},
+            "reference": "XU2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 600,
+              "y": 280
+            },
+            "rotation": 90
+          },
+          "schematicName": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "X"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "U2"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "subscript"
+              }
+            ]
+          },
+          "schematicReference": "XU2",
+          "sourceRef": {
+            "end": {
+              "column": 35,
+              "line": 13,
+              "offset": 629
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 13,
+              "offset": 595
+            }
+          },
+          "symbolId": "hierarchical-symbol-82822626bf0850db"
+        },
+        {
+          "id": "XU3",
+          "importProvenance": {
+            "kind": "subcircuit",
+            "name": "scdac_unit",
+            "sourceTarget": "subcircuit:scdac_unit",
+            "status": "resolved",
+            "terminalMapping": [
+              {
+                "pinName": "bit",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "nbit",
+                "sourcePosition": 1
+              },
+              {
+                "pinName": "bot",
+                "sourcePosition": 2
+              },
+              {
+                "pinName": "vss",
+                "sourcePosition": 3
+              },
+              {
+                "pinName": "vdd",
+                "sourcePosition": 4
+              }
+            ]
+          },
+          "netlist": {
+            "binding": {
+              "childDocumentId": "document-82822626bf0850db",
+              "kind": "subcircuit"
+            },
+            "parameters": {},
+            "reference": "XU3"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 750,
+              "y": 280
+            },
+            "rotation": 90
+          },
+          "schematicReference": "XU3",
+          "sourceRef": {
+            "end": {
+              "column": 35,
+              "line": 14,
+              "offset": 664
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 14,
+              "offset": 630
+            }
+          },
+          "symbolId": "hierarchical-symbol-82822626bf0850db"
+        },
+        {
+          "id": "XU4",
+          "importProvenance": {
+            "kind": "subcircuit",
+            "name": "scdac_unit",
+            "sourceTarget": "subcircuit:scdac_unit",
+            "status": "resolved",
+            "terminalMapping": [
+              {
+                "pinName": "bit",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "nbit",
+                "sourcePosition": 1
+              },
+              {
+                "pinName": "bot",
+                "sourcePosition": 2
+              },
+              {
+                "pinName": "vss",
+                "sourcePosition": 3
+              },
+              {
+                "pinName": "vdd",
+                "sourcePosition": 4
+              }
+            ]
+          },
+          "netlist": {
+            "binding": {
+              "childDocumentId": "document-82822626bf0850db",
+              "kind": "subcircuit"
+            },
+            "parameters": {},
+            "reference": "XU4"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 880,
+              "y": 280
+            },
+            "rotation": 90
+          },
+          "schematicReference": "XU4",
+          "sourceRef": {
+            "end": {
+              "column": 35,
+              "line": 15,
+              "offset": 699
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 15,
+              "offset": 665
+            }
+          },
+          "symbolId": "hierarchical-symbol-82822626bf0850db"
+        },
+        {
+          "id": "XU5",
+          "importProvenance": {
+            "kind": "subcircuit",
+            "name": "scdac_unit",
+            "sourceTarget": "subcircuit:scdac_unit",
+            "status": "resolved",
+            "terminalMapping": [
+              {
+                "pinName": "bit",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "nbit",
+                "sourcePosition": 1
+              },
+              {
+                "pinName": "bot",
+                "sourcePosition": 2
+              },
+              {
+                "pinName": "vss",
+                "sourcePosition": 3
+              },
+              {
+                "pinName": "vdd",
+                "sourcePosition": 4
+              }
+            ]
+          },
+          "netlist": {
+            "binding": {
+              "childDocumentId": "document-82822626bf0850db",
+              "kind": "subcircuit"
+            },
+            "parameters": {},
+            "reference": "XU5"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 1020,
+              "y": 280
+            },
+            "rotation": 90
+          },
+          "schematicReference": "XU5",
+          "sourceRef": {
+            "end": {
+              "column": 35,
+              "line": 16,
+              "offset": 734
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 16,
+              "offset": 700
+            }
+          },
+          "symbolId": "hierarchical-symbol-82822626bf0850db"
+        },
+        {
+          "id": "XRESET",
+          "importProvenance": {
+            "kind": "opaque",
+            "name": "sky130_fd_pr__nfet_01v8",
+            "sourceTarget": "external-subcircuit:sky130_fd_pr__nfet_01v8",
+            "status": "resolved",
+            "symbolMappingRegistryId": "sky130-nfet-four-terminal",
+            "terminalMapping": [
+              {
+                "pinName": "D",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "G",
+                "sourcePosition": 1
+              },
+              {
+                "pinName": "S",
+                "sourcePosition": 2
+              },
+              {
+                "pinName": "B",
+                "sourcePosition": 3
+              }
+            ]
+          },
+          "netlist": {
+            "binding": {
+              "definitionId": "external-subcircuit-e5ee3d17d0c7c89a",
+              "kind": "external-subcircuit"
+            },
+            "parameters": {
+              "l": "0.3",
+              "nf": "2",
+              "w": "2"
+            },
+            "reference": "XRESET"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 1120,
+              "y": 190
+            },
+            "rotation": 0
+          },
+          "schematicReference": "XRESET",
+          "sourceRef": {
+            "end": {
+              "column": 65,
+              "line": 17,
+              "offset": 799
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 17,
+              "offset": 735
+            }
+          },
+          "symbolId": "nmos"
+        },
+        {
+          "id": "C0",
+          "importProvenance": {
+            "kind": "primitive",
+            "name": "capacitor",
+            "sourceTarget": "primitive:capacitor",
+            "status": "resolved",
+            "terminalMapping": [
+              {
+                "pinName": "1",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "2",
+                "sourcePosition": 1
+              }
+            ]
+          },
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {
+              "value": "16f"
+            },
+            "reference": "C0"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 310,
+              "y": 130
+            },
+            "rotation": 0
+          },
+          "schematicReference": "C0",
+          "sourceRef": {
+            "end": {
+              "column": 17,
+              "line": 18,
+              "offset": 816
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 18,
+              "offset": 800
+            }
+          },
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "C1",
+          "importProvenance": {
+            "kind": "primitive",
+            "name": "capacitor",
+            "sourceTarget": "primitive:capacitor",
+            "status": "resolved",
+            "terminalMapping": [
+              {
+                "pinName": "1",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "2",
+                "sourcePosition": 1
+              }
+            ]
+          },
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {
+              "value": "32f"
+            },
+            "reference": "C1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 470,
+              "y": 130
+            },
+            "rotation": 0
+          },
+          "schematicReference": "C1",
+          "sourceRef": {
+            "end": {
+              "column": 17,
+              "line": 19,
+              "offset": 833
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 19,
+              "offset": 817
+            }
+          },
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "C2",
+          "importProvenance": {
+            "kind": "primitive",
+            "name": "capacitor",
+            "sourceTarget": "primitive:capacitor",
+            "status": "resolved",
+            "terminalMapping": [
+              {
+                "pinName": "1",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "2",
+                "sourcePosition": 1
+              }
+            ]
+          },
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {
+              "value": "64f"
+            },
+            "reference": "C2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 630,
+              "y": 130
+            },
+            "rotation": 0
+          },
+          "schematicReference": "C2",
+          "sourceRef": {
+            "end": {
+              "column": 17,
+              "line": 20,
+              "offset": 850
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 20,
+              "offset": 834
+            }
+          },
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "C3",
+          "importProvenance": {
+            "kind": "primitive",
+            "name": "capacitor",
+            "sourceTarget": "primitive:capacitor",
+            "status": "resolved",
+            "terminalMapping": [
+              {
+                "pinName": "1",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "2",
+                "sourcePosition": 1
+              }
+            ]
+          },
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {
+              "value": "128f"
+            },
+            "reference": "C3"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 780,
+              "y": 130
+            },
+            "rotation": 0
+          },
+          "schematicReference": "C3",
+          "sourceRef": {
+            "end": {
+              "column": 18,
+              "line": 21,
+              "offset": 868
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 21,
+              "offset": 851
+            }
+          },
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "C4",
+          "importProvenance": {
+            "kind": "primitive",
+            "name": "capacitor",
+            "sourceTarget": "primitive:capacitor",
+            "status": "resolved",
+            "terminalMapping": [
+              {
+                "pinName": "1",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "2",
+                "sourcePosition": 1
+              }
+            ]
+          },
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {
+              "value": "256f"
+            },
+            "reference": "C4"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 910,
+              "y": 130
+            },
+            "rotation": 0
+          },
+          "schematicReference": "C4",
+          "sourceRef": {
+            "end": {
+              "column": 18,
+              "line": 22,
+              "offset": 886
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 22,
+              "offset": 869
+            }
+          },
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "C5",
+          "importProvenance": {
+            "kind": "primitive",
+            "name": "capacitor",
+            "sourceTarget": "primitive:capacitor",
+            "status": "resolved",
+            "terminalMapping": [
+              {
+                "pinName": "1",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "2",
+                "sourcePosition": 1
+              }
+            ]
+          },
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {
+              "value": "512f"
+            },
+            "reference": "C5"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 1050,
+              "y": 130
+            },
+            "rotation": 0
+          },
+          "schematicReference": "C5",
+          "sourceRef": {
+            "end": {
+              "column": 18,
+              "line": 23,
+              "offset": 904
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 23,
+              "offset": 887
+            }
+          },
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "CDUMMY",
+          "importProvenance": {
+            "kind": "primitive",
+            "name": "capacitor",
+            "sourceTarget": "primitive:capacitor",
+            "status": "resolved",
+            "terminalMapping": [
+              {
+                "pinName": "1",
+                "sourcePosition": 0
+              },
+              {
+                "pinName": "2",
+                "sourcePosition": 1
+              }
+            ]
+          },
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {
+              "value": "16f"
+            },
+            "reference": "CDUMMY"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 1210,
+              "y": 130
+            },
+            "rotation": 0
+          },
+          "schematicReference": "CDUMMY",
+          "sourceRef": {
+            "end": {
+              "column": 20,
+              "line": 24,
+              "offset": 924
+            },
+            "fileId": "source-648e50f6f6cd02ee",
+            "start": {
+              "column": 1,
+              "line": 24,
+              "offset": 905
+            }
+          },
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "cell-pin-8d2d35d48ff5f9ed",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 130,
+              "y": 360
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "cell-pin-a2a67d4f33b799c7",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 1080,
+              "y": 190
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "cell-pin-f3b64e14efff21be",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 280,
+              "y": 210
+            },
+            "rotation": 90
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "cell-pin-47376c4eca117570",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 440,
+              "y": 210
+            },
+            "rotation": 90
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "cell-pin-92d3b5ac7c8ee706",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 600,
+              "y": 210
+            },
+            "rotation": 90
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "cell-pin-ab6266f82f28dfdc",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 750,
+              "y": 210
+            },
+            "rotation": 90
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "cell-pin-6e2af21c7a63f9d6",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 880,
+              "y": 210
+            },
+            "rotation": 90
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "cell-pin-fdb36ad3f48af9f8",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 1020,
+              "y": 210
+            },
+            "rotation": 90
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "cell-pin-c0d84c7e757d32bf",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 130,
+              "y": 170
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "cell-pin-e9e91f330164cbe3",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 130,
+              "y": 90
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        }
+      ],
+      "junctions": [
+        {
+          "id": "junction-ui-27",
+          "netId": "net-split-37570a4f779d22b7",
+          "position": {
+            "x": 460,
+            "y": 360
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-29",
+          "netId": "net-split-37570a4f779d22b7",
+          "position": {
+            "x": 620,
+            "y": 360
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-31",
+          "netId": "net-split-37570a4f779d22b7",
+          "position": {
+            "x": 770,
+            "y": 360
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-33",
+          "netId": "net-split-37570a4f779d22b7",
+          "position": {
+            "x": 900,
+            "y": 360
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-44",
+          "netId": "net-split-47cc1a54ff6091e2",
+          "position": {
+            "x": 410,
+            "y": 200
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-46",
+          "netId": "net-split-47cc1a54ff6091e2",
+          "position": {
+            "x": 570,
+            "y": 200
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-48",
+          "netId": "net-split-47cc1a54ff6091e2",
+          "position": {
+            "x": 720,
+            "y": 200
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-50",
+          "netId": "net-split-47cc1a54ff6091e2",
+          "position": {
+            "x": 850,
+            "y": 200
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-60",
+          "netId": "net-split-37570a4f779d22b7",
+          "position": {
+            "x": 1040,
+            "y": 360
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-63",
+          "netId": "net-split-802ce8f2c4115a8a",
+          "position": {
+            "x": 470,
+            "y": 90
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-65",
+          "netId": "net-split-802ce8f2c4115a8a",
+          "position": {
+            "x": 630,
+            "y": 90
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-67",
+          "netId": "net-split-802ce8f2c4115a8a",
+          "position": {
+            "x": 780,
+            "y": 90
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-69",
+          "netId": "net-split-802ce8f2c4115a8a",
+          "position": {
+            "x": 910,
+            "y": 90
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-71",
+          "netId": "net-split-802ce8f2c4115a8a",
+          "position": {
+            "x": 1050,
+            "y": 90
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-80",
+          "netId": "net-split-802ce8f2c4115a8a",
+          "position": {
+            "x": 1130,
+            "y": 90
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-82",
+          "netId": "net-split-37570a4f779d22b7",
+          "position": {
+            "x": 1130,
+            "y": 360
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-84",
+          "netId": "net-split-37570a4f779d22b7",
+          "position": {
+            "x": 820,
+            "y": 360
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-89",
+          "netId": "net-split-47cc1a54ff6091e2",
+          "position": {
+            "x": 410,
+            "y": 170
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-91",
+          "netId": "net-split-47cc1a54ff6091e2",
+          "position": {
+            "x": 570,
+            "y": 170
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-93",
+          "netId": "net-split-47cc1a54ff6091e2",
+          "position": {
+            "x": 720,
+            "y": 170
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-95",
+          "netId": "net-split-47cc1a54ff6091e2",
+          "position": {
+            "x": 850,
+            "y": 170
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-98",
+          "netId": "net-split-37570a4f779d22b7",
+          "position": {
+            "x": 300,
+            "y": 360
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-103",
+          "netId": "net-split-47cc1a54ff6091e2",
+          "position": {
+            "x": 250,
+            "y": 170
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-107",
+          "netId": "net-split-37570a4f779d22b7",
+          "position": {
+            "x": 1130,
+            "y": 220
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-109",
+          "netId": "net-split-802ce8f2c4115a8a",
+          "position": {
+            "x": 310,
+            "y": 90
+          },
+          "role": "branch"
+        }
+      ],
+      "layoutGroups": [],
+      "name": "switched_capacitor_dac_6bit",
+      "netlist": {
+        "formalParameters": [],
+        "name": "switched_capacitor_dac_6bit",
+        "terminals": [
+          {
+            "direction": "passive",
+            "id": "cell-terminal-8d2d35d48ff5f9ed",
+            "interfaceInstanceIds": [
+              "cell-pin-8d2d35d48ff5f9ed"
+            ],
+            "name": "vss",
+            "netId": "net-split-37570a4f779d22b7"
+          },
+          {
+            "direction": "passive",
+            "id": "cell-terminal-a2a67d4f33b799c7",
+            "interfaceInstanceIds": [
+              "cell-pin-a2a67d4f33b799c7"
+            ],
+            "name": "reset",
+            "netId": "net-b778eaaff63d68d5"
+          },
+          {
+            "direction": "passive",
+            "id": "cell-terminal-f3b64e14efff21be",
+            "interfaceInstanceIds": [
+              "cell-pin-f3b64e14efff21be"
+            ],
+            "name": "b0",
+            "netId": "net-b9d1505a12d36a23"
+          },
+          {
+            "direction": "passive",
+            "id": "cell-terminal-47376c4eca117570",
+            "interfaceInstanceIds": [
+              "cell-pin-47376c4eca117570"
+            ],
+            "name": "b1",
+            "netId": "net-b9d14f5a12d36870"
+          },
+          {
+            "direction": "passive",
+            "id": "cell-terminal-92d3b5ac7c8ee706",
+            "interfaceInstanceIds": [
+              "cell-pin-92d3b5ac7c8ee706"
+            ],
+            "name": "b2",
+            "netId": "net-b9d1525a12d36d89"
+          },
+          {
+            "direction": "passive",
+            "id": "cell-terminal-ab6266f82f28dfdc",
+            "interfaceInstanceIds": [
+              "cell-pin-ab6266f82f28dfdc"
+            ],
+            "name": "b3",
+            "netId": "net-b9d1515a12d36bd6"
+          },
+          {
+            "direction": "passive",
+            "id": "cell-terminal-6e2af21c7a63f9d6",
+            "interfaceInstanceIds": [
+              "cell-pin-6e2af21c7a63f9d6"
+            ],
+            "name": "b4",
+            "netId": "net-b9d1545a12d370ef"
+          },
+          {
+            "direction": "passive",
+            "id": "cell-terminal-fdb36ad3f48af9f8",
+            "interfaceInstanceIds": [
+              "cell-pin-fdb36ad3f48af9f8"
+            ],
+            "name": "b5",
+            "netId": "net-b9d1535a12d36f3c"
+          },
+          {
+            "direction": "passive",
+            "id": "cell-terminal-c0d84c7e757d32bf",
+            "interfaceInstanceIds": [
+              "cell-pin-c0d84c7e757d32bf"
+            ],
+            "name": "vdd",
+            "netId": "net-split-47cc1a54ff6091e2"
+          },
+          {
+            "direction": "passive",
+            "id": "cell-terminal-e9e91f330164cbe3",
+            "interfaceInstanceIds": [
+              "cell-pin-e9e91f330164cbe3"
+            ],
+            "name": "vout",
+            "netId": "net-split-802ce8f2c4115a8a"
+          }
+        ]
+      },
+      "nets": [
+        {
+          "id": "net-b778eaaff63d68d5",
+          "terminals": [
+            {
+              "instanceId": "XRESET",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "cell-pin-a2a67d4f33b799c7",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-b9d1505a12d36a23",
+          "terminals": [
+            {
+              "instanceId": "XU0",
+              "pinName": "bit"
+            },
+            {
+              "instanceId": "cell-pin-f3b64e14efff21be",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-b9d14f5a12d36870",
+          "terminals": [
+            {
+              "instanceId": "XU1",
+              "pinName": "bit"
+            },
+            {
+              "instanceId": "cell-pin-47376c4eca117570",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-b9d1525a12d36d89",
+          "terminals": [
+            {
+              "instanceId": "XU2",
+              "pinName": "bit"
+            },
+            {
+              "instanceId": "cell-pin-92d3b5ac7c8ee706",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-b9d1515a12d36bd6",
+          "terminals": [
+            {
+              "instanceId": "XU3",
+              "pinName": "bit"
+            },
+            {
+              "instanceId": "cell-pin-ab6266f82f28dfdc",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-b9d1545a12d370ef",
+          "terminals": [
+            {
+              "instanceId": "XU4",
+              "pinName": "bit"
+            },
+            {
+              "instanceId": "cell-pin-6e2af21c7a63f9d6",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-b9d1535a12d36f3c",
+          "terminals": [
+            {
+              "instanceId": "XU5",
+              "pinName": "bit"
+            },
+            {
+              "instanceId": "cell-pin-fdb36ad3f48af9f8",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-544c083e1298c65c",
+          "terminals": [
+            {
+              "instanceId": "XU0",
+              "pinName": "nbit"
+            }
+          ]
+        },
+        {
+          "id": "net-2363ccedceb2b67c",
+          "terminals": [
+            {
+              "instanceId": "XU0",
+              "pinName": "bot"
+            },
+            {
+              "instanceId": "C0",
+              "pinName": "2"
+            }
+          ]
+        },
+        {
+          "id": "net-544c093e1298c80f",
+          "terminals": [
+            {
+              "instanceId": "XU1",
+              "pinName": "nbit"
+            }
+          ]
+        },
+        {
+          "id": "net-2363cdedceb2b82f",
+          "terminals": [
+            {
+              "instanceId": "XU1",
+              "pinName": "bot"
+            },
+            {
+              "instanceId": "C1",
+              "pinName": "2"
+            }
+          ]
+        },
+        {
+          "id": "net-544c0a3e1298c9c2",
+          "terminals": [
+            {
+              "instanceId": "XU2",
+              "pinName": "nbit"
+            }
+          ]
+        },
+        {
+          "id": "net-2363ceedceb2b9e2",
+          "terminals": [
+            {
+              "instanceId": "XU2",
+              "pinName": "bot"
+            },
+            {
+              "instanceId": "C2",
+              "pinName": "2"
+            }
+          ]
+        },
+        {
+          "id": "net-544c0b3e1298cb75",
+          "terminals": [
+            {
+              "instanceId": "XU3",
+              "pinName": "nbit"
+            }
+          ]
+        },
+        {
+          "id": "net-2363cfedceb2bb95",
+          "terminals": [
+            {
+              "instanceId": "XU3",
+              "pinName": "bot"
+            },
+            {
+              "instanceId": "C3",
+              "pinName": "2"
+            }
+          ]
+        },
+        {
+          "id": "net-544c043e1298bf90",
+          "terminals": [
+            {
+              "instanceId": "XU4",
+              "pinName": "nbit"
+            }
+          ]
+        },
+        {
+          "id": "net-2363c8edceb2afb0",
+          "terminals": [
+            {
+              "instanceId": "XU4",
+              "pinName": "bot"
+            },
+            {
+              "instanceId": "C4",
+              "pinName": "2"
+            }
+          ]
+        },
+        {
+          "id": "net-544c053e1298c143",
+          "terminals": [
+            {
+              "instanceId": "XU5",
+              "pinName": "nbit"
+            }
+          ]
+        },
+        {
+          "id": "net-2363c9edceb2b163",
+          "terminals": [
+            {
+              "instanceId": "XU5",
+              "pinName": "bot"
+            },
+            {
+              "instanceId": "C5",
+              "pinName": "2"
+            }
+          ]
+        },
+        {
+          "id": "net-split-802ce8f2c4115a8a",
+          "terminals": [
+            {
+              "instanceId": "cell-pin-e9e91f330164cbe3",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "C5",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "C4",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "C3",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "C2",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "C1",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "XRESET",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "C0",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "CDUMMY",
+              "pinName": "1"
+            }
+          ]
+        },
+        {
+          "id": "net-split-37570a4f779d22b7",
+          "terminals": [
+            {
+              "instanceId": "XRESET",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "cell-pin-8d2d35d48ff5f9ed",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "XU0",
+              "pinName": "vss"
+            },
+            {
+              "instanceId": "XU1",
+              "pinName": "vss"
+            },
+            {
+              "instanceId": "XU2",
+              "pinName": "vss"
+            },
+            {
+              "instanceId": "XU3",
+              "pinName": "vss"
+            },
+            {
+              "instanceId": "XU4",
+              "pinName": "vss"
+            },
+            {
+              "instanceId": "XU5",
+              "pinName": "vss"
+            },
+            {
+              "instanceId": "XRESET",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "CDUMMY",
+              "pinName": "2"
+            }
+          ]
+        },
+        {
+          "id": "net-split-47cc1a54ff6091e2",
+          "terminals": [
+            {
+              "instanceId": "XU0",
+              "pinName": "vdd"
+            },
+            {
+              "instanceId": "cell-pin-c0d84c7e757d32bf",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "XU4",
+              "pinName": "vdd"
+            },
+            {
+              "instanceId": "XU3",
+              "pinName": "vdd"
+            },
+            {
+              "instanceId": "XU2",
+              "pinName": "vdd"
+            },
+            {
+              "instanceId": "XU1",
+              "pinName": "vdd"
+            },
+            {
+              "instanceId": "XU5",
+              "pinName": "vdd"
+            }
+          ]
+        }
+      ],
+      "noConnects": [],
+      "presentation": {
+        "compactness": "normal",
+        "grid": 10,
+        "styleProfileId": "razavi-textbook-v1"
+      },
+      "revision": 250,
+      "routes": [
+        {
+          "id": "route-ui-25-a-27-a-98",
+          "legs": [
+            {
+              "id": "route-leg-be92f55863802f75",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-98",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "start": {
+            "instanceId": "XU0",
+            "kind": "terminal",
+            "pinName": "vss"
+          }
+        },
+        {
+          "id": "route-ui-25-a-27-b-98",
+          "legs": [
+            {
+              "id": "route-leg-5c969e62d50862d6",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-27",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "start": {
+            "junctionId": "junction-ui-98",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-25-b-27-a-29",
+          "legs": [
+            {
+              "id": "route-leg-6166bf8f05fe4958",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-29",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "start": {
+            "junctionId": "junction-ui-27",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-25-b-27-b-29-a-31",
+          "legs": [
+            {
+              "id": "route-leg-fe9ef07a500581a1",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-31",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "start": {
+            "junctionId": "junction-ui-29",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-25-b-27-b-29-b-31-a-33-a-84",
+          "legs": [
+            {
+              "id": "route-leg-77f134dfced8bb25",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-84",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "start": {
+            "junctionId": "junction-ui-31",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-25-b-27-b-29-b-31-a-33-b-84",
+          "legs": [
+            {
+              "id": "route-leg-6f10d7ef3562e5d6",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-33",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "start": {
+            "junctionId": "junction-ui-84",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-25-b-27-b-29-b-31-b-33-a-60",
+          "legs": [
+            {
+              "id": "route-leg-af012f81bf4265fa",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-60",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "start": {
+            "junctionId": "junction-ui-33",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-25-b-27-b-29-b-31-b-33-b-60",
+          "legs": [
+            {
+              "id": "route-leg-9c8259ada8f94199",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XU5",
+                  "kind": "terminal",
+                  "pinName": "vss"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "start": {
+            "junctionId": "junction-ui-60",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-28",
+          "legs": [
+            {
+              "id": "route-leg-f2aeaef7bfa438d7",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-27",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "start": {
+            "instanceId": "XU1",
+            "kind": "terminal",
+            "pinName": "vss"
+          }
+        },
+        {
+          "id": "route-ui-30",
+          "legs": [
+            {
+              "id": "route-leg-c45e0a2ff0d6df32",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-29",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "start": {
+            "instanceId": "XU2",
+            "kind": "terminal",
+            "pinName": "vss"
+          }
+        },
+        {
+          "id": "route-ui-32",
+          "legs": [
+            {
+              "id": "route-leg-070d7a164f7d9a04",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-31",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "start": {
+            "instanceId": "XU3",
+            "kind": "terminal",
+            "pinName": "vss"
+          }
+        },
+        {
+          "id": "route-ui-34",
+          "legs": [
+            {
+              "id": "route-leg-b7c7e27a649a7cce",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-33",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "start": {
+            "instanceId": "XU4",
+            "kind": "terminal",
+            "pinName": "vss"
+          }
+        },
+        {
+          "id": "route-ui-35-a-44-b-89",
+          "legs": [
+            {
+              "id": "route-leg-a6669c4690b1cf90",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-44",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-47cc1a54ff6091e2",
+          "start": {
+            "junctionId": "junction-ui-89",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-45",
+          "legs": [
+            {
+              "id": "route-leg-facd6fec39c517d2",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-44",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-47cc1a54ff6091e2",
+          "start": {
+            "instanceId": "XU1",
+            "kind": "terminal",
+            "pinName": "vdd"
+          }
+        },
+        {
+          "id": "route-ui-47",
+          "legs": [
+            {
+              "id": "route-leg-e8bedfd0246ba3a4",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-46",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-47cc1a54ff6091e2",
+          "start": {
+            "instanceId": "XU2",
+            "kind": "terminal",
+            "pinName": "vdd"
+          }
+        },
+        {
+          "id": "route-ui-49",
+          "legs": [
+            {
+              "id": "route-leg-00931ff7fa7adfa6",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-48",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-47cc1a54ff6091e2",
+          "start": {
+            "instanceId": "XU3",
+            "kind": "terminal",
+            "pinName": "vdd"
+          }
+        },
+        {
+          "id": "route-ui-51",
+          "legs": [
+            {
+              "id": "route-leg-31a8df0add1af43f",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-50",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-47cc1a54ff6091e2",
+          "start": {
+            "instanceId": "XU4",
+            "kind": "terminal",
+            "pinName": "vdd"
+          }
+        },
+        {
+          "id": "route-ui-52",
+          "legs": [
+            {
+              "id": "route-leg-fc842942befef15e",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "C0",
+                  "kind": "terminal",
+                  "pinName": "2"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-2363ccedceb2b67c",
+          "start": {
+            "instanceId": "XU0",
+            "kind": "terminal",
+            "pinName": "bot"
+          }
+        },
+        {
+          "id": "route-ui-53",
+          "legs": [
+            {
+              "id": "route-leg-03cbfee26953855d",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XU1",
+                  "kind": "terminal",
+                  "pinName": "bot"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-2363cdedceb2b82f",
+          "start": {
+            "instanceId": "C1",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-ui-54",
+          "legs": [
+            {
+              "id": "route-leg-4a16c0dea8707a14",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XU2",
+                  "kind": "terminal",
+                  "pinName": "bot"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-2363ceedceb2b9e2",
+          "start": {
+            "instanceId": "C2",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-ui-55",
+          "legs": [
+            {
+              "id": "route-leg-37388f169da32ca3",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XU3",
+                  "kind": "terminal",
+                  "pinName": "bot"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-2363cfedceb2bb95",
+          "start": {
+            "instanceId": "C3",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-ui-56",
+          "legs": [
+            {
+              "id": "route-leg-0767d0f849ca98c2",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XU4",
+                  "kind": "terminal",
+                  "pinName": "bot"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-2363c8edceb2afb0",
+          "start": {
+            "instanceId": "C4",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-ui-57",
+          "legs": [
+            {
+              "id": "route-leg-095baeee29dbbdc1",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XU5",
+                  "kind": "terminal",
+                  "pinName": "bot"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-2363c9edceb2b163",
+          "start": {
+            "instanceId": "C5",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-ui-61-a-82-a-107",
+          "legs": [
+            {
+              "id": "route-leg-3204cdabdb64466a",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-107",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "start": {
+            "instanceId": "XRESET",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-ui-61-a-82-b-107",
+          "legs": [
+            {
+              "id": "route-leg-b7711060c178018b",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-82",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "start": {
+            "junctionId": "junction-ui-107",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-61-b-82",
+          "legs": [
+            {
+              "id": "route-leg-6e2a481981e97d99",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-60",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "start": {
+            "junctionId": "junction-ui-82",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-62-a-63-a-109",
+          "legs": [
+            {
+              "id": "route-leg-9e12e006b51e3c42",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-109",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-802ce8f2c4115a8a",
+          "start": {
+            "instanceId": "C0",
+            "kind": "terminal",
+            "pinName": "1"
+          }
+        },
+        {
+          "id": "route-ui-62-a-63-b-109",
+          "legs": [
+            {
+              "id": "route-leg-6f01ecc3c2289b83",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-63",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-802ce8f2c4115a8a",
+          "start": {
+            "junctionId": "junction-ui-109",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-62-b-63-a-65",
+          "legs": [
+            {
+              "id": "route-leg-a3658e3b468af8cd",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-65",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-802ce8f2c4115a8a",
+          "start": {
+            "junctionId": "junction-ui-63",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-62-b-63-b-65-a-67",
+          "legs": [
+            {
+              "id": "route-leg-30921c68c2db3bed",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-67",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-802ce8f2c4115a8a",
+          "start": {
+            "junctionId": "junction-ui-65",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-62-b-63-b-65-b-67-a-69",
+          "legs": [
+            {
+              "id": "route-leg-0483c49004a841d0",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-69",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-802ce8f2c4115a8a",
+          "start": {
+            "junctionId": "junction-ui-67",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-62-b-63-b-65-b-67-b-69-a-71",
+          "legs": [
+            {
+              "id": "route-leg-613e2cf375687669",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-71",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-802ce8f2c4115a8a",
+          "start": {
+            "junctionId": "junction-ui-69",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-62-b-63-b-65-b-67-b-69-b-71-a-80",
+          "legs": [
+            {
+              "id": "route-leg-5800664e1b5406a7",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-80",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-802ce8f2c4115a8a",
+          "start": {
+            "junctionId": "junction-ui-71",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-62-b-63-b-65-b-67-b-69-b-71-b-80",
+          "legs": [
+            {
+              "id": "route-leg-00d63dab165b835c",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XRESET",
+                  "kind": "terminal",
+                  "pinName": "D"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-802ce8f2c4115a8a",
+          "start": {
+            "junctionId": "junction-ui-80",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-73",
+          "legs": [
+            {
+              "id": "route-leg-ad9083aa88f11537",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-63",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-802ce8f2c4115a8a",
+          "start": {
+            "instanceId": "C1",
+            "kind": "terminal",
+            "pinName": "1"
+          }
+        },
+        {
+          "id": "route-ui-74",
+          "legs": [
+            {
+              "id": "route-leg-d80c759a699f35ba",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-65",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-802ce8f2c4115a8a",
+          "start": {
+            "instanceId": "C2",
+            "kind": "terminal",
+            "pinName": "1"
+          }
+        },
+        {
+          "id": "route-ui-77",
+          "legs": [
+            {
+              "id": "route-leg-07ddb3b8bd78a31b",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-67",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-802ce8f2c4115a8a",
+          "start": {
+            "instanceId": "C3",
+            "kind": "terminal",
+            "pinName": "1"
+          }
+        },
+        {
+          "id": "route-ui-78",
+          "legs": [
+            {
+              "id": "route-leg-16a54dc87425183e",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-69",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-802ce8f2c4115a8a",
+          "start": {
+            "instanceId": "C4",
+            "kind": "terminal",
+            "pinName": "1"
+          }
+        },
+        {
+          "id": "route-ui-79",
+          "legs": [
+            {
+              "id": "route-leg-18992bbe54363d3d",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-71",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-802ce8f2c4115a8a",
+          "start": {
+            "instanceId": "C5",
+            "kind": "terminal",
+            "pinName": "1"
+          }
+        },
+        {
+          "id": "route-ui-81",
+          "legs": [
+            {
+              "id": "route-leg-1ffce25913df28b2",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-1ffce25913df28b2",
+                "kind": "bend",
+                "position": {
+                  "x": 1210,
+                  "y": 90
+                }
+              }
+            },
+            {
+              "id": "route-leg-1ffce35913df2a65",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "CDUMMY",
+                  "kind": "terminal",
+                  "pinName": "1"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-802ce8f2c4115a8a",
+          "start": {
+            "junctionId": "junction-ui-80",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-83",
+          "legs": [
+            {
+              "id": "route-leg-62ac523f7285e384",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-62ac523f7285e384",
+                "kind": "bend",
+                "position": {
+                  "x": 1210,
+                  "y": 360
+                }
+              }
+            },
+            {
+              "id": "route-leg-62ac533f7285e537",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "CDUMMY",
+                  "kind": "terminal",
+                  "pinName": "2"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "start": {
+            "junctionId": "junction-ui-82",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-8fa99af934de615e",
+          "legs": [
+            {
+              "id": "route-leg-7f426c2c68964678",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XRESET",
+                  "kind": "terminal",
+                  "pinName": "G"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-b778eaaff63d68d5",
+          "start": {
+            "instanceId": "cell-pin-a2a67d4f33b799c7",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "route-ui-90-a-91",
+          "legs": [
+            {
+              "id": "route-leg-08135adf040fe65a",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-91",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-47cc1a54ff6091e2",
+          "start": {
+            "junctionId": "junction-ui-89",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-90-b-91-a-93",
+          "legs": [
+            {
+              "id": "route-leg-bda2052f30157416",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-93",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-47cc1a54ff6091e2",
+          "start": {
+            "junctionId": "junction-ui-91",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-90-b-91-b-93-a-95",
+          "legs": [
+            {
+              "id": "route-leg-487cc03a99beab51",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-95",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-47cc1a54ff6091e2",
+          "start": {
+            "junctionId": "junction-ui-93",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-90-b-91-b-93-b-95",
+          "legs": [
+            {
+              "id": "route-leg-e0ca220358bc8c52",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-e0ca220358bc8c52",
+                "kind": "bend",
+                "position": {
+                  "x": 990,
+                  "y": 170
+                }
+              }
+            },
+            {
+              "id": "route-leg-e0ca230358bc8e05",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "XU5",
+                  "kind": "terminal",
+                  "pinName": "vdd"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-47cc1a54ff6091e2",
+          "start": {
+            "junctionId": "junction-ui-95",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-92",
+          "legs": [
+            {
+              "id": "route-leg-28302e28eebd3922",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-91",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-47cc1a54ff6091e2",
+          "start": {
+            "junctionId": "junction-ui-46",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-94",
+          "legs": [
+            {
+              "id": "route-leg-105bce0118adc6c0",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-93",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-47cc1a54ff6091e2",
+          "start": {
+            "junctionId": "junction-ui-48",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-96",
+          "legs": [
+            {
+              "id": "route-leg-cde2fe1aba35ab3e",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-95",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-47cc1a54ff6091e2",
+          "start": {
+            "junctionId": "junction-ui-50",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-99",
+          "legs": [
+            {
+              "id": "route-leg-bf1b640b0389361b",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-98",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "start": {
+            "instanceId": "cell-pin-8d2d35d48ff5f9ed",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "route-ui-102-a-103",
+          "legs": [
+            {
+              "id": "route-leg-8bd4690301d9c35c",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-103",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-47cc1a54ff6091e2",
+          "start": {
+            "instanceId": "cell-pin-c0d84c7e757d32bf",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "route-ui-102-b-103",
+          "legs": [
+            {
+              "id": "route-leg-9ddc7cbdaf117649",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-89",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-47cc1a54ff6091e2",
+          "start": {
+            "junctionId": "junction-ui-103",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-104",
+          "legs": [
+            {
+              "id": "route-leg-2d59a80a395a7af5",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-103",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-47cc1a54ff6091e2",
+          "start": {
+            "instanceId": "XU0",
+            "kind": "terminal",
+            "pinName": "vdd"
+          }
+        },
+        {
+          "id": "route-ui-108",
+          "legs": [
+            {
+              "id": "route-leg-b77960519ca8e241",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-b77960519ca8e241",
+                "kind": "bend",
+                "position": {
+                  "x": 1150,
+                  "y": 190
+                }
+              }
+            },
+            {
+              "id": "route-leg-b7795f519ca8e08e",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-b7795f519ca8e08e",
+                "kind": "bend",
+                "position": {
+                  "x": 1150,
+                  "y": 220
+                }
+              }
+            },
+            {
+              "id": "route-leg-b7795e519ca8dedb",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-107",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-37570a4f779d22b7",
+          "presentation": "bulk-dashed",
+          "start": {
+            "instanceId": "XRESET",
+            "kind": "terminal",
+            "pinName": "B"
+          }
+        },
+        {
+          "id": "route-ui-110",
+          "legs": [
+            {
+              "id": "route-leg-bef32b145ec339bc",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-109",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-802ce8f2c4115a8a",
+          "start": {
+            "instanceId": "cell-pin-e9e91f330164cbe3",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        }
+      ],
+      "sourceBinding": {
+        "cellName": "switched_capacitor_dac_6bit",
+        "sourceRef": {
+          "end": {
+            "column": 34,
+            "line": 25,
+            "offset": 958
+          },
+          "fileId": "source-648e50f6f6cd02ee",
+          "start": {
+            "column": 1,
+            "line": 10,
+            "offset": 452
+          }
+        }
+      },
+      "sourceStatus": "connectivity-modified"
+    }
+  ],
+  "externalSubcircuitDefinitions": [
+    {
+      "formalParameters": [],
+      "id": "external-subcircuit-27f716b14d59fc10",
+      "interfaceStatus": "inferred-positional",
+      "name": "sky130_fd_pr__pfet_01v8",
+      "terminals": [
+        {
+          "direction": "passive",
+          "id": "external-subcircuit-terminal-7921a0096089118d",
+          "name": "D"
+        },
+        {
+          "direction": "passive",
+          "id": "external-subcircuit-terminal-79219f0960890fda",
+          "name": "G"
+        },
+        {
+          "direction": "passive",
+          "id": "external-subcircuit-terminal-79219e0960890e27",
+          "name": "S"
+        },
+        {
+          "direction": "passive",
+          "id": "external-subcircuit-terminal-79219d0960890c74",
+          "name": "B"
+        }
+      ]
+    },
+    {
+      "formalParameters": [],
+      "id": "external-subcircuit-e5ee3d17d0c7c89a",
+      "interfaceStatus": "inferred-positional",
+      "name": "sky130_fd_pr__nfet_01v8",
+      "terminals": [
+        {
+          "direction": "passive",
+          "id": "external-subcircuit-terminal-353df4da271bcc2b",
+          "name": "D"
+        },
+        {
+          "direction": "passive",
+          "id": "external-subcircuit-terminal-353df3da271bca78",
+          "name": "G"
+        },
+        {
+          "direction": "passive",
+          "id": "external-subcircuit-terminal-353df6da271bcf91",
+          "name": "S"
+        },
+        {
+          "direction": "passive",
+          "id": "external-subcircuit-terminal-353df5da271bcdde",
+          "name": "B"
+        }
+      ]
+    }
+  ],
+  "id": "project-898510e0e3b15ad5",
+  "name": "Switched_Capacitor_DAC_6bit (SPICE Import Demo)",
+  "schemaVersion": 32,
+  "source": {
+    "dialect": "spice3f5-core",
+    "entry": "circuit.spi",
+    "files": [
+      {
+        "hash": "sha256:99950c766f41c6c293dd7e9f20aebb33b7d94a3d590a1af38a8ffa424eb81b8d",
+        "id": "source-648e50f6f6cd02ee",
+        "path": "circuit.spi"
+      }
+    ],
+    "sourcePolicy": "copy"
+  },
+  "structureRevision": 7,
+  "symbolLibrary": {
+    "hash": "razavi-reference-v1",
+    "id": "razavi-symbols",
+    "version": "1"
+  },
+  "topDocumentId": "document-fb815c3c3f719ef7"
+}

--- a/fixtures/gallery-redline/3tfmrzevfe.icproj.json
+++ b/fixtures/gallery-redline/3tfmrzevfe.icproj.json
@@ -1,0 +1,3626 @@
+{
+  "documents": [
+    {
+      "annotations": [
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 280,
+              "y": 210
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -10,
+              "y": -20
+            },
+            "objectId": "R1"
+          },
+          "binding": {
+            "instanceId": "R1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-R1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 260,
+              "y": 190
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "M3"
+          },
+          "binding": {
+            "instanceId": "M3",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M1-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 260,
+              "y": 290
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "M4"
+          },
+          "binding": {
+            "instanceId": "M4",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M2-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 355,
+              "y": 335
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 5,
+              "y": 15
+            },
+            "objectId": "C1"
+          },
+          "binding": {
+            "instanceId": "C1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-C1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 420,
+              "y": 335
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 15
+            },
+            "objectId": "C2"
+          },
+          "binding": {
+            "instanceId": "C2",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-C2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 475,
+              "y": 335
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 5,
+              "y": 15
+            },
+            "objectId": "C3"
+          },
+          "binding": {
+            "instanceId": "C3",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-C3",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 540,
+              "y": 335
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 15
+            },
+            "objectId": "C4"
+          },
+          "binding": {
+            "instanceId": "C4",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-C4",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 600,
+              "y": 335
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 15
+            },
+            "objectId": "C5"
+          },
+          "binding": {
+            "instanceId": "C5",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-C5",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 325,
+              "y": 285
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -15,
+              "y": 25
+            },
+            "objectId": "M5"
+          },
+          "binding": {
+            "instanceId": "M5",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M5",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 385,
+              "y": 285
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -15,
+              "y": 25
+            },
+            "objectId": "M6"
+          },
+          "binding": {
+            "instanceId": "M6",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M6",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 445,
+              "y": 285
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -15,
+              "y": 25
+            },
+            "objectId": "M7"
+          },
+          "binding": {
+            "instanceId": "M7",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M7",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 500,
+              "y": 285
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 25
+            },
+            "objectId": "M8"
+          },
+          "binding": {
+            "instanceId": "M8",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M8",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 560,
+              "y": 285
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 25
+            },
+            "objectId": "M9"
+          },
+          "binding": {
+            "instanceId": "M9",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M9",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 260,
+              "y": 410
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "M10"
+          },
+          "binding": {
+            "instanceId": "M10",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M10",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 260,
+              "y": 500
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "M11"
+          },
+          "binding": {
+            "instanceId": "M11",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M11",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 370,
+              "y": 500
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "C6"
+          },
+          "binding": {
+            "instanceId": "C6",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-C6",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 230,
+              "y": 115
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": -5
+            },
+            "objectId": "VDD1"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-ui-26"
+          },
+          "id": "power-label-vdd1",
+          "kind": "power-label",
+          "locked": false,
+          "netId": "net-ui-26",
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 225,
+              "y": 355
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -25,
+              "y": -5
+            },
+            "objectId": "VDD2"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-contact-vdd2"
+          },
+          "id": "power-label-vdd2",
+          "kind": "power-label",
+          "locked": false,
+          "netId": "net-contact-vdd2",
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 330,
+              "y": 375
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -10,
+              "y": 15
+            },
+            "objectId": "VDD4"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-ui-22"
+          },
+          "formatOverride": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "V"
+                      },
+                      {
+                        "children": [
+                          {
+                            "kind": "text",
+                            "value": "SS"
+                          }
+                        ],
+                        "kind": "span",
+                        "style": "subscript"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              }
+            ]
+          },
+          "id": "power-label-vdd4",
+          "kind": "power-label",
+          "locked": false,
+          "netId": "net-ui-22",
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 290,
+              "y": 480
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 0,
+              "y": 30
+            },
+            "objectId": "R2"
+          },
+          "binding": {
+            "instanceId": "R2",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-R2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "middle",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 680,
+              "y": 290
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 0,
+              "y": 50
+            },
+            "objectId": "X1"
+          },
+          "binding": {
+            "instanceId": "X1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-X1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        }
+      ],
+      "connectivityEvidence": [
+        {
+          "id": "connectivity-evidence-9cf7eacd6eb3b290",
+          "kind": "name-claim",
+          "name": "VDD",
+          "netId": "net-ui-26",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "VDD1"
+          },
+          "powerDomain": "vdd",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-15554944e5b75cf5",
+          "kind": "name-claim",
+          "name": "VDD",
+          "netId": "net-contact-vdd2",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "VDD2"
+          },
+          "powerDomain": "vdd",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-32c3e3397414c9b9",
+          "kind": "name-claim",
+          "name": "VDD",
+          "netId": "net-ui-41",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "VDD3"
+          },
+          "powerDomain": "vdd",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-67898ea4c8a72157",
+          "kind": "name-claim",
+          "name": "VSS",
+          "netId": "net-ui-22",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "VDD4"
+          },
+          "powerDomain": "vdd",
+          "scope": "global"
+        }
+      ],
+      "constraints": [],
+      "drafting": {
+        "objects": [
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 250,
+                "y": 545
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "V"
+                        },
+                        {
+                          "children": [
+                            {
+                              "kind": "text",
+                              "value": "SS"
+                            }
+                          ],
+                          "kind": "span",
+                          "style": "subscript"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-10",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 165,
+                "y": 450
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "IN_1"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "italic"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "bold"
+                }
+              ]
+            },
+            "id": "note-11",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 600,
+                "y": 140
+              }
+            },
+            "center": {
+              "x": 600,
+              "y": 140
+            },
+            "height": 80,
+            "id": "rectangle-26",
+            "kind": "rectangle",
+            "lineStyle": "solid",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "lineStyle": "dashed"
+            },
+            "width": 140,
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 165,
+                "y": 230
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "IN_1'"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-30",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 550,
+                "y": 140
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "IN_1"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-31",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 650,
+                "y": 140
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "IN_1'"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-32",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 680,
+                "y": 350
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "A1"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-33",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 625,
+                "y": 250
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "IN_1"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-34",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 620,
+                "y": 474
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "IN_1'"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-38",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 319,
+                "y": 320
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "m=1"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-39",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 385,
+                "y": 320
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "m=2"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-40",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 445,
+                "y": 320
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "m=4"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "italic"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "bold"
+                }
+              ]
+            },
+            "id": "note-41",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 505,
+                "y": 320
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "m=8"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-42",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 559,
+                "y": 320
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "m=16"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-43",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 305,
+                "y": 260
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "Q1 "
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-44",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 370,
+                "y": 260
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "Q2"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-45",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 430,
+                "y": 260
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "Q3"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-46",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 550,
+                "y": 260
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "Q5"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-47",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 490,
+                "y": 260
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "Q4"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-48",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 855,
+                "y": 250
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "LS_ZN"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-49",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 855,
+                "y": 450
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "HS_ZA"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-52",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          }
+        ]
+      },
+      "id": "document-main",
+      "instances": [
+        {
+          "id": "R1",
+          "netlist": {
+            "binding": {
+              "deviceClass": "resistor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "R1"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 290,
+              "y": 230
+            },
+            "rotation": 90
+          },
+          "schematicReference": "R1",
+          "symbolId": "resistor"
+        },
+        {
+          "id": "M3",
+          "mosBulkBinding": {
+            "netId": "net-ui-26",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M3"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 240,
+              "y": 180
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M3",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M4",
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M4"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 240,
+              "y": 280
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M4",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "C1",
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "C1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 350,
+              "y": 320
+            },
+            "rotation": 0
+          },
+          "schematicReference": "C1",
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "C2",
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "C2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 410,
+              "y": 320
+            },
+            "rotation": 0
+          },
+          "schematicReference": "C2",
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "C3",
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "C3"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 470,
+              "y": 320
+            },
+            "rotation": 0
+          },
+          "schematicReference": "C3",
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "C4",
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "C4"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 530,
+              "y": 320
+            },
+            "rotation": 0
+          },
+          "schematicReference": "C4",
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "C5",
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "C5"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 590,
+              "y": 320
+            },
+            "rotation": 0
+          },
+          "schematicReference": "C5",
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "M5",
+          "mosBulkBinding": {
+            "netId": "net-ui-26",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M5"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 340,
+              "y": 260
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M5",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M6",
+          "mosBulkBinding": {
+            "netId": "net-ui-26",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M6"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 400,
+              "y": 260
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M6",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M7",
+          "mosBulkBinding": {
+            "netId": "net-ui-26",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M7"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 460,
+              "y": 260
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M7",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M8",
+          "mosBulkBinding": {
+            "netId": "net-ui-26",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M8"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 520,
+              "y": 260
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M8",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M9",
+          "mosBulkBinding": {
+            "netId": "net-ui-26",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M9"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 580,
+              "y": 260
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M9",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "X2",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 770,
+              "y": 250
+            },
+            "rotation": 0
+          },
+          "schematicReference": "X2",
+          "symbolId": "and-gate"
+        },
+        {
+          "id": "M10",
+          "mosBulkBinding": {
+            "netId": "net-ui-26",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M10"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 240,
+              "y": 400
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M10",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M11",
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M11"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 240,
+              "y": 490
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M11",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "C6",
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "C6"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 350,
+              "y": 490
+            },
+            "rotation": 0
+          },
+          "schematicReference": "C6",
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "X3",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 680,
+              "y": 460
+            },
+            "rotation": 0
+          },
+          "schematicReference": "X3",
+          "symbolId": "nor-gate"
+        },
+        {
+          "id": "X4",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 770,
+              "y": 450
+            },
+            "rotation": 0
+          },
+          "schematicReference": "X4",
+          "symbolId": "and-gate"
+        },
+        {
+          "id": "VDD1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 250,
+              "y": 120
+            },
+            "rotation": 0
+          },
+          "schematicReference": "VDD1",
+          "symbolId": "vdd-port"
+        },
+        {
+          "id": "VDD2",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 250,
+              "y": 360
+            },
+            "rotation": 0
+          },
+          "schematicReference": "VDD2",
+          "symbolId": "vdd-port"
+        },
+        {
+          "id": "VDD3",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 250,
+              "y": 530
+            },
+            "rotation": 180
+          },
+          "schematicReference": "VDD3",
+          "symbolId": "vdd-port"
+        },
+        {
+          "id": "VDD4",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 340,
+              "y": 360
+            },
+            "rotation": 180
+          },
+          "schematicReference": "VDD4",
+          "symbolId": "vdd-port"
+        },
+        {
+          "id": "R2",
+          "netlist": {
+            "binding": {
+              "deviceClass": "resistor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "R2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 290,
+              "y": 450
+            },
+            "rotation": 90
+          },
+          "schematicReference": "R2",
+          "symbolId": "resistor"
+        },
+        {
+          "id": "X5",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 600,
+              "y": 140
+            },
+            "rotation": 0
+          },
+          "schematicReference": "X5",
+          "symbolId": "inverter"
+        },
+        {
+          "id": "P1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 200,
+              "y": 450
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "P2",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 200,
+              "y": 230
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "X1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 680,
+              "y": 240
+            },
+            "rotation": 0
+          },
+          "schematicReference": "X1",
+          "symbolId": "nor-gate"
+        },
+        {
+          "id": "P3",
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 810,
+              "y": 250
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "P4",
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 810,
+              "y": 450
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        }
+      ],
+      "junctions": [
+        {
+          "id": "junction-ui-4",
+          "netId": "net-ui-1",
+          "position": {
+            "x": 210,
+            "y": 230
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-6",
+          "netId": "net-ui-1-copy-1",
+          "position": {
+            "x": 250,
+            "y": 230
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-9",
+          "netId": "net-ui-8",
+          "position": {
+            "x": 350,
+            "y": 230
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-11",
+          "netId": "net-ui-8",
+          "position": {
+            "x": 420,
+            "y": 230
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-13",
+          "netId": "net-ui-8",
+          "position": {
+            "x": 480,
+            "y": 230
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-15",
+          "netId": "net-ui-8",
+          "position": {
+            "x": 530,
+            "y": 230
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-24",
+          "netId": "net-ui-22",
+          "position": {
+            "x": 250,
+            "y": 340
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-28",
+          "netId": "net-ui-8",
+          "position": {
+            "x": 550,
+            "y": 230
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-39",
+          "netId": "net-ui-37",
+          "position": {
+            "x": 250,
+            "y": 450
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-45",
+          "netId": "net-ui-33",
+          "position": {
+            "x": 720,
+            "y": 350
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-46",
+          "netId": "net-ui-33",
+          "position": {
+            "x": 690,
+            "y": 350
+          },
+          "role": "route-anchor"
+        },
+        {
+          "id": "junction-lifecycle-2-2",
+          "netId": "net-split-83b11de7bcb0c042",
+          "position": {
+            "x": 310,
+            "y": 450
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-48",
+          "netId": "net-split-83b11de7bcb0c042",
+          "position": {
+            "x": 400,
+            "y": 450
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-lifecycle-35-2",
+          "netId": "net-ui-30",
+          "position": {
+            "x": 710,
+            "y": 240
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-51",
+          "netId": "net-ui-8",
+          "position": {
+            "x": 620,
+            "y": 230
+          },
+          "role": "branch"
+        }
+      ],
+      "layoutGroups": [],
+      "mosBulkDefaults": {
+        "pmosNetId": "net-ui-26"
+      },
+      "name": "Main",
+      "netlist": {
+        "formalParameters": [],
+        "name": "Main",
+        "terminals": [
+          {
+            "direction": "passive",
+            "id": "terminal-p1",
+            "interfaceInstanceIds": [
+              "P1"
+            ],
+            "name": "Vin",
+            "netId": "net-ui-38"
+          },
+          {
+            "direction": "passive",
+            "id": "terminal-p2",
+            "interfaceInstanceIds": [
+              "P2"
+            ],
+            "name": "Vin2",
+            "netId": "net-ui-1"
+          },
+          {
+            "direction": "passive",
+            "id": "terminal-p3",
+            "interfaceInstanceIds": [
+              "P3"
+            ],
+            "name": "Vin3",
+            "netId": "net-contact-p3"
+          },
+          {
+            "direction": "passive",
+            "id": "terminal-p4",
+            "interfaceInstanceIds": [
+              "P4"
+            ],
+            "name": "Vin4",
+            "netId": "net-contact-p4"
+          }
+        ]
+      },
+      "nets": [
+        {
+          "id": "net-ui-1",
+          "terminals": [
+            {
+              "instanceId": "M3",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "P2",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-1-copy-1",
+          "terminals": [
+            {
+              "instanceId": "M3",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "R1",
+              "pinName": "2"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-8",
+          "terminals": [
+            {
+              "instanceId": "R1",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M6",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M7",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M8",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M9",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "X1",
+              "pinName": "A"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-17",
+          "terminals": [
+            {
+              "instanceId": "M5",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "C1",
+              "pinName": "1"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-18",
+          "terminals": [
+            {
+              "instanceId": "M6",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "C2",
+              "pinName": "1"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-19",
+          "terminals": [
+            {
+              "instanceId": "M7",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "C3",
+              "pinName": "1"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-20",
+          "terminals": [
+            {
+              "instanceId": "M8",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "C4",
+              "pinName": "1"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-21",
+          "terminals": [
+            {
+              "instanceId": "M9",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "C5",
+              "pinName": "1"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-22",
+          "terminals": [
+            {
+              "instanceId": "C1",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "C2",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "C3",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "C4",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "C5",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "VDD4",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-26",
+          "terminals": [
+            {
+              "instanceId": "M3",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "VDD1",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M6",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M7",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M8",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M9",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M10",
+              "pinName": "B"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-30",
+          "terminals": [
+            {
+              "instanceId": "X2",
+              "pinName": "A"
+            },
+            {
+              "instanceId": "X1",
+              "pinName": "Y"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-33",
+          "terminals": [
+            {
+              "instanceId": "X2",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "X4",
+              "pinName": "A"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-34",
+          "terminals": [
+            {
+              "instanceId": "X4",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "X3",
+              "pinName": "Y"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-37",
+          "terminals": [
+            {
+              "instanceId": "M10",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M11",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "R2",
+              "pinName": "2"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-38",
+          "terminals": [
+            {
+              "instanceId": "M10",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M11",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "P1",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-41",
+          "terminals": [
+            {
+              "instanceId": "M11",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "C6",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "VDD3",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-split-83b11de7bcb0c042",
+          "terminals": [
+            {
+              "instanceId": "C6",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "X3",
+              "pinName": "A"
+            },
+            {
+              "instanceId": "R2",
+              "pinName": "1"
+            }
+          ]
+        },
+        {
+          "id": "net-contact-vdd2",
+          "terminals": [
+            {
+              "instanceId": "VDD2",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M10",
+              "pinName": "S"
+            }
+          ]
+        },
+        {
+          "id": "net-contact-p3",
+          "terminals": [
+            {
+              "instanceId": "P3",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "X2",
+              "pinName": "Y"
+            }
+          ]
+        },
+        {
+          "id": "net-contact-p4",
+          "terminals": [
+            {
+              "instanceId": "P4",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "X4",
+              "pinName": "Y"
+            }
+          ]
+        }
+      ],
+      "noConnects": [],
+      "presentation": {
+        "compactness": "normal",
+        "grid": 10,
+        "styleProfileId": "razavi-textbook-v1"
+      },
+      "revision": 231,
+      "routes": [
+        {
+          "id": "route-ui-1-copy-1-a-6",
+          "legs": [
+            {
+              "id": "route-leg-0a26f946f44129ca",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-6",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-1-copy-1",
+          "start": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-1-copy-1-b-6",
+          "legs": [
+            {
+              "id": "route-leg-124a2e67b15ff7ab",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M4",
+                  "kind": "terminal",
+                  "pinName": "D"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-1-copy-1",
+          "start": {
+            "junctionId": "junction-ui-6",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-2-copy-1-a-4",
+          "legs": [
+            {
+              "id": "route-leg-22324e5e3d841275",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-22324e5e3d841275",
+                "kind": "bend",
+                "position": {
+                  "x": 210,
+                  "y": 180
+                }
+              }
+            },
+            {
+              "id": "route-leg-22324d5e3d8410c2",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-4",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-1",
+          "start": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "G"
+          }
+        },
+        {
+          "id": "route-ui-2-copy-1-b-4",
+          "legs": [
+            {
+              "id": "route-leg-f91df07e734fbf92",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-22324d5e3d8410c2",
+                "kind": "bend",
+                "position": {
+                  "x": 210,
+                  "y": 280
+                }
+              }
+            },
+            {
+              "id": "route-leg-22324c5e3d840f0f",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M4",
+                  "kind": "terminal",
+                  "pinName": "G"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-1",
+          "start": {
+            "junctionId": "junction-ui-4",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-7",
+          "legs": [
+            {
+              "id": "route-leg-9a9de466acb079d9",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-6",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-1-copy-1",
+          "start": {
+            "instanceId": "R1",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-ui-8-a-9",
+          "legs": [
+            {
+              "id": "route-leg-05662e849956eae0",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-9",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-8",
+          "start": {
+            "instanceId": "R1",
+            "kind": "terminal",
+            "pinName": "1"
+          }
+        },
+        {
+          "id": "route-ui-8-b-9",
+          "legs": [
+            {
+              "id": "route-leg-05662f849956ec93",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M5",
+                  "kind": "terminal",
+                  "pinName": "S"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-8",
+          "start": {
+            "junctionId": "junction-ui-9",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-10-a-11",
+          "legs": [
+            {
+              "id": "route-leg-88ad879b5c4f380c",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-18a9a2a6982e52e6",
+                "kind": "bend",
+                "position": {
+                  "x": 410,
+                  "y": 230
+                }
+              }
+            },
+            {
+              "id": "route-leg-30a6a09d15f88445",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-11",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-8",
+          "start": {
+            "instanceId": "M6",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-ui-10-b-11",
+          "legs": [
+            {
+              "id": "route-leg-88ad889b5c4f39bf",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-9",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-8",
+          "start": {
+            "junctionId": "junction-ui-11",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-12-a-13",
+          "legs": [
+            {
+              "id": "route-leg-45feb7b4fda98d1a",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-143e0fe17e6a2e03",
+                "kind": "bend",
+                "position": {
+                  "x": 470,
+                  "y": 230
+                }
+              }
+            },
+            {
+              "id": "route-leg-cb57c9fd49832274",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-13",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-8",
+          "start": {
+            "instanceId": "M7",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-ui-12-b-13",
+          "legs": [
+            {
+              "id": "route-leg-45feb8b4fda98ecd",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-11",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-8",
+          "start": {
+            "junctionId": "junction-ui-13",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-14-a-15",
+          "legs": [
+            {
+              "id": "route-leg-2c77578d26288638",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-15",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-8",
+          "start": {
+            "instanceId": "M8",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-ui-14-b-15",
+          "legs": [
+            {
+              "id": "route-leg-2c77588d262887eb",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-13",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-8",
+          "start": {
+            "junctionId": "junction-ui-15",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-16-a-28-a-51",
+          "legs": [
+            {
+              "id": "route-leg-3ebbe7a93baf89d6",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-045bba881fd85291",
+                "kind": "bend",
+                "position": {
+                  "x": 590,
+                  "y": 230
+                }
+              }
+            },
+            {
+              "id": "route-leg-fb60e4e874122a12",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-51",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-8",
+          "start": {
+            "instanceId": "M9",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-ui-16-a-28-b-51",
+          "legs": [
+            {
+              "id": "route-leg-908860b0f7ee0151",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-28",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-8",
+          "start": {
+            "junctionId": "junction-ui-51",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-16-b-28",
+          "legs": [
+            {
+              "id": "route-leg-3ebbe8a93baf8b89",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-15",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-8",
+          "start": {
+            "junctionId": "junction-ui-28",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-17",
+          "legs": [
+            {
+              "id": "route-leg-56b8e59fb979bb35",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "C1",
+                  "kind": "terminal",
+                  "pinName": "1"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-17",
+          "start": {
+            "instanceId": "M5",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-18",
+          "legs": [
+            {
+              "id": "route-leg-2193afd79b5cded4",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "C2",
+                  "kind": "terminal",
+                  "pinName": "1"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-18",
+          "start": {
+            "instanceId": "M6",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-19",
+          "legs": [
+            {
+              "id": "route-leg-140975b95ad30063",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "C3",
+                  "kind": "terminal",
+                  "pinName": "1"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-19",
+          "start": {
+            "instanceId": "M7",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-20",
+          "legs": [
+            {
+              "id": "route-leg-8d47b73400233dbf",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "C4",
+                  "kind": "terminal",
+                  "pinName": "1"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-20",
+          "start": {
+            "instanceId": "M8",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-21",
+          "legs": [
+            {
+              "id": "route-leg-4b3248f996c36fe0",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "C5",
+                  "kind": "terminal",
+                  "pinName": "1"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-21",
+          "start": {
+            "instanceId": "M9",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-22-part-1",
+          "legs": [
+            {
+              "id": "route-leg-80408e5fa8039710",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "C2",
+                  "kind": "terminal",
+                  "pinName": "2"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-22",
+          "start": {
+            "instanceId": "C1",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-ui-22-part-2",
+          "legs": [
+            {
+              "id": "route-leg-962c1c719f0d8a8d",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "C3",
+                  "kind": "terminal",
+                  "pinName": "2"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-22",
+          "start": {
+            "instanceId": "C2",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-ui-22-part-3",
+          "legs": [
+            {
+              "id": "route-leg-92853e7bbd8ad10e",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "C4",
+                  "kind": "terminal",
+                  "pinName": "2"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-22",
+          "start": {
+            "instanceId": "C3",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-ui-22-part-4",
+          "legs": [
+            {
+              "id": "route-leg-ceeca44f9da0a0d3",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "C5",
+                  "kind": "terminal",
+                  "pinName": "2"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-22",
+          "start": {
+            "instanceId": "C4",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-ui-23-b-24-a-contact-vdd4-p",
+          "legs": [
+            {
+              "id": "route-leg-fb5c8f5fdb452d3b",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "VDD4",
+                  "kind": "terminal",
+                  "pinName": "P"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-22",
+          "start": {
+            "junctionId": "junction-ui-24",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-23-b-24-b-contact-vdd4-p",
+          "legs": [
+            {
+              "id": "route-leg-0b6741c69c68ddd0",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "C1",
+                  "kind": "terminal",
+                  "pinName": "2"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-22",
+          "start": {
+            "instanceId": "VDD4",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "route-ui-25",
+          "legs": [
+            {
+              "id": "route-leg-a5b59907cb78c394",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-24",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-22",
+          "start": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-ui-26-a-contact-vdd1-p",
+          "legs": [
+            {
+              "id": "route-leg-64fa87174ce40741",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "VDD1",
+                  "kind": "terminal",
+                  "pinName": "P"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-26",
+          "start": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-ui-30",
+          "legs": [
+            {
+              "id": "route-leg-c45e0a2ff0d6df32",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-lifecycle-35-2",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-30",
+          "start": {
+            "instanceId": "X2",
+            "kind": "terminal",
+            "pinName": "A"
+          }
+        },
+        {
+          "id": "route-ui-33-a-45",
+          "legs": [
+            {
+              "id": "route-leg-f42f484e44b04c93",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-67952f8dd149aa15",
+                "kind": "bend",
+                "position": {
+                  "x": 720,
+                  "y": 260
+                }
+              }
+            },
+            {
+              "id": "route-leg-4f98b19753805236",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-45",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-33",
+          "start": {
+            "instanceId": "X2",
+            "kind": "terminal",
+            "pinName": "B"
+          }
+        },
+        {
+          "id": "route-ui-33-b-45",
+          "legs": [
+            {
+              "id": "route-leg-5a0817d18bd0d9e5",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-4f98b19753805236",
+                "kind": "bend",
+                "position": {
+                  "x": 720,
+                  "y": 440
+                }
+              }
+            },
+            {
+              "id": "route-leg-84bd875f719c8b77",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "X4",
+                  "kind": "terminal",
+                  "pinName": "A"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-33",
+          "start": {
+            "junctionId": "junction-ui-45",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-34",
+          "legs": [
+            {
+              "id": "route-leg-b7c7e27a649a7cce",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "X3",
+                  "kind": "terminal",
+                  "pinName": "Y"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-34",
+          "start": {
+            "instanceId": "X4",
+            "kind": "terminal",
+            "pinName": "B"
+          }
+        },
+        {
+          "id": "route-ui-37-a-39",
+          "legs": [
+            {
+              "id": "route-leg-982f18400eb72a2f",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-39",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-37",
+          "start": {
+            "instanceId": "M10",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-37-b-39",
+          "legs": [
+            {
+              "id": "route-leg-3fff1a62d5a14742",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M11",
+                  "kind": "terminal",
+                  "pinName": "D"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-37",
+          "start": {
+            "junctionId": "junction-ui-39",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-38-a-contact-p1-p",
+          "legs": [
+            {
+              "id": "route-leg-29c501f3b057da4a",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-15ce2f1509df290c",
+                "kind": "bend",
+                "position": {
+                  "x": 210,
+                  "y": 400
+                }
+              }
+            },
+            {
+              "id": "route-leg-084414f6c95580fb",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "P1",
+                  "kind": "terminal",
+                  "pinName": "P"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-38",
+          "start": {
+            "instanceId": "M10",
+            "kind": "terminal",
+            "pinName": "G"
+          }
+        },
+        {
+          "id": "route-ui-38-b-contact-p1-p",
+          "legs": [
+            {
+              "id": "route-leg-51a42b453321ea75",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-084414f6c95580fb",
+                "kind": "bend",
+                "position": {
+                  "x": 210,
+                  "y": 490
+                }
+              }
+            },
+            {
+              "id": "route-leg-d31f5f2eab397e1a",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M11",
+                  "kind": "terminal",
+                  "pinName": "G"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-38",
+          "start": {
+            "instanceId": "P1",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "route-ui-41",
+          "legs": [
+            {
+              "id": "route-leg-9b2c48343afa1aee",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "C6",
+                  "kind": "terminal",
+                  "pinName": "2"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-41",
+          "start": {
+            "instanceId": "M11",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-ui-44-a-48",
+          "legs": [
+            {
+              "id": "route-leg-fe744de21b47d151",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-48",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-83b11de7bcb0c042",
+          "start": {
+            "instanceId": "X3",
+            "kind": "terminal",
+            "pinName": "A"
+          }
+        },
+        {
+          "id": "route-ui-44-b-48",
+          "legs": [
+            {
+              "id": "route-leg-7c7bd8f462fe2ad8",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-lifecycle-2-2",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-83b11de7bcb0c042",
+          "start": {
+            "junctionId": "junction-ui-48",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-47",
+          "legs": [
+            {
+              "id": "route-leg-e8bedfd0246ba3a4",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-46",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-33",
+          "start": {
+            "junctionId": "junction-ui-45",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-49",
+          "legs": [
+            {
+              "id": "route-leg-00931ff7fa7adfa6",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-772a0bf8002f45fd",
+                "kind": "bend",
+                "position": {
+                  "x": 350,
+                  "y": 450
+                }
+              }
+            },
+            {
+              "id": "route-leg-75362e02201e20fe",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-48",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-83b11de7bcb0c042",
+          "start": {
+            "instanceId": "C6",
+            "kind": "terminal",
+            "pinName": "1"
+          }
+        },
+        {
+          "id": "route-ui-50",
+          "legs": [
+            {
+              "id": "route-leg-ef9370d073bb2660",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-39",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-37",
+          "start": {
+            "instanceId": "R2",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-ui-52",
+          "legs": [
+            {
+              "id": "route-leg-fc842942befef15e",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-51",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-8",
+          "start": {
+            "instanceId": "X1",
+            "kind": "terminal",
+            "pinName": "A"
+          }
+        }
+      ],
+      "sourceStatus": "connectivity-modified"
+    }
+  ],
+  "externalSubcircuitDefinitions": [],
+  "id": "project-main",
+  "name": "deadtime",
+  "schemaVersion": 32,
+  "source": {
+    "dialect": "none",
+    "entry": null,
+    "files": [],
+    "sourcePolicy": "copy"
+  },
+  "structureRevision": 6,
+  "symbolLibrary": {
+    "hash": "razavi-reference-v1",
+    "id": "razavi-symbols",
+    "version": "1"
+  },
+  "topDocumentId": "document-main"
+}

--- a/fixtures/gallery-redline/7sxpwb4am7.icproj.json
+++ b/fixtures/gallery-redline/7sxpwb4am7.icproj.json
@@ -1,0 +1,1389 @@
+{
+  "documents": [
+    {
+      "annotations": [
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 335,
+              "y": 175
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 15,
+              "y": 5
+            },
+            "objectId": "M1"
+          },
+          "binding": {
+            "instanceId": "M1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 335,
+              "y": 275
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 15,
+              "y": 5
+            },
+            "objectId": "M2"
+          },
+          "binding": {
+            "instanceId": "M2",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 370,
+              "y": 225
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 5
+            },
+            "objectId": "P2"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "terminal-p2"
+          },
+          "id": "instance-label-P2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 435,
+              "y": 175
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -15,
+              "y": 5
+            },
+            "objectId": "M3"
+          },
+          "binding": {
+            "instanceId": "M3",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M3",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 435,
+              "y": 275
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -15,
+              "y": 5
+            },
+            "objectId": "M4"
+          },
+          "binding": {
+            "instanceId": "M4",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M3-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 470,
+              "y": 95
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 10
+            },
+            "objectId": "junction-vdd1-end"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-power-vdd1"
+          },
+          "id": "label-VDD1",
+          "kind": "power-label",
+          "locked": false,
+          "netId": "net-power-vdd1",
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 285,
+              "y": 290
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -5,
+              "y": 20
+            },
+            "objectId": "P3"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "terminal-p3"
+          },
+          "id": "instance-label-P3",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 410,
+              "y": 325
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 5
+            },
+            "objectId": "I1"
+          },
+          "binding": {
+            "instanceId": "I1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-I1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        }
+      ],
+      "connectivityEvidence": [
+        {
+          "id": "connectivity-evidence-068cb49fb1b456b0",
+          "kind": "name-claim",
+          "name": "VDD",
+          "netId": "net-power-vdd1",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "label-VDD1"
+          },
+          "powerDomain": "vdd",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-e8af0c160a91d5f9",
+          "kind": "name-claim",
+          "name": "0",
+          "netId": "net-contact-gnd1",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "GND1"
+          },
+          "powerDomain": "ground",
+          "scope": "global"
+        }
+      ],
+      "constraints": [],
+      "drafting": {
+        "objects": []
+      },
+      "id": "document-775e9872-cc11-4cb6-897b-e7f7068c0f38",
+      "instances": [
+        {
+          "id": "M1",
+          "mosBulkBinding": {
+            "netId": "net-contact-gnd1",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 320,
+              "y": 170
+            },
+            "rotation": 0
+          },
+          "schematicName": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "M"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "3"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "subscript"
+              }
+            ]
+          },
+          "schematicReference": "M1",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M2",
+          "mosBulkBinding": {
+            "netId": "net-contact-gnd1",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 320,
+              "y": 270
+            },
+            "rotation": 0
+          },
+          "schematicName": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "M"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "1"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "subscript"
+              }
+            ]
+          },
+          "schematicReference": "M2",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "P2",
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 350,
+              "y": 220
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "M3",
+          "mosBulkBinding": {
+            "netId": "net-contact-gnd1",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M3"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 450,
+              "y": 170
+            },
+            "rotation": 0
+          },
+          "schematicName": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "M"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "4"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "subscript"
+              }
+            ]
+          },
+          "schematicReference": "M3",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "P1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 420,
+              "y": 220
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "M4",
+          "mosBulkBinding": {
+            "netId": "net-contact-gnd1",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M4"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 450,
+              "y": 270
+            },
+            "rotation": 0
+          },
+          "schematicName": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "M"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "2"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "subscript"
+              }
+            ]
+          },
+          "schematicReference": "M4",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "P3",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 290,
+              "y": 270
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "I1",
+          "netlist": {
+            "binding": {
+              "deviceClass": "current-source",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "I1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 390,
+              "y": 320
+            },
+            "rotation": 0
+          },
+          "schematicName": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "I"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "ss"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "subscript"
+              }
+            ]
+          },
+          "schematicReference": "I1",
+          "symbolId": "current-source"
+        },
+        {
+          "id": "P4",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 290,
+              "y": 300
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "GND1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 390,
+              "y": 350
+            },
+            "rotation": 0
+          },
+          "schematicReference": "GND1",
+          "symbolId": "ground"
+        }
+      ],
+      "junctions": [
+        {
+          "id": "junction-ui-58",
+          "netId": "net-ui-54",
+          "position": {
+            "x": 330,
+            "y": 220
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-63",
+          "netId": "net-split-719bf72556b1921f",
+          "position": {
+            "x": 440,
+            "y": 220
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-vdd1-start",
+          "netId": "net-power-vdd1",
+          "position": {
+            "x": 290,
+            "y": 140
+          },
+          "role": "route-anchor"
+        },
+        {
+          "id": "junction-vdd1-end",
+          "netId": "net-power-vdd1",
+          "position": {
+            "x": 480,
+            "y": 140
+          },
+          "role": "route-anchor"
+        },
+        {
+          "id": "junction-ui-65",
+          "netId": "net-power-vdd1",
+          "position": {
+            "x": 300,
+            "y": 140
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-68",
+          "netId": "net-power-vdd1",
+          "position": {
+            "x": 440,
+            "y": 140
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-70",
+          "netId": "net-power-vdd1",
+          "position": {
+            "x": 470,
+            "y": 140
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-73",
+          "netId": "net-ui-72",
+          "position": {
+            "x": 390,
+            "y": 290
+          },
+          "role": "branch"
+        }
+      ],
+      "layoutGroups": [],
+      "mosBulkDefaults": {
+        "nmosNetId": "net-contact-gnd1",
+        "pmosNetId": "net-power-vdd1"
+      },
+      "name": "Main",
+      "netlist": {
+        "formalParameters": [],
+        "name": "Main",
+        "terminals": [
+          {
+            "direction": "passive",
+            "id": "terminal-p2",
+            "interfaceInstanceIds": [
+              "P2"
+            ],
+            "name": "Vout",
+            "netId": "net-ui-54"
+          },
+          {
+            "direction": "passive",
+            "id": "terminal-p1",
+            "interfaceInstanceIds": [
+              "P1"
+            ],
+            "name": "Vin",
+            "netId": "net-split-719bf72556b1921f"
+          },
+          {
+            "direction": "passive",
+            "id": "terminal-p3",
+            "interfaceInstanceIds": [
+              "P3"
+            ],
+            "name": "Vin",
+            "netId": "net-contact-p3"
+          },
+          {
+            "direction": "passive",
+            "id": "terminal-p4",
+            "interfaceInstanceIds": [
+              "P4"
+            ],
+            "name": "Vin3",
+            "netId": "net-cell-pin-p4"
+          }
+        ]
+      },
+      "nets": [
+        {
+          "id": "net-ui-54",
+          "terminals": [
+            {
+              "instanceId": "M2",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "P2",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-split-719bf72556b1921f",
+          "terminals": [
+            {
+              "instanceId": "P1",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "S"
+            }
+          ]
+        },
+        {
+          "id": "net-power-vdd1",
+          "terminals": [
+            {
+              "instanceId": "M1",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "G"
+            }
+          ]
+        },
+        {
+          "id": "net-contact-p3",
+          "terminals": [
+            {
+              "instanceId": "P3",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "G"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-72",
+          "terminals": [
+            {
+              "instanceId": "M2",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "I1",
+              "pinName": "+"
+            }
+          ]
+        },
+        {
+          "id": "net-contact-gnd1",
+          "terminals": [
+            {
+              "instanceId": "I1",
+              "pinName": "-"
+            },
+            {
+              "instanceId": "GND1",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "B"
+            }
+          ]
+        },
+        {
+          "id": "net-cell-pin-p4",
+          "terminals": [
+            {
+              "instanceId": "P4",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "G"
+            }
+          ]
+        }
+      ],
+      "noConnects": [],
+      "presentation": {
+        "compactness": "normal",
+        "grid": 10,
+        "styleProfileId": "razavi-textbook-v1"
+      },
+      "revision": 99,
+      "routes": [
+        {
+          "id": "route-ui-54-a-contact-p2-p-a-58",
+          "legs": [
+            {
+              "id": "route-leg-4a16c0dea8707a14",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-58",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-54",
+          "start": {
+            "instanceId": "M2",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-54-a-contact-p2-p-b-58",
+          "legs": [
+            {
+              "id": "route-leg-c8110e68e8b8d5cb",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "P2",
+                  "kind": "terminal",
+                  "pinName": "P"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-54",
+          "start": {
+            "junctionId": "junction-ui-58",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-54-b-contact-p2-p",
+          "legs": [
+            {
+              "id": "route-leg-a6a81519d2cc7a0a",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-a7e5e39266de675f",
+                "kind": "bend",
+                "position": {
+                  "x": 330,
+                  "y": 220
+                }
+              }
+            },
+            {
+              "id": "route-leg-b5397db0a739a680",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M1",
+                  "kind": "terminal",
+                  "pinName": "S"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-54",
+          "start": {
+            "instanceId": "P2",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "route-ui-59",
+          "legs": [
+            {
+              "id": "route-leg-970fd6ce9c9bef57",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-58",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-54",
+          "start": {
+            "instanceId": "P2",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "route-ui-61-part-1-a-63",
+          "legs": [
+            {
+              "id": "route-leg-cbf948b44cff48d7",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-63",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-719bf72556b1921f",
+          "start": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-61-part-1-b-63",
+          "legs": [
+            {
+              "id": "route-leg-41c94b73a7fba4e1",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "P1",
+                  "kind": "terminal",
+                  "pinName": "P"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-719bf72556b1921f",
+          "start": {
+            "junctionId": "junction-ui-63",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-61-part-2",
+          "legs": [
+            {
+              "id": "route-leg-96d472ec2ee30f96",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-973c939badb3859b",
+                "kind": "bend",
+                "position": {
+                  "x": 440,
+                  "y": 220
+                }
+              }
+            },
+            {
+              "id": "route-leg-555d25614481472c",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M3",
+                  "kind": "terminal",
+                  "pinName": "S"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-719bf72556b1921f",
+          "start": {
+            "instanceId": "P1",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "route-ui-62",
+          "legs": [
+            {
+              "id": "route-leg-6ab30ffcaddfbab1",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-58",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-54",
+          "start": {
+            "instanceId": "P2",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "route-ui-64",
+          "legs": [
+            {
+              "id": "route-leg-3c904016ebaee0af",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-63",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-719bf72556b1921f",
+          "start": {
+            "instanceId": "P1",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "route-vdd1-rail-a-65",
+          "legs": [
+            {
+              "id": "route-leg-eff3aaf52d37d03c",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-65",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-power-vdd1",
+          "presentation": "power-rail",
+          "start": {
+            "junctionId": "junction-vdd1-start",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-vdd1-rail-b-65-a-68",
+          "legs": [
+            {
+              "id": "route-leg-9a66307770146861",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-68",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-power-vdd1",
+          "presentation": "power-rail",
+          "start": {
+            "junctionId": "junction-ui-65",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-vdd1-rail-b-65-b-68-a-70",
+          "legs": [
+            {
+              "id": "route-leg-aa1b5028666fa43e",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-70",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-power-vdd1",
+          "presentation": "power-rail",
+          "start": {
+            "junctionId": "junction-ui-68",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-vdd1-rail-b-65-b-68-b-70",
+          "legs": [
+            {
+              "id": "route-leg-72637b57e8008e5f",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-vdd1-end",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-power-vdd1",
+          "presentation": "power-rail",
+          "start": {
+            "junctionId": "junction-ui-70",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-66",
+          "legs": [
+            {
+              "id": "route-leg-6523dff0ed585bcd",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-65",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-power-vdd1",
+          "start": {
+            "instanceId": "M1",
+            "kind": "terminal",
+            "pinName": "G"
+          }
+        },
+        {
+          "id": "route-ui-67",
+          "legs": [
+            {
+              "id": "route-leg-5c290a514192334e",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-5c290a514192334e",
+                "kind": "bend",
+                "position": {
+                  "x": 330,
+                  "y": 140
+                }
+              }
+            },
+            {
+              "id": "route-leg-5c290b5141923501",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M1",
+                  "kind": "terminal",
+                  "pinName": "D"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-power-vdd1",
+          "start": {
+            "junctionId": "junction-ui-65",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-69",
+          "legs": [
+            {
+              "id": "route-leg-10d579b0ebf6153c",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-68",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-power-vdd1",
+          "start": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-71",
+          "legs": [
+            {
+              "id": "route-leg-95bc2382b2e1a2d5",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-70",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-power-vdd1",
+          "start": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "G"
+          }
+        },
+        {
+          "id": "route-ui-72-a-73",
+          "legs": [
+            {
+              "id": "route-leg-c0381572938fc358",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-73",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-72",
+          "start": {
+            "instanceId": "M2",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-ui-72-b-73",
+          "legs": [
+            {
+              "id": "route-leg-29772e1148e0a0e5",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M4",
+                  "kind": "terminal",
+                  "pinName": "S"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-72",
+          "start": {
+            "junctionId": "junction-ui-73",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-74",
+          "legs": [
+            {
+              "id": "route-leg-d80c759a699f35ba",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-73",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-72",
+          "start": {
+            "instanceId": "I1",
+            "kind": "terminal",
+            "pinName": "+"
+          }
+        },
+        {
+          "id": "route-ui-75",
+          "legs": [
+            {
+              "id": "route-leg-f0095390e76930b9",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-a95430b250f05dcb",
+                "kind": "bend",
+                "position": {
+                  "x": 470,
+                  "y": 300
+                }
+              }
+            },
+            {
+              "id": "route-leg-c8ecfaeca6d3b06a",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M4",
+                  "kind": "terminal",
+                  "pinName": "G"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-p4",
+          "start": {
+            "instanceId": "P4",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        }
+      ],
+      "sourceStatus": "connectivity-modified"
+    }
+  ],
+  "externalSubcircuitDefinitions": [],
+  "id": "project-6c056e6c-b17b-4a66-aab9-06d0b380b437",
+  "name": "Figure 17.19(b)",
+  "schemaVersion": 32,
+  "source": {
+    "dialect": "none",
+    "entry": null,
+    "files": [],
+    "sourcePolicy": "copy"
+  },
+  "structureRevision": 10,
+  "symbolLibrary": {
+    "hash": "razavi-reference-v1",
+    "id": "razavi-symbols",
+    "version": "1"
+  },
+  "topDocumentId": "document-775e9872-cc11-4cb6-897b-e7f7068c0f38"
+}

--- a/fixtures/gallery-redline/README.md
+++ b/fixtures/gallery-redline/README.md
@@ -1,0 +1,36 @@
+# Gallery red-line corpus
+
+Snapshots of real published Gallery documents, used by
+`packages/edit-engine/src/conductor-topology-redline.test.ts` to assert one
+invariant: **same-Net conductor canonicalization never changes terminal
+connectivity**. A failure there means canonicalization altered real users'
+circuits.
+
+These are fixtures, not live data: the test never touches the network. The
+snapshot was taken 2026-08-31 from `https://analog-canvas.tokenzhang.com`.
+
+## Why these six
+
+A representative subset instead of the full wall (119 entries, ~5MB), chosen
+for pathology and coverage, ~410KB total:
+
+| File | Entry | Why it is here |
+| --- | --- | --- |
+| `ycg43babwa` | LTC3452 | The original feedback pathology: six-route collinear tangles, an opposite-direction duplicate redraw, bend-tail overlaps. |
+| `3tfmrzevfe` | deadtime | Heaviest branch-vertex materialization in the corpus (four new canonical junctions). |
+| `b5cn37k3a9` | widlar | Mixed coalescing and materialization in one small hand-drawn document. |
+| `2rmm2vb45f` | Switched_Capacitor_DAC_6bit | SPICE-import provenance — geometry produced by the importer, not the wire tool. |
+| `7sxpwb4am7` | Figure 17.19(b) | Multi-document project — hierarchy exercises the per-document walk. |
+| `f22q5vhdb5` | suppression of skew | Control: canonicalization changes nothing here, guarding against a pass that "always finds something". |
+
+## Refreshing the snapshot
+
+```bash
+node scripts/refresh-gallery-redline.mjs
+```
+
+The script re-fetches exactly these entry ids from the public Gallery API and
+rewrites the `.icproj.json` files. Refresh deliberately keeps the same ids: the
+value of the corpus is that these documents are known-pathological; swap an id
+only when a document is deleted upstream, and record the replacement's
+pathology in the table above.

--- a/fixtures/gallery-redline/b5cn37k3a9.icproj.json
+++ b/fixtures/gallery-redline/b5cn37k3a9.icproj.json
@@ -1,0 +1,1168 @@
+{
+  "documents": [
+    {
+      "annotations": [
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 300,
+              "y": 290
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 10
+            },
+            "objectId": "Q1"
+          },
+          "binding": {
+            "instanceId": "Q1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-Q1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 170,
+              "y": 270
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -10,
+              "y": -10
+            },
+            "objectId": "Q2"
+          },
+          "binding": {
+            "instanceId": "Q2",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-Q2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 310,
+              "y": 330
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "R1"
+          },
+          "binding": {
+            "instanceId": "R1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-R1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 200,
+              "y": 200
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "R2"
+          },
+          "binding": {
+            "instanceId": "R2",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-R2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 310,
+              "y": 200
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "R3"
+          },
+          "binding": {
+            "instanceId": "R3",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-R3",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 370,
+              "y": 240
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 10
+            },
+            "objectId": "Q3"
+          },
+          "binding": {
+            "instanceId": "Q3",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-Q1-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 380,
+              "y": 110
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "I1"
+          },
+          "binding": {
+            "instanceId": "I1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-I1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 220,
+              "y": 120
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": -10
+            },
+            "objectId": "M1"
+          },
+          "binding": {
+            "instanceId": "M1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 305,
+              "y": 70
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 15,
+              "y": 10
+            },
+            "objectId": "VDD1"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-power-vdd1"
+          },
+          "id": "power-label-vdd1",
+          "kind": "power-label",
+          "locked": false,
+          "netId": "net-power-vdd1",
+          "rotation": 0
+        }
+      ],
+      "connectivityEvidence": [
+        {
+          "id": "connectivity-evidence-5b59a3c4dac05690",
+          "kind": "name-claim",
+          "name": "VDD",
+          "netId": "net-power-vdd1",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "VDD1"
+          },
+          "powerDomain": "vdd",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-98a4484f75a0c27c",
+          "kind": "name-claim",
+          "name": "0",
+          "netId": "net-ui-9",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "GND1"
+          },
+          "powerDomain": "ground",
+          "scope": "global"
+        }
+      ],
+      "constraints": [],
+      "drafting": {
+        "objects": []
+      },
+      "id": "document-main",
+      "instances": [
+        {
+          "id": "Q1",
+          "netlist": {
+            "parameters": {},
+            "reference": "Q1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 290,
+              "y": 280
+            },
+            "rotation": 0
+          },
+          "schematicReference": "Q1",
+          "symbolId": "npn"
+        },
+        {
+          "id": "Q2",
+          "netlist": {
+            "parameters": {},
+            "reference": "Q2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 180,
+              "y": 280
+            },
+            "rotation": 180
+          },
+          "schematicReference": "Q2",
+          "symbolId": "pnp"
+        },
+        {
+          "id": "R1",
+          "netlist": {
+            "binding": {
+              "deviceClass": "resistor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "R1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 290,
+              "y": 320
+            },
+            "rotation": 0
+          },
+          "schematicReference": "R1",
+          "symbolId": "resistor"
+        },
+        {
+          "id": "R2",
+          "netlist": {
+            "binding": {
+              "deviceClass": "resistor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "R2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 180,
+              "y": 190
+            },
+            "rotation": 0
+          },
+          "schematicReference": "R2",
+          "symbolId": "resistor"
+        },
+        {
+          "id": "R3",
+          "netlist": {
+            "binding": {
+              "deviceClass": "resistor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "R3"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 290,
+              "y": 190
+            },
+            "rotation": 0
+          },
+          "schematicReference": "R3",
+          "symbolId": "resistor"
+        },
+        {
+          "id": "Q3",
+          "netlist": {
+            "parameters": {},
+            "reference": "Q3"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 360,
+              "y": 230
+            },
+            "rotation": 0
+          },
+          "schematicReference": "Q3",
+          "symbolId": "npn"
+        },
+        {
+          "id": "I1",
+          "netlist": {
+            "binding": {
+              "deviceClass": "current-source",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "I1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 360,
+              "y": 100
+            },
+            "rotation": 0
+          },
+          "schematicReference": "I1",
+          "symbolId": "current-source"
+        },
+        {
+          "id": "M1",
+          "mosBulkBinding": {
+            "netId": "net-ui-9",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 240,
+              "y": 130
+            },
+            "rotation": 180
+          },
+          "schematicReference": "M1",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "VDD1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 290,
+              "y": 60
+            },
+            "rotation": 0
+          },
+          "schematicReference": "VDD1",
+          "symbolId": "vdd-port"
+        },
+        {
+          "id": "GND1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 250,
+              "y": 360
+            },
+            "rotation": 0
+          },
+          "schematicReference": "GND1",
+          "symbolId": "ground"
+        }
+      ],
+      "junctions": [
+        {
+          "id": "junction-ui-6",
+          "netId": "net-ui-5",
+          "position": {
+            "x": 290,
+            "y": 230
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-12",
+          "netId": "net-ui-3",
+          "position": {
+            "x": 230,
+            "y": 170
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-17",
+          "netId": "net-ui-16",
+          "position": {
+            "x": 240,
+            "y": 280
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-18",
+          "netId": "net-ui-16",
+          "position": {
+            "x": 180,
+            "y": 240
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-22",
+          "netId": "net-ui-9",
+          "position": {
+            "x": 290,
+            "y": 350
+          },
+          "role": "branch"
+        }
+      ],
+      "layoutGroups": [],
+      "mosBulkDefaults": {
+        "nmosNetId": "net-ui-9",
+        "pmosNetId": "net-power-vdd1"
+      },
+      "name": "Main",
+      "netlist": {
+        "formalParameters": [],
+        "name": "Main",
+        "terminals": []
+      },
+      "nets": [
+        {
+          "id": "net-power-vdd1",
+          "terminals": [
+            {
+              "instanceId": "VDD1",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "I1",
+              "pinName": "+"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-3",
+          "terminals": [
+            {
+              "instanceId": "R2",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "R3",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "D"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-5",
+          "terminals": [
+            {
+              "instanceId": "R3",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "Q1",
+              "pinName": "C"
+            },
+            {
+              "instanceId": "Q3",
+              "pinName": "B"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-9",
+          "terminals": [
+            {
+              "instanceId": "R1",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "GND1",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "Q3",
+              "pinName": "E"
+            },
+            {
+              "instanceId": "Q2",
+              "pinName": "E"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-14",
+          "terminals": [
+            {
+              "instanceId": "M1",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "I1",
+              "pinName": "-"
+            },
+            {
+              "instanceId": "Q3",
+              "pinName": "C"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-16",
+          "terminals": [
+            {
+              "instanceId": "Q2",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "Q1",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "R2",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "Q2",
+              "pinName": "C"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-21",
+          "terminals": [
+            {
+              "instanceId": "R1",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "Q1",
+              "pinName": "E"
+            }
+          ]
+        }
+      ],
+      "noConnects": [],
+      "presentation": {
+        "compactness": "normal",
+        "grid": 10,
+        "styleProfileId": "razavi-textbook-v1"
+      },
+      "revision": 54,
+      "routes": [
+        {
+          "id": "route-ui-1",
+          "legs": [
+            {
+              "id": "route-leg-ace29482c237b3d7",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-ace29482c237b3d7",
+                "kind": "bend",
+                "position": {
+                  "x": 230,
+                  "y": 80
+                }
+              }
+            },
+            {
+              "id": "route-leg-ace29382c237b224",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M1",
+                  "kind": "terminal",
+                  "pinName": "S"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-power-vdd1",
+          "start": {
+            "instanceId": "VDD1",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "route-ui-2",
+          "legs": [
+            {
+              "id": "route-leg-77bdbebaa41b7a96",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "I1",
+                  "kind": "terminal",
+                  "pinName": "+"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-power-vdd1",
+          "start": {
+            "instanceId": "VDD1",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "route-ui-3-a-12",
+          "legs": [
+            {
+              "id": "route-leg-950eb45aec291af5",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-12",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-3",
+          "start": {
+            "instanceId": "R2",
+            "kind": "terminal",
+            "pinName": "1"
+          }
+        },
+        {
+          "id": "route-ui-3-b-12",
+          "legs": [
+            {
+              "id": "route-leg-3c18145731133cdb",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "R3",
+                  "kind": "terminal",
+                  "pinName": "1"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-3",
+          "start": {
+            "junctionId": "junction-ui-12",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-4-a-18",
+          "legs": [
+            {
+              "id": "route-leg-c70356568efe97cc",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-18",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-16",
+          "start": {
+            "instanceId": "R2",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-ui-4-b-18",
+          "legs": [
+            {
+              "id": "route-leg-7762718b5e639596",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "Q2",
+                  "kind": "terminal",
+                  "pinName": "C"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-16",
+          "start": {
+            "junctionId": "junction-ui-18",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-5-a-6",
+          "legs": [
+            {
+              "id": "route-leg-b425448e843180bb",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-6",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-5",
+          "start": {
+            "instanceId": "R3",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-ui-5-b-6",
+          "legs": [
+            {
+              "id": "route-leg-45a9ddcb37e4d157",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "Q1",
+                  "kind": "terminal",
+                  "pinName": "C"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-5",
+          "start": {
+            "junctionId": "junction-ui-6",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-7",
+          "legs": [
+            {
+              "id": "route-leg-9a9de466acb079d9",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-6",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-5",
+          "start": {
+            "instanceId": "Q3",
+            "kind": "terminal",
+            "pinName": "B"
+          }
+        },
+        {
+          "id": "route-ui-8-a-22",
+          "legs": [
+            {
+              "id": "route-leg-05662e849956eae0",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-05662e849956eae0",
+                "kind": "bend",
+                "position": {
+                  "x": 360,
+                  "y": 350
+                }
+              }
+            },
+            {
+              "id": "route-leg-05662f849956ec93",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-22",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-9",
+          "start": {
+            "instanceId": "Q3",
+            "kind": "terminal",
+            "pinName": "E"
+          }
+        },
+        {
+          "id": "route-ui-8-b-22",
+          "legs": [
+            {
+              "id": "route-leg-f857045913094f13",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "GND1",
+                  "kind": "terminal",
+                  "pinName": "0"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-9",
+          "start": {
+            "junctionId": "junction-ui-22",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-13",
+          "legs": [
+            {
+              "id": "route-leg-5c4815ab7a011a19",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-12",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-3",
+          "start": {
+            "instanceId": "M1",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-14",
+          "legs": [
+            {
+              "id": "route-leg-2c77578d26288638",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-0be514cff9e77560",
+                "kind": "bend",
+                "position": {
+                  "x": 360,
+                  "y": 130
+                }
+              }
+            },
+            {
+              "id": "route-leg-4dfa830a6347433f",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "I1",
+                  "kind": "terminal",
+                  "pinName": "-"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-14",
+          "start": {
+            "instanceId": "M1",
+            "kind": "terminal",
+            "pinName": "G"
+          }
+        },
+        {
+          "id": "route-ui-15",
+          "legs": [
+            {
+              "id": "route-leg-6e8cc5c78f885417",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "Q3",
+                  "kind": "terminal",
+                  "pinName": "C"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-14",
+          "start": {
+            "instanceId": "I1",
+            "kind": "terminal",
+            "pinName": "-"
+          }
+        },
+        {
+          "id": "route-ui-16-a-17",
+          "legs": [
+            {
+              "id": "route-leg-3ebbe7a93baf89d6",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-17",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-16",
+          "start": {
+            "instanceId": "Q2",
+            "kind": "terminal",
+            "pinName": "B"
+          }
+        },
+        {
+          "id": "route-ui-16-b-17",
+          "legs": [
+            {
+              "id": "route-leg-8e9dcd5f239edfc9",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "Q1",
+                  "kind": "terminal",
+                  "pinName": "B"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-16",
+          "start": {
+            "junctionId": "junction-ui-17",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-19",
+          "legs": [
+            {
+              "id": "route-leg-140975b95ad30063",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-140975b95ad30063",
+                "kind": "bend",
+                "position": {
+                  "x": 230,
+                  "y": 280
+                }
+              }
+            },
+            {
+              "id": "route-leg-140974b95ad2feb0",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-140974b95ad2feb0",
+                "kind": "bend",
+                "position": {
+                  "x": 230,
+                  "y": 240
+                }
+              }
+            },
+            {
+              "id": "route-leg-140977b95ad303c9",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-18",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-16",
+          "start": {
+            "junctionId": "junction-ui-17",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-20",
+          "legs": [
+            {
+              "id": "route-leg-8d47b73400233dbf",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-8d47b73400233dbf",
+                "kind": "bend",
+                "position": {
+                  "x": 180,
+                  "y": 350
+                }
+              }
+            },
+            {
+              "id": "route-leg-8d47b63400233c0c",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "GND1",
+                  "kind": "terminal",
+                  "pinName": "0"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-9",
+          "start": {
+            "instanceId": "Q2",
+            "kind": "terminal",
+            "pinName": "E"
+          }
+        },
+        {
+          "id": "route-ui-21",
+          "legs": [
+            {
+              "id": "route-leg-4b3248f996c36fe0",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "Q1",
+                  "kind": "terminal",
+                  "pinName": "E"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-21",
+          "start": {
+            "instanceId": "R1",
+            "kind": "terminal",
+            "pinName": "1"
+          }
+        },
+        {
+          "id": "route-ui-23",
+          "legs": [
+            {
+              "id": "route-leg-5823016be2073ade",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-22",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-9",
+          "start": {
+            "instanceId": "R1",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        }
+      ],
+      "sourceStatus": "connectivity-modified"
+    }
+  ],
+  "externalSubcircuitDefinitions": [],
+  "id": "project-main",
+  "name": "widlar",
+  "schemaVersion": 32,
+  "source": {
+    "dialect": "none",
+    "entry": null,
+    "files": [],
+    "sourcePolicy": "copy"
+  },
+  "structureRevision": 0,
+  "symbolLibrary": {
+    "hash": "razavi-reference-v1",
+    "id": "razavi-symbols",
+    "version": "1"
+  },
+  "topDocumentId": "document-main"
+}

--- a/fixtures/gallery-redline/f22q5vhdb5.icproj.json
+++ b/fixtures/gallery-redline/f22q5vhdb5.icproj.json
@@ -1,0 +1,2088 @@
+{
+  "documents": [
+    {
+      "annotations": [
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 255,
+              "y": 185
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 15,
+              "y": 5
+            },
+            "objectId": "M3"
+          },
+          "binding": {
+            "instanceId": "M3",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M1-copy-1-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 255,
+              "y": 265
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 15,
+              "y": 5
+            },
+            "objectId": "M4"
+          },
+          "binding": {
+            "instanceId": "M4",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M3-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 255,
+              "y": 340
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 15,
+              "y": 10
+            },
+            "objectId": "M5"
+          },
+          "binding": {
+            "instanceId": "M5",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M4-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 265,
+              "y": 90
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 15,
+              "y": 0
+            },
+            "objectId": "VDD1-copy-1"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-contact-vdd1-copy-1"
+          },
+          "id": "power-label-vdd1-copy-1",
+          "kind": "power-label",
+          "locked": false,
+          "netId": "net-contact-vdd1-copy-1",
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 255,
+              "y": 125
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 15,
+              "y": 5
+            },
+            "objectId": "M2"
+          },
+          "binding": {
+            "instanceId": "M2",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M1-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 195,
+              "y": 125
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -15,
+              "y": 5
+            },
+            "objectId": "P2-copy-1"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "terminal-p2-copy-1"
+          },
+          "id": "instance-label-P2-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 325,
+              "y": 275
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 15,
+              "y": 5
+            },
+            "objectId": "C2"
+          },
+          "binding": {
+            "instanceId": "C2",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-C1-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 20,
+              "y": 185
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 5
+            },
+            "objectId": "P4-copy-1"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "terminal-p4-copy-1"
+          },
+          "formatOverride": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "A"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-P4-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 25,
+              "y": 265
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -15,
+              "y": 5
+            },
+            "objectId": "P5-copy-1"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "terminal-p5-copy-1"
+          },
+          "formatOverride": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "B"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-P5-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 170,
+              "y": 220
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 10
+            },
+            "objectId": "VDD1"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-power-vdd1"
+          },
+          "id": "power-label-vdd1",
+          "kind": "power-label",
+          "locked": false,
+          "netId": "net-power-vdd1",
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 200,
+              "y": 335
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -10,
+              "y": 5
+            },
+            "objectId": "P1"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "terminal-p1"
+          },
+          "id": "instance-label-P1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 335,
+              "y": 220
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 15,
+              "y": 0
+            },
+            "objectId": "P2"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "terminal-p2"
+          },
+          "id": "instance-label-P2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1
+        }
+      ],
+      "connectivityEvidence": [
+        {
+          "id": "connectivity-evidence-e55c74306fd9e424-copy-1",
+          "kind": "name-claim",
+          "name": "0",
+          "netId": "net-contact-gnd1-copy-1",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "GND1-copy-1"
+          },
+          "powerDomain": "ground",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-d1ebe13c1d098630-copy-1",
+          "kind": "name-claim",
+          "name": "VDD",
+          "netId": "net-contact-vdd1-copy-1",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "VDD1-copy-1"
+          },
+          "powerDomain": "vdd",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-d47db1cdc7d63ed0-copy-1",
+          "kind": "name-claim",
+          "name": "0",
+          "netId": "net-contact-gnd2-copy-1",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "GND2-copy-1"
+          },
+          "powerDomain": "ground",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-42053a10dcc9a64e",
+          "kind": "name-claim",
+          "name": "VDD",
+          "netId": "net-power-vdd1",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "VDD1"
+          },
+          "powerDomain": "vdd",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-e4954ccd4595b223",
+          "kind": "name-claim",
+          "name": "0",
+          "netId": "net-contact-gnd1",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "GND1"
+          },
+          "powerDomain": "ground",
+          "scope": "global"
+        }
+      ],
+      "constraints": [],
+      "drafting": {
+        "objects": [
+          {
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 75,
+                "y": 220
+              }
+            },
+            "center": {
+              "x": 75,
+              "y": 220
+            },
+            "height": 120,
+            "id": "rectangle-20-copy-1",
+            "kind": "rectangle",
+            "lineStyle": "solid",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "strokeScale": 1.4
+            },
+            "width": 50,
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 75,
+                "y": 230
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "kind": "text",
+                      "value": "PFD"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "bold"
+                }
+              ]
+            },
+            "id": "note-22-copy-1",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 125,
+                "y": 170
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "Q"
+                        },
+                        {
+                          "children": [
+                            {
+                              "kind": "text",
+                              "value": "A"
+                            }
+                          ],
+                          "kind": "span",
+                          "style": "subscript"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-28-copy-1",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 116,
+                "y": 279
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "Q"
+                        },
+                        {
+                          "children": [
+                            {
+                              "kind": "text",
+                              "value": "B"
+                            }
+                          ],
+                          "kind": "span",
+                          "style": "subscript"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-29-copy-1",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 199,
+                "y": 170
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "kind": "text",
+                              "value": "Q"
+                            },
+                            {
+                              "children": [
+                                {
+                                  "kind": "text",
+                                  "value": "A "
+                                }
+                              ],
+                              "kind": "span",
+                              "style": "subscript"
+                            }
+                          ],
+                          "kind": "span",
+                          "style": "overbar"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-33-copy-1",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          },
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 204,
+                "y": 280
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "Q"
+                        },
+                        {
+                          "children": [
+                            {
+                              "kind": "text",
+                              "value": "BΔ"
+                            }
+                          ],
+                          "kind": "span",
+                          "style": "subscript"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-16",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          }
+        ]
+      },
+      "id": "document-2c1cf795-d4ec-4e5b-90f6-fa1ecb7b018c",
+      "instances": [
+        {
+          "id": "M3",
+          "mosBulkBinding": {
+            "netId": "net-power-vdd1",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M3"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 240,
+              "y": 180
+            },
+            "rotation": 0
+          },
+          "schematicName": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "M"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "4"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "subscript"
+              }
+            ]
+          },
+          "schematicReference": "M3",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M4",
+          "mosBulkBinding": {
+            "netId": "net-contact-gnd1",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M4"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 240,
+              "y": 260
+            },
+            "rotation": 0
+          },
+          "schematicName": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "M"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "3"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "subscript"
+              }
+            ]
+          },
+          "schematicReference": "M4",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M5",
+          "mosBulkBinding": {
+            "netId": "net-contact-gnd1",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M5"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 240,
+              "y": 330
+            },
+            "rotation": 0
+          },
+          "schematicName": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "M"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "1"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "subscript"
+              }
+            ]
+          },
+          "schematicReference": "M5",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "GND1-copy-1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 250,
+              "y": 350
+            },
+            "rotation": 0
+          },
+          "schematicReference": "GND2",
+          "symbolId": "ground"
+        },
+        {
+          "id": "VDD1-copy-1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 250,
+              "y": 90
+            },
+            "rotation": 0
+          },
+          "schematicReference": "VDD2",
+          "symbolId": "vdd-port"
+        },
+        {
+          "id": "M2",
+          "mosBulkBinding": {
+            "netId": "net-power-vdd1",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 240,
+              "y": 120
+            },
+            "rotation": 0
+          },
+          "schematicName": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "M"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "2"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "subscript"
+              }
+            ]
+          },
+          "schematicReference": "M2",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "P2-copy-1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 210,
+              "y": 120
+            },
+            "rotation": 0
+          },
+          "symbolId": "port-filled"
+        },
+        {
+          "id": "C2",
+          "netlist": {
+            "binding": {
+              "deviceClass": "capacitor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "C2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 310,
+              "y": 270
+            },
+            "rotation": 0
+          },
+          "schematicName": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "C"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              }
+            ]
+          },
+          "schematicReference": "C2",
+          "symbolId": "capacitor"
+        },
+        {
+          "id": "GND2-copy-1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 310,
+              "y": 290
+            },
+            "rotation": 0
+          },
+          "schematicReference": "GND3",
+          "symbolId": "ground"
+        },
+        {
+          "id": "P4-copy-1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 40,
+              "y": 180
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "P5-copy-1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 40,
+              "y": 260
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "M1",
+          "mosBulkBinding": {
+            "netId": "net-contact-gnd1",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M1"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 160,
+              "y": 240
+            },
+            "rotation": 270
+          },
+          "schematicReference": "M1",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M6",
+          "mosBulkBinding": {
+            "netId": "net-power-vdd1",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M6"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 160,
+              "y": 280
+            },
+            "rotation": 270
+          },
+          "schematicReference": "M6",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "X1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 160,
+              "y": 180
+            },
+            "rotation": 0
+          },
+          "schematicReference": "X1",
+          "symbolId": "inverter"
+        },
+        {
+          "id": "VDD1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 160,
+              "y": 210
+            },
+            "rotation": 0
+          },
+          "schematicReference": "VDD1",
+          "symbolId": "vdd-port"
+        },
+        {
+          "id": "GND1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 160,
+              "y": 310
+            },
+            "rotation": 0
+          },
+          "schematicReference": "GND1",
+          "symbolId": "ground"
+        },
+        {
+          "id": "P1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 210,
+              "y": 330
+            },
+            "rotation": 0
+          },
+          "symbolId": "port-filled"
+        },
+        {
+          "id": "P2",
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 320,
+              "y": 220
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        }
+      ],
+      "junctions": [
+        {
+          "id": "junction-lifecycle-17-1-copy-1",
+          "netId": "net-ui-25-copy-1",
+          "position": {
+            "x": 250,
+            "y": 130
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-lifecycle-17-3-copy-1",
+          "netId": "net-contact-vdd1-copy-1",
+          "position": {
+            "x": 250,
+            "y": 100
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-29-copy-1",
+          "netId": "net-cell-pin-p3-copy-1",
+          "position": {
+            "x": 250,
+            "y": 210
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-lifecycle-38-1-copy-1",
+          "netId": "net-contact-x1-copy-1",
+          "position": {
+            "x": 190,
+            "y": 180
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-57-copy-1",
+          "netId": "net-split-320c5179e9232d28",
+          "position": {
+            "x": 110,
+            "y": 260
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-61-copy-1",
+          "netId": "net-split-320c5179e9232d28",
+          "position": {
+            "x": 100,
+            "y": 260
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-65",
+          "netId": "net-split-320c5179e9232d28",
+          "position": {
+            "x": 140,
+            "y": 260
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-67",
+          "netId": "net-split-320c5179e9232d28",
+          "position": {
+            "x": 130,
+            "y": 260
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-70",
+          "netId": "net-ui-34-copy-1",
+          "position": {
+            "x": 180,
+            "y": 260
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-75",
+          "netId": "net-ui-74",
+          "position": {
+            "x": 100,
+            "y": 180
+          },
+          "role": "route-anchor"
+        },
+        {
+          "id": "junction-ui-80",
+          "netId": "net-cell-pin-p3-copy-1",
+          "position": {
+            "x": 250,
+            "y": 220
+          },
+          "role": "branch"
+        }
+      ],
+      "layoutGroups": [],
+      "mosBulkDefaults": {
+        "nmosNetId": "net-contact-gnd1",
+        "pmosNetId": "net-power-vdd1"
+      },
+      "name": "Main",
+      "netlist": {
+        "formalParameters": [],
+        "name": "Main",
+        "terminals": [
+          {
+            "direction": "passive",
+            "id": "terminal-p2-copy-1",
+            "interfaceInstanceIds": [
+              "P2-copy-1"
+            ],
+            "name": "Vb2",
+            "netId": "net-contact-p2-copy-1"
+          },
+          {
+            "direction": "passive",
+            "id": "terminal-p4-copy-1",
+            "interfaceInstanceIds": [
+              "P4-copy-1"
+            ],
+            "name": "A",
+            "netId": "net-cell-pin-p4-copy-1"
+          },
+          {
+            "direction": "passive",
+            "id": "terminal-p5-copy-1",
+            "interfaceInstanceIds": [
+              "P5-copy-1"
+            ],
+            "name": "B",
+            "netId": "net-cell-pin-p5-copy-1"
+          },
+          {
+            "direction": "passive",
+            "id": "terminal-p1",
+            "interfaceInstanceIds": [
+              "P1"
+            ],
+            "name": "Vb1",
+            "netId": "net-contact-p1-copy-1"
+          },
+          {
+            "direction": "passive",
+            "id": "terminal-p2",
+            "interfaceInstanceIds": [
+              "P2"
+            ],
+            "name": "Vcont",
+            "netId": "net-cell-pin-p3-copy-1"
+          }
+        ]
+      },
+      "nets": [
+        {
+          "id": "net-ui-25-copy-1",
+          "terminals": [
+            {
+              "instanceId": "M3",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "D"
+            }
+          ]
+        },
+        {
+          "id": "net-contact-gnd1-copy-1",
+          "terminals": [
+            {
+              "instanceId": "GND1-copy-1",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "S"
+            }
+          ]
+        },
+        {
+          "id": "net-contact-p1-copy-1",
+          "terminals": [
+            {
+              "instanceId": "M5",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "P1",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-26-copy-1",
+          "terminals": [
+            {
+              "instanceId": "M5",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "S"
+            }
+          ]
+        },
+        {
+          "id": "net-contact-vdd1-copy-1",
+          "terminals": [
+            {
+              "instanceId": "VDD1-copy-1",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "S"
+            }
+          ]
+        },
+        {
+          "id": "net-contact-p2-copy-1",
+          "terminals": [
+            {
+              "instanceId": "P2-copy-1",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "G"
+            }
+          ]
+        },
+        {
+          "id": "net-cell-pin-p3-copy-1",
+          "terminals": [
+            {
+              "instanceId": "C2",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "P2",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "D"
+            }
+          ]
+        },
+        {
+          "id": "net-contact-gnd2-copy-1",
+          "terminals": [
+            {
+              "instanceId": "GND2-copy-1",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "C2",
+              "pinName": "2"
+            }
+          ]
+        },
+        {
+          "id": "net-contact-x1-copy-1",
+          "terminals": [
+            {
+              "instanceId": "M3",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "X1",
+              "pinName": "Y"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-34-copy-1",
+          "terminals": [
+            {
+              "instanceId": "M4",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M6",
+              "pinName": "D"
+            }
+          ]
+        },
+        {
+          "id": "net-cell-pin-p4-copy-1",
+          "terminals": [
+            {
+              "instanceId": "P4-copy-1",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-cell-pin-p5-copy-1",
+          "terminals": [
+            {
+              "instanceId": "P5-copy-1",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-split-320c5179e9232d28",
+          "terminals": [
+            {
+              "instanceId": "M1",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M6",
+              "pinName": "S"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-74",
+          "terminals": [
+            {
+              "instanceId": "X1",
+              "pinName": "A"
+            }
+          ]
+        },
+        {
+          "id": "net-power-vdd1",
+          "terminals": [
+            {
+              "instanceId": "VDD1",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M6",
+              "pinName": "B"
+            }
+          ]
+        },
+        {
+          "id": "net-contact-gnd1",
+          "terminals": [
+            {
+              "instanceId": "GND1",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "M6",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "B"
+            }
+          ]
+        }
+      ],
+      "noConnects": [],
+      "presentation": {
+        "compactness": "normal",
+        "grid": 10,
+        "styleProfileId": "razavi-textbook-v1"
+      },
+      "revision": 85,
+      "routes": [
+        {
+          "id": "route-ui-25-a-contact-m1-d-copy-1",
+          "legs": [
+            {
+              "id": "route-leg-3f0bd3faac94992b",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M2",
+                  "kind": "terminal",
+                  "pinName": "D"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-25-copy-1",
+          "start": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-ui-25-b-contact-m1-d-copy-1",
+          "legs": [
+            {
+              "id": "route-leg-58d53abb9b0fdb6e",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-lifecycle-17-1-copy-1",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-25-copy-1",
+          "start": {
+            "instanceId": "M2",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-26-copy-1",
+          "legs": [
+            {
+              "id": "route-leg-98563b7fcdd67300",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M4",
+                  "kind": "terminal",
+                  "pinName": "S"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-26-copy-1",
+          "start": {
+            "instanceId": "M5",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-27-a-29-copy-1-a-80",
+          "legs": [
+            {
+              "id": "route-leg-7adc3fbef2b676df",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-80",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-p3-copy-1",
+          "start": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-27-a-29-copy-1-b-80",
+          "legs": [
+            {
+              "id": "route-leg-735b9afa8a136b2a",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-29-copy-1",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-p3-copy-1",
+          "start": {
+            "junctionId": "junction-ui-80",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-27-b-29-copy-1",
+          "legs": [
+            {
+              "id": "route-leg-cc03d8c3a117c5a2",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M3",
+                  "kind": "terminal",
+                  "pinName": "D"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-p3-copy-1",
+          "start": {
+            "junctionId": "junction-ui-29-copy-1",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-179da4c085dcaab1-copy-1",
+          "legs": [
+            {
+              "id": "route-leg-a307839e0c22eb31",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "VDD1-copy-1",
+                  "kind": "terminal",
+                  "pinName": "P"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-contact-vdd1-copy-1",
+          "start": {
+            "junctionId": "junction-lifecycle-17-3-copy-1",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-b81aff2b353e27b1-copy-1",
+          "legs": [
+            {
+              "id": "route-leg-764138c9cf9b35cd",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "GND2-copy-1",
+                  "kind": "terminal",
+                  "pinName": "0"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-contact-gnd2-copy-1",
+          "start": {
+            "instanceId": "C2",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-f6a1756e5bc8808d-copy-1",
+          "legs": [
+            {
+              "id": "route-leg-d8c6be6b045a058e",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-lifecycle-38-1-copy-1",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-contact-x1-copy-1",
+          "start": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "G"
+          }
+        },
+        {
+          "id": "route-ui-62-copy-1",
+          "legs": [
+            {
+              "id": "route-leg-cf53f1b53d43af48",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-61-copy-1",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-320c5179e9232d28",
+          "start": {
+            "junctionId": "junction-ui-57-copy-1",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-63-a-65",
+          "legs": [
+            {
+              "id": "route-leg-68bf3206cdce95b2",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-65",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-320c5179e9232d28",
+          "start": {
+            "instanceId": "M1",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-63-b-65",
+          "legs": [
+            {
+              "id": "route-leg-76932d89f0035a9c",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M6",
+                  "kind": "terminal",
+                  "pinName": "S"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-320c5179e9232d28",
+          "start": {
+            "junctionId": "junction-ui-65",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-64",
+          "legs": [
+            {
+              "id": "route-leg-3c904016ebaee0af",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-65",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-320c5179e9232d28",
+          "start": {
+            "instanceId": "M6",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-25ff1158e7196c86",
+          "legs": [
+            {
+              "id": "route-leg-f080ee9084e1602d",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M1",
+                  "kind": "terminal",
+                  "pinName": "D"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-320c5179e9232d28",
+          "start": {
+            "junctionId": "junction-ui-65",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-66-a-67",
+          "legs": [
+            {
+              "id": "route-leg-6523dff0ed585bcd",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-67",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-320c5179e9232d28",
+          "start": {
+            "junctionId": "junction-ui-57-copy-1",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-66-b-67",
+          "legs": [
+            {
+              "id": "route-leg-6b1ab65ac14e8a83",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-65",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-320c5179e9232d28",
+          "start": {
+            "junctionId": "junction-ui-67",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-68",
+          "legs": [
+            {
+              "id": "route-leg-fdf767e8e128fe2b",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-65",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-320c5179e9232d28",
+          "start": {
+            "junctionId": "junction-ui-67",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-69-a-70",
+          "legs": [
+            {
+              "id": "route-leg-10d579b0ebf6153c",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-70",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-34-copy-1",
+          "start": {
+            "instanceId": "M1",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-ui-69-b-70",
+          "legs": [
+            {
+              "id": "route-leg-d20e1fa3c0a531e4",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M6",
+                  "kind": "terminal",
+                  "pinName": "D"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-34-copy-1",
+          "start": {
+            "junctionId": "junction-ui-70",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-71",
+          "legs": [
+            {
+              "id": "route-leg-95bc2382b2e1a2d5",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-70",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-34-copy-1",
+          "start": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "G"
+          }
+        },
+        {
+          "id": "route-ui-76",
+          "legs": [
+            {
+              "id": "route-leg-c5fe457e544664ac",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-75",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-74",
+          "start": {
+            "instanceId": "X1",
+            "kind": "terminal",
+            "pinName": "A"
+          }
+        },
+        {
+          "id": "route-ee355cd9bb9530ed",
+          "legs": [
+            {
+              "id": "route-leg-583c2baed0fa1b89",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M5",
+                  "kind": "terminal",
+                  "pinName": "S"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-contact-gnd1-copy-1",
+          "start": {
+            "instanceId": "GND1-copy-1",
+            "kind": "terminal",
+            "pinName": "0"
+          }
+        },
+        {
+          "id": "route-ui-79",
+          "legs": [
+            {
+              "id": "route-leg-18992bbe54363d3d",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "P2",
+                  "kind": "terminal",
+                  "pinName": "P"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-p3-copy-1",
+          "start": {
+            "instanceId": "C2",
+            "kind": "terminal",
+            "pinName": "1"
+          }
+        },
+        {
+          "id": "route-ui-81",
+          "legs": [
+            {
+              "id": "route-leg-1ffce25913df28b2",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-80",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-cell-pin-p3-copy-1",
+          "start": {
+            "instanceId": "P2",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        }
+      ],
+      "sourceStatus": "connectivity-modified"
+    }
+  ],
+  "externalSubcircuitDefinitions": [],
+  "id": "project-888e7106-b15b-4186-a980-d5a88c004d4c",
+  "name": "suppression of skew",
+  "schemaVersion": 32,
+  "source": {
+    "dialect": "none",
+    "entry": null,
+    "files": [],
+    "sourcePolicy": "copy"
+  },
+  "structureRevision": 7,
+  "symbolLibrary": {
+    "hash": "razavi-reference-v1",
+    "id": "razavi-symbols",
+    "version": "1"
+  },
+  "topDocumentId": "document-2c1cf795-d4ec-4e5b-90f6-fa1ecb7b018c"
+}

--- a/fixtures/gallery-redline/ycg43babwa.icproj.json
+++ b/fixtures/gallery-redline/ycg43babwa.icproj.json
@@ -1,0 +1,2816 @@
+{
+  "documents": [
+    {
+      "annotations": [
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 345,
+              "y": 70
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 15,
+              "y": 10
+            },
+            "objectId": "VDD1"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-power-vdd1"
+          },
+          "id": "power-label-vdd1",
+          "kind": "power-label",
+          "locked": false,
+          "netId": "net-power-vdd1",
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 280,
+              "y": 180
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 10
+            },
+            "objectId": "M3"
+          },
+          "binding": {
+            "instanceId": "M3",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M2-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 260,
+              "y": 440
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 10
+            },
+            "objectId": "Q1"
+          },
+          "binding": {
+            "instanceId": "Q1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-Q1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 350,
+              "y": 400
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 10
+            },
+            "objectId": "Q2"
+          },
+          "binding": {
+            "instanceId": "Q2",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-Q2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 150,
+              "y": 260
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -10,
+              "y": 10
+            },
+            "objectId": "Q3"
+          },
+          "binding": {
+            "instanceId": "Q3",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-Q3",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 430,
+              "y": 260
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 10
+            },
+            "objectId": "Q4"
+          },
+          "binding": {
+            "instanceId": "Q4",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-Q4",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 430,
+              "y": 360
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 20
+            },
+            "objectId": "Q5"
+          },
+          "binding": {
+            "instanceId": "Q5",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-Q5",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 520,
+              "y": 350
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 10
+            },
+            "objectId": "Q6"
+          },
+          "binding": {
+            "instanceId": "Q6",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-Q6",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 270,
+              "y": 370
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "R1"
+          },
+          "binding": {
+            "instanceId": "R1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-R1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 270,
+              "y": 290
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "R2"
+          },
+          "binding": {
+            "instanceId": "R2",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-R2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 360,
+              "y": 290
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "R3"
+          },
+          "binding": {
+            "instanceId": "R3",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-R3",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 180,
+              "y": 350
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "R4"
+          },
+          "binding": {
+            "instanceId": "R4",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-R4",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 110,
+              "y": 300
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "R5"
+          },
+          "binding": {
+            "instanceId": "R5",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-R5",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 110,
+              "y": 380
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "R6"
+          },
+          "binding": {
+            "instanceId": "R6",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-R6",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 300,
+              "y": 225
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": 5
+            },
+            "objectId": "R7"
+          },
+          "binding": {
+            "instanceId": "R7",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-R7",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 520,
+              "y": 150
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "M4"
+          },
+          "binding": {
+            "instanceId": "M4",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M4",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 430,
+              "y": 120
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "M6"
+          },
+          "binding": {
+            "instanceId": "M6",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M4-copy-2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 150,
+              "y": 120
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 10
+            },
+            "objectId": "M8"
+          },
+          "binding": {
+            "instanceId": "M8",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M4-copy-2-copy-2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        }
+      ],
+      "connectivityEvidence": [
+        {
+          "id": "connectivity-evidence-5b59a3c4dac05690",
+          "kind": "name-claim",
+          "name": "VDD",
+          "netId": "net-split-347ebb07a2a7a37b",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "VDD1"
+          },
+          "powerDomain": "vdd",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-05bc07a4cf424fb3",
+          "kind": "name-claim",
+          "name": "0",
+          "netId": "net-ui-9",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "GND1"
+          },
+          "powerDomain": "ground",
+          "scope": "global"
+        }
+      ],
+      "constraints": [],
+      "drafting": {
+        "objects": [
+          {
+            "alignment": "middle",
+            "anchor": {
+              "kind": "free",
+              "position": {
+                "x": 80,
+                "y": 185
+              }
+            },
+            "content": {
+              "runs": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "kind": "text",
+                          "value": "VBG"
+                        }
+                      ],
+                      "kind": "span",
+                      "style": "bold"
+                    }
+                  ],
+                  "kind": "span",
+                  "style": "italic"
+                }
+              ]
+            },
+            "id": "note-19",
+            "kind": "text",
+            "locked": false,
+            "rotation": 0,
+            "styleOverride": {
+              "sizeScale": 1
+            },
+            "typographyToken": "label",
+            "zIndex": 0
+          }
+        ]
+      },
+      "id": "document-main",
+      "instances": [
+        {
+          "id": "VDD1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 330,
+              "y": 60
+            },
+            "rotation": 0
+          },
+          "schematicReference": "VDD1",
+          "symbolId": "vdd-port"
+        },
+        {
+          "id": "M3",
+          "mosBulkBinding": {
+            "netId": "net-ui-9",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M3"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 300,
+              "y": 170
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M3",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "Q1",
+          "netlist": {
+            "parameters": {},
+            "reference": "Q1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 250,
+              "y": 430
+            },
+            "rotation": 0
+          },
+          "schematicReference": "Q1",
+          "symbolId": "npn"
+        },
+        {
+          "id": "Q2",
+          "netlist": {
+            "parameters": {},
+            "reference": "Q2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 340,
+              "y": 390
+            },
+            "rotation": 0
+          },
+          "schematicReference": "Q2",
+          "symbolId": "npn"
+        },
+        {
+          "id": "Q3",
+          "netlist": {
+            "parameters": {},
+            "reference": "Q3"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 160,
+              "y": 250
+            },
+            "rotation": 0
+          },
+          "schematicReference": "Q3",
+          "symbolId": "npn"
+        },
+        {
+          "id": "Q4",
+          "netlist": {
+            "parameters": {},
+            "reference": "Q4"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 420,
+              "y": 250
+            },
+            "rotation": 0
+          },
+          "schematicReference": "Q4",
+          "symbolId": "npn"
+        },
+        {
+          "id": "Q5",
+          "netlist": {
+            "parameters": {},
+            "reference": "Q5"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 420,
+              "y": 340
+            },
+            "rotation": 0
+          },
+          "schematicReference": "Q5",
+          "symbolId": "npn"
+        },
+        {
+          "id": "Q6",
+          "netlist": {
+            "parameters": {},
+            "reference": "Q6"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 510,
+              "y": 340
+            },
+            "rotation": 0
+          },
+          "schematicReference": "Q6",
+          "symbolId": "npn"
+        },
+        {
+          "id": "R1",
+          "netlist": {
+            "binding": {
+              "deviceClass": "resistor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "R1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 250,
+              "y": 360
+            },
+            "rotation": 0
+          },
+          "schematicReference": "R1",
+          "symbolId": "resistor"
+        },
+        {
+          "id": "R2",
+          "netlist": {
+            "binding": {
+              "deviceClass": "resistor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "R2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 250,
+              "y": 280
+            },
+            "rotation": 0
+          },
+          "schematicReference": "R2",
+          "symbolId": "resistor"
+        },
+        {
+          "id": "R3",
+          "netlist": {
+            "binding": {
+              "deviceClass": "resistor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "R3"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 340,
+              "y": 280
+            },
+            "rotation": 0
+          },
+          "schematicReference": "R3",
+          "symbolId": "resistor"
+        },
+        {
+          "id": "R4",
+          "netlist": {
+            "binding": {
+              "deviceClass": "resistor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "R4"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 160,
+              "y": 340
+            },
+            "rotation": 0
+          },
+          "schematicReference": "R4",
+          "symbolId": "resistor"
+        },
+        {
+          "id": "R5",
+          "netlist": {
+            "binding": {
+              "deviceClass": "resistor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "R5"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 90,
+              "y": 290
+            },
+            "rotation": 0
+          },
+          "schematicReference": "R5",
+          "symbolId": "resistor"
+        },
+        {
+          "id": "R6",
+          "netlist": {
+            "binding": {
+              "deviceClass": "resistor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "R6"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 90,
+              "y": 370
+            },
+            "rotation": 0
+          },
+          "schematicReference": "R6",
+          "symbolId": "resistor"
+        },
+        {
+          "id": "R7",
+          "netlist": {
+            "binding": {
+              "deviceClass": "resistor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "R7"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 290,
+              "y": 220
+            },
+            "rotation": 0
+          },
+          "schematicReference": "R7",
+          "symbolId": "resistor"
+        },
+        {
+          "id": "M4",
+          "mosBulkBinding": {
+            "netId": "net-split-347ebb07a2a7a37b",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M4"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 500,
+              "y": 140
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M4",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M5",
+          "mosBulkBinding": {
+            "netId": "net-split-347ebb07a2a7a37b",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M5"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 500,
+              "y": 140
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M5",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M6",
+          "mosBulkBinding": {
+            "netId": "net-split-347ebb07a2a7a37b",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M6"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 410,
+              "y": 110
+            },
+            "rotation": 0
+          },
+          "schematicName": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "M2"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              }
+            ]
+          },
+          "schematicReference": "M6",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M7",
+          "mosBulkBinding": {
+            "netId": "net-split-347ebb07a2a7a37b",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M7"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 410,
+              "y": 110
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M7",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M8",
+          "mosBulkBinding": {
+            "netId": "net-split-347ebb07a2a7a37b",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M8"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 170,
+              "y": 110
+            },
+            "rotation": 0
+          },
+          "schematicName": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "M1"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              }
+            ]
+          },
+          "schematicReference": "M8",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "GND1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 300,
+              "y": 480
+            },
+            "rotation": 0
+          },
+          "schematicReference": "GND1",
+          "symbolId": "ground"
+        }
+      ],
+      "junctions": [
+        {
+          "id": "junction-ui-6",
+          "netId": "net-split-3f52b798550ad130",
+          "position": {
+            "x": 220,
+            "y": 330
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-23",
+          "netId": "net-ui-22",
+          "position": {
+            "x": 420,
+            "y": 130
+          },
+          "role": "route-anchor"
+        },
+        {
+          "id": "junction-ui-25",
+          "netId": "net-ui-22",
+          "position": {
+            "x": 420,
+            "y": 170
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-28",
+          "netId": "net-split-7bc3714d88068ee2",
+          "position": {
+            "x": 360,
+            "y": 340
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-31",
+          "netId": "net-split-7bc3714d88068ee2",
+          "position": {
+            "x": 400,
+            "y": 340
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-lifecycle-6-1",
+          "netId": "net-split-347ebb07a2a7a37b",
+          "position": {
+            "x": 420,
+            "y": 90
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-lifecycle-7-2",
+          "netId": "net-665f4cbe40f8c964",
+          "position": {
+            "x": 160,
+            "y": 130
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-44",
+          "netId": "net-split-347ebb07a2a7a37b",
+          "position": {
+            "x": 420,
+            "y": 80
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-47",
+          "netId": "net-ui-46",
+          "position": {
+            "x": 510,
+            "y": 170
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-56",
+          "netId": "net-split-347ebb07a2a7a37b",
+          "position": {
+            "x": 290,
+            "y": 80
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-61",
+          "netId": "net-split-347ebb07a2a7a37b",
+          "position": {
+            "x": 290,
+            "y": 100
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-63",
+          "netId": "net-665f4cbe40f8c964",
+          "position": {
+            "x": 210,
+            "y": 110
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-64",
+          "netId": "net-665f4cbe40f8c964",
+          "position": {
+            "x": 160,
+            "y": 140
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-66",
+          "netId": "net-split-3f52b798550ad130",
+          "position": {
+            "x": 250,
+            "y": 330
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-68",
+          "netId": "net-split-7bc3714d88068ee2",
+          "position": {
+            "x": 340,
+            "y": 340
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-canonical-26b3e229ab18ddac",
+          "netId": "net-split-d5a4be795e522687",
+          "position": {
+            "x": 290,
+            "y": 250
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-canonical-917290ea9bdea8de",
+          "netId": "net-split-d5a4be795e522687",
+          "position": {
+            "x": 340,
+            "y": 250
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-71",
+          "netId": "net-split-d5a4be795e522687",
+          "position": {
+            "x": 250,
+            "y": 250
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-canonical-c68e1be232efda00",
+          "netId": "net-ui-9",
+          "position": {
+            "x": 340,
+            "y": 470
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-canonical-30f573ca3fd936af",
+          "netId": "net-ui-9",
+          "position": {
+            "x": 420,
+            "y": 470
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-canonical-80c748947814cceb",
+          "netId": "net-ui-9",
+          "position": {
+            "x": 160,
+            "y": 470
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-73",
+          "netId": "net-ui-9",
+          "position": {
+            "x": 250,
+            "y": 470
+          },
+          "role": "branch"
+        }
+      ],
+      "layoutGroups": [],
+      "mosBulkDefaults": {
+        "nmosNetId": "net-ui-9",
+        "pmosNetId": "net-split-347ebb07a2a7a37b"
+      },
+      "name": "Main",
+      "netlist": {
+        "formalParameters": [],
+        "name": "Main",
+        "terminals": []
+      },
+      "nets": [
+        {
+          "id": "net-power-vdd1",
+          "terminals": []
+        },
+        {
+          "id": "net-ui-4",
+          "terminals": [
+            {
+              "instanceId": "Q3",
+              "pinName": "E"
+            },
+            {
+              "instanceId": "R4",
+              "pinName": "1"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-8",
+          "terminals": [
+            {
+              "instanceId": "R1",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "Q1",
+              "pinName": "C"
+            },
+            {
+              "instanceId": "Q2",
+              "pinName": "B"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-9",
+          "terminals": [
+            {
+              "instanceId": "Q1",
+              "pinName": "E"
+            },
+            {
+              "instanceId": "R6",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "R4",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "Q5",
+              "pinName": "E"
+            },
+            {
+              "instanceId": "Q2",
+              "pinName": "E"
+            },
+            {
+              "instanceId": "Q6",
+              "pinName": "E"
+            },
+            {
+              "instanceId": "GND1",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "B"
+            }
+          ]
+        },
+        {
+          "id": "net-split-cfc8a56233ad32f7",
+          "terminals": [
+            {
+              "instanceId": "R7",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "R5",
+              "pinName": "1"
+            }
+          ]
+        },
+        {
+          "id": "net-split-347ebb07a2a7a37b",
+          "terminals": [
+            {
+              "instanceId": "M3",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "VDD1",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M6",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M7",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M8",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M6",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M7",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M8",
+              "pinName": "B"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-22",
+          "terminals": [
+            {
+              "instanceId": "Q4",
+              "pinName": "C"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M6",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M7",
+              "pinName": "D"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-27",
+          "terminals": [
+            {
+              "instanceId": "Q4",
+              "pinName": "E"
+            },
+            {
+              "instanceId": "Q5",
+              "pinName": "C"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-38",
+          "terminals": [
+            {
+              "instanceId": "R6",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "R5",
+              "pinName": "2"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-46",
+          "terminals": [
+            {
+              "instanceId": "M4",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "Q6",
+              "pinName": "C"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "G"
+            }
+          ]
+        },
+        {
+          "id": "net-665f4cbe40f8c964",
+          "terminals": [
+            {
+              "instanceId": "M6",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M7",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M8",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "Q3",
+              "pinName": "C"
+            }
+          ]
+        },
+        {
+          "id": "net-split-3f52b798550ad130",
+          "terminals": [
+            {
+              "instanceId": "R1",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "R2",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "Q1",
+              "pinName": "B"
+            }
+          ]
+        },
+        {
+          "id": "net-split-7bc3714d88068ee2",
+          "terminals": [
+            {
+              "instanceId": "R3",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "Q5",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "Q2",
+              "pinName": "C"
+            },
+            {
+              "instanceId": "Q6",
+              "pinName": "B"
+            }
+          ]
+        },
+        {
+          "id": "net-split-d5a4be795e522687",
+          "terminals": [
+            {
+              "instanceId": "R2",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "Q3",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "R3",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "Q4",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "R7",
+              "pinName": "2"
+            }
+          ]
+        }
+      ],
+      "noConnects": [],
+      "presentation": {
+        "compactness": "normal",
+        "grid": 10,
+        "styleProfileId": "razavi-textbook-v1"
+      },
+      "revision": 223,
+      "routes": [
+        {
+          "id": "route-ui-1-part-2-a-44",
+          "legs": [
+            {
+              "id": "route-leg-750b4db10a8ae493",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-44",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-347ebb07a2a7a37b",
+          "start": {
+            "instanceId": "VDD1",
+            "kind": "terminal",
+            "pinName": "P"
+          }
+        },
+        {
+          "id": "route-ui-1-part-2-b-44",
+          "legs": [
+            {
+              "id": "route-leg-750b4cb10a8ae2e0",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-lifecycle-6-1",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-347ebb07a2a7a37b",
+          "start": {
+            "junctionId": "junction-ui-44",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-3-a-64",
+          "legs": [
+            {
+              "id": "route-leg-950eb45aec291af5",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-64",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-665f4cbe40f8c964",
+          "start": {
+            "junctionId": "junction-lifecycle-7-2",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-3-b-64",
+          "legs": [
+            {
+              "id": "route-leg-fd0c92bf36a6bb8a",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "Q3",
+                  "kind": "terminal",
+                  "pinName": "C"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-665f4cbe40f8c964",
+          "start": {
+            "junctionId": "junction-ui-64",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-4",
+          "legs": [
+            {
+              "id": "route-leg-c70356568efe97cc",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "R4",
+                  "kind": "terminal",
+                  "pinName": "1"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-4",
+          "start": {
+            "instanceId": "Q3",
+            "kind": "terminal",
+            "pinName": "E"
+          }
+        },
+        {
+          "id": "route-ui-5-a-6-a-66",
+          "legs": [
+            {
+              "id": "route-leg-b425448e843180bb",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-66",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-3f52b798550ad130",
+          "start": {
+            "instanceId": "R2",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-ui-5-a-6-b-66",
+          "legs": [
+            {
+              "id": "route-leg-d905a668dc090dd7",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-6",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-3f52b798550ad130",
+          "start": {
+            "junctionId": "junction-ui-66",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-7",
+          "legs": [
+            {
+              "id": "route-leg-9a9de466acb079d9",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-feb42ed1925487f0",
+                "kind": "bend",
+                "position": {
+                  "x": 210,
+                  "y": 330
+                }
+              }
+            },
+            {
+              "id": "route-leg-9a9de366acb07826",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-6",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-3f52b798550ad130",
+          "start": {
+            "instanceId": "Q1",
+            "kind": "terminal",
+            "pinName": "B"
+          }
+        },
+        {
+          "id": "route-ui-8",
+          "legs": [
+            {
+              "id": "route-leg-05662e849956eae0",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "Q1",
+                  "kind": "terminal",
+                  "pinName": "C"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-8",
+          "start": {
+            "instanceId": "R1",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-ui-10",
+          "legs": [
+            {
+              "id": "route-leg-88ad879b5c4f380c",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-0004ae134170008c",
+                "kind": "bend",
+                "position": {
+                  "x": 250,
+                  "y": 390
+                }
+              }
+            },
+            {
+              "id": "route-leg-f27a93f500e6587b",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "R1",
+                  "kind": "terminal",
+                  "pinName": "2"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-8",
+          "start": {
+            "instanceId": "Q2",
+            "kind": "terminal",
+            "pinName": "B"
+          }
+        },
+        {
+          "id": "route-ui-11-a-28-a-68",
+          "legs": [
+            {
+              "id": "route-leg-7b236d7d1bc58ffb",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-68",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-7bc3714d88068ee2",
+          "start": {
+            "instanceId": "Q2",
+            "kind": "terminal",
+            "pinName": "C"
+          }
+        },
+        {
+          "id": "route-ui-11-a-28-b-68",
+          "legs": [
+            {
+              "id": "route-leg-3433512fb65c8f67",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-28",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-7bc3714d88068ee2",
+          "start": {
+            "junctionId": "junction-ui-68",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-c79afa04fa904c82",
+          "legs": [
+            {
+              "id": "route-leg-475f30ea18231e1e",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "R7",
+                  "kind": "terminal",
+                  "pinName": "1"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-cfc8a56233ad32f7",
+          "start": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-ui-24-a-25",
+          "legs": [
+            {
+              "id": "route-leg-92d7673fc0ab7623",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-25",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-22",
+          "start": {
+            "junctionId": "junction-ui-23",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-24-b-25",
+          "legs": [
+            {
+              "id": "route-leg-3c41290ee68fcf73",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "Q4",
+                  "kind": "terminal",
+                  "pinName": "C"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-22",
+          "start": {
+            "junctionId": "junction-ui-25",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-26",
+          "legs": [
+            {
+              "id": "route-leg-64fa87174ce40741",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-25",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-22",
+          "start": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "G"
+          }
+        },
+        {
+          "id": "route-ui-29-a-31",
+          "legs": [
+            {
+              "id": "route-leg-ab4549138c00fbf8",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-31",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-7bc3714d88068ee2",
+          "start": {
+            "instanceId": "Q5",
+            "kind": "terminal",
+            "pinName": "B"
+          }
+        },
+        {
+          "id": "route-ui-29-b-31",
+          "legs": [
+            {
+              "id": "route-leg-def48e4003db2773",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-28",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-7bc3714d88068ee2",
+          "start": {
+            "junctionId": "junction-ui-31",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-30",
+          "legs": [
+            {
+              "id": "route-leg-c45e0a2ff0d6df32",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "Q5",
+                  "kind": "terminal",
+                  "pinName": "C"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-27",
+          "start": {
+            "instanceId": "Q4",
+            "kind": "terminal",
+            "pinName": "E"
+          }
+        },
+        {
+          "id": "route-ui-32-part-1",
+          "legs": [
+            {
+              "id": "route-leg-bffe5405fd10890b",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "Q5",
+                  "kind": "terminal",
+                  "pinName": "B"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-7bc3714d88068ee2",
+          "start": {
+            "instanceId": "Q6",
+            "kind": "terminal",
+            "pinName": "B"
+          }
+        },
+        {
+          "id": "route-ui-32-part-2",
+          "legs": [
+            {
+              "id": "route-leg-df971e4052f3dbaa",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-31",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-7bc3714d88068ee2",
+          "start": {
+            "instanceId": "Q5",
+            "kind": "terminal",
+            "pinName": "B"
+          }
+        },
+        {
+          "id": "route-ui-37",
+          "legs": [
+            {
+              "id": "route-leg-982f18400eb72a2f",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-982f18400eb72a2f",
+                "kind": "bend",
+                "position": {
+                  "x": 90,
+                  "y": 190
+                }
+              }
+            },
+            {
+              "id": "route-leg-982f17400eb7287c",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "R5",
+                  "kind": "terminal",
+                  "pinName": "1"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-cfc8a56233ad32f7",
+          "start": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-ui-38",
+          "legs": [
+            {
+              "id": "route-leg-29c501f3b057da4a",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "R5",
+                  "kind": "terminal",
+                  "pinName": "2"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-38",
+          "start": {
+            "instanceId": "R6",
+            "kind": "terminal",
+            "pinName": "1"
+          }
+        },
+        {
+          "id": "route-ui-45",
+          "legs": [
+            {
+              "id": "route-leg-facd6fec39c517d2",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-facd6fec39c517d2",
+                "kind": "bend",
+                "position": {
+                  "x": 510,
+                  "y": 80
+                }
+              }
+            },
+            {
+              "id": "route-leg-facd70ec39c51985",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-44",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-347ebb07a2a7a37b",
+          "start": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-ui-46-a-47",
+          "legs": [
+            {
+              "id": "route-leg-d5e0ae08199e5633",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-47",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-46",
+          "start": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-46-b-47",
+          "legs": [
+            {
+              "id": "route-leg-925974eaea0ca3e3",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "Q6",
+                  "kind": "terminal",
+                  "pinName": "C"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-46",
+          "start": {
+            "junctionId": "junction-ui-47",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-48",
+          "legs": [
+            {
+              "id": "route-leg-18901dee78451105",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-18901dee78451105",
+                "kind": "bend",
+                "position": {
+                  "x": 470,
+                  "y": 140
+                }
+              }
+            },
+            {
+              "id": "route-leg-18901cee78450f52",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-18901cee78450f52",
+                "kind": "bend",
+                "position": {
+                  "x": 470,
+                  "y": 170
+                }
+              }
+            },
+            {
+              "id": "route-leg-18901bee78450d9f",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-47",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-46",
+          "start": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "G"
+          }
+        },
+        {
+          "id": "route-ui-55-a-56-a-61",
+          "legs": [
+            {
+              "id": "route-leg-37388f169da32ca3",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-f5aad031b0ad266f",
+                "kind": "bend",
+                "position": {
+                  "x": 160,
+                  "y": 80
+                }
+              }
+            },
+            {
+              "id": "route-leg-55d4a79e0e42dfb3",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-02feea4ff1093f10",
+                "kind": "bend",
+                "position": {
+                  "x": 290,
+                  "y": 80
+                }
+              }
+            },
+            {
+              "id": "route-leg-18ea7861e813328d",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-61",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-347ebb07a2a7a37b",
+          "start": {
+            "instanceId": "M8",
+            "kind": "terminal",
+            "pinName": "S"
+          }
+        },
+        {
+          "id": "route-ui-55-a-56-b-61",
+          "legs": [
+            {
+              "id": "route-leg-7180e9a95f496435",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-56",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-347ebb07a2a7a37b",
+          "start": {
+            "junctionId": "junction-ui-61",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-55-b-56",
+          "legs": [
+            {
+              "id": "route-leg-70cf59ca08a55565",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "VDD1",
+                  "kind": "terminal",
+                  "pinName": "P"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-347ebb07a2a7a37b",
+          "start": {
+            "junctionId": "junction-ui-56",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-60-a-63",
+          "legs": [
+            {
+              "id": "route-leg-9890702521a80313",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-63",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-665f4cbe40f8c964",
+          "start": {
+            "instanceId": "M8",
+            "kind": "terminal",
+            "pinName": "G"
+          }
+        },
+        {
+          "id": "route-ui-60-b-63",
+          "legs": [
+            {
+              "id": "route-leg-d8ea98dcf9aa19d1",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "M7",
+                  "kind": "terminal",
+                  "pinName": "G"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-665f4cbe40f8c964",
+          "start": {
+            "junctionId": "junction-ui-63",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-62",
+          "legs": [
+            {
+              "id": "route-leg-6ab30ffcaddfbab1",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-61",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-347ebb07a2a7a37b",
+          "start": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "D"
+          }
+        },
+        {
+          "id": "route-ui-65",
+          "legs": [
+            {
+              "id": "route-leg-4f3851def64e6850",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-4f3851def64e6850",
+                "kind": "bend",
+                "position": {
+                  "x": 200,
+                  "y": 110
+                }
+              }
+            },
+            {
+              "id": "route-leg-4f3852def64e6a03",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-4f3852def64e6a03",
+                "kind": "bend",
+                "position": {
+                  "x": 200,
+                  "y": 140
+                }
+              }
+            },
+            {
+              "id": "route-leg-4f3853def64e6bb6",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-64",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-665f4cbe40f8c964",
+          "start": {
+            "junctionId": "junction-ui-63",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-67",
+          "legs": [
+            {
+              "id": "route-leg-5c290a514192334e",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-66",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-3f52b798550ad130",
+          "start": {
+            "instanceId": "R1",
+            "kind": "terminal",
+            "pinName": "1"
+          }
+        },
+        {
+          "id": "route-ui-69",
+          "legs": [
+            {
+              "id": "route-leg-10d579b0ebf6153c",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-68",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-7bc3714d88068ee2",
+          "start": {
+            "instanceId": "R3",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-ui-12-b-13-a-15-a-17-a-71",
+          "legs": [
+            {
+              "id": "route-leg-45feb8b4fda98ecd",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-71",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-d5a4be795e522687",
+          "start": {
+            "instanceId": "Q3",
+            "kind": "terminal",
+            "pinName": "B"
+          }
+        },
+        {
+          "id": "route-ui-12-b-13-a-15-a-17-b-71",
+          "legs": [
+            {
+              "id": "route-leg-0d450afedeb26180",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-canonical-26b3e229ab18ddac",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-d5a4be795e522687",
+          "start": {
+            "junctionId": "junction-ui-71",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-18",
+          "legs": [
+            {
+              "id": "route-leg-2193afd79b5cded4",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-canonical-26b3e229ab18ddac",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-d5a4be795e522687",
+          "start": {
+            "instanceId": "R7",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-canonical-394415e236142c61",
+          "legs": [
+            {
+              "id": "route-leg-dc4da67cec027905",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-canonical-917290ea9bdea8de",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-d5a4be795e522687",
+          "start": {
+            "junctionId": "junction-canonical-26b3e229ab18ddac",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-12-a-13",
+          "legs": [
+            {
+              "id": "route-leg-45feb7b4fda98d1a",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "R3",
+                  "kind": "terminal",
+                  "pinName": "1"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-d5a4be795e522687",
+          "start": {
+            "junctionId": "junction-canonical-917290ea9bdea8de",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-14",
+          "legs": [
+            {
+              "id": "route-leg-2c77578d26288638",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "Q4",
+                  "kind": "terminal",
+                  "pinName": "B"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-d5a4be795e522687",
+          "start": {
+            "junctionId": "junction-canonical-917290ea9bdea8de",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-72",
+          "legs": [
+            {
+              "id": "route-leg-c0381572938fc358",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-71",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-split-d5a4be795e522687",
+          "start": {
+            "instanceId": "R2",
+            "kind": "terminal",
+            "pinName": "1"
+          }
+        },
+        {
+          "id": "route-ui-9-a-33-b-39-b-contact-gnd1-0",
+          "legs": [
+            {
+              "id": "route-leg-e83a0ca09b39187b",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-canonical-c68e1be232efda00",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-9",
+          "start": {
+            "instanceId": "GND1",
+            "kind": "terminal",
+            "pinName": "0"
+          }
+        },
+        {
+          "id": "route-ui-9-b-33",
+          "legs": [
+            {
+              "id": "route-leg-477b9ebf02b6bc25",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-canonical-c68e1be232efda00",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-9",
+          "start": {
+            "instanceId": "Q2",
+            "kind": "terminal",
+            "pinName": "E"
+          }
+        },
+        {
+          "id": "route-ui-34-b-35",
+          "legs": [
+            {
+              "id": "route-leg-c36f9d9c8ece088d",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-canonical-30f573ca3fd936af",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-9",
+          "start": {
+            "junctionId": "junction-canonical-c68e1be232efda00",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-52",
+          "legs": [
+            {
+              "id": "route-leg-fc842942befef15e",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-canonical-30f573ca3fd936af",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-9",
+          "start": {
+            "instanceId": "Q5",
+            "kind": "terminal",
+            "pinName": "E"
+          }
+        },
+        {
+          "id": "route-ui-36-b-51",
+          "legs": [
+            {
+              "id": "route-leg-9b045310e0acb28d",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-609ef8b898f22461",
+                "kind": "bend",
+                "position": {
+                  "x": 510,
+                  "y": 470
+                }
+              }
+            },
+            {
+              "id": "route-leg-4aea0aa6a216d034",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "Q6",
+                  "kind": "terminal",
+                  "pinName": "E"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-9",
+          "start": {
+            "junctionId": "junction-canonical-30f573ca3fd936af",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-42",
+          "legs": [
+            {
+              "id": "route-leg-d0517dfc5916f74f",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-canonical-80c748947814cceb",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-9",
+          "start": {
+            "instanceId": "R4",
+            "kind": "terminal",
+            "pinName": "2"
+          }
+        },
+        {
+          "id": "route-ui-9-a-33-a-39-a-73",
+          "legs": [
+            {
+              "id": "route-leg-477b9cbf02b6b8bf",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "junctionId": "junction-ui-73",
+                  "kind": "junction"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-9",
+          "start": {
+            "junctionId": "junction-canonical-80c748947814cceb",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-9-a-33-a-39-b-73",
+          "legs": [
+            {
+              "id": "route-leg-667c6366c97bb022",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "Q1",
+                  "kind": "terminal",
+                  "pinName": "E"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-9",
+          "start": {
+            "junctionId": "junction-ui-73",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-40-a-41",
+          "legs": [
+            {
+              "id": "route-leg-a2741dd3e54eaeed",
+              "mode": "manual",
+              "to": {
+                "bendId": "route-bend-c8597c54b4849ab4",
+                "kind": "bend",
+                "position": {
+                  "x": 90,
+                  "y": 470
+                }
+              }
+            },
+            {
+              "id": "route-leg-a2741cd3e54ead3a",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "R6",
+                  "kind": "terminal",
+                  "pinName": "2"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-9",
+          "start": {
+            "junctionId": "junction-canonical-80c748947814cceb",
+            "kind": "junction"
+          }
+        },
+        {
+          "id": "route-ui-74",
+          "legs": [
+            {
+              "id": "route-leg-d80c759a699f35ba",
+              "mode": "manual",
+              "to": {
+                "endpoint": {
+                  "instanceId": "GND1",
+                  "kind": "terminal",
+                  "pinName": "0"
+                },
+                "kind": "endpoint"
+              }
+            }
+          ],
+          "netId": "net-ui-9",
+          "start": {
+            "junctionId": "junction-ui-73",
+            "kind": "junction"
+          }
+        }
+      ],
+      "sourceStatus": "connectivity-modified"
+    }
+  ],
+  "externalSubcircuitDefinitions": [],
+  "id": "project-main",
+  "name": "LTC3452",
+  "schemaVersion": 32,
+  "source": {
+    "dialect": "none",
+    "entry": null,
+    "files": [],
+    "sourcePolicy": "copy"
+  },
+  "structureRevision": 0,
+  "symbolLibrary": {
+    "hash": "razavi-reference-v1",
+    "id": "razavi-symbols",
+    "version": "1"
+  },
+  "topDocumentId": "document-main"
+}

--- a/packages/edit-engine/src/conductor-topology-redline.test.ts
+++ b/packages/edit-engine/src/conductor-topology-redline.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The red line over real published circuits: same-Net conductor
+ * canonicalization must never change terminal connectivity. The fixtures are
+ * snapshots of Gallery documents users actually drew — including the exact
+ * pathologies from the wire-handling feedback — so a failure here means
+ * canonicalization altered real users' circuits, not a synthetic case.
+ *
+ * fixtures/gallery-redline/README.md documents the corpus and its refresh
+ * procedure. Healing statistics are deliberately NOT asserted: they drift as
+ * users draw; the invariant does not.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { parseProject } from "@icm/project-protocol";
+import { deriveElectricalTopologyProjection } from "@icm/derived";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { normalizeSameNetConductorTopology } from "./conductor-topology.js";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+const CORPUS = resolve(process.cwd(), "fixtures/gallery-redline");
+
+describe("conductor canonicalization red line over the gallery corpus", () => {
+  const files = readdirSync(CORPUS).filter((name) =>
+    name.endsWith(".icproj.json"),
+  );
+
+  it("covers the documented corpus", () => {
+    expect(files.length).toBeGreaterThanOrEqual(6);
+    expect(files).toContain("ycg43babwa.icproj.json");
+  });
+
+  it.each(files)("%s: terminal connectivity survives", (file) => {
+    const project = parseProject(readFileSync(resolve(CORPUS, file), "utf8"));
+    for (const document of project.documents) {
+      const before = deriveElectricalTopologyProjection(document, resolver);
+      const beforeNetIds = new Set(document.nets.map((net) => net.id));
+      const result = normalizeSameNetConductorTopology(document, resolver);
+      const after = deriveElectricalTopologyProjection(document, resolver);
+
+      const violations: string[] = [];
+      for (const [key, netId] of before.endpointToBaseNet) {
+        const afterNet = after.endpointToBaseNet.get(key);
+        if (afterNet === netId) continue;
+        // A junction endpoint may vanish, but only when the normalizer
+        // itself reported it coalesced onto that very Net — a degree-two
+        // anchor folding into the conductor it already belonged to.
+        if (
+          afterNet === undefined &&
+          result.coalescedEndpoints.get(key) === netId
+        ) {
+          continue;
+        }
+        violations.push(
+          `${document.id} ${key}: ${netId} -> ${afterNet ?? "gone"}`,
+        );
+      }
+      for (const [key, netId] of after.endpointToBaseNet) {
+        if (before.endpointToBaseNet.has(key)) continue;
+        // Branch-vertex materialization is the pass's own documented
+        // behavior: where a same-Net vertex rests on another conductor, an
+        // explicit junction-canonical-* anchor appears ON AN EXISTING NET.
+        // That is structure, not an electrical change — do NOT "fix" this
+        // admission away, or every materialized T-vertex becomes a false
+        // connectivity alarm (it did, on this criterion's first draft).
+        if (
+          key.startsWith("junction:junction-canonical-") &&
+          beforeNetIds.has(netId)
+        ) {
+          continue;
+        }
+        violations.push(`${document.id} endpoint appeared: ${key} on ${netId}`);
+      }
+
+      expect(
+        violations,
+        `Canonicalization altered real users' circuits (${file}). ` +
+          "Terminal connectivity must be identical before and after " +
+          "normalizeSameNetConductorTopology; see fixtures/gallery-redline/README.md.",
+      ).toEqual([]);
+    }
+  });
+});

--- a/scripts/refresh-gallery-redline.mjs
+++ b/scripts/refresh-gallery-redline.mjs
@@ -1,0 +1,36 @@
+// Re-fetch the gallery red-line corpus snapshots (fixtures/gallery-redline/).
+// See that directory's README for what the corpus is and why these six ids.
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const BASE = "https://analog-canvas.tokenzhang.com/api/gallery";
+const IDS = [
+  "ycg43babwa",
+  "3tfmrzevfe",
+  "b5cn37k3a9",
+  "2rmm2vb45f",
+  "7sxpwb4am7",
+  "f22q5vhdb5",
+];
+
+const out = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "fixtures",
+  "gallery-redline",
+);
+await mkdir(out, { recursive: true });
+for (const id of IDS) {
+  const response = await fetch(`${BASE}/${id}`, {
+    headers: { "user-agent": "icm-redline-corpus-refresh" },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `${id}: HTTP ${response.status} — see fixtures/gallery-redline/README.md before swapping ids`,
+    );
+  }
+  const payload = await response.json();
+  await writeFile(join(out, `${id}.icproj.json`), payload.projectText);
+  console.log(`refreshed ${id} (${payload.entry?.name ?? "?"})`);
+}


### PR DESCRIPTION
Adopts the corpus measurement harness as a standing guard. Its whole job is one invariant: **same-Net conductor canonicalization must never change terminal connectivity** — a failure means canonicalization altered real users' circuits.

## The measurement this fossilizes (record, deliberately NOT asserted)

Run over all 119 published gallery entries (120 documents) on 2026-08-31:

- **Red line held everywhere**: terminal connectivity bit-identical before/after `normalizeSameNetConductorTopology` in all 120 documents.
- **59/120 documents (49%) change** under canonicalization — half the published wall carried stroke-history debris.
- Routes 2256 → 2131 (**125 redundant routes unified**), 89 degree-two junction endpoints coalesced.
- Findings healed: `VISUAL_ROUTE_OVERLAP` **54 of 64** (the exact class the wire-handling feedback quoted), `VISUAL_WIRE_THROUGH_SYMBOL` 14, `VISUAL_TERMINAL_DEPARTURE` 9.
- Remaining classes are precisely what normalization should not touch: layout findings, unfinished circuits' honest ERC, and 5 real cross-net `VISUAL_AMBIGUOUS_JUNCTION` alarms.

Healing counts drift as users draw, so they live here as the record of what this week's chain (#432/#433) achieved — the committed test asserts only the invariant.

## What lands

- [conductor-topology-redline.test.ts](packages/edit-engine/src/conductor-topology-redline.test.ts) — per-fixture, per-document red-line assertion, 44ms test body. The criterion admits exactly one structural difference, with the reason in a comment so nobody "fixes" it back into a false alarm: a junction endpoint may vanish only when the normalizer reported it coalesced onto its own Net, and a new endpoint may appear only as a `junction-canonical-*` branch vertex materialized on an existing Net. (The criterion's first draft flagged 18 such materializations as connectivity violations before each was traced to the pass's documented behavior.)
- [fixtures/gallery-redline/](fixtures/gallery-redline/README.md) — a six-document snapshot (~410KB, no network in tests), chosen for pathology and coverage and documented per entry: LTC3452 (the original feedback pathology), deadtime (heaviest branch-vertex materialization), widlar (mixed coalesce/materialize), a SPICE-import demo (importer-produced geometry), a multi-document project (hierarchy), and one unchanged control (guarding against a pass that "always finds something").
- [scripts/refresh-gallery-redline.mjs](scripts/refresh-gallery-redline.mjs) — re-pulls exactly these ids and rewrites the fixtures; the smoke run reproduced the snapshot **byte-identically**.

## Validation

Corpus test 7/7 at 44ms, full unit suite 1952/1952, e2e 296/296, typecheck, prettier, `pnpm test:impact`, full `pnpm ci:check` under the gate-slot lock.

Related to #432, #433, and the wire-segmentation feedback assessment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
