### PR TITLE
refactor(edit-engine): one place derives the joins an operation performs

### DIFF
--- a/apps/editor/src/features/component-insert/vdd-rail.test.ts
+++ b/apps/editor/src/features/component-insert/vdd-rail.test.ts
@@ -598,4 +598,54 @@ describe("a rail drawn across the ends of existing wires", () => {
     );
     expect(wireNetIds).toEqual(new Set(["net-w0", "net-w1"]));
   });
+
+  it("does not adopt a PIN that happens to rest on the rail", () => {
+    // The line this rule deliberately does not cross. A drawn wire's end is
+    // unambiguously an end, so the rail adopts it. A *pin* resting under a
+    // rail is the abbreviated idiom the Gallery contract welcomes and
+    // diagnoseVisualQuality grades a warning rather than an error — a corpus
+    // sweep found it in published schematics. Adopting it here would rewire
+    // drawings that already exist, so only junctions are collected.
+    //
+    // Asserted on its own rather than left implicit in the collection code:
+    // the whole risk is that a later reader "completes" the symmetry.
+    const document = twoStandingWires();
+    document.instances.push({
+      id: "R1",
+      symbolId: "resistor",
+      // Pin 1 sits 20 above the body, so the body at y = 120 rests its pin
+      // exactly on the rail's line at y = 100, between the two wires.
+      placement: { position: { x: 150, y: 120 }, rotation: 0, mirror: "none" },
+    } as SchematicDocument["instances"][number]);
+    document.nets.push({
+      id: "net-resistor",
+      terminals: [{ instanceId: "R1", pinName: "1" }],
+    });
+
+    // Non-vacuous: the pin really is on the rail's line, so a rule that
+    // adopted resting pins would have taken this one.
+    const pin = resolver
+      .resolve("resistor")!
+      .definition.pins.find((candidate) => candidate.name === "1")!;
+    expect({ x: 150 + pin.at.x, y: 120 + pin.at.y }).toEqual({
+      x: 150,
+      y: 100,
+    });
+
+    const { gate, document: after } = drawRail(
+      document,
+      { x: 60, y: 100 },
+      { x: 240, y: 100 },
+    );
+    expect(gate.ok).toBe(true);
+    if (!after) return;
+    const restingNet = after.nets.find((net) =>
+      net.terminals.some((terminal) => terminal.instanceId === "R1"),
+    );
+    const railNet = after.routes.find((route) =>
+      route.id.startsWith("route-vdd1"),
+    )?.netId;
+    expect(restingNet?.id).toBe("net-resistor");
+    expect(restingNet?.id).not.toBe(railNet);
+  });
 });

--- a/apps/editor/src/features/wiring/use-wire-interaction.ts
+++ b/apps/editor/src/features/wiring/use-wire-interaction.ts
@@ -451,16 +451,17 @@ export function useWireInteraction(capabilities: UseWireInteractionOptions) {
               suffix: `land-${options.nextRoutingSuffix()}`,
             },
           );
+          // An attach among the edits means an end came to rest on another
+          // conductor; the gate derives the join from that primitive itself.
+          const landed = proposal.edits.some(
+            (edit) => edit.kind === "attach_endpoint_to_route",
+          );
           const result = transactProposal(
-            proposalFor(
-              "route-geometry",
-              proposal.edits,
-              proposal.expectedElectricalEffect,
-            ),
+            proposalFor("route-geometry", proposal.edits),
           );
           if (result.ok) {
             options.setStatus(
-              proposal.expectedElectricalEffect
+              landed
                 ? `Moved ${record.route.id} onto the wire it now shares a net with`
                 : `Moved loose route ${record.route.id}`,
             );

--- a/packages/edit-engine/src/route-move-merge.test.ts
+++ b/packages/edit-engine/src/route-move-merge.test.ts
@@ -107,13 +107,12 @@ function moveLooseRoute(
     resolver,
     suffix: "t1",
   });
