### PR TITLE
fix(worker): restore asset serving, which 1101'd the whole site

### DIFF
--- a/worker/index.test.ts
+++ b/worker/index.test.ts
@@ -56,19 +56,13 @@ describe("static asset serving", () => {
         fetch(request: Request) {
           const path = new URL(request.url).pathname;
           const body = files[path];
-          // With not_found_handling "none" the assets layer answers a miss
-          // with 404 and the request reaches the Worker. index.html is a
-          // real file, so the shell is something the Worker can ask for.
-          if (path === "/index.html") {
-            return Promise.resolve(
-              new Response("<!doctype html><html></html>", {
-                headers: { "content-type": "text/html" },
-              }),
-            );
-          }
+          // Production serves assets before the Worker and answers a miss
+          // with the shell, so that is what the binding hands back here.
           return Promise.resolve(
             body === undefined
-              ? new Response("Not found", { status: 404 })
+              ? new Response("<!doctype html><html></html>", {
+                  headers: { "content-type": "text/html" },
+                })
               : new Response(body, {
                   headers: { "content-type": "text/javascript" },
                 }),
@@ -135,11 +129,10 @@ describe("assets binding wiring", () => {
     const { assets } = wranglerConfig();
     expect(assets.run_worker_first).not.toContain("/assets/*");
     expect(assets.run_worker_first).toContain("/api/*");
-    // "single-page-application" answers a MISSING asset with the shell, and
-    // it does so in front of the Worker — so the 404 below could never run
-    // in production, however green its test was. "none" lets a miss fall
-    // through to the Worker, which is the only place that can tell a stale
-    // chunk name from a route.
-    expect(assets.not_found_handling).toBe("none");
+    // Both ways of routing an asset miss into the Worker end in 1101:
+    // run_worker_first re-enters on every request, and not_found_handling
+    // "none" re-enters on the fall-through, which took the whole site down
+    // in #498. The stale-chunk remedy therefore lives on the client.
+    expect(assets.not_found_handling).toBe("single-page-application");
   });
 });

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -138,38 +138,29 @@ export default {
  * every cache in the path to keep the wrong answer under a name that
  * promised to be immutable.
  *
- * The asset binding cannot make that distinction: `not_found_handling`
- * applies to every miss alike, and it answers before the Worker runs, so a
- * shell-for-everything setting makes the check below unreachable however
- * green its test looks. The binding is therefore set to `none` and the
- * choice is made here, where the path is known. Listing `/assets/*` in
- * `run_worker_first` would be the other way to arrive, and it is not: that
- * makes `env.ASSETS.fetch` re-enter this Worker, and every asset request
- * fails with 1101.
+ * Neither route into the Worker works today, and both were tried. Listing
+ * `/assets/*` in `run_worker_first` makes `env.ASSETS.fetch` re-enter this
+ * Worker: 1101 on every asset. Setting `not_found_handling` to `none` so a
+ * miss falls through does the same thing by another door — the fall-through
+ * re-enters, and the whole site answered 1101 until it was reverted (#498,
+ * reverted here). So this check only fires for a miss that reaches the
+ * Worker some other way, and the served-shell-for-a-missing-chunk problem
+ * of #493 needs a fix on the client, which is where the recovery action
+ * shipped.
  */
 async function serveAsset(request: Request, env: Env): Promise<Response> {
   const response = await env.ASSETS.fetch(request);
-  if (response.status !== 404) return response;
   const path = new URL(request.url).pathname;
-  if (path.startsWith("/assets/")) {
-    return new Response(`Not found: ${path}`, {
-      status: 404,
-      headers: {
-        "content-type": "text/plain; charset=utf-8",
-        "cache-control": "no-store",
-      },
-    });
-  }
-  // Every other miss is a client route: render the shell the app boots from.
-  const shell = await env.ASSETS.fetch(
-    new Request(new URL("/index.html", request.url), request),
+  if (!path.startsWith("/assets/")) return response;
+  const servedShell = (response.headers.get("content-type") ?? "").includes(
+    "text/html",
   );
-  if (!shell.ok) return response;
-  return new Response(shell.body, {
-    status: 200,
+  if (!servedShell) return response;
+  return new Response(`Not found: ${path}`, {
+    status: 404,
     headers: {
-      "content-type": "text/html; charset=utf-8",
-      "cache-control": "public, max-age=0, must-revalidate",
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "no-store",
     },
   });
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -16,10 +16,7 @@
   ],
   "assets": {
     "directory": "./apps/editor/dist",
-    // A miss falls through to the Worker, which tells a stale hashed asset
-    // (404) from a client route (the shell). The single-page-application
-    // setting answers both with the shell, before the Worker runs.
-    "not_found_handling": "none",
+    "not_found_handling": "single-page-application",
     "run_worker_first": ["/api/*"],
   },
   "durable_objects": {


### PR DESCRIPTION
## Outage, and its revert

#498 set `not_found_handling: "none"` so a missing hashed asset would fall through to the Worker and receive an honest 404. **It deployed and every path answered `error code 1101`** — `/editor`, `/mine`, and every asset. The site was down until this revert.

The fall-through re-enters the Worker exactly as listing `/assets/*` in `run_worker_first` does. That is the failure the existing test was written to prevent, and I walked into it through a second door the test did not name.

## What this restores

The wrangler configuration and the Worker's asset path go back to what was deployed before. The harness test goes back to modelling a miss as the shell, because that is what production does.

The configuration test now records **both** dead ends by name, so the next person does not spend an outage rediscovering them:

- `run_worker_first: ["/assets/*"]` → re-enters on every request.
- `not_found_handling: "none"` → re-enters on the fall-through (#498).

## What is kept

The half of #498 that helped the person in #493 and did not cause this: the crash screen recognises a stale-build failure, says the page is running an old version rather than implying the circuit broke, and offers **"Reload with a clean copy"** — discarding this app's shell caches and unregistering its service worker. That path is client-side and unaffected.

## What is still unsolved

The honest 404 for a stale chunk. It is now a known dead end twice over, and needs a route into the Worker that does not re-enter the assets binding — a hosting question rather than a code one. The client-side recovery is what protects users in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)