### PR TITLE
Fix Gallery Reference annotation mapping

### DIFF
--- a/apps/editor/src/examples/common-source-amplifier.icproj.json
+++ b/apps/editor/src/examples/common-source-amplifier.icproj.json
@@ -116,7 +116,11 @@
             },
             "objectId": "M2"
           },
-          "content": {
+          "binding": {
+            "instanceId": "M2",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -599,8 +603,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "capacitor",
-          "reference": "C1"
+          "reference": "C1",
+          "symbolId": "capacitor"
         },
         {
           "id": "C1-copy-1",
@@ -619,8 +623,8 @@
             },
             "rotation": 90
           },
-          "symbolId": "capacitor",
-          "reference": "C2"
+          "reference": "C2",
+          "symbolId": "capacitor"
         },
         {
           "id": "M2",
@@ -639,9 +643,9 @@
             },
             "rotation": 0
           },
+          "reference": "M1",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M1"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "R3",
@@ -660,8 +664,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "resistor",
-          "reference": "R1"
+          "reference": "R1",
+          "symbolId": "resistor"
         },
         {
           "id": "GND5",
@@ -728,8 +732,8 @@
             },
             "rotation": 90
           },
-          "symbolId": "resistor",
-          "reference": "R2"
+          "reference": "R2",
+          "symbolId": "resistor"
         },
         {
           "id": "V6",
@@ -744,8 +748,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "voltage-source",
-          "reference": "V1"
+          "reference": "V1",
+          "symbolId": "voltage-source"
         }
       ],
       "junctions": [
@@ -1340,7 +1344,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/current-mirror-loaded-differential-pair.icproj.json
+++ b/apps/editor/src/examples/current-mirror-loaded-differential-pair.icproj.json
@@ -41,8 +41,8 @@
             "objectId": "M1"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M1"
+            "instanceId": "M1",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M1",
           "kind": "instance-label",
@@ -64,8 +64,8 @@
             "objectId": "M2"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M2"
+            "instanceId": "M2",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M2",
           "kind": "instance-label",
@@ -87,8 +87,8 @@
             "objectId": "M3"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M3"
+            "instanceId": "M3",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M3",
           "kind": "instance-label",
@@ -110,8 +110,8 @@
             "objectId": "M4"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M4"
+            "instanceId": "M4",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M4",
           "kind": "instance-label",
@@ -133,8 +133,8 @@
             "objectId": "M5"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M5"
+            "instanceId": "M5",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M5",
           "kind": "instance-label",
@@ -464,9 +464,9 @@
             },
             "rotation": 0
           },
+          "reference": "M1",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M1"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M2",
@@ -485,9 +485,9 @@
             },
             "rotation": 0
           },
+          "reference": "M2",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M2"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M3",
@@ -506,9 +506,9 @@
             },
             "rotation": 0
           },
+          "reference": "M3",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M3"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M4",
@@ -527,9 +527,9 @@
             },
             "rotation": 0
           },
+          "reference": "M4",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M4"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M5",
@@ -548,9 +548,9 @@
             },
             "rotation": 0
           },
+          "reference": "M5",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M5"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "P1",
@@ -1271,7 +1271,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/fully-differential-two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/fully-differential-two-stage-op-amp.icproj.json
@@ -41,8 +41,8 @@
             "objectId": "M1"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M1"
+            "instanceId": "M1",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M1",
           "kind": "instance-label",
@@ -64,8 +64,8 @@
             "objectId": "M2"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M2"
+            "instanceId": "M2",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M2",
           "kind": "instance-label",
@@ -87,8 +87,8 @@
             "objectId": "M3"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M3"
+            "instanceId": "M3",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M3",
           "kind": "instance-label",
@@ -110,8 +110,8 @@
             "objectId": "M4"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M4"
+            "instanceId": "M4",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M4",
           "kind": "instance-label",
@@ -133,8 +133,8 @@
             "objectId": "M5"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M5"
+            "instanceId": "M5",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M5",
           "kind": "instance-label",
@@ -156,8 +156,8 @@
             "objectId": "M6"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M6"
+            "instanceId": "M6",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M6",
           "kind": "instance-label",
@@ -179,8 +179,8 @@
             "objectId": "M7"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M7"
+            "instanceId": "M7",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M5-copy-1",
           "kind": "instance-label",
@@ -202,8 +202,8 @@
             "objectId": "M8"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M8"
+            "instanceId": "M8",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M6-copy-1",
           "kind": "instance-label",
@@ -361,8 +361,8 @@
             "objectId": "C1"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "C1"
+            "instanceId": "C1",
+            "kind": "instance-reference"
           },
           "id": "instance-label-C1",
           "kind": "instance-label",
@@ -384,8 +384,8 @@
             "objectId": "C2"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "C2"
+            "instanceId": "C2",
+            "kind": "instance-reference"
           },
           "id": "instance-label-C2",
           "kind": "instance-label",
@@ -516,10 +516,6 @@
             },
             "objectId": "I1"
           },
-          "id": "instance-label-I1",
-          "kind": "instance-label",
-          "locked": false,
-          "rotation": 0,
           "content": {
             "runs": [
               {
@@ -555,7 +551,11 @@
                 "style": "subscript"
               }
             ]
-          }
+          },
+          "id": "instance-label-I1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
         },
         {
           "alignment": "start",
@@ -571,10 +571,6 @@
             },
             "objectId": "I2"
           },
-          "id": "instance-label-I2",
-          "kind": "instance-label",
-          "locked": false,
-          "rotation": 0,
           "content": {
             "runs": [
               {
@@ -620,7 +616,11 @@
                 "style": "bold"
               }
             ]
-          }
+          },
+          "id": "instance-label-I2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
         }
       ],
       "connectivityEvidence": [
@@ -756,9 +756,9 @@
             },
             "rotation": 0
           },
+          "reference": "M1",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M1"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M2",
@@ -777,9 +777,9 @@
             },
             "rotation": 0
           },
+          "reference": "M2",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M2"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M3",
@@ -798,9 +798,9 @@
             },
             "rotation": 0
           },
+          "reference": "M3",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M3"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M4",
@@ -819,9 +819,9 @@
             },
             "rotation": 0
           },
+          "reference": "M4",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M4"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M5",
@@ -840,9 +840,9 @@
             },
             "rotation": 0
           },
+          "reference": "M5",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M5"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M6",
@@ -861,9 +861,9 @@
             },
             "rotation": 0
           },
+          "reference": "M6",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M6"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M7",
@@ -882,9 +882,9 @@
             },
             "rotation": 0
           },
+          "reference": "M7",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M7"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M8",
@@ -903,9 +903,9 @@
             },
             "rotation": 0
           },
+          "reference": "M8",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M8"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "P1",
@@ -948,8 +948,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "capacitor",
-          "reference": "C1"
+          "reference": "C1",
+          "symbolId": "capacitor"
         },
         {
           "id": "C2",
@@ -968,8 +968,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "capacitor",
-          "reference": "C2"
+          "reference": "C2",
+          "symbolId": "capacitor"
         },
         {
           "id": "GND3",
@@ -1036,8 +1036,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "current-source",
-          "reference": "I1"
+          "reference": "I1",
+          "symbolId": "current-source"
         },
         {
           "id": "I2",
@@ -1056,8 +1056,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "current-source",
-          "reference": "I2"
+          "reference": "I2",
+          "symbolId": "current-source"
         },
         {
           "id": "GND1",
@@ -2487,7 +2487,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/two-stage-op-amp.icproj.json
@@ -297,8 +297,8 @@
             },
             "rotation": 180
           },
-          "symbolId": "opamp",
-          "reference": "X1"
+          "reference": "X1",
+          "symbolId": "opamp"
         },
         {
           "id": "X8",
@@ -313,8 +313,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "voltage-amplifier",
-          "reference": "X2"
+          "reference": "X2",
+          "symbolId": "voltage-amplifier"
         },
         {
           "id": "C9",
@@ -333,8 +333,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "capacitor",
-          "reference": "C1"
+          "reference": "C1",
+          "symbolId": "capacitor"
         },
         {
           "id": "C10",
@@ -353,8 +353,8 @@
             },
             "rotation": 270
           },
-          "symbolId": "capacitor",
-          "reference": "C2"
+          "reference": "C2",
+          "symbolId": "capacitor"
         },
         {
           "id": "GND11",
@@ -778,7 +778,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/features/clipboard/clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard.test.ts
@@ -1003,6 +1003,112 @@ describe("captureDocumentComposition", () => {
     });
   });
 
