### PR TITLE
feat(ci): look at the build somewhere private before the public does

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -17,8 +17,98 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # A place to look at the build before the public does. Merging to main used
+  # to deploy straight to production, so the only protection was after the
+  # fact: the bad version went live and came back seconds later.
+  #
+  # Skipped entirely when STAGING_ACCESS_KEY is absent, so this lands without
+  # blocking anyone's deploy while the environment is being provisioned. The
+  # production job does not depend on staging SUCCEEDING, only on it not
+  # FAILING, which `always()` plus an explicit result check expresses below.
+  staging:
+    name: Deploy staging
+    runs-on: ubuntu-latest
+    outputs:
+      ran: ${{ steps.gate.outputs.ran }}
+    steps:
+      - id: gate
+        run: |
+          if [ -n "${{ secrets.STAGING_ACCESS_KEY }}" ]; then
+            echo "ran=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ran=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Staging is not provisioned yet; deploying to production directly."
+          fi
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.ran == 'true'
+      - uses: pnpm/action-setup@v4
+        if: steps.gate.outputs.ran == 'true'
+        with:
+          version: 11.16.0
+      - uses: actions/setup-node@v4
+        if: steps.gate.outputs.ran == 'true'
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+        if: steps.gate.outputs.ran == 'true'
+      - run: pnpm --filter @icm/spice-run build
+        if: steps.gate.outputs.ran == 'true'
+      - run: pnpm --filter @icm/editor... build
+        if: steps.gate.outputs.ran == 'true'
+        env:
+          VITE_ICM_TIMING_UI: disabled
+      - name: Deploy to staging
+        if: steps.gate.outputs.ran == 'true'
+        run: pnpm dlx wrangler@4.120.1 deploy --env staging
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Give staging its access key
+        if: steps.gate.outputs.ran == 'true'
+        run: |
+          printf '%s' "$STAGING_ACCESS_KEY" \
+            | pnpm dlx wrangler@4.120.1 secret put STAGING_ACCESS_KEY --env staging
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          STAGING_ACCESS_KEY: ${{ secrets.STAGING_ACCESS_KEY }}
+      # The same checks production gets, against the staging host, with the
+      # access key supplied. A path that fails here never reaches the public.
+      - name: Verify staging
+        if: steps.gate.outputs.ran == 'true'
+        env:
+          STAGING_URL: ${{ secrets.STAGING_URL }}
+          STAGING_ACCESS_KEY: ${{ secrets.STAGING_ACCESS_KEY }}
+        run: |
+          auth=(--header "x-staging-access-key: $STAGING_ACCESS_KEY")
+          for path in / /editor /analytics /api/agent/mcp-manifest.json; do
+            curl --fail --silent --show-error "${auth[@]}" \
+              --retry 5 --retry-delay 2 --retry-all-errors --max-time 20 \
+              "${STAGING_URL}${path}" >/dev/null
+          done
+          stale="$(curl --silent --show-error "${auth[@]}" --max-time 20 \
+            --output /dev/null --write-out '%{http_code}' \
+            "${STAGING_URL}/assets/App-staging-smoke-missing.js")"
+          if [ "$stale" != "404" ]; then
+            echo "A missing hashed asset must answer 404 on staging, got: $stale"
+            exit 1
+          fi
+          # Staging must not be public. Without the key it must refuse, and a
+          # staging that lets an anonymous caller in is a failed deploy.
+          anon="$(curl --silent --output /dev/null --max-time 20 \
+            --write-out '%{http_code}' "${STAGING_URL}/editor")"
+          if [ "$anon" != "401" ]; then
+            echo "Staging must refuse an anonymous caller, got: $anon"
+            exit 1
+          fi
+
   deploy:
     name: Deploy Worker
+    needs: staging
+    # Runs when staging passed OR when staging is not provisioned. It must not
+    # run when staging actually failed: that is the whole point of having one.
+    if: always() && needs.staging.result == 'success'
     runs-on: ubuntu-latest
     environment:
       name: cloudflare-production

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,6 +34,37 @@ never executes. **A green CI run is evidence about the code, not about the
 deployment.** That gap is why verification runs against the live site, and why
 failing it now costs one verification round instead of an afternoon.
 
