### PR TITLE
fix(ci): a failed deploy rolls itself back instead of leaving production broken

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -39,6 +39,27 @@ jobs:
           # Timing simulation remains a localhost development surface until
           # its interaction and presentation contracts are ready to publish.
           VITE_ICM_TIMING_UI: disabled
+      # The version serving right now, captured BEFORE anything changes.
+      # Read afterwards it would already describe the deploy under test, and
+      # a rollback would restore the very thing it is meant to undo.
+      - name: Record the version to roll back to
+        id: rollback_target
+        run: |
+          if ! pnpm dlx wrangler@4.120.1 deployments list --json > /tmp/deployments-before.json; then
+            echo "could not list deployments; rollback will be unavailable"
+            echo "version_id=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if version_id="$(node scripts/deploy-rollback-target.mjs < /tmp/deployments-before.json)"; then
+            echo "version_id=$version_id" >> "$GITHUB_OUTPUT"
+            echo "Rollback target: $version_id"
+          else
+            echo "version_id=" >> "$GITHUB_OUTPUT"
+            echo "No rollback target available for this deploy"
+          fi
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - run: pnpm dlx wrangler@4.120.1 deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -72,6 +93,7 @@ jobs:
           ADMIN_EMAILS: ${{ secrets.ADMIN_EMAILS }}
           ADMIN_EMAILS_EXTRA: ${{ secrets.ADMIN_EMAILS_EXTRA }}
       - name: Verify production deployment
+        id: verify
         run: |
           curl --fail --silent --show-error \
             --retry 5 --retry-delay 2 --retry-all-errors \
@@ -104,3 +126,36 @@ jobs:
               exit 1
               ;;
           esac
+
+      # Detection without recovery is what turned a bad deploy into twenty
+      # minutes of 500s: the pipeline saw them, went red, and left production
+      # broken. This restores the previous version instead, then proves the
+      # restore worked. The job still fails, loudly — a rollback is a recovery,
+      # never a pass.
+      - name: Roll back a failed deployment
+        if: failure() && steps.verify.outcome == 'failure'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ROLLBACK_VERSION: ${{ steps.rollback_target.outputs.version_id }}
+        run: |
+          if [ -z "$ROLLBACK_VERSION" ]; then
+            echo "::error::Verification failed and no rollback target was recorded. Production is serving the failed deploy and needs a human."
+            exit 1
+          fi
+          echo "::warning::Verification failed; rolling back to $ROLLBACK_VERSION"
+          pnpm dlx wrangler@4.120.1 rollback "$ROLLBACK_VERSION" \
+            --yes --message "Automatic rollback: post-deploy verification failed for ${GITHUB_SHA}"
+          # A rollback that is not re-verified is a second unchecked deploy.
+          # These are the same paths the verification step checks, and the
+          # editor is among them because that is what broke.
+          for path in / /editor /analytics /api/agent/mcp-manifest.json; do
+            if ! curl --fail --silent --show-error \
+              --retry 10 --retry-delay 3 --retry-all-errors --max-time 20 \
+              "https://analog-canvas.tokenzhang.com${path}" >/dev/null; then
+              echo "::error::Rollback to $ROLLBACK_VERSION did not restore ${path}. Production is down and needs a human."
+              exit 1
+            fi
+          done
+          echo "::error::Deploy of ${GITHUB_SHA} failed verification and was rolled back to $ROLLBACK_VERSION. Production is serving the previous version."
+          exit 1

