### PR TITLE
fix(symbols): the controlled switch is one shape again, not narrow over wide

### DIFF
--- a/packages/symbols/assets/razavi-v1/catalog.json
+++ b/packages/symbols/assets/razavi-v1/catalog.json
@@ -1139,7 +1139,7 @@
       "palette": true,
       "automaticMappings": ["spice:S"],
       "assetPath": "voltage-controlled-switch.symbol.json",
-      "assetHash": "0fe2629e4289b7eb341ec6df29c0356d1bc27e5802a3db2fe45d5d1a28f435eb"
+      "assetHash": "c7a243285745643126ab4e90220d55b82408bd63219cc2fabe6d8a53e93dd85b"
     },
     {
       "symbolId": "voltage-source",

--- a/packages/symbols/assets/razavi-v1/voltage-controlled-switch.symbol.json
+++ b/packages/symbols/assets/razavi-v1/voltage-controlled-switch.symbol.json
@@ -39,7 +39,7 @@
       "name": "CP",
       "role": "passive",
       "at": {
-        "x": -30,
+        "x": -20,
         "y": 20
       },
       "direction": "west",
@@ -52,7 +52,7 @@
       "name": "CN",
       "role": "passive",
       "at": {
-        "x": 30,
+        "x": 20,
         "y": 20
       },
       "direction": "east",
@@ -144,7 +144,7 @@
     {
       "kind": "line",
       "from": {
-        "x": -30,
+        "x": -20,
         "y": 20
       },
       "to": {
@@ -164,7 +164,7 @@
         "y": 20
       },
       "to": {
-        "x": 30,
+        "x": 20,
         "y": 20
       },
       "style": {

--- a/packages/symbols/src/razavi-catalog.generated.ts
+++ b/packages/symbols/src/razavi-catalog.generated.ts
@@ -1366,7 +1366,7 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
     automaticMappings: ["spice:S"],
     assetPath: "voltage-controlled-switch.symbol.json",
     assetHash:
-      "0fe2629e4289b7eb341ec6df29c0356d1bc27e5802a3db2fe45d5d1a28f435eb",
+      "c7a243285745643126ab4e90220d55b82408bd63219cc2fabe6d8a53e93dd85b",
   },
   {
     symbolId: "voltage-source",
@@ -7795,7 +7795,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         name: "CP",
         role: "passive",
         at: {
-          x: -30,
+          x: -20,
           y: 20,
         },
         direction: "west",
@@ -7808,7 +7808,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
         name: "CN",
         role: "passive",
         at: {
-          x: 30,
+          x: 20,
           y: 20,
         },
         direction: "east",
@@ -7900,7 +7900,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       {
         kind: "line",
         from: {
-          x: -30,
+          x: -20,
           y: 20,
         },
         to: {
@@ -7920,7 +7920,7 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           y: 20,
         },
         to: {
-          x: 30,
+          x: 20,
           y: 20,
         },
         style: {

--- a/packages/symbols/src/razavi-catalog.test.ts
+++ b/packages/symbols/src/razavi-catalog.test.ts
@@ -1736,18 +1736,41 @@ describe("switch port leads", () => {
     }
   });
 
-  it("leaves the control rail whole", () => {
+  it("keeps the control rail a rail, at the switch path's own width", () => {
     // CP/CN are the two ends of ONE horizontal control line, split by the gap
-    // at ±4 that the dashed coupling crosses. Pulling them to ±10 by the same
-    // formula would cut that line into two stubs and stop it reading as a
-    // rail, so they keep their reach. Recorded as a decision, not an
-    // oversight: if the drawing is ever revisited, this is the reason.
+    // at ±4 that the dashed coupling crosses. #470 shortened the switched
+    // path to ±20 and left these at ±30, which is what made the symbol read
+    // as narrow on top and wide underneath. They now match the path above —
+    // the anchor AND the drawn end move together, so the line stays a rail
+    // instead of becoming the two stubs that pulling the anchors alone (to
+    // ±10, by the through-path formula) would have produced. That stub is
+    // the outcome this test exists to prevent; the reach is a means to it.
     const symbol = requireRazaviCatalogSymbol("voltage-controlled-switch");
+    const switchedReach = Math.abs(
+      symbol.pins.find((candidate) => candidate.name === "P")!.at.x,
+    );
     for (const pinName of ["CP", "CN"]) {
       const pin = symbol.pins.find((candidate) => candidate.name === pinName);
       expect(pin, pinName).toBeDefined();
       if (!pin) continue;
-      expect(Math.abs(pin.at.x), `${pinName} anchor`).toBe(30);
+      // One envelope: the control port is as wide as the path it controls.
+      expect(Math.abs(pin.at.x), `${pinName} anchor`).toBe(switchedReach);
+
+      // The rail is drawn from the anchor inward to the coupling gap, and it
+      // must stay long enough to read as a rail rather than a stub.
+      const rail = symbol.primitives.find(
+        (primitive) =>
+          primitive.kind === "line" &&
+          primitive.from.y === pin.at.y &&
+          primitive.to.y === pin.at.y &&
+          (primitive.from.x === pin.at.x || primitive.to.x === pin.at.x),
+      );
+      expect(rail, `${pinName} rail segment`).toBeDefined();
+      if (!rail || rail.kind !== "line") continue;
+      const drawn = Math.abs(rail.to.x - rail.from.x);
+      expect(drawn, `${pinName} rail length`).toBeGreaterThanOrEqual(12);
+      const innerEnd = Math.min(Math.abs(rail.from.x), Math.abs(rail.to.x));
+      expect(innerEnd, `${pinName} coupling gap`).toBe(4);
     }
   });
 });


### PR DESCRIPTION
## The complaint

The voltage-controlled switch reads as two mismatched halves. #470 pulled the switched path in from ±30 to ±20 and left the control rail at ±30 — 40 wide on top, 60 wide underneath.

## What changed

The control rail comes in to ±20 to match. Four numbers move: the CP/CN anchors and the outer end of each drawn rail segment. Nothing else — the Razavi-calibrated blade, the contact circles, the ±4 coupling gap, and the dashed coupling are untouched.

## Why this direction, and not the other two

- **Family.** `ideal-switch` and `closed-switch` both present a 40-wide envelope with anchors at ±20. A controlled switch is an ideal switch plus a control port, not a wider device. Putting P/N back to ±30 would make this symbol the odd one out among its own siblings and restore exactly the stub #470 removed.
- **The stub #470 feared comes from moving an anchor without its line.** The through-path formula would have put CP/CN at ±10 and left 6 units of drawn rail on each side — two stubs. Moving the anchor *and* the drawn end together leaves 16 units per side with the coupling gap intact: still a rail, now at the width of the path it controls.
- **The rail stays one line through two terminals.** CP and CN are the two ends of one control port; drawing them as separate stubs would read as two independent ports.

## The recorded decision moves with the drawing

#470 left "leaves the control rail whole" pinning ±30. That test now pins what the reach was protecting — a rail long enough to read as one, reaching the coupling gap, at the switched path's own width — so a future revision is guided by the reason instead of the number.

## Validation

Symbols + derived + render-svg suites 353/353; typecheck clean. Regeneration followed the required order (catalog → agent kit → build → MCP resources → Agent API artifacts); `generate-razavi-common-assets.mjs` was deliberately not run, since it re-sorts the curated `catalog.entries` — the one hash it would have updated was recomputed in place (sha256 of the asset), leaving the curated order intact. Verified visually in the editor: both halves now share one envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)