### PR TITLE
fix(netlist): convert geometry on the path the product actually takes

### DIFF
--- a/packages/netlist/src/sky130.test.ts
+++ b/packages/netlist/src/sky130.test.ts
@@ -221,3 +221,84 @@ describe("the five-transistor OTA, bound end to end", () => {
     expect(printed).not.toMatch(/^M\d/mu);
   });
 });
+
+describe("the path the product actually takes", () => {
+  /**
+   * Choosing a Sky130 model in the editor makes the instance an EXTERNAL
+   * SUBCIRCUIT: the extractor emits deviceClass "hierarchical" with the
+   * wrapper name as its target and an X reference, already in D G S B order.
+   * So the prefix and node order arrive correct — and the geometry does not.
+   * The editor stores W and L in metres (its own fields read "W / m"), which
+   * is exactly the value Sky130 must not receive.
+   */
+  it("converts geometry on an external-subcircuit instance too", () => {
+    const ir = {
+      topCellName: "amp",
+      globals: [],
+      cells: [
+        {
+          id: "amp",
+          name: "amp",
+          ports: [],
+          nets: [],
+          instances: [
+            {
+              id: "M1",
+              reference: "X1",
+              deviceClass: "hierarchical",
+              target: "sky130_fd_pr__nfet_01v8",
+              nodes: [
+                { pinName: "D", netName: "d" },
+                { pinName: "G", netName: "g" },
+                { pinName: "S", netName: "0" },
+                { pinName: "B", netName: "0" },
+              ],
+              parameters: [
+                { name: "w", rawValue: "96u" },
+                { name: "l", rawValue: "1u" },
+                { name: "nf", rawValue: "12" },
+              ],
+            },
+          ],
+        },
+      ],
+    } as unknown as DesignNetlistIR;
+
+    const printed = printSpiceNetlist(bindSky130Netlist(ir, {}));
+    expect(printed).toContain(
+      "X1 d g 0 0 sky130_fd_pr__nfet_01v8 w=96 l=1 nf=12",
+    );
+    // Metres would have simulated a device a million times too large.
+    expect(printed).not.toContain("96u");
+  });
+
+  it("leaves a subcircuit that is not a PDK device alone", () => {
+    // Our own hierarchy carries no Sky130 geometry convention, so touching
+    // its parameters would corrupt an ordinary design.
+    const ir = {
+      topCellName: "top",
+      globals: [],
+      cells: [
+        {
+          id: "top",
+          name: "top",
+          ports: [],
+          nets: [],
+          instances: [
+            {
+              id: "X1",
+              reference: "X1",
+              deviceClass: "hierarchical",
+              target: "leaf",
+              nodes: [{ pinName: "a", netName: "n1" }],
+              parameters: [{ name: "l", rawValue: "60n" }],
+            },
+          ],
+        },
+      ],
+    } as unknown as DesignNetlistIR;
+    expect(printSpiceNetlist(bindSky130Netlist(ir, {}))).toContain(
+      "X1 n1 leaf l=60n",
+    );
+  });
+});

--- a/packages/netlist/src/sky130.ts
+++ b/packages/netlist/src/sky130.ts
@@ -27,8 +27,21 @@ import type {
  *   measurably different current.
  */
 export interface Sky130BindingOptions {
-  /** Design model target (`nch`, `pch`, …) to Sky130 wrapper name. */
-  readonly modelByTarget: Readonly<Record<string, string>>;
+  /**
+   * Design model target (`nch`, `pch`, …) to Sky130 wrapper name, for designs
+   * whose devices name a generic model. A target that is already a Sky130
+   * wrapper needs no entry: choosing one in the editor makes the instance an
+   * external subcircuit that arrives here named, X-referenced, and in D G S B
+   * order — with its geometry still in metres, which is the part that matters.
+   */
+  readonly modelByTarget?: Readonly<Record<string, string>>;
+}
+
+const SKY130_DEVICE_PREFIX = "sky130_fd_pr__";
+
+/** Whether a netlist target names a Sky130 device wrapper. */
+export function isSky130Device(target: string | null | undefined): boolean {
+  return typeof target === "string" && target.startsWith(SKY130_DEVICE_PREFIX);
 }
 
 const MICROMETRE = 1e-6;
@@ -84,14 +97,38 @@ export function sky130Micrometres(value: string): string {
   return `${Number(micrometres.toPrecision(12))}`;
 }
 
+function withMicrometreGeometry(
+  instance: DesignNetlistInstance,
+): DesignNetlistInstance {
+  return {
+    ...instance,
+    parameters: instance.parameters.map((parameter) =>
+      parameter.name.toLowerCase() === "l" ||
+      parameter.name.toLowerCase() === "w"
+        ? { ...parameter, rawValue: sky130Micrometres(parameter.rawValue) }
+        : parameter,
+    ),
+  };
+}
+
 function bindInstance(
   instance: DesignNetlistInstance,
   cellName: string,
   options: Sky130BindingOptions,
 ): DesignNetlistInstance {
-  if (instance.deviceClass !== "mos") return instance;
+  // A device the editor already bound to the PDK arrives as an external
+  // subcircuit. Everything about it is right except the units.
+  if (instance.deviceClass !== "mos") {
+    return isSky130Device(instance.target)
+      ? withMicrometreGeometry(instance)
+      : instance;
+  }
   const target = instance.target;
-  const model = target ? options.modelByTarget[target] : undefined;
+  const model = isSky130Device(target)
+    ? target!
+    : target
+      ? options.modelByTarget?.[target]
+      : undefined;
   if (!model) {
     throw new Error(
       `No Sky130 model is bound for ${cellName}.${instance.reference} (model ${target ?? "none"})`,
@@ -106,12 +143,7 @@ function bindInstance(
       : `X${instance.reference}`,
     deviceClass: "hierarchical",
     target: model,
-    parameters: instance.parameters.map((parameter) =>
-      parameter.name.toLowerCase() === "l" ||
-      parameter.name.toLowerCase() === "w"
-        ? { ...parameter, rawValue: sky130Micrometres(parameter.rawValue) }
-        : parameter,
-    ),
+    parameters: withMicrometreGeometry(instance).parameters,
   };
 }
 


### PR DESCRIPTION
## The gap

#494 bound MOS instances whose model is a generic name (`nch`, `pch`). **That is not the path a person takes.**

Choosing a Sky130 model in the editor makes the instance an **external subcircuit**: the extractor emits `deviceClass: "hierarchical"` with the wrapper as its target, an `X` reference, and D G S B node order. All of that arrives correct — verified against the shipped behaviour, not assumed.

**The geometry does not.** The editor stores W and L in metres and says so in its own fields ("W / m", value `96u`), while Sky130 reads plain micrometres because the model libraries set `scale=1u`. The binding skipped these instances entirely, so the real product path exported `96u` where it had to export `96` — a device a million times too large, simulating without complaint. Exactly the failure mode the ADR's acceptance evidence exists to catch, on the one path the acceptance test did not cover.

## Fix

Geometry conversion now applies to **any instance whose target names a Sky130 wrapper**, whatever class it arrives as, and to nothing else — an ordinary hierarchical call in someone's own design keeps its parameters untouched, because our hierarchy carries no Sky130 unit convention. A Sky130 target no longer needs a `modelByTarget` entry either: it names itself.

## Validation

Red first: the external-subcircuit case failed on the merged binding before this change. Package suites 1147/1147, typecheck and Prettier clean. The numeric end-to-end evidence from #494 stands — this extends the same conversion to the class the product emits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)