--- a/scripts/deploy-rollback-target.mjs
+++ b/scripts/deploy-rollback-target.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * Pick the version a failed deploy should roll back to.
+ *
+ * Reads `wrangler deployments list --json` on stdin and prints the id of the
+ * version that was serving BEFORE the deployment at the head of the list —
+ * the one a rollback restores.
+ *
+ * This exists as a separate script, tested offline, because it runs in the
+ * one place where being wrong is expensive: the recovery path of a broken
+ * deploy. A rollback that picks the wrong version, or that silently picks
+ * nothing, leaves production broken while reporting that it acted.
+ */
+
+function fail(message) {
+  process.stderr.write(`deploy-rollback-target: ${message}\n`);
+  process.exit(1);
+}
+
+/**
+ * Deployments come newest-first. The head is the deploy just made; the next
+ * distinct version behind it is what was live before, and is the target.
+ *
+ * A deployment can carry several versions during a gradual rollout, so the
+ * comparison is by version id rather than by position: taking "the second
+ * entry" would pick a second slice of the SAME broken deploy when one is in
+ * progress.
+ */
+export function rollbackTargetFrom(deployments) {
+  if (!Array.isArray(deployments) || deployments.length === 0) {
+    return { ok: false, reason: "no deployments reported" };
+  }
+  const idsOf = (deployment) =>
+    (deployment?.versions ?? [])
+      .map((entry) => entry?.version_id ?? entry?.id)
+      .filter((id) => typeof id === "string" && id.length > 0);
+
+  const current = new Set(idsOf(deployments[0]));
+  if (current.size === 0) {
+    return { ok: false, reason: "current deployment reports no version id" };
+  }
+  for (const deployment of deployments.slice(1)) {
+    const candidate = idsOf(deployment).find((id) => !current.has(id));
+    if (candidate) return { ok: true, versionId: candidate };
+  }
+  // A first-ever deploy has nothing behind it. Rolling back is impossible and
+  // saying so is the honest outcome; the caller must not treat it as success.
+  return { ok: false, reason: "no earlier version to roll back to" };
+}
+
+if (import.meta.filename === process.argv[1]) {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch (error) {
+    fail(`could not parse deployments JSON: ${String(error)}`);
+  }
+  const result = rollbackTargetFrom(
+    Array.isArray(parsed) ? parsed : (parsed?.deployments ?? []),
+  );
+  if (!result.ok) fail(result.reason);
+  process.stdout.write(`${result.versionId}\n`);
+}

--- a/scripts/deploy-rollback-target.test.mjs
+++ b/scripts/deploy-rollback-target.test.mjs
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { rollbackTargetFrom } from "./deploy-rollback-target.mjs";
+
+/** Shape wrangler prints for `deployments list --json`, newest first. */
+const deployment = (...versionIds) => ({
+  id: `deployment-${versionIds.join("-")}`,
+  versions: versionIds.map((id) => ({ version_id: id, percentage: 100 })),
+});
+
+describe("rollback target selection", () => {
+  it("picks the version that was live before the deploy just made", () => {
+    expect(
+      rollbackTargetFrom([deployment("broken"), deployment("good")]),
+    ).toEqual({ ok: true, versionId: "good" });
+  });
+
+  it("skips another slice of the same broken deploy", () => {
+    // A gradual rollout puts two versions in one deployment. Taking "the
+    // second entry" would roll back to the other half of what just broke.
+    expect(
+      rollbackTargetFrom([
+        deployment("broken", "good"),
+        deployment("broken"),
+        deployment("older"),
+      ]),
+    ).toEqual({ ok: true, versionId: "older" });
+  });
+
+  it("refuses rather than guessing when nothing precedes the deploy", () => {
+    // A first-ever deploy has nothing to restore. Reporting success here
+    // would leave production broken while claiming the pipeline recovered.
+    expect(rollbackTargetFrom([deployment("only")])).toEqual({
+      ok: false,
+      reason: "no earlier version to roll back to",
+    });
+    expect(rollbackTargetFrom([])).toEqual({
+      ok: false,
+      reason: "no deployments reported",
+    });
+  });
+
+  it("refuses when the current deployment reports no version id", () => {
+    expect(rollbackTargetFrom([{ id: "d1", versions: [] }])).toEqual({
+      ok: false,
+      reason: "current deployment reports no version id",
+    });
+  });
+
+  it("reads the id field wrangler uses when version_id is absent", () => {
+    expect(
+      rollbackTargetFrom([
+        { id: "d1", versions: [{ id: "broken" }] },
+        { id: "d0", versions: [{ id: "good" }] },
+      ]),
+    ).toEqual({ ok: true, versionId: "good" });
+  });
+});

