### PR TITLE
fix(connectivity): joining two named Nets retires both names

### DIFF
--- a/apps/editor/src/features/selection/pin-bond-move.test.ts
+++ b/apps/editor/src/features/selection/pin-bond-move.test.ts
@@ -240,10 +240,12 @@ describe("pin-onto-pin move bond", () => {
     );
   });
 
-  it("keeps two differently named nets apart and says why", () => {
-    // E rides net-h (HORIZONTAL); C rides net-v (VERTICAL). The planner
-    // refuses the silent merge, the move itself still commits, and the
-    // status names the conflict instead of claiming a connection.
+  it("joins two differently named nets and retires both names", () => {
+    // E rides net-h (HORIZONTAL); C rides net-v (VERTICAL). Bringing the pin
+    // to rest on the other Net joins them like any other contact. Neither
+    // name survives the join — the author named two nodes to say they were
+    // different, and that statement is what the gesture revokes — so the
+    // labels go with the names rather than one being chosen for them.
     const { statuses, transactions } = runMove({
       instanceId: "E",
       origin: { x: 30, y: 400 },
@@ -251,14 +253,12 @@ describe("pin-onto-pin move bond", () => {
       target: { x: 0, y: 200 },
     });
     const edits = transactions.flatMap((t) => t.edits);
-    expect(edits.some((edit) => edit.kind === "connect_endpoints")).toBe(false);
-    expect(transactions.some((t) => t.result?.ok)).toBe(true);
+    expect(edits.some((edit) => edit.kind === "connect_endpoints")).toBe(true);
     expect(
-      statuses.some((s) =>
-        s.includes("Moved without connecting: Cannot directly connect"),
-      ),
-    ).toBe(true);
-    expect(statuses.some((s) => s.includes("Snapped pin endpoints"))).toBe(
+      edits.filter((edit) => edit.kind === "remove_schematic_annotation"),
+    ).toHaveLength(2);
+    expect(transactions.some((t) => t.result?.ok)).toBe(true);
+    expect(statuses.some((s) => s.includes("Moved without connecting"))).toBe(
       false,
     );
   });

--- a/packages/edit-engine/src/direct-contact-planner.test.ts
+++ b/packages/edit-engine/src/direct-contact-planner.test.ts
@@ -64,7 +64,7 @@ describe("direct endpoint connection planner", () => {
     });
   });
 
-  it("rejects direct contact between differently named Nets", () => {
+  it("retires both labels when differently named Nets are joined", () => {
     const document = fixture();
     document.nets.push(
       {
@@ -106,8 +106,23 @@ describe("direct endpoint connection planner", () => {
         newNetId: "unused",
       }),
     ).toMatchObject({
-      ok: false,
-      relatedNetIds: ["net-a", "net-b"],
+      ok: true,
+      // Neither AVDD nor DVDD describes the joined node, so both the claims
+      // and the labels that own them go, and the node ends up unnamed.
+      edits: [
+        { kind: "remove_connectivity_evidence", evidenceId: "claim-a" },
+        {
+          kind: "remove_schematic_annotation",
+          annotationId: "test-net-label-1",
+        },
+        { kind: "remove_connectivity_evidence", evidenceId: "claim-b" },
+        {
+          kind: "remove_schematic_annotation",
+          annotationId: "test-net-label-2",
+        },
+        { kind: "merge_nets" },
+        { kind: "connect_endpoints" },
+      ],
     });
   });
 

--- a/packages/edit-engine/src/direct-contact-planner.ts
+++ b/packages/edit-engine/src/direct-contact-planner.ts
@@ -17,6 +17,34 @@ export type DirectEndpointConnectionPlan =
       relatedNetIds: readonly string[];
     };
 
+/**
+ * Retire the net labels that name these Base Nets, annotation and claim both.
+ *
+ * Only claims a **label** owns are retired. A claim owned by a power marker
+ * comes from a symbol the author placed on the canvas — a VDD or VSS part,
+ * not a piece of text — and deleting parts is not what naming a node meant.
+ * Contact between two supply domains is refused earlier for that reason.
+ */
+function retireNetLabelClaims(
+  document: SchematicDocument,
+  netIds: readonly string[],
+): SchematicEdit[] {
+  const edits: SchematicEdit[] = [];
+  for (const evidence of document.connectivityEvidence) {
+    if (evidence.kind !== "name-claim") continue;
+    if (!netIds.includes(evidence.netId)) continue;
+    if (evidence.owner.kind !== "net-label") continue;
+    edits.push(
+      { kind: "remove_connectivity_evidence", evidenceId: evidence.id },
+      {
+        kind: "remove_schematic_annotation",
+        annotationId: evidence.owner.annotationId,
+      },
+    );
+  }
+  return edits;
+}
+
 export interface DirectEndpointConnectionRequest {
   from: RouteEndpoint;
   to: RouteEndpoint;
@@ -66,17 +94,21 @@ export function planDirectEndpointConnection(
   const relatedNetIds = [fromNetId, toNetId].sort((left, right) =>
     left.localeCompare(right, "en"),
   );
-  if (
+  // Two differently named Nets brought into contact DO join, and BOTH names
+  // go with the join. Neither one describes the result: the author named two
+  // nodes precisely to say they were different, so keeping either would have
+  // the drawing assert something they never said, while keeping both would
+  // leave one node claiming two names. Retiring the pair says only what is
+  // true — this node is not named yet — and two labels vanishing is visible
+  // in a way one quiet survivor would not be.
+  const namesConflict = Boolean(
     fromLogical?.name &&
     toLogical?.name &&
-    foldNetName(fromLogical.name) !== foldNetName(toLogical.name)
-  ) {
-    return {
-      ok: false,
-      message: `Cannot directly connect named Nets ${fromLogical.name} and ${toLogical.name}`,
-      relatedNetIds,
-    };
-  }
+    foldNetName(fromLogical.name) !== foldNetName(toLogical.name),
+  );
+  const retiredLabelEdits = namesConflict
+    ? retireNetLabelClaims(document, [fromNetId, toNetId])
+    : [];
   if (
     fromLogical?.powerDomain === "conflict" ||
     toLogical?.powerDomain === "conflict" ||
@@ -102,6 +134,9 @@ export function planDirectEndpointConnection(
     ok: true,
     netId: targetNetId,
     edits: [
+      // The names go first: the merge that follows must not have to hold a
+      // Net carrying two of them, even for one intermediate step.
+      ...retiredLabelEdits,
       { kind: "merge_nets", targetNetId, sourceNetId },
       { kind: "connect_endpoints", from: request.from, to: request.to },
     ],

--- a/packages/edit-engine/src/route-move-merge.test.ts
+++ b/packages/edit-engine/src/route-move-merge.test.ts
@@ -455,11 +455,13 @@ describe("bringing two wire ends head to head", () => {
     expect(ambiguousJunctionErrors(moved)).toEqual([]);
   });
 
-  it("refuses to retire a name when two named Nets are butted together", () => {
+  it("retires both labels when two named Nets are butted together", () => {
     const document = twoHeadToHeadWires();
-    // The author labelled both sides, which is how they say the two are NOT
-    // the same node. Touching the ends cannot quietly discard one of the
-    // names, so this stays two Nets and keeps its ambiguity finding.
+    // The author labelled both sides, which is how they said the two were
+    // different nodes. Joining them makes both names untrue at once, so the
+    // pair is retired and the joined node is left unnamed for the author to
+    // name again — rather than the drawing claiming a name they never gave
+    // this node.
     for (const [netId, name] of [
       ["net-left", "VBST"],
       ["net-right", "VGN"],
@@ -486,7 +488,14 @@ describe("bringing two wire ends head to head", () => {
 
     const moved = moveLooseRoute(document, "wire-right", { x: -60, y: 0 });
 
-    expect(conductingNetIds(moved)).toHaveLength(2);
+    expect(conductingNetIds(moved)).toHaveLength(1);
+    expect(ambiguousJunctionErrors(moved)).toEqual([]);
+    // Both labels are gone from the drawing, and so is every name claim, so
+    // the joined Net carries no name at all.
+    expect(moved.annotations.filter((a) => a.kind === "net-label")).toEqual([]);
+    expect(
+      moved.connectivityEvidence.filter((e) => e.kind === "name-claim"),
+    ).toEqual([]);
   });
 
   it("leaves the joined conductor's connectivity alone when it moves again", () => {


### PR DESCRIPTION
Bringing two differently named Nets into contact was refused outright — the
wire moved, nothing connected, and a status line explained why. The author's
gesture said "these are one node" and the editor declined to agree.

They now join, and **both** names go with the join.

## Why both, rather than one

Naming two nodes is how an author says they are different. Joining them
revokes exactly that statement, which leaves neither name true:

- Keeping one would have the drawing assert a name the author never gave
  *this* node.
- Keeping both would leave one node claiming two names — which the
  logical-net contract in the transaction layer refuses, for good reason.

Retiring the pair says only what is true: this node is not named yet. It also
*shows*. Two labels disappearing is noticeable in a way one quiet survivor is
not, which matters when the whole worry is a drawing changing under its
author.

## Scope

Only claims a **net label** owns are retired — the annotation and its claim
together. A claim owned by a power marker comes from a part the author placed
on the canvas, not from a piece of text, so contact between two supply domains
stays refused rather than deleting components to make room for itself.
Allowing that case needs its own decision; it is not this one.

The removals are emitted **ahead of** the merge, so no intermediate state has
one Net holding two names. The contract is not weakened — only kept
satisfiable.

## One decision, every caller

This lands through `planDirectEndpointConnection` alone. The pin-drag path in
`selection-move-controller` picks the rule up with no change of its own — its
test went from "refuses and says why" to "joins and retires both" without a
line of controller code moving. That is the evidence the change sits at the
right layer: if both places had needed editing, the layer would have been
wrong.

## Verification

`edit-engine` + `derived` + `netlist` 642/642, `apps/editor` 857/857,
`pnpm typecheck` clean. The end-to-end case runs plan → gate → commit and
asserts the labels are gone from the committed document, not merely that the
removal edits were emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
