### PR TITLE
fix(worker): a chunk that no longer exists answers 404, not the shell

### DIFF
--- a/worker/asset-miss.test.ts
+++ b/worker/asset-miss.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import workerEntry from "./index";
+
+/**
+ * The request path a browser actually takes for a chunk name that no longer
+ * exists.
+ *
+ * Why this file is separate and phrased this way: the change that caused the
+ * 2026-09-01 outage passed every check while the deployed Worker threw
+ * Cloudflare 1101 on the same paths. Its tests never exercised the code that
+ * ran. So these drive the exported fetch handler itself, with an ASSETS stub
+ * that behaves the way the platform was MEASURED to behave against workerd:
+ * a miss under `not_found_handling: single-page-application` comes back as
+ * the shell at status 200, not as a 404.
+ *
+ * The stub is written from that measurement rather than from the docs, and
+ * the live curl after deploying is still the evidence that settles it.
+ */
+const SHELL = "<!doctype html><title>Analog Canvas</title>";
+
+function envWithAssets(files: Record<string, string>) {
+  return {
+    ASSETS: {
+      fetch: async (request: Request) => {
+        const path = new URL(request.url).pathname;
+        const body = files[path];
+        if (body !== undefined) {
+          return new Response(body, {
+            headers: {
+              "content-type": path.endsWith(".js")
+                ? "text/javascript; charset=utf-8"
+                : "text/html; charset=utf-8",
+            },
+          });
+        }
+        // Measured platform behaviour: every miss is the shell, at 200.
+        return new Response(SHELL, {
+          headers: { "content-type": "text/html; charset=utf-8" },
+        });
+      },
+    },
+  } as unknown as Parameters<typeof workerEntry.fetch>[1];
+}
+
+const env = envWithAssets({
+  "/index.html": SHELL,
+  "/assets/App-real123.js": "export const ok = true;",
+});
+
+const get = (path: string) =>
+  workerEntry.fetch(new Request(`https://example.test${path}`), env);
+
+describe("a chunk name that no longer exists", () => {
+  it("answers 404, not the shell dressed as a script", async () => {
+    // The user-visible bug: the browser asked for JavaScript, was handed
+    // HTML, and was told it succeeded — which it reports as "Failed to fetch
+    // dynamically imported module".
+    const response = await get("/assets/App-nonexistent.js");
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).toContain("text/plain");
+    expect(await response.text()).not.toContain("doctype");
+  });
+
+  it("does not cache the refusal", async () => {
+    // The next deploy may legitimately publish that name again.
+    const response = await get("/assets/App-nonexistent.js");
+    expect(response.headers.get("cache-control")).toContain("no-store");
+  });
+
+  it("still serves an asset that exists", async () => {
+    const response = await get("/assets/App-real123.js");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("javascript");
+  });
+});
+
+describe("client routes keep the shell", () => {
+  // The other half of the boundary, and the half the earlier attempt broke:
+  // these paths never had a file behind them, so their miss IS the shell.
+  it.each(["/editor", "/analytics", "/g/abc123", "/"])(
+    "%s renders the shell",
+    async (path) => {
+      const response = await get(path);
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("text/html");
+      expect(await response.text()).toContain("doctype");
+    },
+  );
+});

