### PR TITLE
docs(adr): simulation is part of the product, and the version says so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+Notable changes to Analog Canvas. Entries describe what changed for the person
+using the product, not the commits that got there.
+
+## 0.2.0 (unreleased)
+
+### Simulation
+
+Analog Canvas is no longer only an editor. A circuit drawn here can now be
+simulated without leaving it.
+
+Until this release the product's own description ended with "not a simulator",
+and that was accurate: you exported a netlist, went to another tool for the
+answer, and came back to edit. The loop that matters most in analog design was
+the one loop the product did not close.
+
+**What runs.** A circuit whose every instance resolves to a PDK device model,
+hierarchy included. A `.subckt` made of transistors is simulatable, and so is
+a subcircuit of subcircuits of transistors.
+
+**What does not.** A circuit containing an abstract block, such as a
+signal-flow element or a behavioural amplifier, has no device model behind that
+block and is refused. The refusal names the blocks responsible rather than
+failing vaguely, so the way forward is visible: replace them with device-level
+implementations.
+
+**The testbench is yours.** Analog Canvas supplies the circuit and runs the
+simulator. Stimulus, loads, analysis statements, and sweeps come from you. We
+ship no templates and infer no intent, because a testbench encodes what you are
+trying to prove and guessing it would produce confident answers to questions
+you never asked.
+
+**Where it runs.** Simulation runs on hosted containers, which means the
+circuit netlist is uploaded to run. If your circuit is not yours to upload, the
+local host runs the same simulation on your own machine against your own PDK
+version, and returns the same results.
+
+**This release covers DC operating point and AC analysis.** Transient, sweeps,
+and corner runs follow once this path is proven.
+
+### Unchanged
+
+The electrical model is untouched. Connectivity is still explicit, a crossing
+is still not a connection, and wires are still drawing. Simulation reads your
+circuit and never writes it: a result cannot alter a net, and nothing about a
+simulation is saved into the project file.
+
+Existing project files are unaffected. There is no schema change and no
+migration. A file that opened yesterday opens identically today.
+
+See ADR 0055 for the reasoning behind the scope change and the alternatives
+weighed against it.
+
+## 0.1.0
+
+The connectivity-aware schematic editor: structural SPICE import, a typed
+circuit model persisted as one `.icproj.json` file, formal SVG, PNG, and PDF
+export, deterministic SPICE and Spectre design netlists, a published gallery,
+and an Agent API that edits the same live project as the human interface.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-Analog Canvas (repo `interactive-circuit-maker`) is a local-first, connectivity-aware schematic editor: structural SPICE is imported into a typed circuit model, edited in the browser (React + SVG), persisted as one canonical `.icproj.json` Project file, and exported as formal SVG/PNG/PDF and deterministic SPICE/Spectre design netlists. It is an editor and structural circuit tool — not a simulator. A human UI and an authorized Agent API edit the same live Project through the same edit engine; neither may bypass electrical, revision, lock, or transaction invariants.
+Analog Canvas (repo `interactive-circuit-maker`) is a local-first, connectivity-aware schematic editor: structural SPICE is imported into a typed circuit model, edited in the browser (React + SVG), persisted as one canonical `.icproj.json` Project file, and exported as formal SVG/PNG/PDF and deterministic SPICE/Spectre design netlists. It edits circuits and simulates the ones that are fully described at the transistor level: a circuit whose every instance resolves to a PDK device model runs against ngspice, hierarchy included; one containing an abstract block is refused with the block named (ADR 0055). A human UI and an authorized Agent API edit the same live Project through the same edit engine; neither may bypass electrical, revision, lock, or transaction invariants.
 
 pnpm workspace (`apps/*`, `packages/*`, all scoped `@icm/*`), Node >= 24, pnpm >= 11.16, TypeScript, ESM only.
 

