### PR TITLE
fix(routing): normalize routes collapsed by switch pins

### DIFF
--- a/apps/editor/src/document/project-conductor-normalization.test.ts
+++ b/apps/editor/src/document/project-conductor-normalization.test.ts
@@ -76,4 +76,72 @@ describe("imported Project conductor normalization", () => {
     expect(normalized).toEqual({ project, changedDocumentIds: [] });
     expect(normalized.project).toBe(project);
   });
+
+  it("converts a switch Route collapsed by current terminal geometry to direct contact", () => {
+    const project = createEmptyProject("legacy-switch", "Legacy switch");
+    const document = project.documents[0]!;
+    document.instances.push(
+      {
+        id: "X1",
+        symbolId: "ideal-switch",
+        placement: {
+          position: { x: 500, y: 200 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        id: "P1",
+        symbolId: "port",
+        placement: {
+          position: { x: 510, y: 200 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+    );
+    document.nets.push({
+      id: "net-contact",
+      terminals: [
+        { instanceId: "X1", pinName: "2" },
+        { instanceId: "P1", pinName: "P" },
+      ],
+    });
+    document.netlist!.terminals.push({
+      id: "terminal-p1",
+      name: "OUT",
+      netId: "net-contact",
+      direction: "passive",
+      interfaceInstanceIds: ["P1"],
+    });
+    document.routes.push(
+      createRoutePath({
+        id: "legacy-ten-unit-route",
+        netId: "net-contact",
+        start: { kind: "terminal", instanceId: "P1", pinName: "P" },
+        end: { kind: "terminal", instanceId: "X1", pinName: "2" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+
+    const normalized = normalizeImportedProjectConductors(project, resolver);
+
+    expect(normalized.changedDocumentIds).toEqual([document.id]);
+    expect(normalized.project.documents[0]).toMatchObject({
+      revision: 1,
+      sourceStatus: "geometry-only-changed",
+      routes: [],
+      nets: [
+        {
+          id: "net-contact",
+          terminals: [
+            { instanceId: "X1", pinName: "2" },
+            { instanceId: "P1", pinName: "P" },
+          ],
+        },
+      ],
+    });
+    expect(project.documents[0]!.routes).toHaveLength(1);
+  });
 });

--- a/apps/editor/src/document/project-conductor-normalization.ts
+++ b/apps/editor/src/document/project-conductor-normalization.ts
@@ -1,4 +1,7 @@
-import { normalizeSameNetConductorTopology } from "@icm/edit-engine";
+import {
+  normalizeRedundantDirectContactRoutes,
+  normalizeSameNetConductorTopology,
+} from "@icm/edit-engine";
 import { CircuitProjectSchema } from "@icm/model";
 import type { CircuitProject } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
@@ -9,7 +12,7 @@ export interface ImportedConductorNormalization {
 }
 
 /**
- * Canonicalize legacy ordinary-Wire overlap in one explicitly imported copy.
+ * Canonicalize legacy ordinary-Wire geometry in one explicitly imported copy.
  *
  * Project parsing remains byte-preserving and Cloud/recovery opens remain
  * exact. The local File import boundary is the intentional equivalent of an
@@ -23,8 +26,12 @@ export function normalizeImportedProjectConductors(
   const candidate = structuredClone(project);
   const changedDocumentIds: string[] = [];
   for (const document of candidate.documents) {
-    const result = normalizeSameNetConductorTopology(document, resolver);
-    if (!result.changed) continue;
+    const directContacts = normalizeRedundantDirectContactRoutes(
+      document,
+      resolver,
+    );
+    const topology = normalizeSameNetConductorTopology(document, resolver);
+    if (!directContacts.changed && !topology.changed) continue;
     document.revision += 1;
     if (document.sourceStatus === "in-sync") {
       document.sourceStatus = "geometry-only-changed";

--- a/apps/editor/src/features/component-insert/placement-connectivity.test.ts
+++ b/apps/editor/src/features/component-insert/placement-connectivity.test.ts
@@ -5,7 +5,10 @@ import {
   gateRoutingOperationPlan,
   planInstanceDeletion,
 } from "@icm/edit-engine";
-import { resolveDocumentLogicalNets } from "@icm/derived";
+import {
+  resolveDocumentLogicalNets,
+  resolveEndpointConnection,
+} from "@icm/derived";
 import { createEmptyDocument, transformPoint } from "@icm/model";
 import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
@@ -60,6 +63,90 @@ function transaction(expectedRevision: number, edits: unknown[]) {
 }
 
 describe("component placement electrical contacts", () => {
+  it.each([
+    "simple-switch",
+    "ideal-switch",
+    "closed-switch",
+    "spdt-switch",
+    "simple-spdt-switch",
+    "voltage-controlled-switch",
+  ])("connects %s directly to a Cell Port without a Route", (symbolId) => {
+    const document = createEmptyDocument("main", "Main");
+    document.instances.push({
+      id: "P1",
+      symbolId: "port",
+      placement: {
+        position: { x: 0, y: 0 },
+        rotation: 0,
+        mirror: "none",
+      },
+    });
+    document.nets.push({
+      id: "net-port",
+      terminals: [{ instanceId: "P1", pinName: "P" }],
+    });
+    document.netlist!.terminals.push({
+      id: "terminal-p1",
+      name: "OUT",
+      netId: "net-port",
+      direction: "passive",
+      interfaceInstanceIds: ["P1"],
+    });
+    const symbol = resolver.resolve(symbolId)!.definition;
+    const contactedPin = symbol.pins[0]!;
+    const placed = {
+      id: "S1",
+      symbolId,
+      placement: {
+        position: {
+          x: 10 - contactedPin.at.x,
+          y: -contactedPin.at.y,
+        },
+        rotation: 0 as const,
+        mirror: "none" as const,
+      },
+    };
+
+    const portEndpoint = {
+      kind: "terminal" as const,
+      instanceId: "P1",
+      pinName: "P",
+    };
+    const proposal = proposePlacementContact(document, resolver, placed, [
+      {
+        endpoint: portEndpoint,
+        connection: resolveEndpointConnection(
+          document,
+          resolver,
+          portEndpoint,
+        )!,
+        netId: "net-port",
+        preludeEdits: [],
+      },
+    ]);
+
+    expect(proposal).toMatchObject({ matched: true, ambiguous: false });
+    const result = executeTransaction(
+      document,
+      transaction(document.revision, [
+        { kind: "add_instance", instance: placed },
+        ...proposal.edits,
+      ]),
+      context,
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.document.routes).toEqual([]);
+    expect(result.document.nets).toEqual([
+      expect.objectContaining({
+        id: "net-port",
+        terminals: expect.arrayContaining([
+          { instanceId: "P1", pinName: "P" },
+          { instanceId: "S1", pinName: contactedPin.name },
+        ]),
+      }),
+    ]);
+  });
+
   it("splices a two-pin component into one contacted Route", () => {
     const document = createEmptyDocument("main", "Main");
     document.nets.push({ id: "net-signal", terminals: [] });

--- a/apps/editor/src/features/editor-shell/gallery-example-commands.test.ts
+++ b/apps/editor/src/features/editor-shell/gallery-example-commands.test.ts
@@ -1,4 +1,8 @@
-import { createEmptyDocument, createEmptyProject } from "@icm/model";
+import {
+  createEmptyDocument,
+  createEmptyProject,
+  createRoutePath,
+} from "@icm/model";
 import { serializeProject } from "@icm/project-protocol";
 import { describe, expect, it, vi } from "vitest";
 
@@ -46,6 +50,75 @@ describe("Gallery and example commands", () => {
     expect(input.setStatus).toHaveBeenCalledWith(
       expect.stringContaining("Place Scene on the canvas"),
     );
+  });
+
+  it("normalizes a switch Route collapsed by current pins before Gallery placement", () => {
+    const input = dependencies();
+    const imported = createEmptyProject("legacy-switch", "Legacy switch");
+    const document = imported.documents[0]!;
+    document.instances.push(
+      {
+        id: "X1",
+        symbolId: "ideal-switch",
+        placement: {
+          position: { x: 500, y: 200 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        id: "P1",
+        symbolId: "port",
+        placement: {
+          position: { x: 510, y: 200 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+    );
+    document.nets.push({
+      id: "net-contact",
+      terminals: [
+        { instanceId: "X1", pinName: "2" },
+        { instanceId: "P1", pinName: "P" },
+      ],
+    });
+    document.netlist!.terminals.push({
+      id: "terminal-p1",
+      name: "OUT",
+      netId: "net-contact",
+      direction: "passive",
+      interfaceInstanceIds: ["P1"],
+    });
+    document.routes.push(
+      createRoutePath({
+        id: "legacy-ten-unit-route",
+        netId: "net-contact",
+        start: { kind: "terminal", instanceId: "P1", pinName: "P" },
+        end: { kind: "terminal", instanceId: "X1", pinName: "2" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+    const commands = createGalleryExampleCommands(input);
+
+    expect(commands.beginProjectImportPlacement(imported, "Switch")).toBe(true);
+
+    expect(input.beginCopyPlacement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        routes: [],
+        nets: [
+          expect.objectContaining({
+            terminals: expect.arrayContaining([
+              { instanceId: "X1", pinName: "2" },
+              { instanceId: "P1", pinName: "P" },
+            ]),
+          }),
+        ],
+      }),
+      { x: 500, y: 200 },
+    );
+    expect(document.routes).toHaveLength(1);
   });
 
   it("leaves hierarchical Projects for guarded replacement", () => {

--- a/apps/editor/src/features/editor-shell/gallery-example-commands.ts
+++ b/apps/editor/src/features/editor-shell/gallery-example-commands.ts
@@ -1,6 +1,8 @@
 import type { CircuitProject, GridRect } from "@icm/model";
 import { parseProject } from "@icm/project-protocol";
+import { builtInSymbols, createProjectSymbolResolver } from "@icm/symbols";
 
+import { normalizeImportedProjectConductors } from "../../document/project-conductor-normalization";
 import type { ReplaceProjectOptions } from "../../document/use-project-file-lifecycle";
 import {
   createLibraryExampleProject,
@@ -69,14 +71,21 @@ export function createGalleryExampleCommands({
   setStatus,
   fetchImpl = fetch,
 }: GalleryExampleCommandDependencies) {
+  const normalizeImportedProject = (imported: CircuitProject): CircuitProject =>
+    normalizeImportedProjectConductors(
+      imported,
+      createProjectSymbolResolver(imported, builtInSymbols),
+    ).project;
+
   const beginProjectImportPlacement = (
     imported: CircuitProject,
     label: string,
   ): boolean => {
-    const importedDocument = imported.documents.find(
-      (candidate) => candidate.id === imported.topDocumentId,
+    const normalized = normalizeImportedProject(imported);
+    const importedDocument = normalized.documents.find(
+      (candidate) => candidate.id === normalized.topDocumentId,
     );
-    if (!importedDocument || imported.documents.length > 1) return false;
+    if (!importedDocument || normalized.documents.length > 1) return false;
     const clipboard = captureDocumentComposition(importedDocument);
     const anchor = clipboard ? clipboardPlacementAnchor(clipboard) : null;
     if (!clipboard || !anchor) return false;
@@ -105,7 +114,9 @@ export function createGalleryExampleCommands({
         setStatus("This gallery entry is unavailable");
         return;
       }
-      const galleryProject = parseProject(payload.projectText);
+      const galleryProject = normalizeImportedProject(
+        parseProject(payload.projectText),
+      );
       const name = payload.entry?.name ?? galleryProject.name;
       const install = () => {
         replaceActiveProject(galleryProject, defaultViewBox);

--- a/docs/specs/connectivity-and-routing.md
+++ b/docs/specs/connectivity-and-routing.md
@@ -33,6 +33,14 @@ for an explicit Cloud Save or Project export. Cloud opens, recovery, and the
 project-protocol parser remain exact: they never rewrite stored geometry as a
 read side effect.
 
+An ordinary Route that resolves entirely to one exact point after a built-in
+terminal-anchor correction is redundant direct-contact geometry. File,
+Gallery-open, and Gallery-placement import copies remove it only when both
+endpoints still belong to its Base Net and no Annotation, name owner, layout
+group, or constraint owns the Route. The Net membership survives unchanged;
+owned geometry is retained for an explicit diagnostic instead of being
+silently discarded.
+
 Route centerlines are one geometry protocol. Normal interactive Routes may use
 horizontal, vertical, or ±45-degree segments; orthogonal is the default
 authoring constraint, not a second persisted Route shape. `power-rail` is the

--- a/docs/specs/project-file-format.md
+++ b/docs/specs/project-file-format.md
@@ -110,6 +110,10 @@ canonicalized to v36 only after a successful validated write.
 Project entry does not physically merge Base Nets. Matching authoritative names
 resolve as one Logical Net; conflicting claims remain a blocking diagnostic.
 Repeated source-name hints are valid provenance and never imply connectivity.
+The explicit portable-file and Gallery import boundaries may canonicalize
+legacy ordinary-Wire geometry, including removal of an unowned Route that now
+resolves entirely to an already-connected endpoint contact; parsing, Cloud
+open, and recovery remain exact.
 
 Canonical serialization ends with one newline and is byte-stable across
 serialize/parse/serialize. The current corpus is listed in

--- a/packages/edit-engine/src/direct-contact-route-normalization.test.ts
+++ b/packages/edit-engine/src/direct-contact-route-normalization.test.ts
@@ -1,0 +1,88 @@
+import { createEmptyDocument, createRoutePath } from "@icm/model";
+import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { normalizeRedundantDirectContactRoutes } from "./direct-contact-route-normalization.js";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+function legacySwitchContact() {
+  const document = createEmptyDocument("switch-contact", "SwitchContact");
+  document.instances.push(
+    {
+      id: "X1",
+      symbolId: "ideal-switch",
+      placement: {
+        position: { x: 500, y: 200 },
+        rotation: 0,
+        mirror: "none",
+      },
+    },
+    {
+      id: "P1",
+      symbolId: "port",
+      placement: {
+        position: { x: 510, y: 200 },
+        rotation: 0,
+        mirror: "none",
+      },
+    },
+  );
+  document.nets.push({
+    id: "net-contact",
+    terminals: [
+      { instanceId: "X1", pinName: "2" },
+      { instanceId: "P1", pinName: "P" },
+    ],
+  });
+  document.netlist!.terminals.push({
+    id: "terminal-p1",
+    name: "OUT",
+    netId: "net-contact",
+    direction: "passive",
+    interfaceInstanceIds: ["P1"],
+  });
+  document.routes.push(
+    createRoutePath({
+      id: "legacy-ten-unit-route",
+      netId: "net-contact",
+      start: { kind: "terminal", instanceId: "P1", pinName: "P" },
+      end: { kind: "terminal", instanceId: "X1", pinName: "2" },
+      bends: [],
+      modes: ["manual"],
+    }),
+  );
+  return document;
+}
+
+describe("legacy direct-contact Route normalization", () => {
+  it("removes the Route collapsed by the shorter switch lead", () => {
+    const document = legacySwitchContact();
+
+    const result = normalizeRedundantDirectContactRoutes(document, resolver);
+
+    expect(result.changed).toBe(true);
+    expect([...result.removedRouteIds]).toEqual(["legacy-ten-unit-route"]);
+    expect(document.routes).toEqual([]);
+    expect(document.nets[0]!.terminals).toEqual([
+      { instanceId: "X1", pinName: "2" },
+      { instanceId: "P1", pinName: "P" },
+    ]);
+  });
+
+  it("does not discard a collapsed Route with an external layout owner", () => {
+    const document = legacySwitchContact();
+    document.layoutGroups.push({
+      id: "group-route-owner",
+      kind: "custom",
+      objectIds: ["legacy-ten-unit-route"],
+      locked: false,
+    });
+
+    const result = normalizeRedundantDirectContactRoutes(document, resolver);
+
+    expect(result.changed).toBe(false);
+    expect([...result.protectedRouteIds]).toEqual(["legacy-ten-unit-route"]);
+    expect(document.routes).toHaveLength(1);
+  });
+});

--- a/packages/edit-engine/src/direct-contact-route-normalization.ts
+++ b/packages/edit-engine/src/direct-contact-route-normalization.ts
@@ -1,0 +1,93 @@
+import { routeEnd, type SchematicDocument } from "@icm/model";
+import { resolveRouteGeometry } from "@icm/derived";
+import type { SymbolResolver } from "@icm/symbols";
+
+import { endpointOwnerNetId } from "./transaction-routing.js";
+
+export interface DirectContactRouteNormalizationResult {
+  changed: boolean;
+  removedRouteIds: ReadonlySet<string>;
+  protectedRouteIds: ReadonlySet<string>;
+}
+
+function routeHasExternalOwner(
+  document: SchematicDocument,
+  routeId: string,
+): boolean {
+  return (
+    document.annotations.some(
+      (annotation) =>
+        (annotation.anchor.kind === "route" &&
+          annotation.anchor.routeId === routeId) ||
+        (annotation.anchor.kind === "object" &&
+          annotation.anchor.objectId === routeId),
+    ) ||
+    document.connectivityEvidence.some(
+      (evidence) =>
+        evidence.kind === "name-claim" &&
+        evidence.owner.kind === "power-marker" &&
+        evidence.owner.objectId === routeId,
+    ) ||
+    document.layoutGroups.some((group) => group.objectIds.includes(routeId)) ||
+    document.constraints.some((constraint) =>
+      constraint.objectIds.includes(routeId),
+    )
+  );
+}
+
+/**
+ * Remove legacy ordinary-Wire geometry that now resolves to one exact point.
+ *
+ * Symbol terminal anchors are part of persisted Route geometry even though a
+ * Route stores endpoint identity instead of endpoint coordinates. A library
+ * correction can therefore collapse an old one-cell Route after resolution.
+ * When both endpoints still belong to the Route's Base Net, that geometry is
+ * redundant: the coincident endpoints already represent the same direct
+ * electrical contact. Route-owned presentation is never discarded here.
+ */
+export function normalizeRedundantDirectContactRoutes(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+): DirectContactRouteNormalizationResult {
+  const removedRouteIds = new Set<string>();
+  const protectedRouteIds = new Set<string>();
+
+  for (const route of document.routes) {
+    if (
+      (route.presentation ?? "wire") !== "wire" ||
+      route.legs.some((leg) => leg.mode === "locked")
+    ) {
+      continue;
+    }
+    const geometry = resolveRouteGeometry(document, resolver, route);
+    const contactPoint = geometry?.centerline[0];
+    if (
+      !geometry ||
+      !contactPoint ||
+      !geometry.centerline.every(
+        (point) => point.x === contactPoint.x && point.y === contactPoint.y,
+      )
+    ) {
+      continue;
+    }
+    const fromNetId = endpointOwnerNetId(document, route.start);
+    const toNetId = endpointOwnerNetId(document, routeEnd(route));
+    if (fromNetId !== route.netId || toNetId !== route.netId) continue;
+    if (routeHasExternalOwner(document, route.id)) {
+      protectedRouteIds.add(route.id);
+      continue;
+    }
+    removedRouteIds.add(route.id);
+  }
+
+  if (removedRouteIds.size > 0) {
+    document.routes = document.routes.filter(
+      (route) => !removedRouteIds.has(route.id),
+    );
+  }
+  return {
+    changed: removedRouteIds.size > 0,
+    removedRouteIds,
+    protectedRouteIds,
+  };
+}

--- a/packages/edit-engine/src/index.ts
+++ b/packages/edit-engine/src/index.ts
@@ -7,6 +7,7 @@ export * from "./series-splice-planner.js";
 export * from "./power-net-planner.js";
 export * from "./named-net-planner.js";
 export * from "./direct-contact-planner.js";
+export * from "./direct-contact-route-normalization.js";
 export * from "./reference-planner.js";
 export * from "./reference-batch-planner.js";
 export * from "./batch-property-planner.js";

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -1310,6 +1310,10 @@ export function proposeWireCommit(
     draft.routingMode ?? "orthogonal",
     draft.cornerOrder ?? "auto",
   );
+  // Exact endpoint contact is real connectivity but has no conductor length.
+  // Keep the ordinary connect/merge edits above and do not manufacture a
+  // Route whose sole segment begins and ends at the same resolved point.
+  if (routed.points.length < 2) return { routeId, netId, edits };
   edits.push({
     kind: "set_route_path",
     route: createRoutePath({

--- a/packages/edit-engine/src/transaction-route-geometry.ts
+++ b/packages/edit-engine/src/transaction-route-geometry.ts
@@ -15,6 +15,7 @@ import { removeConnectivityEvidenceOwnedBy } from "./transaction-connectivity.js
 import {
   routeFromEdit,
   routeIsProtected,
+  routeRelatedObjectIds,
   validateRoute,
 } from "./transaction-routing.js";
 
@@ -82,7 +83,7 @@ export function applyRouteGeometryEdit(
             "EDIT_PRECONDITION",
             routeError,
             [],
-            [edit.route.id],
+            routeRelatedObjectIds(route),
           ),
         };
       }
@@ -172,7 +173,12 @@ export function applyRouteGeometryEdit(
       if (routeError) {
         return {
           ok: false,
-          rejection: reject("EDIT_PRECONDITION", routeError),
+          rejection: reject(
+            "EDIT_PRECONDITION",
+            routeError,
+            [],
+            routeRelatedObjectIds(route),
+          ),
         };
       }
       if (existingIndex >= 0) draft.routes[existingIndex] = route;

--- a/packages/edit-engine/src/transaction-routing.ts
+++ b/packages/edit-engine/src/transaction-routing.ts
@@ -30,6 +30,18 @@ export function routeIsProtected(route: RouteBranch): boolean {
   return route.legs.some((leg) => leg.mode === "locked");
 }
 
+export function routeRelatedObjectIds(route: RouteBranch): string[] {
+  const end = routeEnd(route);
+  return [
+    route.id,
+    route.netId,
+    ...(route.start.kind === "terminal"
+      ? [route.start.instanceId]
+      : [route.start.junctionId]),
+    ...(end.kind === "terminal" ? [end.instanceId] : [end.junctionId]),
+  ];
+}
+
 export function endpointOwnerNetId(
   document: SchematicDocument,
   endpoint: RouteEndpoint,
@@ -235,7 +247,10 @@ export function validateRoute(
   // rejects only degenerate geometry; which headings a command may author is
   // the edit engine's transient policy, not a rule about legal Routes.
   if (!polylineSatisfiesConstraint(polyline.points, "any-angle")) {
-    return `Route ${route.id} must contain only non-zero segments`;
+    const points = polyline.points
+      .map((point) => `(${point.x},${point.y})`)
+      .join(" -> ");
+    return `Route ${route.id} (${endpointKey(route.start)} -> ${endpointKey(end)}, resolved ${points}) must contain only non-zero segments`;
   }
   if (
     route.presentation === "power-rail" &&

--- a/packages/edit-engine/src/transaction.test.ts
+++ b/packages/edit-engine/src/transaction.test.ts
@@ -171,6 +171,83 @@ describe("Edit Transaction envelope", () => {
     ]);
   });
 
+  it("identifies both endpoint owners when a transaction authors a zero-length Route", () => {
+    const document = createEmptyDocument("document-main", "Main");
+    document.instances.push(
+      {
+        id: "X1",
+        symbolId: "ideal-switch",
+        placement: {
+          position: { x: 500, y: 200 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        id: "P1",
+        symbolId: "port",
+        placement: {
+          position: { x: 510, y: 200 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+    );
+    document.nets.push({
+      id: "net-contact",
+      terminals: [
+        { instanceId: "X1", pinName: "2" },
+        { instanceId: "P1", pinName: "P" },
+      ],
+    });
+    defineCellPin(document, "P1", "OUT", "net-contact");
+
+    const result = executeTransaction(
+      document,
+      {
+        ...transaction(),
+        edits: [
+          {
+            kind: "set_route_path",
+            route: createRoutePath({
+              id: "route-zero",
+              netId: "net-contact",
+              start: {
+                kind: "terminal",
+                instanceId: "P1",
+                pinName: "P",
+              },
+              end: {
+                kind: "terminal",
+                instanceId: "X1",
+                pinName: "2",
+              },
+              bends: [],
+              modes: ["manual"],
+            }),
+          },
+        ],
+      },
+      { symbolResolver: resolver },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "EDIT_PRECONDITION",
+        message: expect.stringContaining(
+          "Route route-zero (terminal:P1:P -> terminal:X1:2, resolved (520,200) -> (520,200))",
+        ),
+      },
+      diagnostics: [
+        expect.objectContaining({
+          path: ["edits", 0],
+          objectIds: ["route-zero", "net-contact", "P1", "X1"],
+        }),
+      ],
+    });
+  });
+
   it("materializes a prepared Base Net before assigning terminal membership", () => {
     const document = createEmptyDocument("document-main", "Main");
     document.instances.push(

--- a/packages/edit-engine/src/transaction.ts
+++ b/packages/edit-engine/src/transaction.ts
@@ -61,6 +61,7 @@ import {
 import {
   addEndpointToNet,
   endpointOwnerNetId,
+  routeRelatedObjectIds,
   routeIsProtected,
   sameResolvedRoutePoints,
   validateRoute,
@@ -960,6 +961,7 @@ export function executeTransaction(
             `Transaction leaves invalid Route geometry for ${route.id}: ${routeError}`,
             [],
             ["routes", route.id],
+            routeRelatedObjectIds(route),
           );
         }
       }

--- a/packages/edit-engine/src/wire-editing.test.ts
+++ b/packages/edit-engine/src/wire-editing.test.ts
@@ -90,6 +90,25 @@ describe("wire editing proposals", () => {
     expect(proposal.edits[3]).not.toHaveProperty("newNetId");
   });
 
+  it("commits coincident endpoints as direct contact without a Route", () => {
+    const from = source(
+      { kind: "terminal", instanceId: "X1", pinName: "2" },
+      { x: 520, y: 200 },
+      "net-contact",
+    );
+    const to = source(
+      { kind: "terminal", instanceId: "P1", pinName: "P" },
+      { x: 520, y: 200 },
+      "net-contact",
+    );
+
+    const proposal = proposeWireCommit(from, to, [], 6);
+
+    expect(proposal.edits).toEqual([
+      { kind: "connect_endpoints", from: from.endpoint, to: to.endpoint },
+    ]);
+  });
+
   it("does not short another pin on a selected endpoint device", () => {
     const from = source(
       { kind: "terminal", instanceId: "R1", pinName: "2" },


### PR DESCRIPTION
## Summary
- normalize legacy ordinary Routes that collapse to an already-connected direct contact after switch Pin geometry changes
- apply the same normalization to portable-file import, Gallery open, and Gallery placement without changing Net semantics
- avoid authoring zero-length Routes for coincident Wire endpoints and surface endpoint coordinates in diagnostics

## Validation
- focused: 11 files, 200 tests
- real artifact: E:\Downloads\New Circuit.icproj.json removes both reported collapsed Route IDs while preserving Net membership
- full-delivery: rerunning after rebase

Test-Impact: tests-updated