+  it("renumbers a mapped Reference and its independent RichText presentation together", () => {
+    const source = createEmptyDocument("source-document", "Source");
+    source.instances.push({
+      id: "M5",
+      symbolId: "nmos",
+      reference: "M5",
+      placement: {
+        position: { x: 20, y: 20 },
+        rotation: 0,
+        mirror: "none",
+      },
+      netlist: { parameters: {} },
+    });
+    source.annotations.push({
+      id: "instance-label-M5",
+      kind: "instance-label",
+      binding: { kind: "instance-reference", instanceId: "M5" },
+      formatOverride: semanticTextDocument("M5", "instance-label"),
+      anchor: {
+        kind: "object",
+        objectId: "M5",
+        localOffset: { x: 0, y: -20 },
+        fallbackPosition: { x: 20, y: 0 },
+      },
+      alignment: "middle",
+      rotation: 0,
+      locked: false,
+    });
+    const target = createEmptyDocument("target-document", "Target");
+    target.instances.push({
+      id: "existing-M5",
+      symbolId: "nmos",
+      reference: "M5",
+      placement: null,
+      netlist: { parameters: {} },
+    });
+
+    const proposal = proposePaste(
+      target,
+      captureDocumentComposition(source)!,
+      { x: 0, y: 0 },
+      1,
+    );
+    const result = executeTransaction(
+      target,
+      {
+        transactionId: "compose-reference-presentation",
+        documentId: target.id,
+        expectedRevision: target.revision,
+        actor: { kind: "human", id: "test" },
+        edits: proposal.edits,
+      },
+      { symbolResolver: resolver },
+    );
+
+    if (!result.ok) throw new Error(JSON.stringify(result, null, 2));
+    const copiedId = proposal.idRemap.instances.M5!;
+    expect(
+      result.document.instances.find((instance) => instance.id === copiedId)
+        ?.reference,
+    ).toBe("M6");
+    const copiedLabel = result.document.annotations.find(
+      (annotation) =>
+        annotation.binding?.kind === "instance-reference" &&
+        annotation.binding.instanceId === copiedId,
+    );
+    expect(copiedLabel?.formatOverride).toBeDefined();
+    expect(flattenRichText(copiedLabel!.formatOverride!)).toBe("M6");
+    expect(copiedLabel!.formatOverride!.runs[0]).toEqual(
+      semanticTextDocument("M5", "instance-label").runs[0],
+    );
+
+    const renamed = executeTransaction(
+      result.document,
+      {
+        transactionId: "rename-composed-reference",
+        documentId: result.document.id,
+        expectedRevision: result.document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: [
+          {
+            kind: "set_instance_reference",
+            instanceId: copiedId,
+            reference: "M21",
+          },
+        ],
+      },
+      { symbolResolver: resolver },
+    );
+
+    if (!renamed.ok) throw new Error(JSON.stringify(renamed, null, 2));
+    expect(
+      renamed.document.instances.find((instance) => instance.id === copiedId)
+        ?.reference,
+    ).toBe("M21");
+    const renamedLabel = renamed.document.annotations.find(
+      (annotation) =>
+        annotation.binding?.kind === "instance-reference" &&
+        annotation.binding.instanceId === copiedId,
+    );
+    expect(flattenRichText(renamedLabel!.formatOverride!)).toBe("M21");
+    expect(renamedLabel!.formatOverride!.runs[0]).toEqual(
+      semanticTextDocument("M5", "instance-label").runs[0],
+    );
+  });
+
   it("owns composed MOS bulk connections per instance without changing target defaults", () => {
     const source = createLibraryExampleProject(
       "fully-differential-two-stage-op-amp",

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -35,6 +35,7 @@ import type { SymbolResolver } from "@icm/symbols";
 import {
   createRoutePath,
   inverseTransformPoint,
+  rewriteRichTextPlainText,
   routeBends,
   routeEnd,
   transformPoint,
@@ -1338,6 +1339,20 @@ export function proposePaste(
   edits.push(
     ...clipboard.annotations.map((annotation): SchematicEdit => {
       const clone = structuredClone(annotation);
+      if (
+        clone.binding?.kind === "instance-reference" &&
+        clone.formatOverride
+      ) {
+        const mappedReference = instanceReferences.get(
+          clone.binding.instanceId,
+        );
+        if (mappedReference) {
+          clone.formatOverride = rewriteRichTextPlainText(
+            clone.formatOverride,
+            mappedReference,
+          );
+        }
+      }
       return {
         kind: "upsert_schematic_annotation",
         annotation: {

--- a/docs/adr/0054-single-instance-reference-authority.md
+++ b/docs/adr/0054-single-instance-reference-authority.md
@@ -89,6 +89,9 @@ parameters, connectivity, or attached annotations.
   hidden Instance identity protocol.
 - Object IDs may still be human-shaped in existing files, but no consumer may
   infer Reference semantics from them.
+- Schema 36 closes the Gallery composition gap: a mapped Reference Annotation
+  owns independent RichText presentation, while Reference allocation and
+  rename rewrite its same-text projection atomically and preserve styling.
 
 ## Validation
 

--- a/docs/overall-product-plan.md
+++ b/docs/overall-product-plan.md
@@ -68,7 +68,7 @@ revision, lock, or transaction invariants.
   ordered hierarchy interface rather than another Net-label mechanism.
 - Routes describe visible geometry; they may stretch locally during movement
   without changing logical connectivity.
-- A Project's canonical content is schema-35 JSON. Explicit Save updates one
+- A Project's canonical content is schema-36 JSON. Explicit Save updates one
   stable private Cloud Project; `.icproj.json` is portable interchange, and
   browser recovery is an origin-local, non-authoritative copy.
 - Visual variants may change presentation but never remove electrical terminal

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -409,8 +409,8 @@ Open, demo load, restore, and human-approved staged import replace the entire
 Project through one replacement boundary; they are not Edit Engine
 transactions. Replacement cancels pending recovery for the outgoing Project
 and terminates its Agent session. A complete Project covered by the schema
-24→35 upgrade chain may be upgraded at the read boundary and then enters the
-editor only as schema-35; migrated files are marked as needing save.
+24→36 upgrade chain may be upgraded at the read boundary and then enters the
+editor only as schema-36; migrated files are marked as needing save.
 
 Selection, viewport, active tool, previews, Agent tokens, and approval UI are
 transient and never enter Project JSON. Recovery is scheduled only after a

--- a/docs/specs/persistence-and-recovery.md
+++ b/docs/specs/persistence-and-recovery.md
@@ -5,21 +5,23 @@ Status: `accepted`
 Primary owner: Worker Cloud Project storage, `packages/project-protocol`, and
 the editor document lifecycle
 
-Project content uses canonical schema-35 JSON. A private Cloud Project is the
+Project content uses canonical schema-36 JSON. A private Cloud Project is the
 formal saved resource; `.icproj.json` is portable import/export and backup.
 The current-only model in `packages/model` validates the normalized shape;
 `packages/project-protocol` owns parsing, compatibility diagnostics,
 and canonical serialization. Persistence validates the complete current schema
-before import or Cloud Save. The explicit schema 24→35 chain upgrades supported
-historical files; serialization always writes schema 35. The 32→33 adapter
+before import or Cloud Save. The explicit schema 24→36 chain upgrades supported
+historical files; serialization always writes schema 36. The 32→33 adapter
 rejects ownerless Net equivalence instead of guessing replacement electrical
 semantics, and the 33→34 adapter removes hidden electrical name authority while
 preserving source spelling as provenance. The 34→35 adapter unifies parallel
-Instance naming fields into one authored Reference. Versions outside the
+Instance naming fields into one authored Reference. The 35→36 adapter repairs
+styled Instance designators that schema 35 materialized as literal labels,
+while retaining descriptive attached text. Versions outside the
 implemented chain are rejected.
 
 Recovery state is a non-authoritative browser safety copy. It may restore a
-complete schema-35 Project or a supported historical record that validates
+complete schema-36 Project or a supported historical record that validates
 after the chained upgrade, associated with a recorded working-copy session.
 Corrupt, incompatible, or partial recovery data is discarded or retained as raw
 data without changing the live Project. User-saved Library examples are the

--- a/docs/specs/project-file-format.md
+++ b/docs/specs/project-file-format.md
@@ -2,14 +2,14 @@
 
 Status: `accepted`
 
-Current Project schema: `35`
+Current Project schema: `36`
 
 Primary owners: `packages/model` (current shape) and
 `packages/project-protocol` (file boundary)
 
 An `.icproj.json` file is canonical JSON for one complete `CircuitProject`.
 `@icm/project-protocol` exposes `parseProject`. The file boundary accepts every
-schema covered by its explicit 24→35 upgrade chain. Schema 32 added optional
+schema covered by its explicit 24→36 upgrade chain. Schema 32 added optional
 presentation-only `Annotation.textColor`; schema 33 removes ownerless
 `explicit-equivalence` connectivity. The 32→33 adapter advances the version
 stamp only when that retired record is absent. If one exists, it rejects at the
@@ -22,9 +22,11 @@ power owner when possible. Schema 35 unifies canvas and emitted Instance
 References: the 34→35 adapter moves one selected value to
 `Instance.reference`, materializes distinct descriptive RichText as an
 attached literal Annotation, converts ordinary default labels to
-`instance-reference`, and removes fabricated marker references. The public file
-boundary supplies only schema 35 in memory and writes only schema 35; versions
-older than 24 or newer than 35 are rejected.
+`instance-reference`, and removes fabricated marker references. Schema 36
+repairs reference-shaped labels that schema 35 accidentally materialized as
+literal text and preserves their RichText as a mapped same-text presentation.
+The public file boundary supplies only schema 36 in memory and writes only
+schema 36; versions older than 24 or newer than 36 are rejected.
 
 ## Current authorities
 
@@ -73,10 +75,11 @@ older than 24 or newer than 35 are rejected.
   ID. `Annotation.textColor`
   is an independent presentation override; when absent, instance reference and
   value annotations inherit their owning Instance foreground, while other
-  annotations inherit the Document foreground. Bound `net-name` and
-  `instance-reference`, `net-name`, and `cell-terminal-name` annotations may
+  annotations inherit the Document foreground. Bound `instance-reference`,
+  `net-name`, and `cell-terminal-name` annotations may
   carry a RichText `formatOverride` only when its flattened text equals the
-  semantic Reference, Net, or terminal name.
+  semantic Reference, Net, or terminal name. Reference allocation and rename
+  update that same-text projection atomically without discarding its styling.
 - A RichText document is either ordinary styled text runs or one atomic
   formula run containing bounded LaTeX source and `inline`/`block` display
   intent. Typeset SVG paths and metrics are derived artifacts, never Project
@@ -90,8 +93,8 @@ older than 24 or newer than 35 are rejected.
 ## Read and write
 
 ```text
-import text -> parse JSON -> require Project schema 24 through 35
--> converge to schema 35 -> strict schema-35 validation -> install unbound
+import text -> parse JSON -> require Project schema 24 through 36
+-> converge to schema 36 -> strict schema-36 validation -> install unbound
 export -> strict validation -> canonical key ordering -> Blob download
 ```
 
@@ -102,7 +105,7 @@ after explicit human approval in the editor.
 A migrated imported file is marked dirty. The editor never overwrites a source
 selected through the browser file input; the user may Save it as a Cloud
 Project or explicitly export upgraded bytes. Browser recovery records may be
-canonicalized to v35 only after a successful validated write.
+canonicalized to v36 only after a successful validated write.
 
 Project entry does not physically merge Base Nets. Matching authoritative names
 resolve as one Logical Net; conflicting claims remain a blocking diagnostic.
@@ -111,7 +114,7 @@ Repeated source-name hints are valid provenance and never imply connectivity.
 Canonical serialization ends with one newline and is byte-stable across
 serialize/parse/serialize. The current corpus is listed in
 `fixtures/projects/compatibility-corpus.json`; its accepted entries must all be
-already canonical Project schema 35. The rejected corpus names expected
+already canonical Project schema 36. The rejected corpus names expected
 validation failures.
 
 Viewport, selection, undo history, canvas overlays, Agent credentials,

--- a/docs/specs/schematic-model.md
+++ b/docs/specs/schematic-model.md
@@ -5,7 +5,7 @@ Status: `accepted`
 Primary owner: `packages/model`
 
 The Project contains Documents; each Document owns revisioned electrical,
-geometric, and presentation facts. The current model is strict schema 35 and has
+geometric, and presentation facts. The current model is strict schema 36 and has
 no compatibility shape.
 
 ## Coordinate domains
@@ -185,11 +185,13 @@ ordinary Schematic edits inside one Project structural transaction. The
 Project's `structureRevision` protects this cross-Document boundary and the
 editor records it as one undoable structural commit.
 
-Persistence writes only schema 35. The reader carries every schema in its
-explicit 24→35 upgrade chain forward, then supplies the current model only; no
+Persistence writes only schema 36. The reader carries every schema in its
+explicit 24→36 upgrade chain forward, then supplies the current model only; no
 compatibility shape enters runtime electrical derivation. The 32→33 step
 rejects ownerless equivalence rather than guessing replacement connectivity.
 The 33→34 step converts hidden imported names into non-electrical hints or
 explicit global declarations and materializes an existing power owner where
 one is available. The 34→35 step converges parallel Instance naming fields to
-one Reference and materializes distinct visible text as an Annotation.
+one Reference and materializes distinct visible text as an Annotation. The
+35→36 step repairs reference-shaped labels that were materialized as literal
+text, maps them to the owning Reference, and retains their RichText styling.

--- a/docs/user/project-compatibility.md
+++ b/docs/user/project-compatibility.md
@@ -1,6 +1,6 @@
 # Project File Compatibility
 
-The released Project schema version is `35`. It retains schematic-only
+The released Project schema version is `36`. It retains schematic-only
 hierarchy integrity, a Project structural revision, stable formal Cell ports,
 and definition-level Cell symbol presentation. It also has one typed Instance
 netlist authority, formal Cell parameters, and Project-local external
@@ -33,7 +33,7 @@ text, a fraction, or a coefficient needs more room, and never clips or shrinks
 the formula to satisfy an undersized request. A canonical v34 file can be
 opened, saved, reopened, and saved again without byte drift.
 
-Schemas v24 through v35 are accepted through the explicit chained upgrades.
+Schemas v24 through v36 are accepted through the explicit chained upgrades.
 Schema v32 adds optional `Annotation.textColor`; schema v33 removes the
 ownerless `explicit-equivalence` record. A v32 file without that record changes
 only its version stamp. A file containing it is rejected at the exact evidence
@@ -42,8 +42,11 @@ was a wire, Label, Alias, or hierarchy terminal. Schema v34 retires the hidden
 `explicit-net-property` naming owner. Source-backed local names become
 non-electrical round-trip hints, explicit SPICE globals retain declaration
 authority, and visible power objects become the owner where one already exists.
+Schema v35 unifies Instance References, and schema v36 restores Gallery-copied
+reference-shaped RichText labels as mapped Reference presentations while
+retaining descriptive attached text.
 The original file is never overwritten silently. Schemas older than v24 and
-versions newer than v34 are rejected by the project-file boundary.
+versions newer than v36 are rejected by the project-file boundary.
 
 The canonical-current corpus at
 [`fixtures/projects/compatibility-corpus.json`](../../fixtures/projects/compatibility-corpus.json)

--- a/fixtures/gallery-redline/2rmm2vb45f.icproj.json
+++ b/fixtures/gallery-redline/2rmm2vb45f.icproj.json
@@ -17,8 +17,8 @@
             "objectId": "XDP"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "XDP"
+            "instanceId": "XDP",
+            "kind": "instance-reference"
           },
           "id": "instance-label-XDP",
           "kind": "instance-label",
@@ -40,8 +40,8 @@
             "objectId": "XDN"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "XDN"
+            "instanceId": "XDN",
+            "kind": "instance-reference"
           },
           "id": "instance-label-XDN",
           "kind": "instance-label",
@@ -63,8 +63,8 @@
             "objectId": "XSP"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "XSP"
+            "instanceId": "XSP",
+            "kind": "instance-reference"
           },
           "id": "instance-label-XSP",
           "kind": "instance-label",
@@ -86,8 +86,8 @@
             "objectId": "XSN"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "XSN"
+            "instanceId": "XSN",
+            "kind": "instance-reference"
           },
           "id": "instance-label-XSN",
           "kind": "instance-label",
@@ -277,6 +277,7 @@
           "id": "XDP",
           "importProvenance": {
             "kind": "opaque",
+            "sourceMasterName": "sky130_fd_pr__pfet_01v8",
             "sourceTarget": "external-subcircuit:sky130_fd_pr__pfet_01v8",
             "status": "resolved",
             "symbolMappingRegistryId": "sky130-pfet-four-terminal",
@@ -297,8 +298,7 @@
                 "pinName": "B",
                 "sourcePosition": 3
               }
-            ],
-            "sourceMasterName": "sky130_fd_pr__pfet_01v8"
+            ]
           },
           "mosBulkBinding": {
             "netId": "net-d7602f62b45329ba",
@@ -323,6 +323,7 @@
             },
             "rotation": 0
           },
+          "reference": "XDP",
           "sourceRef": {
             "end": {
               "column": 63,
@@ -336,13 +337,13 @@
               "offset": 186
             }
           },
-          "symbolId": "pmos",
-          "reference": "XDP"
+          "symbolId": "pmos"
         },
         {
           "id": "XDN",
           "importProvenance": {
             "kind": "opaque",
+            "sourceMasterName": "sky130_fd_pr__nfet_01v8",
             "sourceTarget": "external-subcircuit:sky130_fd_pr__nfet_01v8",
             "status": "resolved",
             "symbolMappingRegistryId": "sky130-nfet-four-terminal",
@@ -363,8 +364,7 @@
                 "pinName": "B",
                 "sourcePosition": 3
               }
-            ],
-            "sourceMasterName": "sky130_fd_pr__nfet_01v8"
+            ]
           },
           "netlist": {
             "binding": {
@@ -385,6 +385,7 @@
             },
             "rotation": 0
           },
+          "reference": "XDN",
           "sourceRef": {
             "end": {
               "column": 63,
@@ -398,13 +399,13 @@
               "offset": 249
             }
           },
