### PR TITLE
fix(editor): the AC plot has styles and names its traces

### DIFF
--- a/apps/editor/src/features/simulation/ac-response-plot.test.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -85,6 +88,40 @@ describe("AC response plot", () => {
         { width: 600, height: 300 },
       ),
     ).toBeNull();
+  });
+
+  it("names every trace on the plot, in its own colour class", () => {
+    // Found by rendering realistic sweeps before any simulator existed: two
+    // traces were drawn identically and unlabelled, so the plot could not be
+    // read at all. The author asked for these expressions by name; printing
+    // them back is the only way to tell the curves apart, and colour alone
+    // would leave anyone who cannot separate the hues with nothing.
+    const svg = acResponseSvg(
+      [
+        { label: "vdb(vout)", points: singlePole().points },
+        { label: "vdb(vout_loaded)", points: singlePole().points },
+      ],
+      { width: 600, height: 300 },
+    )!;
+
+    expect(svg).toContain("vdb(vout)");
+    expect(svg).toContain("vdb(vout_loaded)");
+    expect(svg).toContain("ac-trace-0");
+    expect(svg).toContain("ac-trace-1");
+  });
+
+  it("carries the stylesheet that keeps a polyline from filling solid", () => {
+    // An SVG polyline fills black by default. The plot ships no inline
+    // presentation attributes, so if the class stops being styled every trace
+    // renders as a solid blob — silently, and only in the app.
+    const css = readFileSync(
+      resolve(process.cwd(), "apps/editor/src/styles/editor-simulation.css"),
+      "utf8",
+    );
+    expect(css).toMatch(/\.ac-response \.ac-trace \{[^}]*fill:\s*none/u);
+    for (let index = 0; index < 6; index += 1) {
+      expect(css).toContain(`.ac-trace-${index}`);
+    }
   });
 
   it("labels the frequency axis the way it is spoken", () => {

--- a/apps/editor/src/features/simulation/ac-response-plot.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.ts
@@ -216,11 +216,26 @@ export function acResponseSvg(
     })
     .join("");
 
+  // The author asked for these expressions by name; printing them back is the
+  // only way to tell two curves apart, and colour alone would leave anyone
+  // who cannot separate the hues with an unreadable plot.
+  const legend = traces
+    .map((trace, index) => {
+      const y = frame.y + 12 + index * 14;
+      const swatchX = frame.x + 10;
+      return (
+        `<line class="ac-trace ac-trace-${index % 6}" x1="${swatchX}" y1="${y}" x2="${swatchX + 16}" y2="${y}"/>` +
+        `<text class="ac-legend-text" x="${swatchX + 22}" y="${y + 3}">${escapeXml(trace.label)}</text>`
+      );
+    })
+    .join("");
+
   return (
     `<svg xmlns="http://www.w3.org/2000/svg" class="ac-response" viewBox="0 0 ${size.width} ${size.height}" width="${size.width}" height="${size.height}" role="img" aria-label="AC response">` +
     `<rect class="ac-frame" x="${frame.x}" y="${frame.y}" width="${frame.width}" height="${frame.height}"/>` +
     gridLines +
     curves +
+    legend +
     `</svg>`
   );
 }

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -336,3 +336,62 @@
     min-width: 0;
   }
 }
+
+/* AC response plot. `fill: none` is not decoration here: an SVG polyline
+   fills black by default, so without this rule every trace renders as a
+   solid blob instead of a curve. */
+.ac-response .ac-trace {
+  fill: none;
+  stroke-width: 1.5;
+  stroke-linejoin: round;
+}
+
+.ac-response .ac-trace.ac-phase {
+  stroke-dasharray: 3 2;
+  stroke-width: 1.2;
+}
+
+.ac-response .ac-frame {
+  fill: none;
+  stroke: var(--icm-border, #d5d9e0);
+  stroke-width: 1;
+}
+
+.ac-response .ac-grid {
+  stroke: var(--icm-border-subtle, #eceff3);
+  stroke-width: 1;
+}
+
+.ac-response .ac-axis-label {
+  font-size: 9px;
+  fill: var(--icm-text-muted, #667085);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Traces are distinguished by hue, and one plot may carry several. The
+   sequence keeps adjacent entries far apart in hue so two curves crossing
+   stay separable, and repeats after six rather than fading to nothing. */
+.ac-response .ac-trace-0 {
+  stroke: #175cd3;
+}
+.ac-response .ac-trace-1 {
+  stroke: #b54708;
+}
+.ac-response .ac-trace-2 {
+  stroke: #067647;
+}
+.ac-response .ac-trace-3 {
+  stroke: #6941c6;
+}
+.ac-response .ac-trace-4 {
+  stroke: #b42318;
+}
+.ac-response .ac-trace-5 {
+  stroke: #026aa2;
+}
+
+.ac-response .ac-legend-text {
+  font-size: 10px;
+  fill: var(--icm-text, #101828);
+  font-family: var(--icm-mono, ui-monospace, monospace);
+}


### PR DESCRIPTION
Two defects in the AC plot from #497, found by rendering realistic sweeps — two-pole roll-offs at ngspice's own 20 points per decade — **before any simulator exists**. The same technique that validated the operating-point rule, applied to the plot.

## The severe one: no styles at all

There were no AC plot styles anywhere in the app. The module emits classes and deliberately no presentation attributes, and `fill: none` was living only in my throwaway preview page — so in the real panel **every trace would have rendered as a solid black blob**, because an SVG polyline fills black by default.

This would have shipped looking catastrophically broken while every unit test passed. The tests assert markup, and the markup was correct. Nothing we had could see the difference between a curve and a filled rectangle.

The first preview did not catch it either, because that page carried its own styles and looked fine. It only surfaced when I went to check whether the app had the equivalent rules and found none — which is why the second preview inlines `editor-simulation.css` itself rather than a copy, so what it shows is what the panel will show.

## The second: several traces were indistinguishable

The class carried an index but nothing defined a colour per index, and the label the author asked for — `vdb(vout)` — was carried in the data and never drawn. Two curves, same colour, no legend.

The stylesheet now defines six hues, spaced so adjacent entries stay separable where curves cross, and the plot prints each trace's own expression beside a swatch. **Colour alone would not have been enough**: anyone who cannot separate the hues would still be reading an unlabelled plot.

## An unusual test, deliberately

A unit test now asserts that `editor-simulation.css` keeps `fill: none` on `.ac-trace` and defines all six hues.

Asserting a stylesheet's contents from a unit test is not something to do casually. It is justified here because the failure it guards is invisible to every other check in the repo: correct markup, green tests, and a black rectangle where the measurement should be. The comment says so, so nobody removes it as an odd coupling.

## Validation

Full `ci:check` under the gate lock on a frozen tree: unit 2147/2147 (331 files), e2e 315/315. Rebased onto current main and re-verified.

Related to ADR 0055, follows #497.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
