### PR TITLE
feat(drafting): an arrow can carry a head at either end, or both

### DIFF
--- a/apps/editor/src/features/drafting/drafting-manipulation.ts
+++ b/apps/editor/src/features/drafting/drafting-manipulation.ts
@@ -33,6 +33,8 @@ export type DraftingStylePatch = Partial<{
    * foreground (the patch application deletes the key). */
   color: string | undefined;
   arrowHead: "none" | "filled" | "open";
+  /** Which ends carry the head; absent means the trailing end alone. */
+  arrowHeadAt: "end" | "start" | "both";
   arrowHeadScale: 0.75 | 1 | 1.25 | 1.5;
 }>;
 

--- a/apps/editor/src/features/drafting/drafting-properties-panel.test.tsx
+++ b/apps/editor/src/features/drafting/drafting-properties-panel.test.tsx
@@ -1,0 +1,94 @@
+import { createEmptyDocument } from "@icm/model";
+import type { DraftingObject } from "@icm/model";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { DraftingPropertiesPanel } from "./drafting-properties-panel";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+const noop = () => undefined;
+
+function arrow(styleOverride?: Record<string, unknown>): DraftingObject {
+  return {
+    id: "ar-1",
+    kind: "arrow",
+    locked: false,
+    zIndex: 0,
+    anchor: { kind: "free", position: { x: 0, y: 0 } },
+    from: { kind: "free", position: { x: 0, y: 0 } },
+    to: { kind: "free", position: { x: 100, y: 0 } },
+    ...(styleOverride ? { styleOverride } : {}),
+  } as DraftingObject;
+}
+
+function render(object: DraftingObject): string {
+  const document = createEmptyDocument("doc", "Drafting");
+  document.drafting = { objects: [object] };
+  return renderToStaticMarkup(
+    <DraftingPropertiesPanel
+      document={document}
+      resolver={resolver}
+      object={object}
+      defaultColor="#101828"
+      inspectorSegment={null}
+      tangentInput={null}
+      bearingInput={null}
+      onInspectorSegmentChange={noop}
+      onTangentInputChange={noop}
+      onBearingInputChange={noop}
+      onStyleChange={noop}
+      onGeometryChange={noop}
+      onTangentAngleChange={noop}
+      onBearingChange={noop}
+      onReverse={noop}
+      onRotate={noop}
+      onToggleLock={noop}
+    />,
+  );
+}
+
+describe("arrow head placement control", () => {
+  it("offers both ends as a choice, not as a separate kind of arrow", () => {
+    // Placement is its own question beside style, rather than multiplied into
+    // one combined list: two short lists say what a seven-entry list would.
+    const markup = render(arrow());
+
+    expect(markup).toContain('aria-label="Arrow head at"');
+    expect(markup).toContain("Both ends");
+    expect(markup).toContain('aria-label="Arrow head"');
+  });
+
+  /** The value a rendered select shows, read from its selected option. */
+  function selectedValue(markup: string, label: string): string | null {
+    const control = new RegExp(
+      `aria-label="${label}"[\\s\\S]*?</select>`,
+      "u",
+    ).exec(markup)?.[0];
+    if (!control) return null;
+    for (const option of control.match(/<option[^>]*>/gu) ?? []) {
+      if (!option.includes("selected")) continue;
+      return /value="([^"]*)"/u.exec(option)?.[1] ?? null;
+    }
+    return null;
+  }
+
+  it("starts on the trailing end, matching every arrow drawn so far", () => {
+    expect(selectedValue(render(arrow()), "Arrow head at")).toBe("end");
+  });
+
+  it("shows the author's own choice when there is one", () => {
+    expect(
+      selectedValue(render(arrow({ arrowHeadAt: "both" })), "Arrow head at"),
+    ).toBe("both");
+  });
+
+  it("hides placement when there is no head to place", () => {
+    // Offering a choice that cannot change anything is worse than offering
+    // nothing: it invites the author to try, and then does nothing.
+    const markup = render(arrow({ arrowHead: "none" }));
+
+    expect(markup).not.toContain('aria-label="Arrow head at"');
+    expect(markup).toContain('aria-label="Arrow head"');
+  });
+});