-          "symbolId": "nmos",
-          "reference": "XDN"
+          "symbolId": "nmos"
         },
         {
           "id": "XSP",
           "importProvenance": {
             "kind": "opaque",
+            "sourceMasterName": "sky130_fd_pr__pfet_01v8",
             "sourceTarget": "external-subcircuit:sky130_fd_pr__pfet_01v8",
             "status": "resolved",
             "symbolMappingRegistryId": "sky130-pfet-four-terminal",
@@ -425,8 +426,7 @@
                 "pinName": "B",
                 "sourcePosition": 3
               }
-            ],
-            "sourceMasterName": "sky130_fd_pr__pfet_01v8"
+            ]
           },
           "mosBulkBinding": {
             "netId": "net-d7602f62b45329ba",
@@ -451,6 +451,7 @@
             },
             "rotation": 0
           },
+          "reference": "XSP",
           "sourceRef": {
             "end": {
               "column": 61,
@@ -464,13 +465,13 @@
               "offset": 312
             }
           },
-          "symbolId": "pmos",
-          "reference": "XSP"
+          "symbolId": "pmos"
         },
         {
           "id": "XSN",
           "importProvenance": {
             "kind": "opaque",
+            "sourceMasterName": "sky130_fd_pr__nfet_01v8",
             "sourceTarget": "external-subcircuit:sky130_fd_pr__nfet_01v8",
             "status": "resolved",
             "symbolMappingRegistryId": "sky130-nfet-four-terminal",
@@ -491,8 +492,7 @@
                 "pinName": "B",
                 "sourcePosition": 3
               }
-            ],
-            "sourceMasterName": "sky130_fd_pr__nfet_01v8"
+            ]
           },
           "netlist": {
             "binding": {
@@ -513,6 +513,7 @@
             },
             "rotation": 0
           },
+          "reference": "XSN",
           "sourceRef": {
             "end": {
               "column": 61,
@@ -526,8 +527,7 @@
               "offset": 373
             }
           },
-          "symbolId": "nmos",
-          "reference": "XSN"
+          "symbolId": "nmos"
         },
         {
           "id": "cell-pin-97faf2cad5ec4598",
@@ -1532,8 +1532,8 @@
             "objectId": "XU0"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "XU0"
+            "instanceId": "XU0",
+            "kind": "instance-reference"
           },
           "id": "instance-label-XU0",
           "kind": "instance-label",
@@ -1555,8 +1555,8 @@
             "objectId": "XU1"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "XU1"
+            "instanceId": "XU1",
+            "kind": "instance-reference"
           },
           "id": "instance-label-XU1",
           "kind": "instance-label",
@@ -1577,11 +1577,11 @@
             },
             "objectId": "XU2"
           },
-          "id": "instance-label-XU2",
-          "kind": "instance-label",
-          "locked": false,
-          "rotation": 0,
-          "content": {
+          "binding": {
+            "instanceId": "XU2",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -1616,7 +1616,11 @@
                 "style": "subscript"
               }
             ]
-          }
+          },
+          "id": "instance-label-XU2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
         },
         {
           "alignment": "middle",
@@ -1633,8 +1637,8 @@
             "objectId": "XU3"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "XU3"
+            "instanceId": "XU3",
+            "kind": "instance-reference"
           },
           "id": "instance-label-XU3",
           "kind": "instance-label",
@@ -1656,8 +1660,8 @@
             "objectId": "XU4"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "XU4"
+            "instanceId": "XU4",
+            "kind": "instance-reference"
           },
           "id": "instance-label-XU4",
           "kind": "instance-label",
@@ -1679,8 +1683,8 @@
             "objectId": "XU5"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "XU5"
+            "instanceId": "XU5",
+            "kind": "instance-reference"
           },
           "id": "instance-label-XU5",
           "kind": "instance-label",
@@ -1702,8 +1706,8 @@
             "objectId": "XRESET"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "XRESET"
+            "instanceId": "XRESET",
+            "kind": "instance-reference"
           },
           "id": "instance-label-XRESET",
           "kind": "instance-label",
@@ -1725,8 +1729,8 @@
             "objectId": "C0"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "C0"
+            "instanceId": "C0",
+            "kind": "instance-reference"
           },
           "id": "instance-label-C0",
           "kind": "instance-label",
@@ -1748,8 +1752,8 @@
             "objectId": "C1"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "C1"
+            "instanceId": "C1",
+            "kind": "instance-reference"
           },
           "id": "instance-label-C1",
           "kind": "instance-label",
@@ -1771,8 +1775,8 @@
             "objectId": "C2"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "C2"
+            "instanceId": "C2",
+            "kind": "instance-reference"
           },
           "id": "instance-label-C2",
           "kind": "instance-label",
@@ -1794,8 +1798,8 @@
             "objectId": "C3"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "C3"
+            "instanceId": "C3",
+            "kind": "instance-reference"
           },
           "id": "instance-label-C3",
           "kind": "instance-label",
@@ -1817,8 +1821,8 @@
             "objectId": "C4"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "C4"
+            "instanceId": "C4",
+            "kind": "instance-reference"
           },
           "id": "instance-label-C4",
           "kind": "instance-label",
@@ -1840,8 +1844,8 @@
             "objectId": "C5"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "C5"
+            "instanceId": "C5",
+            "kind": "instance-reference"
           },
           "id": "instance-label-C5",
           "kind": "instance-label",
@@ -1863,8 +1867,8 @@
             "objectId": "CDUMMY"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "CDUMMY"
+            "instanceId": "CDUMMY",
+            "kind": "instance-reference"
           },
           "id": "instance-label-CDUMMY",
           "kind": "instance-label",
@@ -2428,6 +2432,7 @@
           "id": "XU0",
           "importProvenance": {
             "kind": "subcircuit",
+            "sourceMasterName": "scdac_unit",
             "sourceTarget": "subcircuit:scdac_unit",
             "status": "resolved",
             "terminalMapping": [
@@ -2451,8 +2456,7 @@
                 "pinName": "vdd",
                 "sourcePosition": 4
               }
-            ],
-            "sourceMasterName": "scdac_unit"
+            ]
           },
           "netlist": {
             "binding": {
@@ -2469,6 +2473,7 @@
             },
             "rotation": 90
           },
+          "reference": "XU0",
           "sourceRef": {
             "end": {
               "column": 35,
@@ -2482,13 +2487,13 @@
               "offset": 525
             }
           },
-          "symbolId": "hierarchical-symbol-82822626bf0850db",
-          "reference": "XU0"
+          "symbolId": "hierarchical-symbol-82822626bf0850db"
         },
         {
           "id": "XU1",
           "importProvenance": {
             "kind": "subcircuit",
+            "sourceMasterName": "scdac_unit",
             "sourceTarget": "subcircuit:scdac_unit",
             "status": "resolved",
             "terminalMapping": [
@@ -2512,8 +2517,7 @@
                 "pinName": "vdd",
                 "sourcePosition": 4
               }
-            ],
-            "sourceMasterName": "scdac_unit"
+            ]
           },
           "netlist": {
             "binding": {
@@ -2530,6 +2534,7 @@
             },
             "rotation": 90
           },
+          "reference": "XU1",
           "sourceRef": {
             "end": {
               "column": 35,
@@ -2543,13 +2548,13 @@
               "offset": 560
             }
           },
-          "symbolId": "hierarchical-symbol-82822626bf0850db",
-          "reference": "XU1"
+          "symbolId": "hierarchical-symbol-82822626bf0850db"
         },
         {
           "id": "XU2",
           "importProvenance": {
             "kind": "subcircuit",
+            "sourceMasterName": "scdac_unit",
             "sourceTarget": "subcircuit:scdac_unit",
             "status": "resolved",
             "terminalMapping": [
@@ -2573,8 +2578,7 @@
                 "pinName": "vdd",
                 "sourcePosition": 4
               }
-            ],
-            "sourceMasterName": "scdac_unit"
+            ]
           },
           "netlist": {
             "binding": {
@@ -2591,6 +2595,7 @@
             },
             "rotation": 90
           },
+          "reference": "XU2",
           "sourceRef": {
             "end": {
               "column": 35,
@@ -2604,13 +2609,13 @@
               "offset": 595
             }
           },
-          "symbolId": "hierarchical-symbol-82822626bf0850db",
-          "reference": "XU2"
+          "symbolId": "hierarchical-symbol-82822626bf0850db"
         },
         {
           "id": "XU3",
           "importProvenance": {
             "kind": "subcircuit",
+            "sourceMasterName": "scdac_unit",
             "sourceTarget": "subcircuit:scdac_unit",
             "status": "resolved",
             "terminalMapping": [
@@ -2634,8 +2639,7 @@
                 "pinName": "vdd",
                 "sourcePosition": 4
               }
-            ],
-            "sourceMasterName": "scdac_unit"
+            ]
           },
           "netlist": {
             "binding": {
@@ -2652,6 +2656,7 @@
             },
             "rotation": 90
           },
+          "reference": "XU3",
           "sourceRef": {
             "end": {
               "column": 35,
@@ -2665,13 +2670,13 @@
               "offset": 630
             }
           },
-          "symbolId": "hierarchical-symbol-82822626bf0850db",
-          "reference": "XU3"
+          "symbolId": "hierarchical-symbol-82822626bf0850db"
         },
         {
           "id": "XU4",
           "importProvenance": {
             "kind": "subcircuit",
+            "sourceMasterName": "scdac_unit",
             "sourceTarget": "subcircuit:scdac_unit",
             "status": "resolved",
             "terminalMapping": [
@@ -2695,8 +2700,7 @@
                 "pinName": "vdd",
                 "sourcePosition": 4
               }
-            ],
-            "sourceMasterName": "scdac_unit"
+            ]
           },
           "netlist": {
             "binding": {
@@ -2713,6 +2717,7 @@
             },
             "rotation": 90
           },
+          "reference": "XU4",
           "sourceRef": {
             "end": {
               "column": 35,
@@ -2726,13 +2731,13 @@
               "offset": 665
             }
           },
-          "symbolId": "hierarchical-symbol-82822626bf0850db",
-          "reference": "XU4"
+          "symbolId": "hierarchical-symbol-82822626bf0850db"
         },
         {
           "id": "XU5",
           "importProvenance": {
             "kind": "subcircuit",
+            "sourceMasterName": "scdac_unit",
             "sourceTarget": "subcircuit:scdac_unit",
             "status": "resolved",
             "terminalMapping": [
@@ -2756,8 +2761,7 @@
                 "pinName": "vdd",
                 "sourcePosition": 4
               }
-            ],
-            "sourceMasterName": "scdac_unit"
+            ]
           },
           "netlist": {
             "binding": {
@@ -2774,6 +2778,7 @@
             },
             "rotation": 90
           },
+          "reference": "XU5",
           "sourceRef": {
             "end": {
               "column": 35,
@@ -2787,13 +2792,13 @@
               "offset": 700
             }
           },
-          "symbolId": "hierarchical-symbol-82822626bf0850db",
-          "reference": "XU5"
+          "symbolId": "hierarchical-symbol-82822626bf0850db"
         },
         {
           "id": "XRESET",
           "importProvenance": {
             "kind": "opaque",
+            "sourceMasterName": "sky130_fd_pr__nfet_01v8",
             "sourceTarget": "external-subcircuit:sky130_fd_pr__nfet_01v8",
             "status": "resolved",
             "symbolMappingRegistryId": "sky130-nfet-four-terminal",
@@ -2814,8 +2819,7 @@
                 "pinName": "B",
                 "sourcePosition": 3
               }
-            ],
-            "sourceMasterName": "sky130_fd_pr__nfet_01v8"
+            ]
           },
           "netlist": {
             "binding": {
@@ -2836,6 +2840,7 @@
             },
             "rotation": 0
           },
+          "reference": "XRESET",
           "sourceRef": {
             "end": {
               "column": 65,
@@ -2849,13 +2854,13 @@
               "offset": 735
             }
           },
-          "symbolId": "nmos",
-          "reference": "XRESET"
+          "symbolId": "nmos"
         },
         {
           "id": "C0",
           "importProvenance": {
             "kind": "primitive",
+            "sourceMasterName": "capacitor",
             "sourceTarget": "primitive:capacitor",
             "status": "resolved",
             "terminalMapping": [
@@ -2867,8 +2872,7 @@
                 "pinName": "2",
                 "sourcePosition": 1
               }
-            ],
-            "sourceMasterName": "capacitor"
+            ]
           },
           "netlist": {
             "binding": {
@@ -2887,6 +2891,7 @@
             },
             "rotation": 0
           },
+          "reference": "C0",
           "sourceRef": {
             "end": {
               "column": 17,
@@ -2900,13 +2905,13 @@
               "offset": 800
             }
           },
-          "symbolId": "capacitor",
-          "reference": "C0"
+          "symbolId": "capacitor"
         },
         {
           "id": "C1",
           "importProvenance": {
             "kind": "primitive",
+            "sourceMasterName": "capacitor",
             "sourceTarget": "primitive:capacitor",
             "status": "resolved",
             "terminalMapping": [
@@ -2918,8 +2923,7 @@
                 "pinName": "2",
                 "sourcePosition": 1
               }
-            ],
-            "sourceMasterName": "capacitor"
+            ]
           },
           "netlist": {
             "binding": {
@@ -2938,6 +2942,7 @@
             },
             "rotation": 0
           },
+          "reference": "C1",
           "sourceRef": {
             "end": {
               "column": 17,
@@ -2951,13 +2956,13 @@
               "offset": 817
             }
           },
