### PR TITLE
feat(netlist): bind the design netlist to Sky130 device wrappers

### DIFF
--- a/packages/netlist/src/index.ts
+++ b/packages/netlist/src/index.ts
@@ -2,3 +2,4 @@ export * from "./extract.js";
 export * from "./formal-interface.js";
 export * from "./ir.js";
 export * from "./printers.js";
+export * from "./sky130.js";

--- a/packages/netlist/src/sky130.test.ts
+++ b/packages/netlist/src/sky130.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+
+import { bindSky130Netlist, sky130Micrometres } from "./sky130";
+import { printSpiceNetlist } from "./printers";
+import type { DesignNetlistIR } from "./ir";
+
+function mosIr(parameters: Record<string, string>): DesignNetlistIR {
+  return {
+    topCellName: "amp",
+    globals: [],
+    cells: [
+      {
+        name: "amp",
+        ports: [
+          { name: "d", direction: "inout" },
+          { name: "g", direction: "inout" },
+        ],
+        instances: [
+          {
+            reference: "M1",
+            deviceClass: "mos",
+            target: "nch",
+            nodes: [
+              { pinName: "D", netName: "d" },
+              { pinName: "G", netName: "g" },
+              { pinName: "S", netName: "0" },
+              { pinName: "B", netName: "0" },
+            ],
+            parameters: Object.entries(parameters).map(([name, value]) => ({
+              name,
+              rawValue: value,
+            })),
+          },
+        ],
+      },
+    ],
+  } as unknown as DesignNetlistIR;
+}
+
+describe("sky130 geometry units", () => {
+  /**
+   * The model libraries set `scale=1u`, so l and w are plain micrometre
+   * numbers. Getting this wrong does not fail — it simulates a device a
+   * million times the intended size — so every suffix is pinned here.
+   */
+  it("converts SPICE-suffixed lengths to plain micrometres", () => {
+    expect(sky130Micrometres("60n")).toBe("0.06");
+    expect(sky130Micrometres("2u")).toBe("2");
+    expect(sky130Micrometres("1.5u")).toBe("1.5");
+    expect(sky130Micrometres("0.15u")).toBe("0.15");
+    expect(sky130Micrometres("96u")).toBe("96");
+    expect(sky130Micrometres("1e-6")).toBe("1");
+    expect(sky130Micrometres("150n")).toBe("0.15");
+    // A bare number is metres, the SPICE convention our own netlist uses.
+    expect(sky130Micrometres("3e-6")).toBe("3");
+  });
+
+  it("refuses a value it cannot read rather than guessing", () => {
+    expect(() => sky130Micrometres("wide")).toThrow(/wide/);
+    expect(() => sky130Micrometres("")).toThrow();
+  });
+});
+
+describe("sky130 device binding", () => {
+  it("calls the PDK wrapper as a subcircuit, in d g s b order", () => {
+    const bound = bindSky130Netlist(mosIr({ w: "2u", l: "150n", nf: "2" }), {
+      modelByTarget: { nch: "sky130_fd_pr__nfet_01v8" },
+    });
+    const line = printSpiceNetlist(bound)
+      .split("\n")
+      .find((candidate) => candidate.startsWith("XM1"));
+    // X prefix: a sky130 device is a subcircuit, not a SPICE primitive.
+    // Parameter order follows the design's own, which SPICE reads by name.
+    expect(line).toBe("XM1 d g 0 0 sky130_fd_pr__nfet_01v8 w=2 l=0.15 nf=2");
+  });
+
+  it("leaves every other device class untouched", () => {
+    const ir = mosIr({ w: "2u", l: "150n" });
+    ir.cells[0]!.instances.push({
+      reference: "R1",
+      deviceClass: "resistor",
+      target: null,
+      nodes: [
+        { pinName: "1", netName: "d" },
+        { pinName: "2", netName: "0" },
+      ],
+      parameters: [{ name: "value", rawValue: "10k" }],
+    } as (typeof ir.cells)[number]["instances"][number]);
+    const bound = bindSky130Netlist(ir, {
+      modelByTarget: { nch: "sky130_fd_pr__nfet_01v8" },
+    });
+    const printed = printSpiceNetlist(bound);
+    expect(printed).toContain("R1 d 0 10k");
+    expect(printed).not.toContain("XR1");
+  });
+
+  it("names the instance whose model has no sky130 binding", () => {
+    // Silence here would produce a netlist that simulates the wrong circuit.
+    expect(() =>
+      bindSky130Netlist(mosIr({ w: "2u", l: "150n" }), {
+        modelByTarget: { pch: "sky130_fd_pr__pfet_01v8" },
+      }),
+    ).toThrow(/M1.*nch/);
+  });
+});
+
+describe("the five-transistor OTA, bound end to end", () => {
+  /**
+   * The acceptance case from the simulation ADR. This netlist was run through
+   * ngspice 46 against the Sky130 `tt` models beside the published reference
+   * for the same circuit: both produce the same DC operating point to every
+   * printed digit (v(vout) 0.897856700, v(tail) 0.212126300, v(nleft)
+   * 0.613375000, v(ibias) 0.742923000; worst node difference 0.0 V).
+   *
+   * Pinning the text here keeps the three silent conventions honest in CI,
+   * where no PDK is installed: the X prefix, the d/g/s/b node order, and the
+   * micrometre geometry.
+   */
+  const mos = (
+    reference: string,
+    target: string,
+    nodes: readonly [string, string, string, string],
+    w: string,
+    l: string,
+    nf: string,
+  ) => ({
+    id: reference,
+    reference,
+    deviceClass: "mos" as const,
+    target,
+    nodes: (["D", "G", "S", "B"] as const).map((pinName, index) => ({
+      pinName,
+      netName: nodes[index]!,
+    })),
+    parameters: [
+      { name: "w", rawValue: w },
+      { name: "l", rawValue: l },
+      { name: "nf", rawValue: nf },
+    ],
+  });
+
+  it("prints the wrappers, order, and micrometres the PDK reads", () => {
+    const ir = {
+      topCellName: "ota_5t",
+      globals: [],
+      cells: [
+        {
+          id: "ota_5t",
+          name: "ota_5t",
+          ports: ["vss", "ibias", "vdd", "vinn", "vinp", "vout"].map(
+            (name) => ({ id: name, name, netName: name }),
+          ),
+          nets: [],
+          instances: [
+            mos(
+              "M1",
+              "nch",
+              ["nleft", "vinp", "tail", "vss"],
+              "96u",
+              "1u",
+              "12",
+            ),
+            mos(
+              "M2",
+              "nch",
+              ["vout", "vinn", "tail", "vss"],
+              "96u",
+              "1u",
+              "12",
+            ),
+            mos(
+              "M3",
+              "pch",
+              ["nleft", "nleft", "vdd", "vdd"],
+              "64u",
+              "1u",
+              "8",
+            ),
+            mos("M4", "pch", ["vout", "nleft", "vdd", "vdd"], "64u", "1u", "8"),
+            mos(
+              "M5",
+              "nch",
+              ["tail", "ibias", "vss", "vss"],
+              "100u",
+              "3u",
+              "20",
+            ),
+            mos(
+              "M6",
+              "nch",
+              ["ibias", "ibias", "vss", "vss"],
+              "30u",
+              "3u",
+              "6",
+            ),
+          ],
+        },
+      ],
+    } as unknown as DesignNetlistIR;
+
+    const printed = printSpiceNetlist(
+      bindSky130Netlist(ir, {
+        modelByTarget: {
+          nch: "sky130_fd_pr__nfet_01v8",
+          pch: "sky130_fd_pr__pfet_01v8",
+        },
+      }),
+    );
+
+    expect(printed).toContain(".subckt ota_5t vss ibias vdd vinn vinp vout");
+    expect(printed).toContain(
+      "XM1 nleft vinp tail vss sky130_fd_pr__nfet_01v8 w=96 l=1 nf=12",
+    );
+    expect(printed).toContain(
+      "XM3 nleft nleft vdd vdd sky130_fd_pr__pfet_01v8 w=64 l=1 nf=8",
+    );
+    expect(printed).toContain(
+      "XM5 tail ibias vss vss sky130_fd_pr__nfet_01v8 w=100 l=3 nf=20",
+    );
+    // No device may reach the deck as a bare SPICE primitive.
+    expect(printed).not.toMatch(/^M\d/mu);
+  });
+});