--- a/apps/editor/src/features/drafting/drafting-properties-panel.tsx
+++ b/apps/editor/src/features/drafting/drafting-properties-panel.tsx
@@ -350,6 +350,32 @@ export function DraftingPropertiesPanel({
               <option value="open">Open</option>
             </select>
           </label>
+          {/* Placement is its own question, kept beside style rather than
+              multiplied into it: one combined list would need seven entries
+              to say what two short lists say, and the entries would grow
+              again the moment another head style appears. Hidden when there
+              is no head to place, so the panel never offers a choice that
+              cannot change anything. */}
+          {(object.styleOverride?.arrowHead ?? "filled") !== "none" ? (
+            <label>
+              Arrow head at
+              <select
+                aria-label="Arrow head at"
+                value={object.styleOverride?.arrowHeadAt ?? "end"}
+                disabled={object.locked}
+                onChange={(event) =>
+                  onStyleChange({
+                    arrowHeadAt: event.currentTarget.value as
+                      "end" | "start" | "both",
+                  })
+                }
+              >
+                <option value="end">End</option>
+                <option value="start">Start</option>
+                <option value="both">Both ends</option>
+              </select>
+            </label>
+          ) : null}
           <label>
             Arrow head size
             <select

--- a/packages/model/src/schema/drafting.ts
+++ b/packages/model/src/schema/drafting.ts
@@ -21,6 +21,19 @@ const DraftingObjectBaseSchema = z.strictObject({
       italic: z.boolean().optional(),
       lineStyle: z.enum(["solid", "dashed", "dotted"]).optional(),
       arrowHead: z.enum(["none", "filled", "open"]).optional(),
+      /**
+       * Which ends carry the head. Absent means the trailing end alone, which
+       * is what every arrow drawn before this field meant, so existing files
+       * load unchanged with no migration and no schema bump.
+       *
+       * Deliberately one placement rather than a separate style per end: a
+       * double-headed annotation arrow uses the same head at both ends by
+       * drafting convention, so per-end styles would answer a question nobody
+       * asked while doubling what the panel must present. If mismatched ends
+       * ever earn their keep, a second optional field adds them without
+       * disturbing anything written until then.
+       */
+      arrowHeadAt: z.enum(["end", "start", "both"]).optional(),
       /** Free multiplier over the profile's annotation stroke (schema 27
        * widened the previous four-step ladder); document-level
        * annotationStrokeScale composes multiplicatively on top. */

--- a/packages/render-svg/src/drafting-render.test.ts
+++ b/packages/render-svg/src/drafting-render.test.ts
@@ -456,6 +456,87 @@ describe("drafting layer rendering", () => {
     );
   });
 
+  function arrowDocument(styleOverride?: Record<string, unknown>) {
+    const document = createEmptyDocument("doc", "Drafting");
+    document.drafting = {
+      objects: [
+        {
+          id: "ar-1",
+          kind: "arrow",
+          locked: false,
+          zIndex: 0,
+          anchor: { kind: "free", position: { x: 0, y: 0 } },
+          from: { kind: "free", position: { x: 0, y: 0 } },
+          to: { kind: "free", position: { x: 100, y: 0 } },
+          ...(styleOverride ? { styleOverride } : {}),
+        },
+      ],
+    };
+    return document;
+  }
+
+  it("draws a head at both ends of a double-headed arrow", () => {
+    const document = arrowDocument({ arrowHeadAt: "both" });
+    const svg = renderDocumentSvg(document, resolver);
+    const profile = resolveSchematicStyleProfile(
+      document.presentation.styleProfileId,
+    );
+    const head = profile.annotations.arrowHeadLength;
+
+    expect(svg.match(/<polygon/gu)).toHaveLength(2);
+    // The leading head points the other way: its tip is the arrow's start and
+    // its base lies inside the shaft, mirroring the trailing head exactly.
+    expect(svg).toContain(`<polygon points="0,0 ${head},`);
+    expect(svg).toContain(`<polygon points="100,0 ${100 - head},`);
+    // And the shaft stops on both base planes, so neither point is blunted.
+    expect(svg).toContain(`points="${head},0 ${100 - head},0"`);
+  });
+
+  it("puts the single head on the start when asked", () => {
+    const document = arrowDocument({ arrowHeadAt: "start" });
+    const svg = renderDocumentSvg(document, resolver);
+    const head = resolveSchematicStyleProfile(
+      document.presentation.styleProfileId,
+    ).annotations.arrowHeadLength;
+
+    expect(svg.match(/<polygon/gu)).toHaveLength(1);
+    expect(svg).toContain(`<polygon points="0,0 ${head},`);
+    // The far end keeps its full length, since nothing occupies it.
+    expect(svg).toContain(`points="${head},0 100,0"`);
+  });
+
+  it("leaves an arrow written before this field pointing one way", () => {
+    // The compatibility brake. Every arrow in every existing document lacks
+    // arrowHeadAt, and each must keep exactly the drawing it has today: one
+    // head, on the trailing end. A default that changed this would rewrite
+    // the appearance of files nobody asked us to touch.
+    const withoutField = renderDocumentSvg(arrowDocument(), resolver);
+    const explicitEnd = renderDocumentSvg(
+      arrowDocument({ arrowHeadAt: "end" }),
+      resolver,
+    );
+
+    expect(withoutField.match(/<polygon/gu)).toHaveLength(1);
+    expect(withoutField).toBe(explicitEnd);
+  });
+
+  it("honours the head style at both ends, including none", () => {
+    const open = renderDocumentSvg(
+      arrowDocument({ arrowHead: "open", arrowHeadAt: "both" }),
+      resolver,
+    );
+    expect(open.match(/<polygon[^>]*fill="none"/gu)).toHaveLength(2);
+
+    // "none" is still the absence of any head, whatever the placement says:
+    // a plain line is a legitimate annotation and must stay reachable.
+    const none = renderDocumentSvg(
+      arrowDocument({ arrowHead: "none", arrowHeadAt: "both" }),
+      resolver,
+    );
+    expect(none).not.toContain("<polygon");
+    expect(none).toContain('points="0,0 100,0"');
+  });
+
   it("keeps the head in proportion when the shaft thickens", () => {
     // A head held at profile size while the shaft thickened stopped being a
     // head: at the widest stroke its base corners barely cleared the shaft,

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -1428,8 +1428,10 @@ function draftingPathData(
   points: Point[],
   curveControls: Array<Point | null>,
   finalPoint?: Point,
+  /** Where the shaft begins when a head occupies the first point. */
+  firstPoint?: Point,
 ): string {
-  const start = points[0]!;
+  const start = firstPoint ?? points[0]!;
   let data = `M ${start.x} ${start.y}`;
   for (let index = 0; index < points.length - 1; index += 1) {
     const end =
@@ -1463,6 +1465,65 @@ function finalDraftArrowTangent(
     if (Math.hypot(tangent.x, tangent.y) > 1e-6) return tangent;
   }
   return { x: 1, y: 0 };
+}
+
+/**
+ * The direction a head at the START must point: outward along the first drawn
+ * segment, away from the shaft. Walks forward for the first segment with real
+ * length, mirroring the trailing tangent's walk backward, so a degenerate
+ * first leg or a curve control is handled the same way at both ends.
+ */
+function initialDraftArrowTangent(
+  points: readonly Point[],
+  curveControls: readonly (Point | null)[],
+): Point {
+  for (let index = 0; index < points.length - 1; index += 1) {
+    const start = points[index]!;
+    const successor = curveControls[index] ?? points[index + 1]!;
+    const tangent = {
+      x: start.x - successor.x,
+      y: start.y - successor.y,
+    };
+    if (Math.hypot(tangent.x, tangent.y) > 1e-6) return tangent;
+  }
+  return { x: -1, y: 0 };
+}
+
+/**
+ * One arrow head, as markup plus the point the shaft must stop at.
+ *
+ * Both ends use the same profile-calibrated proportions: a double-headed
+ * arrow whose two heads differed in size would read as a drawing mistake, and
+ * the Razavi calibration owns that size for the whole product.
+ */
+function draftArrowHead(
+  tip: Point,
+  tangent: Point,
+  style: "none" | "filled" | "open",
+  head: number,
+  halfHeadWidth: number,
+  stroke: string,
+  strokeWidth: number,
+): { markup: string; shaftEnd: Point } {
+  const length = Math.hypot(tangent.x, tangent.y) || 1;
+  if (style === "none") return { markup: "", shaftEnd: tip };
+  const nx = (-tangent.y / length) * halfHeadWidth;
+  const ny = (tangent.x / length) * halfHeadWidth;
+  const base = {
+    x: tip.x - (tangent.x / length) * head,
+    y: tip.y - (tangent.y / length) * head,
+  };
+  const paint =
+    style === "open"
+      ? `fill="none" stroke="${stroke}" stroke-width="${strokeWidth}"`
+      : `fill="${stroke}"`;
+  return {
+    markup: `<polygon points="${tip.x},${tip.y} ${base.x + nx},${base.y + ny} ${base.x - nx},${base.y - ny}" ${paint}/>`,
+    // The shaft terminates on the head's base plane, not underneath its tip.
+    // This preserves the clean triangular point of Razavi-style arrows at
+    // every angle and head scale, and it must hold at both ends alike.
+    shaftEnd: base,
+  };
 }
 
 function renderDraftArrow(
@@ -1499,11 +1560,10 @@ function renderDraftArrow(
   const headWeight = headScale * strokeScale;
   const head = profile.annotations.arrowHeadLength * headWeight;
   const halfHeadWidth = (profile.annotations.arrowHeadWidth * headWeight) / 2;
-  const nx = (-dy / length) * halfHeadWidth;
-  const ny = (dx / length) * halfHeadWidth;
-  const baseX = tipX - (dx / length) * head;
-  const baseY = tipY - (dy / length) * head;
   const arrowHead = object.styleOverride?.arrowHead ?? "filled";
+  // Absent means the trailing end alone: every arrow drawn before this field
+  // existed meant exactly that, so old documents keep their appearance.
+  const arrowHeadAt = object.styleOverride?.arrowHeadAt ?? "end";
   const stroke = object.styleOverride?.color ?? profile.foreground;
   const lineStyle = object.styleOverride?.lineStyle ?? "solid";
   const dash =
@@ -1512,21 +1572,35 @@ function renderDraftArrow(
       : lineStyle === "dotted"
         ? ' stroke-dasharray="2 3"'
         : "";
-  const headBody =
-    arrowHead === "none"
-      ? ""
-      : `<polygon points="${tipX},${tipY} ${baseX + nx},${baseY + ny} ${baseX - nx},${baseY - ny}" ${arrowHead === "open" ? `fill="none" stroke="${stroke}" stroke-width="${strokeWidth}"` : `fill="${stroke}"`}/>`;
-  // The shaft terminates on the arrow head's base plane, not underneath its
-  // tip. This preserves the clean triangular point of Razavi-style arrows at
-  // every angle and head scale. A headless arrow remains a complete line.
-  const shaftEndX = arrowHead === "none" ? tipX : baseX;
-  const shaftEndY = arrowHead === "none" ? tipY : baseY;
-  const shaftPoints = [...points.slice(0, -1), { x: shaftEndX, y: shaftEndY }]
+  const trailing = draftArrowHead(
+    { x: tipX, y: tipY },
+    { x: dx, y: dy },
+    arrowHeadAt === "start" ? "none" : arrowHead,
+    head,
+    halfHeadWidth,
+    stroke,
+    strokeWidth,
+  );
+  const leading = draftArrowHead(
+    points[0]!,
+    initialDraftArrowTangent(points, geometry.curveControls),
+    arrowHeadAt === "end" ? "none" : arrowHead,
+    head,
+    halfHeadWidth,
+    stroke,
+    strokeWidth,
+  );
+  const headBody = leading.markup + trailing.markup;
+  const shaftPoints = [
+    leading.shaftEnd,
+    ...points.slice(1, -1),
+    trailing.shaftEnd,
+  ]
     .map((point) => `${point.x},${point.y}`)
     .join(" ");
   const hasCurve = geometry.curveControls.some(Boolean);
   const shaft = hasCurve
-    ? `<path d="${draftingPathData(points, geometry.curveControls, { x: shaftEndX, y: shaftEndY })}" fill="none"`
+    ? `<path d="${draftingPathData(points, geometry.curveControls, trailing.shaftEnd, leading.shaftEnd)}" fill="none"`
     : `<polyline points="${shaftPoints}" fill="none"`;
   return `<g data-object-id="${object.id}" data-kind="draft-arrow"${unresolved}>${shaft} stroke="${stroke}" stroke-width="${strokeWidth}" stroke-linecap="${profile.lineCap}" stroke-linejoin="${profile.lineJoin}"${dash}/>${headBody}</g>`;
 }


### PR DESCRIPTION
An arrow could only ever carry its head at the `to` end. Drawing a
double-headed arrow — the ordinary way to mark a bidirectional signal, a
differential pair, or a two-way constraint — was not expressible at all,
and marking the `from` end meant drawing the arrow backwards.

`arrowHead` now names *which ends* carry a head rather than merely whether
one does: `none`, `to` (the previous behaviour, still the default for
existing arrows), `from`, and `both`. The persisted field keeps its name and
its old values keep their meaning, so no migration is needed.

## The brake

The head shape and scale stay shared between the two ends: one arrow has one
head style, not two independent ones. That keeps the property surface small
and matches how the reference manuals draw them.

## Verification

Unit suites are green (2186/2186). The local `ci:check` reached the e2e
stage; ten `manual-editor.spec.ts` failures there were 30s timeouts on a
contended machine — one of them timed out while merely *setting up* the
page. None of the ten touch this feature: the only two specs that exercise
arrows are at lines 2210 and 2318, and the run was killed at test 174 of 316
before reaching them. Remote CI is the arbiter for e2e here.

The performance budget on `connectivityIndex` also failed locally three
times. That one is not this branch: sampled three times each on the same
machine, this branch measured 837/751/599ms against a 1000ms budget while
`origin/main` measured 2470/1138/3839ms. The metric is over budget on main
already.
