### PR TITLE
fix(editor): unify Gallery composition and Net lifecycle

### DIFF
--- a/apps/editor/e2e/hierarchy.spec.ts
+++ b/apps/editor/e2e/hierarchy.spec.ts
@@ -73,8 +73,12 @@ test("shows the hierarchy row only once there is a hierarchy", async ({
   // A flat Project has nothing to navigate, so the row stays out of the way
   // and the first Cell is created from Edit.
   const toolbar = page.locator('.toolbar-row[aria-label="Document hierarchy"]');
+  // A negative count can succeed before the code-split editor route mounts.
+  // Use the always-present Edit command as the positive startup anchor first.
+  await expect(page.getByTestId("edit-manage-cells")).toHaveCount(1, {
+    timeout: 15_000,
+  });
   await expect(toolbar).toHaveCount(0);
-  await expect(page.getByTestId("edit-manage-cells")).toHaveCount(1);
 
   await createCell(page, "FirstStage");
   await expect(toolbar).toHaveCount(1);

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -2982,6 +2982,8 @@ test("Properties toggles reference label visibility for one or many components",
 test("Properties keeps component and Annotation text colors independent", async ({
   page,
 }) => {
+  const clockStart = Date.parse("2026-08-31T00:00:00Z");
+  await page.clock.install({ time: clockStart });
   await page.goto("/editor");
   await placeComponent(page, "resistor", { x: 280, y: 180 });
   await placeComponent(page, "resistor", { x: 480, y: 180 });
@@ -3032,11 +3034,13 @@ test("Properties keeps component and Annotation text colors independent", async 
   // A pending RGB draft belongs to this Annotation only. Selecting another
   // Annotation remounts the keyed Text properties before the deferred blur
   // commit, so R1's draft cannot reach either Annotation.
+  await page.clock.pauseAt(clockStart + 60_000);
   await properties.getByLabel("Text color red").fill("12");
   await page
     .getByTestId("annotation-hit-instance-label-R2")
     .click({ force: true });
-  await page.waitForTimeout(300);
+  await page.clock.runFor(300);
+  await page.clock.resume();
   await expect(label).toHaveAttribute("fill", "#2563eb");
   await expect(secondLabel).not.toHaveAttribute("fill");
   await expect(properties.getByLabel("Text color hex value")).toHaveText(

--- a/apps/editor/src/features/clipboard/clipboard-audit.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard-audit.test.ts
@@ -145,6 +145,9 @@ describe("clipboard audit batch", () => {
 
   it("rotating the clipboard turns drafting objects with the rigid body (#12)", () => {
     const clipboard: SchematicClipboard = {
+      intent: "clone-selection",
+      sourceDocumentId: "document-main",
+      sourceGrid: 10,
       instances: [
         {
           id: "R1",
@@ -157,6 +160,7 @@ describe("clipboard audit batch", () => {
         },
       ],
       cellTerminals: [],
+      formalParameters: [],
       nets: [],
       routes: [],
       junctions: [],
@@ -189,7 +193,8 @@ describe("clipboard audit batch", () => {
           lineStyle: "dashed",
         },
       ],
-      draftingGroups: [],
+      layoutGroups: [],
+      constraints: [],
     };
     const rotated = orientClipboard(clipboard, [
       { kind: "rotate", deltaDegrees: 90 },

--- a/apps/editor/src/features/clipboard/clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard.test.ts
@@ -18,7 +18,7 @@ import {
   copyPlacementOrientationEdits,
   orientClipboard,
   copySelection,
-  copyWholeDocument,
+  captureDocumentComposition,
   proposePaste,
 } from "./clipboard";
 
@@ -380,6 +380,15 @@ describe("schematic clipboard", () => {
         symbolId: "resistor",
         placement: {
           position: { x: 100, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        id: "R3",
+        symbolId: "resistor",
+        placement: {
+          position: { x: 140, y: 20 },
           rotation: 0,
           mirror: "none",
         },
@@ -913,7 +922,514 @@ describe("schematic clipboard", () => {
   });
 });
 
-describe("copyWholeDocument", () => {
+describe("captureDocumentComposition", () => {
+  it("uses composition identity while preserving an available designator", () => {
+    const source = createEmptyDocument("source-document", "Source");
+    source.instances.push({
+      id: "R7",
+      symbolId: "resistor",
+      schematicReference: "R7",
+      placement: {
+        position: { x: 20, y: 20 },
+        rotation: 0,
+        mirror: "none",
+      },
+      netlist: {
+        reference: "R7",
+        binding: { kind: "primitive", deviceClass: "resistor" },
+        parameters: { value: "10k" },
+      },
+    });
+
+    const fragment = captureDocumentComposition(source)!;
+    const proposal = proposePaste(
+      createEmptyDocument("target-document", "Target"),
+      fragment,
+      { x: 0, y: 0 },
+      1,
+    );
+    const added = proposal.edits.find((edit) => edit.kind === "add_instance");
+
+    expect(fragment).toMatchObject({
+      intent: "compose-document",
+      sourceDocumentId: "source-document",
+      sourceGrid: 10,
+    });
+    expect(proposal.operationPlan).toMatchObject({
+      intent: "compose",
+      expectedElectricalEffect: {
+        kind: "compose",
+        boundaryPolicy: "preserve-target-physical",
+      },
+    });
+    expect(proposal.compositionOccurrence).toMatchObject({
+      id: "composition-source-document-copy-1",
+      sourceDocumentId: "source-document",
+      targetDocumentId: "target-document",
+      objectIdRemap: {
+        instances: { R7: "R7-copy-1" },
+      },
+    });
+    expect(added).toMatchObject({
+      kind: "add_instance",
+      instance: {
+        id: "R7-copy-1",
+        schematicReference: "R7",
+        netlist: { reference: "R7" },
+      },
+    });
+  });
+
+  it("owns composed MOS bulk connections per instance without changing target defaults", () => {
+    const source = createLibraryExampleProject(
+      "fully-differential-two-stage-op-amp",
+    )!.documents[0]!;
+    const sourceBindings = source.instances.filter(
+      (instance) => instance.mosBulkBinding,
+    );
+    expect(sourceBindings.length).toBeGreaterThan(0);
+
+    const target = createEmptyDocument("target-document", "Target");
+    const fragment = captureDocumentComposition(source)!;
+    const proposal = proposePaste(target, fragment, { x: 0, y: 0 }, 1);
+    expect(proposal.errors).toEqual([]);
+    const result = executeTransaction(
+      target,
+      {
+        transactionId: "compose-mos-bulk",
+        documentId: target.id,
+        expectedRevision: target.revision,
+        actor: { kind: "human", id: "test" },
+        edits: proposal.edits,
+      },
+      { symbolResolver: resolver },
+    );
+    if (!result.ok) throw new Error(JSON.stringify(result, null, 2));
+
+    expect(result.document.mosBulkDefaults).toBeUndefined();
+    for (const sourceInstance of sourceBindings) {
+      const copiedInstanceId = proposal.idRemap.instances[sourceInstance.id]!;
+      const copiedNetId =
+        proposal.idRemap.nets[sourceInstance.mosBulkBinding!.netId]!;
+      expect(
+        result.document.instances.find(
+          (instance) => instance.id === copiedInstanceId,
+        )?.mosBulkBinding,
+      ).toEqual({ origin: "instance-override", netId: copiedNetId });
+      expect(
+        result.document.nets
+          .find((net) => net.id === copiedNetId)
+          ?.terminals.some(
+            (terminal) =>
+              terminal.instanceId === copiedInstanceId &&
+              terminal.pinName === "B",
+          ),
+      ).toBe(true);
+    }
+  });
+
+  it("closes a still-derived source Cell bulk default before composition", () => {
+    const source = createEmptyDocument("source-document", "Source");
+    source.instances.push({
+      id: "M1",
+      symbolId: "nmos",
+      placement: {
+        position: { x: 20, y: 20 },
+        rotation: 0,
+        mirror: "none",
+      },
+    });
+    source.nets.push({ id: "net-substrate", terminals: [] });
+    source.mosBulkDefaults = { nmosNetId: "net-substrate" };
+
+    const fragment = captureDocumentComposition(source)!;
+    expect(fragment.instances[0]?.mosBulkBinding).toEqual({
+      origin: "cell-default",
+      netId: "net-substrate",
+    });
+    expect(fragment.nets[0]?.terminals).toEqual([
+      { instanceId: "M1", pinName: "B" },
+    ]);
+    const target = createEmptyDocument("target-document", "Target");
+    const result = executeTransaction(
+      target,
+      {
+        transactionId: "compose-derived-bulk",
+        documentId: target.id,
+        expectedRevision: target.revision,
+        actor: { kind: "human", id: "test" },
+        edits: proposePaste(target, fragment, { x: 0, y: 0 }, 1).edits,
+      },
+      { symbolResolver: resolver },
+    );
+    if (!result.ok) throw new Error(JSON.stringify(result, null, 2));
+    expect(result.document.instances[0]?.mosBulkBinding).toEqual({
+      origin: "instance-override",
+      netId: "net-substrate-copy-1",
+    });
+    expect(result.document.nets[0]?.terminals).toEqual([
+      { instanceId: "M1-copy-1", pinName: "B" },
+    ]);
+  });
+
+  it("composes Cell parameters and complete layout ownership through one object map", () => {
+    const source = createEmptyDocument("source-document", "Source");
+    source.instances.push(
+      {
+        id: "P1",
+        symbolId: "port",
+        placement: {
+          position: { x: 20, y: 20 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        id: "P2",
+        symbolId: "port",
+        placement: {
+          position: { x: 80, y: 20 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+    );
+    source.nets.push(
+      {
+        id: "net-a",
+        terminals: [{ instanceId: "P1", pinName: "P" }],
+      },
+      {
+        id: "net-b",
+        terminals: [{ instanceId: "P2", pinName: "P" }],
+      },
+    );
+    source.netlist = {
+      name: "Source",
+      formalParameters: [{ name: "GAIN", defaultValue: "10" }],
+      terminals: [
+        {
+          id: "terminal-a",
+          name: "A",
+          netId: "net-a",
+          direction: "input",
+          interfaceInstanceIds: ["P1"],
+        },
+        {
+          id: "terminal-b",
+          name: "B",
+          netId: "net-b",
+          direction: "output",
+          interfaceInstanceIds: ["P2"],
+        },
+      ],
+    };
+    source.layoutGroups.push({
+      id: "mixed-group",
+      kind: "custom",
+      objectIds: ["P1", "net-a"],
+      locked: false,
+    });
+    source.constraints.push({
+      id: "pin-alignment",
+      kind: "align-y",
+      objectIds: ["P1", "P2"],
+      locked: false,
+    });
+
+    const target = createEmptyDocument("target-document", "Combined");
+    delete target.netlist;
+    const fragment = captureDocumentComposition(source)!;
+    const proposal = proposePaste(target, fragment, { x: 100, y: 0 }, 1);
+    expect(proposal.errors).toEqual([]);
+    expect(proposal.edits[0]).toEqual({
+      kind: "create_cell_interface",
+      name: "Combined",
+    });
+    const result = executeTransaction(
+      target,
+      {
+        transactionId: "compose-interface-layout",
+        documentId: target.id,
+        expectedRevision: target.revision,
+        actor: { kind: "human", id: "test" },
+        edits: proposal.edits,
+      },
+      { symbolResolver: resolver },
+    );
+    if (!result.ok) throw new Error(JSON.stringify(result, null, 2));
+
+    expect(result.document.netlist).toMatchObject({
+      name: "Combined",
+      formalParameters: [{ name: "GAIN", defaultValue: "10" }],
+      terminals: [
+        { id: "terminal-a-copy-1", netId: "net-a-copy-1" },
+        { id: "terminal-b-copy-1", netId: "net-b-copy-1" },
+      ],
+    });
+    expect(result.document.layoutGroups).toEqual([
+      {
+        id: "mixed-group-copy-1",
+        kind: "custom",
+        objectIds: ["P1-copy-1", "net-a-copy-1"],
+        locked: false,
+      },
+    ]);
+    expect(result.document.constraints).toEqual([
+      {
+        id: "pin-alignment-copy-1",
+        kind: "align-y",
+        objectIds: ["P1-copy-1", "P2-copy-1"],
+        locked: false,
+      },
+    ]);
+  });
+
+  it("reports formal-parameter and target-grid conflicts before the transaction", () => {
+    const source = createEmptyDocument("source-document", "Source");
+    source.presentation.grid = 5;
+    source.instances.push({
+      id: "R1",
+      symbolId: "resistor",
+      placement: {
+        position: { x: 5, y: 10 },
+        rotation: 0,
+        mirror: "none",
+      },
+    });
+    source.netlist = {
+      name: "Source",
+      terminals: [],
+      formalParameters: [{ name: "GAIN", defaultValue: "10" }],
+    };
+    const target = createEmptyDocument("target-document", "Target");
+    target.netlist = {
+      name: "Target",
+      terminals: [],
+      formalParameters: [{ name: "gain", defaultValue: "20" }],
+    };
+
+    const proposal = proposePaste(
+      target,
+      captureDocumentComposition(source)!,
+      { x: 0, y: 0 },
+      1,
+    );
+    expect(proposal.errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("formal parameter conflict"),
+        expect.stringContaining("incompatible with target grid 10"),
+      ]),
+    );
+    expect(
+      proposal.edits.find((edit) => edit.kind === "add_instance"),
+    ).toMatchObject({
+      instance: { placement: { position: { x: 5, y: 10 } } },
+    });
+  });
+
+  it("joins repeated local names in the target Document while tracking composition occurrences separately", () => {
+    const source = createEmptyDocument("source-document", "Source");
+    source.instances.push(
+      {
+        id: "R1",
+        symbolId: "resistor",
+        placement: {
+          position: { x: 20, y: 20 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        id: "R2",
+        symbolId: "resistor",
+        placement: {
+          position: { x: 80, y: 20 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+    );
+    source.nets.push(
+      {
+        id: "net-out-a",
+        terminals: [{ instanceId: "R1", pinName: "1" }],
+      },
+      {
+        id: "net-out-b",
+        terminals: [{ instanceId: "R2", pinName: "1" }],
+      },
+      {
+        id: "net-vdd",
+        terminals: [{ instanceId: "R3", pinName: "1" }],
+      },
+    );
+    source.connectivityEvidence.push(
+      {
+        id: "claim-out-a",
+        kind: "name-claim",
+        netId: "net-out-a",
+        name: "OUT",
+        owner: { kind: "explicit-net-property" },
+        scope: "local",
+      },
+      {
+        id: "claim-out-b",
+        kind: "name-claim",
+        netId: "net-out-b",
+        name: "out",
+        owner: { kind: "explicit-net-property" },
+        scope: "local",
+      },
+      {
+        id: "claim-vdd",
+        kind: "name-claim",
+        netId: "net-vdd",
+        name: "VDD",
+        owner: { kind: "explicit-net-property" },
+        scope: "global",
+        powerDomain: "vdd",
+      },
+    );
+    const fragment = captureDocumentComposition(source)!;
+    const firstTarget = createEmptyDocument("target-document", "Target");
+    const firstProposal = proposePaste(
+      firstTarget,
+      fragment,
+      { x: 0, y: 0 },
+      1,
+    );
+    const first = executeTransaction(
+      firstTarget,
+      {
+        transactionId: "compose-first",
+        documentId: firstTarget.id,
+        expectedRevision: firstTarget.revision,
+        actor: { kind: "human", id: "test" },
+        edits: firstProposal.edits,
+      },
+      { symbolResolver: resolver },
+    );
+    if (!first.ok) throw new Error(JSON.stringify(first, null, 2));
+    const secondProposal = proposePaste(
+      first.document,
+      fragment,
+      { x: 200, y: 0 },
+      2,
+    );
+    const second = executeTransaction(
+      first.document,
+      {
+        transactionId: "compose-second",
+        documentId: first.document.id,
+        expectedRevision: first.document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: secondProposal.edits,
+      },
+      { symbolResolver: resolver },
+    );
+    if (!second.ok) throw new Error(JSON.stringify(second, null, 2));
+
+    expect(firstProposal.compositionOccurrence).toMatchObject({
+      id: "composition-source-document-copy-1",
+      sourceDocumentId: "source-document",
+      targetDocumentId: "target-document",
+    });
+    expect(secondProposal.compositionOccurrence).toMatchObject({
+      id: "composition-source-document-copy-2",
+      sourceDocumentId: "source-document",
+      targetDocumentId: "target-document",
+    });
+    expect(firstProposal.compositionOccurrence?.id).not.toBe(
+      secondProposal.compositionOccurrence?.id,
+    );
+    expect(
+      resolveDocumentLogicalNets(second.document)
+        .groups.filter((group) => group.name?.toLowerCase() === "out")
+        .map((group) => group.baseNetIds.length),
+    ).toEqual([4]);
+    expect(
+      resolveDocumentLogicalNets(second.document).groups.find(
+        (group) => group.name === "VDD",
+      )?.baseNetIds,
+    ).toHaveLength(2);
+  });
+
+  it("materializes a label-only Net while placing a Gallery document", () => {
+    const source = createEmptyDocument("document-main", "Label-only Net");
+    source.instances.push({
+      id: "VDD1",
+      symbolId: "vdd-port",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0,
+        mirror: "none",
+      },
+      schematicReference: "VDD1",
+    });
+    source.nets.push(
+      { id: "net-label-only", terminals: [] },
+      { id: "net-empty-source-fact", terminals: [] },
+    );
+    source.annotations.push({
+      id: "power-label-vdd1",
+      kind: "power-label",
+      binding: { kind: "net-name", netId: "net-label-only" },
+      anchor: {
+        kind: "object",
+        objectId: "VDD1",
+        localOffset: { x: 15, y: 10 },
+        fallbackPosition: { x: 115, y: 110 },
+      },
+      netId: "net-label-only",
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    });
+
+    const target = createEmptyDocument("target", "Target");
+    const clipboard = captureDocumentComposition(source);
+    expect(clipboard).not.toBeNull();
+    expect(clipboard?.nets.map((net) => net.id)).toEqual([
+      "net-label-only",
+      "net-empty-source-fact",
+    ]);
+    const proposal = proposePaste(target, clipboard!, { x: 200, y: 50 }, 1);
+    expect(proposal.errors).toEqual([]);
+    const result = executeTransaction(
+      target,
+      {
+        transactionId: "paste-label-only-net",
+        documentId: target.id,
+        expectedRevision: target.revision,
+        actor: { kind: "human", id: "test" },
+        edits: proposal.edits,
+      },
+      { symbolResolver: resolver },
+    );
+
+    if (!result.ok) throw new Error(JSON.stringify(result, null, 2));
+    const copiedNet = result.document.nets.find(
+      (net) => net.id === proposal.idRemap.nets["net-label-only"],
+    );
+    expect(copiedNet).toEqual({
+      id: "net-label-only-copy-1",
+      terminals: [],
+    });
+    expect(result.document.nets).toContainEqual({
+      id: "net-empty-source-fact-copy-1",
+      terminals: [],
+    });
+    expect(result.document.annotations).toEqual([
+      expect.objectContaining({
+        id: "power-label-vdd1-copy-1",
+        netId: "net-label-only-copy-1",
+        binding: { kind: "net-name", netId: "net-label-only-copy-1" },
+      }),
+    ]);
+    expect(result.document.junctions).toEqual([]);
+  });
+
   it("keeps standalone drafting geometry and its layout group", () => {
     const document = createEmptyDocument("document-main", "Drafting scene");
     document.drafting = {
@@ -956,13 +1472,13 @@ describe("copyWholeDocument", () => {
       locked: false,
     });
 
-    const clipboard = copyWholeDocument(document);
+    const clipboard = captureDocumentComposition(document);
     expect(clipboard?.draftingObjects.map((object) => object.kind)).toEqual([
       "rectangle",
       "arrow",
       "leader",
     ]);
-    expect(clipboard?.draftingGroups).toEqual([document.layoutGroups[0]]);
+    expect(clipboard?.layoutGroups).toEqual([document.layoutGroups[0]]);
     expect(clipboardPlacementAnchor(clipboard!)).toEqual({ x: 40, y: 30 });
 
     const target = createEmptyDocument("target", "Target");
@@ -1073,7 +1589,7 @@ describe("copyWholeDocument", () => {
       ],
     };
 
-    const clipboard = copyWholeDocument(document)!;
+    const clipboard = captureDocumentComposition(document)!;
     const proposal = proposePaste(
       createEmptyDocument("target", "Target"),
       clipboard,
@@ -1169,7 +1685,7 @@ describe("copyWholeDocument", () => {
     // rail with no device on it yet is not part of any selection.
     expect(copySelection(document, [])).toBeNull();
 
-    const whole = copyWholeDocument(document);
+    const whole = captureDocumentComposition(document);
     expect(whole?.routes).toHaveLength(1);
     expect(whole?.routes[0]?.presentation).toBe("power-rail");
     expect(whole?.junctions).toHaveLength(2);
@@ -1183,7 +1699,7 @@ describe("copyWholeDocument", () => {
   it("retains migrated Power Rail name claims when inserting an example", () => {
     const example = createLibraryExampleProject("common-source-amplifier");
     expect(example).not.toBeNull();
-    const clipboard = copyWholeDocument(example!.documents[0]!);
+    const clipboard = captureDocumentComposition(example!.documents[0]!);
     expect(clipboard).not.toBeNull();
     const target = createEmptyDocument("target", "Target");
     const proposal = proposePaste(target, clipboard!, { x: 20, y: 20 }, 1);
@@ -1363,7 +1879,7 @@ describe("a copy stands on its own", () => {
     });
 
     const clipboard = copySelection(document, [], ["wave-a", "wave-b"]);
-    expect(clipboard?.draftingGroups).toEqual([document.layoutGroups[0]]);
+    expect(clipboard?.layoutGroups).toEqual([document.layoutGroups[0]]);
 
     const proposal = proposePaste(document, clipboard!, { x: 200, y: 0 }, 1);
     const pastedObjects = proposal.edits.flatMap((edit) =>

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -8,9 +8,11 @@ import {
   captureRoutingCopyFragment,
   createRoutingOperationPlan,
   executeTransaction,
+  gridAlignmentDiagnostics,
   type OperationIdRemap,
   type RoutingOperationPlan,
 } from "@icm/edit-engine";
+import { resolveMosBulkConnection } from "@icm/derived";
 import { translateDraftingObject } from "@icm/edit-engine";
 import type { SchematicEdit } from "@icm/edit-engine";
 import type {
@@ -19,6 +21,7 @@ import type {
   ConnectivityEvidence,
   DraftingObject,
   Instance,
+  LayoutConstraint,
   LayoutGroup,
   Net,
   NoConnect,
@@ -45,8 +48,14 @@ import {
 } from "../../interaction/shortcut-orientation";
 
 export interface SchematicClipboard {
+  intent: "clone-selection" | "compose-document";
+  sourceDocumentId: string;
+  sourceGrid: number;
   instances: Instance[];
   cellTerminals: CellNetlistTerminal[];
+  formalParameters: NonNullable<
+    SchematicDocument["netlist"]
+  >["formalParameters"];
   /**
    * Nets entirely inside the copied selection. They are duplicated when the
    * copy is committed.
@@ -63,8 +72,10 @@ export interface SchematicClipboard {
    * thing a copy needs when nothing electrical is selected.
    */
   draftingObjects: DraftingObject[];
-  /** Layout groups wholly contained in the copied drafting selection. */
-  draftingGroups: LayoutGroup[];
+  /** Layout ownership records wholly contained in the copied closure. */
+  layoutGroups: LayoutGroup[];
+  /** Layout constraints wholly contained in the copied closure. */
+  constraints: LayoutConstraint[];
 }
 
 export interface PasteProposal {
@@ -72,6 +83,17 @@ export interface PasteProposal {
   instanceIds: string[];
   errors: string[];
   idRemap: OperationIdRemap;
+  /**
+   * Non-electrical provenance for this one flattened Document insertion.
+   * It can identify two imports of the same source without changing target
+   * Net naming, topology, or Evidence resolution.
+   */
+  compositionOccurrence?: {
+    id: string;
+    sourceDocumentId: string;
+    targetDocumentId: string;
+    objectIdRemap: OperationIdRemap;
+  };
   operationPlan: RoutingOperationPlan;
 }
 
@@ -448,17 +470,18 @@ function fallbackClipboardPreviewDocument(
     // references to objects deliberately omitted from the ghost and makes the
     // renderer reject otherwise valid clipboard content.
     netlist:
-      clipboard.cellTerminals.length > 0
+      clipboard.cellTerminals.length > 0 ||
+      clipboard.formalParameters.length > 0
         ? {
             name: base.netlist?.name ?? base.name,
-            formalParameters: [],
+            formalParameters: structuredClone(clipboard.formalParameters),
             terminals: structuredClone(clipboard.cellTerminals),
           }
         : undefined,
     mosBulkDefaults: undefined,
     connectivityEvidence: structuredClone(clipboard.connectivityEvidence),
-    layoutGroups: structuredClone(clipboard.draftingGroups),
-    constraints: [],
+    layoutGroups: structuredClone(clipboard.layoutGroups),
+    constraints: structuredClone(clipboard.constraints),
   };
 }
 
@@ -509,6 +532,11 @@ export function clipboardPreviewDocument(
             edit.kind === "set_layout_group" ? [edit.group.id] : [],
           ),
         );
+        const constraintIds = new Set(
+          proposal.edits.flatMap((edit) =>
+            edit.kind === "set_layout_constraint" ? [edit.constraint.id] : [],
+          ),
+        );
         const instances = result.document.instances.filter((instance) =>
           instanceIds.has(instance.id),
         );
@@ -523,6 +551,7 @@ export function clipboardPreviewDocument(
             terminal.interfaceInstanceIds.some((id) => instanceIds.has(id)),
           ) ?? [];
         const netIds = new Set([
+          ...Object.values(proposal.idRemap.nets),
           ...routes.map((route) => route.netId),
           ...annotations.flatMap((annotation) =>
             annotation.netId ? [annotation.netId] : [],
@@ -537,8 +566,12 @@ export function clipboardPreviewDocument(
           ),
         ]);
         const previewClipboard: SchematicClipboard = structuredClone({
+          intent: oriented.intent,
+          sourceDocumentId: base.id,
+          sourceGrid: base.presentation.grid,
           instances,
           cellTerminals,
+          formalParameters: oriented.formalParameters,
           nets: result.document.nets
             .filter((net) => netIds.has(net.id))
             .map((net) => ({
@@ -563,8 +596,11 @@ export function clipboardPreviewDocument(
           draftingObjects: (result.document.drafting?.objects ?? []).filter(
             (object) => draftingIds.has(object.id),
           ),
-          draftingGroups: result.document.layoutGroups.filter((group) =>
+          layoutGroups: result.document.layoutGroups.filter((group) =>
             layoutGroupIds.has(group.id),
+          ),
+          constraints: result.document.constraints.filter((constraint) =>
+            constraintIds.has(constraint.id),
           ),
         });
         return fallbackClipboardPreviewDocument(
@@ -588,79 +624,72 @@ export function clipboardPreviewDocument(
  * yet wired to a device, would otherwise be dropped along with its rail
  * geometry and label.
  */
-export function copyWholeDocument(
+export function captureDocumentComposition(
   document: SchematicDocument,
 ): SchematicClipboard | null {
   const draftingObjects = document.drafting?.objects ?? [];
   if (
     document.instances.length === 0 &&
     document.routes.length === 0 &&
+    document.junctions.length === 0 &&
+    document.annotations.length === 0 &&
     draftingObjects.length === 0
   ) {
     return null;
   }
-  const draftingIds = new Set(draftingObjects.map((object) => object.id));
-  const netIds = new Set<string>([
-    ...document.nets.flatMap((net) =>
-      net.terminals.length > 0 ? [net.id] : [],
-    ),
-    ...document.routes.map((route) => route.netId),
-    ...document.junctions.map((junction) => junction.netId),
-    ...document.annotations.flatMap((annotation) => [
-      ...(annotation.netId ? [annotation.netId] : []),
-      ...(annotation.binding?.kind === "net-name"
-        ? [annotation.binding.netId]
-        : []),
-    ]),
-    ...(document.netlist?.terminals.map((terminal) => terminal.netId) ?? []),
-    ...document.instances.flatMap((instance) =>
-      instance.mosBulkBinding ? [instance.mosBulkBinding.netId] : [],
-    ),
-    ...(document.mosBulkDefaults?.nmosNetId
-      ? [document.mosBulkDefaults.nmosNetId]
-      : []),
-    ...(document.mosBulkDefaults?.pmosNetId
-      ? [document.mosBulkDefaults.pmosNetId]
-      : []),
-  ]);
-  // Explicit equivalence is an intentional connectivity edge, so retain its
-  // complete member set when any member is otherwise reachable.
-  let expanded = true;
-  while (expanded) {
-    expanded = false;
-    for (const evidence of document.connectivityEvidence) {
-      if (
-        evidence.kind !== "explicit-equivalence" ||
-        !evidence.memberNetIds.some((netId) => netIds.has(netId))
-      ) {
-        continue;
-      }
-      for (const netId of evidence.memberNetIds) {
-        if (netIds.has(netId)) continue;
-        netIds.add(netId);
-        expanded = true;
-      }
+  const instances = structuredClone(document.instances);
+  const nets = structuredClone(document.nets);
+  const copiedInstancesById = new Map(
+    instances.map((instance) => [instance.id, instance]),
+  );
+  const copiedNetsById = new Map(nets.map((net) => [net.id, net]));
+  // A Cell default is context, not portable ownership. Close the composition
+  // snapshot by materializing any still-derived source default; proposePaste
+  // will then convert every policy binding to an instance-owned override.
+  for (const sourceInstance of document.instances) {
+    const resolution = resolveMosBulkConnection(document, sourceInstance);
+    if (
+      resolution?.status !== "cell-default" ||
+      resolution.materialized ||
+      !resolution.net
+    ) {
+      continue;
+    }
+    const copiedInstance = copiedInstancesById.get(sourceInstance.id);
+    const copiedNet = copiedNetsById.get(resolution.net.id);
+    if (!copiedInstance || !copiedNet) continue;
+    copiedInstance.mosBulkBinding = {
+      origin: "cell-default",
+      netId: copiedNet.id,
+    };
+    if (
+      !copiedNet.terminals.some(
+        (terminal) =>
+          terminal.instanceId === copiedInstance.id && terminal.pinName === "B",
+      )
+    ) {
+      copiedNet.terminals.push({
+        instanceId: copiedInstance.id,
+        pinName: "B",
+      });
     }
   }
   return structuredClone({
-    instances: document.instances,
+    intent: "compose-document",
+    sourceDocumentId: document.id,
+    sourceGrid: document.presentation.grid,
+    instances,
     cellTerminals: document.netlist?.terminals ?? [],
-    nets: document.nets.filter((net) => netIds.has(net.id)),
+    formalParameters: document.netlist?.formalParameters ?? [],
+    nets,
     routes: document.routes,
     junctions: document.junctions,
     annotations: document.annotations,
     noConnects: document.noConnects,
-    connectivityEvidence: document.connectivityEvidence.filter((evidence) =>
-      evidence.kind === "explicit-equivalence"
-        ? evidence.memberNetIds.every((netId) => netIds.has(netId))
-        : netIds.has(evidence.netId),
-    ),
+    connectivityEvidence: document.connectivityEvidence,
     draftingObjects,
-    draftingGroups: document.layoutGroups.filter(
-      (group) =>
-        group.objectIds.length > 0 &&
-        group.objectIds.every((objectId) => draftingIds.has(objectId)),
-    ),
+    layoutGroups: document.layoutGroups,
+    constraints: document.constraints,
   });
 }
 
@@ -677,11 +706,6 @@ export function copySelection(
   const selectedDrafting = new Set(draftingIds);
   const draftingObjects = (document.drafting?.objects ?? []).filter((object) =>
     selectedDrafting.has(object.id),
-  );
-  const draftingGroups = document.layoutGroups.filter(
-    (group) =>
-      group.objectIds.length > 0 &&
-      group.objectIds.every((objectId) => selectedDrafting.has(objectId)),
   );
   // A drawing-only selection is a complete copy: notes and callouts are
   // worth duplicating on their own, and requiring a part alongside them made
@@ -733,7 +757,26 @@ export function copySelection(
         routeIds.has(annotation.anchor.routeId)),
   );
   const annotationIds = new Set(annotations.map((annotation) => annotation.id));
+  const copiedLayoutObjectIds = new Set<string>([
+    ...selectedIds,
+    ...netIds,
+    ...routeIds,
+    ...junctionIds,
+    ...annotationIds,
+    ...selectedDrafting,
+  ]);
+  const layoutGroups = document.layoutGroups.filter((group) =>
+    group.objectIds.every((objectId) => copiedLayoutObjectIds.has(objectId)),
+  );
+  const constraints = document.constraints.filter((constraint) =>
+    constraint.objectIds.every((objectId) =>
+      copiedLayoutObjectIds.has(objectId),
+    ),
+  );
   return structuredClone({
+    intent: "clone-selection",
+    sourceDocumentId: document.id,
+    sourceGrid: document.presentation.grid,
     instances,
     cellTerminals:
       document.netlist?.terminals.flatMap((terminal) => {
@@ -744,6 +787,7 @@ export function copySelection(
           ? [{ ...terminal, interfaceInstanceIds }]
           : [];
       }) ?? [],
+    formalParameters: [],
     nets: document.nets
       .filter((net) => netIds.has(net.id))
       .map((net) => ({
@@ -785,7 +829,8 @@ export function copySelection(
       }
     }),
     draftingObjects,
-    draftingGroups,
+    layoutGroups,
+    constraints,
   });
 }
 
@@ -815,8 +860,10 @@ function pastedInstanceId(
   nextReference: string | undefined,
   sequence: number,
   occupied: Set<string>,
+  forceRemap = false,
 ): string {
   if (
+    !forceRemap &&
     nextReference !== undefined &&
     source.id === source.netlist?.reference &&
     !occupied.has(nextReference)
@@ -836,9 +883,14 @@ function pastedSchematicReference(
   nextNetlistReference: string | undefined,
   sequence: number,
   reserved: Set<string>,
+  preserveIfAvailable = false,
 ): string | undefined {
   const current = source.schematicReference;
   if (!current) return undefined;
+  if (preserveIfAvailable && !reserved.has(current.toLowerCase())) {
+    reserved.add(current.toLowerCase());
+    return current;
+  }
   // Only a freshly allocated netlist reference may be adopted verbatim.
   // Falling back to the pasted object id was wrong for a device with no
   // netlist block — an ideal switch, say — because that id is a copy id, so
@@ -1009,6 +1061,14 @@ export function proposePaste(
       ...(document.drafting?.objects ?? []),
     ].map((object) => object.id),
   );
+  const compositionOccurrenceId =
+    clipboard.intent === "compose-document"
+      ? uniqueCopyId(
+          `composition-${clipboard.sourceDocumentId}`,
+          sequence,
+          occupied,
+        )
+      : undefined;
   const referenceIndex = createReferenceIndex(document);
   const reservedReferences = new Set<string>();
   const occupiedReferences = new Set(
@@ -1043,6 +1103,14 @@ export function proposePaste(
   const instanceReferences = new Map(
     clipboard.instances.flatMap((instance) => {
       if (!instance.netlist) return [];
+      if (
+        clipboard.intent === "compose-document" &&
+        !occupiedReferences.has(instance.netlist.reference.toLowerCase()) &&
+        !reservedReferences.has(instance.netlist.reference.toLowerCase())
+      ) {
+        reservedReferences.add(instance.netlist.reference.toLowerCase());
+        return [[instance.id, instance.netlist.reference] as const];
+      }
       const policy = referencePolicyForInstance(instance);
       if (policy.kind === "none") {
         const reference = nextMarkerReference(instance.netlist.reference);
@@ -1071,6 +1139,7 @@ export function proposePaste(
         instanceReferences.get(instance.id),
         sequence,
         occupied,
+        clipboard.intent === "compose-document",
       ),
     ]),
   );
@@ -1091,6 +1160,7 @@ export function proposePaste(
         instanceReferences.get(instance.id),
         sequence,
         reservedSchematicReferences,
+        clipboard.intent === "compose-document",
       );
       return reference ? [[instance.id, reference] as const] : [];
     }),
@@ -1126,6 +1196,18 @@ export function proposePaste(
       uniqueCopyId(evidence.id, sequence, occupied),
     ]),
   );
+  const layoutGroupIds = new Map(
+    clipboard.layoutGroups.map((group) => [
+      group.id,
+      uniqueCopyId(group.id, sequence, occupied),
+    ]),
+  );
+  const constraintIds = new Map(
+    clipboard.constraints.map((constraint) => [
+      constraint.id,
+      uniqueCopyId(constraint.id, sequence, occupied),
+    ]),
+  );
   const errors: string[] = [];
   const terminalIds = new Map(
     clipboard.cellTerminals.map((terminal) => [
@@ -1147,20 +1229,63 @@ export function proposePaste(
       );
     }
   }
-  const objectIds = new Map<string, string>([
-    ...instanceIds,
-    ...netIds,
-    ...routeIds,
-    ...junctionIds,
-  ]);
   const draftingIds = new Map(
     clipboard.draftingObjects.map((object) => [
       object.id,
       uniqueCopyId(object.id, sequence, occupied),
     ]),
   );
-  const edits: SchematicEdit[] = clipboard.instances.map(
-    (instance): SchematicEdit => ({
+  const objectIds = new Map<string, string>([
+    ...instanceIds,
+    ...netIds,
+    ...routeIds,
+    ...junctionIds,
+    ...annotationIds,
+    ...draftingIds,
+  ]);
+  const interfaceEdits: SchematicEdit[] = [];
+  const sourceNeedsCellInterface =
+    clipboard.cellTerminals.length > 0 || clipboard.formalParameters.length > 0;
+  if (sourceNeedsCellInterface && !document.netlist) {
+    if (clipboard.intent === "compose-document") {
+      interfaceEdits.push({
+        kind: "create_cell_interface",
+        name: document.name,
+      });
+    } else {
+      errors.push("Target Document has no formal Cell interface");
+    }
+  }
+  if (
+    clipboard.intent === "compose-document" &&
+    clipboard.formalParameters.length > 0
+  ) {
+    const merged = structuredClone(document.netlist?.formalParameters ?? []);
+    const byName = new Map(
+      merged.map((parameter) => [parameter.name.toLowerCase(), parameter]),
+    );
+    for (const parameter of clipboard.formalParameters) {
+      const existing = byName.get(parameter.name.toLowerCase());
+      if (existing) {
+        if (existing.defaultValue !== parameter.defaultValue) {
+          errors.push(
+            `Cell formal parameter conflict: ${parameter.name} has incompatible defaults`,
+          );
+        }
+        continue;
+      }
+      const copy = structuredClone(parameter);
+      merged.push(copy);
+      byName.set(copy.name.toLowerCase(), copy);
+    }
+    interfaceEdits.push({
+      kind: "set_cell_formal_parameters",
+      formalParameters: merged,
+    });
+  }
+  const edits: SchematicEdit[] = [
+    ...interfaceEdits,
+    ...clipboard.instances.map((instance): SchematicEdit => ({
       kind: "add_instance",
       instance: {
         ...structuredClone(instance),
@@ -1182,6 +1307,9 @@ export function proposePaste(
           ? {
               mosBulkBinding: {
                 ...instance.mosBulkBinding,
+                ...(clipboard.intent === "compose-document"
+                  ? { origin: "instance-override" as const }
+                  : {}),
                 netId:
                   netIds.get(instance.mosBulkBinding.netId) ??
                   instance.mosBulkBinding.netId,
@@ -1195,7 +1323,13 @@ export function proposePaste(
             }
           : null,
       },
-    }),
+    })),
+  ];
+  edits.push(
+    ...[...new Set(netIds.values())].map((netId): SchematicEdit => ({
+      kind: "create_base_net",
+      netId,
+    })),
   );
 
   for (const terminal of clipboard.cellTerminals) {
@@ -1293,23 +1427,14 @@ export function proposePaste(
       };
     }),
   );
-  const availableNetIds = new Set([
-    ...document.nets.map((net) => net.id),
-    ...clipboard.nets
-      .filter((net) => net.terminals.length > 0)
-      .map((net) => netIds.get(net.id)!),
-  ]);
   edits.push(
     ...clipboard.junctions.map((junction): SchematicEdit => {
       const netId = netIds.get(junction.netId)!;
-      const createNet = !availableNetIds.has(netId);
-      availableNetIds.add(netId);
       return {
         kind: "add_junction",
         junctionId: junctionIds.get(junction.id)!,
         netId,
         position: movePoint(junction.position, offset),
-        ...(createNet ? { createNet: true } : {}),
       };
     }),
   );
@@ -1481,32 +1606,12 @@ export function proposePaste(
     junctions: Object.fromEntries(junctionIds),
     annotations: Object.fromEntries(annotationIds),
     evidence: Object.fromEntries(evidenceIds),
+    noConnects: Object.fromEntries(noConnectIds),
+    draftingObjects: Object.fromEntries(draftingIds),
+    layoutGroups: Object.fromEntries(layoutGroupIds),
+    constraints: Object.fromEntries(constraintIds),
+    cellTerminals: Object.fromEntries(terminalIds),
   };
-  const operationPlan = createRoutingOperationPlan(document, {
-    intent: "clone",
-    affected: {
-      instances: clipboard.instances.map((item) => item.id),
-      internalRoutes: clipboard.routes.map((item) => item.id),
-      boundaryRoutes: [],
-      externalRoutes: [],
-      internalJunctions: clipboard.junctions.map((item) => item.id),
-      boundaryJunctions: [],
-      electricalAnnotationIds: clipboard.annotations.map((item) => item.id),
-      protectedObjectIds: [],
-    },
-    expectedElectricalEffect: {
-      kind: "clone",
-      mapping: idRemap.instances,
-      boundaryPolicy: "disconnect",
-    },
-    idRemap,
-    edits,
-    diagnostics: errors.map((message) => ({
-      code: "ROUTING_CLONE_SOURCE_UNAVAILABLE",
-      severity: "error" as const,
-      message,
-    })),
-  });
   // Drafting objects carry no connectivity, so a copy is the object itself
   // under a fresh id, shifted by the same placement offset as everything else.
   const pastedAnchorObjectIds = new Map([...objectIds, ...draftingIds]);
@@ -1516,7 +1621,7 @@ export function proposePaste(
     const translated = translateDraftingObject(
       object,
       offset,
-      document.presentation.grid,
+      clipboard.intent === "compose-document" ? 1 : document.presentation.grid,
     );
     edits.push({
       kind: "upsert_drafting_object",
@@ -1532,27 +1637,106 @@ export function proposePaste(
       },
     });
   }
-  for (const group of clipboard.draftingGroups) {
-    const objectIds = group.objectIds.flatMap((objectId) => {
-      const mapped = draftingIds.get(objectId);
-      return mapped ? [mapped] : [];
+  for (const group of clipboard.layoutGroups) {
+    const mappedObjectIds = group.objectIds.flatMap((objectId) => {
+      const mapped = objectIds.get(objectId);
+      if (!mapped) {
+        errors.push(
+          `Layout group ${group.id} references unavailable object ${objectId}`,
+        );
+        return [];
+      }
+      return [mapped];
     });
-    if (objectIds.length === 0) continue;
+    if (mappedObjectIds.length !== group.objectIds.length) continue;
     edits.push({
       kind: "set_layout_group",
       group: {
         ...structuredClone(group),
-        id: uniqueCopyId(group.id, sequence, occupied),
-        objectIds,
+        id: layoutGroupIds.get(group.id)!,
+        objectIds: mappedObjectIds,
       },
     });
   }
+  for (const constraint of clipboard.constraints) {
+    const mappedObjectIds = constraint.objectIds.flatMap((objectId) => {
+      const mapped = objectIds.get(objectId);
+      if (!mapped) {
+        errors.push(
+          `Layout constraint ${constraint.id} references unavailable object ${objectId}`,
+        );
+        return [];
+      }
+      return [mapped];
+    });
+    if (mappedObjectIds.length !== constraint.objectIds.length) continue;
+    edits.push({
+      kind: "set_layout_constraint",
+      constraint: {
+        ...structuredClone(constraint),
+        id: constraintIds.get(constraint.id)!,
+        objectIds: mappedObjectIds,
+      },
+    });
+  }
+  if (clipboard.intent === "compose-document") {
+    const gridErrors = edits.flatMap((edit) =>
+      gridAlignmentDiagnostics(edit, document.presentation.grid),
+    );
+    if (gridErrors.length > 0) {
+      errors.push(
+        `Source geometry is incompatible with target grid ${document.presentation.grid}; composition does not rescale or snap electrical geometry`,
+      );
+    }
+  }
+  const operationPlan = createRoutingOperationPlan(document, {
+    intent: clipboard.intent === "compose-document" ? "compose" : "clone",
+    affected: {
+      instances: clipboard.instances.map((item) => item.id),
+      internalRoutes: clipboard.routes.map((item) => item.id),
+      boundaryRoutes: [],
+      externalRoutes: [],
+      internalJunctions: clipboard.junctions.map((item) => item.id),
+      boundaryJunctions: [],
+      electricalAnnotationIds: clipboard.annotations.map((item) => item.id),
+      protectedObjectIds: [],
+    },
+    expectedElectricalEffect:
+      clipboard.intent === "compose-document"
+        ? {
+            kind: "compose",
+            mapping: idRemap.instances,
+            boundaryPolicy: "preserve-target-physical",
+          }
+        : {
+            kind: "clone",
+            mapping: idRemap.instances,
+            boundaryPolicy: "disconnect",
+          },
+    idRemap,
+    edits,
+    diagnostics: errors.map((message) => ({
+      code: "ROUTING_CLONE_SOURCE_UNAVAILABLE",
+      severity: "error" as const,
+      message,
+    })),
+  });
 
   return {
     edits,
     instanceIds: [...instanceIds.values()],
     errors,
     idRemap,
+    ...(compositionOccurrenceId
+      ? {
+          compositionOccurrence: {
+            id: compositionOccurrenceId,
+            sourceDocumentId: clipboard.sourceDocumentId,
+            targetDocumentId: document.id,
+            objectIdRemap: idRemap,
+          },
+        }
+      : {}),
     operationPlan,
   };
 }

--- a/apps/editor/src/features/clipboard/gallery-placement-contract.test.ts
+++ b/apps/editor/src/features/clipboard/gallery-placement-contract.test.ts
@@ -12,7 +12,7 @@ import { builtInSymbols, createProjectSymbolResolver } from "@icm/symbols";
 import { expect, test } from "vitest";
 
 import { proposeVisualSelectionDeletion } from "../selection/delete-selection";
-import { copyWholeDocument, proposePaste } from "./clipboard";
+import { captureDocumentComposition, proposePaste } from "./clipboard";
 
 interface PlacedScene {
   instanceIds: string[];
@@ -45,7 +45,7 @@ function placeScene(
   sequence: number,
 ): { project: CircuitProject; scene: PlacedScene } {
   const document = project.documents[0]!;
-  const clipboard = copyWholeDocument(source)!;
+  const clipboard = captureDocumentComposition(source)!;
   const proposal = proposePaste(
     document,
     clipboard,

--- a/apps/editor/src/features/editor-shell/gallery-example-commands.ts
+++ b/apps/editor/src/features/editor-shell/gallery-example-commands.ts
@@ -8,7 +8,7 @@ import {
 } from "../../examples/library-examples";
 import {
   clipboardPlacementAnchor,
-  copyWholeDocument,
+  captureDocumentComposition,
   type SchematicClipboard,
 } from "../clipboard/clipboard";
 
@@ -77,7 +77,7 @@ export function createGalleryExampleCommands({
       (candidate) => candidate.id === imported.topDocumentId,
     );
     if (!importedDocument || imported.documents.length > 1) return false;
-    const clipboard = copyWholeDocument(importedDocument);
+    const clipboard = captureDocumentComposition(importedDocument);
     const anchor = clipboard ? clipboardPlacementAnchor(clipboard) : null;
     if (!clipboard || !anchor) return false;
     cancelAllTransientInteraction();

--- a/docs/specs/connectivity-and-routing.md
+++ b/docs/specs/connectivity-and-routing.md
@@ -128,7 +128,10 @@ committing clears the binding before connecting the explicit Net. Deleting the
 explicit route may reconcile only an explicitly configured cell default.
 Source-bound/imported MOS instances remain governed by their fourth-node
 evidence and are never guessed. Legacy persisted `supply-default` bindings are
-readable compatibility data, not a current authoring policy.
+readable compatibility data, not a current authoring policy. Cross-Document
+composition materializes an effective source `cell-default` as an
+`instance-override`: the copied B membership remains fixed to its copied Base
+Net and neither consumes nor changes the target Document's Cell default.
 
 A `power-rail` Route is valid only on a Base Net with an explicit persisted
 name claim whose `powerDomain` is `vdd`. Rail authoring creates or reuses that
@@ -140,6 +143,10 @@ contact evidence.
 The two rail endpoints remain directly resizable along the rail axis; moving
 the rail translates its full connected component, including tap Junctions,
 without splitting the rail into independent pieces.
+Deleting any rail segment or its owned power label likewise removes the whole
+visually continuous rail component and that label/name-owner closure in one
+transaction. Ordinary tapped wires remain; a partial rail cut that would
+strand an unnamed `power-rail` Route is not an authoring operation.
 
 A named global Net is itself an explicit semantic bridge. Separate Ground or
 VDD markers on that Net do not require a drawn trunk or matching label and do
@@ -178,6 +185,14 @@ coordinates.
 Base Nets remain physical connectivity; Logical Nets are derived from
 owner-addressed `name-claim` evidence. Reusing a spelling never merges Route
 geometry.
+
+Name claims resolve by scope and folded name inside the containing Document.
+Flattened Document composition copies those owner-addressed claims into the
+target Document's namespace, so matching local names resolve to one Logical
+Net without merging their Base-Net geometry. A composition occurrence records
+source-to-target identity only in the operation plan and never participates in
+Net resolution. Hierarchical Cell Instances, rather than hidden naming domains,
+provide local-name isolation across Documents.
 
 - Renaming one marker detaches only that owner from its old Base Net, creates
   or joins its requested name semantics, and rebinds its own label. Other

--- a/docs/specs/edit-engine.md
+++ b/docs/specs/edit-engine.md
@@ -73,14 +73,14 @@ for readability; these groups do not create separate mutation endpoints:
   `set_instance_binding`,
   `patch_instance_netlist_parameters`, `bulk_patch_instance_netlist`,
   `set_instance_netlist`;
-- Cell interface: `add_cell_terminal`, `update_cell_terminal`,
+- Cell interface: `create_cell_interface`, `add_cell_terminal`, `update_cell_terminal`,
   `remove_cell_terminal`, `reorder_cell_terminals`,
   `set_cell_formal_parameters`;
 - Route/Junction/connectivity: `set_route_path`, `route_orthogonal`,
   `add_junction`, `attach_endpoint_to_route`, `remove_junction`,
   `move_junction`, `remove_route_geometry`, `cut_connection`, `connect_endpoints`,
   `disconnect_endpoint`;
-- Net/power/MOS: `add_power_rail`, `merge_nets`,
+- Net/power/MOS: `create_base_net`, `add_power_rail`, `merge_nets`,
   `upsert_connectivity_evidence`, `remove_connectivity_evidence`,
   `set_mos_bulk_defaults`,
   `reconcile_mos_bulk`, `clear_mos_bulk_default`;

--- a/docs/specs/schematic-model.md
+++ b/docs/specs/schematic-model.md
@@ -87,6 +87,9 @@ explicit first, then materialized from a configured cell-default Net. Without
 either, it remains unresolved; MOS polarity never creates or selects a power
 Net. Existing persisted `supply-default` bindings remain readable for rolling
 compatibility, but current manual authoring does not create them.
+Cross-Document composition converts an effective source `cell-default` to an
+instance-owned `instance-override` so target Cell policy cannot retarget the
+copied body.
 Imported/source-bound MOS instances with missing fourth-node evidence remain
 unresolved.
 

--- a/packages/agent-adapter/src/schema.ts
+++ b/packages/agent-adapter/src/schema.ts
@@ -424,6 +424,7 @@ export const AgentSnapshotInstanceSchema = z.strictObject({
       status: z.enum([
         "explicit",
         "cell-default",
+        "instance-override",
         "supply-default",
         "no-connect",
         "unresolved",

--- a/packages/agent-adapter/src/service.ts
+++ b/packages/agent-adapter/src/service.ts
@@ -165,6 +165,7 @@ export function agentEditCategory(
     case "set_instance_netlist":
     case "set_instance_binding":
     case "bulk_patch_instance_netlist":
+    case "create_cell_interface":
     case "add_cell_terminal":
     case "update_cell_terminal":
     case "remove_cell_terminal":
@@ -179,6 +180,7 @@ export function agentEditCategory(
     case "remove_route_geometry":
     case "cut_connection":
     case "connect_endpoints":
+    case "create_base_net":
     case "add_power_rail":
     case "merge_nets":
     case "set_mos_bulk_defaults":

--- a/packages/derived/src/diagnostics/erc.ts
+++ b/packages/derived/src/diagnostics/erc.ts
@@ -406,6 +406,7 @@ export function runErcChecks(
           );
           const configuredDefault =
             resolution?.status === "cell-default" ||
+            resolution?.status === "instance-override" ||
             resolution?.status === "supply-default";
           if (!bulkAssessment.electricallySatisfied && !configuredDefault) {
             diagnostics.push({

--- a/packages/derived/src/endpoint-connectivity.ts
+++ b/packages/derived/src/endpoint-connectivity.ts
@@ -135,6 +135,7 @@ export function createEndpointConnectivityClassifier(
         : undefined;
       const configuredDefault =
         resolution?.status === "cell-default" ||
+        resolution?.status === "instance-override" ||
         resolution?.status === "supply-default";
       const externalPeers = assessment.peerEndpoints.filter((candidate) => {
         if (candidate.kind !== "terminal") return true;

--- a/packages/derived/src/mos-bulk.ts
+++ b/packages/derived/src/mos-bulk.ts
@@ -11,7 +11,8 @@ import { routeEnd } from "@icm/model";
 export type MosBulkKind = "nmos" | "pmos";
 export type MosBulkResolution =
   | {
-      status: "explicit" | "cell-default" | "supply-default";
+      status:
+        "explicit" | "cell-default" | "instance-override" | "supply-default";
       instance: Instance;
       net: Net;
       materialized: boolean;

--- a/packages/edit-engine/src/edit-schema.ts
+++ b/packages/edit-engine/src/edit-schema.ts
@@ -172,6 +172,11 @@ export const BulkPatchInstanceNetlistEditSchema = z.strictObject({
   kind: z.literal("bulk_patch_instance_netlist"),
   assignments: z.array(BulkInstanceNetlistAssignmentSchema).min(1).max(5000),
 });
+/** Establish a formal Cell interface on a Document that does not have one. */
+export const CreateCellInterfaceEditSchema = z.strictObject({
+  kind: z.literal("create_cell_interface"),
+  name: z.string().min(1).max(128),
+});
 export const AddCellTerminalEditSchema = z.strictObject({
   kind: z.literal("add_cell_terminal"),
   terminal: CellNetlistTerminalSchema,
@@ -273,6 +278,15 @@ export const ConnectEndpointsEditSchema = z.strictObject({
   from: RouteEndpointSchema,
   to: RouteEndpointSchema,
   newNetId: StableIdSchema.optional(),
+});
+/**
+ * Materialize one physical Base Net without assigning a name, owner, terminal,
+ * or geometry. Document composition uses this before replaying the source
+ * Net's independently typed membership and Evidence edits.
+ */
+export const CreateBaseNetEditSchema = z.strictObject({
+  kind: z.literal("create_base_net"),
+  netId: StableIdSchema,
 });
 
 /** A power rail edit creates/reuses one explicit named Net and its geometry. */
@@ -410,6 +424,7 @@ export const SchematicEditSchema = z.discriminatedUnion("kind", [
   SetInstanceBindingEditSchema,
   SetInstanceNetlistEditSchema,
   BulkPatchInstanceNetlistEditSchema,
+  CreateCellInterfaceEditSchema,
   AddCellTerminalEditSchema,
   UpdateCellTerminalEditSchema,
   RemoveCellTerminalEditSchema,
@@ -425,6 +440,7 @@ export const SchematicEditSchema = z.discriminatedUnion("kind", [
   RemoveRouteGeometryEditSchema,
   CutConnectionEditSchema,
   ConnectEndpointsEditSchema,
+  CreateBaseNetEditSchema,
   AddPowerRailEditSchema,
   MergeNetsEditSchema,
   UpsertConnectivityEvidenceEditSchema,

--- a/packages/edit-engine/src/index.ts
+++ b/packages/edit-engine/src/index.ts
@@ -17,6 +17,7 @@ export * from "./routing-deletion-planner.js";
 export * from "./net-name-operation-planner.js";
 export * from "./instance-lifecycle.js";
 export * from "./transaction.js";
+export * from "./transaction-preflight.js";
 export * from "./project-transaction.js";
 export * from "./hierarchy-planner.js";
 export * from "./cell-reset-planner.js";

--- a/packages/edit-engine/src/routing-deletion-planner.test.ts
+++ b/packages/edit-engine/src/routing-deletion-planner.test.ts
@@ -7,6 +7,62 @@ import { planRoutingDeletion } from "./routing-deletion-planner.js";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
+function segmentedPowerRailDocument() {
+  const document = createEmptyDocument("rail-main", "Rail Main");
+  document.nets.push({ id: "net-vdd", terminals: [] });
+  document.junctions.push(
+    { id: "rail-0", netId: "net-vdd", position: { x: 0, y: 0 } },
+    { id: "rail-1", netId: "net-vdd", position: { x: 100, y: 0 } },
+    { id: "rail-2", netId: "net-vdd", position: { x: 200, y: 0 } },
+    { id: "rail-3", netId: "net-vdd", position: { x: 300, y: 0 } },
+    { id: "tap-end", netId: "net-vdd", position: { x: 200, y: 100 } },
+  );
+  for (const [id, start, end, presentation] of [
+    ["rail-a", "rail-0", "rail-1", "power-rail"],
+    ["rail-b", "rail-1", "rail-2", "power-rail"],
+    ["rail-c", "rail-2", "rail-3", "power-rail"],
+    ["tap", "rail-2", "tap-end", undefined],
+  ] as const) {
+    document.routes.push(
+      createRoutePath({
+        id,
+        netId: "net-vdd",
+        start: { kind: "junction", junctionId: start },
+        end: { kind: "junction", junctionId: end },
+        bends: [],
+        modes: ["manual"],
+        ...(presentation ? { presentation } : {}),
+      }),
+    );
+  }
+  document.annotations.push({
+    id: "label-vdd",
+    kind: "power-label",
+    binding: { kind: "net-name", netId: "net-vdd" },
+    netId: "net-vdd",
+    content: { runs: [{ kind: "text", value: "VDD" }] },
+    anchor: {
+      kind: "object",
+      objectId: "rail-3",
+      localOffset: { x: 10, y: 10 },
+      fallbackPosition: { x: 310, y: 10 },
+    },
+    alignment: "start",
+    rotation: 0,
+    locked: false,
+  });
+  document.connectivityEvidence.push({
+    id: "claim-vdd",
+    kind: "name-claim",
+    netId: "net-vdd",
+    name: "VDD",
+    owner: { kind: "power-marker", objectId: "label-vdd" },
+    scope: "local",
+    powerDomain: "vdd",
+  });
+  return document;
+}
+
 describe("routing deletion planner", () => {
   it("removes an isolated Wire and both orphan anchors in one operation", () => {
     const document = createEmptyDocument("main", "Main");
@@ -91,5 +147,64 @@ describe("routing deletion planner", () => {
         result.evaluated.finalDocument.junctions.map((item) => item.id),
       ).toEqual(["L", "R"]);
     }
+  });
+
+  it("deletes a segmented Power Rail as one component while preserving its tap", () => {
+    const document = segmentedPowerRailDocument();
+    const plan = planRoutingDeletion(
+      document,
+      resolver,
+      { instanceIds: [], routeIds: ["rail-b"], junctionIds: [] },
+      1,
+    );
+    expect(
+      plan.edits.flatMap((edit) =>
+        edit.kind === "cut_connection" ? [edit.routeId] : [],
+      ),
+    ).toEqual(["rail-a", "rail-b", "rail-c"]);
+    expect(plan.edits).toContainEqual({
+      kind: "remove_schematic_annotation",
+      annotationId: "label-vdd",
+    });
+
+    const result = gateRoutingOperationPlan(document, plan, {
+      symbolResolver: resolver,
+    });
+    if (!result.ok) throw new Error(JSON.stringify(result, null, 2));
+    expect(
+      result.evaluated.finalDocument.routes.map((route) => route.id),
+    ).toEqual(["tap"]);
+    expect(
+      result.evaluated.finalDocument.junctions.map((junction) => junction.id),
+    ).toEqual(["rail-2", "tap-end"]);
+    expect(result.evaluated.finalDocument.annotations).toEqual([]);
+    expect(result.evaluated.finalDocument.connectivityEvidence).toEqual([]);
+  });
+
+  it("treats deleting the Power Rail label as deleting the same component", () => {
+    const document = segmentedPowerRailDocument();
+    const plan = planRoutingDeletion(
+      document,
+      resolver,
+      {
+        instanceIds: [],
+        routeIds: [],
+        junctionIds: [],
+        annotationIds: ["label-vdd"],
+      },
+      1,
+    );
+    expect(
+      plan.edits.flatMap((edit) =>
+        edit.kind === "cut_connection" ? [edit.routeId] : [],
+      ),
+    ).toEqual(["rail-a", "rail-b", "rail-c"]);
+    const result = gateRoutingOperationPlan(document, plan, {
+      symbolResolver: resolver,
+    });
+    if (!result.ok) throw new Error(JSON.stringify(result, null, 2));
+    expect(
+      result.evaluated.finalDocument.routes.map((route) => route.id),
+    ).toEqual(["tap"]);
   });
 });

--- a/packages/edit-engine/src/routing-deletion-planner.ts
+++ b/packages/edit-engine/src/routing-deletion-planner.ts
@@ -1,8 +1,9 @@
 import {
+  derivePowerRailComponent,
   deriveRoutingAffectedClosure,
   type RoutingSelectionSeed,
 } from "@icm/derived";
-import type { SchematicDocument } from "@icm/model";
+import { routeEnd, type SchematicDocument } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 
 import {
@@ -20,6 +21,49 @@ export interface RoutingDeletionSeed extends RoutingSelectionSeed {
   readonly draftingIds?: readonly string[];
 }
 
+/** A selected rail label owns the same deletion component as its rail. */
+function expandSelectedPowerRailLabels(
+  document: SchematicDocument,
+  seed: RoutingDeletionSeed,
+): RoutingDeletionSeed {
+  const routeIds = new Set(seed.routeIds);
+  for (const annotationId of seed.annotationIds ?? []) {
+    const annotation = document.annotations.find(
+      (candidate) =>
+        candidate.id === annotationId && candidate.kind === "power-label",
+    );
+    if (!annotation) continue;
+    const anchor = annotation.anchor;
+    const seedRoute = document.routes.find((route) => {
+      if (
+        route.presentation !== "power-rail" ||
+        route.netId !== annotation.netId
+      ) {
+        return false;
+      }
+      if (anchor.kind === "route") {
+        return anchor.routeId === route.id;
+      }
+      return (
+        anchor.kind === "object" &&
+        [route.start, routeEnd(route)].some(
+          (endpoint) =>
+            endpoint.kind === "junction" &&
+            endpoint.junctionId === anchor.objectId,
+        )
+      );
+    });
+    if (!seedRoute) continue;
+    for (const routeId of derivePowerRailComponent(document, seedRoute.id)
+      ?.routeIds ?? []) {
+      routeIds.add(routeId);
+    }
+  }
+  return routeIds.size === seed.routeIds.length
+    ? seed
+    : { ...seed, routeIds: [...routeIds] };
+}
+
 /**
  * Plan one graph deletion. Route selection dominates incidental marquee
  * Junction dots; Junction-only selection owns its incident arms. Instance,
@@ -32,12 +76,13 @@ export function planRoutingDeletion(
   seed: RoutingDeletionSeed,
   sequence: number,
 ): RoutingOperationPlan {
-  const affected = deriveRoutingAffectedClosure(document, seed);
+  const expandedSeed = expandSelectedPowerRailLabels(document, seed);
+  const affected = deriveRoutingAffectedClosure(document, expandedSeed);
   const selectedInstances = new Set(affected.instances);
   const routeDeletion = proposeVisualRouteDeletion(
     document,
-    seed.routeIds,
-    seed.routeIds.length > 0 ? [] : seed.junctionIds,
+    expandedSeed.routeIds,
+    expandedSeed.routeIds.length > 0 ? [] : expandedSeed.junctionIds,
     { instanceIdsScheduledForDeletion: affected.instances },
   );
   const instanceEdits =
@@ -49,7 +94,9 @@ export function planRoutingDeletion(
     selectedInstances,
   );
   const routeAnnotationIds = new Set(routeDeletion.annotationIds);
-  const explicitAnnotationIds = [...new Set(seed.annotationIds ?? [])].filter(
+  const explicitAnnotationIds = [
+    ...new Set(expandedSeed.annotationIds ?? []),
+  ].filter(
     (annotationId) =>
       document.annotations.some(
         (annotation) => annotation.id === annotationId,
@@ -57,8 +104,9 @@ export function planRoutingDeletion(
       !removedWithInstances.has(annotationId) &&
       !routeAnnotationIds.has(annotationId),
   );
-  const draftingIds = [...new Set(seed.draftingIds ?? [])].filter((objectId) =>
-    document.drafting?.objects.some((object) => object.id === objectId),
+  const draftingIds = [...new Set(expandedSeed.draftingIds ?? [])].filter(
+    (objectId) =>
+      document.drafting?.objects.some((object) => object.id === objectId),
   );
   const edits: SchematicEdit[] = [
     ...instanceEdits,

--- a/packages/edit-engine/src/routing-operation-plan.ts
+++ b/packages/edit-engine/src/routing-operation-plan.ts
@@ -22,6 +22,7 @@ export type RoutingOperationIntent =
   | "transform"
   | "route-geometry"
   | "clone"
+  | "compose"
   | "delete"
   | "rename-marker"
   | "rename-net";
@@ -35,6 +36,11 @@ export interface OperationIdRemap {
   readonly junctions: Readonly<Record<string, string>>;
   readonly annotations: Readonly<Record<string, string>>;
   readonly evidence: Readonly<Record<string, string>>;
+  readonly noConnects: Readonly<Record<string, string>>;
+  readonly draftingObjects: Readonly<Record<string, string>>;
+  readonly layoutGroups: Readonly<Record<string, string>>;
+  readonly constraints: Readonly<Record<string, string>>;
+  readonly cellTerminals: Readonly<Record<string, string>>;
 }
 
 export type ExpectedElectricalEffect =
@@ -53,6 +59,11 @@ export type ExpectedElectricalEffect =
       readonly kind: "clone";
       readonly mapping: Readonly<Record<string, string>>;
       readonly boundaryPolicy: "disconnect";
+    }
+  | {
+      readonly kind: "compose";
+      readonly mapping: Readonly<Record<string, string>>;
+      readonly boundaryPolicy: "preserve-target-physical";
     }
   | {
       readonly kind: "rebind-name-owner";
@@ -123,6 +134,11 @@ const EMPTY_ID_REMAP: OperationIdRemap = {
   junctions: {},
   annotations: {},
   evidence: {},
+  noConnects: {},
+  draftingObjects: {},
+  layoutGroups: {},
+  constraints: {},
+  cellTerminals: {},
 };
 
 function unique(values: Iterable<string>): readonly string[] {
@@ -307,6 +323,22 @@ function validateExpectedEffect(
       )
         ? "Routing clone reused a source identity"
         : null;
+    case "compose": {
+      if (
+        Object.entries(expected.mapping).some(
+          ([source, clone]) => source === clone,
+        )
+      ) {
+        return "Document composition reused a source identity";
+      }
+      return existingEndpointKeys(beforeDocument).some(
+        (key) =>
+          before.endpointToBaseNet.get(key) !==
+          after.endpointToBaseNet.get(key),
+      )
+        ? "Document composition changed existing physical Net membership"
+        : null;
+    }
     case "rebind-name-owner": {
       const claim = after.nameClaimsByOwner.get(expected.ownerKey);
       return claim?.name === expected.requestedName &&
@@ -404,7 +436,7 @@ export function expectedElectricalEffectForOperation(
       ]),
     };
   }
-  if (intent === "clone") {
+  if (intent === "clone" || intent === "compose") {
     return { kind: "preserve", endpointKeys: existingEndpointKeys(document) };
   }
   const editedEndpointKeys = endpointKeysFromEdits(edits);

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -781,11 +781,26 @@ export function proposeVisualRouteDeletion(
   const routesToRemove = new Set<string>();
   const bulkRoutesToRemove = new Set<string>();
   const junctionsToRemove = new Set(junctionIds);
-  const includeRouteAndBulkFamily = (route: RouteBranch): boolean => {
+  const removedRailEndpointJunctionIds = new Set<string>();
+  const removedRailNetIds = new Set<string>();
+  const includeRouteAndOwnedFamily = (route: RouteBranch): boolean => {
     let changed = false;
     if (!routesToRemove.has(route.id)) {
       routesToRemove.add(route.id);
       changed = true;
+    }
+    const railComponent = derivePowerRailComponent(document, route.id);
+    if (railComponent) {
+      removedRailNetIds.add(route.netId);
+      railComponent.endpointJunctionIds.forEach((junctionId) =>
+        removedRailEndpointJunctionIds.add(junctionId),
+      );
+      for (const routeId of railComponent.routeIds) {
+        if (!routesToRemove.has(routeId)) {
+          routesToRemove.add(routeId);
+          changed = true;
+        }
+      }
     }
     const family = deriveMosBulkRouteFamily(document, route);
     if (!family) return changed;
@@ -800,7 +815,7 @@ export function proposeVisualRouteDeletion(
   };
   for (const routeId of routeIds) {
     const route = document.routes.find((candidate) => candidate.id === routeId);
-    if (route) includeRouteAndBulkFamily(route);
+    if (route) includeRouteAndOwnedFamily(route);
     else routesToRemove.add(routeId);
   }
   let changed = true;
@@ -813,7 +828,7 @@ export function proposeVisualRouteDeletion(
           junctionsToRemove.has(endpoint.junctionId),
       );
       if (touchesDeletedJunction && !routesToRemove.has(route.id)) {
-        changed = includeRouteAndBulkFamily(route) || changed;
+        changed = includeRouteAndOwnedFamily(route) || changed;
       }
     }
     for (const junction of document.junctions) {
@@ -851,13 +866,9 @@ export function proposeVisualRouteDeletion(
       (annotation) =>
         annotation.kind === "power-label" &&
         annotation.anchor.kind === "object" &&
-        sortedJunctionIds.includes(annotation.anchor.objectId) &&
-        document.routes.some(
-          (route) =>
-            routesToRemove.has(route.id) &&
-            route.presentation === "power-rail" &&
-            route.netId === annotation.netId,
-        ),
+        removedRailEndpointJunctionIds.has(annotation.anchor.objectId) &&
+        annotation.netId !== undefined &&
+        removedRailNetIds.has(annotation.netId),
     )
     .map((annotation) => annotation.id);
   const removedAnnotationIds = [

--- a/packages/edit-engine/src/transaction-cell-interface.ts
+++ b/packages/edit-engine/src/transaction-cell-interface.ts
@@ -8,6 +8,7 @@ type CellInterfaceEdit = Extract<
   EditTransaction["edits"][number],
   {
     kind:
+      | "create_cell_interface"
       | "add_cell_terminal"
       | "update_cell_terminal"
       | "remove_cell_terminal"
@@ -31,6 +32,24 @@ export function applyCellInterfaceEdit(
 ): CellInterfaceEditOutcome {
   const { draft, changedObjectIds, deferNetPrune, reject } = context;
   switch (edit.kind) {
+    case "create_cell_interface": {
+      if (draft.netlist) {
+        return {
+          ok: false,
+          rejection: reject(
+            "EDIT_PRECONDITION",
+            "Document already has a formal Cell interface",
+          ),
+        };
+      }
+      draft.netlist = {
+        name: edit.name,
+        terminals: [],
+        formalParameters: [],
+      };
+      changedObjectIds.add(draft.id);
+      return { ok: true, connectivityChanged: true };
+    }
     case "add_cell_terminal": {
       if (!draft.netlist) {
         return {

--- a/packages/edit-engine/src/transaction-net-power.ts
+++ b/packages/edit-engine/src/transaction-net-power.ts
@@ -22,6 +22,7 @@ type NetPowerEdit = Extract<
   EditTransaction["edits"][number],
   {
     kind:
+      | "create_base_net"
       | "add_power_rail"
       | "merge_nets"
       | "upsert_connectivity_evidence"
@@ -48,6 +49,35 @@ export function applyNetPowerEdit(
   let connectivityChanged = false;
 
   switch (edit.kind) {
+    case "create_base_net": {
+      const occupiedIds = new Set(
+        [
+          ...draft.instances,
+          ...draft.nets,
+          ...draft.routes,
+          ...draft.junctions,
+          ...draft.annotations,
+          ...draft.connectivityEvidence,
+          ...draft.layoutGroups,
+          ...draft.constraints,
+          ...draft.noConnects,
+          ...(draft.netlist?.terminals ?? []),
+          ...(draft.drafting?.objects ?? []),
+        ].map((object) => object.id),
+      );
+      if (occupiedIds.has(edit.netId)) {
+        return rejectAt(
+          "EDIT_PRECONDITION",
+          `Base Net ID already exists: ${edit.netId}`,
+          [],
+          [edit.netId],
+        );
+      }
+      draft.nets.push({ id: edit.netId, terminals: [] });
+      changedObjectIds.add(edit.netId);
+      connectivityChanged = true;
+      break;
+    }
     case "add_power_rail": {
       const horizontal =
         edit.start.y === edit.end.y && edit.start.x !== edit.end.x;

--- a/packages/edit-engine/src/transaction-route-topology.ts
+++ b/packages/edit-engine/src/transaction-route-topology.ts
@@ -699,18 +699,40 @@ export function applyRouteTopologyEdit(
             "Two unconnected endpoints require newNetId",
           );
         }
-        if (draft.nets.some((net) => net.id === edit.newNetId)) {
-          return rejectAt(
-            "EDIT_PRECONDITION",
-            `Net already exists: ${edit.newNetId}`,
-          );
+        const preparedNet = draft.nets.find((net) => net.id === edit.newNetId);
+        if (preparedNet) {
+          const alreadyReferenced =
+            preparedNet.terminals.length > 0 ||
+            draft.routes.some((route) => route.netId === preparedNet.id) ||
+            draft.junctions.some(
+              (junction) => junction.netId === preparedNet.id,
+            ) ||
+            draft.annotations.some(
+              (annotation) =>
+                annotation.netId === preparedNet.id ||
+                (annotation.binding?.kind === "net-name" &&
+                  annotation.binding.netId === preparedNet.id),
+            ) ||
+            draft.connectivityEvidence.some((evidence) =>
+              evidence.kind === "explicit-equivalence"
+                ? evidence.memberNetIds.includes(preparedNet.id)
+                : evidence.netId === preparedNet.id,
+            );
+          if (alreadyReferenced) {
+            return rejectAt(
+              "EDIT_PRECONDITION",
+              `Prepared Base Net is already populated: ${edit.newNetId}`,
+            );
+          }
+          netId = preparedNet.id;
+        } else {
+          netId = edit.newNetId;
+          draft.nets.push({
+            id: netId,
+            terminals: [],
+          });
+          changedObjectIds.add(netId);
         }
-        netId = edit.newNetId;
-        draft.nets.push({
-          id: netId,
-          terminals: [],
-        });
-        changedObjectIds.add(netId);
       }
       addEndpointToNet(draft, netId, edit.from);
       addEndpointToNet(draft, netId, edit.to);

--- a/packages/edit-engine/src/transaction.test.ts
+++ b/packages/edit-engine/src/transaction.test.ts
@@ -171,6 +171,44 @@ describe("Edit Transaction envelope", () => {
     ]);
   });
 
+  it("materializes a prepared Base Net before assigning terminal membership", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.instances.push(
+      { id: "R1", symbolId: "resistor", placement: null },
+      { id: "R2", symbolId: "resistor", placement: null },
+    );
+
+    const result = executeTransaction(
+      document,
+      {
+        ...transaction(),
+        edits: [
+          { kind: "create_base_net", netId: "net-imported" },
+          {
+            kind: "connect_endpoints",
+            from: { kind: "terminal", instanceId: "R1", pinName: "1" },
+            to: { kind: "terminal", instanceId: "R2", pinName: "1" },
+            newNetId: "net-imported",
+          },
+        ],
+      },
+      { symbolResolver: resolver },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.document.nets).toEqual([
+      {
+        id: "net-imported",
+        terminals: [
+          { instanceId: "R1", pinName: "1" },
+          { instanceId: "R2", pinName: "1" },
+        ],
+      },
+    ]);
+    expect(result.document.connectivityEvidence).toEqual([]);
+  });
+
   it("rejects a schematic reference on a formal Cell Pin", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.instances.push({

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -359,6 +359,7 @@ export function executeTransaction(
         connectivityChanged ||= outcome.connectivityChanged ?? false;
         break;
       }
+      case "create_cell_interface":
       case "add_cell_terminal":
       case "update_cell_terminal":
       case "remove_cell_terminal":
@@ -429,6 +430,7 @@ export function executeTransaction(
         connectivityChanged ||= outcome.connectivityChanged ?? false;
         break;
       }
+      case "create_base_net":
       case "add_power_rail":
       case "merge_nets":
       case "upsert_connectivity_evidence":

--- a/packages/model/src/schema.test.ts
+++ b/packages/model/src/schema.test.ts
@@ -37,6 +37,26 @@ describe("CircuitProject schema", () => {
     expect(CircuitProjectJsonSchema).toMatchObject({ type: "object" });
   });
 
+  it("rejects hidden Net naming domains", () => {
+    const document = createEmptyDocument("document", "Document");
+    document.nets.push({ id: "net-out", terminals: [] });
+    const candidate = {
+      ...document,
+      connectivityEvidence: [
+        {
+          id: "claim-out",
+          kind: "name-claim",
+          netId: "net-out",
+          name: "OUT",
+          owner: { kind: "explicit-net-property" },
+          scope: "local",
+          localDomainId: "gallery-occurrence-1",
+        },
+      ],
+    };
+    expect(SchematicDocumentSchema.safeParse(candidate).success).toBe(false);
+  });
+
   it("rejects retired logical projections on physical Base Nets", () => {
     const project = createEmptyProject("project-net", "Net");
     for (const projection of [

--- a/packages/model/src/schema/instance.ts
+++ b/packages/model/src/schema/instance.ts
@@ -123,7 +123,7 @@ export const InstanceImportProvenanceSchema = z.strictObject({
   terminalMapping: z.array(InstanceTerminalMappingSchema).max(128).optional(),
 });
 export const MosBulkBindingSchema = z.strictObject({
-  origin: z.enum(["cell-default", "supply-default"]),
+  origin: z.enum(["cell-default", "instance-override", "supply-default"]),
   netId: StableIdSchema,
 });
 export const InstanceSchema = z
@@ -134,6 +134,8 @@ export const InstanceSchema = z
     sourceRef: SourceSpanSchema.optional(),
     importProvenance: InstanceImportProvenanceSchema.optional(),
     // Present only for an editor-materialized implicit body connection.
+    // Cross-Document composition converts a source Cell policy into an
+    // instance-override so the copied body does not inherit target defaults.
     // Explicit SPICE/user B connections need no parallel metadata.
     mosBulkBinding: MosBulkBindingSchema.optional(),
     placement: PlacementSchema.nullable(),


### PR DESCRIPTION
## Summary

- Treat Gallery insertion as full flattened Document composition, including Base Nets, connectivity Evidence, routes, annotations, drafting geometry, Cell interfaces, layout groups, and constraints, with atomic ID remapping.
- Resolve copied owner-addressed name claims in the target Document namespace: equal visible names form one Logical Net, without localDomainId, a schema bump, or source-Document participation in connectivity.
- Keep composition occurrence metadata non-electrical, materialize source MOS bulk defaults as instance overrides, and delete visually continuous Power Rail components with their owned name closure.
- Make two time-sensitive browser contracts deterministic without weakening their behavioral assertions.

## Regression coverage

- Composed LTC3452.icproj (2) and LTC3452.icproj (3) twice each into the same target Document and validated every result.
- Added clipboard composition, same-name Net, drafting-object, Cell interface, constraint, MOS bulk, schema rejection, and Power Rail deletion regressions.

## Validation

- pnpm install --frozen-lockfile
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main: 1978 unit tests and 147 selected browser tests
- pnpm gate:full: static checks, 1978 unit tests, production build, release/performance/Golden/smoke verification, and 296 browser tests
- git diff --check