-          "symbolId": "capacitor",
-          "reference": "C1"
+          "symbolId": "capacitor"
         },
         {
           "id": "C2",
           "importProvenance": {
             "kind": "primitive",
+            "sourceMasterName": "capacitor",
             "sourceTarget": "primitive:capacitor",
             "status": "resolved",
             "terminalMapping": [
@@ -2969,8 +2974,7 @@
                 "pinName": "2",
                 "sourcePosition": 1
               }
-            ],
-            "sourceMasterName": "capacitor"
+            ]
           },
           "netlist": {
             "binding": {
@@ -2989,6 +2993,7 @@
             },
             "rotation": 0
           },
+          "reference": "C2",
           "sourceRef": {
             "end": {
               "column": 17,
@@ -3002,13 +3007,13 @@
               "offset": 834
             }
           },
-          "symbolId": "capacitor",
-          "reference": "C2"
+          "symbolId": "capacitor"
         },
         {
           "id": "C3",
           "importProvenance": {
             "kind": "primitive",
+            "sourceMasterName": "capacitor",
             "sourceTarget": "primitive:capacitor",
             "status": "resolved",
             "terminalMapping": [
@@ -3020,8 +3025,7 @@
                 "pinName": "2",
                 "sourcePosition": 1
               }
-            ],
-            "sourceMasterName": "capacitor"
+            ]
           },
           "netlist": {
             "binding": {
@@ -3040,6 +3044,7 @@
             },
             "rotation": 0
           },
+          "reference": "C3",
           "sourceRef": {
             "end": {
               "column": 18,
@@ -3053,13 +3058,13 @@
               "offset": 851
             }
           },
-          "symbolId": "capacitor",
-          "reference": "C3"
+          "symbolId": "capacitor"
         },
         {
           "id": "C4",
           "importProvenance": {
             "kind": "primitive",
+            "sourceMasterName": "capacitor",
             "sourceTarget": "primitive:capacitor",
             "status": "resolved",
             "terminalMapping": [
@@ -3071,8 +3076,7 @@
                 "pinName": "2",
                 "sourcePosition": 1
               }
-            ],
-            "sourceMasterName": "capacitor"
+            ]
           },
           "netlist": {
             "binding": {
@@ -3091,6 +3095,7 @@
             },
             "rotation": 0
           },
+          "reference": "C4",
           "sourceRef": {
             "end": {
               "column": 18,
@@ -3104,13 +3109,13 @@
               "offset": 869
             }
           },
-          "symbolId": "capacitor",
-          "reference": "C4"
+          "symbolId": "capacitor"
         },
         {
           "id": "C5",
           "importProvenance": {
             "kind": "primitive",
+            "sourceMasterName": "capacitor",
             "sourceTarget": "primitive:capacitor",
             "status": "resolved",
             "terminalMapping": [
@@ -3122,8 +3127,7 @@
                 "pinName": "2",
                 "sourcePosition": 1
               }
-            ],
-            "sourceMasterName": "capacitor"
+            ]
           },
           "netlist": {
             "binding": {
@@ -3142,6 +3146,7 @@
             },
             "rotation": 0
           },
+          "reference": "C5",
           "sourceRef": {
             "end": {
               "column": 18,
@@ -3155,13 +3160,13 @@
               "offset": 887
             }
           },
-          "symbolId": "capacitor",
-          "reference": "C5"
+          "symbolId": "capacitor"
         },
         {
           "id": "CDUMMY",
           "importProvenance": {
             "kind": "primitive",
+            "sourceMasterName": "capacitor",
             "sourceTarget": "primitive:capacitor",
             "status": "resolved",
             "terminalMapping": [
@@ -3173,8 +3178,7 @@
                 "pinName": "2",
                 "sourcePosition": 1
               }
-            ],
-            "sourceMasterName": "capacitor"
+            ]
           },
           "netlist": {
             "binding": {
@@ -3193,6 +3197,7 @@
             },
             "rotation": 0
           },
+          "reference": "CDUMMY",
           "sourceRef": {
             "end": {
               "column": 20,
@@ -3206,8 +3211,7 @@
               "offset": 905
             }
           },
-          "symbolId": "capacitor",
-          "reference": "CDUMMY"
+          "symbolId": "capacitor"
         },
         {
           "id": "cell-pin-8d2d35d48ff5f9ed",
@@ -5343,7 +5347,7 @@
   ],
   "id": "project-898510e0e3b15ad5",
   "name": "Switched_Capacitor_DAC_6bit (SPICE Import Demo)",
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "source": {
     "dialect": "spice3f5-core",
     "entry": "circuit.spi",

--- a/fixtures/gallery-redline/3tfmrzevfe.icproj.json
+++ b/fixtures/gallery-redline/3tfmrzevfe.icproj.json
@@ -17,8 +17,8 @@
             "objectId": "R1"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "R1"
+            "instanceId": "R1",
+            "kind": "instance-reference"
           },
           "id": "instance-label-R1",
           "kind": "instance-label",
@@ -40,8 +40,8 @@
             "objectId": "M3"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M3"
+            "instanceId": "M3",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M1-copy-1",
           "kind": "instance-label",
@@ -63,8 +63,8 @@
             "objectId": "M4"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M4"
+            "instanceId": "M4",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M2-copy-1",
           "kind": "instance-label",
@@ -86,8 +86,8 @@
             "objectId": "C1"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "C1"
+            "instanceId": "C1",
+            "kind": "instance-reference"
           },
           "id": "instance-label-C1",
           "kind": "instance-label",
@@ -109,8 +109,8 @@
             "objectId": "C2"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "C2"
+            "instanceId": "C2",
+            "kind": "instance-reference"
           },
           "id": "instance-label-C2",
           "kind": "instance-label",
@@ -132,8 +132,8 @@
             "objectId": "C3"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "C3"
+            "instanceId": "C3",
+            "kind": "instance-reference"
           },
           "id": "instance-label-C3",
           "kind": "instance-label",
@@ -155,8 +155,8 @@
             "objectId": "C4"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "C4"
+            "instanceId": "C4",
+            "kind": "instance-reference"
           },
           "id": "instance-label-C4",
           "kind": "instance-label",
@@ -178,8 +178,8 @@
             "objectId": "C5"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "C5"
+            "instanceId": "C5",
+            "kind": "instance-reference"
           },
           "id": "instance-label-C5",
           "kind": "instance-label",
@@ -201,8 +201,8 @@
             "objectId": "M5"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M5"
+            "instanceId": "M5",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M5",
           "kind": "instance-label",
@@ -224,8 +224,8 @@
             "objectId": "M6"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M6"
+            "instanceId": "M6",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M6",
           "kind": "instance-label",
@@ -247,8 +247,8 @@
             "objectId": "M7"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M7"
+            "instanceId": "M7",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M7",
           "kind": "instance-label",
@@ -270,8 +270,8 @@
             "objectId": "M8"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M8"
+            "instanceId": "M8",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M8",
           "kind": "instance-label",
@@ -293,8 +293,8 @@
             "objectId": "M9"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M9"
+            "instanceId": "M9",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M9",
           "kind": "instance-label",
@@ -316,8 +316,8 @@
             "objectId": "M10"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M10"
+            "instanceId": "M10",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M10",
           "kind": "instance-label",
@@ -339,8 +339,8 @@
             "objectId": "M11"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M11"
+            "instanceId": "M11",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M11",
           "kind": "instance-label",
@@ -362,8 +362,8 @@
             "objectId": "C6"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "C6"
+            "instanceId": "C6",
+            "kind": "instance-reference"
           },
           "id": "instance-label-C6",
           "kind": "instance-label",
@@ -488,8 +488,8 @@
             "objectId": "R2"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "R2"
+            "instanceId": "R2",
+            "kind": "instance-reference"
           },
           "id": "instance-label-R2",
           "kind": "instance-label",
@@ -511,8 +511,8 @@
             "objectId": "X1"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "X1"
+            "instanceId": "X1",
+            "kind": "instance-reference"
           },
           "id": "instance-label-X1",
           "kind": "instance-label",
@@ -1408,8 +1408,8 @@
             },
             "rotation": 90
           },
-          "symbolId": "resistor",
-          "reference": "R1"
+          "reference": "R1",
+          "symbolId": "resistor"
         },
         {
           "id": "M3",
@@ -1433,9 +1433,9 @@
             },
             "rotation": 0
           },
+          "reference": "M3",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M3"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M4",
@@ -1455,9 +1455,9 @@
             },
             "rotation": 0
           },
+          "reference": "M4",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M4"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "C1",
@@ -1476,8 +1476,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "capacitor",
-          "reference": "C1"
+          "reference": "C1",
+          "symbolId": "capacitor"
         },
         {
           "id": "C2",
@@ -1496,8 +1496,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "capacitor",
-          "reference": "C2"
+          "reference": "C2",
+          "symbolId": "capacitor"
         },
         {
           "id": "C3",
@@ -1516,8 +1516,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "capacitor",
-          "reference": "C3"
+          "reference": "C3",
+          "symbolId": "capacitor"
         },
         {
           "id": "C4",
@@ -1536,8 +1536,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "capacitor",
-          "reference": "C4"
+          "reference": "C4",
+          "symbolId": "capacitor"
         },
         {
           "id": "C5",
@@ -1556,8 +1556,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "capacitor",
-          "reference": "C5"
+          "reference": "C5",
+          "symbolId": "capacitor"
         },
         {
           "id": "M5",
@@ -1581,9 +1581,9 @@
             },
             "rotation": 0
           },
+          "reference": "M5",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M5"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M6",
@@ -1607,9 +1607,9 @@
             },
             "rotation": 0
           },
+          "reference": "M6",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M6"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M7",
@@ -1633,9 +1633,9 @@
             },
             "rotation": 0
           },
+          "reference": "M7",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M7"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M8",
@@ -1659,9 +1659,9 @@
             },
             "rotation": 0
           },
+          "reference": "M8",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M8"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M9",
@@ -1685,9 +1685,9 @@
             },
             "rotation": 0
           },
+          "reference": "M9",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M9"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "X2",
@@ -1699,8 +1699,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "and-gate",
-          "reference": "X2"
+          "reference": "X2",
+          "symbolId": "and-gate"
         },
         {
           "id": "M10",
@@ -1724,9 +1724,9 @@
             },
             "rotation": 0
           },
+          "reference": "M10",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M10"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M11",
@@ -1746,9 +1746,9 @@
             },
             "rotation": 0
           },
+          "reference": "M11",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M11"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "C6",
@@ -1767,8 +1767,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "capacitor",
-          "reference": "C6"
+          "reference": "C6",
+          "symbolId": "capacitor"
         },
         {
           "id": "X3",
@@ -1780,8 +1780,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "nor-gate",
-          "reference": "X3"
+          "reference": "X3",
+          "symbolId": "nor-gate"
         },
         {
           "id": "X4",
@@ -1793,8 +1793,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "and-gate",
-          "reference": "X4"
+          "reference": "X4",
+          "symbolId": "and-gate"
         },
         {
           "id": "VDD1",
@@ -1861,8 +1861,8 @@
             },
             "rotation": 90
           },
-          "symbolId": "resistor",
-          "reference": "R2"
+          "reference": "R2",
+          "symbolId": "resistor"
         },
         {
           "id": "X5",
@@ -1874,8 +1874,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "inverter",
-          "reference": "X5"
+          "reference": "X5",
+          "symbolId": "inverter"
         },
         {
           "id": "P1",
@@ -1911,8 +1911,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "nor-gate",
-          "reference": "X1"
+          "reference": "X1",
+          "symbolId": "nor-gate"
         },
         {
           "id": "P3",
@@ -3588,7 +3588,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "deadtime",
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/gallery-redline/7sxpwb4am7.icproj.json
+++ b/fixtures/gallery-redline/7sxpwb4am7.icproj.json
@@ -16,66 +16,11 @@
             },
             "objectId": "M1"
           },
-          "id": "instance-label-M1",
-          "kind": "instance-label",
-          "locked": false,
-          "rotation": 0,
-          "content": {
-            "runs": [
-              {
-                "children": [
-                  {
-                    "children": [
-                      {
-                        "kind": "text",
-                        "value": "M"
-                      }
-                    ],
-                    "kind": "span",
-                    "style": "bold"
-                  }
-                ],
-                "kind": "span",
-                "style": "italic"
-              },
-              {
-                "children": [
-                  {
-                    "children": [
-                      {
-                        "kind": "text",
-                        "value": "3"
-                      }
-                    ],
-                    "kind": "span",
-                    "style": "bold"
-                  }
-                ],
-                "kind": "span",
-                "style": "subscript"
-              }
-            ]
-          }
-        },
-        {
-          "alignment": "start",
-          "anchor": {
-            "fallbackPosition": {
-              "x": 335,
-              "y": 275
-            },
-            "kind": "object",
-            "localOffset": {
-              "x": 15,
-              "y": 5
-            },
-            "objectId": "M2"
+          "binding": {
+            "instanceId": "M1",
+            "kind": "instance-reference"
           },
-          "id": "instance-label-M2",
-          "kind": "instance-label",
-          "locked": false,
-          "rotation": 0,
-          "content": {
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -110,7 +55,70 @@
                 "style": "subscript"
               }
             ]
-          }
+          },
+          "id": "instance-label-M1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 335,
+              "y": 275
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 15,
+              "y": 5
+            },
+            "objectId": "M2"
+          },
+          "binding": {
+            "instanceId": "M2",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "M"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "2"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "subscript"
+              }
+            ]
+          },
+          "id": "instance-label-M2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
         },
         {
           "alignment": "start",
@@ -150,11 +158,70 @@
             },
             "objectId": "M3"
           },
