### PR TITLE
fix(editor): a vanished export chunk answers with a refresh, not a stack line

### DIFF
--- a/apps/editor/src/agent/browser-agent-file-host.ts
+++ b/apps/editor/src/agent/browser-agent-file-host.ts
@@ -14,6 +14,7 @@ import type { CircuitProject, SchematicDocument } from "@icm/model";
 import { importSpiceSources } from "@icm/spice";
 import type { SymbolResolver } from "@icm/symbols";
 import { prepareDocumentFormulaArtifacts } from "../features/text-editing/formula-artifacts";
+import { importChunk } from "../components/chunk-import";
 
 type StoredCandidate = {
   project: CircuitProject;
@@ -170,8 +171,10 @@ export class BrowserAgentFileHost {
         );
       }
       if (request.artifact === "png") {
-        const { rasterizeFormalSvgInBrowser } =
-          await import("@icm/exporters/browser-raster");
+        const { rasterizeFormalSvgInBrowser } = await importChunk(
+          "PNG export",
+          () => import("@icm/exporters/browser-raster"),
+        );
         const png = await rasterizeFormalSvgInBrowser(source);
         return this.artifactResponse(
           request,
@@ -180,8 +183,10 @@ export class BrowserAgentFileHost {
           png.bytes,
         );
       }
-      const { vectorizeFormalSvgInBrowser } =
-        await import("@icm/exporters/browser-pdf");
+      const { vectorizeFormalSvgInBrowser } = await importChunk(
+        "PDF export",
+        () => import("@icm/exporters/browser-pdf"),
+      );
       const pdf = await vectorizeFormalSvgInBrowser(source);
       return this.artifactResponse(
         request,

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -440,6 +440,9 @@ export function App({
 
   const [recoveryFailureDismissed, setRecoveryFailureDismissed] =
     useState(false);
+  // Feature name whose on-demand chunk vanished under a redeploy; the banner
+  // offers the refresh that restores the current circuit.
+  const [chunkLoadFailure, setChunkLoadFailure] = useState<string | null>(null);
   const {
     state: recoveryState,
     sessions: recoverySessions,
@@ -3143,6 +3146,7 @@ export function App({
       setImportReviewOpen,
       setSelectionOpen,
       setStatus,
+      onChunkLoadFailure: setChunkLoadFailure,
     });
 
   // Single entry point for selecting a drafting object. Editing is opened
@@ -3876,6 +3880,14 @@ export function App({
       <EditorDialogLayer
         help={
           helpOpen ? { closeButtonRef: helpCloseRef, onClose: closeHelp } : null
+        }
+        chunkLoadFailure={
+          chunkLoadFailure === null
+            ? null
+            : {
+                feature: chunkLoadFailure,
+                onDismiss: () => setChunkLoadFailure(null),
+              }
         }
         recoveryFailure={
           (recoveryState === "quota-exceeded" ||

--- a/apps/editor/src/app/editor-dialog-layer.tsx
+++ b/apps/editor/src/app/editor-dialog-layer.tsx
@@ -3,6 +3,7 @@ import { Suspense, type ComponentProps } from "react";
 import type { AgentFileCandidateSummary } from "@icm/agent-adapter";
 import type { CellResetPlan } from "@icm/edit-engine";
 
+import { ChunkLoadBanner } from "../components/chunk-load-fallback";
 import {
   RecoveryAvailableBanner,
   RecoveryFailureBanner,
@@ -23,6 +24,7 @@ import {
 
 export interface EditorDialogLayerProps {
   help: ComponentProps<typeof LazyEditorHelpDialog> | null;
+  chunkLoadFailure: ComponentProps<typeof ChunkLoadBanner> | null;
   recoveryFailure: ComponentProps<typeof RecoveryFailureBanner> | null;
   recoveryAvailable: ComponentProps<typeof RecoveryAvailableBanner> | null;
   recentRecovery: ComponentProps<typeof LazyRecentRecoveryDialog> | null;
@@ -51,6 +53,7 @@ export interface EditorDialogLayerProps {
 /** All modal/overlay UI kept outside the persistent editor workspace. */
 export function EditorDialogLayer({
   help,
+  chunkLoadFailure,
   recoveryFailure,
   recoveryAvailable,
   recentRecovery,
@@ -70,6 +73,7 @@ export function EditorDialogLayer({
     <>
       <Suspense fallback={null}>
         {help ? <LazyEditorHelpDialog {...help} /> : null}
+        {chunkLoadFailure ? <ChunkLoadBanner {...chunkLoadFailure} /> : null}
         {recoveryFailure ? (
           <RecoveryFailureBanner {...recoveryFailure} />
         ) : null}

--- a/apps/editor/src/components/chunk-import.test.tsx
+++ b/apps/editor/src/components/chunk-import.test.tsx
@@ -1,0 +1,58 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { ChunkLoadError, chunkLoadStatus, importChunk } from "./chunk-import";
+import { ChunkLoadBanner } from "./chunk-load-fallback";
+
+describe("importChunk", () => {
+  it("passes a resolved module through untouched", async () => {
+    const module = { render: () => "ok" };
+    await expect(
+      importChunk("PDF export", () => Promise.resolve(module)),
+    ).resolves.toBe(module);
+  });
+
+  it("wraps a redeploy-vanished chunk into a named ChunkLoadError", async () => {
+    // The exact browser failure a stale tab produces: the SPA fallback
+    // answered index.html where a content-hashed module used to live.
+    const raw = new TypeError(
+      "Failed to fetch dynamically imported module: https://analog-canvas.tokenzhang.com/assets/browser-pdf-D-HT6q.js",
+    );
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const failure = await importChunk("PDF export", () =>
+      Promise.reject(raw),
+    ).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    spy.mockRestore();
+
+    expect(failure).toBeInstanceOf(ChunkLoadError);
+    const chunkError = failure as ChunkLoadError;
+    expect(chunkError.feature).toBe("PDF export");
+    expect(chunkError.cause).toBe(raw);
+    // The user-facing message never contains the technical string.
+    expect(chunkError.message).not.toContain("Failed to fetch");
+    expect(chunkError.message).toContain("PDF export");
+  });
+
+  it("phrases the status line as remedy, not stack trace", () => {
+    const status = chunkLoadStatus("PDF export");
+    expect(status).toContain("PDF export could not load");
+    expect(status).toContain("Refresh");
+    expect(status).toContain("restored automatically");
+  });
+});
+
+describe("ChunkLoadBanner", () => {
+  it("offers the refresh remedy and a dismissal", () => {
+    const markup = renderToStaticMarkup(
+      <ChunkLoadBanner feature="PDF export" onDismiss={() => {}} />,
+    );
+    expect(markup).toContain("PDF export could not load");
+    expect(markup).toContain("restored automatically");
+    expect(markup).toContain("Refresh app");
+    expect(markup).toContain("Not now");
+    expect(markup).not.toContain("Failed to fetch");
+  });
+});

--- a/apps/editor/src/components/chunk-import.ts
+++ b/apps/editor/src/components/chunk-import.ts
@@ -1,0 +1,42 @@
+/**
+ * Guarded dynamic import for on-demand feature chunks.
+ *
+ * Chunk file names carry content hashes and every deploy replaces the whole
+ * asset manifest, so a tab that survived a redeploy asks for names that no
+ * longer exist — and the single-page-application fallback answers with
+ * index.html, which the browser reports as
+ * "Failed to fetch dynamically imported module: …". That string must never
+ * be the user's answer; callers catch {@link ChunkLoadError} and show the
+ * refresh remedy instead. React.lazy surfaces use `lazyChunk` in
+ * app/lazy-editor-dialogs.ts; this is the same contract for plain
+ * `await import()` call sites.
+ */
+export class ChunkLoadError extends Error {
+  constructor(
+    readonly feature: string,
+    override readonly cause: unknown,
+  ) {
+    super(
+      `${feature} could not load — the app has been updated since this tab opened`,
+    );
+    this.name = "ChunkLoadError";
+  }
+}
+
+/** One status-bar line: what failed, why, and the remedy. */
+export function chunkLoadStatus(feature: string): string {
+  return `${feature} could not load — the app has been updated since this tab opened. Refresh to load the new version; your circuit is restored automatically.`;
+}
+
+export async function importChunk<T>(
+  feature: string,
+  load: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await load();
+  } catch (error) {
+    // The raw failure keeps its stack for diagnosis, off the user's screen.
+    console.error(`Chunk for ${feature} failed to load:`, error);
+    throw new ChunkLoadError(feature, error);
+  }
+}

--- a/apps/editor/src/components/chunk-load-fallback.tsx
+++ b/apps/editor/src/components/chunk-load-fallback.tsx
@@ -7,7 +7,7 @@ export interface ChunkLoadFallbackProps {
   onCancel?: () => void;
 }
 
-function refreshWithRestore(): void {
+export function refreshWithRestore(): void {
   try {
     // The recovery coordinator flushes on pagehide, so the snapshot survives
     // this reload; the flag lets the refreshed page restore it automatically.
@@ -105,4 +105,40 @@ export function createChunkLoadFallback(
       </div>
     );
   };
+}
+
+/**
+ * Dismissible banner for a failed on-demand chunk outside any dialog —
+ * an export command whose module vanished under a redeploy. Same remedy as
+ * every chunk failure: refresh, with the current circuit restored.
+ */
+export function ChunkLoadBanner({
+  feature,
+  onDismiss,
+}: {
+  feature: string;
+  onDismiss: () => void;
+}) {
+  return (
+    <aside
+      className="recovery-banner recovery-banner-warning"
+      data-testid="chunk-load-banner"
+      role="alert"
+      aria-label="Feature failed to load"
+    >
+      <p>
+        {feature} could not load — the app has been updated since this tab
+        opened. Refresh to load the new version; your current circuit is
+        restored automatically.
+      </p>
+      <div>
+        <button type="button" onClick={refreshWithRestore}>
+          Refresh app
+        </button>
+        <button type="button" onClick={onDismiss}>
+          Not now
+        </button>
+      </div>
+    </aside>
+  );
 }

--- a/apps/editor/src/features/editor-shell/editor-export-commands.test.ts
+++ b/apps/editor/src/features/editor-shell/editor-export-commands.test.ts
@@ -1,7 +1,11 @@
 import type { DesignNetlistIR } from "@icm/netlist";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { planDesignNetlistExport } from "./editor-export-commands";
+import {
+  describeExportFailure,
+  planDesignNetlistExport,
+} from "./editor-export-commands";
+import { importChunk } from "../../components/chunk-import";
 
 const emptyIr: DesignNetlistIR = {
   topCellId: "top",
@@ -55,5 +59,35 @@ describe("editor export commands", () => {
     expect(plan.artifact.extension).toBe("spi");
     expect(plan.artifact.mediaType).toBe("application/x-spice");
     expect(plan.artifact.report).toBe("Download requested: my-circuit.spi");
+  });
+});
+
+describe("describeExportFailure", () => {
+  it("turns a vanished chunk into the refresh remedy and names the feature", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const chunkError = await importChunk("PDF export", () =>
+      Promise.reject(
+        new TypeError(
+          "Failed to fetch dynamically imported module: https://analog-canvas.tokenzhang.com/assets/browser-pdf-D-HT6q.js",
+        ),
+      ),
+    ).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    spy.mockRestore();
+
+    const failure = describeExportFailure(chunkError);
+    expect(failure.chunkFeature).toBe("PDF export");
+    expect(failure.status).toContain("PDF export could not load");
+    expect(failure.status).toContain("Refresh");
+    expect(failure.status).not.toContain("Failed to fetch");
+  });
+
+  it("keeps an ordinary export error's own message without a banner", () => {
+    expect(describeExportFailure(new Error("Canvas too large"))).toEqual({
+      status: "Canvas too large",
+    });
+    expect(describeExportFailure("boom")).toEqual({ status: "Export failed" });
   });
 });

--- a/apps/editor/src/features/editor-shell/editor-export-commands.ts
+++ b/apps/editor/src/features/editor-shell/editor-export-commands.ts
@@ -4,6 +4,11 @@ import type { DesignNetlistIR, NetlistFormat } from "@icm/netlist";
 import type { SchematicDocument } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 import { prepareDocumentFormulaArtifacts } from "../text-editing/formula-artifacts";
+import {
+  ChunkLoadError,
+  chunkLoadStatus,
+  importChunk,
+} from "../../components/chunk-import";
 
 export interface EditorExportArtifact {
   bytes: BlobPart;
@@ -98,8 +103,10 @@ export async function createVisualExportArtifact(
     projectName,
   );
   if (format === "png") {
-    const { rasterizeFormalSvgInBrowser } =
-      await import("@icm/exporters/browser-raster");
+    const { rasterizeFormalSvgInBrowser } = await importChunk(
+      "PNG export",
+      () => import("@icm/exporters/browser-raster"),
+    );
     const png = await rasterizeFormalSvgInBrowser(source);
     return {
       bytes: png.bytes as BlobPart,
@@ -108,8 +115,10 @@ export async function createVisualExportArtifact(
       report: `Exported PNG revision ${document.revision}`,
     };
   }
-  const { vectorizeFormalSvgInBrowser } =
-    await import("@icm/exporters/browser-pdf");
+  const { vectorizeFormalSvgInBrowser } = await importChunk(
+    "PDF export",
+    () => import("@icm/exporters/browser-pdf"),
+  );
   const pdf = await vectorizeFormalSvgInBrowser(source);
   return {
     bytes: pdf as BlobPart,
@@ -132,4 +141,24 @@ export function requestBrowserDownload(
   anchor.download = `${safeExportBaseName(baseName)}.${artifact.extension}`;
   anchor.click();
   window.setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+/**
+ * User-facing account of a failed export. A vanished on-demand chunk gets
+ * the refresh remedy and names the feature so the App can raise the banner;
+ * anything else keeps its own message.
+ */
+export function describeExportFailure(error: unknown): {
+  status: string;
+  chunkFeature?: string;
+} {
+  if (error instanceof ChunkLoadError) {
+    return {
+      status: chunkLoadStatus(error.feature),
+      chunkFeature: error.feature,
+    };
+  }
+  return {
+    status: error instanceof Error ? error.message : "Export failed",
+  };
 }

--- a/apps/editor/src/features/editor-shell/editor-file-commands.ts
+++ b/apps/editor/src/features/editor-shell/editor-file-commands.ts
@@ -6,6 +6,7 @@ import type { SymbolResolver } from "@icm/symbols";
 import {
   createVisualExportArtifact,
   createSvgExportArtifact,
+  describeExportFailure,
   planDesignNetlistExport,
   requestBrowserDownload,
 } from "./editor-export-commands";
@@ -37,6 +38,8 @@ export interface EditorFileCommandDependencies {
   setImportReviewOpen: (open: boolean) => void;
   setSelectionOpen: (open: boolean) => void;
   setStatus: (status: string) => void;
+  /** Raise the refresh banner when an on-demand chunk has gone missing. */
+  onChunkLoadFailure?: (feature: string) => void;
 }
 
 /** File import/export commands and their user-facing gate/status policy. */
@@ -54,6 +57,7 @@ export function createEditorFileCommands({
   setImportReviewOpen,
   setSelectionOpen,
   setStatus,
+  onChunkLoadFailure,
 }: EditorFileCommandDependencies) {
   const exportSvg = (): void => {
     setStatus("Preparing SVG export");
@@ -99,7 +103,9 @@ export function createEditorFileCommands({
       requestBrowserDownload(artifact, project.name);
       setStatus(artifact.report);
     } catch (error) {
-      setStatus(error instanceof Error ? error.message : "Export failed");
+      const failure = describeExportFailure(error);
+      setStatus(failure.status);
+      if (failure.chunkFeature) onChunkLoadFailure?.(failure.chunkFeature);
     }
   };
 


### PR DESCRIPTION
## Problem

Every deploy replaces the whole asset manifest, and `not_found_handling: single-page-application` answers a missing content-hashed chunk with index.html (200) — the browser reports "Failed to fetch dynamically imported module: …". The export path pushed that string verbatim into the status bar; a real user hit it after 16 same-day deploys and read it as the editor breaking (and blamed the adjacent PMOS bulk warning).

## What ships

- `components/chunk-import.ts`: `importChunk()` + `ChunkLoadError` — the same contract lazy-editor-dialogs' `lazyChunk` already gives React surfaces, for plain `await import()` sites. Raw failure stays in the console.
- The four exporter imports (PNG/PDF × editor commands + Agent file host) are wrapped. `describeExportFailure()` maps a chunk loss to human copy; ordinary export errors keep their own message.
- A dismissible `ChunkLoadBanner` (recovery-banner styling) with the existing `refreshWithRestore` — refresh reloads the new build and restores the current circuit automatically. Wired through EditorDialogLayer; status line carries the same words.
- Agent host's `FILE_EXPORT_FAILED` payload now carries the human message, not the browser string.

Already covered elsewhere, unchanged: dialog chunks (scoped fallback, #410 era) and top-level pages (main.tsx reload-once guard). Deliberately NOT in this PR (pending owner sign-off, per the investigation report): service-worker update notification; retaining N old builds (rejected: custom pipeline, heavy); eager-loading exporters (rejected: first-paint cost).

## Validation

- New tests: importChunk wrapping (with the exact production error string), status/banner copy never contains the technical string, describeExportFailure mapping both ways
- 157 tests across components/editor-shell/agent/app; root typecheck; Prettier; check-test-impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)