### PR TITLE
fix(worker): a missing chunk is missing, and a stuck page can get unstuck

### DIFF
--- a/apps/editor/src/components/editor-error-boundary.test.tsx
+++ b/apps/editor/src/components/editor-error-boundary.test.tsx
@@ -18,4 +18,30 @@ describe("EditorCrashScreen", () => {
     expect(html).toContain("Report bug");
     expect(html).toContain("Recover Local Work");
   });
+
+  it("offers a clean reload when the build is the thing that is stale", () => {
+    // #493: a fresh visit could not open the editor because the app chunk
+    // named in the document no longer existed. An ordinary reload can serve
+    // that same document again, so the screen must say what is wrong and
+    // offer the reload that discards this build's cached copies.
+    const html = renderToStaticMarkup(
+      <EditorCrashScreen
+        message="Failed to fetch dynamically imported module: /assets/App-L9bGmgOj.js"
+        staleBuild
+        onReload={() => undefined}
+        onRecover={() => undefined}
+      />,
+    );
+    expect(html).toContain("running an old version of the editor");
+    expect(html).toContain("Reload with a clean copy");
+    expect(html).toContain("crash-reload-clean");
+  });
+
+  it("keeps the ordinary crash wording for an ordinary crash", () => {
+    const html = renderToStaticMarkup(
+      <EditorCrashScreen message="boom" onReload={() => undefined} />,
+    );
+    expect(html).toContain("The editor hit an unexpected problem");
+    expect(html).not.toContain("crash-reload-clean");
+  });
 });

--- a/apps/editor/src/components/editor-error-boundary.tsx
+++ b/apps/editor/src/components/editor-error-boundary.tsx
@@ -2,6 +2,11 @@ import { Component } from "react";
 import type { ErrorInfo, ReactNode } from "react";
 
 import { BugReportLink } from "./bug-report-link";
+import {
+  browserStaleBuildRecovery,
+  isStaleBuildFailure,
+  recoverFromStaleBuild,
+} from "./stale-build-recovery";
 
 export interface EditorErrorBoundaryProps {
   children: ReactNode;
@@ -41,7 +46,11 @@ export class EditorErrorBoundary extends Component<
       return (
         <EditorCrashScreen
           message={this.state.error.message}
+          staleBuild={isStaleBuildFailure(this.state.error.message)}
           onReload={() => window.location.reload()}
+          onRecover={() =>
+            void recoverFromStaleBuild(browserStaleBuildRecovery())
+          }
         />
       );
     }
