### PR TITLE
fix(editor): an attach declares the join it performs, so a pin can be dragged onto a wire

### DIFF
--- a/apps/editor/e2e/wiring-semantics.spec.ts
+++ b/apps/editor/e2e/wiring-semantics.spec.ts
@@ -221,3 +221,47 @@ test("a power rail drawn across the tops of wires connects to them", async ({
   await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(5);
   await expect(page.getByTestId("statusbar-issues")).toHaveText("No issues");
 });
+
+test("a component dragged onto a wire lands and connects", async ({ page }) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.click({ position: { x: 600, y: 500 } });
+
+  await page.keyboard.press("w");
+  await canvas.click({ position: { x: 240, y: 320 } });
+  await canvas.click({ position: { x: 480, y: 320 } });
+  await page.keyboard.press("Enter");
+  await page.keyboard.press("Escape");
+
+  // Place the port clear of the wire, so no placement contact runs and the
+  // only thing under test is the move.
+  await chooseComponent(page, "vdd-port");
+  await canvas.click({ position: { x: 360, y: 200 } });
+  await page.keyboard.press("Escape");
+  await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(1);
+
+  // Drag it down until its pin comes to rest on the wire. This used to be
+  // refused outright — "That edit would have changed which Nets these objects
+  // belong to" — leaving the part where it started: the author could neither
+  // connect it nor put it there.
+  const instance = page.locator('[data-canvas-hit-kind="instance"]').first();
+  const body = (await instance.boundingBox())!;
+  const wire = (await page
+    .locator('[data-canvas-hit-kind="route"]')
+    .first()
+    .boundingBox())!;
+  const cx = body.x + body.width / 2;
+  const cy = body.y + body.height / 2;
+  const travel = wire.y + wire.height / 2 - (body.y + body.height);
+  await page.mouse.move(cx, cy);
+  await page.mouse.down();
+  await page.mouse.move(cx, cy + travel / 2, { steps: 6 });
+  await page.mouse.move(cx, cy + travel, { steps: 6 });
+  await page.mouse.up();
+
+  await expect(page.getByTestId("status")).toContainText("connected them");
+  // The pin became a real endpoint on the conductor, so the wire is now two
+  // pieces meeting at it.
+  await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(2);
+  await expect(page.getByTestId("statusbar-issues")).toHaveText("No issues");
+});

--- a/packages/edit-engine/src/route-move-merge.test.ts
+++ b/packages/edit-engine/src/route-move-merge.test.ts
@@ -17,11 +17,18 @@ import {
   createRoutePath,
   type SchematicDocument,
 } from "@icm/model";
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { diagnoseVisualQuality } from "@icm/derived";
+import { parseProject } from "@icm/project-protocol";
 import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
-import { proposeLooseRouteTranslation } from "./routing-planner.js";
+import {
+  proposeEndpointRouteAttachment,
+  proposeLooseRouteTranslation,
+} from "./routing-planner.js";
 import {
   createRoutingOperationPlan,
   gateRoutingOperationPlan,
@@ -242,6 +249,50 @@ describe("moving a wire onto another wire", () => {
     ).toBe(true);
   });
 