--- a/scripts/deploy-workflow.test.mjs
+++ b/scripts/deploy-workflow.test.mjs
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The deploy pipeline's own contract.
+ *
+ * On 2026-09-01 a bad deploy served 500s for twenty minutes. The pipeline
+ * DETECTED it — six failed verification attempts — went red, and left
+ * production broken, because detection was all it could do. These assertions
+ * exist so the recovery path cannot quietly disappear the way it was quietly
+ * absent, and because this file is one nobody exercises until the day it
+ * matters.
+ */
+const workflow = readFileSync(".github/workflows/cloudflare.yml", "utf8");
+
+describe("Cloudflare deploy workflow", () => {
+  it("records the rollback target before the deploy changes anything", () => {
+    const capture = workflow.indexOf("Record the version to roll back to");
+    const deploy = workflow.indexOf("wrangler@4.120.1 deploy");
+    expect(capture).toBeGreaterThan(-1);
+    // Read after deploying, the "previous" version is the broken one.
+    expect(capture).toBeLessThan(deploy);
+  });
+
+  it("rolls back when verification fails", () => {
+    expect(workflow).toContain("Roll back a failed deployment");
+    expect(workflow).toMatch(
+      /if:\s*failure\(\)\s*&&\s*steps\.verify\.outcome/u,
+    );
+    expect(workflow).toContain("wrangler@4.120.1 rollback");
+  });
+
+  it("re-verifies after rolling back", () => {
+    // A rollback that is not checked is just a second unverified deploy.
+    const rollbackSection = workflow.slice(
+      workflow.indexOf("Roll back a failed deployment"),
+    );
+    expect(rollbackSection).toContain("/editor");
+    expect(rollbackSection).toContain("did not restore");
+  });
+
+  it("fails the job even when the rollback succeeds", () => {
+    // Recovery is not success: a red run is how anyone learns this happened.
+    const rollbackSection = workflow.slice(
+      workflow.indexOf("Roll back a failed deployment"),
+    );
+    expect(rollbackSection).toContain("was rolled back");
+    expect(rollbackSection.trimEnd().endsWith("exit 1")).toBe(true);
+  });
+
+  it("says so loudly when it cannot roll back at all", () => {
+    // The one outcome worse than a failed deploy is a failed deploy nobody
+    // can undo. It must not be reported the same way as a successful undo.
+    expect(workflow).toContain("no rollback target was recorded");
+    expect(workflow).toContain("needs a human");
+  });
+
+  it("verifies the editor route, which is what broke", () => {
+    const verifySection = workflow.slice(
+      workflow.indexOf("Verify production deployment"),
+      workflow.indexOf("Roll back a failed deployment"),
+    );
+    expect(verifySection).toContain("analog-canvas.tokenzhang.com/editor");
+  });
+});


### PR DESCRIPTION
## The gap this closes

Today `/editor` served 500s for about twenty minutes. **The pipeline was not blind to it** — verification failed six times and the run went red. It simply had nothing it could do, so production stayed broken until a person noticed.

So the gap is not detection. It is recovery, and this is the whole of it.

## One correction to the brief

The brief asked me to add a `/editor` assertion "missing from today's verification". **It is already there** — and it arrived in #503, the very change that broke it. I verified this before writing anything, and added no duplicate check. The recovery path is the only thing that was missing.

## What now happens

1. **Before deploying**, the currently-serving version is recorded. Read afterwards, the "previous" version would already be the deploy under test, and a rollback would restore the thing it is meant to undo.
2. Deploy, then verify (unchanged: `/`, `/editor`, `/analytics`, the MCP manifest, and the stale-asset fallback).
3. **If verification fails**, roll back to the recorded version, then **verify the rollback** — a rollback nobody checks is just a second unverified deploy.
4. **The job fails anyway.** A recovery is not a pass; a red run is how anyone learns this happened.

Worst case moves from "broken until someone notices" to "broken for one verification round", and nobody's delivery habits change.

## Why the target selection is a tested script, not a line of shell

It runs where being wrong costs the most — the recovery path of an already-broken deploy. Two ways a naive version would go wrong, both covered by tests:

- **A gradual rollout puts two versions in one deployment**, so "the second entry in the list" can be the other half of the deploy that just broke. Selection is by version id, not by position.
- **A first-ever deploy has nothing behind it.** The script refuses rather than guessing, and the pipeline then says a human is needed — reporting a recovery that did not happen would be worse than the outage.

## Validation

- 11 tests: 5 on target selection (including both traps above), 6 pinning the pipeline's own contract so the recovery path cannot quietly vanish the way it was quietly absent
- Rehearsed offline against realistic `wrangler deployments list --json` payloads: correct target picked; first-ever deploy refused with a non-zero exit
- `wrangler rollback`'s interface confirmed against wrangler 4.120.1 itself rather than assumed
- Full `pnpm ci:check` green (316/316 Playwright specs) under the gate lock

## Not in this PR

Staging and the promotion gate. Staging needs Cloudflare account changes — a second Worker script, its own hostname, and the owner's requirement that it be private and login-gated — which I will not make unilaterally. Flagged to the coordinator. Also to be written down when staging lands: **staging's four Durable Object namespaces are empty**, because they bind to the script name. That makes it safe, and it means staging catches "the site does not come up" but never "this particular circuit breaks when opened".

🤖 Generated with [Claude Code](https://claude.com/claude-code)