### PR TITLE
perf(editor): complete E0 derived-state optimization

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -1226,7 +1226,6 @@ export function App({
   const {
     logicalNets,
     routeGeometryRecords,
-    netlistAnalysis,
     highlightedTrace,
     highlightedNet,
     highlightedNetId,
@@ -1251,15 +1250,12 @@ export function App({
     highlightedNetOrigin,
     selectedHighlightNetId,
     selectedHighlightEndpoint,
+    searchActive: searchOpen,
     searchQuery,
     routingGuidanceView,
     wireSource,
     bulkDrawInstanceId,
   });
-  const projectNetNameProjection = useMemo(
-    () => deriveProjectNetNameProjection(project),
-    [project],
-  );
   const selectedNetNameAnnotation =
     selectedAnnotation?.binding?.kind === "net-name" &&
     (selectedAnnotation.kind === "net-label" ||
@@ -1281,8 +1277,13 @@ export function App({
   const selectedNetNameLogical = selectedNetNameAnnotation?.netId
     ? logicalNets.byBaseNetId.get(selectedNetNameAnnotation.netId)
     : undefined;
+  const projectNetNameProjection = useMemo(
+    () =>
+      selectedNetNameLogical ? deriveProjectNetNameProjection(project) : null,
+    [project, selectedNetNameLogical],
+  );
   const selectedNetNameProjection = selectedNetNameLogical
-    ? projectNetNameProjection.byDocumentId
+    ? projectNetNameProjection?.byDocumentId
         .get(document.id)
         ?.get(selectedNetNameLogical.id)
     : undefined;

--- a/apps/editor/src/app/use-editor-derived-model.ts
+++ b/apps/editor/src/app/use-editor-derived-model.ts
@@ -8,7 +8,7 @@ import {
   endpointKey,
   isMosBulkTerminal,
   isVisibleEndpoint,
-  resolveDocumentLogicalNets,
+  resolveCommittedDocumentLogicalNets,
   resolveEndpointConnection,
   traceHierarchyNet,
 } from "@icm/derived";
@@ -223,7 +223,7 @@ export function useEditorDerivedModel({
     document.id,
   );
   const logicalNets = useMemo(
-    () => resolveDocumentLogicalNets(document),
+    () => resolveCommittedDocumentLogicalNets(document),
     [document],
   );
   const routeGeometryRecords = useMemo(

--- a/apps/editor/src/app/use-editor-derived-model.ts
+++ b/apps/editor/src/app/use-editor-derived-model.ts
@@ -18,7 +18,6 @@ import type {
   ProjectConnectivityIndex,
 } from "@icm/derived";
 import type { WireSource } from "@icm/edit-engine";
-import { analyzeDesignNetlist } from "@icm/netlist";
 import type {
   CircuitProject,
   RouteEndpoint,
@@ -50,6 +49,7 @@ interface UseEditorDerivedModelOptions {
   highlightedNetOrigin: HighlightedNetOrigin | null;
   selectedHighlightNetId: string | null;
   selectedHighlightEndpoint: RouteEndpoint | undefined;
+  searchActive: boolean;
   searchQuery: string;
   routingGuidanceView: RoutingGuidanceView;
   wireSource: WireSource | null;
@@ -213,6 +213,7 @@ export function useEditorDerivedModel({
   highlightedNetOrigin,
   selectedHighlightNetId,
   selectedHighlightEndpoint,
+  searchActive,
   searchQuery,
   routingGuidanceView,
   wireSource,
@@ -234,10 +235,6 @@ export function useEditorDerivedModel({
         return geometry ? [{ route, geometry }] : [];
       }),
     [document, documentConnectivity],
-  );
-  const netlistAnalysis = useMemo(
-    () => analyzeDesignNetlist(project),
-    [project],
   );
   const highlightedTrace = useMemo(
     () =>
@@ -283,17 +280,12 @@ export function useEditorDerivedModel({
       ),
     [liveDiagnosticSnapshot],
   );
-  const projectSearchIndex = useMemo(
-    () =>
-      buildProjectSearchIndex(project, {
-        connectivityIndex: projectConnectivityIndex,
-      }),
-    [project, projectConnectivityIndex],
-  );
-  const searchResults = useMemo(
-    () => projectSearchIndex.search(searchQuery),
-    [projectSearchIndex, searchQuery],
-  );
+  const searchResults = useMemo(() => {
+    if (!searchActive || searchQuery.trim().length === 0) return [];
+    return buildProjectSearchIndex(project, {
+      connectivityIndex: projectConnectivityIndex,
+    }).search(searchQuery);
+  }, [project, projectConnectivityIndex, searchActive, searchQuery]);
   const flightlines = useMemo(
     () => [
       ...new Map(
@@ -375,7 +367,6 @@ export function useEditorDerivedModel({
     projectConnectivityIndex,
     logicalNets,
     routeGeometryRecords,
-    netlistAnalysis,
     highlightedTrace,
     highlightedNet,
     highlightedNetId,

--- a/apps/editor/src/document/document-controller.test.ts
+++ b/apps/editor/src/document/document-controller.test.ts
@@ -206,6 +206,7 @@ describe("EditorDocumentController", () => {
   it("commits a new child Cell without replacing the Project session", () => {
     const controller = new EditorDocumentController(hierarchicalProject());
     const sessionId = controller.projectSessionId;
+    const resolverBefore = controller.resolver;
     controller.transact([{ kind: "add_instance", instance: instance("Rold") }]);
     const project = structuredClone(controller.project);
     const child = createEmptyDocument("document-cell-1", "Cell1");
@@ -233,6 +234,7 @@ describe("EditorDocumentController", () => {
 
     expect(active.id).toBe(controller.project.topDocumentId);
     expect(controller.projectSessionId).toBe(sessionId);
+    expect(controller.resolver).not.toBe(resolverBefore);
     expect(
       controller.resolver.resolve(hierarchicalSymbolId("Cell1")),
     ).toBeDefined();
@@ -258,7 +260,7 @@ describe("EditorDocumentController", () => {
     ).toBe(true);
   });
 
-  it("dispatches an Agent transaction as one undo item and refreshes state", () => {
+  it("dispatches an Agent transaction as one undo item without rebuilding symbols", () => {
     const controller = new EditorDocumentController(hierarchicalProject());
     const resolverBefore = controller.resolver;
     const revisionBefore = controller.document.revision;
@@ -275,8 +277,7 @@ describe("EditorDocumentController", () => {
     expect(controller.document.instances).toContainEqual(instance("Ragent"));
     expect(controller.document.revision).toBe(revisionBefore + 1);
     expect(controller.canUndo).toBe(true);
-    // A commit refreshes the resolver (new reference) like a human commit.
-    expect(controller.resolver).not.toBe(resolverBefore);
+    expect(controller.resolver).toBe(resolverBefore);
 
     // One Agent transaction is one undo item: a single undo restores the
     // pre-Agent state through the shared history.
@@ -284,6 +285,29 @@ describe("EditorDocumentController", () => {
     expect(controller.document.instances).not.toContainEqual(
       instance("Ragent"),
     );
+    expect(controller.resolver).toBe(resolverBefore);
+  });
+
+  it("rebuilds symbols for a definition-level Document edit", () => {
+    const controller = new EditorDocumentController(hierarchicalProject());
+    controller.openDocument("document-child");
+    const resolverBefore = controller.resolver;
+
+    const result = controller.dispatchTransaction({
+      transactionId: "cell-symbol-presentation",
+      documentId: "document-child",
+      expectedRevision: controller.document.revision,
+      actor: { kind: "human", id: "human-local" },
+      edits: [
+        {
+          kind: "set_cell_symbol_presentation",
+          presentation: { minimumBodySize: { width: 120, height: 80 } },
+        },
+      ],
+    });
+
+    expect(result.ok && result.applied).toBe(true);
+    expect(controller.resolver).not.toBe(resolverBefore);
   });
 
   it("accepts a human transaction via dispatch identical to transact", () => {

--- a/apps/editor/src/document/document-controller.ts
+++ b/apps/editor/src/document/document-controller.ts
@@ -24,6 +24,43 @@ import {
 
 type ProjectSymbolResolver = ReturnType<typeof createProjectSymbolResolver>;
 
+const SYMBOL_DEFINITION_EDIT_KINDS = new Set<SchematicEdit["kind"]>([
+  "create_cell_interface",
+  "add_cell_terminal",
+  "update_cell_terminal",
+  "remove_cell_terminal",
+  "reorder_cell_terminals",
+  "set_cell_symbol_presentation",
+]);
+
+function transactionMayChangeSymbolDefinitions(
+  edits: readonly SchematicEdit[],
+): boolean {
+  return edits.some(
+    (edit) =>
+      SYMBOL_DEFINITION_EDIT_KINDS.has(edit.kind) ||
+      edit.kind === "undo" ||
+      edit.kind === "redo",
+  );
+}
+
+function documentSymbolDefinitionChanged(
+  before: SchematicDocument,
+  after: SchematicDocument,
+): boolean {
+  return (
+    before.name !== after.name ||
+    JSON.stringify(before.sourceBinding) !==
+      JSON.stringify(after.sourceBinding) ||
+    JSON.stringify(before.netlist?.name) !==
+      JSON.stringify(after.netlist?.name) ||
+    JSON.stringify(before.netlist?.terminals) !==
+      JSON.stringify(after.netlist?.terminals) ||
+    JSON.stringify(before.presentation.cellSymbol) !==
+      JSON.stringify(after.presentation.cellSymbol)
+  );
+}
+
 /**
  * A complete authenticated transaction envelope accepted by
  * {@link EditorDocumentController.dispatchTransaction}. Both human and Agent
@@ -256,10 +293,11 @@ export class EditorDocumentController {
    * The single write path for both human and Agent transactions. Selects the
    * matching per-Document history (without retargeting the active Document),
    * dispatches through {@link DocumentHistory.transact}, and on a successful
-   * commit replaces the Project document and refreshes the resolver exactly like
-   * a human commit. `dryRun` mutates no history, Project, resolver, or undo
-   * state. Opening or viewing another Document neither retargets nor cancels an
-   * explicit dispatch.
+   * commit replaces the Project document. Ordinary drawing edits preserve the
+   * resolver because built-in and hierarchical symbol definitions did not
+   * change; definition-level edits and their undo/redo rebuild it. `dryRun`
+   * mutates no history, Project, resolver, or undo state. Opening or viewing
+   * another Document neither retargets nor cancels an explicit dispatch.
    *
    * Unexpected runtime exceptions from the engine or from post-commit Project
    * re-validation are converted into typed `INTERNAL_ERROR` rejections: the
@@ -308,15 +346,23 @@ export class EditorDocumentController {
     }
     if (result.ok && result.applied) {
       const previousProject = this.projectValue;
+      const previousDocument = previousProject.documents.find(
+        (document) => document.id === request.documentId,
+      )!;
       try {
         this.projectValue = replaceProjectDocument(
           this.projectValue,
           result.document,
         );
-        this.resolverValue = createProjectSymbolResolver(
-          this.projectValue,
-          builtInSymbols,
-        );
+        if (
+          transactionMayChangeSymbolDefinitions(request.edits) &&
+          documentSymbolDefinitionChanged(previousDocument, result.document)
+        ) {
+          this.resolverValue = createProjectSymbolResolver(
+            this.projectValue,
+            builtInSymbols,
+          );
+        }
         if (
           !request.edits.some(
             (edit) => edit.kind === "undo" || edit.kind === "redo",

--- a/apps/editor/src/document/editor-session.test.ts
+++ b/apps/editor/src/document/editor-session.test.ts
@@ -23,7 +23,9 @@ describe("editor session project helpers", () => {
     const next = replaceProjectDocument(project, replacement);
 
     expect(next).not.toBe(project);
+    expect(next.documents[0]).toBe(original);
     expect(next.documents[0]).toEqual(original);
+    expect(next.documents[1]).not.toBe(replacement);
     expect(next.documents[1]).toEqual(replacement);
   });
 

--- a/apps/editor/src/document/editor-session.ts
+++ b/apps/editor/src/document/editor-session.ts
@@ -6,12 +6,26 @@ export function replaceProjectDocument(
   project: CircuitProject,
   document: SchematicDocument,
 ): CircuitProject {
-  return CircuitProjectSchema.parse({
+  const parsed = CircuitProjectSchema.parse({
     ...project,
     documents: project.documents.map((candidate) =>
       candidate.id === document.id ? document : candidate,
     ),
   });
+  const previousDocuments = new Map(
+    project.documents.map((candidate) => [candidate.id, candidate] as const),
+  );
+  return {
+    ...parsed,
+    // Whole-Project validation clones every Document. Restore the already
+    // validated, unchanged revisions so downstream WeakMap caches and React
+    // readers can retain their identity across an unrelated Document edit.
+    documents: parsed.documents.map((candidate) =>
+      candidate.id === document.id
+        ? candidate
+        : (previousDocuments.get(candidate.id) ?? candidate),
+    ),
+  };
 }
 
 /** Resolve the active Document, falling back deterministically to top. */

--- a/packages/derived/src/annotation-presentation.ts
+++ b/packages/derived/src/annotation-presentation.ts
@@ -21,6 +21,7 @@ import {
   richTextMetrics,
 } from "./rich-text-layout.js";
 import type { SchematicStyleProfile } from "./style-profile.js";
+import type { ResolvedDocumentLogicalNets } from "./logical-net.js";
 
 /** Shared SVG, editor-hit, marquee, and export presentation of an annotation. */
 export interface AnnotationPresentation {
@@ -51,9 +52,14 @@ export interface AnnotationPresentation {
 export function isSchematicAnnotationVisible(
   document: SchematicDocument,
   annotation: Annotation,
+  logicalNets?: ResolvedDocumentLogicalNets,
 ): boolean {
   if (annotation.visible === false) return false;
-  if (!flattenRichText(resolveAnnotationText(document, annotation)).trim()) {
+  if (
+    !flattenRichText(
+      resolveAnnotationText(document, annotation, logicalNets),
+    ).trim()
+  ) {
     return false;
   }
   const anchoredInstanceId =
@@ -87,6 +93,7 @@ export function resolveAnnotationPresentation(
     document,
     resolver,
   ),
+  logicalNets?: ResolvedDocumentLogicalNets,
 ): AnnotationPresentation {
   const anchor = resolveVisualAnchor(
     document,
@@ -96,7 +103,7 @@ export function resolveAnnotationPresentation(
   );
   const sizeScale = annotation.sizeScale ?? 1;
   const fontSize = annotationFontSize(annotation, styleProfile) * sizeScale;
-  const text = resolveAnnotationText(document, annotation);
+  const text = resolveAnnotationText(document, annotation, logicalNets);
   const textLayout = measureRichTextDocument(text, {
     ...richTextMetrics(styleProfile, "label", sizeScale),
     fontSize,

--- a/packages/derived/src/annotation-text.ts
+++ b/packages/derived/src/annotation-text.ts
@@ -6,7 +6,10 @@ import type {
 } from "@icm/model";
 
 import { displayableInstanceValue } from "./instance-value.js";
-import { resolveDocumentLogicalNets } from "./logical-net.js";
+import {
+  resolveDocumentLogicalNets,
+  type ResolvedDocumentLogicalNets,
+} from "./logical-net.js";
 
 const EMPTY_TEXT: RichTextDocument = { runs: [{ kind: "line-break" }] };
 
@@ -18,6 +21,7 @@ const EMPTY_TEXT: RichTextDocument = { runs: [{ kind: "line-break" }] };
 export function resolveAnnotationText(
   document: SchematicDocument,
   annotation: Annotation,
+  logicalNets?: ResolvedDocumentLogicalNets,
 ): RichTextDocument {
   const binding = annotation.binding;
   if (!binding) return annotation.content ?? EMPTY_TEXT;
@@ -55,9 +59,9 @@ export function resolveAnnotationText(
               evidence.owner.kind === "power-marker" &&
               evidence.owner.objectId === annotation.anchor.objectId)),
       );
-      const logicalName = resolveDocumentLogicalNets(document).byBaseNetId.get(
-        binding.netId,
-      )?.name;
+      const logicalName = (
+        logicalNets ?? resolveDocumentLogicalNets(document)
+      ).byBaseNetId.get(binding.netId)?.name;
       const ownerClaimName =
         ownerClaim?.kind === "name-claim" ? ownerClaim.name : undefined;
       return semanticTextDocument(

--- a/packages/derived/src/logical-net.test.ts
+++ b/packages/derived/src/logical-net.test.ts
@@ -1,9 +1,36 @@
 import { createEmptyDocument } from "@icm/model";
 import { describe, expect, it } from "vitest";
 
-import { resolveDocumentLogicalNets } from "./logical-net.js";
+import {
+  resolveCommittedDocumentLogicalNets,
+  resolveDocumentLogicalNets,
+} from "./logical-net.js";
 
 describe("resolved logical Nets", () => {
+  it("reuses only explicitly committed Document revisions", () => {
+    const document = createEmptyDocument("document-cache", "Document cache");
+    document.nets.push({ id: "net-a", terminals: [] });
+
+    const first = resolveCommittedDocumentLogicalNets(document);
+    const repeated = resolveCommittedDocumentLogicalNets(document);
+    expect(repeated).toBe(first);
+
+    document.nets.push({ id: "net-b", terminals: [] });
+    document.revision += 1;
+    const revised = resolveCommittedDocumentLogicalNets(document);
+    expect(revised).not.toBe(first);
+    expect(revised.groups.map((group) => group.id)).toEqual(["net-a", "net-b"]);
+  });
+
+  it("keeps the raw resolver live for mutable transaction drafts", () => {
+    const document = createEmptyDocument("document-draft", "Document draft");
+    document.nets.push({ id: "net-a", terminals: [] });
+    expect(resolveDocumentLogicalNets(document).groups).toHaveLength(1);
+
+    document.nets.push({ id: "net-b", terminals: [] });
+    expect(resolveDocumentLogicalNets(document).groups).toHaveLength(2);
+  });
+
   it("keeps source name hints non-electrical while resolving visible scoped names deterministically", () => {
     const document = createEmptyDocument("document", "Document");
     document.nets.push(

--- a/packages/derived/src/logical-net.ts
+++ b/packages/derived/src/logical-net.ts
@@ -28,6 +28,14 @@ export interface ResolvedDocumentLogicalNets {
   byBaseNetId: ReadonlyMap<string, ResolvedLogicalNet>;
 }
 
+const committedDocumentLogicalNetCache = new WeakMap<
+  SchematicDocument,
+  {
+    revision: number;
+    resolution: ResolvedDocumentLogicalNets;
+  }
+>();
+
 export type LogicalNetContractIssue = {
   code:
     | "CONFLICTING_LOGICAL_NET_NAME"
@@ -235,6 +243,30 @@ export function resolveDocumentLogicalNets(
     ),
   );
   return { groups, byId, byBaseNetId };
+}
+
+/**
+ * Reuse Logical-Net resolution for an immutable, committed Document revision.
+ *
+ * This is deliberately separate from {@link resolveDocumentLogicalNets}.
+ * Edit-engine transactions mutate one draft object through several edits
+ * before advancing its revision, so mutable drafts must always use the raw
+ * resolver. Editor/render read models may opt into this cache only after a
+ * Document revision has been committed.
+ */
+export function resolveCommittedDocumentLogicalNets(
+  document: SchematicDocument,
+): ResolvedDocumentLogicalNets {
+  const cached = committedDocumentLogicalNetCache.get(document);
+  if (cached && cached.revision === document.revision) {
+    return cached.resolution;
+  }
+  const resolution = resolveDocumentLogicalNets(document);
+  committedDocumentLogicalNetCache.set(document, {
+    revision: document.revision,
+    resolution,
+  });
+  return resolution;
 }
 
 /** Electrical naming invariants evaluated on the one resolved semantic view. */

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -31,6 +31,7 @@ import { flattenRichText } from "@icm/model";
 import type {
   EndpointJoin,
   DocumentContactEvidence,
+  ResolvedDocumentLogicalNets,
   ResolvedDocumentRoutingGeometry,
   ResolvedDraftingGeometry,
   SchematicStyleProfile,
@@ -90,12 +91,13 @@ function renderAnnotationText(
   document: SchematicDocument,
   annotation: SchematicDocument["annotations"][number],
   profile: SchematicStyleProfile,
+  logicalNets: ResolvedDocumentLogicalNets,
 ): string {
   const fontSize =
     schematicTextFontSize(annotation.kind, profile) *
     (annotation.sizeScale ?? 1);
   return renderRichTextDocument(
-    resolveAnnotationText(document, annotation),
+    resolveAnnotationText(document, annotation, logicalNets),
     profile,
     { fontSize },
   );
@@ -599,6 +601,7 @@ function deriveBounds(
   routingGeometry: ResolvedDocumentRoutingGeometry,
   margin: number,
   profile: SchematicStyleProfile,
+  logicalNets: ResolvedDocumentLogicalNets,
 ): DerivedRect {
   const bounds: DerivedRect[] = [];
   const estimatedTextBounds = (
@@ -653,13 +656,15 @@ function deriveBounds(
     });
   }
   for (const annotation of document.annotations) {
-    if (!isSchematicAnnotationVisible(document, annotation)) continue;
+    if (!isSchematicAnnotationVisible(document, annotation, logicalNets))
+      continue;
     const presentation = resolveAnnotationPresentation(
       document,
       resolver,
       annotation,
       profile,
       routingGeometry,
+      logicalNets,
     );
     const routePlacement =
       annotation.anchor.kind === "route"
@@ -672,7 +677,9 @@ function deriveBounds(
     const textPosition = routePlacement.labelPosition;
     bounds.push(
       estimatedTextBounds(
-        flattenRichText(resolveAnnotationText(document, annotation)),
+        flattenRichText(
+          resolveAnnotationText(document, annotation, logicalNets),
+        ),
         textPosition.x,
         textPosition.y,
         "middle",
@@ -747,7 +754,14 @@ export function buildSvgScene(
   );
   const viewBox = options.bounds
     ? RectSchema.parse(options.bounds)
-    : deriveBounds(document, resolver, routingGeometry, margin, profile);
+    : deriveBounds(
+        document,
+        resolver,
+        routingGeometry,
+        margin,
+        profile,
+        logicalNets,
+      );
 
   const joinedJunctionIds = new Set(
     routingGeometry.endpointJoins.flatMap((join) =>
@@ -937,10 +951,12 @@ export function buildSvgScene(
     })
     .join("");
   const annotations = [...document.annotations]
-    .filter((annotation) => isSchematicAnnotationVisible(document, annotation))
+    .filter((annotation) =>
+      isSchematicAnnotationVisible(document, annotation, logicalNets),
+    )
     .sort((left, right) => left.id.localeCompare(right.id, "en"))
     .map((annotation) => {
-      const content = resolveAnnotationText(document, annotation);
+      const content = resolveAnnotationText(document, annotation, logicalNets);
       const attachment = ` data-anchor-kind="${annotation.anchor.kind}"`;
       const presentation = resolveAnnotationPresentation(
         document,
@@ -948,6 +964,7 @@ export function buildSvgScene(
         annotation,
         profile,
         routingGeometry,
+        logicalNets,
       );
       const resolvedAnchor = presentation.anchor;
       const routeMarkerPlacement =
@@ -1034,7 +1051,7 @@ export function buildSvgScene(
         });
         const text = formula
           ? formula
-          : `<text x="${markerTextX}" y="${markerTextY}" text-anchor="${textAnchor}"${colorOverride ? ` fill="${colorOverride}"` : ""}${schematicTextSizeAttribute("route-marker", profile, annotation.sizeScale)}>${renderAnnotationText(document, annotation, profile)}</text>`;
+          : `<text x="${markerTextX}" y="${markerTextY}" text-anchor="${textAnchor}"${colorOverride ? ` fill="${colorOverride}"` : ""}${schematicTextSizeAttribute("route-marker", profile, annotation.sizeScale)}>${renderAnnotationText(document, annotation, profile, logicalNets)}</text>`;
         return `<g ${attributes}><g transform="${transform}"><polygon data-role="current-arrow-head" points="${tipX},${y} ${baseX},${y - halfHeadWidth} ${baseX},${y + halfHeadWidth}" fill="${profile.foreground}"/></g>${text}</g>`;
       }
       if (annotation.kind === "power-label") {
@@ -1050,7 +1067,7 @@ export function buildSvgScene(
         });
         const text = formula
           ? `<g transform="${transform}">${formula}</g>`
-          : `<text x="${position.x}" y="${position.y}" text-anchor="${annotation.alignment}" transform="${transform}"${colorOverride ? ` fill="${colorOverride}"` : ""}${schematicTextSizeAttribute("power-label", profile, annotation.sizeScale)}>${renderAnnotationText(document, annotation, profile)}</text>`;
+          : `<text x="${position.x}" y="${position.y}" text-anchor="${annotation.alignment}" transform="${transform}"${colorOverride ? ` fill="${colorOverride}"` : ""}${schematicTextSizeAttribute("power-label", profile, annotation.sizeScale)}>${renderAnnotationText(document, annotation, profile, logicalNets)}</text>`;
         return `<g ${attributes}>${text}</g>`;
       }
       if (
@@ -1076,7 +1093,7 @@ export function buildSvgScene(
         });
         const text = formula
           ? formula
-          : `<text x="${position.x}" y="${position.y}" text-anchor="${annotation.alignment}"${colorOverride ? ` fill="${colorOverride}"` : ""}${schematicTextSizeAttribute("route-marker", profile, annotation.sizeScale)}>${renderAnnotationText(document, annotation, profile)}</text>`;
+          : `<text x="${position.x}" y="${position.y}" text-anchor="${annotation.alignment}"${colorOverride ? ` fill="${colorOverride}"` : ""}${schematicTextSizeAttribute("route-marker", profile, annotation.sizeScale)}>${renderAnnotationText(document, annotation, profile, logicalNets)}</text>`;
         return `<g ${attributes}><text data-role="polarity-positive" x="${position.x + positiveOffset.x}" y="${position.y + positiveOffset.y + 4}" text-anchor="middle" font-size="${profile.typography.polarityFontSize}" style="${polarityStyle}">+</text><text data-role="polarity-negative" x="${position.x + negativeOffset.x}" y="${position.y + negativeOffset.y + 4}" text-anchor="middle" font-size="${profile.typography.polarityFontSize}" style="${polarityStyle}">−</text>${text}</g>`;
       }
       const emphasis = "";
@@ -1124,7 +1141,7 @@ export function buildSvgScene(
       if (positioned) {
         return `<g transform="${transform}"><text ${attributes} x="${position.x}" y="${position.y}" text-anchor="start"${emphasis}${colorOverride ? ` fill="${colorOverride}"` : ""}${schematicTextSizeAttribute(annotation.kind, profile, annotation.sizeScale)}>${positioned.tspans}</text>${positioned.decorations}</g>${globalBadge}`;
       }
-      return `<text ${attributes} x="${position.x}" y="${position.y}" text-anchor="${annotation.alignment}" transform="${transform}"${emphasis}${colorOverride ? ` fill="${colorOverride}" color="${colorOverride}"` : ""}${schematicTextSizeAttribute(annotation.kind, profile, annotation.sizeScale)}>${renderAnnotationText(document, annotation, profile)}</text>${globalBadge}`;
+      return `<text ${attributes} x="${position.x}" y="${position.y}" text-anchor="${annotation.alignment}" transform="${transform}"${emphasis}${colorOverride ? ` fill="${colorOverride}" color="${colorOverride}"` : ""}${schematicTextSizeAttribute(annotation.kind, profile, annotation.sizeScale)}>${renderAnnotationText(document, annotation, profile, logicalNets)}</text>${globalBadge}`;
     })
     .join("");
 

--- a/scripts/performance-baseline.mjs
+++ b/scripts/performance-baseline.mjs
@@ -29,6 +29,7 @@ const budgets = {
   agentSnapshot: 1000,
   editTransaction: 1000,
   connectivityIndex: 1000,
+  connectivityRenderSvg: 2000,
   spiceImport: 2000,
   atomicSave: 1000,
 };
@@ -171,6 +172,11 @@ const edit = await measure(() =>
 const connectivityIndex = await measure(() =>
   buildProjectConnectivityIndex(validatedConnectivityProject, resolver),
 );
+const connectivityRender = await measure(() =>
+  renderDocumentSvg(validatedConnectivityProject.documents[0], resolver, {
+    title: validatedConnectivityProject.name,
+  }),
+);
 const sourcePath = resolve("fixtures/spice-baseline/core.cir");
 const modelPath = resolve("fixtures/spice-baseline/models.lib");
 const imported = await measure(async () =>
@@ -198,6 +204,7 @@ const measurements = {
   agentSnapshot: snapshot.milliseconds,
   editTransaction: edit.milliseconds,
   connectivityIndex: connectivityIndex.milliseconds,
+  connectivityRenderSvg: connectivityRender.milliseconds,
   spiceImport: imported.milliseconds,
   atomicSave: saved.milliseconds,
 };


### PR DESCRIPTION
## Summary\n- defer unused netlist analysis, closed search indexing, and unselected Net-name projection\n- cache Logical-Net resolution only for committed immutable revisions and reuse one result through SVG annotation rendering\n- retain SymbolResolver and sibling Document identities across ordinary edits while preserving definition-level refreshes\n- add the 200-Net/200-label SVG path to the performance baseline\n\n## Safety\n- mutable edit-engine drafts continue using the uncached Logical-Net resolver\n- Project structural commits, definition edits, Project undo/redo, and Project replacement still rebuild symbols\n- no incremental DOM rendering, deferred diagnostics, or visible loading-state changes\n\n## Validation\n- pnpm ci:check\n- 350 unit files: 2288 passed, 5 skipped\n- 333 Playwright tests passed\n- route/label-heavy SVG baseline: approximately 25 ms on the local validation host\n