+## What the rollback does not protect
+
+The rollback restores a previous Worker **version**. Three things it does not
+do, all learned on 2026-09-01 when it fired for the first time on real
+traffic:
+
+**A rollback does not undo a check that was wrong.** #519 made a missing
+hashed asset answer 404, which is correct. The smoke check still required the
+old shell-at-200 answer, so verification failed and the deploy was rolled
+back — the machinery obeying a wrong instruction, perfectly. Every later
+merge then hit the same check and rolled back too. When a change alters
+behaviour a verification asserts, **the verification is part of the change**;
+shipping one without the other blocks the pipeline for everyone.
+
+**Repeated rollbacks do not return to a known state.** After three failed
+deploys and three rollbacks, production was measured serving the NEW
+behaviour: a missing chunk returned 404 with the Worker's own message. The
+version selection after a previous rollback did not land where a reading of
+the deployment list predicts, and the exact bookkeeping Cloudflare applies to
+a rollback's own deployment entry was not established here. Treat "it rolled
+back" as "a previous version is live", not as "the version you had before".
+**Measure production after a rollback, every time.**
+
+**A rollback does not undo bound resources.** Wrangler says so in its own
+warning: Durable Objects, D1, R2 and KV are not restored. A deploy that
+migrates data is not made safe by this protection.
+
+None of that makes the rollback worthless — production stayed up through all
+three failures, which is the whole point. It makes the rollback a way to keep
+serving, not a way to be sure what you are serving.
+
 ## What CI cannot tell you
 
 Anything that only exists at Worker runtime:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -76,17 +76,42 @@ Anything that only exists at Worker runtime:
 
 For those, the live check after deploying is the only evidence.
 
-## Planned: staging before production
+## Staging before production
 
 A staging environment (`env.staging` in `wrangler.jsonc`) deploys first, gets
-the same verification, and promotes to production when it passes. It is not
-yet in place; it needs Cloudflare account changes, and the owner requires the
-staging hostname to be private and login-gated so it is never mistaken for the
-product.
+the same verification against its own hostname, and production runs only if
+staging did not fail. Merging to `main` no longer reaches the public without
+something having looked at the build first.
 
-**Promotion is automatic by default, and manual when the version changes.**
-An ordinary merge flows through staging to production without anyone waiting;
-a version bump stops at an approval gate.
+**Staging is private, and it fails closed.** The gate in
+`worker/staging-gate.ts` refuses every request unless the caller carries the
+shared key, and refuses _everyone_ when no key is configured at all — which is
+the state a freshly provisioned environment starts in. An unlisted hostname is
+not privacy: search engines index what gets linked, and a half-built product
+answering to the public is worse than having no staging. The key may arrive as
+a header, a cookie, or a one-time `?key=` that is immediately traded for a
+cookie so the secret leaves the address bar and the browser history. The
+staging verification asserts the refusal too: a staging that admits an
+anonymous caller fails its own deploy.
+
+**Promotion is automatic by default, and manual when the version changes.** An
+ordinary merge flows through staging to production without anyone waiting; a
+version bump stops at an approval gate.
+
+**Staging has no rollback, deliberately.** Nothing public serves from it, so a
+bad staging deploy is a failed gate rather than an outage — it simply stops
+production from happening. Rollback stays where the users are.
+
+### Until it is provisioned
+
+The staging job **skips itself** when `STAGING_ACCESS_KEY` is absent, and
+production proceeds exactly as before. This is why the code could land before
+the Cloudflare environment existed: an unprovisioned staging that blocked
+deploys would jam the pipeline for everybody, which is the failure this
+repository already spent a night recovering from. Provisioning needs a second
+Worker script, a hostname for it, and three repository secrets
+(`STAGING_ACCESS_KEY`, `STAGING_URL`, and the existing Cloudflare credentials
+already present).
 
 ### The limit to state plainly
 

--- a/scripts/deploy-workflow.test.mjs
+++ b/scripts/deploy-workflow.test.mjs
@@ -14,11 +14,58 @@ import { describe, expect, it } from "vitest";
  */
 const workflow = readFileSync(".github/workflows/cloudflare.yml", "utf8");
 
