### PR TITLE
test(editor): #394 regression case through the properties-panel producer

### DIFF
--- a/apps/editor/src/features/component-insert/placement-reference-allocation.test.ts
+++ b/apps/editor/src/features/component-insert/placement-reference-allocation.test.ts
@@ -7,9 +7,12 @@
  * comes from nextReference() — an allocator that only avoids the
  * netlist.reference domain. The document-level schema additionally requires
  * schematicReference to be unique across instances (case-insensitively).
- * Ordinary edits can part the two domains: `set_instance_schematic_reference`
- * renames only the visible designator, leaving netlist.reference behind.
- * After that, the lowest free netlist reference can equal an occupied
+ * Ordinary edits can part the two domains, in either direction:
+ * `set_instance_schematic_reference` (Agent API) renames only the visible
+ * designator, leaving netlist.reference behind; the properties panel's
+ * Netlist reference field (`set_instance_reference`) moves only
+ * netlist.reference, leaving the visible designator behind. After either,
+ * the lowest free netlist reference can equal an occupied
  * schematicReference, and every subsequent placement of that prefix assembles
  * a duplicate — rejected at commit as INVALID_RESULT with
  * "Duplicate schematic instance reference: <ref>". The user-visible headline
@@ -19,7 +22,7 @@
  */
 import { executeTransaction } from "@icm/edit-engine";
 import type { SchematicEdit } from "@icm/edit-engine";
-import { createEmptyDocument } from "@icm/model";
+import { createEmptyDocument, createEmptyProject } from "@icm/model";
 import type { Instance, SchematicDocument } from "@icm/model";
 import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
@@ -28,6 +31,7 @@ import {
   initialInstanceNetlist,
   nextInstanceDesignator,
 } from "../netlist-export/netlist-authoring";
+import { createSelectionPropertyCommands } from "../properties/selection-property-commands";
 import { defaultRazaviSymbolVariantId } from "../../presentation/razavi-presentation";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
@@ -159,5 +163,60 @@ describe("placement reference allocation", () => {
       result.ok,
       `placement was refused: ${!result.ok ? result.diagnostics[0]?.message : ""}`,
     ).toBe(true);
+  });
+
+  it("places an nmos after the properties panel renumbers a netlist reference", () => {
+    // The GUI's actual domain-splitting entry: the properties panel's
+    // Netlist reference field moves only netlist.reference and leaves the
+    // visible designator behind. Drive the split through the same producer
+    // the panel uses, so this breaks if that producer changes shape.
+    let document = createEmptyDocument("issue-394-gui", "Issue 394 GUI");
+
+    const m1 = assemblePlacedNmos(document, 100, 100);
+    document = transact(document, [{ kind: "add_instance", instance: m1 }]);
+
+    const commands = createSelectionPropertyCommands({
+      project: createEmptyProject("issue-394-gui", "Issue 394 GUI"),
+      document,
+      resolver,
+      selectedInstance: document.instances.find(
+        (instance) => instance.id === "M1",
+      ),
+      selectedInstanceIsMos: true,
+      selectedAnnotation: null,
+      commitStructure: () => false,
+      transact: (edits) => {
+        document = transact(document, [...edits]);
+        return { ok: true };
+      },
+      replaceAnnotationSelection: () => {},
+      setStatus: () => {},
+    });
+    expect(commands.updateSelectedReference("M9")).toBe(true);
+    // The split state the panel leaves behind: label M1, reference M9.
+    const renumbered = document.instances.find(
+      (instance) => instance.id === "M1",
+    );
+    expect(renumbered?.schematicReference).toBe("M1");
+    expect(renumbered?.netlist?.reference).toBe("M9");
+
+    const next = assemblePlacedNmos(document, 200, 100);
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "ref-alloc-gui-final",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: [{ kind: "add_instance", instance: next }],
+      },
+      { symbolResolver: resolver },
+    );
+
+    expect(
+      result.ok,
+      `placement was refused: ${!result.ok ? result.diagnostics[0]?.message : ""}`,
+    ).toBe(true);
+    expect(next.schematicReference).toBe("M2");
   });
 });


### PR DESCRIPTION
Related to #394. Closes a coverage gap left by #448: both committed regression cases split the reference domains via `set_instance_schematic_reference` — an edit only the Agent API produces (zero GUI producers). The path an actual user takes is the properties panel's **Netlist reference** field (`updateSelectedReference` → `set_instance_reference`), which moves only `netlist.reference` and leaves the visible designator behind — the mirror image of the same allocator blindness. That path was verified once by hand in production after #448 landed, and a hand-verification guards nothing.

## What lands

One test case in [placement-reference-allocation.test.ts](apps/editor/src/features/component-insert/placement-reference-allocation.test.ts): place M1 the way the GUI assembles it, renumber its netlist reference to M9 **through `createSelectionPropertyCommands` itself** (so the case also breaks if the panel's producer changes shape), assert the split state the panel leaves behind (label M1 / reference M9), then place again and assert the allocator hands out M2 instead of reissuing the occupied M1. The file's header comment now describes both split directions.

## Red-then-green

Verified red on `c6d54a9e^` (the pre-fix commit — all three cases fail there, the new one included) and green on current main: unit 1956/1956 (311 files), e2e 296/296, full `ci:check` exit 0 under the gate lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
