### PR TITLE
fix(ci): a staging deploy must not change what the public site serves

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -58,6 +58,25 @@ jobs:
         if: steps.gate.outputs.ran == 'true'
         env:
           VITE_ICM_TIMING_UI: disabled
+      # How the public site answers for its own script, captured BEFORE the
+      # staging deploy. On 2026-09-03 that deploy moved the production custom
+      # domain onto the staging script (wrangler's `routes` key inherits into
+      # an environment) and the public site served 401 for every script while
+      # its cached shell still loaded, so production looked up and was down.
+      # The comparison after the deploy is what would have said so, by name.
+      - name: Record how the production domain answers
+        id: production_before
+        if: steps.gate.outputs.ran == 'true'
+        run: |
+          asset="$(curl --silent --show-error --max-time 20 \
+            https://analog-canvas.tokenzhang.com/editor \
+            | grep -o '/assets/index-[^"]*\.js' | head -n 1)"
+          answer="$(curl --silent --output /dev/null --max-time 20 \
+            --write-out '%{http_code} %{content_type}' \
+            "https://analog-canvas.tokenzhang.com${asset}")"
+          echo "asset=$asset" >> "$GITHUB_OUTPUT"
+          echo "answer=$answer" >> "$GITHUB_OUTPUT"
+          echo "Production answers ${asset} with: ${answer}"
       # The deployed hostname comes from the deploy itself, not from a second
       # secret someone has to keep in step with it. A hand-entered URL that
       # drifts fails verification, and a failed staging blocks every
@@ -127,6 +146,30 @@ jobs:
           echo "public on a workers.dev hostname. Refusing to continue."
           exit 1
 
+      # A staging deploy must not change what the public site serves. The
+      # answer is compared with its own earlier answer rather than with "200",
+      # so a domain that is already wrong does not block the production
+      # deploy that puts it right: that deploy re-attaches the custom domain.
+      - name: Production domain still answers as before
+        if: steps.gate.outputs.ran == 'true'
+        env:
+          BEFORE: ${{ steps.production_before.outputs.answer }}
+          ASSET: ${{ steps.production_before.outputs.asset }}
+        run: |
+          after="$(curl --silent --output /dev/null --max-time 20 \
+            --write-out '%{http_code} %{content_type}' \
+            "https://analog-canvas.tokenzhang.com${ASSET}")"
+          echo "Production answers ${ASSET} with: ${after}"
+          if [ "$after" != "$BEFORE" ]; then
+            echo "::error::The staging deploy changed how the production domain answers (was: ${BEFORE}, now: ${after}). Staging must not have taken the production domain: env.staging in wrangler.jsonc has to declare \"routes\": [], and analog-canvas.tokenzhang.com belongs to the interactive-circuit-maker Worker, never to interactive-circuit-maker-staging."
+            exit 1
+          fi
+          case "$after" in
+            "200 text/javascript"* | "200 application/javascript"*) ;;
+            *)
+              echo "::warning::The production domain is not serving its own script (${after}); the production deploy that follows re-attaches the custom domain."
+              ;;
+          esac
       # The same checks production gets, against the staging host, with the
       # access key supplied. A path that fails here never reaches the public.
       - name: Verify staging

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -98,6 +98,19 @@ anonymous caller fails its own deploy.
 ordinary merge flows through staging to production without anyone waiting; a
 version bump stops at an approval gate.
 
+**Staging declares no routes, deliberately.** `routes` is an inheritable key
+in `wrangler.jsonc`, so an environment that does not override it inherits the
+production custom domain, and `wrangler deploy --env staging` then attaches
+`analog-canvas.tokenzhang.com` to the staging script. That happened on
+2026-09-03: the public site kept serving its cached shell while every script
+request met the staging gate's 401, so the site looked up and was blank.
+`env.staging` therefore sets `"routes": []` and is reachable only through its
+workers.dev hostname, and the staging job records how the production domain
+answers for its own script before the deploy and fails if that answer changed
+afterwards. The comparison is against the earlier answer rather than against
+"200" so that a domain which is already wrong does not block the production
+deploy that re-attaches it.
+
 **Staging has no rollback, deliberately.** Nothing public serves from it, so a
 bad staging deploy is a failed gate rather than an outage — it simply stops
 production from happening. Rollback stays where the users are.

--- a/scripts/deploy-workflow.test.mjs
+++ b/scripts/deploy-workflow.test.mjs
@@ -94,6 +94,27 @@ describe("staging before production", () => {
     // work. Being unlisted is not being private.
     expect(workflow).toContain("Staging must refuse an anonymous caller");
   });
+
+  it("fails staging when its deploy changed what the public site serves", () => {
+    const stagingJob = workflow.slice(
+      workflow.indexOf("  staging:\n"),
+      workflow.indexOf("  deploy:\n"),
+    );
+    const before = stagingJob.indexOf(
+      "Record how the production domain answers",
+    );
+    const deploy = stagingJob.indexOf("deploy --env staging");
+    const after = stagingJob.indexOf(
+      "Production domain still answers as before",
+    );
+    expect(before).toBeGreaterThan(-1);
+    expect(after).toBeGreaterThan(-1);
+    // Captured before the deploy and compared after it; the other way round
+    // the comparison could only ever agree with itself.
+    expect(before).toBeLessThan(deploy);
+    expect(deploy).toBeLessThan(after);
+    expect(stagingJob).toContain("must not have taken the production domain");
+  });
 });
 
 describe("Cloudflare deploy workflow", () => {


### PR DESCRIPTION
Rebased on #552, which already lands `"routes": []` and the gate in front of every staging path. What remains here is the check that would have named tonight's failure the moment it happened.

The staging job records how the production domain answers for its own script **before** the staging deploy and fails, saying why and what to do, if that answer changed afterwards. It compares with the earlier answer rather than with `200`, so a domain that is already wrong does not block the production deploy that puts it right: that deploy re-attaches the custom domain, which is how tonight's recovery worked.

- `docs/deployment.md` records the inheritance rule and the incident.
- `scripts/deploy-workflow.test.mjs` pins the order of the two steps around the staging deploy (18 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
