### PR TITLE
Pan the canvas with arrow-key commands

### DIFF
--- a/apps/editor/e2e/wheel-behavior.spec.ts
+++ b/apps/editor/e2e/wheel-behavior.spec.ts
@@ -68,3 +68,46 @@ test("a wheel zooms and a trackpad pans, and the setting overrides both", async 
   await awaitEditorReady(page);
   await expect(page.getByLabel("Scroll wheel")).toHaveValue("pan");
 });
+
+test("arrow keys pan the camera by one stable screen-space step", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await awaitEditorReady(page);
+  const canvas = page.getByTestId("schematic-canvas");
+  const bounds = await canvas.boundingBox();
+  expect(bounds).not.toBeNull();
+  await canvas.click({
+    position: { x: bounds!.width - 12, y: bounds!.height - 12 },
+  });
+
+  const readViewBox = async () =>
+    (await canvas.getAttribute("viewBox"))!.split(" ").map(Number) as [
+      number,
+      number,
+      number,
+      number,
+    ];
+  const initial = await readViewBox();
+  await page.keyboard.press("ArrowRight");
+  await expect.poll(readViewBox).not.toEqual(initial);
+  const right = await readViewBox();
+  expect(right[2]).toBe(initial[2]);
+  expect(right[3]).toBe(initial[3]);
+  expect(((right[0] - initial[0]) * bounds!.width) / initial[2]).toBeCloseTo(
+    48,
+    1,
+  );
+
+  await page.keyboard.press("ArrowLeft");
+  await expect.poll(readViewBox).toEqual(initial);
+  await page.keyboard.press("ArrowDown");
+  await expect.poll(readViewBox).not.toEqual(initial);
+  const down = await readViewBox();
+  expect(((down[1] - initial[1]) * bounds!.height) / initial[3]).toBeCloseTo(
+    48,
+    1,
+  );
+  await page.keyboard.press("ArrowUp");
+  await expect.poll(readViewBox).toEqual(initial);
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -2417,6 +2417,7 @@ export function App({
   });
   const {
     fitView,
+    panView,
     zoomViewAtCenter,
     handleWheel,
     zoomAtClientPoint,
@@ -3125,6 +3126,7 @@ export function App({
       addText: addPlainText,
       openProperties,
       closeProperties,
+      panView,
       fitView,
       report: setStatus,
     },

--- a/apps/editor/src/canvas/canvas-gesture-controller.ts
+++ b/apps/editor/src/canvas/canvas-gesture-controller.ts
@@ -32,7 +32,9 @@ import { normalizedRect } from "./canvas-geometry";
 import {
   fitCameraToBounds,
   fitCameraToVisibleBounds,
+  panCameraByScreenPixels,
   zoomCameraAtAnchor,
+  type CameraPanDirection,
   type CameraRectInput,
   type CanvasInsets,
 } from "./fit-view";
@@ -40,6 +42,7 @@ import {
 // A stiff middle button drifts under the hand; keep a larger slop than an
 // ordinary drag so a click can still cycle the active wire corner.
 const PAN_START_DISTANCE_PX = 10;
+export const KEYBOARD_PAN_STEP_PX = 48;
 const DRAFTING_SNAP_CAPTURE_RADIUS_PX = 7;
 
 type SetViewBox = (
@@ -282,6 +285,21 @@ export function createCanvasGestureController({
   const zoomViewAtCenter = (factor: number): void => {
     setViewBox((current) =>
       zoomCameraAtAnchor(current, factor, { x: 0.5, y: 0.5 }),
+    );
+  };
+
+  const panView = (direction: CameraPanDirection): void => {
+    const viewport = measureCanvasView?.()?.viewport ?? {
+      width: defaultViewBox.width,
+      height: defaultViewBox.height,
+    };
+    setViewBox((current) =>
+      panCameraByScreenPixels(
+        current,
+        direction,
+        KEYBOARD_PAN_STEP_PX,
+        viewport,
+      ),
     );
   };
 
@@ -602,6 +620,7 @@ export function createCanvasGestureController({
 
   return {
     fitView,
+    panView,
     zoomViewAtCenter,
     handleWheel,
     zoomAtClientPoint,

--- a/apps/editor/src/canvas/editor-canvas-event-handlers.ts
+++ b/apps/editor/src/canvas/editor-canvas-event-handlers.ts
@@ -258,6 +258,10 @@ export function createEditorCanvasEventHandlers({
     onPointerDownCapture(event: CanvasPointerEvent) {
       const target = event.target as Element;
       if (target.closest('[data-testid="canvas-text-editor"]')) return;
+      // The canvas is the keyboard-command surface. Explicitly take focus on
+      // pointer entry so an earlier toolbar or Project-name input cannot keep
+      // swallowing canvas shortcuts after the user returns to the drawing.
+      event.currentTarget.focus({ preventScroll: true });
       if (
         cellSymbolLayoutEnabled &&
         target.closest('[data-testid="cell-symbol-layout-overlay"]')

--- a/apps/editor/src/canvas/editor-canvas-surface.tsx
+++ b/apps/editor/src/canvas/editor-canvas-surface.tsx
@@ -207,6 +207,8 @@ export function EditorCanvasSurface({
         data-testid="schematic-canvas"
         role="img"
         aria-label="Schematic canvas"
+        aria-keyshortcuts="ArrowLeft ArrowRight ArrowUp ArrowDown"
+        tabIndex={0}
         viewBox={viewBox}
         {...eventHandlers}
       >

--- a/apps/editor/src/canvas/fit-view.test.ts
+++ b/apps/editor/src/canvas/fit-view.test.ts
@@ -6,6 +6,7 @@ import {
   fitCameraToBounds,
   fitCameraToVisibleBounds,
   normalizeCameraRect,
+  panCameraByScreenPixels,
   zoomCameraAtAnchor,
 } from "./fit-view";
 
@@ -89,6 +90,41 @@ describe("zoomCameraAtAnchor", () => {
     // maxHeight (3000 -> 3500, scale 7/6) binds before maxWidth.
     expect(grown.height).toBe(CAMERA_ZOOM_LIMITS.maxHeight);
     expect(grown.width).toBeCloseTo((4000 * 7) / 6, 10);
+  });
+});
+
+describe("panCameraByScreenPixels", () => {
+  it("keeps the keyboard step constant in screen space across zoom levels", () => {
+    const viewport = { width: 800, height: 400 };
+    expect(
+      panCameraByScreenPixels(
+        { x: 100, y: 200, width: 800, height: 400 },
+        "right",
+        48,
+        viewport,
+      ),
+    ).toEqual({ x: 148, y: 200, width: 800, height: 400 });
+    expect(
+      panCameraByScreenPixels(
+        { x: 100, y: 200, width: 400, height: 200 },
+        "down",
+        48,
+        viewport,
+      ),
+    ).toEqual({ x: 100, y: 224, width: 400, height: 200 });
+  });
+
+  it("moves each direction without changing zoom", () => {
+    const current = { x: 100, y: 200, width: 800, height: 400 };
+    const viewport = { width: 800, height: 400 };
+    expect(panCameraByScreenPixels(current, "left", 40, viewport)).toEqual({
+      ...current,
+      x: 60,
+    });
+    expect(panCameraByScreenPixels(current, "up", 40, viewport)).toEqual({
+      ...current,
+      y: 160,
+    });
   });
 });
 

--- a/apps/editor/src/canvas/fit-view.ts
+++ b/apps/editor/src/canvas/fit-view.ts
@@ -193,6 +193,46 @@ export const CAMERA_ZOOM_LIMITS: CameraZoomLimits = {
   maxHeight: 3500,
 };
 
+export type CameraPanDirection = "left" | "right" | "up" | "down";
+
+/**
+ * Moves the camera by a screen-space distance.
+ *
+ * Keyboard navigation is expected to feel constant at every zoom level, so
+ * its public step is measured in CSS pixels and converted here to Document
+ * units. Positive x/y moves the viewport toward the right/bottom of the
+ * schematic, matching wheel and middle-button camera semantics.
+ */
+export function panCameraByScreenPixels(
+  current: GridRect,
+  direction: CameraPanDirection,
+  pixels: number,
+  viewport: { width: number; height: number },
+): GridRect {
+  if (
+    !Number.isFinite(pixels) ||
+    pixels < 0 ||
+    !Number.isFinite(viewport.width) ||
+    !Number.isFinite(viewport.height) ||
+    viewport.width <= 0 ||
+    viewport.height <= 0
+  ) {
+    return current;
+  }
+  const dx = (pixels * current.width) / viewport.width;
+  const dy = (pixels * current.height) / viewport.height;
+  switch (direction) {
+    case "left":
+      return { ...current, x: current.x - dx };
+    case "right":
+      return { ...current, x: current.x + dx };
+    case "up":
+      return { ...current, y: current.y - dy };
+    case "down":
+      return { ...current, y: current.y + dy };
+  }
+}
+
 /**
  * Scales the camera rect around a viewport-relative anchor (0..1 in each
  * axis), the shared core of cursor-anchored wheel zoom and center-anchored

--- a/apps/editor/src/commands/editor-command.test.ts
+++ b/apps/editor/src/commands/editor-command.test.ts
@@ -60,6 +60,7 @@ function fixture(overrides: Partial<EditorCommandContext> = {}) {
     addText: vi.fn(),
     openProperties: vi.fn(),
     closeProperties: vi.fn(),
+    panView: vi.fn(),
     fitView: vi.fn(),
     report: vi.fn(),
   };
@@ -209,6 +210,16 @@ describe("editor command router", () => {
     });
     router.execute({ id: "tool.activate", tool: "arrow" });
     expect(operations.activateTool).toHaveBeenCalledWith("arrow");
+  });
+
+  it("routes camera panning through the shared command plane", () => {
+    const { router, operations } = fixture({ interactionMode: "wire" });
+    expect(router.state({ id: "view.pan", direction: "left" })).toEqual({
+      enabled: true,
+      active: false,
+    });
+    router.execute({ id: "view.pan", direction: "up" });
+    expect(operations.panView).toHaveBeenCalledWith("up");
   });
 
   it("leaves history and tool re-entry lifecycle to their domain owners", () => {

--- a/apps/editor/src/commands/editor-command.ts
+++ b/apps/editor/src/commands/editor-command.ts
@@ -26,6 +26,7 @@ export type EditorCommandRequest =
   | { id: "drafting.add-text" }
   | { id: "properties.open" }
   | { id: "properties.close" }
+  | { id: "view.pan"; direction: "left" | "right" | "up" | "down" }
   | { id: "view.fit" };
 
 export interface EditorCommandState {
@@ -94,6 +95,7 @@ export interface EditorCommandOperations {
   addText(): void;
   openProperties(): void;
   closeProperties(): void;
+  panView(direction: "left" | "right" | "up" | "down"): void;
   fitView(): void;
   report(message: string): void;
 }
@@ -249,6 +251,7 @@ export function createEditorCommandRouter(
       case "tool.activate":
         return enabled(context.activeTool === request.tool);
       case "drafting.add-text":
+      case "view.pan":
       case "view.fit":
         return enabled();
       case "properties.open":
@@ -401,6 +404,9 @@ export function createEditorCommandRouter(
         break;
       case "view.fit":
         options.operations.fitView();
+        break;
+      case "view.pan":
+        options.operations.panView(request.direction);
         break;
     }
     return { status: "executed" };

--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -239,6 +239,23 @@ describe("editor shortcut contract", () => {
     expect(resolve("x")).toBeNull();
   });
 
+  it("maps unmodified arrow keys to camera pan commands", () => {
+    expect(resolve("ArrowLeft")).toEqual(
+      command({ id: "view.pan", direction: "left" }),
+    );
+    expect(resolve("ArrowRight")).toEqual(
+      command({ id: "view.pan", direction: "right" }),
+    );
+    expect(resolve("ArrowUp", { interactionMode: "wire" })).toEqual(
+      command({ id: "view.pan", direction: "up" }),
+    );
+    expect(resolve("ArrowDown", { interactionMode: "drawing" })).toEqual(
+      command({ id: "view.pan", direction: "down" }),
+    );
+    expect(resolve("ArrowLeft", {}, { shiftKey: true })).toBeNull();
+    expect(resolve("ArrowRight", { isTyping: true })).toBeNull();
+  });
+
   it("opens Wire options with F3 only while Wire owns the canvas", () => {
     expect(resolve("F3")).toBeNull();
     expect(resolve("F3", { interactionMode: "wire" })).toEqual({

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -128,6 +128,28 @@ export function resolveEditorShortcut(
     return { kind: "run-command", command: { id: "editor.cancel" } };
   }
 
+  if (
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.altKey &&
+    !event.shiftKey &&
+    (event.key === "ArrowLeft" ||
+      event.key === "ArrowRight" ||
+      event.key === "ArrowUp" ||
+      event.key === "ArrowDown")
+  ) {
+    const directions = {
+      ArrowLeft: "left",
+      ArrowRight: "right",
+      ArrowUp: "up",
+      ArrowDown: "down",
+    } as const;
+    return {
+      kind: "run-command",
+      command: { id: "view.pan", direction: directions[event.key] },
+    };
+  }
+
   if (interactionActive) {
     if (commandModifier && key === "a") {
       return { kind: "blocked-interaction-command", command: "Select All" };


### PR DESCRIPTION
## Summary
- route unmodified arrow keys through the shared editor command router
- pan by a fixed 48 CSS-pixel camera step at every zoom level
- make the canvas the explicit keyboard focus surface without stealing arrows from text inputs

## Validation
- pnpm build
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
  - 314 unit files / 1999 tests
  - 124 manual-editor browser tests
  - 10 command browser tests
  - 2 viewport browser tests