### PR TITLE
perf(gallery): remove invisible feed bottlenecks

### DIFF
--- a/worker/auth.test.ts
+++ b/worker/auth.test.ts
@@ -537,13 +537,16 @@ describe("sessionUserOf (module seam for the gallery)", () => {
   it("resolves the signed-in user through the binding and null otherwise", async () => {
     const auth = harness({ RESEND_API_KEY: "rk", ADMIN_EMAILS: "b@e.co" });
     const cookie = await emailSignIn(auth, "b@e.co");
+    let bindingFetches = 0;
     const env = {
       AUTH: {
         getByName: () => ({
-          fetch: (input: Request | string, init?: RequestInit) =>
-            auth.durable.fetch(
+          fetch: (input: Request | string, init?: RequestInit) => {
+            bindingFetches += 1;
+            return auth.durable.fetch(
               typeof input === "string" ? new Request(input, init) : input,
-            ),
+            );
+          },
         }),
       },
     };
@@ -554,11 +557,21 @@ describe("sessionUserOf (module seam for the gallery)", () => {
       env,
     );
     expect(signedIn?.isAdmin).toBe(true);
+    expect(bindingFetches).toBe(1);
     const anonymous = await sessionUserOf(
       new Request(`${ORIGIN}/api/gallery/submissions`),
       env,
     );
     expect(anonymous).toBeNull();
+    expect(bindingFetches).toBe(1);
+    const emptySession = await sessionUserOf(
+      new Request(`${ORIGIN}/api/gallery/submissions`, {
+        headers: { Cookie: "icm_visitor=visitor; icm_session=" },
+      }),
+      env,
+    );
+    expect(emptySession).toBeNull();
+    expect(bindingFetches).toBe(1);
     const unbound = await sessionUserOf(
       new Request(`${ORIGIN}/api/gallery/submissions`),
       {},

--- a/worker/auth.ts
+++ b/worker/auth.ts
@@ -1,5 +1,13 @@
 export * from "./auth-do";
-import type { AuthEnv, SessionUser } from "./auth-do";
+import { AUTH_SESSION_COOKIE, type AuthEnv, type SessionUser } from "./auth-do";
+
+function hasSessionCookie(request: Request): boolean {
+  const prefix = `${AUTH_SESSION_COOKIE}=`;
+  return (request.headers.get("Cookie") ?? "").split(";").some((part) => {
+    const cookie = part.trim();
+    return cookie.startsWith(prefix) && cookie.length > prefix.length;
+  });
+}
 
 /**
  * Resolve the signed-in user (with the per-request admin flag) for another
@@ -10,7 +18,11 @@ export async function sessionUserOf(
   request: Request,
   env: Partial<AuthEnv>,
 ): Promise<SessionUser | null> {
-  if (!env.AUTH) return null;
+  // An absent session cookie proves the request is anonymous. Avoid waking
+  // the global AuthDO only to have it make the same observation; Gallery
+  // reads are the hottest caller and otherwise serialize this unnecessary
+  // cross-object round trip ahead of every public feed query.
+  if (!env.AUTH || !hasSessionCookie(request)) return null;
   try {
     const response = await env.AUTH.getByName("auth").fetch(
       "https://auth/internal/session-user",

--- a/worker/gallery-do.ts
+++ b/worker/gallery-do.ts
@@ -43,7 +43,7 @@ import {
   type CircuitProject,
 } from "@icm/model";
 
-import { sessionUserOf, type AuthNamespaceLike } from "./auth";
+import type { AuthNamespaceLike } from "./auth";
 
 /**
  * A circuit's id is its address, so it is short enough to read out loud and
@@ -292,12 +292,35 @@ interface EntryRow {
   preview_revision: string;
 }
 
+type EntrySummaryRow = Pick<
+  EntryRow,
+  | "id"
+  | "name"
+  | "author"
+  | "description"
+  | "created_at"
+  | "schema_version"
+  | "tags"
+  | "netlistable"
+  | "preview_revision"
+>;
+
+interface PreviewAccessRow {
+  status: string;
+  owner_user_id: string | null;
+  preview_revision: string;
+}
+
+interface PreviewRow extends PreviewAccessRow {
+  svg_text: string;
+}
+
 const TOKENZHANG_BYLINE_MIGRATION = "2026-08-26-tokenzhang-to-zhishuai-zhang";
 const TOKENZHANG_BYLINE = "Zhishuai Zhang";
 const VERSION_RETENTION_MIGRATION = "2026-08-27-gallery-version-retention-2";
 
 function summaryOf(
-  row: EntryRow & { likes?: number; liked_by_viewer?: number },
+  row: EntrySummaryRow & { likes?: number; liked_by_viewer?: number },
 ): GalleryEntrySummary {
   return {
     id: row.id,
@@ -506,6 +529,10 @@ export class GalleryDO {
         return this.entry(String(body.id), "public");
       case "any-entry":
         return this.entry(String(body.id), null);
+      case "preview-access":
+        return this.previewAccess(String(body.id));
+      case "preview":
+        return this.preview(String(body.id));
       case "set-status":
         return this.setStatus(
           String(body.id),
@@ -746,8 +773,9 @@ export class GalleryDO {
       bindings.push(cursor);
     }
     const rows = this.sql
-      .exec<EntryRow & { likes: number; liked_by_viewer: number }>(
-        `SELECT e.*,
+      .exec<EntrySummaryRow & { likes: number; liked_by_viewer: number }>(
+        `SELECT e.id, e.name, e.author, e.description, e.created_at,
+           e.schema_version, e.tags, e.netlistable, e.preview_revision,
            (SELECT COUNT(*) FROM gallery_likes WHERE entry_id = e.id) AS likes,
            (SELECT COUNT(*) FROM gallery_likes
              WHERE entry_id = e.id AND user_id = ?) AS liked_by_viewer
@@ -764,6 +792,41 @@ export class GalleryDO {
         ? `${page.at(-1)!.created_at}|${page.at(-1)!.id}`
         : null;
     return Response.json({ entries: page.map(summaryOf), nextCursor, total });
+  }
+
+  /** Minimum row needed to decide whether an immutable preview cache hit is valid. */
+  private previewAccess(id: string): Response {
+    const row = this.sql
+      .exec<PreviewAccessRow>(
+        `SELECT status, owner_user_id, preview_revision
+         FROM gallery_entries WHERE id = ?`,
+        id,
+      )
+      .toArray()[0];
+    if (!row) return Response.json({ error: "not-found" }, { status: 404 });
+    return Response.json({
+      status: row.status,
+      ownerUserId: row.owner_user_id,
+      previewRevision: row.preview_revision || "legacy",
+    });
+  }
+
+  /** Preview bytes without the unrelated canonical Project payload. */
+  private preview(id: string): Response {
+    const row = this.sql
+      .exec<PreviewRow>(
+        `SELECT status, owner_user_id, preview_revision, svg_text
+         FROM gallery_entries WHERE id = ?`,
+        id,
+      )
+      .toArray()[0];
+    if (!row) return Response.json({ error: "not-found" }, { status: 404 });
+    return Response.json({
+      status: row.status,
+      ownerUserId: row.owner_user_id,
+      previewRevision: row.preview_revision || "legacy",
+      svgText: row.svg_text,
+    });
   }
 
   /**

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -19,15 +19,17 @@ import {
   SHORT_ID_LENGTH,
   shortId,
   type GalleryEnv,
+  type GalleryPreviewCache,
 } from "./gallery";
 import { AuthDO, type AuthEnv } from "./auth";
 
-function sqliteState() {
+function sqliteState(queries?: string[]) {
   const db = new DatabaseSync(":memory:");
   return {
     storage: {
       sql: {
         exec<T>(query: string, ...bindings: unknown[]) {
+          queries?.push(query);
           const statement = db.prepare(query);
           if (/^\s*(select|with|pragma)/iu.test(query)) {
             const rows = statement.all(
@@ -61,6 +63,7 @@ type Harness = GalleryEnv & {
   authDurable: AuthDO;
   /** The gallery's own storage, for seeding rows a route cannot create. */
   gallerySql: ReturnType<typeof sqliteState>["storage"]["sql"];
+  galleryQueries: string[];
 };
 
 /**
@@ -68,7 +71,8 @@ type Harness = GalleryEnv & {
  * only way to publish anything.
  */
 function environment(): Harness {
-  const galleryState = sqliteState();
+  const galleryQueries: string[] = [];
+  const galleryState = sqliteState(galleryQueries);
   const durable = new GalleryDO(galleryState);
   const authDurable = new AuthDO(sqliteState(), {
     RESEND_API_KEY: "rk",
@@ -91,6 +95,7 @@ function environment(): Harness {
     },
     authDurable,
     gallerySql: galleryState.storage.sql,
+    galleryQueries,
   };
 }
 
@@ -175,6 +180,27 @@ async function route(env: GalleryEnv, request: Request) {
   const response = await routeGalleryRequest(request, env);
   if (!response) throw new Error("gallery route did not match");
   return response;
+}
+
+function memoryPreviewCache(): GalleryPreviewCache & {
+  readonly matchCalls: string[];
+  readonly putCalls: string[];
+} {
+  const responses = new Map<string, Response>();
+  const matchCalls: string[] = [];
+  const putCalls: string[] = [];
+  return {
+    matchCalls,
+    putCalls,
+    async match(request) {
+      matchCalls.push(request.url);
+      return responses.get(request.url)?.clone();
+    },
+    async put(request, response) {
+      putCalls.push(request.url);
+      responses.set(request.url, response.clone());
+    },
+  };
 }
 
 function cookieHeaders(cookie: string): HeadersInit {
@@ -431,6 +457,22 @@ describe("newest-first gallery feed", () => {
     const full = await galleryPage(env);
     expect(full.entries).toHaveLength(2);
     expect(full.nextCursor).toBeNull();
+  });
+
+  it("reads feed summaries without loading stored Project or SVG payloads", async () => {
+    const env = environment();
+    await wallOf(env, 2);
+    env.galleryQueries.length = 0;
+
+    const page = await galleryPage(env);
+    expect(page.entries).toHaveLength(2);
+    const feedQuery = env.galleryQueries.find((query) =>
+      query.includes("FROM gallery_entries e"),
+    );
+    expect(feedQuery).toBeDefined();
+    expect(feedQuery).not.toContain("e.*");
+    expect(feedQuery).not.toContain("project_text");
+    expect(feedQuery).not.toContain("svg_text");
   });
 
   it("carries the whole wall's total on every page and counts the filtered set", async () => {
@@ -936,6 +978,64 @@ describe("gallery submissions", () => {
     expect(immutablePreview.headers.get("cache-control")).toBe(
       "public, max-age=31536000, immutable",
     );
+  });
+
+  it("caches immutable preview bytes behind a live publication check", async () => {
+    const env = environment();
+    const adminCookie = await adminOf(env);
+    const id = await submitOne(env, "Cached Preview", { cookie: adminCookie });
+    const list = await route(env, new Request(`${ORIGIN}/api/gallery`));
+    const revision = (
+      (await list.json()) as {
+        entries: { previewRevision: string }[];
+      }
+    ).entries[0]!.previewRevision;
+    const previewUrl = `${ORIGIN}/api/gallery/${id}/preview.svg?v=${revision}`;
+    const cache = memoryPreviewCache();
+
+    env.galleryQueries.length = 0;
+    const first = await routeGalleryRequest(new Request(previewUrl), env, {
+      previewCache: cache,
+    });
+    expect(first?.status).toBe(200);
+    const firstSvg = await first!.text();
+    expect(firstSvg).toContain("<svg");
+    expect(cache.putCalls).toEqual([previewUrl]);
+    const coldQuery = env.galleryQueries.find((query) =>
+      query.includes("svg_text"),
+    );
+    expect(coldQuery).toBeDefined();
+    expect(coldQuery).not.toContain("project_text");
+
+    env.galleryQueries.length = 0;
+    const second = await routeGalleryRequest(new Request(previewUrl), env, {
+      previewCache: cache,
+    });
+    expect(await second!.text()).toBe(firstSvg);
+    expect(cache.putCalls).toHaveLength(1);
+    expect(env.galleryQueries.some((query) => query.includes("svg_text"))).toBe(
+      false,
+    );
+    expect(
+      env.galleryQueries.some(
+        (query) =>
+          query.includes("status") && query.includes("preview_revision"),
+      ),
+    ).toBe(true);
+
+    const recycled = await route(
+      env,
+      new Request(`${ORIGIN}/api/gallery/${id}/recycle`, {
+        method: "POST",
+        headers: cookieHeaders(adminCookie),
+      }),
+    );
+    expect(recycled.status).toBe(200);
+    const hidden = await routeGalleryRequest(new Request(previewUrl), env, {
+      previewCache: cache,
+    });
+    expect(hidden?.status).toBe(404);
+    expect(hidden?.headers.get("cache-control")).toBe("no-store");
   });
 
   it("publishes and updates a hierarchical Project with its top-level Cell preview", async () => {
@@ -1593,7 +1693,8 @@ function wiredProjectText(name = "Wired", secondResistorX = 200): string {
         rotation: 0,
         mirror: "none",
       },
-      reference: "R1", netlist: { parameters: {} },
+      reference: "R1",
+      netlist: { parameters: {} },
     },
     {
       id: "R2",
@@ -1603,7 +1704,8 @@ function wiredProjectText(name = "Wired", secondResistorX = 200): string {
         rotation: 0,
         mirror: "none",
       },
-      reference: "R2", netlist: { parameters: {} },
+      reference: "R2",
+      netlist: { parameters: {} },
     },
   ];
   document.nets = [

--- a/worker/gallery.ts
+++ b/worker/gallery.ts
@@ -54,6 +54,49 @@ async function callGallery<T>(
   return { status: response.status, payload: (await response.json()) as T };
 }
 
+export interface GalleryPreviewCache {
+  match(request: Request): Promise<Response | undefined>;
+  put(request: Request, response: Response): Promise<void>;
+}
+
+export interface GalleryRouteRuntime {
+  /** Injectable in tests; production falls back to Cloudflare's default cache. */
+  previewCache?: GalleryPreviewCache | null;
+}
+
+function defaultPreviewCache(): GalleryPreviewCache | null {
+  if (typeof caches === "undefined") return null;
+  return (
+    (caches as CacheStorage & { readonly default?: Cache }).default ?? null
+  );
+}
+
+async function matchPreviewCache(
+  cache: GalleryPreviewCache | null,
+  request: Request,
+): Promise<Response | undefined> {
+  if (!cache) return undefined;
+  try {
+    return await cache.match(request);
+  } catch {
+    // A cache outage must degrade to the canonical GalleryDO path.
+    return undefined;
+  }
+}
+
+async function storePreviewCache(
+  cache: GalleryPreviewCache | null,
+  request: Request,
+  response: Response,
+): Promise<void> {
+  if (!cache) return;
+  try {
+    await cache.put(request, response);
+  } catch {
+    // The response is still valid when an edge refuses or evicts the entry.
+  }
+}
+
 function sameOrigin(request: Request): boolean {
   const expected = new URL(request.url).origin;
   const origin = request.headers.get("Origin");
@@ -494,6 +537,7 @@ async function handleEntryUpdate(
 export async function routeGalleryRequest(
   request: Request,
   env: GalleryEnv,
+  runtime: GalleryRouteRuntime = {},
 ): Promise<Response | null> {
   const url = new URL(request.url);
   if (url.pathname === "/api/projects") {
@@ -743,12 +787,36 @@ export async function routeGalleryRequest(
     return Response.json(payload, { status });
   }
   if (segments.length === 2 && segments[1] === "preview.svg") {
+    const requestedRevision = url.searchParams.get("v");
+    const previewCache =
+      request.method === "GET" && requestedRevision
+        ? runtime.previewCache === undefined
+          ? defaultPreviewCache()
+          : runtime.previewCache
+        : null;
+    const cached = await matchPreviewCache(previewCache, request);
+    if (cached) {
+      // A content URL stays immutable, but publication status does not. Check
+      // the tiny access row before serving an edge hit so recycle/reject/delete
+      // and a newer current revision retain exactly their existing behavior.
+      const access = await callGallery<{
+        status?: string;
+        previewRevision?: string;
+      }>(env, "preview-access", { id: segments[0] });
+      if (
+        access.status === 200 &&
+        access.payload.status === "public" &&
+        access.payload.previewRevision === requestedRevision
+      ) {
+        return cached;
+      }
+    }
     const { status, payload } = await callGallery<{
       status?: string;
-      entry?: GalleryEntrySummary;
       ownerUserId?: string | null;
+      previewRevision?: string;
       svgText?: string;
-    }>(env, "any-entry", { id: segments[0] });
+    }>(env, "preview", { id: segments[0] });
     if (status !== 200 || !payload.svgText) {
       return Response.json(
         { error: "not-found" },
@@ -759,12 +827,11 @@ export async function routeGalleryRequest(
       // A matching revision URL names immutable bytes. Old and unversioned
       // clients still receive the current image, but it is never stored under
       // a mutable or incorrect cache key.
-      const requestedRevision = url.searchParams.get("v");
-      const currentRevision = payload.entry?.previewRevision;
+      const currentRevision = payload.previewRevision;
       const immutable =
         typeof currentRevision === "string" &&
         requestedRevision === String(currentRevision);
-      return new Response(payload.svgText, {
+      const response = new Response(payload.svgText, {
         headers: {
           "content-type": "image/svg+xml",
           "cache-control": immutable
@@ -774,6 +841,10 @@ export async function routeGalleryRequest(
             "default-src 'none'; style-src 'unsafe-inline'",
         },
       });
+      if (immutable) {
+        await storePreviewCache(previewCache, request, response.clone());
+      }
+      return response;
     }
     const allowed =
       (await canReview(request, env)) ||


### PR DESCRIPTION
## Summary

- skip the AuthDO round trip when no non-empty icm_session cookie exists
- read only Gallery summary fields for feed pages and only preview fields for SVG requests
- cache revision-addressed public previews at the edge while revalidating publication status and current revision on every hit
- keep the editor, DOM, CSS, 30-entry pagination, rendering, filtering, likes, and moderation behavior unchanged

## Behavior boundary

A cached preview is never served solely because the URL exists. The Worker first checks the GalleryDO's minimal access row; recycled, rejected, deleted, or superseded entries follow the same 404/no-store or owner/reviewer path as before.

## Validation

- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
  - 347 test files, 2261 passed, 5 skipped
  - Gallery browser: 40 passed
- pnpm build
- git diff --check

Test-Impact: tests-updated