### PR TITLE
feat(editor): copy visual selections and group drawing exports

### DIFF
--- a/apps/editor/e2e/context-menu.spec.ts
+++ b/apps/editor/e2e/context-menu.spec.ts
@@ -1,6 +1,36 @@
 import { expect, test, type Page } from "@playwright/test";
 
-import { chooseComponent, clickDrawTool } from "./editor-fixtures";
+import {
+  chooseComponent,
+  clickDrawTool,
+  clickCommand,
+  openMenu,
+} from "./editor-fixtures";
+
+async function captureImageClipboard(
+  page: Page,
+  reject = false,
+): Promise<void> {
+  await page.addInitScript((deny) => {
+    Object.defineProperty(navigator.clipboard, "write", {
+      configurable: true,
+      value: async (items: ClipboardItem[]) => {
+        if (deny) throw new DOMException("Denied", "NotAllowedError");
+        const item = items[0]!;
+        const mime = item.types[0]!;
+        const blob = await item.getType(mime);
+        (
+          window as unknown as {
+            copiedImage: { mime: string; bytes: number[] };
+          }
+        ).copiedImage = {
+          mime,
+          bytes: Array.from(new Uint8Array(await blob.arrayBuffer())),
+        };
+      },
+    });
+  }, reject);
+}
 
 async function placeComponent(
   page: Page,
@@ -165,6 +195,204 @@ test("device annotation shares device additive selection and context menu", asyn
   await expect(menu).toBeVisible();
   await expect(menu).not.toContainText("Swap device");
   await expect(menu.getByRole("menuitem", { name: "Delete" })).toBeEnabled();
+});
+
+test("visual clipboard preserves mixed selection and exports only its formal SVG", async ({
+  page,
+}) => {
+  await captureImageClipboard(page);
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 280, y: 220 });
+  await placeComponent(page, "capacitor", { x: 540, y: 320 });
+  await clickDrawTool(page, "text");
+  await page.getByRole("textbox", { name: "Canvas text editor" }).fill("BIAS");
+  await page.getByRole("button", { name: "Apply text changes" }).click();
+  const resistor = page.locator('[data-canvas-hit-kind="instance"]').first();
+  const text = page.locator('[data-canvas-hit-kind="drafting"]').first();
+  await resistor.click();
+  await text.click({ modifiers: ["Shift"] });
+  const canvas = page.getByTestId("schematic-canvas");
+  const before = await canvas.locator('[data-layer="formal"]').innerHTML();
+  await text.click({ button: "right" });
+  await page
+    .getByRole("menuitem", { name: "Copy as SVG", exact: true })
+    .click();
+  await expect(page.getByTestId("status")).toHaveText(
+    "Copied selection as SVG",
+  );
+  const copied = await page.evaluate(
+    () =>
+      (window as unknown as { copiedImage: { mime: string; bytes: number[] } })
+        .copiedImage,
+  );
+  const svg = Buffer.from(copied.bytes).toString("utf8");
+  expect(copied.mime).toBe("image/svg+xml");
+  expect(svg).toContain('data-symbol-id="resistor"');
+  expect(svg).not.toContain('data-symbol-id="capacitor"');
+  expect(svg).toContain("BIAS");
+  expect(svg).not.toMatch(
+    /hit-target|selection-halo|flightline|editor-overlay/,
+  );
+  expect(await canvas.locator('[data-layer="formal"]').innerHTML()).toBe(
+    before,
+  );
+  await expect(resistor).toHaveClass(/selected/);
+  await expect(text).toHaveClass(/selected/);
+  // Empty-canvas right-click preserves the same mixed selection.
+  await canvas.click({ button: "right", position: { x: 650, y: 450 } });
+  await expect(
+    page.getByRole("menuitem", { name: "Copy as PNG" }),
+  ).toBeEnabled();
+  await expect(resistor).toHaveClass(/selected/);
+  await expect(text).toHaveClass(/selected/);
+});
+
+test("visual clipboard rasterizes an independent Wire as transparent PNG without changing history", async ({
+  page,
+}) => {
+  await captureImageClipboard(page);
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await clickDrawTool(page, "wire");
+  await canvas.click({ position: { x: 300, y: 200 } });
+  await canvas.dblclick({ position: { x: 500, y: 200 } });
+  await page.keyboard.press("Escape");
+  const wire = page.locator('[data-canvas-hit-kind="route"]').first();
+  await expect(wire).toHaveCount(1);
+  const midpoint = await wire.evaluate((element) => {
+    const line = element as SVGPolylineElement;
+    const from = line.points.getItem(0);
+    const to = line.points.getItem(1);
+    const point = new DOMPoint(
+      (from.x + to.x) / 2,
+      (from.y + to.y) / 2,
+    ).matrixTransform(line.getScreenCTM()!);
+    return { x: point.x, y: point.y };
+  });
+  await page.mouse.click(midpoint.x, midpoint.y, { button: "right" });
+  await page.getByRole("menuitem", { name: "Copy as PNG" }).click();
+  await expect(page.getByTestId("status")).toHaveText(
+    "Copied selection as PNG",
+  );
+  const copied = await page.evaluate(
+    () =>
+      (window as unknown as { copiedImage: { mime: string; bytes: number[] } })
+        .copiedImage,
+  );
+  const png = await page.evaluate(async (bytes) => {
+    const bitmap = await createImageBitmap(
+      new Blob([new Uint8Array(bytes)], { type: "image/png" }),
+    );
+    const canvas = document.createElement("canvas");
+    canvas.width = bitmap.width;
+    canvas.height = bitmap.height;
+    const context = canvas.getContext("2d")!;
+    context.drawImage(bitmap, 0, 0);
+    const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
+    const result = {
+      width: bitmap.width,
+      height: bitmap.height,
+      cornerAlpha: pixels[3],
+      hasInk: pixels.some((value, index) => index % 4 === 3 && value > 0),
+    };
+    bitmap.close();
+    canvas.width = canvas.height = 0;
+    return result;
+  }, copied.bytes);
+  expect(copied.mime).toBe("image/png");
+  expect(png.width).toBeGreaterThan(png.height);
+  expect(png.cornerAlpha).toBe(0);
+  expect(png.hasInk).toBe(true);
+  await page.keyboard.press("ControlOrMeta+Z");
+  await expect(wire).toHaveCount(0);
+});
+
+test("visual clipboard reports denied access and empty selection without downloads", async ({
+  page,
+}) => {
+  await captureImageClipboard(page, true);
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.click({ button: "right", position: { x: 600, y: 400 } });
+  await expect(
+    page.getByRole("menuitem", { name: "Copy as PNG" }),
+  ).toBeDisabled();
+  await expect(
+    page.getByRole("menuitem", { name: "Copy as SVG" }),
+  ).toBeDisabled();
+  await page.keyboard.press("Escape");
+  await placeComponent(page, "resistor", { x: 300, y: 220 });
+  const downloads: string[] = [];
+  page.on("download", (download) =>
+    downloads.push(download.suggestedFilename()),
+  );
+  await page
+    .locator('[data-canvas-hit-kind="instance"]')
+    .first()
+    .click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Copy as PNG" }).click();
+  await expect(page.getByTestId("status")).toContainText(
+    "Clipboard access was denied",
+  );
+  expect(downloads).toEqual([]);
+});
+
+test("File exports are folded into exclusive drawing and netlist submenus", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await placeComponent(page, "resistor", { x: 300, y: 220 });
+  await placeComponent(page, "capacitor", { x: 550, y: 320 });
+  await page.locator('[data-canvas-hit-kind="instance"]').first().click();
+  const menu = await openMenu(page, "File");
+  await expect(
+    menu.getByRole("button", { name: "Export SVG", exact: true }),
+  ).toBeHidden();
+  await menu
+    .getByRole("button", { name: "Export netlist", exact: true })
+    .click();
+  await expect(
+    menu.getByRole("button", { name: "Export SPICE netlist", exact: true }),
+  ).toBeVisible();
+  await menu
+    .getByRole("button", { name: "Export drawing", exact: true })
+    .click();
+  await expect(
+    menu.getByRole("button", { name: "Export SPICE netlist", exact: true }),
+  ).toBeHidden();
+  await expect(
+    menu.getByRole("button", { name: "Export SVG", exact: true }),
+  ).toBeVisible();
+  const viewBox = await page
+    .getByTestId("schematic-canvas")
+    .getAttribute("viewBox");
+  await menu
+    .getByRole("button", { name: "Export drawing", exact: true })
+    .press("ArrowRight");
+  await expect(
+    menu.getByRole("button", { name: "Export SVG", exact: true }),
+  ).toBeFocused();
+  expect(
+    await page.getByTestId("schematic-canvas").getAttribute("viewBox"),
+  ).toBe(viewBox);
+  await menu
+    .getByRole("button", { name: "Export SVG", exact: true })
+    .press("ArrowLeft");
+  await expect(
+    menu.getByRole("button", { name: "Export drawing", exact: true }),
+  ).toBeFocused();
+  await expect(
+    menu.getByRole("button", { name: "Export SVG", exact: true }),
+  ).toBeHidden();
+  const download = page.waitForEvent("download");
+  await clickCommand(page, "File", "Export SVG");
+  const stream = await (await download).createReadStream();
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk));
+  const svg = Buffer.concat(chunks).toString("utf8");
+  expect(svg).toContain('data-symbol-id="resistor"');
+  expect(svg).toContain('data-symbol-id="capacitor"');
+  await expect(menu).not.toHaveAttribute("open");
 });
 
 test("toolbar undo and redo buttons follow history state", async ({ page }) => {

--- a/apps/editor/e2e/editor-fixtures.ts
+++ b/apps/editor/e2e/editor-fixtures.ts
@@ -42,6 +42,17 @@ export async function clickCommand(
   button: string,
 ): Promise<void> {
   const details = await openMenu(page, menu);
+  if (
+    menu === "File" &&
+    /^Export (?:SVG|PNG|PDF|SPICE netlist|Spectre netlist)$/u.test(button)
+  ) {
+    const group = details.getByRole("button", {
+      name: button.endsWith("netlist") ? "Export netlist" : "Export drawing",
+      exact: true,
+    });
+    if ((await group.getAttribute("aria-expanded")) !== "true")
+      await group.click();
+  }
   await details.getByRole("button", { name: button, exact: true }).click();
 }
 

--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -3796,6 +3796,7 @@ test("right-drag frames a region and fits the camera to it transiently", async (
   await page.mouse.up({ button: "right" });
 
   await expect(page.getByTestId("zoom-box")).toHaveCount(0);
+  await expect(page.getByTestId("canvas-context-menu")).toHaveCount(0);
   await expect(canvas).not.toHaveAttribute("viewBox", before!);
   await expect(page.getByTestId("status")).toHaveText(
     "Zoomed to framed region",
@@ -3809,12 +3810,15 @@ test("right-drag frames a region and fits the camera to it transiently", async (
   await page.mouse.down({ button: "right" });
   await page.mouse.up({ button: "right" });
   await expect(canvas).toHaveAttribute("viewBox", framed!);
+  await expect(page.getByTestId("canvas-context-menu")).toBeVisible();
 
   // Alt+left-drag frames the same region for environments whose system
   // software hooks the right button before the browser sees the drag.
   await page.keyboard.down("Alt");
   await page.mouse.move(box.x + 200, box.y + 140);
   await page.mouse.down();
+  // Dismiss the non-modal menu without consuming this framing gesture.
+  await expect(page.getByTestId("canvas-context-menu")).toHaveCount(0);
   await page.mouse.move(box.x + 460, box.y + 340, { steps: 4 });
   await expect(page.getByTestId("zoom-box")).toBeVisible();
   await page.mouse.up();

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -573,6 +573,7 @@ export function App({
     x: number;
     y: number;
   } | null>(null);
+  const canvasContextMenuSuppressed = useRef(false);
   const [pendingCellReset, setPendingCellReset] = useState<{
     plan: CellResetPlan;
     command: string;
@@ -2581,6 +2582,10 @@ export function App({
       wheelBehavior: () => wheelBehaviorRef.current,
     },
     gestureSession: {
+      setContextMenuSuppressed: (suppressed) => {
+        canvasContextMenuSuppressed.current = suppressed;
+        if (suppressed) setCanvasContextMenu(null);
+      },
       boxPreview,
       setBoxPreview,
       panPreview,
@@ -3741,6 +3746,7 @@ export function App({
       },
       openContextMenu: (target, clientX, clientY) => {
         if (
+          canvasContextMenuSuppressed.current ||
           canvasDragSessionRef.current !== null ||
           simulationPickNetsActive ||
           target.closest('[data-testid="canvas-text-editor"]')

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -139,6 +139,7 @@ import {
 } from "../features/component-insert/symbol-catalog";
 import { SymbolArtwork } from "../features/component-insert/symbol-artwork";
 import { CanvasContextMenu } from "../features/selection/canvas-context-menu";
+import { useVisualClipboard } from "../features/clipboard/visual-clipboard";
 import { deriveWireUnderSymbolWarnings } from "../canvas/wire-under-symbol";
 import { createPlacementTrayCommands } from "../features/component-insert/placement-tray-commands";
 import { componentTargetDescription } from "../features/properties/component-identity-properties";
@@ -1623,6 +1624,12 @@ export function App({
     clientX: number,
     clientY: number,
   ): void {
+    if (
+      tool !== "pointer" ||
+      getCurrentInteractionState().kind !== "idle" ||
+      canvasDragSessionRef.current !== null
+    )
+      return;
     const ids = typeof objectIds === "string" ? [objectIds] : objectIds;
     if (!ids.every((id) => selectedVisualIds(kind).includes(id))) {
       selectVisualObjects(kind, ids, false);
@@ -3162,10 +3169,19 @@ export function App({
     };
   }, []);
 
+  const visualClipboard = useVisualClipboard({
+    document,
+    selection: visualSelection,
+    resolver,
+    report: setStatus,
+    onChunkLoadFailure: setChunkLoadFailure,
+  });
   const editorCommands = createEditorCommandRouter({
     getContext: () => ({
       interactionMode: getCurrentInteractionState().kind,
       activeTool: tool,
+      canCopyVisualSelection:
+        hasVisualSelection(visualSelection) && !visualClipboard.busy,
       hasDeletableSelection:
         hasVisualSelection(visualSelection) || selectedEndpoint !== null,
       hasMoveSelection: canBeginKeyboardSelectionMove(),
@@ -3244,6 +3260,7 @@ export function App({
         }
         armVerb("copy");
       },
+      copyVisualSelection: visualClipboard.copy,
       beginMove: (detach) => {
         if (canBeginKeyboardSelectionMove()) {
           beginKeyboardSelectionMoveFromSelection(undefined, { detach });
@@ -3362,6 +3379,13 @@ export function App({
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent): void {
+      // File flyout arrows navigate the focused menu, never pan the canvas.
+      if (
+        event.target instanceof Element &&
+        event.target.closest(".export-submenu") &&
+        ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(event.key)
+      )
+        return;
       if (
         (event.ctrlKey || event.metaKey) &&
         event.key.toLowerCase() === "f" &&
@@ -3714,6 +3738,29 @@ export function App({
       },
       handleCanvasHitPointerDown: (event) => {
         if (!simulationPickNetsActive) handleCanvasHitPointerDown(event);
+      },
+      openContextMenu: (target, clientX, clientY) => {
+        if (
+          canvasDragSessionRef.current !== null ||
+          simulationPickNetsActive ||
+          target.closest('[data-testid="canvas-text-editor"]')
+        )
+          return;
+        const hit = target.closest("[data-canvas-hit-kind]");
+        const kind = hit?.getAttribute("data-canvas-hit-kind");
+        const id = hit?.getAttribute("data-canvas-hit-id");
+        if (
+          id &&
+          (kind === "route" ||
+            kind === "drafting" ||
+            kind === "junction" ||
+            kind === "instance" ||
+            kind === "annotation")
+        ) {
+          openVisualContextMenu(kind, id, clientX, clientY);
+        } else {
+          setCanvasContextMenu({ x: clientX, y: clientY });
+        }
       },
     },
     placement: {
@@ -5209,7 +5256,20 @@ export function App({
               selectedEndpoint,
               supplementalJunctionIds: supplementalSelection.junctionIds,
               endpointLabel: endpointTestId,
-              onEndpointActions: (candidate) => {
+              onEndpointActions: (candidate, clientX, clientY) => {
+                if (
+                  candidate.endpoint.kind === "junction" &&
+                  tool === "pointer" &&
+                  getCurrentInteractionState().kind === "idle"
+                ) {
+                  openVisualContextMenu(
+                    "junction",
+                    candidate.endpoint.junctionId,
+                    clientX,
+                    clientY,
+                  );
+                  return;
+                }
                 selectEndpoint(candidate);
                 setStatus(
                   `Endpoint actions: ${endpointTestId(candidate.endpoint)}`,
@@ -5402,6 +5462,18 @@ export function App({
               editorCommands.execute({ id: "selection.align", mode })
             }
             actions={[
+              ...(["png", "svg"] as const).map((format) => ({
+                label: `Copy as ${format.toUpperCase()}`,
+                enabled: editorCommands.state({
+                  id: "selection.copy-image",
+                  format,
+                }).enabled,
+                execute: () =>
+                  editorCommands.execute({
+                    id: "selection.copy-image",
+                    format,
+                  }),
+              })),
               {
                 label: "Rotate (R)",
                 enabled: editorCommands.state({ id: "transform.rotate" })

--- a/apps/editor/src/canvas/canvas-gesture-controller.ts
+++ b/apps/editor/src/canvas/canvas-gesture-controller.ts
@@ -88,6 +88,8 @@ export interface CanvasGestureControllerDependencies {
     paintSnapGuides: (guides: readonly SnapGuideLine[]) => void;
     noteCanvasPoint: (point: Point) => void;
     setStatus: (status: string) => void;
+    /** A completed right-button frame consumes that gesture's context menu. */
+    setContextMenuSuppressed: (suppressed: boolean) => void;
     /** Canvas size and how far floating docks reach over it; see fitView. */
     measureCanvasView?: () => {
       viewport: { width: number; height: number };
@@ -229,6 +231,7 @@ export function createCanvasGestureController({
     paintSnapGuides,
     noteCanvasPoint,
     setStatus,
+    setContextMenuSuppressed,
     measureCanvasView,
   },
   selection: {
@@ -390,10 +393,11 @@ export function createCanvasGestureController({
   };
 
   const begin = (event: ReactPointerEvent<SVGSVGElement>): void => {
+    setContextMenuSuppressed(false);
     // Visual objects own their context menu. Starting the background framing
     // gesture on any of these hit layers would capture the pointer and swallow
-    // the later contextmenu event. Routes and endpoints keep their existing
-    // canvas behavior until they expose the shared menu themselves.
+    // the later contextmenu event. Route strokes and endpoint circles are
+    // already excluded by the background-target classifier below.
     const contextMenuHitKind = (event.target as Element).getAttribute?.(
       "data-canvas-hit-kind",
     );
@@ -597,6 +601,7 @@ export function createCanvasGestureController({
         rect.width > document.presentation.grid &&
         rect.height > document.presentation.grid
       ) {
+        if (event.button === 2) setContextMenuSuppressed(true);
         setViewBox(fitCameraToBounds(rect, document.presentation.grid));
         setStatus("Zoomed to framed region");
       }

--- a/apps/editor/src/canvas/editor-canvas-event-handlers.ts
+++ b/apps/editor/src/canvas/editor-canvas-event-handlers.ts
@@ -59,6 +59,11 @@ interface CanvasEventHandlerDependencies {
      */
     pressActsOnSelection: (target: Element) => boolean;
     handleCanvasHitPointerDown: (event: CanvasPointerEvent) => void;
+    openContextMenu: (
+      target: Element,
+      clientX: number,
+      clientY: number,
+    ) => void;
   };
   placement: {
     pendingSymbolId: string | null;
@@ -137,6 +142,7 @@ export function createEditorCanvasEventHandlers({
     clearDraftingSelection,
     pressActsOnSelection,
     handleCanvasHitPointerDown,
+    openContextMenu,
   },
   placement: {
     pendingSymbolId,
@@ -278,6 +284,7 @@ export function createEditorCanvasEventHandlers({
       // selection, not replacing one) and for a press on any member of the
       // current selection (the press is about to drag it or open its menu).
       if (
+        event.button === 0 &&
         selectedDrafting &&
         (selectedDrafting.kind === "arrow" ||
           selectedDrafting.kind === "construction-line" ||
@@ -474,6 +481,9 @@ export function createEditorCanvasEventHandlers({
         return;
       }
       if (tool === "wire") cancelWire();
+      if (tool === "pointer" && interactionKind() === "idle") {
+        openContextMenu(event.target as Element, event.clientX, event.clientY);
+      }
     },
     onDragOver(event: ReactDragEvent<SVGSVGElement>) {
       event.preventDefault();

--- a/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
+++ b/apps/editor/src/canvas/editor-canvas-hit-layer.tsx
@@ -90,7 +90,11 @@ interface EndpointHitTargetProps {
   selectedEndpoint: WireSource | null;
   supplementalJunctionIds: readonly string[];
   endpointLabel: (endpoint: WireSource["endpoint"]) => string;
-  onEndpointActions: (endpoint: WireSource) => void;
+  onEndpointActions: (
+    endpoint: WireSource,
+    clientX: number,
+    clientY: number,
+  ) => void;
   onRouteStretch: (
     event: ReactPointerEvent<SVGCircleElement>,
     routeId: string,
@@ -375,7 +379,7 @@ function EndpointHitTargets({
         onContextMenu={(event) => {
           event.preventDefault();
           event.stopPropagation();
-          onEndpointActions(candidate);
+          onEndpointActions(candidate, event.clientX, event.clientY);
         }}
         onPointerDown={(event) => {
           if (tool === "pointer" && selectedRoute && powerRailEndIndex >= 0) {

--- a/apps/editor/src/commands/editor-command.test.ts
+++ b/apps/editor/src/commands/editor-command.test.ts
@@ -12,6 +12,7 @@ function fixture(overrides: Partial<EditorCommandContext> = {}) {
     interactionMode: "idle",
     activeTool: "pointer",
     hasDeletableSelection: true,
+    canCopyVisualSelection: true,
     hasMoveSelection: true,
     hasAlignableSelection: true,
     hasRotatableSelection: true,
@@ -41,6 +42,7 @@ function fixture(overrides: Partial<EditorCommandContext> = {}) {
     clearSelection: vi.fn(),
     deleteSelection: vi.fn(),
     beginCopy: vi.fn(),
+    copyVisualSelection: vi.fn(),
     beginMove: vi.fn(),
     alignSelection: vi.fn(),
     rotatePlacement: vi.fn(),
@@ -75,6 +77,26 @@ function fixture(overrides: Partial<EditorCommandContext> = {}) {
 }
 
 describe("editor command router", () => {
+  it("copies visual content without arming circuit copy or mutating history", () => {
+    const { router, operations } = fixture();
+    router.execute({ id: "selection.copy-image", format: "svg" });
+    expect(operations.copyVisualSelection).toHaveBeenCalledWith("svg");
+    expect(operations.beginCopy).not.toHaveBeenCalled();
+    expect(operations.undo).not.toHaveBeenCalled();
+    for (const override of [
+      { canCopyVisualSelection: false },
+      { canvasDragActive: true },
+      { hasArmedVerb: true },
+      { interactionMode: "copy-placement" as const },
+    ]) {
+      const blocked = fixture(override);
+      expect(
+        blocked.router.execute({ id: "selection.copy-image", format: "png" })
+          .status,
+      ).toBe("rejected");
+      expect(blocked.operations.copyVisualSelection).not.toHaveBeenCalled();
+    }
+  });
   it("routes every alignment surface through one selection command", () => {
     const { router, operations } = fixture();
     router.execute({ id: "selection.align", mode: "left" });

--- a/apps/editor/src/commands/editor-command.ts
+++ b/apps/editor/src/commands/editor-command.ts
@@ -14,6 +14,7 @@ export type EditorCommandRequest =
   | { id: "selection.clear" }
   | { id: "selection.delete" }
   | { id: "selection.copy" }
+  | { id: "selection.copy-image"; format: "png" | "svg" }
   /**
    * `detach` follows Virtuoso's Shift+M: the parts move on their own and each
    * connected wire stays exactly where it was, re-anchored to a Junction stub.
@@ -49,6 +50,7 @@ export interface EditorCommandContext {
   interactionMode: InteractionMode;
   activeTool: EditorTool;
   hasDeletableSelection: boolean;
+  canCopyVisualSelection: boolean;
   hasMoveSelection: boolean;
   hasAlignableSelection: boolean;
   hasRotatableSelection: boolean;
@@ -79,6 +81,7 @@ export interface EditorCommandOperations {
   clearSelection(): void;
   deleteSelection(): void;
   beginCopy(): void;
+  copyVisualSelection(format: "png" | "svg"): void;
   beginMove(detach: boolean): void;
   alignSelection(mode: EdgeAlignmentMode): void;
   rotatePlacement(deltaDegrees: 90 | -90): void;
@@ -203,6 +206,15 @@ export function createEditorCommandRouter(
           context.interactionMode === "idle"
           ? enabled()
           : disabled("Select an object before deleting it");
+      case "selection.copy-image":
+        return context.interactionMode === "idle" &&
+          !context.canvasDragActive &&
+          !context.hasArmedVerb &&
+          context.canCopyVisualSelection
+          ? enabled()
+          : disabled(
+              "Finish the active operation and select visible objects before copying",
+            );
       case "selection.copy":
         if (
           context.interactionMode !== "idle" &&
@@ -325,6 +337,9 @@ export function createEditorCommandRouter(
         break;
       case "selection.copy":
         options.operations.beginCopy();
+        break;
+      case "selection.copy-image":
+        options.operations.copyVisualSelection(request.format);
         break;
       case "selection.move":
         options.operations.beginMove(request.detach === true);

--- a/apps/editor/src/features/clipboard/visual-clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/visual-clipboard.test.ts
@@ -1,0 +1,188 @@
+import { createEmptyDocument, semanticTextDocument } from "@icm/model";
+import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EMPTY_VISUAL_SELECTION } from "../selection/visual-selection";
+import {
+  createSelectionClipboardBlob,
+  visualClipboardObjectIds,
+  writeSelectionClipboard,
+} from "./visual-clipboard";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+function fixture() {
+  const document = createEmptyDocument("main", "Clipboard drawing");
+  document.instances.push({
+    id: "R1",
+    symbolId: "resistor",
+    placement: { position: { x: 100, y: 100 }, rotation: 90, mirror: "x" },
+  });
+  document.nets.push({
+    id: "supply",
+    terminals: [{ instanceId: "R1", pinName: "1" }],
+  });
+  document.annotations.push(
+    {
+      id: "name",
+      kind: "instance-label",
+      content: semanticTextDocument("R1", "instance-label"),
+      anchor: {
+        kind: "object",
+        objectId: "R1",
+        localOffset: { x: 0, y: -20 },
+        fallbackPosition: { x: 900, y: 900 },
+      },
+      alignment: "middle",
+      rotation: 0,
+      locked: false,
+    },
+    {
+      id: "distant",
+      kind: "net-label",
+      netId: "supply",
+      binding: { kind: "net-name", netId: "supply" },
+      anchor: { kind: "free", position: { x: 900, y: 900 } },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    },
+  );
+  return {
+    document,
+    selection: { ...EMPTY_VISUAL_SELECTION, instanceIds: ["R1"] },
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("visual clipboard", () => {
+  it("includes owned labels but never grows through a Net or touches the Document", async () => {
+    const { document, selection } = fixture();
+    const before = structuredClone(document);
+    expect([...visualClipboardObjectIds(document, selection)]).toEqual([
+      "R1",
+      "name",
+    ]);
+    const blob = await createSelectionClipboardBlob(
+      "svg",
+      document,
+      selection,
+      resolver,
+    );
+    const svg = await blob.text();
+    expect(blob.type).toBe("image/svg+xml");
+    expect(svg).toContain('data-object-id="name"');
+    expect(svg).toContain("rotate(90)");
+    expect(svg).not.toContain('data-object-id="distant"');
+    expect(svg).not.toMatch(/editor-overlay|hit-target|flightline/);
+    expect(svg).not.toMatch(/<rect[^>]+fill="#fff/);
+    expect(document).toEqual(before);
+  });
+
+  it("copies a label alone using its unselected owner's real anchor", async () => {
+    const { document } = fixture();
+    const svg = await (
+      await createSelectionClipboardBlob(
+        "svg",
+        document,
+        {
+          ...EMPTY_VISUAL_SELECTION,
+          annotationIds: ["name"],
+        },
+        resolver,
+      )
+    ).text();
+    expect(svg).toContain('data-object-id="name"');
+    expect(svg).not.toContain('data-object-id="R1"');
+    const viewBox = /viewBox="([^"]+)"/u.exec(svg)![1]!.split(" ").map(Number);
+    expect(viewBox[0]).toBeLessThan(200);
+    expect(viewBox[1]).toBeLessThan(200);
+  });
+
+  it("does not copy the whole drawing for an empty or stale selection", async () => {
+    const { document } = fixture();
+    await expect(
+      createSelectionClipboardBlob(
+        "svg",
+        document,
+        EMPTY_VISUAL_SELECTION,
+        resolver,
+      ),
+    ).rejects.toThrow("Select visible");
+    await expect(
+      createSelectionClipboardBlob(
+        "svg",
+        document,
+        { ...EMPTY_VISUAL_SELECTION, instanceIds: ["deleted"] },
+        resolver,
+      ),
+    ).rejects.toThrow("Select visible");
+  });
+
+  it("writes during the gesture and captures the revision before asynchronous preparation", async () => {
+    const { document, selection } = fixture();
+    let item: { data: Record<string, Promise<Blob>> } | undefined;
+    const write = vi.fn((items: { data: Record<string, Promise<Blob>> }[]) => {
+      item = items[0];
+      return item!.data["image/svg+xml"]!.then(() => {});
+    });
+    vi.stubGlobal("isSecureContext", true);
+    vi.stubGlobal("navigator", { clipboard: { write } });
+    vi.stubGlobal(
+      "ClipboardItem",
+      class {
+        static supports() {
+          return true;
+        }
+        constructor(public data: Record<string, Promise<Blob>>) {}
+      },
+    );
+    const result = writeSelectionClipboard(
+      "svg",
+      document,
+      selection,
+      resolver,
+    );
+    expect(write).toHaveBeenCalledTimes(1);
+    document.instances = [];
+    selection.instanceIds.length = 0;
+    await result;
+    const svg = await (await item!.data["image/svg+xml"]!).text();
+    expect(svg).toContain('data-object-id="R1"');
+    expect(Object.keys(item!.data)).toEqual(["image/svg+xml"]);
+  });
+
+  it("rejects unavailable MIME and permission failures without downloading or reporting a different format", async () => {
+    const { document, selection } = fixture();
+    const write = vi.fn();
+    vi.stubGlobal("isSecureContext", true);
+    vi.stubGlobal("navigator", { clipboard: { write } });
+    vi.stubGlobal(
+      "ClipboardItem",
+      class {
+        static supports() {
+          return false;
+        }
+      },
+    );
+    await expect(
+      writeSelectionClipboard("svg", document, selection, resolver),
+    ).rejects.toThrow("Try Copy as PNG");
+    expect(write).not.toHaveBeenCalled();
+    vi.stubGlobal(
+      "ClipboardItem",
+      class {
+        static supports() {
+          return true;
+        }
+      },
+    );
+    write.mockRejectedValue(new DOMException("Denied", "NotAllowedError"));
+    await expect(
+      writeSelectionClipboard("svg", document, selection, resolver),
+    ).rejects.toMatchObject({ name: "NotAllowedError" });
+    vi.stubGlobal("isSecureContext", false);
+    await expect(
+      writeSelectionClipboard("png", document, selection, resolver),
+    ).rejects.toThrow("HTTPS or localhost");
+  });
+});

--- a/apps/editor/src/features/clipboard/visual-clipboard.ts
+++ b/apps/editor/src/features/clipboard/visual-clipboard.ts
@@ -1,0 +1,180 @@
+import { useRef, useState } from "react";
+import { createFormalExportSource } from "@icm/exporters";
+import { annotationOwningInstanceId } from "@icm/derived";
+import type { SchematicDocument } from "@icm/model";
+import type { SymbolResolver } from "@icm/symbols";
+import type { VisualSelection } from "../selection/visual-selection";
+import { prepareDocumentFormulaArtifacts } from "../text-editing/formula-artifacts";
+import { importChunk } from "../../components/chunk-import";
+import { describeExportFailure } from "../editor-shell/editor-export-commands";
+
+export type VisualClipboardFormat = "png" | "svg";
+
+/** Paint ownership only: never grow through a Logical Net or clone circuit data. */
+export function visualClipboardObjectIds(
+  document: SchematicDocument,
+  selection: VisualSelection,
+): Set<string> {
+  const ids = new Set(Object.values(selection).flat());
+  const owners = new Set([
+    ...selection.instanceIds,
+    ...selection.routeIds,
+    ...selection.junctionIds,
+  ]);
+  for (const annotation of document.annotations) {
+    const anchor = annotation.anchor;
+    const owner = annotationOwningInstanceId(annotation);
+    if (
+      (owner !== undefined && owners.has(owner)) ||
+      (anchor.kind === "object" && owners.has(anchor.objectId)) ||
+      (anchor.kind === "route" && owners.has(anchor.routeId))
+    )
+      ids.add(annotation.id);
+  }
+  // A rectangle's label is a drafting child, not an electrical annotation.
+  for (const object of document.drafting?.objects ?? []) {
+    if (
+      object.kind === "text" &&
+      object.anchor.kind === "object" &&
+      selection.draftingIds.includes(object.anchor.objectId)
+    )
+      ids.add(object.id);
+  }
+  for (const marker of document.noConnects) {
+    const endpoint = marker.endpoint;
+    if (owners.has(endpoint.instanceId)) ids.add(marker.id);
+  }
+  return ids;
+}
+
+export async function createSelectionClipboardBlob(
+  format: VisualClipboardFormat,
+  document: SchematicDocument,
+  selection: VisualSelection,
+  resolver: SymbolResolver,
+): Promise<Blob> {
+  const objectIds = visualClipboardObjectIds(document, selection);
+  if (objectIds.size === 0)
+    throw new Error("Select visible objects before copying");
+  const prepared = await prepareDocumentFormulaArtifacts({
+    ...document,
+    annotations: document.annotations.filter((item) => objectIds.has(item.id)),
+    ...(document.drafting
+      ? {
+          drafting: {
+            ...document.drafting,
+            objects: document.drafting.objects.filter((item) =>
+              objectIds.has(item.id),
+            ),
+          },
+        }
+      : {}),
+  });
+  try {
+    const source = createFormalExportSource(document, resolver, {
+      title: document.name + " — selection",
+      margin: 10,
+      background: "transparent",
+      objectIds,
+    });
+    const svg = new Blob([source.svg], { type: "image/svg+xml" });
+    if (svg.size > 16_000_000)
+      throw new Error("Selection is too large to copy; select fewer objects");
+    if (format === "svg") return svg;
+    const { rasterizeFormalSvgInBrowser } = await importChunk(
+      "PNG export",
+      () => import("@icm/exporters/browser-raster"),
+    );
+    const png = await rasterizeFormalSvgInBrowser(source, 3, {
+      background: "transparent",
+    });
+    return new Blob([png.bytes as BlobPart], { type: "image/png" });
+  } finally {
+    prepared.release();
+  }
+}
+
+/** Call synchronously from the gesture: Blob preparation runs inside ClipboardItem. */
+export function writeSelectionClipboard(
+  format: VisualClipboardFormat,
+  document: SchematicDocument,
+  selection: VisualSelection,
+  resolver: SymbolResolver,
+): Promise<void> {
+  if (
+    !globalThis.isSecureContext ||
+    !navigator.clipboard?.write ||
+    typeof ClipboardItem === "undefined"
+  ) {
+    return Promise.reject(
+      new Error(
+        "Clipboard images are unavailable here. Use HTTPS or localhost and a supported browser",
+      ),
+    );
+  }
+  const mime = format === "svg" ? "image/svg+xml" : "image/png";
+  if (
+    typeof ClipboardItem.supports === "function" &&
+    !ClipboardItem.supports(mime)
+  ) {
+    return Promise.reject(
+      new Error(
+        format === "svg"
+          ? "This browser cannot copy SVG images. Try Copy as PNG"
+          : "This browser cannot copy PNG images",
+      ),
+    );
+  }
+  // Capture before any await: later document/selection changes cannot change the result.
+  const data = createSelectionClipboardBlob(
+    format,
+    structuredClone(document),
+    structuredClone(selection),
+    resolver,
+  );
+  void data.catch(() => {}); // The clipboard may reject before it consumes the Blob promise.
+  try {
+    return navigator.clipboard.write([new ClipboardItem({ [mime]: data })]);
+  } catch (error) {
+    return Promise.reject(error);
+  }
+}
+
+export function useVisualClipboard({
+  document,
+  selection,
+  resolver,
+  report,
+  onChunkLoadFailure,
+}: {
+  document: SchematicDocument;
+  selection: VisualSelection;
+  resolver: SymbolResolver;
+  report: (message: string) => void;
+  onChunkLoadFailure: (feature: string) => void;
+}) {
+  const pending = useRef(false);
+  const [busy, setBusy] = useState(false);
+  const copy = (format: VisualClipboardFormat): void => {
+    if (pending.current) return;
+    pending.current = true;
+    setBusy(true);
+    report(`Copying selection as ${format.toUpperCase()}`);
+    void writeSelectionClipboard(format, document, selection, resolver)
+      .then(() => report(`Copied selection as ${format.toUpperCase()}`))
+      .catch((error: unknown) => {
+        const failure = describeExportFailure(error);
+        report(
+          error instanceof Error && error.name === "NotAllowedError"
+            ? "Clipboard access was denied. Allow clipboard access and try again"
+            : `Selection was not copied: ${failure.status}`,
+        );
+        if (failure.chunkFeature) onChunkLoadFailure(failure.chunkFeature);
+      })
+      .finally(() => {
+        pending.current = false;
+        setBusy(false);
+      });
+  };
+  return { busy, copy };
+}

--- a/apps/editor/src/features/editor-shell/file-command-menu.tsx
+++ b/apps/editor/src/features/editor-shell/file-command-menu.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from "react";
+import { useRef, useState, type ReactNode, type RefObject } from "react";
 
 import {
   CLOUD_PROJECT_LIMIT,
@@ -30,6 +30,79 @@ export interface FileCommandMenuProps {
   onOpenRecovery: () => void;
 }
 
+function ExportSubmenu({
+  title,
+  open,
+  onToggle,
+  onClose,
+  children,
+}: {
+  title: string;
+  open: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  const trigger = useRef<HTMLButtonElement>(null);
+  return (
+    <div
+      className="export-submenu"
+      onKeyDown={(event) => {
+        if (open && event.key === "ArrowLeft") {
+          event.preventDefault();
+          event.stopPropagation();
+          onClose();
+          trigger.current?.focus();
+        }
+      }}
+    >
+      <button
+        ref={trigger}
+        type="button"
+        aria-expanded={open}
+        aria-controls={
+          title === "Export netlist"
+            ? "export-netlist-options"
+            : "export-drawing-options"
+        }
+        onClick={(event) => {
+          event.stopPropagation();
+          onToggle();
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+            event.preventDefault();
+            if (!open) onToggle();
+            requestAnimationFrame(() =>
+              trigger.current?.parentElement
+                ?.querySelector<HTMLButtonElement>(
+                  ".export-submenu-options button",
+                )
+                ?.focus(),
+            );
+          }
+        }}
+      >
+        {title}
+        <span aria-hidden="true">›</span>
+      </button>
+      <div
+        className="export-submenu-options"
+        id={
+          title === "Export netlist"
+            ? "export-netlist-options"
+            : "export-drawing-options"
+        }
+        role="group"
+        aria-label={title}
+        hidden={!open}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
 export function FileCommandMenu({
   cloudProjects,
   activeCloudProjectId,
@@ -51,12 +124,16 @@ export function FileCommandMenu({
   onRevert,
   onOpenRecovery,
 }: FileCommandMenuProps) {
+  const [exportGroup, setExportGroup] = useState<"netlist" | "drawing" | null>(
+    null,
+  );
   return (
     <details
       className="command-menu"
       name="editor-command-menu"
       onToggle={(event) => {
         if (event.currentTarget.open) onRefreshCloudProjects();
+        else setExportGroup(null);
       }}
     >
       <summary>File</summary>
@@ -136,38 +213,57 @@ export function FileCommandMenu({
         <button type="button" onClick={onExportProject}>
           Export Project File…
         </button>
-        <span className="command-group-label">Export Drawing</span>
-        <button type="button" aria-label="Export SVG" onClick={onExportSvg}>
-          SVG
-        </button>
-        <button
-          type="button"
-          aria-label="Export PNG"
-          onClick={() => onExportRaster("png")}
-        >
-          PNG
-        </button>
-        <button
-          type="button"
-          aria-label="Export PDF"
-          onClick={() => onExportRaster("pdf")}
-        >
-          PDF
-        </button>
-        <button
-          type="button"
-          aria-label="Export SPICE netlist"
-          onClick={() => onExportNetlist("spice")}
-        >
-          SPICE netlist
-        </button>
-        <button
-          type="button"
-          aria-label="Export Spectre netlist"
-          onClick={() => onExportNetlist("spectre")}
-        >
-          Spectre netlist
-        </button>
+        <div>
+          <ExportSubmenu
+            title="Export netlist"
+            open={exportGroup === "netlist"}
+            onToggle={() =>
+              setExportGroup(exportGroup === "netlist" ? null : "netlist")
+            }
+            onClose={() => setExportGroup(null)}
+          >
+            <button
+              type="button"
+              aria-label="Export SPICE netlist"
+              onClick={() => onExportNetlist("spice")}
+            >
+              SPICE
+            </button>
+            <button
+              type="button"
+              aria-label="Export Spectre netlist"
+              onClick={() => onExportNetlist("spectre")}
+            >
+              Spectre
+            </button>
+          </ExportSubmenu>
+          <ExportSubmenu
+            title="Export drawing"
+            open={exportGroup === "drawing"}
+            onToggle={() =>
+              setExportGroup(exportGroup === "drawing" ? null : "drawing")
+            }
+            onClose={() => setExportGroup(null)}
+          >
+            <button type="button" aria-label="Export SVG" onClick={onExportSvg}>
+              SVG
+            </button>
+            <button
+              type="button"
+              aria-label="Export PNG"
+              onClick={() => onExportRaster("png")}
+            >
+              PNG
+            </button>
+            <button
+              type="button"
+              aria-label="Export PDF"
+              onClick={() => onExportRaster("pdf")}
+            >
+              PDF
+            </button>
+          </ExportSubmenu>
+        </div>
         <button type="button" onClick={onRefresh}>
           Refresh app
         </button>

--- a/apps/editor/src/features/selection/canvas-context-menu.tsx
+++ b/apps/editor/src/features/selection/canvas-context-menu.tsx
@@ -68,92 +68,95 @@ export function CanvasContextMenu({
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") onClose();
     };
+    const onPointerDown = (event: PointerEvent) => {
+      if (
+        event.target instanceof Node &&
+        !menuRef.current?.contains(event.target)
+      )
+        onClose();
+    };
     window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    // Non-modal dismissal: the same outside press still reaches the canvas,
+    // including marquee/Alt framing and middle-button pan gestures.
+    window.addEventListener("pointerdown", onPointerDown, true);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("pointerdown", onPointerDown, true);
+    };
   }, [onClose]);
 
   return (
     <div
-      className="canvas-context-menu-backdrop"
-      data-testid="canvas-context-menu-backdrop"
-      onPointerDown={onClose}
-      onContextMenu={(event) => {
-        event.preventDefault();
-        onClose();
-      }}
+      ref={menuRef}
+      className="canvas-context-menu"
+      data-testid="canvas-context-menu"
+      role="menu"
+      style={{ left: placed.x, top: placed.y }}
+      onPointerDown={(event) => event.stopPropagation()}
+      onContextMenu={(event) => event.preventDefault()}
     >
-      <div
-        ref={menuRef}
-        className="canvas-context-menu"
-        data-testid="canvas-context-menu"
-        role="menu"
-        style={{ left: placed.x, top: placed.y }}
-        onPointerDown={(event) => event.stopPropagation()}
-        onContextMenu={(event) => event.preventDefault()}
-      >
-        {variants.length > 0 ? (
-          <div className="context-menu-section">
-            <div className="context-menu-heading">Swap device</div>
-            <div className="context-menu-variants" role="group">
-              {variants.map((variant) => (
-                <button
-                  key={variant.symbolId}
-                  type="button"
-                  role="menuitem"
-                  className="context-menu-variant"
-                  title={variant.name}
-                  data-testid={`context-swap-${variant.symbolId}`}
-                  onClick={() => {
-                    onSwapVariant(variant.symbolId);
-                    onClose();
-                  }}
-                >
-                  {renderVariantArtwork(variant.symbolId)}
-                </button>
-              ))}
-            </div>
-          </div>
-        ) : null}
-        {alignmentEnabled ? (
-          <div className="context-menu-section">
-            <div className="context-menu-heading">Align</div>
-            {EDGE_ALIGNMENT_MODES.map(({ mode, label }) => (
+      {variants.length > 0 ? (
+        <div className="context-menu-section">
+          <div className="context-menu-heading">Swap device</div>
+          <div className="context-menu-variants" role="group">
+            {variants.map((variant) => (
               <button
-                key={mode}
+                key={variant.symbolId}
                 type="button"
                 role="menuitem"
-                className="context-menu-item"
-                data-testid={`context-align-${mode}`}
+                className="context-menu-variant"
+                title={variant.name}
+                data-testid={`context-swap-${variant.symbolId}`}
                 onClick={() => {
-                  onAlign(mode);
+                  onSwapVariant(variant.symbolId);
                   onClose();
                 }}
               >
-                {label}
+                {renderVariantArtwork(variant.symbolId)}
               </button>
             ))}
           </div>
-        ) : null}
-        {actions.length > 0 ? (
-          <div className="context-menu-section">
-            {actions.map((action) => (
-              <button
-                key={action.label}
-                type="button"
-                role="menuitem"
-                className="context-menu-item"
-                disabled={!action.enabled}
-                onClick={() => {
-                  action.execute();
-                  onClose();
-                }}
-              >
-                {action.label}
-              </button>
-            ))}
-          </div>
-        ) : null}
-      </div>
+        </div>
+      ) : null}
+      {alignmentEnabled ? (
+        <div className="context-menu-section">
+          <div className="context-menu-heading">Align</div>
+          {EDGE_ALIGNMENT_MODES.map(({ mode, label }) => (
+            <button
+              key={mode}
+              type="button"
+              role="menuitem"
+              className="context-menu-item"
+              data-testid={`context-align-${mode}`}
+              onClick={() => {
+                onAlign(mode);
+                onClose();
+              }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+      {actions.length > 0 ? (
+        <div className="context-menu-section">
+          {actions.map((action) => (
+            <button
+              key={action.label}
+              type="button"
+              role="menuitem"
+              className="context-menu-item"
+              disabled={!action.enabled}
+              onClick={() => {
+                action.execute();
+                onClose();
+              }}
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/editor/src/styles/editor-chrome.css
+++ b/apps/editor/src/styles/editor-chrome.css
@@ -451,6 +451,40 @@
   white-space: nowrap;
 }
 
+.command-popover .export-submenu {
+  position: relative;
+}
+
+.command-popover .export-submenu > button {
+  justify-content: space-between;
+}
+
+.command-popover .export-submenu-options {
+  position: absolute;
+  z-index: 1;
+  left: 100%;
+  top: -6px;
+  display: grid;
+  min-width: 9rem;
+  padding: 6px;
+  border: 1px solid var(--icm-border);
+  border-radius: 10px;
+  background: var(--icm-surface);
+  box-shadow: 0 8px 24px rgb(15 15 15 / 12%);
+}
+
+.command-popover .export-submenu-options[hidden] {
+  display: none;
+}
+
+@media (max-width: 480px) {
+  .command-popover .export-submenu-options {
+    position: static;
+    margin-left: 12px;
+    box-shadow: none;
+  }
+}
+
 .cloud-project-command {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;

--- a/apps/editor/src/styles/editor-context-menu.css
+++ b/apps/editor/src/styles/editor-context-menu.css
@@ -8,6 +8,8 @@
   position: fixed;
   min-width: 180px;
   max-width: 280px;
+  max-height: calc(100vh - 8px);
+  overflow-y: auto;
   padding: 6px;
   display: flex;
   flex-direction: column;

--- a/apps/editor/src/styles/editor-context-menu.css
+++ b/apps/editor/src/styles/editor-context-menu.css
@@ -1,11 +1,6 @@
-.canvas-context-menu-backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 60;
-}
-
 .canvas-context-menu {
   position: fixed;
+  z-index: 60;
   min-width: 180px;
   max-width: 280px;
   max-height: calc(100vh - 8px);

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -99,10 +99,23 @@ when you need to import them again.
 
 ## Export
 
-The **File** menu exports SVG, PNG, and PDF containing only formal schematic
+**File / Export drawing** exports the entire current drawing as SVG, PNG, or PDF containing only formal schematic
 layers. PNG uses 3x raster scale. Browser PDF converts the same formal SVG to
 vector paths and text on a page matching the SVG viewBox, so circuit geometry
 stays sharp when enlarged.
+
+To reuse only selected content, right-click a selected object and choose
+**Copy as PNG** or **Copy as SVG**, then paste into another application.
+Existing multi-selection is retained; right-clicking a different object selects
+that object. On empty canvas the menu uses the existing selection, never the whole
+drawing. Attached visible labels travel with their selected objects, but remote
+objects sharing a Net do not. Clipboard copies omit editor overlays, use a
+transparent page background, and do not change the circuit or Undo history.
+PNG is rendered at 3x with a bounded image size. SVG stays vector; formula glyphs
+remain paths, and the receiving application determines paste/editing support.
+Clipboard writes require HTTPS or localhost and browser permission. Failures are
+reported without silently downloading a file or substituting a different format.
+These commands do not change the existing **C** copy-placement workflow.
 
 Use the toolbar's **Check and Save** to check the whole Project for ERC and
 visual issues and save it through the existing private Cloud Project service.
@@ -119,7 +132,7 @@ The dialog reports structural netlist findings and current-revision ERC
 readiness separately; the ERC section is the same evidence used by Gallery.
 When a structural IR is available, it previews the deterministic SPICE or
 Spectre text. Use either the dialog's
-download button or **File / SPICE netlist** and **File / Spectre netlist** to
+download button or **File / Export netlist / SPICE** and **File / Export netlist / Spectre** to
 download it. These files contain structure only: they do not add PDK includes,
 models, corners, stimuli, analyses, or simulator options.
 

--- a/packages/exporters/src/browser-raster.test.ts
+++ b/packages/exporters/src/browser-raster.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { rasterizeFormalSvgInBrowser } from "./browser-raster.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("browser PNG lifecycle", () => {
+  it("rejects excessive dimensions before allocating a canvas or URL", async () => {
+    const allocate = vi.spyOn(URL, "createObjectURL");
+    await expect(
+      rasterizeFormalSvgInBrowser({
+        svg: "<svg/>",
+        bounds: { x: 0, y: 0, width: 100000, height: 100000 },
+      }),
+    ).rejects.toThrow("too large");
+    expect(allocate).not.toHaveBeenCalled();
+  });
+  it.each(["white", "transparent"] as const)(
+    "uses %s background and releases the canvas and URL",
+    async (background) => {
+      const fillRect = vi.fn();
+      const drawImage = vi.fn();
+      const canvas = {
+        width: 0,
+        height: 0,
+        getContext: () => ({ fillRect, drawImage, fillStyle: "" }),
+        toBlob: (callback: (blob: Blob) => void) => callback(new Blob(["png"])),
+      };
+      vi.stubGlobal("document", { createElement: () => canvas });
+      vi.stubGlobal(
+        "Image",
+        class {
+          onload: (() => void) | null = null;
+          set src(_: string) {
+            queueMicrotask(() => this.onload?.());
+          }
+        },
+      );
+      const release = vi.spyOn(URL, "revokeObjectURL");
+      const image = await rasterizeFormalSvgInBrowser(
+        {
+          svg: "<svg/>",
+          bounds: { x: 0, y: 0, width: 20, height: 10 },
+        },
+        3,
+        { background },
+      );
+      expect(image.width).toBe(60);
+      expect(image.height).toBe(30);
+      expect(fillRect).toHaveBeenCalledTimes(background === "white" ? 1 : 0);
+      expect(drawImage).toHaveBeenCalledTimes(1);
+      expect(release).toHaveBeenCalledTimes(1);
+      expect(canvas.width).toBe(0);
+      expect(canvas.height).toBe(0);
+    },
+  );
+});

--- a/packages/exporters/src/browser-raster.ts
+++ b/packages/exporters/src/browser-raster.ts
@@ -23,21 +23,42 @@ function canvasBlob(canvas: HTMLCanvasElement): Promise<Blob> {
 export async function rasterizeFormalSvgInBrowser(
   source: FormalExportSource,
   scale = DEFAULT_EXPORT_SCALE,
+  options: {
+    background?: "white" | "transparent";
+    maxPixels?: number;
+    maxDimension?: number;
+  } = {},
 ): Promise<RasterExport> {
   const width = Math.max(1, Math.round(source.bounds.width * scale));
   const height = Math.max(1, Math.round(source.bounds.height * scale));
+  if (
+    !Number.isFinite(scale) ||
+    scale <= 0 ||
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width > (options.maxDimension ?? 16384) ||
+    height > (options.maxDimension ?? 16384) ||
+    width * height > (options.maxPixels ?? 64_000_000)
+  ) {
+    throw new Error(
+      "Image is too large to rasterize safely; select fewer objects or use SVG",
+    );
+  }
+  let canvas: HTMLCanvasElement | undefined;
   const svgUrl = URL.createObjectURL(
     new Blob([source.svg], { type: "image/svg+xml" }),
   );
   try {
     const image = await loadImage(svgUrl);
-    const canvas = document.createElement("canvas");
+    canvas = document.createElement("canvas");
     canvas.width = width;
     canvas.height = height;
     const context = canvas.getContext("2d");
     if (!context) throw new Error("Canvas 2D is unavailable");
-    context.fillStyle = "white";
-    context.fillRect(0, 0, width, height);
+    if (options.background !== "transparent") {
+      context.fillStyle = "white";
+      context.fillRect(0, 0, width, height);
+    }
     context.drawImage(image, 0, 0, width, height);
     const bytes = new Uint8Array(
       await (await canvasBlob(canvas)).arrayBuffer(),
@@ -45,5 +66,9 @@ export async function rasterizeFormalSvgInBrowser(
     return { bytes, width, height, mediaType: "image/png" };
   } finally {
     URL.revokeObjectURL(svgUrl);
+    if (canvas) {
+      canvas.width = 0;
+      canvas.height = 0;
+    }
   }
 }

--- a/packages/exporters/src/index.ts
+++ b/packages/exporters/src/index.ts
@@ -1,5 +1,6 @@
 import type { Rect, SchematicDocument } from "@icm/model";
 import { renderDocumentSvg } from "@icm/render-svg";
+import type { SvgRenderOptions } from "@icm/render-svg";
 import type { SymbolResolver } from "@icm/symbols";
 
 export const EXPORT_VERSION = "0.1";
@@ -20,7 +21,10 @@ export interface RasterExport {
 export function createFormalExportSource(
   document: SchematicDocument,
   resolver: SymbolResolver,
-  options: { title?: string; margin?: number } = {},
+  options: Pick<
+    SvgRenderOptions,
+    "title" | "margin" | "objectIds" | "background"
+  > = {},
 ): FormalExportSource {
   const svg = renderDocumentSvg(document, resolver, options);
   const match = /viewBox="([^"]+)"/u.exec(svg);

--- a/packages/render-svg/src/render.test.ts
+++ b/packages/render-svg/src/render.test.ts
@@ -47,6 +47,43 @@ const definition = {
 };
 
 describe("render svg", () => {
+  it("paints selected routes using original junction decisions and crops only included geometry", () => {
+    const doc = createEmptyDocument("selection", "Selection");
+    doc.nets.push({ id: "net", terminals: [] });
+    doc.junctions.push(
+      { id: "L", netId: "net", position: { x: 0, y: 0 } },
+      { id: "J", netId: "net", position: { x: 40, y: 0 }, role: "branch" },
+      { id: "R", netId: "net", position: { x: 80, y: 0 } },
+      { id: "B", netId: "net", position: { x: 40, y: 1000 } },
+    );
+    for (const [id, from, to] of [
+      ["left", "L", "J"],
+      ["right", "J", "R"],
+      ["bottom", "J", "B"],
+    ]) {
+      doc.routes.push(
+        createRoutePath({
+          id: id!,
+          netId: "net",
+          start: { kind: "junction", junctionId: from! },
+          end: { kind: "junction", junctionId: to! },
+          bends: [],
+          modes: ["manual"],
+        }),
+      );
+    }
+    const resolver = new InMemorySymbolResolver([]);
+    const full = buildSvgScene(doc, resolver);
+    const scene = buildSvgScene(doc, resolver, {
+      objectIds: new Set(["left", "right"]),
+      margin: 10,
+    });
+    expect(scene.formalBody).toContain('<circle data-object-id="J"');
+    expect(scene.formalBody).not.toContain('data-object-id="bottom"');
+    expect(scene.formalBody).toContain('points="0,0 40,0"');
+    expect(scene.viewBox).toEqual({ x: -10, y: -10, width: 100, height: 20 });
+    expect(buildSvgScene(doc, resolver)).toEqual(full);
+  });
   it("renders identically from one shared routing read model", () => {
     const doc = createEmptyDocument("shared", "Shared read model");
     doc.nets.push({ id: "net", terminals: [] });

--- a/packages/render-svg/src/render.ts
+++ b/packages/render-svg/src/render.ts
@@ -71,6 +71,10 @@ import {
 } from "./signal-flow-formula.js";
 
 export interface SvgRenderOptions {
+  /** Read-only paint filter. Geometry and electrical facts still use the full Document. */
+  objectIds?: ReadonlySet<string>;
+  /** Page background only; explicit object fills are preserved. */
+  background?: "document" | "transparent";
   /** Explicit render crop is a caller-owned grid rectangle. */
   bounds?: GridRect;
   margin?: number;
@@ -173,10 +177,12 @@ function renderNoConnectMarkers(
   document: SchematicDocument,
   resolver: SymbolResolver,
   profile: SchematicStyleProfile,
+  objectIds?: ReadonlySet<string>,
 ): string {
   const halfExtent = Math.max(profile.strokes.normal * 3, 4);
   const strokeWidth = profile.strokes.normal;
   return [...document.noConnects]
+    .filter((item) => !objectIds || objectIds.has(item.id))
     .sort((left, right) => left.id.localeCompare(right.id, "en"))
     .flatMap((noConnect) => {
       const point = resolveEndpointPoint(
@@ -602,6 +608,7 @@ function deriveBounds(
   margin: number,
   profile: SchematicStyleProfile,
   logicalNets: ResolvedDocumentLogicalNets,
+  objectIds?: ReadonlySet<string>,
 ): DerivedRect {
   const bounds: DerivedRect[] = [];
   const estimatedTextBounds = (
@@ -626,7 +633,9 @@ function deriveBounds(
     };
   };
   for (const instance of document.instances.filter(
-    (candidate) => candidate.placement !== null,
+    (candidate) =>
+      candidate.placement !== null &&
+      (!objectIds || objectIds.has(candidate.id)),
   )) {
     const resolved = resolver.resolve(
       instance.symbolId,
@@ -639,6 +648,7 @@ function deriveBounds(
     bounds.push(instanceBox);
   }
   for (const route of document.routes) {
+    if (objectIds && !objectIds.has(route.id)) continue;
     const geometry = routingGeometry.routes.get(route.id);
     if (!geometry) {
       throw new Error(`Cannot derive bounds for unresolved route: ${route.id}`);
@@ -648,6 +658,7 @@ function deriveBounds(
     }
   }
   for (const junction of document.junctions) {
+    if (objectIds && !objectIds.has(junction.id)) continue;
     bounds.push({
       x: junction.position.x,
       y: junction.position.y,
@@ -656,6 +667,7 @@ function deriveBounds(
     });
   }
   for (const annotation of document.annotations) {
+    if (objectIds && !objectIds.has(annotation.id)) continue;
     if (!isSchematicAnnotationVisible(document, annotation, logicalNets))
       continue;
     const presentation = resolveAnnotationPresentation(
@@ -670,6 +682,7 @@ function deriveBounds(
       annotation.anchor.kind === "route"
         ? resolveRouteMarkerPlacement(routingGeometry, annotation.anchor)
         : null;
+    if (objectIds) bounds.push(presentation.bounds);
     if (!routePlacement) {
       bounds.push(presentation.bounds);
       continue;
@@ -691,10 +704,12 @@ function deriveBounds(
   // callouts and floating symbols outside the circuit are not clipped.
   // Resolved geometry is derived.
   for (const object of document.drafting?.objects ?? []) {
+    if (objectIds && !objectIds.has(object.id)) continue;
     const geometry = resolveDraftingObjectGeometry(document, resolver, object);
     bounds.push(geometry.bounds);
   }
   if (bounds.length === 0) {
+    if (objectIds) throw new Error("Select visible objects before copying");
     return { x: 0, y: 0, width: 960, height: 640 };
   }
   const minX = Math.min(...bounds.map((bound) => bound.x)) - margin;
@@ -717,6 +732,8 @@ export function buildSvgScene(
   options: SvgRenderOptions = {},
 ): SvgScene {
   const document = SchematicDocumentSchema.parse(input);
+  const objectIds = options.objectIds;
+  const included = (id: string): boolean => !objectIds || objectIds.has(id);
   const profile = resolveDocumentStyleProfile(document.presentation);
   const margin = options.margin ?? 40;
   if (!Number.isInteger(margin) || margin < 0) {
@@ -761,6 +778,7 @@ export function buildSvgScene(
         margin,
         profile,
         logicalNets,
+        objectIds,
       );
 
   const joinedJunctionIds = new Set(
@@ -792,6 +810,7 @@ export function buildSvgScene(
   }
 
   const routes = [...document.routes]
+    .filter((route) => included(route.id))
     .sort((left, right) => left.id.localeCompare(right.id, "en"))
     .map((route) => {
       const geometry = routingGeometry.routes.get(route.id);
@@ -824,7 +843,21 @@ export function buildSvgScene(
     })
     .join("");
   const junctionBridges = renderJunctionMiterBridges(
-    routingGeometry.endpointJoins,
+    routingGeometry.endpointJoins.filter((join) => {
+      if (!objectIds || join.kind !== "junction-miter") return true;
+      return document.routes
+        .filter((route) => {
+          const end = route.legs.at(-1)?.to;
+          return (
+            (route.start.kind === "junction" &&
+              route.start.junctionId === join.junctionId) ||
+            (end?.kind === "endpoint" &&
+              end.endpoint.kind === "junction" &&
+              end.endpoint.junctionId === join.junctionId)
+          );
+        })
+        .every((route) => included(route.id));
+    }),
     profile,
     junctionBridgeColors,
   );
@@ -832,6 +865,16 @@ export function buildSvgScene(
     options.contactEvidence ??
     deriveDocumentContactEvidence(document, resolver, routingGeometry);
   const junctions = contactEvidence.contacts
+    .filter(
+      (contact) =>
+        !objectIds ||
+        contact.incidents.some((incident) => included(incident.objectId)) ||
+        contact.endpoints.some((endpoint) =>
+          endpoint.kind === "junction"
+            ? included(endpoint.junctionId)
+            : included(endpoint.instanceId),
+        ),
+    )
     .filter((contact) => {
       if (
         contact.incidents.some(
@@ -887,11 +930,17 @@ export function buildSvgScene(
       return `<circle data-object-id="${escapeXml(objectId)}"${derivedAttribute} cx="${contact.point.x}" cy="${contact.point.y}" r="${profile.nodes.junctionRadius}" fill="${profile.foreground}"/>`;
     })
     .join("");
-  const noConnectMarkers = renderNoConnectMarkers(document, resolver, profile);
+  const noConnectMarkers = renderNoConnectMarkers(
+    document,
+    resolver,
+    profile,
+    objectIds,
+  );
   const noConnectLayer = noConnectMarkers
     ? `<g data-layer="no-connects">${noConnectMarkers}</g>`
     : "";
   const symbols = [...document.instances]
+    .filter((instance) => included(instance.id))
     .filter((instance) => instance.placement !== null)
     .sort((left, right) => left.id.localeCompare(right.id, "en"))
     .map((instance) => {
@@ -951,6 +1000,7 @@ export function buildSvgScene(
     })
     .join("");
   const annotations = [...document.annotations]
+    .filter((annotation) => included(annotation.id))
     .filter((annotation) =>
       isSchematicAnnotationVisible(document, annotation, logicalNets),
     )
@@ -1147,7 +1197,7 @@ export function buildSvgScene(
 
   return {
     viewBox,
-    formalBody: `<g data-layer="formal"><g data-layer="routes">${routes}${junctionBridges}</g><g data-layer="junctions">${junctions}</g><g data-layer="symbols">${symbols}</g>${noConnectLayer}<g data-layer="annotations">${annotations}</g>${renderDraftingLayer(document, resolver, profile)}</g>`,
+    formalBody: `<g data-layer="formal"><g data-layer="routes">${routes}${junctionBridges}</g><g data-layer="junctions">${junctions}</g><g data-layer="symbols">${symbols}</g>${noConnectLayer}<g data-layer="annotations">${annotations}</g>${renderDraftingLayer(document, resolver, profile, objectIds)}</g>`,
   };
 }
 
@@ -1204,11 +1254,13 @@ function renderDraftingLayer(
   document: SchematicDocument,
   resolver: SymbolResolver,
   profile: SchematicStyleProfile,
+  objectIds?: ReadonlySet<string>,
 ): string {
   const objects = document.drafting?.objects ?? [];
   if (objects.length === 0) return "";
   const sorted = [...objects].sort((left, right) => left.zIndex - right.zIndex);
   const body = sorted
+    .filter((object) => !objectIds || objectIds.has(object.id))
     .map((object) => {
       const geometry = resolveDraftingObjectGeometry(
         document,
@@ -1711,8 +1763,20 @@ export function renderDocumentSvg(
   options: SvgRenderOptions = {},
 ): string {
   const scene = buildSvgScene(document, resolver, options);
+  if (
+    options.objectIds &&
+    !/<(?:path|polyline|polygon|circle|ellipse|rect|line|text)\b/u.test(
+      scene.formalBody,
+    )
+  ) {
+    throw new Error("Select visible objects before copying");
+  }
   const profile = resolveDocumentStyleProfile(document.presentation);
   const title = escapeXml(options.title ?? document.name);
   const { x, y, width, height } = scene.viewBox;
-  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${x} ${y} ${width} ${height}" role="img" aria-labelledby="title" data-style-profile="${profile.id}"><title id="title">${title}</title><rect x="${x}" y="${y}" width="${width}" height="${height}" fill="${profile.background}"/><style>${schematicRoundPeriodFontFaceCss}svg{font-size:${profile.typography.annotationFontSize}px;fill:${profile.foreground}}text{font-family:${profile.typography.fontFamily}}</style>${scene.formalBody}</svg>\n`;
+  const background =
+    options.background === "transparent"
+      ? ""
+      : `<rect x="${x}" y="${y}" width="${width}" height="${height}" fill="${profile.background}"/>`;
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${x} ${y} ${width} ${height}" role="img" aria-labelledby="title" data-style-profile="${profile.id}"><title id="title">${title}</title>${background}<style>${schematicRoundPeriodFontFaceCss}svg{font-size:${profile.typography.annotationFontSize}px;fill:${profile.foreground}}text{font-family:${profile.typography.fontFamily}}</style>${scene.formalBody}</svg>\n`;
 }


### PR DESCRIPTION
## Summary

Implements the agreed first slice of #545 without changing circuit copy/paste or adding selected-file export.

- Add `Copy as PNG` / `Copy as SVG` to the existing canvas context menu, dispatched through the existing Editor command router.
- Copy explicit visual selection plus its owned visible text, not the electrical Net closure. Resolve pins, anchors, route geometry and junction appearance against the original Document; the paint filter never creates a circuit subdocument or engine transaction.
- Use the canonical formal SVG pipeline for both clipboard formats. Omit page background and editor overlays, use transparent 3x PNG, bound allocations, and release temporary formula and raster resources. Capture document/selection before asynchronous preparation and invoke clipboard write within the user gesture.
- Group File exports into `Export netlist` (SPICE / Spectre) and `Export drawing` (SVG / PNG / PDF), retaining whole-document file export.
- Preserve C copy-placement, existing multi-selection and active-tool right-click behavior. Submenu triggers stay open; leaf actions use the existing dismissal path. Menu arrows do not pan the canvas.
- Keep canvas menus non-modal: an outside press closes the menu and still starts the intended drag. A completed right-button frame consumes its context-menu event; an ordinary subsequent right click remains available.

## Validation

- Frozen dependency install; gate plan selects full-delivery because shared renderer/exporter code is touched.
- Focused tests cover render filtering with original junction context, clipboard capture/permissions, transparent rasterization and allocation bounds, and command dispatch.
- Browser regressions cover mixed selection, independent Wire PNG pixels, unchanged undo history, denied/empty clipboard actions, exclusive File submenus, keyboard focus, and whole-drawing file output with a partial selection.
- Real local browser reports successful PNG and SVG writes. External Office/Visio paste and editability are not certified; clipboard MIME support and the receiving application determine compatibility.
- Local full-delivery completed static/typecheck, 358 unit files (2344 passed / 5 skipped), build, unchanged goldens, release smoke and performance checks. Its browser stage passed 340/341 and exposed one right-click/framing interaction regression. Follow-up `417fb788` fixes the root cause and strengthens that regression; all 10 affected context-menu/framing browser scenarios, typecheck and formatting pass. No existing golden or test requirement was weakened.
- All seven required remote checks passed on `417fb788`: Static contracts, Unit and integration tests, Release contracts, and all four full-browser shards. [Final CI run](https://github.com/cascode-ai/analog-canvas/actions/runs/33758884018). This branch is not being merged by this task.

## Scope deliberately left out

- No selected-file download, PDF clipboard, screenshot mode, circuit/Net migration, Agent protocol, or new copy-placement semantics.
- No automatic file download or format substitution on clipboard failure.

Refs #545. Review branch only; not merged.
