### PR TITLE
test(editor): prove the recovery button recovers, not just that it clears

### DIFF
--- a/apps/editor/e2e/runtime-crash-safety.spec.ts
+++ b/apps/editor/e2e/runtime-crash-safety.spec.ts
@@ -63,6 +63,54 @@ test("a repeated route chunk failure is not misreported as an old build", async 
   await expect(crashScreen.getByTestId("crash-reload-clean")).toBeVisible();
 });
 
+/**
+ * The recovery screen's own promise, tested end to end.
+ *
+ * #529 was reported twice by the same person. Everything shipped for it so
+ * far made the failure honest — an accurate message, a correct diagnosis —
+ * and none of it proved the way out actually works. The unit tests show the
+ * button clears the shell caches and unregisters the worker; they cannot show
+ * that the page boots afterwards, which is the only part the person cares
+ * about.
+ */
+test("the recovery button gets a stuck page back into the editor", async ({
+  page,
+}) => {
+  // A retired chunk: the shape that genuinely means "this document can no
+  // longer boot", as distinct from the transient failure above.
+  let chunkRetired = true;
+  await page.route("**/src/app/App.tsx*", (route) => {
+    if (chunkRetired) return route.fulfill({ status: 404, body: "" });
+    return route.continue();
+  });
+  await page.goto("/editor");
+
+  const crashScreen = page.getByTestId("editor-crash-screen");
+  await expect(crashScreen).toBeVisible();
+  const recover = crashScreen.getByTestId("crash-reload-clean");
+  await expect(recover).toBeVisible();
+
+  // A shell cache from the build that can no longer boot. Without this the
+  // test would pass on an ordinary reload and prove nothing about the word
+  // "clean", which is the half that gets a genuinely stuck page unstuck.
+  await page.evaluate(async () => {
+    const cache = await caches.open("icm-static-shell-stale-build");
+    await cache.put("/stale-marker", new Response("stale"));
+  });
+
+  // Reloading with a clean copy is what a person does after a deploy has
+  // finished, so the chunk it asks for exists again.
+  chunkRetired = false;
+  await recover.click();
+
+  await expect(page.getByTestId("schematic-canvas")).toBeVisible();
+  await expect(crashScreen).toHaveCount(0);
+  // The build's cached shell is gone, not merely bypassed by the reload.
+  expect(await page.evaluate(() => caches.keys())).not.toContain(
+    "icm-static-shell-stale-build",
+  );
+});
+
 test("a failed dialog chunk degrades to a scoped notice, not the crash screen", async ({
   page,
 }) => {


### PR DESCRIPTION
Follows #530 on issue #529. Tests only; no production defect is fixed here.

## What #529 actually was, and where it stands

The reporter's screenshot shows the recovery screen working: it rendered even
though the missing module *was* the App chunk, and it already offered "Reload
with a clean copy". So the fallback survives the failure it exists for.

#530 landed and deployed about half an hour before this branch, and corrected
the diagnosis: the chunk named in the report belonged to the current
deployment, so the browser's generic dynamic-import message was not evidence of
a stale build. Calling it one was the defect.

**Production verified healthy while writing this**, in a browser rather than
from a pipeline badge: `/editor` loads, the canvas renders, no console errors,
the current entry chunk answers `200`, and the chunk named in the report is
retired as expected. The shell is served `max-age=0, must-revalidate`, and the
service worker treats navigation as network-first, so an ordinary reload does
reach a fresh document.

## The gap this closes

Everything shipped for #529 so far made the failure *honest*: #454 offered a
refresh, #519 made a missing chunk 404 truthfully, #530 stopped misnaming a
transient failure. None of it proved the way out **works**, and the way out is
the only part the person is asking about — they reported the same thing twice.

The unit tests show the button clears the shell caches and unregisters the
worker. They cannot show the page boots afterwards. This drives the real screen
in a browser: retire the App chunk, let the recovery screen appear, restore the
chunk the way a finished deploy would, click the button, and require the editor
to come back.

**The first version of this test was worthless and I nearly shipped it.** It
passed with the recovery swapped for an ordinary reload, so it proved nothing
about the word "clean" — only that a reload works once the chunk exists again.
It now seeds a shell cache from the build that cannot boot and requires that
cache to be gone afterwards. Removing the clearing turns it red, which is the
whole point of having it.

## Verification

- Five browser tests in `runtime-crash-safety.spec.ts`, all green, run under
  the gate lock on an uncontended machine.
- Verified red-then-green twice: once against the recovery being removed, and
  once against the weaker first draft, which is why the assertion is what it is.

## Still open, and not mine to decide

The reporter has had no reply he can act on. The existing comment on #529 is
addressed to the owner and explains the code. He was never told what to do to
get unstuck, which is why a second report was reasonable. A reply is drafted
and waiting on the repository owner, since it posts publicly under their
account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
