### PR TITLE
fix(text): preserve bound-label semantics in formulas

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -423,6 +423,79 @@ test("authors one validated formula through the canonical text editor", async ({
   expect(pdf.toString("latin1")).not.toContain("/Subtype /Image");
 });
 
+test("converts a non-equivalent Reference formula into attached literal text", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await awaitEditorReady(page);
+  await chooseComponent(page, "resistor");
+  await page.getByTestId("schematic-canvas").click({
+    position: { x: 360, y: 240 },
+  });
+  await page.keyboard.press("Escape");
+  await page.getByTestId("annotation-hit-instance-label-R1").dblclick();
+  await page.getByRole("button", { name: "Insert formula" }).click();
+
+  await page.getByRole("textbox", { name: "Formula LaTeX source" }).fill("R_1");
+  await page
+    .getByRole("dialog", { name: "Formula" })
+    .getByRole("button", { name: "Insert", exact: true })
+    .click();
+  await expect(page.getByRole("dialog", { name: "Formula" })).toHaveCount(0);
+  await expect(
+    page.getByRole("textbox", { name: "Canvas text editor" }).locator("sub"),
+  ).toHaveText("1");
+  await page.getByRole("button", { name: "Apply text changes" }).click();
+  await expect(
+    page.locator('[data-object-id="instance-label-R1"]'),
+  ).toContainText("R1");
+
+  await page.getByTestId("annotation-hit-instance-label-R1").dblclick();
+  await page.getByRole("button", { name: "Insert formula" }).click();
+
+  const latex = String.raw`R_1=4kT`;
+  await page.getByRole("textbox", { name: "Formula LaTeX source" }).fill(latex);
+  let prompt = "";
+  page.once("dialog", async (dialog) => {
+    prompt = dialog.message();
+    await dialog.accept();
+  });
+  await page
+    .getByRole("dialog", { name: "Formula" })
+    .getByRole("button", { name: "Insert", exact: true })
+    .click();
+
+  await expect
+    .poll(() => prompt)
+    .toContain("does not preserve the electrical name");
+  await expect(page.getByTestId("canvas-text-editor")).toHaveCount(0);
+  await expect(page.getByTestId("status")).toHaveText(
+    "Added a component formula annotation; the electrical Reference is unchanged",
+  );
+  await expect(
+    page.locator('[data-object-id^="instance-formula-"] [data-role="formula"]'),
+  ).toHaveCount(1);
+  await expect(
+    page.locator('[data-object-id="instance-label-R1"]'),
+  ).toContainText("R1");
+
+  const project = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(
+      "utf8",
+    ),
+  );
+  expect(project.documents[0].instances[0].reference).toBe("R1");
+  expect(
+    project.documents[0].annotations.find((annotation: { id: string }) =>
+      annotation.id.startsWith("instance-formula-"),
+    ),
+  ).toMatchObject({
+    kind: "instance-value",
+    content: { runs: [{ kind: "math", latex, display: "inline" }] },
+    anchor: { kind: "object", objectId: "R1" },
+  });
+});
+
 test("keeps unsafe formula source out of the Project", async ({ page }) => {
   await page.goto("/editor");
   await awaitEditorReady(page);

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -1453,6 +1453,7 @@ export function App({
     commitNetLabelEditing,
     commitPendingNetLabelDraft,
     commitTextEditing,
+    convertFormulaToAttachedLiteral,
     clearTextEditing,
     cancelAdditionalParameters,
     deleteSelectedRouteNetLabel,
@@ -1505,6 +1506,10 @@ export function App({
       );
     },
     commitCellPinAnnotation: editCellTerminalAnnotation,
+    nextId: (prefix) => {
+      uniqueSuffixCounter.current += 1;
+      return `${prefix}-${uniqueSuffixCounter.current}`;
+    },
   });
   function selectedVisualIds(kind: VisualSelectionKind): readonly string[] {
     switch (kind) {
@@ -5188,6 +5193,7 @@ export function App({
               setStatus("Cancelled text changes");
             },
             onTextDelete: deleteTextEditing,
+            onConvertFormulaToLiteral: convertFormulaToAttachedLiteral,
             ...(editingAnnotation &&
             isRoutedMarker(editingAnnotation) &&
             effectiveRouteAttachment(editingAnnotation)

--- a/apps/editor/src/canvas/editor-transient-preview-overlays.test.tsx
+++ b/apps/editor/src/canvas/editor-transient-preview-overlays.test.tsx
@@ -56,6 +56,7 @@ describe("editor transient preview overlays", () => {
           onTextCommit={vi.fn()}
           onTextCancel={vi.fn()}
           onTextDelete={vi.fn()}
+          onConvertFormulaToLiteral={vi.fn()}
         />
       </svg>,
     );

--- a/apps/editor/src/canvas/editor-transient-preview-overlays.tsx
+++ b/apps/editor/src/canvas/editor-transient-preview-overlays.tsx
@@ -89,6 +89,7 @@ export function EditorInteractionPreviews({
   onTextCommit,
   onTextCancel,
   onTextDelete,
+  onConvertFormulaToLiteral,
   onReverseCurrentArrow,
 }: {
   boxPreview: BoxPreview | null;
@@ -107,6 +108,7 @@ export function EditorInteractionPreviews({
   onTextCommit: () => void;
   onTextCancel: () => void;
   onTextDelete: () => void;
+  onConvertFormulaToLiteral?: CanvasTextEditorOverlayProps["onConvertFormulaToLiteral"];
   onReverseCurrentArrow?: () => void;
 }) {
   return (
@@ -155,6 +157,7 @@ export function EditorInteractionPreviews({
           onCommit={onTextCommit}
           onCancel={onTextCancel}
           onDelete={onTextDelete}
+          {...(onConvertFormulaToLiteral ? { onConvertFormulaToLiteral } : {})}
           {...(onReverseCurrentArrow ? { onReverseCurrentArrow } : {})}
         />
       ) : null}

--- a/apps/editor/src/features/properties/use-properties-editor.ts
+++ b/apps/editor/src/features/properties/use-properties-editor.ts
@@ -33,6 +33,7 @@ import {
   updateTextEditingSession,
 } from "../text-editing/text-editing";
 import type { TextEditingSession } from "../text-editing/text-editing";
+import { attachedInstanceFormulaAnnotation } from "../text-editing/bound-formula";
 import { planElectricalMarkerName } from "./electrical-marker-name";
 
 export interface InstancePropertyDraft {
@@ -139,6 +140,7 @@ export interface UsePropertiesEditorOptions {
   ) => SchematicEdit[];
   isCellPinAnnotation?: (annotation: Annotation) => boolean;
   commitCellPinAnnotation?: (annotation: Annotation, name: string) => boolean;
+  nextId: (prefix: string) => string;
 }
 
 /** Flat owner for property drafts, Net Labels, and canvas text sessions. */
@@ -844,6 +846,39 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     setTextEditing(null);
   };
 
+  const convertFormulaToAttachedLiteral = (
+    formula: RichTextDocument,
+  ): boolean => {
+    if (!textEditing || textEditing.owner !== "annotation") return false;
+    const source = options.document.annotations.find(
+      (annotation) => annotation.id === textEditing.id,
+    );
+    if (!source) return false;
+    const annotation = attachedInstanceFormulaAnnotation({
+      document: options.document,
+      source,
+      formula,
+      resolver: options.resolver,
+      id: options.nextId("instance-formula"),
+    });
+    if (!annotation) {
+      options.setStatus("This formula cannot be attached to the component");
+      return false;
+    }
+    if (
+      !options.transact([{ kind: "upsert_schematic_annotation", annotation }])
+        .ok
+    ) {
+      return false;
+    }
+    setTextEditing(null);
+    options.selectOnly("annotation", [annotation.id]);
+    options.setStatus(
+      "Added a component formula annotation; the electrical Reference is unchanged",
+    );
+    return true;
+  };
+
   return {
     additionalParameterDraft,
     additionalParameterDraftChanges: !sameAdditionalParameterDrafts(
@@ -861,6 +896,7 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     commitNetLabelEditing,
     commitPendingNetLabelDraft,
     commitTextEditing,
+    convertFormulaToAttachedLiteral,
     cancelAdditionalParameters,
     clearTextEditing: () => setTextEditing(null),
     deleteSelectedRouteNetLabel,

--- a/apps/editor/src/features/text-editing/bound-formula.test.ts
+++ b/apps/editor/src/features/text-editing/bound-formula.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { createEmptyProject } from "@icm/model";
+import type { Annotation, RichTextDocument } from "@icm/model";
+import { builtInSymbols, createProjectSymbolResolver } from "@icm/symbols";
+
+import {
+  attachedInstanceFormulaAnnotation,
+  boundFormulaPresentation,
+} from "./bound-formula";
+
+const formula = (latex: string): RichTextDocument => ({
+  runs: [{ kind: "math", latex, display: "inline" }],
+});
+
+describe("bound formula semantics", () => {
+  it("compiles only presentation-equivalent formulas for a bound name", () => {
+    expect(boundFormulaPresentation("M_1", "M1")).toEqual({
+      runs: [
+        { kind: "text", value: "M" },
+        {
+          kind: "span",
+          style: "subscript",
+          children: [{ kind: "text", value: "1" }],
+        },
+      ],
+    });
+    expect(
+      boundFormulaPresentation(String.raw`\overline{I_n^2}`, "In2"),
+    ).not.toBeNull();
+    expect(boundFormulaPresentation("M_1=4kT", "M1")).toBeNull();
+    expect(boundFormulaPresentation(String.raw`\frac{M}{1}`, "M1")).toBeNull();
+  });
+
+  it("converts a mismatched Reference formula into literal instance-attached text", () => {
+    const project = createEmptyProject("formula", "Formula");
+    const document = project.documents[0]!;
+    document.instances.push({
+      id: "M1",
+      reference: "M1",
+      symbolId: "nmos",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0,
+        mirror: "none",
+      },
+      netlist: {
+        binding: { kind: "model", deviceClass: "mos", name: "nmos" },
+        parameters: {},
+      },
+    });
+    const source: Annotation = {
+      id: "instance-label-M1",
+      kind: "instance-label",
+      binding: { kind: "instance-reference", instanceId: "M1" },
+      anchor: {
+        kind: "object",
+        objectId: "M1",
+        localOffset: { x: 30, y: -20 },
+        fallbackPosition: { x: 130, y: 80 },
+      },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    };
+    const content = formula(String.raw`\overline{I_n^2}=4kT\gamma g_m`);
+    const annotation = attachedInstanceFormulaAnnotation({
+      document,
+      source,
+      formula: content,
+      resolver: createProjectSymbolResolver(project, builtInSymbols),
+      id: "instance-formula-1",
+    });
+
+    expect(annotation).toMatchObject({
+      id: "instance-formula-1",
+      kind: "instance-value",
+      content,
+      anchor: { kind: "object", objectId: "M1" },
+    });
+    expect(annotation).not.toHaveProperty("binding");
+    expect(document.instances[0]!.reference).toBe("M1");
+  });
+});

--- a/apps/editor/src/features/text-editing/bound-formula.ts
+++ b/apps/editor/src/features/text-editing/bound-formula.ts
@@ -1,0 +1,205 @@
+import {
+  defaultInstanceLabelPlacement,
+  resolveDocumentStyleProfile,
+} from "@icm/derived";
+import { flattenRichText, normalizeRichText } from "@icm/model";
+import type {
+  Annotation,
+  RichTextDocument,
+  RichTextRun,
+  SchematicDocument,
+} from "@icm/model";
+import type { SymbolResolver } from "@icm/symbols";
+
+/**
+ * Formula source is presentation, not an electrical identifier grammar. A
+ * bound label can keep a formula only when its canonical plain projection is
+ * exactly the name it already owns; every other formula must become literal
+ * attached text instead of leaking LaTeX into Instance.reference.
+ */
+export function boundFormulaPresentation(
+  latex: string,
+  semanticText: string,
+): RichTextDocument | null {
+  const parser = new BoundNameFormulaParser(latex);
+  const runs = parser.parse();
+  if (!runs) return null;
+  const document = normalizeRichText({ runs });
+  return flattenRichText(document).trim() === semanticText.trim()
+    ? document
+    : null;
+}
+
+const GREEK_COMMANDS: Readonly<Record<string, string>> = {
+  alpha: "α",
+  beta: "β",
+  gamma: "γ",
+  delta: "δ",
+  epsilon: "ε",
+  theta: "θ",
+  lambda: "λ",
+  mu: "μ",
+  pi: "π",
+  phi: "φ",
+  omega: "ω",
+  Delta: "Δ",
+  Omega: "Ω",
+};
+
+/**
+ * Deliberately small LaTeX projection for a bound electrical name. It accepts
+ * only syntax that canonical RichText can represent without adding semantic
+ * characters. Unsupported mathematics is not guessed.
+ */
+class BoundNameFormulaParser {
+  private index = 0;
+
+  constructor(private readonly source: string) {}
+
+  parse(): RichTextRun[] | null {
+    const runs = this.parseRuns(null);
+    return runs && this.index === this.source.length && runs.length > 0
+      ? runs
+      : null;
+  }
+
+  private parseRuns(stop: "}" | null): RichTextRun[] | null {
+    const runs: RichTextRun[] = [];
+    let text = "";
+    const flush = (): void => {
+      if (!text) return;
+      runs.push({ kind: "text", value: text });
+      text = "";
+    };
+
+    while (this.index < this.source.length) {
+      const character = this.source[this.index]!;
+      if (character === "}") {
+        if (stop !== "}") return null;
+        flush();
+        this.index += 1;
+        return runs;
+      }
+      if (/\s/u.test(character)) {
+        this.index += 1;
+        continue;
+      }
+      if (character === "{") {
+        flush();
+        this.index += 1;
+        const group = this.parseRuns("}");
+        if (!group) return null;
+        runs.push(...group);
+        continue;
+      }
+      if (character === "_" || character === "^") {
+        flush();
+        this.index += 1;
+        const children = this.parseArgument();
+        if (!children?.length) return null;
+        runs.push({
+          kind: "span",
+          style: character === "_" ? "subscript" : "superscript",
+          children,
+        });
+        continue;
+      }
+      if (character === "\\") {
+        flush();
+        const command = this.parseCommand();
+        if (!command) return null;
+        runs.push(...command);
+        continue;
+      }
+      text += character;
+      this.index += 1;
+    }
+    if (stop) return null;
+    flush();
+    return runs;
+  }
+
+  private parseArgument(): RichTextRun[] | null {
+    if (this.source[this.index] === "{") {
+      this.index += 1;
+      return this.parseRuns("}");
+    }
+    if (this.index >= this.source.length) return null;
+    if (this.source[this.index] === "\\") return this.parseCommand();
+    const value = this.source[this.index]!;
+    this.index += 1;
+    return [{ kind: "text", value }];
+  }
+
+  private parseCommand(): RichTextRun[] | null {
+    this.index += 1;
+    const start = this.index;
+    while (/[A-Za-z]/u.test(this.source[this.index] ?? "")) this.index += 1;
+    const command = this.source.slice(start, this.index);
+    if (!command) {
+      const literal = this.source[this.index];
+      if (!literal) return null;
+      this.index += 1;
+      return [{ kind: "text", value: literal }];
+    }
+    const greek = GREEK_COMMANDS[command];
+    if (greek) return [{ kind: "text", value: greek }];
+    const style =
+      command === "overline" || command === "bar"
+        ? "overbar"
+        : command === "mathbf"
+          ? "bold"
+          : command === "mathit"
+            ? "italic"
+            : null;
+    if (!style) return null;
+    const children = this.parseArgument();
+    return children?.length ? [{ kind: "span", style, children }] : null;
+  }
+}
+
+/** Build the literal, object-attached formula chosen by the mismatch prompt. */
+export function attachedInstanceFormulaAnnotation(options: {
+  document: SchematicDocument;
+  source: Annotation;
+  formula: RichTextDocument;
+  resolver: SymbolResolver;
+  id: string;
+}): Annotation | null {
+  const { document, source, formula, resolver, id } = options;
+  const binding = source.binding;
+  if (binding?.kind !== "instance-reference") return null;
+  const instance = document.instances.find(
+    (candidate) => candidate.id === binding.instanceId,
+  );
+  if (!instance?.placement) return null;
+  const symbol = resolver.resolve(instance.symbolId, instance.symbolVariantId);
+  if (!symbol) return null;
+  const placement = defaultInstanceLabelPlacement(
+    instance,
+    symbol,
+    resolveDocumentStyleProfile(document.presentation),
+    document.presentation.grid,
+    "value",
+  );
+  if (!placement) return null;
+
+  return {
+    id,
+    kind: "instance-value",
+    content: formula,
+    anchor: {
+      kind: "object",
+      objectId: instance.id,
+      localOffset: {
+        x: placement.position.x - instance.placement.position.x,
+        y: placement.position.y - instance.placement.position.y,
+      },
+      fallbackPosition: placement.position,
+    },
+    alignment: placement.alignment,
+    rotation: 0,
+    locked: false,
+    sizeScale: source.sizeScale ?? 1,
+  };
+}

--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 
 import type { DerivedRect, GridRect } from "@icm/model";
+import { flattenRichText } from "@icm/model";
 
 import { RichTextEditor } from "./rich-text-editor";
 import type { TextEditingSession } from "./text-editing";
@@ -25,6 +26,7 @@ export interface CanvasTextEditorOverlayProps {
   onCancel(): void;
   onDelete(): void;
   onReverseCurrentArrow?(): void;
+  onConvertFormulaToLiteral?(formula: TextEditingSession["content"]): boolean;
 }
 
 /**
@@ -123,6 +125,7 @@ export function CanvasTextEditorOverlay({
   onCancel,
   onDelete,
   onReverseCurrentArrow,
+  onConvertFormulaToLiteral,
 }: CanvasTextEditorOverlayProps) {
   const anchorRef = useRef<SVGGElement | null>(null);
   const [canvasSize, setCanvasSize] = useState<{
@@ -174,6 +177,11 @@ export function CanvasTextEditorOverlay({
       : null,
     measuredLayoutHeight,
   );
+  const sourceOnly =
+    session.bound &&
+    session.bindingKind !== "instance-reference" &&
+    session.bindingKind !== "net-name" &&
+    session.bindingKind !== "cell-terminal-name";
 
   return (
     <g
@@ -202,12 +210,7 @@ export function CanvasTextEditorOverlay({
           disabled={disabled}
           sizeScale={session.sizeScale}
           alignment={session.alignment}
-          sourceOnly={
-            session.bound &&
-            session.bindingKind !== "instance-reference" &&
-            session.bindingKind !== "net-name" &&
-            session.bindingKind !== "cell-terminal-name"
-          }
+          sourceOnly={sourceOnly}
           multiline={!session.bound}
           onChange={(content) => onUpdate({ content })}
           onSizeChange={(sizeScale) => onUpdate({ sizeScale })}
@@ -215,6 +218,13 @@ export function CanvasTextEditorOverlay({
           onCommit={onCommit}
           onCancel={onCancel}
           onDelete={onDelete}
+          {...(session.bound && !sourceOnly
+            ? { formulaSemanticText: flattenRichText(session.content) }
+            : {})}
+          {...(session.bindingKind === "instance-reference" &&
+          onConvertFormulaToLiteral
+            ? { onConvertFormulaToLiteral }
+            : {})}
           onLayoutHeightChange={handleLayoutHeightChange}
           {...(onReverseCurrentArrow ? { onReverseCurrentArrow } : {})}
         />

--- a/apps/editor/src/features/text-editing/rich-text-editor.tsx
+++ b/apps/editor/src/features/text-editing/rich-text-editor.tsx
@@ -18,6 +18,8 @@ import {
 } from "@icm/math-typesetting/cache";
 import type { RichTextDocument, RichTextRun } from "@icm/model";
 
+import { boundFormulaPresentation } from "./bound-formula";
+
 export interface RichTextEditorProps {
   targetKey: string;
   content: RichTextDocument;
@@ -40,6 +42,10 @@ export interface RichTextEditorProps {
   onCancel(): void;
   onDelete(): void;
   onReverseCurrentArrow?(): void;
+  /** Electrical name represented by this editor, when Formula is constrained. */
+  formulaSemanticText?: string;
+  /** Convert a non-equivalent Formula into literal attached text. */
+  onConvertFormulaToLiteral?(formula: RichTextDocument): boolean;
   onLayoutHeightChange?(height: number): void;
 }
 
@@ -436,6 +442,8 @@ export function RichTextEditor({
   onCancel,
   onDelete,
   onReverseCurrentArrow,
+  formulaSemanticText,
+  onConvertFormulaToLiteral,
   onLayoutHeightChange,
 }: RichTextEditorProps) {
   const shellRef = useRef<HTMLDivElement>(null);
@@ -610,9 +618,33 @@ export function RichTextEditor({
     const next: RichTextDocument = {
       runs: [{ kind: "math", latex, display: formulaDisplay }],
     };
-    onChange(next);
+    const boundPresentation =
+      formulaSemanticText === undefined
+        ? null
+        : boundFormulaPresentation(latex, formulaSemanticText);
+    if (formulaSemanticText !== undefined && !boundPresentation) {
+      if (!onConvertFormulaToLiteral) {
+        setFormulaError(
+          `A bound electrical name formula must preserve “${formulaSemanticText}”`,
+        );
+        return;
+      }
+      const convert = window.confirm(
+        `This formula does not preserve the electrical name “${formulaSemanticText}”. Add it as a component formula annotation instead? The electrical name will stay unchanged.`,
+      );
+      if (!convert) return;
+      if (!onConvertFormulaToLiteral(next)) {
+        setFormulaError("This formula could not be attached to the component");
+        return;
+      }
+      setFormulaOpen(false);
+      setFormulaError(null);
+      return;
+    }
+    const inserted = boundPresentation ?? next;
+    onChange(inserted);
     if (editableRef.current) {
-      editableRef.current.innerHTML = toEditableHtml(next);
+      editableRef.current.innerHTML = toEditableHtml(inserted);
     }
     setFormulaOpen(false);
     setFormulaError(null);

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -412,6 +412,16 @@ math profile, and replaces the current RichText document with one atomic
 formula only after validation succeeds. Ordinary bold, italic, script,
 overbar, alignment, multiline, and symbol controls remain the same RichText
 system; formulas do not create an Additional Text or Annotation side channel.
+For a semantic name binding, Formula Insert checks the proposed formula before
+it changes the editing session. A bounded formula made only from groups,
+scripts, overbar, bold/italic wrappers, and supported Greek symbols is compiled
+to the same canonical RichText presentation when its flattened characters
+still equal the bound name. A non-equivalent Instance Reference formula offers to become a
+literal formula annotation attached at the Instance's value-label position;
+accepting keeps `Instance.reference` unchanged. Declining leaves the Formula
+editor open. Other bound electrical names refuse a non-equivalent formula in
+the Formula panel. Ordinary character edits and formatting commands do not use
+this formula-only decision path.
 
 ## Files, recovery, and replacement
 

--- a/docs/specs/visual-language.md
+++ b/docs/specs/visual-language.md
@@ -93,6 +93,13 @@ Formula SVG is embedded into the same formal
 scene used by canvas, SVG, PNG, and vector PDF; it is never rasterized or
 persisted.
 
+An ordinary RichText overbar is one explicit decoration over its authored
+span. A subscript/superscript stack under that span does not inherit separate
+bars, and text before or after the span neither breaks nor extends the bar.
+The complete line is measured before start, center, or end alignment is
+resolved, so continuation text cannot shift the anchor or escape export
+bounds.
+
 Derived visual diagnostics cover unplaced or unresolved symbols, symbol and
 label overlap, short route segments, ambiguous Junction dots, unsatisfied
 layout constraints, and optional export-page bounds. Diagnostics never mutate

--- a/packages/render-svg/src/positioned-rich-text.test.ts
+++ b/packages/render-svg/src/positioned-rich-text.test.ts
@@ -35,7 +35,10 @@ function overbarExpression(options?: {
   };
 }
 
-function render(document: RichTextDocument) {
+function render(
+  document: RichTextDocument,
+  alignment: "start" | "middle" | "end" = "start",
+) {
   const rendered = renderPositionedOverbarScriptDocument(
     document,
     razaviTextbookProfile,
@@ -43,7 +46,7 @@ function render(document: RichTextDocument) {
       x: 100,
       y: 50,
       fontSize: 20,
-      alignment: "start",
+      alignment,
     },
   );
   expect(rendered).not.toBeNull();
@@ -390,5 +393,55 @@ describe("an overbar followed by more of the line", () => {
     const rendered = render(meanValueThenEquation());
     expect(rendered.tspans).toContain("=4kT");
     expect(rendered.tspans).toContain("m");
+  });
+  it("positions one exact bar when ordinary text precedes the expression", () => {
+    const document = meanValueThenEquation();
+    const bold = document.runs[0];
+    if (bold?.kind !== "span") throw new Error("Expected bold wrapper");
+    const italic = bold.children[0];
+    if (italic?.kind !== "span") throw new Error("Expected italic wrapper");
+    italic.children.unshift({ kind: "text", value: "S=" });
+
+    const rendered = render(document);
+    expect(rendered.decorations.match(/<line\b/g)).toHaveLength(1);
+    expect(rendered.tspans).toContain("S=");
+    expect(rendered.tspans).toContain("=4kT");
+    expect(rendered.tspans).not.toContain("text-decoration");
+  });
+
+  it.each([["middle", 100] as const, ["end", 100] as const])(
+    "aligns the complete continued line for %s alignment",
+    (alignment, x) => {
+      const rendered = render(meanValueThenEquation(), alignment);
+      const base = tagAttributes(
+        rendered.tspans,
+        "tspan",
+        'data-text-run="base"',
+      );
+      const startX = numericAttribute(base, "x");
+
+      expect(
+        alignment === "middle"
+          ? startX + rendered.width / 2
+          : startX + rendered.width,
+      ).toBeCloseTo(x, 6);
+    },
+  );
+
+  it("measures styled continuation runs with the shared RichText layout", () => {
+    const document = meanValueThenEquation();
+    const italic = document.runs[0];
+    if (italic?.kind !== "span") throw new Error("Expected bold wrapper");
+    const inner = italic.children[0];
+    if (inner?.kind !== "span") throw new Error("Expected italic wrapper");
+    inner.children.splice(1, inner.children.length - 1, {
+      kind: "fraction",
+      numerator: { runs: [{ kind: "text", value: "gm" }] },
+      denominator: { runs: [{ kind: "text", value: "ro" }] },
+    });
+
+    const rendered = render(document);
+    expect(rendered.width).toBeGreaterThan(0);
+    expect(rendered.tspans).toContain('data-text-run="fraction"');
   });
 });

--- a/packages/render-svg/src/positioned-rich-text.ts
+++ b/packages/render-svg/src/positioned-rich-text.ts
@@ -1,4 +1,4 @@
-import { richTextAdvanceEm } from "@icm/derived";
+import { measureRichTextDocument, richTextAdvanceEm } from "@icm/derived";
 import type { SchematicStyleProfile } from "@icm/derived";
 import type { RichTextDocument, RichTextRun } from "@icm/model";
 
@@ -170,23 +170,25 @@ export function renderPositionedOverbarScriptDocument(
     italic: options.defaultItalic ?? false,
     bold: options.defaultBold ?? false,
   });
-  if (
-    outer.runs.length === 0 ||
-    outer.runs[0]!.kind !== "span" ||
-    outer.runs[0]!.style !== "overbar"
-  ) {
-    return null;
-  }
+  const overbarIndexes = outer.runs.flatMap((run, index) =>
+    run.kind === "span" && run.style === "overbar" ? [index] : [],
+  );
+  if (overbarIndexes.length !== 1) return null;
 
-  const overbar = outer.runs[0] as Extract<RichTextRun, { kind: "span" }>;
-  // Anything after the barred name is ordinary inline text. It has to be
+  const overbarIndex = overbarIndexes[0]!;
+  const overbar = outer.runs[overbarIndex] as Extract<
+    RichTextRun,
+    { kind: "span" }
+  >;
+  // Ordinary text may precede or follow the barred expression. It has to be
   // rendered here rather than left to the generic path, because the generic
   // path draws the bar with CSS `text-decoration: overline`, which SVG
   // inherits into every nested tspan: the subscript and the superscript each
   // grow a bar of their own, at their own size and height. That is the defect
   // in issue #495, and it appeared the moment someone appended `=4kT` to a
   // name that had been rendering correctly on its own.
-  const continuation = outer.runs.slice(1);
+  const prefix = outer.runs.slice(0, overbarIndex);
+  const continuation = outer.runs.slice(overbarIndex + 1);
   const expression = unwrapWholeTextStyles(overbar.children, outer.style);
   if (expression.runs.length === 0) return null;
 
@@ -233,22 +235,39 @@ export function renderPositionedOverbarScriptDocument(
     scripts.length > 0
       ? options.fontSize * profile.typography.subscriptHorizontalGapEm
       : 0;
-  const width =
+  const nameWidth =
     baseWidth + attachmentGap + Math.max(subscriptWidth, superscriptWidth);
+  const metrics = {
+    fontSize: options.fontSize,
+    lineHeight: profile.typography.lineHeight,
+    subscriptScale: profile.typography.subscriptScale,
+    subscriptBaselineShiftEm: profile.typography.subscriptBaselineShiftEm,
+    subscriptHorizontalGapEm: profile.typography.subscriptHorizontalGapEm,
+  };
+  const prefixWidth =
+    prefix.length > 0
+      ? measureRichTextDocument({ runs: prefix }, metrics).width
+      : 0;
+  const continuationWidth =
+    continuation.length > 0
+      ? measureRichTextDocument({ runs: continuation }, metrics).width
+      : 0;
+  const width = prefixWidth + nameWidth + continuationWidth;
   const startX =
     options.alignment === "start"
       ? options.x
       : options.alignment === "end"
         ? options.x - width
         : options.x - width / 2;
-  const scriptX = startX + baseWidth + attachmentGap;
+  const nameStartX = startX + prefixWidth;
+  const scriptX = nameStartX + baseWidth + attachmentGap;
   const shift =
     options.fontSize * scale * profile.typography.subscriptBaselineShiftEm;
   const superscriptY = options.y - shift;
   const subscriptY = options.y + shift;
 
   const baseTspans = renderSegments(base, {
-    x: startX,
+    x: nameStartX,
     y: options.y,
     fontSize: options.fontSize,
     scale: 1,
@@ -287,39 +306,37 @@ export function renderPositionedOverbarScriptDocument(
     : baseTop;
   const lineY = Math.min(baseTop, superscriptTop) - overbarGap;
   const strokeWidth = Math.max(1, profile.strokes.annotation);
-  // The bar belongs to the name, so it ends where the name ends. `width`
-  // grows to cover the continuation, but the line does not.
-  const nameWidth = width;
-  const continuationTspans =
-    continuation.length > 0
-      ? `<tspan x="${number(startX + nameWidth)}" y="${number(options.y)}">${renderRichTextDocument(
-          { runs: continuation },
+  // The bar belongs to the name, so it starts after any prefix and ends where
+  // the name ends. Alignment belongs to the complete line.
+  const prefixTspans =
+    prefix.length > 0
+      ? `<tspan x="${number(startX)}" y="${number(options.y)}">${renderRichTextDocument(
+          { runs: prefix },
           profile,
           {
-            lineOriginX: startX + nameWidth,
+            lineOriginX: startX,
             fontSize: options.fontSize,
             defaultBold: outer.style.bold,
             defaultItalic: outer.style.italic,
           },
         )}</tspan>`
       : "";
-  const continuationWidth =
+  const continuationTspans =
     continuation.length > 0
-      ? richTextAdvanceEm(plainText(continuation)) * options.fontSize
-      : 0;
+      ? `<tspan x="${number(nameStartX + nameWidth)}" y="${number(options.y)}">${renderRichTextDocument(
+          { runs: continuation },
+          profile,
+          {
+            lineOriginX: nameStartX + nameWidth,
+            fontSize: options.fontSize,
+            defaultBold: outer.style.bold,
+            defaultItalic: outer.style.italic,
+          },
+        )}</tspan>`
+      : "";
   return {
-    width: nameWidth + continuationWidth,
-    tspans: `<tspan data-text-run="overbar">${baseTspans}<tspan data-text-run="script-stack">${orderedScripts}</tspan></tspan>${continuationTspans}`,
-    decorations: `<line data-text-decoration="overbar" x1="${number(startX)}" y1="${number(lineY)}" x2="${number(startX + nameWidth)}" y2="${number(lineY)}" stroke="${options.color ?? profile.foreground}" stroke-width="${number(strokeWidth)}"/>`,
+    width,
+    tspans: `${prefixTspans}<tspan data-text-run="overbar">${baseTspans}<tspan data-text-run="script-stack">${orderedScripts}</tspan></tspan>${continuationTspans}`,
+    decorations: `<line data-text-decoration="overbar" x1="${number(nameStartX)}" y1="${number(lineY)}" x2="${number(nameStartX + nameWidth)}" y2="${number(lineY)}" stroke="${options.color ?? profile.foreground}" stroke-width="${number(strokeWidth)}"/>`,
   };
-}
-
-/** Flat text of a run list, for advancing the pen past the continuation. */
-function plainText(runs: readonly RichTextRun[]): string {
-  let output = "";
-  for (const run of runs) {
-    if (run.kind === "text") output += run.value;
-    else if (run.kind === "span") output += plainText(run.children);
-  }
-  return output;
 }


### PR DESCRIPTION
## Summary

- compile formula input into canonical RichText only when it preserves the bound electrical name
- offer to create an attached formula note when an `fx` expression is not a legal/equivalent instance Reference, without mutating `Instance.reference`
- complete the overbar renderer from #500 for prefixes, full-line alignment, and styled/fraction continuations
- document the semantic boundary between instance identity and formula presentation

## Behavior

- `R_1` on Reference `R1`: accepted as presentation; electrical Reference remains `R1`
- `R_1=4kT` on Reference `R1`: confirmation offers an attached formula note; electrical Reference remains `R1`
- prompts occur only from Formula Insert, not ordinary text editing

## Validation

- `pnpm gate:preflight -- --base origin/main`
- `pnpm gate:full`
  - 336 unit-test files / 2169 tests passed (5 skipped)
  - all workspace builds, release checks, goldens, performance checks, and smoke checks passed
  - 316/316 Playwright tests passed

Closes #495