### PR TITLE
fix(text): preserve literal identifier characters

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -2510,6 +2510,37 @@ test("edits instance, electrical Net, and free text with bounded label handles",
   expect(afterBox?.x).not.toBe(beforeBox.x);
 });
 
+test("keeps punctuation literal when formatting a bound Net label", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 280, y: 180 });
+  await placeComponent(page, "resistor", { x: 480, y: 180 });
+  await clickDrawTool(page, "wire");
+  await page.getByTestId("terminal-R1-2").click();
+  await page.getByTestId("terminal-R2-1").click();
+  await page.keyboard.press("Escape");
+
+  await clickRoute(page, "route-ui-1", 0.5, 0);
+  await openSelectionShelf(page);
+  await page
+    .getByRole("textbox", { name: "Electrical Net label" })
+    .fill("A1_wi");
+  const label = page.getByTestId("annotation-hit-net-label-route-ui-1");
+  await label.dblclick();
+  const editor = page.getByRole("textbox", { name: "Canvas text editor" });
+  await editor.press("ControlOrMeta+A");
+  await page.getByRole("button", { name: "Italic" }).click();
+  await page.getByRole("button", { name: "Apply text changes" }).click();
+
+  await expect(page.locator('[data-layer="annotations"]')).toContainText(
+    "A1_wi",
+  );
+  await expect(page.getByTestId("status")).not.toContainText(
+    "Could not update Cell structure",
+  );
+});
+
 test("keeps literal text line breaks and overbars visible while editing", async ({
   page,
 }) => {

--- a/apps/editor/src/features/clipboard/clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard.test.ts
@@ -749,7 +749,7 @@ describe("schematic clipboard", () => {
         { kind: "upsert_schematic_annotation" }
       > => edit.kind === "upsert_schematic_annotation",
     );
-    expect(flattenRichText(pastedLabel!.annotation.content!)).toBe("Rload");
+    expect(flattenRichText(pastedLabel!.annotation.content!)).toBe("R_load");
     expect(proposal.instanceIds).toEqual(["R2"]);
   });
 

--- a/docs/specs/visual-language.md
+++ b/docs/specs/visual-language.md
@@ -73,11 +73,14 @@ has no electrical meaning.
 
 Under `razavi-textbook-v1`, instance identifiers and recognized voltage,
 current, power, and pin labels are composed into deterministic SVG
-`<tspan>` runs. An explicit underscore selects the subscript; otherwise an
-instance designator or leading `V`/`I` is the base. Trailing `+` and `-` signs
-remain upright. Notes and figure captions are never parsed implicitly. The
-persisted annotation string remains unchanged, and the same composed formal
-SVG scene feeds SVG, PNG, and PDF export.
+`<tspan>` runs. The leading symbol is the base and the remaining identifier
+defaults to its subscript; trailing `+` and `-` signs remain upright. This is a
+style compiler, not an input grammar: underscores, braces, carets, backslashes,
+letter case, and every other authored character remain literal. Users change
+ordinary RichText formatting through the explicit toolbar, while only the
+explicit Formula editor interprets LaTeX syntax. The persisted semantic name
+and the flattened RichText projection therefore remain identical, and the same
+composed formal SVG scene feeds SVG, PNG, and PDF export.
 
 An authored formula is the atomic alternative to ordinary styled RichText,
 not another text object type. Its persisted facts are bounded LaTeX source and

--- a/fixtures/gallery-redline/2rmm2vb45f.icproj.json
+++ b/fixtures/gallery-redline/2rmm2vb45f.icproj.json
@@ -1904,7 +1904,7 @@
                     "children": [
                       {
                         "kind": "text",
-                        "value": "R"
+                        "value": "r"
                       }
                     ],
                     "kind": "span",

--- a/packages/derived/src/annotation-text.test.ts
+++ b/packages/derived/src/annotation-text.test.ts
@@ -182,15 +182,15 @@ describe("bound annotation text", () => {
 
     const before = structuredClone(annotation.anchor);
     expect(flattenRichText(resolveAnnotationText(document, annotation))).toBe(
-      "Vin,cm",
+      "V_{in,cm}",
     );
     expect(flattenRichText(resolveAnnotationText(document, annotation))).toBe(
-      "Vin,cm",
+      "V_{in,cm}",
     );
     const claim = document.connectivityEvidence[0];
     if (claim?.kind === "name-claim") claim.name = "V_{refp}";
     expect(flattenRichText(resolveAnnotationText(document, annotation))).toBe(
-      "Vrefp",
+      "V_{refp}",
     );
     expect(annotation.anchor).toEqual(before);
   });
@@ -221,7 +221,7 @@ describe("bound annotation text", () => {
     };
 
     expect(flattenRichText(resolveAnnotationText(document, annotation))).toBe(
-      "sky130nfet",
+      "sky130_nfet",
     );
   });
 });

