### PR TITLE
fix(editor): placement reference allocation avoids visible designators

### DIFF
--- a/apps/editor/src/features/component-insert/placement-reference-allocation.test.ts
+++ b/apps/editor/src/features/component-insert/placement-reference-allocation.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Issue #394: "Transaction result failed Document validation" while placing
+ * an nmos.
+ *
+ * Placement assembles a new Instance with
+ * `schematicReference: netlist?.reference ?? id`, where `netlist.reference`
+ * comes from nextReference() — an allocator that only avoids the
+ * netlist.reference domain. The document-level schema additionally requires
+ * schematicReference to be unique across instances (case-insensitively).
+ * Ordinary edits can part the two domains: `set_instance_schematic_reference`
+ * renames only the visible designator, leaving netlist.reference behind.
+ * After that, the lowest free netlist reference can equal an occupied
+ * schematicReference, and every subsequent placement of that prefix assembles
+ * a duplicate — rejected at commit as INVALID_RESULT with
+ * "Duplicate schematic instance reference: <ref>". The user-visible headline
+ * is exactly the screenshot in #394, and it recurs on every retry.
+ *
+ * RED until placement allocation respects both reference domains.
+ */
+import { executeTransaction } from "@icm/edit-engine";
+import type { SchematicEdit } from "@icm/edit-engine";
+import { createEmptyDocument } from "@icm/model";
+import type { Instance, SchematicDocument } from "@icm/model";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import {
+  initialInstanceNetlist,
+  nextInstanceDesignator,
+} from "../netlist-export/netlist-authoring";
+import { defaultRazaviSymbolVariantId } from "../../presentation/razavi-presentation";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+let transactionCounter = 0;
+function transact(
+  document: SchematicDocument,
+  edits: SchematicEdit[],
+): SchematicDocument {
+  const result = executeTransaction(
+    document,
+    {
+      transactionId: `ref-alloc-${transactionCounter++}`,
+      documentId: document.id,
+      expectedRevision: document.revision,
+      actor: { kind: "human", id: "test" },
+      edits,
+    },
+    { symbolResolver: resolver },
+  );
+  if (!result.ok) {
+    throw new Error(
+      `setup transaction failed: ${result.error.message} :: ${
+        result.diagnostics[0]?.message ?? ""
+      }`,
+    );
+  }
+  return result.document;
+}
+
+/** The exact assembly placeNewComponent performs for a plain symbol click. */
+function assemblePlacedNmos(
+  document: SchematicDocument,
+  x: number,
+  y: number,
+): Instance {
+  const id = nextInstanceDesignator(document, "nmos");
+  const symbolVariantId = defaultRazaviSymbolVariantId("nmos");
+  const netlist = initialInstanceNetlist(document, "nmos", {}, undefined);
+  return {
+    id,
+    symbolId: "nmos",
+    schematicReference: netlist?.reference ?? id,
+    ...(symbolVariantId ? { symbolVariantId } : {}),
+    placement: { position: { x, y }, rotation: 0, mirror: "none" },
+    ...(netlist ? { netlist } : {}),
+  } as Instance;
+}
+
+describe("placement reference allocation", () => {
+  it("places an nmos after delete + rename move a designator between domains (#394)", () => {
+    let document = createEmptyDocument("issue-394", "Issue 394");
+
+    // Place two nmos the way the GUI does: M1, then M2.
+    const m1 = assemblePlacedNmos(document, 100, 100);
+    document = transact(document, [{ kind: "add_instance", instance: m1 }]);
+    const m2 = assemblePlacedNmos(document, 200, 100);
+    document = transact(document, [{ kind: "add_instance", instance: m2 }]);
+    expect([m1.id, m2.id]).toEqual(["M1", "M2"]);
+
+    // Delete M1, then rename M2's visible designator to the vacated "M1".
+    // Both edits succeed — the document stays valid throughout.
+    document = transact(document, [
+      { kind: "remove_instance", instanceId: "M1" },
+    ]);
+    document = transact(document, [
+      {
+        kind: "set_instance_schematic_reference",
+        instanceId: "M2",
+        reference: "M1",
+      },
+    ]);
+
+    // Place another nmos. The allocator hands out netlist reference "M1"
+    // (free in its own domain), placement promotes it to schematicReference,
+    // and the commit is refused: "Transaction result failed Document
+    // validation — Duplicate schematic instance reference: M1". A plain
+    // placement on a valid document must commit instead.
+    const next = assemblePlacedNmos(document, 300, 100);
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "ref-alloc-final",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: [{ kind: "add_instance", instance: next }],
+      },
+      { symbolResolver: resolver },
+    );
+
+    expect(
+      result.ok,
+      `placement was refused: ${!result.ok ? result.diagnostics[0]?.message : ""}`,
+    ).toBe(true);
+  });
+});

--- a/apps/editor/src/features/component-insert/placement-reference-allocation.test.ts
+++ b/apps/editor/src/features/component-insert/placement-reference-allocation.test.ts
@@ -124,4 +124,40 @@ describe("placement reference allocation", () => {
       `placement was refused: ${!result.ok ? result.diagnostics[0]?.message : ""}`,
     ).toBe(true);
   });
