### PR TITLE
feat(symbols): ADC and DAC blocks that say which way the conversion runs

### DIFF
--- a/apps/editor/src/features/component-insert/symbol-catalog.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.ts
@@ -69,6 +69,8 @@ export function symbolCategory(symbolId: string): string {
   }
   if (
     [
+      "adc",
+      "dac",
       "opamp",
       "opamp-lettered",
       "voltage-amplifier-lettered",

--- a/apps/editor/src/features/editor-shell/shapes-panel.test.ts
+++ b/apps/editor/src/features/editor-shell/shapes-panel.test.ts
@@ -20,7 +20,7 @@ describe("shapes quick-place", () => {
       }),
     );
 
-    expect(symbols).toHaveLength(61);
+    expect(symbols).toHaveLength(63);
     expect(markup).toContain("All devices");
     expect(markup.match(/data-testid="shapes-chip-/g)).toHaveLength(
       symbols.length,
@@ -37,7 +37,7 @@ describe("shapes quick-place", () => {
       ["Power and Ports", 5],
       ["Sources", 3],
       ["Switches", 5],
-      ["Analog Blocks", 7],
+      ["Analog Blocks", 9],
       ["Logic Gates", 11],
       ["Signal Flow", 7],
       ["Annotations", 8],

--- a/apps/editor/src/features/editor-shell/shapes-panel.tsx
+++ b/apps/editor/src/features/editor-shell/shapes-panel.tsx
@@ -42,6 +42,8 @@ const COMPACT_LIBRARY_LABELS: Readonly<Record<string, string>> = {
   ndmos: "NDMOS",
   npn: "NPN",
   opamp: "OpAmp",
+  adc: "ADC",
+  dac: "DAC",
   "opamp-lettered": "OpAmp A",
   "opamp-differential": "FD Amp",
   "opamp-differential-crossed": "FD Amp X",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "symbols:razavi-inductor:check": "node scripts/generate-razavi-inductor-asset.mjs --check",
     "symbols:razavi-opamp": "node scripts/generate-razavi-opamp-asset.mjs",
     "symbols:razavi-opamp:check": "node scripts/generate-razavi-opamp-asset.mjs --check",
+    "symbols:converters": "node scripts/generate-converter-assets.mjs",
+    "symbols:converters:check": "node scripts/generate-converter-assets.mjs --check",
     "symbols:lettered-amps": "node scripts/generate-lettered-amplifiers.mjs",
     "symbols:lettered-amps:check": "node scripts/generate-lettered-amplifiers.mjs --check",
     "symbols:swap-inputs": "node scripts/generate-input-swapped-amplifiers.mjs",

--- a/packages/render-svg/src/symbol-body-text.test.ts
+++ b/packages/render-svg/src/symbol-body-text.test.ts
@@ -178,3 +178,44 @@ describe("editable body text as a general Symbol capability", () => {
     ]);
   });
 });
+
+describe("converter blocks carry the same editable body text", () => {
+  it("renders ADC and DAC defaults and honours a per-Instance override", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.instances.push(
+      {
+        id: "U1",
+        symbolId: "adc",
+        placement: {
+          position: { x: 100, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        id: "U2",
+        symbolId: "dac",
+        placement: {
+          position: { x: 300, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        id: "U3",
+        symbolId: "adc",
+        placement: {
+          position: { x: 500, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+        signalFlowParameters: { formula: "12b ADC" },
+      },
+    );
+    expect(letters(renderDocumentSvg(document, resolver))).toEqual([
+      "ADC",
+      "DAC",
+      "12b ADC",
+    ]);
+  });
+});

--- a/packages/symbols/assets/razavi-v1/adc.symbol.json
+++ b/packages/symbols/assets/razavi-v1/adc.symbol.json
@@ -1,0 +1,115 @@
+{
+  "schemaVersion": 1,
+  "id": "adc",
+  "name": "Analog-to-Digital Converter",
+  "viewBox": {
+    "x": -34,
+    "y": -19,
+    "width": 68,
+    "height": 38
+  },
+  "pins": [
+    {
+      "name": "IN",
+      "role": "input",
+      "at": {
+        "x": -30,
+        "y": 0
+      },
+      "direction": "west",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 5
+      }
+    },
+    {
+      "name": "OUT",
+      "role": "output",
+      "at": {
+        "x": 30,
+        "y": 0
+      },
+      "direction": "east",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 5
+      }
+    }
+  ],
+  "primitives": [
+    {
+      "kind": "line",
+      "from": {
+        "x": -30,
+        "y": 0
+      },
+      "to": {
+        "x": -25,
+        "y": 0
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "polygon",
+      "points": [
+        {
+          "x": 25,
+          "y": -15
+        },
+        {
+          "x": -15,
+          "y": -15
+        },
+        {
+          "x": -25,
+          "y": 0
+        },
+        {
+          "x": -15,
+          "y": 15
+        },
+        {
+          "x": 25,
+          "y": 15
+        }
+      ],
+      "fill": "none",
+      "stroke": "foreground",
+      "style": {
+        "strokeRole": "emphasis",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 25,
+        "y": 0
+      },
+      "to": {
+        "x": 30,
+        "y": 0
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    }
+  ],
+  "variants": [],
+  "formulaPresentation": {
+    "defaultFormula": "ADC",
+    "supportsCoefficient": false,
+    "center": {
+      "x": 2.41,
+      "y": 0
+    },
+    "fontSize": 12
+  }
+}

--- a/packages/symbols/assets/razavi-v1/catalog.json
+++ b/packages/symbols/assets/razavi-v1/catalog.json
@@ -1375,6 +1375,34 @@
         "converterPath": "scripts/generate-razavi-zener-asset.mjs",
         "converterVersion": 1
       }
+    },
+    {
+      "symbolId": "adc",
+      "name": "Analog-to-Digital Converter",
+      "category": "analog-block",
+      "reviewStatus": "reviewed",
+      "provenance": "house",
+      "houseReason": "The reference draws converter internals, never a block standing for one on a sheet. Drawn here as the arrow a data path is read through.",
+      "pinOrder": ["IN", "OUT"],
+      "palette": true,
+      "automaticMappings": [],
+      "manualOnlyReason": "A converter block stands for a subsystem; SPICE has no primitive for one.",
+      "assetPath": "adc.symbol.json",
+      "assetHash": "27855e5142d4ae54d83562ac76952e98ba1d4234c188801a73efc8358a4ae09c"
+    },
+    {
+      "symbolId": "dac",
+      "name": "Digital-to-Analog Converter",
+      "category": "analog-block",
+      "reviewStatus": "reviewed",
+      "provenance": "house",
+      "houseReason": "The reference draws converter internals, never a block standing for one on a sheet. Drawn here as the ADC's mirror so a signal chain reads in both directions.",
+      "pinOrder": ["IN", "OUT"],
+      "palette": true,
+      "automaticMappings": [],
+      "manualOnlyReason": "A converter block stands for a subsystem; SPICE has no primitive for one.",
+      "assetPath": "dac.symbol.json",
+      "assetHash": "4be7f9a855d6055575402bd783a27e10152097b1a85c31e487479ed4612b8d16"
     }
   ],
   "semanticPrimitives": [

--- a/packages/symbols/assets/razavi-v1/dac.symbol.json
+++ b/packages/symbols/assets/razavi-v1/dac.symbol.json
@@ -1,0 +1,115 @@
+{
+  "schemaVersion": 1,
+  "id": "dac",
+  "name": "Digital-to-Analog Converter",
+  "viewBox": {
+    "x": -34,
+    "y": -19,
+    "width": 68,
+    "height": 38
+  },
+  "pins": [
+    {
+      "name": "IN",
+      "role": "input",
+      "at": {
+        "x": -30,
+        "y": 0
+      },
+      "direction": "west",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 5
+      }
+    },
+    {
+      "name": "OUT",
+      "role": "output",
+      "at": {
+        "x": 30,
+        "y": 0
+      },
+      "direction": "east",
+      "presentation": {
+        "visibility": "visible",
+        "leadLength": 5
+      }
+    }
+  ],
+  "primitives": [
+    {
+      "kind": "line",
+      "from": {
+        "x": -30,
+        "y": 0
+      },
+      "to": {
+        "x": -25,
+        "y": 0
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "polygon",
+      "points": [
+        {
+          "x": -25,
+          "y": -15
+        },
+        {
+          "x": 15,
+          "y": -15
+        },
+        {
+          "x": 25,
+          "y": 0
+        },
+        {
+          "x": 15,
+          "y": 15
+        },
+        {
+          "x": -25,
+          "y": 15
+        }
+      ],
+      "fill": "none",
+      "stroke": "foreground",
+      "style": {
+        "strokeRole": "emphasis",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    },
+    {
+      "kind": "line",
+      "from": {
+        "x": 25,
+        "y": 0
+      },
+      "to": {
+        "x": 30,
+        "y": 0
+      },
+      "style": {
+        "strokeRole": "normal",
+        "lineCap": "butt",
+        "lineJoin": "miter"
+      }
+    }
+  ],
+  "variants": [],
+  "formulaPresentation": {
+    "defaultFormula": "DAC",
+    "supportsCoefficient": false,
+    "center": {
+      "x": -2.41,
+      "y": 0
+    },
+    "fontSize": 12
+  }
+}

--- a/packages/symbols/src/builtins.test.ts
+++ b/packages/symbols/src/builtins.test.ts
@@ -58,6 +58,8 @@ const PRODUCT_IDS = [
   "xnor-gate",
   "xor-gate",
   "zener-diode",
+  "adc",
+  "dac",
 ] as const;
 
 describe("built-in Symbol libraries", () => {

--- a/packages/symbols/src/converter-blocks.test.ts
+++ b/packages/symbols/src/converter-blocks.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { requireRazaviCatalogSymbol } from "./razavi-catalog.js";
+import { SYMBOL_CONNECTION_GRID, SymbolDefinitionSchema } from "./schema.js";
+
+const CONVERTERS = ["adc", "dac"] as const;
+
+function bodyPolygon(symbolId: string) {
+  const symbol = requireRazaviCatalogSymbol(symbolId);
+  const polygon = symbol.primitives.find(
+    (primitive) => primitive.kind === "polygon",
+  );
+  expect(polygon, `${symbolId} body`).toBeDefined();
+  return polygon as Extract<typeof polygon, { kind: "polygon" }>;
+}
+
+describe("converter blocks", () => {
+  it("draws a five-sided arrow that points the way the conversion runs", () => {
+    const adc = bodyPolygon("adc");
+    const dac = bodyPolygon("dac");
+    expect(adc.points).toHaveLength(5);
+    expect(dac.points).toHaveLength(5);
+    // The tip is the lone vertex on the mid-line; the ADC's sits left, the
+    // DAC's right, so a signal chain reads in both directions.
+    const tip = (points: readonly { x: number; y: number }[]) =>
+      points.find((point) => point.y === 0)!.x;
+    expect(tip(adc.points)).toBeLessThan(0);
+    expect(tip(dac.points)).toBeGreaterThan(0);
+  });
+
+  it("keeps the body empty, like every other symbol on the sheet", () => {
+    for (const id of CONVERTERS) {
+      expect(bodyPolygon(id).fill).toBe("none");
+    }
+  });
+
+  it("lands its pins on the grid and keeps the leads short", () => {
+    for (const id of CONVERTERS) {
+      const symbol = requireRazaviCatalogSymbol(id);
+      expect(symbol.pins.map((pin) => pin.name)).toEqual(["IN", "OUT"]);
+      for (const pin of symbol.pins) {
+        expect(
+          Math.abs(pin.at.x) % SYMBOL_CONNECTION_GRID,
+          `${id} ${pin.name} anchor`,
+        ).toBe(0);
+        expect(pin.at.y).toBe(0);
+        expect(
+          pin.presentation.leadLength,
+          `${id} ${pin.name} lead`,
+        ).toBeLessThanOrEqual(10);
+      }
+    }
+  });
+
+  it("draws the body as a polygon so bounds come from the artwork", () => {
+    // visibleSymbolLocalBounds falls back to the declaration viewBox for a
+    // `path` body; a polygon is measured from its own points, so the hit box
+    // hugs the arrow the way every other primitive-drawn Symbol's does.
+    for (const id of CONVERTERS) {
+      const symbol = requireRazaviCatalogSymbol(id);
+      expect(
+        symbol.primitives.some((primitive) => primitive.kind === "path"),
+        `${id} must not use a path body`,
+      ).toBe(false);
+      const points = bodyPolygon(id).points;
+      const extentX = Math.max(...points.map((point) => Math.abs(point.x)));
+      expect(extentX).toBeLessThan(symbol.viewBox.width / 2);
+    }
+  });
+
+  it("carries an editable body label defaulting to its own name", () => {
+    for (const [id, text] of [
+      ["adc", "ADC"],
+      ["dac", "DAC"],
+    ] as const) {
+      const presentation = requireRazaviCatalogSymbol(id).formulaPresentation;
+      expect(presentation, `${id} body text`).toBeDefined();
+      expect(presentation!.defaultFormula).toBe(text);
+      // Naming a block is not scaling it.
+      expect(presentation!.supportsCoefficient).toBe(false);
+    }
+  });
+
+  it("parses under the Symbol contract", () => {
+    for (const id of CONVERTERS) {
+      const symbol = requireRazaviCatalogSymbol(id);
+      expect(SymbolDefinitionSchema.parse(symbol)).toEqual(symbol);
+    }
+  });
+});

--- a/packages/symbols/src/razavi-catalog.generated.ts
+++ b/packages/symbols/src/razavi-catalog.generated.ts
@@ -1647,6 +1647,40 @@ export const razaviSymbolCatalogEntries: readonly RazaviSymbolCatalogEntry[] = [
       converterVersion: 1,
     },
   },
+  {
+    symbolId: "adc",
+    name: "Analog-to-Digital Converter",
+    category: "analog-block",
+    reviewStatus: "reviewed",
+    provenance: "house",
+    houseReason:
+      "The reference draws converter internals, never a block standing for one on a sheet. Drawn here as the arrow a data path is read through.",
+    pinOrder: ["IN", "OUT"],
+    palette: true,
+    automaticMappings: [],
+    manualOnlyReason:
+      "A converter block stands for a subsystem; SPICE has no primitive for one.",
+    assetPath: "adc.symbol.json",
+    assetHash:
+      "27855e5142d4ae54d83562ac76952e98ba1d4234c188801a73efc8358a4ae09c",
+  },
+  {
+    symbolId: "dac",
+    name: "Digital-to-Analog Converter",
+    category: "analog-block",
+    reviewStatus: "reviewed",
+    provenance: "house",
+    houseReason:
+      "The reference draws converter internals, never a block standing for one on a sheet. Drawn here as the ADC's mirror so a signal chain reads in both directions.",
+    pinOrder: ["IN", "OUT"],
+    palette: true,
+    automaticMappings: [],
+    manualOnlyReason:
+      "A converter block stands for a subsystem; SPICE has no primitive for one.",
+    assetPath: "dac.symbol.json",
+    assetHash:
+      "4be7f9a855d6055575402bd783a27e10152097b1a85c31e487479ed4612b8d16",
+  },
 ];
 
 export const razaviSemanticPrimitives: readonly RazaviSemanticPrimitiveEntry[] =
@@ -9448,5 +9482,235 @@ export const razaviCatalogSymbols: readonly SymbolDefinition[] = [
       },
     ],
     variants: [],
+  },
+  {
+    schemaVersion: 1,
+    id: "adc",
+    name: "Analog-to-Digital Converter",
+    viewBox: {
+      x: -34,
+      y: -19,
+      width: 68,
+      height: 38,
+    },
+    pins: [
+      {
+        name: "IN",
+        role: "input",
+        at: {
+          x: -30,
+          y: 0,
+        },
+        direction: "west",
+        presentation: {
+          visibility: "visible",
+          leadLength: 5,
+        },
+      },
+      {
+        name: "OUT",
+        role: "output",
+        at: {
+          x: 30,
+          y: 0,
+        },
+        direction: "east",
+        presentation: {
+          visibility: "visible",
+          leadLength: 5,
+        },
+      },
+    ],
+    primitives: [
+      {
+        kind: "line",
+        from: {
+          x: -30,
+          y: 0,
+        },
+        to: {
+          x: -25,
+          y: 0,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "polygon",
+        points: [
+          {
+            x: 25,
+            y: -15,
+          },
+          {
+            x: -15,
+            y: -15,
+          },
+          {
+            x: -25,
+            y: 0,
+          },
+          {
+            x: -15,
+            y: 15,
+          },
+          {
+            x: 25,
+            y: 15,
+          },
+        ],
+        fill: "none",
+        stroke: "foreground",
+        style: {
+          strokeRole: "emphasis",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 25,
+          y: 0,
+        },
+        to: {
+          x: 30,
+          y: 0,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+    ],
+    variants: [],
+    formulaPresentation: {
+      defaultFormula: "ADC",
+      supportsCoefficient: false,
+      center: {
+        x: 2.41,
+        y: 0,
+      },
+      fontSize: 12,
+    },
+  },
+  {
+    schemaVersion: 1,
+    id: "dac",
+    name: "Digital-to-Analog Converter",
+    viewBox: {
+      x: -34,
+      y: -19,
+      width: 68,
+      height: 38,
+    },
+    pins: [
+      {
+        name: "IN",
+        role: "input",
+        at: {
+          x: -30,
+          y: 0,
+        },
+        direction: "west",
+        presentation: {
+          visibility: "visible",
+          leadLength: 5,
+        },
+      },
+      {
+        name: "OUT",
+        role: "output",
+        at: {
+          x: 30,
+          y: 0,
+        },
+        direction: "east",
+        presentation: {
+          visibility: "visible",
+          leadLength: 5,
+        },
+      },
+    ],
+    primitives: [
+      {
+        kind: "line",
+        from: {
+          x: -30,
+          y: 0,
+        },
+        to: {
+          x: -25,
+          y: 0,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "polygon",
+        points: [
+          {
+            x: -25,
+            y: -15,
+          },
+          {
+            x: 15,
+            y: -15,
+          },
+          {
+            x: 25,
+            y: 0,
+          },
+          {
+            x: 15,
+            y: 15,
+          },
+          {
+            x: -25,
+            y: 15,
+          },
+        ],
+        fill: "none",
+        stroke: "foreground",
+        style: {
+          strokeRole: "emphasis",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+      {
+        kind: "line",
+        from: {
+          x: 25,
+          y: 0,
+        },
+        to: {
+          x: 30,
+          y: 0,
+        },
+        style: {
+          strokeRole: "normal",
+          lineCap: "butt",
+          lineJoin: "miter",
+        },
+      },
+    ],
+    variants: [],
+    formulaPresentation: {
+      defaultFormula: "DAC",
+      supportsCoefficient: false,
+      center: {
+        x: -2.41,
+        y: 0,
+      },
+      fontSize: 12,
+    },
   },
 ];

--- a/packages/symbols/src/razavi-catalog.test.ts
+++ b/packages/symbols/src/razavi-catalog.test.ts
@@ -217,6 +217,8 @@ describe("Razavi symbol catalog", () => {
       ["xnor-gate", "reviewed", "razavi-reference-v1"],
       ["xor-gate", "reviewed", "razavi-reference-v1"],
       ["zener-diode", "reviewed", "razavi-reference-v1"],
+      ["adc", "reviewed", "house"],
+      ["dac", "reviewed", "house"],
     ]);
   });
 
@@ -559,7 +561,7 @@ describe("Razavi symbol catalog", () => {
   });
 
   it("uses reviewed catalog objects as the sole built-in product library", () => {
-    expect(razaviCatalogSymbols).toHaveLength(57);
+    expect(razaviCatalogSymbols).toHaveLength(59);
     for (const catalogSymbol of razaviProductSymbols) {
       expect(
         builtInSymbols.find((symbol) => symbol.id === catalogSymbol.id),
@@ -621,6 +623,8 @@ describe("Razavi symbol catalog", () => {
       "xnor-gate",
       "xor-gate",
       "zener-diode",
+      "adc",
+      "dac",
     ]);
     for (const entry of razaviSymbolCatalogEntries) {
       expect(isRazaviProductCatalogEntry(entry)).toBe(

--- a/scripts/generate-converter-assets.mjs
+++ b/scripts/generate-converter-assets.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+// Draws the data-converter blocks: an ADC and a DAC, each a five-sided arrow
+// whose point states which way the conversion runs — left into the digital
+// domain, right back out of it.
+//
+// House-drawn: the reference covers converter internals, never a block for
+// one on a sheet, so these claim no textbook authority.
+//
+// Body text uses the general editable-body-text contract: the Symbol says
+// the default (`ADC`, `DAC`) and where it sits, and each Instance owns the
+// text through `signalFlowParameters.formula`. A sheet with two converters
+// can name them without them becoming different parts.
+//
+// Geometry notes:
+// - `polygon`, not `path`, so `visibleSymbolLocalBounds` bounds the artwork
+//   from its own drawn points instead of falling back to the viewBox. The
+//   hit box then hugs the shape the way every other primitive-drawn Symbol's
+//   does.
+// - Pin anchors land on multiples of the connection grid and the leads are
+//   short (5), matching the switch family rather than the older long-lead
+//   symbols.
+// - The text sits on the AREA centroid, not the bounding-box centre: the
+//   point pulls a pentagon's visual middle towards the blunt end, and text
+//   centred on the box would drift into the tip.
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import { relative, resolve } from "node:path";
+import process from "node:process";
+
+import { format } from "prettier";
+
+const root = resolve(import.meta.dirname, "..");
+const assetRoot = resolve(root, "packages/symbols/assets/razavi-v1");
+const catalogPath = resolve(assetRoot, "catalog.json");
+const check = process.argv.includes("--check");
+
+function fail(message) {
+  console.error(`generate-converter-assets: ${message}`);
+  process.exit(1);
+}
+
+const normalize = (text) => text.replace(/\r\n/gu, "\n").trimEnd() + "\n";
+const hash = (text) => createHash("sha256").update(text).digest("hex");
+
+/** Half-extents of the body, and how far a lead reaches past it. */
+const BODY_HALF_WIDTH = 25;
+const BODY_HALF_HEIGHT = 15;
+const TIP_INSET = 10;
+const PIN_ANCHOR_X = 30;
+const LEAD_LENGTH = PIN_ANCHOR_X - BODY_HALF_WIDTH;
+const FONT_SIZE = 12;
+
+/**
+ * Area centroid of a simple polygon. The shoelace form, so the point comes
+ * from the shape itself rather than from an average of its corners — for an
+ * arrow the two differ by several units, which is the difference between
+ * text that looks centred and text that looks pushed.
+ */
+function polygonCentroid(points) {
+  let twiceArea = 0;
+  let x = 0;
+  let y = 0;
+  for (const [index, current] of points.entries()) {
+    const next = points[(index + 1) % points.length];
+    const cross = current.x * next.y - next.x * current.y;
+    twiceArea += cross;
+    x += (current.x + next.x) * cross;
+    y += (current.y + next.y) * cross;
+  }
+  if (twiceArea === 0) fail("degenerate body polygon");
+  const round = (value) => Math.round(value * 100) / 100;
+  return { x: round(x / (3 * twiceArea)), y: round(y / (3 * twiceArea)) };
+}
+
+/**
+ * The arrow body. `pointsRight` puts the tip on the output side, which is
+ * the DAC; the ADC mirrors it so its tip leads into the digital domain.
+ */
+function bodyPoints(pointsRight) {
+  const sign = pointsRight ? 1 : -1;
+  return [
+    { x: -sign * BODY_HALF_WIDTH, y: -BODY_HALF_HEIGHT },
+    { x: sign * (BODY_HALF_WIDTH - TIP_INSET), y: -BODY_HALF_HEIGHT },
+    { x: sign * BODY_HALF_WIDTH, y: 0 },
+    { x: sign * (BODY_HALF_WIDTH - TIP_INSET), y: BODY_HALF_HEIGHT },
+    { x: -sign * BODY_HALF_WIDTH, y: BODY_HALF_HEIGHT },
+  ];
+}
+
+function converterSymbol({ id, name, defaultText, pointsRight }) {
+  const points = bodyPoints(pointsRight);
+  return {
+    schemaVersion: 1,
+    id,
+    name,
+    viewBox: {
+      x: -(PIN_ANCHOR_X + 4),
+      y: -(BODY_HALF_HEIGHT + 4),
+      width: (PIN_ANCHOR_X + 4) * 2,
+      height: (BODY_HALF_HEIGHT + 4) * 2,
+    },
+    pins: [
+      {
+        name: "IN",
+        role: "input",
+        at: { x: -PIN_ANCHOR_X, y: 0 },
+        direction: "west",
+        presentation: { visibility: "visible", leadLength: LEAD_LENGTH },
+      },
+      {
+        name: "OUT",
+        role: "output",
+        at: { x: PIN_ANCHOR_X, y: 0 },
+        direction: "east",
+        presentation: { visibility: "visible", leadLength: LEAD_LENGTH },
+      },
+    ],
+    primitives: [
+      {
+        kind: "line",
+        from: { x: -PIN_ANCHOR_X, y: 0 },
+        to: { x: -BODY_HALF_WIDTH, y: 0 },
+        style: { strokeRole: "normal", lineCap: "butt", lineJoin: "miter" },
+      },
+      {
+        kind: "polygon",
+        points,
+        // Empty inside, like every other body on the sheet.
+        fill: "none",
+        stroke: "foreground",
+        style: { strokeRole: "emphasis", lineCap: "butt", lineJoin: "miter" },
+      },
+      {
+        kind: "line",
+        from: { x: BODY_HALF_WIDTH, y: 0 },
+        to: { x: PIN_ANCHOR_X, y: 0 },
+        style: { strokeRole: "normal", lineCap: "butt", lineJoin: "miter" },
+      },
+    ],
+    variants: [],
+    formulaPresentation: {
+      defaultFormula: defaultText,
+      // The label names the block; nothing scales it.
+      supportsCoefficient: false,
+      center: polygonCentroid(points),
+      fontSize: FONT_SIZE,
+    },
+  };
+}
+
+const CONVERTERS = [
+  {
+    id: "adc",
+    name: "Analog-to-Digital Converter",
+    defaultText: "ADC",
+    pointsRight: false,
+    houseReason:
+      "The reference draws converter internals, never a block standing for one on a sheet. Drawn here as the arrow a data path is read through.",
+  },
+  {
+    id: "dac",
+    name: "Digital-to-Analog Converter",
+    defaultText: "DAC",
+    pointsRight: true,
+    houseReason:
+      "The reference draws converter internals, never a block standing for one on a sheet. Drawn here as the ADC's mirror so a signal chain reads in both directions.",
+  },
+];
+
+const catalog = JSON.parse(await readFile(catalogPath, "utf8"));
+const outputs = [];
+
+for (const converter of CONVERTERS) {
+  const symbol = converterSymbol(converter);
+  const source = normalize(
+    await format(JSON.stringify(symbol, null, 2), { parser: "json" }),
+  );
+  const assetPath = `${converter.id}.symbol.json`;
+  outputs.push([resolve(assetRoot, assetPath), source]);
+
+  const entry = {
+    symbolId: converter.id,
+    name: converter.name,
+    category: "analog-block",
+    reviewStatus: "reviewed",
+    provenance: "house",
+    houseReason: converter.houseReason,
+    pinOrder: ["IN", "OUT"],
+    palette: true,
+    automaticMappings: [],
+    manualOnlyReason:
+      "A converter block stands for a subsystem; SPICE has no primitive for one.",
+    assetPath,
+    assetHash: hash(source),
+  };
+  const existingIndex = catalog.entries.findIndex(
+    (candidate) => candidate.symbolId === converter.id,
+  );
+  if (existingIndex >= 0) catalog.entries[existingIndex] = entry;
+  else catalog.entries.push(entry);
+}
+
+outputs.push([
+  catalogPath,
+  normalize(await format(JSON.stringify(catalog, null, 2), { parser: "json" })),
+]);
+
+if (check) {
+  for (const [path, source] of outputs) {
+    const existing = await readFile(path, "utf8").catch(() => null);
+    if (existing === null || normalize(existing) !== source) {
+      fail(`${relative(root, path)} is stale`);
+    }
+  }
+} else {
+  for (const [path, source] of outputs) {
+    await writeFile(path, source, "utf8");
+  }
+}
+
+console.log(
+  `${check ? "Validated" : "Generated"} converter blocks ` +
+    `(${CONVERTERS.map((converter) => converter.id).join(", ")})`,
+);


### PR DESCRIPTION
## What

Two Library tiles — **ADC** and **DAC** — each a five-sided arrow whose point states the direction of conversion: the ADC's tip leads left into the digital domain, the DAC's right back out of it. Empty inside (`fill: "none"`), same stroke weight as every other body; no new fill value was added or needed.

The centre label is **editable per Instance**, defaulting to `ADC` / `DAC`. This is the first outside user of the body-text contract that shipped in #474 and it needed **no code** — the Symbol declares `formulaPresentation`, the Instance owns the text through `signalFlowParameters.formula`. Two converters on one sheet can read `12b ADC` and `DAC` without becoming different parts.

## The two things the owner named

- **Short leads.** Pin anchors sit at ±30 — multiples of the connection grid — and the leads are **5** long, following the switch family from #470 rather than the older 16–20 unit leads. Pinned by test.
- **Hit box like everything else.** The body is a `polygon`, not a `path`, so `visibleSymbolLocalBounds` measures it from the artwork's own drawn points instead of falling back to the declaration `viewBox` (its documented fallback for paths). Also pinned by test.

## Details

- Label sits on the **area centroid** (shoelace), not the bounding-box centre: on an arrow the two differ by ~2.4 units, which is the difference between text that looks centred and text drifting toward the tip.
- **House provenance** with a stated reason: the reference draws converter internals, never a block standing for one. Category `analog-block`; Library group **Analog Blocks**.
- **No reference-designator prefix yet** — the prefix policy for these blocks is still open, and since #476 an absent prefix no longer leaves an empty label, so this stays a deliberate omission rather than a guess.
- New generator `scripts/generate-converter-assets.mjs` (+ `symbols:converters`/`:check`); entries appended in curated order, never re-sorted, and `generate-razavi-common-assets.mjs` was not run.

## Validation

- New `converter-blocks.test.ts`: arrow direction per part, empty body, grid-aligned anchors with leads ≤10, polygon-not-path bounds, default label + `supportsCoefficient: false`, schema parse
- Render test: `ADC`/`DAC` defaults plus a per-Instance override to `12b ADC`
- 1038 tests across symbols / render-svg / agent-adapter / editor; typecheck; Prettier
- Drift gates: `symbols:converters:check`, `symbols:lettered-amps:check`, `agent-kit:catalog:check`, `mcp:resources:check`, `agent-api:artifacts:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)