### PR TITLE
fix(editor): a power rail ending on a wire connects to it

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -712,6 +712,30 @@ test("constructs VDD as a drawn dotless power rail", async ({ page }) => {
   await expect(canvas.getByText("VDD", { exact: true })).toHaveCount(0);
 });
 
+test("a rail ending on a wire joins it, and says so in plain words", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  // One horizontal wire out of a resistor pin, drawn the ordinary way.
+  await placeComponent(page, "resistor", { x: 300, y: 200 });
+  await clickDrawTool(page, "wire");
+  await page.getByTestId("terminal-R1-2").click();
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.dblclick({ position: { x: 600, y: 300 } });
+  await page.keyboard.press("Escape");
+  await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(1);
+
+  // A rail drawn down onto that wire ENDS on it, which connects — the same
+  // gesture as dropping a pin on a wire. It used to be refused with the
+  // routing gate's own vocabulary.
+  await page.getByTestId("shapes-chip-vdd").click();
+  await canvas.click({ position: { x: 500, y: 180 } });
+  await canvas.click({ position: { x: 500, y: 300 } });
+  await expect(page.getByTestId("status")).toContainText("Added VDD rail");
+  await expect(page.getByTestId("status")).not.toContainText("preserve effect");
+  await expect(page.getByTestId("route-hit-route-vdd1-rail")).toHaveCount(1);
+});
+
 test("keeps a tapped VDD rail movable and stretchable as one supply bar", async ({
   page,
 }) => {

--- a/apps/editor/src/app/editor-transaction-commands.test.ts
+++ b/apps/editor/src/app/editor-transaction-commands.test.ts
@@ -2,7 +2,10 @@ import { createEmptyProject } from "@icm/model";
 import { describe, expect, it, vi } from "vitest";
 
 import type { InteractionMode } from "../interaction/interaction-state";
-import { createEditorTransactionCommands } from "./editor-transaction-commands";
+import {
+  createEditorTransactionCommands,
+  plainRoutingRefusal,
+} from "./editor-transaction-commands";
 
 function dependencies() {
   const project = createEmptyProject("project", "Project");
@@ -111,6 +114,31 @@ describe("editor transaction commands", () => {
     expect(input.cancelAllTransientInteraction).toHaveBeenCalledOnce();
     expect(input.setStatus).toHaveBeenCalledWith(
       "INTERNAL_ERROR: wrapper failed — operation cancelled; circuit unchanged",
+    );
+  });
+});
+
+describe("routing refusals shown to a person", () => {
+  it("restates electrical invariants as what the drawing refused to do", () => {
+    const preserve = plainRoutingRefusal(
+      "Routing operation changed endpoint Net membership outside a preserve effect",
+    );
+    // The invariant's own vocabulary never survives to the status bar.
+    expect(preserve).not.toContain("preserve effect");
+    expect(preserve).not.toContain("endpoint Net membership");
+    expect(preserve).toContain("Nets");
+    expect(
+      plainRoutingRefusal("Routing merge did not join endpoint group a, b"),
+    ).not.toContain("endpoint group");
+    expect(
+      plainRoutingRefusal("Routing partition retained a Route declared as cut"),
+    ).not.toContain("partition");
+  });
+
+  it("passes an unrecognized refusal through unchanged", () => {
+    // An honest technical sentence beats a vague friendly one.
+    expect(plainRoutingRefusal("Route route-1 contains a locked segment")).toBe(
+      "Route route-1 contains a locked segment",
     );
   });
 });

--- a/apps/editor/src/app/editor-transaction-commands.ts
+++ b/apps/editor/src/app/editor-transaction-commands.ts
@@ -45,6 +45,30 @@ export interface EditorTransactionCommandDependencies {
  * boundary owns only transaction envelopes, status messages, connectivity
  * gating, and the rule that an unrelated commit cancels a transient tool.
  */
+/**
+ * Restate an electrical-invariant refusal in the words of the drawing.
+ *
+ * The routing gate names the invariant it defends ("outside a preserve
+ * effect"), which is the right vocabulary for a planner and the wrong one for
+ * the person holding the mouse. Unknown refusals pass through unchanged: an
+ * honest technical sentence beats a vague friendly one.
+ */
+export function plainRoutingRefusal(message: string): string {
+  if (message.includes("outside a preserve effect")) {
+    return "That edit would have changed which Nets these objects belong to, so it was not applied. Connect them explicitly — end a wire on the conductor, or give both the same Net Label.";
+  }
+  if (message.includes("Routing merge did not join")) {
+    return "The objects this edit should have connected did not end up on one Net, so it was not applied.";
+  }
+  if (message.includes("Routing partition retained")) {
+    return "The conductor this edit should have cut is still whole, so it was not applied.";
+  }
+  if (message.includes("Routing removal retained")) {
+    return "Something this edit should have removed is still connected, so it was not applied.";
+  }
+  return message;
+}
+
 export function createEditorTransactionCommands({
   project,
   document,
@@ -160,13 +184,16 @@ export function createEditorTransactionCommands({
     if (!gate.ok) {
       // Say which rule refused, the way applyResult does for direct edits:
       // the headline alone ("Transaction result failed Document validation")
-      // names no field and leaves nothing to report or fix.
+      // names no field and leaves nothing to report or fix. The electrical
+      // invariants speak in their own vocabulary, though, and a person who
+      // just drew a wire cannot act on "outside a preserve effect" — those
+      // are restated as what the editor refused to do to their circuit.
       const detail = gate.diagnostics[0]?.message;
-      setStatus(
+      const raw =
         detail && detail !== gate.message
           ? `${gate.message} — ${detail}`
-          : gate.message,
-      );
+          : gate.message;
+      setStatus(plainRoutingRefusal(raw));
       return null;
     }
     return transact([...gate.edits], options);

--- a/apps/editor/src/features/component-insert/use-component-placement.ts
+++ b/apps/editor/src/features/component-insert/use-component-placement.ts
@@ -617,19 +617,29 @@ export function useComponentPlacement(options: UseComponentPlacementOptions) {
     while (idsExist(`VDD${sequence}`)) sequence += 1;
     const instanceId = `VDD${sequence}`;
     const routeId = `route-${instanceId.toLowerCase()}-rail`;
-    const railPlan = planVddRailEdits(options.document, {
-      instanceId,
-      start,
-      end,
-      netName: options.vddRailNetName ?? "VDD",
-    });
+    const railPlan = planVddRailEdits(
+      options.document,
+      {
+        instanceId,
+        start,
+        end,
+        netName: options.vddRailNetName ?? "VDD",
+      },
+      options.resolver,
+    );
     if (!railPlan.ok) {
       options.setStatus(
         `Cannot add ${options.vddRailNetName ?? "VDD"} rail: ${railPlan.message}`,
       );
       return;
     }
-    const result = options.transactConnectivity("connect", [...railPlan.edits]);
+    const result = options.transactConnectivity(
+      "connect",
+      [...railPlan.edits],
+      railPlan.expectedElectricalEffect
+        ? { expectedElectricalEffect: railPlan.expectedElectricalEffect }
+        : {},
+    );
     if (!result?.ok) return;
     options.selectOnly("route", [routeId]);
     options.completeVddRailPlacement();

--- a/apps/editor/src/features/component-insert/vdd-rail.test.ts
+++ b/apps/editor/src/features/component-insert/vdd-rail.test.ts
@@ -1,13 +1,19 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import {
   createRoutingOperationPlan,
   evaluateRoutingOperationPlan,
+  gateRoutingOperationPlan,
   executeTransaction,
   proposeVisualRouteDeletion,
 } from "@icm/edit-engine";
 import { resolveDocumentLogicalNets } from "@icm/derived";
-import { createEmptyDocument } from "@icm/model";
+import { createEmptyDocument, createRoutePath } from "@icm/model";
+import type { SchematicDocument } from "@icm/model";
+import { parseProject } from "@icm/project-protocol";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 
 import {
@@ -343,5 +349,137 @@ describe("drawn VDD rail construction", () => {
         { kind: "reconcile_mos_bulk" },
       ],
     });
+  });
+});
+
+describe("a drawn rail meeting an existing wire", () => {
+  /**
+   * The routing fixture's ports, repositioned so route-h spans exactly
+   * (0,300) → (110,300): an ordinary conductor with real pin endpoints.
+   */
+  function documentWithWire(): SchematicDocument {
+    const document = parseProject(
+      readFileSync(
+        resolve(
+          process.cwd(),
+          "fixtures/projects/phase-3-routing/project.icproj.json",
+        ),
+        "utf8",
+      ),
+    ).documents[0]!;
+    document.instances.find((instance) => instance.id === "A")!.placement = {
+      position: { x: -10, y: 300 },
+      rotation: 0,
+      mirror: "none",
+    };
+    document.instances.find((instance) => instance.id === "B")!.placement = {
+      position: { x: 120, y: 300 },
+      rotation: 0,
+      mirror: "x",
+    };
+    const wired = executeTransaction(
+      document,
+      {
+        transactionId: "seed-route",
+        documentId: document.id,
+        expectedRevision: 0,
+        actor: { kind: "human", id: "test" },
+        edits: [
+          {
+            kind: "set_route_path",
+            route: createRoutePath({
+              id: "route-h",
+              netId: "net-h",
+              start: { kind: "terminal", instanceId: "A", pinName: "P" },
+              end: { kind: "terminal", instanceId: "B", pinName: "P" },
+              bends: [],
+              modes: ["manual"],
+            }),
+          },
+        ],
+      },
+      { symbolResolver: resolver },
+    );
+    if (!wired.ok) throw new Error(wired.error.message);
+    return wired.document;
+  }
+
+  /** Drive the rail exactly as the editor does: plan, gate, then commit. */
+  function drawRail(
+    document: SchematicDocument,
+    start: { x: number; y: number },
+    end: { x: number; y: number },
+  ) {
+    const plan = planVddRailEdits(
+      document,
+      { instanceId: "VDD1", start, end },
+      resolver,
+    );
+    if (!plan.ok) throw new Error(plan.message);
+    const operation = createRoutingOperationPlan(document, {
+      intent: "connect",
+      diagnostics: [],
+      edits: plan.edits,
+      ...(plan.expectedElectricalEffect
+        ? { expectedElectricalEffect: plan.expectedElectricalEffect }
+        : {}),
+    });
+    const evaluated = gateRoutingOperationPlan(document, operation, {
+      symbolResolver: resolver,
+    });
+    if (!evaluated.ok) return { gate: evaluated, document: null };
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "draw-rail",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: [...evaluated.edits],
+      },
+      { symbolResolver: resolver },
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    return { gate: evaluated, document: result.document };
+  }
+
+  const wireNetId = (document: SchematicDocument) =>
+    document.nets.find((net) =>
+      net.terminals.some((terminal) => terminal.instanceId === "A"),
+    )?.id;
+
+  it("connects when the rail ENDPOINT lands on the wire", () => {
+    // The rail runs down from above and stops exactly on the wire.
+    const { gate, document } = drawRail(
+      documentWithWire(),
+      { x: 50, y: 200 },
+      { x: 50, y: 300 },
+    );
+    expect(gate.ok).toBe(true);
+    if (!document) return;
+    const railEnd = document.junctions.find(
+      (junction) => junction.id === "junction-vdd1-end",
+    );
+    expect(railEnd).toBeDefined();
+    // One conductor family: the wire's pins and the rail's endpoint share a
+    // Base Net, exactly as a pin dropped onto a wire does.
+    expect(railEnd!.netId).toBe(wireNetId(document));
+  });
+
+  it("keeps a rail that CROSSES the wire electrically separate", () => {
+    // Same gesture, but the rail passes through and continues below: a
+    // crossing is not a connection and must never become one.
+    const { gate, document } = drawRail(
+      documentWithWire(),
+      { x: 50, y: 200 },
+      { x: 50, y: 400 },
+    );
+    expect(gate.ok).toBe(true);
+    if (!document) return;
+    const railEnd = document.junctions.find(
+      (junction) => junction.id === "junction-vdd1-end",
+    );
+    expect(railEnd!.netId).toBe("net-power-vdd1");
+    expect(railEnd!.netId).not.toBe(wireNetId(document));
   });
 });

--- a/apps/editor/src/features/component-insert/vdd-rail.ts
+++ b/apps/editor/src/features/component-insert/vdd-rail.ts
@@ -1,6 +1,17 @@
-import type { SchematicEdit } from "@icm/edit-engine";
-import { resolveDocumentLogicalNets } from "@icm/derived";
-import { foldNetName, type Point, type SchematicDocument } from "@icm/model";
+import type { ExpectedElectricalEffect, SchematicEdit } from "@icm/edit-engine";
+import {
+  endpointKey,
+  findRouteSegmentsAtPoint,
+  resolveDocumentLogicalNets,
+  resolveDocumentRoutingGeometry,
+} from "@icm/derived";
+import {
+  foldNetName,
+  routeEnd,
+  type Point,
+  type SchematicDocument,
+} from "@icm/model";
+import type { SymbolResolver } from "@icm/symbols";
 
 import { planInitialMosBulkDefault } from "./mos-bulk-defaults";
 
@@ -14,8 +25,60 @@ export interface VddRailConstruction {
 }
 
 export type VddRailPlan =
-  | { ok: true; netId: string; edits: readonly SchematicEdit[] }
+  | {
+      ok: true;
+      netId: string;
+      edits: readonly SchematicEdit[];
+      /**
+       * Present only when an end of the rail lands on an existing conductor,
+       * which is the one case where placing a rail joins two Base Nets.
+       */
+      expectedElectricalEffect?: ExpectedElectricalEffect;
+    }
   | { ok: false; message: string };
+
+/**
+ * The Net merges a drawn rail performs, declared from geometry.
+ *
+ * A rail END that lands on an existing conductor connects to it, exactly as a
+ * pin dropped on a wire does. A rail that merely CROSSES a wire touches it at
+ * an interior point of both and connects nothing — the crossing invariant —
+ * so only the two rail ends are considered, and each is paired with the
+ * conductor it terminates on. Without this declaration the operation reads as
+ * "preserve" and the routing gate refuses the very connection the gesture
+ * asked for.
+ */
+function railEndpointMergeEffect(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  construction: { start: Point; end: Point },
+  junctionIds: { startJunctionId: string; endJunctionId: string },
+): ExpectedElectricalEffect | undefined {
+  const geometry = resolveDocumentRoutingGeometry(document, resolver);
+  const groups = (
+    [
+      [construction.start, junctionIds.startJunctionId],
+      [construction.end, junctionIds.endJunctionId],
+    ] as const
+  ).flatMap(([point, junctionId]) => {
+    const partners = findRouteSegmentsAtPoint(geometry, point).flatMap(
+      (address) => {
+        const route = document.routes.find(
+          (candidate) => candidate.id === address.routeId,
+        );
+        return route
+          ? [endpointKey(route.start), endpointKey(routeEnd(route))]
+          : [];
+      },
+    );
+    return partners.length > 0
+      ? [[endpointKey({ kind: "junction", junctionId }), ...new Set(partners)]]
+      : [];
+  });
+  return groups.length > 0
+    ? { kind: "merge", endpointGroups: groups }
+    : undefined;
+}
 
 /**
  * Constrain a snapped pointer to one straight Power Rail axis. The dominant
@@ -71,6 +134,7 @@ export function constructVddRailEdits({
 export function planVddRailEdits(
   document: SchematicDocument,
   construction: VddRailConstruction,
+  resolver?: SymbolResolver,
 ): VddRailPlan {
   const netName = construction.netName?.trim() || "VDD";
   const requested = construction.netId
@@ -101,9 +165,17 @@ export function planVddRailEdits(
   }
   const netId =
     target?.id ?? `net-power-${construction.instanceId.toLowerCase()}`;
+  const key = construction.instanceId.toLowerCase();
+  const mergeEffect = resolver
+    ? railEndpointMergeEffect(document, resolver, construction, {
+        startJunctionId: `junction-${key}-start`,
+        endJunctionId: `junction-${key}-end`,
+      })
+    : undefined;
   return {
     ok: true,
     netId,
+    ...(mergeEffect ? { expectedElectricalEffect: mergeEffect } : {}),
     edits: [
       ...constructVddRailEdits({
         ...construction,


### PR DESCRIPTION
## The defect

Drawing a VDD rail whose endpoint lands on an existing wire was refused, and the refusal handed the user an internal invariant name:

> `Routing operation changed endpoint Net membership outside a preserve effect`

The rail never appeared.

## Cause

`planVddRailEdits` emits one `add_power_rail` edit, committed under the `connect` intent. But `expectedElectricalEffectForOperation` derives a `merge` effect only from `connect_endpoints` edits; with none present it degrades to `preserve`. Committing a rail whose end sits on a conductor legitimately joins that conductor's Base Net with the rail's supply Net — so the gate caught a real membership change against a declaration that was never true, and refused a correct edit.

## Fix, and why this shape

The rail planner declares what it actually does, rather than the engine guessing. Given a resolver it resolves document routing geometry, and for each rail **end** that lies on an existing Route it emits a merge group pairing that rail junction with that Route's endpoints. With no such contact it declares nothing and the preserve default stands.

Declaring it in the planner (not in `expectedElectricalEffectForOperation`) is deliberate: a truthful declaration needs geometry to know *whether* an end actually coincides, the engine's generic inference takes only `(document, intent, edits)` and has no resolver, and the repo already has this precedent — the series-splice planner returns its own `expectedElectricalEffect`. It also cannot over-connect: only the two rail **ends** are considered, so a rail **crossing** a wire (an interior point of both) declares and performs no connection.

## The message a person sees

Gate refusals that reach the status bar are restated in the drawing's own words (`plainRoutingRefusal`). Unrecognized refusals pass through unchanged — an honest technical sentence beats a vague friendly one.

## Tests — red first, and paired so the fix cannot overshoot

- Unit: drive plan → gate → commit. **Rail end on the wire** shares the wire's Base Net (before: the gate refused, observed red). **Rail crossing the wire** keeps its own Net (green before and after — this guards the crossing invariant against an over-broad fix).
- Copy: the invariant vocabulary never reaches the status bar; unknown refusals pass through verbatim.
- E2E: draws a wire, then a rail ending on it, asserting the rail lands and "preserve effect" never appears.

## Validation

Editor + edit-engine units 1154/1154; `manual-editor` + `wiring-semantics` e2e 129/129; typecheck and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)