--- a/packages/model/src/schema.test.ts
+++ b/packages/model/src/schema.test.ts
@@ -450,6 +450,30 @@ describe("CircuitProject schema", () => {
       ],
     };
     expect(SchematicDocumentSchema.safeParse(document).success).toBe(true);
+    document.connectivityEvidence[0] = {
+      ...originalLabelClaim,
+      name: "A1_wi",
+    };
+    document.annotations[0]!.formatOverride = {
+      runs: [
+        {
+          kind: "span",
+          style: "italic",
+          children: [{ kind: "text", value: "A1_wi" }],
+        },
+      ],
+    };
+    expect(SchematicDocumentSchema.safeParse(document).success).toBe(true);
+    document.connectivityEvidence[0] = originalLabelClaim;
+    document.annotations[0]!.formatOverride = {
+      runs: [
+        {
+          kind: "span",
+          style: "italic",
+          children: [{ kind: "text", value: "A" }],
+        },
+      ],
+    };
     document.annotations[0]!.anchor = {
       kind: "object",
       objectId: "P1",

--- a/packages/model/src/semantic-text.test.ts
+++ b/packages/model/src/semantic-text.test.ts
@@ -25,16 +25,16 @@ describe("semantic formal-Port text", () => {
     });
   });
 
-  it("uses the same explicit multi-character subscript grammar for Ports and Net Labels", () => {
+  it("preserves punctuation instead of interpreting it as subscript markup", () => {
     const port = semanticTextDocument("V_{in,cm}", "formal-port");
     const net = semanticTextDocument("V_{in,cm}", "net-label");
 
     expect(port).toEqual(net);
-    expect(flattenRichText(port)).toBe("Vin,cm");
+    expect(flattenRichText(port)).toBe("V_{in,cm}");
     expect(port.runs[1]).toMatchObject({
       kind: "span",
       style: "subscript",
-      children: [{ children: [{ value: "in,cm" }] }],
+      children: [{ children: [{ value: "_{in,cm}" }] }],
     });
   });
 
@@ -98,13 +98,13 @@ describe("house text style", () => {
     });
   });
 
