### PR TITLE
refactor(properties): simplify color and target copy

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3033,8 +3033,10 @@ test("Properties toggles reference label visibility for one or many components",
     componentProperties.getByText("Appearance", { exact: true }),
   ).toBeVisible();
   await expect(
-    componentProperties.getByLabel("Component identity"),
-  ).toContainText("TargetBuilt-in primitive: resistor");
+    componentProperties.getByText("Built-in primitive: resistor", {
+      exact: true,
+    }),
+  ).toHaveCount(0);
   await expect(
     componentProperties.getByText("Netlist target", { exact: true }),
   ).toHaveCount(0);

--- a/apps/editor/src/features/properties/annotation-color-properties.test.tsx
+++ b/apps/editor/src/features/properties/annotation-color-properties.test.tsx
@@ -34,6 +34,7 @@ describe("annotation color properties", () => {
     expect(markup).toContain(
       'aria-label="Text color picker" type="color" value="#dc2626"',
     );
+    expect(markup).toContain("Auto uses the inherited text color.");
   });
 
   it("shows the annotation-owned override instead of inherited ink", () => {

--- a/apps/editor/src/features/properties/annotation-color-properties.tsx
+++ b/apps/editor/src/features/properties/annotation-color-properties.tsx
@@ -26,10 +26,7 @@ export function AnnotationColorProperties({
           disabled={annotation.locked}
           onChange={onChange}
         />
-        <small>
-          Auto inherits the owning instance's effective foreground for reference
-          and value text; other annotations use the document foreground.
-        </small>
+        <small>Auto uses the inherited text color.</small>
       </div>
     </section>
   );

--- a/apps/editor/src/features/properties/component-identity-properties.test.tsx
+++ b/apps/editor/src/features/properties/component-identity-properties.test.tsx
@@ -8,7 +8,7 @@ import {
 } from "./component-identity-properties";
 
 describe("component identity properties", () => {
-  it("describes a built-in primitive target", () => {
+  it("omits the internal target description for a built-in primitive", () => {
     const document = createEmptyDocument("cell", "Cell");
     const instance: (typeof document.instances)[number] = {
       id: "R1",
@@ -20,9 +20,7 @@ describe("component identity properties", () => {
         binding: { kind: "primitive", deviceClass: "resistor" },
       },
     };
-    expect(componentTargetDescription(instance)).toBe(
-      "Built-in primitive: resistor",
-    );
+    expect(componentTargetDescription(instance)).toBeNull();
   });
 
   it("renders identity, editable marker name, and model suggestions", () => {

--- a/apps/editor/src/features/properties/component-identity-properties.tsx
+++ b/apps/editor/src/features/properties/component-identity-properties.tsx
@@ -45,11 +45,11 @@ export function componentTargetDescription(
   instance: Instance,
   internalCellName?: string,
   externalSubcircuitName?: string,
-): string {
+): string | null {
   const binding = instance.netlist?.binding;
   switch (binding?.kind) {
     case "primitive":
-      return `Built-in primitive: ${binding.deviceClass}`;
+      return null;
     case "subcircuit":
       return `Internal Cell: ${internalCellName ?? "unresolved"}`;
     case "external-subcircuit":

--- a/apps/editor/src/features/properties/component-style-properties.test.tsx
+++ b/apps/editor/src/features/properties/component-style-properties.test.tsx
@@ -38,8 +38,7 @@ describe("component style properties", () => {
     expect(markup).toContain('aria-pressed="true"');
     expect(markup).toContain("Gray · #6b7280");
     expect(markup).not.toContain("Violet");
-    expect(markup).toContain("Colors apply only to this component");
-    expect(markup).toContain("Reference and value text inherit");
+    expect(markup).toContain("Colors apply to this component only.");
   });
 
   it("converts custom RGB values to canonical six-digit hex", () => {

--- a/apps/editor/src/features/properties/component-style-properties.tsx
+++ b/apps/editor/src/features/properties/component-style-properties.tsx
@@ -28,11 +28,7 @@ export function ComponentStyleProperties({
   return (
     <div className="property-card component-appearance-card">
       <div className="property-section-heading">Appearance</div>
-      <small>
-        Colors apply only to this component. Reference and value text inherit
-        the line color when their own text color remains Auto. Wires and
-        document defaults stay unchanged.
-      </small>
+      <small>Colors apply to this component only.</small>
       <ColorOverrideControl
         label="Line / foreground"
         value={instance.styleOverride?.foreground}


### PR DESCRIPTION
## Summary
- shorten the component and annotation color guidance without changing controls or inheritance
- hide the implementation-facing built-in primitive target row while preserving netlist bindings
- retain actionable model and subcircuit target surfaces

## Validation
- pnpm install --frozen-lockfile
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
  - 322 unit-test files / 2077 tests
  - 127 manual-editor browser tests

Test-Impact: tests-updated