+          "binding": {
+            "instanceId": "M3",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "M"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "3"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "subscript"
+              }
+            ]
+          },
           "id": "instance-label-M3",
           "kind": "instance-label",
           "locked": false,
-          "rotation": 0,
-          "content": {
+          "rotation": 0
+        },
+        {
+          "alignment": "end",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 435,
+              "y": 275
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": -15,
+              "y": 5
+            },
+            "objectId": "M4"
+          },
+          "binding": {
+            "instanceId": "M4",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -189,62 +256,11 @@
                 "style": "subscript"
               }
             ]
-          }
-        },
-        {
-          "alignment": "end",
-          "anchor": {
-            "fallbackPosition": {
-              "x": 435,
-              "y": 275
-            },
-            "kind": "object",
-            "localOffset": {
-              "x": -15,
-              "y": 5
-            },
-            "objectId": "M4"
           },
           "id": "instance-label-M3-copy-1",
           "kind": "instance-label",
           "locked": false,
-          "rotation": 0,
-          "content": {
-            "runs": [
-              {
-                "children": [
-                  {
-                    "children": [
-                      {
-                        "kind": "text",
-                        "value": "M"
-                      }
-                    ],
-                    "kind": "span",
-                    "style": "bold"
-                  }
-                ],
-                "kind": "span",
-                "style": "italic"
-              },
-              {
-                "children": [
-                  {
-                    "children": [
-                      {
-                        "kind": "text",
-                        "value": "2"
-                      }
-                    ],
-                    "kind": "span",
-                    "style": "bold"
-                  }
-                ],
-                "kind": "span",
-                "style": "subscript"
-              }
-            ]
-          }
+          "rotation": 0
         },
         {
           "alignment": "start",
@@ -308,10 +324,6 @@
             },
             "objectId": "I1"
           },
-          "id": "instance-label-I1",
-          "kind": "instance-label",
-          "locked": false,
-          "rotation": 0,
           "content": {
             "runs": [
               {
@@ -347,7 +359,11 @@
                 "style": "subscript"
               }
             ]
-          }
+          },
+          "id": "instance-label-I1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
         }
       ],
       "connectivityEvidence": [
@@ -404,9 +420,9 @@
             },
             "rotation": 0
           },
+          "reference": "M1",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M1"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M2",
@@ -430,9 +446,9 @@
             },
             "rotation": 0
           },
+          "reference": "M2",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M2"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "P2",
@@ -468,9 +484,9 @@
             },
             "rotation": 0
           },
+          "reference": "M3",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M3"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "P1",
@@ -506,9 +522,9 @@
             },
             "rotation": 0
           },
+          "reference": "M4",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M4"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "P3",
@@ -539,8 +555,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "current-source",
-          "reference": "I1"
+          "reference": "I1",
+          "symbolId": "current-source"
         },
         {
           "id": "P4",
@@ -1346,7 +1362,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-6c056e6c-b17b-4a66-aab9-06d0b380b437",
   "name": "Figure 17.19(b)",
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/gallery-redline/b5cn37k3a9.icproj.json
+++ b/fixtures/gallery-redline/b5cn37k3a9.icproj.json
@@ -17,8 +17,8 @@
             "objectId": "Q1"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "Q1"
+            "instanceId": "Q1",
+            "kind": "instance-reference"
           },
           "id": "instance-label-Q1",
           "kind": "instance-label",
@@ -40,8 +40,8 @@
             "objectId": "Q2"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "Q2"
+            "instanceId": "Q2",
+            "kind": "instance-reference"
           },
           "id": "instance-label-Q2",
           "kind": "instance-label",
@@ -63,8 +63,8 @@
             "objectId": "R1"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "R1"
+            "instanceId": "R1",
+            "kind": "instance-reference"
           },
           "id": "instance-label-R1",
           "kind": "instance-label",
@@ -86,8 +86,8 @@
             "objectId": "R2"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "R2"
+            "instanceId": "R2",
+            "kind": "instance-reference"
           },
           "id": "instance-label-R2",
           "kind": "instance-label",
@@ -109,8 +109,8 @@
             "objectId": "R3"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "R3"
+            "instanceId": "R3",
+            "kind": "instance-reference"
           },
           "id": "instance-label-R3",
           "kind": "instance-label",
@@ -132,8 +132,8 @@
             "objectId": "Q3"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "Q3"
+            "instanceId": "Q3",
+            "kind": "instance-reference"
           },
           "id": "instance-label-Q1-copy-1",
           "kind": "instance-label",
@@ -155,8 +155,8 @@
             "objectId": "I1"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "I1"
+            "instanceId": "I1",
+            "kind": "instance-reference"
           },
           "id": "instance-label-I1",
           "kind": "instance-label",
@@ -178,8 +178,8 @@
             "objectId": "M1"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M1"
+            "instanceId": "M1",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M1",
           "kind": "instance-label",
@@ -256,8 +256,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "npn",
-          "reference": "Q1"
+          "reference": "Q1",
+          "symbolId": "npn"
         },
         {
           "id": "Q2",
@@ -272,8 +272,8 @@
             },
             "rotation": 180
           },
-          "symbolId": "pnp",
-          "reference": "Q2"
+          "reference": "Q2",
+          "symbolId": "pnp"
         },
         {
           "id": "R1",
@@ -292,8 +292,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "resistor",
-          "reference": "R1"
+          "reference": "R1",
+          "symbolId": "resistor"
         },
         {
           "id": "R2",
@@ -312,8 +312,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "resistor",
-          "reference": "R2"
+          "reference": "R2",
+          "symbolId": "resistor"
         },
         {
           "id": "R3",
@@ -332,8 +332,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "resistor",
-          "reference": "R3"
+          "reference": "R3",
+          "symbolId": "resistor"
         },
         {
           "id": "Q3",
@@ -348,8 +348,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "npn",
-          "reference": "Q3"
+          "reference": "Q3",
+          "symbolId": "npn"
         },
         {
           "id": "I1",
@@ -368,8 +368,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "current-source",
-          "reference": "I1"
+          "reference": "I1",
+          "symbolId": "current-source"
         },
         {
           "id": "M1",
@@ -393,9 +393,9 @@
             },
             "rotation": 180
           },
+          "reference": "M1",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M1"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "VDD1",
@@ -1141,7 +1141,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "widlar",
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/gallery-redline/f22q5vhdb5.icproj.json
+++ b/fixtures/gallery-redline/f22q5vhdb5.icproj.json
@@ -16,66 +16,11 @@
             },
             "objectId": "M3"
           },
-          "id": "instance-label-M1-copy-1-copy-1",
-          "kind": "instance-label",
-          "locked": false,
-          "rotation": 0,
-          "content": {
-            "runs": [
-              {
-                "children": [
-                  {
-                    "children": [
-                      {
-                        "kind": "text",
-                        "value": "M"
-                      }
-                    ],
-                    "kind": "span",
-                    "style": "bold"
-                  }
-                ],
-                "kind": "span",
-                "style": "italic"
-              },
-              {
-                "children": [
-                  {
-                    "children": [
-                      {
-                        "kind": "text",
-                        "value": "4"
-                      }
-                    ],
-                    "kind": "span",
-                    "style": "bold"
-                  }
-                ],
-                "kind": "span",
-                "style": "subscript"
-              }
-            ]
-          }
-        },
-        {
-          "alignment": "start",
-          "anchor": {
-            "fallbackPosition": {
-              "x": 255,
-              "y": 265
-            },
-            "kind": "object",
-            "localOffset": {
-              "x": 15,
-              "y": 5
-            },
-            "objectId": "M4"
+          "binding": {
+            "instanceId": "M3",
+            "kind": "instance-reference"
           },
-          "id": "instance-label-M3-copy-1",
-          "kind": "instance-label",
-          "locked": false,
-          "rotation": 0,
-          "content": {
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -110,27 +55,31 @@
                 "style": "subscript"
               }
             ]
-          }
+          },
+          "id": "instance-label-M1-copy-1-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
         },
         {
           "alignment": "start",
           "anchor": {
             "fallbackPosition": {
               "x": 255,
-              "y": 340
+              "y": 265
             },
             "kind": "object",
             "localOffset": {
               "x": 15,
-              "y": 10
+              "y": 5
             },
-            "objectId": "M5"
+            "objectId": "M4"
           },
-          "id": "instance-label-M4-copy-1",
-          "kind": "instance-label",
-          "locked": false,
-          "rotation": 0,
-          "content": {
+          "binding": {
+            "instanceId": "M4",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -154,7 +103,7 @@
                     "children": [
                       {
                         "kind": "text",
-                        "value": "1"
+                        "value": "4"
                       }
                     ],
                     "kind": "span",
@@ -165,7 +114,70 @@
                 "style": "subscript"
               }
             ]
-          }
+          },
+          "id": "instance-label-M3-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
+        },
+        {
+          "alignment": "start",
+          "anchor": {
+            "fallbackPosition": {
+              "x": 255,
+              "y": 340
+            },
+            "kind": "object",
+            "localOffset": {
+              "x": 15,
+              "y": 10
+            },
+            "objectId": "M5"
+          },
+          "binding": {
+            "instanceId": "M5",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
+            "runs": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "M"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "italic"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "text",
+                        "value": "5"
+                      }
+                    ],
+                    "kind": "span",
+                    "style": "bold"
+                  }
+                ],
+                "kind": "span",
+                "style": "subscript"
+              }
+            ]
+          },
+          "id": "instance-label-M4-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
         },
         {
           "alignment": "start",
@@ -205,11 +217,11 @@
             },
             "objectId": "M2"
           },
-          "id": "instance-label-M1-copy-1",
-          "kind": "instance-label",
-          "locked": false,
-          "rotation": 0,
-          "content": {
+          "binding": {
+            "instanceId": "M2",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -244,7 +256,11 @@
                 "style": "subscript"
               }
             ]
-          }
+          },
+          "id": "instance-label-M1-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
         },
         {
           "alignment": "end",
@@ -284,10 +300,6 @@
             },
             "objectId": "C2"
           },
-          "id": "instance-label-C1-copy-1",
-          "kind": "instance-label",
-          "locked": false,
-          "rotation": 0,
           "content": {
             "runs": [
               {
@@ -307,7 +319,11 @@
                 "style": "italic"
               }
             ]
-          }
+          },
+          "id": "instance-label-C1-copy-1",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
         },
         {
           "alignment": "end",
@@ -820,9 +836,9 @@
             },
             "rotation": 0
           },
+          "reference": "M3",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M3"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M4",
@@ -846,9 +862,9 @@
             },
             "rotation": 0
           },
+          "reference": "M4",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M4"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M5",
@@ -872,9 +888,9 @@
             },
             "rotation": 0
           },
+          "reference": "M5",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M5"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "GND1-copy-1",
@@ -922,9 +938,9 @@
             },
             "rotation": 0
           },
+          "reference": "M2",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M2"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "P2-copy-1",
@@ -955,8 +971,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "capacitor",
-          "reference": "C2"
+          "reference": "C2",
+          "symbolId": "capacitor"
         },
         {
           "id": "GND2-copy-1",
@@ -1016,9 +1032,9 @@
             },
             "rotation": 270
           },
+          "reference": "M1",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M1"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M6",
@@ -1042,9 +1058,9 @@
             },
             "rotation": 270
           },
+          "reference": "M6",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M6"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "X1",
@@ -1056,8 +1072,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "inverter",
-          "reference": "X1"
+          "reference": "X1",
+          "symbolId": "inverter"
         },
         {
           "id": "VDD1",
@@ -2039,7 +2055,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-888e7106-b15b-4186-a980-d5a88c004d4c",
   "name": "suppression of skew",
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/gallery-redline/ycg43babwa.icproj.json
+++ b/fixtures/gallery-redline/ycg43babwa.icproj.json
@@ -41,8 +41,8 @@
             "objectId": "M3"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M3"
+            "instanceId": "M3",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M2-copy-1",
           "kind": "instance-label",
@@ -64,8 +64,8 @@
             "objectId": "Q1"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "Q1"
+            "instanceId": "Q1",
+            "kind": "instance-reference"
           },
           "id": "instance-label-Q1",
           "kind": "instance-label",
@@ -87,8 +87,8 @@
             "objectId": "Q2"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "Q2"
+            "instanceId": "Q2",
+            "kind": "instance-reference"
           },
           "id": "instance-label-Q2",
           "kind": "instance-label",
@@ -110,8 +110,8 @@
             "objectId": "Q3"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "Q3"
+            "instanceId": "Q3",
+            "kind": "instance-reference"
           },
           "id": "instance-label-Q3",
           "kind": "instance-label",
@@ -133,8 +133,8 @@
             "objectId": "Q4"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "Q4"
+            "instanceId": "Q4",
+            "kind": "instance-reference"
           },
           "id": "instance-label-Q4",
           "kind": "instance-label",
@@ -156,8 +156,8 @@
             "objectId": "Q5"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "Q5"
+            "instanceId": "Q5",
+            "kind": "instance-reference"
           },
           "id": "instance-label-Q5",
           "kind": "instance-label",
@@ -179,8 +179,8 @@
             "objectId": "Q6"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "Q6"
+            "instanceId": "Q6",
+            "kind": "instance-reference"
           },
           "id": "instance-label-Q6",
           "kind": "instance-label",
@@ -202,8 +202,8 @@
             "objectId": "R1"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "R1"
+            "instanceId": "R1",
+            "kind": "instance-reference"
           },
           "id": "instance-label-R1",
           "kind": "instance-label",
