### PR TITLE
Complete scoped Net naming and Cadence round trip

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -23,6 +23,7 @@ import {
   computeNetHighlight,
   annotationOwningInstanceId,
   deriveNetConnectivity,
+  deriveProjectNetNameProjection,
   deriveRoutingAffectedClosure,
   diagnosticPresentationGroup,
   resolveDraftingObjectGeometry,
@@ -1249,6 +1250,36 @@ export function App({
     wireSource,
     bulkDrawInstanceId,
   });
+  const projectNetNameProjection = useMemo(
+    () => deriveProjectNetNameProjection(project),
+    [project],
+  );
+  const selectedNetNameAnnotation =
+    selectedAnnotation?.binding?.kind === "net-name" &&
+    (selectedAnnotation.kind === "net-label" ||
+      selectedAnnotation.kind === "power-label")
+      ? selectedAnnotation
+      : (selectedRouteNetLabel ?? null);
+  const selectedNetNameClaim = selectedNetNameAnnotation
+    ? document.connectivityEvidence.find(
+        (evidence) =>
+          evidence.kind === "name-claim" &&
+          ((evidence.owner.kind === "net-label" &&
+            evidence.owner.annotationId === selectedNetNameAnnotation.id) ||
+            (evidence.owner.kind === "power-marker" &&
+              selectedNetNameAnnotation.anchor.kind === "object" &&
+              evidence.owner.objectId ===
+                selectedNetNameAnnotation.anchor.objectId)),
+      )
+    : undefined;
+  const selectedNetNameLogical = selectedNetNameAnnotation?.netId
+    ? logicalNets.byBaseNetId.get(selectedNetNameAnnotation.netId)
+    : undefined;
+  const selectedNetNameProjection = selectedNetNameLogical
+    ? projectNetNameProjection.byDocumentId
+        .get(document.id)
+        ?.get(selectedNetNameLogical.id)
+    : undefined;
   const sceneSnapTargetIndex = useMemo(
     () => buildSceneSnapTargetIndex(document, resolver, visibleEndpoints),
     [document, resolver, visibleEndpoints],
@@ -1408,6 +1439,7 @@ export function App({
   const {
     netLabelForRoute,
     netLabelEditsForRoute,
+    netLabelScopeEdit,
     netNameEditsForAnnotation,
     propertyParametersForInstance,
     instancePropertyEdits,
@@ -1450,6 +1482,7 @@ export function App({
     beginNetLabelEditing,
     commitInstancePropertyDraft,
     commitElectricalMarkerName,
+    commitNetLabelScope,
     commitNetLabelEditing,
     commitPendingNetLabelDraft,
     commitTextEditing,
@@ -1491,6 +1524,7 @@ export function App({
     clearSelectionKinds,
     netLabelForRoute,
     netLabelEditsForRoute,
+    netLabelScopeEdit,
     netNameEditsForAnnotation,
     instancePropertyEdits,
     referenceLabelVisibilityEdits,
@@ -4617,6 +4651,28 @@ export function App({
                       );
                     }
                   },
+                }
+              : null
+          }
+          netName={
+            selectedNetNameAnnotation &&
+            selectedNetNameClaim?.kind === "name-claim"
+              ? {
+                  annotationId: selectedNetNameAnnotation.id,
+                  authoredScope: selectedNetNameClaim.scope,
+                  editableScope: selectedNetNameAnnotation.kind === "net-label",
+                  effectiveScope:
+                    selectedNetNameLogical?.scope ?? selectedNetNameClaim.scope,
+                  preferredSpelling:
+                    selectedNetNameProjection?.preferredSpelling ??
+                    selectedNetNameLogical?.name,
+                  spellings:
+                    selectedNetNameProjection?.spellings ??
+                    (selectedNetNameLogical?.name
+                      ? [selectedNetNameLogical.name]
+                      : []),
+                  onScopeChange: (scope) =>
+                    commitNetLabelScope(selectedNetNameAnnotation, scope),
                 }
               : null
           }

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -1280,6 +1280,9 @@ export function App({
         .get(document.id)
         ?.get(selectedNetNameLogical.id)
     : undefined;
+  const selectedNetPreferredSpelling =
+    selectedNetNameProjection?.preferredSpelling ??
+    selectedNetNameLogical?.name;
   const sceneSnapTargetIndex = useMemo(
     () => buildSceneSnapTargetIndex(document, resolver, visibleEndpoints),
     [document, resolver, visibleEndpoints],
@@ -4662,9 +4665,9 @@ export function App({
                   editableScope: selectedNetNameAnnotation.kind === "net-label",
                   effectiveScope:
                     selectedNetNameLogical?.scope ?? selectedNetNameClaim.scope,
-                  preferredSpelling:
-                    selectedNetNameProjection?.preferredSpelling ??
-                    selectedNetNameLogical?.name,
+                  ...(selectedNetPreferredSpelling
+                    ? { preferredSpelling: selectedNetPreferredSpelling }
+                    : {}),
                   spellings:
                     selectedNetNameProjection?.spellings ??
                     (selectedNetNameLogical?.name

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -3192,10 +3192,7 @@ export function App({
       document,
       resolver,
       defaultViewBox: DEFAULT_VIEWBOX,
-      netlistIr: netlistAnalysis.ir,
-      exportWarningsPresent:
-        netlistAnalysis.diagnostics.length > 0 ||
-        electricalDiagnostics.length > 0,
+      electricalWarningsPresent: electricalDiagnostics.length > 0,
       guardDirtyReplacement,
       replaceActiveProject,
       setNetlistPreflightOpen,
@@ -3743,7 +3740,8 @@ export function App({
             refreshApp();
           },
           onImportProject: (file) => void openProjectFile(file),
-          onImportSpice: (files) => void importSpiceFiles(files),
+          onImportSpice: (files, namingProfile) =>
+            void importSpiceFiles(files, namingProfile),
           onExportProject: exportProjectFile,
           onExportSvg: exportSvg,
           onExportRaster: (format) => void exportRaster(format),
@@ -4105,12 +4103,13 @@ export function App({
           netlistPreflightOpen
             ? {
                 open: netlistPreflightOpen,
-                result: netlistAnalysis,
+                project,
                 electricalDiagnostics,
                 onClose: () => setNetlistPreflightOpen(false),
                 onNavigate: navigateToNetlistDiagnostic,
                 onNavigateElectrical: jumpToProjectDiagnostic,
-                onExport: (format) => exportDesignNetlist(format, true),
+                onExport: (format, namingProfile) =>
+                  exportDesignNetlist(format, true, namingProfile),
               }
             : null
         }

--- a/apps/editor/src/app/editor-properties-dock.tsx
+++ b/apps/editor/src/app/editor-properties-dock.tsx
@@ -13,6 +13,7 @@ import { ComponentSignalFlowProperties } from "../features/properties/component-
 import { ComponentPlacementProperties } from "../features/properties/component-placement-properties";
 import { ComponentStyleProperties } from "../features/properties/component-style-properties";
 import { AnnotationColorProperties } from "../features/properties/annotation-color-properties";
+import { NetNameProperties } from "../features/properties/net-name-properties";
 import { DraftingPropertiesPanel } from "../features/drafting/drafting-properties-panel";
 import {
   AnnotationActionsSection,
@@ -52,6 +53,7 @@ export interface EditorPropertiesDockProps {
   groupDisplay: ComponentProps<typeof GroupDisplayToggles>;
   component: ComponentPropertiesModel | null;
   annotationText: ComponentProps<typeof AnnotationColorProperties> | null;
+  netName: ComponentProps<typeof NetNameProperties> | null;
   drafting: ComponentProps<typeof DraftingPropertiesPanel> | null;
   placementTray: ComponentProps<typeof PlacementTrayPanel>;
   routeActions: ComponentProps<typeof RouteActionsSection>;
@@ -77,6 +79,7 @@ export function EditorPropertiesDock({
   groupDisplay,
   component,
   annotationText,
+  netName,
   drafting,
   placementTray,
   routeActions,
@@ -162,6 +165,7 @@ export function EditorPropertiesDock({
               {...annotationText}
             />
           ) : null}
+          {netName ? <NetNameProperties {...netName} /> : null}
           {drafting ? (
             <DraftingPropertiesPanel key={drafting.object.id} {...drafting} />
           ) : null}

--- a/apps/editor/src/features/editor-shell/editor-file-commands.ts
+++ b/apps/editor/src/features/editor-shell/editor-file-commands.ts
@@ -1,4 +1,5 @@
-import type { DesignNetlistIR, NetlistFormat } from "@icm/netlist";
+import { analyzeDesignNetlist } from "@icm/netlist";
+import type { NetlistFormat, NetlistNamingProfile } from "@icm/netlist";
 import type { CircuitProject, GridRect, SchematicDocument } from "@icm/model";
 import { importSpiceSources } from "@icm/spice";
 import type { SymbolResolver } from "@icm/symbols";
@@ -22,8 +23,7 @@ export interface EditorFileCommandDependencies {
   document: SchematicDocument;
   resolver: SymbolResolver;
   defaultViewBox: GridRect;
-  netlistIr: DesignNetlistIR | null;
-  exportWarningsPresent: boolean;
+  electricalWarningsPresent: boolean;
   guardDirtyReplacement: (
     label: string,
     replace: () => void | Promise<void>,
@@ -48,8 +48,7 @@ export function createEditorFileCommands({
   document,
   resolver,
   defaultViewBox,
-  netlistIr,
-  exportWarningsPresent,
+  electricalWarningsPresent,
   guardDirtyReplacement,
   replaceActiveProject,
   setNetlistPreflightOpen,
@@ -74,11 +73,14 @@ export function createEditorFileCommands({
   const exportDesignNetlist = (
     format: NetlistFormat,
     warningsReviewed = false,
+    namingProfile: NetlistNamingProfile = "native",
   ): void => {
+    const analysis = analyzeDesignNetlist(project, { format, namingProfile });
     const plan = planDesignNetlistExport({
       format,
-      ir: netlistIr,
-      warningsPresent: exportWarningsPresent,
+      ir: analysis.ir,
+      warningsPresent:
+        analysis.diagnostics.length > 0 || electricalWarningsPresent,
       warningsReviewed,
       projectName: project.name,
     });
@@ -109,7 +111,10 @@ export function createEditorFileCommands({
     }
   };
 
-  const importSpiceFiles = async (files: FileList | null): Promise<void> => {
+  const importSpiceFiles = async (
+    files: FileList | null,
+    namingProfile: "native" | "cadence-bang" = "native",
+  ): Promise<void> => {
     if (!files || files.length === 0) return;
     const sourceInputs = await Promise.all(
       [...files].map(async (file) => ({
@@ -138,6 +143,8 @@ export function createEditorFileCommands({
       const result = await importSpiceSources(
         sourceInputs,
         entryCandidates[0]!.path,
+        {},
+        { namingProfile },
       );
       const nextImportReport: SpiceImportReport = {
         entryPath: entryCandidates[0]!.path,

--- a/apps/editor/src/features/editor-shell/file-command-menu.test.tsx
+++ b/apps/editor/src/features/editor-shell/file-command-menu.test.tsx
@@ -45,6 +45,9 @@ describe("FileCommandMenu", () => {
     expect(markup).toContain('class="cloud-project-time"');
     expect(markup).toContain("cloud-project-cloud-1");
     expect(markup).toContain("Import Project File…");
+    expect(markup).toContain("Import SPICE…");
+    expect(markup).toContain("Import Cadence SPICE (`!` globals)…");
+    expect(markup).toContain('data-testid="cadence-spice-files"');
     expect(markup).toContain("Export Project File…");
     expect(markup).not.toContain("Download Backup");
     expect(markup).not.toContain("Previous Project");

--- a/apps/editor/src/features/editor-shell/file-command-menu.tsx
+++ b/apps/editor/src/features/editor-shell/file-command-menu.tsx
@@ -18,7 +18,10 @@ export interface FileCommandMenuProps {
   onDeleteCloudProject: (project: CloudProjectSummary) => void;
   onRefresh: () => void;
   onImportProject: (file: File | null) => void;
-  onImportSpice: (files: FileList | null) => void;
+  onImportSpice: (
+    files: FileList | null,
+    namingProfile?: "native" | "cadence-bang",
+  ) => void;
   onExportProject: () => void;
   onExportSvg: () => void;
   onExportRaster: (format: "png" | "pdf") => void;
@@ -116,6 +119,18 @@ export function FileCommandMenu({
             accept=".spi,.cir,.sp,.inc,.lib"
             multiple
             onChange={(event) => onImportSpice(event.currentTarget.files)}
+          />
+        </label>
+        <label className="file-import">
+          Import Cadence SPICE (`!` globals)…
+          <input
+            data-testid="cadence-spice-files"
+            type="file"
+            accept=".spi,.cir,.sp,.inc,.lib"
+            multiple
+            onChange={(event) =>
+              onImportSpice(event.currentTarget.files, "cadence-bang")
+            }
           />
         </label>
         <button type="button" onClick={onExportProject}>

--- a/apps/editor/src/features/netlist-export/imported-global-cut.test.ts
+++ b/apps/editor/src/features/netlist-export/imported-global-cut.test.ts
@@ -1,0 +1,119 @@
+import { executeTransaction } from "@icm/edit-engine";
+import { createEmptyProject, createRoutePath } from "@icm/model";
+import { analyzeDesignNetlist, printSpiceNetlist } from "@icm/netlist";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+describe("imported global cut", () => {
+  it("exports the detached component as a distinct node", () => {
+    const project = createEmptyProject("imported-global-cut", "Imported Cut");
+    const document = project.documents[0]!;
+    document.netlist!.name = "imported_cut";
+    document.instances.push(
+      {
+        id: "R1",
+        symbolId: "resistor",
+        placement: null,
+        reference: "R1",
+        netlist: {
+          binding: { kind: "primitive", deviceClass: "resistor" },
+          parameters: { value: "1k" },
+        },
+      },
+      {
+        id: "R2",
+        symbolId: "resistor",
+        placement: null,
+        reference: "R2",
+        netlist: {
+          binding: { kind: "primitive", deviceClass: "resistor" },
+          parameters: { value: "2k" },
+        },
+      },
+    );
+    document.nets.push({
+      id: "net-vdd",
+      terminals: [
+        { instanceId: "R1", pinName: "1" },
+        { instanceId: "R2", pinName: "1" },
+      ],
+    });
+    document.noConnects.push(
+      {
+        id: "nc-r1-2",
+        endpoint: { kind: "terminal", instanceId: "R1", pinName: "2" },
+      },
+      {
+        id: "nc-r2-2",
+        endpoint: { kind: "terminal", instanceId: "R2", pinName: "2" },
+      },
+    );
+    document.connectivityEvidence.push(
+      {
+        id: "global-vdd",
+        kind: "name-claim",
+        netId: "net-vdd",
+        name: "VDD",
+        scope: "global",
+        owner: {
+          kind: "global-declaration",
+          sourceNetId: "source-vdd",
+        },
+      },
+      {
+        id: "source-vdd",
+        kind: "spice-source",
+        netId: "net-vdd",
+        sourceNetId: "source-vdd",
+      },
+      {
+        id: "source-vdd-name",
+        kind: "net-name-hint",
+        netId: "net-vdd",
+        sourceName: "VDD",
+        origin: "spice-import",
+      },
+    );
+    document.routes.push(
+      createRoutePath({
+        id: "route-vdd",
+        netId: "net-vdd",
+        start: { kind: "terminal", instanceId: "R1", pinName: "1" },
+        end: { kind: "terminal", instanceId: "R2", pinName: "1" },
+        bends: [],
+        modes: ["manual"],
+      }),
+    );
+
+    const cut = executeTransaction(
+      document,
+      {
+        transactionId: "cut-imported-global",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: [{ kind: "cut_connection", routeId: "route-vdd" }],
+      },
+      { symbolResolver: resolver },
+    );
+    expect(cut.ok).toBe(true);
+    if (!cut.ok) return;
+    project.documents[0] = cut.document;
+
+    const analysis = analyzeDesignNetlist(project);
+    expect(analysis.ir).not.toBeNull();
+    const cell = analysis.ir!.cells[0]!;
+    expect(cell.nets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "VDD", scope: "global" }),
+        expect.objectContaining({ name: "VDD__2", scope: "local" }),
+      ]),
+    );
+    const spice = printSpiceNetlist(analysis.ir!);
+    expect(spice).toContain(".global VDD");
+    expect(spice).toContain("R1 VDD NC0001 1k");
+    expect(spice).toContain("R2 VDD__2 NC0002 2k");
+  });
+});

--- a/apps/editor/src/features/netlist-export/netlist-preflight-dialog.test.tsx
+++ b/apps/editor/src/features/netlist-export/netlist-preflight-dialog.test.tsx
@@ -1,5 +1,5 @@
 import type { Diagnostic } from "@icm/derived";
-import type { DesignNetlistAnalysisResult } from "@icm/netlist";
+import { createEmptyProject } from "@icm/model";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
@@ -7,10 +7,8 @@ import { NetlistPreflightDialog } from "./netlist-preflight-dialog";
 
 describe("NetlistPreflightDialog", () => {
   it("shows current electrical readiness separately from structural analysis", () => {
-    const result: DesignNetlistAnalysisResult = {
-      ir: null,
-      diagnostics: [],
-    };
+    const project = createEmptyProject("project", "Project", "main");
+    project.documents[0]!.netlist = undefined;
     const electrical: Diagnostic = {
       id: "erc:unconnected:main:M1:D",
       domain: "erc",
@@ -32,7 +30,7 @@ describe("NetlistPreflightDialog", () => {
     const markup = renderToStaticMarkup(
       <NetlistPreflightDialog
         open
-        result={result}
+        project={project}
         electricalDiagnostics={[electrical]}
         onClose={() => undefined}
         onNavigate={() => undefined}
@@ -48,5 +46,24 @@ describe("NetlistPreflightDialog", () => {
     expect(markup).toContain('aria-label="Netlist diagnostics"');
     expect(markup).toContain('data-has-preview="false"');
     expect(markup).toContain('data-has-diagnostics="true"');
+  });
+
+  it("offers an explicit non-persisted Cadence bang export profile", () => {
+    const project = createEmptyProject("project", "Project", "main");
+    const markup = renderToStaticMarkup(
+      <NetlistPreflightDialog
+        open
+        project={project}
+        electricalDiagnostics={[]}
+        onClose={() => undefined}
+        onNavigate={() => undefined}
+        onNavigateElectrical={() => undefined}
+        onExport={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Netlist naming profile"');
+    expect(markup).toContain('value="cadence-bang"');
+    expect(markup).toContain("Cadence `!` globals");
   });
 });

--- a/apps/editor/src/features/netlist-export/netlist-preflight-dialog.tsx
+++ b/apps/editor/src/features/netlist-export/netlist-preflight-dialog.tsx
@@ -1,16 +1,17 @@
-import { printDesignNetlist } from "@icm/netlist";
+import { analyzeDesignNetlist, printDesignNetlist } from "@icm/netlist";
 import type { Diagnostic } from "@icm/derived";
 import type {
-  DesignNetlistAnalysisResult,
   NetlistDiagnostic,
   NetlistFormat,
+  NetlistNamingProfile,
 } from "@icm/netlist";
+import type { CircuitProject } from "@icm/model";
 import { useMemo, useState } from "react";
 
 /** Presentation-only composition of structural analysis and current ERC. */
 export function NetlistPreflightDialog({
   open,
-  result,
+  project,
   electricalDiagnostics,
   onClose,
   onNavigate,
@@ -18,14 +19,20 @@ export function NetlistPreflightDialog({
   onExport,
 }: {
   open: boolean;
-  result: DesignNetlistAnalysisResult;
+  project: CircuitProject;
   electricalDiagnostics: readonly Diagnostic[];
   onClose(): void;
   onNavigate(diagnostic: NetlistDiagnostic): void;
   onNavigateElectrical(diagnostic: Diagnostic): void;
-  onExport(format: NetlistFormat): void;
+  onExport(format: NetlistFormat, namingProfile: NetlistNamingProfile): void;
 }) {
   const [format, setFormat] = useState<NetlistFormat>("spice");
+  const [namingProfile, setNamingProfile] =
+    useState<NetlistNamingProfile>("native");
+  const result = useMemo(
+    () => analyzeDesignNetlist(project, { format, namingProfile }),
+    [format, namingProfile, project],
+  );
   // The same finding repeated once per object says nothing many times over;
   // count it instead. Seven identical lines was most of what the report said.
   const groupedFindings = useMemo(() => {
@@ -127,7 +134,25 @@ export function NetlistPreflightDialog({
                     <option value="spectre">Spectre (.scs)</option>
                   </select>
                 </label>
-                <button type="button" onClick={() => onExport(format)}>
+                <label>
+                  Naming profile
+                  <select
+                    aria-label="Netlist naming profile"
+                    value={namingProfile}
+                    onChange={(event) =>
+                      setNamingProfile(
+                        event.currentTarget.value as NetlistNamingProfile,
+                      )
+                    }
+                  >
+                    <option value="native">Native declarations</option>
+                    <option value="cadence-bang">Cadence `!` globals</option>
+                  </select>
+                </label>
+                <button
+                  type="button"
+                  onClick={() => onExport(format, namingProfile)}
+                >
                   Download {format === "spice" ? "SPICE" : "Spectre"} netlist
                 </button>
               </div>

--- a/apps/editor/src/features/properties/net-name-properties.test.tsx
+++ b/apps/editor/src/features/properties/net-name-properties.test.tsx
@@ -1,0 +1,47 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { NetNameProperties } from "./net-name-properties";
+
+describe("NetNameProperties", () => {
+  it("separates authored scope from the derived export projection", () => {
+    const markup = renderToStaticMarkup(
+      <NetNameProperties
+        annotationId="label-vdd"
+        authoredScope="local"
+        editableScope
+        effectiveScope="global"
+        preferredSpelling="VDD"
+        spellings={["VDD", "vdd"]}
+        onScopeChange={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Net identity"');
+    expect(markup).toContain('aria-label="Net Label scope"');
+    expect(markup).toContain('value="local" selected=""');
+    expect(markup).toContain('data-scope="global"');
+    expect(markup).toContain("Preferred export spelling");
+    expect(markup).toContain("VDD, vdd");
+    expect(markup).toContain(
+      "Wire membership and source provenance are unchanged",
+    );
+  });
+
+  it("keeps marker-owned global scope read-only", () => {
+    const markup = renderToStaticMarkup(
+      <NetNameProperties
+        annotationId="power-vdd"
+        authoredScope="global"
+        editableScope={false}
+        effectiveScope="global"
+        preferredSpelling="VDD"
+        spellings={["VDD"]}
+        onScopeChange={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Net Label scope"');
+    expect(markup).toContain("disabled");
+  });
+});

--- a/apps/editor/src/features/properties/net-name-properties.tsx
+++ b/apps/editor/src/features/properties/net-name-properties.tsx
@@ -1,0 +1,72 @@
+export interface NetNamePropertiesProps {
+  annotationId: string;
+  authoredScope: "local" | "global";
+  editableScope: boolean;
+  effectiveScope: "local" | "global";
+  preferredSpelling?: string;
+  spellings: readonly string[];
+  onScopeChange: (scope: "local" | "global") => void;
+}
+
+/** Owner-scoped authoring plus read-only revision-scoped export projection. */
+export function NetNameProperties({
+  annotationId,
+  authoredScope,
+  editableScope,
+  effectiveScope,
+  preferredSpelling,
+  spellings,
+  onScopeChange,
+}: NetNamePropertiesProps) {
+  return (
+    <section
+      className="property-section net-name-properties"
+      aria-label="Net identity"
+    >
+      <div className="property-section-heading">Net identity</div>
+      <label>
+        Label scope
+        <select
+          key={`${annotationId}-${authoredScope}`}
+          aria-label="Net Label scope"
+          value={authoredScope}
+          disabled={!editableScope}
+          onChange={(event) =>
+            onScopeChange(event.currentTarget.value as "local" | "global")
+          }
+        >
+          <option value="local">Local to Cell</option>
+          <option value="global">Global across Cells</option>
+        </select>
+      </label>
+      <dl className="component-readonly-fields">
+        <div>
+          <dt>Effective scope</dt>
+          <dd>
+            {effectiveScope === "global" ? (
+              <span className="net-scope-badge" data-scope="global">
+                Global
+              </span>
+            ) : (
+              "Local"
+            )}
+          </dd>
+        </div>
+        <div>
+          <dt>Preferred export spelling</dt>
+          <dd>{preferredSpelling ?? "Unnamed"}</dd>
+        </div>
+        {spellings.length > 1 ? (
+          <div className="net-spelling-variants">
+            <dt>Spelling variants</dt>
+            <dd>{spellings.join(", ")}</dd>
+          </div>
+        ) : null}
+      </dl>
+      <small>
+        Scope edits this Label claim only. Wire membership and source provenance
+        are unchanged.
+      </small>
+    </section>
+  );
+}

--- a/apps/editor/src/features/properties/property-edit-planner.test.ts
+++ b/apps/editor/src/features/properties/property-edit-planner.test.ts
@@ -175,6 +175,46 @@ describe("property edit planner", () => {
     );
   });
 
+  it("changes only the selected Net Label owner's existing scope claim", () => {
+    const input = routedFixture();
+    const annotation: Annotation = {
+      id: "label-vdd",
+      kind: "net-label",
+      binding: { kind: "net-name", netId: "net" },
+      netId: "net",
+      anchor: { kind: "free", position: { x: 0, y: 0 } },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    };
+    input.document.annotations.push(annotation);
+    input.document.connectivityEvidence.push({
+      id: "claim-vdd",
+      kind: "name-claim",
+      netId: "net",
+      name: "VDD",
+      scope: "local",
+      owner: { kind: "net-label", annotationId: annotation.id },
+    });
+    const before = structuredClone(input.document);
+    const planner = createPropertyEditPlanner(input);
+
+    expect(planner.netLabelScopeEdit(annotation, "global")).toEqual([
+      {
+        kind: "upsert_connectivity_evidence",
+        evidence: {
+          id: "claim-vdd",
+          kind: "name-claim",
+          netId: "net",
+          name: "VDD",
+          scope: "global",
+          owner: { kind: "net-label", annotationId: "label-vdd" },
+        },
+      },
+    ]);
+    expect(input.document).toEqual(before);
+  });
+
   it("plans parameter patches, snapped movement, and rotation atomically", () => {
     const input = fixture();
     input.document.presentation.grid = 10;

--- a/apps/editor/src/features/properties/property-edit-planner.ts
+++ b/apps/editor/src/features/properties/property-edit-planner.ts
@@ -259,6 +259,35 @@ export function createPropertyEditPlanner({
     ];
   };
 
+  const netLabelScopeEdit = (
+    annotation: Annotation,
+    scope: "local" | "global",
+  ): SchematicEdit[] | null => {
+    if (annotation.kind !== "net-label") {
+      setStatus("Power markers keep their required global scope");
+      return null;
+    }
+    const claim = document.connectivityEvidence.find(
+      (
+        evidence,
+      ): evidence is Extract<ConnectivityEvidence, { kind: "name-claim" }> =>
+        evidence.kind === "name-claim" &&
+        evidence.owner.kind === "net-label" &&
+        evidence.owner.annotationId === annotation.id,
+    );
+    if (!claim) {
+      setStatus("This Net Label has no editable scope claim");
+      return null;
+    }
+    if (claim.scope === scope) return [];
+    return [
+      {
+        kind: "upsert_connectivity_evidence",
+        evidence: { ...claim, scope },
+      },
+    ];
+  };
+
   const propertyParametersForInstance = (
     instance: SchematicDocument["instances"][number],
   ) => {
@@ -366,6 +395,7 @@ export function createPropertyEditPlanner({
   return {
     netLabelForRoute,
     netLabelEditsForRoute,
+    netLabelScopeEdit,
     netNameEditsForAnnotation,
     propertyParametersForInstance,
     instancePropertyEdits,

--- a/apps/editor/src/features/properties/use-properties-editor.ts
+++ b/apps/editor/src/features/properties/use-properties-editor.ts
@@ -120,6 +120,10 @@ export interface UsePropertiesEditorOptions {
       formatOverride?: RichTextDocument;
     },
   ) => SchematicEdit[] | null;
+  netLabelScopeEdit: (
+    annotation: Annotation,
+    scope: "local" | "global",
+  ) => SchematicEdit[] | null;
   netNameEditsForAnnotation?: (
     annotation: Annotation,
     name: string,
@@ -450,6 +454,19 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
       setNetLabelDraft("");
       options.setStatus(
         `Deleted Net Label ${flattenRichText(resolveAnnotationText(options.document, label))}`,
+      );
+    }
+  };
+
+  const commitNetLabelScope = (
+    annotation: Annotation,
+    scope: "local" | "global",
+  ): void => {
+    const edits = options.netLabelScopeEdit(annotation, scope);
+    if (!edits || edits.length === 0) return;
+    if (transactNamedNet(edits)) {
+      options.setStatus(
+        `Net Label ${flattenRichText(resolveAnnotationText(options.document, annotation))} is now ${scope}`,
       );
     }
   };
@@ -893,6 +910,7 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     beginNetLabelEditing,
     commitInstancePropertyDraft,
     commitElectricalMarkerName,
+    commitNetLabelScope,
     commitNetLabelEditing,
     commitPendingNetLabelDraft,
     commitTextEditing,

--- a/apps/editor/src/styles/editor-properties.css
+++ b/apps/editor/src/styles/editor-properties.css
@@ -267,6 +267,33 @@
   white-space: nowrap;
 }
 
+.net-name-properties {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.net-name-properties > small {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+
+.net-name-properties .net-spelling-variants {
+  grid-column: 1 / -1;
+}
+
+.net-scope-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.25rem;
+  padding: 0 0.4rem;
+  border: 1px solid rgb(var(--icm-accent-rgb) / 40%);
+  border-radius: 999px;
+  background: var(--icm-accent-soft);
+  color: var(--icm-accent);
+  font-size: var(--icm-font-xs);
+  font-weight: 700;
+}
+
 .cell-symbol-layout-properties {
   display: grid;
   gap: 0.55rem;

--- a/docs/adr/0056-derived-net-scope-and-dialect-spelling.md
+++ b/docs/adr/0056-derived-net-scope-and-dialect-spelling.md
@@ -1,0 +1,49 @@
+# ADR 0056: Derived Net Scope and Dialect Spelling
+
+Status: `accepted`
+
+Date: `2026-09-02`
+
+Owners: `packages/derived`, `packages/netlist`, `apps/editor`
+
+## Context
+
+Net scope and output spelling were being treated as one fact. That makes two
+unsafe outcomes possible: a local and global Net can collapse onto one
+simulator token, while one project-global Net can acquire different spellings
+in different Cells.
+
+## Decision
+
+- Each visible Label or marker continues to own one persisted `name-claim`
+  with its authored `name` and `scope`.
+- Disconnected equal-folded local and global claims remain distinct Logical
+  Nets.
+- If equal-folded local and global claims are already on the same physical
+  Logical-Net group, its effective scope is derived as global. No owner claim
+  is promoted or rewritten.
+- Project-global spelling is selected transiently from current owner claims,
+  Cell Pins, declarations, and source hints in that order. Exact variants are
+  retained for explanation.
+- A target-specific codec converts the selected semantic spelling to an
+  ngspice or Spectre token and blocks collisions between distinct identities.
+- Cadence bang spelling is an explicit operation profile, never persisted
+  scope and never inferred in generic SPICE mode.
+
+## Consequences
+
+Connecting same-name local and global conductors is an explicit physical
+contact and resolves global. Cutting them relies only on the existing Base-Net
+partition and owner-evidence allocation, after which scope is derived again.
+Naming logic adds no promotion lifecycle, hidden equivalence, or physical edit.
+
+Distinct schematic Nets are never silently shorted by export spelling. Source
+hints may be disambiguated, but authoritative authored names cause a blocking
+diagnostic when the selected dialect cannot represent them uniquely.
+
+## Related documents
+
+- [`0052-owner-explainable-net-authority.md`](0052-owner-explainable-net-authority.md)
+- [`../specs/schematic-model.md`](../specs/schematic-model.md)
+- [`../specs/netlist-export.md`](../specs/netlist-export.md)
+- [`../roadmap/net-naming-resolution-export-p0.md`](../roadmap/net-naming-resolution-export-p0.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,6 +49,7 @@ major boundaries exist.
 - [`0041-physical-cut-and-endpoint-readiness.md`](0041-physical-cut-and-endpoint-readiness.md) — physical cut and endpoint readiness
 - [`0048-routing-operation-plan.md`](0048-routing-operation-plan.md) — evaluated routing-operation plan
 - [`0052-owner-explainable-net-authority.md`](0052-owner-explainable-net-authority.md) — owner-explainable Net authority and non-electrical provenance
+- [`0056-derived-net-scope-and-dialect-spelling.md`](0056-derived-net-scope-and-dialect-spelling.md) — derived effective scope and operation-scoped dialect spelling
 
 ## Lifecycle and deletion policy
 

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -7,7 +7,7 @@ boundaries.
 
 | Area                                                  | Status                                                        | Current authority                                                                                                       |
 | ----------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| Net naming, global projection, and export correctness | proposed P0                                                   | [P0 boundary and delivery plan](net-naming-resolution-export-p0.md)                                                     |
+| Net naming, global projection, and export correctness | proposed P0-P2                                                | [staged boundary and delivery plan](net-naming-resolution-export-p0.md)                                                 |
 | Connectivity, routing, and electrical debugging       | active                                                        | [unification plan](connectivity-routing-debugging-plan.md)                                                              |
 | Browser-authorized Agent sessions                     | implementation validation complete; deployment review pending | [session integration plan](web-agent-session-integration-plan.md) and [web-session spec](../specs/web-agent-session.md) |
 | Current-only Agent/Project/asset contract             | implemented; branch validation in progress                    | [Agent API spec](../specs/agent-api.md) and [ADR 0007](../adr/0007-snapshot-driven-agent-workflow.md)                   |

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -5,11 +5,12 @@ boundaries.
 
 ## Delivery status
 
-| Area                                                                      | Status                                                                    | Current authority                                                                                                                          |
-| ------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Connectivity, routing, and electrical debugging                           | active                                                                    | [unification plan](connectivity-routing-debugging-plan.md)                                                                                 |
-| Browser-authorized Agent sessions                                         | implementation validation complete; deployment review pending             | [session integration plan](web-agent-session-integration-plan.md) and [web-session spec](../specs/web-agent-session.md)                    |
-| Current-only Agent/Project/asset contract                                 | implemented; branch validation in progress                                | [Agent API spec](../specs/agent-api.md) and [ADR 0007](../adr/0007-snapshot-driven-agent-workflow.md)                                      |
+| Area                                                  | Status                                                        | Current authority                                                                                                       |
+| ----------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Net naming, global projection, and export correctness | proposed P0                                                   | [P0 boundary and delivery plan](net-naming-resolution-export-p0.md)                                                     |
+| Connectivity, routing, and electrical debugging       | active                                                        | [unification plan](connectivity-routing-debugging-plan.md)                                                              |
+| Browser-authorized Agent sessions                     | implementation validation complete; deployment review pending | [session integration plan](web-agent-session-integration-plan.md) and [web-session spec](../specs/web-agent-session.md) |
+| Current-only Agent/Project/asset contract             | implemented; branch validation in progress                    | [Agent API spec](../specs/agent-api.md) and [ADR 0007](../adr/0007-snapshot-driven-agent-workflow.md)                   |
 
 ## Active planning rules
 

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -7,7 +7,7 @@ boundaries.
 
 | Area                                                  | Status                                                        | Current authority                                                                                                       |
 | ----------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| Net naming, global projection, and export correctness | proposed P0-P2                                                | [staged boundary and delivery plan](net-naming-resolution-export-p0.md)                                                 |
+| Net naming, global projection, and export correctness | proposed C0, P0-P2                                            | [staged boundary and delivery plan](net-naming-resolution-export-p0.md)                                                 |
 | Connectivity, routing, and electrical debugging       | active                                                        | [unification plan](connectivity-routing-debugging-plan.md)                                                              |
 | Browser-authorized Agent sessions                     | implementation validation complete; deployment review pending | [session integration plan](web-agent-session-integration-plan.md) and [web-session spec](../specs/web-agent-session.md) |
 | Current-only Agent/Project/asset contract             | implemented; branch validation in progress                    | [Agent API spec](../specs/agent-api.md) and [ADR 0007](../adr/0007-snapshot-driven-agent-workflow.md)                   |

--- a/docs/roadmap/net-naming-resolution-export-p0.md
+++ b/docs/roadmap/net-naming-resolution-export-p0.md
@@ -1,0 +1,286 @@
+# P0 - Net Naming, Global Projection, and Export Correctness
+
+Status: `proposed`
+
+Owners: `packages/derived`, `packages/netlist`, `apps/editor`
+
+## Objective
+
+Close the naming defects that can make an exported netlist express different
+electrical connectivity from the schematic, without changing physical
+connectivity or Net lifecycle behavior.
+
+This is a Net naming/resolution/export boundary target. It is not a
+connectivity-lifecycle target.
+
+## Why this is P0
+
+The schematic currently distinguishes Logical Nets with scoped name identity,
+while extraction eventually emits plain simulator tokens. If scope or
+project-wide spelling is discarded before those tokens are proven unique, two
+distinct schematic Nets can become one simulator node, or one intended global
+Net can become multiple simulator nodes.
+
+Two correctness cases must be impossible:
+
+```text
+one Cell contains local VDD and global VDD
+-> both export as VDD
+-> the global declaration silently promotes and shorts the local node
+```
+
+```text
+top Cell spells a global VDD and a child Cell spells the same global vdd
+-> extraction preserves two spellings
+-> a dialect may interpret them as two nodes instead of one project global
+```
+
+Export must either produce one deliberate identity, produce two provably
+distinct dialect tokens, or block with a precise diagnostic. It must never
+silently change connectivity.
+
+## Naming model
+
+The existing persisted authority remains:
+
+```text
+Base Net
+  + owner-addressed name-claim { name, scope, owner, powerDomain? }
+  + formal Cell-Pin names
+  + non-authoritative import provenance
+        |
+        v
+Document Logical-Net resolver
+        |
+        v
+Project global-name projection
+        |
+        v
+Dialect identifier codec and collision check
+        |
+        v
+DesignNetlistIR
+```
+
+- `BaseNet.id` and terminal membership remain the physical authority.
+- `name-claim` remains the only editable Label/marker naming authority.
+- `LogicalNet.id` remains a revision-scoped derived handle.
+- `spice-source` and `net-name-hint` remain provenance only.
+- Project-global spelling and encoded dialect tokens are transient export
+  projections. They are not persisted identities.
+
+## Scope rules
+
+The intended authoring rules are:
+
+- an ordinary Net Label defaults to `local`;
+- VDD/power markers and Power Rails default to `global`;
+- Ground is the global reference node `0`;
+- imported explicit `.global` facts remain global declarations;
+- a Label may explicitly edit its existing `scope` claim between `local` and
+  `global` through the normal owner-addressed evidence edit path;
+- two disconnected claims with the same visible spelling but different scopes
+  remain distinct Logical Nets;
+- when the same physically connected Logical-Net group carries the same name
+  in both scopes, its effective scope is derived as `global`; owner claims are
+  not rewritten. Different names or incompatible power roles remain conflicts.
+
+The last rule changes the current accepted conflict policy and therefore
+requires the corresponding ADR/spec amendment in the implementation target.
+It does not authorize a new persisted promotion state.
+
+Because `VDD` may legally denote a local Net while another `VDD` is global,
+the editor must expose scope in Properties. A compact Global badge or equivalent
+presentation cue is required before this coexistence is treated as ordinary
+UI, but that cue has no electrical authority.
+
+## Spelling and dialect rules
+
+P0 separates three concepts that must not be collapsed:
+
+1. **Logical identity** decides whether authored claims denote the same
+   Logical Net.
+2. **Project spelling projection** selects one deterministic display/export
+   spelling for every project-global identity and uses it in every reachable
+   Cell.
+3. **Dialect codec** converts that identity to a legal SPICE or Spectre token
+   and checks uniqueness under that dialect's comparison rules.
+
+The current accepted model uses case-folded schematic name identity. P0 must
+preserve that rule unless a dedicated ADR deliberately changes it together
+with import, Properties, resolver, hierarchy, and compatibility tests. Case
+sensitivity must not change accidentally inside an exporter fix.
+
+The project-global projection must use one deterministic representative
+spelling for every folded global identity. Selection must be independent of
+array traversal and must be covered by stable-order tests. Every Cell node
+reference and the project global declaration consume that same projection.
+
+The dialect codec owns simulator syntax such as whether an authored `VDD!`
+can be emitted directly, must be escaped, or is unsupported. The shared model
+must not reject a valid authored name merely because the old portable ASCII
+subset cannot print it. Conversely, a printer must not strip punctuation,
+fold case, or append a suffix to an authoritative name when doing so can
+change identity.
+
+When two distinct Logical Nets map to one dialect token, extraction returns a
+blocking `NET_NAME_COLLISION`-class diagnostic naming both Nets, their scopes,
+and the conflicting token. Automatic `__2` disambiguation remains permitted
+only for non-authoritative source hints or generated unnamed local Nets, never
+for an authored Label, Cell Pin, or global declaration.
+
+## Strict implementation boundary
+
+### Allowed changes
+
+- pure Logical-Net name and effective-scope resolution;
+- the project-level global index and canonical spelling projection;
+- netlist extraction, dialect codecs, and collision diagnostics;
+- Properties editing of the existing `name-claim.scope` field;
+- a presentation-only Global indicator;
+- focused tests and the accepted specs/ADR required by these semantics.
+
+No new persisted field is required.
+
+### Systems that must remain unchanged
+
+- `connect_endpoints` and `merge_nets`;
+- `cut_connection` and `disconnect_endpoint`;
+- connected-components partitioning;
+- Base-Net split and stable-ID allocation;
+- terminal, Route, and Junction reassignment;
+- Label/marker evidence migration by owner;
+- orphan-Net pruning;
+- `sourceStatus` transitions;
+- imported-provenance copying;
+- undo/redo;
+- reset/clear;
+- hierarchy occurrence identity and traversal.
+
+The implementation must not:
+
+- rewrite every same-name Label to `global` after contact;
+- add a scope-promotion or scope-demotion lifecycle;
+- persist a hidden logical connection;
+- modify source provenance to preserve a naming result;
+- invoke Base-Net merge/split operations from a Label scope or spelling edit.
+
+The required behavior is purely derived:
+
+```text
+Wire connect/cut
+-> existing physical Base-Net transactions run unchanged
+-> existing owner evidence follows the resulting Base Nets unchanged
+-> resolver recomputes names and effective scope for the new revision
+-> export projection and codec recompute output tokens
+```
+
+## Work packages
+
+### WP-P0.1 - Characterize the electrical boundary
+
+- Add fixtures for local/global same-spelling Nets, cross-Cell global spelling,
+  `VDD!`, node `0`, and dialect collisions.
+- Snapshot physical topology and lifecycle state before changing the resolver
+  or exporter.
+- Main modules: `packages/derived`, `packages/netlist` tests and fixtures.
+
+### WP-P0.2 - Resolve effective scope without persisted promotion
+
+- Derive global effective scope for one already-connected, same-name group
+  containing local and global owner claims.
+- Keep disconnected local/global groups distinct.
+- Preserve all existing Base-Net and evidence ownership mutations.
+- Main module: `packages/derived`.
+
+### WP-P0.3 - Project one global identity and spelling
+
+- Extend the project global index with a deterministic canonical spelling.
+- Apply that projection to every reachable Cell before IR construction.
+- Diagnose contradictory global identities instead of repairing Project data.
+- Main modules: `packages/derived`, `packages/netlist`.
+
+### WP-P0.4 - Encode and prove dialect names
+
+- Centralize per-dialect identifier validation/encoding.
+- Detect local/global and encoded-token collisions before printer invocation.
+- Keep generated-name and non-authoritative hint disambiguation deterministic.
+- Main module: `packages/netlist`.
+
+### WP-P0.5 - Expose authored scope safely
+
+- Edit only the selected Label's existing owner-addressed scope claim.
+- Show enough scope information to distinguish equal visible local/global names.
+- Reuse the existing transaction, validation, undo, and redo paths.
+- Main module: `apps/editor`; supporting typed edit only if the existing edit
+  surface cannot express the field change.
+
+Each work package is a separate bounded implementation target unless its
+changed files and validation surface clearly coincide with an adjacent package.
+
+## Acceptance scenarios
+
+| Scenario                                                                          | Required result                                                                                                             |
+| --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Disconnected local `VDD` and global `VDD` in one Cell                             | They remain distinct. Export emits distinct legal tokens or blocks; it never silently shorts them.                          |
+| A local `VDD` Wire is physically connected to a global `VDD` marker               | The existing Base Net is unchanged by naming logic; the derived Logical Net is global and exports consistently.             |
+| That Wire is cut                                                                  | Existing split/evidence ownership decides the new Base Nets; the resolver recomputes scope without promotion history.       |
+| Top `VDD` and child `vdd` are one global identity under the accepted folding rule | Every Cell reference and the global declaration use one canonical project spelling/token.                                   |
+| Two distinct identities encode to the same dialect token                          | Export blocks with a collision diagnostic referencing both Logical/Base Nets.                                               |
+| An authored name is `VDD!`                                                        | The selected dialect emits a defined legal representation or blocks as unsupported; punctuation is never silently stripped. |
+| Ground marker                                                                     | It remains global node `0`; no naming projection creates an alias.                                                          |
+| Label scope changes through Properties                                            | Only that owner's claim changes; physical membership, Routes, Junctions, provenance, and unrelated claims do not.           |
+| Undo/redo of a scope edit                                                         | Existing project transaction semantics restore exactly the prior/new evidence and derived export result.                    |
+
+## Regression invariants
+
+For identical physical editing operations before and after this work, tests
+must prove equality of:
+
+- Base-Net connected-component partitions and stable-ID allocation;
+- terminal, Route, and Junction ownership;
+- owner-addressed evidence reassignment after split;
+- orphan pruning and `sourceStatus`;
+- imported provenance;
+- undo/redo and reset/clear state transitions;
+- hierarchy occurrence edges.
+
+Only these outputs may change:
+
+- Logical-Net name/effective-scope resolution;
+- project-global grouping and canonical spelling;
+- exported node/global tokens;
+- naming, scope, representability, and collision diagnostics;
+- Properties/presentation of the existing scope fact.
+
+## Deterministic validation
+
+- focused `packages/derived` Logical-Net and project-index tests;
+- focused `packages/netlist` extraction and SPICE/Spectre golden tests;
+- structural SPICE reparse for every successfully emitted fixture;
+- focused editor Properties tests for the existing scope edit;
+- existing edit-engine connect, cut, split, evidence migration, lifecycle,
+  reset, and undo/redo regressions with no golden-state changes;
+- `pnpm gate:affected -- --base <base-ref>` for each implementation target;
+- the repository mainline delivery gate before merge.
+
+## Out of scope
+
+- PDK lookup, model libraries, simulation profiles, corners, or analyses;
+- physical connectivity algorithms or lifecycle redesign;
+- persisted Logical-Net IDs or Logical-Net lineage;
+- hierarchy-occurrence redesign;
+- bus naming and vector expansion;
+- source-text round-trip beyond preserving typed provenance;
+- automatic inference that arbitrary names such as `VDD`, `AVDD`, or `DVDD`
+  are global merely because of their spelling.
+
+## Exit gate
+
+P0 is complete only when every acceptance scenario is deterministic in both
+SPICE and Spectre export, no successful export can collapse two distinct
+schematic Net identities, and unchanged connectivity/lifecycle regression
+fixtures produce byte-identical physical state.
+
+Dependent netlist-import/export closure work may then rely on project-global
+identity and dialect spelling as explicit, tested boundaries.

--- a/docs/roadmap/net-naming-resolution-export-p0.md
+++ b/docs/roadmap/net-naming-resolution-export-p0.md
@@ -12,8 +12,9 @@ spelling and Cadence-compatible round-trip behavior, without changing physical
 connectivity or Net lifecycle behavior.
 
 This is a Net naming/resolution/export boundary target. It is not a
-connectivity-lifecycle target. Delivery is ordered P0 correctness, P1 naming
-authority and dialect capability, then P2 source-spelling compatibility.
+connectivity-lifecycle target. Delivery is ordered as the separately committed
+C0 lifecycle correction, P0 naming correctness, P1 naming authority and
+dialect capability, then P2 source-spelling compatibility.
 
 ## Why this is P0
 
@@ -246,6 +247,66 @@ After a Wire cut, existing evidence-copy rules remain authoritative. If two
 resulting Nets retain the same source hint, the exporter may disambiguate those
 non-authoritative hints and report it; it must not reconnect the Nets.
 
+## Prerequisite C0 - Imported-global split allocation
+
+This is a separate P0 connectivity-correctness target that must land before the
+naming P0 work. It is recorded here because a stale imported global authority
+can invalidate every later spelling/export guarantee, but it is not part of
+the naming implementation boundary.
+
+The importer correctly maps an explicit source declaration:
+
+```spice
+.global VDD
+```
+
+to an authoritative global `name-claim` owned by `global-declaration`. The
+defect occurs later: the common split propagation currently copies that
+non-spatial declaration to every Base-Net component after `cut_connection`.
+The resolver then joins those components again by global scoped name, so the
+physical split does not become an electrical/netlist split.
+
+The accepted split allocation is:
+
+| Evidence after cut                 | Allocation                                                                |
+| ---------------------------------- | ------------------------------------------------------------------------- |
+| `spice-source`                     | Copy to every surviving component as provenance.                          |
+| `net-name-hint`                    | Copy to every surviving component as non-electrical spelling provenance.  |
+| `global-declaration`               | Keep only on the primary component that retains the original Base-Net ID. |
+| Label or Power Marker `name-claim` | Continue following its existing spatial owner to the surviving component. |
+
+No importer mapping, schema, resolver rule, project-global projection, or new
+lifecycle state is required. The existing split algorithm already chooses the
+primary component and retains the original Base-Net ID, so retaining the
+original declaration requires no second ownership rule. The existing
+connectivity transaction continues setting `sourceStatus` to
+`connectivity-modified`.
+
+Required C0 acceptance scenarios:
+
+1. Cutting an imported global with no spatial name owner produces two Base
+   Nets and two Logical Nets; only the primary remains global.
+2. When both resulting components independently retain same-name Global
+   Markers, they remain two Base Nets but intentionally resolve to one global
+   Logical Net.
+3. When only one component has a current global owner, the other component
+   does not inherit global scope from source provenance.
+4. Both components retain their `spice-source` and `net-name-hint` evidence,
+   and imported routing guidance remains non-electrical.
+5. Undo and redo restore the exact Base-Net, evidence, Logical-Net, and
+   `sourceStatus` results.
+
+### Separate delivery boundary
+
+- C0 owns only split evidence allocation and its focused Edit Engine/derived
+  regression tests.
+- C0 must be committed and reviewed independently from resolver spelling,
+  project-global projection, dialect codec, and Properties changes.
+- Naming P0-P2 commits must not use C0 as permission to rewrite the common
+  connect/cut/split lifecycle.
+- A test that only observes physical Base-Net partitioning is insufficient;
+  C0 must assert post-cut Logical-Net resolution and exported connectivity.
+
 ## Accepted product decisions
 
 | Decision                         | Accepted policy                                                                                                                     |
@@ -257,6 +318,10 @@ non-authoritative hints and report it; it must not reconnect the Nets.
 | Persistence                      | Keep one authored `name-claim`; preferred spelling, variants, codec tokens, and profiles remain transient.                          |
 
 ## Strict implementation boundary
+
+The following boundary applies to the naming P0-P2 work packages. Prerequisite
+C0 is the separately committed correction described above and is the only
+planned change to split evidence allocation.
 
 ### Allowed changes
 
@@ -451,6 +516,9 @@ Only these outputs may change:
 
 ## Phase exit gates
 
+- C0 is complete when cutting an imported global cannot regain connectivity
+  through copied declaration authority, while provenance, owner-following,
+  source status, and undo/redo retain their existing contracts.
 - P0 is complete when no successful export can collapse two distinct schematic
   Net identities, all reachable references use one project-global spelling,
   and unchanged connectivity/lifecycle fixtures produce byte-identical

--- a/docs/roadmap/net-naming-resolution-export-p0.md
+++ b/docs/roadmap/net-naming-resolution-export-p0.md
@@ -1,4 +1,4 @@
-# P0 - Net Naming, Global Projection, and Export Correctness
+# Net Naming, Global Projection, and Export Plan
 
 Status: `proposed`
 
@@ -7,11 +7,13 @@ Owners: `packages/derived`, `packages/netlist`, `apps/editor`
 ## Objective
 
 Close the naming defects that can make an exported netlist express different
-electrical connectivity from the schematic, without changing physical
+electrical connectivity from the schematic, then establish deterministic
+spelling and Cadence-compatible round-trip behavior, without changing physical
 connectivity or Net lifecycle behavior.
 
 This is a Net naming/resolution/export boundary target. It is not a
-connectivity-lifecycle target.
+connectivity-lifecycle target. Delivery is ordered P0 correctness, P1 naming
+authority and dialect capability, then P2 source-spelling compatibility.
 
 ## Why this is P0
 
@@ -94,9 +96,27 @@ the editor must expose scope in Properties. A compact Global badge or equivalent
 presentation cue is required before this coexistence is treated as ordinary
 UI, but that cue has no electrical authority.
 
-## Spelling and dialect rules
+## Case and identity rule
 
-P0 separates three concepts that must not be collapsed:
+Schematic Net identity remains case-insensitive, matching the current
+`foldNetName()` contract and ngspice-style node identity:
+
+```text
+VDD == vdd == Vdd
+```
+
+Original case remains spelling, not electrical identity. Scope remains part of
+identity, so disconnected local `VDD` and global `vdd` are still different
+Logical Nets. A Spectre or compatibility codec may apply a different output
+syntax, but it must not redefine schematic identity.
+
+Changing this case-folded identity would require a dedicated ADR covering
+import, Properties, resolver, hierarchy, compatibility, and migration. It is
+not part of this plan.
+
+## Spelling authority
+
+The plan separates three concepts that must not be collapsed:
 
 1. **Logical identity** decides whether authored claims denote the same
    Logical Net.
@@ -106,28 +126,135 @@ P0 separates three concepts that must not be collapsed:
 3. **Dialect codec** converts that identity to a legal SPICE or Spectre token
    and checks uniqueness under that dialect's comparison rules.
 
-The current accepted model uses case-folded schematic name identity. P0 must
-preserve that rule unless a dedicated ADR deliberately changes it together
-with import, Properties, resolver, hierarchy, and compatibility tests. Case
-sensitivity must not change accidentally inside an exporter fix.
+The project-global projection retains every exact spelling variant and selects
+one preferred spelling through this semantic priority:
 
-The project-global projection must use one deterministic representative
-spelling for every folded global identity. Selection must be independent of
-array traversal and must be covered by stable-order tests. Every Cell node
-reference and the project global declaration consume that same projection.
+```text
+current visible Label or Power Marker
+  (prefer the top Cell, then the nearest reachable hierarchy depth)
+-> Cell Pin name
+-> imported global declaration
+-> source hint
+-> generated name
+```
 
-The dialect codec owns simulator syntax such as whether an authored `VDD!`
-can be emitted directly, must be escaped, or is unsupported. The shared model
-must not reject a valid authored name merely because the old portable ASCII
-subset cannot print it. Conversely, a printer must not strip punctuation,
-fold case, or append a suffix to an authoritative name when doing so can
-change identity.
+Within the same priority tier, a stable lexical comparison selects the
+preferred spelling. Evidence ID or incidental array order must not select it.
+The projection exposes transient fields such as:
+
+```typescript
+spellings: readonly string[];
+preferredSpelling?: string;
+```
+
+These fields are never persisted. Every Cell node reference and the project
+global declaration consume the same preferred project spelling.
+
+Multiple exact spellings for one case-folded identity are legal and produce a
+non-blocking `GLOBAL_NAME_SPELLING_NORMALIZED`-class diagnostic that lists the
+variants and selected output spelling. Labels continue to display their own
+authored text; normalization never rewrites owner claims. Properties may show
+the preferred export spelling and all variants.
+
+This plan deliberately chooses stable automatic selection plus a warning. It
+does not block export merely because `VDD` and `vdd` occur on the same identity.
+
+## Dialect name codec
+
+One pure codec boundary converts preferred semantic names to output tokens:
+
+```typescript
+encodeNetName({ name, scope, dialect, namingProfile }) => ({
+  token,
+  collisionKey,
+  diagnostics,
+});
+```
+
+It owns legal characters, reserved words, escaping, the target's case
+comparison, global output form, and encoded-token collision checks. Project
+projection decides that a Net is named `VDD`; the codec decides how the target
+format can represent it.
+
+The SPICE target uses ngspice semantics: node identity is case-insensitive,
+Ground is node `0`, and global scope is emitted with `.global`. The Spectre
+target has its own syntax and collision rules. The current shared portable
+identifier subset remains the P0 safety baseline, then P1 replaces it with
+explicit target codecs.
+
+The shared model must not reject a valid authored name merely because the old
+portable ASCII subset cannot print it. Conversely, a codec must not strip
+punctuation, fold display case, or append a suffix to an authoritative name
+when doing so can change identity.
 
 When two distinct Logical Nets map to one dialect token, extraction returns a
 blocking `NET_NAME_COLLISION`-class diagnostic naming both Nets, their scopes,
 and the conflicting token. Automatic `__2` disambiguation remains permitted
 only for non-authoritative source hints or generated unnamed local Nets, never
 for an authored Label, Cell Pin, or global declaration.
+
+## Cadence `!` compatibility
+
+Core semantic state remains clean and typed:
+
+```text
+name = VDD
+scope = global
+canvas = VDD plus a Global indicator
+```
+
+Default ngspice and Spectre export use their explicit global declarations.
+Cadence bang-style is an explicit import/export naming profile, not a new Net
+type and not a second persisted Net name. When selected, it may encode the
+same semantic global as `VDD!` according to the target format. The profile is
+operation configuration and is not persisted in the Project.
+
+Cadence-compatible import of `vdd!` separates semantic and lexical facts:
+
+```yaml
+name-claim:
+  name: vdd
+  scope: global
+net-name-hint:
+  sourceName: vdd!
+```
+
+Generic SPICE import must not unconditionally remove `!`, because outside the
+explicit compatibility profile it may be part of the literal node name. This
+plan therefore chooses an explicit Cadence-compatible profile rather than
+guessing from punctuation.
+
+## Source spelling policy
+
+Source spelling remains provenance and requires no new lifecycle state. Output
+selection follows:
+
+```text
+current authored name-claim
+-> project-global preferred spelling
+-> one unambiguous source hint encodable by the target
+-> generated name
+```
+
+`sourceStatus` does not enable or disable individual source hints. It is a
+Document-level statement about source correspondence; an unrelated edit must
+not invalidate every useful Net spelling. `connectivity-modified` means exact
+source round-trip is no longer promised, while safe hints may still be reused.
+
+An authored rename or newly placed marker wins without deleting provenance.
+After a Wire cut, existing evidence-copy rules remain authoritative. If two
+resulting Nets retain the same source hint, the exporter may disambiguate those
+non-authoritative hints and report it; it must not reconnect the Nets.
+
+## Accepted product decisions
+
+| Decision                         | Accepted policy                                                                                                                     |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Schematic case identity          | Case-insensitive through the existing folding contract; exact case is spelling only.                                                |
+| Equal-identity spelling variants | Select deterministically by semantic priority and lexical tie-break, then warn; do not block or rewrite owners.                     |
+| Cadence bang interpretation      | Enable only through an explicit import/export compatibility profile; never infer electrical scope from punctuation in generic mode. |
+| Source-hint eligibility          | Current authority wins; Document-level `sourceStatus` does not globally disable safe hints.                                         |
+| Persistence                      | Keep one authored `name-claim`; preferred spelling, variants, codec tokens, and profiles remain transient.                          |
 
 ## Strict implementation boundary
 
@@ -177,6 +304,8 @@ Wire connect/cut
 
 ## Work packages
 
+### P0 - Exported connectivity correctness
+
 ### WP-P0.1 - Characterize the electrical boundary
 
 - Add fixtures for local/global same-spelling Nets, cross-Cell global spelling,
@@ -200,37 +329,78 @@ Wire connect/cut
 - Diagnose contradictory global identities instead of repairing Project data.
 - Main modules: `packages/derived`, `packages/netlist`.
 
-### WP-P0.4 - Encode and prove dialect names
+### WP-P0.4 - Block output-token collisions
+
+- Compute target comparison keys for the currently supported identifier
+  subset.
+- Block local/global and cross-identity collisions before printer invocation.
+- Do not automatically rename authored Labels, Cell Pins, or globals.
+- Main module: `packages/netlist`.
+
+### P1 - Spelling authority and dialect capability
+
+### WP-P1.1 - Preserve variants and select preferred spelling
+
+- Add derived `spellings` and `preferredSpelling` projections.
+- Implement the accepted semantic priority and lexical tie-break.
+- Emit normalization warnings without rewriting owner claims.
+- Main modules: `packages/derived`, `packages/netlist`.
+
+### WP-P1.2 - Introduce ngspice and Spectre codecs
 
 - Centralize per-dialect identifier validation/encoding.
 - Detect local/global and encoded-token collisions before printer invocation.
 - Keep generated-name and non-authoritative hint disambiguation deterministic.
 - Main module: `packages/netlist`.
 
-### WP-P0.5 - Expose authored scope safely
+### WP-P1.3 - Expose authored scope and spelling safely
 
 - Edit only the selected Label's existing owner-addressed scope claim.
-- Show enough scope information to distinguish equal visible local/global names.
+- Show scope, preferred export spelling, and variants without treating the
+  projection as editable persisted state.
+- Show enough presentation information to distinguish equal visible
+  local/global names.
 - Reuse the existing transaction, validation, undo, and redo paths.
 - Main module: `apps/editor`; supporting typed edit only if the existing edit
   surface cannot express the field change.
+
+### P2 - Cadence spelling and source round-trip
+
+### WP-P2.1 - Add the explicit Cadence bang profile
+
+- Normalize bang-style source spelling only when the profile is selected.
+- Preserve the exact source token as a non-electrical hint.
+- Encode typed globals using the target profile without changing their semantic
+  name or scope.
+- Main modules: `packages/spice`, `packages/netlist`, import/export UI.
+
+### WP-P2.2 - Complete source-spelling selection
+
+- Apply the accepted authored/project/hint/generated precedence.
+- Keep hint eligibility independent of Document-level `sourceStatus`.
+- Diagnose ambiguous or disambiguated hints and never claim exact round-trip
+  after connectivity modification.
+- Main modules: `packages/netlist`, import/export UI.
 
 Each work package is a separate bounded implementation target unless its
 changed files and validation surface clearly coincide with an adjacent package.
 
 ## Acceptance scenarios
 
-| Scenario                                                                          | Required result                                                                                                             |
-| --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| Disconnected local `VDD` and global `VDD` in one Cell                             | They remain distinct. Export emits distinct legal tokens or blocks; it never silently shorts them.                          |
-| A local `VDD` Wire is physically connected to a global `VDD` marker               | The existing Base Net is unchanged by naming logic; the derived Logical Net is global and exports consistently.             |
-| That Wire is cut                                                                  | Existing split/evidence ownership decides the new Base Nets; the resolver recomputes scope without promotion history.       |
-| Top `VDD` and child `vdd` are one global identity under the accepted folding rule | Every Cell reference and the global declaration use one canonical project spelling/token.                                   |
-| Two distinct identities encode to the same dialect token                          | Export blocks with a collision diagnostic referencing both Logical/Base Nets.                                               |
-| An authored name is `VDD!`                                                        | The selected dialect emits a defined legal representation or blocks as unsupported; punctuation is never silently stripped. |
-| Ground marker                                                                     | It remains global node `0`; no naming projection creates an alias.                                                          |
-| Label scope changes through Properties                                            | Only that owner's claim changes; physical membership, Routes, Junctions, provenance, and unrelated claims do not.           |
-| Undo/redo of a scope edit                                                         | Existing project transaction semantics restore exactly the prior/new evidence and derived export result.                    |
+| Scenario                                                                          | Required result                                                                                                       |
+| --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Disconnected local `VDD` and global `VDD` in one Cell                             | They remain distinct. Export emits distinct legal tokens or blocks; it never silently shorts them.                    |
+| A local `VDD` Wire is physically connected to a global `VDD` marker               | The existing Base Net is unchanged by naming logic; the derived Logical Net is global and exports consistently.       |
+| That Wire is cut                                                                  | Existing split/evidence ownership decides the new Base Nets; the resolver recomputes scope without promotion history. |
+| Top `VDD` and child `vdd` are one global identity under the accepted folding rule | Every Cell reference and the global declaration use one canonical project spelling/token.                             |
+| One identity has visible spellings `VDD`, `vdd`, and `Vdd`                        | Export selects one spelling by semantic priority, reports all variants, and does not rewrite any Label.               |
+| Two distinct identities encode to the same dialect token                          | Export blocks with a collision diagnostic referencing both Logical/Base Nets.                                         |
+| An authored literal name is `VDD!` in generic SPICE mode                          | It remains literal and is encoded or rejected by ngspice rules; punctuation is never silently stripped.               |
+| Cadence-compatible import reads global `vdd!`                                     | Semantic state is global `vdd`, exact `vdd!` remains provenance, and the canvas need not display the suffix.          |
+| The same Project exports normally and with Cadence compatibility                  | Both outputs preserve one electrical identity; only the selected lexical representation changes.                      |
+| Ground marker                                                                     | It remains global node `0`; no naming projection creates an alias.                                                    |
+| Label scope changes through Properties                                            | Only that owner's claim changes; physical membership, Routes, Junctions, provenance, and unrelated claims do not.     |
+| Undo/redo of a scope edit                                                         | Existing project transaction semantics restore exactly the prior/new evidence and derived export result.              |
 
 ## Regression invariants
 
@@ -257,6 +427,10 @@ Only these outputs may change:
 
 - focused `packages/derived` Logical-Net and project-index tests;
 - focused `packages/netlist` extraction and SPICE/Spectre golden tests;
+- order-permutation tests proving spelling output is independent of evidence ID
+  and Project array order;
+- paired generic/Cadence profile fixtures proving identical electrical identity
+  with intentionally different spelling;
 - structural SPICE reparse for every successfully emitted fixture;
 - focused editor Properties tests for the existing scope edit;
 - existing edit-engine connect, cut, split, evidence migration, lifecycle,
@@ -275,12 +449,18 @@ Only these outputs may change:
 - automatic inference that arbitrary names such as `VDD`, `AVDD`, or `DVDD`
   are global merely because of their spelling.
 
-## Exit gate
+## Phase exit gates
 
-P0 is complete only when every acceptance scenario is deterministic in both
-SPICE and Spectre export, no successful export can collapse two distinct
-schematic Net identities, and unchanged connectivity/lifecycle regression
-fixtures produce byte-identical physical state.
+- P0 is complete when no successful export can collapse two distinct schematic
+  Net identities, all reachable references use one project-global spelling,
+  and unchanged connectivity/lifecycle fixtures produce byte-identical
+  physical state.
+- P1 is complete when spelling selection no longer depends on evidence IDs or
+  array order, variants are explainable, and ngspice/Spectre codecs prove every
+  emitted token under their own rules.
+- P2 is complete when Cadence bang-style import/export is explicit and
+  deterministic, source hints follow the accepted precedence, and modified
+  Documents make no false exact-round-trip claim.
 
 Dependent netlist-import/export closure work may then rely on project-global
 identity and dialect spelling as explicit, tested boundaries.

--- a/docs/specs/schematic-model.md
+++ b/docs/specs/schematic-model.md
@@ -41,9 +41,11 @@ migration. Invalid coordinates are rejected with their data path.
   Base Net at a time. The pure Logical-Net resolver joins distinct Base Nets
   through matching folded authoritative names in the same scope or matching
   formal Cell-Pin names. A `net-name-hint` and `spice-source` record are
-  provenance only and never join Nets. Conflicting name, scope, or power claims
-  remain explicit errors; no claim type silently wins. There is no generic
-  persisted equivalence edge.
+  provenance only and never join Nets. Equal-folded local and global claims on
+  one already-connected group derive an effective global scope without
+  rewriting either owner. Disconnected claims remain separate; different-name
+  scope combinations and incompatible power claims remain explicit errors.
+  There is no generic persisted equivalence edge.
 - `Route` owns editable geometry for one Net and connects terminal or Junction
   endpoints only.
 - `Junction` owns explicit branch/anchor geometry.
@@ -82,7 +84,9 @@ High-level GUI Net naming starts from an existing candidate Base Net plus a
 stable Net Label owner. It writes or updates that owner's `name-claim`; it
 never emits `merge_nets` or creates a new `Net.name` projection. Matching
 claims join only in the derived Logical-Net view. Physical contact alone uses
-the internal Base-Net merge primitive.
+the internal Base-Net merge primitive. Explicitly contacting equal-folded
+local and global Nets is permitted; the merged group's effective scope is
+global while both authored claims remain unchanged.
 
 The editor does not normalize from inert legacy Base-Net metadata or coalesce
 Base Nets by text. Compatible same-name claims are ordinary logical identity;

--- a/packages/derived/src/index.ts
+++ b/packages/derived/src/index.ts
@@ -19,6 +19,7 @@ export * from "./instance-value.js";
 export * from "./logical-net.js";
 export * from "./net-highlight.js";
 export * from "./net-label.js";
+export * from "./net-name-projection.js";
 export * from "./mos-bulk.js";
 export * from "./object-locator.js";
 export * from "./project-search.js";

--- a/packages/derived/src/logical-net.test.ts
+++ b/packages/derived/src/logical-net.test.ts
@@ -113,6 +113,38 @@ describe("resolved logical Nets", () => {
     );
   });
 
+  it("derives global scope for same-name local and global claims on one physical Net", () => {
+    const document = createEmptyDocument("document", "Document");
+    document.nets.push({ id: "net-vdd", terminals: [] });
+    document.connectivityEvidence.push(
+      {
+        id: "claim-local",
+        kind: "name-claim",
+        netId: "net-vdd",
+        name: "VDD",
+        owner: { kind: "net-label", annotationId: "label-local" },
+        scope: "local",
+      },
+      {
+        id: "claim-global",
+        kind: "name-claim",
+        netId: "net-vdd",
+        name: "vdd",
+        owner: { kind: "power-marker", objectId: "VDD1" },
+        scope: "global",
+        powerDomain: "vdd",
+      },
+    );
+
+    expect(resolveDocumentLogicalNets(document).groups[0]).toMatchObject({
+      name: "vdd",
+      scope: "global",
+      conflicts: [],
+      evidenceIds: ["claim-global", "claim-local"],
+    });
+    expect(document.connectivityEvidence).toHaveLength(2);
+  });
+
   it("does not promote a legacy source spelling into a Logical Net name", () => {
     const document = createEmptyDocument("document", "Document");
     document.nets.push(

--- a/packages/derived/src/logical-net.ts
+++ b/packages/derived/src/logical-net.ts
@@ -192,7 +192,13 @@ export function resolveDocumentLogicalNets(
       if (namesByFolded.size > 1) {
         conflicts.push("name-conflict");
       }
-      if (scopes.size > 1) conflicts.push("scope-conflict");
+      // Scope is a property of one name identity, not a second physical
+      // partition. When the same already-connected Net carries local and
+      // global claims for that one name, global is the effective scope. Keep
+      // both owner claims intact so a later cut can re-derive each side.
+      if (scopes.size > 1 && namesByFolded.size !== 1) {
+        conflicts.push("scope-conflict");
+      }
       if (powerDomain === "conflict") {
         conflicts.push("power-domain-conflict");
       }
@@ -211,7 +217,9 @@ export function resolveDocumentLogicalNets(
           : {}),
         ...(scopes.size === 1
           ? { scope: [...scopes][0] as "local" | "global" }
-          : {}),
+          : namesByFolded.size === 1 && scopes.has("global")
+            ? { scope: "global" as const }
+            : {}),
         powerDomain,
         evidenceIds: evidence.map((item) => item.id),
         formalTerminalIds: memberFormalNames.map((item) => item.id).sort(),

--- a/packages/derived/src/net-name-projection.test.ts
+++ b/packages/derived/src/net-name-projection.test.ts
@@ -1,0 +1,147 @@
+import { createEmptyDocument, createEmptyProject } from "@icm/model";
+import { describe, expect, it } from "vitest";
+
+import { deriveProjectNetNameProjection } from "./net-name-projection.js";
+
+function addClaim(
+  document: ReturnType<typeof createEmptyDocument>,
+  input: {
+    id: string;
+    netId: string;
+    name: string;
+    owner: "label" | "global-declaration";
+  },
+): void {
+  if (input.owner === "label") {
+    const annotationId = `annotation-${input.id}`;
+    document.annotations.push({
+      id: annotationId,
+      kind: "net-label",
+      binding: { kind: "net-name", netId: input.netId },
+      netId: input.netId,
+      anchor: { kind: "free", position: { x: 0, y: 0 } },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    });
+    document.connectivityEvidence.push({
+      id: input.id,
+      kind: "name-claim",
+      netId: input.netId,
+      name: input.name,
+      scope: "global",
+      owner: { kind: "net-label", annotationId },
+    });
+    return;
+  }
+  document.connectivityEvidence.push({
+    id: input.id,
+    kind: "name-claim",
+    netId: input.netId,
+    name: input.name,
+    scope: "global",
+    owner: { kind: "global-declaration", sourceNetId: input.netId },
+  });
+}
+
+describe("Project Net name projection", () => {
+  it("prefers current object-owned spelling independently of Evidence ID", () => {
+    const project = createEmptyProject("project", "Project", "top");
+    const top = project.documents[0]!;
+    top.nets.push({ id: "net-vdd", terminals: [] });
+    addClaim(top, {
+      id: "a-imported",
+      netId: "net-vdd",
+      name: "vdd",
+      owner: "global-declaration",
+    });
+    addClaim(top, {
+      id: "z-visible",
+      netId: "net-vdd",
+      name: "VDD",
+      owner: "label",
+    });
+
+    const projected = deriveProjectNetNameProjection(project)
+      .byDocumentId.get("top")
+      ?.get("net-vdd");
+
+    expect(projected).toMatchObject({
+      spellings: ["VDD", "vdd"],
+      preferredSpelling: "VDD",
+      scope: "global",
+    });
+  });
+
+  it("uses the nearest reachable spelling and ignores orphan influence", () => {
+    const project = createEmptyProject("project", "Project", "top");
+    const top = project.documents[0]!;
+    const child = createEmptyDocument("child", "Child");
+    const orphan = createEmptyDocument("orphan", "Orphan");
+    project.documents.push(child, orphan);
+    top.instances.push({
+      id: "X1",
+      symbolId: "child-symbol",
+      placement: null,
+      reference: "X1",
+      netlist: {
+        binding: { kind: "subcircuit", childDocumentId: "child" },
+        parameters: {},
+      },
+    });
+    for (const [document, netId, spelling] of [
+      [top, "net-top", "VDD"],
+      [child, "net-child", "vdd"],
+      [orphan, "net-orphan", "Vdd"],
+    ] as const) {
+      document.nets.push({ id: netId, terminals: [] });
+      addClaim(document, {
+        id: `claim-${netId}`,
+        netId,
+        name: spelling,
+        owner: "label",
+      });
+    }
+
+    const projection = deriveProjectNetNameProjection(project);
+    expect(projection.byDocumentId.get("top")?.get("net-top")).toMatchObject({
+      spellings: ["VDD", "vdd"],
+      preferredSpelling: "VDD",
+    });
+    expect(
+      projection.byDocumentId.get("child")?.get("net-child"),
+    ).toMatchObject({
+      spellings: ["VDD", "vdd"],
+      preferredSpelling: "VDD",
+    });
+    expect(
+      projection.byDocumentId.get("orphan")?.get("net-orphan"),
+    ).toMatchObject({
+      spellings: ["VDD", "vdd"],
+      preferredSpelling: "VDD",
+    });
+  });
+
+  it("uses a unique source hint only for an otherwise unnamed Net", () => {
+    const project = createEmptyProject("project", "Project", "top");
+    const top = project.documents[0]!;
+    top.nets.push({ id: "net-imported", terminals: [] });
+    top.connectivityEvidence.push({
+      id: "hint",
+      kind: "net-name-hint",
+      netId: "net-imported",
+      sourceName: "bias.p",
+      origin: "spice-import",
+    });
+
+    expect(
+      deriveProjectNetNameProjection(project)
+        .byDocumentId.get("top")
+        ?.get("net-imported"),
+    ).toMatchObject({
+      spellings: ["bias.p"],
+      preferredSpelling: "bias.p",
+      scope: "local",
+    });
+  });
+});

--- a/packages/derived/src/net-name-projection.ts
+++ b/packages/derived/src/net-name-projection.ts
@@ -1,0 +1,231 @@
+import { foldNetName } from "@icm/model";
+import type { CircuitProject, SchematicDocument } from "@icm/model";
+
+import {
+  resolveDocumentLogicalNets,
+  type ResolvedLogicalNet,
+} from "./logical-net.js";
+
+export interface ProjectedNetName {
+  documentId: string;
+  logicalNetId: string;
+  baseNetIds: readonly string[];
+  scope: "local" | "global";
+  spellings: readonly string[];
+  preferredSpelling?: string;
+}
+
+export interface ProjectNetNameProjection {
+  byDocumentId: ReadonlyMap<string, ReadonlyMap<string, ProjectedNetName>>;
+}
+
+type NameCandidate = {
+  spelling: string;
+  authorityRank: number;
+  documentDepth: number;
+};
+
+type MutableProjection = {
+  value: ProjectedNetName;
+  candidates: readonly NameCandidate[];
+  reachable: boolean;
+};
+
+function compareExactText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function compareCandidates(left: NameCandidate, right: NameCandidate): number {
+  return (
+    left.authorityRank - right.authorityRank ||
+    left.documentDepth - right.documentDepth ||
+    compareExactText(left.spelling, right.spelling)
+  );
+}
+
+function uniqueSpellings(candidates: readonly NameCandidate[]): string[] {
+  return [...new Set(candidates.map((candidate) => candidate.spelling))].sort(
+    compareExactText,
+  );
+}
+
+function hierarchyDepths(project: CircuitProject): ReadonlyMap<string, number> {
+  const documentsById = new Map(
+    project.documents.map((document) => [document.id, document]),
+  );
+  const depths = new Map<string, number>();
+  const pending = [{ documentId: project.topDocumentId, depth: 0 }];
+  for (let index = 0; index < pending.length; index += 1) {
+    const current = pending[index]!;
+    const prior = depths.get(current.documentId);
+    if (prior !== undefined && prior <= current.depth) continue;
+    depths.set(current.documentId, current.depth);
+    const document = documentsById.get(current.documentId);
+    if (!document) continue;
+    for (const instance of document.instances) {
+      const binding = instance.netlist?.binding;
+      if (binding?.kind !== "subcircuit") continue;
+      pending.push({
+        documentId: binding.childDocumentId,
+        depth: current.depth + 1,
+      });
+    }
+  }
+  return depths;
+}
+
+function candidatesForLogicalNet(
+  document: SchematicDocument,
+  logicalNet: ResolvedLogicalNet,
+  documentDepth: number,
+): readonly NameCandidate[] {
+  const memberNetIds = new Set(logicalNet.baseNetIds);
+  const foldedIdentity = logicalNet.name
+    ? foldNetName(logicalNet.name)
+    : undefined;
+  const authoritative: NameCandidate[] = [];
+  const hints: NameCandidate[] = [];
+
+  for (const evidence of document.connectivityEvidence) {
+    if (!memberNetIds.has(evidence.netId)) continue;
+    if (evidence.kind === "name-claim") {
+      if (foldedIdentity && foldNetName(evidence.name) !== foldedIdentity) {
+        continue;
+      }
+      authoritative.push({
+        spelling: evidence.name.trim(),
+        authorityRank: evidence.owner.kind === "global-declaration" ? 2 : 0,
+        documentDepth,
+      });
+    } else if (evidence.kind === "net-name-hint") {
+      if (
+        foldedIdentity &&
+        foldNetName(evidence.sourceName) !== foldedIdentity
+      ) {
+        continue;
+      }
+      hints.push({
+        spelling: evidence.sourceName.trim(),
+        authorityRank: 3,
+        documentDepth,
+      });
+    }
+  }
+
+  for (const terminal of document.netlist?.terminals ?? []) {
+    if (!memberNetIds.has(terminal.netId)) continue;
+    if (foldedIdentity && foldNetName(terminal.name) !== foldedIdentity) {
+      continue;
+    }
+    authoritative.push({
+      spelling: terminal.name.trim(),
+      authorityRank: 1,
+      documentDepth,
+    });
+  }
+
+  if (authoritative.length > 0) return authoritative;
+  if (foldedIdentity) {
+    return [
+      {
+        spelling: logicalNet.name!.trim(),
+        authorityRank: 2,
+        documentDepth,
+      },
+    ];
+  }
+
+  const hintIdentities = new Set(
+    hints.map((candidate) => foldNetName(candidate.spelling)),
+  );
+  return hintIdentities.size === 1 ? hints : [];
+}
+
+function projectedName(
+  document: SchematicDocument,
+  logicalNet: ResolvedLogicalNet,
+  documentDepth: number,
+  reachable: boolean,
+): MutableProjection {
+  const candidates = [
+    ...candidatesForLogicalNet(document, logicalNet, documentDepth),
+  ].sort(compareCandidates);
+  return {
+    value: {
+      documentId: document.id,
+      logicalNetId: logicalNet.id,
+      baseNetIds: logicalNet.baseNetIds,
+      scope: logicalNet.scope ?? "local",
+      spellings: uniqueSpellings(candidates),
+      ...(candidates[0] ? { preferredSpelling: candidates[0].spelling } : {}),
+    },
+    candidates,
+    reachable,
+  };
+}
+
+/**
+ * Pure revision-scoped spelling projection. It never changes Base Nets,
+ * owner-addressed evidence, or source provenance.
+ */
+export function deriveProjectNetNameProjection(
+  project: CircuitProject,
+): ProjectNetNameProjection {
+  const depths = hierarchyDepths(project);
+  const mutableByDocument = new Map<string, Map<string, MutableProjection>>();
+  const globalGroups = new Map<string, MutableProjection[]>();
+
+  for (const document of project.documents) {
+    const reachableDepth = depths.get(document.id);
+    const documentDepth = reachableDepth ?? Number.MAX_SAFE_INTEGER;
+    const byLogicalNetId = new Map<string, MutableProjection>();
+    for (const logicalNet of resolveDocumentLogicalNets(document).groups) {
+      const projected = projectedName(
+        document,
+        logicalNet,
+        documentDepth,
+        reachableDepth !== undefined,
+      );
+      byLogicalNetId.set(logicalNet.id, projected);
+      if (projected.value.scope === "global" && logicalNet.name) {
+        const foldedName = foldNetName(logicalNet.name);
+        const members = globalGroups.get(foldedName) ?? [];
+        members.push(projected);
+        globalGroups.set(foldedName, members);
+      }
+    }
+    mutableByDocument.set(document.id, byLogicalNetId);
+  }
+
+  for (const members of globalGroups.values()) {
+    const candidateMembers = members.some((member) => member.reachable)
+      ? members.filter((member) => member.reachable)
+      : members;
+    const candidates = candidateMembers
+      .flatMap((member) => member.candidates)
+      .sort(compareCandidates);
+    const spellings = uniqueSpellings(candidates);
+    const preferredSpelling = candidates[0]?.spelling;
+    for (const member of members) {
+      member.value = {
+        ...member.value,
+        spellings,
+        ...(preferredSpelling ? { preferredSpelling } : {}),
+      };
+    }
+  }
+
+  return {
+    byDocumentId: new Map(
+      [...mutableByDocument.entries()].map(([documentId, projections]) => [
+        documentId,
+        new Map(
+          [...projections.entries()].map(([logicalNetId, projection]) => [
+            logicalNetId,
+            projection.value,
+          ]),
+        ),
+      ]),
+    ),
+  };
+}

--- a/packages/edit-engine/src/direct-contact-planner.test.ts
+++ b/packages/edit-engine/src/direct-contact-planner.test.ts
@@ -110,4 +110,49 @@ describe("direct endpoint connection planner", () => {
       relatedNetIds: ["net-a", "net-b"],
     });
   });
+
+  it("allows same-name local and global Nets to make explicit physical contact", () => {
+    const document = fixture();
+    document.nets.push(
+      {
+        id: "net-local",
+        terminals: [{ instanceId: "A", pinName: "P" }],
+      },
+      {
+        id: "net-global",
+        terminals: [{ instanceId: "B", pinName: "P" }],
+      },
+    );
+    document.connectivityEvidence.push(
+      {
+        id: "claim-local",
+        kind: "name-claim",
+        netId: "net-local",
+        name: "VDD",
+        scope: "local",
+        owner: { kind: "net-label", annotationId: "label-local" },
+      },
+      {
+        id: "claim-global",
+        kind: "name-claim",
+        netId: "net-global",
+        name: "vdd",
+        scope: "global",
+        powerDomain: "vdd",
+        owner: { kind: "power-marker", objectId: "VDD1" },
+      },
+    );
+
+    expect(
+      planDirectEndpointConnection(document, {
+        from: endpoint("A"),
+        to: endpoint("B"),
+        newNetId: "unused",
+      }),
+    ).toMatchObject({
+      ok: true,
+      edits: [{ kind: "merge_nets" }, { kind: "connect_endpoints" }],
+    });
+    expect(document.connectivityEvidence).toHaveLength(2);
+  });
 });

--- a/packages/edit-engine/src/direct-contact-planner.ts
+++ b/packages/edit-engine/src/direct-contact-planner.ts
@@ -90,20 +90,6 @@ export function planDirectEndpointConnection(
       relatedNetIds,
     };
   }
-  if (
-    fromLogical?.name &&
-    toLogical?.name &&
-    fromLogical.scope &&
-    toLogical.scope &&
-    fromLogical.scope !== toLogical.scope
-  ) {
-    return {
-      ok: false,
-      message: "Cannot directly connect named Nets with incompatible scopes",
-      relatedNetIds,
-    };
-  }
-
   const fromHasSemantics = Boolean(
     fromLogical?.evidenceIds.length || fromLogical?.sourceNetIds.length,
   );

--- a/packages/edit-engine/src/routing.test.ts
+++ b/packages/edit-engine/src/routing.test.ts
@@ -3012,14 +3012,41 @@ describe("routing Edit Engine", () => {
     );
   });
 
-  it("physically splits a global-Net Route instead of hiding the cut behind global Evidence", () => {
+  it("keeps an imported global declaration only on the primary component after a cut", () => {
     const document = documentFixture();
     const net = document.nets.find((candidate) => candidate.id === "net-v")!;
-    for (const evidence of document.connectivityEvidence) {
-      if (evidence.kind === "name-claim" && evidence.netId === net.id) {
-        evidence.scope = "global";
-      }
-    }
+    document.netlist!.terminals.find(
+      (terminal) => terminal.id === "cell-terminal-c",
+    )!.name = "LEFT";
+    document.netlist!.terminals.find(
+      (terminal) => terminal.id === "cell-terminal-d",
+    )!.name = "RIGHT";
+    document.connectivityEvidence.push(
+      {
+        id: "imported-global-vdd",
+        kind: "name-claim",
+        netId: net.id,
+        name: "VDD",
+        scope: "global",
+        owner: {
+          kind: "global-declaration",
+          sourceNetId: "source-vdd",
+        },
+      },
+      {
+        id: "source-vdd",
+        kind: "spice-source",
+        netId: net.id,
+        sourceNetId: "source-vdd",
+      },
+      {
+        id: "source-vdd-name",
+        kind: "net-name-hint",
+        netId: net.id,
+        sourceName: "VDD",
+        origin: "spice-import",
+      },
+    );
     document.routes = [
       createRoutePath({
         id: "route-global",
@@ -3051,6 +3078,39 @@ describe("routing Edit Engine", () => {
         candidate.terminals.some((terminal) => terminal.instanceId === "D"),
       ),
     ).toMatchObject({ terminals: [{ instanceId: "D" }] });
+    const splitNetIds = result.document.nets
+      .filter((candidate) =>
+        candidate.terminals.some((terminal) =>
+          ["C", "D"].includes(terminal.instanceId),
+        ),
+      )
+      .map((candidate) => candidate.id)
+      .sort();
+    expect(
+      result.document.connectivityEvidence.flatMap((evidence) =>
+        evidence.kind === "name-claim" &&
+        evidence.owner.kind === "global-declaration"
+          ? [evidence.netId]
+          : [],
+      ),
+    ).toEqual(["net-v"]);
+    for (const kind of ["spice-source", "net-name-hint"] as const) {
+      expect(
+        result.document.connectivityEvidence
+          .filter((evidence) => evidence.kind === kind)
+          .map((evidence) => evidence.netId)
+          .filter((netId) => splitNetIds.includes(netId))
+          .sort(),
+      ).toEqual(splitNetIds);
+    }
+    const logicalNets = resolveDocumentLogicalNets(result.document);
+    const left = logicalNets.byBaseNetId.get("net-v");
+    const rightNetId = splitNetIds.find((netId) => netId !== "net-v")!;
+    const right = logicalNets.byBaseNetId.get(rightNetId);
+    expect(left).toMatchObject({ name: "VDD", scope: "global" });
+    expect(right).toMatchObject({ scope: "local" });
+    expect(right?.name).toBe("RIGHT");
+    expect(left?.id).not.toBe(right?.id);
     expect(result.document.sourceStatus).toBe("connectivity-modified");
   });
 

--- a/packages/edit-engine/src/transaction-connectivity.ts
+++ b/packages/edit-engine/src/transaction-connectivity.ts
@@ -525,41 +525,6 @@ export function propagateSpiceSourceEvidenceAfterSplit(
       changedObjectIds.add(id);
     }
   }
-  const globalClaims = draft.connectivityEvidence.filter(
-    (
-      evidence,
-    ): evidence is Extract<
-      SchematicDocument["connectivityEvidence"][number],
-      { kind: "name-claim" }
-    > & { owner: { kind: "global-declaration"; sourceNetId: string } } =>
-      evidence.kind === "name-claim" &&
-      evidence.owner.kind === "global-declaration" &&
-      evidence.netId === originalNetId,
-  );
-  for (const claim of globalClaims) {
-    for (const netId of splitNetIds) {
-      if (
-        draft.connectivityEvidence.some(
-          (evidence) =>
-            evidence.kind === "name-claim" &&
-            evidence.netId === netId &&
-            evidence.owner.kind === "global-declaration" &&
-            evidence.owner.sourceNetId === claim.owner.sourceNetId &&
-            foldNetName(evidence.name) === foldNetName(claim.name),
-        )
-      ) {
-        continue;
-      }
-      const id = deriveStableId(
-        "connectivity-evidence",
-        "global-declaration",
-        claim.id,
-        netId,
-      );
-      draft.connectivityEvidence.push({ ...claim, id, netId });
-      changedObjectIds.add(id);
-    }
-  }
 }
 
 /**

--- a/packages/netlist/src/current-contract.test.ts
+++ b/packages/netlist/src/current-contract.test.ts
@@ -410,7 +410,7 @@ describe("current formal cell interface", () => {
     });
   });
 
-  it("reports conflicting local/global claims on one Logical Net", () => {
+  it("exports same-name local/global claims on one physical Net as global", () => {
     const project = createEmptyProject("project", "Project");
     const document = project.documents[0]!;
     document.nets.push({
@@ -423,13 +423,11 @@ describe("current formal cell interface", () => {
 
     const result = analyzeDesignNetlist(project);
 
-    expect(result.ir).toBeNull();
-    expect(result.diagnostics).toContainEqual(
-      expect.objectContaining({
-        code: "CONFLICTING_LOGICAL_NET_SCOPE",
-        objectIds: expect.arrayContaining(["net-global"]),
-      }),
-    );
+    expect(result.diagnostics).toEqual([]);
+    expect(result.ir?.globals).toEqual(["BIAS"]);
+    expect(result.ir?.cells[0]?.nets).toEqual([
+      { id: "net-global", name: "BIAS", scope: "global" },
+    ]);
   });
 
   it("blocks distinct local and global Nets that encode to the same node token", () => {

--- a/packages/netlist/src/current-contract.test.ts
+++ b/packages/netlist/src/current-contract.test.ts
@@ -422,6 +422,83 @@ describe("current formal cell interface", () => {
     );
   });
 
+  it("blocks distinct local and global Nets that encode to the same node token", () => {
+    const project = createEmptyProject("project", "Project");
+    const document = project.documents[0]!;
+    document.nets.push(
+      { id: "net-local-vdd", terminals: [] },
+      { id: "net-global-vdd", terminals: [] },
+    );
+    claimNet(document, "net-local-vdd", "VDD", "local");
+    claimNet(document, "net-global-vdd", "vdd", "global");
+
+    const result = analyzeDesignNetlist(project);
+
+    expect(result.ir).toBeNull();
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "DIALECT_NAME_COLLISION",
+        objectIds: expect.arrayContaining(["net-local-vdd", "net-global-vdd"]),
+      }),
+    );
+  });
+
+  it("projects one preferred global spelling through every reachable Cell", () => {
+    const project = createEmptyProject("project", "Project", "top");
+    const top = project.documents[0]!;
+    const child = createEmptyProject("child-project", "Child", "child")
+      .documents[0]!;
+    child.netlist!.name = "child";
+    project.documents.push(child);
+    top.instances.push({
+      id: "X1",
+      symbolId: "child-symbol",
+      placement: null,
+      reference: "X1",
+      netlist: {
+        binding: { kind: "subcircuit", childDocumentId: "child" },
+        parameters: {},
+      },
+    });
+    for (const [document, reference, netId, spelling] of [
+      [top, "R1", "net-top-vdd", "VDD"],
+      [child, "R2", "net-child-vdd", "vdd"],
+    ] as const) {
+      document.instances.push({
+        id: reference,
+        symbolId: "resistor",
+        placement: null,
+        reference,
+        netlist: {
+          binding: { kind: "primitive", deviceClass: "resistor" },
+          parameters: { value: "1k" },
+        },
+      });
+      document.nets.push({
+        id: netId,
+        terminals: [{ instanceId: reference, pinName: "1" }],
+      });
+      document.noConnects.push({
+        id: `nc-${reference}`,
+        endpoint: { kind: "terminal", instanceId: reference, pinName: "2" },
+      });
+      claimNet(document, netId, spelling, "global");
+    }
+
+    const result = analyzeDesignNetlist(project);
+
+    expect(
+      result.diagnostics.filter((item) => item.severity === "error"),
+    ).toEqual([]);
+    expect(result.ir?.globals).toEqual(["VDD"]);
+    expect(
+      result.ir?.cells.map(
+        (cell) => cell.nets.find((net) => net.scope === "global")?.name,
+      ),
+    ).toEqual(["VDD", "VDD"]);
+    expect(printSpiceNetlist(result.ir!)).toContain("R2 VDD NC0001 1k");
+  });
+
   it("exports a ground net marker without inventing a netlist record", () => {
     const project = createEmptyProject("project", "Project");
     const document = project.documents[0]!;

--- a/packages/netlist/src/current-contract.test.ts
+++ b/packages/netlist/src/current-contract.test.ts
@@ -8,10 +8,14 @@ import {
 import {
   analyzeDesignNetlist as analyzeCurrentDesignNetlist,
   printSpiceNetlist,
+  type DesignNetlistAnalysisOptions,
 } from "./index.js";
 
-function analyzeDesignNetlist(project: CircuitProject) {
-  return analyzeCurrentDesignNetlist(project);
+function analyzeDesignNetlist(
+  project: CircuitProject,
+  options?: DesignNetlistAnalysisOptions,
+) {
+  return analyzeCurrentDesignNetlist(project, options);
 }
 
 function claimNet(
@@ -189,7 +193,13 @@ describe("current formal cell interface", () => {
 
     const result = analyzeDesignNetlist(project);
 
-    expect(result.diagnostics).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "NET_NAME_SPELLING_NORMALIZED",
+        severity: "warning",
+        message: "local Net spellings [VIN, vin] export as VIN",
+      }),
+    ]);
     expect(result.ir?.cells[0]?.ports).toEqual([
       {
         id: "net-vin-a",
@@ -443,6 +453,51 @@ describe("current formal cell interface", () => {
     );
   });
 
+  it("applies the selected dialect codec after semantic Net resolution", () => {
+    const project = createEmptyProject("project", "Project");
+    const document = project.documents[0]!;
+    document.nets.push({ id: "net-bus", terminals: [] });
+    claimNet(document, "net-bus", "DATA<3>");
+
+    const spice = analyzeDesignNetlist(project, { format: "spice" });
+    const spectre = analyzeDesignNetlist(project, { format: "spectre" });
+
+    expect(spice.ir).toBeNull();
+    expect(spice.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "UNREPRESENTABLE_NGSPICE_NET_NAME" }),
+    );
+    expect(spectre.diagnostics).toEqual([]);
+    expect(spectre.ir?.cells[0]?.nets).toContainEqual({
+      id: "net-bus",
+      name: "DATA\\<3\\>",
+      scope: "local",
+    });
+  });
+
+  it("projects typed globals through the explicit Cadence bang profile", () => {
+    const project = createEmptyProject("project", "Project");
+    const document = project.documents[0]!;
+    document.nets.push({ id: "net-vdd", terminals: [] });
+    claimNet(document, "net-vdd", "VDD", "global");
+
+    const native = analyzeDesignNetlist(project, {
+      format: "spectre",
+      namingProfile: "native",
+    });
+    const cadence = analyzeDesignNetlist(project, {
+      format: "spectre",
+      namingProfile: "cadence-bang",
+    });
+
+    expect(native.ir?.globals).toEqual(["VDD"]);
+    expect(cadence.ir?.globals).toEqual(["VDD!"]);
+    expect(cadence.ir?.cells[0]?.nets).toContainEqual({
+      id: "net-vdd",
+      name: "VDD!",
+      scope: "global",
+    });
+  });
+
   it("projects one preferred global spelling through every reachable Cell", () => {
     const project = createEmptyProject("project", "Project", "top");
     const top = project.documents[0]!;
@@ -491,6 +546,12 @@ describe("current formal cell interface", () => {
       result.diagnostics.filter((item) => item.severity === "error"),
     ).toEqual([]);
     expect(result.ir?.globals).toEqual(["VDD"]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "GLOBAL_NAME_SPELLING_NORMALIZED",
+        message: "global Net spellings [VDD, vdd] export as VDD",
+      }),
+    );
     expect(
       result.ir?.cells.map(
         (cell) => cell.nets.find((net) => net.scope === "global")?.name,

--- a/packages/netlist/src/current-contract.test.ts
+++ b/packages/netlist/src/current-contract.test.ts
@@ -313,6 +313,31 @@ describe("current formal cell interface", () => {
     );
   });
 
+  it("keeps current authored spelling authoritative after source correspondence changes", () => {
+    const project = resistorProject({ value: "10k" });
+    const document = project.documents[0]!;
+    document.sourceStatus = "connectivity-modified";
+    document.connectivityEvidence.push({
+      id: "old-source-name",
+      kind: "net-name-hint",
+      netId: "net-in",
+      sourceName: "old_input",
+      origin: "spice-import",
+    });
+
+    const result = analyzeDesignNetlist(project);
+
+    expect(result.ir?.cells[0]?.instances[0]?.nodes[0]).toEqual({
+      pinName: "1",
+      netName: "VIN",
+    });
+    expect(result.ir?.cells[0]?.nets).toContainEqual({
+      id: "net-in",
+      name: "VIN",
+      scope: "local",
+    });
+  });
+
   it("exports explicit NoConnect terminals through deterministic floating nodes", () => {
     const project = resistorProject({ value: "10k" });
     const document = project.documents[0]!;

--- a/packages/netlist/src/extract.ts
+++ b/packages/netlist/src/extract.ts
@@ -1,7 +1,9 @@
 import { foldNetName, projectCellInterface, routeEndpoints } from "@icm/model";
 import {
+  deriveProjectNetNameProjection,
   directObjectLocator,
   resolveDocumentLogicalNets,
+  type ProjectedNetName,
   type ResolvedLogicalNet,
 } from "@icm/derived";
 import type {
@@ -159,6 +161,7 @@ interface CellNetContext {
 function buildNetContext(
   document: SchematicDocument,
   documentsById: Map<string, SchematicDocument>,
+  projectedNames: ReadonlyMap<string, ProjectedNetName>,
   diagnostics: NetlistDiagnostic[],
 ): CellNetContext {
   if (document.nets.length > MAX_NETS_PER_CELL) {
@@ -200,18 +203,32 @@ function buildNetContext(
         [...logicalNet.baseNetIds, ...logicalNet.evidenceIds],
       );
     }
-    if (!logicalNet.name) continue;
-    const folded = foldNetName(logicalNet.name);
-    if (!explicitNames.has(folded)) {
+    const projectedName = projectedNames.get(logicalNet.id);
+    const explicitName = logicalNet.name
+      ? (projectedName?.preferredSpelling ?? logicalNet.name)
+      : undefined;
+    if (!explicitName) continue;
+    const folded = foldNetName(explicitName);
+    const prior = explicitNames.get(folded);
+    if (prior && prior !== logicalNet.id) {
+      const priorNet = logicalNets.byId.get(prior);
+      diagnostic(
+        diagnostics,
+        document.id,
+        "DIALECT_NAME_COLLISION",
+        `${logicalNet.scope ?? "local"} Net ${explicitName} and ${priorNet?.scope ?? "local"} Net ${explicitName} encode to the same portable node token`,
+        [...(priorNet?.baseNetIds ?? [prior]), ...logicalNet.baseNetIds],
+      );
+    } else if (!prior) {
       explicitNames.set(folded, logicalNet.id);
     }
     occupiedNames.add(folded);
-    if (!isIdentifier(logicalNet.name, true)) {
+    if (!isIdentifier(explicitName, true)) {
       diagnostic(
         diagnostics,
         document.id,
         "INVALID_NET_NAME",
-        `Net name is outside the portable identifier subset: ${logicalNet.name}`,
+        `Net name is outside the portable identifier subset: ${explicitName}`,
         [...logicalNet.baseNetIds],
       );
     }
@@ -251,7 +268,14 @@ function buildNetContext(
   const nameByNetId = new Map<string, string>();
   let generatedIndex = 1;
   for (const logicalNet of logicalNets.groups) {
-    let name = formalTerminalByLogicalId.get(logicalNet.id) ?? logicalNet.name;
+    const projectedName = projectedNames.get(logicalNet.id);
+    let name =
+      logicalNet.scope === "global"
+        ? (projectedName?.preferredSpelling ?? logicalNet.name)
+        : (formalTerminalByLogicalId.get(logicalNet.id) ??
+          (logicalNet.name
+            ? (projectedName?.preferredSpelling ?? logicalNet.name)
+            : undefined));
     if (!name) {
       const memberNetIds = new Set(logicalNet.baseNetIds);
       const hints = document.connectivityEvidence.filter(
@@ -855,6 +879,7 @@ function extractCell(
   project: CircuitProject,
   document: SchematicDocument,
   documentsById: Map<string, SchematicDocument>,
+  projectedNames: ReadonlyMap<string, ProjectedNetName>,
   diagnostics: NetlistDiagnostic[],
 ): DesignNetlistCell | null {
   if (!document.netlist) {
@@ -891,7 +916,12 @@ function extractCell(
       `Cell has ${document.instances.length} instances; maximum is ${MAX_INSTANCES_PER_CELL}`,
     );
   }
-  const context = buildNetContext(document, documentsById, diagnostics);
+  const context = buildNetContext(
+    document,
+    documentsById,
+    projectedNames,
+    diagnostics,
+  );
   const interfaceProjection = projectCellInterface(document.netlist);
   const ports = interfaceProjection.ports.flatMap((port) => {
     let hasMissingNet = false;
@@ -1009,6 +1039,7 @@ export function analyzeDesignNetlist(
 ): DesignNetlistAnalysisResult {
   const diagnostics: NetlistDiagnostic[] = [];
   const documents = reachableDocuments(project, diagnostics);
+  const nameProjection = deriveProjectNetNameProjection(project);
   const documentsById = new Map(
     project.documents.map((document) => [document.id, document]),
   );
@@ -1031,7 +1062,13 @@ export function analyzeDesignNetlist(
         cellNames.set(folded, document.id);
       }
     }
-    const cell = extractCell(project, document, documentsById, diagnostics);
+    const cell = extractCell(
+      project,
+      document,
+      documentsById,
+      nameProjection.byDocumentId.get(document.id) ?? new Map(),
+      diagnostics,
+    );
     if (cell) cells.push(cell);
   }
   diagnostics.sort(

--- a/packages/netlist/src/extract.ts
+++ b/packages/netlist/src/extract.ts
@@ -26,6 +26,13 @@ import type {
   DesignNetlistInstance,
   NetlistDiagnostic,
 } from "./ir.js";
+import {
+  encodedNetNameCollisionKey,
+  encodeNetName,
+  type EncodedNetName,
+  type NetlistFormat,
+  type NetlistNamingProfile,
+} from "./net-name-codec.js";
 
 const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/u;
 const MAX_CELLS = 1024;
@@ -158,10 +165,27 @@ interface CellNetContext {
   nets: DesignNetlistCell["nets"];
 }
 
+export interface DesignNetlistAnalysisOptions {
+  format?: NetlistFormat;
+  namingProfile?: NetlistNamingProfile;
+}
+
+type ResolvedDesignNetlistAnalysisOptions =
+  Required<DesignNetlistAnalysisOptions>;
+
+function encodeCandidate(
+  name: string,
+  scope: "local" | "global",
+  options: ResolvedDesignNetlistAnalysisOptions,
+): EncodedNetName {
+  return encodeNetName(name, scope, options.format, options.namingProfile);
+}
+
 function buildNetContext(
   document: SchematicDocument,
   documentsById: Map<string, SchematicDocument>,
   projectedNames: ReadonlyMap<string, ProjectedNetName>,
+  options: ResolvedDesignNetlistAnalysisOptions,
   diagnostics: NetlistDiagnostic[],
 ): CellNetContext {
   if (document.nets.length > MAX_NETS_PER_CELL) {
@@ -173,7 +197,7 @@ function buildNetContext(
     );
   }
   const explicitNames = new Map<string, string>();
-  const occupiedNames = new Set<string>();
+  const occupiedNames = new Map<string, string>();
   const logicalNets = resolveDocumentLogicalNets(document);
   for (const logicalNet of logicalNets.groups) {
     if (logicalNet.conflicts.includes("name-conflict")) {
@@ -209,27 +233,19 @@ function buildNetContext(
       : undefined;
     if (!explicitName) continue;
     const folded = foldNetName(explicitName);
-    const prior = explicitNames.get(folded);
-    if (prior && prior !== logicalNet.id) {
-      const priorNet = logicalNets.byId.get(prior);
-      diagnostic(
-        diagnostics,
-        document.id,
-        "DIALECT_NAME_COLLISION",
-        `${logicalNet.scope ?? "local"} Net ${explicitName} and ${priorNet?.scope ?? "local"} Net ${explicitName} encode to the same portable node token`,
-        [...(priorNet?.baseNetIds ?? [prior]), ...logicalNet.baseNetIds],
-      );
-    } else if (!prior) {
+    if (!explicitNames.has(folded)) {
       explicitNames.set(folded, logicalNet.id);
     }
-    occupiedNames.add(folded);
-    if (!isIdentifier(explicitName, true)) {
+    if ((projectedName?.spellings.length ?? 0) > 1) {
       diagnostic(
         diagnostics,
         document.id,
-        "INVALID_NET_NAME",
-        `Net name is outside the portable identifier subset: ${explicitName}`,
-        [...logicalNet.baseNetIds],
+        logicalNet.scope === "global"
+          ? "GLOBAL_NAME_SPELLING_NORMALIZED"
+          : "NET_NAME_SPELLING_NORMALIZED",
+        `${logicalNet.scope ?? "local"} Net spellings [${projectedName!.spellings.join(", ")}] export as ${explicitName}`,
+        [...logicalNet.baseNetIds, ...logicalNet.evidenceIds],
+        "warning",
       );
     }
   }
@@ -261,7 +277,29 @@ function buildNetContext(
         );
       }
       formalTerminalByLogicalId.set(logicalId, port.name);
-      occupiedNames.add(port.key);
+    }
+  }
+
+  // Authoritative authored/interface names reserve their dialect tokens before
+  // source hints are considered. A copied import hint may be suffixed; a
+  // current Label, marker, Cell Pin, or declaration may not.
+  for (const logicalNet of logicalNets.groups) {
+    const projectedName = projectedNames.get(logicalNet.id);
+    const authoritativeName =
+      logicalNet.scope === "global"
+        ? (projectedName?.preferredSpelling ?? logicalNet.name)
+        : (formalTerminalByLogicalId.get(logicalNet.id) ??
+          (logicalNet.name
+            ? (projectedName?.preferredSpelling ?? logicalNet.name)
+            : undefined));
+    if (!authoritativeName) continue;
+    const encoded = encodeCandidate(
+      authoritativeName,
+      logicalNet.scope ?? "local",
+      options,
+    );
+    if (encoded.ok && !occupiedNames.has(encoded.collisionKey)) {
+      occupiedNames.set(encoded.collisionKey, logicalNet.id);
     }
   }
 
@@ -296,12 +334,25 @@ function buildNetContext(
       }
       if (namesByFolded.size === 1) {
         const preferredName = [...namesByFolded.values()][0]!;
-        if (isIdentifier(preferredName, true)) {
+        const encodedHint = encodeCandidate(
+          preferredName,
+          logicalNet.scope ?? "local",
+          options,
+        );
+        if (encodedHint.ok) {
           name = preferredName;
+          let encodedName = encodedHint;
           let suffix = 2;
-          while (occupiedNames.has(foldNetName(name))) {
+          while (occupiedNames.has(encodedName.collisionKey)) {
             name = `${preferredName}__${suffix}`;
             suffix += 1;
+            const encodedSuffix = encodeCandidate(
+              name,
+              logicalNet.scope ?? "local",
+              options,
+            );
+            if (!encodedSuffix.ok) break;
+            encodedName = encodedSuffix;
           }
           if (name !== preferredName) {
             diagnostic(
@@ -313,13 +364,12 @@ function buildNetContext(
               "warning",
             );
           }
-          occupiedNames.add(foldNetName(name));
         } else {
           diagnostic(
             diagnostics,
             document.id,
             "UNREPRESENTABLE_SOURCE_NET_NAME",
-            `Source node spelling is outside the portable identifier subset: ${preferredName}`,
+            `Source node ${preferredName} cannot be encoded for ${options.format}: ${encodedHint.message}`,
             [...logicalNet.baseNetIds, ...hints.map((hint) => hint.id)],
             "warning",
           );
@@ -336,11 +386,15 @@ function buildNetContext(
       }
     }
     if (!name && logicalNet.scope !== "global") {
+      let encodedGenerated: EncodedNetName;
       do {
         name = `N${String(generatedIndex).padStart(4, "0")}`;
         generatedIndex += 1;
-      } while (occupiedNames.has(foldNetName(name)));
-      occupiedNames.add(foldNetName(name));
+        encodedGenerated = encodeCandidate(name, "local", options);
+      } while (
+        encodedGenerated.ok &&
+        occupiedNames.has(encodedGenerated.collisionKey)
+      );
       diagnostic(
         diagnostics,
         document.id,
@@ -351,8 +405,32 @@ function buildNetContext(
       );
     }
     if (!name) continue;
+    const encoded = encodeCandidate(name, logicalNet.scope ?? "local", options);
+    if (!encoded.ok) {
+      diagnostic(diagnostics, document.id, encoded.code, encoded.message, [
+        ...logicalNet.baseNetIds,
+        ...logicalNet.evidenceIds,
+      ]);
+      continue;
+    }
+    const priorLogicalId = occupiedNames.get(encoded.collisionKey);
+    if (priorLogicalId && priorLogicalId !== logicalNet.id) {
+      const priorNet = logicalNets.byId.get(priorLogicalId);
+      diagnostic(
+        diagnostics,
+        document.id,
+        "DIALECT_NAME_COLLISION",
+        `${logicalNet.scope ?? "local"} Net ${name} and ${priorNet?.scope ?? "local"} Net ${priorNet?.name ?? priorLogicalId} encode to ${encoded.token} for ${options.format}`,
+        [
+          ...(priorNet?.baseNetIds ?? [priorLogicalId]),
+          ...logicalNet.baseNetIds,
+        ],
+      );
+    } else {
+      occupiedNames.set(encoded.collisionKey, logicalNet.id);
+    }
     for (const netId of logicalNet.baseNetIds) {
-      nameByNetId.set(netId, name);
+      nameByNetId.set(netId, encoded.token);
     }
   }
   const netByTerminal = new Map<string, ResolvedLogicalNet>();
@@ -412,11 +490,19 @@ function buildNetContext(
     left.id.localeCompare(right.id),
   )) {
     let generated = "";
+    let encodedGenerated: EncodedNetName;
     do {
       generated = `NC${String(noConnectIndex).padStart(4, "0")}`;
       noConnectIndex += 1;
-    } while (occupiedNames.has(foldNetName(generated)));
-    occupiedNames.add(foldNetName(generated));
+      encodedGenerated = encodeCandidate(generated, "local", options);
+    } while (
+      encodedGenerated.ok &&
+      occupiedNames.has(encodedGenerated.collisionKey)
+    );
+    if (encodedGenerated.ok) {
+      occupiedNames.set(encodedGenerated.collisionKey, noConnect.id);
+      generated = encodedGenerated.token;
+    }
     const key = `${noConnect.endpoint.instanceId}\u0000${noConnect.endpoint.pinName}`;
     noConnectNameByTerminal.set(key, generated);
     noConnectNets.push({ id: noConnect.id, name: generated, scope: "local" });
@@ -439,9 +525,9 @@ function buildNetContext(
       ...logicalNets.groups.flatMap((logicalNet) => {
         const name = nameByNetId.get(logicalNet.baseNetIds[0]!);
         if (!name) return [];
-        const foldedName = foldNetName(name);
-        if (emittedNetNames.has(foldedName)) return [];
-        emittedNetNames.add(foldedName);
+        const collisionKey = encodedNetNameCollisionKey(name, options.format);
+        if (emittedNetNames.has(collisionKey)) return [];
+        emittedNetNames.add(collisionKey);
         return [
           {
             id: logicalNet.id,
@@ -880,6 +966,7 @@ function extractCell(
   document: SchematicDocument,
   documentsById: Map<string, SchematicDocument>,
   projectedNames: ReadonlyMap<string, ProjectedNetName>,
+  options: ResolvedDesignNetlistAnalysisOptions,
   diagnostics: NetlistDiagnostic[],
 ): DesignNetlistCell | null {
   if (!document.netlist) {
@@ -920,6 +1007,7 @@ function extractCell(
     document,
     documentsById,
     projectedNames,
+    options,
     diagnostics,
   );
   const interfaceProjection = projectCellInterface(document.netlist);
@@ -937,18 +1025,27 @@ function extractCell(
       );
     }
     if (hasMissingNet) return [];
-    if (!isIdentifier(port.name, true)) {
+    const logicalNet = resolveDocumentLogicalNets(document).byBaseNetId.get(
+      port.netIds[0]!,
+    );
+    const encodedPort = encodeCandidate(
+      port.name,
+      logicalNet?.scope ?? "local",
+      options,
+    );
+    if (!encodedPort.ok) {
       diagnostic(
         diagnostics,
         document.id,
-        "INVALID_PORT_NAME",
-        `Port name is outside the portable identifier subset: ${port.name}`,
+        encodedPort.code,
+        `Port ${port.name} cannot be encoded for ${options.format}: ${encodedPort.message}`,
         [...port.netIds],
       );
+      return [];
     }
     const representativeNetId = port.netIds[0]!;
     const netName = context.nameByNetId.get(representativeNetId) ?? port.name;
-    return [{ id: representativeNetId, name: port.name, netName }];
+    return [{ id: representativeNetId, name: encodedPort.token, netName }];
   });
 
   const referenceIndex = createReferenceIndex(document);
@@ -1036,7 +1133,12 @@ function extractCell(
 
 export function analyzeDesignNetlist(
   project: CircuitProject,
+  options: DesignNetlistAnalysisOptions = {},
 ): DesignNetlistAnalysisResult {
+  const resolvedOptions: ResolvedDesignNetlistAnalysisOptions = {
+    format: options.format ?? "spice",
+    namingProfile: options.namingProfile ?? "native",
+  };
   const diagnostics: NetlistDiagnostic[] = [];
   const documents = reachableDocuments(project, diagnostics);
   const nameProjection = deriveProjectNetNameProjection(project);
@@ -1067,6 +1169,7 @@ export function analyzeDesignNetlist(
       document,
       documentsById,
       nameProjection.byDocumentId.get(document.id) ?? new Map(),
+      resolvedOptions,
       diagnostics,
     );
     if (cell) cells.push(cell);

--- a/packages/netlist/src/index.ts
+++ b/packages/netlist/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./extract.js";
 export * from "./formal-interface.js";
 export * from "./ir.js";
+export * from "./net-name-codec.js";
 export * from "./printers.js";
 export * from "./sky130.js";

--- a/packages/netlist/src/net-name-codec.test.ts
+++ b/packages/netlist/src/net-name-codec.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { encodeNetName } from "./net-name-codec.js";
+
+describe("Net name codecs", () => {
+  it("uses ngspice case-insensitive identity and native global declarations", () => {
+    expect(encodeNetName("VDD!", "global", "spice")).toEqual({
+      ok: true,
+      token: "VDD!",
+      collisionKey: "vdd!",
+    });
+    expect(encodeNetName("bias.p", "local", "spice")).toEqual({
+      ok: true,
+      token: "bias.p",
+      collisionKey: "bias.p",
+    });
+    expect(encodeNetName("DATA<3>", "local", "spice")).toMatchObject({
+      ok: false,
+      code: "UNREPRESENTABLE_NGSPICE_NET_NAME",
+    });
+  });
+
+  it("escapes supported Spectre punctuation without changing semantic identity", () => {
+    expect(encodeNetName("DATA<3>", "local", "spectre")).toEqual({
+      ok: true,
+      token: "DATA\\<3\\>",
+      collisionKey: "DATA\\<3\\>",
+    });
+    expect(encodeNetName("net/1", "local", "spectre")).toEqual({
+      ok: true,
+      token: "net\\/1",
+      collisionKey: "net\\/1",
+    });
+    expect(encodeNetName("VDD!", "global", "spectre")).toEqual({
+      ok: true,
+      token: "VDD!",
+      collisionKey: "VDD!",
+    });
+  });
+
+  it("adds Cadence bang spelling only for typed non-ground globals", () => {
+    expect(
+      encodeNetName("VDD", "global", "spectre", "cadence-bang"),
+    ).toMatchObject({ ok: true, token: "VDD!" });
+    expect(
+      encodeNetName("VDD", "local", "spectre", "cadence-bang"),
+    ).toMatchObject({ ok: true, token: "VDD" });
+    expect(
+      encodeNetName("0", "global", "spectre", "cadence-bang"),
+    ).toMatchObject({ ok: true, token: "0" });
+  });
+});

--- a/packages/netlist/src/net-name-codec.ts
+++ b/packages/netlist/src/net-name-codec.ts
@@ -1,0 +1,110 @@
+export type NetlistFormat = "spice" | "spectre";
+export type NetlistNamingProfile = "native" | "cadence-bang";
+
+export type EncodedNetName =
+  | { ok: true; token: string; collisionKey: string }
+  | { ok: false; code: string; message: string };
+
+const NGSPICE_TOKEN = /^[A-Za-z0-9_!+./:$-]+$/u;
+const SPECTRE_PLAIN_TOKEN = /^[A-Za-z0-9_!]+$/u;
+const SPECTRE_ESCAPABLE = new Set([
+  "+",
+  "-",
+  ".",
+  "/",
+  ":",
+  "<",
+  ">",
+  "[",
+  "]",
+]);
+const SPECTRE_RESERVED = new Set([
+  "ends",
+  "global",
+  "parameters",
+  "simulator",
+  "subckt",
+]);
+
+function profileSpelling(
+  name: string,
+  scope: "local" | "global",
+  profile: NetlistNamingProfile,
+): string {
+  if (
+    profile !== "cadence-bang" ||
+    scope !== "global" ||
+    name === "0" ||
+    name.endsWith("!")
+  ) {
+    return name;
+  }
+  return `${name}!`;
+}
+
+function encodeNgspice(name: string): EncodedNetName {
+  if (!NGSPICE_TOKEN.test(name)) {
+    return {
+      ok: false,
+      code: "UNREPRESENTABLE_NGSPICE_NET_NAME",
+      message: `Net name ${name} contains characters that ngspice cannot safely read as one node token`,
+    };
+  }
+  return { ok: true, token: name, collisionKey: name.toLowerCase() };
+}
+
+function encodeSpectre(name: string): EncodedNetName {
+  if (SPECTRE_RESERVED.has(name.toLowerCase())) {
+    return {
+      ok: false,
+      code: "RESERVED_SPECTRE_NET_NAME",
+      message: `Net name ${name} is reserved by Spectre`,
+    };
+  }
+  if (SPECTRE_PLAIN_TOKEN.test(name)) {
+    return { ok: true, token: name, collisionKey: name };
+  }
+  let token = "";
+  for (const character of name) {
+    if (/[A-Za-z0-9_!]/u.test(character)) {
+      token += character;
+    } else if (SPECTRE_ESCAPABLE.has(character)) {
+      token += `\\${character}`;
+    } else {
+      return {
+        ok: false,
+        code: "UNREPRESENTABLE_SPECTRE_NET_NAME",
+        message: `Net name ${name} contains a character without a supported Spectre escape`,
+      };
+    }
+  }
+  return { ok: true, token, collisionKey: token };
+}
+
+/** Pure dialect projection for one semantic Net name and scope. */
+export function encodeNetName(
+  name: string,
+  scope: "local" | "global",
+  format: NetlistFormat,
+  profile: NetlistNamingProfile = "native",
+): EncodedNetName {
+  const spelling = profileSpelling(name.trim(), scope, profile);
+  if (!spelling) {
+    return {
+      ok: false,
+      code: "EMPTY_NET_NAME",
+      message: "Net name is empty",
+    };
+  }
+  if (spelling === "0") {
+    return { ok: true, token: "0", collisionKey: "0" };
+  }
+  return format === "spice" ? encodeNgspice(spelling) : encodeSpectre(spelling);
+}
+
+export function encodedNetNameCollisionKey(
+  token: string,
+  format: NetlistFormat,
+): string {
+  return format === "spice" ? token.toLowerCase() : token;
+}

--- a/packages/netlist/src/printers.ts
+++ b/packages/netlist/src/printers.ts
@@ -4,8 +4,9 @@ import type {
   DesignNetlistInstance,
   DesignNetlistParameter,
 } from "./ir.js";
+import type { NetlistFormat } from "./net-name-codec.js";
 
-export type NetlistFormat = "spice" | "spectre";
+export type { NetlistFormat } from "./net-name-codec.js";
 
 export interface NetlistFileDescriptor {
   extension: ".spi" | ".scs";

--- a/packages/netlist/src/roundtrip.test.ts
+++ b/packages/netlist/src/roundtrip.test.ts
@@ -259,6 +259,51 @@ function normalizedSemantics(ir: DesignNetlistIR) {
 }
 
 describe("structural SPICE round trip", () => {
+  it("keeps Cadence bang spelling separate from global electrical identity", async () => {
+    const imported = await importSpiceSources(
+      [
+        {
+          path: "cadence.spi",
+          bytes: new TextEncoder().encode(
+            "Cadence bang\nV1 vdd! 0 DC 1.8\n.end\n",
+          ),
+        },
+      ],
+      "cadence.spi",
+      {},
+      { namingProfile: "cadence-bang" },
+    );
+    expect(imported.successful).toBe(true);
+
+    const native = analyzeDesignNetlist(imported.project!, {
+      format: "spice",
+      namingProfile: "native",
+    });
+    const cadence = analyzeDesignNetlist(imported.project!, {
+      format: "spice",
+      namingProfile: "cadence-bang",
+    });
+
+    expect(native.ir?.globals).toEqual(["0", "vdd"]);
+    expect(cadence.ir?.globals).toEqual(["0", "vdd!"]);
+    expect(printSpiceNetlist(native.ir!)).toContain(".global vdd");
+    expect(printSpiceNetlist(cadence.ir!)).toContain(".global vdd!");
+    expect(imported.project!.documents[0]!.connectivityEvidence).toContainEqual(
+      expect.objectContaining({
+        kind: "net-name-hint",
+        sourceName: "vdd!",
+      }),
+    );
+
+    imported.project!.documents[0]!.sourceStatus = "connectivity-modified";
+    expect(
+      analyzeDesignNetlist(imported.project!, {
+        format: "spice",
+        namingProfile: "cadence-bang",
+      }).ir,
+    ).toEqual(cadence.ir);
+  });
+
   it("keeps capacitor plate pin order independent of schematic orientation", () => {
     const project = structuralProject();
     const capacitor = project.documents

--- a/packages/render-svg/src/current-contract.test.ts
+++ b/packages/render-svg/src/current-contract.test.ts
@@ -380,6 +380,38 @@ describe("current rendering contract", () => {
     expect(svg).not.toContain("baseline-shift");
   });
 
+  it("marks an ordinary global Net Label without changing its authored text", () => {
+    const document = createEmptyDocument("doc", "Global label");
+    document.nets.push({ id: "net-bias", terminals: [] });
+    document.annotations.push({
+      id: "label-bias",
+      kind: "net-label",
+      netId: "net-bias",
+      binding: { kind: "net-name", netId: "net-bias" },
+      anchor: { kind: "free", position: { x: 40, y: 40 } },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    });
+    document.connectivityEvidence.push({
+      id: "claim-bias",
+      kind: "name-claim",
+      netId: "net-bias",
+      name: "BIAS",
+      scope: "global",
+      owner: { kind: "net-label", annotationId: "label-bias" },
+    });
+
+    const svg = renderDocumentSvg(document, resolver);
+
+    expect(svg).toContain('data-role="global-net-badge"');
+    expect(svg).toContain('data-object-id="label-bias"');
+    expect(document.connectivityEvidence[0]).toMatchObject({
+      name: "BIAS",
+      scope: "global",
+    });
+  });
+
   it("does not interpret a BJT base route as a MOS bulk connection", () => {
     const document = createEmptyDocument("doc", "BJT base route");
     document.instances.push({

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -981,6 +981,18 @@ export function buildSvgScene(
       );
       const colorOverride =
         resolvedColor === profile.foreground ? undefined : resolvedColor;
+      const globalLabel =
+        annotation.kind === "net-label" &&
+        document.connectivityEvidence.some(
+          (evidence) =>
+            evidence.kind === "name-claim" &&
+            evidence.scope === "global" &&
+            evidence.owner.kind === "net-label" &&
+            evidence.owner.annotationId === annotation.id,
+        );
+      const globalBadge = globalLabel
+        ? `<g data-role="global-net-badge" transform="${transform}"><rect x="${position.x - 8}" y="${position.y - annotationFontSize - 2}" width="7" height="7" rx="2" fill="${profile.background}" stroke="${profile.foreground}" stroke-width="0.8"/><text x="${position.x - 4.5}" y="${position.y - annotationFontSize + 3.3}" text-anchor="middle" font-size="5px" font-weight="700">G</text></g>`
+        : "";
       if (
         annotation.kind === "route-marker" &&
         annotation.markerKind === "current"
@@ -1075,7 +1087,7 @@ export function buildSvgScene(
           ? (content.runs[0] as Extract<RichTextRun, { kind: "fraction" }>)
           : null;
       if (fractionRun) {
-        return renderStackedFractionAnnotation(fractionRun, {
+        const fraction = renderStackedFractionAnnotation(fractionRun, {
           attributes,
           position,
           alignment: annotation.alignment,
@@ -1086,6 +1098,7 @@ export function buildSvgScene(
           ...(colorOverride ? { color: colorOverride } : {}),
           profile,
         });
+        return `<g>${fraction}${globalBadge}</g>`;
       }
       const formula = renderFormulaDocument(content, profile, {
         x: position.x,
@@ -1095,7 +1108,7 @@ export function buildSvgScene(
         ...(colorOverride ? { color: colorOverride } : {}),
       });
       if (formula) {
-        return `<g ${attributes} transform="${transform}">${formula}</g>`;
+        return `<g ${attributes} transform="${transform}">${formula}</g>${globalBadge}`;
       }
       const positioned = renderPositionedOverbarScriptDocument(
         content,
@@ -1109,9 +1122,9 @@ export function buildSvgScene(
         },
       );
       if (positioned) {
-        return `<g transform="${transform}"><text ${attributes} x="${position.x}" y="${position.y}" text-anchor="start"${emphasis}${colorOverride ? ` fill="${colorOverride}"` : ""}${schematicTextSizeAttribute(annotation.kind, profile, annotation.sizeScale)}>${positioned.tspans}</text>${positioned.decorations}</g>`;
+        return `<g transform="${transform}"><text ${attributes} x="${position.x}" y="${position.y}" text-anchor="start"${emphasis}${colorOverride ? ` fill="${colorOverride}"` : ""}${schematicTextSizeAttribute(annotation.kind, profile, annotation.sizeScale)}>${positioned.tspans}</text>${positioned.decorations}</g>${globalBadge}`;
       }
-      return `<text ${attributes} x="${position.x}" y="${position.y}" text-anchor="${annotation.alignment}" transform="${transform}"${emphasis}${colorOverride ? ` fill="${colorOverride}" color="${colorOverride}"` : ""}${schematicTextSizeAttribute(annotation.kind, profile, annotation.sizeScale)}>${renderAnnotationText(document, annotation, profile)}</text>`;
+      return `<text ${attributes} x="${position.x}" y="${position.y}" text-anchor="${annotation.alignment}" transform="${transform}"${emphasis}${colorOverride ? ` fill="${colorOverride}" color="${colorOverride}"` : ""}${schematicTextSizeAttribute(annotation.kind, profile, annotation.sizeScale)}>${renderAnnotationText(document, annotation, profile)}</text>${globalBadge}`;
     })
     .join("");
 

--- a/packages/spice/src/compiler.test.ts
+++ b/packages/spice/src/compiler.test.ts
@@ -7,6 +7,85 @@ import { importCompileResult } from "./importer.js";
 import { loadSourceBundleFromFile } from "./node-source.js";
 
 describe("SPICE elaboration and Project import", () => {
+  it("applies Cadence bang globals only through the explicit import profile", async () => {
+    const compiled = await compileSpiceSources(
+      [
+        {
+          path: "bang.spi",
+          bytes: Buffer.from("Bang profile\nR1 vdd! 0 1k\n.end\n"),
+        },
+      ],
+      "bang.spi",
+    );
+
+    const native = importCompileResult(compiled);
+    const cadence = importCompileResult(compiled, {
+      namingProfile: "cadence-bang",
+    });
+    const nativeEvidence = native.project!.documents[0]!.connectivityEvidence;
+    const cadenceEvidence = cadence.project!.documents[0]!.connectivityEvidence;
+
+    expect(nativeEvidence).toContainEqual(
+      expect.objectContaining({
+        kind: "net-name-hint",
+        sourceName: "vdd!",
+      }),
+    );
+    expect(nativeEvidence).not.toContainEqual(
+      expect.objectContaining({
+        kind: "name-claim",
+        name: "vdd",
+        scope: "global",
+      }),
+    );
+    expect(cadenceEvidence).toContainEqual(
+      expect.objectContaining({
+        kind: "name-claim",
+        name: "vdd",
+        scope: "global",
+        owner: expect.objectContaining({ kind: "global-declaration" }),
+      }),
+    );
+    expect(cadenceEvidence).toContainEqual(
+      expect.objectContaining({
+        kind: "net-name-hint",
+        sourceName: "vdd!",
+      }),
+    );
+  });
+
+  it("preserves a literal bang in an explicitly global generic SPICE name", async () => {
+    const imported = importCompileResult(
+      await compileSpiceSources(
+        [
+          {
+            path: "literal-bang.spi",
+            bytes: Buffer.from(
+              "Literal bang\n.global vdd!\nR1 vdd! 0 1k\n.end\n",
+            ),
+          },
+        ],
+        "literal-bang.spi",
+      ),
+    );
+
+    expect(imported.project!.documents[0]!.connectivityEvidence).toContainEqual(
+      expect.objectContaining({
+        kind: "name-claim",
+        name: "vdd!",
+        scope: "global",
+      }),
+    );
+    expect(
+      imported.project!.documents[0]!.connectivityEvidence,
+    ).not.toContainEqual(
+      expect.objectContaining({
+        kind: "name-claim",
+        name: "vdd",
+      }),
+    );
+  });
+
   it("imports capacitor source positions onto stable plate pins", async () => {
     const imported = importCompileResult(
       await compileSpiceSources(

--- a/packages/spice/src/importer.ts
+++ b/packages/spice/src/importer.ts
@@ -33,6 +33,22 @@ export interface SpiceImportResult extends SpiceCompileResult {
 
 export interface SpiceImportOptions {
   symbolMappings?: readonly PdkSymbolMappingOverride[];
+  namingProfile?: "native" | "cadence-bang";
+}
+
+function importedNetName(
+  name: string,
+  scope: "local" | "global",
+  namingProfile: NonNullable<SpiceImportOptions["namingProfile"]>,
+): { name: string; scope: "local" | "global"; sourceName: string } {
+  if (
+    namingProfile === "cadence-bang" &&
+    name.length > 1 &&
+    name.endsWith("!")
+  ) {
+    return { name: name.slice(0, -1), scope: "global", sourceName: name };
+  }
+  return { name, scope, sourceName: name };
 }
 
 interface ImportSymbolMapping {
@@ -311,8 +327,10 @@ function importDocument(
   cell: CircuitCellIR,
   diagnostics: SpiceDiagnostic[],
   modelTypeByName: ReadonlyMap<string, string>,
-  symbolMappings: readonly PdkSymbolMappingOverride[],
+  options: SpiceImportOptions,
 ): SchematicDocument {
+  const symbolMappings = options.symbolMappings ?? [];
+  const namingProfile = options.namingProfile ?? "native";
   const documentId = deriveStableId("document", cell.name.toLowerCase());
   const visibleInstances = cell.instances.filter((instance) => {
     if (instance.terminals.length > 0) return true;
@@ -355,11 +373,16 @@ function importDocument(
       ),
   }));
   const formalTerminals = cell.ports.map((port, index) => {
+    const importedPortName = importedNetName(
+      port.name,
+      cell.nets.find((net) => net.id === port.netId)?.scope ?? "local",
+      namingProfile,
+    ).name;
     const interfaceInstanceId = deriveStableId(
       "cell-pin",
       documentId,
       String(index),
-      port.name,
+      importedPortName,
     );
     instances.push({
       id: interfaceInstanceId,
@@ -369,8 +392,13 @@ function importDocument(
     const net = nets.find((candidate) => candidate.id === port.netId);
     net?.terminals.push({ instanceId: interfaceInstanceId, pinName: "P" });
     return {
-      id: deriveStableId("cell-terminal", documentId, String(index), port.name),
-      name: port.name,
+      id: deriveStableId(
+        "cell-terminal",
+        documentId,
+        String(index),
+        importedPortName,
+      ),
+      name: importedPortName,
       netId: port.netId,
       direction: "passive" as const,
       interfaceInstanceIds: [interfaceInstanceId],
@@ -392,58 +420,79 @@ function importDocument(
     },
     instances,
     nets,
-    connectivityEvidence: cell.nets.flatMap((net) => [
-      ...(net.name
-        ? [
-            net.scope === "global"
-              ? {
-                  id: deriveStableId(
-                    "connectivity-evidence",
-                    documentId,
-                    "global-declaration",
-                    net.id,
-                    net.name,
-                  ),
-                  kind: "name-claim" as const,
-                  netId: net.id,
-                  name: net.name,
-                  owner: {
-                    kind: "global-declaration" as const,
-                    sourceNetId: net.id,
+    connectivityEvidence: cell.nets.flatMap((net) => {
+      const importedName = importedNetName(net.name, net.scope, namingProfile);
+      return [
+        ...(importedName.name
+          ? [
+              importedName.scope === "global"
+                ? {
+                    id: deriveStableId(
+                      "connectivity-evidence",
+                      documentId,
+                      "global-declaration",
+                      net.id,
+                      importedName.name,
+                    ),
+                    kind: "name-claim" as const,
+                    netId: net.id,
+                    name: importedName.name,
+                    owner: {
+                      kind: "global-declaration" as const,
+                      sourceNetId: net.id,
+                    },
+                    scope: "global" as const,
+                    ...(importedName.name === "0"
+                      ? { powerDomain: "ground" as const }
+                      : {}),
+                  }
+                : {
+                    id: deriveStableId(
+                      "connectivity-evidence",
+                      documentId,
+                      "net-name-hint",
+                      net.id,
+                      net.name,
+                    ),
+                    kind: "net-name-hint" as const,
+                    netId: net.id,
+                    sourceName: importedName.sourceName,
+                    origin: "spice-import" as const,
                   },
-                  scope: "global" as const,
-                  ...(net.name === "0"
-                    ? { powerDomain: "ground" as const }
-                    : {}),
-                }
-              : {
-                  id: deriveStableId(
-                    "connectivity-evidence",
-                    documentId,
-                    "net-name-hint",
-                    net.id,
-                    net.name,
-                  ),
-                  kind: "net-name-hint" as const,
-                  netId: net.id,
-                  sourceName: net.name,
-                  origin: "spice-import" as const,
-                },
-          ]
-        : []),
-      ...[net.id].map((sourceNetId) => ({
-        id: deriveStableId(
-          "connectivity-evidence",
-          documentId,
-          "spice-source",
-          net.id,
+            ]
+          : []),
+        ...(importedName.scope === "global" &&
+        importedName.sourceName !== importedName.name
+          ? [
+              {
+                id: deriveStableId(
+                  "connectivity-evidence",
+                  documentId,
+                  "net-name-hint",
+                  net.id,
+                  importedName.sourceName,
+                ),
+                kind: "net-name-hint" as const,
+                netId: net.id,
+                sourceName: importedName.sourceName,
+                origin: "spice-import" as const,
+              },
+            ]
+          : []),
+        ...[net.id].map((sourceNetId) => ({
+          id: deriveStableId(
+            "connectivity-evidence",
+            documentId,
+            "spice-source",
+            net.id,
+            sourceNetId,
+          ),
+          kind: "spice-source" as const,
+          netId: net.id,
           sourceNetId,
-        ),
-        kind: "spice-source" as const,
-        netId: net.id,
-        sourceNetId,
-      })),
-    ]),
+        })),
+      ];
+    }),
     routes: [],
     junctions: [],
     annotations: [],
@@ -573,12 +622,7 @@ export function importCircuitIR(
     ]),
   );
   const importedDocuments = ir.cells.map((cell) =>
-    importDocument(
-      cell,
-      diagnostics,
-      modelTypeByName,
-      options.symbolMappings ?? [],
-    ),
+    importDocument(cell, diagnostics, modelTypeByName, options),
   );
   const { documents, externalSubcircuitDefinitions } =
     bindImportedChildDocuments(importedDocuments);


### PR DESCRIPTION
## Summary

- detach imported global declarations when a physical wire is cut while preserving provenance
- derive project-wide Net spelling and effective local/global scope without changing Base Net topology or lifecycle ownership
- add ngspice/Spectre name codecs, collision diagnostics, Properties scope controls, and explicit Cadence `!` import/export compatibility

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm gate:preflight -- --base origin/main`
- `pnpm gate:full` (second complete run: 340 unit files, 2195 passed / 5 skipped; 316 browser tests passed)
- `git diff --check`