### PR TITLE
ci: bound validation growth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          # Pull requests need their complete commit range for Test-Impact.
+          # Forced-full events inspect only the checked-out merge/scheduled
+          # commit, so two commits avoid an unbounded all-ref fetch.
+          fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '2' }}
       - id: plan
         name: Plan CI validation
         env:
           EVENT_NAME: ${{ github.event_name }}
           PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
         shell: bash
         run: |
           force_args=()
@@ -40,7 +42,7 @@ jobs:
               base="$PULL_REQUEST_BASE_SHA"
               ;;
             merge_group)
-              base="$MERGE_GROUP_BASE_SHA"
+              base="$(git rev-parse HEAD^ 2>/dev/null || git rev-parse HEAD)"
               force_args+=(--force-full)
               ;;
             *)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,15 +139,16 @@ Before a non-document change is merged or pushed to `main`:
 1. Start from a clean dependency state with
    `pnpm install --frozen-lockfile`. Run `pnpm setup:e2e` once on a machine that
    does not yet have the matching Playwright Chromium installation.
-2. Run `pnpm gate:preflight -- --base <base-ref>` and
-   `pnpm gate:affected -- --base <base-ref>`.
-3. Run `pnpm gate:full` when the printed plan selects `full-delivery`: shared
-   core, production boundaries, gate-policy changes, and unclassified code all
-   take this conservative path. A bounded mapped change does not repeat the
-   complete browser suite locally.
-4. Push a review branch and wait for all five GitHub required checks. Static,
+2. Run `pnpm gate:preflight -- --base <base-ref>`.
+3. When the printed plan selects `full-delivery`, run `pnpm gate:full` once;
+   the complete gate supersedes affected static, unit, focused-browser,
+   release, and branch checks. Otherwise run
+   `pnpm gate:affected -- --base <base-ref>`. Shared core, production
+   boundaries, gate-policy changes, and unclassified code take the
+   conservative full path without repeating its covered work locally.
+4. Push a review branch and wait for all seven GitHub required checks. Static,
    full unit, and release/performance checks run for every implementation PR;
-   the two browser checks run focused specs or automatically fall back to the
+   the four browser checks run focused specs or automatically fall back to the
    complete suite. Merge-queue, nightly, and manual CI runs are always full.
 5. If a remote check fails, keep the target active: inspect its log, repair the
    reported cause, and repeat verification. A successful `git push` is not a

--- a/config/validation-gates.json
+++ b/config/validation-gates.json
@@ -26,7 +26,68 @@
       "apps/editor/src/features/search/**",
       "apps/editor/src/features/selection/**",
       "apps/editor/src/features/text-editing/**",