--- a/worker/index.test.ts
+++ b/worker/index.test.ts
@@ -48,7 +48,11 @@ describe("analytics request normalization", () => {
 describe("assets binding wiring", () => {
   /** wrangler.jsonc allows comments and trailing commas; JSON does not. */
   function wranglerConfig(): {
-    assets: { run_worker_first?: string[]; not_found_handling?: string };
+    assets: {
+      binding?: string;
+      run_worker_first?: string[];
+      not_found_handling?: string;
+    };
   } {
     const source = readFileSync(
       resolve(process.cwd(), "wrangler.jsonc"),
@@ -60,16 +64,24 @@ describe("assets binding wiring", () => {
     return JSON.parse(stripped) as ReturnType<typeof wranglerConfig>;
   }
 
-  it("keeps the Worker out of the asset path", () => {
-    // Listing "/assets/*" in run_worker_first made env.ASSETS.fetch re-enter
-    // the Worker and every asset request returned 1101. Assets are served
-    // directly; the missing-asset 404 has to be built some other way.
+  it("routes asset requests through the Worker, with a binding to fetch", () => {
+    // This test previously pinned the opposite, on the belief that listing
+    // "/assets/*" in run_worker_first made env.ASSETS.fetch re-enter the
+    // Worker and produce 1101. That belief was wrong, and it was expensive:
+    // it left the shell-for-a-missing-chunk bug unfixable in principle.
+    //
+    // Measured against workerd locally: with the binding declared, a Worker
+    // that runs first for /assets/* and calls env.ASSETS.fetch gets the
+    // asset back for a hit and the SPA shell for a miss. No re-entry, no
+    // 1101. The 1101 came from the binding being ABSENT, so env.ASSETS was
+    // undefined and the first request to reach that line threw — which the
+    // same local harness reproduced exactly, by omitting the binding.
     const { assets } = wranglerConfig();
-    expect(assets.run_worker_first).not.toContain("/assets/*");
+    expect(assets.binding).toBe("ASSETS");
+    expect(assets.run_worker_first).toContain("/assets/*");
     expect(assets.run_worker_first).toContain("/api/*");
-    // Cloudflare owns client-route fallback in front of the Worker. Missing
-    // chunks also receive the shell, which the client stale-build recovery
-    // recognizes; routing /assets/* through the Worker causes 1101 re-entry.
+    // Client routes still get the shell from Cloudflare; the Worker only
+    // separates "a hashed file that is gone" from "a route with no file".
     expect(assets.not_found_handling).toBe("single-page-application");
   });
 });

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -122,9 +122,48 @@ export default {
       return Response.json({ error: "Not found" }, { status: 404 });
     }
 
-    return env.ASSETS.fetch(request);
+    return serveAsset(request, env);
   },
 };
+
+/**
+ * Serve a static asset, and let a missing one be missing.
+ *
+ * The boundary, which is the thing an earlier attempt did not draw: a path
+ * under `/assets/` names a CONTENT-HASHED FILE. The name is a promise about
+ * the bytes behind it, so if those bytes are gone the honest answer is 404.
+ * Every other path is a CLIENT ROUTE — `/editor`, `/g/<id>` — which never had
+ * a file behind it, and whose miss is answered with the shell so the app can
+ * boot and route it.
+ *
+ * The asset layer cannot tell them apart: `not_found_handling:
+ * single-page-application` answers both with index.html at status 200. That
+ * is right for a route and wrong for an asset, and it is the bug a browser
+ * reports as "Failed to fetch dynamically imported module" after a redeploy
+ * retires a chunk name. So `/assets/*` runs the Worker first, and the shell
+ * arriving where a script was requested is recognised and turned into a 404.
+ *
+ * Detection is by content type rather than by comparing bytes: a real file
+ * under /assets/ is script, style, font or image, and never text/html.
+ */
+async function serveAsset(request: Request, env: Env): Promise<Response> {
+  const response = await env.ASSETS.fetch(request);
+  const path = new URL(request.url).pathname;
+  if (!path.startsWith("/assets/")) return response;
+  const isShellFallback = (response.headers.get("content-type") ?? "")
+    .toLowerCase()
+    .includes("text/html");
+  if (!isShellFallback) return response;
+  return new Response(`Not found: ${path}`, {
+    status: 404,
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      // A retired name must not be cached as anything, least of all as a
+      // 404 that outlives the next deploy that might reuse it.
+      "cache-control": "no-store",
+    },
+  });
+}
 
 async function trackPageView(request: Request, env: Env): Promise<Response> {
   const noContent = () => new Response(null, { status: 204 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,12 +15,22 @@
     },
   ],
   "assets": {
+    // The binding the Worker fetches through. Its absence is what produced
+    // error 1101 on 2026-09-01: `env.ASSETS` was undefined, so the moment a
+    // request reached the Worker's asset path it threw. Reproduced locally
+    // against workerd, and it is the reason the earlier "binding re-entry"
+    // explanation was wrong — routing /assets/* through the Worker does not
+    // re-enter it.
+    "binding": "ASSETS",
     "directory": "./apps/editor/dist",
-    // Client routes and stale asset names receive the SPA shell before the
-    // Worker runs. The client recognizes a stale module response and reloads;
-    // routing /assets/* through the Worker causes binding re-entry and 1101.
+    // A path under /assets/ names a content-hashed file: the name is a
+    // promise about the bytes, so a miss is a miss and must say 404. Every
+    // other path is a client route with no file behind it, and its miss is
+    // the shell. The Worker sees /assets/* in order to tell those two apart,
+    // because the asset layer alone answers both with the shell and a
+    // browser expecting JavaScript gets HTML at status 200.
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/api/*"],
+    "run_worker_first": ["/api/*", "/assets/*"],
   },
   "durable_objects": {
     "bindings": [


### PR DESCRIPTION
Refixes #493. A retired hashed chunk still returned `200 text/html`, so a browser asking for JavaScript got HTML and was told it succeeded, which it reports as "Failed to fetch dynamically imported module".

## The boundary the earlier attempt never drew

- A path under `/assets/` names a **content-hashed file**. Its name is a promise about the bytes, so a miss is a miss and must say 404.
- Every other path is a **client route** that never had a file behind it, so its miss is the shell.

The asset layer answers both the same way, at status 200. That is right for a route and wrong for an asset. Now the Worker sees `/assets/*` and separates them; the comment in `worker/index.ts` states the boundary so the next person does not have to re-derive it.

## The recursion story was wrong, and being wrong is what made this look unfixable

The repo asserted, in a code comment **and in a test**, that listing `/assets/*` in `run_worker_first` makes `env.ASSETS.fetch` re-enter the Worker and produce 1101. I built a minimal workerd harness and measured it:

- **With the binding declared**: Worker runs first for `/assets/*`, calls `env.ASSETS.fetch`, gets the file for a hit and the shell for a miss. **No re-entry, no 1101.**
- **With the binding omitted**: the exact production failure reproduced — `TypeError: Cannot read properties of undefined (reading 'fetch')`, which is what Cloudflare reports as 1101.

## A live landmine, closed here

`wrangler.jsonc` declared **no `binding` for assets** while `worker/index.ts` called `env.ASSETS.fetch`. On main today, `env.ASSETS` is undefined and the first non-API request to reach that line takes the site down. It has not fired only because the asset layer answers those paths before the Worker runs. This PR declares the binding.

## Verification

Unit tests are not the evidence here — #503 passed eight checks while the deployed Worker threw 1101. So:

- **Real workerd, real Worker logic**: missing chunk `404 text/plain`; real chunk `200 text/javascript`; `/editor` and `/` unchanged at `200 text/html`
- 10 unit tests drive the exported fetch handler through the real request path, with an ASSETS stub written from the measured platform behaviour rather than from docs
- Full `pnpm ci:check`: **2226/2226 unit tests pass**. Three e2e specs failed in the 19-minute full run (label handles, text colours, Cloud Save) — none related to asset routing. Verified as pre-existing flakiness under load, not a regression: all three **pass on clean main** and **pass on this branch** when run directly, and the machine was at load 13-25 with four sessions running.
- Production `curl` follows the deploy: `/editor` 200, missing chunk 404, `/` 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