-  it("capitalizes the leading symbol and subscripts the remainder", () => {
+  it("preserves the leading symbol case while subscripting the remainder", () => {
     const content = semanticTextDocument("vout", "net-label");
 
-    expect(flattenRichText(content)).toBe("Vout");
+    expect(flattenRichText(content)).toBe("vout");
     expect(content.runs[0]).toMatchObject({
       style: "italic",
-      children: [{ children: [{ value: "V" }] }],
+      children: [{ children: [{ value: "v" }] }],
     });
     expect(content.runs[1]).toMatchObject({
       style: "subscript",
@@ -132,7 +132,7 @@ describe("drafting text", () => {
   it("subscripts an identifier typed into a text box", () => {
     const content = defaultDraftTextDocument("vbias");
 
-    expect(flattenRichText(content)).toBe("Vbias");
+    expect(flattenRichText(content)).toBe("vbias");
     expect(content.runs).toHaveLength(2);
     expect(content.runs[1]).toMatchObject({ style: "subscript" });
   });
@@ -140,8 +140,14 @@ describe("drafting text", () => {
   it("keeps a multi-word note as prose instead of one long subscript", () => {
     const content = defaultDraftTextDocument("design note");
 
-    expect(flattenRichText(content)).toBe("Design note");
+    expect(flattenRichText(content)).toBe("design note");
     expect(content.runs).toHaveLength(1);
     expect(content.runs[0]).toMatchObject({ style: "italic" });
+  });
+
+  it("keeps ordinary text punctuation literal while applying the house style", () => {
+    for (const value of ["A1_wi", "x^2", String.raw`V\{in\}`]) {
+      expect(flattenRichText(defaultDraftTextDocument(value))).toBe(value);
+    }
   });
 });

--- a/packages/model/src/semantic-text.ts
+++ b/packages/model/src/semantic-text.ts
@@ -3,11 +3,10 @@ import type { RichTextDocument, RichTextRun, RichTextStyle } from "./schema.js";
 /**
  * Semantic text emitted by current authoring for standardized schematic names.
  *
- * This is deliberately not a markup parser: `_{}`, `\\it{}`, and other markup
- * spellings are invalid Project text. Callers either supply an explicit
- * RichText AST or use this helper for a semantic
- * identifier such as an instance reference or a conventional voltage/current
- * label.
+ * This is deliberately not a markup parser. Every input character remains in
+ * the RichText projection; this helper only assigns the initial Razavi house
+ * style. Callers use an explicit RichText AST for later formatting and the
+ * explicit Formula editor for LaTeX syntax.
  */
 export type SemanticTextKind =
   | "default-instance"
@@ -46,19 +45,19 @@ function mathSubscript(value: string): RichTextRun {
 }
 
 /**
- * House style for an authored identifier: the leading character is the
- * capitalized symbol and everything after it defaults to its subscript. Both
- * halves stay editable afterwards.
+ * House style for an authored identifier: the leading character is the symbol
+ * and everything after it defaults to its subscript. Both halves stay editable
+ * afterwards. Styling must never rewrite the semantic identifier: punctuation
+ * and letter case are preserved exactly.
  *
  * Whitespace marks prose rather than an identifier — a drafting note must not
  * be swallowed into one long subscript — so a multi-word value keeps its
- * capitalized first letter and stays a single upright-size run.
+ * authored spelling and stays a single upright-size run.
  */
 function symbolRuns(value: string): RichTextRun[] {
-  const capitalized = value.slice(0, 1).toUpperCase() + value.slice(1);
-  if (/\s/u.test(capitalized)) return [mathBase(capitalized)];
-  const head = capitalized.slice(0, 1);
-  const tail = capitalized.slice(1);
+  if (/\s/u.test(value)) return [mathBase(value)];
+  const head = value.slice(0, 1);
+  const tail = value.slice(1);
   return tail.length > 0
     ? [mathBase(head), mathSubscript(tail)]
     : [mathBase(head)];
@@ -67,43 +66,17 @@ function symbolRuns(value: string): RichTextRun[] {
 /** Construct the initial Razavi-style RichText for a free drafting label. */
 export function defaultDraftTextDocument(value: string): RichTextDocument {
   if (value.length === 0) return { runs: [{ kind: "line-break" }] };
-  if (/[\\{}^]/u.test(value)) return { runs: [{ kind: "text", value }] };
-
-  const underscore = value.indexOf("_");
-  if (underscore > 0 && underscore < value.length - 1) {
-    return {
-      runs: [
-        mathBase(value.slice(0, underscore)),
-        mathSubscript(value.slice(underscore + 1)),
-      ],
-    };
-  }
-
   return { runs: symbolRuns(value) };
 }
 
 /** Construct current-authoring RichText for a conventional semantic label. */
 export function semanticTextDocument(
   value: string,
-  kind: SemanticTextKind,
+  _kind: SemanticTextKind,
 ): RichTextDocument {
   if (value.length === 0) return { runs: [{ kind: "line-break" }] };
-  // `_suffix` and `_{suffix}` are the one explicit identifier notation the
-  // product accepts. Parse it before role-specific shorthand so Cell Pins,
-  // ordinary labels, and hierarchy pin names never diverge on V_in.
-  const explicitSubscript = /^(.+?)_(?:\{(.+)\}|(.+))$/u.exec(value);
-  if (explicitSubscript) {
-    return {
-      runs: [
-        mathBase(explicitSubscript[1]!),
-        mathSubscript(explicitSubscript[2] ?? explicitSubscript[3]!),
-      ],
-    };
-  }
-  if (/[\\{}^]/u.test(value)) return { runs: [{ kind: "text", value }] };
-
-  // Every authored label follows one rule: capitalized leading symbol, the
-  // rest as its subscript. A trailing polarity sign stays outside the
+  // Every authored label follows one styling rule: leading symbol, then the
+  // remainder as its subscript. A trailing polarity sign stays outside the
   // subscript because it qualifies the whole identifier.
   const signed = /^(.+?)([+-])$/u.exec(value);
   if (!signed) return { runs: symbolRuns(value) };


### PR DESCRIPTION
## Summary
- keep Razavi annotation compilation as presentation-only styling
- preserve underscores, braces, carets, backslashes, case, and every authored identifier character
- cover bound Net Label formatting through schema, model, clipboard, gallery-corpus, and browser regressions

## Validation
- static checks, typecheck, 1996 unit tests, workspace build, performance budgets, goldens, production/release smoke
- 298/298 browser scenarios passed in the final CI-configured rerun

Fixes #458