### PR TITLE
fix(render-svg): keep the mean-value bar whole when the equation continues

### DIFF
--- a/packages/render-svg/src/positioned-rich-text.test.ts
+++ b/packages/render-svg/src/positioned-rich-text.test.ts
@@ -294,3 +294,101 @@ describe("renderPositionedOverbarScriptDocument", () => {
     ).toBeNull();
   });
 });
+
+describe("an overbar followed by more of the line", () => {
+  /**
+   * Issue #495, taken from the reporter's own Project file: a mean-value name
+   * with both a subscript and a superscript, then the rest of the equation
+   * appended after it.
+   */
+  function meanValueThenEquation(): RichTextDocument {
+    return {
+      runs: [
+        {
+          kind: "span",
+          style: "bold",
+          children: [
+            {
+              kind: "span",
+              style: "italic",
+              children: [
+                {
+                  kind: "span",
+                  style: "overbar",
+                  children: [
+                    { kind: "text", value: "I" },
+                    {
+                      kind: "span",
+                      style: "subscript",
+                      children: [{ kind: "text", value: "n" }],
+                    },
+                    {
+                      kind: "span",
+                      style: "superscript",
+                      children: [{ kind: "text", value: "2" }],
+                    },
+                  ],
+                },
+                { kind: "text", value: "=4kT" },
+                {
+                  kind: "span",
+                  style: "subscript",
+                  children: [{ kind: "text", value: "m" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  // The reported defect: appending to the name dropped the whole line to CSS
+  // `text-decoration: overline`, which SVG inherits into every nested tspan,
+  // so the subscript and the superscript each grew a bar of their own at their
+  // own height. One drawn line, and no inherited decoration anywhere.
+  it("keeps one drawn bar over the name when the equation continues", () => {
+    const rendered = render(meanValueThenEquation());
+
+    expect(rendered.decorations.match(/<line\b/g)).toHaveLength(1);
+    expect(rendered.tspans).not.toContain("text-decoration");
+    expect(rendered.decorations).not.toContain("text-decoration:");
+  });
+
+  // The bar covers the name it belongs to and stops there; it must not run on
+  // over the equation that follows.
+  it("stops the bar at the end of the name, not the end of the line", () => {
+    const rendered = render(meanValueThenEquation());
+    const overbar = tagAttributes(
+      rendered.decorations,
+      "line",
+      'data-text-decoration="overbar"',
+    );
+    const base = tagAttributes(
+      rendered.tspans,
+      "tspan",
+      'data-text-run="base"',
+    );
+    const subscript = tagAttributes(
+      rendered.tspans,
+      "tspan",
+      'data-text-run="subscript"',
+    );
+
+    expect(numericAttribute(overbar, "x1")).toBe(numericAttribute(base, "x"));
+    const nameRight =
+      numericAttribute(subscript, "x") +
+      numericAttribute(subscript, "textLength");
+    expect(numericAttribute(overbar, "x2")).toBeCloseTo(nameRight, 6);
+    // The reported width covers the whole line, so the bar ends short of it.
+    expect(numericAttribute(overbar, "x2")).toBeLessThan(
+      numericAttribute(base, "x") + rendered.width,
+    );
+  });
+
+  it("still renders the appended equation", () => {
+    const rendered = render(meanValueThenEquation());
+    expect(rendered.tspans).toContain("=4kT");
+    expect(rendered.tspans).toContain("m");
+  });
+});

--- a/packages/render-svg/src/positioned-rich-text.ts
+++ b/packages/render-svg/src/positioned-rich-text.ts
@@ -2,6 +2,8 @@ import { richTextAdvanceEm } from "@icm/derived";
 import type { SchematicStyleProfile } from "@icm/derived";
 import type { RichTextDocument, RichTextRun } from "@icm/model";
 
+import { renderRichTextDocument } from "./rich-text.js";
+
 interface TextStyle {
   italic: boolean;
   bold: boolean;
@@ -169,7 +171,7 @@ export function renderPositionedOverbarScriptDocument(
     bold: options.defaultBold ?? false,
   });
   if (
-    outer.runs.length !== 1 ||
+    outer.runs.length === 0 ||
     outer.runs[0]!.kind !== "span" ||
     outer.runs[0]!.style !== "overbar"
   ) {
@@ -177,6 +179,14 @@ export function renderPositionedOverbarScriptDocument(
   }
 
   const overbar = outer.runs[0] as Extract<RichTextRun, { kind: "span" }>;
+  // Anything after the barred name is ordinary inline text. It has to be
+  // rendered here rather than left to the generic path, because the generic
+  // path draws the bar with CSS `text-decoration: overline`, which SVG
+  // inherits into every nested tspan: the subscript and the superscript each
+  // grow a bar of their own, at their own size and height. That is the defect
+  // in issue #495, and it appeared the moment someone appended `=4kT` to a
+  // name that had been rendering correctly on its own.
+  const continuation = outer.runs.slice(1);
   const expression = unwrapWholeTextStyles(overbar.children, outer.style);
   if (expression.runs.length === 0) return null;
 
@@ -277,9 +287,39 @@ export function renderPositionedOverbarScriptDocument(
     : baseTop;
   const lineY = Math.min(baseTop, superscriptTop) - overbarGap;
   const strokeWidth = Math.max(1, profile.strokes.annotation);
+  // The bar belongs to the name, so it ends where the name ends. `width`
+  // grows to cover the continuation, but the line does not.
+  const nameWidth = width;
+  const continuationTspans =
+    continuation.length > 0
+      ? `<tspan x="${number(startX + nameWidth)}" y="${number(options.y)}">${renderRichTextDocument(
+          { runs: continuation },
+          profile,
+          {
+            lineOriginX: startX + nameWidth,
+            fontSize: options.fontSize,
+            defaultBold: outer.style.bold,
+            defaultItalic: outer.style.italic,
+          },
+        )}</tspan>`
+      : "";
+  const continuationWidth =
+    continuation.length > 0
+      ? richTextAdvanceEm(plainText(continuation)) * options.fontSize
+      : 0;
   return {
-    width,
-    tspans: `<tspan data-text-run="overbar">${baseTspans}<tspan data-text-run="script-stack">${orderedScripts}</tspan></tspan>`,
-    decorations: `<line data-text-decoration="overbar" x1="${number(startX)}" y1="${number(lineY)}" x2="${number(startX + width)}" y2="${number(lineY)}" stroke="${options.color ?? profile.foreground}" stroke-width="${number(strokeWidth)}"/>`,
+    width: nameWidth + continuationWidth,
+    tspans: `<tspan data-text-run="overbar">${baseTspans}<tspan data-text-run="script-stack">${orderedScripts}</tspan></tspan>${continuationTspans}`,
+    decorations: `<line data-text-decoration="overbar" x1="${number(startX)}" y1="${number(lineY)}" x2="${number(startX + nameWidth)}" y2="${number(lineY)}" stroke="${options.color ?? profile.foreground}" stroke-width="${number(strokeWidth)}"/>`,
   };
+}
+
+/** Flat text of a run list, for advancing the pen past the continuation. */
+function plainText(runs: readonly RichTextRun[]): string {
+  let output = "";
+  for (const run of runs) {
+    if (run.kind === "text") output += run.value;
+    else if (run.kind === "span") output += plainText(run.children);
+  }
+  return output;
 }


### PR DESCRIPTION
Fixes the second half of #495. The first half is diagnosed below but **not**
fixed here, deliberately.

## The bar that broke

A name like I̅ₙ² rendered correctly on its own and broke the moment its author
appended `=4kTγgₘ`: the bar split, and the subscript and superscript each grew
one of their own at their own height.

Reproduced from the reporter's own Project file rather than the screenshot,
which showed exactly why. The positioned renderer draws the bar as a real
`<line>`, but it only accepted a document whose *single* run was the overbar.
Adding anything after the name failed that test, so the whole label fell back
to the generic path, which draws the bar with CSS `text-decoration: overline`
— and SVG inherits that into every nested tspan.

The fallback's own comment already described this exact failure. It had simply
never been reachable from a shape anyone had drawn until now.

The renderer now accepts a barred name that opens a longer line, renders the
continuation after it, and reports the full width. The bar still ends where
the name ends rather than running on over the equation, which is what a mean
value means.

**Verified on the reporter's file:** both labels now render one continuous bar
over the name, with the appended equation unbarred beside it.

## The formula insert: diagnosed, not fixed

The reporter's other complaint is that a formula shown correctly in the
preview cannot be inserted into the label. I traced it and am reporting rather
than patching, because a guard on this would have been a fix in appearance
only.

What happens on a component label:

1. `applyFormula` replaces the label content with a single `math` run.
2. On Apply, a bound label's name is taken from `flattenRichText(content)`,
   which for a math run is its **raw LaTeX**.
3. `\overline{V_{n}^{2}}` is then proposed as the component's reference and
   refused by the prefix rule (`EDIT_PRECONDITION`), or, when it gets past
   that, by a model invariant: *a bound RichText format override must preserve
   the semantic name text* (`INVALID_RESULT`).
4. The transaction fails, the formula is dropped, **and the styling already on
   the label is replaced by plain text** — worse than a refusal.

That invariant is deliberate and correct: a designator's formatting may style
the name but must not change what it says, or the sheet and the netlist would
disagree. So a formula genuinely cannot be a designator, and the honest fix is
a clear refusal rather than making it work.

I wrote that refusal and it worked on the reporter's file. I am not shipping
it, because while testing it I found the defect underneath: **the math run
survives the editor's DOM round-trip only sometimes.** A regression test for
the refusal passed two runs in three. The insert path is racy, so a guard on
its output would fire inconsistently and look like a fix while the data loss
continued.

That race is the real first-half defect and wants a proper fix in the rich
text editor's formula round-trip, with a deterministic reproduction, rather
than a 2am guard.

## Verification

- 2114 unit tests, `pnpm ci:static`, typecheck green.
- Three new render tests: one drawn bar and no inherited decoration; the bar
  stops at the end of the name; the appended equation still renders.
- Verified red-then-green, and confirmed on the reporter's own file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
