### PR TITLE
fix(connectivity): two wire ends butted together join their Nets

### DIFF
--- a/packages/edit-engine/src/route-move-merge.test.ts
+++ b/packages/edit-engine/src/route-move-merge.test.ts
@@ -364,3 +364,144 @@ describe("a pin resting on a conductor, in published drawings", () => {
     }
   });
 });
+
+/**
+ * Two wire ENDS brought head to head in mid-air.
+ *
+ * The same rule as landing on a conductor, seen from the case where neither
+ * point lies in the other's span. Butting two ends together is the commonest
+ * way to join wires while drawing, and it is *more* deliberate than dropping
+ * an end on a wire's middle, not less. Before this rule the move merged
+ * nothing and flagged the meeting point ambiguous from both sides at once.
+ */
+function twoHeadToHeadWires(): SchematicDocument {
+  const document = createEmptyDocument("head-to-head", "Head to head");
+  document.presentation.grid = 10;
+  document.nets.push(
+    { id: "net-left", terminals: [] },
+    { id: "net-right", terminals: [] },
+  );
+  document.junctions.push(
+    {
+      id: "L1",
+      netId: "net-left",
+      position: { x: 100, y: 200 },
+      role: "route-anchor",
+    },
+    {
+      id: "L2",
+      netId: "net-left",
+      position: { x: 200, y: 200 },
+      role: "route-anchor",
+    },
+    {
+      id: "R1",
+      netId: "net-right",
+      position: { x: 260, y: 200 },
+      role: "route-anchor",
+    },
+    {
+      id: "R2",
+      netId: "net-right",
+      position: { x: 360, y: 200 },
+      role: "route-anchor",
+    },
+  );
+  document.routes.push(
+    createRoutePath({
+      id: "wire-left",
+      netId: "net-left",
+      start: { kind: "junction", junctionId: "L1" },
+      end: { kind: "junction", junctionId: "L2" },
+      bends: [],
+      modes: ["manual"],
+    }),
+    createRoutePath({
+      id: "wire-right",
+      netId: "net-right",
+      start: { kind: "junction", junctionId: "R1" },
+      end: { kind: "junction", junctionId: "R2" },
+      bends: [],
+      modes: ["manual"],
+    }),
+  );
+  return document;
+}
+
+describe("bringing two wire ends head to head", () => {
+  it("joins the two Nets when the ends meet in mid-air", () => {
+    // The right wire starts at x = 260; slide it 60 left so its start lands
+    // exactly on the left wire's end at (200, 200). Neither point is in the
+    // other's span: this is end against end.
+    const moved = moveLooseRoute(twoHeadToHeadWires(), "wire-right", {
+      x: -60,
+      y: 0,
+    });
+
+    expect(conductingNetIds(moved)).toHaveLength(1);
+    expect(ambiguousJunctionErrors(moved)).toEqual([]);
+  });
+
+  it("still refuses to merge two wires that merely cross", () => {
+    // The brake, restated for this path: the vertical wire now spans
+    // y = 170..230 across the horizontal one, touching at an interior point
+    // of both with neither end resting on anything.
+    const moved = moveLooseRoute(twoLooseWires(), "wire-vertical", {
+      x: 0,
+      y: 70,
+    });
+
+    expect(conductingNetIds(moved)).toHaveLength(2);
+    expect(ambiguousJunctionErrors(moved)).toEqual([]);
+  });
+
+  it("refuses to retire a name when two named Nets are butted together", () => {
+    const document = twoHeadToHeadWires();
+    // The author labelled both sides, which is how they say the two are NOT
+    // the same node. Touching the ends cannot quietly discard one of the
+    // names, so this stays two Nets and keeps its ambiguity finding.
+    for (const [netId, name] of [
+      ["net-left", "VBST"],
+      ["net-right", "VGN"],
+    ] as const) {
+      document.annotations.push({
+        id: `label-${netId}`,
+        kind: "net-label",
+        binding: { kind: "net-name", netId },
+        netId,
+        anchor: { kind: "free", position: { x: 0, y: 0 } },
+        alignment: "start",
+        rotation: 0,
+        locked: false,
+      });
+      document.connectivityEvidence.push({
+        id: `claim-${netId}`,
+        kind: "name-claim",
+        netId,
+        name,
+        owner: { kind: "net-label", annotationId: `label-${netId}` },
+        scope: "local",
+      });
+    }
+
+    const moved = moveLooseRoute(document, "wire-right", { x: -60, y: 0 });
+
+    expect(conductingNetIds(moved)).toHaveLength(2);
+  });
+
+  it("leaves the joined conductor's connectivity alone when it moves again", () => {
+    const joined = moveLooseRoute(twoHeadToHeadWires(), "wire-right", {
+      x: -60,
+      y: 0,
+    });
+    expect(conductingNetIds(joined)).toHaveLength(1);
+    // The two collinear wires are one conductor now, so the id to move next
+    // is whatever canonicalization left behind rather than either original.
+    const joinedRouteId = joined.routes[0]!.id;
+
+    // Moving it must neither split the Net nor invent a second join.
+    const movedAgain = moveLooseRoute(joined, joinedRouteId, { x: 0, y: -40 });
+    expect(conductingNetIds(movedAgain)).toHaveLength(1);
+    expect(ambiguousJunctionErrors(movedAgain)).toEqual([]);
+  });
+});

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -43,6 +43,7 @@ import {
 import type { SymbolResolver } from "@icm/symbols";
 
 import type { SchematicEdit } from "./transaction.js";
+import { planDirectEndpointConnection } from "./direct-contact-planner.js";
 import { rebuildRoutePath } from "./route-leg-mutation.js";
 
 export interface WireEndpointGeometry {
@@ -563,6 +564,46 @@ function looseRouteAnchorIds(
 }
 
 /**
+ * A landing that rests on another Net's conductor, in one of the two shapes
+ * the model can express: against a bare END of that conductor, or part-way
+ * along its SPAN. They are the same gesture electrically and different
+ * structurally — splicing a wire in two at a point that is already its end
+ * would ask for a zero-length conductor, so an end meeting an end is stated
+ * as the direct contact it is.
+ */
+type LooseRouteLanding =
+  | {
+      kind: "span";
+      routeId: string;
+      request: EndpointRouteAttachmentRequest;
+    }
+  | {
+      kind: "endpoint";
+      routeId: string;
+      movedJunctionId: string;
+      targetEndpoint: RouteEndpoint;
+    };
+
+/** The endpoint of `candidate` that sits exactly at `point`, if either does. */
+function routeEndpointAt(
+  document: SchematicDocument,
+  candidate: RouteBranch,
+  point: Point,
+): RouteEndpoint | null {
+  for (const endpoint of routeEndpoints(candidate)) {
+    if (endpoint.kind !== "junction") continue;
+    const junction = document.junctions.find(
+      (record) => record.id === endpoint.junctionId,
+    );
+    if (!junction) continue;
+    if (junction.position.x === point.x && junction.position.y === point.y) {
+      return endpoint;
+    }
+  }
+  return null;
+}
+
+/**
  * Where a moved loose end comes to rest on a conductor of another Net.
  *
  * Only the two ENDS are considered. A wire whose middle crosses another wire
@@ -576,11 +617,8 @@ function looseRouteLandingContacts(
   route: RouteBranch,
   anchorIds: readonly string[],
   delta: Point,
-): Array<{ routeId: string; request: EndpointRouteAttachmentRequest }> {
-  const contacts: Array<{
-    routeId: string;
-    request: EndpointRouteAttachmentRequest;
-  }> = [];
+): LooseRouteLanding[] {
+  const contacts: LooseRouteLanding[] = [];
   for (const junctionId of anchorIds) {
     const junction = document.junctions.find(
       (candidate) => candidate.id === junctionId,
@@ -596,12 +634,26 @@ function looseRouteLandingContacts(
       if (candidate.id === route.id || candidate.netId === route.netId) {
         continue;
       }
+      // An end resting on the other wire's end is checked first: such a point
+      // also satisfies "on the segment", and taking it as a span landing is
+      // exactly the splice that cannot be made.
+      const targetEndpoint = routeEndpointAt(document, candidate, landing);
+      if (targetEndpoint) {
+        contacts.push({
+          kind: "endpoint",
+          routeId: candidate.id,
+          movedJunctionId: junctionId,
+          targetEndpoint,
+        });
+        break;
+      }
       const geometry = resolveRouteGeometry(document, resolver, candidate);
       const segmentIndex = geometry?.segments.findIndex((segment) =>
         pointOnSegment(landing, segment.from, segment.to),
       );
       if (segmentIndex === undefined || segmentIndex < 0) continue;
       contacts.push({
+        kind: "span",
         routeId: candidate.id,
         request: {
           endpoint: { kind: "junction", junctionId },
@@ -682,6 +734,21 @@ export function proposeLooseRouteTranslation(
 
   const byTargetRoute = new Map<string, EndpointRouteAttachmentRequest[]>();
   for (const contact of contacts) {
+    if (contact.kind === "endpoint") {
+      // End against end: state the contact directly rather than splicing the
+      // target at a point that is already its own end.
+      const direct = planDirectEndpointConnection(document, {
+        from: { kind: "junction", junctionId: contact.movedJunctionId },
+        to: contact.targetEndpoint,
+        newNetId: `net-${landing.suffix}`,
+      });
+      // Two differently NAMED Nets are the one case this gesture cannot
+      // settle: joining them would retire a name its author chose. The move
+      // still happens, the ends still touch, and the existing ambiguity
+      // finding is left standing for the author to resolve deliberately.
+      if (direct.ok) edits.push(...direct.edits);
+      continue;
+    }
     const requests = byTargetRoute.get(contact.routeId) ?? [];
     requests.push(contact.request);
     byTargetRoute.set(contact.routeId, requests);


### PR DESCRIPTION
Copy two devices, move one so the wires meet, and each meeting point drew a
red circle labelled `2` instead of connecting. The gesture said "these join";
the drawing said "ambiguous", and nothing cleared it except moving away again.

## What was actually broken

The landing was detected all along. `pointOnSegment` treats a segment as
closed, so an end resting on another wire's **end** satisfies it. That landing
was then handed to `attach_endpoint_to_route`, which splices the target in two
at the point. Splicing a conductor where it already ends asks for a
zero-length conductor, so the gate refused — `Junction position is not inside
route segment 0` — and the join was dropped.

So this was never a detection gap. It was a landing routed to the wrong
primitive.

The `2` beside the circle is the number of **diagnostics** at that point
(`group.length` in `diagnostic-markers.ts`), not a count of objects: end
against end raises one ambiguity finding from each side. That the count was
two is itself evidence the two ends really were touching.

## The fix

Landings are classified before they are acted on. One that coincides with an
endpoint of the target Route goes through `planDirectEndpointConnection` — the
primitive this repository already uses for pin-on-pin contact in selection
moves and component placement, and which `proposeLooseRouteTranslation` was
alone in never calling. A landing part-way along a span keeps the attachment
path.

End-against-end is tested first, because such a point satisfies both tests and
only one of them can be honoured.

## Brakes, both covered by tests

- **A crossing still connects nothing.** Unchanged: a crossing produces no
  endpoint landing at all.
- **A name its author chose is never retired.** Butting two *labelled* Nets
  together (the `VBST` / `VGN` shape) leaves them separate and leaves the
  ambiguity finding standing, rather than silently discarding one name. This
  follows the idiom the selection-move caller already uses for the same
  refusal.

## Verification

`packages/edit-engine` 395/395 green on this base, `pnpm typecheck` clean.
The three new cases were red first for the right reason — the failure message
was the `not inside route segment 0` refusal quoted above.

Not covered here: the copy-then-move path the report also mentioned. Copying
mints a new Net, which is correct; the defect was entirely in what happens
when the two meet, so the same fix covers it. A copy-specific e2e case is
worth adding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
