### PR TITLE
Fix stale degree-two branch corner seams

### DIFF
--- a/docs/adr/0014-resolved-route-geometry.md
+++ b/docs/adr/0014-resolved-route-geometry.md
@@ -14,20 +14,19 @@ Implementation status: `implemented` (R10, 2026-08-17)
 At the time of this decision there was no single resolved geometry for a Route.
 The stored centerline,
 manual path, Agent escape, local/group stretch, the SVG renderer's private
-terminal and route-anchor miter bridges (`packages/render-svg/src/render.ts`
-`renderTerminalMiterBridges` at `:85` and `renderRouteAnchorMiterBridges` at
-`:133`), editor hit targets, segment drag handles, route-marker attachment, and
+terminal and Junction miter bridges (`packages/render-svg/src/render.ts`),
+editor hit targets, segment drag handles, route-marker attachment, and
 visual diagnostics each compute or assume slightly different geometry. The
 roadmap (§4.3.2, §5.3) identifies this as the second core problem: the same Wire
 is seen differently by different consumers, which is why direct-Pin corners and
-degree-2 route-anchor joins can show seams or interactive disagreement.
+degree-2 Junction joins can show seams or interactive disagreement.
 
 Two behaviors must be preserved verbatim and are pinned by existing tests:
 terminal miter bridges close the anti-alias seam at a direct Pin corner without
 adding route geometry (`render.test.ts` "bridges direct terminal corners"), and
