### PR TITLE
test(editor): cover Shift+M over a multi-part selection

### DIFF
--- a/apps/editor/e2e/detach-move.spec.ts
+++ b/apps/editor/e2e/detach-move.spec.ts
@@ -297,4 +297,14 @@ test("Shift+M carries a whole multi-part selection", async ({ page }) => {
     Math.round(topAfter.x - topBefore.x),
   );
   expect(await routePoints(page)).toEqual(wireBefore);
+
+  // Both selected parts are electrically open, not just visually adrift. The
+  // wire between them was the only thing on that Net, so nothing is left on it.
+  const terminals = await exportedTerminals(page);
+  expect(terminals).not.toContainEqual(
+    expect.objectContaining({ instanceId: ids[0] }),
+  );
+  expect(terminals).not.toContainEqual(
+    expect.objectContaining({ instanceId: ids[1] }),
+  );
 });

--- a/apps/editor/e2e/detach-move.spec.ts
+++ b/apps/editor/e2e/detach-move.spec.ts
@@ -262,3 +262,39 @@ test("Shift+M with nothing selected arms the detached move for the next click", 
   expect(after.x).toBeGreaterThan(before.x + 100);
   expect(await routePoints(page)).toEqual(wireBefore);
 });
+
+// The reason the keyboard verb earns its place beside Ctrl+drag: the drag
+// detaches only the part under the pointer, while Shift+M carries every
+// selected part and detaches all of them together.
+test("Shift+M carries a whole multi-part selection", async ({ page }) => {
+  const { ids, wireBefore } = await wiredPair(page);
+
+  const top = page.getByTestId(`hit-${ids[0]}`);
+  const bottom = page.getByTestId(`hit-${ids[1]}`);
+  await top.click();
+  await bottom.click({ modifiers: ["Shift"] });
+  await expect(top).toHaveClass(/selected/);
+  await expect(bottom).toHaveClass(/selected/);
+
+  const topBefore = (await top.boundingBox())!;
+  const bottomBefore = (await bottom.boundingBox())!;
+
+  await page.keyboard.press("Shift+M");
+  await expect(page.getByTestId("status")).toContainText("without wires");
+
+  const target = {
+    x: topBefore.x + 200,
+    y: topBefore.y + topBefore.height / 2,
+  };
+  await page.mouse.move(target.x, target.y);
+  await page.mouse.click(target.x, target.y);
+
+  // Both parts moved by the same delta, and the wire between them did not.
+  const topAfter = (await page.getByTestId(`hit-${ids[0]}`).boundingBox())!;
+  const bottomAfter = (await page.getByTestId(`hit-${ids[1]}`).boundingBox())!;
+  expect(topAfter.x).toBeGreaterThan(topBefore.x + 100);
+  expect(Math.round(bottomAfter.x - bottomBefore.x)).toBe(
+    Math.round(topAfter.x - topBefore.x),
+  );
+  expect(await routePoints(page)).toEqual(wireBefore);
+});


### PR DESCRIPTION
Follow-up to #486, tests only.

#486 claimed the keyboard verb's reason to exist beside `Ctrl/Cmd+drag` is that
the drag detaches only the part under the pointer while `Shift+M` carries the
whole selection. That claim was true but untested, so this asserts it: two
selected parts move by the same delta, the wire between them keeps its exact
geometry, and both parts leave the Net.

The connectivity half matters more than the geometry half. My original specs in
#486 checked route points only, which would have passed a part that moved away
while still a member of its Net. That is exactly the defect the electrical fix
on that branch corrected, and it is the assertion those specs were missing.

Written after #486 was queued rather than pushed onto it, so the queued merge
was not ejected and restarted.

## Verification

- Six browser tests in `detach-move.spec.ts` pass on top of the squashed main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)