### PR TITLE
fix(editor): diagnose route chunk failures before recovery

### DIFF
--- a/apps/editor/e2e/runtime-crash-safety.spec.ts
+++ b/apps/editor/e2e/runtime-crash-safety.spec.ts
@@ -38,6 +38,31 @@ test("a render crash shows the recovery screen instead of a blank page", async (
   await expect(page.getByTestId("schematic-canvas")).toBeVisible();
 });
 
+test("a repeated route chunk failure is not misreported as an old build", async ({
+  page,
+}) => {
+  // #529 named the App chunk from the current deployment. Aborting its route
+  // reproduces a transient dynamic-import failure rather than a retired 404.
+  await page.route("**/src/app/App.tsx*", (route) => route.abort());
+  await page.goto("/editor");
+
+  // The loader retries one navigation. The second failure reaches a neutral,
+  // correctly diagnosed loading screen instead of the stale-build warning.
+  const crashScreen = page.getByTestId("editor-crash-screen");
+  await expect(crashScreen).toBeVisible();
+  await expect(crashScreen).toContainText(
+    "The editor could not finish loading",
+  );
+  await expect(crashScreen).toContainText("temporarily unavailable");
+  await expect(crashScreen).not.toContainText(
+    "This page is running an old version",
+  );
+  await expect(
+    crashScreen.getByRole("button", { name: "Try again" }),
+  ).toBeVisible();
+  await expect(crashScreen.getByTestId("crash-reload-clean")).toBeVisible();
+});
+
 test("a failed dialog chunk degrades to a scoped notice, not the crash screen", async ({
   page,
 }) => {

--- a/apps/editor/src/components/editor-error-boundary.test.tsx
+++ b/apps/editor/src/components/editor-error-boundary.test.tsx
@@ -44,4 +44,21 @@ describe("EditorCrashScreen", () => {
     expect(html).toContain("The editor hit an unexpected problem");
     expect(html).not.toContain("crash-reload-clean");
   });
+
+  it("does not call a temporary module failure an old version", () => {
+    const html = renderToStaticMarkup(
+      <EditorCrashScreen
+        message="A required editor file was temporarily unavailable: /assets/App-current.js"
+        moduleLoadFailure
+        onReload={() => undefined}
+        onRecover={() => undefined}
+      />,
+    );
+    expect(html).toContain("The editor could not finish loading");
+    expect(html).toContain("temporarily unavailable");
+    expect(html).toContain("Try again");
+    expect(html).toContain("Reload with a clean copy");
+    expect(html).not.toContain("running an old version");
+    expect(html).toContain('data-kind="load"');
+  });
 });

--- a/apps/editor/src/components/editor-error-boundary.tsx
+++ b/apps/editor/src/components/editor-error-boundary.tsx
@@ -5,6 +5,7 @@ import { BugReportLink } from "./bug-report-link";
 import {
   browserStaleBuildRecovery,
   isStaleBuildFailure,
+  isTemporaryModuleLoadFailure,
   recoverFromStaleBuild,
 } from "./stale-build-recovery";
 