+  it("declares the join an attach performs, so a pin can be dragged onto a wire", () => {
+    // The move controller already emits attach_endpoint_to_route when a
+    // dragged pin lands on a conductor, but the effect derivation read merge
+    // only from connect_endpoints. Every attach therefore declared "preserve"
+    // while performing a join, and the gate refused the gesture with "That
+    // edit would have changed which Nets these objects belong to" — the pin
+    // would not land, and the part could not be placed where the author put
+    // it.
+    const document = twoLooseWires();
+    document.instances.push({
+      id: "VDD1",
+      symbolId: "vdd-port",
+      placement: { position: { x: 150, y: 180 }, rotation: 0, mirror: "none" },
+    } as SchematicDocument["instances"][number]);
+    document.nets.push({
+      id: "net-vdd",
+      terminals: [{ instanceId: "VDD1", pinName: "P" }],
+    });
+
+    const attachment = proposeEndpointRouteAttachment(
+      document,
+      { kind: "terminal", instanceId: "VDD1", pinName: "P" },
+      "net-vdd",
+      "wire-horizontal",
+      { x: 150, y: 200 },
+      0,
+      "t2",
+    );
+    const plan = createRoutingOperationPlan(document, {
+      intent: "attach-to-route",
+      edits: attachment.edits,
+      diagnostics: [],
+    });
+    const gate = gateRoutingOperationPlan(document, plan, context);
+
+    expect(
+      gate.ok,
+      gate.ok ? "" : `${gate.message} :: ${gate.diagnostics[0]?.message ?? ""}`,
+    ).toBe(true);
+    // The declaration is derived, not hand-written: it names the attached
+    // endpoint together with the conductor it joins.
+    expect(plan.expectedElectricalEffect).toMatchObject({ kind: "merge" });
+  });
+
   it("stays a no-op when a moved end lands on a conductor of its own Net", () => {
     // Second half of the same guard: landing on a wire already on this Net has
     // nothing to merge, so the move must not manufacture an edit or an error.
@@ -257,5 +308,60 @@ describe("moving a wire onto another wire", () => {
 
     expect(netMembership(moved)).toEqual(before);
     expect(ambiguousJunctionErrors(moved)).toEqual([]);
+  });
+});
+
+describe("a pin resting on a conductor, in published drawings", () => {
+  /**
+   * Dragging a pin onto a wire connects it — that is a gesture. A pin that
+   * merely RESTS on a conductor in a drawing someone already published is not
+   * a gesture and must stay unconnected: the Gallery contract welcomes
+   * abbreviated schematics, and `diagnoseVisualQuality` grades the idiom a
+   * warning rather than an error for exactly that reason.
+   *
+   * Asserted against real published circuits rather than a synthetic case,
+   * because the risk being guarded is "we silently rewired drawings that
+   * already exist".
+   */
+  const corpus = resolve(process.cwd(), "fixtures/gallery-redline");
+  const files = readdirSync(corpus).filter((name) =>
+    name.endsWith(".icproj.json"),
+  );
+
+  it("finds the idiom in the corpus at all", () => {
+    // A guard on the guard: if the corpus ever stops containing a resting
+    // pin, the assertion below would pass vacuously and prove nothing.
+    const resting = files.flatMap((file) =>
+      parseProject(
+        readFileSync(resolve(corpus, file), "utf8"),
+      ).documents.flatMap((document) =>
+        diagnoseVisualQuality(document, resolver).filter(
+          (finding) => finding.code === "VISUAL_TERMINAL_ON_FOREIGN_ROUTE",
+        ),
+      ),
+    );
+    expect(resting.length).toBeGreaterThan(0);
+  });
+
+  it.each(files)("%s: a resting pin is still not a member", (file) => {
+    const project = parseProject(readFileSync(resolve(corpus, file), "utf8"));
+    for (const document of project.documents) {
+      const findings = diagnoseVisualQuality(document, resolver).filter(
+        (finding) => finding.code === "VISUAL_TERMINAL_ON_FOREIGN_ROUTE",
+      );
+      for (const finding of findings) {
+        const [instanceId, routeId] = finding.objectIds ?? [];
+        const route = document.routes.find(
+          (candidate) => candidate.id === routeId,
+        );
+        const restingNet = document.nets.find((net) =>
+          net.terminals.some((terminal) => terminal.instanceId === instanceId),
+        );
+        // The finding exists precisely because the pin is NOT on the
+        // conductor's Net. If these ever coincided, the drawing would have
+        // been rewired underneath its author.
+        expect(restingNet?.id).not.toBe(route?.netId);
+      }
+    }
   });
 });

