### PR TITLE
fix(editor): a label anchored to anything but an Instance can be dragged

### DIFF
--- a/apps/editor/src/features/text-editing/annotation-drag-model.test.ts
+++ b/apps/editor/src/features/text-editing/annotation-drag-model.test.ts
@@ -84,6 +84,93 @@ describe("annotation drag model", () => {
     });
   });
 
+  it("moves a power label anchored to its rail Junction", () => {
+    // A power rail's label anchors to the Junction at the rail's end, not to
+    // an Instance. Rendering resolves it as junction position + localOffset,
+    // so a drag that updates only fallbackPosition leaves the label where it
+    // was and the gesture appears to do nothing.
+    const document = createEmptyDocument("document", "Document");
+    document.presentation.grid = 10;
+    document.nets.push({ id: "vdd-net", terminals: [] });
+    document.junctions.push({
+      id: "vdd-junction",
+      netId: "vdd-net",
+      position: { x: 100, y: 100 },
+      role: "route-anchor",
+    });
+    const annotation: Annotation = {
+      id: "vdd-label",
+      kind: "power-label",
+      netId: "vdd-net",
+      binding: { kind: "net-name", netId: "vdd-net" },
+      anchor: {
+        kind: "object",
+        objectId: "vdd-junction",
+        localOffset: { x: 10, y: 10 },
+        fallbackPosition: { x: 110, y: 110 },
+      },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    };
+
+    const dragged = draggedAnnotationAtPosition(context(document), annotation, {
+      x: 160,
+      y: 40,
+    });
+
+    expect(dragged.anchor.kind).toBe("object");
+    if (dragged.anchor.kind !== "object") return;
+    // localOffset is what rendering reads, so it has to carry the drag.
+    expect(dragged.anchor.localOffset).toEqual({ x: 60, y: -60 });
+    expect(dragged.anchor.fallbackPosition).toEqual({ x: 160, y: 40 });
+  });
+
+  it("moves a drafting label anchored to its rectangle", () => {
+    // Same class as the power label: the anchor target is not an Instance, so
+    // a lookup that only knows Instances silently drops the drag.
+    const document = createEmptyDocument("document", "Document");
+    document.presentation.grid = 10;
+    document.drafting = {
+      objects: [
+        {
+          id: "box",
+          kind: "rectangle",
+          center: { x: 200, y: 200 },
+          width: 80,
+          height: 40,
+          rotation: 0,
+          lineStyle: "solid",
+          locked: false,
+          zIndex: 0,
+          anchor: { kind: "free", position: { x: 200, y: 200 } },
+        },
+      ],
+    };
+    const annotation: Annotation = {
+      id: "box-label",
+      kind: "instance-label",
+      anchor: {
+        kind: "object",
+        objectId: "box",
+        localOffset: { x: 0, y: 0 },
+        fallbackPosition: { x: 200, y: 200 },
+      },
+      alignment: "middle",
+      rotation: 0,
+      locked: false,
+    };
+
+    const dragged = draggedAnnotationAtPosition(context(document), annotation, {
+      x: 230,
+      y: 170,
+    });
+
+    expect(dragged.anchor.kind).toBe("object");
+    if (dragged.anchor.kind !== "object") return;
+    expect(dragged.anchor.localOffset).toEqual({ x: 30, y: -30 });
+  });
+
   it("reanchors an imported Net Label along its routed Net", () => {
     const document = createEmptyDocument("document", "Document");
     document.nets.push({ id: "net", terminals: [] });

--- a/apps/editor/src/features/text-editing/annotation-drag-model.ts
+++ b/apps/editor/src/features/text-editing/annotation-drag-model.ts
@@ -1,4 +1,7 @@
-import type { ResolvedRouteGeometry } from "@icm/derived";
+import {
+  resolveAnchorTargetPosition,
+  type ResolvedRouteGeometry,
+} from "@icm/derived";
 import type {
   Annotation,
   DerivedPoint,
@@ -169,18 +172,23 @@ export function draggedAnnotationAtPosition(
 
   const position = constrainAnnotationPosition(context, annotation, candidate);
   if (annotation.anchor.kind === "object") {
-    const anchor = annotation.anchor;
-    const instance = document.instances.find(
-      (item) => item.id === anchor.objectId,
+    // Rendering resolves an object anchor as target position + localOffset, so
+    // localOffset is what a drag has to carry. Ask the resolver's own lookup
+    // rather than only for an Instance: a power rail's label hangs off its
+    // Junction, and a drafting label off its rectangle, and updating just
+    // fallbackPosition would leave both rendering where they already were.
+    const target = resolveAnchorTargetPosition(
+      document,
+      annotation.anchor.objectId,
     );
-    if (instance?.placement) {
+    if (target) {
       return {
         ...annotation,
         anchor: {
           ...annotation.anchor,
           localOffset: {
-            x: position.x - instance.placement.position.x,
-            y: position.y - instance.placement.position.y,
+            x: position.x - target.x,
+            y: position.y - target.y,
           },
           fallbackPosition: position,
         },

--- a/packages/derived/src/anchor.ts
+++ b/packages/derived/src/anchor.ts
@@ -64,7 +64,7 @@ function resolveObjectAnchor(
   document: SchematicDocument,
   anchor: Extract<VisualAnchor, { kind: "object" }>,
 ): ResolvedAnchor {
-  const target = findObjectPlacement(document, anchor.objectId);
+  const target = resolveAnchorTargetPosition(document, anchor.objectId);
   if (!target) {
     return {
       position: anchor.fallbackPosition,
@@ -161,7 +161,13 @@ function unresolvedRoute(
  * Junction. A DraftingObject is intentionally not a valid V1 anchor target
  * (ADR 0010: no drafting-to-drafting attachment).
  */
-function findObjectPlacement(
+/**
+ * The position an `object` anchor hangs off. Exported because anchor
+ * resolution is not the only caller: a drag that rewrites localOffset must
+ * measure against the same target this resolves, or the two disagree and the
+ * dragged label renders back where it started.
+ */
+export function resolveAnchorTargetPosition(
   document: SchematicDocument,
   objectId: string,
 ): GridPoint | null {


### PR DESCRIPTION
## What you see

A power rail's VDD label will not move. You drag it, release, and it is back where it started. The same is true of a drafting label attached to a rectangle.

## Why

Anchor resolution and the drag disagreed about what an `object` anchor is allowed to point at.

`resolveVisualAnchor` resolves an object anchor as **target position + localOffset**, and its lookup knows four kinds of target: Instances, Junctions, drafting rectangles, and circles (`packages/derived/src/anchor.ts`).

The drag looked only at `document.instances`. A power label hangs off the Junction at the rail's end, so the lookup missed, and the code fell through to a branch that rewrites `fallbackPosition` alone. `fallbackPosition` is read only when the anchor target is **missing**, so for a label whose target is present the committed edit changed nothing that renders. The gesture was real, the transaction succeeded, and the picture did not move.

## Fix

The lookup is exported as `resolveAnchorTargetPosition` and the drag measures its new `localOffset` against it. One lookup on both sides, so they cannot drift apart again.

Instance labels are unaffected: same function, and they keep their existing clamp to the device body. Junction-anchored labels have no clamp, which is right for a rail label an author places by hand.

## Tests

Two cases in `annotation-drag-model.test.ts`, both verified red before the fix and green after:

- a power label anchored to its rail Junction carries the drag in `localOffset`
- a drafting label anchored to its rectangle does the same

Not a regression from this week: `annotation-drag-model.ts` last changed in #335, and the instance-only lookup dates from before that.

Reported by the repository owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)