### PR TITLE
feat(symbols): the selector's plain drawing is a state, not a sixth tile

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -712,6 +712,52 @@ test("constructs VDD as a drawn dotless power rail", async ({ page }) => {
   await expect(canvas.getByText("VDD", { exact: true })).toHaveCount(0);
 });
 
+test("a switch changes contact style in place, keeping its wires", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await awaitEditorReady(page);
+  await chooseComponent(page, "spdt-switch");
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.click({ position: { x: 360, y: 220 } });
+  await page.keyboard.press("Escape");
+
+  // Wire the common terminal, so the swap has something to lose.
+  await clickDrawTool(page, "wire");
+  await page.getByTestId("terminal-S1-COM").click();
+  await canvas.dblclick({ position: { x: 200, y: 320 } });
+  await page.keyboard.press("Escape");
+  await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(1);
+
+  await page.locator('[data-canvas-hit-kind="instance"]').first().click();
+  await page.getByTestId("selection-shelf").click();
+  const toggle = page.getByTestId("swap-switch-contact-style");
+  await expect(toggle).toBeVisible();
+
+  // The plain drawing is a state of this component, not a second part: the
+  // Library never grew a tile for it.
+  await expect(page.getByTestId("shapes-chip-simple-spdt-switch")).toHaveCount(
+    0,
+  );
+
+  await toggle.click();
+  await expect(page.locator("[data-symbol-id]").first()).toHaveAttribute(
+    "data-symbol-id",
+    "simple-spdt-switch",
+  );
+  // Same instance, same designator, same wire: the exchange keeps terminal
+  // identity, so nothing is orphaned.
+  await expect(page.getByTestId("hit-S1")).toHaveCount(1);
+  await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(1);
+
+  await toggle.click();
+  await expect(page.locator("[data-symbol-id]").first()).toHaveAttribute(
+    "data-symbol-id",
+    "spdt-switch",
+  );
+  await expect(page.locator('[data-layer="routes"] polyline')).toHaveCount(1);
+});
+
 test("a rail ending on a wire joins it, and says so in plain words", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -162,6 +162,11 @@ import {
   ShapesPanel,
 } from "../features/editor-shell/shapes-panel";
 import {
+  drawsContactCircles,
+  planSwitchContactStyleSwap,
+  switchContactStyleSibling,
+} from "../features/editor-shell/switch-contact-style";
+import {
   differentialOutputSibling,
   planDifferentialOutputSwap,
 } from "../features/editor-shell/differential-output-swap";
@@ -4476,6 +4481,24 @@ export function App({
                       }),
                     onReturnToTray: () =>
                       returnInstancesToTray([selectedInstance.id]),
+                    ...(switchContactStyleSibling(selectedInstance.symbolId)
+                      ? {
+                          onSwapContactStyle: {
+                            label: drawsContactCircles(
+                              selectedInstance.symbolId,
+                            )
+                              ? "Draw without contact circles"
+                              : "Draw with contact circles",
+                            run: () =>
+                              transact(
+                                planSwitchContactStyleSwap(
+                                  selectedInstance.id,
+                                  selectedInstance.symbolId,
+                                ),
+                              ),
+                          },
+                        }
+                      : {}),
                     ...(differentialOutputSibling(selectedInstance.symbolId)
                       ? {
                           onSwapOutputs: () =>

--- a/apps/editor/src/features/editor-shell/switch-contact-style.test.ts
+++ b/apps/editor/src/features/editor-shell/switch-contact-style.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  planSwitchContactStyleSwap,
+  switchContactStyleSibling,
+} from "./switch-contact-style";
+
+describe("switch contact style", () => {
+  it("pairs each switch with its other drawing, both ways", () => {
+    // Two axes are deliberately not mixed: this one is how the contacts are
+    // DRAWN. The number of terminals is a different device, never a style.
+    expect(switchContactStyleSibling("ideal-switch")).toBe("simple-switch");
+    expect(switchContactStyleSibling("simple-switch")).toBe("ideal-switch");
+    expect(switchContactStyleSibling("spdt-switch")).toBe("simple-spdt-switch");
+    expect(switchContactStyleSibling("simple-spdt-switch")).toBe("spdt-switch");
+  });
+
+  it("offers nothing where there is no second drawing", () => {
+    // A closed switch and a controlled switch have one drawing each; a
+    // resistor has none. Silence is the answer, not an empty toggle.
+    expect(switchContactStyleSibling("closed-switch")).toBeUndefined();
+    expect(
+      switchContactStyleSibling("voltage-controlled-switch"),
+    ).toBeUndefined();
+    expect(switchContactStyleSibling("resistor")).toBeUndefined();
+  });
+
+  it("swaps by exchanging Symbols so every wired terminal survives", () => {
+    // The pair shares pin names and anchor positions, so exchanging the
+    // Symbol keeps each terminal's identity — and with it every Net and
+    // every drawn wire. Nothing is hidden, so nothing is orphaned.
+    expect(planSwitchContactStyleSwap("S1", "spdt-switch")).toEqual([
+      {
+        kind: "set_instance_symbol",
+        instanceId: "S1",
+        symbolId: "simple-spdt-switch",
+      },
+    ]);
+    expect(planSwitchContactStyleSwap("S1", "closed-switch")).toEqual([]);
+  });
+});

--- a/apps/editor/src/features/editor-shell/switch-contact-style.ts
+++ b/apps/editor/src/features/editor-shell/switch-contact-style.ts
@@ -1,0 +1,44 @@
+import type { SchematicEdit } from "@icm/edit-engine";
+
+/**
+ * How a switch draws its contacts, as a state of one component rather than a
+ * shelf of near-duplicate parts.
+ *
+ * Each pair is two Symbols with identical pin names at identical anchors and
+ * only the contact circles differing, so exchanging them keeps every terminal
+ * identity — and with it every Net and every drawn wire. This is the same
+ * mechanism the differential outputs use, for the same reason.
+ *
+ * Terminal COUNT is deliberately not on this axis. A two-terminal switch and
+ * a selector are different devices, and expressing that as a Symbol variant
+ * with `hiddenPinNames` would keep a wired terminal attached while removing
+ * it from the drawing: the Project would still carry the connection that the
+ * schematic no longer shows.
+ */
+const CONTACT_STYLE_SIBLINGS: Readonly<Record<string, string>> = {
+  "ideal-switch": "simple-switch",
+  "simple-switch": "ideal-switch",
+  "spdt-switch": "simple-spdt-switch",
+  "simple-spdt-switch": "spdt-switch",
+};
+
+export function switchContactStyleSibling(
+  symbolId: string,
+): string | undefined {
+  return CONTACT_STYLE_SIBLINGS[symbolId];
+}
+
+/** Whether the sibling draws contact circles, for naming the action. */
+export function drawsContactCircles(symbolId: string): boolean {
+  return symbolId === "ideal-switch" || symbolId === "spdt-switch";
+}
+
+export function planSwitchContactStyleSwap(
+  instanceId: string,
+  symbolId: string,
+): SchematicEdit[] {
+  const sibling = switchContactStyleSibling(symbolId);
+  return sibling
+    ? [{ kind: "set_instance_symbol", instanceId, symbolId: sibling }]
+    : [];
+}

--- a/apps/editor/src/features/properties/component-placement-properties.tsx
+++ b/apps/editor/src/features/properties/component-placement-properties.tsx
@@ -16,6 +16,7 @@ export function ComponentPlacementProperties({
   onMirror,
   onReturnToTray,
   onSwapOutputs,
+  onSwapContactStyle,
   onSwapInputs,
   onDiscard,
 }: {
@@ -30,6 +31,7 @@ export function ComponentPlacementProperties({
   onMirror: (direction: "left-right" | "top-bottom") => void;
   onReturnToTray: () => void;
   onSwapOutputs?: () => void;
+  onSwapContactStyle?: { label: string; run: () => void };
   onSwapInputs?: () => void;
   onDiscard: () => void;
 }) {
@@ -107,6 +109,19 @@ export function ComponentPlacementProperties({
           >
             Return to tray
           </button>
+          {onSwapContactStyle ? (
+            <div className="component-mirror-row" aria-label="Switch drawing">
+              <button
+                type="button"
+                data-testid="swap-switch-contact-style"
+                aria-label={onSwapContactStyle.label}
+                title={onSwapContactStyle.label}
+                onClick={onSwapContactStyle.run}
+              >
+                {onSwapContactStyle.label}
+              </button>
+            </div>
+          ) : null}
           {onSwapOutputs || onSwapInputs ? (
             <div
               className="component-mirror-row property-amplifier-actions"

--- a/packages/devices/src/descriptors/index.ts
+++ b/packages/devices/src/descriptors/index.ts
@@ -18,6 +18,7 @@ export { variableResistorDevice } from "./variable-resistor.js";
 export { closedSwitchDevice } from "./closed-switch.js";
 export { idealSwitchDevice } from "./ideal-switch.js";
 export { simpleSwitchDevice } from "./simple-switch.js";
+export { simpleSpdtSwitchDevice } from "./simple-spdt-switch.js";
 export { spdtSwitchDevice } from "./spdt-switch.js";
 export { voltageControlledSwitchDevice } from "./voltage-controlled-switch.js";
 export { vddPortDevice } from "./vdd-port.js";

--- a/packages/devices/src/descriptors/simple-spdt-switch.ts
+++ b/packages/devices/src/descriptors/simple-spdt-switch.ts
@@ -1,0 +1,27 @@
+import type { DeviceDescriptor } from "../contract.js";
+
+/**
+ * The single-pole double-throw switch drawn without contact circles: the
+ * same device as `spdt-switch`, in the plain style analog schematics use.
+ *
+ * Drawing only. SPICE has no three-terminal switch primitive — the usual
+ * netlist form is a pair of controlled switches sharing a node, which is a
+ * different circuit than this one Symbol, and inventing it here would be
+ * guessing at the person's intent. It designates `S` alongside the rest of
+ * the family.
+ */
+export const simpleSpdtSwitchDevice = {
+  id: "simple-spdt-switch",
+  symbolId: "simple-spdt-switch",
+  deviceClass: "switch",
+  referencePrefix: "S",
+  pinOrder: ["COM", "A", "B"],
+  targetPolicy: "none",
+  parameters: [],
+  dialects: ["spice", "spectre"],
+  capabilities: {
+    supportsModel: false,
+    supportsBulkBinding: false,
+    supportsValueAnnotation: false,
+  },
+} satisfies DeviceDescriptor;

--- a/packages/devices/src/registry.ts
+++ b/packages/devices/src/registry.ts
@@ -24,6 +24,7 @@ import {
   idealSwitchDevice,
   closedSwitchDevice,
   simpleSwitchDevice,
+  simpleSpdtSwitchDevice,
   spdtSwitchDevice,
 } from "./descriptors/index.js";
 import { validateDeviceDescriptors } from "./validation.js";
@@ -73,6 +74,7 @@ export const deviceRegistry = defineDeviceRegistry([
   idealSwitchDevice,
   closedSwitchDevice,
   simpleSwitchDevice,
+  simpleSpdtSwitchDevice,
   spdtSwitchDevice,
   groundDevice,
   vddPortDevice,

--- a/packages/symbols/assets/razavi-v1/catalog.json
+++ b/packages/symbols/assets/razavi-v1/catalog.json
@@ -1047,6 +1047,20 @@
       }
     },
     {
+      "symbolId": "simple-spdt-switch",
+      "name": "Simple SPDT Switch",
+      "category": "switch",
+      "reviewStatus": "reviewed",
+      "provenance": "house",
+      "houseReason": "The contact-circle drawing of a selector and its plain drawing are one component in two states. Drawn here as the SPDT's sibling so the state is reached by an action rather than by a second Library tile.",
+      "pinOrder": ["COM", "A", "B"],
+      "palette": false,
+      "automaticMappings": [],
+      "manualOnlyReason": "Three-terminal selector; SPICE has no single-pole double-throw primitive.",
+      "assetPath": "simple-spdt-switch.symbol.json",
+      "assetHash": "c586e487e5a4f2dd6fb48f096fa9183162ea9cb02b6ad1edc7706a706f1122cf"
+    },
+    {
       "symbolId": "simple-switch",
       "name": "Simple Switch",
       "category": "switch",

--- a/packages/symbols/assets/razavi-v1/simple-spdt-switch.symbol.json
+++ b/packages/symbols/assets/razavi-v1/simple-spdt-switch.symbol.json
@@ -1,0 +1,119 @@
+{
+  "schemaVersion": 1,
+  "id": "simple-spdt-switch",
+  "name": "Simple SPDT Switch",
+  "viewBox": {
+    "x": -34,
+    "y": -20,
+    "width": 68,
+    "height": 40
+  },
+  "pins": [
+    {
+      "name": "COM",
+      "role": "passive",
+      "at": {
+        "x": -20,
+        "y": 0
+      },
+      "direction": "west",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 10
+      }
+    },
+    {
+      "name": "A",
+      "role": "passive",
+      "at": {
+        "x": 20,
+        "y": -10
+      },
+      "direction": "east",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 10
+      }
+    },
+    {
+      "name": "B",
+      "role": "passive",
+      "at": {
+        "x": 20,
+        "y": 10
+      },
+      "direction": "east",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 10
+      }
+    }
+  ],
+  "primitives": [
+    {
+      "kind": "line",
+      "from": {
+        "x": -20,
+        "y": 0
+      },
+      "to": {
+        "x": -10,
+        "y": 0
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": -10,
+        "y": 0
+      },
+      "to": {
+        "x": 8,
+        "y": -9
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 10,
+        "y": -10
+      },
+      "to": {
+        "x": 20,
+        "y": -10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 10,
+        "y": 10
+      },
+      "to": {
+        "x": 20,
+        "y": 10
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    }
+  ],
+  "variants": []
+}

--- a/packages/symbols/src/razavi-catalog.generated.ts
+++ b/packages/symbols/src/razavi-catalog.generated.ts
@@ -1253,6 +1253,23 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
     },
   },
   {
+    symbolId: "simple-spdt-switch",
+    name: "Simple SPDT Switch",
+    category: "switch",
+    reviewStatus: "reviewed",
+    provenance: "house",
+    houseReason:
+      "The contact-circle drawing of a selector and its plain drawing are one component in two states. Drawn here as the SPDT's sibling so the state is reached by an action rather than by a second Library tile.",
+    pinOrder: ["COM", "A", "B"],
+    palette: false,
+    automaticMappings: [],
+    manualOnlyReason:
+      "Three-terminal selector; SPICE has no single-pole double-throw primitive.",
+    assetPath: "simple-spdt-switch.symbol.json",
+    assetHash:
+      "c586e487e5a4f2dd6fb48f096fa9183162ea9cb02b6ad1edc7706a706f1122cf",
+  },
+  {
     symbolId: "simple-switch",
     name: "Simple Switch",
     category: "switch",
@@ -7623,6 +7640,125 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
           lineCap: "butt",
           lineJoin: "miter",
           miterLimit: 12,
+        },
+      },
+    ],
+    variants: [],
+  },
+  {
+    schemaVersion: 1,
+    id: "simple-spdt-switch",
+    name: "Simple SPDT Switch",
+    viewBox: {
+      x: -34,
+      y: -20,
+      width: 68,
+      height: 40,
+    },
+    pins: [
+      {
+        name: "COM",
+        role: "passive",
+        at: {
+          x: -20,
+          y: 0,
+        },
+        direction: "west",
+        presentation: {
+          visibility: "visible",
+          leadLength: 10,
+        },
+      },
+      {
+        name: "A",
+        role: "passive",
+        at: {
+          x: 20,
+          y: -10,
+        },
+        direction: "east",
+        presentation: {
+          visibility: "visible",
+          leadLength: 10,
+        },
+      },
+      {
+        name: "B",
+        role: "passive",
+        at: {
+          x: 20,
+          y: 10,
+        },
+        direction: "east",
+        presentation: {
+          visibility: "visible",
+          leadLength: 10,
+        },
+      },
+    ],
+    primitives: [
+      {
+        kind: "line",
+        from: {
+          x: -20,
+          y: 0,
+        },
+        to: {
+          x: -10,
+          y: 0,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: -10,
+          y: 0,
+        },
+        to: {
+          x: 8,
+          y: -9,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 10,
+          y: -10,
+        },
+        to: {
+          x: 20,
+          y: -10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 10,
+          y: 10,
+        },
+        to: {
+          x: 20,
+          y: 10,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
         },
       },
     ],

--- a/packages/symbols/src/razavi-catalog.test.ts
+++ b/packages/symbols/src/razavi-catalog.test.ts
@@ -202,6 +202,7 @@ describe("Razavi symbol catalog", () => {
       ["port", "reviewed", "razavi-reference-v1"],
       ["port-filled", "reviewed", "razavi-reference-v1"],
       ["resistor", "reviewed", "razavi-reference-v1"],
+      ["simple-spdt-switch", "reviewed", "house"],
       ["simple-switch", "reviewed", "house"],
       ["spdt-switch", "reviewed", "house"],
       ["variable-capacitor", "reviewed", "razavi-reference-v1"],
@@ -558,7 +559,7 @@ describe("Razavi symbol catalog", () => {
   });
 
   it("uses reviewed catalog objects as the sole built-in product library", () => {
-    expect(razaviCatalogSymbols).toHaveLength(56);
+    expect(razaviCatalogSymbols).toHaveLength(57);
     for (const catalogSymbol of razaviProductSymbols) {
       expect(
         builtInSymbols.find((symbol) => symbol.id === catalogSymbol.id),
@@ -1968,6 +1969,26 @@ describe("house-drawn switch additions", () => {
     expect(blade, "blade").toBeDefined();
     if (!blade || blade.kind !== "line") return;
     expect(blade.to.y).toBeLessThan(blade.from.y);
+  });
+
+  it("keeps the plain selector out of the Library and identical in pins", () => {
+    // The point of this entry is that it does NOT add a sixth switch tile:
+    // it is the SPDT's other drawing, reached by an action. Its pins match
+    // the circled one exactly, which is what lets the exchange keep every
+    // wired terminal.
+    const entry = getRazaviCatalogEntry("simple-spdt-switch");
+    expect(entry?.palette).toBe(false);
+    const plain = requireRazaviCatalogSymbol("simple-spdt-switch");
+    const circled = requireRazaviCatalogSymbol("spdt-switch");
+    expect(plain.pins.map((pin) => pin.name)).toEqual(
+      circled.pins.map((pin) => pin.name),
+    );
+    expect(plain.pins.map((pin) => pin.at)).toEqual(
+      circled.pins.map((pin) => pin.at),
+    );
+    // Same device, different drawing: no contact circles at all.
+    expect(plain.primitives.every((p) => p.kind === "line")).toBe(true);
+    expect(circled.primitives.some((p) => p.kind === "circle")).toBe(true);
   });
 
   it("keeps both additions off the automatic netlist path", () => {


### PR DESCRIPTION
## What

The Library's SPDT draws contact circles; analog schematics more often draw the same selector as plain lines. That is one component in two drawings, so it arrives the way the crossed differential outputs did in #472 — a sibling Symbol reached by an action, with the Library keeping **one** tile (`palette: false`, tile count stays at five).

`simple-spdt-switch` carries the circled selector's pin names at the same anchors and differs only in the drawing. A contact-style pair table (`ideal ↔ simple`, `spdt ↔ simple-spdt`) plans a `set_instance_symbol` exchange, offered in Properties as **"Draw without contact circles"** and back.

## The electrical question, answered rather than hedged

Because each pair shares terminal identity, **every Net and every drawn wire survives the exchange**. The e2e wires the common terminal first, then swaps both directions and proves the wire, the instance, and the `S1` designator are all still there.

## Why not `SymbolVariant` — rejected, not overlooked

The variant mechanism can hide pins (`hiddenPinNames`), which looks like a way to express two-terminal ↔ three-terminal on one Symbol. It is not, and the reason is in the engine: `set_instance_symbol` validates against `resolved.definition.pins`, not the variant's visible subset, so hiding a **wired** terminal keeps the connection in the Project while removing it from the drawing — a Net the schematic no longer explains. (The MOS bulk is the one place this is handled, and only through bespoke machinery: `auxiliaryPins` plus `mosBulkShouldBeVisible`.)

So terminal **count** stays off this axis: a two-terminal switch and a selector remain two devices, and the existing same-shape swap already refuses that exchange out loud when a wire would be orphaned. Contact **style** — same pins, same anchors — is the axis that can be a state, and that is what this adds.

## Plumbing

Descriptor mirrors `spdt-switch` (prefix `S`, `targetPolicy: none` — SPICE has no double-throw primitive), registered in the device registry. Catalog entry inserted at its alphabetical position with the hash computed in place, leaving the curated order untouched; regeneration followed the required order (symbol catalog → agent kit → build → MCP resources → Agent API artifacts).

## Validation

Red before green (the pair module's tests failed to import before it existed). Full unit suite 1883/1883 before rebase, 875/875 on the affected packages after rebasing onto #474 (one `toHaveLength` conflict resolved to 57 = upstream's 56 + this sibling), typecheck and Prettier clean, both drawings and the toggle verified in the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)