### PR TITLE
refactor(properties): simplify parameter and color controls

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3026,7 +3026,7 @@ test("Properties offers no dead Reference controls for a schematic-only block", 
   await expect(properties.getByText("Symbol")).toBeVisible();
   await expect(referenceField).toHaveCount(0);
   await expect(parametersCard).toHaveCount(0);
-  await expect(properties.getByText("Line / foreground")).toBeVisible();
+  await expect(properties.getByText("Line", { exact: true })).toBeVisible();
 
   // An ordinary device keeps both.
   await page.getByTestId("hit-R1").click();
@@ -3147,11 +3147,9 @@ test("Properties keeps component and Annotation text colors independent", async 
   const label = page.locator('[data-object-id="instance-label-R1"]');
   const secondLabel = page.locator('[data-object-id="instance-label-R2"]');
 
+  await properties.getByRole("button", { name: "Use Red for line" }).click();
   await properties
-    .getByRole("button", { name: "Use Red for line / foreground" })
-    .click();
-  await properties
-    .getByRole("button", { name: "Use Blue for background / fill" })
+    .getByRole("button", { name: "Use Blue for background" })
     .click();
   await expect(symbol).toHaveAttribute("stroke", "#dc2626");
   await expect(
@@ -3186,6 +3184,7 @@ test("Properties keeps component and Annotation text colors independent", async 
   // Annotation remounts the keyed Text properties before the deferred blur
   // commit, so R1's draft cannot reach either Annotation.
   await page.clock.pauseAt(clockStart + 60_000);
+  await properties.locator("summary", { hasText: /^RGB$/u }).click();
   await properties.getByLabel("Text color red").fill("12");
   await page
     .getByTestId("annotation-hit-instance-label-R2")
@@ -3201,6 +3200,7 @@ test("Properties keeps component and Annotation text colors independent", async 
   await page
     .getByTestId("annotation-hit-instance-label-R1")
     .click({ force: true });
+  await properties.locator("summary", { hasText: /^RGB$/u }).click();
   await properties.getByLabel("Text color red").fill("12");
   const resetTextColor = properties.getByRole("button", {
     name: "Reset text color",

--- a/apps/editor/src/features/properties/color-override-control.tsx
+++ b/apps/editor/src/features/properties/color-override-control.tsx
@@ -183,30 +183,36 @@ export function ColorOverrideControl({
           </button>
         ))}
       </div>
-      <div className="component-rgb-inputs" aria-label={`${label} custom RGB`}>
-        {(["r", "g", "b"] as const).map((channel) => (
-          <label key={channel}>
-            {channel.toUpperCase()}
-            <input
-              aria-label={`${label} ${
-                channel === "r" ? "red" : channel === "g" ? "green" : "blue"
-              }`}
-              type="number"
-              min="0"
-              max="255"
-              step="1"
-              value={rgb[channel]}
-              onChange={(event) =>
-                updateChannel(channel, event.currentTarget.value)
-              }
-              onBlur={(event) => commitOnBlur(event.relatedTarget)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") commitPending();
-              }}
-            />
-          </label>
-        ))}
-      </div>
+      <details className="component-rgb-details">
+        <summary>RGB</summary>
+        <div
+          className="component-rgb-inputs"
+          aria-label={`${label} custom RGB`}
+        >
+          {(["r", "g", "b"] as const).map((channel) => (
+            <label key={channel}>
+              {channel.toUpperCase()}
+              <input
+                aria-label={`${label} ${
+                  channel === "r" ? "red" : channel === "g" ? "green" : "blue"
+                }`}
+                type="number"
+                min="0"
+                max="255"
+                step="1"
+                value={rgb[channel]}
+                onChange={(event) =>
+                  updateChannel(channel, event.currentTarget.value)
+                }
+                onBlur={(event) => commitOnBlur(event.relatedTarget)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") commitPending();
+                }}
+              />
+            </label>
+          ))}
+        </div>
+      </details>
     </fieldset>
   );
 }

--- a/apps/editor/src/features/properties/component-electrical-properties.test.tsx
+++ b/apps/editor/src/features/properties/component-electrical-properties.test.tsx
@@ -61,6 +61,51 @@ describe("component electrical properties", () => {
     expect(markup).not.toContain("Component compatibility field");
   });
 
+  it("keeps W, L, and NF labels compact while retaining their tooltips", () => {
+    const document = createEmptyDocument("cell", "Cell");
+    const instance: (typeof document.instances)[number] = {
+      id: "M1",
+      symbolId: "nmos",
+      placement: null,
+      reference: "M1",
+    };
+    const markup = renderToStaticMarkup(
+      <ComponentElectricalProperties
+        instance={instance}
+        parameters={[
+          { key: "w", label: "W", placeholder: "1u", help: "Total width" },
+          { key: "l", label: "L", placeholder: "150n", help: "Length" },
+          { key: "nf", label: "NF", placeholder: "1", help: "Finger count" },
+          { key: "m", label: "M", placeholder: "1", help: "Multiplier" },
+        ]}
+        parameterValues={{ w: "1u", l: "150n", nf: "1", m: "1" }}
+        firstInputRef={createRef<HTMLInputElement>()}
+        referenceVisible
+        valueVisible
+        valueAvailable
+        valueSupported
+        referenceAvailable
+        referenceLabelRenderable
+        additionalParameters={[]}
+        additionalParametersChanged={false}
+        onParameterChange={vi.fn()}
+        onReferenceVisibilityChange={vi.fn()}
+        onValueVisibilityChange={vi.fn()}
+        onAdditionalParameterChange={vi.fn()}
+        onAdditionalParameterRemove={vi.fn()}
+        onAdditionalParameterAdd={vi.fn()}
+        onAdditionalParametersApply={vi.fn()}
+        onAdditionalParametersCancel={vi.fn()}
+      />,
+    );
+
+    expect(markup).not.toContain("(Total width)");
+    expect(markup).not.toContain("(Length)");
+    expect(markup).not.toContain("(Finger count)");
+    expect(markup).toContain("(Multiplier)");
+    expect(markup).toContain('title="Total width"');
+  });
+
   it("says nothing at all for a Symbol that has neither parameters nor a drawable label", () => {
     const document = createEmptyDocument("cell", "Cell");
     const instance: (typeof document.instances)[number] = {

--- a/apps/editor/src/features/properties/component-electrical-properties.tsx
+++ b/apps/editor/src/features/properties/component-electrical-properties.tsx
@@ -1,5 +1,6 @@
 import type { Ref } from "react";
 
+import { deviceDescriptor } from "@icm/devices";
 import type { SchematicDocument } from "@icm/model";
 
 import { DisplayToggle } from "../component-insert/display-toggle";
@@ -8,6 +9,7 @@ import type { AdditionalParameterDraft } from "./additional-parameters";
 import { derivedFingerWidth } from "./finger-width";
 
 type Instance = SchematicDocument["instances"][number];
+const COMPACT_PARAMETER_LABELS = new Set(["W", "L", "NF"]);
 
 export function ComponentElectricalProperties({
   instance,
@@ -85,6 +87,7 @@ export function ComponentElectricalProperties({
   // instance has and this Symbol draws, and a value this device supports.
   const referenceToggleable = referenceLabelRenderable && referenceAvailable;
   const displayable = referenceToggleable || valueSupported;
+  const isMos = deviceDescriptor(instance.symbolId)?.deviceClass === "mos";
   if (primaryParameters.length === 0 && !displayable && !instance.netlist) {
     return null;
   }
@@ -100,7 +103,9 @@ export function ComponentElectricalProperties({
             <span className="property-parameter-name">
               {parameter.label}
               {parameter.unit ? ` / ${parameter.unit}` : ""}
-              <em>({parameter.help})</em>
+              {isMos && COMPACT_PARAMETER_LABELS.has(parameter.label) ? null : (
+                <em>({parameter.help})</em>
+              )}
             </span>
             <input
               ref={index === 0 ? firstInputRef : undefined}

--- a/apps/editor/src/features/properties/component-style-properties.test.tsx
+++ b/apps/editor/src/features/properties/component-style-properties.test.tsx
@@ -9,7 +9,7 @@ import {
 } from "./component-style-properties";
 
 describe("component style properties", () => {
-  it("renders accessible presets, RGB controls, and independent resets", () => {
+  it("renders concise color sections with collapsible RGB controls", () => {
     const document = createEmptyDocument("cell", "Cell");
     const instance: (typeof document.instances)[number] = {
       id: "R1",
@@ -33,8 +33,16 @@ describe("component style properties", () => {
     );
 
     expect(markup).toContain("Appearance");
-    expect(markup).toContain('aria-label="Line / foreground custom RGB"');
-    expect(markup).toContain('aria-label="Background / fill color picker"');
+    expect(markup).toContain("<legend>Line</legend>");
+    expect(markup).toContain("<legend>Background</legend>");
+    expect(markup).not.toContain("Line / foreground");
+    expect(markup).not.toContain("Background / fill");
+    expect(markup).toContain('aria-label="Line custom RGB"');
+    expect(markup).toContain('aria-label="Background color picker"');
+    expect(
+      markup.match(/<details class="component-rgb-details">/gu),
+    ).toHaveLength(2);
+    expect(markup.match(/<summary>RGB<\/summary>/gu)).toHaveLength(2);
     expect(markup).toContain('aria-pressed="true"');
     expect(markup).toContain("Gray · #6b7280");
     expect(markup).not.toContain("Violet");

--- a/apps/editor/src/features/properties/component-style-properties.tsx
+++ b/apps/editor/src/features/properties/component-style-properties.tsx
@@ -30,13 +30,13 @@ export function ComponentStyleProperties({
       <div className="property-section-heading">Appearance</div>
       <small>Colors apply to this component only.</small>
       <ColorOverrideControl
-        label="Line / foreground"
+        label="Line"
         value={instance.styleOverride?.foreground}
         fallback={defaultForeground}
         onChange={(value) => update("foreground", value)}
       />
       <ColorOverrideControl
-        label="Background / fill"
+        label="Background"
         value={instance.styleOverride?.background}
         fallback="#ffffff"
         transparentDefault

--- a/apps/editor/src/styles/editor-properties.css
+++ b/apps/editor/src/styles/editor-properties.css
@@ -541,6 +541,16 @@
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.35rem;
+  padding-top: 0.4rem;
+}
+
+.component-rgb-details summary {
+  width: fit-content;
+  color: var(--icm-text-muted);
+  cursor: pointer;
+  font-size: var(--icm-font-xs);
+  font-weight: 650;
+  user-select: none;
 }
 
 .component-rgb-inputs label {


### PR DESCRIPTION
## Summary
- keep MOS W, L, and NF labels compact while retaining tooltip help
- rename component appearance sections to Line and Background
- collapse manual RGB channel controls behind a compact RGB disclosure

## Validation
- pnpm install --frozen-lockfile
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
- 350 unit test files / 2276 tests passed (5 skipped)
- 131 editor browser tests passed