### PR TITLE
fix(protocol): load any Project the upgrade chain can carry forward

### DIFF
--- a/fixtures/legacy-projects/README.md
+++ b/fixtures/legacy-projects/README.md
@@ -1,0 +1,17 @@
+# Legacy Project fixtures
+
+Real and synthetic `.icproj.json` files at **historical schema versions**,
+guarding the promise that a user's saved canonical Project file keeps
+loading after the schema moves on. Unlike `fixtures/projects/`, nothing
+here is in the current form on purpose — do not "fix" these files to the
+current schema; their old `schemaVersion` is the point.
+
+| File | Version | Origin |
+| --- | --- | --- |
+| `issue-446-bias-ini.v25.icproj.json` | 25 | Attached by the reporter of issue #446 to demonstrate the failure ("上周保存的project或因版本更新导致无法导入?"). A real bias-network circuit: 15 instances, 11 nets, 33 routes. Kept byte-identical to the attachment. |
+
+Loading behavior is asserted by
+`packages/project-protocol/src/legacy-load.test.ts`, which also covers the
+other historical versions with minimal synthetic projects. If a schema bump
+adds a migration step, that test's supported-version range is the place that
+must keep the whole chain honest.

--- a/fixtures/legacy-projects/issue-446-bias-ini.v25.icproj.json
+++ b/fixtures/legacy-projects/issue-446-bias-ini.v25.icproj.json
@@ -1,0 +1,1724 @@
+{
+  "documents": [
+    {
+      "annotations": [
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 320,
+              "y": 220
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 10
+            },
+            "objectId": "M1"
+          },
+          "binding": {
+            "instanceId": "M1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 460,
+              "y": 180
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "M2"
+          },
+          "binding": {
+            "instanceId": "M2",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M1-copy-4",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 470,
+              "y": 260
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "R1"
+          },
+          "binding": {
+            "instanceId": "R1",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-R1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 460,
+              "y": 60
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "M4"
+          },
+          "binding": {
+            "instanceId": "M4",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M4",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 470,
+              "y": 120
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "R2"
+          },
+          "binding": {
+            "instanceId": "R2",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-R2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 460,
+              "y": 0
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "M5"
+          },
+          "binding": {
+            "instanceId": "M5",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M4-copy-6",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 320,
+              "y": 0
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 10
+            },
+            "objectId": "M6"
+          },
+          "binding": {
+            "instanceId": "M6",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M4-copy-6-copy-9",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 320,
+              "y": 60
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 10
+            },
+            "objectId": "M7"
+          },
+          "binding": {
+            "instanceId": "M7",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M4-copy-6-copy-10",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 410,
+              "y": -40
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 20,
+              "y": 10
+            },
+            "objectId": "VDD1"
+          },
+          "binding": {
+            "kind": "net-name",
+            "netId": "net-power-vdd1"
+          },
+          "id": "power-label-vdd1",
+          "kind": "power-label",
+          "locked": false,
+          "netId": "net-power-vdd1",
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 200,
+              "y": 240
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 10
+            },
+            "objectId": "M3"
+          },
+          "binding": {
+            "instanceId": "M3",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M3",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 140,
+              "y": 180
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 10
+            },
+            "objectId": "M8"
+          },
+          "binding": {
+            "instanceId": "M8",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M8",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 200,
+              "y": 120
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -20,
+              "y": 10
+            },
+            "objectId": "M9"
+          },
+          "binding": {
+            "instanceId": "M9",
+            "kind": "instance-schematic-name"
+          },
+          "id": "instance-label-M9",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 420,
+              "y": 160
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 10,
+              "y": -10
+            },
+            "objectId": "P1"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "terminal-p1"
+          },
+          "formatOverride": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "V"
+                      },
+                      {
+                        "children": [
+                          {
+                            "kind": "text",
+                            "value": "FB2"
+                          }
+                        ],
+                        "kind": "span",
+                        "style": "subscript"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "italic"
+                  }
+                ],
+                "kind": "span",
+                "style": "bold"
+              }
+            ]
+          },
+          "id": "instance-label-P1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 340,
+              "y": 160
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 0,
+              "y": -10
+            },
+            "objectId": "P2"
+          },
+          "binding": {
+            "kind": "cell-terminal-name",
+            "terminalId": "terminal-p2"
+          },
+          "id": "instance-label-P2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0,
+          "sizeScale": 1
+        }
+      ],
+      "connectivityEvidence": [
+        {
+          "id": "connectivity-evidence-527e329ebc0cf3bb",
+          "kind": "name-claim",
+          "name": "0",
+          "netId": "net-ui-22",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "GND1"
+          },
+          "powerDomain": "ground",
+          "scope": "global"
+        },
+        {
+          "id": "connectivity-evidence-5b59a3c4dac05690",
+          "kind": "name-claim",
+          "name": "VDD",
+          "netId": "net-power-vdd1",
+          "owner": {
+            "kind": "power-marker",
+            "objectId": "VDD1"
+          },
+          "powerDomain": "vdd",
+          "scope": "global"
+        }
+      ],
+      "constraints": [],
+      "drafting": {
+        "objects": []
+      },
+      "id": "document-main",
+      "instances": [
+        {
+          "id": "M1",
+          "mosBulkBinding": {
+            "netId": "net-ui-22",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M1"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 340,
+              "y": 210
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M1",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M2",
+          "mosBulkBinding": {
+            "netId": "net-ui-22",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 440,
+              "y": 170
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M2",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "R1",
+          "netlist": {
+            "binding": {
+              "deviceClass": "resistor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "R1"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 450,
+              "y": 250
+            },
+            "rotation": 0
+          },
+          "schematicReference": "R1",
+          "symbolId": "resistor"
+        },
+        {
+          "id": "M4",
+          "mosBulkBinding": {
+            "netId": "net-power-vdd1",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M4"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 440,
+              "y": 50
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M4",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "R2",
+          "netlist": {
+            "binding": {
+              "deviceClass": "resistor",
+              "kind": "primitive"
+            },
+            "parameters": {},
+            "reference": "R2"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 450,
+              "y": 110
+            },
+            "rotation": 0
+          },
+          "schematicReference": "R2",
+          "symbolId": "resistor"
+        },
+        {
+          "id": "M5",
+          "mosBulkBinding": {
+            "netId": "net-power-vdd1",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M5"
+          },
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 440,
+              "y": -10
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M5",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M6",
+          "mosBulkBinding": {
+            "netId": "net-power-vdd1",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M6"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 340,
+              "y": -10
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M6",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M7",
+          "mosBulkBinding": {
+            "netId": "net-power-vdd1",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M7"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 340,
+              "y": 50
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M7",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "GND1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 380,
+              "y": 280
+            },
+            "rotation": 0
+          },
+          "schematicReference": "GND1",
+          "symbolId": "ground"
+        },
+        {
+          "id": "VDD1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 390,
+              "y": -50
+            },
+            "rotation": 0
+          },
+          "schematicReference": "VDD1",
+          "symbolId": "vdd-port"
+        },
+        {
+          "id": "M3",
+          "mosBulkBinding": {
+            "netId": "net-ui-22",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M3"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 220,
+              "y": 230
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M3",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M8",
+          "mosBulkBinding": {
+            "netId": "net-ui-22",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M8"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 160,
+              "y": 170
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M8",
+          "symbolId": "nmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "M9",
+          "mosBulkBinding": {
+            "netId": "net-power-vdd1",
+            "origin": "cell-default"
+          },
+          "netlist": {
+            "parameters": {
+              "l": "150n",
+              "m": "1",
+              "nf": "1",
+              "w": "1u"
+            },
+            "reference": "M9"
+          },
+          "placement": {
+            "mirror": "x",
+            "position": {
+              "x": 220,
+              "y": 110
+            },
+            "rotation": 0
+          },
+          "schematicReference": "M9",
+          "symbolId": "pmos",
+          "symbolVariantId": "textbook-3terminal"
+        },
+        {
+          "id": "P1",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 410,
+              "y": 170
+            },
+            "rotation": 0
+          },
+          "symbolId": "port"
+        },
+        {
+          "id": "P2",
+          "placement": {
+            "mirror": "none",
+            "position": {
+              "x": 340,
+              "y": 170
+            },
+            "rotation": 180
+          },
+          "symbolId": "port"
+        }
+      ],
+      "junctions": [
+        {
+          "id": "junction-ui-2",
+          "netId": "net-ui-1",
+          "position": {
+            "x": 450,
+            "y": 210
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-12",
+          "netId": "net-split-b0b135411688e702",
+          "position": {
+            "x": 390,
+            "y": -10
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-13",
+          "netId": "net-split-b0b135411688e702",
+          "position": {
+            "x": 450,
+            "y": 80
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-15",
+          "netId": "net-ui-9",
+          "position": {
+            "x": 370,
+            "y": 50
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-16",
+          "netId": "net-ui-9",
+          "position": {
+            "x": 450,
+            "y": 140
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-18",
+          "netId": "net-split-b0b13b411688f134",
+          "position": {
+            "x": 330,
+            "y": 170
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-24",
+          "netId": "net-ui-23",
+          "position": {
+            "x": 210,
+            "y": 170
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-28",
+          "netId": "net-split-b0b13b411688f134",
+          "position": {
+            "x": 260,
+            "y": 170
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-31",
+          "netId": "net-split-b0b135411688e702",
+          "position": {
+            "x": 390,
+            "y": 80
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-33",
+          "netId": "net-ui-22",
+          "position": {
+            "x": 330,
+            "y": 270
+          },
+          "role": "branch"
+        },
+        {
+          "id": "junction-ui-35",
+          "netId": "net-ui-22",
+          "position": {
+            "x": 210,
+            "y": 270
+          },
+          "role": "branch"
+        }
+      ],
+      "layoutGroups": [],
+      "mosBulkDefaults": {
+        "nmosNetId": "net-ui-22",
+        "pmosNetId": "net-power-vdd1"
+      },
+      "name": "Main",
+      "netlist": {
+        "formalParameters": [],
+        "name": "Main",
+        "terminals": [
+          {
+            "direction": "passive",
+            "id": "terminal-p1",
+            "interfaceInstanceIds": [
+              "P1"
+            ],
+            "name": "VFB2",
+            "netId": "net-cell-pin-p1"
+          },
+          {
+            "direction": "passive",
+            "id": "terminal-p2",
+            "interfaceInstanceIds": [
+              "P2"
+            ],
+            "name": "VFB1",
+            "netId": "net-split-b0b13b411688f134"
+          }
+        ]
+      },
+      "nets": [
+        {
+          "id": "net-ui-1",
+          "terminals": [
+            {
+              "instanceId": "R1",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "G"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-9",
+          "terminals": [
+            {
+              "instanceId": "M7",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "R2",
+              "pinName": "2"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-21",
+          "terminals": [
+            {
+              "instanceId": "M6",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M9",
+              "pinName": "S"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-22",
+          "terminals": [
+            {
+              "instanceId": "R1",
+              "pinName": "2"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "GND1",
+              "pinName": "0"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M8",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "S"
+            },
+            {
+              "instanceId": "M8",
+              "pinName": "S"
+            }
+          ]
+        },
+        {
+          "id": "net-power-vdd1",
+          "terminals": [
+            {
+              "instanceId": "VDD1",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M6",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M7",
+              "pinName": "B"
+            },
+            {
+              "instanceId": "M9",
+              "pinName": "B"
+            }
+          ]
+        },
+        {
+          "id": "net-ui-23",
+          "terminals": [
+            {
+              "instanceId": "M9",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M3",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M8",
+              "pinName": "G"
+            }
+          ]
+        },
+        {
+          "id": "net-split-b0b135411688e702",
+          "terminals": [
+            {
+              "instanceId": "M6",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M5",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "R2",
+              "pinName": "1"
+            },
+            {
+              "instanceId": "M8",
+              "pinName": "D"
+            }
+          ]
+        },
+        {
+          "id": "net-split-b0b13b411688f134",
+          "terminals": [
+            {
+              "instanceId": "M3",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M9",
+              "pinName": "G"
+            },
+            {
+              "instanceId": "M1",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M7",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "P2",
+              "pinName": "P"
+            }
+          ]
+        },
+        {
+          "id": "net-split-a3fa8dc4f9d51c4c",
+          "terminals": [
+            {
+              "instanceId": "M5",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M4",
+              "pinName": "S"
+            }
+          ]
+        },
+        {
+          "id": "net-split-b5fecac5043c30f3",
+          "terminals": [
+            {
+              "instanceId": "M6",
+              "pinName": "D"
+            },
+            {
+              "instanceId": "M7",
+              "pinName": "S"
+            }
+          ]
+        },
+        {
+          "id": "net-cell-pin-p1",
+          "terminals": [
+            {
+              "instanceId": "P1",
+              "pinName": "P"
+            },
+            {
+              "instanceId": "M2",
+              "pinName": "G"
+            }
+          ]
+        }
+      ],
+      "noConnects": [],
+      "presentation": {
+        "compactness": "normal",
+        "grid": 10,
+        "styleProfileId": "razavi-textbook-v1"
+      },
+      "revision": 80,
+      "routes": [
+        {
+          "from": {
+            "instanceId": "R1",
+            "kind": "terminal",
+            "pinName": "1"
+          },
+          "id": "route-ui-1-a-2",
+          "netId": "net-ui-1",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-2",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-2",
+            "kind": "junction"
+          },
+          "id": "route-ui-1-b-2",
+          "netId": "net-ui-1",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M2",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M1",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "id": "route-ui-3",
+          "netId": "net-ui-1",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-2",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-18",
+            "kind": "junction"
+          },
+          "id": "route-ui-4-b-18",
+          "netId": "net-split-b0b13b411688f134",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M1",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "R2",
+            "kind": "terminal",
+            "pinName": "2"
+          },
+          "id": "route-ui-6-a-16",
+          "netId": "net-ui-9",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-16",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-16",
+            "kind": "junction"
+          },
+          "id": "route-ui-6-b-16",
+          "netId": "net-ui-9",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M2",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "R2",
+            "kind": "terminal",
+            "pinName": "1"
+          },
+          "id": "route-ui-7-a-13",
+          "netId": "net-split-b0b135411688e702",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-13",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-13",
+            "kind": "junction"
+          },
+          "id": "route-ui-7-b-13",
+          "netId": "net-split-b0b135411688e702",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M5",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "id": "route-ui-8",
+          "netId": "net-split-a3fa8dc4f9d51c4c",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M7",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "id": "route-ui-9-a-15",
+          "netId": "net-ui-9",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-15",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-15",
+            "kind": "junction"
+          },
+          "id": "route-ui-9-b-15",
+          "netId": "net-ui-9",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M4",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M6",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "id": "route-ui-10-a-12",
+          "netId": "net-split-b0b135411688e702",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-12",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-12",
+            "kind": "junction"
+          },
+          "id": "route-ui-10-b-12",
+          "netId": "net-split-b0b135411688e702",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M5",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-12",
+            "kind": "junction"
+          },
+          "id": "route-ui-14-a-31",
+          "netId": "net-split-b0b135411688e702",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-31",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-31",
+            "kind": "junction"
+          },
+          "id": "route-ui-14-b-31",
+          "netId": "net-split-b0b135411688e702",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-13",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-15",
+            "kind": "junction"
+          },
+          "id": "route-ui-17",
+          "netId": "net-ui-9",
+          "segmentModes": [
+            "manual",
+            "manual",
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-16",
+            "kind": "junction"
+          },
+          "waypoints": [
+            {
+              "x": 380,
+              "y": 50
+            },
+            {
+              "x": 380,
+              "y": 140
+            }
+          ]
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-18",
+            "kind": "junction"
+          },
+          "id": "route-ui-19",
+          "netId": "net-split-b0b13b411688f134",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M7",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M7",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "id": "route-ui-20",
+          "netId": "net-split-b5fecac5043c30f3",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M6",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M6",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "id": "route-ui-21",
+          "netId": "net-ui-21",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M5",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "R1",
+            "kind": "terminal",
+            "pinName": "2"
+          },
+          "id": "route-ui-22-a-contact-gnd1-0",
+          "netId": "net-ui-22",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "GND1",
+            "kind": "terminal",
+            "pinName": "0"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "GND1",
+            "kind": "terminal",
+            "pinName": "0"
+          },
+          "id": "route-ui-22-b-contact-gnd1-0-a-33",
+          "netId": "net-ui-22",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-33",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-33",
+            "kind": "junction"
+          },
+          "id": "route-ui-22-b-contact-gnd1-0-b-33",
+          "netId": "net-ui-22",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M1",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M9",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "id": "route-ui-23-a-24",
+          "netId": "net-ui-23",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-24",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-24",
+            "kind": "junction"
+          },
+          "id": "route-ui-23-b-24",
+          "netId": "net-ui-23",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M8",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "id": "route-ui-25",
+          "netId": "net-ui-23",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-24",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "id": "route-ui-26-a-28",
+          "netId": "net-split-b0b13b411688f134",
+          "segmentModes": [
+            "manual",
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-28",
+            "kind": "junction"
+          },
+          "waypoints": [
+            {
+              "x": 260,
+              "y": 230
+            }
+          ]
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-28",
+            "kind": "junction"
+          },
+          "id": "route-ui-26-b-28",
+          "netId": "net-split-b0b13b411688f134",
+          "segmentModes": [
+            "manual",
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M9",
+            "kind": "terminal",
+            "pinName": "G"
+          },
+          "waypoints": [
+            {
+              "x": 260,
+              "y": 110
+            }
+          ]
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-28",
+            "kind": "junction"
+          },
+          "id": "route-ui-29",
+          "netId": "net-split-b0b13b411688f134",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-18",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "instanceId": "M6",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "id": "route-ui-30",
+          "netId": "net-ui-21",
+          "segmentModes": [
+            "manual",
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M9",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "waypoints": [
+            {
+              "x": 210,
+              "y": -30
+            }
+          ]
+        },
+        {
+          "from": {
+            "instanceId": "M8",
+            "kind": "terminal",
+            "pinName": "D"
+          },
+          "id": "route-ui-32",
+          "netId": "net-split-b0b135411688e702",
+          "segmentModes": [
+            "manual",
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-31",
+            "kind": "junction"
+          },
+          "waypoints": [
+            {
+              "x": 150,
+              "y": 80
+            }
+          ]
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-33",
+            "kind": "junction"
+          },
+          "id": "route-ui-34-a-35",
+          "netId": "net-ui-22",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "junctionId": "junction-ui-35",
+            "kind": "junction"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-35",
+            "kind": "junction"
+          },
+          "id": "route-ui-34-b-35",
+          "netId": "net-ui-22",
+          "segmentModes": [
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M3",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "waypoints": []
+        },
+        {
+          "from": {
+            "junctionId": "junction-ui-35",
+            "kind": "junction"
+          },
+          "id": "route-ui-36",
+          "netId": "net-ui-22",
+          "segmentModes": [
+            "manual",
+            "manual"
+          ],
+          "to": {
+            "instanceId": "M8",
+            "kind": "terminal",
+            "pinName": "S"
+          },
+          "waypoints": [
+            {
+              "x": 150,
+              "y": 270
+            }
+          ]
+        }
+      ],
+      "sourceStatus": "connectivity-modified"
+    }
+  ],
+  "externalSubcircuitDefinitions": [],
+  "id": "project-main",
+  "name": "BIAS_INI",
+  "schemaVersion": 25,
+  "source": {
+    "dialect": "none",
+    "entry": null,
+    "files": [],
+    "sourcePolicy": "copy"
+  },
+  "structureRevision": 5,
+  "symbolLibrary": {
+    "hash": "razavi-reference-v1",
+    "id": "razavi-symbols",
+    "version": "1"
+  },
+  "topDocumentId": "document-main"
+}