+describe("staging before production", () => {
+  it("puts a staging job in front of the production one", () => {
+    expect(workflow).toContain("Deploy staging");
+    expect(workflow).toMatch(
+      /deploy:\s*\n\s*name: Deploy Worker\s*\n\s*needs: staging/u,
+    );
+  });
+
+  it("does not block production when staging is not provisioned yet", () => {
+    // This lands before the Cloudflare environment exists. If an unprovisioned
+    // staging blocked deploys, it would jam the pipeline for everyone — the
+    // exact failure this repository spent a night recovering from.
+    expect(workflow).toContain("Staging is not provisioned yet");
+    expect(workflow).toMatch(/needs\.staging\.result == 'success'/u);
+  });
+
+  it("refuses to reach production when staging actually failed", () => {
+    // always() alone would run production regardless. The result check is
+    // what makes staging a gate rather than a decoration.
+    const gate = workflow.slice(workflow.indexOf("needs: staging"));
+    expect(gate).toContain("always() && needs.staging.result == 'success'");
+  });
+
+  it("checks staging with the same paths production is checked with", () => {
+    const stagingJob = workflow.slice(
+      workflow.indexOf("Verify staging"),
+      workflow.indexOf("deploy:\n"),
+    );
+    for (const path of ["/editor", "/analytics", "mcp-manifest.json"]) {
+      expect(stagingJob).toContain(path);
+    }
+    expect(stagingJob).toContain("must answer 404");
+  });
+
+  it("fails the deploy if staging is reachable without the key", () => {
+    // A staging anyone can open is a second public site showing half-built
+    // work. Being unlisted is not being private.
+    expect(workflow).toContain("Staging must refuse an anonymous caller");
+  });
+});
+
 describe("Cloudflare deploy workflow", () => {
-  it("records the rollback target before the deploy changes anything", () => {
-    const capture = workflow.indexOf("Record the version to roll back to");
-    const deploy = workflow.indexOf("wrangler@4.120.1 deploy");
+  it("records the rollback target before the production deploy", () => {
+    // Scoped to the production job: the staging job deploys too, and a naive
+    // search finds its deploy first. Staging deliberately has no rollback —
+    // nothing public is serving from it, so a bad staging deploy is a failed
+    // gate rather than an outage.
+    const productionJob = workflow.slice(workflow.indexOf("  deploy:\n"));
+    const capture = productionJob.indexOf("Record the version to roll back to");
+    const deploy = productionJob.indexOf("wrangler@4.120.1 deploy");
     expect(capture).toBeGreaterThan(-1);
+    expect(deploy).toBeGreaterThan(-1);
     // Read after deploying, the "previous" version is the broken one.
     expect(capture).toBeLessThan(deploy);
   });

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -15,6 +15,7 @@ import {
 } from "./agent-session";
 import { routeGalleryRequest, type GalleryNamespaceLike } from "./gallery";
 import { routeSimulationRequest, type SimulationEnv } from "./simulation";
+import { stagingAccessGate, type StagingEnv } from "./staging-gate";
 import { routeAuthRequest, type AuthNamespaceLike } from "./auth";
 
 export { AnalyticsDO } from "./analytics";
@@ -22,23 +23,24 @@ export { AgentSessionDO } from "./agent-session";
 export { GalleryDO } from "./gallery";
 export { AuthDO } from "./auth";
 
-type Env = SimulationEnv & {
-  ANALYTICS: DurableObjectNamespaceLike;
-  ASSETS: { fetch(request: Request): Promise<Response> };
-  ANALYTICS_KEY: string | undefined;
-  AGENT_SESSION: AgentSessionNamespaceLike;
-  AGENT_ALLOWED_ORIGIN?: string;
-  GALLERY: GalleryNamespaceLike;
-  AUTH: AuthNamespaceLike;
-  GH_OAUTH_CLIENT_ID?: string;
-  GH_OAUTH_CLIENT_SECRET?: string;
-  GOOGLE_CLIENT_ID?: string;
-  GOOGLE_CLIENT_SECRET?: string;
-  RESEND_API_KEY?: string;
-  AUTH_EMAIL_FROM?: string;
-  ADMIN_EMAILS?: string;
-  ADMIN_EMAILS_EXTRA?: string;
-};
+type Env = SimulationEnv &
+  StagingEnv & {
+    ANALYTICS: DurableObjectNamespaceLike;
+    ASSETS: { fetch(request: Request): Promise<Response> };
+    ANALYTICS_KEY: string | undefined;
+    AGENT_SESSION: AgentSessionNamespaceLike;
+    AGENT_ALLOWED_ORIGIN?: string;
+    GALLERY: GalleryNamespaceLike;
+    AUTH: AuthNamespaceLike;
+    GH_OAUTH_CLIENT_ID?: string;
+    GH_OAUTH_CLIENT_SECRET?: string;
+    GOOGLE_CLIENT_ID?: string;
+    GOOGLE_CLIENT_SECRET?: string;
+    RESEND_API_KEY?: string;
+    AUTH_EMAIL_FROM?: string;
+    ADMIN_EMAILS?: string;
+    ADMIN_EMAILS_EXTRA?: string;
+  };
 
 type RequestCf = {
   country?: string;
@@ -95,6 +97,12 @@ const REFERRER_CATEGORIES: readonly (readonly [string, readonly string[]])[] = [
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
+    // Before any route, including the APIs: a staging deployment that cannot
+    // identify its caller serves nobody. Production leaves ICM_ENVIRONMENT
+    // unset, so this returns null there and costs one comparison.
+    const stagingRefusal = stagingAccessGate(request, env);
+    if (stagingRefusal) return stagingRefusal;
+
     const url = new URL(request.url);
 
     const agentResponse = await routeAgentSessionRequest(request, env);

--- a/worker/staging-gate.test.ts
+++ b/worker/staging-gate.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { stagingAccessGate } from "./staging-gate";
+
+const req = (url = "https://staging.test/editor", headers?: HeadersInit) =>
+  new Request(url, headers ? { headers } : undefined);
+
+describe("staging access gate", () => {
+  it("is absent from production", () => {
+    // Production leaves ICM_ENVIRONMENT unset. If this ever returned a
+    // refusal there, the gate would take the live site down.
+    expect(stagingAccessGate(req(), {})).toBeNull();
+    expect(
+      stagingAccessGate(req(), { STAGING_ACCESS_KEY: "secret" }),
+    ).toBeNull();
+  });
+
+  it("serves nobody when no key is configured", () => {
+    // Fail closed. A staging deployment whose secret has not been provisioned
+    // yet must not be browsable: an unlisted URL is not privacy, and the
+    // failure mode of missing configuration must never be "everybody gets in".
+    const response = stagingAccessGate(req(), { ICM_ENVIRONMENT: "staging" });
+    expect(response?.status).toBe(401);
+    expect(response?.headers.get("x-robots-tag")).toContain("noindex");
+  });
+
+  it("refuses a caller with no key, and does not hint at one", () => {
+    const response = stagingAccessGate(req(), {
+      ICM_ENVIRONMENT: "staging",
+      STAGING_ACCESS_KEY: "secret",
+    });
+    expect(response?.status).toBe(401);
+    expect(response?.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("admits a header or a cookie", () => {
+    const env = { ICM_ENVIRONMENT: "staging", STAGING_ACCESS_KEY: "secret" };
+    expect(
+      stagingAccessGate(
+        req(undefined, { "x-staging-access-key": "secret" }),
+        env,
+      ),
+    ).toBeNull();
+    expect(
+      stagingAccessGate(
+        req(undefined, { cookie: "other=1; icm_staging_access=secret" }),
+        env,
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects a wrong key by every route in", () => {
+    const env = { ICM_ENVIRONMENT: "staging", STAGING_ACCESS_KEY: "secret" };
+    expect(
+      stagingAccessGate(
+        req(undefined, { "x-staging-access-key": "wrong" }),
+        env,
+      )?.status,
+    ).toBe(401);
+    expect(
+      stagingAccessGate(
+        req(undefined, { cookie: "icm_staging_access=wrong" }),
+        env,
+      )?.status,
+    ).toBe(401);
+    expect(
+      stagingAccessGate(req("https://staging.test/editor?key=wrong"), env)
+        ?.status,
+    ).toBe(401);
+  });
+
+  it("takes the secret out of the address bar after admitting it", () => {
+    // A link with the key in it gets pasted, shared, and kept in history.
+    // Trading it for a cookie once keeps the secret out of all three.
+    const response = stagingAccessGate(
+      req("https://staging.test/editor?key=secret&doc=7"),
+      { ICM_ENVIRONMENT: "staging", STAGING_ACCESS_KEY: "secret" },
+    );
+    expect(response?.status).toBe(302);
+    const location = response?.headers.get("location") ?? "";
+    expect(location).not.toContain("key=secret");
+    expect(location).toContain("doc=7");
+    expect(response?.headers.get("set-cookie")).toContain("HttpOnly");
+    expect(response?.headers.get("set-cookie")).toContain("Secure");
+  });
+});

--- a/worker/staging-gate.ts
+++ b/worker/staging-gate.ts
@@ -1,0 +1,84 @@
+/**
+ * The staging environment's front door.
+ *
+ * Staging exists to be looked at before production is, which means it must
+ * not be findable. An unlisted hostname is not privacy: search engines index
+ * what they are linked to, and a half-built product answering to the public
+ * is worse than no staging at all.
+ *
+ * So the gate FAILS CLOSED. With no shared secret configured, staging serves
+ * nothing to anyone — including on its very first deploy, before a person has
+ * had the chance to provision anything. The failure mode of a missing
+ * configuration is "nobody gets in", never "everybody does".
+ *
+ * Production has no gate: `stagingAccessGate` is only consulted when the
+ * deployment declares itself staging, so this code cannot lock the live site
+ * out by accident.
+ */
+export interface StagingEnv {
+  /** Set only in the staging environment; production leaves it unset. */
+  ICM_ENVIRONMENT?: string;
+  /** The shared secret that opens staging. Absent means nobody enters. */
+  STAGING_ACCESS_KEY?: string;
+}
+
+const COOKIE_NAME = "icm_staging_access";
+
+function unauthorized(message: string): Response {
+  return new Response(message, {
+    status: 401,
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      // Nothing here should be cached, indexed, or followed.
+      "cache-control": "no-store",
+      "x-robots-tag": "noindex, nofollow, noarchive",
+    },
+  });
+}
+
+/**
+ * Returns a refusal when the request may not see staging, or null to let it
+ * through. Accepts the key as a cookie, a header, or a one-time query
+ * parameter that sets the cookie, so a person can open the site by pasting
+ * one link and stay in afterwards.
+ */
+export function stagingAccessGate(
+  request: Request,
+  env: StagingEnv,
+): Response | null {
+  if (env.ICM_ENVIRONMENT !== "staging") return null;
+
+  const key = env.STAGING_ACCESS_KEY;
+  if (!key) {
+    return unauthorized(
+      "This staging deployment has no access key configured, so it serves nobody.",
+    );
+  }
+
+  const url = new URL(request.url);
+  const fromQuery = url.searchParams.get("key");
+  if (fromQuery && fromQuery === key) {
+    // Redirect so the secret leaves the address bar and the browsing history.
+    url.searchParams.delete("key");
+    return new Response(null, {
+      status: 302,
+      headers: {
+        location: url.toString(),
+        "set-cookie": `${COOKIE_NAME}=${key}; Path=/; HttpOnly; Secure; SameSite=Lax`,
+        "cache-control": "no-store",
+      },
+    });
+  }
+
+  const header = request.headers.get("x-staging-access-key");
+  if (header && header === key) return null;
+
+  const cookies = request.headers.get("cookie") ?? "";
+  const match = cookies
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(`${COOKIE_NAME}=`));
+  if (match && match.slice(COOKIE_NAME.length + 1) === key) return null;
+
+  return unauthorized("Staging is not public.");
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -73,4 +73,54 @@
   "observability": {
     "enabled": true,
   },
+  // A place to look at a build before the public does. Merging to main used
+  // to deploy straight to production, so the only protection was after the
+  // fact: the bad version went live and came back seconds later. This is the
+  // interception that happens first.
+  //
+  // Bindings do NOT inherit into an environment; every one below is repeated
+  // deliberately, and a binding forgotten here is simply absent at runtime.
+  //
+  // WHAT STAGING CANNOT TELL YOU: its four Durable Object namespaces are
+  // EMPTY. They key on the script name, and this environment is a separate
+  // script, so there are no gallery entries, no accounts, no agent sessions.
+  // That is good for safety and it bounds what passing staging proves: it
+  // catches "the site does not come up", never "this particular circuit
+  // breaks when opened". See docs/deployment.md.
+  //
+  // No simulation container here on purpose: container time bills per
+  // environment, and a broken simulation route does not take the site down.
+  // Staging verifies only that the route exists and refuses correctly.
+  "env": {
+    "staging": {
+      "name": "interactive-circuit-maker-staging",
+      "workers_dev": true,
+      "vars": {
+        // Switches on the access gate in worker/staging-gate.ts. Without the
+        // STAGING_ACCESS_KEY secret beside it, staging serves nobody, which
+        // is the intended state until someone provisions the key.
+        "ICM_ENVIRONMENT": "staging",
+      },
+      "assets": {
+        "binding": "ASSETS",
+        "directory": "./apps/editor/dist",
+        "not_found_handling": "single-page-application",
+        "run_worker_first": ["/api/*", "/assets/*"],
+      },
+      "durable_objects": {
+        "bindings": [
+          { "name": "ANALYTICS", "class_name": "AnalyticsDO" },
+          { "name": "AGENT_SESSION", "class_name": "AgentSessionDO" },
+          { "name": "GALLERY", "class_name": "GalleryDO" },
+          { "name": "AUTH", "class_name": "AuthDO" },
+        ],
+      },
+      "migrations": [
+        { "tag": "v1", "new_sqlite_classes": ["AnalyticsDO"] },
+        { "tag": "v2", "new_sqlite_classes": ["AgentSessionDO"] },
+        { "tag": "v3", "new_sqlite_classes": ["GalleryDO"] },
+        { "tag": "v4", "new_sqlite_classes": ["AuthDO"] },
+      ],
+    },
+  },
 }


### PR DESCRIPTION
Stacked on #526 (both touch `docs/deployment.md`; stacking avoids a certain conflict). The owner's words: 现在绝对不能直接进生产，现在这样会容易翻车的.

## The gap

Merging to `main` deployed straight to production. The only protection was **after the fact** — the bad version went live and came back seconds later. That is recovery, not interception, and it fired three times last night.

Staging now deploys first, gets the same verification against its own hostname, and production runs **only if staging did not fail**.

## Staging is private, and it fails closed

`worker/staging-gate.ts` refuses every request without the shared key, and refuses **everyone** when no key is configured at all — the state a fresh environment starts in. An unlisted hostname is not privacy: search engines index what gets linked, and a half-built product answering the public is worse than having no staging.

The key may arrive as a header, a cookie, or a one-time `?key=` that is **immediately traded for a cookie**, so the secret leaves the address bar and the browser history. Staging's own verification asserts the refusal: **a staging that admits an anonymous caller fails its deploy.**

## Two judgement calls worth reviewing

**Staging skips itself while unprovisioned, and production proceeds as before.** This lands before the Cloudflare side exists, and a half-built staging that blocked deploys would jam the pipeline for everyone — precisely the failure this repository spent last night recovering from. The production job's condition is what makes staging a gate rather than a decoration: it runs when staging passed or was skipped, never when it failed.

**Staging has no rollback, deliberately.** Nothing public serves from it, so a bad staging deploy is a gate that held, not an outage. Rollback belongs where the users are. This answers the coordinator's question about whether two-stage inherits the rollback's config limitation: staging does not need one.

That decision cost one honest test correction — a naive search for the deploy step found *staging's* first, so the rollback-ordering assertion is now scoped to the production job.

## What staging will not prove

Its four Durable Object namespaces are **empty**: they key on the script name, and this is a separate script. Bindings do not inherit either, so all four are repeated explicitly. Staging catches "the site does not come up" — last night's exact failure — and never "this particular circuit breaks when opened". Stated plainly in `docs/deployment.md` so nobody reads a green staging as proof of correctness. No simulation container there either: container time bills per environment, and a broken simulation route does not take the site down.

## Still needed, and not mine to do

Provisioning: a second Worker script, a hostname, and repository secrets `STAGING_ACCESS_KEY` and `STAGING_URL`. **I did not touch account settings**, per the standing instruction. Until those exist this code is inert.

## Validation

- 27 unit tests across the gate and the pipeline contract, including one asserting production is not blocked by an unprovisioned staging
- Full `pnpm ci:check` green (330/330 Playwright specs) under the gate lock, taken with a real pid and released

🤖 Generated with [Claude Code](https://claude.com/claude-code)
