### PR TITLE
fix(editor): an end resting on a conductor connects, a crossing still does not

### DIFF
--- a/apps/editor/e2e/wiring-semantics.spec.ts
+++ b/apps/editor/e2e/wiring-semantics.spec.ts
@@ -189,3 +189,35 @@ test("dragging a wire's end onto another wire joins them into one net", async ({
   // Drawing and model agree, so there is nothing ambiguous left to report.
   await expect(page.getByTestId("statusbar-issues")).toHaveText("No issues");
 });
+
+test("a power rail drawn across the tops of wires connects to them", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.click({ position: { x: 600, y: 500 } });
+
+  // Two wires standing side by side with their upper ends level.
+  for (const x of [300, 460]) {
+    await page.keyboard.press("w");
+    await canvas.click({ position: { x, y: 400 } });
+    await canvas.click({ position: { x, y: 280 } });
+    await page.keyboard.press("Enter");
+    await page.keyboard.press("Escape");
+  }
+  await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(2);
+
+  // A VDD rail laid across both tops. This used to refuse outright with
+  // "That edit would have changed which Nets these objects belong to" — the
+  // mirror of the rail-end-on-wire case, and just as deliberate a gesture.
+  await chooseComponent(page, "vdd");
+  await canvas.click({ position: { x: 240, y: 280 } });
+  await canvas.click({ position: { x: 520, y: 280 } });
+
+  await expect(page.getByTestId("status")).toContainText("Added VDD rail");
+  // The rail tapped both wires on the way across, so it arrives split into
+  // three pieces — two wires plus three rail segments — rather than lying
+  // over them as one unconnected conductor.
+  await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(5);
+  await expect(page.getByTestId("statusbar-issues")).toHaveText("No issues");
+});

--- a/apps/editor/e2e/wiring-semantics.spec.ts
+++ b/apps/editor/e2e/wiring-semantics.spec.ts
@@ -117,3 +117,75 @@ test("middle click cycles the wire corner and never commits the wire", async ({
   await destination.click();
   await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(1);
 });
+
+test("dragging a wire's end onto another wire joins them into one net", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+
+  // A horizontal wire, then a separate vertical one clear above it. A wire
+  // drawn on free grid points finishes on Enter, not on the second click.
+  await canvas.click({ position: { x: 600, y: 500 } });
+  await page.keyboard.press("w");
+  await canvas.click({ position: { x: 240, y: 320 } });
+  await canvas.click({ position: { x: 480, y: 320 } });
+  await page.keyboard.press("Enter");
+  await page.keyboard.press("Escape");
+  await page.keyboard.press("w");
+  await canvas.click({ position: { x: 360, y: 160 } });
+  await canvas.click({ position: { x: 360, y: 240 } });
+  await page.keyboard.press("Enter");
+  await page.keyboard.press("Escape");
+  await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(2);
+  await expect(page.getByTestId("statusbar-issues")).toHaveText("No issues");
+
+  // Drag the vertical wire down so its lower end comes to rest on the
+  // horizontal one. This is the gesture that used to leave two nets touching
+  // at a point, with an ambiguous-junction error the author could not clear.
+  // The travel is measured from what is actually rendered rather than assumed
+  // from the click coordinates, so page scale cannot leave the end just shy.
+  const routes = page.locator('[data-canvas-hit-kind="route"]');
+  const drawn = await routes.evaluateAll((elements) =>
+    elements.map((element) => {
+      const points = (element.getAttribute("points") ?? "")
+        .trim()
+        .split(/\s+/u)
+        .map((pair) => pair.split(",").map(Number));
+      const xs = points.map((point) => point[0]!);
+      const ys = points.map((point) => point[1]!);
+      return {
+        minX: Math.min(...xs),
+        maxX: Math.max(...xs),
+        minY: Math.min(...ys),
+        maxY: Math.max(...ys),
+      };
+    }),
+  );
+  const horizontal = drawn.find((route) => route.maxX - route.minX > 0)!;
+  const vertical = drawn.find((route) => route.maxY - route.minY > 0)!;
+  // Drawn coordinates are document units; the drag is in screen pixels, so
+  // derive the scale from a span that is known in both.
+  const horizontalBox = (await routes
+    .nth(drawn.indexOf(horizontal))
+    .boundingBox())!;
+  const verticalBox = (await routes
+    .nth(drawn.indexOf(vertical))
+    .boundingBox())!;
+  const scale = horizontalBox.width / (horizontal.maxX - horizontal.minX);
+  const travel = (horizontal.minY - vertical.maxY) * scale;
+  const grabX = verticalBox.x + verticalBox.width / 2;
+  const grabY = verticalBox.y + verticalBox.height / 2;
+  await page.mouse.move(grabX, grabY);
+  await page.mouse.down();
+  await page.mouse.move(grabX, grabY + travel / 2, { steps: 6 });
+  await page.mouse.move(grabX, grabY + travel, { steps: 6 });
+  await page.mouse.up();
+
+  // The landing tapped the horizontal wire: it splits, and a junction dot
+  // marks the connection — exactly what drawing the same wire would produce.
+  await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(3);
+  await expect(page.locator('g[data-layer="junctions"] circle')).toHaveCount(1);
+  // Drawing and model agree, so there is nothing ambiguous left to report.
+  await expect(page.getByTestId("statusbar-issues")).toHaveText("No issues");
+});