-a degree-2 route-anchor join renders as one continuous dotless wire even when
-stored as two Routes (`render.test.ts` "bridges a reconnected dotless
-route-anchor").
+a retained degree-2 Junction join renders as one continuous dotless wire even
+when stored as two Routes (`render.test.ts` "bridges a retained dotless
+degree-two branch corner").
 
 ## Decision
 
@@ -43,7 +42,7 @@ persisted.
 interface ResolvedRouteGeometry {
   routeId: string;
   netId: string;
-  centerline: readonly Point[];          // strictly [from, …waypoints, to]
+  centerline: readonly Point[]; // strictly [from, …waypoints, to]
   segments: readonly ResolvedRouteSegment[];
   vertices: readonly ResolvedRouteVertex[];
   endpointJoins: readonly EndpointJoin[]; // terminal miter recipes
@@ -63,10 +62,10 @@ interface ResolvedRouteVertex {
 }
 
 interface EndpointJoin {
-  kind: "terminal-miter" | "route-anchor-miter";
+  kind: "terminal-miter" | "junction-miter";
   at: Point;
   // terminal joins carry pinOutward + routeDirection;
-  // route-anchor joins carry junctionId + the two incident directions.
+  // Junction joins carry junctionId + the two incident directions.
 }
 ```
 
@@ -77,8 +76,8 @@ interface EndpointJoin {
   bend control; Agent escape is an authoring helper, not stored extra points).
 - `endpointJoins` carry exactly the miter bridge strokes the renderer currently
   computes privately: the terminal bridge that closes the direct-Pin corner
-  seam, and the degree-2 route-anchor bridge that renders two stored Routes as
-  one continuous dotless wire. Moving the bridges out of the renderer does not
+  seam, and the degree-2 Junction bridge that renders two stored Routes as one
+  continuous dotless wire. Moving the bridges out of the renderer does not
   add waypoints, change topology, or persist extra points.
 - A segment address is revision-scoped and positional. It is never persisted as
   an identity across split, insertion, normalization, or stretch.
@@ -114,8 +113,9 @@ R10 deliberately keeps the revision-scoped positional `RouteSegmentAddress`.
 It does not introduce synthetic stable IDs or an attachment-remap protocol:
 after a structural edit, existing marker recovery follows the persisted anchor
 and fallback semantics. `EndpointJoin` remains a raw recipe; the renderer
-resolves profile-specific stroke overlap. Document-level route-anchor joins are
-exposed by the document routing-geometry aggregate carried by ADR 0013's index.
+resolves profile-specific stroke overlap. Document-level retained Junction
+joins are exposed by the document routing-geometry aggregate carried by ADR
+0013's index.
 
 ## Alternatives considered
 
@@ -139,7 +139,7 @@ exposed by the document routing-geometry aggregate carried by ADR 0013's index.
 ### Positive
 
 - Render, hit, drag, marker, export, and diagnostics share one geometry.
-- Direct-Pin corners and degree-2 route-anchor joins are seam-free across all
+- Direct-Pin corners and retained degree-2 Junction joins are seam-free across all
   outputs, not just SVG.
 - Marker attachment and segment identity become stable across edits.
 
@@ -160,7 +160,7 @@ stretch planning.
 - Characterization tests pin centerline, endpoint joins, route tap, and
   attachment behavior.
 - Edit Engine tests pin plan preview/commit parity and orthogonal mutation.
-- SVG renderer tests retain the terminal and route-anchor miter seam behavior.
+- SVG renderer tests retain the terminal and Junction miter seam behavior.
 - Negative test: `centerline` is unchanged by adding/removing a terminal bridge.
 
 ## Related documents

--- a/docs/specs/connectivity-and-routing.md
+++ b/docs/specs/connectivity-and-routing.md
@@ -16,10 +16,10 @@ drift as parallel arrays. Junctions are explicit branch/route anchors. A
 perpendicular geometric crossing does not create electrical contact by itself.
 Collinear same-Net overlap is never canonical persisted geometry: the Edit
 Engine unions the covered conductor, materializes true branch vertices, and
-removes redundant degree-two Junctions — an unowned collinear branch join
-disappears, and a degree-two route-anchor is no longer a loose end, so its
-two arms coalesce into one Route whether they continue straight or fold into
-an interior bend. An explicit cross-Net Wire
+removes redundant degree-two Junctions. An unowned ordinary-Wire Junction is
+no longer a branch or loose end once only two arms remain, regardless of its
+historical `branch`/`route-anchor` role: its arms coalesce into one Route,
+continuing straight or folding into an interior bend. An explicit cross-Net Wire
 connection merges compatible Base Nets before the same normalization; passive
 transforms never silently merge different Nets. Power-rail, MOS bulk, and
 locked presentations retain their own authored geometry and do not participate
@@ -73,11 +73,12 @@ Route transaction.
   disconnected. Pin-to-route attachment remains a snapped typed intent
   because it changes the selected Route's identity and geometry.
 - Route splitting is reversible topology, not permanent stroke history. When
-  a branch is cut, an unowned degree-two collinear Junction is removed and its
-  surviving arms coalesce into one Route; a Wire continued from a loose end
-  extends the existing conductor the same way instead of leaving two pieces
-  joined by an invisible anchor. Route labels, markers, layout references, and
-  stable leg ownership follow the normalized conductor.
+  a branch is cut, an unowned degree-two Junction is removed and its surviving
+  arms coalesce into one Route, with an angled join retained as an interior
+  bend. A Wire continued from a loose end extends the existing conductor the
+  same way instead of leaving two pieces joined by an invisible anchor. Route
+  labels, markers, layout references, and stable leg ownership follow the
+  normalized conductor.
 - Placing a component with one eligible pair of exact pin contacts on one
   continuous ordinary Route performs one atomic series splice: the two
   contacts split the conductor, the between-pin span is removed, and the Base
@@ -247,8 +248,8 @@ overlap.
 - Route normalization removes duplicate and collinear interior points without
   changing endpoint identity.
 - Same-Net conductor normalization unions duplicate coverage, preserves every
-  true branch/contact vertex, and removes unowned degree-two Junctions —
-  collinear branch joins and route-anchor joins alike.
+  true branch/contact vertex, and removes every unowned degree-two ordinary-
+  Wire Junction, independent of historical role or join angle.
 - A failed multi-edit transaction changes nothing; a successful one advances
   revision once.
 - GUI and Agent use the same planners, transaction engine, derived geometry,

--- a/packages/derived/src/resolved-route-geometry.test.ts
+++ b/packages/derived/src/resolved-route-geometry.test.ts
@@ -244,7 +244,7 @@ describe("resolved route geometry", () => {
     ]);
   });
 
-  it("aggregates deterministic route order and degree-two route-anchor joins", () => {
+  it("aggregates deterministic route order and degree-two Junction joins", () => {
     const schematic = document("route-anchor");
     schematic.junctions.push(
       { id: "left", netId: "n", position: { x: 0, y: 0 } },
@@ -279,7 +279,7 @@ describe("resolved route geometry", () => {
     expect([...geometry.routes.keys()]).toEqual(["a-left", "z-right"]);
     expect(geometry.endpointJoins).toEqual([
       {
-        kind: "route-anchor-miter",
+        kind: "junction-miter",
         junctionId: "anchor",
         at: { x: 100, y: 0 },
         directions: [
@@ -288,5 +288,49 @@ describe("resolved route geometry", () => {
         ],
       },
     ]);
+  });
+
+  it("bridges a retained degree-two branch corner without treating it as a visible branch", () => {
+    const schematic = document("branch-corner");
+    schematic.junctions.push(
+      { id: "left", netId: "n", position: { x: 0, y: 0 } },
+      {
+        id: "corner",
+        netId: "n",
+        position: { x: 100, y: 0 },
+        role: "branch",
+      },
+      { id: "bottom", netId: "n", position: { x: 100, y: 100 } },
+    );
+    schematic.routes.push(
+      createRoutePath({
+        id: "horizontal",
+        netId: "n",
+        start: { kind: "junction", junctionId: "left" },
+        end: { kind: "junction", junctionId: "corner" },
+        bends: [],
+        modes: ["manual"],
+      }),
+      createRoutePath({
+        id: "vertical",
+        netId: "n",
+        start: { kind: "junction", junctionId: "corner" },
+        end: { kind: "junction", junctionId: "bottom" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+
+    expect(
+      resolveDocumentRoutingGeometry(schematic, resolver).endpointJoins,
+    ).toContainEqual({
+      kind: "junction-miter",
+      junctionId: "corner",
+      at: { x: 100, y: 0 },
+      directions: [
+        { x: -1, y: 0 },
+        { x: 0, y: 1 },
+      ],
+    });
   });
 });

--- a/packages/derived/src/resolved-route-geometry.ts
+++ b/packages/derived/src/resolved-route-geometry.ts
@@ -46,7 +46,7 @@ export type EndpointJoin =
       routeDirection: Point;
     }
   | {
-      kind: "route-anchor-miter";
+      kind: "junction-miter";
       junctionId: string;
       at: Point;
       directions: readonly [Point, Point];
@@ -187,12 +187,12 @@ export function resolveDocumentRoutingGeometry(
     routes,
     endpointJoins: [
       ...terminalJoins,
-      ...resolveRouteAnchorJoinsFromGeometry(document, routes),
+      ...resolveJunctionJoinsFromGeometry(document, routes),
     ],
   };
 }
 
-export function resolveRouteAnchorJoins(
+export function resolveJunctionJoins(
   document: SchematicDocument,
   resolver: SymbolResolver,
 ): EndpointJoin[] {
@@ -201,16 +201,17 @@ export function resolveRouteAnchorJoins(
     const geometry = resolveRouteGeometry(document, resolver, route);
     if (geometry) routes.set(route.id, geometry);
   }
-  return resolveRouteAnchorJoinsFromGeometry(document, routes);
+  return resolveJunctionJoinsFromGeometry(document, routes);
 }
 
-function resolveRouteAnchorJoinsFromGeometry(
+function resolveJunctionJoinsFromGeometry(
   document: SchematicDocument,
   routes: ReadonlyMap<string, ResolvedRouteGeometry>,
 ): EndpointJoin[] {
   const anchors = new Map<string, { point: Point; directions: Point[] }>();
   for (const junction of document.junctions) {
-    if (junction.role === "route-anchor") {
+    const role = junction.role ?? "branch";
+    if (role === "branch" || role === "route-anchor") {
       anchors.set(junction.id, { point: junction.position, directions: [] });
     }
   }
@@ -231,7 +232,7 @@ function resolveRouteAnchorJoinsFromGeometry(
     .filter(([, anchor]) => anchor.directions.length === 2)
     .sort(([left], [right]) => left.localeCompare(right, "en"))
     .map(([junctionId, anchor]): EndpointJoin => ({
-      kind: "route-anchor-miter",
+      kind: "junction-miter",
       junctionId,
       at: anchor.point,
       directions: [anchor.directions[0]!, anchor.directions[1]!] as readonly [

--- a/packages/edit-engine/src/conductor-topology.test.ts
+++ b/packages/edit-engine/src/conductor-topology.test.ts
@@ -18,7 +18,10 @@ import {
   createRoutingOperationPlan,
   gateRoutingOperationPlan,
 } from "./routing-operation-plan.js";
-import { proposeWireIntent } from "./routing-planner.js";
+import {
+  proposeWireIntent,
+  proposeWireSegmentMove,
+} from "./routing-planner.js";
 import { executeTransaction } from "./transaction.js";
 
 const resolver = new InMemorySymbolResolver(builtInSymbols);
@@ -237,6 +240,89 @@ describe("same-Net conductor topology normalization", () => {
       "left",
       "down",
     ]);
+  });
+
+  it("folds an unprotected degree-two branch corner and keeps its middle segment editable", () => {
+    // A Junction's role records how it was authored, not permanent topology.
+    // Once a former branch has only two ordinary-Wire arms, the conductor
+    // must become one Route even when the surviving arms turn a corner.
+    const document = documentWith(
+      [
+        junction("left", 0, 0),
+        junction("former-branch", 50, 0, "branch"),
+        junction("right", 100, 50),
+      ],
+      [
+        route("first", "left", "former-branch"),
+        route("second", "former-branch", "right", [{ x: 50, y: 50 }]),
+      ],
+    );
+
+    const normalized = normalizeSameNetConductorTopology(document, resolver);
+
+    expect(normalized.changed).toBe(true);
+    expect(document.routes).toHaveLength(1);
+    expect(document.junctions.some(({ id }) => id === "former-branch")).toBe(
+      false,
+    );
+    expect(routeBends(document.routes[0]!)).toEqual([
+      { x: 50, y: 0 },
+      { x: 50, y: 50 },
+    ]);
+
+    const move = proposeWireSegmentMove(
+      document,
+      resolver,
+      document.routes[0]!.id,
+      1,
+      { x: 60, y: 20 },
+    );
+    const moved = executeTransaction(
+      document,
+      {
+        transactionId: "move-coalesced-middle-segment",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        dryRun: false,
+        edits: move.edits,
+      },
+      { symbolResolver: resolver },
+    );
+    expect(moved.ok).toBe(true);
+    if (!moved.ok) return;
+    expect(routeBends(moved.document.routes[0]!)).toEqual([
+      { x: 60, y: 0 },
+      { x: 60, y: 50 },
+    ]);
+  });
+
+  it("retains an externally owned degree-two branch corner", () => {
+    const document = documentWith(
+      [
+        junction("left", 0, 0),
+        junction("owned-corner", 50, 0, "branch"),
+        junction("bottom", 50, 50),
+      ],
+      [
+        route("horizontal", "left", "owned-corner"),
+        route("vertical", "owned-corner", "bottom"),
+      ],
+    );
+    document.layoutGroups.push({
+      id: "group",
+      kind: "custom",
+      objectIds: ["owned-corner"],
+      locked: false,
+    });
+
+    const result = normalizeSameNetConductorTopology(document, resolver);
+
+    expect(result.changed).toBe(false);
+    expect(document.routes).toHaveLength(2);
+    expect(document.junctions.some(({ id }) => id === "owned-corner")).toBe(
+      true,
+    );
   });
 
   it("keeps a lone loose wire and its degree-one anchors untouched", () => {

--- a/packages/edit-engine/src/conductor-topology.ts
+++ b/packages/edit-engine/src/conductor-topology.ts
@@ -147,24 +147,6 @@ function pointOnClosedSegment(point: Point, from: Point, to: Point): boolean {
   return pointOnSegment(point, from, to, { epsilon: EPSILON });
 }
 
-function collinearContinuation(
-  point: Point,
-  incident: readonly AtomicEdge[],
-): boolean {
-  if (incident.length !== 2) return false;
-  const other = (edge: AtomicEdge) =>
-    samePoint(edge.from, point) ? edge.to : edge.from;
-  const first = other(incident[0]!);
-  const second = other(incident[1]!);
-  const firstVector = { x: first.x - point.x, y: first.y - point.y };
-  const secondVector = { x: second.x - point.x, y: second.y - point.y };
-  return (
-    Math.abs(firstVector.x * secondVector.y - firstVector.y * secondVector.x) <=
-      EPSILON &&
-    firstVector.x * secondVector.x + firstVector.y * secondVector.y < 0
-  );
-}
-
 function routePresentation(route: RouteBranch): string {
   return route.presentation ?? "wire";
 }
@@ -354,17 +336,12 @@ export function normalizeSameNetConductorTopology(
         continue;
       }
       const incident = incidentByPoint.get(pointKey(junction.position)) ?? [];
-      if (role === "branch") {
-        if (collinearContinuation(junction.position, incident)) {
-          collapsibleJunctionIds.add(junction.id);
-        }
-        continue;
-      }
-      // A degree-two route-anchor is no longer a loose end: its two arms are
-      // one continuous conductor, joined collinearly (the join point
-      // disappears) or at a corner (the join becomes an interior bend).
-      // Collapsing it makes segmentation follow the drawing, not the stroke
-      // history — the W-tool continuation repro.
+      // A Junction role records how the point was authored; current conductor
+      // degree decides whether it is still a branch. Once either a branch or
+      // route-anchor has exactly two ordinary-Wire arms, those arms are one
+      // continuous conductor. A collinear join disappears and a corner join
+      // becomes an interior bend. Protected and same-transaction Junctions
+      // were excluded above, so stable external ownership is preserved.
       if (incident.length === 2) {
         collapsibleJunctionIds.add(junction.id);
       }

--- a/packages/render-svg/src/render.test.ts
+++ b/packages/render-svg/src/render.test.ts
@@ -82,6 +82,44 @@ describe("render svg", () => {
     );
   });
 
+  it("bridges a retained dotless degree-two branch corner", () => {
+    const doc = createEmptyDocument("branch-corner", "Branch corner");
+    doc.nets.push({ id: "net", terminals: [] });
+    doc.junctions.push(
+      { id: "left", netId: "net", position: { x: 0, y: 0 } },
+      {
+        id: "corner",
+        netId: "net",
+        position: { x: 40, y: 0 },
+        role: "branch",
+      },
+      { id: "bottom", netId: "net", position: { x: 40, y: 40 } },
+    );
+    doc.routes.push(
+      createRoutePath({
+        id: "horizontal",
+        netId: "net",
+        start: { kind: "junction", junctionId: "left" },
+        end: { kind: "junction", junctionId: "corner" },
+        bends: [],
+        modes: ["manual"],
+      }),
+      createRoutePath({
+        id: "vertical",
+        netId: "net",
+        start: { kind: "junction", junctionId: "corner" },
+        end: { kind: "junction", junctionId: "bottom" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+
+    const scene = buildSvgScene(doc, new InMemorySymbolResolver([]));
+
+    expect(scene.formalBody).toContain('data-role="junction-miter-bridge"');
+    expect(scene.formalBody).toContain('data-junction-id="corner"');
+  });
+
   it("renders a Route override while an unstyled Route keeps the profile color", () => {
     const doc = createEmptyDocument("wire-color", "Wire color");
     doc.nets.push({ id: "net", terminals: [] });

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -215,11 +215,13 @@ function renderTerminalMiterBridges(
 }
 
 /**
- * A free wire end is a `route-anchor` Junction. Once a second route is joined
- * to it, preserve the dotless EDA appearance while rendering both route ends
- * as one sharp path. A real branch Junction owns its dot instead.
+ * Any retained degree-two Junction is visually one dotless conductor even
+ * when storage keeps two Route strokes (for example because an annotation or
+ * constraint owns the Junction). Bridge the strokes through one SVG miter so
+ * storage history cannot expose a butt-cap seam. A true branch has more than
+ * two incident Route directions and therefore produces no recipe here.
  */
-function renderRouteAnchorMiterBridges(
+function renderJunctionMiterBridges(
   joins: readonly EndpointJoin[],
   profile: SchematicStyleProfile,
   strokeColors: ReadonlyMap<string, string>,
@@ -227,14 +229,14 @@ function renderRouteAnchorMiterBridges(
   const overlap = Math.max(profile.strokes.wire, profile.strokes.symbol) * 0.75;
   return joins
     .filter(
-      (join): join is Extract<EndpointJoin, { kind: "route-anchor-miter" }> =>
-        join.kind === "route-anchor-miter",
+      (join): join is Extract<EndpointJoin, { kind: "junction-miter" }> =>
+        join.kind === "junction-miter",
     )
     .map((join) => {
       const [first, second] = join.directions;
       const strokeColor =
         strokeColors.get(join.junctionId) ?? profile.foreground;
-      return `<path data-role="route-anchor-miter-bridge" data-junction-id="${escapeXml(join.junctionId)}" d="M ${join.at.x + first.x * overlap} ${join.at.y + first.y * overlap} L ${join.at.x} ${join.at.y} L ${join.at.x + second.x * overlap} ${join.at.y + second.y * overlap}" fill="none" stroke="${escapeXml(strokeColor)}" stroke-width="${profile.strokes.wire}" stroke-linecap="${profile.lineCap}" stroke-linejoin="miter"${profileMiterAttribute(profile)}/>`;
+      return `<path data-role="junction-miter-bridge" data-junction-id="${escapeXml(join.junctionId)}" d="M ${join.at.x + first.x * overlap} ${join.at.y + first.y * overlap} L ${join.at.x} ${join.at.y} L ${join.at.x + second.x * overlap} ${join.at.y + second.y * overlap}" fill="none" stroke="${escapeXml(strokeColor)}" stroke-width="${profile.strokes.wire}" stroke-linecap="${profile.lineCap}" stroke-linejoin="miter"${profileMiterAttribute(profile)}/>`;
     })
     .join("");
 }
@@ -747,12 +749,12 @@ export function buildSvgScene(
     ? RectSchema.parse(options.bounds)
     : deriveBounds(document, resolver, routingGeometry, margin, profile);
 
-  const routeAnchorIds = new Set(
+  const joinedJunctionIds = new Set(
     routingGeometry.endpointJoins.flatMap((join) =>
-      join.kind === "route-anchor-miter" ? [join.junctionId] : [],
+      join.kind === "junction-miter" ? [join.junctionId] : [],
     ),
   );
-  const routeAnchorColorSets = new Map<string, Set<string>>();
+  const junctionColorSets = new Map<string, Set<string>>();
   for (const route of document.routes) {
     const color = route.styleOverride?.color ?? profile.foreground;
     const end = route.legs.at(-1)?.to;
@@ -763,16 +765,16 @@ export function buildSvgScene(
         : []),
     ];
     for (const junctionId of endpointJunctionIds) {
-      if (!routeAnchorIds.has(junctionId)) continue;
-      const colors = routeAnchorColorSets.get(junctionId) ?? new Set<string>();
+      if (!joinedJunctionIds.has(junctionId)) continue;
+      const colors = junctionColorSets.get(junctionId) ?? new Set<string>();
       colors.add(color);
-      routeAnchorColorSets.set(junctionId, colors);
+      junctionColorSets.set(junctionId, colors);
     }
   }
-  const routeAnchorBridgeColors = new Map<string, string>();
-  for (const [junctionId, colors] of routeAnchorColorSets) {
+  const junctionBridgeColors = new Map<string, string>();
+  for (const [junctionId, colors] of junctionColorSets) {
     if (colors.size === 1)
-      routeAnchorBridgeColors.set(junctionId, [...colors][0]!);
+      junctionBridgeColors.set(junctionId, [...colors][0]!);
   }
 
   const routes = [...document.routes]
@@ -807,10 +809,10 @@ export function buildSvgScene(
       return `<polyline data-object-id="${escapeXml(route.id)}" data-net-id="${escapeXml(route.netId)}"${presentationAttribute} points="${pointList(geometry.centerline)}" fill="none" stroke="${escapeXml(strokeColor)}" stroke-width="${strokeWidth}" stroke-linecap="${profile.lineCap}" stroke-linejoin="${profile.lineJoin}"${dash}${profileMiterAttribute(profile)}/>${terminalBridges}`;
     })
     .join("");
-  const routeAnchorBridges = renderRouteAnchorMiterBridges(
+  const junctionBridges = renderJunctionMiterBridges(
     routingGeometry.endpointJoins,
     profile,
-    routeAnchorBridgeColors,
+    junctionBridgeColors,
   );
   const contactEvidence =
     options.contactEvidence ??
@@ -1115,7 +1117,7 @@ export function buildSvgScene(
 
   return {
     viewBox,
-    formalBody: `<g data-layer="formal"><g data-layer="routes">${routes}${routeAnchorBridges}</g><g data-layer="junctions">${junctions}</g><g data-layer="symbols">${symbols}</g>${noConnectLayer}<g data-layer="annotations">${annotations}</g>${renderDraftingLayer(document, resolver, profile)}</g>`,
+    formalBody: `<g data-layer="formal"><g data-layer="routes">${routes}${junctionBridges}</g><g data-layer="junctions">${junctions}</g><g data-layer="symbols">${symbols}</g>${noConnectLayer}<g data-layer="annotations">${annotations}</g>${renderDraftingLayer(document, resolver, profile)}</g>`,
   };
 }
 


### PR DESCRIPTION
## Summary
- collapse unprotected ordinary-wire degree-two Junctions regardless of historical branch/route-anchor role
- preserve angled joins as editable interior bends and retain externally owned Junctions
- generalize miter bridge rendering for retained degree-two Junctions

## Validation
- focused edit-engine/derived/render suites: 641/641
- focused editor E2E: 2/2
- typecheck passed
- exact supplied New Circuit project probe collapsed all three stale output-corner Junctions and emitted fallback miters before normalization
- earlier full local run passed static checks, 2022/2022 unit tests, build, performance, goldens, and release smoke; browser phase exposed unrelated schema-34 expectations on main and its Vite service later exited

Test-Impact: tests-updated