### PR TITLE
fix(editor): near-miss hint only names pins the symbol shows

### DIFF
--- a/apps/editor/src/features/component-insert/placement-near-miss.test.ts
+++ b/apps/editor/src/features/component-insert/placement-near-miss.test.ts
@@ -151,4 +151,23 @@ describe("placement near misses", () => {
       findPlacementNearMisses(document, resolver, resistorAt(300, 330)),
     ).toEqual([]);
   });
+
+  it("never hints about a pin the symbol hides", () => {
+    // A three-terminal NMOS hides its bulk pin B. At (280,310) against the
+    // wire at y=300, hidden B (300,310) and visible G (260,310) and D
+    // (290,290) are all exactly one grid away: the hint may name the pins a
+    // person can see, and must not name the one they cannot.
+    const document = documentWithWire();
+    const mos = {
+      id: "M9",
+      symbolId: "nmos",
+      symbolVariantId: "textbook-3terminal",
+      placement: { position: { x: 280, y: 310 }, rotation: 0, mirror: "none" },
+    } as Instance;
+    const misses = findPlacementNearMisses(document, resolver, mos);
+    const pinNames = misses.map((miss) => miss.pinName);
+    expect(pinNames).toContain("G");
+    expect(pinNames).toContain("D");
+    expect(pinNames).not.toContain("B");
+  });
 });

--- a/apps/editor/src/features/component-insert/placement-near-miss.ts
+++ b/apps/editor/src/features/component-insert/placement-near-miss.ts
@@ -74,6 +74,16 @@ export function findPlacementNearMisses(
 
   const misses: PlacementNearMiss[] = [];
   for (const pin of resolved.definition.pins) {
+    // The hint names pins a person can point at. A variant-hidden or
+    // implicit pin is not drawn, so "pin B is 1 grid from a wire" would
+    // describe something invisible — same visibility rule as placement
+    // contact resolution.
+    if (
+      resolved.variant?.hiddenPinNames.includes(pin.name) ||
+      pin.presentation.visibility === "implicit"
+    ) {
+      continue;
+    }
     const at = transformPoint(
       pin.at,
       instance.placement.position,


### PR DESCRIPTION
Follow-through on the observation recorded during the #439 takeover review: the near-miss hint iterated every definition pin, so a variant-hidden pin — a three-terminal NMOS's bulk **B** one grid from a wire — could produce a hint naming a pin the person cannot see. Left to the original author then; adopted now that the work is reassigned.

## Change

One filter in [placement-near-miss.ts](apps/editor/src/features/component-insert/placement-near-miss.ts), reusing the exact visibility rule placement contact resolution already applies (`variant.hiddenPinNames` + `presentation.visibility === "implicit"`), with the reason in a comment: the hint names pins a person can point at.

## Test (red-first)

A three-terminal NMOS placed so hidden **B** and visible **G**/**D** are all exactly one grid from the wire: the hint must name G and D and stay silent about B — before the filter it named B. The #439 states (one-grid hint, on-wire attach, far-away silence) keep their existing guards.

Validation: near-miss suite 9/9, full unit 1953/1953, e2e 296/296, typecheck, prettier, `pnpm ci:check` under the gate lock.

Related to #439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)