@@ -43,10 +44,13 @@ export class EditorErrorBoundary extends Component<
 
   override render(): ReactNode {
     if (this.state.error !== null) {
+      const staleBuild = isStaleBuildFailure(this.state.error);
+      const moduleLoadFailure = isTemporaryModuleLoadFailure(this.state.error);
       return (
         <EditorCrashScreen
           message={this.state.error.message}
-          staleBuild={isStaleBuildFailure(this.state.error.message)}
+          staleBuild={staleBuild}
+          moduleLoadFailure={moduleLoadFailure}
           onReload={() => window.location.reload()}
           onRecover={() =>
             void recoverFromStaleBuild(browserStaleBuildRecovery())
@@ -66,6 +70,8 @@ export interface EditorCrashScreenProps {
    * reload can hand back the same document and fail again. Reported in #493.
    */
   staleBuild?: boolean;
+  /** The named module was not missing, so do not mislabel it as an update. */
+  moduleLoadFailure?: boolean;
   onRecover?(): void;
 }
 
@@ -73,8 +79,10 @@ export function EditorCrashScreen({
   message,
   onReload,
   staleBuild = false,
+  moduleLoadFailure = false,
   onRecover,
 }: EditorCrashScreenProps) {
+  const kind = staleBuild ? "stale" : moduleLoadFailure ? "load" : "crash";
   return (
     <div
       className="editor-crash-screen"
@@ -82,16 +90,20 @@ export function EditorCrashScreen({
       role="alert"
       aria-labelledby="editor-crash-title"
     >
-      <div className="editor-crash-panel">
+      <div className="editor-crash-panel" data-kind={kind}>
         <h1 id="editor-crash-title">
           {staleBuild
             ? "This page is running an old version of the editor"
-            : "The editor hit an unexpected problem"}
+            : moduleLoadFailure
+              ? "The editor could not finish loading"
+              : "The editor hit an unexpected problem"}
         </h1>
         <p>
           {staleBuild
             ? "The app was updated after this page opened, so part of it can no longer load. Reloading with a clean copy fixes it. Your recent committed work is kept in this browser's recovery copies."
-            : "Rendering stopped with an internal error. Your recent committed work is kept in this browser's recovery copies."}
+            : moduleLoadFailure
+              ? "A required application file was temporarily unavailable. Try again; if the problem continues, reload with a clean copy. Your browser recovery copies are safe."
+              : "Rendering stopped with an internal error. Your recent committed work is kept in this browser's recovery copies."}
         </p>
         <p>
           <code>{message}</code>
@@ -107,8 +119,17 @@ export function EditorCrashScreen({
             </button>
           ) : null}
           <button type="button" onClick={onReload}>
-            Reload editor
+            {moduleLoadFailure ? "Try again" : "Reload editor"}
           </button>
+          {moduleLoadFailure && onRecover ? (
+            <button
+              type="button"
+              data-testid="crash-reload-clean"
+              onClick={onRecover}
+            >
+              Reload with a clean copy
+            </button>
+          ) : null}
           <BugReportLink
             testId="crash-report-bug"
             surface="Unexpected problem screen"

--- a/apps/editor/src/components/route-chunk-loader.test.ts
+++ b/apps/editor/src/components/route-chunk-loader.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { guardedRouteChunk } from "./route-chunk-loader";
+import type { RouteChunkRuntime } from "./route-chunk-loader";
+import {
+  ConfirmedStaleBuildError,
+  TemporaryModuleLoadError,
+} from "./stale-build-recovery";
+import type { ModuleLoadDiagnosis } from "./stale-build-recovery";
+
+function runtime(
+  diagnosis: ModuleLoadDiagnosis,
+  remembered: string | null = null,
+) {
+  const reload = vi.fn();
+  const cleanReload = vi.fn(() => Promise.resolve());
+  const rememberReload = vi.fn(() => true);
+  const forgetReload = vi.fn();
+  const delay = vi.fn(() => Promise.resolve());
+  const value: RouteChunkRuntime = {
+    pathname: "/editor",
+    rememberedReload: () => remembered,
+    rememberReload,
+    forgetReload,
+    diagnose: () => Promise.resolve(diagnosis),
+    delay,
+    reload,
+    cleanReload,
+  };
+  return {
+    value,
+    reload,
+    cleanReload,
+    rememberReload,
+    forgetReload,
+    delay,
+  };
+}
+
+describe("guardedRouteChunk", () => {
+  it("passes a loaded route through and clears the retry guard", async () => {
+    const context = runtime({ kind: "temporary", assetUrl: null });
+    const module = { default: "editor" };
+    await expect(
+      guardedRouteChunk(() => Promise.resolve(module), context.value)(),
+    ).resolves.toBe(module);
+    expect(context.forgetReload).toHaveBeenCalledOnce();
+  });
+
+  it("clean-reloads once when the named asset is confirmed missing", async () => {
+    const context = runtime({
+      kind: "stale-build",
+      assetUrl: "https://example.test/assets/App-old.js",
+      status: 404,
+    });
+    void guardedRouteChunk(
+      () => Promise.reject(new TypeError("dynamic import failed")),
+      context.value,
+    )();
+    await vi.waitFor(() => expect(context.cleanReload).toHaveBeenCalledOnce());
+    expect(context.rememberReload).toHaveBeenCalledWith("/editor");
+    expect(context.reload).not.toHaveBeenCalled();
+  });
+
+  it("delays and ordinarily reloads once for a temporary failure", async () => {
+    const context = runtime({
+      kind: "temporary",
+      assetUrl: "https://example.test/assets/App-current.js",
+      status: 200,
+    });
+    void guardedRouteChunk(
+      () => Promise.reject(new TypeError("dynamic import failed")),
+      context.value,
+    )();
+    await vi.waitFor(() => expect(context.reload).toHaveBeenCalledOnce());
+    expect(context.delay).toHaveBeenCalledWith(750);
+    expect(context.cleanReload).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the confirmed diagnosis instead of reloading twice", async () => {
+    const stale = runtime(
+      {
+        kind: "stale-build",
+        assetUrl: "https://example.test/assets/App-old.js",
+        status: 404,
+      },
+      "/editor",
+    );
+    await expect(
+      guardedRouteChunk(
+        () => Promise.reject(new TypeError("dynamic import failed")),
+        stale.value,
+      )(),
+    ).rejects.toBeInstanceOf(ConfirmedStaleBuildError);
+    expect(stale.cleanReload).not.toHaveBeenCalled();
+
+    const temporary = runtime(
+      {
+        kind: "temporary",
+        assetUrl: "https://example.test/assets/App-current.js",
+        status: 200,
+      },
+      "/editor",
+    );
+    await expect(
+      guardedRouteChunk(
+        () => Promise.reject(new TypeError("dynamic import failed")),
+        temporary.value,
+      )(),
+    ).rejects.toBeInstanceOf(TemporaryModuleLoadError);
+    expect(temporary.reload).not.toHaveBeenCalled();
+  });
+});

--- a/apps/editor/src/components/route-chunk-loader.ts
+++ b/apps/editor/src/components/route-chunk-loader.ts
@@ -1,0 +1,101 @@
+import {
+  browserStaleBuildRecovery,
+  ConfirmedStaleBuildError,
+  diagnoseModuleLoadFailure,
+  recoverFromStaleBuild,
+  TemporaryModuleLoadError,
+} from "./stale-build-recovery";
+import type { ModuleLoadDiagnosis } from "./stale-build-recovery";
+
+const CHUNK_RELOAD_KEY = "icm-chunk-reload";
+const TEMPORARY_RETRY_DELAY_MS = 750;
+
+export interface RouteChunkRuntime {
+  readonly pathname: string;
+  rememberedReload(): string | null;
+  rememberReload(pathname: string): boolean;
+  forgetReload(): void;
+  diagnose(error: unknown): Promise<ModuleLoadDiagnosis>;
+  delay(milliseconds: number): Promise<void>;
+  reload(): void;
+  cleanReload(): Promise<void>;
+}
+
+function browserRuntime(): RouteChunkRuntime {
+  return {
+    pathname: window.location.pathname,
+    rememberedReload: () => {
+      try {
+        return sessionStorage.getItem(CHUNK_RELOAD_KEY);
+      } catch {
+        return window.location.pathname;
+      }
+    },
+    rememberReload: (pathname) => {
+      try {
+        sessionStorage.setItem(CHUNK_RELOAD_KEY, pathname);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    forgetReload: () => {
+      try {
+        sessionStorage.removeItem(CHUNK_RELOAD_KEY);
+      } catch {
+        // A private browser can refuse storage; there is nothing to forget.
+      }
+    },
+    diagnose: (error) =>
+      diagnoseModuleLoadFailure(error, {
+        currentUrl: window.location.href,
+        fetch: (input, init) => window.fetch(input, init),
+      }),
+    delay: (milliseconds) =>
+      new Promise((resolve) => window.setTimeout(resolve, milliseconds)),
+    reload: () => window.location.reload(),
+    cleanReload: () => recoverFromStaleBuild(browserStaleBuildRecovery()),
+  };
+}
+
+function publicFailure(diagnosis: ModuleLoadDiagnosis, cause: unknown): Error {
+  return diagnosis.kind === "stale-build"
+    ? new ConfirmedStaleBuildError(diagnosis.assetUrl, cause)
+    : new TemporaryModuleLoadError(diagnosis.assetUrl, cause);
+}
+
+/**
+ * Load one route chunk and recover once without guessing why it failed.
+ *
+ * A confirmed missing asset receives a clean reload. A current, unreachable,
+ * or otherwise unconfirmed asset receives one delayed ordinary reload. The
+ * second failure is surfaced with the diagnosis instead of entering a loop.
+ */
+export function guardedRouteChunk<T>(
+  load: () => Promise<T>,
+  runtime: RouteChunkRuntime = browserRuntime(),
+): () => Promise<T> {
+  return async () => {
+    try {
+      const module = await load();
+      runtime.forgetReload();
+      return module;
+    } catch (cause) {
+      const diagnosis = await runtime.diagnose(cause);
+      const failure = publicFailure(diagnosis, cause);
+      if (runtime.rememberedReload() === runtime.pathname) throw failure;
+      if (!runtime.rememberReload(runtime.pathname)) throw failure;
+
+      if (diagnosis.kind === "stale-build") {
+        await runtime.cleanReload();
+      } else {
+        await runtime.delay(TEMPORARY_RETRY_DELAY_MS);
+        runtime.reload();
+      }
+
+      // Navigation replaces this document. Keep React.lazy pending so the
+      // failed graph cannot render or report a second error while it unloads.
+      return await new Promise<T>(() => {});
+    }
+  };
+}

--- a/apps/editor/src/components/stale-build-recovery.test.ts
+++ b/apps/editor/src/components/stale-build-recovery.test.ts
@@ -1,35 +1,108 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  ConfirmedStaleBuildError,
+  diagnoseModuleLoadFailure,
   isStaleBuildFailure,
+  isTemporaryModuleLoadFailure,
   recoverFromStaleBuild,
+  TemporaryModuleLoadError,
 } from "./stale-build-recovery";
 
 describe("recognising a build a page can no longer load", () => {
-  it("knows the browsers' several spellings of a missing chunk", () => {
-    // The message a person reported in #493, plus the forms other engines
-    // use for the same event. Getting this wrong offers the wrong remedy.
+  it("does not call a browser's ambiguous import message proof of a stale build", () => {
+    // #529 named a module that was part of the current deployment and later
+    // answered 200. Browsers use the same message for that transient failure
+    // and for the true missing-chunk failure from #493.
     expect(
       isStaleBuildFailure(
-        "Failed to fetch dynamically imported module: https://example.test/assets/App-L9bGmgOj.js",
+        new TypeError(
+          "Failed to fetch dynamically imported module: https://example.test/assets/App-current.js",
+        ),
       ),
-    ).toBe(true);
-    expect(
-      isStaleBuildFailure("error loading dynamically imported module"),
-    ).toBe(true);
-    expect(isStaleBuildFailure("Importing a module script failed.")).toBe(true);
-    expect(
-      isStaleBuildFailure(
-        "Properties could not load — the app has been updated since this tab opened",
-      ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it("does not claim an ordinary crash is a stale build", () => {
-    expect(isStaleBuildFailure("Cannot read properties of undefined")).toBe(
-      false,
+  it("recognises only errors created after the asset probe", () => {
+    const raw = new TypeError("dynamic import failed");
+    const stale = new ConfirmedStaleBuildError(
+      "https://example.test/assets/App-old.js",
+      raw,
     );
-    expect(isStaleBuildFailure("Route net does not exist: net-h")).toBe(false);
+    const temporary = new TemporaryModuleLoadError(
+      "https://example.test/assets/App-current.js",
+      raw,
+    );
+    expect(isStaleBuildFailure(stale)).toBe(true);
+    expect(isStaleBuildFailure(temporary)).toBe(false);
+    expect(isTemporaryModuleLoadFailure(temporary)).toBe(true);
+    expect(isTemporaryModuleLoadFailure(raw)).toBe(false);
+  });
+});
+
+describe("diagnosing a dynamic module failure", () => {
+  const currentUrl = "https://example.test/editor";
+  const failure = new TypeError(
+    "Failed to fetch dynamically imported module: https://example.test/assets/App-build.js",
+  );
+
+  it("confirms a stale build only when the named same-origin asset is 404", async () => {
+    const fetch = vi.fn(() =>
+      Promise.resolve(new Response(null, { status: 404 })),
+    );
+    await expect(
+      diagnoseModuleLoadFailure(failure, { currentUrl, fetch }),
+    ).resolves.toEqual({
+      kind: "stale-build",
+      assetUrl: "https://example.test/assets/App-build.js",
+      status: 404,
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      "https://example.test/assets/App-build.js",
+      expect.objectContaining({ method: "HEAD", cache: "no-store" }),
+    );
+  });
+
+  it("keeps a current asset failure temporary when the probe is 200", async () => {
+    await expect(
+      diagnoseModuleLoadFailure(failure, {
+        currentUrl,
+        fetch: () => Promise.resolve(new Response(null, { status: 200 })),
+      }),
+    ).resolves.toEqual({
+      kind: "temporary",
+      assetUrl: "https://example.test/assets/App-build.js",
+      status: 200,
+    });
+  });
+
+  it("keeps network, cross-origin, and URL-less failures temporary", async () => {
+    await expect(
+      diagnoseModuleLoadFailure(failure, {
+        currentUrl,
+        fetch: () => Promise.reject(new Error("offline")),
+      }),
+    ).resolves.toEqual({
+      kind: "temporary",
+      assetUrl: "https://example.test/assets/App-build.js",
+    });
+    await expect(
+      diagnoseModuleLoadFailure(
+        new TypeError(
+          "Failed to fetch dynamically imported module: https://other.test/assets/App-build.js",
+        ),
+        {
+          currentUrl,
+          fetch: () => Promise.resolve(new Response(null, { status: 404 })),
+        },
+      ),
+    ).resolves.toEqual({ kind: "temporary", assetUrl: null });
+    await expect(
+      diagnoseModuleLoadFailure(new TypeError("module load failed"), {
+        currentUrl,
+        fetch: () => Promise.resolve(new Response(null, { status: 404 })),
+      }),
+    ).resolves.toEqual({ kind: "temporary", assetUrl: null });
   });
 });
 

--- a/apps/editor/src/components/stale-build-recovery.ts
+++ b/apps/editor/src/components/stale-build-recovery.ts
@@ -15,21 +15,118 @@
  */
 const SHELL_CACHE_PREFIX = "icm-static-shell-";
 
+export type ModuleLoadDiagnosis =
+  | {
+      kind: "stale-build";
+      assetUrl: string;
+      status: 404;
+    }
+  | {
+      kind: "temporary";
+      assetUrl: string | null;
+      status?: number;
+    };
+
+export interface ModuleLoadProbeSurfaces {
+  readonly currentUrl: string;
+  fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+}
+
+export class ConfirmedStaleBuildError extends Error {
+  override readonly name = "ConfirmedStaleBuildError";
+
+  constructor(
+    readonly assetUrl: string,
+    override readonly cause: unknown,
+  ) {
+    super(`This build can no longer load ${new URL(assetUrl).pathname}`);
+  }
+}
+
+export class TemporaryModuleLoadError extends Error {
+  override readonly name = "TemporaryModuleLoadError";
+
+  constructor(
+    readonly assetUrl: string | null,
+    override readonly cause: unknown,
+  ) {
+    super(
+      assetUrl === null
+        ? "A required editor file was temporarily unavailable"
+        : `A required editor file was temporarily unavailable: ${new URL(assetUrl).pathname}`,
+    );
+  }
+}
+
 export interface StaleBuildRecoverySurfaces {
   readonly caches?: CacheStorage;
   readonly serviceWorker?: ServiceWorkerContainer;
   reload(): void;
 }
 
-/** Whether a failure looks like a chunk this build can no longer fetch. */
-export function isStaleBuildFailure(message: string): boolean {
-  const text = message.toLowerCase();
-  return (
-    text.includes("dynamically imported module") ||
-    text.includes("failed to fetch dynamically") ||
-    text.includes("importing a module script failed") ||
-    text.includes("has been updated since this tab opened")
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function moduleAssetUrl(error: unknown, currentUrl: string): string | null {
+  const match = messageOf(error).match(
+    /(?:https?:\/\/[^\s"'<>]+|\/assets\/[^\s"'<>]+\.js(?:\?[^\s"'<>]*)?)/u,
   );
+  if (!match) return null;
+  try {
+    const current = new URL(currentUrl);
+    const asset = new URL(match[0], current);
+    if (
+      asset.origin !== current.origin ||
+      !asset.pathname.startsWith("/assets/") ||
+      !asset.pathname.endsWith(".js")
+    ) {
+      return null;
+    }
+    return asset.toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Probe the file named by a dynamic-import failure before blaming a deploy.
+ * The browser uses the same error text for a retired chunk, a network outage,
+ * and a temporarily unavailable current chunk. Only an observed 404 proves
+ * that this document names a file the active deployment no longer has.
+ */
+export async function diagnoseModuleLoadFailure(
+  error: unknown,
+  surfaces: ModuleLoadProbeSurfaces,
+): Promise<ModuleLoadDiagnosis> {
+  const assetUrl = moduleAssetUrl(error, surfaces.currentUrl);
+  if (assetUrl === null) return { kind: "temporary", assetUrl: null };
+  try {
+    const response = await surfaces.fetch(assetUrl, {
+      method: "HEAD",
+      cache: "no-store",
+      credentials: "same-origin",
+    });
+    if (response.status === 404) {
+      return { kind: "stale-build", assetUrl, status: 404 };
+    }
+    return {
+      kind: "temporary",
+      assetUrl,
+      status: response.status,
+    };
+  } catch {
+    return { kind: "temporary", assetUrl };
+  }
+}
+
+/** Whether a failure has been confirmed as a missing chunk, not guessed. */
+export function isStaleBuildFailure(error: unknown): boolean {
+  return error instanceof ConfirmedStaleBuildError;
+}
+
+export function isTemporaryModuleLoadFailure(error: unknown): boolean {
+  return error instanceof TemporaryModuleLoadError;
 }
 
 export async function recoverFromStaleBuild(

--- a/apps/editor/src/main.tsx
+++ b/apps/editor/src/main.tsx
@@ -2,6 +2,7 @@ import { lazy, StrictMode, Suspense, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 
 import { EditorErrorBoundary } from "./components/editor-error-boundary";
+import { guardedRouteChunk } from "./components/route-chunk-loader";
 import "./styles.css";
 
 const container = document.getElementById("root");
@@ -12,58 +13,8 @@ if (!container) {
 
 type VisitStats = { pv: number; uv: number; scope: "all" };
 
-/**
- * Load a route chunk, surviving a deploy that lands mid-session.
- *
- * Chunk names carry a content hash, so a page that has been open across a
- * deploy asks for names the current build no longer has. Reloading is the
- * whole remedy: `index.html` is served `must-revalidate` and the service
- * worker fetches navigations network-first, so the next document names the
- * assets that do exist.
- *
- * Exactly once per route per session. If the freshly loaded graph still
- * cannot produce the chunk, the failure is real and belongs in front of the
- * person rather than in a reload loop.
- */
-const CHUNK_RELOAD_KEY = "icm-chunk-reload";
-
-function rememberedReload(): string | null {
-  try {
-    return sessionStorage.getItem(CHUNK_RELOAD_KEY);
-  } catch {
-    // Private modes can refuse storage; then a reload is simply not retried.
-    return window.location.pathname;
-  }
-}
-
-function lazyChunk<T>(load: () => Promise<T>): () => Promise<T> {
-  return () =>
-    load().then(
-      (module) => {
-        try {
-          sessionStorage.removeItem(CHUNK_RELOAD_KEY);
-        } catch {
-          // Nothing to clear when storage is unavailable.
-        }
-        return module;
-      },
-      (error: unknown) => {
-        if (rememberedReload() === window.location.pathname) throw error;
-        try {
-          sessionStorage.setItem(CHUNK_RELOAD_KEY, window.location.pathname);
-        } catch {
-          // Without storage the guard cannot hold, so do not reload at all.
-          throw error;
-        }
-        window.location.reload();
-        // The reload replaces this document; nothing downstream should run.
-        return new Promise<T>(() => {});
-      },
-    );
-}
-
 const EditorApp = lazy(
-  lazyChunk(() =>
+  guardedRouteChunk(() =>
     import("./app/App").then((module) => ({
       default: module.App,
     })),
@@ -71,7 +22,7 @@ const EditorApp = lazy(
 );
 
 const AnalyticsPage = lazy(
-  lazyChunk(() =>
+  guardedRouteChunk(() =>
     import("./components/analytics-page").then((module) => ({
       default: module.AnalyticsPage,
     })),
@@ -79,7 +30,7 @@ const AnalyticsPage = lazy(
 );
 
 const GalleryFeed = lazy(
-  lazyChunk(() =>
+  guardedRouteChunk(() =>
     import("./components/gallery-feed").then((module) => ({
       default: module.GalleryFeed,
     })),
@@ -87,7 +38,7 @@ const GalleryFeed = lazy(
 );
 
 const Moderation = lazy(
-  lazyChunk(() =>
+  guardedRouteChunk(() =>
     import("./components/moderation").then((module) => ({
       default: module.Moderation,
     })),
@@ -95,7 +46,7 @@ const Moderation = lazy(
 );
 
 const MySubmissions = lazy(
-  lazyChunk(() =>
+  guardedRouteChunk(() =>
     import("./components/my-submissions").then((module) => ({
       default: module.MySubmissions,
     })),

--- a/apps/editor/src/styles/editor-chrome.css
+++ b/apps/editor/src/styles/editor-chrome.css
@@ -800,6 +800,11 @@
   box-shadow: var(--icm-shadow-lg);
 }
 
+.editor-crash-panel[data-kind="load"] {
+  border-color: var(--icm-border-strong);
+  background: var(--icm-surface);
+}
+
 .editor-crash-panel h1 {
   margin: 0;
   font-size: var(--icm-font-lg);


### PR DESCRIPTION
## What changed

- probe the same-origin module named by a route import failure before selecting recovery
- treat only an observed 404 as a confirmed stale build and perform one clean reload
- treat current, unreachable, 5xx, and unconfirmed modules as temporary failures with one delayed retry
- show a neutral, accurate loading screen if a temporary failure repeats
- keep the existing generic crash boundary unchanged

## Why

Issue #529 reported App-BiXdSVz4.js, which is the App chunk referenced by the current production entry and currently returns 200 text/javascript. The browser's generic dynamic-import message therefore was not proof that the page was old. The previous string-only classifier misdiagnosed transient availability failures as stale builds.

## Validation

- pnpm gate:preflight -- --base origin/main
- ICM_E2E_PORT=4175 ICM_E2E_ISOLATED=1 pnpm gate:affected -- --base origin/main
  - 350 unit files passed; 2272 tests passed, 5 skipped
  - 7 runtime/chrome browser tests passed
- controlled browser reproduction by withholding the real App chunk

The isolated E2E port avoids a user-owned Editor dev server already running from another worktree on port 4173.