### PR TITLE
fix(editor): a Net label answers a simulation pick again

### DIFF
--- a/apps/editor/e2e/manual-editor.spec.ts
+++ b/apps/editor/e2e/manual-editor.spec.ts
@@ -211,6 +211,13 @@ test("opens one digital simulation window and picks a Net from the canvas", asyn
   await expect(simulation.getByLabel("Saved Nets")).toContainText("None");
   await clickRoute(page, "route-simulation-pick", 0.5);
   await expect(simulation.getByLabel("Saved Nets")).toContainText("HORIZONTAL");
+  // A Net label names its Net as directly as the wire does, and its press
+  // is claimed by the same router that claims the wire's.
+  const clockLabel = page.getByTestId("annotation-hit-test-net-label-1");
+  await clockLabel.click();
+  await expect(simulation.getByLabel("Saved Nets")).toContainText("CK");
+  await clockLabel.click();
+  await expect(simulation.getByLabel("Saved Nets")).not.toContainText("CK");
   await page.keyboard.press("Escape");
   await expect(page.locator(".schematic-canvas")).not.toHaveClass(
     /simulation-net-pick-active/u,

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -2520,6 +2520,7 @@ export function App({
       ),
       tool,
       cellSymbolLayoutEnabled,
+      simulationPickNetsActive,
     },
     actions: {
       beginInstanceMove: beginMoveFromSelection,
@@ -2549,6 +2550,19 @@ export function App({
       setStatus,
       suppressNextClick: () => {
         suppressInstanceClick.current = true;
+      },
+      pickSimulationNet: (kind, id) => {
+        const netId =
+          kind === "route"
+            ? document.routes.find((route) => route.id === id)?.netId
+            : kind === "annotation"
+              ? document.annotations.find((annotation) => annotation.id === id)
+                  ?.netId
+              : kind === "junction"
+                ? document.junctions.find((junction) => junction.id === id)
+                    ?.netId
+                : undefined;
+        if (netId) toggleSimulationSavedNet(netId);
       },
       consumeArmedVerb: (kind, id) => {
         if (kind === "instance") return consumeArmedVerbOnInstance(id);
@@ -3745,9 +3759,7 @@ export function App({
         }
         return false;
       },
-      handleCanvasHitPointerDown: (event) => {
-        if (!simulationPickNetsActive) handleCanvasHitPointerDown(event);
-      },
+      handleCanvasHitPointerDown,
       openContextMenu: (target, clientX, clientY) => {
         if (
           canvasContextMenuSuppressed.current ||

--- a/apps/editor/src/canvas/canvas-hit-controller.ts
+++ b/apps/editor/src/canvas/canvas-hit-controller.ts
@@ -6,7 +6,10 @@ import type { Annotation, DraftingObject, SchematicDocument } from "@icm/model";
 import type { EditorTool } from "../interaction/interaction-state";
 import { planSelectionMove } from "../features/selection/selection-move-plan";
 import type { VisualSelection } from "../features/selection/visual-selection";
-import { resolveCanvasHitAtPoint } from "./canvas-hit-resolver";
+import {
+  resolveCanvasHitAtPoint,
+  type CanvasHitKind,
+} from "./canvas-hit-resolver";
 import { resolvePointerDownAction } from "./pointer-down-router";
 
 export interface CanvasHitControllerDependencies {
@@ -23,6 +26,8 @@ export interface CanvasHitControllerDependencies {
     placementOwnsCanvas: boolean;
     tool: EditorTool;
     cellSymbolLayoutEnabled: boolean;
+    /** The Simulation panel is picking Nets; a press names a Net, nothing more. */
+    simulationPickNetsActive: boolean;
   };
   actions: {
     beginInstanceMove: (
@@ -65,6 +70,8 @@ export interface CanvasHitControllerDependencies {
     consumeArmedVerb?: (kind: string, id: string) => boolean;
     /** Swallow the click that follows a press an armed verb consumed. */
     suppressNextClick?: () => void;
+    /** Name the Net a picked conductor, Junction, or Net label belongs to. */
+    pickSimulationNet?: (kind: CanvasHitKind, id: string) => void;
   };
 }
 
@@ -83,6 +90,7 @@ export function createCanvasHitController({
     placementOwnsCanvas,
     tool,
     cellSymbolLayoutEnabled,
+    simulationPickNetsActive,
   },
   actions: {
     beginInstanceMove,
@@ -96,6 +104,7 @@ export function createCanvasHitController({
     setStatus,
     consumeArmedVerb,
     suppressNextClick,
+    pickSimulationNet,
   },
 }: CanvasHitControllerDependencies) {
   const compositeSelectionOwnsHit = (
@@ -168,9 +177,12 @@ export function createCanvasHitController({
           event.altKey ? 1 : 0,
         )
       : null;
+    // The offer runs the verb, so it is withheld while Nets are being picked:
+    // a pick names a Net and must not rotate, copy, or delete what it names.
     const armedVerbConsumesHit =
       hit !== null &&
       hit.kind !== "handle" &&
+      !simulationPickNetsActive &&
       Boolean(consumeArmedVerb?.(hit.kind, hit.id));
     const compositeOwnsHit = Boolean(
       hit &&
@@ -202,6 +214,7 @@ export function createCanvasHitController({
         planSelectionMove(document, selection).previewObjectIds.length > 0,
       primaryInstanceId,
       armedVerbConsumesHit,
+      simulationPickNetsActive,
     });
 
     // Only an action this dispatcher owns claims the press; everything else
@@ -223,6 +236,9 @@ export function createCanvasHitController({
     }
 
     switch (action.kind) {
+      case "simulation-pick":
+        pickSimulationNet?.(action.hitKind, action.id);
+        return;
       case "consume-armed-verb":
         // The offer already ran the verb. The click that follows this press
         // must not also land: it would re-select the object and undo it.

--- a/apps/editor/src/canvas/pointer-down-router.test.ts
+++ b/apps/editor/src/canvas/pointer-down-router.test.ts
@@ -30,6 +30,7 @@ const facts = (
   compositeMovePlanHasPreview: false,
   primaryInstanceId: null,
   armedVerbConsumesHit: false,
+  simulationPickNetsActive: false,
   ...overrides,
 });
 
@@ -51,6 +52,39 @@ describe("who owns one press on the canvas", () => {
     expect(
       resolvePointerDownAction(facts({ hit: hitOf("junction", "j1") })),
     ).toEqual({ kind: "select-junction", junctionId: "j1" });
+  });
+
+  it("reads a press as a Net pick while the Simulation panel is picking", () => {
+    // A conductor, a Junction, or a Net label names a Net. A part does not,
+    // and nothing is selected, moved, or handed to an armed verb meanwhile.
+    // The label case is the one that was lost when its element handler went.
+    const picking = {
+      simulationPickNetsActive: true,
+      armedVerbConsumesHit: true,
+    };
+    expect(
+      resolvePointerDownAction(
+        facts({ ...picking, hit: hitOf("annotation", "label-1") }),
+      ),
+    ).toEqual({
+      kind: "simulation-pick",
+      hitKind: "annotation",
+      id: "label-1",
+    });
+    expect(
+      resolvePointerDownAction(
+        facts({ ...picking, hit: hitOf("route", "route-1") }),
+      ),
+    ).toEqual({ kind: "simulation-pick", hitKind: "route", id: "route-1" });
+    expect(
+      resolvePointerDownAction(
+        facts({ ...picking, hit: hitOf("junction", "j1") }),
+      ),
+    ).toEqual({ kind: "simulation-pick", hitKind: "junction", id: "j1" });
+    expect(resolvePointerDownAction(facts({ ...picking })).kind).toBe("ignore");
+    expect(
+      resolvePointerDownAction(facts({ ...picking, hit: null })).kind,
+    ).toBe("ignore");
   });
 
   it("gives an Instance label no press of its own", () => {

--- a/apps/editor/src/canvas/pointer-down-router.ts
+++ b/apps/editor/src/canvas/pointer-down-router.ts
@@ -43,6 +43,12 @@ export interface PointerDownFacts {
   readonly primaryInstanceId: string | null;
   /** A verb (rotate/copy/move/delete) was armed before a target was picked. */
   readonly armedVerbConsumesHit: boolean;
+  /**
+   * The Simulation panel is picking Nets from the canvas. A press then names
+   * the Net under it and does nothing else: no selection, no drag, and no
+   * verb, however one was armed.
+   */
+  readonly simulationPickNetsActive: boolean;
 }
 
 export type PointerDownAction =
@@ -112,6 +118,22 @@ export function resolvePointerDownAction(
   const hit = facts.hit;
   if (!hit) return { kind: "ignore", reason: "no hit under the pointer" };
   if (hit.kind === "handle") return { kind: "handle-passthrough" };
+
+  // Picking a Net for simulation reads the press for the Net it names: a
+  // conductor, a Junction, or a Net label. A part names nothing and is left
+  // alone, and so is a terminal pin, which carries no hit kind and keeps the
+  // circle handler that picks it. This used to live on the label element
+  // itself, which is how the label's pick was lost when that handler went.
+  if (facts.simulationPickNetsActive) {
+    if (
+      hit.kind === "route" ||
+      hit.kind === "annotation" ||
+      hit.kind === "junction"
+    ) {
+      return { kind: "simulation-pick", hitKind: hit.kind, id: hit.id };
+    }
+    return { kind: "ignore", reason: "picking Nets for simulation" };
+  }
 
   // An armed verb owns the press: the pointed-at object is acted on rather
   // than picked up or selected.


### PR DESCRIPTION
Picking Nets for the Simulation panel lost one of its targets in #523: the Net label's press was answered by the annotation element's own `onPointerDown`, which toggled the label's Net while picking, and that handler went when press ownership moved into the router. Wires and endpoint circles kept theirs, which is why the existing browser test, which only clicked a wire, stayed green.

The pick now lives in the router: while the panel is picking, a press on a conductor, a Junction, or a Net label is a `simulation-pick` and nothing else (no selection, no drag, no armed verb). A press on a part is ignored, as before, so a terminal pin keeps the circle handler that picks it. The capture-phase gate that skipped the dispatcher while picking is gone with it.

- `pointer-down-router.test.ts`: the picking branch, including that an armed verb does not win a pick (12 tests).
- `manual-editor.spec.ts` "picks a Net from the canvas": now also clicks the `CK` Net label to pick and un-pick it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