--- a/packages/edit-engine/src/routing-operation-plan.ts
+++ b/packages/edit-engine/src/routing-operation-plan.ts
@@ -1,4 +1,4 @@
-import type { SchematicDocument } from "@icm/model";
+import { routeEndpoints, type SchematicDocument } from "@icm/model";
 import {
   deriveElectricalTopologyProjection,
   endpointKey,
@@ -395,11 +395,33 @@ export function expectedElectricalEffectForOperation(
   edits: readonly SchematicEdit[],
 ): ExpectedElectricalEffect {
   if (intent === "connect" || intent === "attach-to-route") {
-    const groups = edits.flatMap((edit) =>
-      edit.kind === "connect_endpoints"
-        ? [[endpointKey(edit.from), endpointKey(edit.to)]]
-        : [],
-    );
+    const groups = edits.flatMap((edit) => {
+      if (edit.kind === "connect_endpoints") {
+        return [[endpointKey(edit.from), endpointKey(edit.to)]];
+      }
+      // Attaching an endpoint to a Route is the other way this operation
+      // joins Nets: the endpoint becomes the common node of the two Route
+      // halves, so it ends up sharing that conductor's Net. Deriving merge
+      // only from connect_endpoints left every attach declaring "preserve"
+      // while performing a join, and the gate refused the gesture — a pin
+      // dragged onto a wire simply would not land.
+      if (edit.kind === "attach_endpoint_to_route") {
+        const route = document.routes.find(
+          (candidate) => candidate.id === edit.routeId,
+        );
+        return route
+          ? [
+              [
+                endpointKey(edit.endpoint),
+                ...routeEndpoints(route).map((endpoint) =>
+                  endpointKey(endpoint),
+                ),
+              ],
+            ]
+          : [];
+      }
+      return [];
+    });
     return groups.length > 0
       ? { kind: "merge", endpointGroups: groups }
       : { kind: "preserve", endpointKeys: existingEndpointKeys(document) };


### PR DESCRIPTION
Reported as "the VDD port cannot be nudged one grid down": a port whose pin sat on a wire refused to move, with

> That edit would have changed which Nets these objects belong to, so it was not applied. Connect them explicitly — end a wire on the conductor, or give both the same Net Label.

Reproduced through the e2e harness, the refused edit turns out to be the move that brings the pin **onto** the wire. The part could not be put there at all: it stayed where it started, apparently resting on the conductor and connected to nothing. From there the author could neither connect it nor move it — the "resting" state was the wreckage of the refusal, not a state anyone chose.

## Same root cause as #478, one level up

The selection move controller **already** emits `attach_endpoint_to_route` when a dragged pin lands on a conductor — it even has a status message for it, *"Snapped pin endpoints and connected them without a wire"*. But `expectedElectricalEffectForOperation` derived `merge` only from `connect_endpoints` edits. Every attach therefore declared `preserve` while performing a join, and the gate refused a declaration that was never true.

The gate was right again. The declaration was the lie.

## Why the derivation, not another planner

#478 fixed this class by teaching two planners to hand-write their declarations. Doing that a third time would leave the next caller of the attach path with the same bug. Instead the derivation now recognises the **primitive**: an endpoint attached to a Route becomes the common node of the two halves, so it ends up sharing that conductor's Net. That is a fact about `attach_endpoint_to_route` itself, it belongs in the same function that already derives merge from `connect_endpoints`, and it covers every present and future caller at once.

## Resting is untouched — verified against published drawings

Nothing here emits an attach. A pin that merely **rests** on a conductor in a drawing someone already published stays unconnected, which is what the Gallery contract promises and why `diagnoseVisualQuality` grades the idiom a warning rather than an error.

That is asserted rather than argued. Two of the six published snapshots in the red-line corpus contain a resting pin — `7sxpwb4am7` (I1 on route-ui-75) and `ycg43babwa` (M8 on route-ui-3-a-64) — and the new corpus test walks every such finding in every corpus document, asserting the pin is still **not** a member of the conductor's Net. A companion test fails if the corpus ever stops containing the idiom, so the assertion cannot pass vacuously.

Those corpus tests were green before this change and stay green: that is the evidence that resting semantics did not move.

## Tests

Red before green: an attach under `attach-to-route` intent now gates through and carries a derived `merge` declaration naming the attached endpoint together with its conductor's endpoints. One e2e drags a port onto a wire on the real canvas and asserts it lands, reports connecting, and splits the conductor into two pieces meeting at the pin.

Every #478 case — end-lands-on-conductor merges, crossing stays separate and silent, moves to empty page and onto one's own Net stay no-ops — was green before and remains green.

## Validation

Full `ci:check` under the gate lock, rebased onto current main: unit 2070/2070 (321 files), e2e 309/309, typecheck, format, drift gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