@@ -225,8 +225,8 @@
             "objectId": "R2"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "R2"
+            "instanceId": "R2",
+            "kind": "instance-reference"
           },
           "id": "instance-label-R2",
           "kind": "instance-label",
@@ -248,8 +248,8 @@
             "objectId": "R3"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "R3"
+            "instanceId": "R3",
+            "kind": "instance-reference"
           },
           "id": "instance-label-R3",
           "kind": "instance-label",
@@ -271,8 +271,8 @@
             "objectId": "R4"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "R4"
+            "instanceId": "R4",
+            "kind": "instance-reference"
           },
           "id": "instance-label-R4",
           "kind": "instance-label",
@@ -294,8 +294,8 @@
             "objectId": "R5"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "R5"
+            "instanceId": "R5",
+            "kind": "instance-reference"
           },
           "id": "instance-label-R5",
           "kind": "instance-label",
@@ -317,8 +317,8 @@
             "objectId": "R6"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "R6"
+            "instanceId": "R6",
+            "kind": "instance-reference"
           },
           "id": "instance-label-R6",
           "kind": "instance-label",
@@ -340,8 +340,8 @@
             "objectId": "R7"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "R7"
+            "instanceId": "R7",
+            "kind": "instance-reference"
           },
           "id": "instance-label-R7",
           "kind": "instance-label",
@@ -363,8 +363,8 @@
             "objectId": "M4"
           },
           "binding": {
-            "kind": "instance-reference",
-            "instanceId": "M4"
+            "instanceId": "M4",
+            "kind": "instance-reference"
           },
           "id": "instance-label-M4",
           "kind": "instance-label",
@@ -385,11 +385,11 @@
             },
             "objectId": "M6"
           },
-          "id": "instance-label-M4-copy-2",
-          "kind": "instance-label",
-          "locked": false,
-          "rotation": 0,
-          "content": {
+          "binding": {
+            "instanceId": "M6",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -397,7 +397,7 @@
                     "children": [
                       {
                         "kind": "text",
-                        "value": "M2"
+                        "value": "M6"
                       }
                     ],
                     "kind": "span",
@@ -408,7 +408,11 @@
                 "style": "italic"
               }
             ]
-          }
+          },
+          "id": "instance-label-M4-copy-2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
         },
         {
           "alignment": "end",
@@ -424,11 +428,11 @@
             },
             "objectId": "M8"
           },
-          "id": "instance-label-M4-copy-2-copy-2",
-          "kind": "instance-label",
-          "locked": false,
-          "rotation": 0,
-          "content": {
+          "binding": {
+            "instanceId": "M8",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -436,7 +440,7 @@
                     "children": [
                       {
                         "kind": "text",
-                        "value": "M1"
+                        "value": "M8"
                       }
                     ],
                     "kind": "span",
@@ -447,7 +451,11 @@
                 "style": "italic"
               }
             ]
-          }
+          },
+          "id": "instance-label-M4-copy-2-copy-2",
+          "kind": "instance-label",
+          "locked": false,
+          "rotation": 0
         }
       ],
       "connectivityEvidence": [
@@ -556,9 +564,9 @@
             },
             "rotation": 0
           },
+          "reference": "M3",
           "symbolId": "nmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M3"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "Q1",
@@ -573,8 +581,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "npn",
-          "reference": "Q1"
+          "reference": "Q1",
+          "symbolId": "npn"
         },
         {
           "id": "Q2",
@@ -589,8 +597,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "npn",
-          "reference": "Q2"
+          "reference": "Q2",
+          "symbolId": "npn"
         },
         {
           "id": "Q3",
@@ -605,8 +613,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "npn",
-          "reference": "Q3"
+          "reference": "Q3",
+          "symbolId": "npn"
         },
         {
           "id": "Q4",
@@ -621,8 +629,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "npn",
-          "reference": "Q4"
+          "reference": "Q4",
+          "symbolId": "npn"
         },
         {
           "id": "Q5",
@@ -637,8 +645,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "npn",
-          "reference": "Q5"
+          "reference": "Q5",
+          "symbolId": "npn"
         },
         {
           "id": "Q6",
@@ -653,8 +661,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "npn",
-          "reference": "Q6"
+          "reference": "Q6",
+          "symbolId": "npn"
         },
         {
           "id": "R1",
@@ -673,8 +681,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "resistor",
-          "reference": "R1"
+          "reference": "R1",
+          "symbolId": "resistor"
         },
         {
           "id": "R2",
@@ -693,8 +701,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "resistor",
-          "reference": "R2"
+          "reference": "R2",
+          "symbolId": "resistor"
         },
         {
           "id": "R3",
@@ -713,8 +721,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "resistor",
-          "reference": "R3"
+          "reference": "R3",
+          "symbolId": "resistor"
         },
         {
           "id": "R4",
@@ -733,8 +741,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "resistor",
-          "reference": "R4"
+          "reference": "R4",
+          "symbolId": "resistor"
         },
         {
           "id": "R5",
@@ -753,8 +761,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "resistor",
-          "reference": "R5"
+          "reference": "R5",
+          "symbolId": "resistor"
         },
         {
           "id": "R6",
@@ -773,8 +781,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "resistor",
-          "reference": "R6"
+          "reference": "R6",
+          "symbolId": "resistor"
         },
         {
           "id": "R7",
@@ -793,8 +801,8 @@
             },
             "rotation": 0
           },
-          "symbolId": "resistor",
-          "reference": "R7"
+          "reference": "R7",
+          "symbolId": "resistor"
         },
         {
           "id": "M4",
@@ -818,9 +826,9 @@
             },
             "rotation": 0
           },
+          "reference": "M4",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M4"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M5",
@@ -844,9 +852,9 @@
             },
             "rotation": 0
           },
+          "reference": "M5",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M5"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M6",
@@ -870,9 +878,9 @@
             },
             "rotation": 0
           },
+          "reference": "M6",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M6"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M7",
@@ -896,9 +904,9 @@
             },
             "rotation": 0
           },
+          "reference": "M7",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M7"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "M8",
@@ -922,9 +930,9 @@
             },
             "rotation": 0
           },
+          "reference": "M8",
           "symbolId": "pmos",
-          "symbolVariantId": "textbook-3terminal",
-          "reference": "M8"
+          "symbolVariantId": "textbook-3terminal"
         },
         {
           "id": "GND1",
@@ -2770,7 +2778,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "LTC3452",
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/compatibility-corpus.json
+++ b/fixtures/projects/compatibility-corpus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "description": "Canonical schema-v35 Project corpus. Historical schema upgrades are covered by synthesized tests rather than retained duplicate assets.",
+  "description": "Canonical schema-v36 Project corpus. Historical schema upgrades are covered by synthesized tests rather than retained duplicate assets.",
   "current": [
     "fixtures/projects/minimal/project.icproj.json",
     "fixtures/projects/phase-1-manual/project.icproj.json",

--- a/fixtures/projects/instance-value-display/project.icproj.json
+++ b/fixtures/projects/instance-value-display/project.icproj.json
@@ -16,7 +16,11 @@
             },
             "objectId": "M1"
           },
-          "content": {
+          "binding": {
+            "instanceId": "M1",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -125,7 +129,11 @@
             },
             "objectId": "M2"
           },
-          "content": {
+          "binding": {
+            "instanceId": "M2",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -180,7 +188,11 @@
             },
             "objectId": "R1"
           },
-          "content": {
+          "binding": {
+            "instanceId": "R1",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -268,7 +280,11 @@
             },
             "objectId": "R2"
           },
-          "content": {
+          "binding": {
+            "instanceId": "R2",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -356,7 +372,11 @@
             },
             "objectId": "C1"
           },
-          "content": {
+          "binding": {
+            "instanceId": "C1",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -444,7 +464,11 @@
             },
             "objectId": "L1"
           },
-          "content": {
+          "binding": {
+            "instanceId": "L1",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -532,7 +556,11 @@
             },
             "objectId": "V1"
           },
-          "content": {
+          "binding": {
+            "instanceId": "V1",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -620,7 +648,11 @@
             },
             "objectId": "I1"
           },
-          "content": {
+          "binding": {
+            "instanceId": "I1",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -708,7 +740,11 @@
             },
             "objectId": "M3"
           },
