### PR TITLE
feat(editor): Shift+M moves a selection without its wires

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -305,6 +305,7 @@ test("keeps quick-start shortcuts in the upper-right corner until the first comp
     "IInsert component",
     "RRotate",
     "MMove selection",
+    "ShiftMMove without wires",
     "UUndo",
     "PPlace Cell Pin",
     "CCopy selection",

--- a/apps/editor/e2e/detach-move.spec.ts
+++ b/apps/editor/e2e/detach-move.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import { chooseComponent } from "./editor-fixtures";
+import { chooseComponent, downloadBytes } from "./editor-fixtures";
 
 async function placeComponent(
   page: Page,
@@ -26,6 +26,23 @@ function routePoints(page: Page) {
     .evaluateAll((elements) =>
       elements.map((element) => element.getAttribute("points")),
     );
+}
+
+async function exportedTerminals(
+  page: Page,
+): Promise<Array<{ instanceId: string; pinName: string }>> {
+  const saved = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(
+      "utf8",
+    ),
+  ) as {
+    documents: Array<{
+      nets: Array<{
+        terminals: Array<{ instanceId: string; pinName: string }>;
+      }>;
+    }>;
+  };
+  return saved.documents[0]!.nets.flatMap((net) => net.terminals);
 }
 
 const META = 4; // CDP Input modifier bitmask (Cmd; macOS turns Ctrl+left into a right press)
@@ -102,7 +119,7 @@ test("Ctrl+drag moves only the part; its wire stays exactly in place", async ({
 
   await ctrlDrag(page, center, { x: center.x + 180, y: center.y });
 
-  // The part moved; the wire kept its exact geometry on the same net.
+  // The part moved; the now-open wire kept its exact authored geometry.
   const after = (await top.boundingBox())!;
   expect(after.x).toBeGreaterThan(before.x + 100);
   const wireAfter = await routePoints(page);
@@ -178,6 +195,16 @@ test("Shift+M moves the selection and leaves its wires where they were", async (
   const after = (await page.getByTestId(`hit-${ids[0]}`).boundingBox())!;
   expect(after.x).toBeGreaterThan(before.x + 100);
   expect(await routePoints(page)).toEqual(wireBefore);
+
+  // Geometry alone is insufficient: Shift+M is a real electrical disconnect,
+  // not a same-Net flightline disguised as a detached wire.
+  const terminals = await exportedTerminals(page);
+  expect(terminals).not.toContainEqual(
+    expect.objectContaining({ instanceId: ids[0] }),
+  );
+  expect(terminals).toContainEqual(
+    expect.objectContaining({ instanceId: ids[1] }),
+  );
 });
 
 // The brake: plain M must still drag the wire along, or Shift+M would have
@@ -199,6 +226,13 @@ test("M still stretches the wire along with the part", async ({ page }) => {
   const after = (await page.getByTestId(`hit-${ids[0]}`).boundingBox())!;
   expect(after.x).toBeGreaterThan(before.x + 100);
   expect(await routePoints(page)).not.toEqual(wireBefore);
+  const terminals = await exportedTerminals(page);
+  expect(terminals).toContainEqual(
+    expect.objectContaining({ instanceId: ids[0] }),
+  );
+  expect(terminals).toContainEqual(
+    expect.objectContaining({ instanceId: ids[1] }),
+  );
 });
 
 // Shift+M is verb-first the same way M is: pressed with nothing selected it

--- a/apps/editor/e2e/detach-move.spec.ts
+++ b/apps/editor/e2e/detach-move.spec.ts
@@ -129,3 +129,102 @@ test("Ctrl+click without a drag still toggles selection", async ({ page }) => {
   const settled = (await hit.boundingBox())!;
   expect(Math.abs(settled.x - box.x)).toBeLessThan(2);
 });
+
+/**
+ * Build two resistors joined by one wire, with nothing selected. Returns the
+ * instance ids and the wire's geometry before anything moves.
+ */
+async function wiredPair(page: Page): Promise<{
+  ids: string[];
+  wireBefore: (string | null)[];
+}> {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 300, y: 180 });
+  await placeComponent(page, "resistor", { x: 300, y: 400 });
+  const ids = await instanceIds(page);
+
+  await page.keyboard.press("w");
+  await page.getByTestId(`terminal-${ids[0]}-2`).click();
+  await page.getByTestId(`terminal-${ids[1]}-1`).click();
+  await page.keyboard.press("Escape");
+  await expect(page.locator('[data-canvas-hit-kind="route"]')).toHaveCount(1);
+  await page.getByTestId("schematic-canvas").click({
+    position: { x: 620, y: 420 },
+  });
+  return { ids, wireBefore: await routePoints(page) };
+}
+
+// Issue #485: Virtuoso's Shift+M. The same detachment Ctrl+drag performs,
+// reached through the verb-first path so it works from the keyboard on a
+// selection rather than only under the pointer.
+test("Shift+M moves the selection and leaves its wires where they were", async ({
+  page,
+}) => {
+  const { ids, wireBefore } = await wiredPair(page);
+
+  const top = page.getByTestId(`hit-${ids[0]}`);
+  await top.click();
+  await expect(top).toHaveClass(/selected/);
+  const before = (await top.boundingBox())!;
+
+  await page.keyboard.press("Shift+M");
+  await expect(page.getByTestId("status")).toContainText("without wires");
+
+  const target = { x: before.x + 200, y: before.y + before.height / 2 };
+  await page.mouse.move(target.x, target.y);
+  await page.mouse.click(target.x, target.y);
+
+  // The part moved and the wire kept its exact geometry.
+  const after = (await page.getByTestId(`hit-${ids[0]}`).boundingBox())!;
+  expect(after.x).toBeGreaterThan(before.x + 100);
+  expect(await routePoints(page)).toEqual(wireBefore);
+});
+
+// The brake: plain M must still drag the wire along, or Shift+M would have
+// silently replaced the behaviour it is supposed to sit beside.
+test("M still stretches the wire along with the part", async ({ page }) => {
+  const { ids, wireBefore } = await wiredPair(page);
+
+  const top = page.getByTestId(`hit-${ids[0]}`);
+  await top.click();
+  const before = (await top.boundingBox())!;
+
+  await page.keyboard.press("m");
+  await expect(page.getByTestId("status")).toContainText("Move: move the");
+
+  const target = { x: before.x + 200, y: before.y + before.height / 2 };
+  await page.mouse.move(target.x, target.y);
+  await page.mouse.click(target.x, target.y);
+
+  const after = (await page.getByTestId(`hit-${ids[0]}`).boundingBox())!;
+  expect(after.x).toBeGreaterThan(before.x + 100);
+  expect(await routePoints(page)).not.toEqual(wireBefore);
+});
+
+// Shift+M is verb-first the same way M is: pressed with nothing selected it
+// arms, and the next click picks up whatever it points at.
+test("Shift+M with nothing selected arms the detached move for the next click", async ({
+  page,
+}) => {
+  const { ids, wireBefore } = await wiredPair(page);
+
+  await page.keyboard.press("Shift+M");
+  await expect(page.getByTestId("status")).toContainText(
+    "Move without wires: click",
+  );
+
+  const top = page.getByTestId(`hit-${ids[0]}`);
+  const before = (await top.boundingBox())!;
+  await page.mouse.click(
+    before.x + before.width / 2,
+    before.y + before.height / 2,
+  );
+
+  const target = { x: before.x + 200, y: before.y + before.height / 2 };
+  await page.mouse.move(target.x, target.y);
+  await page.mouse.click(target.x, target.y);
+
+  const after = (await page.getByTestId(`hit-${ids[0]}`).boundingBox())!;
+  expect(after.x).toBeGreaterThan(before.x + 100);
+  expect(await routePoints(page)).toEqual(wireBefore);
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -915,7 +915,7 @@ export function App({
    * over to their own placement/move interactions on the first target.
    */
   const [armedVerb, setArmedVerb] = useState<
-    "rotate" | "copy" | "move" | "delete" | null
+    "rotate" | "copy" | "move" | "move-detached" | "delete" | null
   >(null);
   /** The click paired with an armed-verb pickup must not commit a placement. */
   const suppressCommitClickRef = useRef(false);
@@ -1848,7 +1848,9 @@ export function App({
   });
 
   /** Arm a verb so the next object pointed at is the one acted on. */
-  function armVerb(verb: "rotate" | "copy" | "move" | "delete"): void {
+  function armVerb(
+    verb: "rotate" | "copy" | "move" | "move-detached" | "delete",
+  ): void {
     setArmedVerb(verb);
     setStatus(
       verb === "rotate"
@@ -1857,7 +1859,9 @@ export function App({
           ? "Copy: click a part to pick up a copy · Esc cancels"
           : verb === "move"
             ? "Move: click a part to pick it up · Esc cancels"
-            : "Delete: click objects to delete them · Esc exits",
+            : verb === "move-detached"
+              ? "Move without wires: click a part to pick it up · Esc cancels"
+              : "Delete: click objects to delete them · Esc exits",
     );
   }
 
@@ -1901,14 +1905,18 @@ export function App({
       beginCopyPlacementFromSelection([instanceId]);
       return true;
     }
-    if (armedVerb === "move") {
+    if (armedVerb === "move" || armedVerb === "move-detached") {
+      const detach = armedVerb === "move-detached";
       setArmedVerb(null);
       selectOnly("instance", [instanceId]);
       suppressCommitClickRef.current = true;
-      beginKeyboardSelectionMoveFromSelection({
-        ...EMPTY_VISUAL_SELECTION,
-        instanceIds: [instanceId],
-      });
+      beginKeyboardSelectionMoveFromSelection(
+        {
+          ...EMPTY_VISUAL_SELECTION,
+          instanceIds: [instanceId],
+        },
+        { detach },
+      );
       return true;
     }
     deleteSelectionFromSelection({ instanceIds: [instanceId] });
@@ -3055,12 +3063,12 @@ export function App({
         }
         armVerb("copy");
       },
-      beginMove: () => {
+      beginMove: (detach) => {
         if (canBeginKeyboardSelectionMove()) {
-          beginKeyboardSelectionMoveFromSelection();
+          beginKeyboardSelectionMoveFromSelection(undefined, { detach });
           return;
         }
-        armVerb("move");
+        armVerb(detach ? "move-detached" : "move");
       },
       alignSelection,
       rotatePlacement: rotatePendingComponentFromHook,

--- a/apps/editor/src/canvas/editor-canvas-surface.tsx
+++ b/apps/editor/src/canvas/editor-canvas-surface.tsx
@@ -72,6 +72,7 @@ const CADENCE_QUICK_SHORTCUTS = [
   { keys: ["I"], action: "Insert component" },
   { keys: ["R"], action: "Rotate" },
   { keys: ["M"], action: "Move selection" },
+  { keys: ["Shift", "M"], action: "Move without wires" },
   { keys: ["U"], action: "Undo" },
   { keys: ["P"], action: "Place Cell Pin" },
   { keys: ["C"], action: "Copy selection" },

--- a/apps/editor/src/commands/editor-command.ts
+++ b/apps/editor/src/commands/editor-command.ts
@@ -14,7 +14,12 @@ export type EditorCommandRequest =
   | { id: "selection.clear" }
   | { id: "selection.delete" }
   | { id: "selection.copy" }
-  | { id: "selection.move" }
+  /**
+   * `detach` follows Virtuoso's Shift+M: the parts move on their own and each
+   * connected wire stays exactly where it was, re-anchored to a Junction stub.
+   * Plain Move stretches those wires along with the part.
+   */
+  | { id: "selection.move"; detach?: boolean }
   | { id: "selection.align"; mode: EdgeAlignmentMode }
   | { id: "transform.rotate"; deltaDegrees?: 90 | -90 }
   | { id: "transform.rotate-next" }
@@ -74,7 +79,7 @@ export interface EditorCommandOperations {
   clearSelection(): void;
   deleteSelection(): void;
   beginCopy(): void;
-  beginMove(): void;
+  beginMove(detach: boolean): void;
   alignSelection(mode: EdgeAlignmentMode): void;
   rotatePlacement(deltaDegrees: 90 | -90): void;
   rotateCopy(deltaDegrees: 90 | -90): void;
@@ -322,7 +327,7 @@ export function createEditorCommandRouter(
         options.operations.beginCopy();
         break;
       case "selection.move":
-        options.operations.beginMove();
+        options.operations.beginMove(request.detach === true);
         break;
       case "selection.align":
         options.operations.alignSelection(request.mode);

--- a/apps/editor/src/features/selection/detached-move.test.ts
+++ b/apps/editor/src/features/selection/detached-move.test.ts
@@ -1,0 +1,99 @@
+import {
+  createRoutingOperationPlan,
+  gateRoutingOperationPlan,
+} from "@icm/edit-engine";
+import { resolveDocumentRoutingGeometry } from "@icm/derived";
+import { createEmptyDocument, createRoutePath } from "@icm/model";
+import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { planDetachedMove } from "./detached-move";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+describe("detached move planning", () => {
+  it("keeps routed geometry on Junction stubs and removes terminal membership", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.instances.push(
+      {
+        id: "R1",
+        symbolId: "resistor",
+        placement: {
+          position: { x: 100, y: 100 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+      {
+        id: "R2",
+        symbolId: "resistor",
+        placement: {
+          position: { x: 100, y: 300 },
+          rotation: 0,
+          mirror: "none",
+        },
+      },
+    );
+    document.nets.push({
+      id: "signal",
+      terminals: [
+        { instanceId: "R1", pinName: "2" },
+        { instanceId: "R2", pinName: "1" },
+      ],
+    });
+    document.routes.push(
+      createRoutePath({
+        id: "wire",
+        netId: "signal",
+        start: { kind: "terminal", instanceId: "R1", pinName: "2" },
+        end: { kind: "terminal", instanceId: "R2", pinName: "1" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+    document.noConnects.push({
+      id: "open-r1-1",
+      endpoint: { kind: "terminal", instanceId: "R1", pinName: "1" },
+    });
+    const before = resolveDocumentRoutingGeometry(
+      document,
+      resolver,
+    ).routes.get("wire")!.centerline;
+
+    const planned = planDetachedMove(document, resolver, new Set(["R1"]), 4);
+    expect(planned.edits.map((edit) => edit.kind)).toEqual([
+      "add_junction",
+      "set_route_path",
+      "disconnect_endpoint",
+    ]);
+    const gate = gateRoutingOperationPlan(
+      document,
+      createRoutingOperationPlan(document, {
+        intent: "transform",
+        diagnostics: [],
+        edits: planned.edits,
+        expectedElectricalEffect: {
+          kind: "remove",
+          removedEndpointKeys: planned.disconnectedEndpointKeys,
+        },
+      }),
+      { symbolResolver: resolver },
+    );
+
+    expect(gate.ok).toBe(true);
+    if (!gate.ok) return;
+    const result = gate.evaluated.finalDocument;
+    expect(result.nets[0]!.terminals).toEqual([
+      { instanceId: "R2", pinName: "1" },
+    ]);
+    expect(result.noConnects).toEqual(document.noConnects);
+    expect(result.routes[0]!.start).toEqual({
+      kind: "junction",
+      junctionId: "junction-lifecycle-4-1",
+    });
+    expect(
+      resolveDocumentRoutingGeometry(result, resolver).routes.get("wire")!
+        .centerline,
+    ).toEqual(before);
+  });
+});

--- a/apps/editor/src/features/selection/detached-move.ts
+++ b/apps/editor/src/features/selection/detached-move.ts
@@ -1,0 +1,63 @@
+import { endpointKey } from "@icm/derived";
+import {
+  planRoutedTerminalDetachment,
+  type SchematicEdit,
+} from "@icm/edit-engine";
+import { routeEndpoints, type SchematicDocument } from "@icm/model";
+import type { SymbolResolver } from "@icm/symbols";
+
+export interface DetachedMovePlan {
+  /** Existing typed edits; this planner adds no editor or Engine protocol. */
+  edits: readonly SchematicEdit[];
+  /** Terminal memberships intentionally removed by the move. */
+  disconnectedEndpointKeys: readonly string[];
+}
+
+/**
+ * Leave every routed wire at its authored coordinates, then electrically
+ * disconnect only the selected terminals that those wires used to end on.
+ *
+ * The lifecycle detachment planner remains unchanged because returning an
+ * Instance to the Placement Tray must preserve connectivity. Shift+M and
+ * Ctrl/Cmd-drag instead compose that geometry-preserving planner with the
+ * existing disconnect_endpoint edit.
+ */
+export function planDetachedMove(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  instanceIds: ReadonlySet<string>,
+  sequence: number,
+): DetachedMovePlan {
+  const routedTerminalKeys = new Set(
+    document.routes.flatMap((route) =>
+      routeEndpoints(route).flatMap((endpoint) =>
+        endpoint.kind === "terminal" && instanceIds.has(endpoint.instanceId)
+          ? [endpointKey(endpoint)]
+          : [],
+      ),
+    ),
+  );
+  const disconnectedEndpointKeys: string[] = [];
+  const disconnectEdits = document.nets.flatMap((net): SchematicEdit[] =>
+    net.terminals.flatMap((terminal): SchematicEdit[] => {
+      const endpoint = { kind: "terminal" as const, ...terminal };
+      const key = endpointKey(endpoint);
+      if (!routedTerminalKeys.has(key)) return [];
+      disconnectedEndpointKeys.push(key);
+      return [{ kind: "disconnect_endpoint", endpoint }];
+    }),
+  );
+
+  return {
+    edits: [
+      ...planRoutedTerminalDetachment(
+        document,
+        resolver,
+        instanceIds,
+        sequence,
+      ),
+      ...disconnectEdits,
+    ],
+    disconnectedEndpointKeys,
+  };
+}

--- a/apps/editor/src/features/selection/selection-move-controller.ts
+++ b/apps/editor/src/features/selection/selection-move-controller.ts
@@ -14,6 +14,7 @@ import {
 import { deviceDescriptor } from "@icm/devices";
 import {
   deriveNetConnectivity,
+  endpointKey,
   findRouteSegmentsAtPoint,
   isMosBulkTerminal,
   isVisibleEndpoint,
@@ -548,6 +549,9 @@ export function createSelectionMoveController({
   ): void => {
     const sourceDocument = projection?.document ?? document;
     const prefixEdits = [...(projection?.prefixEdits ?? [])];
+    const disconnectedEndpointKeys = prefixEdits.flatMap((edit) =>
+      edit.kind === "disconnect_endpoint" ? [endpointKey(edit.endpoint)] : [],
+    );
     const { snap: resolvedSnap, moves } =
       projection?.resolvedMove ??
       resolveInstanceMove(
@@ -707,12 +711,26 @@ export function createSelectionMoveController({
         }
         return plan.edits;
       })();
+      const hasRouteContact = contactEdits.length > 0;
+      const hasDirectContact = directEdits.length > 0;
+      const operationIntent: RoutingOperationIntent = hasRouteContact
+        ? "attach-to-route"
+        : hasDirectContact
+          ? "connect"
+          : "transform";
+      const expectedElectricalEffect: ExpectedElectricalEffect | undefined =
+        seriesSplice
+          ? seriesSplice.expectedElectricalEffect
+          : disconnectedEndpointKeys.length > 0 &&
+              !hasRouteContact &&
+              !hasDirectContact
+            ? {
+                kind: "remove",
+                removedEndpointKeys: disconnectedEndpointKeys,
+              }
+            : undefined;
       const result = transactConnectivity(
-        targetElectrical?.kind === "route"
-          ? "attach-to-route"
-          : targetElectrical?.kind === "endpoint"
-            ? "connect"
-            : "transform",
+        operationIntent,
         [
           ...prefixEdits,
           ...groupMove.edits,
@@ -720,9 +738,7 @@ export function createSelectionMoveController({
           ...contactEdits,
           ...directEdits,
         ],
-        seriesSplice
-          ? { expectedElectricalEffect: seriesSplice.expectedElectricalEffect }
-          : undefined,
+        expectedElectricalEffect ? { expectedElectricalEffect } : undefined,
       );
       if (result?.ok && seriesSplice) {
         setStatus("Inserted the moved component in series into the wire");
@@ -733,6 +749,8 @@ export function createSelectionMoveController({
         setStatus("Snapped pin endpoints and connected them without a wire");
       } else if (result?.ok && directContactRejection) {
         setStatus(`Moved without connecting: ${directContactRejection}`);
+      } else if (result?.ok && disconnectedEndpointKeys.length > 0) {
+        setStatus("Moved selection without wires; original endpoints are open");
       } else if (result?.ok && prefixEdits.length > 0) {
         setStatus("Moved and transformed selection");
       }

--- a/apps/editor/src/features/selection/use-selection-interaction.ts
+++ b/apps/editor/src/features/selection/use-selection-interaction.ts
@@ -16,7 +16,6 @@ import {
   createRoutingOperationPlan,
   executeTransaction,
   gateRoutingOperationPlan,
-  planRoutedTerminalDetachment,
   planRoutingDeletion,
   planRoutingTransform,
   type RoutingOperationIntent,
@@ -34,6 +33,7 @@ import {
 } from "../../canvas/canvas-drag-session";
 import { startCanvasDragVisual } from "../../canvas/canvas-drag-visual";
 import type { ScreenFlip } from "../../interaction/shortcut-orientation";
+import { planDetachedMove } from "./detached-move";
 import type { VisualSelection } from "./visual-selection";
 import {
   planSelectionMove,
@@ -41,38 +41,6 @@ import {
 } from "./selection-move-plan";
 
 type TransactionResult = { ok: boolean; revision: number };
-
-/**
- * Preview projection of the detach edits: apply the planned Junction stubs
- * and re-anchored routes to a document clone so the drag ghost shows the
- * wires already staying put. The real edits still commit atomically as the
- * move transaction's prefix.
- */
-function projectDetachedDocument(
-  document: SchematicDocument,
-  edits: readonly SchematicEdit[],
-): SchematicDocument {
-  if (edits.length === 0) return document;
-  const next = structuredClone(document) as SchematicDocument & {
-    junctions: SchematicDocument["junctions"][number][];
-    routes: SchematicDocument["routes"][number][];
-  };
-  for (const edit of edits) {
-    if (edit.kind === "add_junction") {
-      next.junctions.push({
-        id: edit.junctionId,
-        netId: edit.netId,
-        position: edit.position,
-      });
-    } else if (edit.kind === "set_route_path") {
-      const index = next.routes.findIndex(
-        (candidate) => candidate.id === edit.route.id,
-      );
-      if (index >= 0) next.routes[index] = edit.route;
-    }
-  }
-  return next;
-}
 
 interface ResolvedInstanceMove {
   snap: SnapResult;
@@ -259,6 +227,44 @@ export function useSelectionInteraction(
       return { ok: false, revision: options.document.revision };
     }
     return options.transact([...gate.edits], options_);
+  };
+
+  /**
+   * One validated prefix shared by Shift+M and Ctrl/Cmd-drag. The gate both
+   * rejects protected interface terminals before a preview starts and gives
+   * the renderer the exact post-disconnect Document the final move uses.
+   */
+  const prepareDetachedMove = (
+    instanceIds: ReadonlySet<string>,
+  ): { document: SchematicDocument; edits: SchematicEdit[] } => {
+    detachSequenceRef.current += 1;
+    const planned = planDetachedMove(
+      options.document,
+      options.resolver,
+      instanceIds,
+      detachSequenceRef.current,
+    );
+    if (planned.edits.length === 0) {
+      return { document: options.document, edits: [] };
+    }
+    const gate = gateRoutingOperationPlan(
+      options.document,
+      createRoutingOperationPlan(options.document, {
+        intent: "transform",
+        diagnostics: [],
+        edits: planned.edits,
+        expectedElectricalEffect: {
+          kind: "remove",
+          removedEndpointKeys: planned.disconnectedEndpointKeys,
+        },
+      }),
+      { symbolResolver: options.resolver },
+    );
+    if (!gate.ok) throw new Error(gate.message);
+    return {
+      document: gate.evaluated.finalDocument,
+      edits: [...gate.edits],
+    };
   };
 
   const projectedInstancePreview = (
@@ -480,20 +486,15 @@ export function useSelectionInteraction(
         return;
       }
       try {
-        detachSequenceRef.current += 1;
-        detachEdits = planRoutedTerminalDetachment(
-          options.document,
-          options.resolver,
-          new Set(detaching.instanceIds),
-          detachSequenceRef.current,
-        );
+        const prepared = prepareDetachedMove(new Set(detaching.instanceIds));
+        detachEdits = prepared.edits;
+        baseDocument = prepared.document;
       } catch (error) {
         options.setStatus(
           error instanceof Error ? error.message : "Detach move failed",
         );
         return;
       }
-      baseDocument = projectDetachedDocument(options.document, detachEdits);
     }
     const movePlan = planSelectionMove(baseDocument, selection);
     if (movePlan.previewObjectIds.length === 0) {
@@ -851,8 +852,8 @@ export function useSelectionInteraction(
     options.suppressInstanceClickRef.current =
       hitTarget.getAttribute("data-canvas-hit-kind") === "instance";
     // Ctrl-drag follows Virtuoso: the drag moves ONLY the part, leaving its
-    // wires exactly where they are (they re-anchor onto Junction stubs and
-    // stay on the Net, so the missing path shows as a flightline). Cmd
+    // wires exactly where they are on open Junction stubs while the old
+    // terminal memberships are disconnected. Cmd
     // serves the same role because macOS browsers convert Ctrl+left-press
     // into a right-button press before the page ever sees it. A plain
     // modifier-click without a drag keeps its toggle-selection meaning.
@@ -866,23 +867,15 @@ export function useSelectionInteraction(
     let previewBaseDocument = options.document;
     if (detachDrag) {
       try {
-        detachSequenceRef.current += 1;
-        detachEdits = planRoutedTerminalDetachment(
-          options.document,
-          options.resolver,
-          new Set([instanceId]),
-          detachSequenceRef.current,
-        );
+        const prepared = prepareDetachedMove(new Set([instanceId]));
+        detachEdits = prepared.edits;
+        previewBaseDocument = prepared.document;
       } catch (error) {
         options.setStatus(
           error instanceof Error ? error.message : "Detach move failed",
         );
         return;
       }
-      previewBaseDocument = projectDetachedDocument(
-        options.document,
-        detachEdits,
-      );
     }
     const movingSelection: VisualSelection =
       !detachDrag && options.selectedIds.includes(instanceId)
@@ -894,7 +887,7 @@ export function useSelectionInteraction(
             annotationIds: [],
             draftingIds: [],
           };
-    const movePlan = planSelectionMove(options.document, movingSelection);
+    const movePlan = planSelectionMove(previewBaseDocument, movingSelection);
     const movingIds = movePlan.instanceIds;
     // A detach drag defers selection: a threshold-crossing drag selects the
     // moved part on finish, while a mere modifier-click keeps its
@@ -955,6 +948,7 @@ export function useSelectionInteraction(
         tolerance,
         suppressSnap,
         lastSnap,
+        detachDrag ? previewBaseDocument : undefined,
       );
       lastSnap = resolved.snap;
       const input = {
@@ -1080,7 +1074,7 @@ export function useSelectionInteraction(
           }
           if (detachEdits.length > 0) {
             options.setStatus(
-              `Moved ${instanceId} without its wires — reconnect via the flightlines`,
+              `Moved ${instanceId} without its wires; original wire endpoints remain open`,
             );
           }
         } else if (detachDrag) {

--- a/apps/editor/src/features/selection/use-selection-interaction.ts
+++ b/apps/editor/src/features/selection/use-selection-interaction.ts
@@ -456,6 +456,7 @@ export function useSelectionInteraction(
 
   const beginKeyboardSelectionMove = (
     explicitSelection?: VisualSelection,
+    moveOptions?: { detach?: boolean },
   ): void => {
     if (commandMoveSessionRef.current) {
       options.setStatus(
@@ -463,12 +464,38 @@ export function useSelectionInteraction(
       );
       return;
     }
+    const detach = moveOptions?.detach === true;
     // An explicit selection serves the armed Move verb: the pointed-at part
     // is picked up directly, independent of the live selection state.
-    const movePlan = planSelectionMove(
-      options.document,
-      explicitSelection ?? options.visualSelection,
-    );
+    const selection = explicitSelection ?? options.visualSelection;
+    // Shift+M cuts the parts loose before anything moves, so the move plans
+    // against the topology the detach creates. Planning first and detaching
+    // after would stretch the very wires the detach is meant to leave alone.
+    let detachEdits: SchematicEdit[] = [];
+    let baseDocument = options.document;
+    if (detach) {
+      const detaching = planSelectionMove(options.document, selection);
+      if (detaching.instanceIds.length === 0) {
+        options.setStatus("Select a part to move without its wires");
+        return;
+      }
+      try {
+        detachSequenceRef.current += 1;
+        detachEdits = planRoutedTerminalDetachment(
+          options.document,
+          options.resolver,
+          new Set(detaching.instanceIds),
+          detachSequenceRef.current,
+        );
+      } catch (error) {
+        options.setStatus(
+          error instanceof Error ? error.message : "Detach move failed",
+        );
+        return;
+      }
+      baseDocument = projectDetachedDocument(options.document, detachEdits);
+    }
+    const movePlan = planSelectionMove(baseDocument, selection);
     if (movePlan.previewObjectIds.length === 0) {
       options.setStatus(
         "Selected objects are attached or locked and cannot move",
@@ -481,7 +508,7 @@ export function useSelectionInteraction(
         null)
       : (options.selectedIds.at(-1) ?? movePlan.instanceIds.at(0) ?? null);
     const primary = primaryInstanceId
-      ? options.document.instances.find((item) => item.id === primaryInstanceId)
+      ? baseDocument.instances.find((item) => item.id === primaryInstanceId)
       : undefined;
     const instancePreview = primary?.placement
       ? {
@@ -489,7 +516,7 @@ export function useSelectionInteraction(
           primaryInstanceId: primaryInstanceId!,
           originalPositions: Object.fromEntries(
             movePlan.instanceIds.flatMap((id) => {
-              const item = options.document.instances.find(
+              const item = baseDocument.instances.find(
                 (candidate) => candidate.id === id,
               );
               return item?.placement
@@ -511,8 +538,8 @@ export function useSelectionInteraction(
         : options.visualMoveOrigin(movePlan),
       visual: null,
       routeVisual: null,
-      projectedDocument: options.document,
-      prefixEdits: [],
+      projectedDocument: baseDocument,
+      prefixEdits: detachEdits,
       latestPoint: null,
       latestScreenPoint: null,
       svg: null,
@@ -522,7 +549,9 @@ export function useSelectionInteraction(
     options.setProjectedMovePreview(null);
     options.beginSelectionMoveInteraction();
     options.setStatus(
-      "Move: move the pointer, then click to place (Esc to cancel)",
+      detach
+        ? "Move without wires: move the pointer, then click to place (Esc to cancel)"
+        : "Move: move the pointer, then click to place (Esc to cancel)",
     );
   };
 

--- a/apps/editor/src/interaction/editor-shortcuts.test.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.test.ts
@@ -199,6 +199,12 @@ describe("editor shortcut contract", () => {
     );
     expect(resolve("p")).toEqual(command({ id: "insert.cell-pin" }));
     expect(resolve("m")).toEqual(command({ id: "selection.move" }));
+    // Virtuoso's pairing: M stretches the wires along with the part, Shift+M
+    // leaves them where they are. Shift used to fall through to plain Move
+    // because `plain` only excludes Ctrl/Meta/Alt.
+    expect(resolve("m", {}, { shiftKey: true })).toEqual(
+      command({ id: "selection.move", detach: true }),
+    );
     expect(resolve("l")).toEqual({ kind: "net-label-selection-required" });
     expect(resolve("l", { hasRouteSelection: true })).toEqual({
       kind: "edit-net-label",

--- a/apps/editor/src/interaction/editor-shortcuts.ts
+++ b/apps/editor/src/interaction/editor-shortcuts.ts
@@ -161,7 +161,12 @@ export function resolveEditorShortcut(
     }
     if (plain && key === "m") {
       return context.interactionMode === "moving-selection"
-        ? { kind: "run-command", command: { id: "selection.move" } }
+        ? {
+            kind: "run-command",
+            command: event.shiftKey
+              ? { id: "selection.move", detach: true }
+              : { id: "selection.move" },
+          }
         : { kind: "blocked-interaction-command", command: "Move" };
     }
     if (plain && key === "i") {
@@ -277,7 +282,14 @@ export function resolveEditorShortcut(
     return { kind: "run-command", command: { id: "selection.copy" } };
   }
   if (plain && key === "m") {
-    return { kind: "run-command", command: { id: "selection.move" } };
+    // Shift+M is Virtuoso's move-without-wires. `plain` allows Shift through,
+    // so this branch must read it rather than let it fall to a plain Move.
+    return {
+      kind: "run-command",
+      command: event.shiftKey
+        ? { id: "selection.move", detach: true }
+        : { id: "selection.move" },
+    };
   }
   if (plain && key === "i") {
     return { kind: "run-command", command: { id: "insert.open" } };

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -250,6 +250,16 @@ routing closure. The editor keeps only gesture state; the Edit Engine's
 the typed edits committed on pointer release. Neither object is Project data or
 an Agent API payload, and no pointer handler invents an independent follow set.
 
+Schematic movement follows the Virtuoso pairing. Plain `M` translates the
+selection while internal conductors follow and boundary Routes stretch without
+changing connectivity. `Shift+M` (and its Ctrl/Cmd-drag direct gesture) moves
+the selected Instances without their wires: every routed terminal is first
+replaced by an open Junction stub at the original landing, then the existing
+`disconnect_endpoint` edit removes that terminal from the old Base Net. The
+wire geometry remains byte-for-byte in place and the moved pin is electrically
+open. Both gestures use the same selection-move controller and existing typed
+edits; detached move is not a persisted mode or a second mutation protocol.
+
 The visual marquee is the user's explicit intent. Electrical closure then
 classifies that intent without changing connectivity:
 


### PR DESCRIPTION
Closes #485.

## Behaviour

Virtuoso-style schematic movement is now explicit:

- `M` moves the selection while preserving connectivity: internal conductors follow and boundary wires stretch.
- `Shift+M` moves the selected component(s) without their wires: each original wire endpoint becomes an open Junction stub at the same coordinates, and the moved terminal is removed from the old Base Net.
- `Ctrl/Cmd+drag` uses the same detached-move path as `Shift+M`.

The wire geometry stays byte-for-byte in place for detached move. This is a real electrical disconnect, not a same-Net flightline.

## Existing framework only

No Project field, Edit Engine edit kind, Agent API, or second movement protocol was added. The implementation composes existing primitives:

1. `planRoutedTerminalDetachment()` preserves the original Route geometry on Junction stubs.
2. Existing `disconnect_endpoint` edits remove only the routed terminals being moved.
3. The existing selection-move controller previews and commits the movement atomically.
4. The existing routing-operation gate validates the prefix with its existing `remove` electrical effect before preview begins.

Protected formal Cell terminals are therefore rejected before a misleading preview can start. Plain `M` remains unchanged.

## Attribution

The original shortcut, unified Command wiring, verb-first flow, move-session integration, shortcut help, and first browser coverage were authored by @Arcadia-1 in commit `6f2d338e`. The follow-up commit preserves that history and also carries an explicit `Co-authored-by` trailer while tightening the electrical semantics requested in the issue.

## Verification

Local validation after the combined implementation:

- static preflight and test-impact checks passed;
- 324 unit-test files / 2093 tests passed;
- 127 editor interaction browser tests passed;
- 10 editor-command browser tests passed;
- 10 selection browser tests passed;
- 2 viewport browser tests passed;
- focused `detach-move.spec.ts`: 5/5 passed.

The browser contract exports the Project after each gesture and verifies both sides of the distinction: `Shift+M` removes the moved terminal from the original Net, while `M` retains both terminal memberships.
