### PR TITLE
feat(editor): Shift+drag moves parts without their wires

### DIFF
--- a/apps/editor/e2e/detach-move.spec.ts
+++ b/apps/editor/e2e/detach-move.spec.ts
@@ -46,17 +46,19 @@ async function exportedTerminals(
 }
 
 const META = 4; // CDP Input modifier bitmask (Cmd; macOS turns Ctrl+left into a right press)
+const SHIFT = 8; // CDP Input modifier bitmask for Shift
 
 /**
  * Playwright's high-level mouse API cannot attach keyboard modifiers to
- * pointer events, so the detach drag goes through the raw CDP input
+ * pointer events, so a modified drag goes through the raw CDP input
  * pipeline. Cmd stands in for Ctrl because macOS converts Ctrl+left-press
  * into a right-button press before the page sees it.
  */
-async function ctrlDrag(
+async function modifierDrag(
   page: Page,
   from: { x: number; y: number },
   to: { x: number; y: number },
+  modifiers: number = META,
 ): Promise<void> {
   const cdp = await page.context().newCDPSession(page);
   await cdp.send("Input.dispatchMouseEvent", {
@@ -66,7 +68,7 @@ async function ctrlDrag(
     button: "left",
     buttons: 1,
     clickCount: 1,
-    modifiers: META,
+    modifiers,
   });
   const steps = 8;
   for (let step = 1; step <= steps; step += 1) {
@@ -76,7 +78,7 @@ async function ctrlDrag(
       y: from.y + ((to.y - from.y) * step) / steps,
       button: "left",
       buttons: 1,
-      modifiers: META,
+      modifiers,
     });
   }
   await cdp.send("Input.dispatchMouseEvent", {
@@ -86,9 +88,27 @@ async function ctrlDrag(
     button: "left",
     buttons: 0,
     clickCount: 1,
-    modifiers: META,
+    modifiers,
   });
   await cdp.detach();
+}
+
+/** Ctrl/Cmd variant, the gesture shipped in #413. */
+async function ctrlDrag(
+  page: Page,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+): Promise<void> {
+  await modifierDrag(page, from, to, META);
+}
+
+/** Shift variant, asked for so the drag matches Shift+M. */
+async function shiftDrag(
+  page: Page,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+): Promise<void> {
+  await modifierDrag(page, from, to, SHIFT);
 }
 
 test("Ctrl+drag moves only the part; its wire stays exactly in place", async ({
@@ -307,4 +327,57 @@ test("Shift+M carries a whole multi-part selection", async ({ page }) => {
   expect(terminals).not.toContainEqual(
     expect.objectContaining({ instanceId: ids[1] }),
   );
+});
+
+// Shift+drag is the pointer form of Shift+M: the parts move, the wires stay
+// where they were and their old endpoints go electrically open. Shift+click
+// with no movement must still mean "add to selection".
+test("Shift+drag moves the part and leaves its wire in place", async ({
+  page,
+}) => {
+  const { ids, wireBefore } = await wiredPair(page);
+
+  const top = page.getByTestId(`hit-${ids[0]}`);
+  const before = (await top.boundingBox())!;
+  const center = {
+    x: before.x + before.width / 2,
+    y: before.y + before.height / 2,
+  };
+
+  await shiftDrag(page, center, { x: center.x + 180, y: center.y });
+
+  const after = (await top.boundingBox())!;
+  expect(after.x).toBeGreaterThan(before.x + 100);
+  expect(await routePoints(page)).toEqual(wireBefore);
+
+  const terminals = await exportedTerminals(page);
+  expect(terminals).not.toContainEqual(
+    expect.objectContaining({ instanceId: ids[0] }),
+  );
+  expect(terminals).toContainEqual(
+    expect.objectContaining({ instanceId: ids[1] }),
+  );
+});
+
+// The brake: Shift is this editor's add-to-selection modifier, and a
+// stationary Shift+click must keep meaning exactly that.
+test("Shift+click without a drag still adds to the selection", async ({
+  page,
+}) => {
+  const { ids } = await wiredPair(page);
+
+  const top = page.getByTestId(`hit-${ids[0]}`);
+  const bottom = page.getByTestId(`hit-${ids[1]}`);
+  await top.click();
+  await expect(top).toHaveClass(/selected/);
+
+  const box = (await bottom.boundingBox())!;
+  const center = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+  await shiftDrag(page, center, center);
+
+  // Both are selected, and neither moved.
+  await expect(top).toHaveClass(/selected/);
+  await expect(bottom).toHaveClass(/selected/);
+  const settled = (await bottom.boundingBox())!;
+  expect(Math.abs(settled.x - box.x)).toBeLessThan(2);
 });

--- a/apps/editor/src/features/selection/use-selection-interaction.ts
+++ b/apps/editor/src/features/selection/use-selection-interaction.ts
@@ -847,27 +847,48 @@ export function useSelectionInteraction(
       (candidate) => candidate.id === instanceId,
     );
     if (!instance?.placement) return;
-    const hasSelectionModifier =
-      event.shiftKey || event.ctrlKey || event.metaKey;
     options.suppressInstanceClickRef.current =
       hitTarget.getAttribute("data-canvas-hit-kind") === "instance";
-    // Ctrl-drag follows Virtuoso: the drag moves ONLY the part, leaving its
-    // wires exactly where they are on open Junction stubs while the old
-    // terminal memberships are disconnected. Cmd
-    // serves the same role because macOS browsers convert Ctrl+left-press
-    // into a right-button press before the page ever sees it. A plain
-    // modifier-click without a drag keeps its toggle-selection meaning.
-    const detachDrag = (event.ctrlKey || event.metaKey) && !event.shiftKey;
-    if (hasSelectionModifier && !detachDrag) {
-      selectInstance(instanceId, true);
-      options.setStatus(`Selected ${instanceId}`);
-      return;
-    }
+    // A modified drag follows Virtuoso: it moves the parts and leaves their
+    // wires exactly where they are on open Junction stubs, with the old
+    // terminal memberships disconnected. Cmd serves the same role as Ctrl
+    // because macOS browsers convert Ctrl+left-press into a right-button
+    // press before the page ever sees it.
+    //
+    // The two modifiers differ in what they pick up, and that follows what
+    // each already means here. Ctrl/Cmd is the "just this part" gesture from
+    // #413 and stays that. Shift is this editor's add-to-selection modifier,
+    // so Shift+drag carries the whole selection the way Shift+M does.
+    //
+    // Either modifier pressed and released without moving keeps its
+    // toggle-selection meaning; the drag threshold below decides which
+    // happened, so nothing is committed on a stationary click.
+    const detachDrag = event.ctrlKey || event.metaKey || event.shiftKey;
+    const detachCarriesSelection =
+      event.shiftKey && options.selectedIds.includes(instanceId);
+    const movingSelection: VisualSelection =
+      (!detachDrag || detachCarriesSelection) &&
+      options.selectedIds.includes(instanceId)
+        ? options.visualSelection
+        : {
+            instanceIds: [instanceId],
+            routeIds: [],
+            junctionIds: [],
+            annotationIds: [],
+            draftingIds: [],
+          };
     let detachEdits: SchematicEdit[] = [];
     let previewBaseDocument = options.document;
     if (detachDrag) {
       try {
-        const prepared = prepareDetachedMove(new Set([instanceId]));
+        // Detach every part the move will actually carry, planned against the
+        // undetached Document, so a multi-part Shift+drag opens all of their
+        // endpoints rather than only the one under the pointer.
+        const prepared = prepareDetachedMove(
+          new Set(
+            planSelectionMove(options.document, movingSelection).instanceIds,
+          ),
+        );
         detachEdits = prepared.edits;
         previewBaseDocument = prepared.document;
       } catch (error) {
@@ -877,16 +898,6 @@ export function useSelectionInteraction(
         return;
       }
     }
-    const movingSelection: VisualSelection =
-      !detachDrag && options.selectedIds.includes(instanceId)
-        ? options.visualSelection
-        : {
-            instanceIds: [instanceId],
-            routeIds: [],
-            junctionIds: [],
-            annotationIds: [],
-            draftingIds: [],
-          };
     const movePlan = planSelectionMove(previewBaseDocument, movingSelection);
     const movingIds = movePlan.instanceIds;
     // A detach drag defers selection: a threshold-crossing drag selects the


### PR DESCRIPTION
The pointer form of `Shift+M`, so the gesture and the keyboard verb agree.
`Shift+drag` now performs the same detached move: the parts follow the
pointer, each wire stays at its authored coordinates, and the old terminal
memberships are disconnected.

## Shift already meant something, and it still does

`Shift+click` on a part adds it to the selection. That is kept. The drag
threshold decides which gesture happened: a press-release without movement
falls through to the same toggle the `Ctrl/Cmd` path has always used, so
nothing is committed on a stationary click.

A spec asserts this directly. Losing add-to-selection would be a worse
regression than this feature is a win, so it is nailed down rather than left
to reasoning.

## Why the two modifiers pick up different things

Each follows what it already means in this editor:

- **`Ctrl/Cmd+drag`** stays the "just this part" gesture from #413. Its
  existing spec is unchanged.
- **`Shift+drag`** carries the whole selection, the way `Shift+M` does.

So with three parts selected, `Shift+drag` moves all three and `Ctrl+drag`
moves one. If that split is wrong, the fix is one line in either direction —
worth naming here rather than discovering later.

The detach is planned over every part the move will actually carry, not only
the one under the pointer, so a multi-part `Shift+drag` opens all of their
endpoints.

## Verification

- 8 browser tests in `detach-move.spec.ts`, including both brakes:
  `Ctrl+drag` behaviour unchanged, and `Shift+click` still adds to selection.
- 798 editor unit tests, `pnpm ci:static`, typecheck.
- Verified red-then-green: the `Shift+drag` spec fails before the change and
  the `Shift+click` spec passes throughout.
- Full local Playwright run: 313 passed, 2 failed
  (`project-file.spec.ts:80`, `recovery-hardening.spec.ts:72`). Both pass in
  isolation (13/13), and neither can reach this change — `recovery-hardening`
  uses no modifiers and `project-file` only the `Control+s` save shortcut,
  while this change is confined to instance pointer-down. Flagged rather than
  omitted; CI is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)