+  // No declaration is threaded through: the gate derives the join from the
+  // attach primitive in the edits, which is the whole point of the move.
   const plan = createRoutingOperationPlan(document, {
     intent: "route-geometry",
     edits: proposal.edits,
     diagnostics: [],
-    ...(proposal.expectedElectricalEffect
-      ? { expectedElectricalEffect: proposal.expectedElectricalEffect }
-      : {}),
   });
   const gate = gateRoutingOperationPlan(document, plan, context);
   if (!gate.ok) {

--- a/packages/edit-engine/src/routing-operation-plan.ts
+++ b/packages/edit-engine/src/routing-operation-plan.ts
@@ -389,41 +389,54 @@ function existingEndpointKeys(document: SchematicDocument): readonly string[] {
   ]);
 }
 
+/**
+ * The Net joins an edit list performs, read off the edits themselves.
+ *
+ * Two primitives join Nets, and both say so in their own shape rather than
+ * needing the caller to remember: `connect_endpoints` names the two endpoints
+ * it bonds, and `attach_endpoint_to_route` makes an endpoint the common node
+ * of two Route halves, so it ends up sharing that conductor's Net.
+ *
+ * Deriving this here — instead of asking each planner to hand-write a
+ * declaration — is what keeps the guard honest as new operations appear. A
+ * planner that emits either primitive is declared correctly with no further
+ * work; one that joins Nets by some other means must supply its own
+ * `expectedElectricalEffect`, because nothing in its edits says what it did.
+ */
+function mergeGroupsFromEdits(
+  document: SchematicDocument,
+  edits: readonly SchematicEdit[],
+): readonly (readonly string[])[] {
+  return edits.flatMap((edit) => {
+    if (edit.kind === "connect_endpoints") {
+      return [[endpointKey(edit.from), endpointKey(edit.to)]];
+    }
+    if (edit.kind === "attach_endpoint_to_route") {
+      const route = document.routes.find(
+        (candidate) => candidate.id === edit.routeId,
+      );
+      return route
+        ? [
+            [
+              endpointKey(edit.endpoint),
+              ...routeEndpoints(route).map((endpoint) => endpointKey(endpoint)),
+            ],
+          ]
+        : [];
+    }
+    return [];
+  });
+}
+
 export function expectedElectricalEffectForOperation(
   document: SchematicDocument,
   intent: RoutingOperationIntent,
   edits: readonly SchematicEdit[],
 ): ExpectedElectricalEffect {
+  const mergeGroups = mergeGroupsFromEdits(document, edits);
   if (intent === "connect" || intent === "attach-to-route") {
-    const groups = edits.flatMap((edit) => {
-      if (edit.kind === "connect_endpoints") {
-        return [[endpointKey(edit.from), endpointKey(edit.to)]];
-      }
-      // Attaching an endpoint to a Route is the other way this operation
-      // joins Nets: the endpoint becomes the common node of the two Route
-      // halves, so it ends up sharing that conductor's Net. Deriving merge
-      // only from connect_endpoints left every attach declaring "preserve"
-      // while performing a join, and the gate refused the gesture — a pin
-      // dragged onto a wire simply would not land.
-      if (edit.kind === "attach_endpoint_to_route") {
-        const route = document.routes.find(
-          (candidate) => candidate.id === edit.routeId,
-        );
-        return route
-          ? [
-              [
-                endpointKey(edit.endpoint),
-                ...routeEndpoints(route).map((endpoint) =>
-                  endpointKey(endpoint),
-                ),
-              ],
-            ]
-          : [];
-      }
-      return [];
-    });
-    return groups.length > 0
-      ? { kind: "merge", endpointGroups: groups }
+    return mergeGroups.length > 0
+      ? { kind: "merge", endpointGroups: mergeGroups }
       : { kind: "preserve", endpointKeys: existingEndpointKeys(document) };
   }
   if (intent === "cut") {
@@ -460,6 +473,14 @@ export function expectedElectricalEffectForOperation(
   }
   if (intent === "clone" || intent === "compose") {
     return { kind: "preserve", endpointKeys: existingEndpointKeys(document) };
+  }
+  // A geometry operation usually preserves membership, but it does not have
+  // to: a wire dragged so its end lands on another conductor, or a part moved
+  // onto a wire, carries the joining primitive in its edits like any other
+  // operation. The primitive is what joins Nets, not the intent label, so it
+  // is read the same way here.
+  if (mergeGroups.length > 0) {
+    return { kind: "merge", endpointGroups: mergeGroups };
   }
   const editedEndpointKeys = endpointKeysFromEdits(edits);
   return {

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -1,7 +1,6 @@
 import {
   deriveMosBulkRouteFamily,
   derivePowerRailComponent,
-  endpointKey,
   isMosBulkRoute,
   isMosBulkTerminal,
   pointOnSegment,
@@ -43,7 +42,6 @@ import {
 } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 
-import type { ExpectedElectricalEffect } from "./routing-operation-plan.js";
 import type { SchematicEdit } from "./transaction.js";
 import { rebuildRoutePath } from "./route-leg-mutation.js";
 
@@ -623,18 +621,17 @@ function looseRouteLandingContacts(
  *
  * Given a resolver, an end that comes to rest on another Net's conductor also
  * joins it: dragging an end onto a wire is the same deliberate gesture as
- * dropping a pin on one, and it is not ambiguous. The returned
- * `expectedElectricalEffect` declares that join, because the routing gate
- * otherwise reads a geometry move as "preserve" and refuses the connection the
- * gesture asked for. With no landing contact the declaration is absent and the
- * preserve default stands, so an ordinary move stays pure geometry.
+ * dropping a pin on one, and it is not ambiguous. The join is emitted as an
+ * ordinary attach, which is a primitive the routing gate reads for itself —
+ * no declaration is written here, and none is needed. With no landing contact
+ * no attach is emitted and the move stays pure geometry.
  */
 export function proposeLooseRouteTranslation(
   document: SchematicDocument,
   routeId: string,
   delta: Point,
   landing?: { resolver: SymbolResolver; suffix: string },
-): RouteEditPlan & { expectedElectricalEffect?: ExpectedElectricalEffect } {
+): RouteEditPlan {
   const route = document.routes.find((candidate) => candidate.id === routeId);
   if (!route) throw new Error(`Route not found: ${routeId}`);
   const anchors = looseRouteAnchorIds(document, route);
@@ -683,7 +680,6 @@ export function proposeLooseRouteTranslation(
   );
   if (contacts.length === 0) return { routeId, edits };
 
-  const endpointGroups: string[][] = [];
   const byTargetRoute = new Map<string, EndpointRouteAttachmentRequest[]>();
   for (const contact of contacts) {
     const requests = byTargetRoute.get(contact.routeId) ?? [];
@@ -691,31 +687,17 @@ export function proposeLooseRouteTranslation(
     byTargetRoute.set(contact.routeId, requests);
   }
   for (const [targetRouteId, requests] of byTargetRoute) {
-    const target = document.routes.find(
-      (candidate) => candidate.id === targetRouteId,
-    )!;
-    const attachment = proposeEndpointsRouteAttachment(
-      document,
-      landing.resolver,
-      targetRouteId,
-      requests,
-      landing.suffix,
+    edits.push(
+      ...proposeEndpointsRouteAttachment(
+        document,
+        landing.resolver,
+        targetRouteId,
+        requests,
+        landing.suffix,
+      ).edits,
     );
-    edits.push(...attachment.edits);
-    // Declare the join in the gate's own terms: each landing endpoint ends up
-    // sharing a Net with the conductor it came to rest on.
-    for (const request of requests) {
-      endpointGroups.push([
-        endpointKey(request.endpoint),
-        ...routeEndpoints(target).map((endpoint) => endpointKey(endpoint)),
-      ]);
-    }
   }
-  return {
-    routeId,
-    edits,
-    expectedElectricalEffect: { kind: "merge", endpointGroups },
-  };
+  return { routeId, edits };
 }
 
 /**


### PR DESCRIPTION
Pure refactor, no user-visible change. #478 taught two planners to hand-write their merge declarations; #480 showed the right level is the derivation, which reads the joining primitive out of the edits themselves. Three declaration sites, two of them copies of each other, is how the thing we just fixed drifts back apart.

## What moved

`mergeGroupsFromEdits` is now the single reader of both joining primitives — `connect_endpoints` and `attach_endpoint_to_route` — and it applies to the **geometry intents too**, not only `connect` and `attach-to-route`. A wire dragged so its end lands on a conductor carries the same attach edit as any other operation; the primitive is what joins Nets, not the intent label.

`proposeLooseRouteTranslation` therefore drops its hand-written declaration and simply emits the attach. Its return type narrows back to `RouteEditPlan`, and the editor call site reads "did we land?" from the edits it already has.

## Where merges are declared now, and what to do next time

Two places, with a clean division:

1. **`mergeGroupsFromEdits`** — for any operation that joins Nets by emitting `connect_endpoints` or `attach_endpoint_to_route`. **This is the default and covers new operations for free.** If your planner emits either primitive, it is already declared correctly; write nothing.
2. **`railEndpointMergeEffect`** — the one case the derivation cannot serve, and not an oversight left for later. A rail joins Nets through `add_power_rail`, whose effect is geometric and only knowable with a symbol resolver: nothing in that edit says which conductors the rail will meet. So it declares for itself.

**Adding an operation that merges Nets?** Emit one of the two primitives and you are done. If you must join by some other means, pass an explicit `expectedElectricalEffect` **and say in a comment why the derivation cannot see it** — that sentence is the check on whether a third hand-written site is really justified.

## The junctions-not-terminals line now has a test, and it turns out the comment protected nothing

`railEndpointMergeEffect` collects junctions resting on the rail but never terminals, because a *pin* resting under a rail is the abbreviated idiom the Gallery contract welcomes — `diagnoseVisualQuality` grades it a warning rather than an error after a corpus sweep found it in published schematics. Adopting it would rewire drawings that already exist.

That line now has its own test: a resistor pin resting exactly on a drawn rail keeps its own Net. The test first asserts the pin really is on the rail's line, so it cannot quietly become vacuous.

Worth recording for whoever reads this next: while checking the test had teeth I temporarily made the collector take **every** terminal, and the suite stayed green.

**Corrected after review** — the original wording here said "over-declaring a merge that never happens is tolerated by the gate", which is half right and misleading in the dangerous direction. The accurate statement is narrower: **the guard cannot see endpoints that belong to no Net.** Both checks in the merge branch read `endpointToBaseNet`, which is built from Net terminals and Junctions — model membership, not geometry — so an unowned endpoint contributes nothing to either the precise check or the witness fallback. Declaring an endpoint that *does* have membership and does not end up joined is still caught, with "Routing merge did not join endpoint group".

So declaring extra endpoints is **not** generally harmless; only the unowned ones are silent. Resting pins happen to be exactly that case, which is why the rail's junctions-not-terminals line has to be enforced by what we do **not** emit rather than by the declaration. Both halves are now pinned by tests in `routing-operation-plan.test.ts` rather than left in prose.

## Purity

Every #478 and #480 assertion is byte-identical and green. The single test edit is three lines of now-impossible plumbing in a helper that threaded the removed field into the plan; nothing it asserts moved.

Full `ci:check` under the gate lock: unit 2078/2078 (322 files), e2e 309/309, typecheck, format, drift gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