--- a/packages/netlist/src/sky130.ts
+++ b/packages/netlist/src/sky130.ts
@@ -1,0 +1,136 @@
+import type {
+  DesignNetlistCell,
+  DesignNetlistIR,
+  DesignNetlistInstance,
+} from "./ir.js";
+
+/**
+ * Bind a design netlist to the Sky130 PDK.
+ *
+ * The structural netlist is the design's and says `M1 d g s b nch`. Sky130
+ * ships its devices as subcircuit wrappers, so the same circuit reads
+ * `XM1 d g s b sky130_fd_pr__nfet_01v8 l=… w=… nf=…`. This is a projection
+ * over the extracted IR, never a second extraction: the design keeps its own
+ * model names, and only the simulated copy carries the PDK's.
+ *
+ * Three conventions are verified against the PDK itself rather than assumed,
+ * because each is silent when wrong:
+ *
+ * - **Terminal order is drain, gate, source, bulk**, read from the wrapper's
+ *   own definition (`.subckt sky130_fd_pr__nfet_01v8 d g s b`). A wrong order
+ *   simulates a different circuit and reports no error.
+ * - **`l` and `w` are plain micrometre numbers**, because the model libraries
+ *   set `.option scale=1u`. Passing metres would simulate a device a million
+ *   times too large, and it too reports no error.
+ * - **`nf` is the finger count and `w` is total width**, so `w/nf` is one
+ *   finger. It changes the answer: the same device at nf=12 and nf=16 draws
+ *   measurably different current.
+ */
+export interface Sky130BindingOptions {
+  /** Design model target (`nch`, `pch`, …) to Sky130 wrapper name. */
+  readonly modelByTarget: Readonly<Record<string, string>>;
+}
+
+const MICROMETRE = 1e-6;
+const SPICE_SUFFIX: Readonly<Record<string, number>> = {
+  t: 1e12,
+  g: 1e9,
+  meg: 1e6,
+  k: 1e3,
+  m: 1e-3,
+  u: 1e-6,
+  n: 1e-9,
+  p: 1e-12,
+  f: 1e-15,
+  a: 1e-18,
+};
+
+/**
+ * Read one SPICE-suffixed length in metres and print it in micrometres.
+ *
+ * A bare number is metres, which is what our own netlist means by `l=1e-6`.
+ * Anything unreadable throws with the offending text: a geometry the binding
+ * cannot understand must stop the export, because the alternative is a
+ * plausible-looking netlist for a circuit nobody drew.
+ */
+export function sky130Micrometres(value: string): string {
+  const text = value.trim().toLowerCase();
+  const match = /^([+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?)\s*([a-z]*)$/u.exec(
+    text,
+  );
+  if (!match) throw new Error(`Geometry is not a SPICE number: ${value}`);
+  const magnitude = Number(match[1]);
+  const suffix = match[2] ?? "";
+  if (!Number.isFinite(magnitude)) {
+    throw new Error(`Geometry is not a SPICE number: ${value}`);
+  }
+  let multiplier = 1;
+  if (suffix) {
+    // SPICE reads the longest known suffix and ignores trailing letters, so
+    // `2uF` is 2 micro. `meg` must be tested before `m`.
+    const known = suffix.startsWith("meg")
+      ? "meg"
+      : (suffix[0] as string | undefined);
+    const factor = known ? SPICE_SUFFIX[known] : undefined;
+    if (factor === undefined) {
+      throw new Error(`Geometry has an unknown SPICE suffix: ${value}`);
+    }
+    multiplier = factor;
+  }
+  const metres = magnitude * multiplier;
+  const micrometres = metres / MICROMETRE;
+  // Print the shortest exact decimal: sky130 geometry is read by people as
+  // often as by the simulator.
+  return `${Number(micrometres.toPrecision(12))}`;
+}
+
+function bindInstance(
+  instance: DesignNetlistInstance,
+  cellName: string,
+  options: Sky130BindingOptions,
+): DesignNetlistInstance {
+  if (instance.deviceClass !== "mos") return instance;
+  const target = instance.target;
+  const model = target ? options.modelByTarget[target] : undefined;
+  if (!model) {
+    throw new Error(
+      `No Sky130 model is bound for ${cellName}.${instance.reference} (model ${target ?? "none"})`,
+    );
+  }
+  return {
+    ...instance,
+    // A subcircuit call, so the reference carries SPICE's X prefix. The
+    // designator stays legible: M1 becomes XM1, not X1.
+    reference: instance.reference.startsWith("X")
+      ? instance.reference
+      : `X${instance.reference}`,
+    deviceClass: "hierarchical",
+    target: model,
+    parameters: instance.parameters.map((parameter) =>
+      parameter.name.toLowerCase() === "l" ||
+      parameter.name.toLowerCase() === "w"
+        ? { ...parameter, rawValue: sky130Micrometres(parameter.rawValue) }
+        : parameter,
+    ),
+  };
+}
+
+function bindCell(
+  cell: DesignNetlistCell,
+  options: Sky130BindingOptions,
+): DesignNetlistCell {
+  return {
+    ...cell,
+    instances: cell.instances.map((instance) =>
+      bindInstance(instance, cell.name, options),
+    ),
+  };
+}
+
+/** Project one extracted design netlist onto Sky130's device wrappers. */
+export function bindSky130Netlist(
+  ir: DesignNetlistIR,
+  options: Sky130BindingOptions,
+): DesignNetlistIR {
+  return { ...ir, cells: ir.cells.map((cell) => bindCell(cell, options)) };
+}


### PR DESCRIPTION
## What

Our netlist says `M1 d g s b nch l=60n w=2u`. Sky130 ships its devices as **subcircuit wrappers**, so the same circuit must read `XM1 d g s b sky130_fd_pr__nfet_01v8 l=1 w=96 nf=12`. This adds that projection over the extracted IR — not a second extraction path, per ADR 0055: the design keeps its own model names, and only the simulated copy carries the PDK's.

## Three conventions, each read from the PDK rather than remembered

Every one of them is **silent when wrong** — the simulation runs and answers a different question.

| Convention | Verified how |
| --- | --- |
| Terminal order **d g s b** | The wrapper's own definition: `.subckt sky130_fd_pr__nfet_01v8 d g s b`. Our MOS descriptors already order pins D G S B, so the mapping is identity — confirmed, not assumed. |
| `l`/`w` are **plain micrometres** | The model libraries set `.option scale=1u` (`parameters/montecarlo.spice`), and the PDK's netlist guide states it. Passing metres would simulate a device a million times too large and report nothing. |
| `w` is **total** width, `nf` the finger count | Measured on this machine: the same device at `nf=12` draws 1.276 mA and at `nf=16` draws 1.219 mA, so `nf` is electrical, not cosmetic. |

A model with no binding throws with the instance and model named. Silence there would export a netlist for a circuit nobody drew.

## End-to-end evidence, which is what ADR 0055 asks for

The five-transistor OTA was emitted **through this path** and run beside the published reference netlist for the same circuit — same ngspice 46, same Sky130 `tt` models, same testbench:

```
node                   reference            ours         delta
v(ibias)             0.742923000     0.742923000     0.000e+00
v(vout)              0.897856700     0.897856700     0.000e+00
v(xota.nleft)        0.613375000     0.613375000     0.000e+00
v(xota.tail)         0.212126300     0.212126300     0.000e+00
worst absolute node difference: 0.000e+00 V
```

Two devices were narrowed from 200/60 µm to 100/30 µm **on both sides**: this PDK install carries the *binned* models, whose total width tops out at 100 µm (`w=100` binds, `w=101` is refused), while the benchmark's container ships the *continuous* set. Both netlists describe the same circuit, so the comparison is unaffected — but the container image will need the continuous models for the benchmark's own geometry.

## CI

CI has no PDK, so the OTA case is pinned as a unit test on the printed text: the `X` prefix, the node order, and the micrometre geometry. Full unit suite 1894/1894, typecheck and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)