### PR TITLE
fix: preserve complete formula SVG output

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -455,25 +455,45 @@ test("converts a non-equivalent Reference formula into attached literal text", a
 
   const latex = String.raw`R_1=4kT`;
   await page.getByRole("textbox", { name: "Formula LaTeX source" }).fill(latex);
-  let prompt = "";
+  let nativeDialogOpened = false;
   page.once("dialog", async (dialog) => {
-    prompt = dialog.message();
-    await dialog.accept();
+    nativeDialogOpened = true;
+    await dialog.dismiss();
   });
   await page
     .getByRole("dialog", { name: "Formula" })
     .getByRole("button", { name: "Insert", exact: true })
     .click();
 
-  await expect
-    .poll(() => prompt)
-    .toContain("does not preserve the electrical name");
+  const confirmation = page.getByTestId("formula-conversion-confirmation");
+  await expect(confirmation).toContainText(
+    "Formula does not match the electrical name",
+  );
+  await expect(confirmation).toContainText(
+    "Reference “R1” will remain unchanged",
+  );
+  expect(nativeDialogOpened).toBe(false);
+  await confirmation.getByRole("button", { name: "Keep editing" }).click();
+  await expect(confirmation).toHaveCount(0);
+  await expect(page.getByRole("dialog", { name: "Formula" })).toBeVisible();
+  await page
+    .getByRole("dialog", { name: "Formula" })
+    .getByRole("button", { name: "Insert", exact: true })
+    .click();
+  await confirmation
+    .getByRole("button", { name: "Add as formula note" })
+    .click();
   await expect(page.getByTestId("canvas-text-editor")).toHaveCount(0);
   await expect(page.getByTestId("status")).toHaveText(
     "Added a component formula annotation; the electrical Reference is unchanged",
   );
   await expect(
     page.locator('[data-object-id^="instance-formula-"] [data-role="formula"]'),
+  ).toHaveCount(1);
+  await expect(
+    page.locator(
+      '[data-object-id^="instance-formula-"] [data-role="formula"] [data-latex="="]',
+    ),
   ).toHaveCount(1);
   await expect(
     page.locator('[data-object-id="instance-label-R1"]'),

--- a/apps/editor/src/features/text-editing/rich-text-editor.tsx
+++ b/apps/editor/src/features/text-editing/rich-text-editor.tsx
@@ -460,6 +460,8 @@ export function RichTextEditor({
     existingFormula?.display ?? "inline",
   );
   const [formulaError, setFormulaError] = useState<string | null>(null);
+  const [pendingFormulaConversion, setPendingFormulaConversion] =
+    useState<RichTextDocument | null>(null);
 
   useLayoutEffect(() => {
     const shell = shellRef.current;
@@ -600,7 +602,20 @@ export function RichTextEditor({
     setFormulaDraft(formula?.latex ?? (selection || "V_{OUT}"));
     setFormulaDisplay(formula?.display ?? "inline");
     setFormulaError(null);
+    setPendingFormulaConversion(null);
     setFormulaOpen(true);
+  };
+
+  const closeFormulaEditor = (): void => {
+    setFormulaOpen(false);
+    setFormulaError(null);
+    setPendingFormulaConversion(null);
+  };
+
+  const updateFormulaDraft = (value: string): void => {
+    setFormulaDraft(value);
+    setFormulaError(null);
+    setPendingFormulaConversion(null);
   };
 
   const applyFormula = async (): Promise<void> => {
@@ -629,16 +644,8 @@ export function RichTextEditor({
         );
         return;
       }
-      const convert = window.confirm(
-        `This formula does not preserve the electrical name “${formulaSemanticText}”. Add it as a component formula annotation instead? The electrical name will stay unchanged.`,
-      );
-      if (!convert) return;
-      if (!onConvertFormulaToLiteral(next)) {
-        setFormulaError("This formula could not be attached to the component");
-        return;
-      }
-      setFormulaOpen(false);
       setFormulaError(null);
+      setPendingFormulaConversion(next);
       return;
     }
     const inserted = boundPresentation ?? next;
@@ -646,8 +653,17 @@ export function RichTextEditor({
     if (editableRef.current) {
       editableRef.current.innerHTML = toEditableHtml(inserted);
     }
-    setFormulaOpen(false);
-    setFormulaError(null);
+    closeFormulaEditor();
+  };
+
+  const confirmFormulaConversion = (): void => {
+    if (!pendingFormulaConversion || !onConvertFormulaToLiteral) return;
+    if (!onConvertFormulaToLiteral(pendingFormulaConversion)) {
+      setFormulaError("This formula could not be attached to the component");
+      setPendingFormulaConversion(null);
+      return;
+    }
+    closeFormulaEditor();
   };
 
   return (
@@ -882,7 +898,7 @@ export function RichTextEditor({
             <button
               type="button"
               aria-label="Close formula editor"
-              onClick={() => setFormulaOpen(false)}
+              onClick={closeFormulaEditor}
             >
               ×
             </button>
@@ -896,7 +912,7 @@ export function RichTextEditor({
               <FormulaMathfield
                 ref={formulaMathfieldRef}
                 value={formulaDraft}
-                onChange={setFormulaDraft}
+                onChange={updateFormulaDraft}
               />
             </section>
             <div
@@ -956,7 +972,7 @@ export function RichTextEditor({
                 aria-label="Formula LaTeX source"
                 spellCheck={false}
                 rows={3}
-                onChange={(event) => setFormulaDraft(event.target.value)}
+                onChange={(event) => updateFormulaDraft(event.target.value)}
               />
             </label>
             {formulaError ? (
@@ -965,31 +981,68 @@ export function RichTextEditor({
               </div>
             ) : null}
           </div>
-          <div className="rich-text-formula-actions">
-            <div className="rich-text-formula-display-toggle">
+          {pendingFormulaConversion && formulaSemanticText !== undefined ? (
+            <div
+              className="rich-text-formula-conversion"
+              data-testid="formula-conversion-confirmation"
+              role="alert"
+            >
+              <div>
+                <strong>Formula does not match the electrical name</strong>
+                <span>
+                  Reference “{formulaSemanticText}” will remain unchanged. Add
+                  this expression as a component formula note?
+                </span>
+              </div>
+              <div className="rich-text-formula-conversion-actions">
+                <button
+                  type="button"
+                  onClick={() => setPendingFormulaConversion(null)}
+                >
+                  Keep editing
+                </button>
+                <button
+                  className="rich-text-formula-primary-action"
+                  type="button"
+                  onClick={confirmFormulaConversion}
+                >
+                  Add as formula note
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="rich-text-formula-actions">
+              <div className="rich-text-formula-display-toggle">
+                <button
+                  type="button"
+                  aria-pressed={formulaDisplay === "inline"}
+                  onClick={() => {
+                    setFormulaDisplay("inline");
+                    setPendingFormulaConversion(null);
+                  }}
+                >
+                  Inline
+                </button>
+                <button
+                  type="button"
+                  aria-pressed={formulaDisplay === "block"}
+                  onClick={() => {
+                    setFormulaDisplay("block");
+                    setPendingFormulaConversion(null);
+                  }}
+                >
+                  Display
+                </button>
+              </div>
               <button
+                className="rich-text-formula-primary-action"
                 type="button"
-                aria-pressed={formulaDisplay === "inline"}
-                onClick={() => setFormulaDisplay("inline")}
+                onClick={() => void applyFormula()}
               >
-                Inline
-              </button>
-              <button
-                type="button"
-                aria-pressed={formulaDisplay === "block"}
-                onClick={() => setFormulaDisplay("block")}
-              >
-                Display
+                Insert
               </button>
             </div>
-            <button
-              className="rich-text-formula-primary-action"
-              type="button"
-              onClick={() => void applyFormula()}
-            >
-              Insert
-            </button>
-          </div>
+          )}
         </div>
       ) : null}
       {sourceOnly ? (

--- a/apps/editor/src/styles/editor-canvas.css
+++ b/apps/editor/src/styles/editor-canvas.css
@@ -958,6 +958,35 @@
   background: var(--icm-accent);
 }
 
+.rich-text-formula-conversion {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.55rem;
+  border-top: 1px solid var(--icm-border);
+  background: var(--icm-surface-muted);
+}
+
+.rich-text-formula-conversion > div:first-child {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.rich-text-formula-conversion strong {
+  font-size: var(--icm-font-sm);
+}
+
+.rich-text-formula-conversion span {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  line-height: 1.35;
+}
+
+.rich-text-formula-conversion-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.4rem;
+}
+
 .rich-text-editable [data-rich-text-script-stack] > sup {
   top: -0.28em;
 }

--- a/packages/math-typesetting/src/index.test.ts
+++ b/packages/math-typesetting/src/index.test.ts
@@ -28,6 +28,10 @@ const corpus = [
   String.raw`\begin{cases}V_{OH},&x>0\\V_{OL},&x\leq0\end{cases}`,
 ];
 
+function countSvgTags(svg: string, closing = false): number {
+  return [...svg.matchAll(closing ? /<\/svg>/g : /<svg\b/g)].length;
+}
+
 describe("Analog Canvas formula typesetter", () => {
   it("renders the formula corpus as standalone path-based SVG", async () => {
     const typesetter = createFormulaTypesetter();
@@ -43,10 +47,49 @@ describe("Analog Canvas formula typesetter", () => {
       );
       expect(result.artifact.svg).toContain("<svg");
       expect(result.artifact.svg).toContain("<path");
+      expect(countSvgTags(result.artifact.svg)).toBe(
+        countSvgTags(result.artifact.svg, true),
+      );
       expect(result.artifact.svg).not.toContain("<foreignObject");
       expect(result.artifact.svg).not.toContain("<image");
       expect(result.artifact.svg).not.toMatch(/(?:href|xlink:href)=/);
     }
+  });
+
+  it("keeps the complete expression when MathJax emits nested SVG glyphs", async () => {
+    const typesetter = createFormulaTypesetter();
+    const prefix = typesetter.typesetSync({
+      ...baseRequest,
+      latex: String.raw`\overline{I_1^{n}}`,
+    });
+    const expression = typesetter.typesetSync({
+      ...baseRequest,
+      latex: String.raw`\overline{I_1^{n}}=4kt`,
+    });
+
+    expect(prefix).toMatchObject({ ok: true });
+    expect(expression).toMatchObject({ ok: true });
+    if (!prefix.ok || !expression.ok) return;
+
+    expect(expression.artifact.width).toBeGreaterThan(prefix.artifact.width);
+    expect(expression.artifact.svg).toContain('data-latex="="');
+    expect(expression.artifact.svg).toContain('data-latex="4"');
+    expect(expression.artifact.svg).toContain('data-latex="k"');
+    expect(expression.artifact.svg).toContain('data-latex="t"');
+    expect(countSvgTags(expression.artifact.svg)).toBe(
+      countSvgTags(expression.artifact.svg, true),
+    );
+  });
+
+  it("does not truncate ordinary operators after the first glyph", () => {
+    const result = createFormulaTypesetter().typesetSync({
+      ...baseRequest,
+      latex: "x+y",
+    });
+    expect(result).toMatchObject({ ok: true });
+    if (!result.ok) return;
+    expect(result.artifact.svg).toContain('data-latex="+"');
+    expect(result.artifact.svg).toContain('data-latex="y"');
   });
 
   it("produces deterministic markup, metrics, and source hashes", async () => {

--- a/packages/math-typesetting/src/index.ts
+++ b/packages/math-typesetting/src/index.ts
@@ -40,6 +40,26 @@ const SVG_START = /<svg\b/;
 const DIMENSION_EX = /^(-?(?:\d+(?:\.\d+)?|\.\d+))ex$/;
 const VERTICAL_ALIGN_EX = /vertical-align:\s*(-?(?:\d+(?:\.\d+)?|\.\d+))ex/;
 
+function findOuterSvgRange(
+  markup: string,
+): { start: number; end: number } | null {
+  const tags = /<\/?svg\b[^>]*>/g;
+  let depth = 0;
+  let start = -1;
+  for (let match = tags.exec(markup); match; match = tags.exec(markup)) {
+    const tag = match[0];
+    if (tag.startsWith("</")) {
+      if (start < 0 || depth === 0) return null;
+      depth -= 1;
+      if (depth === 0) return { start, end: tags.lastIndex };
+      continue;
+    }
+    if (start < 0) start = match.index;
+    if (!tag.endsWith("/>")) depth += 1;
+  }
+  return null;
+}
+
 function parseEx(value: string | null, fontSize: number): number | undefined {
   const match = value?.match(DIMENSION_EX);
   if (!match) return undefined;
@@ -51,13 +71,14 @@ function extractSvg(
   markup: string,
   request: FormulaRequest,
 ): Omit<FormulaArtifact, "sourceHash"> {
-  const start = markup.search(SVG_START);
-  const end = markup.indexOf("</svg>", start);
-  if (start < 0 || end < 0) {
-    throw new Error("Math renderer did not return a standalone SVG element.");
+  const range = findOuterSvgRange(markup);
+  if (!range || SVG_START.test(markup.slice(range.end))) {
+    throw new Error(
+      "Math renderer did not return one balanced standalone SVG element.",
+    );
   }
 
-  let svg = markup.slice(start, end + "</svg>".length);
+  let svg = markup.slice(range.start, range.end);
   const openTag = svg.slice(0, svg.indexOf(">") + 1);
   const width = parseEx(
     openTag.match(/\bwidth="([^"]+)"/)?.[1] ?? null,
@@ -105,7 +126,15 @@ export function createFormulaTypesetter(): FormulaTypesetter {
       differentialD: String.raw`\mathrm{d}`,
     },
   });
-  const output = new SVG({ fontCache: "none" });
+  // A Formula artifact is one self-contained SVG. MathJax 4 enables inline
+  // line breaking by default and otherwise emits sibling SVG fragments around
+  // operators (for example, `x` and `+y`). That shape cannot be embedded as a
+  // single drafting object, so keep the expression on one MathJax line and let
+  // the editor's formula source panel handle horizontal overflow.
+  const output = new SVG({
+    fontCache: "none",
+    linebreaks: { inline: false },
+  });
   const document = mathjax.document("", {
     InputJax: input,
     OutputJax: output,


### PR DESCRIPTION
MathJax 4 enables inline line breaking by default, which split expressions at operators into sibling SVG fragments. The formula extractor then persisted only the first fragment, leaving formulas truncated and potentially corrupting later annotation markup.

Disable inline MathJax breaks for atomic formula artifacts, require one balanced outer SVG, and cover nested overbars plus trailing operators. Replace the native Reference-conversion confirm with an in-panel decision that preserves the electrical name and supports returning to editing.

Validation: pnpm test:local packages/math-typesetting/src/index.test.ts apps/editor/src/features/text-editing/formula-artifacts.test.ts apps/editor/src/features/text-editing/bound-formula.test.ts packages/render-svg/src/drafting-render.test.ts packages/render-svg/src/instance-style-render.test.ts; pnpm test:e2e:local apps/editor/e2e/drafting.spec.ts (36 passed); pnpm typecheck; gate preflight static-contracts.

Test-Impact: tests-updated
