### PR TITLE
fix(editor): show drafting text during copy placement

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -666,7 +666,9 @@ test("snaps quick Text creation after a non-grid viewport zoom", async ({
   expect(textObject.anchor.position.y % 5).toBe(0);
 });
 
-test("copies a selected text with C", async ({ page }) => {
+test("previews a copied text at the cursor and commits its rotated pose atomically", async ({
+  page,
+}) => {
   await page.goto("/editor");
   const canvas = page.getByTestId("schematic-canvas");
 
@@ -679,6 +681,9 @@ test("copies a selected text with C", async ({ page }) => {
   const texts = page.locator('[data-kind="draft-text"]');
   await expect(texts).toHaveCount(1);
   const origin = (await texts.first().boundingBox())!;
+  const originalId = await texts.first().getAttribute("data-object-id");
+  const original = page.locator(`[data-object-id="${originalId}"]`);
+  const revision = Number(await page.getByTestId("revision").textContent());
 
   // Select the text and copy it. A drawing-only selection used to be refused
   // outright — "Select at least one component to copy".
@@ -690,7 +695,34 @@ test("copies a selected text with C", async ({ page }) => {
   await expect(page.getByTestId("status")).toContainText("Place copy");
 
   const box = (await canvas.boundingBox())!;
+  const ghost = page.getByTestId("copy-placement-preview");
+  const previewText = ghost.locator('[data-kind="draft-text"]');
+  await page.mouse.move(box.x + 320, box.y + 280);
+  await expect(previewText).toBeInViewport();
+  await expect(previewText).toContainText("Design note");
+  const firstPreview = (await previewText.boundingBox())!;
   await page.mouse.move(box.x + 420, box.y + 380);
+  const movedPreview = (await previewText.boundingBox())!;
+  expect(movedPreview.x).toBeGreaterThan(firstPreview.x + 50);
+  expect(movedPreview.y).toBeGreaterThan(firstPreview.y + 50);
+  expect(await original.boundingBox()).toEqual(origin);
+  await expect(page.getByTestId("revision")).toHaveText(String(revision));
+
+  await page.keyboard.press("Escape");
+  await expect(ghost).toHaveCount(0);
+  await expect(texts).toHaveCount(1);
+  await expect(page.getByTestId("revision")).toHaveText(String(revision));
+
+  await page.mouse.click(
+    origin.x + origin.width / 2,
+    origin.y + origin.height / 2,
+  );
+  await page.keyboard.press("c");
+  await page.mouse.move(box.x + 420, box.y + 380);
+  await page.keyboard.press("r");
+  await expect(previewText).toBeInViewport();
+  const rotatedPreview = (await previewText.boundingBox())!;
+  expect(rotatedPreview.height).toBeGreaterThan(rotatedPreview.width);
   await canvas.click({ position: { x: 420, y: 380 } });
   await page.keyboard.press("Escape");
 
@@ -701,6 +733,16 @@ test("copies a selected text with C", async ({ page }) => {
   expect(both.filter((value) => value?.includes("Design note"))).toHaveLength(
     2,
   );
+  const placed = (await texts.last().boundingBox())!;
+  for (const key of ["x", "y", "width", "height"] as const) {
+    expect(placed[key]).toBeCloseTo(rotatedPreview[key], 1);
+  }
+  await expect(page.getByTestId("revision")).toHaveText(String(revision + 1));
+  await page.keyboard.press("Control+z");
+  await expect(texts).toHaveCount(1);
+  expect(await original.boundingBox()).toEqual(origin);
+  await page.keyboard.press("Control+Shift+z");
+  await expect(texts).toHaveCount(2);
 });
 
 test("fits drafting text with F using an integer grid camera", async ({

--- a/apps/editor/src/features/clipboard/clipboard.test.ts
+++ b/apps/editor/src/features/clipboard/clipboard.test.ts
@@ -4,7 +4,7 @@ import {
   resolveAnnotationText,
   resolveDocumentLogicalNets,
 } from "@icm/derived";
-import type { Annotation, Instance } from "@icm/model";
+import type { Annotation, DraftingObject, Instance } from "@icm/model";
 import {
   createEmptyDocument,
   flattenRichText,
@@ -28,6 +28,236 @@ import {
 const resolver = new InMemorySymbolResolver(builtInSymbols);
 
 describe("schematic clipboard", () => {
+  it.each(["fallback", "dry-run"])(
+    "keeps %s drawing previews at the same coordinates as the paste",
+    (mode) => {
+      const document = createEmptyDocument(
+        "drawing-preview",
+        "Drawing preview",
+      );
+      const free = (x: number, y: number) => ({
+        kind: "free" as const,
+        position: { x, y },
+      });
+      const common = {
+        locked: false,
+        zIndex: 0,
+        anchor: free(103, 107),
+      };
+      const text = {
+        content: semanticTextDocument("Vout", "instance-label"),
+        alignment: "end" as const,
+        rotation: 90 as const,
+        styleOverride: { sizeScale: 1.5, color: "#2244AA" },
+      };
+      const objects: DraftingObject[] = [
+        { ...common, ...text, id: "note", kind: "text" },
+        {
+          ...common,
+          id: "arrow",
+          kind: "arrow",
+          from: free(103, 107),
+          to: free(143, 147),
+          waypoints: [{ x: 123, y: 107 }],
+          curveControls: [{ x: 113, y: 97 }, null],
+        },
+        {
+          ...common,
+          id: "line",
+          kind: "construction-line",
+          points: [
+            { x: 103, y: 107 },
+            { x: 143, y: 147 },
+          ],
+          curveControls: [{ x: 113, y: 97 }],
+          lineStyle: "dashed",
+        },
+        {
+          ...common,
+          id: "rectangle",
+          kind: "rectangle",
+          center: { x: 103, y: 107 },
+          width: 40,
+          height: 20,
+          rotation: 30,
+          lineStyle: "solid",
+        },
+        {
+          ...common,
+          id: "circle",
+          kind: "circle",
+          center: { x: 103, y: 107 },
+          radius: 20,
+          lineStyle: "solid",
+        },
+        { ...common, id: "leader", kind: "leader", target: free(143, 147) },
+        {
+          ...common,
+          ...text,
+          id: "callout",
+          kind: "callout",
+          target: free(143, 147),
+        },
+      ];
+      document.drafting = { objects };
+      const before = structuredClone(document);
+      const clipboard = copySelection(
+        document,
+        [],
+        objects.map((object) => object.id),
+      )!;
+      const offset = { x: 60, y: 40 };
+      const proposal = proposePaste(document, clipboard, offset, 1);
+      const paste = executeTransaction(
+        document,
+        {
+          transactionId: "drawing-paste",
+          documentId: document.id,
+          expectedRevision: document.revision,
+          actor: { kind: "human", id: "test" },
+          edits: proposal.edits,
+        },
+        { symbolResolver: resolver },
+      );
+      expect(paste.ok, JSON.stringify(paste.diagnostics)).toBe(true);
+      if (!paste.ok) return;
+      const preview = clipboardPreviewDocument(
+        document,
+        clipboard,
+        offset,
+        [],
+        mode === "dry-run" ? resolver : undefined,
+        1,
+      );
+      const expected = paste.document.drafting!.objects.filter((object) =>
+        Object.values(proposal.idRemap.draftingObjects).includes(object.id),
+      );
+      expect(
+        preview.drafting!.objects.map((object, index) => ({
+          ...object,
+          id: objects[index]!.id,
+        })),
+      ).toEqual(
+        expected.map((object, index) => ({
+          ...object,
+          id: objects[index]!.id,
+        })),
+      );
+      expect(preview.drafting!.objects[0]!.anchor).toEqual(free(163, 147));
+      expect(preview.drafting!.objects[0]).toMatchObject(text);
+      expect(() => buildSvgScene(preview, resolver)).not.toThrow();
+      expect(document).toEqual(before);
+      expect(clipboard.draftingObjects).toEqual(objects);
+    },
+  );
+
+  it("keeps rotated mixed-copy text aligned with its remapped component labels", () => {
+    const document = createEmptyDocument("mixed-preview", "Mixed preview");
+    document.instances.push({
+      id: "R1",
+      reference: "R1",
+      symbolId: "resistor",
+      placement: { position: { x: 100, y: 100 }, rotation: 0, mirror: "none" },
+    });
+    const anchor = {
+      kind: "object" as const,
+      objectId: "R1",
+      localOffset: { x: 20, y: 30 },
+      fallbackPosition: { x: 120, y: 130 },
+    };
+    document.annotations.push({
+      id: "reference",
+      kind: "instance-label",
+      locked: false,
+      binding: { kind: "instance-reference", instanceId: "R1" },
+      anchor,
+      alignment: "start",
+      rotation: 0,
+    });
+    const note = {
+      kind: "text" as const,
+      locked: false,
+      zIndex: 0,
+      content: { runs: [{ kind: "text" as const, value: "Design note" }] },
+      alignment: "middle" as const,
+      rotation: 0 as const,
+    };
+    document.drafting = {
+      objects: [
+        {
+          ...note,
+          id: "free-note",
+          anchor: { kind: "free", position: { x: 143, y: 127 } },
+        },
+        { ...note, id: "attached-note", anchor },
+      ],
+    };
+    const before = structuredClone(document);
+    const clipboard = copySelection(
+      document,
+      ["R1"],
+      ["free-note", "attached-note"],
+    )!;
+    const turns = [{ kind: "rotate" as const, deltaDegrees: 90 as const }];
+    const offset = { x: 60, y: 40 };
+    const proposal = proposePaste(
+      document,
+      orientClipboard(clipboard, turns),
+      offset,
+      1,
+    );
+    const paste = executeTransaction(
+      document,
+      {
+        transactionId: "mixed-paste",
+        documentId: document.id,
+        expectedRevision: document.revision,
+        actor: { kind: "human", id: "test" },
+        edits: proposal.edits,
+      },
+      { symbolResolver: resolver },
+    );
+    expect(paste.ok, JSON.stringify(paste.diagnostics)).toBe(true);
+    if (!paste.ok) return;
+    const preview = clipboardPreviewDocument(
+      document,
+      clipboard,
+      offset,
+      turns,
+      resolver,
+      1,
+    );
+    expect(preview.drafting!.objects).toEqual(
+      paste.document.drafting!.objects.filter((object) =>
+        Object.values(proposal.idRemap.draftingObjects).includes(object.id),
+      ),
+    );
+    expect(preview.drafting!.objects[0]).toMatchObject({
+      anchor: { kind: "free", position: { x: 133, y: 183 } },
+      rotation: 90,
+    });
+    expect(preview.drafting!.objects[1]!.anchor).toEqual({
+      kind: "object",
+      objectId: proposal.instanceIds[0],
+      localOffset: { x: -30, y: 20 },
+      fallbackPosition: { x: 130, y: 160 },
+    });
+    expect(resolveAnnotationText(preview, preview.annotations[0]!)).toEqual(
+      resolveAnnotationText(
+        paste.document,
+        paste.document.annotations.find(
+          (annotation) =>
+            annotation.id === proposal.idRemap.annotations.reference,
+        )!,
+      ),
+    );
+    expect(
+      flattenRichText(resolveAnnotationText(preview, preview.annotations[0]!)),
+    ).toBe("R2");
+    expect(() => buildSvgScene(preview, resolver)).not.toThrow();
+    expect(document).toEqual(before);
+  });
+
   it("copies a Cell Pin with an independent interface and Base Net", () => {
     const document = createEmptyDocument("document-main", "Clipboard");
     document.instances.push({

--- a/apps/editor/src/features/clipboard/clipboard.ts
+++ b/apps/editor/src/features/clipboard/clipboard.ts
@@ -410,6 +410,20 @@ function fallbackClipboardPreviewDocument(
     }
     return preview;
   });
+  // The dry run has already remapped ownership; this step only moves its
+  // isolated geometry back from the clearance position. Use the paste
+  // transforms for every drafting coordinate, including leader/callout tips
+  // and attached-anchor fallbacks, without renaming or re-snapping the copy.
+  const unchangedIds = new Map<string, string>();
+  const draftingObjects = clipboard.draftingObjects.map((object) =>
+    remapPastedDraftingAnchors(
+      translateDraftingObject(object, offset, base.presentation.grid),
+      unchangedIds,
+      unchangedIds,
+      unchangedIds,
+      offset,
+    ),
+  );
   return {
     ...base,
     instances: clipboard.instances.map((instance) => ({
@@ -460,9 +474,7 @@ function fallbackClipboardPreviewDocument(
     noConnects: structuredClone(clipboard.noConnects),
     annotations,
     drafting:
-      clipboard.draftingObjects.length > 0
-        ? { objects: structuredClone(clipboard.draftingObjects) }
-        : undefined,
+      draftingObjects.length > 0 ? { objects: draftingObjects } : undefined,
     // A copy ghost is an isolated fragment, not a filtered view of the base
     // Document. Every reference-bearing Document field must therefore be
     // owned explicitly here. Inheriting any of these through `...base` leaves


### PR DESCRIPTION
## Summary
Fixes #544.

The isolated copy-preview dry run uses a large clearance offset to avoid contacting the original circuit. Its translation back to the visible canvas omitted DraftingObject geometry, so ordinary Text was present in the preview SVG but far outside the viewport. Reuse the existing paste geometry and anchor transforms; no new text protocol, model contract, or connectivity behavior.

Cover ordinary rich Text, drawing shapes, attached-anchor fallbacks, and rotated mixed selections with remapped reference labels. The browser regression verifies visible cursor tracking, rotation, exact preview/placement agreement, cancellation without mutation, and atomic undo/redo.

## Validation
- Clipboard and clipboard audit: 37 unit tests passed; regressions reproduced before the fix.
- Focused copy Text browser regression: passed.
- Frozen dependency install and gate preflight: passed.
- Complete local gate passed: formatting, documentation/generated-contract checks, typecheck, 360 unit files (2357 passed / 5 skipped), workspace build, performance budgets, visual/export goldens, PWA icons, production/package smoke, and all 342 browser tests.
- All seven required GitHub checks plus Change scope passed.
- Pre-existing unrelated untracked .vscode/ settings are untouched and excluded from this PR. The local planner included this unclassified file, so the conservative full gate was run; no checks were weakened or bypassed.