### PR TITLE
fix(ci): the deploy check expected the bug it was meant to catch

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -116,13 +116,34 @@ jobs:
             --output /tmp/analog-canvas-stale-asset.txt \
             --write-out '%{http_code} %{content_type}' \
             https://analog-canvas.tokenzhang.com/assets/App-deploy-smoke-missing.js)"
+          # A hashed asset name is a promise about bytes, so a name with no
+          # file behind it must say 404. This check asserted the opposite
+          # until #519: it required the shell at 200, which was the bug
+          # (#493) written down as the expected answer. The first deploy of
+          # the fix was therefore rolled back by this very step, correctly
+          # following an instruction that was itself wrong.
           case "$stale_asset" in
-            "200 text/html"*)
-              grep -qi '<!doctype html>' /tmp/analog-canvas-stale-asset.txt
+            "404 "*)
               ;;
             *)
-              echo "Stale hashed asset returned: $stale_asset"
+              echo "A missing hashed asset must answer 404, got: $stale_asset"
               cat /tmp/analog-canvas-stale-asset.txt
+              exit 1
+              ;;
+          esac
+          # The other half of the boundary: a client route has no file behind
+          # it either, and must still receive the shell rather than a 404.
+          route_shell="$(curl --silent --show-error \
+            --max-time 20 \
+            --output /tmp/analog-canvas-route-shell.txt \
+            --write-out '%{http_code} %{content_type}' \
+            https://analog-canvas.tokenzhang.com/editor)"
+          case "$route_shell" in
+            "200 text/html"*)
+              grep -qi '<!doctype html>' /tmp/analog-canvas-route-shell.txt
+              ;;
+            *)
+              echo "A client route must receive the shell, got: $route_shell"
               exit 1
               ;;
           esac

--- a/scripts/deploy-workflow.test.mjs
+++ b/scripts/deploy-workflow.test.mjs
@@ -56,6 +56,31 @@ describe("Cloudflare deploy workflow", () => {
     expect(workflow).toContain("needs a human");
   });
 
+  it("requires a missing hashed asset to answer 404", () => {
+    // This check once asserted the opposite: it required the shell at 200,
+    // which was the #493 bug recorded as the expected answer. It then rolled
+    // back the fix for that bug, correctly obeying a wrong instruction. The
+    // assertion exists so the old expectation cannot come back quietly.
+    const verifySection = workflow.slice(
+      workflow.indexOf("Verify production deployment"),
+      workflow.indexOf("Roll back a failed deployment"),
+    );
+    expect(verifySection).toContain("App-deploy-smoke-missing.js");
+    expect(verifySection).toMatch(/"404 "\*\)/u);
+    expect(verifySection).toContain("must answer 404");
+  });
+
+  it("still requires a client route to receive the shell", () => {
+    // The other half of the boundary. Turning every miss into a 404 would
+    // break /editor, which is the failure this whole area started from.
+    const verifySection = workflow.slice(
+      workflow.indexOf("Verify production deployment"),
+      workflow.indexOf("Roll back a failed deployment"),
+    );
+    expect(verifySection).toContain("must receive the shell");
+    expect(verifySection).toContain("doctype html");
+  });
+
   it("verifies the editor route, which is what broke", () => {
     const verifySection = workflow.slice(
       workflow.indexOf("Verify production deployment"),


### PR DESCRIPTION
**Urgent: main currently cannot deploy.** It carries #519's Worker fix while the smoke check still forbids the behaviour that fix produces, so every deploy from main will fail verification and roll back until this lands.

## What happened

#519 deployed, and the pipeline rolled it back. **The pipeline was right to do that**, and the machinery worked exactly as designed:

1. Deploy succeeded
2. Verification **failed**: `Stale hashed asset returned: 404 text/plain`
3. Rollback restored the previous version, **re-verified it**, and failed the run loudly
4. Production served the old version the whole time

The instruction it was obeying was simply wrong. The smoke check required a missing hashed asset to return the shell at `200 text/html` — the #493 bug, written down as the expected answer, back when that behaviour was believed unfixable. #519 made it return 404, which is correct, and the check called that a failure.

So this is a correction, not an incident. Nothing was harmed, and the rollback protection from #511 did its job on its first real firing.

## The fix

- A missing hashed asset must answer **404**. A name with no file behind it is a broken promise, not a page.
- `/editor` must **still receive the shell**. This is the other half of the same boundary, and it is asserted separately because a check that only demanded 404 would break client routing while looking correct.

Both are pinned by tests in `scripts/deploy-workflow.test.mjs`, so the old expectation cannot come back quietly.

## Validation

- 8 tests on the workflow contract, including one that exists specifically to stop the previous expectation returning
- Production verified healthy on the rolled-back version before writing this: `/`, `/editor`, `/analytics` all 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
