### PR TITLE
feat(editor): the simulation surface — testbench, refusal, voltages on canvas, AC plot

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -104,6 +104,10 @@ import {
   type SpiceImportReport,
 } from "../features/editor-shell/editor-file-commands";
 import { EditorStatusbar } from "../features/editor-shell/editor-statusbar";
+import {
+  operatingPointLabels,
+  type OperatingPointDisplay,
+} from "../features/simulation/operating-point-labels";
 import { TimingSimulationPanel } from "../features/simulation/timing-simulation-panel";
 import { TIMING_UI_ENABLED } from "../features/simulation/timing-ui";
 import { updateComponentParameterValues } from "../features/component-insert/component-parameters";
@@ -1251,6 +1255,50 @@ export function App({
   );
   const [issuesFocusToken, setIssuesFocusToken] = useState(0);
   const [issuesSectionOpen, setIssuesSectionOpen] = useState(false);
+  /**
+   * The last DC operating point, kept in view state only. A simulation result
+   * is never persisted into the Project (ADR 0055), so it lives here and dies
+   * with the session rather than entering the document or the undo history.
+   *
+   * The setters have no caller yet by design, not by omission: the producer is
+   * the SPICE panel's run result, and the run route is still being built. This
+   * is the seam it attaches to — `setOperatingPointVoltages(result.operating
+   * Point)` on success and `new Map()` on a new run. Do not delete it as dead
+   * code; deleting it would silently remove the canvas half of the feature.
+   */
+  const [operatingPointVoltages, setOperatingPointVoltages] = useState<
+    ReadonlyMap<string, number>
+  >(() => new Map());
+  const [operatingPointDisplay, setOperatingPointDisplay] =
+    useState<OperatingPointDisplay>("named");
+  const operatingPointBadges = useMemo(
+    () =>
+      operatingPointVoltages.size === 0
+        ? []
+        : operatingPointLabels({
+            document,
+            resolver,
+            voltages: operatingPointVoltages,
+            display: operatingPointDisplay,
+            // "Pointed at" is whichever net the selected wire carries; the
+            // highlight already tracks hover for the net-highlight overlay.
+            selectedNetIds: selectedRouteId
+              ? document.routes
+                  .filter((route) => route.id === selectedRouteId)
+                  .map((route) => route.netId)
+              : [],
+            hoveredNetId: highlightedNetId ?? null,
+          }),
+    [
+      document,
+      resolver,
+      operatingPointVoltages,
+      operatingPointDisplay,
+      selectedRouteId,
+      highlightedNetId,
+    ],
+  );
+
   const diagnosticMarkers = useMemo(
     () =>
       buildDiagnosticMarkers({
@@ -4799,6 +4847,7 @@ export function App({
             markers: diagnosticMarkers,
             onSelectMarker: jumpToProjectDiagnostic,
           }}
+          operatingPoint={{ badges: operatingPointBadges }}
           netLabelTether={netLabelTether}
           copyPreviewInnerHtml={copyPreviewInnerHtml}
           copyPreviewTransform={copyPreviewTransform}

--- a/apps/editor/src/canvas/editor-canvas-overlays.tsx
+++ b/apps/editor/src/canvas/editor-canvas-overlays.tsx
@@ -279,6 +279,74 @@ export function DiagnosticMarkersOverlay({
   );
 }
 
+/**
+ * One operating-point voltage, ready to paint. Declared structurally so the
+ * canvas layer stays below features: the simulation feature decides which
+ * nets earn a badge and where it sits, and hands the result down.
+ */
+export interface OperatingPointBadge {
+  netId: string;
+  netLabel: string;
+  text: string;
+  at: { x: number; y: number };
+  /** Permanent because the author named the net, or transient on demand. */
+  reason: "named" | "selected" | "hovered" | "all";
+}
+
+/**
+ * Simulated node voltages, drawn over the schematic and never part of it.
+ *
+ * Pure annotation: no pointer events, no hit geometry, nothing selectable.
+ * A simulation result is not a document object — ADR 0055 keeps results out
+ * of the model entirely — so this layer must not offer any way to grab one.
+ *
+ * Each badge gets an opaque plate because a bare number over a wire and the
+ * grid is unreadable exactly where it matters most.
+ */
+export function OperatingPointOverlay({
+  badges,
+}: {
+  badges: readonly OperatingPointBadge[];
+}) {
+  if (badges.length === 0) return null;
+  return (
+    <g
+      data-testid="operating-point-badges"
+      className="operating-point-badges"
+      pointerEvents="none"
+      aria-hidden="true"
+    >
+      {badges.map((badge) => (
+        <g
+          key={badge.netId}
+          className="operating-point-badge"
+          data-reason={badge.reason}
+          data-net-id={badge.netId}
+        >
+          {/* Sized from the text length: the canvas has no measurement pass,
+              and a plate that is too small is worse than none. */}
+          <rect
+            className="operating-point-plate"
+            x={badge.at.x - badge.text.length * 3.1 - 3}
+            y={badge.at.y - 17}
+            width={badge.text.length * 6.2 + 6}
+            height={13}
+            rx={2}
+          />
+          <text
+            className="operating-point-text"
+            x={badge.at.x}
+            y={badge.at.y - 7}
+            textAnchor="middle"
+          >
+            {badge.text}
+          </text>
+        </g>
+      ))}
+    </g>
+  );
+}
+
 export interface NetLabelTether {
   label: { x: number; y: number };
   conductor: { x: number; y: number };

--- a/apps/editor/src/canvas/editor-canvas-surface.tsx
+++ b/apps/editor/src/canvas/editor-canvas-surface.tsx
@@ -7,6 +7,7 @@ import {
   CanvasInputPlanes,
   NetHighlightOverlay,
   DiagnosticMarkersOverlay,
+  OperatingPointOverlay,
   WireUnderSymbolOverlay,
   NetLabelTetherOverlay,
   type NetLabelTether,
@@ -54,6 +55,7 @@ export interface EditorCanvasSurfaceProps {
   netHighlight: ComponentProps<typeof NetHighlightOverlay>;
   wireUnderSymbol: ComponentProps<typeof WireUnderSymbolOverlay>;
   diagnosticMarkers: ComponentProps<typeof DiagnosticMarkersOverlay>;
+  operatingPoint: ComponentProps<typeof OperatingPointOverlay>;
   netLabelTether: NetLabelTether | null;
   copyPreviewInnerHtml: { __html: string } | null;
   copyPreviewTransform: string | undefined;
@@ -110,6 +112,7 @@ export function EditorCanvasSurface({
   netHighlight,
   wireUnderSymbol,
   diagnosticMarkers,
+  operatingPoint,
   netLabelTether,
   copyPreviewInnerHtml,
   copyPreviewTransform,
@@ -239,6 +242,9 @@ export function EditorCanvasSurface({
           <EditorDraftingHitTargets {...draftingHitTargets} />
           <WireUnderSymbolOverlay {...wireUnderSymbol} />
           <DiagnosticMarkersOverlay {...diagnosticMarkers} />
+          {/* Above the diagnostics so a voltage is never hidden by a marker,
+              and below the handles so it never covers something grabbable. */}
+          <OperatingPointOverlay {...operatingPoint} />
           <EditorDraftingHandles {...draftingHandles} />
           <EditorInteractionPreviews {...interactionPreviews} />
         </g>

--- a/apps/editor/src/canvas/operating-point-overlay.test.tsx
+++ b/apps/editor/src/canvas/operating-point-overlay.test.tsx
@@ -1,0 +1,66 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  OperatingPointOverlay,
+  type OperatingPointBadge,
+} from "./editor-canvas-overlays";
+
+const badges: OperatingPointBadge[] = [
+  {
+    netId: "net-out",
+    netLabel: "VOUT",
+    text: "900 mV",
+    at: { x: 200, y: 100 },
+    reason: "named",
+  },
+  {
+    netId: "net-tail",
+    netLabel: "net-tail",
+    text: "12.3 mV",
+    at: { x: 200, y: 200 },
+    reason: "hovered",
+  },
+];
+
+describe("OperatingPointOverlay", () => {
+  it("draws nothing at all before a simulation has produced anything", () => {
+    // An empty frame would read as "measured, and it is zero".
+    expect(renderToStaticMarkup(<OperatingPointOverlay badges={[]} />)).toBe(
+      "",
+    );
+  });
+
+  it("paints each voltage over the conductor it belongs to", () => {
+    const markup = renderToStaticMarkup(
+      <OperatingPointOverlay badges={badges} />,
+    );
+
+    expect(markup).toContain("900 mV");
+    expect(markup).toContain("12.3 mV");
+    // Anchored above the wire midpoint the feature chose, not floating.
+    expect(markup).toContain('x="200"');
+  });
+
+  it("offers no way to grab a result, because a result is not an object", () => {
+    // ADR 0055: simulation reads the model and never writes it. A layer that
+    // could be clicked or dragged would be the first step toward a result
+    // that behaves like part of the drawing.
+    const markup = renderToStaticMarkup(
+      <OperatingPointOverlay badges={badges} />,
+    );
+
+    expect(markup).toContain('pointer-events="none"');
+    expect(markup).not.toContain("data-canvas-hit-kind");
+    expect(markup).not.toContain("data-drag-object-id");
+  });
+
+  it("says why each badge is on screen, so transient ones can look transient", () => {
+    const markup = renderToStaticMarkup(
+      <OperatingPointOverlay badges={badges} />,
+    );
+
+    expect(markup).toContain('data-reason="named"');
+    expect(markup).toContain('data-reason="hovered"');
+  });
+});

--- a/apps/editor/src/features/simulation/ac-response-plot.test.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  acResponseSvg,
+  formatFrequency,
+  layoutAcPlot,
+  type AcTrace,
+} from "./ac-response-plot";
+
+/** A single-pole roll-off: flat 40 dB, corner at 1 kHz, -20 dB/decade after. */
+function singlePole(): AcTrace {
+  const points = [];
+  for (let decade = 0; decade <= 6; decade += 1) {
+    const frequency = 10 ** decade;
+    const ratio = frequency / 1000;
+    points.push({
+      frequency,
+      magnitudeDb: 40 - 10 * Math.log10(1 + ratio * ratio),
+      phaseDeg: -(Math.atan(ratio) * 180) / Math.PI,
+    });
+  }
+  return { label: "vdb(vout)", points };
+}
+
+describe("AC response plot", () => {
+  it("puts whole decades on the frequency axis", () => {
+    const layout = layoutAcPlot([singlePole()], { width: 600, height: 300 });
+    expect(layout).not.toBeNull();
+    // A sweep from 1 Hz to 1 MHz reads as decades, not as raw sample points.
+    expect(layout!.frequency.ticks).toEqual([1, 10, 100, 1e3, 1e4, 1e5, 1e6]);
+  });
+
+  it("rounds the magnitude axis outward to readable steps", () => {
+    const layout = layoutAcPlot([singlePole()], { width: 600, height: 300 })!;
+    // The trace spans about -20 dB to 40 dB; the axis must contain it and
+    // land on round gridlines rather than on the data's own extremes.
+    expect(layout.magnitude.min).toBeLessThanOrEqual(-20);
+    expect(layout.magnitude.max).toBeGreaterThanOrEqual(40);
+    expect(layout.magnitude.ticks).toContain(0);
+  });
+
+  it("reads a frequency back from a position, for a crosshair", () => {
+    const layout = layoutAcPlot([singlePole()], { width: 600, height: 300 })!;
+    const left = layout.frequencyAt(layout.frame.x);
+    const right = layout.frequencyAt(layout.frame.x + layout.frame.width);
+
+    expect(left).toBeCloseTo(1, 6);
+    expect(right).toBeCloseTo(1e6, 0);
+    // Logarithmic, so the midpoint is the geometric mean, not the average.
+    expect(layout.frequencyAt(layout.frame.x + layout.frame.width / 2)).toBeCloseTo(
+      1e3,
+      6,
+    );
+  });
+
+  it("draws magnitude and phase as separate traces on one frame", () => {
+    const svg = acResponseSvg([singlePole()], { width: 600, height: 300 })!;
+
+    expect(svg.startsWith("<svg")).toBe(true);
+    // One polyline for magnitude and one for phase, per trace.
+    expect(svg.match(/<polyline/gu)).toHaveLength(2);
+    expect(svg).toContain('class="ac-trace ac-trace-0 ac-phase"');
+    expect(svg).toContain('aria-label="AC response"');
+  });
+
+  it("declines to invent a plot when there is nothing to draw", () => {
+    // A DC-only result, or a failed run, must not produce an empty frame that
+    // looks like a measurement.
+    expect(layoutAcPlot([], { width: 600, height: 300 })).toBeNull();
+    expect(
+      layoutAcPlot([{ label: "vdb(vout)", points: [] }], {
+        width: 600,
+        height: 300,
+      }),
+    ).toBeNull();
+    // A zero or negative frequency has no place on a log axis and is dropped
+    // rather than silently plotted somewhere arbitrary.
+    expect(
+      layoutAcPlot(
+        [
+          {
+            label: "vdb(vout)",
+            points: [{ frequency: 0, magnitudeDb: 1, phaseDeg: 0 }],
+          },
+        ],
+        { width: 600, height: 300 },
+      ),
+    ).toBeNull();
+  });
+
+  it("labels the frequency axis the way it is spoken", () => {
+    expect(formatFrequency(1)).toBe("1 Hz");
+    expect(formatFrequency(1e3)).toBe("1 kHz");
+    expect(formatFrequency(2.5e6)).toBe("2.5 MHz");
+  });
+});

--- a/apps/editor/src/features/simulation/ac-response-plot.test.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.test.ts
@@ -47,10 +47,9 @@ describe("AC response plot", () => {
     expect(left).toBeCloseTo(1, 6);
     expect(right).toBeCloseTo(1e6, 0);
     // Logarithmic, so the midpoint is the geometric mean, not the average.
-    expect(layout.frequencyAt(layout.frame.x + layout.frame.width / 2)).toBeCloseTo(
-      1e3,
-      6,
-    );
+    expect(
+      layout.frequencyAt(layout.frame.x + layout.frame.width / 2),
+    ).toBeCloseTo(1e3, 6);
   });
 
   it("draws magnitude and phase as separate traces on one frame", () => {

--- a/apps/editor/src/features/simulation/ac-response-plot.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.ts
@@ -1,0 +1,226 @@
+/**
+ * A Bode plot for AC analysis results.
+ *
+ * Why this draws its own SVG rather than reusing either of the two obvious
+ * options:
+ *
+ * - **Not a charting library.** One plot type is needed, not a toolkit. A
+ *   dependency would also render in its own idiom, beside a product that
+ *   draws everything else as SVG through one style profile.
+ * - **Not the digital-waveform path.** `timing-waveform.ts` composes drafting
+ *   objects and hands them to `renderDocumentSvg`, which is right for a
+ *   handful of step edges. Drafting objects are persistable user drawing
+ *   primitives and there is no polyline among them, so an AC sweep — hundreds
+ *   of points per trace — would become hundreds of persistable objects. Wrong
+ *   weight and wrong meaning.
+ *
+ * The output is a plain SVG string plus the geometry a caller needs to read
+ * values back off it, so the panel can show a crosshair without this module
+ * knowing anything about React.
+ */
+
+export interface AcPoint {
+  /** Hertz. Must be positive: the frequency axis is logarithmic. */
+  frequency: number;
+  /** Magnitude in decibels. */
+  magnitudeDb: number;
+  /** Phase in degrees. */
+  phaseDeg: number;
+}
+
+export interface AcTrace {
+  /** The expression the author asked for, printed verbatim as the legend. */
+  label: string;
+  points: readonly AcPoint[];
+}
+
+export interface AcPlotSize {
+  width: number;
+  height: number;
+}
+
+export interface AcPlotAxis {
+  /** Decade boundaries actually drawn, low to high. */
+  ticks: readonly number[];
+  min: number;
+  max: number;
+}
+
+export interface AcPlotLayout {
+  size: AcPlotSize;
+  /** Drawing area inside the axes, in SVG units. */
+  frame: { x: number; y: number; width: number; height: number };
+  frequency: AcPlotAxis;
+  magnitude: AcPlotAxis;
+  phase: AcPlotAxis;
+  /** Frequency in Hz for an x in SVG units, for crosshair readout. */
+  frequencyAt: (x: number) => number;
+}
+
+const MARGIN = { left: 56, right: 56, top: 16, bottom: 32 };
+
+function niceDecades(min: number, max: number): number[] {
+  const low = Math.floor(Math.log10(min));
+  const high = Math.ceil(Math.log10(max));
+  const ticks: number[] = [];
+  for (let decade = low; decade <= high; decade += 1) {
+    ticks.push(10 ** decade);
+  }
+  return ticks;
+}
+
+/** Round a linear range outward to readable round numbers. */
+function niceLinear(min: number, max: number, step: number): AcPlotAxis {
+  const low = Math.floor(min / step) * step;
+  const high = Math.ceil(max / step) * step;
+  const ticks: number[] = [];
+  for (let value = low; value <= high + step / 2; value += step) {
+    ticks.push(Math.round(value * 1e6) / 1e6);
+  }
+  return { ticks, min: low, max: high === low ? low + step : high };
+}
+
+export function layoutAcPlot(
+  traces: readonly AcTrace[],
+  size: AcPlotSize,
+): AcPlotLayout | null {
+  const points = traces.flatMap((trace) => trace.points);
+  const usable = points.filter((point) => point.frequency > 0);
+  if (usable.length === 0) return null;
+
+  const frequencies = usable.map((point) => point.frequency);
+  const magnitudes = usable.map((point) => point.magnitudeDb);
+  const phases = usable.map((point) => point.phaseDeg);
+  const frame = {
+    x: MARGIN.left,
+    y: MARGIN.top,
+    width: Math.max(1, size.width - MARGIN.left - MARGIN.right),
+    height: Math.max(1, size.height - MARGIN.top - MARGIN.bottom),
+  };
+  const fMin = Math.min(...frequencies);
+  const fMax = Math.max(...frequencies);
+  const decades = niceDecades(fMin, fMax);
+  const frequency: AcPlotAxis = {
+    ticks: decades,
+    min: decades[0]!,
+    max: decades.at(-1)!,
+  };
+  const logMin = Math.log10(frequency.min);
+  const logSpan = Math.log10(frequency.max) - logMin || 1;
+
+  return {
+    size,
+    frame,
+    frequency,
+    magnitude: niceLinear(Math.min(...magnitudes), Math.max(...magnitudes), 20),
+    phase: niceLinear(Math.min(...phases), Math.max(...phases), 45),
+    frequencyAt: (x: number) =>
+      10 ** (logMin + ((x - frame.x) / frame.width) * logSpan),
+  };
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+/** Hertz with an engineering suffix, the way a frequency axis is read. */
+export function formatFrequency(hertz: number): string {
+  if (hertz >= 1e9) return `${hertz / 1e9} GHz`;
+  if (hertz >= 1e6) return `${hertz / 1e6} MHz`;
+  if (hertz >= 1e3) return `${hertz / 1e3} kHz`;
+  if (hertz >= 1) return `${hertz} Hz`;
+  return `${hertz * 1e3} mHz`;
+}
+
+interface Projection {
+  x: (frequency: number) => number;
+  magnitudeY: (db: number) => number;
+  phaseY: (deg: number) => number;
+}
+
+function projection(layout: AcPlotLayout): Projection {
+  const { frame, frequency, magnitude, phase } = layout;
+  const logMin = Math.log10(frequency.min);
+  const logSpan = Math.log10(frequency.max) - logMin || 1;
+  const span = (axis: AcPlotAxis) => axis.max - axis.min || 1;
+  return {
+    x: (hz) => frame.x + ((Math.log10(hz) - logMin) / logSpan) * frame.width,
+    magnitudeY: (db) =>
+      frame.y +
+      frame.height -
+      ((db - magnitude.min) / span(magnitude)) * frame.height,
+    phaseY: (deg) =>
+      frame.y + frame.height - ((deg - phase.min) / span(phase)) * frame.height,
+  };
+}
+
+function polyline(
+  trace: AcTrace,
+  project: Projection,
+  axis: "magnitude" | "phase",
+): string {
+  return trace.points
+    .filter((point) => point.frequency > 0)
+    .map((point) => {
+      const y =
+        axis === "magnitude"
+          ? project.magnitudeY(point.magnitudeDb)
+          : project.phaseY(point.phaseDeg);
+      return `${project.x(point.frequency).toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
+}
+
+/**
+ * Magnitude and phase on one frame: magnitude solid against the left axis,
+ * phase dashed against the right. Two stacked frames read better on paper but
+ * halve the vertical resolution of each in a side panel, and the pairing that
+ * matters — gain and phase at the same frequency — is read along one vertical
+ * line.
+ */
+export function acResponseSvg(
+  traces: readonly AcTrace[],
+  size: AcPlotSize,
+): string | null {
+  const layout = layoutAcPlot(traces, size);
+  if (!layout) return null;
+  const project = projection(layout);
+  const { frame } = layout;
+
+  const gridLines = [
+    ...layout.frequency.ticks.map((hz) => {
+      const x = project.x(hz).toFixed(2);
+      return `<line class="ac-grid" x1="${x}" y1="${frame.y}" x2="${x}" y2="${frame.y + frame.height}"/><text class="ac-axis-label" x="${x}" y="${frame.y + frame.height + 18}" text-anchor="middle">${escapeXml(formatFrequency(hz))}</text>`;
+    }),
+    ...layout.magnitude.ticks.map((db) => {
+      const y = project.magnitudeY(db).toFixed(2);
+      return `<line class="ac-grid" x1="${frame.x}" y1="${y}" x2="${frame.x + frame.width}" y2="${y}"/><text class="ac-axis-label" x="${frame.x - 8}" y="${y}" text-anchor="end" dominant-baseline="middle">${db} dB</text>`;
+    }),
+    ...layout.phase.ticks.map((deg) => {
+      const y = project.phaseY(deg).toFixed(2);
+      return `<text class="ac-axis-label ac-phase" x="${frame.x + frame.width + 8}" y="${y}" dominant-baseline="middle">${deg}°</text>`;
+    }),
+  ].join("");
+
+  const curves = traces
+    .map((trace, index) => {
+      const magnitude = polyline(trace, project, "magnitude");
+      const phase = polyline(trace, project, "phase");
+      return (
+        `<polyline class="ac-trace ac-trace-${index % 6}" points="${magnitude}"/>` +
+        `<polyline class="ac-trace ac-trace-${index % 6} ac-phase" points="${phase}"/>`
+      );
+    })
+    .join("");
+
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" class="ac-response" viewBox="0 0 ${size.width} ${size.height}" width="${size.width}" height="${size.height}" role="img" aria-label="AC response">` +
+    `<rect class="ac-frame" x="${frame.x}" y="${frame.y}" width="${frame.width}" height="${frame.height}"/>` +
+    gridLines +
+    curves +
+    `</svg>`
+  );
+}

--- a/apps/editor/src/features/simulation/operating-point-labels.test.ts
+++ b/apps/editor/src/features/simulation/operating-point-labels.test.ts
@@ -1,0 +1,139 @@
+import { createEmptyDocument, createRoutePath } from "@icm/model";
+import type { SchematicDocument } from "@icm/model";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import {
+  formatNodeVoltage,
+  operatingPointLabels,
+} from "./operating-point-labels";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+/**
+ * Two conductors: `net-named` carries an author-given name, `net-plain` does
+ * not. Both are ordinary horizontal wires between two anchors.
+ */
+function twoNetDocument(): SchematicDocument {
+  const document = createEmptyDocument("op", "Operating point");
+  document.presentation.grid = 10;
+  for (const [index, netId] of ["net-named", "net-plain"].entries()) {
+    const y = 100 + index * 100;
+    document.nets.push({ id: netId, terminals: [] });
+    document.junctions.push(
+      { id: `${netId}-a`, netId, position: { x: 100, y }, role: "route-anchor" },
+      { id: `${netId}-b`, netId, position: { x: 300, y }, role: "route-anchor" },
+    );
+    document.routes.push(
+      createRoutePath({
+        id: `wire-${netId}`,
+        netId,
+        start: { kind: "junction", junctionId: `${netId}-a` },
+        end: { kind: "junction", junctionId: `${netId}-b` },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+  }
+  document.connectivityEvidence.push({
+    id: "claim-vout",
+    kind: "name-claim",
+    netId: "net-named",
+    name: "VOUT",
+    scope: "global",
+    owner: { kind: "global-declaration", sourceNetId: "net-named" },
+  });
+  return document;
+}
+
+const voltages = new Map([
+  ["net-named", 0.9],
+  ["net-plain", 0.0123],
+]);
+
+describe("operating point labels", () => {
+  it("annotates the nets the author named and leaves the rest alone", () => {
+    // The readability rule: a name is the author saying this net matters, so
+    // it earns permanent screen space. An unnamed node does not, or a sixty
+    // node circuit buries its own schematic.
+    const labels = operatingPointLabels({
+      document: twoNetDocument(),
+      resolver,
+      voltages,
+      display: "named",
+    });
+
+    expect(labels.map((label) => label.netId)).toEqual(["net-named"]);
+    expect(labels[0]).toMatchObject({
+      netLabel: "VOUT",
+      text: "900 mV",
+      reason: "named",
+    });
+  });
+
+  it("answers on demand for a net the author points at", () => {
+    const document = twoNetDocument();
+    const selected = operatingPointLabels({
+      document,
+      resolver,
+      voltages,
+      display: "named",
+      selectedNetIds: ["net-plain"],
+    });
+    const hovered = operatingPointLabels({
+      document,
+      resolver,
+      voltages,
+      display: "named",
+      hoveredNetId: "net-plain",
+    });
+
+    expect(selected.map((label) => [label.netId, label.reason])).toEqual([
+      ["net-named", "named"],
+      ["net-plain", "selected"],
+    ]);
+    expect(hovered.find((label) => label.netId === "net-plain")?.reason).toBe(
+      "hovered",
+    );
+  });
+
+  it("shows everything only when explicitly asked", () => {
+    const labels = operatingPointLabels({
+      document: twoNetDocument(),
+      resolver,
+      voltages,
+      display: "all",
+    });
+
+    expect(labels.map((label) => label.netId)).toEqual([
+      "net-named",
+      "net-plain",
+    ]);
+    // A named net keeps saying it is named, even in the full picture.
+    expect(labels[0]?.reason).toBe("named");
+    expect(labels[1]?.reason).toBe("all");
+  });
+
+  it("anchors a badge on the conductor it describes", () => {
+    const labels = operatingPointLabels({
+      document: twoNetDocument(),
+      resolver,
+      voltages,
+      display: "all",
+    });
+
+    // Midpoint of the wire, so the number sits beside the conductor it
+    // belongs to rather than floating.
+    expect(labels[0]?.at).toEqual({ x: 200, y: 100 });
+    expect(labels[1]?.at).toEqual({ x: 200, y: 200 });
+  });
+
+  it("keeps a millivolt node readable instead of rounding it to zero", () => {
+    // The whole point of an operating point is small differences; a format
+    // that prints 0.00 V for a 12 mV node hides exactly what was asked.
+    expect(formatNodeVoltage(0.0123)).toBe("12.3 mV");
+    expect(formatNodeVoltage(-1.8)).toBe("-1.800 V");
+    expect(formatNodeVoltage(2.5e-6)).toBe("2.50 µV");
+    expect(formatNodeVoltage(0)).toBe("0 V");
+  });
+});

--- a/apps/editor/src/features/simulation/operating-point-labels.test.ts
+++ b/apps/editor/src/features/simulation/operating-point-labels.test.ts
@@ -138,6 +138,57 @@ describe("operating point labels", () => {
     expect(labels[1]?.at).toEqual({ x: 200, y: 200 });
   });
 
+  it("moves a badge off artwork instead of covering it", () => {
+    // Found by rendering the rule over a real published circuit: the anchor
+    // knew the conductor but not what was already drawn there, so a voltage
+    // could land on a component's own label. A number that hides the part it
+    // describes is worse than one that sits a little lower.
+    const document = twoNetDocument();
+    document.instances.push({
+      id: "R9",
+      symbolId: "resistor",
+      // Straddling the named net's wire at y = 100, right where the badge
+      // would otherwise go.
+      placement: { position: { x: 200, y: 100 }, rotation: 0, mirror: "none" },
+    } as SchematicDocument["instances"][number]);
+
+    const labels = operatingPointLabels({
+      document,
+      resolver,
+      voltages,
+      display: "named",
+    });
+
+    expect(labels).toHaveLength(1);
+    const at = labels[0]!.at;
+    // Clear of the symbol: the resistor stands at x = 200, and a badge is
+    // about 43 units wide, so anything within ~30 units would still cover it.
+    expect(Math.abs(at.x - 200)).toBeGreaterThan(30);
+    // And still on the conductor it describes — sliding along the wire, not
+    // drifting into blank page where the reader must work out what it means.
+    expect(at.x).toBeGreaterThanOrEqual(100);
+    expect(at.x).toBeLessThanOrEqual(300);
+    expect(at.y).toBe(100);
+  });
+
+  it("does not stack two badges on the same spot", () => {
+    // Two nets whose best anchors coincide would otherwise print one voltage
+    // over the other, which reads as a single wrong number.
+    const document = twoNetDocument();
+    document.junctions.forEach((junction) => {
+      if (junction.netId === "net-plain") junction.position.y = 100;
+    });
+    const labels = operatingPointLabels({
+      document,
+      resolver,
+      voltages,
+      display: "all",
+    });
+
+    expect(labels).toHaveLength(2);
+    expect(labels[0]!.at).not.toEqual(labels[1]!.at);
+  });
+
   it("keeps a millivolt node readable instead of rounding it to zero", () => {
     // The whole point of an operating point is small differences; a format
     // that prints 0.00 V for a 12 mV node hides exactly what was asked.

--- a/apps/editor/src/features/simulation/operating-point-labels.test.ts
+++ b/apps/editor/src/features/simulation/operating-point-labels.test.ts
@@ -21,8 +21,18 @@ function twoNetDocument(): SchematicDocument {
     const y = 100 + index * 100;
     document.nets.push({ id: netId, terminals: [] });
     document.junctions.push(
-      { id: `${netId}-a`, netId, position: { x: 100, y }, role: "route-anchor" },
-      { id: `${netId}-b`, netId, position: { x: 300, y }, role: "route-anchor" },
+      {
+        id: `${netId}-a`,
+        netId,
+        position: { x: 100, y },
+        role: "route-anchor",
+      },
+      {
+        id: `${netId}-b`,
+        netId,
+        position: { x: 300, y },
+        role: "route-anchor",
+      },
     );
     document.routes.push(
       createRoutePath({

--- a/apps/editor/src/features/simulation/operating-point-labels.ts
+++ b/apps/editor/src/features/simulation/operating-point-labels.ts
@@ -1,0 +1,149 @@
+import {
+  resolveDocumentLogicalNets,
+  resolveDocumentRoutingGeometry,
+} from "@icm/derived";
+import type { Point, SchematicDocument } from "@icm/model";
+import type { SymbolResolver } from "@icm/symbols";
+
+/**
+ * Where operating-point voltages go on the canvas.
+ *
+ * A DC operating point produces one number per node, and a real circuit has
+ * dozens. Painting all of them destroys the drawing they are annotating —
+ * the schematic stops being readable exactly when the author is trying to
+ * read it. Painting none of them makes the result useless at a glance.
+ *
+ * The rule here uses a signal the author already gave us: **a net they took
+ * the trouble to name is a net they care about.** Named nets carry their
+ * voltage permanently; everything else answers on demand, when the net is
+ * selected or hovered. A deliberate "all" mode stays available for the moment
+ * someone genuinely wants the full picture and accepts the clutter.
+ *
+ * This adds no label where the author has not already accepted one, and it
+ * scales: a sixty-node circuit typically names five or ten nets.
+ */
+export type OperatingPointDisplay = "named" | "all";
+
+export interface OperatingPointLabel {
+  netId: string;
+  /** What to call the net out loud; its name when it has one. */
+  netLabel: string;
+  /** Formatted voltage, already carrying its unit. */
+  text: string;
+  at: Point;
+  /** Why this label is on screen, so the view can style transient ones. */
+  reason: "named" | "selected" | "hovered" | "all";
+}
+
+/**
+ * Node voltages in volts, keyed by Base Net id. The simulator reports node
+ * names; mapping those back to Net ids belongs to the result adapter, not
+ * here, so this module stays independent of any simulator's spelling.
+ */
+export type NodeVoltages = ReadonlyMap<string, number>;
+
+/**
+ * Engineering notation with a fixed significant width, so a column of
+ * voltages lines up and a millivolt-scale node does not read as "0.00 V".
+ */
+export function formatNodeVoltage(volts: number): string {
+  const magnitude = Math.abs(volts);
+  if (magnitude === 0) return "0 V";
+  if (magnitude < 1e-6) return `${(volts * 1e9).toPrecision(3)} nV`;
+  if (magnitude < 1e-3) return `${(volts * 1e6).toPrecision(3)} µV`;
+  if (magnitude < 1) return `${(volts * 1e3).toPrecision(3)} mV`;
+  if (magnitude < 1e3) return `${volts.toPrecision(4)} V`;
+  return `${(volts / 1e3).toPrecision(3)} kV`;
+}
+
+/**
+ * A stable, readable anchor for one net's badge: the midpoint of its longest
+ * horizontal conductor, because text sits beside a horizontal wire without
+ * crossing it. Falls back to the longest segment of any orientation, then to
+ * any junction, so a net always gets an anchor if it has any geometry at all.
+ */
+function netAnchor(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  netId: string,
+): Point | null {
+  const geometry = resolveDocumentRoutingGeometry(document, resolver);
+  let best: { at: Point; length: number; horizontal: boolean } | null = null;
+  for (const route of geometry.routes.values()) {
+    if (route.netId !== netId) continue;
+    for (const segment of route.segments) {
+      const dx = segment.to.x - segment.from.x;
+      const dy = segment.to.y - segment.from.y;
+      const length = Math.hypot(dx, dy);
+      if (length === 0) continue;
+      const horizontal = Math.abs(dy) < Math.abs(dx);
+      const better =
+        best === null ||
+        (horizontal && !best.horizontal) ||
+        (horizontal === best.horizontal && length > best.length);
+      if (!better) continue;
+      best = {
+        at: {
+          x: (segment.from.x + segment.to.x) / 2,
+          y: (segment.from.y + segment.to.y) / 2,
+        },
+        length,
+        horizontal,
+      };
+    }
+  }
+  if (best) return best.at;
+  const junction = document.junctions.find(
+    (candidate) => candidate.netId === netId,
+  );
+  return junction ? junction.position : null;
+}
+
+export interface OperatingPointLabelInput {
+  document: SchematicDocument;
+  resolver: SymbolResolver;
+  voltages: NodeVoltages;
+  display: OperatingPointDisplay;
+  selectedNetIds?: readonly string[];
+  hoveredNetId?: string | null;
+}
+
+/** The badges to paint, in a deterministic order. */
+export function operatingPointLabels({
+  document,
+  resolver,
+  voltages,
+  display,
+  selectedNetIds = [],
+  hoveredNetId = null,
+}: OperatingPointLabelInput): readonly OperatingPointLabel[] {
+  const logical = resolveDocumentLogicalNets(document);
+  const selected = new Set(selectedNetIds);
+  const labels: OperatingPointLabel[] = [];
+  for (const [netId, volts] of voltages) {
+    const name = logical.byBaseNetId.get(netId)?.name;
+    // Order matters: an explicit "all" is the author asking for everything,
+    // and a net they pointed at should read as pointed-at even when named.
+    const reason: OperatingPointLabel["reason"] | null =
+      hoveredNetId === netId
+        ? "hovered"
+        : selected.has(netId)
+          ? "selected"
+          : name
+            ? "named"
+            : display === "all"
+              ? "all"
+              : null;
+    if (!reason) continue;
+    const at = netAnchor(document, resolver, netId);
+    if (!at) continue;
+    labels.push({
+      netId,
+      netLabel: name ?? netId,
+      text: formatNodeVoltage(volts),
+      at,
+      reason,
+    });
+  }
+  return labels.sort((left, right) => left.netId.localeCompare(right.netId));
+}

--- a/apps/editor/src/features/simulation/operating-point-labels.ts
+++ b/apps/editor/src/features/simulation/operating-point-labels.ts
@@ -1,6 +1,7 @@
 import {
   resolveDocumentLogicalNets,
   resolveDocumentRoutingGeometry,
+  visibleSymbolInkBounds,
 } from "@icm/derived";
 import type { Point, SchematicDocument } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
@@ -56,19 +57,96 @@ export function formatNodeVoltage(volts: number): string {
   return `${(volts / 1e3).toPrecision(3)} kV`;
 }
 
+interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+function overlaps(a: Rect, b: Rect): boolean {
+  return (
+    a.x < b.x + b.width &&
+    b.x < a.x + a.width &&
+    a.y < b.y + b.height &&
+    b.y < a.y + a.height
+  );
+}
+
 /**
- * A stable, readable anchor for one net's badge: the midpoint of its longest
- * horizontal conductor, because text sits beside a horizontal wire without
- * crossing it. Falls back to the longest segment of any orientation, then to
- * any junction, so a net always gets an anchor if it has any geometry at all.
+ * What is already drawn and must not be covered: symbol artwork, and the
+ * labels the author placed. Text has no measured width here — the canvas has
+ * no measurement pass — so a label is treated as a modest box around its
+ * anchor. Under-estimating is the safe direction: a badge that clears a
+ * generous box certainly clears the real glyphs.
  */
-function netAnchor(
+function occupiedRects(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+): Rect[] {
+  const rects: Rect[] = [];
+  for (const instance of document.instances) {
+    if (!instance.placement) continue;
+    const resolved = resolver.resolve(
+      instance.symbolId,
+      instance.symbolVariantId,
+    );
+    if (!resolved) continue;
+    const ink = visibleSymbolInkBounds(resolved, instance.signalFlowParameters);
+    // Ink bounds are symbol-local; the placement translates them. Rotation is
+    // ignored deliberately: a rotated bounding box is at most the same size
+    // swapped, and the inflation below already covers that error.
+    rects.push({
+      x: instance.placement.position.x + ink.x - 4,
+      y: instance.placement.position.y + ink.y - 4,
+      width: ink.width + 8,
+      height: ink.height + 8,
+    });
+  }
+  for (const annotation of document.annotations) {
+    const anchor = annotation.anchor;
+    const at =
+      anchor.kind === "free"
+        ? anchor.position
+        : anchor.kind === "object" || anchor.kind === "route"
+          ? anchor.fallbackPosition
+          : null;
+    if (!at) continue;
+    rects.push({ x: at.x - 26, y: at.y - 10, width: 52, height: 20 });
+  }
+  return rects;
+}
+
+const BADGE_HEIGHT = 13;
+const BADGE_LIFT = 17;
+
+function badgeRect(at: Point, text: string): Rect {
+  const width = text.length * 6.2 + 6;
+  return {
+    x: at.x - width / 2,
+    y: at.y - BADGE_LIFT,
+    width,
+    height: BADGE_HEIGHT,
+  };
+}
+
+/**
+ * Candidate anchors for one net's badge, best first.
+ *
+ * The first choice is the midpoint of the longest horizontal conductor: text
+ * sits beside a horizontal wire without crossing it. What follows are the
+ * same point flipped below the wire, then the other segment midpoints, so a
+ * badge that would land on artwork has somewhere to go instead of covering
+ * it. Falls back to a junction, so a net with any geometry gets an anchor.
+ */
+function netAnchors(
   document: SchematicDocument,
   resolver: SymbolResolver,
   netId: string,
-): Point | null {
+): Point[] {
   const geometry = resolveDocumentRoutingGeometry(document, resolver);
-  let best: { at: Point; length: number; horizontal: boolean } | null = null;
+  const midpoints: { at: Point; length: number; horizontal: boolean }[] = [];
+  const segments: { from: Point; to: Point }[] = [];
   for (const route of geometry.routes.values()) {
     if (route.netId !== netId) continue;
     for (const segment of route.segments) {
@@ -76,27 +154,50 @@ function netAnchor(
       const dy = segment.to.y - segment.from.y;
       const length = Math.hypot(dx, dy);
       if (length === 0) continue;
-      const horizontal = Math.abs(dy) < Math.abs(dx);
-      const better =
-        best === null ||
-        (horizontal && !best.horizontal) ||
-        (horizontal === best.horizontal && length > best.length);
-      if (!better) continue;
-      best = {
+      segments.push({ from: segment.from, to: segment.to });
+      midpoints.push({
         at: {
           x: (segment.from.x + segment.to.x) / 2,
           y: (segment.from.y + segment.to.y) / 2,
         },
         length,
-        horizontal,
-      };
+        horizontal: Math.abs(dy) < Math.abs(dx),
+      });
     }
   }
-  if (best) return best.at;
-  const junction = document.junctions.find(
-    (candidate) => candidate.netId === netId,
+  midpoints.sort((left, right) =>
+    left.horizontal === right.horizontal
+      ? right.length - left.length
+      : left.horizontal
+        ? -1
+        : 1,
   );
-  return junction ? junction.position : null;
+  const candidates: Point[] = [];
+  for (const midpoint of midpoints) {
+    candidates.push(midpoint.at);
+    // Same spot, badge hanging below the conductor instead of above it.
+    candidates.push({ x: midpoint.at.x, y: midpoint.at.y + BADGE_LIFT + 10 });
+  }
+  // Then slide along each conductor. A badge that has to move stays on the
+  // wire it describes rather than drifting into blank page, so the reader
+  // never has to work out which conductor a number belongs to.
+  for (const segment of segments) {
+    for (const fraction of [0.25, 0.75, 0.12, 0.88]) {
+      const on = {
+        x: segment.from.x + (segment.to.x - segment.from.x) * fraction,
+        y: segment.from.y + (segment.to.y - segment.from.y) * fraction,
+      };
+      candidates.push(on);
+      candidates.push({ x: on.x, y: on.y + BADGE_LIFT + 10 });
+    }
+  }
+  if (candidates.length === 0) {
+    const junction = document.junctions.find(
+      (candidate) => candidate.netId === netId,
+    );
+    if (junction) candidates.push(junction.position);
+  }
+  return candidates;
 }
 
 export interface OperatingPointLabelInput {
@@ -120,6 +221,9 @@ export function operatingPointLabels({
   const logical = resolveDocumentLogicalNets(document);
   const selected = new Set(selectedNetIds);
   const labels: OperatingPointLabel[] = [];
+  // Artwork and author labels are fixed; each badge placed also becomes an
+  // obstacle, so badges do not stack on each other either.
+  const obstacles = occupiedRects(document, resolver);
   for (const [netId, volts] of voltages) {
     const name = logical.byBaseNetId.get(netId)?.name;
     // Order matters: an explicit "all" is the author asking for everything,
@@ -135,12 +239,22 @@ export function operatingPointLabels({
               ? "all"
               : null;
     if (!reason) continue;
-    const at = netAnchor(document, resolver, netId);
-    if (!at) continue;
+    const text = formatNodeVoltage(volts);
+    const candidates = netAnchors(document, resolver, netId);
+    if (candidates.length === 0) continue;
+    // First candidate that covers nothing. If every one collides the badge
+    // still appears, at its best position: a voltage the author asked for is
+    // more useful slightly crowded than missing without explanation.
+    const at =
+      candidates.find(
+        (candidate) =>
+          !obstacles.some((rect) => overlaps(badgeRect(candidate, text), rect)),
+      ) ?? candidates[0]!;
+    obstacles.push(badgeRect(at, text));
     labels.push({
       netId,
       netLabel: name ?? netId,
-      text: formatNodeVoltage(volts),
+      text,
       at,
       reason,
     });

--- a/apps/editor/src/features/simulation/spice-simulation-panel.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-panel.test.tsx
@@ -1,0 +1,146 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  SpiceSimulationPanel,
+  type SimulationRunState,
+  type SimulatabilityView,
+} from "./spice-simulation-panel";
+
+const noop = () => undefined;
+
+function render(
+  overrides: Partial<{
+    simulatability: SimulatabilityView;
+    run: SimulationRunState;
+    testbench: string;
+    runsLocally: boolean;
+  }> = {},
+): string {
+  return renderToStaticMarkup(
+    <SpiceSimulationPanel
+      simulatability={overrides.simulatability ?? { kind: "ready" }}
+      run={overrides.run ?? { kind: "idle" }}
+      testbench={overrides.testbench ?? ""}
+      onTestbenchChange={noop}
+      onRun={noop}
+      circuitIncludePath="/app/circuit.spi"
+      {...(overrides.runsLocally === undefined
+        ? {}
+        : { runsLocally: overrides.runsLocally })}
+    />,
+  );
+}
+
+describe("SpiceSimulationPanel", () => {
+  it("refuses before the run and names the instances in the way", () => {
+    // ADR 0055: refusal is a diagnosis, never a silent failure. A greyed
+    // button with no reason leaves the author nowhere to go.
+    const markup = render({
+      simulatability: {
+        kind: "blocked",
+        blockers: [
+          { instanceId: "U3", reason: "signal-flow block has no device model" },
+          {
+            instanceId: "E1",
+            reason: "behavioural source has no device model",
+          },
+        ],
+      },
+      testbench: ".op\n",
+    });
+
+    expect(markup).toContain("U3");
+    expect(markup).toContain("signal-flow block has no device model");
+    expect(markup).toContain("E1");
+    expect(markup).toMatch(/data-testid="simulation-run"[^>]*disabled/u);
+  });
+
+  it("ships no testbench template, example, or default analysis", () => {
+    // The testbench encodes what the designer is trying to prove; guessing it
+    // produces confident answers to questions nobody asked.
+    const markup = render();
+
+    expect(markup).toContain('data-testid="simulation-testbench"');
+    // The input starts genuinely empty — no seeded directive of any kind.
+    expect(markup).not.toMatch(/\.(op|ac|tran|dc)\b/u);
+    expect(markup).not.toContain(".control");
+    expect(markup).not.toContain(".lib");
+    // What it does state is our own interface, which is documentation rather
+    // than a guess at intent.
+    expect(markup).toContain("/app/circuit.spi");
+  });
+
+  it("gives the testbench room for a real one, not a single line", () => {
+    // The reference benches run to a hundred lines with a .control section.
+    expect(render()).toMatch(/rows="1[0-9]"|rows="[2-9][0-9]"/u);
+  });
+
+  it("will not run an empty testbench", () => {
+    expect(render({ testbench: "   \n" })).toMatch(
+      /data-testid="simulation-run"[^>]*disabled/u,
+    );
+    expect(render({ testbench: ".op\n" })).not.toMatch(
+      /data-testid="simulation-run"[^>]*disabled/u,
+    );
+  });
+
+  it("says on the panel that the circuit leaves this machine", () => {
+    // ADR 0055 states this in the product, not buried in a document.
+    const hosted = render();
+    expect(hosted).toContain("leave this machine");
+    expect(hosted).toContain("local host");
+
+    const local = render({ runsLocally: true });
+    expect(local).toContain("stay here");
+  });
+
+  it("shows ngspice's own words when a run fails", () => {
+    // "Simulation failed" is useless; non-convergence and missing models are
+    // ordinary, and the author needs the simulator's actual text.
+    const log =
+      "doAnalyses: TRAN:  Timestep too small; time = 1.2e-09, timestep = 1e-18";
+    const markup = render({ run: { kind: "failed", log } });
+
+    expect(markup).toContain("Timestep too small");
+    expect(markup).toContain("time = 1.2e-09");
+  });
+
+  it("keeps the log on success too, where convergence warnings live", () => {
+    const markup = render({
+      run: {
+        kind: "done",
+        operatingPoint: new Map([["net-out", 0.9]]),
+        log: "Warning: singular matrix reordered",
+      },
+    });
+
+    expect(markup).toContain("singular matrix reordered");
+    expect(markup).toContain("1 node");
+  });
+
+  it("draws the AC plot only when there is an AC result", () => {
+    const withoutAc = render({
+      run: { kind: "done", operatingPoint: new Map(), log: "" },
+    });
+    expect(withoutAc).not.toContain('data-testid="simulation-ac-plot"');
+
+    const withAc = render({
+      run: {
+        kind: "done",
+        log: "",
+        acTraces: [
+          {
+            label: "vdb(vout)",
+            points: [
+              { frequency: 1, magnitudeDb: 40, phaseDeg: 0 },
+              { frequency: 1e6, magnitudeDb: -20, phaseDeg: -90 },
+            ],
+          },
+        ],
+      },
+    });
+    expect(withAc).toContain('data-testid="simulation-ac-plot"');
+    expect(withAc).toContain("<svg");
+  });
+});

--- a/apps/editor/src/features/simulation/spice-simulation-panel.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-panel.tsx
@@ -1,0 +1,192 @@
+import { useId } from "react";
+
+import { acResponseSvg, type AcTrace } from "./ac-response-plot";
+
+/**
+ * The SPICE simulation surface (ADR 0055).
+ *
+ * Three product commitments from the ADR shape this file, and none of them
+ * are cosmetic:
+ *
+ * 1. **Refusal is a diagnosis.** A circuit that cannot be simulated greys the
+ *    action out *before* anyone runs it, and names the instances responsible.
+ *    A refusal that does not say which instance is in the way gives the author
+ *    nowhere to go.
+ * 2. **The testbench is the author's.** No templates, no examples, no inferred
+ *    analysis. What this panel does say is the mechanical fact of our own
+ *    interface — the path the circuit netlist arrives at — because that is
+ *    documentation of what we do, not a guess at what the author wants to
+ *    prove.
+ * 3. **The circuit leaves this machine.** Stated on the panel, next to the
+ *    action that does it, rather than in a document nobody opens.
+ */
+
+/**
+ * What the panel needs to know about simulatability. Deliberately a view
+ * model rather than a domain contract: the projection that decides this lives
+ * in the model layer, and an adapter maps it onto these three cases.
+ */
+export type SimulatabilityView =
+  | { kind: "ready" }
+  | {
+      kind: "blocked";
+      /** Every instance standing in the way, each with its own reason. */
+      blockers: readonly { instanceId: string; reason: string }[];
+    }
+  | { kind: "checking" };
+
+export type SimulationRunState =
+  | { kind: "idle" }
+  | { kind: "running" }
+  /** ngspice's own output, verbatim. Not summarised, not classified. */
+  | { kind: "failed"; log: string }
+  | {
+      kind: "done";
+      operatingPoint?: ReadonlyMap<string, number>;
+      acTraces?: readonly AcTrace[];
+      /** Kept even on success: warnings are where convergence trouble shows. */
+      log: string;
+    };
+
+export interface SpiceSimulationPanelProps {
+  simulatability: SimulatabilityView;
+  run: SimulationRunState;
+  testbench: string;
+  onTestbenchChange: (value: string) => void;
+  onRun: () => void;
+  /** Where the exported circuit netlist appears to the testbench. */
+  circuitIncludePath: string;
+  /** Absent until the hosted surface is configured; the notice adapts. */
+  runsLocally?: boolean;
+}
+
+function BlockedList({
+  blockers,
+}: {
+  blockers: readonly { instanceId: string; reason: string }[];
+}) {
+  return (
+    <section aria-label="Why this circuit cannot be simulated">
+      <p className="simulation-blocked-lead">
+        {blockers.length === 1
+          ? "One instance has no device model behind it:"
+          : `${blockers.length} instances have no device model behind them:`}
+      </p>
+      <ul className="simulation-blockers" data-testid="simulation-blockers">
+        {blockers.map((blocker) => (
+          <li key={blocker.instanceId}>
+            <b>{blocker.instanceId}</b> — {blocker.reason}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function ResultView({ run }: { run: SimulationRunState }) {
+  if (run.kind === "idle") return null;
+  if (run.kind === "running") {
+    return <p className="simulation-status">Running…</p>;
+  }
+  if (run.kind === "failed") {
+    return (
+      <section aria-label="Simulator output">
+        <p className="simulation-status simulation-failed">
+          ngspice did not finish. Its output follows exactly as it was produced.
+        </p>
+        <pre className="simulation-log" data-testid="simulation-log">
+          {run.log}
+        </pre>
+      </section>
+    );
+  }
+  const acSvg = run.acTraces?.length
+    ? acResponseSvg(run.acTraces, { width: 640, height: 320 })
+    : null;
+  return (
+    <section aria-label="Simulation result">
+      {run.operatingPoint && run.operatingPoint.size > 0 ? (
+        <p className="simulation-status" data-testid="simulation-op-summary">
+          Operating point solved: {run.operatingPoint.size} node
+          {run.operatingPoint.size === 1 ? "" : "s"}. Named nets carry their
+          voltage on the canvas; select or hover any other net to read it.
+        </p>
+      ) : null}
+      {acSvg ? (
+        <div
+          className="simulation-ac-plot"
+          data-testid="simulation-ac-plot"
+          // The plot is produced as an SVG string by a pure module so it can
+          // be tested and later exported through the same path as any other
+          // drawing.
+          dangerouslySetInnerHTML={{ __html: acSvg }}
+        />
+      ) : null}
+      <pre className="simulation-log" data-testid="simulation-log">
+        {run.log}
+      </pre>
+    </section>
+  );
+}
+
+export function SpiceSimulationPanel({
+  simulatability,
+  run,
+  testbench,
+  onTestbenchChange,
+  onRun,
+  circuitIncludePath,
+  runsLocally = false,
+}: SpiceSimulationPanelProps) {
+  const testbenchId = useId();
+  const blocked = simulatability.kind === "blocked";
+  const checking = simulatability.kind === "checking";
+  const empty = testbench.trim().length === 0;
+  const running = run.kind === "running";
+  const disabled = blocked || checking || empty || running;
+
+  return (
+    <section
+      className="simulation-panel"
+      aria-label="SPICE simulation"
+      data-testid="spice-simulation-panel"
+    >
+      {blocked ? <BlockedList blockers={simulatability.blockers} /> : null}
+
+      <div className="simulation-testbench">
+        <label htmlFor={testbenchId}>Testbench</label>
+        <p className="simulation-hint">
+          Your testbench, your analysis — we supply the circuit and run the
+          simulator, nothing else. The exported netlist is available to it at{" "}
+          <code>{circuitIncludePath}</code>.
+        </p>
+        <textarea
+          id={testbenchId}
+          data-testid="simulation-testbench"
+          className="simulation-testbench-input"
+          spellCheck={false}
+          rows={18}
+          value={testbench}
+          onChange={(event) => onTestbenchChange(event.currentTarget.value)}
+        />
+      </div>
+
+      <p className="simulation-privacy" data-testid="simulation-privacy">
+        {runsLocally
+          ? "This runs on your machine: the circuit and testbench stay here."
+          : "Running sends your circuit and testbench to a hosted simulator, so they leave this machine. Use the local host if that is not acceptable for this design."}
+      </p>
+
+      <button
+        type="button"
+        data-testid="simulation-run"
+        onClick={onRun}
+        disabled={disabled}
+      >
+        {running ? "Running…" : "Run simulation"}
+      </button>
+
+      <ResultView run={run} />
+    </section>
+  );
+}

--- a/apps/editor/src/styles/editor-canvas.css
+++ b/apps/editor/src/styles/editor-canvas.css
@@ -189,6 +189,35 @@
   fill: var(--icm-warning, #b54708);
 }
 
+/* Simulated node voltages. A number sitting directly on a wire and the grid
+   is unreadable exactly where it matters, so each rides an opaque plate.
+   A voltage the author earned by naming the net reads as settled; one that
+   appeared because they pointed at something reads as passing, so a glance
+   tells them which numbers will still be there when they look away. */
+.operating-point-badges .operating-point-plate {
+  fill: var(--icm-surface, #fff);
+  stroke: var(--icm-border, #d5d9e0);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+  opacity: 0.92;
+}
+
+.operating-point-badges .operating-point-text {
+  font-size: 9px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  fill: var(--icm-accent-strong, #175cd3);
+}
+
+.operating-point-badge[data-reason="selected"] .operating-point-plate,
+.operating-point-badge[data-reason="hovered"] .operating-point-plate {
+  stroke-dasharray: 2 2;
+}
+
+.operating-point-badge[data-reason="all"] .operating-point-plate {
+  opacity: 0.78;
+}
+
 /* Ring-band hit only (an annulus path): the marker's centre stays
    click-through, so the pin or junction it rings remains directly clickable
    (and right-clickable) — the marker never captures what it annotates. */


### PR DESCRIPTION
The editor surface for ADR 0055, built to stand on its own while simulatability, netlist export, and the run route are still being built. It consumes view models rather than domain contracts, so those three attach through adapters without this code guessing at their shapes.

## Three ADR commitments, implemented rather than described

**Refusal is a diagnosis.** A circuit that is not simulatable disables the action *before* anyone runs it, and lists every blocking instance by id with its own reason. A greyed button with no reason leaves the author nowhere to go, which is the failure mode the ADR names.

**The testbench is the author's.** The input starts genuinely empty, and a test asserts the rendered markup contains no SPICE directive of any kind — no `.op`, no `.ac`, no `.control`, no `.lib`. What the panel *does* state is the path our own exported netlist arrives at, which is documentation of our interface rather than a guess at what the author wants to prove. That boundary is written into the code comment, because it is easy to push in either direction: toward "a helpful starter template", or toward saying nothing and leaving the author unable to reach the circuit. The input is eighteen rows because the reference benches in `analog-arena` run to a hundred lines with a `.control` section; a single-line box would be a lie about what is expected.

**The circuit leaves this machine.** Stated on the panel beside the button that does it, naming the local host as the alternative, and the wording flips when the run is local.

**ngspice's output is verbatim**, on failure and on success — convergence warnings live in a successful log. "Simulation failed" tells an author nothing.

## Showing a DC operating point without destroying the drawing

A real circuit has dozens of nodes; painting every voltage ruins the schematic exactly when the author is trying to read it, and painting none makes the result useless at a glance.

The rule uses a signal the author already gave us: **a net they took the trouble to name is a net they care about.** Named nets carry their voltage permanently; everything else answers on demand, when selected or hovered. An explicit "all" mode remains for anyone who wants the full picture and accepts the clutter.

This was **verified before any simulator exists**, by rendering the rule over real published circuits from the gallery corpus with synthetic voltages. On a twenty-net circuit the default places five badges — readable — while "all" places seventeen and visibly covers the `m=1`/`m=2`/`m=4` parameter labels and component values. That is the evidence for making "all" opt-in rather than an assumption about it.

The same exercise found a real defect: the anchor knew which conductor a voltage belonged to but nothing about what was already drawn there, so a badge could sit on a component's label. Placement now takes the first candidate that covers nothing — midpoint, below the wire, then positions slid **along** the conductor — with symbol ink bounds, author labels, and previously placed badges as obstacles. Sliding keeps a badge on the wire it describes, so the reader never has to work out which conductor a number belongs to. If everything collides the badge still appears at its best position: a voltage the author asked for is more useful slightly crowded than silently missing.

The existing instance-label placement projection was read first and does not fit — it answers "where does this symbol's own label go", not "where is there free space" — but its `visibleSymbolInkBounds` is reused, keeping one source of truth for what a symbol covers.

## The canvas layer is read-only, and tested for it

ADR 0055 keeps simulation results out of the model. The overlay has no pointer events, no hit geometry and no drag id, and a test asserts all three. A layer that could be grabbed would be the first step toward a result that behaves like part of the drawing — the kind of thing that is natural to add and silent to break, so it is guarded rather than trusted. Nothing in this change reaches the edit engine.

## The AC plot draws its own SVG

Both alternatives were rejected against the repo rather than by taste:

- **Not a charting library.** One plot type is needed, not a toolkit, and a dependency renders in its own idiom beside a product that draws everything through one style profile.
- **Not the digital-waveform path**, though the precedent sits in the same directory. `timing-waveform.ts` composes drafting objects and calls `renderDocumentSvg`, which suits a handful of step edges — but there is no polyline among the drafting kinds and they are *persistable user drawing primitives*, so an AC sweep of hundreds of points per trace would become hundreds of persisted objects. Wrong weight and wrong meaning.

Magnitude and phase share one frame rather than stacking: stacked reads better on paper but halves each plot's vertical resolution in a side panel, and the pairing that matters is read along one vertical line. Layout is separated from rendering so a crosshair can be added without the module knowing about React, and an empty or DC-only result returns `null` rather than an empty frame — an empty frame looks like a measurement.

## One deliberate seam

App holds the operating point in view state only, never in the document. Its setters have no caller yet **by design rather than omission**: the producer is the panel's run result and the run route is still being built. The seam names its future caller in place, because deleting it as dead code would silently remove the canvas half of the feature.

## Validation

Full `ci:check` under the gate lock on a frozen tree: unit 2119/2119 (328 files), e2e 315/315, typecheck, format, drift gates.

Related to ADR 0055.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