--- a/packages/project-protocol/src/instance-style-migration.test.ts
+++ b/packages/project-protocol/src/instance-style-migration.test.ts
@@ -67,14 +67,15 @@ describe("schema migrations through Annotation text color", () => {
     expect(result.project.schemaVersion).toBe(32);
   });
 
-  it("does not keep schema 30 in the rolling read window", () => {
+  it("keeps schema 30 loadable through the upgrade chain", () => {
     const current = JSON.parse(
       serializeProject(createEmptyProject("test", "Test")),
     ) as Record<string, unknown>;
     const v30 = JSON.stringify({ ...current, schemaVersion: 30 });
     expect(tryParseProjectWithMetadata(v30)).toMatchObject({
-      ok: false,
-      diagnostics: [{ code: "UNSUPPORTED_SCHEMA_VERSION" }],
+      ok: true,
+      sourceSchemaVersion: 30,
+      migrated: true,
     });
   });
 

--- a/packages/project-protocol/src/legacy-load.test.ts
+++ b/packages/project-protocol/src/legacy-load.test.ts
@@ -70,19 +70,22 @@ describe("legacy Project loading (#446)", () => {
     { length: CURRENT_PROJECT_SCHEMA_VERSION - OLDEST_CHAINED_VERSION },
     (_, index) => OLDEST_CHAINED_VERSION + index,
   );
-  it.each(versions)("loads a minimal v%i project through the chain", (version) => {
-    const result = tryParseProjectWithMetadata(minimalProjectAt(version));
-    expect(
-      result.ok,
-      result.ok
-        ? ""
-        : `refused: ${result.diagnostics.map((d) => `${d.code} ${d.message}`).join("; ")}`,
-    ).toBe(true);
-    if (!result.ok) return;
-    expect(result.sourceSchemaVersion).toBe(version);
-    expect(result.migrated).toBe(true);
-    expect(result.project.schemaVersion).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
-  });
+  it.each(versions)(
+    "loads a minimal v%i project through the chain",
+    (version) => {
+      const result = tryParseProjectWithMetadata(minimalProjectAt(version));
+      expect(
+        result.ok,
+        result.ok
+          ? ""
+          : `refused: ${result.diagnostics.map((d) => `${d.code} ${d.message}`).join("; ")}`,
+      ).toBe(true);
+      if (!result.ok) return;
+      expect(result.sourceSchemaVersion).toBe(version);
+      expect(result.migrated).toBe(true);
+      expect(result.project.schemaVersion).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
+    },
+  );
 
   it("still refuses versions older than the chain start", () => {
     const result = tryParseProjectWithMetadata(minimalProjectAt(23));

--- a/packages/project-protocol/src/legacy-load.test.ts
+++ b/packages/project-protocol/src/legacy-load.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Issue #446: a Project saved days earlier ("上周保存的project") was refused
+ * with UNSUPPORTED_SCHEMA_VERSION. The `.icproj.json` file is the canonical
+ * Project — a saved file must keep loading after the schema moves on.
+ *
+ * The per-version upgrade transforms all exist and are individually tested;
+ * what regressed was the loader's acceptance window, which kept only
+ * {previous, current} while the schema advanced 11 versions in nine days.
+ * These tests pin the whole reachable chain: every version the transform
+ * chain can carry must load, oldest first, with the #446 reporter's real
+ * file as the end-to-end witness.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
+import { describe, expect, it } from "vitest";
+
+import { serializeProject } from "./save.js";
+import { tryParseProjectWithMetadata } from "./load.js";
+import { createEmptyProject } from "@icm/model";
+
+const OLDEST_CHAINED_VERSION = 24;
+
+const reporterFile = readFileSync(
+  resolve(
+    process.cwd(),
+    "fixtures/legacy-projects/issue-446-bias-ini.v25.icproj.json",
+  ),
+  "utf8",
+);
+
+/**
+ * A minimal Project stamped with an older schemaVersion. The collections a
+ * fresh Project carries are empty, and every historical migration step is a
+ * no-op over empty collections, so the same minimal shape is a valid
+ * starting point at each version — what changes per version is which
+ * upgrade steps must run to bring `schemaVersion` forward.
+ */
+function minimalProjectAt(version: number): string {
+  const project = JSON.parse(
+    serializeProject(createEmptyProject("legacy-load", "Legacy load")),
+  ) as Record<string, unknown>;
+  project.schemaVersion = version;
+  return JSON.stringify(project);
+}
+
+describe("legacy Project loading (#446)", () => {
+  it("loads the #446 reporter's real v25 file, contents intact", () => {
+    const result = tryParseProjectWithMetadata(reporterFile);
+    expect(
+      result.ok,
+      result.ok
+        ? ""
+        : `refused: ${result.diagnostics.map((d) => `${d.code} ${d.message}`).join("; ")}`,
+    ).toBe(true);
+    if (!result.ok) return;
+    expect(result.sourceSchemaVersion).toBe(25);
+    expect(result.migrated).toBe(true);
+    expect(result.project.schemaVersion).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
+    const document = result.project.documents[0]!;
+    // The circuit the reporter drew survives the migration intact.
+    expect(result.project.name).toBe("BIAS_INI");
+    expect(document.instances).toHaveLength(15);
+    expect(document.nets).toHaveLength(11);
+    expect(document.routes).toHaveLength(33);
+  });
+
+  const versions = Array.from(
+    { length: CURRENT_PROJECT_SCHEMA_VERSION - OLDEST_CHAINED_VERSION },
+    (_, index) => OLDEST_CHAINED_VERSION + index,
+  );
+  it.each(versions)("loads a minimal v%i project through the chain", (version) => {
+    const result = tryParseProjectWithMetadata(minimalProjectAt(version));
+    expect(
+      result.ok,
+      result.ok
+        ? ""
+        : `refused: ${result.diagnostics.map((d) => `${d.code} ${d.message}`).join("; ")}`,
+    ).toBe(true);
+    if (!result.ok) return;
+    expect(result.sourceSchemaVersion).toBe(version);
+    expect(result.migrated).toBe(true);
+    expect(result.project.schemaVersion).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
+  });
+
+  it("still refuses versions older than the chain start", () => {
+    const result = tryParseProjectWithMetadata(minimalProjectAt(23));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.diagnostics[0]?.code).toBe("UNSUPPORTED_SCHEMA_VERSION");
+  });
+
+  it("still loads a current-version project unmigrated", () => {
+    const result = tryParseProjectWithMetadata(
+      minimalProjectAt(CURRENT_PROJECT_SCHEMA_VERSION),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.migrated).toBe(false);
+  });
+});

--- a/packages/project-protocol/src/load.ts
+++ b/packages/project-protocol/src/load.ts
@@ -12,9 +12,35 @@ import {
 } from "./diagnostics.js";
 import {
   ProjectMigrationError,
+  upgradeSchema24To25,
+  upgradeSchema25To26,
+  upgradeSchema26To27,
+  upgradeSchema27To28,
+  upgradeSchema28To29,
+  upgradeSchema29To30,
+  upgradeSchema30To31,
   upgradeSchema31To32,
 } from "./previous-to-current.js";
-import { PREVIOUS_PROJECT_SCHEMA_VERSION } from "./version.js";
+import { OLDEST_SUPPORTED_PROJECT_SCHEMA_VERSION } from "./version.js";
+
+/**
+ * One upgrade step per historical version, oldest first: entry N carries a
+ * Project from schemaVersion OLDEST + N to OLDEST + N + 1. A file loads by
+ * running every step from its own version to the current one, so the whole
+ * window stays honest as long as this chain stays contiguous.
+ */
+const UPGRADE_CHAIN: ReadonlyArray<
+  (raw: Record<string, unknown>) => Record<string, unknown>
+> = [
+  upgradeSchema24To25,
+  upgradeSchema25To26,
+  upgradeSchema26To27,
+  upgradeSchema27To28,
+  upgradeSchema28To29,
+  upgradeSchema29To30,
+  upgradeSchema30To31,
+  upgradeSchema31To32,
+];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -87,17 +113,16 @@ export function tryParseProjectWithMetadata(
 
   const sourceSchemaVersion = parsed.schemaVersion as number;
   const migrated = sourceSchemaVersion !== CURRENT_PROJECT_SCHEMA_VERSION;
-  const supported = new Set([
-    PREVIOUS_PROJECT_SCHEMA_VERSION,
-    CURRENT_PROJECT_SCHEMA_VERSION,
-  ]);
-  if (!supported.has(sourceSchemaVersion)) {
+  if (
+    sourceSchemaVersion < OLDEST_SUPPORTED_PROJECT_SCHEMA_VERSION ||
+    sourceSchemaVersion > CURRENT_PROJECT_SCHEMA_VERSION
+  ) {
     return {
       ok: false,
       diagnostics: [
         {
           code: "UNSUPPORTED_SCHEMA_VERSION",
-          message: `Project schemaVersion must be ${PREVIOUS_PROJECT_SCHEMA_VERSION} or ${CURRENT_PROJECT_SCHEMA_VERSION}`,
+          message: `Project schemaVersion must be between ${OLDEST_SUPPORTED_PROJECT_SCHEMA_VERSION} and ${CURRENT_PROJECT_SCHEMA_VERSION}`,
           path: ["schemaVersion"],
         },
       ],
@@ -106,10 +131,17 @@ export function tryParseProjectWithMetadata(
 
   let current: Record<string, unknown>;
   try {
-    current =
-      sourceSchemaVersion === PREVIOUS_PROJECT_SCHEMA_VERSION
-        ? upgradeSchema31To32(parsed)
-        : parsed;
+    current = parsed;
+    for (
+      let version = sourceSchemaVersion;
+      version < CURRENT_PROJECT_SCHEMA_VERSION;
+      version += 1
+    ) {
+      current =
+        UPGRADE_CHAIN[version - OLDEST_SUPPORTED_PROJECT_SCHEMA_VERSION]!(
+          current,
+        );
+    }
   } catch (error) {
     if (error instanceof ProjectMigrationError) {
       return {

--- a/packages/project-protocol/src/persistence.test.ts
+++ b/packages/project-protocol/src/persistence.test.ts
@@ -388,12 +388,12 @@ describe("Project persistence", () => {
     ).toBe(serializeProject(parsed.project));
   });
 
-  it("rejects schemas outside the current-and-previous window", () => {
+  it("rejects schemas outside the supported chain window", () => {
     const project = createEmptyProject("project-test", "Test Project");
-    for (const schemaVersion of [23, 24, 25, 26, 27, 28, 29, 30, 33, 99]) {
+    for (const schemaVersion of [1, 22, 23, 33, 99]) {
       expect(() =>
         parseProject(JSON.stringify({ ...project, schemaVersion })),
-      ).toThrow(/must be 31 or 32/);
+      ).toThrow(/must be between 24 and 32/);
     }
   });
 });

--- a/packages/project-protocol/src/protocol.test.ts
+++ b/packages/project-protocol/src/protocol.test.ts
@@ -37,13 +37,13 @@ describe("Project protocol boundary", () => {
     });
   });
 
-  it("rejects projects older than the rolling compatibility window", () => {
+  it("rejects projects older than the supported chain window", () => {
     const current = JSON.parse(
       serializeProject(createEmptyProject("protocol-project", "Protocol")),
     ) as Record<string, unknown>;
     expect(
       tryParseProjectWithMetadata(
-        JSON.stringify({ ...current, schemaVersion: 25 }),
+        JSON.stringify({ ...current, schemaVersion: 23 }),
       ),
     ).toMatchObject({
       ok: false,

--- a/packages/project-protocol/src/version.ts
+++ b/packages/project-protocol/src/version.ts
@@ -1,5 +1,11 @@
 /**
- * The rolling compatibility window is deliberately explicit. Advancing the
- * current schema replaces this adapter instead of extending a migration chain.
+ * The compatibility window is deliberately explicit: it reaches exactly as
+ * far back as the upgrade chain in previous-to-current.ts can carry a file
+ * forward. A saved `.icproj.json` is the canonical Project, so a version may
+ * leave this window only when its files can no longer exist in the wild —
+ * never merely because the schema moved on (#446 was users' saved files
+ * refused three days after saving, while the schema advanced 11 versions in
+ * nine days).
  */
+export const OLDEST_SUPPORTED_PROJECT_SCHEMA_VERSION = 24;
 export const PREVIOUS_PROJECT_SCHEMA_VERSION = 31;


### PR DESCRIPTION
Related to #446. Do not auto-close: the issue stays open for the reporter.

## The incident

A user's project saved days earlier ("上周保存的project") was refused with `Project not opened — UNSUPPORTED_SCHEMA_VERSION at schemaVersion: Project schemaVersion must be 31 or 32`. Their file is schemaVersion 25. The loader kept a deliberate two-version window `{previous, current}` while the schema advanced **11 versions in nine days** (21 on 08-21 → 32 on 08-30), so **every `.icproj.json` saved before ~08-28 stopped opening** — the canonical-file promise broken for anything more than a few days old. The public gallery is unaffected (audited: all 119 entries store schemaVersion 32, including the oldest from 08-21 — the worker converges stored text); the blast radius is users' local files and stale browser recovery copies.

## Root cause and fix

Every per-version upgrade transform from 24→25 through 31→32 **already exists, is exported from previous-to-current.ts, and is individually tested** — the five schema bumps since #335 each replaced only the loader's wiring, never the steps. `tryParseProjectWithMetadata` simply accepted `{31, 32}` and invoked the single last step.

The loader now accepts 24..32 and runs the chain from the file's version to current ([load.ts](packages/project-protocol/src/load.ts)); [version.ts](packages/project-protocol/src/version.ts) gains `OLDEST_SUPPORTED_PROJECT_SCHEMA_VERSION = 24` and states the window's real contract: it reaches exactly as far back as the chain can carry a file, and a version may leave it only when its files can no longer exist in the wild — never merely because the schema moved on. (Whether the window policy itself changes further is an ADR-level decision deliberately not taken here.)

Current-version behavior is unchanged: v32 passes through unmigrated, v31 output is identical, and the #445 gallery-corpus red line stays green. All three consumers heal at once — file open, and both browser-recovery paths share this loader.

## Red-then-green

- `97fc0540` lands the failing coverage alone: [fixtures/legacy-projects/](fixtures/legacy-projects/README.md) with the reporter's real v25 file **byte-identical to the #446 attachment** (15 instances / 11 nets / 33 routes), plus [legacy-load.test.ts](packages/project-protocol/src/legacy-load.test.ts) — the reporter's file asserted loadable with contents intact, minimal synthetic projects at every version 24..31, v23 still refused, v32 still unmigrated. Eight cases red on main.
- `42fb0cfd` lands the chain loader; all eleven cases green. Three tests that mirrored the old two-version window are updated to guard the chain window instead.

## Validation

Full `ci:check` under the gate lock: unit 1967/1967 (312 files), e2e 296/296, typecheck, format, docs/references/catalog checks, test-impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
