### PR TITLE
feat(editor): the docked Gallery pages, counts, searches and filters like the wall

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -407,36 +407,6 @@ export function App({
       setGalleryRefreshSignal((previous) => previous + 1);
     });
   }, [visibleLibraryPanelOpen]);
-  useEffect(() => {
-    if (!visibleLibraryPanelOpen) return;
-    let cancelled = false;
-    const generation = ++galleryLoadGenerationRef.current;
-    void (async () => {
-      try {
-        const response = await fetch("/api/gallery?limit=60", {
-          credentials: "same-origin",
-        });
-        if (!response.ok) return;
-        const payload = (await response.json()) as {
-          entries?: {
-            id: string;
-            name: string;
-            author: string;
-            description: string;
-            previewRevision?: string;
-          }[];
-        };
-        if (!cancelled && generation === galleryLoadGenerationRef.current) {
-          setGalleryExamples(payload.entries ?? []);
-        }
-      } catch {
-        // Unreachable worker (offline dev): the bundled list stands in.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [visibleLibraryPanelOpen, galleryRefreshSignal]);
 
   const [recoveryFailureDismissed, setRecoveryFailureDismissed] =
     useState(false);
@@ -633,16 +603,6 @@ export function App({
   }, [activeProjectId]);
   // The Examples panel reads the same community gallery as the landing
   // feed; null means unreachable, so the bundled list stands in.
-  const [galleryExamples, setGalleryExamples] = useState<
-    | readonly {
-        id: string;
-        name: string;
-        author: string;
-        description: string;
-        previewRevision?: string;
-      }[]
-    | null
-  >(null);
   const [publishGates, setPublishGates] = useState<SubmissionGateReport | null>(
     null,
   );
@@ -4197,7 +4157,6 @@ export function App({
         ) : (
           <ExamplesPanel
             open={visibleLibraryPanelOpen}
-            galleryExamples={galleryExamples}
             onOpenGalleryExample={(id) => void insertGalleryEntryById(id)}
             onOpenExample={openLibraryExample}
           />

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -8,47 +8,34 @@ import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 import { libraryProjectExamples } from "../examples/library-examples";
 import {
   announceGalleryChange,
+  galleryCountLabel,
+  galleryEntryMatchesQuery,
   galleryPreviewUrl,
+  loadGalleryFeed,
+  loadGalleryTags,
   subscribeGalleryRefresh,
+  type GalleryFeedEntry,
+  type GalleryFeedPage,
+  type GalleryFeedState,
+  type GalleryTagOption,
 } from "../gallery-client";
+
+// The wall and the canvas-side panel share one data layer, so a search that
+// finds a circuit here finds it there too. These re-exports keep every
+// existing importer of this module working unchanged.
+export {
+  galleryEntryMatchesQuery,
+  loadGalleryFeed,
+  loadGalleryTags,
+  type GalleryFeedEntry,
+  type GalleryFeedPage,
+  type GalleryFeedState,
+  type GalleryTagOption,
+};
 import { fetchSessionUser } from "./account";
 import { GalleryChrome } from "./gallery-chrome";
 import { Masonry } from "./masonry";
 import { ShelfWall } from "./shelf-wall";
-
-export interface GalleryFeedEntry {
-  id: string;
-  name: string;
-  author: string;
-  description: string;
-  createdAt: string;
-  /** Absent only while a newer client is rolling out against an older API. */
-  previewRevision?: string;
-  schemaVersion: number;
-  tags?: string[];
-  /**
-   * Whether the circuit extracts to a design netlist. A mark of extra
-   * completeness, never a gate — a schematic is allowed to be abbreviated,
-   * and one without this is listed exactly like one with it.
-   */
-  netlistable?: boolean;
-  likes?: number;
-  likedByViewer?: boolean;
-}
-
-export interface GalleryFeedPage {
-  entries: GalleryFeedEntry[];
-  nextCursor: string | null;
-  /** Whole filtered wall's size; null while a pre-totals API answers. */
-  total: number | null;
-}
-
-export interface GalleryFeedState {
-  status: "loading" | "ready" | "unavailable";
-  entries: GalleryFeedEntry[];
-  nextCursor: string | null;
-  total: number | null;
-}
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 /**
@@ -262,16 +249,6 @@ function HeartIcon({ filled }: { filled: boolean }) {
  * (trimmed, lowercased); fields answer case-insensitively. A tag counts as
  * content, so a query matching a tag matches the circuits that carry it.
  */
-export function galleryEntryMatchesQuery(
-  entry: Pick<GalleryFeedEntry, "name" | "author" | "description" | "tags">,
-  normalizedQuery: string,
-): boolean {
-  if (!normalizedQuery) return true;
-  return [entry.name, entry.author, entry.description, ...(entry.tags ?? [])]
-    .filter((field): field is string => Boolean(field))
-    .some((field) => field.toLowerCase().includes(normalizedQuery));
-}
-
 /**
  * The wall's size, said only when the server has said it: a pre-totals API
  * or a still-loading feed renders nothing rather than a guess. "Filtered"
@@ -288,18 +265,11 @@ export function GalleryCountPanel({
   filtered?: boolean;
   search?: { visible: number; settled: boolean } | null;
 }) {
-  if (total === null) return null;
-  const noun = total === 1 ? "circuit" : "circuits";
-  const base = `${total.toLocaleString()} ${filtered ? `filtered ${noun}` : noun}`;
-  const clause = search
-    ? ` · ${search.visible} ${search.visible === 1 ? "match" : "matches"}${
-        search.settled ? "" : " so far"
-      }`
-    : "";
+  const label = galleryCountLabel(total, { filtered, search });
+  if (label === null) return null;
   return (
     <span className="gallery-count-panel" data-testid="gallery-count-panel">
-      {base}
-      {clause}
+      {label}
     </span>
   );
 }
@@ -331,43 +301,6 @@ function bundledTiles() {
 }
 
 /** One feed page; the plain first request stays exactly `/api/gallery`. */
-export async function loadGalleryFeed(
-  fetchLike: typeof fetch = fetch,
-  options: {
-    cursor?: string | null;
-    author?: string | null;
-    tags?: readonly string[];
-  } = {},
-): Promise<GalleryFeedPage | null> {
-  const params = new URLSearchParams();
-  if (options.author) params.set("author", options.author);
-  if (options.tags && options.tags.length > 0) {
-    params.set("tags", options.tags.join(","));
-  }
-  if (options.cursor) params.set("cursor", options.cursor);
-  const query = params.toString();
-  try {
-    const response = await fetchLike(
-      `/api/gallery${query ? `?${query}` : ""}`,
-      { credentials: "same-origin" },
-    );
-    if (!response.ok) return null;
-    const payload = (await response.json()) as {
-      entries?: GalleryFeedEntry[];
-      nextCursor?: unknown;
-      total?: unknown;
-    };
-    return {
-      entries: payload.entries ?? [],
-      nextCursor:
-        typeof payload.nextCursor === "string" ? payload.nextCursor : null,
-      total: typeof payload.total === "number" ? payload.total : null,
-    };
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Full-screen landing feed: every tile is one published circuit that opens
  * in the editor at `/g/<id>`. Bundled Library examples fill the wall while

--- a/apps/editor/src/features/editor-shell/examples-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/examples-panel.test.ts
@@ -2,8 +2,25 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
+import { galleryEntryMatchesQuery } from "../../gallery-client";
 import { libraryProjectExamples } from "../../examples/library-examples";
-import { ExamplesPanel } from "./examples-panel";
+import { deriveGalleryPanelView, ExamplesPanel } from "./examples-panel";
+
+function entry(
+  overrides: Partial<Parameters<typeof galleryEntryMatchesQuery>[0]> & {
+    id: string;
+  },
+) {
+  return {
+    name: "Ring Oscillator",
+    author: "Mei Chen",
+    description: "Three-stage inverter ring",
+    createdAt: "2026-08-30T00:00:00.000Z",
+    schemaVersion: 33,
+    tags: ["clock"],
+    ...overrides,
+  } as never;
+}
 
 describe("ExamplesPanel", () => {
   it("presents every bundled example outside the Library device panel", () => {
@@ -26,37 +43,99 @@ describe("ExamplesPanel", () => {
   });
 });
 
-describe("gallery-backed library", () => {
-  it("lists the community gallery when available and falls back bundled", () => {
-    const gallery = renderToStaticMarkup(
-      createElement(ExamplesPanel, {
-        open: true,
-        galleryExamples: [
-          {
-            id: "g-1",
-            name: "StrongArm Comparator",
-            author: "Zhishuai Zhang",
-            description: "Clocked comparator",
-          },
-        ],
-        onOpenGalleryExample: () => undefined,
-        onOpenExample: () => undefined,
-      }),
-    );
-    expect(gallery).toContain('data-testid="gallery-example-g-1"');
-    expect(gallery).toContain("StrongArm Comparator");
-    expect(gallery).toContain("Zhishuai Zhang");
-    expect(gallery).not.toContain('data-testid="shapes-example-');
+/**
+ * The panel and the Gallery wall must answer the same question the same way.
+ * These cases drive the panel's derivation with the SHARED matcher and count
+ * wording, so a change that makes one surface disagree with the other has to
+ * fail here rather than be discovered by a person who searched in both places.
+ */
+describe("gallery panel view", () => {
+  const feed = {
+    status: "ready" as const,
+    entries: [
+      entry({ id: "g-1" }),
+      entry({ id: "g-2", name: "Bandgap", author: "Lin", tags: ["bias"] }),
+    ],
+    nextCursor: null,
+    total: 120,
+  };
 
-    const fallback = renderToStaticMarkup(
-      createElement(ExamplesPanel, {
-        open: true,
-        galleryExamples: null,
-        onOpenExample: () => undefined,
-      }),
+  it("says the wall's size from the server, never a guess", () => {
+    expect(
+      deriveGalleryPanelView(feed, { searchQuery: "", selectedTags: [] })
+        .countLabel,
+    ).toBe("120 circuits");
+    // A pre-totals API answers null; the panel then says nothing at all.
+    expect(
+      deriveGalleryPanelView(
+        { ...feed, total: null },
+        { searchQuery: "", selectedTags: [] },
+      ).countLabel,
+    ).toBeNull();
+  });
+
+  it("names a server-side narrowing as filtered, matching the wall", () => {
+    expect(
+      deriveGalleryPanelView(feed, {
+        searchQuery: "",
+        selectedTags: ["bias"],
+      }).countLabel,
+    ).toBe("120 filtered circuits");
+  });
+
+  it("counts text matches separately from the wall's size", () => {
+    const view = deriveGalleryPanelView(feed, {
+      searchQuery: "bandgap",
+      selectedTags: [],
+    });
+    expect(view.visibleEntries.map((candidate) => candidate.id)).toEqual([
+      "g-2",
+    ]);
+    expect(view.countLabel).toBe("120 circuits · 1 match");
+  });
+
+  it("searches the same fields the wall searches", () => {
+    // name / author / description / tag — one case each, through the shared
+    // matcher, so the panel cannot quietly narrow the search.
+    for (const query of ["ring", "mei", "three-stage", "clock"]) {
+      const view = deriveGalleryPanelView(feed, {
+        searchQuery: query,
+        selectedTags: [],
+      });
+      expect(view.visibleEntries.some((c) => c.id === "g-1")).toBe(true);
+    }
+  });
+
+  it("does not deny a circuit it has not fetched yet", () => {
+    const paging = { ...feed, nextCursor: "cursor-1" };
+    const view = deriveGalleryPanelView(paging, {
+      searchQuery: "zzz",
+      selectedTags: [],
+    });
+    expect(view.emptyMessage).toBe(
+      "No matches yet — searching older circuits…",
     );
-    expect(fallback).toContain('data-testid="shapes-example-');
-    expect(fallback).not.toContain('data-testid="gallery-example-');
+    expect(view.countLabel).toBe("120 circuits · 0 matches so far");
+  });
+
+  it("says nothing matches only once the feed is exhausted", () => {
+    const view = deriveGalleryPanelView(feed, {
+      searchQuery: "zzz",
+      selectedTags: [],
+    });
+    expect(view.emptyMessage).toBe("No circuits match “zzz”.");
+    expect(view.countLabel).toBe("120 circuits · 0 matches");
+  });
+
+  it("stands the bundled circuits in while the feed is unavailable", () => {
+    for (const status of ["loading", "unavailable"] as const) {
+      const view = deriveGalleryPanelView(
+        { status, entries: [], nextCursor: null, total: null },
+        { searchQuery: "", selectedTags: [] },
+      );
+      expect(view.showGallery).toBe(false);
+      expect(view.countLabel).toBeNull();
+    }
   });
 });
 

--- a/apps/editor/src/features/editor-shell/examples-panel.tsx
+++ b/apps/editor/src/features/editor-shell/examples-panel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { renderDocumentSvg } from "@icm/render-svg";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
@@ -7,7 +7,16 @@ import {
   libraryProjectExamples,
   type LibraryProjectExample,
 } from "../../examples/library-examples";
-import { galleryPreviewUrl } from "../../gallery-client";
+import {
+  galleryCountLabel,
+  galleryEntryMatchesQuery,
+  galleryPreviewUrl,
+  loadGalleryFeed,
+  loadGalleryTags,
+  subscribeGalleryRefresh,
+  type GalleryFeedEntry,
+  type GalleryTagOption,
+} from "../../gallery-client";
 
 export interface GalleryExampleSummary {
   id: string;
@@ -19,32 +28,178 @@ export interface GalleryExampleSummary {
 
 export interface ExamplesPanelProps {
   open: boolean;
-  /**
-   * The community gallery — the same source as the landing feed. Null or
-   * empty falls back to the bundled starter circuits (offline dev).
-   */
-  galleryExamples?: readonly GalleryExampleSummary[] | null;
   onOpenGalleryExample?(id: string): void;
   onOpenExample(example: LibraryProjectExample): void;
+  /** Injected in tests; production uses the global. */
+  fetchImpl?: typeof fetch;
 }
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+interface FeedState {
+  status: "loading" | "ready" | "unavailable";
+  entries: GalleryFeedEntry[];
+  nextCursor: string | null;
+  total: number | null;
+}
+
+const EMPTY_FEED: FeedState = {
+  status: "loading",
+  entries: [],
+  nextCursor: null,
+  total: null,
+};
+
+export interface GalleryPanelView {
+  /** False while the feed is loading or unreachable: bundled circuits stand in. */
+  showGallery: boolean;
+  visibleEntries: GalleryFeedEntry[];
+  /** Null when the server has not said the size; never a guess. */
+  countLabel: string | null;
+  /**
+   * Null unless a query hides every loaded circuit. While pages remain it says
+   * the search is still running, because a wall paged 30 at a time cannot yet
+   * deny a circuit it has not fetched.
+   */
+  emptyMessage: string | null;
+}
+
+/**
+ * Everything the panel shows, derived from the feed and the two filters. It is
+ * a pure function so the panel's behaviour can be asserted against the same
+ * rule table as the Gallery wall — the two surfaces share their matcher and
+ * their count wording, and this is where that sharing is proved rather than
+ * assumed.
+ */
+export function deriveGalleryPanelView(
+  feed: Pick<FeedState, "status" | "entries" | "nextCursor" | "total">,
+  options: { searchQuery: string; selectedTags: readonly string[] },
+): GalleryPanelView {
+  const normalizedQuery = options.searchQuery.trim().toLowerCase();
+  const showGallery = feed.status === "ready" && feed.entries.length > 0;
+  const visibleEntries = normalizedQuery
+    ? feed.entries.filter((entry) =>
+        galleryEntryMatchesQuery(entry, normalizedQuery),
+      )
+    : feed.entries;
+  const exhausted = feed.nextCursor === null;
+  return {
+    showGallery,
+    visibleEntries,
+    countLabel: showGallery
+      ? galleryCountLabel(feed.total, {
+          filtered: options.selectedTags.length > 0,
+          search: normalizedQuery
+            ? { visible: visibleEntries.length, settled: exhausted }
+            : null,
+        })
+      : null,
+    emptyMessage:
+      showGallery && normalizedQuery && visibleEntries.length === 0
+        ? exhausted
+          ? `No circuits match “${options.searchQuery.trim()}”.`
+          : "No matches yet — searching older circuits…"
+        : null,
+  };
+}
 
 /**
  * The circuit gallery, docked beside the canvas. Every card carries a preview
  * of the circuit itself: a name and a sentence do not tell you whether a
  * circuit is the one you want to borrow from.
+ *
+ * It reads the same feed as the Gallery wall through the same shared data
+ * layer, so paging, search and tag filtering behave identically in both
+ * places. Only the presentation differs: the panel is narrow, so its tags live
+ * in a menu rather than a chip row.
  */
 export function ExamplesPanel({
   open,
-  galleryExamples = null,
   onOpenGalleryExample,
   onOpenExample,
+  fetchImpl,
 }: ExamplesPanelProps) {
-  const showGallery = galleryExamples !== null && galleryExamples.length > 0;
+  const fetcher = fetchImpl ?? fetch;
+  const [feed, setFeed] = useState<FeedState>(EMPTY_FEED);
+  const [tagOptions, setTagOptions] = useState<GalleryTagOption[]>([]);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [tagMenuOpen, setTagMenuOpen] = useState(false);
+  const [refreshSignal, setRefreshSignal] = useState(0);
+  const loadGenerationRef = useRef(0);
+  const loadingMoreRef = useRef(false);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
 
-  // Bundled circuits render from the same renderer the feed uses; the work is
-  // per circuit, not per relayout, so it is memoized rather than repeated.
+  useEffect(() => {
+    if (!open) return;
+    return subscribeGalleryRefresh(() => {
+      setRefreshSignal((previous) => previous + 1);
+    });
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void loadGalleryTags(fetcher).then((tags) => {
+      if (!cancelled) setTagOptions(tags);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, fetcher, refreshSignal]);
+
+  // The first page for the current server-side filter. A changed tag selection
+  // is a new query, not more of the old one, so the list restarts.
+  useEffect(() => {
+    if (!open) return;
+    const generation = ++loadGenerationRef.current;
+    setFeed(EMPTY_FEED);
+    void loadGalleryFeed(fetcher, { tags: selectedTags }).then((page) => {
+      if (generation !== loadGenerationRef.current) return;
+      setFeed(
+        page === null
+          ? { ...EMPTY_FEED, status: "unavailable" }
+          : {
+              status: "ready",
+              entries: page.entries,
+              nextCursor: page.nextCursor,
+              total: page.total,
+            },
+      );
+    });
+  }, [open, fetcher, selectedTags, refreshSignal]);
+
+  // More pages arrive as the sentinel comes into view. A filtered list stays
+  // short, so the sentinel keeps showing and the feed keeps arriving until it
+  // is exhausted — which is what lets the empty state below tell the truth.
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!open || !sentinel || feed.nextCursor === null) return;
+    if (typeof IntersectionObserver === "undefined") return;
+    const cursor = feed.nextCursor;
+    const observer = new IntersectionObserver((entries) => {
+      if (!entries.some((entry) => entry.isIntersecting)) return;
+      if (loadingMoreRef.current) return;
+      loadingMoreRef.current = true;
+      const generation = loadGenerationRef.current;
+      void loadGalleryFeed(fetcher, { cursor, tags: selectedTags })
+        .then((page) => {
+          if (page === null || generation !== loadGenerationRef.current) return;
+          setFeed((previous) => ({
+            ...previous,
+            entries: [...previous.entries, ...page.entries],
+            nextCursor: page.nextCursor,
+            total: page.total ?? previous.total,
+          }));
+        })
+        .finally(() => {
+          loadingMoreRef.current = false;
+        });
+    });
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [open, fetcher, feed.nextCursor, selectedTags]);
+
   const bundledPreviews = useMemo(
     () =>
       new Map(
@@ -57,6 +212,19 @@ export function ExamplesPanel({
       ),
     [],
   );
+
+  const { showGallery, visibleEntries, countLabel, emptyMessage } =
+    deriveGalleryPanelView(feed, { searchQuery, selectedTags });
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const exhausted = feed.nextCursor === null;
+
+  function toggleTag(tag: string): void {
+    setSelectedTags((previous) =>
+      previous.includes(tag)
+        ? previous.filter((candidate) => candidate !== tag)
+        : [...previous, tag],
+    );
+  }
 
   return (
     <aside
@@ -71,12 +239,74 @@ export function ExamplesPanel({
       data-open={open ? "true" : "false"}
     >
       <div className="shapes-panel-body">
+        {showGallery ? (
+          <div className="examples-panel-controls">
+            <input
+              type="search"
+              className="examples-panel-search"
+              value={searchQuery}
+              placeholder="Name, author, tag…"
+              aria-label="Search circuits"
+              data-testid="examples-panel-search"
+              onChange={(event) => setSearchQuery(event.target.value)}
+            />
+            {tagOptions.length > 0 ? (
+              <div className="examples-panel-tag-menu">
+                <button
+                  type="button"
+                  className="examples-panel-tag-toggle"
+                  aria-expanded={tagMenuOpen}
+                  data-testid="examples-panel-tag-toggle"
+                  onClick={() => setTagMenuOpen((previous) => !previous)}
+                >
+                  {selectedTags.length > 0
+                    ? `Tags (${selectedTags.length})`
+                    : "Tags"}
+                </button>
+                {tagMenuOpen ? (
+                  <div
+                    className="examples-panel-tag-options"
+                    role="group"
+                    aria-label="Filter by tag"
+                    data-testid="examples-panel-tag-options"
+                  >
+                    {tagOptions.map((option) => (
+                      <label
+                        key={option.tag}
+                        className="examples-panel-tag-option"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={selectedTags.includes(option.tag)}
+                          data-testid={`examples-panel-tag-${option.tag}`}
+                          onChange={() => toggleTag(option.tag)}
+                        />
+                        <span>{option.tag}</span>
+                        <span className="examples-panel-tag-count">
+                          {option.count}
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+            {countLabel ? (
+              <span
+                className="examples-panel-count"
+                data-testid="examples-panel-count"
+              >
+                {countLabel}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
         {/* Columns follow the panel's dragged width, the same way the Library
             tiles do; a separate control for the same thing is one knob too
             many. */}
         <div className="shapes-example-list">
           {showGallery
-            ? galleryExamples.map((example) => (
+            ? visibleEntries.map((example) => (
                 <button
                   key={example.id}
                   type="button"
@@ -128,6 +358,26 @@ export function ExamplesPanel({
                 </button>
               ))}
         </div>
+        {/* Says "still looking" while pages remain, and only claims nothing
+            matches once the feed is exhausted — a wall of 120 circuits paged
+            30 at a time would otherwise deny a circuit that is simply not
+            loaded yet. */}
+        {emptyMessage ? (
+          <p
+            className="examples-panel-empty"
+            data-testid="examples-panel-empty"
+          >
+            {emptyMessage}
+          </p>
+        ) : null}
+        {showGallery && !exhausted ? (
+          <div
+            ref={sentinelRef}
+            className="examples-panel-sentinel"
+            data-testid="examples-panel-sentinel"
+            aria-hidden="true"
+          />
+        ) : null}
       </div>
     </aside>
   );

--- a/apps/editor/src/gallery-client.ts
+++ b/apps/editor/src/gallery-client.ts
@@ -149,3 +149,149 @@ export function subscribeGalleryRefresh(
     }
   };
 }
+
+/**
+ * The community feed's data layer, shared by every surface that shows the
+ * Gallery: the wall itself and the panel docked beside the canvas. It lives
+ * here rather than in either component so the two cannot drift — a circuit
+ * that a search finds on the wall must be found by the same search in the
+ * panel, or people reasonably conclude the software is broken.
+ */
+
+export interface GalleryFeedEntry {
+  id: string;
+  name: string;
+  author: string;
+  description: string;
+  createdAt: string;
+  /** Absent only while a newer client is rolling out against an older API. */
+  previewRevision?: string;
+  schemaVersion: number;
+  tags?: string[];
+  /**
+   * Whether the circuit extracts to a design netlist. A mark of extra
+   * completeness, never a gate — a schematic is allowed to be abbreviated,
+   * and one without this is listed exactly like one with it.
+   */
+  netlistable?: boolean;
+  likes?: number;
+  likedByViewer?: boolean;
+}
+
+export interface GalleryFeedPage {
+  entries: GalleryFeedEntry[];
+  nextCursor: string | null;
+  /** Whole filtered wall's size; null while a pre-totals API answers. */
+  total: number | null;
+}
+
+export interface GalleryFeedState {
+  status: "loading" | "ready" | "unavailable";
+  entries: GalleryFeedEntry[];
+  nextCursor: string | null;
+  total: number | null;
+}
+
+/**
+ * Whether one entry answers a search. Case-insensitive substring over the
+ * fields a person would search by: what it is called, who drew it, what it
+ * says about itself, and how it is tagged.
+ */
+export function galleryEntryMatchesQuery(
+  entry: Pick<GalleryFeedEntry, "name" | "author" | "description" | "tags">,
+  normalizedQuery: string,
+): boolean {
+  if (!normalizedQuery) return true;
+  return [entry.name, entry.author, entry.description, ...(entry.tags ?? [])]
+    .filter((field): field is string => Boolean(field))
+    .some((field) => field.toLowerCase().includes(normalizedQuery));
+}
+
+/** Tag menu entries, newest count first, as the wall's tag bar shows them. */
+export interface GalleryTagOption {
+  tag: string;
+  count: number;
+}
+
+export async function loadGalleryFeed(
+  fetchLike: typeof fetch = fetch,
+  options: {
+    cursor?: string | null;
+    author?: string | null;
+    tags?: readonly string[];
+  } = {},
+): Promise<GalleryFeedPage | null> {
+  const params = new URLSearchParams();
+  if (options.author) params.set("author", options.author);
+  if (options.tags && options.tags.length > 0) {
+    params.set("tags", options.tags.join(","));
+  }
+  if (options.cursor) params.set("cursor", options.cursor);
+  const query = params.toString();
+  try {
+    const response = await fetchLike(
+      `/api/gallery${query ? `?${query}` : ""}`,
+      { credentials: "same-origin" },
+    );
+    if (!response.ok) return null;
+    const payload = (await response.json()) as {
+      entries?: GalleryFeedEntry[];
+      nextCursor?: unknown;
+      total?: unknown;
+    };
+    return {
+      entries: payload.entries ?? [],
+      nextCursor:
+        typeof payload.nextCursor === "string" ? payload.nextCursor : null,
+      total: typeof payload.total === "number" ? payload.total : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** The tag menu's options. An unreachable worker leaves the menu empty. */
+export async function loadGalleryTags(
+  fetchLike: typeof fetch = fetch,
+): Promise<GalleryTagOption[]> {
+  try {
+    const response = await fetchLike("/api/gallery/tags", {
+      credentials: "same-origin",
+    });
+    if (!response.ok) return [];
+    const payload = (await response.json()) as {
+      tags?: GalleryTagOption[];
+    };
+    return payload.tags ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The wall's size in words, said only when the server has said it: a
+ * pre-totals API or a still-loading feed renders nothing rather than a guess.
+ * "Filtered" names the server-side narrowing (author, tags); "match" belongs
+ * to the text query, whose clause counts VISIBLE entries and says "so far"
+ * until the feed is exhausted.
+ */
+export function galleryCountLabel(
+  total: number | null,
+  options: {
+    filtered?: boolean;
+    search?: { visible: number; settled: boolean } | null;
+  } = {},
+): string | null {
+  if (total === null) return null;
+  const noun = total === 1 ? "circuit" : "circuits";
+  const base = `${total.toLocaleString()} ${
+    options.filtered ? `filtered ${noun}` : noun
+  }`;
+  const search = options.search ?? null;
+  const clause = search
+    ? ` · ${search.visible} ${search.visible === 1 ? "match" : "matches"}${
+        search.settled ? "" : " so far"
+      }`
+    : "";
+  return `${base}${clause}`;
+}

--- a/apps/editor/src/styles/editor-workspace.css
+++ b/apps/editor/src/styles/editor-workspace.css
@@ -638,3 +638,93 @@
     height: 36px;
   }
 }
+
+/* The docked gallery's controls: a search box, a tag menu and the wall's size.
+   The panel is narrow, so tags live behind a menu rather than in a chip row —
+   the only difference from the Gallery wall, whose behaviour it otherwise
+   shares exactly. */
+.examples-panel-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--icm-space-2);
+  padding: 0 var(--icm-space-2);
+}
+
+.examples-panel-search {
+  flex: 1 1 8rem;
+  min-width: 0;
+  padding: var(--icm-space-1) var(--icm-space-2);
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface);
+  color: inherit;
+  font-size: var(--icm-font-xs);
+}
+
+.examples-panel-tag-menu {
+  position: relative;
+}
+
+.examples-panel-tag-toggle {
+  padding: var(--icm-space-1) var(--icm-space-2);
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface);
+  color: inherit;
+  font-size: var(--icm-font-xs);
+  cursor: pointer;
+}
+
+.examples-panel-tag-options {
+  position: absolute;
+  z-index: 2;
+  top: calc(100% + var(--icm-space-1));
+  left: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--icm-space-1);
+  max-height: 16rem;
+  min-width: 10rem;
+  padding: var(--icm-space-2);
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface-raised, var(--icm-surface));
+  box-shadow: var(--icm-shadow-panel, 0 4px 12px rgb(0 0 0 / 18%));
+  overflow: auto;
+}
+
+.examples-panel-tag-option {
+  display: flex;
+  align-items: center;
+  gap: var(--icm-space-1);
+  font-size: var(--icm-font-xs);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.examples-panel-tag-count {
+  margin-left: auto;
+  color: var(--icm-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.examples-panel-count {
+  flex-basis: 100%;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.examples-panel-empty {
+  margin: 0;
+  padding: 0 var(--icm-space-2);
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+
+/* Watched to fetch the next page; it has no size of its own, so a short
+   filtered list keeps it in view and the feed keeps arriving. */
+.examples-panel-sentinel {
+  height: 1px;
+}


### PR DESCRIPTION
## Problem

The Gallery panel docked beside the canvas fetched `?limit=60` once and stopped. The wall holds 120 circuits and the server caps a page at 60, so the panel silently showed **half the gallery** with no sign the rest existed — a display cap the reader could neither see nor lift. The wall itself pages, so the same person browsing in two places got two different galleries.

## What ships

The panel now reads the same feed the wall reads, through one shared data layer:

- **Paging** by cursor, on the same sentinel-in-view mechanism the wall uses.
- **The count**, from the server's own `total` — and, like the wall, it says nothing rather than a guess when a pre-totals API answers.
- **Search** over name, author, description and tags — the same four fields, through the same matcher.
- **Tag filtering**, server-side, with the same OR semantics.

Only the presentation differs: the panel is narrow, so tags live behind a menu rather than a chip row.

## The sharing is the point

`galleryEntryMatchesQuery`, `loadGalleryFeed`, `loadGalleryTags` and the count wording move into `gallery-client`, which both surfaces already imported. `gallery-feed` re-exports them, so no existing importer changes and the wall's nine tests pass untouched — the refactor is proved behaviour-preserving before the panel is wired to it.

A circuit a search finds on the wall is found by the same search in the panel, because it *is* the same search.

## Keeping it that way

`deriveGalleryPanelView` makes the panel's whole view a pure function, so its cases assert the shared matcher and the shared count wording directly rather than re-describing them. A change that makes one surface disagree with the other fails in this file instead of being discovered by someone who searched in both places and got different answers.

The empty state inherits the wall's honesty: with pages still unfetched it says the search is still running, and only claims nothing matches once the feed is exhausted — a wall paged 30 at a time must not deny a circuit it has not fetched.

## Validation

Full `pnpm ci:check` green under the gate lock: unit 2001/2001 (314 files), e2e 297/297, typecheck, prettier, build, release verify.