--- a/apps/editor/e2e/chrome-isolation.spec.ts
+++ b/apps/editor/e2e/chrome-isolation.spec.ts
@@ -51,7 +51,7 @@ test("carries the version and project resource links inside Help", async ({
 
   const about = page.getByRole("dialog");
   await expect(about).toContainText("About Analog Canvas");
-  await expect(about).toContainText("Version 0.1.0");
+  await expect(about).toContainText("Version 0.2.0");
   const repositoryLink = about.getByRole("link", { name: "Repository" });
   await expect(repositoryLink).toHaveAttribute(
     "href",

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icm/editor",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/editor/src/components/editor-help-dialog.test.tsx
+++ b/apps/editor/src/components/editor-help-dialog.test.tsx
@@ -13,7 +13,7 @@ describe("EditorHelpDialog", () => {
 
     expect(markup).toContain('role="dialog"');
     expect(markup).toContain("About Analog Canvas");
-    expect(markup).toContain("Version <strong>0.1.0</strong>");
+    expect(markup).toContain("Version <strong>0.2.0</strong>");
     expect(markup).toContain(
       'href="https://github.com/cascode-ai/analog-canvas"',
     );

--- a/apps/local-host/package.json
+++ b/apps/local-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icm/local-host",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/local-host/src/cli.ts
+++ b/apps/local-host/src/cli.ts
@@ -10,4 +10,4 @@ const editorRoot = resolve(
     : "apps/editor/dist",
 );
 const running = await startLocalHost({ editorRoot, port: 4173 });
-process.stdout.write(`Interactive Circuit Maker v0.1.0: ${running.origin}\n`);
+process.stdout.write(`Interactive Circuit Maker v0.2.0: ${running.origin}\n`);

--- a/apps/local-host/src/index.ts
+++ b/apps/local-host/src/index.ts
@@ -53,7 +53,7 @@ export async function startLocalHost(
     }
     if (request.url === "/healthz") {
       response.writeHead(200, { "content-type": "application/json" });
-      response.end('{"status":"ok","version":"0.1.0"}\n');
+      response.end('{"status":"ok","version":"0.2.0"}\n');
       return;
     }
     try {

--- a/apps/local-host/src/local-host.test.ts
+++ b/apps/local-host/src/local-host.test.ts
@@ -25,7 +25,7 @@ describe("portable local host", () => {
       expect(response.headers.get("cache-control")).toBe("no-cache");
       expect(await (await fetch(`${running.origin}/healthz`)).json()).toEqual({
         status: "ok",
-        version: "0.1.0",
+        version: "0.2.0",
       });
       expect((await fetch(`${running.origin}/..%2Fsecret.txt`)).status).toBe(
         404,

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icm/mcp-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -18,7 +18,7 @@ import {
 import type { McpServerHandler, McpServerInfo } from "./protocol.js";
 
 export const MCP_SERVER_NAME = "analog-canvas";
-export const MCP_SERVER_VERSION = "0.1.0";
+export const MCP_SERVER_VERSION = "0.2.0";
 
 export interface McpServerConfig {
   apiBaseUrl: string;

--- a/config/agent-mcp-distribution.json
+++ b/config/agent-mcp-distribution.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "name": "analog-canvas",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "node": ">=24.0.0",
   "packageName": "@analog-canvas/mcp-server",
   "binaryName": "analog-canvas-mcp",
@@ -9,8 +9,8 @@
   "release": {
     "buildPlatform": "linux",
     "repository": "cascode-ai/analog-canvas",
-    "tag": "mcp-v0.1.0",
-    "asset": "analog-canvas-mcp-server-0.1.0.tgz",
+    "tag": "mcp-v0.2.0",
+    "asset": "analog-canvas-mcp-server-0.2.0.tgz",
     "sha256": "0383d9d26d4665339a89e80a9d8ecff91edcecb3022b268a038503260643dfda"
   }
 }

--- a/docs/adr/0055-simulation-is-part-of-the-product.md
+++ b/docs/adr/0055-simulation-is-part-of-the-product.md
@@ -1,0 +1,159 @@
+# 0055 - Simulation is part of the product
+
+Status: `accepted`
+
+Date: `2026-09-01`
+
+Owners: `packages/netlist`, `packages/derived`, `packages/devices`, `worker`,
+`apps/editor`, `apps/local-host`
+
+## Context
+
+Every document in this repository has opened with the same sentence: Analog
+Canvas is an editor and a structural circuit tool, **not a simulator**. That
+boundary was not an oversight. It kept the model honest — a Net is an
+electrical fact, a Route is drawing — and it kept the product finishable.
+
+It also left the person who draws a circuit with no way to ask whether the
+circuit works. They export a netlist, leave for another tool, and come back to
+edit. The drawing and the answer live in different places, so the loop that
+matters most in analog design is the one the product does not close.
+
+The owner has decided to close it. This ADR records that the boundary moved,
+why, and what did not move with it.
+
+Three facts shaped the design:
+
+**The netlist already exists.** `@icm/netlist` emits a deterministic,
+hierarchical SPICE netlist today (`.subckt`, `X` calls, devices with
+parameters). Simulation does not need a second extraction path; it needs a
+binding from our device descriptors to a specific PDK's model names and
+parameter conventions.
+
+**The PDK a simulator needs is small.** The full Sky130 distribution measures
+2.1 GB, but the SPICE model files ngspice actually reads are **52 MB**. The
+rest is layout and standard-cell data no circuit simulator touches. That
+difference is what makes a hosted container practical rather than absurd.
+
+**ngspice is a native program.** A Cloudflare Worker is a V8 isolate; it runs
+JavaScript and WebAssembly and cannot execute a native binary. Cloudflare
+Containers do run ordinary images, with a 20 GB image ceiling and 1 to 3
+second cold starts.
+
+## Decision
+
+**Simulation is part of the product.** The opening sentence of `CLAUDE.md`
+changes from "not a simulator" to a scoped statement: Analog Canvas edits
+circuits and can simulate the ones that are fully described at the transistor
+level.
+
+**A circuit is simulatable when every instance resolves to a PDK device
+model.** Hierarchy does not disqualify it: a `.subckt` whose contents are
+transistors is simulatable, recursively. Abstract blocks — signal-flow
+elements, behavioural amplifiers, anything with no device model behind it —
+are not, and a document containing one is refused with the specific instances
+named. Refusal is a diagnosis, never a silent failure.
+
+**The testbench is the author's, not ours.** Analog Canvas supplies the
+circuit netlist and runs the simulator. Stimulus, loads, analysis statements,
+and sweeps come from the author. We ship no templates and infer no intent.
+This is deliberate: a testbench encodes what the designer is trying to prove,
+and guessing it would produce confident answers to questions nobody asked.
+
+**Simulation runs server-side first, on Cloudflare Containers**, with the
+local host as the second surface behind the same interface. Both consume the
+same netlist and return the same result shape; only the location of ngspice
+differs.
+
+**The first release covers DC operating point and AC analysis.** Transient,
+sweeps, and PVT corners follow once the path is proven end to end.
+
+## Alternatives considered
+
+### ngspice compiled to WebAssembly, in the browser
+
+- Benefits: no server, no cost, the circuit never leaves the machine.
+- Costs: the model library ships to every visitor; browser memory and single
+  thread bound the circuit size; the WASM build becomes ours to maintain.
+- Reason not selected: the owner judged it the wrong shape for the problem,
+  and the same build server-side would inherit tighter limits than a browser
+  tab, not looser ones.
+
+### Local host only
+
+- Benefits: the circuit never leaves the machine; the user's own PDK version;
+  no hosting cost; `apps/local-host` already exists.
+- Costs: only users who install it can simulate, which is most of them not.
+- Reason not selected as the first surface: it serves the fewest people while
+  costing the same engineering. It remains the **second** surface, because the
+  privacy argument is real for anyone whose circuit is not theirs to upload.
+
+### A conventional server or virtual machine
+
+- Benefits: no platform limits.
+- Costs: a second deployment target, its own operations, its own bill.
+- Reason not selected: Containers reach the same capability inside the
+  deployment we already have.
+
+## Consequences
+
+### Positive
+
+- The design loop closes inside one tool.
+- The simulatability verdict is a reusable projection: the editor can grey out
+  the action and say why before anyone runs anything.
+- The netlist path gains a real consumer, which is the strongest test a
+  netlist printer can have.
+
+### Negative or limiting
+
+- **The circuit leaves the author's machine.** A hosted simulation uploads the
+  netlist to a container. This is stated in the product, not buried: anyone
+  whose circuit may not be uploaded must use the local host instead. That is
+  why the local surface is a commitment in this ADR and not an aspiration.
+- Simulation costs money per run. At the metered rates a run is on the order
+  of one hundredth of a cent, and the paid plan's included allowance covers
+  roughly two thousand runs a month before overage, but the cost is not zero
+  and grows with use.
+- A container starts with a fresh disk. Nothing accumulates between runs, so
+  every run pays its own setup.
+- Abstract blocks stay unsimulatable until someone gives them device-level
+  implementations. This is a real limit of the first release, not a defect.
+
+### Not changed by this decision
+
+The electrical invariants are untouched. Connectivity is still explicit; a
+Crossing is still not a Junction; Routes are still drawing. Simulation reads
+the model and never writes it: a simulation result is not persisted into the
+Project and cannot alter a Net. The edit engine remains the sole mutation
+boundary, and nothing in this feature edits a document.
+
+## Compatibility and migration
+
+No change to the persisted Project. No schema version bump, no migration, and
+no existing file loads differently. Simulation is additive: a document that
+could be opened yesterday opens identically today and merely gains an action
+that may report it is not simulatable.
+
+The version moves `0.1.0` to `0.2.0` to mark the scope change, and a
+`CHANGELOG.md` starts at that entry.
+
+## Validation
+
+- A benchmark circuit from `analog-arena` (`sky130-ota-5t`, a five-transistor
+  OTA whose netlist is `.subckt` plus six `sky130_fd_pr__nfet_01v8` and
+  `pfet_01v8` instances) is drawn in the editor, exported, simulated, and its
+  operating point compared against ngspice run directly on the reference
+  netlist. Agreement on node voltages is the evidence that the export binding
+  is correct.
+- A document containing a signal-flow block is refused, and the refusal names
+  the block.
+- A hierarchical document whose subcircuits contain only transistors is
+  accepted, proving the recursive rule.
+
+## Related documents
+
+- `docs/specs/schematic-model.md` for what an Instance carries.
+- ADR 0054 for the single Instance Reference authority the netlist prints.
+- `analog-arena` `benchmarks/v2` for the circuit and testbench shapes this
+  targets.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,6 +37,7 @@ major boundaries exist.
 - [`0036-named-power-and-mos-bulk-semantics.md`](0036-named-power-and-mos-bulk-semantics.md) — named power and MOS bulk policy
 - [`0038-document-style-overrides.md`](0038-document-style-overrides.md) — Document style overrides
 - [`0054-single-instance-reference-authority.md`](0054-single-instance-reference-authority.md) — one authored Instance Reference across canvas, copy, Agent, and export
+- [`0055-simulation-is-part-of-the-product.md`](0055-simulation-is-part-of-the-product.md) — simulation joins the product; what is simulatable, whose testbench, and where ngspice runs
 
 ### Connectivity and routing
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -126,7 +126,7 @@ Build the versioned bundle and start it with Node 24:
 
 ```powershell
 pnpm release:package
-node output/release/interactive-circuit-maker-v0.1.0/start.mjs
+node output/release/interactive-circuit-maker-v0.2.0/start.mjs
 ```
 
 Open `http://127.0.0.1:4173`. Chromium can install the app from its browser

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interactive-circuit-maker",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@11.16.0",

--- a/packages/exporters/package.json
+++ b/packages/exporters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icm/exporters",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/platform-node/package.json
+++ b/packages/platform-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icm/platform-node",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/mcp-release-smoke.mjs
+++ b/scripts/mcp-release-smoke.mjs
@@ -6,7 +6,10 @@ import { join, resolve } from "node:path";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
 
-const releaseRoot = resolve("output/release/interactive-circuit-maker-v0.1.0");
+const { version } = JSON.parse(await readFile(resolve("package.json"), "utf8"));
+const releaseRoot = resolve(
+  `output/release/interactive-circuit-maker-v${version}`,
+);
 const metadata = JSON.parse(
   await readFile(resolve(releaseRoot, "release.json"), "utf8"),
 );

--- a/scripts/package-release.mjs
+++ b/scripts/package-release.mjs
@@ -5,7 +5,15 @@ const root = resolve(import.meta.dirname, "..");
 const mcpDistribution = JSON.parse(
   await readFile(resolve(root, "config/agent-mcp-distribution.json"), "utf8"),
 );
-const output = resolve(root, "output/release/interactive-circuit-maker-v0.1.0");
+// One source for the release version: the workspace manifest. Hard-coding it
+// here and in the two smoke scripts is what broke the 0.1.0 to 0.2.0 bump.
+const { version } = JSON.parse(
+  await readFile(resolve(root, "package.json"), "utf8"),
+);
+const output = resolve(
+  root,
+  `output/release/interactive-circuit-maker-v${version}`,
+);
 await rm(output, { recursive: true, force: true });
 await mkdir(output, { recursive: true });
 await cp(resolve(root, "apps/editor/dist"), resolve(output, "editor"), {
@@ -19,7 +27,7 @@ await cp(resolve(root, "output/mcp"), resolve(output, "mcp"), {
 });
 await writeFile(
   resolve(output, "start.mjs"),
-  `import { resolve } from "node:path";\nimport { startLocalHost } from "./host/index.js";\nconst running = await startLocalHost({ editorRoot: resolve(import.meta.dirname, "editor"), port: 4173 });\nprocess.stdout.write(\`Interactive Circuit Maker v0.1.0: \${running.origin}\\n\`);\n`,
+  `import { resolve } from "node:path";\nimport { startLocalHost } from "./host/index.js";\nconst running = await startLocalHost({ editorRoot: resolve(import.meta.dirname, "editor"), port: 4173 });\nprocess.stdout.write(\`Interactive Circuit Maker v${version}: \${running.origin}\\n\`);\n`,
 );
 const manifest = JSON.parse(
   await readFile(
@@ -32,7 +40,7 @@ await writeFile(
   `${JSON.stringify(
     {
       name: "interactive-circuit-maker",
-      version: "0.1.0",
+      version,
       node: mcpDistribution.node,
       pwa: manifest.name,
       mcp: `mcp/analog-canvas-mcp-v${mcpDistribution.version}/bin/analog-canvas-mcp.mjs`,

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -1,13 +1,18 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
-import { startLocalHost } from "../output/release/interactive-circuit-maker-v0.1.0/host/index.js";
+const { version } = JSON.parse(await readFile(resolve("package.json"), "utf8"));
+const { startLocalHost } = await import(
+  `../output/release/interactive-circuit-maker-v${version}/host/index.js`
+);
 
-const releaseRoot = resolve("output/release/interactive-circuit-maker-v0.1.0");
+const releaseRoot = resolve(
+  `output/release/interactive-circuit-maker-v${version}`,
+);
 const metadata = JSON.parse(
   await readFile(resolve(releaseRoot, "release.json"), "utf8"),
 );
-if (metadata.version !== "0.1.0")
+if (metadata.version !== version)
   throw new Error("Release metadata version mismatch");
 const running = await startLocalHost({
   editorRoot: resolve(releaseRoot, "editor"),
@@ -19,7 +24,7 @@ try {
     fetch(`${running.origin}/sw.js`),
     fetch(running.origin),
   ]);
-  if (!health.ok || (await health.json()).version !== "0.1.0")
+  if (!health.ok || (await health.json()).version !== version)
     throw new Error("Release health check failed");
   const manifestData = await manifest.json();
   if (manifestData.icons.length < 2 || manifestData.display !== "standalone")

--- a/worker/agent-session.test.ts
+++ b/worker/agent-session.test.ts
@@ -358,7 +358,7 @@ describe("public Agent session routes", () => {
     expect(manifest).toMatchObject({
       format: AGENT_MCP_BOOTSTRAP_FORMAT,
       name: "analog-canvas",
-      version: "0.1.0",
+      version: "0.2.0",
       transport: "stdio",
       requirements: { node: ">=24.0.0" },
       fallback: {
@@ -367,7 +367,7 @@ describe("public Agent session routes", () => {
       },
     });
     expect(manifest.launch.args.join(" ")).toContain(
-      "analog-canvas-mcp-server-0.1.0.tgz",
+      "analog-canvas-mcp-server-0.2.0.tgz",
     );
     expect(manifest.hosts.codex.command).toContain("codex mcp add");
     expect(manifest.hosts.cursor.config.mcpServers["analog-canvas"]).toEqual(


### PR DESCRIPTION
The foundation for 0.2.0's simulation work. Docs, version, and one contract four parallel efforts build against.

## What changed

**ADR 0055** records that the owner moved the boundary every document in this repository opened with, and fixes the shape of what follows:

- A circuit is simulatable when every instance resolves to a PDK device model. Hierarchy does not disqualify it and **the rule is recursive**, so a subcircuit of subcircuits of transistors runs.
- An abstract block is refused **with the block named**. A refusal that does not say which instance is at fault leaves no way forward.
- **The testbench is the author's.** We supply the circuit and run the simulator; stimulus, loads, analyses, and sweeps come from them. Guessing one would produce confident answers to questions nobody asked.
- Simulation runs on Cloudflare Containers, with the local host as the second surface behind the same interface.

Two measurements decided the hosting: the Sky130 files ngspice actually reads are **52 MB** of the 2.1 GB distribution, and a container image may be 20 GB. A Worker is a V8 isolate and cannot execute a native binary at all.

The hosted path uploads the circuit. That is stated in the product rather than buried, and is why the local surface is a commitment in the ADR and not an aspiration.

**CLAUDE.md** stops saying "not a simulator" and says what is and is not simulatable. **CHANGELOG.md** starts at 0.2.0. The version moves across the workspace.

## Nothing in the model changes

No schema bump, no migration, every existing file opens identically. Simulation reads and never writes: a result is not persisted and cannot alter a Net.

## One fix the gate earned

My first version sweep missed `scripts/`, so the release smoke checks still looked for `v0.1.0`. Rather than substitute the number a fourth time, the three scripts now read it from the workspace manifest, since one number copied into three files is what broke the bump.

Three `0.1.0` are deliberately untouched: the export manifest and performance report version their own **formats**, not the application, and the golden records the format it was generated against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)