--- a/apps/editor/src/features/component-insert/vdd-rail.test.ts
+++ b/apps/editor/src/features/component-insert/vdd-rail.test.ts
@@ -483,3 +483,119 @@ describe("a drawn rail meeting an existing wire", () => {
     expect(railEnd!.netId).not.toBe(wireNetId(document));
   });
 });
+
+describe("a rail drawn across the ends of existing wires", () => {
+  /**
+   * Two vertical wires standing side by side, each on its own Net, with loose
+   * upper ends level at y = 100 — the drawing a bus is normally added to.
+   */
+  function twoStandingWires(): SchematicDocument {
+    const document = createEmptyDocument("rail-over-ends", "Rail over ends");
+    document.presentation.grid = 10;
+    for (const [index, x] of [100, 200].entries()) {
+      const netId = `net-w${index}`;
+      document.nets.push({ id: netId, terminals: [] });
+      document.junctions.push(
+        {
+          id: `W${index}-top`,
+          netId,
+          position: { x, y: 100 },
+          role: "route-anchor",
+        },
+        {
+          id: `W${index}-bottom`,
+          netId,
+          position: { x, y: 200 },
+          role: "route-anchor",
+        },
+      );
+      document.routes.push(
+        createRoutePath({
+          id: `wire-${index}`,
+          netId,
+          start: { kind: "junction", junctionId: `W${index}-top` },
+          end: { kind: "junction", junctionId: `W${index}-bottom` },
+          bends: [],
+          modes: ["manual"],
+        }),
+      );
+    }
+    return document;
+  }
+
+  function drawRail(
+    document: SchematicDocument,
+    start: { x: number; y: number },
+    end: { x: number; y: number },
+  ) {
+    const plan = planVddRailEdits(
+      document,
+      { instanceId: "VDD1", start, end },
+      resolver,
+    );
+    if (!plan.ok) throw new Error(plan.message);
+    const operation = createRoutingOperationPlan(document, {
+      intent: "connect",
+      diagnostics: [],
+      edits: plan.edits,
+      ...(plan.expectedElectricalEffect
+        ? { expectedElectricalEffect: plan.expectedElectricalEffect }
+        : {}),
+    });
+    const gate = gateRoutingOperationPlan(document, operation, {
+      symbolResolver: resolver,
+    });
+    if (!gate.ok) return { gate, document: null };
+    const result = executeTransaction(
+      document,
+      {
+        transactionId: "draw-rail",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: [...gate.edits],
+      },
+      { symbolResolver: resolver },
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    return { gate, document: result.document };
+  }
+
+  it("joins every wire whose END rests on the rail", () => {
+    // The mirror of the endpoint rule #469 established: there the rail's end
+    // landed on a wire, here the wires' ends land on the rail. The gesture is
+    // the same deliberate act, so the refusal — "That edit would have changed
+    // which Nets these objects belong to" — was wrong in both directions.
+    const { gate, document } = drawRail(
+      twoStandingWires(),
+      { x: 60, y: 100 },
+      { x: 240, y: 100 },
+    );
+    expect(
+      gate.ok,
+      gate.ok ? "" : `${gate.message} :: ${gate.diagnostics[0]?.message ?? ""}`,
+    ).toBe(true);
+    if (!document) return;
+    const netIds = new Set(document.routes.map((route) => route.netId));
+    expect(netIds.size).toBe(1);
+  });
+
+  it("leaves a wire the rail merely crosses on its own Net", () => {
+    // Same rail, drawn across the wires' MIDDLES instead of their ends. Two
+    // conductors meeting at an interior point of both say nothing about
+    // intent, so nothing connects — a Crossing is not a Junction.
+    const { gate, document } = drawRail(
+      twoStandingWires(),
+      { x: 60, y: 150 },
+      { x: 240, y: 150 },
+    );
+    expect(gate.ok).toBe(true);
+    if (!document) return;
+    const wireNetIds = new Set(
+      document.routes
+        .filter((route) => route.id.startsWith("wire-"))
+        .map((route) => route.netId),
+    );
+    expect(wireNetIds).toEqual(new Set(["net-w0", "net-w1"]));
+  });
+});

--- a/apps/editor/src/features/component-insert/vdd-rail.ts
+++ b/apps/editor/src/features/component-insert/vdd-rail.ts
@@ -37,16 +37,33 @@ export type VddRailPlan =
     }
   | { ok: false; message: string };
 
