### PR TITLE
fix(project-protocol): reopen a published circuit, and edit Symbol body text on the canvas

### DIFF
--- a/apps/editor/e2e/symbol-body-text.spec.ts
+++ b/apps/editor/e2e/symbol-body-text.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { chooseComponent, downloadBytes } from "./editor-fixtures";
+
+async function placeSymbol(page: Page, symbolId: string): Promise<void> {
+  await page.goto("/editor");
+  await chooseComponent(page, symbolId);
+  await page.getByTestId("schematic-canvas").click({
+    position: { x: 360, y: 240 },
+  });
+  await page.keyboard.press("Escape");
+}
+
+function bodyText(page: Page) {
+  // Scoped to the drawing: the Library chips draw the same body text.
+  return page.locator(
+    '[data-testid="schematic-canvas"] [data-role="signal-flow-formula"]',
+  );
+}
+
+/**
+ * The owner's complaint: text drawn inside a Symbol's own body was the one
+ * text in the editor that could not be edited where it is drawn. Everything
+ * else — net labels, notes, designators — edits on the canvas, so the same
+ * gesture meant two different things depending on where the text lived.
+ */
+test("double-clicking a Symbol's body text edits it on the canvas", async ({
+  page,
+}) => {
+  await placeSymbol(page, "dac");
+  await expect(bodyText(page)).toContainText("DAC");
+
+  await page.getByTestId("hit-X1").dblclick();
+  const editor = page.getByRole("textbox", { name: "Canvas text editor" });
+  await expect(editor).toBeVisible();
+  await expect(editor).toHaveValue("DAC");
+
+  await editor.fill("8-bit DAC");
+  await page.getByRole("button", { name: "Apply text changes" }).click();
+
+  await expect(bodyText(page)).toContainText("8-bit DAC");
+});
+
+// Both surfaces write one field, so they cannot drift apart.
+test("the Properties field shows what the canvas edit committed", async ({
+  page,
+}) => {
+  await placeSymbol(page, "dac");
+
+  await page.getByTestId("hit-X1").dblclick();
+  await page
+    .getByRole("textbox", { name: "Canvas text editor" })
+    .fill("current steering");
+  await page.getByRole("button", { name: "Apply text changes" }).click();
+
+  await page.getByTestId("hit-X1").click();
+  await expect(page.getByLabel("Formula")).toHaveValue("current steering");
+
+  const saved = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(
+      "utf8",
+    ),
+  ) as {
+    documents: Array<{
+      instances: Array<{ signalFlowParameters?: { formula?: string } }>;
+    }>;
+  };
+  expect(saved.documents[0]!.instances[0]!.signalFlowParameters?.formula).toBe(
+    "current steering",
+  );
+});
+
+// The Symbol's own text is a plain string in a compact script syntax, so the
+// canvas editor offers no rich-text or formula affordances on it. Offering
+// them would promise formatting the field cannot store — the shape of defect
+// that #495 was.
+test("the Symbol body editor offers no formatting it cannot keep", async ({
+  page,
+}) => {
+  await placeSymbol(page, "integrator");
+
+  await page.getByTestId("hit-X1").dblclick();
+  await expect(
+    page.getByRole("textbox", { name: "Canvas text editor" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Insert formula" }),
+  ).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Overbar" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Bold" })).toHaveCount(0);
+});
+
+// The owner reported this on a DAC and said several other circuits have it
+// too. Every Symbol that draws its own body text is covered, so none is left
+// reachable only from the Properties panel.
+for (const symbolId of [
+  "dac",
+  "adc",
+  "opamp-lettered",
+  "voltage-amplifier-lettered",
+  "transconductance",
+  "integrator",
+  "unit-delay",
+  "discrete-time-integrator",
+]) {
+  test(`${symbolId} edits its body text on the canvas`, async ({ page }) => {
+    await placeSymbol(page, symbolId);
+
+    await page.getByTestId("hit-X1").dblclick();
+    const editor = page.getByRole("textbox", { name: "Canvas text editor" });
+    await expect(editor).toBeVisible();
+    await expect(editor).not.toHaveValue("");
+
+    await editor.fill("Zz");
+    await page.getByRole("button", { name: "Apply text changes" }).click();
+    await expect(bodyText(page)).toContainText("Zz");
+  });
+}
+
+// The swapped-input sibling has no Library tile of its own: it is reached by
+// swapping a placed op-amp's inputs, so it is covered through that path.
+test("the swapped-input op-amp edits its body text too", async ({ page }) => {
+  await placeSymbol(page, "opamp-lettered");
+  await page.getByTestId("hit-X1").click();
+  await page.getByTestId("selection-shelf").click();
+  await page
+    .getByLabel("Amplifier placement actions")
+    .getByRole("button", { name: "Swap the + and - inputs" })
+    .click();
+
+  await page.getByTestId("hit-X1").dblclick();
+  const editor = page.getByRole("textbox", { name: "Canvas text editor" });
+  await expect(editor).toBeVisible();
+  await editor.fill("Zz");
+  await page.getByRole("button", { name: "Apply text changes" }).click();
+
+  await expect(bodyText(page)).toContainText("Zz");
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -81,6 +81,7 @@ import {
   type CanvasDragSession,
 } from "../canvas/canvas-drag-session";
 import { startCanvasDragVisual } from "../canvas/canvas-drag-visual";
+import { instanceVisibleHitBox } from "../canvas/instance-geometry";
 import { createCanvasHitController } from "../canvas/canvas-hit-controller";
 import { buildDiagnosticMarkers } from "../canvas/diagnostic-markers";
 import {
@@ -1484,6 +1485,7 @@ export function App({
     applyNetLabel,
     beginAnnotationTextEditing,
     beginDraftingTextEditing,
+    beginInstanceFormulaEditing,
     beginNetLabelEditing,
     commitInstancePropertyDraft,
     commitElectricalMarkerName,
@@ -2148,6 +2150,13 @@ export function App({
     textEditingTarget?.owner === "drafting"
       ? textEditingTarget.object
       : undefined;
+  const editingInstanceFormula =
+    textEditingTarget?.owner === "instance-formula"
+      ? textEditingTarget.object
+      : undefined;
+  const editingInstanceFormulaSymbol = editingInstanceFormula
+    ? resolver.resolve(editingInstanceFormula.symbolId)
+    : undefined;
   const textEditingBounds = editingAnnotation
     ? annotationHitBox(
         document,
@@ -2165,8 +2174,17 @@ export function App({
     : editingDrafting?.kind === "text"
       ? resolveDraftingObjectGeometry(document, resolver, editingDrafting)
           .bounds
-      : null;
-  const textEditingLocked = Boolean(textEditingTarget?.object.locked);
+      : editingInstanceFormulaSymbol && editingInstanceFormula
+        ? instanceVisibleHitBox(
+            editingInstanceFormula,
+            editingInstanceFormulaSymbol,
+          )
+        : null;
+  // A Symbol has no lock on its own body text; the other two owners do.
+  const textEditingLocked =
+    textEditingTarget !== null &&
+    textEditingTarget?.owner !== "instance-formula" &&
+    Boolean(textEditingTarget?.object.locked);
 
   const internalSelection = deriveRoutingAffectedClosure(document, {
     instanceIds: selectedIds,
@@ -5007,9 +5025,27 @@ export function App({
                 selectInstanceFromSelection(instance.id, additive);
               },
               onInstanceOpen: (instance) => {
-                if (referencedDocumentId(project, instance))
+                if (referencedDocumentId(project, instance)) {
                   enterHierarchy(instance.id);
-                else inspectInstance(instance.id);
+                  return;
+                }
+                // A Symbol that draws text inside its own body edits that text
+                // where it is drawn, like every other text on the canvas. It
+                // used to be reachable only from the Properties panel, which
+                // made the same gesture mean two different things depending on
+                // where the text happened to live.
+                const presentation = resolver.resolve(
+                  instance.symbolId,
+                  instance.symbolVariantId,
+                )?.definition.formulaPresentation;
+                if (presentation) {
+                  beginInstanceFormulaEditing(
+                    instance,
+                    presentation.defaultFormula,
+                  );
+                  return;
+                }
+                inspectInstance(instance.id);
               },
               onInstancePointerDown: (event, instance) => {
                 if (simulationPickNetsActive) {

--- a/apps/editor/src/features/properties/use-properties-editor.ts
+++ b/apps/editor/src/features/properties/use-properties-editor.ts
@@ -611,6 +611,24 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     setTextEditing(createTextEditingSession({ owner: "drafting", object }));
   };
 
+  /**
+   * The text a Symbol draws inside its own body. It edits on the canvas where
+   * it is drawn, through the same session and overlay every other editable
+   * text uses, and commits to the same field the Properties panel writes.
+   */
+  const beginInstanceFormulaEditing = (
+    instance: Instance,
+    defaultFormula: string,
+  ): void => {
+    setTextEditing(
+      createTextEditingSession({
+        owner: "instance-formula",
+        object: instance,
+        defaultFormula,
+      }),
+    );
+  };
+
   const updateTextEditing = (
     change: Partial<
       Pick<TextEditingSession, "content" | "sizeScale" | "alignment">
@@ -907,6 +925,7 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     applyAdditionalParameters,
     beginAnnotationTextEditing,
     beginDraftingTextEditing,
+    beginInstanceFormulaEditing,
     beginNetLabelEditing,
     commitInstancePropertyDraft,
     commitElectricalMarkerName,

--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
@@ -178,10 +178,14 @@ export function CanvasTextEditorOverlay({
     measuredLayoutHeight,
   );
   const sourceOnly =
-    session.bound &&
-    session.bindingKind !== "instance-reference" &&
-    session.bindingKind !== "net-name" &&
-    session.bindingKind !== "cell-terminal-name";
+    // A Symbol's body text is a plain string in the Symbol's own script
+    // syntax. Offering bold, an overbar or the formula tool on a field that
+    // cannot store any of them would promise formatting the commit drops.
+    session.owner === "instance-formula" ||
+    (session.bound &&
+      session.bindingKind !== "instance-reference" &&
+      session.bindingKind !== "net-name" &&
+      session.bindingKind !== "cell-terminal-name");
 
   return (
     <g

--- a/apps/editor/src/features/text-editing/text-editing.test.ts
+++ b/apps/editor/src/features/text-editing/text-editing.test.ts
@@ -205,3 +205,106 @@ describe("unified text editing", () => {
     });
   });
 });
+
+describe("Symbol body text edits in place", () => {
+  const dac = (formula?: string) => ({
+    id: "X1",
+    symbolId: "dac",
+    placement: {
+      position: { x: 100, y: 100 },
+      rotation: 0 as const,
+      mirror: "none" as const,
+    },
+    ...(formula ? { signalFlowParameters: { formula } } : {}),
+  });
+
+  // The text inside a Symbol body is a plain string with its own compact
+  // script syntax, not a RichText document. It rides the same session so the
+  // canvas overlay can host it, carried as one text run.
+  it("opens a session on the Symbol's own default text", () => {
+    const session = createTextEditingSession({
+      owner: "instance-formula",
+      object: dac(),
+      defaultFormula: "DAC",
+    });
+
+    expect(session).toMatchObject({
+      owner: "instance-formula",
+      id: "X1",
+      content: { runs: [{ kind: "text", value: "DAC" }] },
+    });
+  });
+
+  it("opens a session on the override once the person has set one", () => {
+    const session = createTextEditingSession({
+      owner: "instance-formula",
+      object: dac("8-bit"),
+      defaultFormula: "DAC",
+    });
+
+    expect(session.content).toEqual({
+      runs: [{ kind: "text", value: "8-bit" }],
+    });
+  });
+
+  // Editing in place writes the same field the Properties panel writes, so the
+  // two surfaces cannot drift: there is one value, not two copies of it.
+  it("commits the edited text as a signal-flow parameter override", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.instances.push(dac());
+    const session = updateTextEditingSession(
+      createTextEditingSession({
+        owner: "instance-formula",
+        object: dac(),
+        defaultFormula: "DAC",
+      }),
+      { content: { runs: [{ kind: "text", value: "8-bit DAC" }] } },
+    );
+
+    expect(proposeTextEditingCommit(document, session)).toEqual({
+      kind: "update",
+      id: "X1",
+      edit: {
+        kind: "set_instance_signal_flow_parameters",
+        instanceId: "X1",
+        parameters: { formula: "8-bit DAC" },
+      },
+    });
+  });
+
+  // Typing the Symbol's own default back is not an override: storing it would
+  // freeze a copy of a default that is allowed to change.
+  it("clears the override when the text returns to the Symbol default", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.instances.push(dac("8-bit"));
+    const session = updateTextEditingSession(
+      createTextEditingSession({
+        owner: "instance-formula",
+        object: dac("8-bit"),
+        defaultFormula: "DAC",
+      }),
+      { content: { runs: [{ kind: "text", value: "DAC" }] } },
+    );
+
+    expect(proposeTextEditingCommit(document, session)).toMatchObject({
+      kind: "update",
+      edit: { parameters: null },
+    });
+  });
+
+  it("reports no change when the text is untouched", () => {
+    const document = createEmptyDocument("main", "Main");
+    document.instances.push(dac("8-bit"));
+
+    expect(
+      proposeTextEditingCommit(
+        document,
+        createTextEditingSession({
+          owner: "instance-formula",
+          object: dac("8-bit"),
+          defaultFormula: "DAC",
+        }),
+      ),
+    ).toEqual({ kind: "unchanged" });
+  });
+});

--- a/apps/editor/src/features/text-editing/text-editing.ts
+++ b/apps/editor/src/features/text-editing/text-editing.ts
@@ -11,9 +11,23 @@ import type {
 
 export type DraftingTextObject = Extract<DraftingObject, { kind: "text" }>;
 
+type Instance = SchematicDocument["instances"][number];
+
 export type EditableTextTarget =
   | { owner: "annotation"; object: Annotation }
-  | { owner: "drafting"; object: DraftingTextObject };
+  | { owner: "drafting"; object: DraftingTextObject }
+  /**
+   * The text a Symbol draws inside its own body — a DAC's "DAC", an
+   * integrator's transfer function, the letter in a lettered op-amp. It is a
+   * plain string in the Symbol's own compact script syntax (`z^-1`, `1/(1-z)`),
+   * not a RichText document, and `defaultFormula` is what the Symbol draws
+   * when the Instance overrides nothing.
+   */
+  | {
+      owner: "instance-formula";
+      object: Instance;
+      defaultFormula: string;
+    };
 
 export interface TextEditingSession {
   owner: EditableTextTarget["owner"];
@@ -24,6 +38,8 @@ export interface TextEditingSession {
   /** Semantic displays edit their source field, not a copied RichText AST. */
   bound: boolean;
   bindingKind?: AnnotationTextBinding["kind"];
+  /** Symbol body text only: what the Symbol draws with no override. */
+  defaultFormula?: string;
 }
 
 export type TextEditingCommitProposal =
@@ -48,6 +64,22 @@ export function createTextEditingSession(
       alignment: annotation.alignment,
       bound: annotation.binding !== undefined,
       ...(annotation.binding ? { bindingKind: annotation.binding.kind } : {}),
+    };
+  }
+  if (target.owner === "instance-formula") {
+    // Carried as one text run so the canvas overlay can host it unchanged.
+    // The overlay shows this as a plain source field, with no rich-text or
+    // formula affordances, because the field cannot store them.
+    const value =
+      target.object.signalFlowParameters?.formula ?? target.defaultFormula;
+    return {
+      owner: "instance-formula",
+      id: target.object.id,
+      content: { runs: [{ kind: "text", value }] },
+      sizeScale: 1,
+      alignment: "middle",
+      bound: true,
+      defaultFormula: target.defaultFormula,
     };
   }
   return {
@@ -79,6 +111,18 @@ export function resolveTextEditingTarget(
     );
     return object ? { owner: "annotation", object } : null;
   }
+  if (session.owner === "instance-formula") {
+    const object = document.instances.find(
+      (candidate) => candidate.id === session.id,
+    );
+    return object
+      ? {
+          owner: "instance-formula",
+          object,
+          defaultFormula: session.defaultFormula ?? "",
+        }
+      : null;
+  }
   const object = document.drafting?.objects.find(
     (candidate): candidate is DraftingTextObject =>
       candidate.id === session.id && candidate.kind === "text",
@@ -87,9 +131,17 @@ export function resolveTextEditingTarget(
 }
 
 export function textDeletionEdit(session: TextEditingSession): SchematicEdit {
-  return session.owner === "annotation"
-    ? { kind: "remove_schematic_annotation", annotationId: session.id }
-    : { kind: "remove_drafting_object", objectId: session.id };
+  if (session.owner === "annotation")
+    return { kind: "remove_schematic_annotation", annotationId: session.id };
+  // Emptying a Symbol's body text drops back to what the Symbol draws; the
+  // Instance itself is not a text object and is not deleted with its label.
+  if (session.owner === "instance-formula")
+    return {
+      kind: "set_instance_signal_flow_parameters",
+      instanceId: session.id,
+      parameters: null,
+    };
+  return { kind: "remove_drafting_object", objectId: session.id };
 }
 
 function richTextEqual(
@@ -105,6 +157,35 @@ export function proposeTextEditingCommit(
   document: SchematicDocument,
   session: TextEditingSession,
 ): TextEditingCommitProposal {
+  if (session.owner === "instance-formula") {
+    const instance = document.instances.find(
+      (candidate) => candidate.id === session.id,
+    );
+    if (!instance) return { kind: "blocked" };
+    const edited = flattenRichText(session.content).trim();
+    const current = instance.signalFlowParameters?.formula;
+    // Typing the Symbol's own default back is not an override: storing it
+    // would freeze a copy of a default the Symbol is allowed to change. The
+    // Properties panel reads the same rule, so the two surfaces agree.
+    const nextFormula =
+      edited && edited !== session.defaultFormula ? edited : undefined;
+    if (nextFormula === current) return { kind: "unchanged" };
+    const rest = { ...instance.signalFlowParameters };
+    delete rest.formula;
+    const parameters = {
+      ...rest,
+      ...(nextFormula ? { formula: nextFormula } : {}),
+    };
+    return {
+      kind: "update",
+      id: session.id,
+      edit: {
+        kind: "set_instance_signal_flow_parameters",
+        instanceId: session.id,
+        parameters: Object.keys(parameters).length > 0 ? parameters : null,
+      },
+    };
+  }
   const plainText = flattenRichText(session.content).trim();
   const emptied = !plainText;
   const emptyTarget = emptied
@@ -126,7 +207,10 @@ export function proposeTextEditingCommit(
   }
 
   const target = resolveTextEditingTarget(document, session);
-  if (!target || target.object.locked) return { kind: "blocked" };
+  // Symbol body text returned above; what remains carries a lock of its own.
+  if (!target || target.owner === "instance-formula")
+    return { kind: "blocked" };
+  if (target.object.locked) return { kind: "blocked" };
 
   if (target.owner === "annotation") {
     const annotation = target.object;

--- a/config/validation-gates.json
+++ b/config/validation-gates.json
@@ -94,6 +94,10 @@
       "packages/devices/src/descriptors/*switch*",
       "apps/editor/e2e/empty-label-ghost.spec.ts"
     ],
+    "symbolBodyText": [
+      "apps/editor/src/features/text-editing/**",
+      "apps/editor/e2e/symbol-body-text.spec.ts"
+    ],
     "componentInsert": [
       "apps/editor/src/features/component-insert/**",
       "apps/editor/e2e/component-insert.spec.ts"
@@ -434,6 +438,18 @@
       "ci": { "e2eArgs": ["apps/editor/e2e/empty-label-ghost.spec.ts"] }
     },
     {
+      "id": "symbol-body-text-browser",
+      "stage": "affected",
+      "groups": ["symbolBodyText"],
+      "description": "Validate in-place editing of the text a Symbol draws in its own body.",
+      "command": [
+        "pnpm",
+        "test:e2e:local",
+        "apps/editor/e2e/symbol-body-text.spec.ts"
+      ],
+      "ci": { "e2eArgs": ["apps/editor/e2e/symbol-body-text.spec.ts"] }
+    },
+    {
       "id": "release-verification",
       "stage": "affected",
       "groups": ["release"],
@@ -473,6 +489,7 @@
         "placement-near-miss-browser",
         "thin-target-hit-browser",
         "empty-label-ghost-browser",
+        "symbol-body-text-browser",
         "release-verification",
         "branch-verification"
       ]

--- a/packages/model/src/index.ts
+++ b/packages/model/src/index.ts
@@ -9,4 +9,5 @@ export * from "./orientation-reflect.js";
 export * from "./route-path.js";
 export * from "./rich-text.js";
 export * from "./semantic-text.js";
+export * from "./schema/bound-annotation-text.js";
 export * from "./schema.js";

--- a/packages/model/src/schema/bound-annotation-text.ts
+++ b/packages/model/src/schema/bound-annotation-text.ts
@@ -8,9 +8,9 @@ import type { RichTextDocument } from "../schema.js";
  * a stale format override has to be repaired.
  */
 interface BoundAnnotationSource {
-  instances: readonly { id: string; reference?: string | undefined }[];
+  instances?: readonly { id: string; reference?: string | undefined }[];
   netlist?: { terminals: readonly { id: string; name: string }[] } | undefined;
-  connectivityEvidence: readonly {
+  connectivityEvidence?: readonly {
     kind: string;
     netId?: string | undefined;
     name?: string | undefined;
@@ -61,8 +61,9 @@ export function boundAnnotationSemanticText(
 
   if (binding.kind === "instance-reference") {
     return semanticTextDocument(
-      document.instances.find((instance) => instance.id === binding.instanceId)
-        ?.reference ?? "",
+      (document.instances ?? []).find(
+        (instance) => instance.id === binding.instanceId,
+      )?.reference ?? "",
       "instance-label",
     );
   }
@@ -76,7 +77,9 @@ export function boundAnnotationSemanticText(
   }
   if (binding.kind !== "net-name") return null;
 
-  const nameClaim = document.connectivityEvidence.find(
+  // Pre-parse callers reach this before schema defaults are applied, so the
+  // arrays this reads may legitimately be absent rather than empty.
+  const nameClaim = (document.connectivityEvidence ?? []).find(
     (evidence) =>
       evidence.kind === "name-claim" &&
       evidence.netId === binding.netId &&

--- a/packages/model/src/schema/bound-annotation-text.ts
+++ b/packages/model/src/schema/bound-annotation-text.ts
@@ -1,0 +1,97 @@
+import { semanticTextDocument } from "../semantic-text.js";
+import type { RichTextDocument } from "../schema.js";
+
+/**
+ * The Document shape this reader needs. It is stated structurally rather than
+ * as the parsed `SchematicDocument` so the compatibility layer can call it on
+ * a Project that has not been through the schema yet — which is exactly when
+ * a stale format override has to be repaired.
+ */
+interface BoundAnnotationSource {
+  instances: readonly { id: string; reference?: string | undefined }[];
+  netlist?: { terminals: readonly { id: string; name: string }[] } | undefined;
+  connectivityEvidence: readonly {
+    kind: string;
+    netId?: string | undefined;
+    name?: string | undefined;
+    // Not every evidence kind carries an owner; only name claims do.
+    owner?:
+      | {
+          kind: string;
+          annotationId?: string | undefined;
+          objectId?: string | undefined;
+        }
+      | undefined;
+  }[];
+}
+
+interface BoundAnnotationLike {
+  id: string;
+  kind: string;
+  anchor: { kind: string; objectId?: string | undefined };
+  binding?:
+    | {
+        kind: string;
+        instanceId?: string | undefined;
+        terminalId?: string | undefined;
+        netId?: string | undefined;
+      }
+    | undefined;
+}
+
+/**
+ * The text a bound Annotation is obliged to read as: its Instance's Reference,
+ * its Cell terminal's name, or the Net name it claims, compiled to the house
+ * style.
+ *
+ * This is the single authority for that question. The schema uses it to refuse
+ * a format override that no longer says the name it presents, and the
+ * compatibility layer uses it to repair one — and those two must never drift,
+ * because a repair computed differently from the check either fails to fix the
+ * file or reports success on a file that still cannot load.
+ *
+ * Returns null when the Annotation binds to nothing, which has no obligation.
+ */
+export function boundAnnotationSemanticText(
+  document: BoundAnnotationSource,
+  annotation: BoundAnnotationLike,
+): RichTextDocument | null {
+  const binding = annotation.binding;
+  if (!binding) return null;
+
+  if (binding.kind === "instance-reference") {
+    return semanticTextDocument(
+      document.instances.find((instance) => instance.id === binding.instanceId)
+        ?.reference ?? "",
+      "instance-label",
+    );
+  }
+  if (binding.kind === "cell-terminal-name") {
+    return semanticTextDocument(
+      document.netlist?.terminals.find(
+        (terminal) => terminal.id === binding.terminalId,
+      )?.name ?? "",
+      "formal-port",
+    );
+  }
+  if (binding.kind !== "net-name") return null;
+
+  const nameClaim = document.connectivityEvidence.find(
+    (evidence) =>
+      evidence.kind === "name-claim" &&
+      evidence.netId === binding.netId &&
+      ((evidence.owner?.kind === "net-label" &&
+        evidence.owner.annotationId === annotation.id) ||
+        // A power-marker claim is owned by the marker instance for supply
+        // ports, but a drawn power rail's claim is owned by the label
+        // annotation itself — both spellings name this annotation's net.
+        (evidence.owner?.kind === "power-marker" &&
+          ((annotation.anchor.kind === "object" &&
+            evidence.owner.objectId === annotation.anchor.objectId) ||
+            evidence.owner.objectId === annotation.id))),
+  );
+  return semanticTextDocument(
+    nameClaim?.name ?? "",
+    annotation.kind === "power-label" ? "power-label" : "net-label",
+  );
+}

--- a/packages/model/src/schema/document.ts
+++ b/packages/model/src/schema/document.ts
@@ -16,7 +16,7 @@ import { JunctionSchema, RouteBranchSchema } from "./routing.js";
 import { AnnotationSchema } from "./annotations.js";
 import { DraftingLayerSchema } from "./drafting.js";
 import { flattenRichText } from "../rich-text.js";
-import { semanticTextDocument } from "../semantic-text.js";
+import { boundAnnotationSemanticText } from "./bound-annotation-text.js";
 import {
   LayoutConstraintSchema,
   LayoutGroupSchema,
@@ -350,46 +350,7 @@ export const SchematicDocumentSchema = SchematicDocumentBaseSchema.superRefine(
         });
       }
       if (!annotation.formatOverride || !binding) continue;
-      const annotationNameClaim = document.connectivityEvidence.find(
-        (evidence) =>
-          evidence.kind === "name-claim" &&
-          evidence.netId ===
-            (binding.kind === "net-name" ? binding.netId : undefined) &&
-          ((evidence.owner.kind === "net-label" &&
-            evidence.owner.annotationId === annotation.id) ||
-            // A power-marker claim is owned by the marker instance for supply
-            // ports, but a drawn power rail's claim is owned by the label
-            // annotation itself — both spellings name this annotation's net.
-            (evidence.owner.kind === "power-marker" &&
-              ((annotation.anchor.kind === "object" &&
-                evidence.owner.objectId === annotation.anchor.objectId) ||
-                evidence.owner.objectId === annotation.id))),
-      );
-      const semanticContent =
-        binding.kind === "instance-reference"
-          ? semanticTextDocument(
-              document.instances.find(
-                (instance) => instance.id === binding.instanceId,
-              )?.reference ?? "",
-              "instance-label",
-            )
-          : binding.kind === "cell-terminal-name"
-            ? semanticTextDocument(
-                document.netlist?.terminals.find(
-                  (terminal) => terminal.id === binding.terminalId,
-                )?.name ?? "",
-                "formal-port",
-              )
-            : binding.kind === "net-name"
-              ? semanticTextDocument(
-                  (annotationNameClaim?.kind === "name-claim"
-                    ? annotationNameClaim.name
-                    : undefined) ?? "",
-                  annotation.kind === "power-label"
-                    ? "power-label"
-                    : "net-label",
-                )
-              : null;
+      const semanticContent = boundAnnotationSemanticText(document, annotation);
       if (
         semanticContent &&
         flattenRichText(annotation.formatOverride) !==

--- a/packages/project-protocol/src/bound-format-override-migration.test.ts
+++ b/packages/project-protocol/src/bound-format-override-migration.test.ts
@@ -90,3 +90,43 @@ describe("stale bound format overrides", () => {
     expect(overrides).toEqual(expect.arrayContaining(["reset", "XU2"]));
   });
 });
+
+// The repair runs before the schema applies its defaults, so the arrays it
+// reads can be absent rather than empty. Assuming otherwise threw inside the
+// loader and took the whole editor down on open — invisible to every unit test
+// here, because they all start from complete fixtures. A browser test caught
+// it, and the cast at the call site was what hid it from the typechecker.
+describe("repair on incomplete pre-schema input", () => {
+  it("does not throw when a Project's optional arrays are absent", () => {
+    const sparse = {
+      schemaVersion: 36,
+      id: "project-1",
+      name: "Sparse",
+      topDocumentId: "document-main",
+      documents: [
+        {
+          id: "document-main",
+          name: "Main",
+          annotations: [
+            {
+              id: "annotation-1",
+              kind: "net-label",
+              binding: { kind: "net-name", netId: "net-1" },
+              formatOverride: { runs: [{ kind: "text", value: "vdd" }] },
+              anchor: { kind: "free", position: { x: 0, y: 0 } },
+              alignment: "start",
+              rotation: 0,
+              locked: false,
+            },
+          ],
+        },
+      ],
+    };
+
+    // This Project is far from valid, and reporting that is fine. The repair
+    // must not be what fails: it may produce diagnostics, never an exception.
+    expect(() =>
+      tryParseProjectWithMetadata(JSON.stringify(sparse)),
+    ).not.toThrow();
+  });
+});

--- a/packages/project-protocol/src/bound-format-override-migration.test.ts
+++ b/packages/project-protocol/src/bound-format-override-migration.test.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { flattenRichText } from "@icm/model";
+
+import { tryParseProjectWithMetadata } from "./load.js";
+
+/**
+ * #463 retired the rule that capitalized an identifier's leading character.
+ * Every format override authored before that carries the capital the old
+ * compiler produced, so a terminal named `reset` has an override reading
+ * `Reset` — and the schema refuses the whole Project, because a bound override
+ * must still say the name it decorates.
+ *
+ * That commit repaired the one copy in this repository by hand. It could not
+ * reach the copies already published, which is why a circuit on the gallery
+ * wall stopped opening. A published circuit that will not open is, to its
+ * author, a circuit that is gone, so loading repairs it.
+ *
+ * The case here is not invented: it is this repository's own gallery fixture
+ * put back into the state #463 found it in, which is the state the published
+ * copy is still in.
+ */
+const REPAIRED_FIXTURE = "fixtures/gallery-redline/2rmm2vb45f.icproj.json";
+
+function publishedBeforeTheRuleChanged(): string {
+  const repaired = readFileSync(REPAIRED_FIXTURE, "utf8");
+  const broken = repaired.replace('"value": "r"', '"value": "R"');
+  expect(broken).not.toBe(repaired);
+  return broken;
+}
+
+describe("stale bound format overrides", () => {
+  it("loads a Project the retired rule left behind instead of refusing it", () => {
+    const result = tryParseProjectWithMetadata(publishedBeforeTheRuleChanged());
+
+    if (!result.ok) {
+      throw new Error(
+        `Expected a repair, got: ${result.diagnostics
+          .map((diagnostic) => diagnostic.message)
+          .join("; ")}`,
+      );
+    }
+    expect(result.ok).toBe(true);
+  });
+
+  it("restores the text the bound name actually reads", () => {
+    const result = tryParseProjectWithMetadata(publishedBeforeTheRuleChanged());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const overrides = result.project.documents
+      .flatMap((document) => document.annotations)
+      .filter((annotation) => annotation.formatOverride)
+      .map((annotation) => flattenRichText(annotation.formatOverride!));
+    expect(overrides).toContain("reset");
+    expect(overrides).not.toContain("Reset");
+  });
+
+  // Repair, not erasure: the only thing wrong was one character's case, and
+  // the author's styling was never in question. The strongest way to say that
+  // is that repairing the broken copy reproduces the repaired one exactly —
+  // the same result #463 reached by hand, reached by loading.
+  it("reproduces the hand-repaired file exactly", () => {
+    const repaired = tryParseProjectWithMetadata(
+      readFileSync(REPAIRED_FIXTURE, "utf8"),
+    );
+    const fromBroken = tryParseProjectWithMetadata(
+      publishedBeforeTheRuleChanged(),
+    );
+
+    expect(repaired.ok).toBe(true);
+    expect(fromBroken.ok).toBe(true);
+    if (!repaired.ok || !fromBroken.ok) return;
+    expect(fromBroken.project.documents).toEqual(repaired.project.documents);
+  });
+
+  it("leaves an already-correct Project untouched", () => {
+    const result = tryParseProjectWithMetadata(
+      readFileSync(REPAIRED_FIXTURE, "utf8"),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const overrides = result.project.documents
+      .flatMap((document) => document.annotations)
+      .filter((annotation) => annotation.formatOverride)
+      .map((annotation) => flattenRichText(annotation.formatOverride!));
+    expect(overrides).toEqual(expect.arrayContaining(["reset", "XU2"]));
+  });
+});

--- a/packages/project-protocol/src/load.ts
+++ b/packages/project-protocol/src/load.ts
@@ -25,6 +25,7 @@ import {
   upgradeSchema34To35,
   upgradeSchema35To36,
 } from "./previous-to-current.js";
+import { repairBoundFormatOverrides } from "./transforms/bound-format-override.js";
 import { OLDEST_SUPPORTED_PROJECT_SCHEMA_VERSION } from "./version.js";
 
 /**
@@ -165,6 +166,12 @@ export function tryParseProjectWithMetadata(
     }
     throw error;
   }
+  // A bound format override is derived from the name it decorates. When the
+  // two have drifted apart — #463 retired the leading-capital rule under
+  // overrides already written and published — restore the text instead of
+  // refusing the Project, because a file that will not open is, to its
+  // author, a file that is gone.
+  current = repairBoundFormatOverrides(current);
   const diagnostics = invalidProjectDiagnostics(current);
   if (diagnostics.length > 0) return { ok: false, diagnostics };
   return {

--- a/packages/project-protocol/src/previous-to-current.ts
+++ b/packages/project-protocol/src/previous-to-current.ts
@@ -94,6 +94,7 @@ export {
   upgradeSchema35To36,
   upgradeSchema35To36WithReport,
 } from "./transforms/instance-reference-annotation.js";
+
 export type {
   Schema35To36MigrationReport,
   Schema35To36MigrationResult,

--- a/packages/project-protocol/src/transforms/bound-format-override.ts
+++ b/packages/project-protocol/src/transforms/bound-format-override.ts
@@ -1,0 +1,81 @@
+import {
+  boundAnnotationSemanticText,
+  flattenRichText,
+  rewriteRichTextPlainText,
+  RichTextDocumentSchema,
+} from "@icm/model";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function records(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+/**
+ * Repair bound format overrides that no longer read as the name they present.
+ *
+ * #463 retired the rule that capitalized an identifier's leading character.
+ * Every override authored before that carries the capital the old compiler
+ * produced, so a terminal named `reset` has an override reading `Reset` — and
+ * the schema refuses the whole Project, because a bound override must still
+ * say the name it decorates.
+ *
+ * The circuits this hits are already published. A published circuit that will
+ * not open is, to its author, a circuit that is gone, so loading repairs the
+ * override rather than refusing the file.
+ *
+ * The repair rewrites only the characters, through the same helper the editor
+ * uses, so the author's italic, bold, and subscript survive: the text was
+ * wrong, the formatting never was. An override that cannot be reconciled —
+ * one whose name has since disappeared — is dropped, and the label falls back
+ * to the house style rather than taking the Project down with it.
+ *
+ * The semantic name comes from `boundAnnotationSemanticText`, the same
+ * function the schema checks against. A repair computed any other way would
+ * either miss files the check still refuses or claim success on a file that
+ * still cannot load.
+ *
+ * This runs on every load rather than as one numbered migration step. An
+ * override is derived from the name it decorates, so the two agreeing is a
+ * standing invariant, not a format that changed once: a file written at any
+ * version by any client is repaired the same way. It also costs nothing on
+ * the overwhelming majority of Projects, where no annotation carries an
+ * override at all.
+ */
+export function repairBoundFormatOverrides(
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  const project: Record<string, unknown> = { ...raw };
+  project.documents = records(project.documents).map((document) => {
+    const annotations = records(document.annotations);
+    if (annotations.length === 0) return document;
+    let changed = false;
+    const repaired = annotations.map((annotation) => {
+      if (!annotation.formatOverride || !annotation.binding) return annotation;
+      const parsed = RichTextDocumentSchema.safeParse(
+        annotation.formatOverride,
+      );
+      if (!parsed.success) return annotation;
+      const semantic = boundAnnotationSemanticText(
+        document as never,
+        annotation as never,
+      );
+      if (!semantic) return annotation;
+      const name = flattenRichText(semantic);
+      if (flattenRichText(parsed.data) === name) return annotation;
+      changed = true;
+      if (!name.trim()) {
+        const { formatOverride: _dropped, ...rest } = annotation;
+        return rest;
+      }
+      return {
+        ...annotation,
+        formatOverride: rewriteRichTextPlainText(parsed.data, name),
+      };
+    });
+    return changed ? { ...document, annotations: repaired } : document;
+  });
+  return project;
+}


### PR DESCRIPTION
Three changes that were finished, tested, and then stranded when the session
that produced them was interrupted. Rebased onto current main and re-verified.

## A published circuit that would not open

`2rmm2vb45f` on the gallery wall was refused with *"A bound RichText format
override must preserve the semantic name text"*.

**The loader was not broken.** #463 retired the rule that capitalized an
identifier's leading character, so a terminal named `reset` compiled to `R` +
subscript `eset` under the old rule and its stored override reads `Reset`.
After the change the semantic name reads `reset`, the two disagree, and the
schema refuses the whole Project.

That commit repaired this repository's own copy by hand — the fixture diff is
one character, `"R"` to `"r"`. It could not reach copies already published,
which is why the wall has a circuit nobody can open. **This is a class, not one
file:** any published circuit whose author styled a name with a lowercase
leading character before #463 is in the same state.

Loading now restores the text instead of refusing the Project. A published
circuit that will not open is, to its author, a circuit that is gone.

The repair rewrites only the characters, through the same helper the editor
uses, so italic, bold and subscript survive: the text was wrong, the formatting
never was. The test says this the strongest way available — re-break this
repository's own fixture, load it, and the result equals the file #463 produced
by hand.

Two decisions worth naming:

**One shared authority for the semantic name.** The schema's check and this
repair both call `boundAnnotationSemanticText`, extracted unchanged from the
schema. A repair computed any other way would either miss files the check still
refuses or report success on a file that still cannot load — and that drift is
not hypothetical, since two independent readings of this rule already disagreed
while this bug was being diagnosed.

**It runs on every load, not as a numbered migration.** An override is derived
from the name it decorates, so the two agreeing is a standing invariant, not a
format that changed once. A version bump would also have worked, but it would
have rewritten every fixture in the compatibility corpus to prove a point about
one character, and it would not catch a bad override written at a later
version.

## A Symbol's own body text edits on the canvas

The owner's complaint, on a DAC: the text drawn inside a Symbol's body was the
one text in the editor you could not edit where it is drawn. Net labels, notes
and designators all open in place; this opened the Properties panel. Double
click meant two different things depending on where the text happened to live.

Nine Symbols draw body text and all nine are covered, not the reported one. The
list is not a guess: it is every Symbol whose definition declares
`formulaPresentation` — the four signal-flow blocks, the three lettered
amplifiers, and ADC and DAC. The swapped-input op-amp has no Library tile, so
its test reaches it the way a person does, by swapping a placed one's inputs.

This reuses the existing canvas editor rather than adding a second one. The
session model gains a third owner beside annotations and drafting text, and the
commit maps to the same `set_instance_signal_flow_parameters` edit the
Properties panel already dispatches. Two surfaces, one field: they cannot
drift, because there is nothing to keep in step.

The Properties panel stays. Its explanatory line — that this text changes no
netlist identity or connectivity — is worth keeping and does not fit on canvas.

The canvas editor shows this field as a plain source input, with no bold,
overbar or formula controls. A Symbol's body text is a plain string in the
Symbol's own compact script syntax (`z^-1`), and it cannot store rich text.
Offering formatting the commit would drop is the shape of defect #495 was.

## Verification

- 2187 unit tests before the rebase; after rebasing onto current main,
  typecheck plus the model, project-protocol and text-editing suites (160
  tests) are green.
- Twelve browser tests for the body-text work, covering every one of the nine
  Symbols.
- Both changes verified red-then-green.

**Not yet re-run since the rebase:** the full browser suite. The earlier full
run on this work was taken on a saturated machine (12.3 minutes against a
normal 4, ten failures, all in the persistence/recovery/gallery cluster and
none related to these changes). I am re-running it under the gate lock and will
report before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
