### PR TITLE
perf(gallery): optimize initial loading and masonry previews

### DIFF
--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -19,6 +19,8 @@ const ENTRY = {
   description: "Three-stage loop",
   createdAt: "2026-08-21T10:00:00.000Z",
   previewRevision: "revision-0",
+  previewWidth: 640,
+  previewHeight: 360,
   schemaVersion: 23,
 };
 
@@ -125,6 +127,12 @@ test("the site lands on the full-screen gallery feed", async ({ page }) => {
   await expect(
     page.getByTestId(`gallery-tile-${ENTRY.id}`).locator("img"),
   ).toHaveAttribute("src", `/api/gallery/${ENTRY.id}/preview.svg?v=revision-0`);
+  await expect(
+    page.getByTestId(`gallery-tile-${ENTRY.id}`).locator("img"),
+  ).toHaveAttribute("width", "640");
+  await expect(
+    page.getByTestId(`gallery-tile-${ENTRY.id}`).locator("img"),
+  ).toHaveAttribute("height", "360");
   await expect(
     page.getByTestId("gallery-bundled-common-source-amplifier"),
   ).toHaveCount(0);

--- a/apps/editor/e2e/gallery.spec.ts
+++ b/apps/editor/e2e/gallery.spec.ts
@@ -184,8 +184,13 @@ test("an open Gallery switches to a newly published preview revision", async ({
 test("the Owner rejects a Gallery entry with an author-visible reason", async ({
   page,
 }) => {
-  await page.route("**/api/auth/me", (route) =>
-    route.fulfill({
+  let sessionRequests = 0;
+  await page.route("**/api/auth/providers", (route) =>
+    route.fulfill({ json: { github: true, google: false, email: false } }),
+  );
+  await page.route("**/api/auth/me", (route) => {
+    sessionRequests += 1;
+    return route.fulfill({
       json: {
         user: {
           id: "owner-1",
@@ -196,8 +201,8 @@ test("the Owner rejects a Gallery entry with an author-visible reason", async ({
           isAdmin: true,
         },
       },
-    }),
-  );
+    });
+  });
   await mockGallery(page, [ENTRY]);
   let rejectReason = "";
   await page.route(`**/api/gallery/${ENTRY.id}/reject`, async (route) => {
@@ -209,6 +214,7 @@ test("the Owner rejects a Gallery entry with an author-visible reason", async ({
   await page.goto("/");
   const menu = page.getByTestId(`gallery-owner-menu-${ENTRY.id}`);
   await expect(menu).toBeVisible();
+  expect(sessionRequests).toBe(1);
   await menu.locator("summary").click();
   await expect(
     page.getByTestId(`gallery-owner-edit-${ENTRY.id}`),

--- a/apps/editor/src/components/account.test.tsx
+++ b/apps/editor/src/components/account.test.tsx
@@ -2,7 +2,11 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import { AccountMenuView, type AccountState } from "./account";
+import {
+  AccountMenuView,
+  fetchSessionUser,
+  type AccountState,
+} from "./account";
 
 function markupFor(state: AccountState, notice: string | null = null): string {
   return renderToStaticMarkup(
@@ -58,5 +62,24 @@ describe("AccountMenuView", () => {
     expect(markup).toContain('data-testid="account-owner"');
     expect(markup).toContain('data-testid="account-signout"');
     expect(markup).not.toContain("account-signin");
+  });
+});
+
+describe("fetchSessionUser", () => {
+  it("coalesces concurrent and nearby consumers onto one session request", async () => {
+    let requests = 0;
+    const fetchLike = (async () => {
+      requests += 1;
+      return new Response(JSON.stringify({ user: null }), { status: 200 });
+    }) as typeof fetch;
+
+    const [first, second] = await Promise.all([
+      fetchSessionUser(fetchLike),
+      fetchSessionUser(fetchLike),
+    ]);
+    const third = await fetchSessionUser(fetchLike);
+
+    expect([first, second, third]).toEqual([null, null, null]);
+    expect(requests).toBe(1);
   });
 });

--- a/apps/editor/src/components/account.tsx
+++ b/apps/editor/src/components/account.tsx
@@ -34,20 +34,45 @@ const NO_PROVIDERS: AuthProviders = {
   email: false,
 };
 
+const SESSION_CACHE_MS = 30_000;
+const sessionRequests = new WeakMap<
+  typeof fetch,
+  { expiresAt: number; request: Promise<SessionUser | null> }
+>();
+
+function cacheSessionUser(
+  fetchLike: typeof fetch,
+  user: SessionUser | null,
+): void {
+  sessionRequests.set(fetchLike, {
+    expiresAt: Date.now() + SESSION_CACHE_MS,
+    request: Promise.resolve(user),
+  });
+}
+
 /** The signed-in user, or null (also on any failure). */
 export async function fetchSessionUser(
   fetchLike: typeof fetch = fetch,
 ): Promise<SessionUser | null> {
-  try {
-    const response = await fetchLike("/api/auth/me", {
-      credentials: "same-origin",
-    });
-    if (!response.ok) return null;
-    const payload = (await response.json()) as { user?: SessionUser | null };
-    return payload.user ?? null;
-  } catch {
-    return null;
-  }
+  const cached = sessionRequests.get(fetchLike);
+  if (cached && cached.expiresAt > Date.now()) return cached.request;
+  const request = (async (): Promise<SessionUser | null> => {
+    try {
+      const response = await fetchLike("/api/auth/me", {
+        credentials: "same-origin",
+      });
+      if (!response.ok) return null;
+      const payload = (await response.json()) as { user?: SessionUser | null };
+      return payload.user ?? null;
+    } catch {
+      return null;
+    }
+  })();
+  sessionRequests.set(fetchLike, {
+    expiresAt: Date.now() + SESSION_CACHE_MS,
+    request,
+  });
+  return request;
 }
 
 /** Providers plus session; a dark or unreachable worker reads as no-auth. */
@@ -298,13 +323,17 @@ export function AccountMenu() {
       }}
       onRename={(displayName) => {
         void renameAccount(displayName).then((user) => {
-          if (user) setState({ providers: state.providers, user });
+          if (user) {
+            setState({ providers: state.providers, user });
+            cacheSessionUser(fetch, user);
+          }
         });
       }}
       onSignOut={() => {
-        void signOut().then(() =>
-          setState({ providers: state.providers, user: null }),
-        );
+        void signOut().then(() => {
+          setState({ providers: state.providers, user: null });
+          cacheSessionUser(fetch, null);
+        });
       }}
     />
   );

--- a/apps/editor/src/components/gallery-bundled-fallback.ts
+++ b/apps/editor/src/components/gallery-bundled-fallback.ts
@@ -1,0 +1,31 @@
+import { renderDocumentSvg } from "@icm/render-svg";
+import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
+
+import { libraryProjectExamples } from "../examples/library-examples";
+
+export interface BundledGalleryTile {
+  id: string;
+  name: string;
+  description: string;
+  svg: string;
+}
+
+/**
+ * Render the starter wall only after the community feed has settled empty.
+ * Keeping this work in its own dynamic module means a populated Gallery never
+ * downloads the renderer, symbol catalogue, or bundled Project fixtures.
+ */
+export function loadBundledGalleryTiles(): BundledGalleryTile[] {
+  const resolver = new InMemorySymbolResolver(builtInSymbols);
+  return libraryProjectExamples.map((example) => {
+    const topDocument = example.project.documents.find(
+      (document) => document.id === example.project.topDocumentId,
+    )!;
+    return {
+      id: example.id,
+      name: example.name,
+      description: example.description,
+      svg: renderDocumentSvg(topDocument, resolver),
+    };
+  });
+}

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -843,6 +843,13 @@ export function GalleryFeed({
                               entry.previewRevision,
                             )}
                             alt={`Preview of ${entry.name}`}
+                            {...(entry.previewWidth !== undefined &&
+                            entry.previewHeight !== undefined
+                              ? {
+                                  width: entry.previewWidth,
+                                  height: entry.previewHeight,
+                                }
+                              : {})}
                           />
                           <span className="gallery-tile-copy">
                             <span className="gallery-tile-name">

--- a/apps/editor/src/components/gallery-feed.tsx
+++ b/apps/editor/src/components/gallery-feed.tsx
@@ -2,10 +2,6 @@ import { useEffect, useRef, useState } from "react";
 import { TilePreview } from "./tile-preview";
 import "../styles/gallery-entry.css";
 
-import { renderDocumentSvg } from "@icm/render-svg";
-import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
-
-import { libraryProjectExamples } from "../examples/library-examples";
 import {
   announceGalleryChange,
   galleryCountLabel,
@@ -19,6 +15,7 @@ import {
   type GalleryFeedState,
   type GalleryTagOption,
 } from "../gallery-client";
+import type { BundledGalleryTile } from "./gallery-bundled-fallback";
 
 // The wall and the canvas-side panel share one data layer, so a search that
 // finds a circuit here finds it there too. These re-exports keep every
@@ -37,7 +34,6 @@ import { GalleryChrome } from "./gallery-chrome";
 import { Masonry } from "./masonry";
 import { ShelfWall } from "./shelf-wall";
 
-const resolver = new InMemorySymbolResolver(builtInSymbols);
 /**
  * How many tags the bar shows before it offers the rest. One row at a typical
  * desktop width; the wall is what the reader came for, so the tags stay a
@@ -285,21 +281,6 @@ function savedAtLabel(createdAt: string): string {
       });
 }
 
-/** Bundled examples double as never-empty starter tiles for the feed. */
-function bundledTiles() {
-  return libraryProjectExamples.map((example) => {
-    const topDocument = example.project.documents.find(
-      (document) => document.id === example.project.topDocumentId,
-    )!;
-    return {
-      id: example.id,
-      name: example.name,
-      description: example.description,
-      svg: renderDocumentSvg(topDocument, resolver),
-    };
-  });
-}
-
 /** One feed page; the plain first request stays exactly `/api/gallery`. */
 /**
  * Full-screen landing feed: every tile is one published circuit that opens
@@ -344,6 +325,10 @@ export function GalleryFeed({
     { tag: string; count: number }[]
   >([]);
   const [refreshSignal, setRefreshSignal] = useState(0);
+  const [bundledFallback, setBundledFallback] = useState<{
+    status: "idle" | "loading" | "ready" | "failed";
+    tiles: BundledGalleryTile[];
+  }>({ status: "idle", tiles: [] });
 
   useEffect(() => {
     let cancelled = false;
@@ -617,6 +602,25 @@ export function GalleryFeed({
   }
 
   const entries = state.entries;
+  const needsBundledFallback =
+    state.status !== "loading" && entries.length === 0 && author === null;
+
+  useEffect(() => {
+    if (!needsBundledFallback || bundledFallback.status !== "idle") return;
+    let cancelled = false;
+    setBundledFallback({ status: "loading", tiles: [] });
+    void import("./gallery-bundled-fallback")
+      .then(({ loadBundledGalleryTiles }) => loadBundledGalleryTiles())
+      .then((tiles) => {
+        if (!cancelled) setBundledFallback({ status: "ready", tiles });
+      })
+      .catch(() => {
+        if (!cancelled) setBundledFallback({ status: "failed", tiles: [] });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [needsBundledFallback]);
 
   const normalizedSearchQuery = searchQuery.trim().toLowerCase();
   const visibleEntries = normalizedSearchQuery
@@ -811,7 +815,10 @@ export function GalleryFeed({
               {ownerNotice}
             </p>
           ) : null}
-          {state.status === "loading" ? (
+          {state.status === "loading" ||
+          (needsBundledFallback &&
+            (bundledFallback.status === "idle" ||
+              bundledFallback.status === "loading")) ? (
             <p className="gallery-status" data-testid="gallery-loading">
               Loading gallery…
             </p>
@@ -944,8 +951,8 @@ export function GalleryFeed({
                       </div>
                     ),
                   })),
-                  ...(entries.length === 0 && author === null
-                    ? bundledTiles()
+                  ...(needsBundledFallback
+                    ? bundledFallback.tiles
                         .filter((tile) =>
                           galleryEntryMatchesQuery(
                             { ...tile, author: "", tags: [] },

--- a/apps/editor/src/components/masonry.test.ts
+++ b/apps/editor/src/components/masonry.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { masonryColumnCount, shortestColumn } from "./masonry";
+import {
+  createFrameCoalescer,
+  masonryColumnCount,
+  shortestColumn,
+} from "./masonry";
 
 describe("masonryColumnCount", () => {
   it("fits as many min-width columns as the container allows", () => {
@@ -37,5 +41,38 @@ describe("shortestColumn", () => {
     // Three tiles fill the top row in order; the fourth lands under the
     // shortest (the first, 120-tall) column.
     expect(placed).toEqual([0, 1, 2, 0]);
+  });
+});
+
+describe("createFrameCoalescer", () => {
+  it("runs one layout for a burst and cancels queued work on cleanup", () => {
+    const frames = new Map<number, FrameRequestCallback>();
+    let nextFrame = 0;
+    let layouts = 0;
+    const coalescer = createFrameCoalescer(
+      () => {
+        layouts += 1;
+      },
+      (callback) => {
+        nextFrame += 1;
+        frames.set(nextFrame, callback);
+        return nextFrame;
+      },
+      (handle) => {
+        frames.delete(handle);
+      },
+    );
+
+    coalescer.schedule();
+    coalescer.schedule();
+    coalescer.schedule();
+    expect(frames.size).toBe(1);
+    frames.get(1)!(0);
+    expect(layouts).toBe(1);
+
+    coalescer.schedule();
+    expect(frames.has(2)).toBe(true);
+    coalescer.cancel();
+    expect(frames.has(2)).toBe(false);
   });
 });

--- a/apps/editor/src/components/masonry.tsx
+++ b/apps/editor/src/components/masonry.tsx
@@ -30,6 +30,31 @@ export function shortestColumn(heights: readonly number[]): number {
   return column;
 }
 
+/** Collapse any number of observer notifications into one animation frame. */
+export function createFrameCoalescer(
+  callback: () => void,
+  requestFrame: (
+    callback: FrameRequestCallback,
+  ) => number = requestAnimationFrame,
+  cancelFrame: (handle: number) => void = cancelAnimationFrame,
+): { schedule: () => void; cancel: () => void } {
+  let frame: number | null = null;
+  return {
+    schedule() {
+      if (frame !== null) return;
+      frame = requestFrame(() => {
+        frame = null;
+        callback();
+      });
+    },
+    cancel() {
+      if (frame === null) return;
+      cancelFrame(frame);
+      frame = null;
+    },
+  };
+}
+
 export interface MasonryItem {
   key: string;
   node: ReactNode;
@@ -62,20 +87,38 @@ export function Masonry({
       const count = masonryColumnCount(width, minColumnWidth, gap);
       const columnWidth = (width - gap * (count - 1)) / count;
       const heights = new Array<number>(count).fill(0);
+      const widthStyle = `${columnWidth}px`;
+      // Write every width before measuring any height. This produces one
+      // layout flush instead of alternating N writes with N reads.
       for (const tile of tiles) {
-        tile.style.width = `${columnWidth}px`;
-        const height = tile.offsetHeight;
-        const column = shortestColumn(heights);
-        tile.style.transform = `translate(${column * (columnWidth + gap)}px, ${heights[column]}px)`;
-        heights[column] = heights[column]! + height + gap;
+        if (tile.style.width !== widthStyle) tile.style.width = widthStyle;
       }
-      container.style.height = `${Math.max(0, Math.max(...heights) - gap)}px`;
+      const tileHeights = tiles.map((tile) => tile.offsetHeight);
+      const placements = tileHeights.map((height) => {
+        const column = shortestColumn(heights);
+        const transform = `translate(${column * (columnWidth + gap)}px, ${heights[column]}px)`;
+        heights[column] = heights[column]! + height + gap;
+        return transform;
+      });
+      for (const [index, tile] of tiles.entries()) {
+        const transform = placements[index]!;
+        if (tile.style.transform !== transform)
+          tile.style.transform = transform;
+      }
+      const heightStyle = `${Math.max(0, Math.max(...heights) - gap)}px`;
+      if (container.style.height !== heightStyle) {
+        container.style.height = heightStyle;
+      }
     };
-    const observer = new ResizeObserver(relayout);
+    const coalescer = createFrameCoalescer(relayout);
+    const observer = new ResizeObserver(coalescer.schedule);
     observer.observe(container);
     for (const child of container.children) observer.observe(child);
     relayout();
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      coalescer.cancel();
+    };
   }, [items, minColumnWidth, gap]);
 
   return (

--- a/apps/editor/src/components/tile-preview.test.tsx
+++ b/apps/editor/src/components/tile-preview.test.tsx
@@ -4,13 +4,29 @@ import { describe, expect, it } from "vitest";
 import { TilePreview } from "./tile-preview";
 
 describe("TilePreview", () => {
-  it("renders the image markup with lazy loading", () => {
+  it("reserves known preview dimensions while loading lazily", () => {
     const html = renderToStaticMarkup(
-      <TilePreview src="/p.svg" alt="Preview of Amp" />,
+      <TilePreview
+        src="/p.svg"
+        alt="Preview of Amp"
+        width={640}
+        height={360}
+      />,
     );
     expect(html).toContain('src="/p.svg"');
     expect(html).toContain('alt="Preview of Amp"');
     expect(html).toContain('loading="lazy"');
+    expect(html).toContain('decoding="async"');
+    expect(html).toContain('width="640"');
+    expect(html).toContain('height="360"');
     expect(html).not.toContain("gallery-tile-placeholder");
+  });
+
+  it("omits incomplete dimensions for an older Gallery response", () => {
+    const html = renderToStaticMarkup(
+      <TilePreview src="/legacy.svg" alt="Legacy preview" width={640} />,
+    );
+    expect(html).not.toContain('width="640"');
+    expect(html).not.toContain("height=");
   });
 });

--- a/apps/editor/src/components/tile-preview.tsx
+++ b/apps/editor/src/components/tile-preview.tsx
@@ -6,8 +6,25 @@ import { useState } from "react";
  * backfilled, or a drawing the renderer cannot handle), the tile shows a
  * quiet schematic placeholder instead of the browser's broken-image glyph.
  */
-export function TilePreview({ src, alt }: { src: string; alt: string }) {
+export function TilePreview({
+  src,
+  alt,
+  width,
+  height,
+}: {
+  src: string;
+  alt: string;
+  width?: number;
+  height?: number;
+}) {
   const [failed, setFailed] = useState(false);
+  const hasIntrinsicSize =
+    typeof width === "number" &&
+    Number.isFinite(width) &&
+    width > 0 &&
+    typeof height === "number" &&
+    Number.isFinite(height) &&
+    height > 0;
   return (
     <span
       className={
@@ -44,6 +61,8 @@ export function TilePreview({ src, alt }: { src: string; alt: string }) {
           src={src}
           alt={alt}
           loading="lazy"
+          decoding="async"
+          {...(hasIntrinsicSize ? { width, height } : {})}
           onError={() => setFailed(true)}
         />
       )}

--- a/apps/editor/src/gallery-client.ts
+++ b/apps/editor/src/gallery-client.ts
@@ -166,6 +166,9 @@ export interface GalleryFeedEntry {
   createdAt: string;
   /** Absent only while a newer client is rolling out against an older API. */
   previewRevision?: string;
+  /** Intrinsic SVG viewBox size, used to reserve the tile before image load. */
+  previewWidth?: number;
+  previewHeight?: number;
   schemaVersion: number;
   tags?: string[];
   /**

--- a/docs/specs/community-gallery.md
+++ b/docs/specs/community-gallery.md
@@ -22,7 +22,10 @@ restrictive content-security-policy.
   `author` filters to that exact byline and optional `tags=a,b` to
   entries carrying ANY listed tag, both ahead of pagination). Rejected and
   recycled entries never appear. Every entry includes the content-derived
-  `previewRevision` used by its thumbnail URL.
+  `previewRevision` used by its thumbnail URL plus `previewWidth` and
+  `previewHeight` from the stored SVG viewBox. Older or invalid previews may
+  omit the dimensions; clients must then retain their existing natural-size
+  fallback.
 - `GET /api/gallery/tags` — distinct public tags with counts, most
   frequent first (feeds the multi-select menu).
 - `GET /api/gallery/<id>` — one public entry with its canonical
@@ -36,7 +39,10 @@ restrictive content-security-policy.
   editor's Examples panel reads the same gallery list and opens entries
   through the same path as `/g/<id>`. While the gallery is empty or
   unreachable, the feed and the panel both fall back to the bundled
-  Library examples, so neither surface is ever blank.
+  Library examples, so neither surface is ever blank. The landing feed loads
+  its renderer, symbol catalogue, and bundled Projects only after the remote
+  feed has settled empty or unavailable; a populated Gallery never pays for
+  those fallback-only dependencies.
 
 ## Publishing
 

--- a/worker/gallery-do.ts
+++ b/worker/gallery-do.ts
@@ -148,6 +148,35 @@ export const GALLERY_MAX_VERSIONS_PER_ENTRY = 2;
 export const GALLERY_DEFAULT_LIST_LIMIT = 30;
 export const GALLERY_MAX_LIST_LIMIT = 60;
 
+export interface SvgPreviewDimensions {
+  width: number;
+  height: number;
+}
+
+/** Read the renderer-owned SVG viewBox without parsing or trusting its body. */
+export function svgPreviewDimensions(
+  svgText: string,
+): SvgPreviewDimensions | null {
+  const root = /<svg\b[^>]*>/iu.exec(svgText)?.[0];
+  const value = root
+    ? /\bviewBox\s*=\s*(["'])(.*?)\1/iu.exec(root)?.[2]
+    : undefined;
+  if (!value) return null;
+  const parts = value
+    .trim()
+    .split(/[\s,]+/u)
+    .map(Number);
+  if (
+    parts.length !== 4 ||
+    !parts.every(Number.isFinite) ||
+    parts[2]! <= 0 ||
+    parts[3]! <= 0
+  ) {
+    return null;
+  }
+  return { width: parts[2]!, height: parts[3]! };
+}
+
 type SqlResult<T> = {
   toArray(): T[];
   one(): T;
@@ -223,6 +252,9 @@ export interface GalleryEntrySummary {
    * existing immutable response.
    */
   previewRevision: string;
+  /** Intrinsic preview ratio; absent only for an invalid or legacy SVG. */
+  previewWidth?: number;
+  previewHeight?: number;
   schemaVersion: number;
   tags: string[];
   /**
@@ -290,6 +322,8 @@ interface EntryRow {
   svg_text: string;
   netlistable: number;
   preview_revision: string;
+  preview_width: number | null;
+  preview_height: number | null;
 }
 
 type EntrySummaryRow = Pick<
@@ -303,6 +337,8 @@ type EntrySummaryRow = Pick<
   | "tags"
   | "netlistable"
   | "preview_revision"
+  | "preview_width"
+  | "preview_height"
 >;
 
 interface PreviewAccessRow {
@@ -318,6 +354,7 @@ interface PreviewRow extends PreviewAccessRow {
 const TOKENZHANG_BYLINE_MIGRATION = "2026-08-26-tokenzhang-to-zhishuai-zhang";
 const TOKENZHANG_BYLINE = "Zhishuai Zhang";
 const VERSION_RETENTION_MIGRATION = "2026-08-27-gallery-version-retention-2";
+const PREVIEW_DIMENSIONS_MIGRATION = "2026-09-02-gallery-preview-dimensions";
 
 function summaryOf(
   row: EntrySummaryRow & { likes?: number; liked_by_viewer?: number },
@@ -332,6 +369,12 @@ function summaryOf(
     // them off the formerly mutable URL once; their next SVG write stores a
     // content hash like every new row.
     previewRevision: row.preview_revision || "legacy",
+    ...(row.preview_width !== null && row.preview_height !== null
+      ? {
+          previewWidth: row.preview_width,
+          previewHeight: row.preview_height,
+        }
+      : {}),
     schemaVersion: row.schema_version,
     tags: unwrapTags(row.tags),
     netlistable: row.netlistable === 1,
@@ -361,7 +404,9 @@ export class GalleryDO {
         submitter_provider TEXT,
         project_text TEXT NOT NULL,
         svg_text TEXT NOT NULL,
-        preview_revision TEXT NOT NULL DEFAULT ''
+        preview_revision TEXT NOT NULL DEFAULT '',
+        preview_width REAL,
+        preview_height REAL
       ) WITHOUT ROWID
     `);
     this.sql.exec(`
@@ -452,6 +497,8 @@ export class GalleryDO {
       "ALTER TABLE gallery_entries ADD COLUMN submitter_provider TEXT",
       "ALTER TABLE gallery_entries ADD COLUMN netlistable INTEGER NOT NULL DEFAULT 0",
       "ALTER TABLE gallery_entries ADD COLUMN preview_revision TEXT NOT NULL DEFAULT ''",
+      "ALTER TABLE gallery_entries ADD COLUMN preview_width REAL",
+      "ALTER TABLE gallery_entries ADD COLUMN preview_height REAL",
       "ALTER TABLE cloud_projects ADD COLUMN preview_svg TEXT NOT NULL DEFAULT ''",
     ]) {
       try {
@@ -466,6 +513,37 @@ export class GalleryDO {
         applied_at TEXT NOT NULL
       ) WITHOUT ROWID
     `);
+    this.state.storage.transactionSync(() => {
+      const applied = this.sql
+        .exec<{ id: string }>(
+          "SELECT id FROM data_migrations WHERE id = ?",
+          PREVIEW_DIMENSIONS_MIGRATION,
+        )
+        .toArray();
+      if (applied.length > 0) return;
+      const rows = this.sql
+        .exec<{ id: string; svg_text: string }>(
+          `SELECT id, svg_text FROM gallery_entries
+           WHERE preview_width IS NULL OR preview_height IS NULL`,
+        )
+        .toArray();
+      for (const row of rows) {
+        const dimensions = svgPreviewDimensions(row.svg_text);
+        if (!dimensions) continue;
+        this.sql.exec(
+          `UPDATE gallery_entries SET preview_width = ?, preview_height = ?
+           WHERE id = ?`,
+          dimensions.width,
+          dimensions.height,
+          row.id,
+        );
+      }
+      this.sql.exec(
+        "INSERT INTO data_migrations(id, applied_at) VALUES (?, ?)",
+        PREVIEW_DIMENSIONS_MIGRATION,
+        new Date().toISOString(),
+      );
+    });
     this.state.storage.transactionSync(() => {
       const applied = this.sql
         .exec<{ id: string }>(
@@ -663,6 +741,7 @@ export class GalleryDO {
   private submit(body: Record<string, unknown>): Response {
     const entry = body.entry as EntryRow;
     const previewRevision = sha256Hex(entry.svg_text);
+    const previewDimensions = svgPreviewDimensions(entry.svg_text);
     const day = String(body.day);
     // The daily quota is anti-garbage protection for ordinary submitters;
     // admin and moderator sessions are exempt (they curate).
@@ -708,8 +787,8 @@ export class GalleryDO {
           id, name, author, description, created_at, schema_version,
           status, recycled_at, owner_user_id, submitter_email,
           submitter_provider, tags, project_text, svg_text, netlistable,
-          preview_revision
-        ) VALUES (?, ?, ?, ?, ?, ?, 'public', NULL, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          preview_revision, preview_width, preview_height
+        ) VALUES (?, ?, ?, ?, ?, ?, 'public', NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         entry.id,
         entry.name,
         entry.author,
@@ -724,6 +803,8 @@ export class GalleryDO {
         entry.svg_text,
         entry.netlistable ?? 0,
         previewRevision,
+        previewDimensions?.width ?? null,
+        previewDimensions?.height ?? null,
       );
       this.sweepRecycledRows(entry.owner_user_id ?? "");
       return { status: "stored" as const };
@@ -776,6 +857,7 @@ export class GalleryDO {
       .exec<EntrySummaryRow & { likes: number; liked_by_viewer: number }>(
         `SELECT e.id, e.name, e.author, e.description, e.created_at,
            e.schema_version, e.tags, e.netlistable, e.preview_revision,
+           e.preview_width, e.preview_height,
            (SELECT COUNT(*) FROM gallery_likes WHERE entry_id = e.id) AS likes,
            (SELECT COUNT(*) FROM gallery_likes
              WHERE entry_id = e.id AND user_id = ?) AS liked_by_viewer
@@ -892,13 +974,15 @@ export class GalleryDO {
     if (!row) return Response.json({ error: "not-found" }, { status: 404 });
     const svgText = String(body.svgText);
     const previewRevision = sha256Hex(svgText);
+    const previewDimensions = svgPreviewDimensions(svgText);
     this.state.storage.transactionSync(() => {
       this.snapshotEntry(row, String(body.at ?? row.created_at));
       this.sql.exec(
         `UPDATE gallery_entries
          SET name = ?, author = ?, description = ?, project_text = ?,
              svg_text = ?, schema_version = ?, status = ?, tags = ?,
-             netlistable = ?, preview_revision = ?
+             netlistable = ?, preview_revision = ?, preview_width = ?,
+             preview_height = ?
          WHERE id = ?`,
         String(body.name),
         String(body.author),
@@ -910,6 +994,8 @@ export class GalleryDO {
         typeof body.tags === "string" ? body.tags : "",
         Number(body.netlistable) === 1 ? 1 : 0,
         previewRevision,
+        previewDimensions?.width ?? null,
+        previewDimensions?.height ?? null,
         row.id,
       );
     });
@@ -1019,13 +1105,14 @@ export class GalleryDO {
     const restoredProjectText = serializeProject(restoredProject);
     const netlistable = analyzeDesignNetlist(restoredProject).ir ? 1 : 0;
     const previewRevision = sha256Hex(version.svg_text);
+    const previewDimensions = svgPreviewDimensions(version.svg_text);
     this.state.storage.transactionSync(() => {
       this.snapshotEntry(entry, String(body.at));
       this.sql.exec(
         `UPDATE gallery_entries
          SET name = ?, author = ?, description = ?, project_text = ?,
              svg_text = ?, schema_version = ?, tags = ?, netlistable = ?,
-             preview_revision = ?
+             preview_revision = ?, preview_width = ?, preview_height = ?
          WHERE id = ?`,
         version.name,
         version.author,
@@ -1036,6 +1123,8 @@ export class GalleryDO {
         version.tags ?? "",
         netlistable,
         previewRevision,
+        previewDimensions?.width ?? null,
+        previewDimensions?.height ?? null,
         entry.id,
       );
     });
@@ -1334,15 +1423,18 @@ export class GalleryDO {
         if (typeof svgText !== "string") {
           throw new Error("Backup row has invalid svg_text");
         }
+        const previewDimensions = svgPreviewDimensions(svgText);
         this.sql.exec(
           `INSERT INTO gallery_entries
            (id, name, author, description, created_at, schema_version, status,
             recycled_at, owner_user_id, submitter_email, submitter_provider,
             project_text, svg_text, reject_reason, reviewed_at, reviewed_by,
-            tags, netlistable, preview_revision)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            tags, netlistable, preview_revision, preview_width, preview_height)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
           ...values,
           sha256Hex(svgText),
+          previewDimensions?.width ?? null,
+          previewDimensions?.height ?? null,
         );
       }
       for (const row of galleryEntryVersions) {
@@ -1777,15 +1869,18 @@ export class GalleryDO {
     if (!row) return Response.json({ error: "not-found" }, { status: 404 });
     const svgText = String(body.svgText);
     const previewRevision = sha256Hex(svgText);
+    const previewDimensions = svgPreviewDimensions(svgText);
     this.sql.exec(
       `UPDATE gallery_entries
        SET project_text = ?, schema_version = ?, svg_text = ?,
-           preview_revision = ?
+           preview_revision = ?, preview_width = ?, preview_height = ?
        WHERE id = ?`,
       String(body.projectText),
       Number(body.schemaVersion),
       svgText,
       previewRevision,
+      previewDimensions?.width ?? null,
+      previewDimensions?.height ?? null,
       String(body.id),
     );
     return Response.json({ id: row.id, previewRevision });

--- a/worker/gallery.test.ts
+++ b/worker/gallery.test.ts
@@ -18,6 +18,7 @@ import {
   routeGalleryRequest,
   SHORT_ID_LENGTH,
   shortId,
+  svgPreviewDimensions,
   type GalleryEnv,
   type GalleryPreviewCache,
 } from "./gallery";
@@ -203,6 +204,18 @@ function memoryPreviewCache(): GalleryPreviewCache & {
   };
 }
 
+describe("svgPreviewDimensions", () => {
+  it("reads a positive SVG viewBox and rejects incomplete geometry", () => {
+    expect(
+      svgPreviewDimensions(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="-20 10 640 360"></svg>',
+      ),
+    ).toEqual({ width: 640, height: 360 });
+    expect(svgPreviewDimensions('<svg viewBox="0 0 20 0"></svg>')).toBeNull();
+    expect(svgPreviewDimensions("<svg></svg>")).toBeNull();
+  });
+});
+
 function cookieHeaders(cookie: string): HeadersInit {
   return { Cookie: cookie };
 }
@@ -246,6 +259,39 @@ async function submitOne(
 }
 
 describe("gallery data migrations", () => {
+  it("backfills intrinsic preview dimensions for existing entries once", () => {
+    const state = sqliteState();
+    new GalleryDO(state);
+    state.storage.sql.exec(
+      `INSERT INTO gallery_entries
+       (id, name, author, description, created_at, schema_version, status,
+        project_text, svg_text)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      "legacy-preview",
+      "Legacy preview",
+      "Author",
+      "",
+      "2026-08-01T00:00:00.000Z",
+      CURRENT_PROJECT_SCHEMA_VERSION,
+      "public",
+      projectText("Legacy preview"),
+      '<svg viewBox="-10 -20 320 180"></svg>',
+    );
+    state.storage.sql.exec(
+      "DELETE FROM data_migrations WHERE id LIKE '%preview-dimensions%'",
+    );
+
+    new GalleryDO(state);
+    expect(
+      state.storage.sql
+        .exec<{ preview_width: number; preview_height: number }>(
+          `SELECT preview_width, preview_height FROM gallery_entries
+           WHERE id = 'legacy-preview'`,
+        )
+        .one(),
+    ).toEqual({ preview_width: 320, preview_height: 180 });
+  });
+
   it("renames tokenzhang across entries and restorable versions once", () => {
     const state = sqliteState();
     new GalleryDO(state);
@@ -944,6 +990,8 @@ describe("gallery submissions", () => {
         id: string;
         name: string;
         previewRevision: string;
+        previewWidth: number;
+        previewHeight: number;
         schemaVersion: number;
       }[];
     };
@@ -953,6 +1001,8 @@ describe("gallery submissions", () => {
       schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION,
     });
     expect(listed.entries[0]!.previewRevision).toMatch(/^[a-f0-9]{64}$/u);
+    expect(listed.entries[0]!.previewWidth).toBeGreaterThan(0);
+    expect(listed.entries[0]!.previewHeight).toBeGreaterThan(0);
 
     const detail = await route(env, new Request(`${ORIGIN}/api/gallery/${id}`));
     const payload = (await detail.json()) as { projectText: string };


### PR DESCRIPTION
Summary: defer bundled Gallery rendering dependencies until the remote feed settles empty or unavailable; share nearby session reads; persist and backfill SVG preview dimensions for native lazy loading; and batch Masonry observer work plus DOM reads and writes. Final Gallery visuals, SVG bytes, card sizing, filtering, pagination, and fallback content are unchanged. Older or invalid metadata uses the prior natural-size behavior. Validation: gate preflight and affected passed (2281 unit tests, 5 skipped; 40 Gallery browser tests), production build passed, and editor production smoke passed.