-          "content": {
+          "binding": {
+            "instanceId": "M3",
+            "kind": "instance-reference"
+          },
+          "formatOverride": {
             "runs": [
               {
                 "children": [
@@ -1039,7 +1075,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "instance-value-display",
   "name": "Instance Value Display",
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/minimal/project.icproj.json
+++ b/fixtures/projects/minimal/project.icproj.json
@@ -32,7 +32,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-minimal",
   "name": "Minimal Project",
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-1-manual/project.icproj.json
+++ b/fixtures/projects/phase-1-manual/project.icproj.json
@@ -58,7 +58,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-1-manual",
   "name": "Phase 1 Manual Editor",
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-3-routing/project.icproj.json
+++ b/fixtures/projects/phase-3-routing/project.icproj.json
@@ -170,7 +170,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-routing",
   "name": "Phase 3 Routing Demo",
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-5-dense-analog/project.icproj.json
+++ b/fixtures/projects/phase-5-dense-analog/project.icproj.json
@@ -421,7 +421,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-5-dense-analog",
   "name": "Current Differential Stage",
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/rejected-missing-top/project.icproj.json
+++ b/fixtures/projects/rejected-missing-top/project.icproj.json
@@ -32,7 +32,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-rejected",
   "name": "Rejected",
-  "schemaVersion": 35,
+  "schemaVersion": 36,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/packages/edit-engine/src/transaction-instance-annotations.ts
+++ b/packages/edit-engine/src/transaction-instance-annotations.ts
@@ -1,4 +1,8 @@
-import { inverseTransformPoint, transformPoint } from "@icm/model";
+import {
+  inverseTransformPoint,
+  rewriteRichTextPlainText,
+  transformPoint,
+} from "@icm/model";
 import type {
   Annotation,
   Orientation,
@@ -190,8 +194,10 @@ export function refreshInstanceValueAnnotation(
 }
 
 /**
- * Mark the live Reference projection changed after the authored Reference
- * changes. Literal object-anchored annotations remain independent text.
+ * Re-project every live Reference annotation after the authored Reference
+ * changes. Its RichText tree remains an independently editable presentation,
+ * so a same-text override follows the semantic name without losing styles.
+ * Literal object-anchored annotations remain independent text.
  */
 export function refreshInstanceReferenceAnnotation(
   draft: SchematicDocument,
@@ -214,14 +220,18 @@ export function refreshInstanceReferenceAnnotation(
   for (const annotation of draft.annotations) {
     if (
       annotation.kind !== "instance-label" ||
-      annotation.anchor.kind !== "object" ||
-      annotation.anchor.objectId !== instanceId
+      annotation.binding?.kind !== "instance-reference" ||
+      annotation.binding.instanceId !== instanceId
     ) {
       continue;
     }
-    if (annotation.binding?.kind === "instance-reference") {
-      changedObjectIds.add(annotation.id);
+    if (annotation.formatOverride) {
+      annotation.formatOverride = rewriteRichTextPlainText(
+        annotation.formatOverride,
+        nextReference,
+      );
     }
+    changedObjectIds.add(annotation.id);
   }
 }
 

--- a/packages/edit-engine/src/transaction-instance-netlist.ts
+++ b/packages/edit-engine/src/transaction-instance-netlist.ts
@@ -223,6 +223,8 @@ export function applyInstanceNetlistEdit(
           ),
         };
       }
+      const before: SchematicDocument["instances"][number] =
+        structuredClone(instance);
       instance.reference = edit.reference;
       const failure = referencePolicyFailure(draft, instance.id);
       if (failure) {
@@ -231,14 +233,12 @@ export function applyInstanceNetlistEdit(
           rejection: reject("EDIT_PRECONDITION", failure, [], [instance.id]),
         };
       }
-      for (const annotation of draft.annotations) {
-        if (
-          annotation.binding?.kind === "instance-reference" &&
-          annotation.binding.instanceId === instance.id
-        ) {
-          changedObjectIds.add(annotation.id);
-        }
-      }
+      refreshInstanceReferenceAnnotation(
+        draft,
+        before,
+        instance.id,
+        changedObjectIds,
+      );
       return { ok: true, connectivityChanged: false };
     }
     case "set_instance_binding": {

--- a/packages/edit-engine/src/transaction.test.ts
+++ b/packages/edit-engine/src/transaction.test.ts
@@ -2198,6 +2198,44 @@ describe("Edit Transaction envelope", () => {
     );
   });
 
+  it("renames a mapped Reference RichText projection without losing its styles", () => {
+    const document = documentWithInstance();
+    document.annotations.push({
+      id: "instance-label-M1",
+      kind: "instance-label",
+      binding: { kind: "instance-reference", instanceId: "M1" },
+      formatOverride: semanticTextDocument("M1", "instance-label"),
+      anchor: {
+        kind: "object",
+        objectId: "M1",
+        localOffset: { x: 0, y: -20 },
+        fallbackPosition: { x: 0, y: -20 },
+      },
+      alignment: "middle",
+      rotation: 0,
+      locked: false,
+    });
+
+    const renamed = executeTransaction(document, {
+      ...transaction(),
+      edits: [
+        { kind: "set_instance_reference", instanceId: "M1", reference: "M21" },
+      ],
+    });
+
+    expect(renamed).toMatchObject({ ok: true });
+    if (!renamed.ok) return;
+    expect(renamed.document.instances[0]!.reference).toBe("M21");
+    const presentation = renamed.document.annotations[0]!.formatOverride!;
+    expect(flattenRichText(presentation)).toBe("M21");
+    expect(presentation.runs[0]).toEqual(
+      semanticTextDocument("M1", "instance-label").runs[0],
+    );
+    expect(presentation.runs[1]).toEqual(
+      semanticTextDocument("M21", "instance-label").runs[1],
+    );
+  });
+
   it("applies a bounded bulk netlist patch atomically", () => {
     const document = documentWithInstance();
     document.instances.push({

--- a/packages/model/src/rich-text.test.ts
+++ b/packages/model/src/rich-text.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { flattenRichText, normalizeRichText } from "./rich-text.js";
+import {
+  flattenRichText,
+  normalizeRichText,
+  rewriteRichTextPlainText,
+} from "./rich-text.js";
 import { RichTextDocumentSchema } from "./schema.js";
 import type { RichTextDocument } from "./schema.js";
 
@@ -130,5 +134,65 @@ describe("canonical RichText helpers", () => {
         ],
       }).success,
     ).toBe(false);
+  });
+
+  it("rewrites a semantic name while preserving its independent RichText styles", () => {
+    const content: RichTextDocument = {
+      runs: [
+        {
+          kind: "span",
+          style: "italic",
+          children: [
+            {
+              kind: "span",
+              style: "bold",
+              children: [{ kind: "text", value: "M" }],
+            },
+          ],
+        },
+        {
+          kind: "span",
+          style: "subscript",
+          children: [
+            {
+              kind: "span",
+              style: "bold",
+              children: [{ kind: "text", value: "15" }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const rewritten = rewriteRichTextPlainText(content, "M21");
+
+    expect(flattenRichText(rewritten)).toBe("M21");
+    expect(rewritten).toEqual({
+      runs: [
+        {
+          kind: "span",
+          style: "italic",
+          children: [
+            {
+              kind: "span",
+              style: "bold",
+              children: [{ kind: "text", value: "M" }],
+            },
+          ],
+        },
+        {
+          kind: "span",
+          style: "subscript",
+          children: [
+            {
+              kind: "span",
+              style: "bold",
+              children: [{ kind: "text", value: "21" }],
+            },
+          ],
+        },
+      ],
+    });
+    expect(RichTextDocumentSchema.safeParse(rewritten).success).toBe(true);
   });
 });

--- a/packages/model/src/rich-text.ts
+++ b/packages/model/src/rich-text.ts
@@ -1,4 +1,4 @@
-import type { RichTextDocument, RichTextRun } from "./schema.js";
+import type { RichTextDocument, RichTextRun, RichTextStyle } from "./schema.js";
 
 export type RichTextMathRun = Extract<RichTextRun, { kind: "math" }>;
 
@@ -65,4 +65,129 @@ export function normalizeRichText(
   };
   document.runs.forEach(append);
   return { runs: normalized };
+}
+
+interface StyledCharacter {
+  readonly value: string;
+  readonly styles: readonly RichTextStyle[];
+}
+
+function collectStyledCharacters(
+  runs: readonly RichTextRun[],
+  styles: readonly RichTextStyle[],
+  output: StyledCharacter[],
+): boolean {
+  for (const run of runs) {
+    if (run.kind === "text") {
+      output.push(
+        ...[...run.value].map((value) => ({ value, styles: [...styles] })),
+      );
+      continue;
+    }
+    if (run.kind === "span") {
+      if (
+        !collectStyledCharacters(run.children, [...styles, run.style], output)
+      )
+        return false;
+      continue;
+    }
+    // Semantic names are styled text, not formulas, fractions, or multiline
+    // prose. Callers still get a valid deterministic projection if legacy
+    // data contains one of those unsupported presentation nodes.
+    return false;
+  }
+  return true;
+}
+
+function styledTextRun(
+  value: string,
+  styles: readonly RichTextStyle[],
+): RichTextRun {
+  let run: RichTextRun = { kind: "text", value };
+  for (let index = styles.length - 1; index >= 0; index -= 1) {
+    run = { kind: "span", style: styles[index]!, children: [run] };
+  }
+  return run;
+}
+
+/**
+ * Replace the plain-text value of a semantic RichText projection while
+ * retaining the authored style of every unchanged character and the nearest
+ * replaced character. This is the shared bridge between an authoritative
+ * semantic name and its independently editable RichText presentation.
+ */
+export function rewriteRichTextPlainText(
+  document: RichTextDocument,
+  replacement: string,
+): RichTextDocument {
+  const source: StyledCharacter[] = [];
+  if (!collectStyledCharacters(document.runs, [], source)) {
+    return { runs: [{ kind: "text", value: replacement }] };
+  }
+  const target = [...replacement];
+  let prefixLength = 0;
+  while (
+    prefixLength < source.length &&
+    prefixLength < target.length &&
+    source[prefixLength]!.value === target[prefixLength]
+  ) {
+    prefixLength += 1;
+  }
+  let suffixLength = 0;
+  while (
+    suffixLength < source.length - prefixLength &&
+    suffixLength < target.length - prefixLength &&
+    source[source.length - suffixLength - 1]!.value ===
+      target[target.length - suffixLength - 1]
+  ) {
+    suffixLength += 1;
+  }
+
+  const replacementStyles =
+    source[prefixLength]?.styles ??
+    source[source.length - suffixLength - 1]?.styles ??
+    source.at(-1)?.styles ??
+    [];
+  const styledTarget: StyledCharacter[] = [
+    ...source.slice(0, prefixLength),
+    ...target
+      .slice(prefixLength, target.length - suffixLength)
+      .map((value) => ({ value, styles: replacementStyles })),
+    ...(suffixLength > 0 ? source.slice(source.length - suffixLength) : []),
+  ];
+
+  const runs: RichTextRun[] = [];
+  for (const character of styledTarget) {
+    const previous = runs.at(-1);
+    const previousStyles =
+      previous?.kind === "text"
+        ? []
+        : previous?.kind === "span"
+          ? (() => {
+              const nested: RichTextStyle[] = [];
+              let cursor: RichTextRun = previous;
+              while (cursor.kind === "span") {
+                nested.push(cursor.style);
+                cursor = cursor.children[0]!;
+              }
+              return cursor.kind === "text" ? nested : null;
+            })()
+          : null;
+    if (
+      previousStyles &&
+      previousStyles.length === character.styles.length &&
+      previousStyles.every((style, index) => style === character.styles[index])
+    ) {
+      let leaf = previous!;
+      while (leaf.kind === "span") leaf = leaf.children[0]!;
+      if (leaf.kind === "text") {
+        leaf.value += character.value;
+        continue;
+      }
+    }
+    runs.push(styledTextRun(character.value, character.styles));
+  }
+  return {
+    runs: runs.length > 0 ? runs : [{ kind: "line-break" }],
+  };
 }

--- a/packages/model/src/schema/common.ts
+++ b/packages/model/src/schema/common.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-export const CURRENT_PROJECT_SCHEMA_VERSION = 35;
+export const CURRENT_PROJECT_SCHEMA_VERSION = 36;
 
 export const StableIdSchema = z.string().min(1).max(256);
 /** Strict persisted/presentation hex color token. Format: `#RRGGBB`. */

--- a/packages/model/src/schema/instance-style.test.ts
+++ b/packages/model/src/schema/instance-style.test.ts
@@ -150,12 +150,12 @@ describe("SignalFlowParametersSchema", () => {
 });
 
 describe("CircuitProject schema version", () => {
-  it("current schema version is 35", () => {
-    expect(CURRENT_PROJECT_SCHEMA_VERSION).toBe(35);
+  it("current schema version is 36", () => {
+    expect(CURRENT_PROJECT_SCHEMA_VERSION).toBe(36);
   });
 
-  it("createEmptyProject produces schema version 35", () => {
-    expect(createEmptyProject("test", "Test").schemaVersion).toBe(35);
+  it("createEmptyProject produces schema version 36", () => {
+    expect(createEmptyProject("test", "Test").schemaVersion).toBe(36);
   });
 
   it("validates style and Signal Flow metadata together", () => {

--- a/packages/project-protocol/src/annotation-text-color-migration.test.ts
+++ b/packages/project-protocol/src/annotation-text-color-migration.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { createEmptyProject } from "@icm/model";
+import { createEmptyProject, CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
 
 import { parseProjectWithMetadata } from "./load.js";
 import { serializeProject } from "./save.js";
@@ -88,7 +88,7 @@ describe("schema 31 to 32 migration (Annotation text color)", () => {
 
     expect(result.sourceSchemaVersion).toBe(31);
     expect(result.migrated).toBe(true);
-    expect(result.project.schemaVersion).toBe(35);
+    expect(result.project.schemaVersion).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
     expect(result.project.documents[0]!.instances[0]).toMatchObject({
       styleOverride: {
         foreground: "#DC2626",

--- a/packages/project-protocol/src/explicit-equivalence-migration.test.ts
+++ b/packages/project-protocol/src/explicit-equivalence-migration.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { createEmptyProject } from "@icm/model";
+import { createEmptyProject, CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
 
 import { tryParseProjectWithMetadata } from "./load.js";
 import { serializeProject } from "./save.js";
@@ -55,7 +55,7 @@ describe("schema 32 to 33 migration (ownerless Net equivalence)", () => {
     });
   });
 
-  it("loads an ordinary schema-32 Project through canonical schema 35", () => {
+  it("loads an ordinary schema-32 Project through the canonical schema", () => {
     const result = tryParseProjectWithMetadata(
       JSON.stringify(schema32Project()),
     );
@@ -64,7 +64,7 @@ describe("schema 32 to 33 migration (ownerless Net equivalence)", () => {
       ok: true,
       sourceSchemaVersion: 32,
       migrated: true,
-      project: { schemaVersion: 35 },
+      project: { schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION },
     });
   });
 
@@ -85,7 +85,7 @@ describe("schema 32 to 33 migration (ownerless Net equivalence)", () => {
     });
   });
 
-  it("does not admit the retired record in a current schema-35 Project", () => {
+  it("does not admit the retired record in a current Project", () => {
     const current = schema32Project();
     current.schemaVersion = 34;
     addOwnerlessEquivalence(current);

--- a/packages/project-protocol/src/instance-reference-annotation-migration.test.ts
+++ b/packages/project-protocol/src/instance-reference-annotation-migration.test.ts
@@ -1,0 +1,110 @@
+import {
+  createEmptyProject,
+  flattenRichText,
+  semanticTextDocument,
+} from "@icm/model";
+import { describe, expect, it } from "vitest";
+
+import { parseProjectWithMetadata } from "./load.js";
+import { upgradeSchema35To36WithReport } from "./previous-to-current.js";
+
+function schema35Project(): Record<string, unknown> {
+  const project = createEmptyProject(
+    "reference-annotation",
+    "Reference Annotation",
+  );
+  const raw = structuredClone(project) as unknown as Record<string, unknown>;
+  raw.schemaVersion = 35;
+  const document = (raw.documents as Record<string, unknown>[])[0]!;
+  document.instances = [
+    {
+      id: "copied-mos",
+      symbolId: "nmos",
+      reference: "M15",
+      placement: null,
+      netlist: { parameters: {} },
+    },
+    {
+      id: "tail-current",
+      symbolId: "current-source",
+      reference: "I1",
+      placement: null,
+      netlist: { parameters: {} },
+    },
+  ];
+  document.annotations = [
+    {
+      id: "instance-label-copied-mos",
+      kind: "instance-label",
+      content: semanticTextDocument("M5", "instance-label"),
+      anchor: {
+        kind: "object",
+        objectId: "copied-mos",
+        localOffset: { x: 0, y: 0 },
+        fallbackPosition: { x: 0, y: 0 },
+      },
+      alignment: "middle",
+      rotation: 0,
+      locked: false,
+    },
+    {
+      id: "instance-label-tail-current",
+      kind: "instance-label",
+      content: semanticTextDocument("ISS", "instance-label"),
+      anchor: {
+        kind: "object",
+        objectId: "tail-current",
+        localOffset: { x: 0, y: 0 },
+        fallbackPosition: { x: 0, y: 0 },
+      },
+      alignment: "middle",
+      rotation: 0,
+      locked: false,
+    },
+  ];
+  return raw;
+}
+
+describe("schema 35 to 36 Instance Reference Annotation migration", () => {
+  it("restores a copied designator mapping while retaining a descriptive label", () => {
+    const result = upgradeSchema35To36WithReport(schema35Project());
+    const document = (
+      result.project.documents as Record<string, unknown>[]
+    )[0]!;
+    const annotations = document.annotations as Record<string, unknown>[];
+
+    expect(result.project.schemaVersion).toBe(36);
+    expect(annotations[0]).toMatchObject({
+      binding: { kind: "instance-reference", instanceId: "copied-mos" },
+    });
+    expect(annotations[0]).not.toHaveProperty("content");
+    expect(flattenRichText(annotations[0]!.formatOverride as never)).toBe(
+      "M15",
+    );
+    expect(annotations[0]!.formatOverride).toMatchObject({
+      runs: [
+        { kind: "span", style: "italic" },
+        { kind: "span", style: "subscript" },
+      ],
+    });
+    expect(annotations[1]).not.toHaveProperty("binding");
+    expect(flattenRichText(annotations[1]!.content as never)).toBe("ISS");
+    expect(result.report).toEqual({
+      repairedReferenceAnnotations: 1,
+      retainedAttachedLabels: 1,
+      changed: true,
+    });
+  });
+
+  it("loads schema 35 through the contiguous chain into schema 36", () => {
+    const parsed = parseProjectWithMetadata(JSON.stringify(schema35Project()));
+
+    expect(parsed.sourceSchemaVersion).toBe(35);
+    expect(parsed.migrated).toBe(true);
+    expect(parsed.project.schemaVersion).toBe(36);
+    expect(parsed.project.documents[0]!.annotations[0]!.binding).toEqual({
+      kind: "instance-reference",
+      instanceId: "copied-mos",
+    });
+  });
+});

--- a/packages/project-protocol/src/instance-reference-migration.test.ts
+++ b/packages/project-protocol/src/instance-reference-migration.test.ts
@@ -1,4 +1,8 @@
-import { createEmptyProject, flattenRichText } from "@icm/model";
+import {
+  createEmptyProject,
+  CURRENT_PROJECT_SCHEMA_VERSION,
+  flattenRichText,
+} from "@icm/model";
 import { describe, expect, it } from "vitest";
 
 import { parseProjectWithMetadata } from "./load.js";
@@ -136,14 +140,14 @@ describe("schema 34 to 35 Instance Reference migration", () => {
     expect(
       parseProjectWithMetadata(JSON.stringify(result.project)).project
         .schemaVersion,
-    ).toBe(35);
+    ).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
   });
 
   it("loads schema 34 through the contiguous chain into the strict current schema", () => {
     const parsed = parseProjectWithMetadata(JSON.stringify(schema34Project()));
     expect(parsed.sourceSchemaVersion).toBe(34);
     expect(parsed.migrated).toBe(true);
-    expect(parsed.project.schemaVersion).toBe(35);
+    expect(parsed.project.schemaVersion).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
     expect(parsed.project.documents[0]!.instances[0]).toMatchObject({
       id: "opaque-mos",
       reference: "M7",

--- a/packages/project-protocol/src/instance-style-migration.test.ts
+++ b/packages/project-protocol/src/instance-style-migration.test.ts
@@ -29,6 +29,7 @@ import {
   upgradeSchema33To34WithReport,
 } from "./transforms/net-name-provenance.js";
 import { upgradeSchema34To35 } from "./transforms/instance-reference.js";
+import { upgradeSchema35To36 } from "./transforms/instance-reference-annotation.js";
 
 describe("schema migrations through hidden Net-name retirement", () => {
   it("keeps each retained historical transform independently usable", () => {
@@ -42,6 +43,7 @@ describe("schema migrations through hidden Net-name retirement", () => {
     const v33 = upgradeSchema32To33(v32);
     const v34 = upgradeSchema33To34(v33);
     const v35 = upgradeSchema34To35(v34);
+    const v36 = upgradeSchema35To36(v35);
 
     expect(v29.schemaVersion).toBe(29);
     expect(v30.schemaVersion).toBe(30);
@@ -49,7 +51,8 @@ describe("schema migrations through hidden Net-name retirement", () => {
     expect(v32.schemaVersion).toBe(32);
     expect(v33.schemaVersion).toBe(33);
     expect(v34.schemaVersion).toBe(34);
-    expect(v35.schemaVersion).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
+    expect(v35.schemaVersion).toBe(35);
+    expect(v36.schemaVersion).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
   });
 
   it("reports non-rewriting 28→29 through 32→33 upgrades as unchanged", () => {
@@ -73,7 +76,7 @@ describe("schema migrations through hidden Net-name retirement", () => {
     ).toBe(false);
   });
 
-  it("migrates schema 31 through 35 at the project boundary", () => {
+  it("migrates schema 31 through 36 at the project boundary", () => {
     const current = JSON.parse(
       serializeProject(createEmptyProject("test", "Test")),
     ) as Record<string, unknown>;
@@ -84,7 +87,7 @@ describe("schema migrations through hidden Net-name retirement", () => {
     if (!result.ok) return;
     expect(result.sourceSchemaVersion).toBe(31);
     expect(result.migrated).toBe(true);
-    expect(result.project.schemaVersion).toBe(35);
+    expect(result.project.schemaVersion).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
   });
 
   it("keeps schema 30 loadable through the upgrade chain", () => {

--- a/packages/project-protocol/src/load.ts
+++ b/packages/project-protocol/src/load.ts
@@ -23,6 +23,7 @@ import {
   upgradeSchema32To33,
   upgradeSchema33To34,
   upgradeSchema34To35,
+  upgradeSchema35To36,
 } from "./previous-to-current.js";
 import { OLDEST_SUPPORTED_PROJECT_SCHEMA_VERSION } from "./version.js";
 
@@ -46,6 +47,7 @@ const UPGRADE_CHAIN: ReadonlyArray<
   upgradeSchema32To33,
   upgradeSchema33To34,
   upgradeSchema34To35,
+  upgradeSchema35To36,
 ];
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/project-protocol/src/net-name-provenance-migration.test.ts
+++ b/packages/project-protocol/src/net-name-provenance-migration.test.ts
@@ -1,4 +1,4 @@
-import { createEmptyProject } from "@icm/model";
+import { createEmptyProject, CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
 import { describe, expect, it } from "vitest";
 
 import { tryParseProjectWithMetadata } from "./load.js";
@@ -101,7 +101,7 @@ describe("schema 33 to 34 migration (Net name provenance)", () => {
     );
   });
 
-  it("loads schema 33 through the canonical schema 35 validator", () => {
+  it("loads schema 33 through the canonical current validator", () => {
     const result = tryParseProjectWithMetadata(
       JSON.stringify(schema33Project()),
     );
@@ -109,7 +109,7 @@ describe("schema 33 to 34 migration (Net name provenance)", () => {
       ok: true,
       sourceSchemaVersion: 33,
       migrated: true,
-      project: { schemaVersion: 35 },
+      project: { schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION },
     });
   });
 });

--- a/packages/project-protocol/src/persistence.test.ts
+++ b/packages/project-protocol/src/persistence.test.ts
@@ -400,10 +400,12 @@ describe("Project persistence", () => {
 
   it("rejects schemas outside the supported chain window", () => {
     const project = createEmptyProject("project-test", "Test Project");
-    for (const schemaVersion of [1, 22, 23, 36, 99]) {
+    for (const schemaVersion of [1, 22, 23, 37, 99]) {
       expect(() =>
         parseProject(JSON.stringify({ ...project, schemaVersion })),
-      ).toThrow(/must be between 24 and 35/);
+      ).toThrow(
+        new RegExp(`must be between 24 and ${CURRENT_PROJECT_SCHEMA_VERSION}`),
+      );
     }
   });
 });

--- a/packages/project-protocol/src/previous-to-current.ts
+++ b/packages/project-protocol/src/previous-to-current.ts
@@ -90,3 +90,11 @@ export type {
   Schema34To35MigrationReport,
   Schema34To35MigrationResult,
 } from "./transforms/instance-reference.js";
+export {
+  upgradeSchema35To36,
+  upgradeSchema35To36WithReport,
+} from "./transforms/instance-reference-annotation.js";
+export type {
+  Schema35To36MigrationReport,
+  Schema35To36MigrationResult,
+} from "./transforms/instance-reference-annotation.js";

--- a/packages/project-protocol/src/transforms/instance-reference-annotation.ts
+++ b/packages/project-protocol/src/transforms/instance-reference-annotation.ts
@@ -1,0 +1,118 @@
+import {
+  flattenRichText,
+  rewriteRichTextPlainText,
+  RichTextDocumentSchema,
+} from "@icm/model";
+
+export interface Schema35To36MigrationReport {
+  readonly repairedReferenceAnnotations: number;
+  readonly retainedAttachedLabels: number;
+  readonly changed: boolean;
+}
+
+export interface Schema35To36MigrationResult {
+  readonly project: Record<string, unknown>;
+  readonly report: Schema35To36MigrationReport;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function referencePrefix(value: string): string | null {
+  return /^([a-z]+)\d+(?:[_-]\d+)*$/iu.exec(value)?.[1]?.toLowerCase() ?? null;
+}
+
+/**
+ * Schema 35 accidentally materialized some former styled Instance References
+ * as literal attached labels. A literal identifier is repaired only when both
+ * it and the owning Instance's current Reference have the same conventional
+ * alphabetic prefix and numeric designator shape. Descriptive labels such as
+ * `ISS`, `RD`, and prose remain independent attached RichText.
+ */
+function isRecoverableReferenceLabel(
+  literal: string,
+  reference: string,
+): boolean {
+  if (literal === reference) return true;
+  const literalPrefix = referencePrefix(literal);
+  return literalPrefix !== null && literalPrefix === referencePrefix(reference);
+}
+
+export function upgradeSchema35To36WithReport(
+  raw: Record<string, unknown>,
+): Schema35To36MigrationResult {
+  const project = structuredClone(raw);
+  let repairedReferenceAnnotations = 0;
+  let retainedAttachedLabels = 0;
+  const documents = Array.isArray(project.documents) ? project.documents : [];
+
+  for (const document of documents) {
+    if (!isRecord(document)) continue;
+    const instances = Array.isArray(document.instances)
+      ? document.instances.filter(isRecord)
+      : [];
+    const referenceByInstanceId = new Map(
+      instances.flatMap((instance) => {
+        const id = stringValue(instance.id);
+        const reference = stringValue(instance.reference);
+        return id && reference ? [[id, reference] as const] : [];
+      }),
+    );
+    const annotations = Array.isArray(document.annotations)
+      ? document.annotations.filter(isRecord)
+      : [];
+
+    for (const annotation of annotations) {
+      if (
+        annotation.kind !== "instance-label" ||
+        annotation.binding !== undefined ||
+        !isRecord(annotation.content) ||
+        !isRecord(annotation.anchor) ||
+        annotation.anchor.kind !== "object"
+      ) {
+        continue;
+      }
+      const instanceId = stringValue(annotation.anchor.objectId);
+      const reference = instanceId
+        ? referenceByInstanceId.get(instanceId)
+        : undefined;
+      const parsedContent = RichTextDocumentSchema.safeParse(
+        annotation.content,
+      );
+      if (!instanceId || !reference || !parsedContent.success) continue;
+      const literal = flattenRichText(parsedContent.data);
+      if (!isRecoverableReferenceLabel(literal, reference)) {
+        retainedAttachedLabels += 1;
+        continue;
+      }
+      delete annotation.content;
+      annotation.binding = { kind: "instance-reference", instanceId };
+      annotation.formatOverride = rewriteRichTextPlainText(
+        parsedContent.data,
+        reference,
+      );
+      repairedReferenceAnnotations += 1;
+    }
+  }
+
+  project.schemaVersion = 36;
+  return {
+    project,
+    report: {
+      repairedReferenceAnnotations,
+      retainedAttachedLabels,
+      changed: repairedReferenceAnnotations > 0,
+    },
+  };
+}
+
+export function upgradeSchema35To36(
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  return upgradeSchema35To36WithReport(raw).project;
+}

--- a/worker/gallery-do.ts
+++ b/worker/gallery-do.ts
@@ -30,6 +30,7 @@ import {
   upgradeSchema32To33WithReport,
   upgradeSchema33To34WithReport,
   upgradeSchema34To35WithReport,
+  upgradeSchema35To36WithReport,
 } from "@icm/project-protocol";
 import { renderDocumentSvg } from "@icm/render-svg";
 import {
@@ -1394,7 +1395,8 @@ export class GalleryDO {
         | ReturnType<typeof upgradeSchema31To32WithReport>["report"]
         | ReturnType<typeof upgradeSchema32To33WithReport>["report"]
         | ReturnType<typeof upgradeSchema33To34WithReport>["report"]
-        | ReturnType<typeof upgradeSchema34To35WithReport>["report"];
+        | ReturnType<typeof upgradeSchema34To35WithReport>["report"]
+        | ReturnType<typeof upgradeSchema35To36WithReport>["report"];
     }> = [];
     for (const source of sources) {
       const versions: Record<string, number> = {};
@@ -1476,6 +1478,15 @@ export class GalleryDO {
           }
           if (lifted.schemaVersion === 34) {
             const migration = upgradeSchema34To35WithReport(lifted);
+            lifted = migration.project;
+            migrationReports.push({
+              table: source.table,
+              id: row.id,
+              report: migration.report,
+            });
+          }
+          if (lifted.schemaVersion === 35) {
+            const migration = upgradeSchema35To36WithReport(lifted);
             lifted = migration.project;
             migrationReports.push({
               table: source.table,


### PR DESCRIPTION
## Summary
- make Instance.reference the single semantic designator while preserving mapped Annotation RichText as an independently styled presentation
- remap formatted Reference annotations during Gallery composition and atomically synchronize them on later Property edits
- add schema 35→36 repair for stale reference-shaped labels, update canonical fixtures, and carry the same migration through Gallery/Cloud database convergence

## Why
Gallery composition allocated a new Instance Reference but retained the source annotation's old formatOverride. A later Property edit then left the Document with two disagreeing values and strict validation rejected the transaction. The mapping is now explicit and shared across composition, editing, persistence, and storage maintenance; descriptive attached labels remain independent literal text.

## Validation
- pnpm install --frozen-lockfile
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- pnpm gate:full
  - 2,030 unit tests passed
  - 299 browser tests passed
  - all builds, release smoke, performance, visual/export golden, and production smoke checks passed
- real Common-Source Amplifier.icproj.json migration and M15→M21 transaction verified locally

Test-Impact: tests-updated