### PR TITLE
fix(editor): a part with no designator offers no Reference toggle

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -712,6 +712,41 @@ test("constructs VDD as a drawn dotless power rail", async ({ page }) => {
   await expect(canvas.getByText("VDD", { exact: true })).toHaveCount(0);
 });
 
+test("a part with no designator offers no Reference toggle", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await awaitEditorReady(page);
+  // A voltage amplifier has no device descriptor, so it never designates.
+  await placeComponent(page, "voltage-amplifier", { x: 300, y: 200 });
+  await openSelectionShelf(page);
+  const properties = page.getByRole("complementary", { name: "Properties" });
+  await expect(properties).toContainText("voltage-amplifier");
+  // The row switched something that does not exist, so it is not there.
+  await expect(properties.getByLabel("Component display toggles")).toHaveCount(
+    0,
+  );
+
+  // The brake: a resistor designates R1 and carries a value, so its toggles
+  // are untouched and still work.
+  await placeComponent(page, "resistor", { x: 500, y: 200 });
+  await openSelectionShelf(page);
+  const toggles = properties.getByLabel("Component display toggles");
+  await expect(toggles).toBeVisible();
+  await expect(toggles).toContainText("Reference");
+  await expect(toggles).toContainText("Value");
+  const reference = toggles.getByLabel("Reference");
+  await expect(reference).toBeChecked();
+  const drawnLabel = page.locator(
+    '[data-layer="annotations"] [data-object-id="instance-label-R1"]',
+  );
+  await expect(drawnLabel).toHaveCount(1);
+  await reference.uncheck();
+  await expect(drawnLabel).toHaveCount(0);
+  await reference.check();
+  await expect(drawnLabel).toHaveCount(1);
+});
+
 test("a switch changes contact style in place, keeping its wires", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -27,6 +27,8 @@ import {
   diagnosticPresentationGroup,
   resolveDraftingObjectGeometry,
   displayableInstanceValue,
+  symbolCarriesReference,
+  symbolSupportsValueAnnotation,
   resolveMosBulkConnection,
   resolveDocumentStyleProfile,
   resolveRouteTap,
@@ -4471,6 +4473,12 @@ export function App({
                       selectedInstanceValue !== null &&
                       selectedInstanceValue.visible !== false,
                     valueAvailable: selectedInstanceValueAvailable,
+                    valueSupported: selectedInstance
+                      ? symbolSupportsValueAnnotation(selectedInstance.symbolId)
+                      : false,
+                    referenceAvailable: selectedInstance
+                      ? symbolCarriesReference(selectedInstance.symbolId)
+                      : false,
                     referenceLabelRenderable: selectedLabelRenderable,
                     additionalParameters: additionalParameterDraft,
                     additionalParametersChanged:

--- a/apps/editor/src/features/properties/component-electrical-properties.test.tsx
+++ b/apps/editor/src/features/properties/component-electrical-properties.test.tsx
@@ -38,6 +38,8 @@ describe("component electrical properties", () => {
         referenceVisible
         valueVisible
         valueAvailable
+        valueSupported
+        referenceAvailable
         referenceLabelRenderable
         additionalParameters={[
           { id: "extra", originalName: "ad", name: "ad", value: "1p" },
@@ -75,6 +77,8 @@ describe("component electrical properties", () => {
         referenceVisible={false}
         valueVisible={false}
         valueAvailable={false}
+        valueSupported={false}
+        referenceAvailable={false}
         referenceLabelRenderable={false}
         additionalParameters={[]}
         additionalParametersChanged={false}
@@ -111,6 +115,8 @@ describe("component electrical properties", () => {
         referenceVisible={false}
         valueVisible={false}
         valueAvailable
+        valueSupported
+        referenceAvailable
         referenceLabelRenderable={false}
         additionalParameters={[]}
         additionalParametersChanged={false}
@@ -126,5 +132,96 @@ describe("component electrical properties", () => {
     );
     expect(markup).toContain("Value");
     expect(markup).not.toContain(">Reference<");
+  });
+});
+
+describe("the Display row only offers what the drawing can show", () => {
+  const render = (
+    instance: Parameters<typeof ComponentElectricalProperties>[0]["instance"],
+    flags: {
+      referenceAvailable?: boolean;
+      valueSupported?: boolean;
+      valueAvailable?: boolean;
+      referenceLabelRenderable?: boolean;
+    },
+  ) =>
+    renderToStaticMarkup(
+      <ComponentElectricalProperties
+        instance={instance}
+        parameters={[]}
+        parameterValues={{}}
+        firstInputRef={createRef<HTMLInputElement>()}
+        referenceVisible
+        valueVisible
+        valueAvailable={flags.valueAvailable ?? false}
+        valueSupported={flags.valueSupported ?? false}
+        referenceAvailable={flags.referenceAvailable ?? false}
+        referenceLabelRenderable={flags.referenceLabelRenderable ?? true}
+        additionalParameters={[]}
+        additionalParametersChanged={false}
+        onParameterChange={vi.fn()}
+        onReferenceVisibilityChange={vi.fn()}
+        onValueVisibilityChange={vi.fn()}
+        onAdditionalParameterChange={vi.fn()}
+        onAdditionalParameterRemove={vi.fn()}
+        onAdditionalParameterAdd={vi.fn()}
+        onAdditionalParametersApply={vi.fn()}
+        onAdditionalParametersCancel={vi.fn()}
+      />,
+    );
+
+  it("drops the whole row for a part that has neither a reference nor a value", () => {
+    // A voltage amplifier has no device descriptor, so it has no designator
+    // to show. The toggle switched something that does not exist.
+    const markup = render(
+      { id: "X3", symbolId: "voltage-amplifier", placement: null },
+      {},
+    );
+    expect(markup).not.toContain("Component display toggles");
+    expect(markup).not.toContain("Reference");
+    expect(markup).not.toContain(">Value<");
+  });
+
+  it("keeps both toggles for a part that has both", () => {
+    // The brake: a resistor designates R1 and carries a value, so nothing
+    // about it changes.
+    const markup = render(
+      { id: "R1", symbolId: "resistor", placement: null, reference: "R1" },
+      { referenceAvailable: true, valueSupported: true, valueAvailable: true },
+    );
+    expect(markup).toContain("Component display toggles");
+    expect(markup).toContain("Reference");
+    expect(markup).toContain("Value");
+  });
+
+  it("keeps a value toggle that is merely unset, and says why", () => {
+    // "No value yet" is not "no value ever": the row must stay so the person
+    // can see the remedy.
+    const markup = render(
+      { id: "R1", symbolId: "resistor", placement: null, reference: "R1" },
+      { referenceAvailable: true, valueSupported: true, valueAvailable: false },
+    );
+    expect(markup).toContain("Value");
+    expect(markup).toContain("Set the device parameters first");
+  });
+
+  it("offers only the reference for a part that can never show a value", () => {
+    // A switch designates S1 but has no value annotation at all.
+    const markup = render(
+      { id: "S1", symbolId: "ideal-switch", placement: null, reference: "S1" },
+      { referenceAvailable: true, valueSupported: false },
+    );
+    expect(markup).toContain("Reference");
+    expect(markup).not.toContain(">Value<");
+  });
+
+  it("still hides the reference for a Symbol that draws no label", () => {
+    // Ground and the signal-flow blocks: the artwork shows no label, so the
+    // toggle would edit something invisible even where a reference exists.
+    const markup = render(
+      { id: "G1", symbolId: "ground", placement: null, reference: "G1" },
+      { referenceAvailable: true, referenceLabelRenderable: false },
+    );
+    expect(markup).not.toContain("Reference");
   });
 });

--- a/apps/editor/src/features/properties/component-electrical-properties.tsx
+++ b/apps/editor/src/features/properties/component-electrical-properties.tsx
@@ -17,6 +17,8 @@ export function ComponentElectricalProperties({
   referenceVisible,
   valueVisible,
   valueAvailable,
+  valueSupported,
+  referenceAvailable,
   referenceLabelRenderable,
   additionalParameters,
   additionalParametersChanged,
@@ -36,6 +38,21 @@ export function ComponentElectricalProperties({
   referenceVisible: boolean;
   valueVisible: boolean;
   valueAvailable: boolean;
+  /**
+   * Whether this device can ever annotate a value. A switch designates S1 and
+   * carries no value at all, so its Value toggle would switch nothing. This
+   * is not the same as {@link valueAvailable}, which is false only until the
+   * parameters are filled in and keeps its toggle so the remedy is visible.
+   */
+  valueSupported: boolean;
+  /**
+   * Whether this instance has a reference designator to show. A part with no
+   * device descriptor — a voltage amplifier, an op amp, the signal-flow
+   * blocks — never gets one, so a "Reference" toggle would switch something
+   * that does not exist. Read from the reference policy rather than a list of
+   * Symbol names, so a Symbol added later is right without anyone editing it.
+   */
+  referenceAvailable: boolean;
   /**
    * Whether this Symbol can draw a reference label at all. A Symbol that
    * declares `labelVisibility: "hidden"` — a summing junction, a 1/s block,
@@ -64,7 +81,10 @@ export function ComponentElectricalProperties({
   // control: schematic-only glyphs neither draw a reference nor carry a
   // value, and a Symbol with no parameters and no netlist has nothing left
   // for this card to say.
-  const displayable = referenceLabelRenderable || valueAvailable;
+  // Offer only what the drawing can actually show: a reference this
+  // instance has and this Symbol draws, and a value this device supports.
+  const referenceToggleable = referenceLabelRenderable && referenceAvailable;
+  const displayable = referenceToggleable || valueSupported;
   if (primaryParameters.length === 0 && !displayable && !instance.netlist) {
     return null;
   }
@@ -107,7 +127,7 @@ export function ComponentElectricalProperties({
             className="display-toggle-row"
             aria-label="Component display toggles"
           >
-            {referenceLabelRenderable ? (
+            {referenceToggleable ? (
               <DisplayToggle
                 label={
                   instance.symbolId === "port" ||
@@ -119,15 +139,17 @@ export function ComponentElectricalProperties({
                 onChange={onReferenceVisibilityChange}
               />
             ) : null}
-            <DisplayToggle
-              label="Value"
-              checked={valueVisible}
-              disabled={!valueAvailable}
-              help={
-                valueAvailable ? undefined : "Set the device parameters first"
-              }
-              onChange={onValueVisibilityChange}
-            />
+            {valueSupported ? (
+              <DisplayToggle
+                label="Value"
+                checked={valueVisible}
+                disabled={!valueAvailable}
+                help={
+                  valueAvailable ? undefined : "Set the device parameters first"
+                }
+                onChange={onValueVisibilityChange}
+              />
+            ) : null}
           </div>
         </div>
       ) : null}

--- a/packages/derived/src/instance-value.ts
+++ b/packages/derived/src/instance-value.ts
@@ -1,5 +1,9 @@
 import type { RichTextDocument } from "@icm/model";
-import { deviceDescriptor, type DeviceParameterDefinition } from "@icm/devices";
+import {
+  deviceDescriptor,
+  referencePolicyForSymbol,
+  type DeviceParameterDefinition,
+} from "@icm/devices";
 
 export type InstanceValueDisplay =
   | { readonly kind: "displayable"; readonly content: RichTextDocument }
@@ -57,6 +61,34 @@ function boldDocument(value: string): RichTextDocument {
  * writes back. Display is Razavi textbook style: upright bold text with the
  * engineering unit, and a stacked fraction bar for MOS W/L.
  */
+/**
+ * Whether this Symbol's device can ever annotate a value.
+ *
+ * Different from {@link displayableInstanceValue}, which answers whether one
+ * instance has a value to show right now: a resistor with no resistance typed
+ * yet is undisplayable but value-capable, and its Value control belongs on
+ * screen so the person can see what is missing. A switch, and anything with
+ * no device descriptor at all, can never carry one.
+ */
+export function symbolSupportsValueAnnotation(symbolId: string): boolean {
+  return (
+    deviceDescriptor(symbolId)?.capabilities.supportsValueAnnotation === true
+  );
+}
+
+/**
+ * Whether an instance of this Symbol gets a reference designator.
+ *
+ * A Symbol with no device descriptor — a voltage amplifier, an op amp, the
+ * signal-flow blocks — has no reference prefix, so its instances have no
+ * designator to show or hide. Asked through the reference policy rather than
+ * a list of Symbol names, so a Symbol added later answers correctly without
+ * anyone remembering to update a list.
+ */
+export function symbolCarriesReference(symbolId: string): boolean {
+  return referencePolicyForSymbol(symbolId).kind !== "none";
+}
+
 export function displayableInstanceValue(
   instance: InstanceValueSource,
 ): InstanceValueDisplay {


### PR DESCRIPTION
## What was wrong

Selecting a voltage amplifier showed **Display: ☑ Reference ☐ Value**, and neither box changed the drawing. The part has no device descriptor, so it has no reference prefix and no designator to show — the checkbox switched something that does not exist. Op amps, comparators, the logic family and the signal-flow blocks are all in the same position, the last of them deliberately since #386.

This is the other half of #476, which stopped the empty label from rendering as a selectable ghost but left the control behind.

## The rule, asked of the part rather than of a name list

So a Symbol added later is right without anyone remembering to maintain a list:

- **Reference** appears when the instance carries a designator (its reference policy is not `"none"`) **and** the Symbol draws a label at all. The second half already existed, for Ground and the 1/s blocks.
- **Value** appears when the device supports a value annotation. That is a different question from whether a value is set: a resistor with nothing typed **keeps** its toggle, disabled, saying what is missing, while a switch — which can never carry a value — no longer shows one.
- With neither, the **whole Display row** goes, rather than leaving an empty heading or a lone box that does nothing.

Two predicates carry it, placed next to the value projection that already answers the neighbouring question: `symbolCarriesReference` and `symbolSupportsValueAnnotation`.

## Saved files

Unaffected. These parts never had a designator to draw, so a stored visibility flag changed nothing before and changes nothing now. The project-file suite passes unchanged, which is the load path the request asked about.

## Tests, red first and with a brake

Red: the row survived for a part with neither, and a switch still showed a Value box it can never use. Green after. The brake is explicit — a resistor keeps both toggles and they still work, asserted in the unit tests and again end to end by unchecking Reference, watching `instance-label-R1` leave the annotation layer, and checking it back.

Unit 2003/2003; `manual-editor` + `project-file` e2e 137/137; typecheck and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)