-      "apps/editor/src/features/wiring/**"
+      "apps/editor/src/features/wiring/**",
+      "apps/editor/e2e/drafting.spec.ts",
+      "apps/editor/e2e/instance-table.spec.ts",
+      "apps/editor/e2e/manual-editor.spec.ts"
+    ],
+    "editorCommands": [
+      "apps/editor/src/app/editor-transaction-commands*",
+      "apps/editor/src/commands/**",
+      "apps/editor/src/interaction/editor-shortcuts*",
+      "apps/editor/src/features/selection/canvas-context-menu*",
+      "apps/editor/src/features/selection/selection-context-actions*",
+      "apps/editor/e2e/context-menu.spec.ts",
+      "apps/editor/e2e/verb-first.spec.ts"
+    ],
+    "editorDiagnostics": [
+      "apps/editor/src/canvas/diagnostic-markers*",
+      "apps/editor/src/canvas/editor-canvas-overlays*",
+      "apps/editor/src/features/editor-shell/editor-statusbar*",
+      "apps/editor/src/features/selection/selection-inspector-details*",
+      "apps/editor/e2e/diagnostics-surfacing.spec.ts"
+    ],
+    "editorRuntimeSafety": [
+      "apps/editor/src/app/crash-test-hooks.ts",
+      "apps/editor/src/app/editor-runtime-helpers.ts",
+      "apps/editor/src/app/lazy-editor-dialogs.ts",
+      "apps/editor/src/components/chunk-load-fallback.tsx",
+      "apps/editor/src/components/editor-error-boundary.tsx",
+      "apps/editor/src/components/editor-help-dialog.tsx",
+      "apps/editor/src/styles/editor-chrome.css",
+      "apps/editor/e2e/chrome-isolation.spec.ts",
+      "apps/editor/e2e/runtime-crash-safety.spec.ts"
+    ],
+    "editorSelection": [
+      "apps/editor/src/canvas/editor-canvas-hit-layer*",
+      "apps/editor/src/canvas/editor-canvas-overlays*",
+      "apps/editor/src/canvas/editor-selection-halo*",
+      "apps/editor/src/features/selection/**",
+      "apps/editor/e2e/detach-move.spec.ts",
+      "apps/editor/e2e/net-highlight.spec.ts",
+      "apps/editor/e2e/overlap-warning.spec.ts",
+      "apps/editor/e2e/selection-visuals.spec.ts"
+    ],
+    "editorViewport": [
+      "apps/editor/src/canvas/canvas-gesture-controller*",
+      "apps/editor/src/canvas/canvas-viewport*",
+      "apps/editor/src/canvas/editor-canvas-surface.tsx",
+      "apps/editor/src/canvas/fit-view*",
+      "apps/editor/e2e/wheel-behavior.spec.ts"
+    ],
+    "editorWiring": [
+      "apps/editor/src/canvas/editor-wiring-overlay*",
+      "apps/editor/src/features/wiring/**",
+      "apps/editor/e2e/wiring-semantics.spec.ts"
+    ],
+    "placementNearMiss": [
+      "apps/editor/src/features/component-insert/placement-near-miss*",
+      "apps/editor/e2e/placement-near-miss.spec.ts"
+    ],
+    "thinTargetHit": [
+      "apps/editor/src/canvas/canvas-hit-controller.ts",
+      "apps/editor/src/canvas/canvas-hit-resolver*",
+      "apps/editor/e2e/thin-target-hit.spec.ts"
     ],
     "componentInsert": [
       "apps/editor/src/features/component-insert/**",
@@ -43,7 +104,10 @@
     ],
     "projectPersistence": [
       "apps/editor/src/document/**",
+      "apps/editor/e2e/auto-fit.spec.ts",
       "apps/editor/e2e/project-file.spec.ts",
+      "apps/editor/e2e/recovery-dialog.spec.ts",
+      "apps/editor/e2e/recovery-hardening.spec.ts",
       "packages/model/**",
       "packages/project-protocol/**"
     ],