@@ -52,11 +61,19 @@ export class EditorErrorBoundary extends Component<
 export interface EditorCrashScreenProps {
   message: string;
   onReload(): void;
+  /**
+   * The failure is a chunk this build can no longer fetch, so an ordinary
+   * reload can hand back the same document and fail again. Reported in #493.
+   */
+  staleBuild?: boolean;
+  onRecover?(): void;
 }
 
 export function EditorCrashScreen({
   message,
   onReload,
+  staleBuild = false,
+  onRecover,
 }: EditorCrashScreenProps) {
   return (
     <div
@@ -66,15 +83,29 @@ export function EditorCrashScreen({
       aria-labelledby="editor-crash-title"
     >
       <div className="editor-crash-panel">
-        <h1 id="editor-crash-title">The editor hit an unexpected problem</h1>
+        <h1 id="editor-crash-title">
+          {staleBuild
+            ? "This page is running an old version of the editor"
+            : "The editor hit an unexpected problem"}
+        </h1>
         <p>
-          Rendering stopped with an internal error. Your recent committed work
-          is kept in this browser's recovery copies.
+          {staleBuild
+            ? "The app was updated after this page opened, so part of it can no longer load. Reloading with a clean copy fixes it. Your recent committed work is kept in this browser's recovery copies."
+            : "Rendering stopped with an internal error. Your recent committed work is kept in this browser's recovery copies."}
         </p>
         <p>
           <code>{message}</code>
         </p>
         <div className="editor-crash-actions">
+          {staleBuild && onRecover ? (
+            <button
+              type="button"
+              data-testid="crash-reload-clean"
+              onClick={onRecover}
+            >
+              Reload with a clean copy
+            </button>
+          ) : null}
           <button type="button" onClick={onReload}>
             Reload editor
           </button>

--- a/apps/editor/src/components/stale-build-recovery.test.ts
+++ b/apps/editor/src/components/stale-build-recovery.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  isStaleBuildFailure,
+  recoverFromStaleBuild,
+} from "./stale-build-recovery";
+
+describe("recognising a build a page can no longer load", () => {
+  it("knows the browsers' several spellings of a missing chunk", () => {
+    // The message a person reported in #493, plus the forms other engines
+    // use for the same event. Getting this wrong offers the wrong remedy.
+    expect(
+      isStaleBuildFailure(
+        "Failed to fetch dynamically imported module: https://example.test/assets/App-L9bGmgOj.js",
+      ),
+    ).toBe(true);
+    expect(
+      isStaleBuildFailure("error loading dynamically imported module"),
+    ).toBe(true);
+    expect(isStaleBuildFailure("Importing a module script failed.")).toBe(true);
+    expect(
+      isStaleBuildFailure(
+        "Properties could not load — the app has been updated since this tab opened",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not claim an ordinary crash is a stale build", () => {
+    expect(isStaleBuildFailure("Cannot read properties of undefined")).toBe(
+      false,
+    );
+    expect(isStaleBuildFailure("Route net does not exist: net-h")).toBe(false);
+  });
+});
+
+describe("recovering from a build a page can no longer load", () => {
+  function surfaces(overrides: { keys?: string[] } = {}) {
+    const deleted: string[] = [];
+    const unregistered: string[] = [];
+    const reload = vi.fn();
+    return {
+      deleted,
+      unregistered,
+      reload,
+      value: {
+        caches: {
+          keys: () =>
+            Promise.resolve(
+              overrides.keys ?? [
+                "icm-static-shell-abc",
+                "icm-static-shell-def",
+                "some-other-cache",
+              ],
+            ),
+          delete: (key: string) => {
+            deleted.push(key);
+            return Promise.resolve(true);
+          },
+        } as unknown as CacheStorage,
+        serviceWorker: {
+          getRegistrations: () =>
+            Promise.resolve([
+              {
+                unregister: () => {
+                  unregistered.push("sw");
+                  return Promise.resolve(true);
+                },
+              },
+            ]),
+        } as unknown as ServiceWorkerContainer,
+        reload,
+      },
+    };
+  }
+
+  it("drops this app's shell caches, its worker, and reloads", async () => {
+    const context = surfaces();
+    await recoverFromStaleBuild(context.value);
+    expect(context.deleted).toEqual([
+      "icm-static-shell-abc",
+      "icm-static-shell-def",
+    ]);
+    // A cache this app did not create is somebody else's to manage.
+    expect(context.deleted).not.toContain("some-other-cache");
+    expect(context.unregistered).toEqual(["sw"]);
+    expect(context.reload).toHaveBeenCalledOnce();
+  });
+
+  it("still reloads when the browser refuses its caches", async () => {
+    // Private modes and locked-down browsers throw here. The reload is the
+    // part that gets the person moving, so it must not be skipped.
+    const reload = vi.fn();
+    await recoverFromStaleBuild({
+      caches: {
+        keys: () => Promise.reject(new Error("denied")),
+      } as unknown as CacheStorage,
+      reload,
+    });
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("reloads when there is no service worker at all", async () => {
+    const reload = vi.fn();
+    await recoverFromStaleBuild({ reload });
+    expect(reload).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/editor/src/components/stale-build-recovery.ts
+++ b/apps/editor/src/components/stale-build-recovery.ts
@@ -1,0 +1,70 @@
+/**
+ * Get a page out of a build it can no longer load.
+ *
+ * A tab holds a document that names content-hashed chunks. Once a deploy
+ * replaces them, that document can never boot again: the chunk it asks for
+ * is gone, and an ordinary reload can hand back the same document from a
+ * cache, so the person sees the same failure a second time and has no way
+ * out. Reported as issue #493, where a fresh visit to /editor could not open
+ * the editor at all because the failing chunk was the app itself.
+ *
+ * Recovery discards what this build cached — the shell caches this app
+ * installed, and the service worker registration that serves them — and then
+ * reloads. Nothing here touches a Project: recovery copies live in
+ * IndexedDB, which is deliberately not cleared.
+ */
+const SHELL_CACHE_PREFIX = "icm-static-shell-";
+
+export interface StaleBuildRecoverySurfaces {
+  readonly caches?: CacheStorage;
+  readonly serviceWorker?: ServiceWorkerContainer;
+  reload(): void;
+}
+
+/** Whether a failure looks like a chunk this build can no longer fetch. */
+export function isStaleBuildFailure(message: string): boolean {
+  const text = message.toLowerCase();
+  return (
+    text.includes("dynamically imported module") ||
+    text.includes("failed to fetch dynamically") ||
+    text.includes("importing a module script failed") ||
+    text.includes("has been updated since this tab opened")
+  );
+}
+
+export async function recoverFromStaleBuild(
+  surfaces: StaleBuildRecoverySurfaces,
+): Promise<void> {
+  try {
+    const keys = (await surfaces.caches?.keys()) ?? [];
+    await Promise.all(
+      keys
+        .filter((key) => key.startsWith(SHELL_CACHE_PREFIX))
+        .map((key) => surfaces.caches!.delete(key)),
+    );
+  } catch (error) {
+    // A browser that refuses cache access still deserves the reload.
+    console.error("Could not clear the stale shell cache:", error);
+  }
+  try {
+    const registrations =
+      (await surfaces.serviceWorker?.getRegistrations()) ?? [];
+    await Promise.all(
+      registrations.map((registration) => registration.unregister()),
+    );
+  } catch (error) {
+    console.error("Could not unregister the stale service worker:", error);
+  }
+  surfaces.reload();
+}
+
+/** The browser-backed surfaces, for callers that have no reason to inject. */
+export function browserStaleBuildRecovery(): StaleBuildRecoverySurfaces {
+  return {
+    ...(typeof caches !== "undefined" ? { caches } : {}),
+    ...(typeof navigator !== "undefined" && "serviceWorker" in navigator
+      ? { serviceWorker: navigator.serviceWorker }
+      : {}),
+    reload: () => window.location.reload(),
+  };
+}

--- a/worker/index.test.ts
+++ b/worker/index.test.ts
@@ -56,11 +56,19 @@ describe("static asset serving", () => {
         fetch(request: Request) {
           const path = new URL(request.url).pathname;
           const body = files[path];
+          // With not_found_handling "none" the assets layer answers a miss
+          // with 404 and the request reaches the Worker. index.html is a
+          // real file, so the shell is something the Worker can ask for.
+          if (path === "/index.html") {
+            return Promise.resolve(
+              new Response("<!doctype html><html></html>", {
+                headers: { "content-type": "text/html" },
+              }),
+            );
+          }
           return Promise.resolve(
             body === undefined
-              ? new Response("<!doctype html><html></html>", {
-                  headers: { "content-type": "text/html" },
-                })
+              ? new Response("Not found", { status: 404 })
               : new Response(body, {
                   headers: { "content-type": "text/javascript" },
                 }),
@@ -127,6 +135,11 @@ describe("assets binding wiring", () => {
     const { assets } = wranglerConfig();
     expect(assets.run_worker_first).not.toContain("/assets/*");
     expect(assets.run_worker_first).toContain("/api/*");
-    expect(assets.not_found_handling).toBe("single-page-application");
+    // "single-page-application" answers a MISSING asset with the shell, and
+    // it does so in front of the Worker — so the 404 below could never run
+    // in production, however green its test was. "none" lets a miss fall
+    // through to the Worker, which is the only place that can tell a stale
+    // chunk name from a route.
+    expect(assets.not_found_handling).toBe("none");
   });
 });

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -125,29 +125,47 @@ export default {
 /**
  * Serve a static asset, and let a missing one be missing.
  *
- * `not_found_handling: "single-page-application"` is right for a route like
- * `/g/<id>`, which has no file behind it and must render the shell. It is
- * wrong for `/assets/*`: those names carry a content hash, so a request for
- * one that is not there is a stale page asking for a build that no longer
- * exists — not a route. Answering it with `200 text/html` hands the browser
- * a document where it asked for a module, which surfaces as "error loading
+ * A route like `/g/<id>` has no file behind it and must render the shell. A
+ * request for `/assets/App-<hash>.js` is the opposite: those names carry a
+ * content hash, so one that is not there is a stale page asking for a build
+ * that no longer exists. Answering it with `200 text/html` hands the browser
+ * a document where it asked for a module, which surfaces as "Failed to fetch
  * dynamically imported module" instead of a plain missing file, and invites
  * every cache in the path to keep the wrong answer under a name that
  * promised to be immutable.
+ *
+ * The asset binding cannot make that distinction: `not_found_handling`
+ * applies to every miss alike, and it answers before the Worker runs, so a
+ * shell-for-everything setting makes the check below unreachable however
+ * green its test looks. The binding is therefore set to `none` and the
+ * choice is made here, where the path is known. Listing `/assets/*` in
+ * `run_worker_first` would be the other way to arrive, and it is not: that
+ * makes `env.ASSETS.fetch` re-enter this Worker, and every asset request
+ * fails with 1101.
  */
 async function serveAsset(request: Request, env: Env): Promise<Response> {
   const response = await env.ASSETS.fetch(request);
+  if (response.status !== 404) return response;
   const path = new URL(request.url).pathname;
-  if (!path.startsWith("/assets/")) return response;
-  const servedShell = (response.headers.get("content-type") ?? "").includes(
-    "text/html",
+  if (path.startsWith("/assets/")) {
+    return new Response(`Not found: ${path}`, {
+      status: 404,
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+        "cache-control": "no-store",
+      },
+    });
+  }
+  // Every other miss is a client route: render the shell the app boots from.
+  const shell = await env.ASSETS.fetch(
+    new Request(new URL("/index.html", request.url), request),
   );
-  if (!servedShell) return response;
-  return new Response(`Not found: ${path}`, {
-    status: 404,
+  if (!shell.ok) return response;
+  return new Response(shell.body, {
+    status: 200,
     headers: {
-      "content-type": "text/plain; charset=utf-8",
-      "cache-control": "no-store",
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "public, max-age=0, must-revalidate",
     },
   });
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -16,7 +16,10 @@
   ],
   "assets": {
     "directory": "./apps/editor/dist",
-    "not_found_handling": "single-page-application",
+    // A miss falls through to the Worker, which tells a stale hashed asset
+    // (404) from a client route (the shell). The single-page-application
+    // setting answers both with the shell, before the Worker runs.
+    "not_found_handling": "none",
     "run_worker_first": ["/api/*"],
   },
   "durable_objects": {


### PR DESCRIPTION
Fixes #493.

## What the person saw

They typed the editor's address and could not open it. The document named `/assets/App-<hash>.js`, that build was gone, the answer was `200 text/html`, and so the browser reported "Failed to fetch dynamically imported module". The crash screen offered "Reload editor", which the same caches can answer with the same document.

## Two things were wrong, and neither was the one the report named

**1. The honest 404 could never run.** The Worker already refuses a missing hashed asset (#290). But assets are served *before* the Worker, and `not_found_handling: "single-page-application"` answers every miss with the shell — so `serveAsset`'s 404 was unreachable in production. Its test passed because the harness modelled the SPA fallback *inside* `ASSETS.fetch`, which is not where production puts it: green on a wiring the product does not have. Confirmed against the live site, where the reported URL still answers `200 text/html`.

The binding is now `"none"`, so a miss falls through and the Worker decides where the path is known: `/assets/*` is a stale name and gets a plain `404`; anything else is a client route and gets the shell. Listing `/assets/*` in `run_worker_first` remains the wrong way to arrive there — it re-enters the Worker and every asset request fails with 1101 — and the test that forbids it stays.

**2. The person had no way out.** The crash screen now recognises a stale-build failure by its message, says *the page is running an old version* instead of implying the circuit broke, and offers **"Reload with a clean copy"**: it discards this app's shell caches, unregisters its service worker, then reloads. Projects are untouched — recovery copies live in IndexedDB and are deliberately not cleared.

## Verification

Local: worker suite red first (the three cases fail on the old wiring), then green; full unit suite 2053/2053; typecheck and Prettier clean.

Production is the only place the hosting behaviour exists, so after this deploys I check that `/assets/App-L9bGmgOj.js` answers `404 text/plain` while `/editor`, `/g/<id>` and `/mine` still render the shell, and report the result on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)