+/** Whether `point` lies on the straight span between `from` and `to`. */
+function pointOnRailSpan(point: Point, from: Point, to: Point): boolean {
+  const withinX =
+    point.x >= Math.min(from.x, to.x) && point.x <= Math.max(from.x, to.x);
+  const withinY =
+    point.y >= Math.min(from.y, to.y) && point.y <= Math.max(from.y, to.y);
+  const onLine =
+    (to.x - from.x) * (point.y - from.y) ===
+    (to.y - from.y) * (point.x - from.x);
+  return onLine && withinX && withinY;
+}
+
 /**
  * The Net merges a drawn rail performs, declared from geometry.
  *
- * A rail END that lands on an existing conductor connects to it, exactly as a
- * pin dropped on a wire does. A rail that merely CROSSES a wire touches it at
- * an interior point of both and connects nothing — the crossing invariant —
- * so only the two rail ends are considered, and each is paired with the
- * conductor it terminates on. Without this declaration the operation reads as
- * "preserve" and the routing gate refuses the very connection the gesture
- * asked for.
+ * An END resting on a conductor connects to it, exactly as a pin dropped on a
+ * wire does, and the relation is symmetric: it holds whether the rail's own
+ * end lands on an existing wire, or an existing wire's end lands on the span
+ * of the new rail — the ordinary "bus across the tops of several wires"
+ * drawing. Both directions are collected here.
+ *
+ * What is never collected is a CROSSING: two conductors meeting at an
+ * interior point of both, where the picture cannot say whether a connection
+ * was meant. That is why this looks only at endpoints — the rail's two ends,
+ * and the existing endpoints resting on the rail — and never at interior
+ * intersections. Without the declaration the operation reads as "preserve"
+ * and the routing gate refuses the very connection the gesture asked for.
  */
 function railEndpointMergeEffect(
   document: SchematicDocument,
@@ -55,6 +72,11 @@ function railEndpointMergeEffect(
   junctionIds: { startJunctionId: string; endJunctionId: string },
 ): ExpectedElectricalEffect | undefined {
   const geometry = resolveDocumentRoutingGeometry(document, resolver);
+  const railKeys = [
+    endpointKey({ kind: "junction", junctionId: junctionIds.startJunctionId }),
+    endpointKey({ kind: "junction", junctionId: junctionIds.endJunctionId }),
+  ];
+  // Direction one: a rail end comes to rest on an existing conductor.
   const groups = (
     [
       [construction.start, junctionIds.startJunctionId],
@@ -75,6 +97,17 @@ function railEndpointMergeEffect(
       ? [[endpointKey({ kind: "junction", junctionId }), ...new Set(partners)]]
       : [];
   });
+  // Direction two: an existing endpoint comes to rest on the rail's span.
+  for (const junction of document.junctions) {
+    if (
+      !pointOnRailSpan(junction.position, construction.start, construction.end)
+    )
+      continue;
+    groups.push([
+      endpointKey({ kind: "junction", junctionId: junction.id }),
+      ...railKeys,
+    ]);
+  }
   return groups.length > 0
     ? { kind: "merge", endpointGroups: groups }
     : undefined;

--- a/apps/editor/src/features/wiring/use-wire-interaction.ts
+++ b/apps/editor/src/features/wiring/use-wire-interaction.ts
@@ -18,6 +18,7 @@ import {
   proposeWireSegmentMove,
   proposeWireCommitThroughContacts,
   type SchematicEdit,
+  type ExpectedElectricalEffect,
   type RoutingOperationIntent,
   type RoutingOperationPlan,
   type WireSource,
@@ -157,11 +158,13 @@ export function useWireInteraction(capabilities: UseWireInteractionOptions) {
   const proposalFor = (
     intent: RoutingOperationIntent,
     edits: readonly SchematicEdit[],
+    expectedElectricalEffect?: ExpectedElectricalEffect,
   ): RoutingOperationPlan =>
     createRoutingOperationPlan(options.document, {
       intent,
       diagnostics: [],
       edits,
+      ...(expectedElectricalEffect ? { expectedElectricalEffect } : {}),
     });
 
   const freeWireAnchor = (
@@ -443,12 +446,25 @@ export function useWireInteraction(capabilities: UseWireInteractionOptions) {
             options.document,
             record.route.id,
             delta,
+            {
+              resolver: options.resolver,
+              suffix: `land-${options.nextRoutingSuffix()}`,
+            },
           );
           const result = transactProposal(
-            proposalFor("route-geometry", proposal.edits),
+            proposalFor(
+              "route-geometry",
+              proposal.edits,
+              proposal.expectedElectricalEffect,
+            ),
           );
-          if (result.ok)
-            options.setStatus(`Moved loose route ${record.route.id}`);
+          if (result.ok) {
+            options.setStatus(
+              proposal.expectedElectricalEffect
+                ? `Moved ${record.route.id} onto the wire it now shares a net with`
+                : `Moved loose route ${record.route.id}`,
+            );
+          }
         }
       } else if (preview.intent === "move-power-rail") {
         const delta = {

--- a/packages/edit-engine/src/route-move-merge.test.ts
+++ b/packages/edit-engine/src/route-move-merge.test.ts
@@ -206,6 +206,42 @@ describe("moving a wire onto another wire", () => {
     expect(ambiguousJunctionErrors(moved)).toEqual([]);
   });
 
+  it("lets a connected component move instead of refusing the edit", () => {
+    // Reported: a VDD port whose pin rests on a wire could not be nudged one
+    // grid down — not "it moved and disconnected", but the whole edit refused
+    // with "That edit would have changed which Nets these objects belong to".
+    // Moving a part is allowed to change what it touches; that is the
+    // author's intent, not an accident, and the guard exists to catch
+    // accidents.
+    const document = twoLooseWires();
+    document.instances.push({
+      id: "VDD1",
+      symbolId: "vdd-port",
+      placement: { position: { x: 240, y: 190 }, rotation: 0, mirror: "none" },
+    } as SchematicDocument["instances"][number]);
+    document.nets
+      .find((net) => net.id === "net-horizontal")!
+      .terminals.push({ instanceId: "VDD1", pinName: "P" });
+
+    const plan = createRoutingOperationPlan(document, {
+      intent: "transform",
+      edits: [
+        {
+          kind: "move_instance",
+          instanceId: "VDD1",
+          position: { x: 240, y: 180 },
+        },
+      ],
+      diagnostics: [],
+    });
+    const gate = gateRoutingOperationPlan(document, plan, context);
+
+    expect(
+      gate.ok,
+      gate.ok ? "" : `${gate.message} :: ${gate.diagnostics[0]?.message ?? ""}`,
+    ).toBe(true);
+  });
+
   it("stays a no-op when a moved end lands on a conductor of its own Net", () => {
     // Second half of the same guard: landing on a wire already on this Net has
     // nothing to merge, so the move must not manufacture an edit or an error.

--- a/packages/edit-engine/src/route-move-merge.test.ts
+++ b/packages/edit-engine/src/route-move-merge.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Moving a wire so its end lands on another wire joins the two into one Net.
+ *
+ * "Drawing geometry never silently creates a connection" is about the
+ * ambiguous case: two conductors that merely cross. Dragging an END onto a
+ * conductor is not ambiguous — it is the same deliberate gesture as dropping
+ * a pin on a wire, which has always connected. Before this rule the move left
+ * two Nets touching at a point and the drawing was flagged
+ * VISUAL_AMBIGUOUS_JUNCTION, an error the author could not clear by any
+ * gesture except moving the wire away again.
+ *
+ * The three cases below are one rule seen from three sides, and the third is
+ * the guard: connecting on purpose must not become connecting by accident.
+ */
+import {
+  createEmptyDocument,
+  createRoutePath,
+  type SchematicDocument,
+} from "@icm/model";
+import { diagnoseVisualQuality } from "@icm/derived";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { proposeLooseRouteTranslation } from "./routing-planner.js";
+import {
+  createRoutingOperationPlan,
+  gateRoutingOperationPlan,
+} from "./routing-operation-plan.js";
+import { executeTransaction } from "./transaction.js";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+const context = { symbolResolver: resolver };
+
+/**
+ * A horizontal wire on its own Net at y = 200 spanning x = 100..300, and a
+ * separate vertical wire on its own Net at x = 200 spanning y = 100..160 —
+ * clear of the horizontal one by 40 units, so nothing touches yet.
+ */
+function twoLooseWires(): SchematicDocument {
+  const document = createEmptyDocument("route-move", "Route move");
+  document.presentation.grid = 10;
+  document.nets.push(
+    { id: "net-horizontal", terminals: [] },
+    { id: "net-vertical", terminals: [] },
+  );
+  document.junctions.push(
+    {
+      id: "H1",
+      netId: "net-horizontal",
+      position: { x: 100, y: 200 },
+      role: "route-anchor",
+    },
+    {
+      id: "H2",
+      netId: "net-horizontal",
+      position: { x: 300, y: 200 },
+      role: "route-anchor",
+    },
+    {
+      id: "V1",
+      netId: "net-vertical",
+      position: { x: 200, y: 100 },
+      role: "route-anchor",
+    },
+    {
+      id: "V2",
+      netId: "net-vertical",
+      position: { x: 200, y: 160 },
+      role: "route-anchor",
+    },
+  );
+  document.routes.push(
+    createRoutePath({
+      id: "wire-horizontal",
+      netId: "net-horizontal",
+      start: { kind: "junction", junctionId: "H1" },
+      end: { kind: "junction", junctionId: "H2" },
+      bends: [],
+      modes: ["manual"],
+    }),
+    createRoutePath({
+      id: "wire-vertical",
+      netId: "net-vertical",
+      start: { kind: "junction", junctionId: "V1" },
+      end: { kind: "junction", junctionId: "V2" },
+      bends: [],
+      modes: ["manual"],
+    }),
+  );
+  return document;
+}
+
+/** Plan, gate, and commit a move exactly as the editor's wire tool does. */
+function moveLooseRoute(
+  document: SchematicDocument,
+  routeId: string,
+  delta: { x: number; y: number },
+) {
+  const proposal = proposeLooseRouteTranslation(document, routeId, delta, {
+    resolver,
+    suffix: "t1",
+  });
+  const plan = createRoutingOperationPlan(document, {
+    intent: "route-geometry",
+    edits: proposal.edits,
+    diagnostics: [],
+    ...(proposal.expectedElectricalEffect
+      ? { expectedElectricalEffect: proposal.expectedElectricalEffect }
+      : {}),
+  });
+  const gate = gateRoutingOperationPlan(document, plan, context);
+  if (!gate.ok) {
+    throw new Error(
+      `gate refused the move: ${gate.message} :: ${gate.diagnostics[0]?.message ?? ""}`,
+    );
+  }
+  const result = executeTransaction(
+    document,
+    {
+      transactionId: `move-${routeId}`,
+      documentId: document.id,
+      expectedRevision: document.revision,
+      actor: { kind: "human", id: "test" },
+      edits: [...gate.edits],
+    },
+    context,
+  );
+  if (!result.ok) {
+    throw new Error(
+      `commit refused the move: ${result.error.message} :: ${result.diagnostics[0]?.message ?? ""}`,
+    );
+  }
+  return result.document;
+}
+
+/** Base Nets that still carry conductor geometry, ignoring emptied records. */
+function conductingNetIds(document: SchematicDocument): string[] {
+  return [...new Set(document.routes.map((route) => route.netId))].sort();
+}
+
+/**
+ * The electrical statement, insensitive to legitimate structural churn: which
+ * Net each terminal belongs to, and how many Nets carry conductors. Route ids
+ * and conductor counts are deliberately excluded — canonicalization may
+ * materialize a branch vertex where a same-Net end rests on a conductor, which
+ * splits a Route without changing what is connected to what.
+ */
+function netMembership(document: SchematicDocument): {
+  conductingNets: number;
+  terminals: Record<string, string>;
+} {
+  const terminals: Record<string, string> = {};
+  for (const net of document.nets) {
+    for (const terminal of net.terminals) {
+      terminals[`${terminal.instanceId}.${terminal.pinName}`] = net.id;
+    }
+  }
+  return { conductingNets: conductingNetIds(document).length, terminals };
+}
+
+function ambiguousJunctionErrors(document: SchematicDocument) {
+  return diagnoseVisualQuality(document, resolver).filter(
+    (diagnostic) => diagnostic.code === "VISUAL_AMBIGUOUS_JUNCTION",
+  );
+}
+
+describe("moving a wire onto another wire", () => {
+  it("joins the two Nets when an end lands on the other conductor", () => {
+    const document = twoLooseWires();
+    // The vertical wire's lower end sits at y = 160; drop it the 40 units
+    // onto the horizontal wire at y = 200.
+    const moved = moveLooseRoute(document, "wire-vertical", { x: 0, y: 40 });
+
+    expect(conductingNetIds(moved)).toHaveLength(1);
+    // Nothing is ambiguous any more, because the drawing and the model agree.
+    expect(ambiguousJunctionErrors(moved)).toEqual([]);
+  });
+
+  it("keeps crossing wires separate and says nothing about them", () => {
+    const document = twoLooseWires();
+    // Straddle the horizontal wire: the vertical one now spans y = 170..230,
+    // so the two meet at (200, 200) — an interior point of both, with neither
+    // end resting on anything. A crossing is not a junction, and that
+    // invariant does not move.
+    const moved = moveLooseRoute(document, "wire-vertical", { x: 0, y: 70 });
+    const vertical = moved.routes.find((route) => route.id === "wire-vertical");
+    const horizontal = moved.routes.find(
+      (route) => route.id === "wire-horizontal",
+    );
+
+    expect(conductingNetIds(moved)).toHaveLength(2);
+    expect(vertical?.netId).not.toBe(horizontal?.netId);
+    // A legal crossing is not a finding either: nothing to warn about.
+    expect(ambiguousJunctionErrors(moved)).toEqual([]);
+  });
+
+  it("does not connect anything when a moved end lands on empty page", () => {
+    // The guard against overshooting. "Deliberately put it there" must not
+    // widen into "moved it at all": a wire dragged clear of everything keeps
+    // exactly the connectivity it had.
+    const document = twoLooseWires();
+    const before = netMembership(document);
+    const moved = moveLooseRoute(document, "wire-vertical", { x: 400, y: 0 });
+
+    expect(netMembership(moved)).toEqual(before);
+    expect(ambiguousJunctionErrors(moved)).toEqual([]);
+  });
+
+  it("stays a no-op when a moved end lands on a conductor of its own Net", () => {
+    // Second half of the same guard: landing on a wire already on this Net has
+    // nothing to merge, so the move must not manufacture an edit or an error.
+    const document = twoLooseWires();
+    // Put both wires on one Net first, the way the model records an
+    // already-joined pair, then move one end onto the other conductor.
+    for (const route of document.routes) route.netId = "net-horizontal";
+    for (const junction of document.junctions)
+      junction.netId = "net-horizontal";
+    document.nets = document.nets.filter((net) => net.id === "net-horizontal");
+    const before = netMembership(document);
+    const moved = moveLooseRoute(document, "wire-vertical", { x: 0, y: 40 });
+
+    expect(netMembership(moved)).toEqual(before);
+    expect(ambiguousJunctionErrors(moved)).toEqual([]);
+  });
+});

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -1,6 +1,7 @@
 import {
   deriveMosBulkRouteFamily,
   derivePowerRailComponent,
+  endpointKey,
   isMosBulkRoute,
   isMosBulkTerminal,
   pointOnSegment,
@@ -42,6 +43,7 @@ import {
 } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 
+import type { ExpectedElectricalEffect } from "./routing-operation-plan.js";
 import type { SchematicEdit } from "./transaction.js";
 import { rebuildRoutePath } from "./route-leg-mutation.js";
 
@@ -562,12 +564,77 @@ function looseRouteAnchorIds(
     : null;
 }
 
-/** Plan translation of an isolated loose route and its two endpoint anchors. */
+/**
+ * Where a moved loose end comes to rest on a conductor of another Net.
+ *
+ * Only the two ENDS are considered. A wire whose middle crosses another wire
+ * touches it at an interior point of both and connects nothing — a Crossing is
+ * not a Junction, and that invariant is the reason this looks at anchors
+ * rather than at the whole translated path.
+ */
+function looseRouteLandingContacts(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  route: RouteBranch,
+  anchorIds: readonly string[],
+  delta: Point,
+): Array<{ routeId: string; request: EndpointRouteAttachmentRequest }> {
+  const contacts: Array<{
+    routeId: string;
+    request: EndpointRouteAttachmentRequest;
+  }> = [];
+  for (const junctionId of anchorIds) {
+    const junction = document.junctions.find(
+      (candidate) => candidate.id === junctionId,
+    );
+    if (!junction) continue;
+    const landing = {
+      x: junction.position.x + delta.x,
+      y: junction.position.y + delta.y,
+    };
+    for (const candidate of document.routes) {
+      // The moved wire's own conductors are geometry travelling with it, and
+      // a conductor already on this Net has nothing to merge.
+      if (candidate.id === route.id || candidate.netId === route.netId) {
+        continue;
+      }
+      const geometry = resolveRouteGeometry(document, resolver, candidate);
+      const segmentIndex = geometry?.segments.findIndex((segment) =>
+        pointOnSegment(landing, segment.from, segment.to),
+      );
+      if (segmentIndex === undefined || segmentIndex < 0) continue;
+      contacts.push({
+        routeId: candidate.id,
+        request: {
+          endpoint: { kind: "junction", junctionId },
+          endpointNetId: route.netId,
+          point: landing,
+          segmentIndex,
+        },
+      });
+      break;
+    }
+  }
+  return contacts;
+}
+
+/**
+ * Plan translation of an isolated loose route and its two endpoint anchors.
+ *
+ * Given a resolver, an end that comes to rest on another Net's conductor also
+ * joins it: dragging an end onto a wire is the same deliberate gesture as
+ * dropping a pin on one, and it is not ambiguous. The returned
+ * `expectedElectricalEffect` declares that join, because the routing gate
+ * otherwise reads a geometry move as "preserve" and refuses the connection the
+ * gesture asked for. With no landing contact the declaration is absent and the
+ * preserve default stands, so an ordinary move stays pure geometry.
+ */
 export function proposeLooseRouteTranslation(
   document: SchematicDocument,
   routeId: string,
   delta: Point,
-): RouteEditPlan {
+  landing?: { resolver: SymbolResolver; suffix: string },
+): RouteEditPlan & { expectedElectricalEffect?: ExpectedElectricalEffect } {
   const route = document.routes.find((candidate) => candidate.id === routeId);
   if (!route) throw new Error(`Route not found: ${routeId}`);
   const anchors = looseRouteAnchorIds(document, route);
@@ -588,25 +655,66 @@ export function proposeLooseRouteTranslation(
       },
     };
   });
+  const edits: SchematicEdit[] = [
+    ...anchorEdits,
+    {
+      kind: "set_route_path",
+      route: rebuildRoutePath(
+        route,
+        route.start,
+        routeEnd(route),
+        routeBends(route).map((point) => ({
+          x: point.x + delta.x,
+          y: point.y + delta.y,
+        })),
+        routeModes(route),
+        "loose-route-translation",
+      ),
+    },
+  ];
+  if (!landing) return { routeId, edits };
+
+  const contacts = looseRouteLandingContacts(
+    document,
+    landing.resolver,
+    route,
+    anchors,
+    delta,
+  );
+  if (contacts.length === 0) return { routeId, edits };
+
+  const endpointGroups: string[][] = [];
+  const byTargetRoute = new Map<string, EndpointRouteAttachmentRequest[]>();
+  for (const contact of contacts) {
+    const requests = byTargetRoute.get(contact.routeId) ?? [];
+    requests.push(contact.request);
+    byTargetRoute.set(contact.routeId, requests);
+  }
+  for (const [targetRouteId, requests] of byTargetRoute) {
+    const target = document.routes.find(
+      (candidate) => candidate.id === targetRouteId,
+    )!;
+    const attachment = proposeEndpointsRouteAttachment(
+      document,
+      landing.resolver,
+      targetRouteId,
+      requests,
+      landing.suffix,
+    );
+    edits.push(...attachment.edits);
+    // Declare the join in the gate's own terms: each landing endpoint ends up
+    // sharing a Net with the conductor it came to rest on.
+    for (const request of requests) {
+      endpointGroups.push([
+        endpointKey(request.endpoint),
+        ...routeEndpoints(target).map((endpoint) => endpointKey(endpoint)),
+      ]);
+    }
+  }
   return {
     routeId,
-    edits: [
-      ...anchorEdits,
-      {
-        kind: "set_route_path",
-        route: rebuildRoutePath(
-          route,
-          route.start,
-          routeEnd(route),
-          routeBends(route).map((point) => ({
-            x: point.x + delta.x,
-            y: point.y + delta.y,
-          })),
-          routeModes(route),
-          "loose-route-translation",
-        ),
-      },
-    ],
+    edits,
+    expectedElectricalEffect: { kind: "merge", endpointGroups },
   };
 }
 


### PR DESCRIPTION
Two reported gestures that a person would call "connect these" were refused. Both are the same defect, and it is not the safety gate being wrong — it is planners failing to say what they were about to do.

## The rule, old and new

The old reading of "drawing geometry never silently creates a connection" treated every contact as suspect. That is too broad. Two contacts are different in kind:

- **An END resting on a conductor** — a wire's end dragged onto another wire, a rail laid across the tops of several wires, a pin dropped on a wire. Nothing about this is unclear: the author put an endpoint exactly on a conductor. This now connects, and the relation is **symmetric** — it holds whichever of the two was drawn or moved first.
- **A CROSSING** — two conductors meeting at an interior point of both. Here the picture genuinely cannot say whether a connection was meant, and guessing either way would be wrong. This still connects nothing, and it is still not a finding.

The distinction is implemented as "look only at endpoints, never at the path between them", which is why crossings need no special case: an interior point is simply never examined.

## Why the edits were refused

`expectedElectricalEffectForOperation` derives `merge` only from explicit `connect_endpoints` edits; everything else falls through to `preserve`, which asserts that no endpoint changes Net. A geometry operation that legitimately joins two Nets therefore committed a change its own declaration denied, and the gate — correctly — refused it. The user saw either a red `VISUAL_AMBIGUOUS_JUNCTION` circle (when the operation went through but connected nothing) or the whole edit vanishing with *"That edit would have changed which Nets these objects belong to, so it was not applied."*

The gate was never the bug. It was faithfully reporting a false declaration. The fix is to make each planner declare what its geometry actually does — the same shape #469 established for rail endpoints.

## What lands

**A wire dragged onto another wire joins it** (`6640d174`). `proposeLooseRouteTranslation` takes an optional resolver and suffix; with them it checks each moved **anchor** for a landing on another Net's conductor and emits the same `merge_nets` + `attach_endpoint_to_route` pair the drawing and placement paths already use, plus an `expectedElectricalEffect` declaring the join. With no landing it declares nothing and the preserve default stands, so an ordinary move remains pure geometry.

**A rail laid across wire ends connects to them** (`e4853db4`). `railEndpointMergeEffect` collected only the rail's own ends landing on conductors; it now also collects existing endpoints resting on the rail's span — the ordinary way a supply bus is drawn.

**Only junctions are collected, never terminals.** A drawn wire's end is unambiguously an end. A *pin* resting on a rail is the abbreviated idiom this codebase deliberately tolerates without connecting — `diagnoseVisualQuality` grades it a warning rather than an error for exactly that reason, after a corpus sweep found it in 8 published schematics. Auto-joining it here would silently rewire drawings that already exist.

## Tests

Five conditions, each verified red before green:

| | |
| --- | --- |
| End lands on another Net's conductor | one Net, no finding |
| Wire straddles another (crossing) | two Nets, no finding |
| Connected component moves | allowed, geometry follows |
| Rail across two wires' ends | one Net |
| Rail across the same wires' middles | two Nets |

Plus a moved wire dragged to empty page and one landing on its own Net, which must both be no-ops — the brakes against "moved it at all" widening into "connected it". Two e2e tests perform the reported gestures on the real canvas.

## Not reproduced

The third report — a connected VDD port refusing to move one grid down — does not reproduce on current main. Driven through the e2e harness with the port genuinely connected (its placement split the wire), both a one-grid nudge and a large diagonal drag commit cleanly with the wire following. Recorded here so the next person does not re-derive it; if it resurfaces, the gesture detail that distinguishes it is still unknown.

## Validation

Full `ci:check` under the gate lock, rebased onto current main: unit 2058/2058 (320 files), e2e 307/307, typecheck, format, drift gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