@@ -187,6 +251,7 @@
       ],
       "ci": {
         "e2eArgs": [
+          "apps/editor/e2e/auto-fit.spec.ts",
           "apps/editor/e2e/project-file.spec.ts",
           "apps/editor/e2e/recovery-dialog.spec.ts",
           "apps/editor/e2e/recovery-hardening.spec.ts"
@@ -232,6 +297,126 @@
       }
     },
     {
+      "id": "editor-commands-browser",
+      "stage": "affected",
+      "groups": ["editorCommands"],
+      "description": "Validate verb-first commands and contextual editor actions.",
+      "command": [
+        "pnpm",
+        "test:e2e:local",
+        "apps/editor/e2e/context-menu.spec.ts",
+        "apps/editor/e2e/verb-first.spec.ts"
+      ],
+      "ci": {
+        "e2eArgs": [
+          "apps/editor/e2e/context-menu.spec.ts",
+          "apps/editor/e2e/verb-first.spec.ts"
+        ]
+      }
+    },
+    {
+      "id": "editor-diagnostics-browser",
+      "stage": "affected",
+      "groups": ["editorDiagnostics"],
+      "description": "Validate diagnostic badges, markers, and workbench navigation.",
+      "command": [
+        "pnpm",
+        "test:e2e:local",
+        "apps/editor/e2e/diagnostics-surfacing.spec.ts"
+      ],
+      "ci": {
+        "e2eArgs": ["apps/editor/e2e/diagnostics-surfacing.spec.ts"]
+      }
+    },
+    {
+      "id": "editor-runtime-safety-browser",
+      "stage": "affected",
+      "groups": ["editorRuntimeSafety"],
+      "description": "Validate editor chrome isolation and scoped crash recovery.",
+      "command": [
+        "pnpm",
+        "test:e2e:local",
+        "apps/editor/e2e/chrome-isolation.spec.ts",
+        "apps/editor/e2e/runtime-crash-safety.spec.ts"
+      ],
+      "ci": {
+        "e2eArgs": [
+          "apps/editor/e2e/chrome-isolation.spec.ts",
+          "apps/editor/e2e/runtime-crash-safety.spec.ts"
+        ]
+      }
+    },
+    {
+      "id": "editor-selection-browser",
+      "stage": "affected",
+      "groups": ["editorSelection"],
+      "description": "Validate selection, move, highlight, and overlap workflows.",
+      "command": [
+        "pnpm",
+        "test:e2e:local",
+        "apps/editor/e2e/detach-move.spec.ts",
+        "apps/editor/e2e/net-highlight.spec.ts",
+        "apps/editor/e2e/overlap-warning.spec.ts",
+        "apps/editor/e2e/selection-visuals.spec.ts"
+      ],
+      "ci": {
+        "e2eArgs": [
+          "apps/editor/e2e/detach-move.spec.ts",
+          "apps/editor/e2e/net-highlight.spec.ts",
+          "apps/editor/e2e/overlap-warning.spec.ts",
+          "apps/editor/e2e/selection-visuals.spec.ts"
+        ]
+      }
+    },
+    {
+      "id": "editor-viewport-browser",
+      "stage": "affected",
+      "groups": ["editorViewport"],
+      "description": "Validate camera fitting and wheel interaction behavior.",
+      "command": [
+        "pnpm",
+        "test:e2e:local",
+        "apps/editor/e2e/wheel-behavior.spec.ts"
+      ],
+      "ci": { "e2eArgs": ["apps/editor/e2e/wheel-behavior.spec.ts"] }
+    },
+    {
+      "id": "editor-wiring-browser",
+      "stage": "affected",
+      "groups": ["editorWiring"],
+      "description": "Validate browser-authoritative wire editing semantics.",
+      "command": [
+        "pnpm",
+        "test:e2e:local",
+        "apps/editor/e2e/wiring-semantics.spec.ts"
+      ],
+      "ci": { "e2eArgs": ["apps/editor/e2e/wiring-semantics.spec.ts"] }
+    },
+    {
+      "id": "placement-near-miss-browser",
+      "stage": "affected",
+      "groups": ["placementNearMiss"],
+      "description": "Validate near-miss feedback for component placement.",
+      "command": [
+        "pnpm",
+        "test:e2e:local",
+        "apps/editor/e2e/placement-near-miss.spec.ts"
+      ],
+      "ci": { "e2eArgs": ["apps/editor/e2e/placement-near-miss.spec.ts"] }
+    },
+    {
+      "id": "thin-target-hit-browser",
+      "stage": "affected",
+      "groups": ["thinTargetHit"],
+      "description": "Validate visible thin-target precedence during canvas hit testing.",
+      "command": [
+        "pnpm",
+        "test:e2e:local",
+        "apps/editor/e2e/thin-target-hit.spec.ts"
+      ],
+      "ci": { "e2eArgs": ["apps/editor/e2e/thin-target-hit.spec.ts"] }
+    },
+    {
       "id": "release-verification",
       "stage": "affected",
       "groups": ["release"],
@@ -251,7 +436,28 @@
       "stage": "final",
       "groups": ["highRisk"],
       "description": "Canonical complete gate for shared-core and production-boundary changes.",
-      "command": ["pnpm", "ci:check"]
+      "command": ["pnpm", "ci:check"],
+      "supersedes": [
+        "documentation-links",
+        "static-contracts",
+        "workspace-unit",
+        "component-insert-browser",
+        "hierarchy-browser",
+        "project-file-browser",
+        "gallery-browser",
+        "agent-browser",
+        "editor-browser",
+        "editor-commands-browser",
+        "editor-diagnostics-browser",
+        "editor-runtime-safety-browser",
+        "editor-selection-browser",
+        "editor-viewport-browser",
+        "editor-wiring-browser",
+        "placement-near-miss-browser",
+        "thin-target-hit-browser",
+        "release-verification",
+        "branch-verification"
+      ]
     }
   ],
   "fullFallback": {

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -40,15 +40,23 @@ The versioned catalog at `config/validation-gates.json` maps repository paths
 to preflight, affected, and final gates. Shared-core, production-boundary,
 unknown non-documentation, and gate-policy changes select the conservative
 branch/full fallback. Bounded changes select focused browser contracts; this
-does not skip any required GitHub check because the existing two browser check
-names remain present and run the selected specs.
+does not skip any required GitHub check because all four browser check names
+remain present and run the selected specs.
 
 `gate:preflight` runs cheap static contracts and cross-checks the commit's test
 impact declaration. `gate:affected` runs the catalog's bounded unit, focused
 browser, release, or branch checks. Review the printed reasons before
-execution; run `gate:full` when the plan selects `full-delivery`. Run
-`pnpm setup:e2e` once per machine or Playwright version instead of paying for a
-browser installation on every full check.
+execution. When the plan selects `full-delivery`, that complete gate
+supersedes static, unit, focused-browser, release, and branch verification:
+run `gate:preflight` for the independent Test-Impact declaration, skip the
+empty affected stage, and run `gate:full` once. Run `pnpm setup:e2e` once per
+machine or Playwright version instead of paying for a browser installation on
+every full check.
+
+Every `apps/editor/e2e/*.spec.ts` file must belong to a focused path group and
+select itself. The gate-planner tests enumerate the directory so adding a spec
+without routing ownership fails deterministically instead of silently making
+that path fall back to the complete browser suite.
 
 ## Pull-request batching
 
@@ -58,9 +66,10 @@ Every implementation pull request keeps the inexpensive broad protection:
 - `Unit and integration tests` runs the complete unit/module suite.
 - `Release contracts` runs the build, release goldens, production smoke, and
   `performance-baseline.mjs` budgets.
-- `Browser tests (1/2)` and `Browser tests (2/2)` run the fixed affected specs
-  with two workers per shard. If the path map is missing, high risk, or itself
-  changed, both checks automatically run the complete browser suite.
+- `Browser tests (1/4)` through `Browser tests (4/4)` run the fixed affected
+  specs with two workers per shard. If the path map is missing, high risk, or
+  itself changed, all four checks automatically run the complete browser
+  suite.
 
 The merge queue, nightly schedule, and manual workflow always force complete
 browser coverage. CI does not repeat on the subsequent `main` push; the

--- a/scripts/lib/ci-validation-plan.test.mjs
+++ b/scripts/lib/ci-validation-plan.test.mjs
@@ -1,3 +1,5 @@
+import { readdir } from "node:fs/promises";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -67,6 +69,20 @@ describe("CI validation planning", () => {
     expect(plan.reasons).toContain(
       "uncovered browser impact: apps/editor/src/lib/new-helper.ts",
     );
+  });
+
+  it("keeps every browser spec reachable through a focused route", async () => {
+    const directory = new URL("../../apps/editor/e2e/", import.meta.url);
+    const specs = (await readdir(directory))
+      .filter((name) => name.endsWith(".spec.ts"))
+      .map((name) => `apps/editor/e2e/${name}`)
+      .sort();
+
+    for (const spec of specs) {
+      const plan = ciPlan([spec]);
+      expect(plan.mode, spec).toBe("focused");
+      expect(plan.e2eArgs, spec).toContain(spec);
+    }
   });
 
   it("treats validation-policy documentation as a full fallback", () => {

--- a/scripts/lib/validation-gates.test.mjs
+++ b/scripts/lib/validation-gates.test.mjs
@@ -30,6 +30,16 @@ describe("validation gate planning", () => {
     expect(missing).toEqual([]);
   });
 
+  it("keeps the complete delivery gate as the single owner of covered work", () => {
+    const full = catalog.gates.find((gate) => gate.id === "full-delivery");
+    const covered = catalog.gates
+      .filter((gate) => gate.stage !== "final" && gate.id !== "test-impact")
+      .map((gate) => gate.id)
+      .sort();
+
+    expect([...full.supersedes].sort()).toEqual(covered);
+  });
+
   it("matches repository globs without treating a single star as a slash", () => {
     expect(
       globPattern("apps/**/src/**").test("apps/editor/src/app/App.tsx"),
@@ -64,12 +74,7 @@ describe("validation gate planning", () => {
 
   it("expands shared protocol changes to hierarchy and persistence", () => {
     const selected = ids(["packages/project-protocol/src/persistence.ts"]);
-    expect(selected).toContain("static-contracts");
-    expect(selected).toContain("test-impact");
-    expect(selected).toContain("workspace-unit");
-    expect(selected).toContain("hierarchy-browser");
-    expect(selected).toContain("project-file-browser");
-    expect(selected).toContain("full-delivery");
+    expect(selected).toEqual(["test-impact", "full-delivery"]);
   });
 
   it("maps Gallery and account changes to their dedicated browser workflow", () => {
@@ -90,24 +95,39 @@ describe("validation gate planning", () => {
     expect(plan.fullReasons).toContain(
       "gate contract changed: .github/workflows/ci.yml",
     );
-    expect(plan.gates.map((gate) => gate.id)).toContain("branch-verification");
-    expect(plan.gates.map((gate) => gate.id)).toContain("full-delivery");
-    expect(plan.gates.map((gate) => gate.id)).toContain("static-contracts");
+    expect(plan.gates.map((gate) => gate.id)).toEqual([
+      "test-impact",
+      "full-delivery",
+    ]);
   });
 
   it("runs static contracts for documentation that defines the gate contract", () => {
     const plan = planValidation(["docs/testing/README.md"], catalog);
     expect(plan.docsOnly).toBe(true);
     expect(plan.requiresFull).toBe(true);
-    expect(plan.gates.map((gate) => gate.id)).toContain("static-contracts");
+    expect(plan.gates.map((gate) => gate.id)).toEqual(["full-delivery"]);
   });
 
   it("forces a full fallback for an unclassified implementation path", () => {
     const plan = planValidation(["tooling/new-runner.toml"], catalog);
     expect(plan.unknownPaths).toEqual(["tooling/new-runner.toml"]);
     expect(plan.requiresFull).toBe(true);
-    expect(plan.gates.map((gate) => gate.id)).toContain("static-contracts");
-    expect(plan.gates.map((gate) => gate.id)).toContain("branch-verification");
+    expect(plan.gates.map((gate) => gate.id)).toEqual([
+      "test-impact",
+      "full-delivery",
+    ]);
+  });
+
+  it("routes specialized editor behavior to its dedicated browser contracts", () => {
+    expect(ids(["apps/editor/src/canvas/diagnostic-markers.ts"])).toContain(
+      "editor-diagnostics-browser",
+    );
+    expect(
+      ids(["apps/editor/src/features/component-insert/placement-near-miss.ts"]),
+    ).toContain("placement-near-miss-browser");
+    expect(ids(["apps/editor/src/canvas/canvas-hit-resolver.ts"])).toContain(
+      "thin-target-hit-browser",
+    );
   });
 
   it("ignores local stores and renders the selected base", () => {


### PR DESCRIPTION
## Summary

- make `full-delivery` supersede the local static, unit, focused-browser, release, and branch checks it already contains
- give all 24 Playwright specs focused routing ownership, with dedicated editor behavior groups and a regression test that rejects future unmapped specs
- keep pull-request history for Test-Impact while bounding forced-full merge-queue, scheduled, and manual checkout depth
- update Agent and testing documentation for four browser shards and seven required checks

## Validation

- `pnpm exec vitest run scripts/lib/validation-gates.test.mjs scripts/lib/ci-validation-plan.test.mjs --maxWorkers=2`
- `pnpm ci:static`
- Playwright collection: 296 tests in 24 files
- representative focused and forced-full planner smoke checks
- `pnpm gate:preflight -- --base origin/main`
- `pnpm gate:affected -- --base origin/main` (no covered work remains)

The complete browser suite is intentionally delegated to this PRs required four-shard CI so the local repair does not reproduce the resource spike it removes.