### PR TITLE
Remove the canvas focus frame

### DIFF
--- a/apps/editor/e2e/wheel-behavior.spec.ts
+++ b/apps/editor/e2e/wheel-behavior.spec.ts
@@ -80,6 +80,7 @@ test("arrow keys pan the camera by one stable screen-space step", async ({
   await canvas.click({
     position: { x: bounds!.width - 12, y: bounds!.height - 12 },
   });
+  await expect(canvas).toHaveCSS("outline-style", "none");
 
   const readViewBox = async () =>
     (await canvas.getAttribute("viewBox"))!.split(" ").map(Number) as [

--- a/apps/editor/src/canvas/editor-canvas-surface.tsx
+++ b/apps/editor/src/canvas/editor-canvas-surface.tsx
@@ -208,7 +208,7 @@ export function EditorCanvasSurface({
         role="img"
         aria-label="Schematic canvas"
         aria-keyshortcuts="ArrowLeft ArrowRight ArrowUp ArrowDown"
-        tabIndex={0}
+        tabIndex={-1}
         viewBox={viewBox}
         {...eventHandlers}
       >

--- a/apps/editor/src/styles/editor-canvas.css
+++ b/apps/editor/src/styles/editor-canvas.css
@@ -29,6 +29,12 @@
   -webkit-user-select: none;
 }
 
+/* Focus exists only to hand global shortcuts back from a prior input. The
+   canvas is not a form control and must never gain a browser-drawn frame. */
+.schematic-canvas:focus {
+  outline: none;
+}
+
 /* The inline text editor is the one place canvas text is really edited;
    restore selection inside it so caret and range editing keep working. */
 .canvas-text-editor-overlay,


### PR DESCRIPTION
## Summary
- remove the browser-drawn black outline from the focused SVG canvas
- keep programmatic focus handoff for arrow-key commands
- remove the canvas from sequential Tab navigation

## Validation
- focused wheel/keyboard-pan browser tests: 2 passed
- typecheck and preflight passed