### PR TITLE
feat(symbols): a plain switch and a single-pole double-throw switch

### DIFF
--- a/apps/editor/src/features/component-insert/symbol-catalog.test.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.test.ts
@@ -57,6 +57,8 @@ describe("component insertion catalog", () => {
     expect(symbolCategory("zener-diode")).toBe("Extended Devices");
     expect(symbolCategory("ideal-switch")).toBe("Switches");
     expect(symbolCategory("closed-switch")).toBe("Switches");
+    expect(symbolCategory("simple-switch")).toBe("Switches");
+    expect(symbolCategory("spdt-switch")).toBe("Switches");
     expect(symbolCategory("discrete-time-integrator")).toBe("Signal Flow");
     expect(symbolCategory("ndmos")).toBe("Extended Devices");
     expect(symbolCategory("pdmos")).toBe("Extended Devices");

--- a/apps/editor/src/features/component-insert/symbol-catalog.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.ts
@@ -117,9 +117,13 @@ export function symbolCategory(symbolId: string): string {
     return "Sources";
   }
   if (
-    ["ideal-switch", "closed-switch", "voltage-controlled-switch"].includes(
-      symbolId,
-    )
+    [
+      "ideal-switch",
+      "closed-switch",
+      "simple-switch",
+      "spdt-switch",
+      "voltage-controlled-switch",
+    ].includes(symbolId)
   ) {
     return "Switches";
   }

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -20,7 +20,7 @@ describe("shapes quick-place", () => {
       }),
     );
 
-    expect(symbols).toHaveLength(58);
+    expect(symbols).toHaveLength(60);
     expect(markup).toContain("All devices");
     expect(markup.match(/data-testid="shapes-chip-/g)).toHaveLength(
       symbols.length,
@@ -36,7 +36,7 @@ describe("shapes quick-place", () => {
       ["Passives", 4],
       ["Power and Ports", 5],
       ["Sources", 3],
-      ["Switches", 3],
+      ["Switches", 5],
       ["Analog Blocks", 6],
       ["Logic Gates", 11],
       ["Signal Flow", 7],

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -31,6 +31,8 @@ const COMPACT_LIBRARY_LABELS: Readonly<Record<string, string>> = {
   "d-flip-flop": "DFF",
   "d-flip-flop-q": "DFQ",
   "ideal-switch": "Open",
+  "simple-switch": "Simple",
+  "spdt-switch": "SPDT",
   // "Voltage-Controlled Switch" overflows the tile; the SPICE letter is what
   // a reader is looking for anyway.
   "voltage-controlled-switch": "S Switch",

--- a/packages/symbols/assets/razavi-v1/catalog.json
+++ b/packages/symbols/assets/razavi-v1/catalog.json
@@ -993,6 +993,34 @@
       }
     },
     {
+      "symbolId": "simple-switch",
+      "name": "Simple Switch",
+      "category": "switch",
+      "reviewStatus": "reviewed",
+      "provenance": "house",
+      "houseReason": "The reviewed page draws its switch with contact circles. Analog schematics far more often draw the same element as one broken line with a blade, so it is drawn here rather than by removing evidence from the traced symbol.",
+      "pinOrder": ["1", "2"],
+      "palette": true,
+      "automaticMappings": [],
+      "manualOnlyReason": "Two-terminal switch; SPICE S has a four-terminal control contract.",
+      "assetPath": "simple-switch.symbol.json",
+      "assetHash": "d379bb5a1986dca82cf603c7b7721b7fe8680ccabc33b72bc0ab4bf3e5460cbe"
+    },
+    {
+      "symbolId": "spdt-switch",
+      "name": "SPDT Switch",
+      "category": "switch",
+      "reviewStatus": "reviewed",
+      "provenance": "house",
+      "houseReason": "A single-pole double-throw switch does not appear on the reviewed page; it is drawn here in the family's idiom, with the traced switch's contact circles and blade angle.",
+      "pinOrder": ["COM", "A", "B"],
+      "palette": true,
+      "automaticMappings": [],
+      "manualOnlyReason": "Three-terminal selector; SPICE has no single-pole double-throw primitive.",
+      "assetPath": "spdt-switch.symbol.json",
+      "assetHash": "619b00cf2fdb0a6b81830a245018425fcabb38641eec39fe2bb21fd4a285e92d"
+    },
+    {
       "symbolId": "variable-capacitor",
       "name": "Variable Capacitor",
       "category": "passive",

--- a/packages/symbols/assets/razavi-v1/simple-switch.symbol.json
+++ b/packages/symbols/assets/razavi-v1/simple-switch.symbol.json
@@ -1,0 +1,90 @@
+{
+  "schemaVersion": 1,
+  "id": "simple-switch",
+  "name": "Simple Switch",
+  "viewBox": {
+    "x": -34,
+    "y": -18,
+    "width": 68,
+    "height": 30
+  },
+  "pins": [
+    {
+      "name": "1",
+      "role": "passive",
+      "at": {
+        "x": -20,
+        "y": 0
+      },
+      "direction": "west",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 10
+      }
+    },
+    {
+      "name": "2",
+      "role": "passive",
+      "at": {
+        "x": 20,
+        "y": 0
+      },
+      "direction": "east",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 10
+      }
+    }
+  ],
+  "primitives": [
+    {
+      "kind": "line",
+      "from": {
+        "x": -20,
+        "y": 0
+      },
+      "to": {
+        "x": -10,
+        "y": 0
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -10,
+        "y": 0
+      },
+      "to": {
+        "x": 6,
+        "y": -11
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 10,
+        "y": 0
+      },
+      "to": {
+        "x": 20,
+        "y": 0
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    }
+  ],
+  "variants": []
+}

--- a/packages/symbols/assets/razavi-v1/spdt-switch.symbol.json
+++ b/packages/symbols/assets/razavi-v1/spdt-switch.symbol.json
@@ -1,0 +1,164 @@
+{
+  "schemaVersion": 1,
+  "id": "spdt-switch",
+  "name": "SPDT Switch",
+  "viewBox": {
+    "x": -34,
+    "y": -20,
+    "width": 68,
+    "height": 40
+  },
+  "pins": [
+    {
+      "name": "COM",
+      "role": "passive",
+      "at": {
+        "x": -20,
+        "y": 0
+      },
+      "direction": "west",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 10
+      }
+    },
+    {
+      "name": "A",
+      "role": "passive",
+      "at": {
+        "x": 20,
+        "y": -10
+      },
+      "direction": "east",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 10
+      }
+    },
+    {
+      "name": "B",
+      "role": "passive",
+      "at": {
+        "x": 20,
+        "y": 10
+      },
+      "direction": "east",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 10
+      }
+    }
+  ],
+  "primitives": [
+    {
+      "kind": "line",
+      "from": {
+        "x": -20,
+        "y": 0
+      },
+      "to": {
+        "x": -13,
+        "y": 0
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "circle",
+      "center": {
+        "x": -10,
+        "y": 0
+      },
+      "radius": 3,
+      "fill": "none",
+      "stroke": "foreground",
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -7.32,
+        "y": -1.34
+      },
+      "to": {
+        "x": 7.32,
+        "y": -8.66
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "circle",
+      "center": {
+        "x": 10,
+        "y": -10
+      },
+      "radius": 3,
+      "fill": "none",
+      "stroke": "foreground",
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 13,
+        "y": -10
+      },
+      "to": {
+        "x": 20,
+        "y": -10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "circle",
+      "center": {
+        "x": 10,
+        "y": 10
+      },
+      "radius": 3,
+      "fill": "none",
+      "stroke": "foreground",
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 13,
+        "y": 10
+      },
+      "to": {
+        "x": 20,
+        "y": 10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    }
+  ],
+  "variants": []
+}

--- a/packages/symbols/src/builtins.test.ts
+++ b/packages/symbols/src/builtins.test.ts
@@ -44,6 +44,8 @@ const PRODUCT_IDS = [
   "port",
   "port-filled",
   "resistor",
+  "simple-switch",
+  "spdt-switch",
   "variable-capacitor",
   "variable-inductor",
   "variable-resistor",

--- a/packages/symbols/src/razavi-catalog.generated.ts
+++ b/packages/symbols/src/razavi-catalog.generated.ts
@@ -1191,6 +1191,40 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
     },
   },
   {
+    symbolId: "simple-switch",
+    name: "Simple Switch",
+    category: "switch",
+    reviewStatus: "reviewed",
+    provenance: "house",
+    houseReason:
+      "The reviewed page draws its switch with contact circles. Analog schematics far more often draw the same element as one broken line with a blade, so it is drawn here rather than by removing evidence from the traced symbol.",
+    pinOrder: ["1", "2"],
+    palette: true,
+    automaticMappings: [],
+    manualOnlyReason:
+      "Two-terminal switch; SPICE S has a four-terminal control contract.",
+    assetPath: "simple-switch.symbol.json",
+    assetHash:
+      "d379bb5a1986dca82cf603c7b7721b7fe8680ccabc33b72bc0ab4bf3e5460cbe",
+  },
+  {
+    symbolId: "spdt-switch",
+    name: "SPDT Switch",
+    category: "switch",
+    reviewStatus: "reviewed",
+    provenance: "house",
+    houseReason:
+      "A single-pole double-throw switch does not appear on the reviewed page; it is drawn here in the family's idiom, with the traced switch's contact circles and blade angle.",
+    pinOrder: ["COM", "A", "B"],
+    palette: true,
+    automaticMappings: [],
+    manualOnlyReason:
+      "Three-terminal selector; SPICE has no single-pole double-throw primitive.",
+    assetPath: "spdt-switch.symbol.json",
+    assetHash:
+      "619b00cf2fdb0a6b81830a245018425fcabb38641eec39fe2bb21fd4a285e92d",
+  },
+  {
     symbolId: "variable-capacitor",
     name: "Variable Capacitor",
     category: "passive",
@@ -7156,6 +7190,260 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           lineCap: "butt",
           lineJoin: "miter",
           miterLimit: 12,
+        },
+      },
+    ],
+    variants: [],
+  },
+  {
+    schemaVersion: 1,
+    id: "simple-switch",
+    name: "Simple Switch",
+    viewBox: {
+      x: -34,
+      y: -18,
+      width: 68,
+      height: 30,
+    },
+    pins: [
+      {
+        name: "1",
+        role: "passive",
+        at: {
+          x: -20,
+          y: 0,
+        },
+        direction: "west",
+        presentation: {
+          visibility: "visible",
+          leadLength: 10,
+        },
+      },
+      {
+        name: "2",
+        role: "passive",
+        at: {
+          x: 20,
+          y: 0,
+        },
+        direction: "east",
+        presentation: {
+          visibility: "visible",
+          leadLength: 10,
+        },
+      },
+    ],
+    primitives: [
+      {
+        kind: "line",
+        from: {
+          x: -20,
+          y: 0,
+        },
+        to: {
+          x: -10,
+          y: 0,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -10,
+          y: 0,
+        },
+        to: {
+          x: 6,
+          y: -11,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 10,
+          y: 0,
+        },
+        to: {
+          x: 20,
+          y: 0,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+    ],
+    variants: [],
+  },
+  {
+    schemaVersion: 1,
+    id: "spdt-switch",
+    name: "SPDT Switch",
+    viewBox: {
+      x: -34,
+      y: -20,
+      width: 68,
+      height: 40,
+    },
+    pins: [
+      {
+        name: "COM",
+        role: "passive",
+        at: {
+          x: -20,
+          y: 0,
+        },
+        direction: "west",
+        presentation: {
+          visibility: "visible",
+          leadLength: 10,
+        },
+      },
+      {
+        name: "A",
+        role: "passive",
+        at: {
+          x: 20,
+          y: -10,
+        },
+        direction: "east",
+        presentation: {
+          visibility: "visible",
+          leadLength: 10,
+        },
+      },
+      {
+        name: "B",
+        role: "passive",
+        at: {
+          x: 20,
+          y: 10,
+        },
+        direction: "east",
+        presentation: {
+          visibility: "visible",
+          leadLength: 10,
+        },
+      },
+    ],
+    primitives: [
+      {
+        kind: "line",
+        from: {
+          x: -20,
+          y: 0,
+        },
+        to: {
+          x: -13,
+          y: 0,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "circle",
+        center: {
+          x: -10,
+          y: 0,
+        },
+        radius: 3,
+        fill: "none",
+        stroke: "foreground",
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -7.32,
+          y: -1.34,
+        },
+        to: {
+          x: 7.32,
+          y: -8.66,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "circle",
+        center: {
+          x: 10,
+          y: -10,
+        },
+        radius: 3,
+        fill: "none",
+        stroke: "foreground",
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 13,
+          y: -10,
+        },
+        to: {
+          x: 20,
+          y: -10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "circle",
+        center: {
+          x: 10,
+          y: 10,
+        },
+        radius: 3,
+        fill: "none",
+        stroke: "foreground",
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 13,
+          y: 10,
+        },
+        to: {
+          x: 20,
+          y: 10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
         },
       },
     ],

--- a/packages/symbols/src/razavi-catalog.test.ts
+++ b/packages/symbols/src/razavi-catalog.test.ts
@@ -200,6 +200,8 @@ describe("Razavi symbol catalog", () => {
       ["port", "reviewed", "razavi-reference-v1"],
       ["port-filled", "reviewed", "razavi-reference-v1"],
       ["resistor", "reviewed", "razavi-reference-v1"],
+      ["simple-switch", "reviewed", "house"],
+      ["spdt-switch", "reviewed", "house"],
       ["variable-capacitor", "reviewed", "razavi-reference-v1"],
       ["variable-inductor", "reviewed", "razavi-reference-v1"],
       ["variable-resistor", "reviewed", "razavi-reference-v1"],
@@ -556,7 +558,7 @@ describe("Razavi symbol catalog", () => {
   });
 
   it("uses reviewed catalog objects as the sole built-in product library", () => {
-    expect(razaviCatalogSymbols).toHaveLength(51);
+    expect(razaviCatalogSymbols).toHaveLength(53);
     for (const catalogSymbol of razaviProductSymbols) {
       expect(
         builtInSymbols.find((symbol) => symbol.id === catalogSymbol.id),
@@ -604,6 +606,8 @@ describe("Razavi symbol catalog", () => {
       "port",
       "port-filled",
       "resistor",
+      "simple-switch",
+      "spdt-switch",
       "variable-capacitor",
       "variable-inductor",
       "variable-resistor",
@@ -1771,6 +1775,72 @@ describe("switch port leads", () => {
       expect(drawn, `${pinName} rail length`).toBeGreaterThanOrEqual(12);
       const innerEnd = Math.min(Math.abs(rail.from.x), Math.abs(rail.to.x));
       expect(innerEnd, `${pinName} coupling gap`).toBe(4);
+    }
+  });
+});
+
+describe("house-drawn switch additions", () => {
+  it("draws the simple switch as one broken line, with no contact circles", () => {
+    // The point of this symbol is what it does NOT have: the contact circles
+    // of the traced switch. Analog schematics draw a sampling switch as a
+    // line with a blade, and that is what makes it quicker to read in a
+    // dense circuit.
+    const symbol = requireRazaviCatalogSymbol("simple-switch");
+    expect(symbol.primitives.every((p) => p.kind === "line")).toBe(true);
+    expect(symbol.pins.map((pin) => pin.name)).toEqual(["1", "2"]);
+    for (const pin of symbol.pins) {
+      expect(Math.abs(pin.at.x), `${pin.name} anchor`).toBe(20);
+      expect(pin.at.y).toBe(0);
+    }
+    // The blade leaves the left contact and stops short of the right one:
+    // the gap is the open state, so a closed-looking bridge would be wrong.
+    const blade = symbol.primitives.find(
+      (p) => p.kind === "line" && p.from.y !== p.to.y,
+    );
+    expect(blade, "blade").toBeDefined();
+    if (!blade || blade.kind !== "line") return;
+    const rightLead = symbol.primitives.find(
+      (p) =>
+        p.kind === "line" && p.from.y === 0 && p.to.y === 0 && p.to.x === 20,
+    );
+    expect(rightLead, "right lead").toBeDefined();
+    if (!rightLead || rightLead.kind !== "line") return;
+    expect(blade.to.x).toBeLessThan(rightLead.from.x);
+  });
+
+  it("gives the SPDT switch one common terminal and two throws", () => {
+    // Pin ORDER is a shared contract: common first, then the throws in the
+    // order they are drawn, top to bottom. Anything reading this device by
+    // position depends on it, so it changes only with its callers.
+    const symbol = requireRazaviCatalogSymbol("spdt-switch");
+    expect(symbol.pins.map((pin) => pin.name)).toEqual(["COM", "A", "B"]);
+    const at = (name: string) =>
+      symbol.pins.find((pin) => pin.name === name)!.at;
+    expect(at("COM")).toEqual({ x: -20, y: 0 });
+    // A is the upper throw, B the lower — the drawing and the order agree.
+    expect(at("A")).toEqual({ x: 20, y: -10 });
+    expect(at("B")).toEqual({ x: 20, y: 10 });
+    // The blade rests on a throw rather than floating between them, so the
+    // symbol states a position instead of showing both contacts open.
+    const circles = symbol.primitives.filter((p) => p.kind === "circle");
+    expect(circles).toHaveLength(3);
+    const blade = symbol.primitives.find(
+      (p) => p.kind === "line" && p.from.y !== p.to.y,
+    );
+    expect(blade, "blade").toBeDefined();
+    if (!blade || blade.kind !== "line") return;
+    expect(blade.to.y).toBeLessThan(blade.from.y);
+  });
+
+  it("keeps both additions off the automatic netlist path", () => {
+    // A two-terminal switch has no SPICE form and a double-throw switch has
+    // no primitive at all; emitting either would write a line no simulator
+    // accepts. They stay manual, stated in the catalog rather than implied.
+    for (const symbolId of ["simple-switch", "spdt-switch"]) {
+      const entry = getRazaviCatalogEntry(symbolId);
+      expect(entry, symbolId).toBeDefined();
+      expect(entry?.automaticMappings, symbolId).toEqual([]);
+      expect(entry?.manualOnlyReason, symbolId).toBeTruthy();
     }
   });
 });


### PR DESCRIPTION
## What

Two switches the library did not have, both house-drawn because the reviewed page contains neither.

**Simple Switch** — the drawing analog designers actually use: one line, broken, with a blade leaving the left contact and stopping short of the right one. No contact circles; that absence *is* the symbol, and it is what makes a row of sampling switches quick to read.

**SPDT Switch** — one common terminal and two throws, drawn with the family's contact circles and blade angle so it belongs to the same set. The blade rests on a throw rather than floating between them, so the drawing states a position instead of showing two open contacts.

## The pin-order contract, fixed deliberately

`[COM, A, B]` — common first, then the throws in the order they are drawn, top to bottom.

Common-first matches the relay convention and the way a future subcircuit mapping would read (`X<ref> COM A B`). `A`/`B` stay neutral where `NO`/`NC` would assert a rest state the drawing does not. Order is a shared contract: it changes only with its callers, which is why it is stated here rather than left to whoever reads the pins first.

## Why neither device gets a descriptor yet

Not an oversight — a measured constraint. A two-terminal switch has no SPICE form (`S` needs four nodes and a model card) and SPICE has no double-throw primitive. Extraction emits any device whose class is not `net-marker` (`packages/netlist/src/extract.ts`), so giving these descriptors today would write element lines no simulator accepts. They join `ideal-switch` and `closed-switch` as catalog entries with an explicit `manualOnlyReason`. The family-wide descriptor question — reference prefixes for switches — is being settled in parallel; these two should join that one answer rather than fork a second.

They are likewise absent from the Agent authoring catalog, which by design admits only `razavi-reference-v1` symbols — the same treatment `voltage-controlled-switch` already has.

## Geometry

Both anchor one grid cell out from the body at ±20, the width #470 and #471 settled for the family. No stubs, nothing off-grid.

## The curated-catalog landmine

`generate-razavi-common-assets.mjs` re-sorts `catalog.entries` alphabetically while the repository keeps a curated order, so running it rewrites the whole file and reddens three catalog tests. The two new entries were therefore inserted at their alphabetical position by hand with hashes computed in place (sha256 of the asset, the generator's own rule) — which is also where a future generator run would put them, so this adds no divergence. Downstream generation followed the required order: symbol catalog → agent kit → build → MCP resources → Agent API artifacts.

## Validation

Full unit suite 1872/1872 (303 files), typecheck and Prettier clean, both symbols verified visually in the editor. Library shows them under Switches as "Simple" and "SPDT".

🤖 Generated with [Claude Code](https://claude.com/claude-code)