### PR TITLE
docs(changelog): record what 0.2.0 actually shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,89 @@ version, and returns the same results.
 **This release covers DC operating point and AC analysis.** Transient, sweeps,
 and corner runs follow once this path is proven.
 
+### Drawing
+
+**Move a part without dragging its wires along.** `Shift+M` arms the move and
+the next click picks the part up; `Shift+drag` does it with the pointer. This
+is the Virtuoso distinction: plain `M` stretches the wires with the part,
+`Shift` leaves them where they were. The shortcut panel lists it, because a
+capability nobody can find is one that does not exist.
+
+**A dragged wire shows the path it will take.** The preview used to pull a
+diagonal out of a wire whose far end stayed put, which is not a shape a
+schematic wire can have.
+
+**Wire ends that meet, join.** Dragging a wire so its end lands on another
+conductor merges the two into one net, and so does dragging a part until its
+pin lands on a wire. A wire that merely crosses another still does not
+connect, and no longer complains about it. That distinction is the point: the
+end you place deliberately is intent, the crossing is not.
+
+**Arrows point both ways.** An arrow chooses whether its head sits at the end,
+at the start, or at both, alongside the existing choice of head style.
+
+### Symbols
+
+**Switches reach their wire in one grid cell.** The leads on the three switch
+symbols ran nearly two cells; the bodies are untouched. Two more switches
+join the library: a plain-line switch without contact circles, and a
+single-pole double-throw. The plain switch carries the double-throw as an
+option rather than a sixth tile.
+
+**Amplifiers can carry the letter their stage is named by**, editable per
+instance, and ADC and DAC blocks join them with their own editable text. The
+two converters sit next to each other in the Library, where alphabetical
+order had put four tiles between them.
+
+**The crossed differential amplifier is a state, not a second part.** Its
+outputs already swapped from the properties panel, so the separate tile was
+a duplicate of a control that existed.
+
+**The comparator's glyph clears its body outline**, which it had been
+overlapping by about a stroke width, and the quantizer is square rather than
+half again as wide as it is tall.
+
+### Text and labels
+
+**A label with no text no longer sits on the canvas as an invisible target.**
+Twenty-eight of the palette's parts had no designator to display, so their
+labels rendered empty yet stayed clickable. Parts with nothing to show now
+also drop the Reference toggle, which had been switching a thing that was
+not there.
+
+**Formatting a net name works.** Applying bold or underline to a bound name
+used to be refused, because the name was compiled in a way that dropped
+characters and the result no longer matched the name it was bound to. The
+compiler now preserves every authored character, which also means underscores
+and letter case stay as written rather than being reinterpreted.
+
+**A label attached to something other than a part can be dragged.** A power
+rail's label hangs off its junction and a drafting label off its rectangle;
+neither could be moved, and the gesture silently did nothing.
+
+### Gallery
+
+**The docked Gallery pages, counts, searches, and filters like the wall
+does**, through the same code, so the two cannot answer the same question
+differently.
+
+**A withdrawn circuit stays in your recycle bin while it is among your 25
+most recent withdrawals.** Nothing expires on a clock, so the card states the
+rule rather than naming a removal date it cannot honour.
+
+### Reliability
+
+**A failed deploy rolls itself back.** Post-deploy verification already
+checked the live site; when it failed it left the site failing. It now
+restores the previous version instead.
+
+**A project saved before a schema change still opens.** The loader accepted
+only the two most recent versions, which refused files saved the week before;
+it now accepts anything the upgrade chain can carry forward.
+
+**A missing code chunk answers with a refresh rather than a stack trace**, and
+a stuck page can get itself unstuck.
+
 ### Unchanged
 
 The electrical model is untouched. Connectivity is still explicit, a crossing


### PR DESCRIPTION
The 0.2.0 entry covered simulation and stopped there, while nineteen more functional changes landed underneath it. A changelog that covers one feature and misses the rest is worse than none, because it reads as complete.

Grouped by what a person was doing when the change reaches them rather than by package: **Drawing**, **Symbols**, **Text and labels**, **Gallery**, **Reliability**.

Each entry says what changed for the person using the product, and where the reason is not obvious, why the old behaviour was wrong. The wire-merge entry states the distinction it turns on, since "ends that meet join, crossings do not" is the rule people have to hold in their head.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)