### PR TITLE
fix(editor): a dragged wire previews the path it will commit

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -5925,6 +5925,56 @@ test("double-click ends the wire even when it lands on another wire", async ({
   await expect(page.getByTestId("status")).toContainText("Wire finished");
 });
 
+test("dragging a wire previews the orthogonal path it will commit", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await awaitEditorReady(page);
+  await placeComponent(page, "resistor", { x: 260, y: 200 });
+  const canvas = page.getByTestId("schematic-canvas");
+  // A wire from a terminal out to a free end, drawn at a free angle: the
+  // shape the report was about.
+  await clickDrawTool(page, "wire");
+  await page.getByTestId("terminal-R1-2").click();
+  for (let step = 0; step < 4; step += 1) {
+    await canvas.click({ button: "middle", position: { x: 380, y: 260 } });
+  }
+  await canvas.dblclick({ position: { x: 520, y: 300 } });
+  await page.keyboard.press("Escape");
+
+  const drawnPoints = async () => {
+    const points = await page
+      .locator('[data-layer="routes"] polyline')
+      .first()
+      .getAttribute("points");
+    return (points ?? "")
+      .trim()
+      .split(/\s+/u)
+      .map((pair) => pair.split(",").map(Number) as [number, number]);
+  };
+  const everyLegAxisAligned = (points: [number, number][]) =>
+    points.every((point, index) => {
+      if (index === 0) return true;
+      const previous = points[index - 1]!;
+      return point[0] === previous[0] || point[1] === previous[1];
+    });
+
+  const route = page.locator('[data-canvas-hit-kind="route"]').first();
+  const box = (await route.boundingBox())!;
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(
+    box.x + box.width / 2 + 20,
+    box.y + box.height / 2 + 70,
+    { steps: 8 },
+  );
+  // While the pointer is down the preview used to close back at the old free
+  // end, drawing a triangle the editor never commits.
+  expect(everyLegAxisAligned(await drawnPoints())).toBe(true);
+  await page.mouse.up();
+  expect(everyLegAxisAligned(await drawnPoints())).toBe(true);
+});
+
 test("draws a wire at an angle the 45-degree grid cannot reach", async ({
   page,
 }) => {

--- a/apps/editor/src/features/wiring/segment-drag-preview.test.ts
+++ b/apps/editor/src/features/wiring/segment-drag-preview.test.ts
@@ -1,0 +1,90 @@
+import { createRoutePath } from "@icm/model";
+import { describe, expect, it } from "vitest";
+
+import { segmentDragPreviewPolyline } from "./segment-drag-preview";
+
+const route = (
+  start: Parameters<typeof createRoutePath>[0]["start"],
+  end: Parameters<typeof createRoutePath>[0]["end"],
+) =>
+  createRoutePath({
+    id: "route-1",
+    netId: "net-1",
+    start,
+    end,
+    bends: [],
+    modes: ["manual"],
+  });
+
+const junction = (junctionId: string) =>
+  ({ kind: "junction", junctionId }) as const;
+const terminal = (instanceId: string) =>
+  ({ kind: "terminal", instanceId, pinName: "P" }) as const;
+
+describe("what a segment drag draws while the pointer is down", () => {
+  it("follows the endpoint the plan moves, so no slanted edge closes it", () => {
+    // The reported shape: a wire from a terminal out to a free end, dragged
+    // by its middle. The planner repairs the slant by moving the free end,
+    // and the preview has to move with it or the last leg cuts across.
+    const points = segmentDragPreviewPolyline(
+      route(terminal("R1"), junction("j-free")),
+      [
+        { x: 230, y: 230 },
+        { x: 510, y: 320 },
+      ],
+      [
+        { x: 230, y: 350 },
+        { x: 510, y: 350 },
+      ],
+      [{ junctionId: "j-free", position: { x: 510, y: 350 } }],
+    );
+    expect(points).toEqual([
+      { x: 230, y: 230 },
+      { x: 230, y: 350 },
+      { x: 510, y: 350 },
+      { x: 510, y: 350 },
+    ]);
+    // Every leg is axis-aligned: no triangle.
+    for (let index = 0; index < points.length - 1; index += 1) {
+      const from = points[index]!;
+      const to = points[index + 1]!;
+      expect(from.x === to.x || from.y === to.y).toBe(true);
+    }
+  });
+
+  it("leaves an endpoint the plan does not move exactly where it is", () => {
+    // Both ends on device terminals: the wire stretches between them and the
+    // anchors are not the drag's to move.
+    const points = segmentDragPreviewPolyline(
+      route(terminal("R1"), terminal("R2")),
+      [
+        { x: 230, y: 230 },
+        { x: 550, y: 230 },
+      ],
+      [
+        { x: 230, y: 290 },
+        { x: 550, y: 290 },
+      ],
+      [],
+    );
+    expect(points).toEqual([
+      { x: 230, y: 230 },
+      { x: 230, y: 290 },
+      { x: 550, y: 290 },
+      { x: 550, y: 230 },
+    ]);
+  });
+
+  it("ignores a junction move that belongs to another Route", () => {
+    const points = segmentDragPreviewPolyline(
+      route(terminal("R1"), junction("j-free")),
+      [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+      ],
+      [{ x: 0, y: 40 }],
+      [{ junctionId: "j-somewhere-else", position: { x: 999, y: 999 } }],
+    );
+    expect(points.at(-1)).toEqual({ x: 100, y: 0 });
+  });
+});

--- a/apps/editor/src/features/wiring/segment-drag-preview.ts
+++ b/apps/editor/src/features/wiring/segment-drag-preview.ts
@@ -1,0 +1,45 @@
+import { routeEnd, type Point, type SchematicDocument } from "@icm/model";
+
+type Route = SchematicDocument["routes"][number];
+
+export interface SegmentDragJunctionMove {
+  readonly junctionId: string;
+  readonly position: Point;
+}
+
+/**
+ * The polyline a segment drag should draw while the pointer is down.
+ *
+ * The planner repairs a dragged segment into orthogonal legs and, where an
+ * end of the Route is a free Junction, moves that Junction to suit. The
+ * preview has to follow it. Drawing the planned waypoints between the Route's
+ * ORIGINAL endpoints leaves the far end where it was, so the last leg closes
+ * back at an angle and the drag reads as a triangle — even though releasing
+ * commits the orthogonal path the planner intended. The person sees a shape
+ * the editor never builds.
+ *
+ * An endpoint the plan does not move stays exactly where it is: a wire that
+ * ends on a device terminal is anchored there, and the drag may not pretend
+ * otherwise.
+ */
+export function segmentDragPreviewPolyline(
+  route: Route,
+  centerline: readonly Point[],
+  waypoints: readonly Point[],
+  junctionMoves: readonly SegmentDragJunctionMove[],
+): Point[] {
+  const moved = new Map(
+    junctionMoves.map((move) => [move.junctionId, move.position]),
+  );
+  const endpointPoint = (
+    endpoint: Route["start"],
+    fallback: Point | undefined,
+  ): Point | undefined =>
+    endpoint.kind === "junction"
+      ? (moved.get(endpoint.junctionId) ?? fallback)
+      : fallback;
+
+  const start = endpointPoint(route.start, centerline[0]);
+  const end = endpointPoint(routeEnd(route), centerline.at(-1));
+  return [...(start ? [start] : []), ...waypoints, ...(end ? [end] : [])];
+}

--- a/apps/editor/src/features/wiring/use-wire-interaction.ts
+++ b/apps/editor/src/features/wiring/use-wire-interaction.ts
@@ -4,6 +4,8 @@ import type {
   PointerEvent as ReactPointerEvent,
 } from "react";
 
+import { segmentDragPreviewPolyline } from "./segment-drag-preview";
+
 import {
   type WireDraftStep,
   createRoutingOperationPlan,
@@ -731,11 +733,17 @@ export function useWireInteraction(capabilities: UseWireInteractionOptions) {
           // point used to plan once more, fail, and snap the wire back to
           // where it started, discarding everything the preview had shown.
           preview.point = point;
-          dragVisual().setPolyline([
-            record.geometry.centerline[0]!,
-            ...proposal.waypoints,
-            record.geometry.centerline.at(-1)!,
-          ]);
+          // Draw what the plan will commit. Pinning the Route's original
+          // endpoints here left a moved free end behind, so the closing leg
+          // cut across at an angle and the drag read as a triangle.
+          dragVisual().setPolyline(
+            segmentDragPreviewPolyline(
+              record.route,
+              record.geometry.centerline,
+              proposal.waypoints,
+              plan.preview?.junctions ?? [],
+            ),
+          );
         } catch {
           // Keep the last valid preview; commit lands on it instead.
         }


### PR DESCRIPTION
## What was reported

Dragging a wire drew a **triangle**: one end held, a leg down to the pointer, and a slanted edge closing back to where the far end used to be.

## Measured before changing anything

Two behaviours were candidates and only one is a defect, so all three were driven in the real editor first:

| Gesture | Preview | Commit |
| --- | --- | --- |
| Wire between two devices, dragged | orthogonal | orthogonal — **already correct** |
| Device moved, wire attached | gains corners, orthogonal | same — **already correct**, and the stretch invariant it rests on is untouched here |
| Wire from a terminal to a free end, free angle, dragged by its middle | `230,230 → 230,349 → 510,320` — **a triangle** | `230,230 → 230,350 → 510,350` — orthogonal |

So the planner had been repairing the slant all along. **The preview was not following it**, and the shape on screen was one the editor never builds.

## The cause

The preview drew the planned waypoints between the Route's **original** endpoints. When the plan also moves a free end, that pinned endpoint is stale and the closing leg cuts across to reach it.

The endpoint now comes from the plan's own junction moves — exactly what the endpoint-resize branch of the same drag already did fifty lines above. An endpoint the plan does **not** move, such as a device terminal, still does not move.

## The brake

A free-angle wire a person drew on purpose keeps its angle: that gesture translates the whole route and never enters segment repair. Its end-to-end case passes unchanged, alongside a new one asserting every leg stays axis-aligned **during** the drag as well as after release.

## Validation

Unit 2023/2023, including three new cases on the extracted preview helper. The `manual-editor` free-angle case and the new drag case both pass; `wiring-semantics` + `detach-move` 14/14; typecheck and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
