### PR TITLE
fix(editor): Shift+drag duplicates, the way Virtuoso does

### DIFF
--- a/apps/editor/e2e/detach-move.spec.ts
+++ b/apps/editor/e2e/detach-move.spec.ts
@@ -329,10 +329,11 @@ test("Shift+M carries a whole multi-part selection", async ({ page }) => {
   );
 });
 
-// Shift+drag is the pointer form of Shift+M: the parts move, the wires stay
-// where they were and their old endpoints go electrically open. Shift+click
-// with no movement must still mean "add to selection".
-test("Shift+drag moves the part and leaves its wire in place", async ({
+// Virtuoso's pairing for the two modified drags: Ctrl/Cmd moves a part off its
+// wires, and Shift duplicates. Shift+drag therefore leaves the original alone
+// and drops a copy where the pointer lands. Shift+click with no movement must
+// still mean "add to selection".
+test("Shift+drag leaves the original in place and drops a copy", async ({
   page,
 }) => {
   const { ids, wireBefore } = await wiredPair(page);
@@ -346,12 +347,17 @@ test("Shift+drag moves the part and leaves its wire in place", async ({
 
   await shiftDrag(page, center, { x: center.x + 180, y: center.y });
 
-  const after = (await top.boundingBox())!;
-  expect(after.x).toBeGreaterThan(before.x + 100);
-  expect(await routePoints(page)).toEqual(wireBefore);
+  // A third part now exists, and the two originals never moved.
+  const after = await instanceIds(page);
+  expect(after).toHaveLength(3);
+  expect(after).toEqual(expect.arrayContaining(ids));
+  const settled = (await top.boundingBox())!;
+  expect(Math.abs(settled.x - before.x)).toBeLessThan(2);
 
+  // Duplicating never disturbs the wiring the originals already had.
+  expect(await routePoints(page)).toEqual(wireBefore);
   const terminals = await exportedTerminals(page);
-  expect(terminals).not.toContainEqual(
+  expect(terminals).toContainEqual(
     expect.objectContaining({ instanceId: ids[0] }),
   );
   expect(terminals).toContainEqual(

--- a/apps/editor/src/features/selection/use-selection-interaction.ts
+++ b/apps/editor/src/features/selection/use-selection-interaction.ts
@@ -833,6 +833,73 @@ export function useSelectionInteraction(
     options.updateInstanceSelection(instanceId, additive);
   };
 
+  /**
+   * Shift-drag duplicates, the way Virtuoso does. The copy rides the existing
+   * copy-placement preview so it snaps and renders like any other paste, and
+   * the release commits it; the original is never touched.
+   *
+   * A stationary Shift-press is not a duplicate, it is this editor's
+   * add-to-selection click, so the copy only starts once the drag threshold is
+   * crossed and a press-release without movement falls through to the toggle.
+   */
+  const beginCopyDrag = (
+    event: ReactPointerEvent<SVGElement>,
+    instanceId: string,
+    hitTarget: SVGElement,
+  ): void => {
+    const svg = (hitTarget.ownerSVGElement ?? hitTarget) as SVGSVGElement;
+    // Duplicate what a plain drag would have carried: the live selection when
+    // the pressed part belongs to it, otherwise just that part.
+    const copiedIds = options.selectedIds.includes(instanceId)
+      ? options.selectedIds
+      : [instanceId];
+    let started = false;
+    options.canvasDragSessionRef.current?.cancel();
+    options.canvasDragSessionRef.current = startCanvasDragSession({
+      target: hitTarget,
+      pointerId: event.pointerId,
+      startClient: { x: event.clientX, y: event.clientY },
+      thresholdPx: 4,
+      onPreview: (client) => {
+        const point = options.pointFromClient(client.x, client.y, svg, false);
+        if (!started) {
+          beginCopyPlacement(copiedIds);
+          if (options.getInteractionState().kind !== "copy-placement") {
+            options.canvasDragSessionRef.current?.cancel();
+            return;
+          }
+          started = true;
+        }
+        options.setCopyPreviewPoint({
+          x: options.snapCoordinate(
+            point.x,
+            options.document.presentation.grid,
+          ),
+          y: options.snapCoordinate(
+            point.y,
+            options.document.presentation.grid,
+          ),
+        });
+      },
+      onFinish: ({ client, dragged }) => {
+        options.canvasDragSessionRef.current = null;
+        if (!dragged || !started) {
+          // A modifier-click that never moved keeps its toggle meaning.
+          selectInstance(instanceId, true);
+          options.setStatus(`Selected ${instanceId}`);
+          return;
+        }
+        commitCopyPlacement(
+          options.pointFromClient(client.x, client.y, svg, false),
+        );
+      },
+      onCancel: () => {
+        options.canvasDragSessionRef.current = null;
+        if (started) options.cancelInteraction();
+      },
+    });
+  };
+
   const beginMove = (
     event: ReactPointerEvent<SVGElement>,
     instanceId: string,
@@ -849,26 +916,26 @@ export function useSelectionInteraction(
     if (!instance?.placement) return;
     options.suppressInstanceClickRef.current =
       hitTarget.getAttribute("data-canvas-hit-kind") === "instance";
-    // A modified drag follows Virtuoso: it moves the parts and leaves their
-    // wires exactly where they are on open Junction stubs, with the old
-    // terminal memberships disconnected. Cmd serves the same role as Ctrl
-    // because macOS browsers convert Ctrl+left-press into a right-button
-    // press before the page ever sees it.
+    // The two modified drags follow Virtuoso, where they mean different
+    // things. Ctrl/Cmd-drag moves a part off its wires, leaving them exactly
+    // where they are on open Junction stubs with the old terminal memberships
+    // disconnected. Shift-drag duplicates instead: the original never moves
+    // and a copy lands where the pointer is released.
     //
-    // The two modifiers differ in what they pick up, and that follows what
-    // each already means here. Ctrl/Cmd is the "just this part" gesture from
-    // #413 and stays that. Shift is this editor's add-to-selection modifier,
-    // so Shift+drag carries the whole selection the way Shift+M does.
+    // Cmd stands in for Ctrl because macOS browsers convert Ctrl+left-press
+    // into a right-button press before the page ever sees it.
     //
     // Either modifier pressed and released without moving keeps its
-    // toggle-selection meaning; the drag threshold below decides which
-    // happened, so nothing is committed on a stationary click.
-    const detachDrag = event.ctrlKey || event.metaKey || event.shiftKey;
-    const detachCarriesSelection =
-      event.shiftKey && options.selectedIds.includes(instanceId);
+    // toggle-selection meaning; the drag threshold decides which happened, so
+    // nothing is committed on a stationary click.
+    const detachDrag = (event.ctrlKey || event.metaKey) && !event.shiftKey;
+    const copyDrag = event.shiftKey && !(event.ctrlKey || event.metaKey);
+    if (copyDrag) {
+      beginCopyDrag(event, instanceId, hitTarget);
+      return;
+    }
     const movingSelection: VisualSelection =
-      (!detachDrag || detachCarriesSelection) &&
-      options.selectedIds.includes(instanceId)
+      !detachDrag && options.selectedIds.includes(instanceId)
         ? options.visualSelection
         : {
             instanceIds: [instanceId],
@@ -881,14 +948,7 @@ export function useSelectionInteraction(
     let previewBaseDocument = options.document;
     if (detachDrag) {
       try {
-        // Detach every part the move will actually carry, planned against the
-        // undetached Document, so a multi-part Shift+drag opens all of their
-        // endpoints rather than only the one under the pointer.
-        const prepared = prepareDetachedMove(
-          new Set(
-            planSelectionMove(options.document, movingSelection).instanceIds,
-          ),
-        );
+        const prepared = prepareDetachedMove(new Set([instanceId]));
         detachEdits = prepared.edits;
         previewBaseDocument = prepared.document;
       } catch (error) {


### PR DESCRIPTION
Corrects #489, which bound `Shift+drag` to the detached move.

That was wrong, and the mistake was mine: I reasoned from this editor's
internal consistency (Shift is the selection modifier here, so `Shift+drag`
should carry the selection) instead of checking the program the feature is
imitating. #489 was merged before that got caught, so this is a fix forward.

## What Virtuoso actually does

The two modified drags in the Virtuoso schematic editor mean different things:

| Gesture | Virtuoso |
|---|---|
| `Ctrl+drag` | move a part off its wires, wires stay put |
| `Shift+drag` | create a copy |

So `Ctrl/Cmd+drag` from #413 was already right and is untouched. `Shift+drag`
becomes duplicate. Binding it to a move also spent the key the duplicate
gesture needs.

**On source quality, plainly:** these are community hotkey references
([analoghub.ie](https://analoghub.ie/category/cadenceTricks/article/cadenceTricksHotkeys),
[miscircuitos.com](https://miscircuitos.com/cadence-keyboard-shortcuts-keybinds-go-faster/)),
not Cadence's own documentation, which needs a login. Two independent
references agree. Anyone with Virtuoso can settle it in one gesture.

Separately, I could find no source binding `Shift+M` to anything in the
schematic editor — in layout it is "Merge shapes". The already-shipped
`Shift+M` does what issue #485 asked for and is listed in the shortcut panel,
but it is not a Virtuoso-standard binding, which is worth knowing.

## Behaviour

The copy rides the existing copy-placement preview, so it snaps and renders
like any other paste and the release commits it. The original is never
touched, and neither is the wiring the originals already had.

`Shift+click` keeps its add-to-selection meaning: the duplicate starts only
once the drag threshold is crossed, and a press-release without movement falls
through to the same toggle the `Ctrl/Cmd` path uses.

## Verification

- Full local Playwright suite: **315 passed, 0 failed**.
- 799 editor unit tests, `pnpm ci:static`, typecheck.
- Red-then-green: the duplicate spec fails before this change.
- Three brakes asserted: `Ctrl+drag` behaviour unchanged, `Shift+click` still
  adds to selection, and duplicating leaves the originals' wiring intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)