+
+  it("places an nmos after a rename alone parts the domains — no delete needed", () => {
+    let document = createEmptyDocument("issue-394-rename", "Issue 394 rename");
+
+    // Place M1, then rename its visible designator to "M2". The rename is
+    // valid — no other instance shows M2 — but netlist.reference stays "M1",
+    // so the allocator's lowest free netlist reference is now "M2": exactly
+    // the designator the canvas already shows.
+    const m1 = assemblePlacedNmos(document, 100, 100);
+    document = transact(document, [{ kind: "add_instance", instance: m1 }]);
+    document = transact(document, [
+      {
+        kind: "set_instance_schematic_reference",
+        instanceId: "M1",
+        reference: "M2",
+      },
+    ]);
+
+    const next = assemblePlacedNmos(document, 200, 100);
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "ref-alloc-rename-final",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: [{ kind: "add_instance", instance: next }],
+      },
+      { symbolResolver: resolver },
+    );
+
+    expect(
+      result.ok,
+      `placement was refused: ${!result.ok ? result.diagnostics[0]?.message : ""}`,
+    ).toBe(true);
+  });
 });

--- a/apps/editor/src/features/netlist-export/netlist-authoring.ts
+++ b/apps/editor/src/features/netlist-export/netlist-authoring.ts
@@ -109,6 +109,26 @@ function defaultBinding(symbolId: string): InstanceNetlistBinding | undefined {
   return undefined;
 }
 
+/**
+ * Designators already visible on the canvas: every instance id and schematic
+ * reference, case-folded. The reference index consults only the
+ * netlist.reference domain, but a freshly allocated reference is promoted to
+ * the placed instance's schematicReference — which the Document schema
+ * requires to be unique across instances. A rename can part the two domains
+ * (schematicReference moves, netlist.reference stays), so allocation must
+ * avoid the visible domains too, exactly as nextInstanceDesignator does.
+ */
+function reservedVisibleReferences(document: SchematicDocument): Set<string> {
+  const reserved = new Set<string>();
+  for (const instance of document.instances) {
+    reserved.add(instance.id.toLowerCase());
+    if (instance.schematicReference) {
+      reserved.add(instance.schematicReference.toLowerCase());
+    }
+  }
+  return reserved;
+}
+
 export function initialInstanceNetlist(
   document: SchematicDocument,
   symbolId: string,
@@ -120,7 +140,10 @@ export function initialInstanceNetlist(
   const binding = defaultBinding(symbolId);
   return {
     reference:
-      reference ?? nextReference(createReferenceIndex(document), policy)!,
+      reference ??
+      nextReference(createReferenceIndex(document), policy, {
+        reservedReferences: reservedVisibleReferences(document),
+      })!,
     ...(binding ? { binding } : {}),
     parameters: rawParameters(parameterValues),
   };


### PR DESCRIPTION
Related to #394. Do not auto-close: the issue stays open for the reporter.

## The user-visible symptom

After certain designator renames, **every subsequent nmos placement was refused** with `Transaction result failed Document validation` — the exact headline in the #394 screenshot — and kept being refused on every retry. Minimal recipe, all ordinary GUI steps: place an NMOS (M1), rename it to M2 in the properties panel, place another NMOS. Refused, forever.

## Root cause

Placement assembles `schematicReference: netlist.reference ?? id`. The netlist reference comes from `nextReference()`, whose allocation loop consults only the netlist.reference domain — but the Document schema requires `schematicReference` uniqueness across instances (case-insensitive). `set_instance_schematic_reference` renames only the visible designator, so the two domains diverge; after that, the allocator's lowest free netlist reference can equal a designator already shown on the canvas. Placement promotes it, and the commit dies as `INVALID_RESULT` with `Duplicate schematic instance reference: <ref>`.

Entered with the 2026-08-21 reference-unification commit (`911d86b2`, "feat(protocol): unify schematic references and port lifecycle"), which introduced both the promotion and the rename edit. Issue filed 2026-08-29.

## The fix

`initialInstanceNetlist` now passes every instance id and schematicReference (case-folded) into `nextReference`'s existing `reservedReferences` option — fixing the allocator's blindness where it lives, in the same case-insensitive loop, rather than routing around it at one call site. Allocation now respects the same three domains `nextInstanceDesignator` already scans, so a placed part's id, visible designator, and netlist reference agree again in every rename ordering.

## Red-then-green

- `1509e571` lands the reproduction test alone — red on its parent (verified before the fix existed).
- `2161cd44` lands the fix plus a second, shorter trigger case (rename alone, no delete needed); both cases verified red without the fix and green with it.

Since #417 the same refusal names its rule (`… — Duplicate schematic instance reference: M1`), so any recurrence of this class is now self-diagnosing in the status bar.

## Validation

Full `ci:check` under the gate lock: unit 1955/1955 (311 files), e2e 296/296, typecheck, format, test-impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
