### PR TITLE
fix(editor): the two converters sit together in the Library

### DIFF
--- a/apps/editor/src/features/component-insert/symbol-catalog.test.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.test.ts
@@ -265,6 +265,30 @@ describe("reach order inside a category", () => {
     ]);
   });
 
+  it("keeps the two converters together in Analog Blocks", () => {
+    const groups = componentCatalog("razavi-textbook-v1", "");
+    const blocks = groups
+      .find((group) => group.category === "Analog Blocks")!
+      .symbols.map((symbol) => symbol.id);
+    // Alphabetical order put ADC at the head of the group and DAC four tiles
+    // later, with two comparators and a differential amplifier between them.
+    // Someone looking for one converter is looking for the pair.
+    expect(blocks.indexOf("dac") - blocks.indexOf("adc")).toBe(1);
+    // And the pair sits after the parts an analog schematic reaches for more
+    // often, rather than leading the group as the letter A did.
+    expect(blocks).toEqual([
+      "opamp",
+      "opamp-lettered",
+      "opamp-differential",
+      "voltage-amplifier",
+      "voltage-amplifier-lettered",
+      "comparator",
+      "comparator-unmarked",
+      "adc",
+      "dac",
+    ]);
+  });
+
   it("orders logic gates by family rather than by name", () => {
     const groups = componentCatalog("razavi-textbook-v1", "");
     const gates = groups

--- a/apps/editor/src/features/component-insert/symbol-catalog.ts
+++ b/apps/editor/src/features/component-insert/symbol-catalog.ts
@@ -224,6 +224,20 @@ const SYMBOL_ORDER: readonly string[] = [
   "quantizer",
   // Annotations: drawing tools first (toolbar order), then the polarity
   // label, standalone signs, and fixed decorative marks last.
+  // Analog Blocks. Alphabetical order split the two converters apart, putting
+  // ADC at the head of the group and DAC four tiles later with comparators and
+  // a differential amplifier between them. A reader looking for one converter
+  // is looking for the pair, so they sit together, after the amplifiers and
+  // comparators an analog schematic reaches for far more often.
+  "opamp",
+  "opamp-lettered",
+  "opamp-differential",
+  "voltage-amplifier",
+  "voltage-amplifier-lettered",
+  "comparator",
+  "comparator-unmarked",
+  "adc",
+  "dac",
   "annotation-arrow",
   "annotation-line",
   "annotation-rectangle",


### PR DESCRIPTION
Reported by the repository owner: ADC and DAC should sit next to each other.

## What the Library showed

Analog Blocks listed ADC, Comp, Comp U, FD Amp, DAC, OpAmp, OpAmp A, V Amp, V Amp A. Alphabetical order put ADC at the head of the group and DAC four tiles later, with two comparators and a differential amplifier between them. Someone looking for one converter is looking for the pair.

## Cause

The group had **no explicit order at all**. `SYMBOL_ORDER` ranks 44 symbols and not one of them is an analog block, so every tile in the group fell back to `name.localeCompare`. Passives and Logic Gates already state their own order for exactly this reason.

## Order

Amplifiers first, since an analog schematic reaches for them most, then the comparators, then the converters as a pair:

`opamp`, `opamp-lettered`, `opamp-differential`, `voltage-amplifier`, `voltage-amplifier-lettered`, `comparator`, `comparator-unmarked`, `adc`, `dac`

This also moves the converters out of the lead position the letter A had given the ADC on its own.

## Test

Verified red before the change and green after. It asserts adjacency directly (`indexOf("dac") - indexOf("adc") === 1`) as well as the full order, so a later change that keeps the list plausible but parts the two converters still fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)