### PR TITLE
fix(editor): place Check and Save before Gallery publish

### DIFF
--- a/apps/editor/src/app/App.test.tsx
+++ b/apps/editor/src/app/App.test.tsx
@@ -109,6 +109,14 @@ describe("editor shell", () => {
     expect(markup).toContain("<summary>Netlist</summary>");
     expect(markup).toContain("Check Report…");
     expect(markup).toContain('data-testid="check-and-save"');
+    const checkAndSaveEnd =
+      markup.indexOf(
+        "</button>",
+        markup.indexOf('data-testid="check-and-save"'),
+      ) + "</button>".length;
+    expect(markup.slice(checkAndSaveEnd)).toMatch(
+      /^<button[^>]*data-testid="publish-gallery-button"/u,
+    );
     expect(markup).toContain("Not checked");
     expect(erc).not.toHaveBeenCalled();
     expect(checks).not.toHaveBeenCalled();

--- a/apps/editor/src/app/editor-app-chrome.tsx
+++ b/apps/editor/src/app/editor-app-chrome.tsx
@@ -174,16 +174,6 @@ export function EditorAppChrome({
         >
           <div className="menubar-row">
             <FileCommandMenu {...fileCommands} />
-            <button
-              type="button"
-              data-testid="check-and-save"
-              disabled={!checkAndSave.enabled}
-              onClick={checkAndSave.execute}
-              title="Check ERC and visual issues, and save this Cloud Project"
-            >
-              <span className="toolbar-check-glyph" aria-hidden="true" />
-              Check and Save
-            </button>
             <details className="command-menu" name="editor-command-menu">
               <summary>Edit</summary>
               <div className="command-popover">
@@ -306,6 +296,16 @@ export function EditorAppChrome({
                 </div>
               </details>
             ) : null}
+            <button
+              type="button"
+              data-testid="check-and-save"
+              disabled={!checkAndSave.enabled}
+              onClick={checkAndSave.execute}
+              title="Check ERC and visual issues, and save this Cloud Project"
+            >
+              <span className="toolbar-check-glyph" aria-hidden="true" />
+              Check and Save
+            </button>
             <button
               type="button"
               data-testid="publish-gallery-button"


### PR DESCRIPTION
## Scope

Move the existing **Check and Save** button to immediately before **Publish to Gallery** in the top menubar, as requested by the owner.

The button's callback, disabled condition, glyph, wording, title and styling remain unchanged. No ERC, Save, Gallery or other control behavior changes. The only other changed file extends the existing editor-shell render test to check the requested adjacency.

## Validation

- All 14 App.test.tsx tests and full static contracts passed during implementation.
- Delivery used a clean temporary worktree at the exact PR head so unrelated, untracked local .vscode settings were neither changed nor included in gate planning.
- Frozen dependency install and gate:preflight passed. gate:affected passed 356 unit files (2334 tests; 5 existing skips). Its first browser launch exposed missing dist outputs in the fresh worktree; a capped-concurrency workspace build supplied them without source changes.
- The selected manual-editor browser spec then passed 130/132 cases. Two cases timed out during the same local execution stall (the tool wait itself took 112 seconds); both passed twice each on a one-worker rerun (4/4). No code, test assertions or timeouts were changed to obtain that result.
- All seven required PR checks passed on `42f31aa5`, including every browser shard: [PR CI](https://github.com/cascode-ai/analog-canvas/actions/runs/33731023843).
- All seven merge-queue checks also passed, including the full browser suite: [queue CI](https://github.com/cascode-ai/analog-canvas/actions/runs/33732000530). Merged to main as `85cf2c5d` following the owner request.

Test-Impact: tests-updated