### PR TITLE
fix(worker): stop SPA fallback recursion

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -79,4 +79,25 @@ jobs:
           curl --fail --silent --show-error \
             --retry 5 --retry-delay 2 --retry-all-errors \
             --max-time 20 \
+            https://analog-canvas.tokenzhang.com/editor >/dev/null
+          curl --fail --silent --show-error \
+            --retry 5 --retry-delay 2 --retry-all-errors \
+            --max-time 20 \
+            https://analog-canvas.tokenzhang.com/analytics >/dev/null
+          curl --fail --silent --show-error \
+            --retry 5 --retry-delay 2 --retry-all-errors \
+            --max-time 20 \
             https://analog-canvas.tokenzhang.com/api/agent/mcp-manifest.json >/dev/null
+          missing_asset="$(curl --silent --show-error \
+            --max-time 20 \
+            --output /tmp/analog-canvas-missing-asset.txt \
+            --write-out '%{http_code} %{content_type}' \
+            https://analog-canvas.tokenzhang.com/assets/App-deploy-smoke-missing.js)"
+          case "$missing_asset" in
+            "404 text/plain"*) ;;
+            *)
+              echo "Missing hashed asset returned: $missing_asset"
+              cat /tmp/analog-canvas-missing-asset.txt
+              exit 1
+              ;;
+          esac

--- a/worker/index.test.ts
+++ b/worker/index.test.ts
@@ -46,36 +46,29 @@ describe("analytics request normalization", () => {
 });
 
 describe("static asset serving", () => {
-  /**
-   * The assets binding is configured with single-page-application not-found
-   * handling, so anything it cannot match comes back as the shell.
-   */
   function envServing(files: Record<string, string>) {
-    return {
+    const requestedPaths: string[] = [];
+    const env = {
       ASSETS: {
         fetch(request: Request) {
           const path = new URL(request.url).pathname;
+          requestedPaths.push(path);
           const body = files[path];
-          // With not_found_handling "none" the assets layer answers a miss
-          // with 404 and the request reaches the Worker. index.html is a
-          // real file, so the shell is something the Worker can ask for.
-          if (path === "/index.html") {
-            return Promise.resolve(
-              new Response("<!doctype html><html></html>", {
-                headers: { "content-type": "text/html" },
-              }),
-            );
-          }
           return Promise.resolve(
             body === undefined
               ? new Response("Not found", { status: 404 })
               : new Response(body, {
-                  headers: { "content-type": "text/javascript" },
+                  headers: {
+                    "content-type": path.endsWith(".html")
+                      ? "text/html"
+                      : "text/javascript",
+                  },
                 }),
           );
         },
       },
     } as unknown as Parameters<typeof worker.fetch>[1];
+    return { env, requestedPaths };
   }
 
   const call = (env: unknown, path: string) =>
@@ -84,32 +77,38 @@ describe("static asset serving", () => {
       env as Parameters<typeof worker.fetch>[1],
     );
 
-  it("serves an asset that exists", async () => {
-    const env = envServing({ "/assets/App-abc.js": "export const a = 1;" });
-    const response = await call(env, "/assets/App-abc.js");
-    expect(response.status).toBe(200);
-    expect(await response.text()).toContain("export const a");
-  });
-
   it("404s a hashed asset the build no longer has", async () => {
     // A page open across a deploy asks for names this build does not carry.
     // Answering with the shell hands the browser a document where it asked
     // for a module, and every cache in the path is invited to keep it under
     // a name that promised to be immutable.
-    const env = envServing({});
+    const { env, requestedPaths } = envServing({
+      "/index.html": "<!doctype html><html></html>",
+    });
     const response = await call(env, "/assets/App-gone.js");
     expect(response.status).toBe(404);
     expect(response.headers.get("content-type")).toContain("text/plain");
     expect(response.headers.get("cache-control")).toBe("no-store");
+    // Re-fetching the missing path through the binding re-enters the Worker
+    // under not_found_handling "none" and produces Cloudflare error 1101.
+    expect(requestedPaths).toEqual([]);
   });
 
   it("still renders the shell for a route with no file behind it", async () => {
-    const env = envServing({});
-    for (const path of ["/g/2cdq4dmhy9", "/editor", "/mine"]) {
+    const { env, requestedPaths } = envServing({
+      "/index.html": "<!doctype html><html></html>",
+    });
+    for (const path of ["/g/2cdq4dmhy9", "/editor", "/analytics", "/mine"]) {
       const response = await call(env, path);
       expect(response.status).toBe(200);
       expect(response.headers.get("content-type")).toContain("text/html");
     }
+    expect(requestedPaths).toEqual([
+      "/index.html",
+      "/index.html",
+      "/index.html",
+      "/index.html",
+    ]);
   });
 });
 

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -122,12 +122,12 @@ export default {
       return Response.json({ error: "Not found" }, { status: 404 });
     }
 
-    return serveAsset(request, env);
+    return serveStaticMiss(request, env);
   },
 };
 
 /**
- * Serve a static asset, and let a missing one be missing.
+ * Resolve a URL that the static asset layer has already reported missing.
  *
  * A route like `/g/<id>` has no file behind it and must render the shell. A
  * request for `/assets/App-<hash>.js` is the opposite: those names carry a
@@ -147,9 +147,7 @@ export default {
  * makes `env.ASSETS.fetch` re-enter this Worker, and every asset request
  * fails with 1101.
  */
-async function serveAsset(request: Request, env: Env): Promise<Response> {
-  const response = await env.ASSETS.fetch(request);
-  if (response.status !== 404) return response;
+async function serveStaticMiss(request: Request, env: Env): Promise<Response> {
   const path = new URL(request.url).pathname;
   if (path.startsWith("/assets/")) {
     return new Response(`Not found: ${path}`, {
@@ -160,11 +158,15 @@ async function serveAsset(request: Request, env: Env): Promise<Response> {
       },
     });
   }
-  // Every other miss is a client route: render the shell the app boots from.
+
+  // Static Assets invokes the Worker only after this URL has already missed
+  // the asset manifest. Fetching the same URL here re-enters the Worker and
+  // ends in Cloudflare 1101. Every non-API, non-hashed miss is a client route,
+  // so ask only for the known index file; that real asset is served directly.
   const shell = await env.ASSETS.fetch(
     new Request(new URL("/index.html", request.url), request),
   );
-  if (!shell.ok) return response;
+  if (!shell.ok) return shell;
   return new Response(shell.body, {
     status: 200,
     headers: {


### PR DESCRIPTION
## Incident\n\n/editor and /analytics return Cloudflare error 1101 after the static-assets missing-file change. A miss reaches the Worker, which fetched the same missing URL from nv.ASSETS; that miss re-entered the Worker recursively. The root asset and APIs stayed healthy, so the deployment smoke check did not catch it.\n\n## Fix\n\n- return a definitive no-store 404 for missing /assets/* requests that reach the Worker\n- resolve client routes by fetching only the known /index.html asset\n- cover binding access in unit tests\n- probe /editor, /analytics, and a missing hashed asset after deployment\n\n## Validation\n\n- pnpm test:local worker/index.test.ts — 5 passed\n- pnpm gate:preflight -- --base origin/main — passed\n- full unit stage completed before urgent delivery — 333 files / 2158 tests passed\n- formatting and static typecheck passed\n\nTest-Impact: tests-updated