### PR TITLE
feat(deploy): a preview channel that every merge deploys, kept off production

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# The container build context is the repository root so the Dockerfile can
+# copy the staged Sky130 model files from pdk/. Nothing else belongs in the
+# context: node_modules alone would make every build upload gigabytes.
+*
+!containers
+!pdk

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,151 @@
+name: Deploy Preview
+
+# The preview channel (ADR 0057): every merge to main deploys the preview
+# Worker at analog-canvas-preview.tokenzhang.com and verifies it. Production
+# is a different workflow with a different trigger; nothing here can reach it.
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-preview
+  cancel-in-progress: false
+
+env:
+  PREVIEW_URL: https://analog-canvas-preview.tokenzhang.com
+  # The Sky130 model files the container image copies, pinned to one volare
+  # release by tag and by the SHA-256 of each archive. Changing the models is
+  # a deliberate edit here, never a drift.
+  SKY130_TAG: sky130-c6d73a35f524070e85faff4a6a9eef49553ebc2b
+  SKY130_COMMON_SHA256: 8a7f06212c6d9fa5a1da6145f559f48a903434a5c5b6cd5352363700b6cadb94
+  SKY130_FD_PR_SHA256: dcb49c7450dfb55c91ce315d258563895df1ed75d4a9090064aade8290030a87
+
+jobs:
+  preview:
+    name: Deploy preview
+    runs-on: ubuntu-latest
+    environment:
+      name: cloudflare-preview
+      url: https://analog-canvas-preview.tokenzhang.com
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.16.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @icm/spice-run build
+      - run: pnpm --filter @icm/editor... build
+        env:
+          VITE_ICM_TIMING_UI: disabled
+      # The Dockerfile copies pdk/sky130A/libs.tech/ngspice and
+      # pdk/sky130A/libs.ref/sky130_fd_pr from the build context. Only those
+      # two trees are extracted: the archives also carry sky130B and every
+      # other tool's files, none of which ngspice reads.
+      - name: Stage the Sky130 model files for the container image
+        run: |
+          set -euo pipefail
+          mkdir -p pdk/download
+          for asset in common sky130_fd_pr; do
+            curl --fail --silent --show-error --location --max-time 300 \
+              --output "pdk/download/${asset}.tar.zst" \
+              "https://github.com/efabless/volare/releases/download/${SKY130_TAG}/${asset}.tar.zst"
+          done
+          echo "${SKY130_COMMON_SHA256}  pdk/download/common.tar.zst" | sha256sum --check -
+          echo "${SKY130_FD_PR_SHA256}  pdk/download/sky130_fd_pr.tar.zst" | sha256sum --check -
+          tar --zstd -xf pdk/download/common.tar.zst -C pdk --wildcards 'sky130A/libs.tech/ngspice/*'
+          tar --zstd -xf pdk/download/sky130_fd_pr.tar.zst -C pdk --wildcards 'sky130A/libs.ref/sky130_fd_pr/spice/*'
+          rm -rf pdk/download
+          test -f pdk/sky130A/libs.tech/ngspice/sky130.lib.spice
+          du -sh pdk/sky130A/libs.tech/ngspice pdk/sky130A/libs.ref/sky130_fd_pr/spice
+      - name: Deploy to preview
+        run: pnpm dlx wrangler@4.120.1 deploy --config wrangler.preview.jsonc
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # What a preview is for: the page renders, the gallery reads and never
+      # writes, nothing is indexed, and the simulator answers.
+      - name: Verify preview
+        run: |
+          set -euo pipefail
+          channel="$(curl --fail --silent --show-error --max-time 20 \
+            --retry 5 --retry-delay 2 --retry-all-errors \
+            "${PREVIEW_URL}/api/channel")"
+          case "$channel" in
+            *'"preview"'*) ;;
+            *) echo "The preview does not know it is the preview: $channel"; exit 1 ;;
+          esac
+          shell="$(curl --fail --silent --show-error --max-time 20 "${PREVIEW_URL}/editor")"
+          entry="$(printf '%s' "$shell" | grep -o '/assets/[A-Za-z0-9._-]*\.js' | head -n 1)"
+          if [ -z "$entry" ]; then
+            echo "The editor shell references no script; it cannot boot."
+            exit 1
+          fi
+          entry_result="$(curl --silent --output /dev/null --max-time 20 \
+            --write-out '%{http_code} %{content_type}' "${PREVIEW_URL}${entry}")"
+          case "$entry_result" in
+            200*javascript*) ;;
+            *) echo "The editor's entry script answered: $entry_result"; exit 1 ;;
+          esac
+          stale="$(curl --silent --output /dev/null --max-time 20 \
+            --write-out '%{http_code}' "${PREVIEW_URL}/assets/App-preview-smoke-missing.js")"
+          if [ "$stale" != "404" ]; then
+            echo "A missing hashed asset must answer 404, got: $stale"
+            exit 1
+          fi
+          robots="$(curl --fail --silent --show-error --max-time 20 "${PREVIEW_URL}/robots.txt")"
+          case "$robots" in
+            *"Disallow: /"*) ;;
+            *) echo "The preview must refuse robots, got: $robots"; exit 1 ;;
+          esac
+          noindex="$(curl --silent --head --max-time 20 "${PREVIEW_URL}/editor" | tr -d '\r' | grep -i '^x-robots-tag:' || true)"
+          case "$noindex" in
+            *noindex*) ;;
+            *) echo "Preview responses must carry noindex, got: ${noindex:-nothing}"; exit 1 ;;
+          esac
+          gallery="$(curl --silent --output /dev/null --max-time 20 \
+            --write-out '%{http_code}' "${PREVIEW_URL}/api/gallery")"
+          if [ "$gallery" != "200" ]; then
+            echo "The preview must read the production gallery, got: $gallery"
+            exit 1
+          fi
+          write="$(curl --silent --output /dev/null --max-time 20 -X POST \
+            --write-out '%{http_code}' "${PREVIEW_URL}/api/gallery/preview-smoke/like")"
+          if [ "$write" != "403" ]; then
+            echo "A gallery write on the preview must be refused, got: $write"
+            exit 1
+          fi
+      # A resistor divider, the smallest circuit ngspice can answer for. It
+      # proves the whole chain: container built, models present, harness up,
+      # Worker talking to it. The circuit's own answer is checked by tests
+      # elsewhere; here the question is only "did a simulation happen".
+      - name: Simulate one circuit on the preview
+        run: |
+          set -euo pipefail
+          body="$(node -e '
+            const netlist = [".subckt divider in out", "R1 in out 1k", "R2 out 0 1k", ".ends divider"].join("\n");
+            const testbench = ["V1 in 0 DC 1", "X1 in out divider", ".op", ".end"].join("\n");
+            process.stdout.write(JSON.stringify({ netlist, testbench, inputRevision: "preview-smoke", timeoutMs: 60000 }));
+          ')"
+          result="$(curl --silent --show-error --max-time 120 \
+            --output /tmp/preview-simulation.json \
+            --write-out '%{http_code}' \
+            -H 'content-type: application/json' --data "$body" \
+            "${PREVIEW_URL}/api/simulate")"
+          cat /tmp/preview-simulation.json; echo
+          if [ "$result" != "200" ]; then
+            echo "The preview simulator answered HTTP $result; see the body above."
+            exit 1
+          fi
+          grep -q '"executor":"hosted-container"' /tmp/preview-simulation.json

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ netlists/*/agent-*-layout.svg
 
 # Target plans are a local working area, not a published artifact.
 plan/
+
+# Sky130 model files staged by the preview deploy for the container image.
+pdk/

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -92,6 +92,10 @@ import {
 } from "../canvas/canvas-drag-session";
 import { startCanvasDragVisual } from "../canvas/canvas-drag-visual";
 import { instanceVisibleHitBox } from "../canvas/instance-geometry";
+import {
+  loadReleaseChannel,
+  type ReleaseChannel,
+} from "../document/release-channel";
 import { createCanvasHitController } from "../canvas/canvas-hit-controller";
 import { screenScaleHitRadius } from "../canvas/canvas-hit-resolver";
 import { buildDiagnosticMarkers } from "../canvas/diagnostic-markers";
@@ -517,6 +521,19 @@ export function App({
   const cameraRuntime = cameraRuntimeRef.current;
   useEffect(() => () => cameraRuntime.dispose(), [cameraRuntime]);
   const [gridDotsVisible, setGridDotsVisible] = useState(true);
+  // Which channel serves this build (ADR 0057). Asked once; anything but a
+  // clear "preview" is production, so the public site never wears the banner.
+  const [releaseChannel, setReleaseChannel] =
+    useState<ReleaseChannel>("production");
+  useEffect(() => {
+    let cancelled = false;
+    void loadReleaseChannel().then((channel) => {
+      if (!cancelled) setReleaseChannel(channel);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   // Annotations and drafting place on their own pitch; the Document grid
   // stays the electrical contract for devices, wires, and junctions.
   const [annotationGrid, setAnnotationGridState] = useState<1 | 5 | 10>(() => {
@@ -3859,6 +3876,7 @@ export function App({
     <main className="app-shell">
       {renderCrashRequested() ? <RenderCrashProbe /> : null}
       <EditorAppChrome
+        releaseChannel={releaseChannel}
         projectName={project.name}
         projectSchemaVersion={project.schemaVersion}
         projectNameDraft={projectNameDraft}
@@ -4020,7 +4038,17 @@ export function App({
             : null
         }
         publishGalleryOpen={publishGalleryOpen}
-        onPublishGallery={() => setPublishGalleryOpen(true)}
+        onPublishGallery={() => {
+          // The preview reads the gallery and never writes it (ADR 0057);
+          // saying so here beats a sign-in dialog with nowhere to sign in.
+          if (releaseChannel === "preview") {
+            setStatus(
+              "Preview builds cannot publish to the gallery; publish from the production site.",
+            );
+            return;
+          }
+          setPublishGalleryOpen(true);
+        }}
         helpButtonRef={helpButtonRef}
         helpOpen={helpOpen}
         onOpenHelp={() => setHelpOpen(true)}

--- a/apps/editor/src/app/editor-app-chrome.tsx
+++ b/apps/editor/src/app/editor-app-chrome.tsx
@@ -3,6 +3,7 @@ import type { ComponentProps, RefObject } from "react";
 import { BugReportLink } from "../components/bug-report-link";
 import { DrawingToolbar } from "../features/editor-shell/drawing-toolbar";
 import { EditorTestTelemetry } from "../features/editor-shell/editor-test-telemetry";
+import type { ReleaseChannel } from "../document/release-channel";
 import { FileCommandMenu } from "../features/editor-shell/file-command-menu";
 import { ToolIcon } from "../features/editor-shell/tool-icon";
 import { HierarchyToolbar } from "../features/hierarchy/hierarchy-toolbar";
@@ -61,6 +62,8 @@ export interface EditorAppChromeProps {
   drawingToolbar: ComponentProps<typeof DrawingToolbar>;
   hierarchyToolbar: ComponentProps<typeof HierarchyToolbar>;
   telemetry: ComponentProps<typeof EditorTestTelemetry>;
+  /** Which channel serves this build; the preview wears a banner. */
+  releaseChannel: ReleaseChannel;
 }
 
 /** Persistent command chrome above the document workspace. */
@@ -100,10 +103,21 @@ export function EditorAppChrome({
   drawingToolbar,
   hierarchyToolbar,
   telemetry,
+  releaseChannel,
 }: EditorAppChromeProps) {
   const displayedProjectName = projectNameDraft ?? projectName;
   return (
     <header className="app-chrome">
+      {releaseChannel === "preview" ? (
+        <p
+          className="app-channel-banner"
+          role="status"
+          data-testid="release-channel-banner"
+        >
+          Preview build: unreleased features, simulation included. The gallery
+          is read-only here; publish on the production site.
+        </p>
+      ) : null}
       <div className="app-chrome-main">
         <div className="app-brand">
           <a

--- a/apps/editor/src/document/release-channel.test.ts
+++ b/apps/editor/src/document/release-channel.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { loadReleaseChannel } from "./release-channel";
+
+const answering = (status: number, body: unknown): typeof fetch =>
+  (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    })) as unknown as typeof fetch;
+
+describe("release channel discovery", () => {
+  it("reads a preview answer", async () => {
+    expect(
+      await loadReleaseChannel(answering(200, { channel: "preview" })),
+    ).toBe("preview");
+  });
+
+  it("is production for every other answer", async () => {
+    // The public site must never be dressed up as a preview: an old Worker
+    // without the endpoint, a failed request, or no network all read as
+    // production.
+    expect(
+      await loadReleaseChannel(answering(200, { channel: "production" })),
+    ).toBe("production");
+    expect(await loadReleaseChannel(answering(404, { error: "x" }))).toBe(
+      "production",
+    );
+    expect(
+      await loadReleaseChannel((async () => {
+        throw new Error("offline");
+      }) as unknown as typeof fetch),
+    ).toBe("production");
+    expect(await loadReleaseChannel(null)).toBe("production");
+  });
+});

--- a/apps/editor/src/document/release-channel.ts
+++ b/apps/editor/src/document/release-channel.ts
@@ -1,0 +1,26 @@
+/**
+ * Which release channel this editor is being served from (ADR 0057).
+ *
+ * The same build serves the public site and the preview; only the Worker
+ * knows which, and it says so at /api/channel. Anything short of a clear
+ * "preview" answer is production: a failed request, an old Worker without
+ * the endpoint, or a test with no network must never dress the public site
+ * up as a preview.
+ */
+export type ReleaseChannel = "production" | "preview";
+
+export async function loadReleaseChannel(
+  fetchLike: typeof fetch | null = typeof fetch === "function" ? fetch : null,
+): Promise<ReleaseChannel> {
+  if (!fetchLike) return "production";
+  try {
+    const response = await fetchLike("/api/channel", {
+      credentials: "same-origin",
+    });
+    if (!response.ok) return "production";
+    const body = (await response.json()) as { channel?: unknown };
+    return body.channel === "preview" ? "preview" : "production";
+  } catch {
+    return "production";
+  }
+}

--- a/apps/editor/src/styles/editor-chrome.css
+++ b/apps/editor/src/styles/editor-chrome.css
@@ -967,3 +967,15 @@
     padding-inline: 0.35rem;
   }
 }
+
+/* The preview channel's banner (ADR 0057): always visible, never dismissable,
+   so a screenshot or a shared tab cannot be mistaken for the public site. */
+.app-channel-banner {
+  margin: 0;
+  padding: 2px var(--icm-space-3);
+  background: #8a4b00;
+  color: #fff;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  text-align: center;
+}

--- a/docs/adr/0057-release-channels-preview-and-production.md
+++ b/docs/adr/0057-release-channels-preview-and-production.md
@@ -1,0 +1,146 @@
+# 0057 - Release channels: preview and production
+
+Status: `accepted`
+
+Date: `2026-09-04`
+
+Owners: `worker`, `.github/workflows`, `apps/editor`, `docs/deployment.md`
+
+## Context
+
+Merging to `main` deployed straight to the public site. The owner wants to
+ship a large version and the simulation feature (ADR 0055) somewhere people
+can try them first, and promote to the public site only after looking.
+
+The first attempt at a pre-production environment, `env.staging` in
+`wrangler.jsonc` with an access gate inside the Worker, caused the outage of
+2026-09-03: wrangler's `routes` key inherits into an environment, so a
+staging deploy attached the production custom domain to the staging script,
+and the public site answered every script request with the gate's 401 while
+its cached shell still loaded. The same run's staging verification failed,
+which skipped the production deploy that would have taken the domain back.
+Two lessons stand: an environment that shares a configuration file with
+production is one forgotten override away from production, and a
+pre-production stage that production depends on in the same pipeline run can
+jam every deploy.
+
+## Decision
+
+There are exactly two release channels. They are the same build, deployed
+to two Workers, told apart at runtime by one variable.
+
+**Preview.** Worker `interactive-circuit-maker-preview`, configured in its
+own file `wrangler.preview.jsonc`, served only at
+`analog-canvas-preview.tokenzhang.com`. Nothing in that file inherits from
+`wrangler.jsonc`; the workers.dev and version-preview hostnames are off, so
+the preview has one address. The preview has no access gate and no login: it
+is public but declares `noindex` on every response and answers `/robots.txt`
+with `Disallow: /`, and the editor shows a permanent preview banner. Every
+merge to `main` deploys the preview automatically, then verifies it: the
+shell must reference a script that answers as JavaScript, a missing hashed
+asset must answer 404, `/api/channel` must say `preview`, the gallery must
+read, a gallery write must be refused, and the simulation route must answer.
+
+**Production.** Worker `interactive-circuit-maker`, `wrangler.jsonc`,
+`analog-canvas.tokenzhang.com`. It deploys only from a release: a `v*` tag,
+or a manual dispatch naming a commit. Either way the commit must have a
+green preview deploy behind it. The existing rollback and re-verification
+stay.
+
+**Data.** The preview reads the production gallery live, through a Durable
+Object binding that names the production script (`script_name`), and it is
+read-only toward everything it shares: publishing, liking, moderation, and
+Cloud Project saves are refused on the preview with `preview-read-only`.
+Accounts, agent sessions, and analytics are the preview's own namespaces,
+and no login provider is configured there, so the preview has no sign-in.
+The Durable Object code that runs against shared data is production's: a
+change inside a Durable Object class cannot be previewed here and ships
+through production with its own tests and migration.
+
+**Simulation.** The ngspice container is bound on the preview and not yet on
+production. The preview is where the simulation feature lands and is tried;
+production gains the binding when the owner promotes a release that carries
+it.
+
+**Features.** A feature that must not show on the public site yet is
+merged to `main` behind the channel: the editor reads `/api/channel` once
+at boot and the Worker exposes `ICM_CHANNEL`. Long-lived feature branches are
+not the mechanism; `main` stays releasable.
+
+**Retirement.** Once the preview is verified live and production has moved
+to release-only deploys, `env.staging` and `worker/staging-gate.ts` are
+deleted. Until then "merge to `main` deploys production" still holds.
+
+## Alternatives considered
+
+### Workers Versions with preview URLs
+
+- Benefits: one Worker, no second environment to drift, instant promotion
+  and rollback between versions.
+- Costs: a preview version shares production's bindings and data, so a
+  write-path defect in an unreleased build reaches the real gallery; preview
+  URLs are extra public hostnames.
+- Reason not selected: the preview exists precisely to run unverified code,
+  and it must not be able to write real data.
+
+### `env.staging` in the production configuration file
+
+- Benefits: one file.
+- Costs: every inheritable key is a hazard that only human memory guards.
+- Reason not selected: it took the public site down on 2026-09-03.
+
+### An access-gated staging (Cloudflare Access or a Worker gate)
+
+- Benefits: unreleased work stays private.
+- Costs: a gate outside the request path fails open when it is absent or
+  misconfigured; a gate inside the Worker has to cover every path and needs
+  its own verification, which is what jammed the pipeline.
+- Reason not selected: the owner chose an open preview at a distinct
+  address; `noindex` and the banner are the mitigations.
+
+## Consequences
+
+### Positive
+
+- Nothing reaches the public site without having been deployed and
+  verified somewhere first.
+- A broken preview cannot block a production release, and a production
+  release cannot be made by accident: it needs a tag or a named commit.
+- Big features and simulation can sit on the preview for as long as the
+  owner wants, on the real gallery data, without any risk of writing it.
+
+### Negative or limiting
+
+- Two Workers to pay for, including container time on the preview.
+- A hotfix to production goes through a tag like any release; when `main`
+  carries unreleased work, that work ships dark behind the channel flag.
+- Durable Object changes cannot be previewed against shared data.
+- The preview is public. Anyone with the address sees unreleased work.
+
+## Compatibility and migration
+
+- Adds `wrangler.preview.jsonc`, `.github/workflows/deploy-preview.yml`,
+  `worker/channel.ts`, `worker/ngspice-container.ts`, and the editor's
+  channel banner. Production configuration and workflow are unchanged in the
+  first step.
+- The second step changes the production trigger to releases and removes
+  `env.staging`, the staging job, and `worker/staging-gate.ts`, with
+  `docs/deployment.md` and `AGENTS.md` updated to say that merging to
+  `main` deploys the preview.
+- No Project file, API, or fixture changes. `/api/channel` is a new
+  read-only endpoint that production answers with `production`.
+
+## Validation
+
+- `worker/channel.test.ts` and `worker/preview-config.test.ts` pin the
+  channel rules and the preview configuration.
+- `scripts/preview-workflow.test.mjs` pins the preview workflow: its own
+  configuration file, pinned model archives, and the verification it runs.
+- The deploy itself is the evidence: a preview deploy that fails its
+  verification is red and names the failing check.
+
+## Related documents
+
+- [ADR 0055](0055-simulation-is-part-of-the-product.md)
+- [docs/deployment.md](../deployment.md)
+- [simulation spec](../specs/simulation.md)

--- a/docs/adr/0057-release-channels-preview-and-production.md
+++ b/docs/adr/0057-release-channels-preview-and-production.md
@@ -47,15 +47,19 @@ or a manual dispatch naming a commit. Either way the commit must have a
 green preview deploy behind it. The existing rollback and re-verification
 stay.
 
-**Data.** The preview reads the production gallery live, through a Durable
-Object binding that names the production script (`script_name`), and it is
-read-only toward everything it shares: publishing, liking, moderation, and
-Cloud Project saves are refused on the preview with `preview-read-only`.
-Accounts, agent sessions, and analytics are the preview's own namespaces,
-and no login provider is configured there, so the preview has no sign-in.
-The Durable Object code that runs against shared data is production's: a
-change inside a Durable Object class cannot be previewed here and ships
-through production with its own tests and migration.
+**Data.** The preview binds no Durable Object of the production script.
+Gallery reads are fetched from the public site's own API over HTTP, with no
+cookie, so the preview sees exactly what an anonymous visitor sees and can
+do nothing an anonymous visitor cannot: that is read-only by construction,
+not by a rule in the very code being previewed. Publishing, liking,
+moderation, and Cloud Project saves are refused on the preview with
+`preview-read-only` before any handler runs. Accounts, sessions, agent
+sessions, analytics, and the preview's own (empty) gallery store are its own
+namespaces; no login provider is configured there, so the preview has no
+sign-in. Session cookies are host-only, so a visitor to the preview never
+carries a production session either. What the preview cannot show is a
+change inside a Durable Object class; that ships through production with
+its own tests and migration.
 
 **Simulation.** The ngspice container is bound on the preview and not yet on
 production. The preview is where the simulation feature lands and is tried;
@@ -89,6 +93,16 @@ deleted. Until then "merge to `main` deploys production" still holds.
 - Costs: every inheritable key is a hazard that only human memory guards.
 - Reason not selected: it took the public site down on 2026-09-03.
 
+### A Durable Object binding to the production gallery (`script_name`)
+
+- Benefits: one live store, no proxy hop, every gallery view identical.
+- Costs: a binding has no read-only mode; unreleased code would hold write
+  capability over real submissions, and the same mechanism would have
+  handed it the accounts and sessions store.
+- Reason not selected: the preview exists to run unaccepted code, so its
+  reach into real data must be bounded by construction, not by a check in
+  that code.
+
 ### An access-gated staging (Cloudflare Access or a Worker gate)
 
 - Benefits: unreleased work stays private.
@@ -114,13 +128,15 @@ deleted. Until then "merge to `main` deploys production" still holds.
 - Two Workers to pay for, including container time on the preview.
 - A hotfix to production goes through a tag like any release; when `main`
   carries unreleased work, that work ships dark behind the channel flag.
-- Durable Object changes cannot be previewed against shared data.
+- Durable Object changes cannot be previewed; the preview's gallery view is
+  the public API's view, one HTTP hop away.
 - The preview is public. Anyone with the address sees unreleased work.
 
 ## Compatibility and migration
 
 - Adds `wrangler.preview.jsonc`, `.github/workflows/deploy-preview.yml`,
-  `worker/channel.ts`, `worker/ngspice-container.ts`, and the editor's
+  `worker/channel.ts` (channel, read-through, refusals),
+  `worker/ngspice-container.ts`, and the editor's
   channel banner. Production configuration and workflow are unchanged in the
   first step.
 - The second step changes the production trigger to releases and removes

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -50,6 +50,7 @@ major boundaries exist.
 - [`0048-routing-operation-plan.md`](0048-routing-operation-plan.md) — evaluated routing-operation plan
 - [`0052-owner-explainable-net-authority.md`](0052-owner-explainable-net-authority.md) — owner-explainable Net authority and non-electrical provenance
 - [`0056-derived-net-scope-and-dialect-spelling.md`](0056-derived-net-scope-and-dialect-spelling.md) — derived effective scope and operation-scoped dialect spelling
+- [`0057-release-channels-preview-and-production.md`](0057-release-channels-preview-and-production.md) — a preview Worker every merge deploys, and production that deploys only from a release
 
 ## Lifecycle and deletion policy
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -84,8 +84,9 @@ channels built from one artifact: the **preview**, its own Worker at
 and deployed by `.github/workflows/deploy-preview.yml` on every merge to
 `main`; and **production**, which will deploy only from a release once the
 preview is verified live. The preview is public but `noindex`, has no login,
-reads the production gallery and refuses every write to it, and is where the
-simulation container is bound first. Nothing in the preview file inherits from
+reads the gallery through the public site's own API with no cookie, binds
+no Durable Object of the production script, refuses every gallery and
+Cloud Project write, and is where the simulation container is bound first. Nothing in the preview file inherits from
 `wrangler.jsonc`, which is the whole point of it being a separate file. The
 staging environment below is retired once production moves to release-only
 deploys.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -76,6 +76,20 @@ Anything that only exists at Worker runtime:
 
 For those, the live check after deploying is the only evidence.
 
+## Release channels
+
+[ADR 0057](adr/0057-release-channels-preview-and-production.md) defines two
+channels built from one artifact: the **preview**, its own Worker at
+`analog-canvas-preview.tokenzhang.com` configured by `wrangler.preview.jsonc`
+and deployed by `.github/workflows/deploy-preview.yml` on every merge to
+`main`; and **production**, which will deploy only from a release once the
+preview is verified live. The preview is public but `noindex`, has no login,
+reads the production gallery and refuses every write to it, and is where the
+simulation container is bound first. Nothing in the preview file inherits from
+`wrangler.jsonc`, which is the whole point of it being a separate file. The
+staging environment below is retired once production moves to release-only
+deploys.
+
 ## Staging before production
 
 A staging environment (`env.staging` in `wrangler.jsonc`) deploys first, gets

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "pnpm": ">=11.16.0"
   },
   "dependencies": {
+    "@cloudflare/containers": "0.3.7",
     "@icm/agent-adapter": "workspace:*",
     "@icm/derived": "workspace:*",
     "@icm/model": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      "@cloudflare/containers":
+        specifier: 0.3.7
+        version: 0.3.7
       "@icm/agent-adapter":
         specifier: workspace:*
         version: link:packages/agent-adapter
@@ -392,6 +395,12 @@ packages:
         integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==,
       }
     engines: { node: ">=6.9.0" }
+
+  "@cloudflare/containers@0.3.7":
+    resolution:
+      {
+        integrity: sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw==,
+      }
 
   "@cortex-js/compute-engine@0.58.0":
     resolution:
@@ -1793,6 +1802,8 @@ snapshots:
   "@arnog/colors@0.5.0": {}
 
   "@babel/runtime@7.29.7": {}
+
+  "@cloudflare/containers@0.3.7": {}
 
   "@cortex-js/compute-engine@0.58.0":
     dependencies:

--- a/scripts/preview-workflow.test.mjs
+++ b/scripts/preview-workflow.test.mjs
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The preview pipeline's own contract (ADR 0057). The preview is where every
+ * merge lands and where the simulation feature is tried; these assertions
+ * keep it from ever becoming a second way to reach production.
+ */
+const preview = readFileSync(".github/workflows/deploy-preview.yml", "utf8");
+const production = readFileSync(".github/workflows/cloudflare.yml", "utf8");
+
+describe("the preview deploy", () => {
+  it("deploys the preview configuration file and nothing else", () => {
+    expect(preview).toContain("deploy --config wrangler.preview.jsonc");
+    // Never an environment of the production file, never the production
+    // file itself, and never the production hostname.
+    expect(preview).not.toContain("--env");
+    expect(preview).not.toContain("analog-canvas.tokenzhang.com");
+    expect(preview).toContain("analog-canvas-preview.tokenzhang.com");
+  });
+
+  it("pins the model files it bakes into the container image", () => {
+    expect(preview).toMatch(/SKY130_TAG: sky130-[0-9a-f]{40}/u);
+    expect(preview).toMatch(/SKY130_COMMON_SHA256: [0-9a-f]{64}/u);
+    expect(preview).toMatch(/SKY130_FD_PR_SHA256: [0-9a-f]{64}/u);
+    expect(preview).toContain("sha256sum --check");
+    expect(preview).toContain("sky130.lib.spice");
+  });
+
+  it("verifies what a preview is for", () => {
+    expect(preview).toContain("/api/channel");
+    expect(preview).toContain('"preview"');
+    // A page-shaped 200 is not a page: follow the shell to its script.
+    expect(preview).toContain("references no script; it cannot boot");
+    expect(preview).toMatch(/200\*javascript\*/u);
+    expect(preview).toContain("must answer 404");
+    expect(preview).toContain("Disallow: /");
+    expect(preview).toContain("noindex");
+    expect(preview).toContain("must read the production gallery");
+    expect(preview).toContain("must be refused");
+    expect(preview).toContain("/api/simulate");
+    expect(preview).toContain("hosted-container");
+  });
+
+  it("does not leak into the production workflow", () => {
+    expect(production).not.toContain("wrangler.preview.jsonc");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,20 @@
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // The Workers runtime module behind @cloudflare/containers; see
+      // worker/test-support/cloudflare-workers-stub.ts for why a stub is enough.
+      "cloudflare:workers": fileURLToPath(
+        new URL(
+          "./worker/test-support/cloudflare-workers-stub.ts",
+          import.meta.url,
+        ),
+      ),
+    },
+  },
   test: {
     coverage: {
       enabled: false,

--- a/worker/channel.test.ts
+++ b/worker/channel.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  channelResponse,
+  markPreviewResponse,
+  previewRobotsResponse,
+  previewWriteRefusal,
+  releaseChannel,
+} from "./channel";
+
+const req = (path: string, method = "GET") =>
+  new Request(`https://preview.test${path}`, { method });
+
+describe("release channel", () => {
+  it("is production unless the deployment says preview", () => {
+    // Production never sets the variable. Anything but the exact word is
+    // production too: a typo must not switch the public site into preview.
+    expect(releaseChannel({})).toBe("production");
+    expect(releaseChannel({ ICM_CHANNEL: "staging" })).toBe("production");
+    expect(releaseChannel({ ICM_CHANNEL: "preview" })).toBe("preview");
+  });
+
+  it("tells the editor which channel it is on", async () => {
+    const body = (await channelResponse({ ICM_CHANNEL: "preview" }).json()) as {
+      channel: string;
+    };
+    expect(body.channel).toBe("preview");
+    expect(
+      ((await channelResponse({}).json()) as { channel: string }).channel,
+    ).toBe("production");
+  });
+
+  it("refuses every write to the shared gallery and projects on the preview", async () => {
+    const env = { ICM_CHANNEL: "preview" };
+    for (const [path, method] of [
+      ["/api/gallery/submissions", "POST"],
+      ["/api/gallery/abc/like", "POST"],
+      ["/api/gallery/abc", "DELETE"],
+      ["/api/projects", "POST"],
+      ["/api/projects/p1", "PUT"],
+    ] as const) {
+      const refusal = previewWriteRefusal(req(path, method), env);
+      expect(refusal?.status, `${method} ${path}`).toBe(403);
+      const body = (await refusal!.json()) as { error: string };
+      expect(body.error).toBe("preview-read-only");
+    }
+  });
+
+  it("lets the preview read, and leaves other routes alone", () => {
+    const env = { ICM_CHANNEL: "preview" };
+    expect(previewWriteRefusal(req("/api/gallery"), env)).toBeNull();
+    expect(previewWriteRefusal(req("/api/projects/p1"), env)).toBeNull();
+    // Simulation runs are the preview's whole purpose; agent sessions and
+    // analytics are its own namespaces. None of these reach shared data.
+    expect(previewWriteRefusal(req("/api/simulate", "POST"), env)).toBeNull();
+    expect(previewWriteRefusal(req("/api/track", "POST"), env)).toBeNull();
+    expect(
+      previewWriteRefusal(req("/api/agent/sessions", "POST"), env),
+    ).toBeNull();
+  });
+
+  it("never refuses anything on production", () => {
+    expect(
+      previewWriteRefusal(req("/api/gallery/submissions", "POST"), {}),
+    ).toBeNull();
+  });
+
+  it("keeps the preview out of search engines", async () => {
+    expect(await previewRobotsResponse().text()).toContain("Disallow: /");
+    const marked = markPreviewResponse(new Response("shell"), {
+      ICM_CHANNEL: "preview",
+    });
+    expect(marked.headers.get("x-robots-tag")).toContain("noindex");
+    // Production responses pass through untouched.
+    const untouched = markPreviewResponse(new Response("shell"), {});
+    expect(untouched.headers.get("x-robots-tag")).toBeNull();
+  });
+});

--- a/worker/channel.test.ts
+++ b/worker/channel.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   channelResponse,
   markPreviewResponse,
+  previewGalleryReadThrough,
   previewRobotsResponse,
   previewWriteRefusal,
   releaseChannel,
@@ -63,6 +64,64 @@ describe("release channel", () => {
     expect(
       previewWriteRefusal(req("/api/gallery/submissions", "POST"), {}),
     ).toBeNull();
+  });
+
+  it("serves gallery reads from the public site, as an anonymous visitor", async () => {
+    const env = {
+      ICM_CHANNEL: "preview",
+      ICM_GALLERY_UPSTREAM: "https://public.test",
+    };
+    const seen: { url: string; init: RequestInit }[] = [];
+    const fetchLike = (async (url: string, init: RequestInit) => {
+      seen.push({ url, init });
+      return new Response(JSON.stringify({ entries: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json", "set-cookie": "x=1" },
+      });
+    }) as unknown as typeof fetch;
+    const request = new Request("https://preview.test/api/gallery?page=2", {
+      headers: { cookie: "icm_session=secret", accept: "application/json" },
+    });
+    const response = await previewGalleryReadThrough(request, env, fetchLike);
+    expect(response?.status).toBe(200);
+    expect(await response!.json()).toEqual({ entries: [] });
+    // Same path and query on the public origin; the visitor's cookie never
+    // travels, and the upstream's own cookie never comes back.
+    expect(seen[0]?.url).toBe("https://public.test/api/gallery?page=2");
+    expect(new Headers(seen[0]?.init.headers).get("cookie")).toBeNull();
+    expect(response?.headers.get("set-cookie")).toBeNull();
+    expect(response?.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("reads through only on the preview, only for gallery reads", async () => {
+    const env = {
+      ICM_CHANNEL: "preview",
+      ICM_GALLERY_UPSTREAM: "https://public.test",
+    };
+    const never = (async () => {
+      throw new Error("must not be called");
+    }) as unknown as typeof fetch;
+    expect(
+      await previewGalleryReadThrough(req("/api/gallery"), {}, never),
+    ).toBeNull();
+    expect(
+      await previewGalleryReadThrough(req("/api/projects/p1"), env, never),
+    ).toBeNull();
+    expect(
+      await previewGalleryReadThrough(
+        req("/api/gallery/x/like", "POST"),
+        env,
+        never,
+      ),
+    ).toBeNull();
+    // A preview with no upstream says so instead of showing its empty store
+    // as if it were the gallery.
+    const unconfigured = await previewGalleryReadThrough(
+      req("/api/gallery"),
+      { ICM_CHANNEL: "preview" },
+      never,
+    );
+    expect(unconfigured?.status).toBe(503);
   });
 
   it("keeps the preview out of search engines", async () => {

--- a/worker/channel.ts
+++ b/worker/channel.ts
@@ -11,6 +11,12 @@ export type ReleaseChannel = "production" | "preview";
 export interface ChannelEnv {
   /** "preview" on the preview Worker; production leaves it unset. */
   ICM_CHANNEL?: string;
+  /**
+   * The public site's origin, set only on the preview: gallery reads are
+   * fetched from there over HTTP, so the preview can do to real data exactly
+   * what an anonymous visitor can, and nothing more.
+   */
+  ICM_GALLERY_UPSTREAM?: string;
 }
 
 export function releaseChannel(env: ChannelEnv): ReleaseChannel {
@@ -50,6 +56,58 @@ export function previewWriteRefusal(
     },
     { status: 403, headers: { "cache-control": "no-store" } },
   );
+}
+
+/**
+ * Serve a gallery read on the preview from the public site's own API.
+ *
+ * A Durable Object binding to the production script would have been simpler
+ * and would have handed unreleased code a namespace with no read-only mode.
+ * Fetching the public API instead is read-only by construction: the request
+ * carries no cookie, so it is an anonymous visitor's view, and every write
+ * has already been refused by `previewWriteRefusal` before this runs.
+ */
+export async function previewGalleryReadThrough(
+  request: Request,
+  env: ChannelEnv,
+  fetchLike: typeof fetch = fetch,
+): Promise<Response | null> {
+  if (releaseChannel(env) !== "preview") return null;
+  if (request.method !== "GET" && request.method !== "HEAD") return null;
+  const url = new URL(request.url);
+  if (!url.pathname.startsWith("/api/gallery")) return null;
+  const upstream = env.ICM_GALLERY_UPSTREAM;
+  if (!upstream) {
+    return Response.json(
+      {
+        error: "preview-gallery-unconfigured",
+        message: "This preview has no gallery upstream configured.",
+      },
+      { status: 503, headers: { "cache-control": "no-store" } },
+    );
+  }
+  const target = new URL(url.pathname + url.search, upstream);
+  let response: Response;
+  try {
+    response = await fetchLike(target.toString(), {
+      method: request.method,
+      headers: { accept: request.headers.get("accept") ?? "*/*" },
+      redirect: "manual",
+    });
+  } catch (error) {
+    return Response.json(
+      {
+        error: "preview-gallery-unavailable",
+        message: error instanceof Error ? error.message : String(error),
+      },
+      { status: 502, headers: { "cache-control": "no-store" } },
+    );
+  }
+  const headers = new Headers();
+  const contentType = response.headers.get("content-type");
+  if (contentType) headers.set("content-type", contentType);
+  headers.set("cache-control", "no-store");
+  return new Response(response.body, { status: response.status, headers });
 }
 
 /** A preview is public but not for finding: nothing on it is listed. */

--- a/worker/channel.ts
+++ b/worker/channel.ts
@@ -1,0 +1,82 @@
+/**
+ * Which release channel this deployment is, and what that changes.
+ *
+ * Two channels exist (ADR 0057): the public site and a preview that every
+ * merge to main deploys. They are one build, told apart by `ICM_CHANNEL`.
+ * Production leaves it unset, so every check below is free there and the
+ * preview rules cannot reach the public site by accident.
+ */
+export type ReleaseChannel = "production" | "preview";
+
+export interface ChannelEnv {
+  /** "preview" on the preview Worker; production leaves it unset. */
+  ICM_CHANNEL?: string;
+}
+
+export function releaseChannel(env: ChannelEnv): ReleaseChannel {
+  return env.ICM_CHANNEL === "preview" ? "preview" : "production";
+}
+
+/** What the editor asks at boot so it can show the preview banner. */
+export function channelResponse(env: ChannelEnv): Response {
+  return Response.json(
+    { channel: releaseChannel(env) },
+    { headers: { "cache-control": "no-store" } },
+  );
+}
+
+const READ_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+/**
+ * The preview reads the production gallery live and must never write to it.
+ * Every path whose writes would reach the shared store is refused here,
+ * before any route handler runs, so no handler can forget.
+ */
+export function previewWriteRefusal(
+  request: Request,
+  env: ChannelEnv,
+): Response | null {
+  if (releaseChannel(env) !== "preview") return null;
+  if (READ_METHODS.has(request.method)) return null;
+  const path = new URL(request.url).pathname;
+  if (!path.startsWith("/api/gallery") && !path.startsWith("/api/projects")) {
+    return null;
+  }
+  return Response.json(
+    {
+      error: "preview-read-only",
+      message:
+        "The preview build reads the gallery but never writes to it. Publish, like, moderate, and save Cloud Projects on the production site.",
+    },
+    { status: 403, headers: { "cache-control": "no-store" } },
+  );
+}
+
+/** A preview is public but not for finding: nothing on it is listed. */
+export function previewRobotsResponse(): Response {
+  return new Response("User-agent: *\nDisallow: /\n", {
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "no-store",
+    },
+  });
+}
+
+/**
+ * Stamp every preview response so nothing on it is indexed, followed, or
+ * archived. Asset-layer responses arrive with immutable headers, so the
+ * response is rebuilt rather than mutated.
+ */
+export function markPreviewResponse(
+  response: Response,
+  env: ChannelEnv,
+): Response {
+  if (releaseChannel(env) !== "preview") return response;
+  const headers = new Headers(response.headers);
+  headers.set("x-robots-tag", "noindex, nofollow, noarchive");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -16,15 +16,25 @@ import {
 import { routeGalleryRequest, type GalleryNamespaceLike } from "./gallery";
 import { routeSimulationRequest, type SimulationEnv } from "./simulation";
 import { stagingAccessGate, type StagingEnv } from "./staging-gate";
+import {
+  channelResponse,
+  markPreviewResponse,
+  previewRobotsResponse,
+  previewWriteRefusal,
+  releaseChannel,
+  type ChannelEnv,
+} from "./channel";
 import { routeAuthRequest, type AuthNamespaceLike } from "./auth";
 
 export { AnalyticsDO } from "./analytics";
 export { AgentSessionDO } from "./agent-session";
 export { GalleryDO } from "./gallery";
 export { AuthDO } from "./auth";
+export { NgspiceContainer } from "./ngspice-container";
 
 type Env = SimulationEnv &
-  StagingEnv & {
+  StagingEnv &
+  ChannelEnv & {
     ANALYTICS: DurableObjectNamespaceLike;
     ASSETS: { fetch(request: Request): Promise<Response> };
     ANALYTICS_KEY: string | undefined;
@@ -97,42 +107,59 @@ const REFERRER_CATEGORIES: readonly (readonly [string, readonly string[]])[] = [
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    // Before any route, including the APIs: a staging deployment that cannot
-    // identify its caller serves nobody. Production leaves ICM_ENVIRONMENT
-    // unset, so this returns null there and costs one comparison.
-    const stagingRefusal = stagingAccessGate(request, env);
-    if (stagingRefusal) return stagingRefusal;
-
-    const url = new URL(request.url);
-
-    const agentResponse = await routeAgentSessionRequest(request, env);
-    if (agentResponse) return agentResponse;
-
-    const authResponse = await routeAuthRequest(request, env);
-    if (authResponse) return authResponse;
-
-    const galleryResponse = await routeGalleryRequest(request, env);
-    if (galleryResponse) return galleryResponse;
-
-    const simulationResponse = await routeSimulationRequest(request, env);
-    if (simulationResponse) return simulationResponse;
-
-    if (url.pathname === "/api/track" && request.method === "POST") {
-      return trackPageView(request, env);
-    }
-    if (url.pathname === "/api/stats" && request.method === "GET") {
-      return stats(env);
-    }
-    if (url.pathname === "/api/analytics" && request.method === "GET") {
-      return analytics(request, env);
-    }
-    if (url.pathname.startsWith("/api/")) {
-      return Response.json({ error: "Not found" }, { status: 404 });
-    }
-
-    return serveAsset(request, env);
+    // Every preview response is stamped noindex on the way out (ADR 0057).
+    return markPreviewResponse(await route(request, env), env);
   },
 };
+
+async function route(request: Request, env: Env): Promise<Response> {
+  // Before any route, including the APIs: a staging deployment that cannot
+  // identify its caller serves nobody. Production leaves ICM_ENVIRONMENT
+  // unset, so this returns null there and costs one comparison.
+  const stagingRefusal = stagingAccessGate(request, env);
+  if (stagingRefusal) return stagingRefusal;
+
+  const url = new URL(request.url);
+
+  // The channel is a fact about the deployment, answered before anything
+  // that depends on it; the preview's robots answer and its refusal of
+  // shared-store writes sit here so no later handler can forget them.
+  if (url.pathname === "/api/channel" && request.method === "GET") {
+    return channelResponse(env);
+  }
+  if (url.pathname === "/robots.txt" && releaseChannel(env) === "preview") {
+    return previewRobotsResponse();
+  }
+  const readOnlyRefusal = previewWriteRefusal(request, env);
+  if (readOnlyRefusal) return readOnlyRefusal;
+
+  const agentResponse = await routeAgentSessionRequest(request, env);
+  if (agentResponse) return agentResponse;
+
+  const authResponse = await routeAuthRequest(request, env);
+  if (authResponse) return authResponse;
+
+  const galleryResponse = await routeGalleryRequest(request, env);
+  if (galleryResponse) return galleryResponse;
+
+  const simulationResponse = await routeSimulationRequest(request, env);
+  if (simulationResponse) return simulationResponse;
+
+  if (url.pathname === "/api/track" && request.method === "POST") {
+    return trackPageView(request, env);
+  }
+  if (url.pathname === "/api/stats" && request.method === "GET") {
+    return stats(env);
+  }
+  if (url.pathname === "/api/analytics" && request.method === "GET") {
+    return analytics(request, env);
+  }
+  if (url.pathname.startsWith("/api/")) {
+    return Response.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return serveAsset(request, env);
+}
 
 /**
  * Serve a static asset, and let a missing one be missing.

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -19,6 +19,7 @@ import { stagingAccessGate, type StagingEnv } from "./staging-gate";
 import {
   channelResponse,
   markPreviewResponse,
+  previewGalleryReadThrough,
   previewRobotsResponse,
   previewWriteRefusal,
   releaseChannel,
@@ -132,6 +133,8 @@ async function route(request: Request, env: Env): Promise<Response> {
   }
   const readOnlyRefusal = previewWriteRefusal(request, env);
   if (readOnlyRefusal) return readOnlyRefusal;
+  const galleryReadThrough = await previewGalleryReadThrough(request, env);
+  if (galleryReadThrough) return galleryReadThrough;
 
   const agentResponse = await routeAgentSessionRequest(request, env);
   if (agentResponse) return agentResponse;

--- a/worker/ngspice-container.ts
+++ b/worker/ngspice-container.ts
@@ -1,0 +1,18 @@
+import { Container } from "@cloudflare/containers";
+
+/**
+ * The Durable Object that owns one ngspice container (ADR 0055).
+ *
+ * The container's harness listens on 8080 (containers/ngspice/entrypoint.mjs)
+ * and every run is self-contained, so the class adds nothing beyond the port
+ * and how long an idle container stays warm. Ten minutes covers a person
+ * iterating on a testbench; a container that sleeps wakes with a fresh disk.
+ *
+ * The routing module reads the binding as an optional `NGSPICE` namespace:
+ * a deployment without the binding answers "not configured" instead of
+ * failing, which is how production behaves until a release carries this.
+ */
+export class NgspiceContainer extends Container {
+  override defaultPort = 8080;
+  override sleepAfter = "10m";
+}

--- a/worker/preview-config.test.ts
+++ b/worker/preview-config.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/** wrangler.jsonc allows comments and trailing commas; JSON does not. */
+function readConfig(file: string): {
+  name?: string;
+  workers_dev?: boolean;
+  preview_urls?: boolean;
+  routes?: { pattern: string; custom_domain?: boolean }[];
+  vars?: Record<string, string>;
+  assets?: { binding?: string; run_worker_first?: string[] | boolean };
+  durable_objects?: {
+    bindings: { name: string; class_name: string; script_name?: string }[];
+  };
+  migrations?: { tag: string; new_sqlite_classes?: string[] }[];
+  containers?: { class_name: string; image: string; max_instances?: number }[];
+  env?: Record<string, unknown>;
+} {
+  const source = readFileSync(resolve(process.cwd(), file), "utf8");
+  const stripped = source
+    .replace(/^\s*\/\/.*$/gmu, "")
+    .replace(/,(\s*[}\]])/gu, "$1");
+  return JSON.parse(stripped) as ReturnType<typeof readConfig>;
+}
+
+describe("the preview channel configuration (ADR 0057)", () => {
+  const preview = readConfig("wrangler.preview.jsonc");
+  const production = readConfig("wrangler.jsonc");
+
+  it("is its own Worker at its own single address", () => {
+    expect(preview.name).toBe("interactive-circuit-maker-preview");
+    expect(preview.routes).toEqual([
+      { pattern: "analog-canvas-preview.tokenzhang.com", custom_domain: true },
+    ]);
+    // Two more hostnames would be two more unlisted doors to the same build.
+    expect(preview.workers_dev).toBe(false);
+    expect(preview.preview_urls).toBe(false);
+    // And it must never name the production domain, inherited or written.
+    expect(JSON.stringify(preview)).not.toContain(
+      "analog-canvas.tokenzhang.com",
+    );
+    expect(preview.env).toBeUndefined();
+  });
+
+  it("declares its channel, and production declares none", () => {
+    expect(preview.vars?.ICM_CHANNEL).toBe("preview");
+    expect(production.vars?.ICM_CHANNEL).toBeUndefined();
+  });
+
+  it("reads the production gallery and owns everything else", () => {
+    const bindings = new Map(
+      preview.durable_objects!.bindings.map((binding) => [
+        binding.name,
+        binding,
+      ]),
+    );
+    expect(bindings.get("GALLERY")).toEqual({
+      name: "GALLERY",
+      class_name: "GalleryDO",
+      script_name: "interactive-circuit-maker",
+    });
+    for (const own of ["ANALYTICS", "AGENT_SESSION", "AUTH"]) {
+      expect(bindings.get(own)?.script_name, own).toBeUndefined();
+    }
+  });
+
+  it("binds the simulation container to a migrated class", () => {
+    const binding = preview.durable_objects!.bindings.find(
+      (candidate) => candidate.name === "NGSPICE",
+    );
+    expect(binding?.class_name).toBe("NgspiceContainer");
+    expect(preview.containers?.[0]?.class_name).toBe("NgspiceContainer");
+    expect(preview.containers?.[0]?.image).toBe(
+      "./containers/ngspice/Dockerfile",
+    );
+    expect(preview.containers?.[0]?.max_instances).toBe(1);
+    expect(
+      preview.migrations?.some((migration) =>
+        migration.new_sqlite_classes?.includes("NgspiceContainer"),
+      ),
+    ).toBe(true);
+    // Production has no container yet: it arrives with a promoted release.
+    expect(
+      production.durable_objects?.bindings.some((b) => b.name === "NGSPICE"),
+    ).toBe(false);
+  });
+
+  it("answers robots.txt itself so the preview is never listed", () => {
+    expect(preview.assets?.binding).toBe("ASSETS");
+    expect(preview.assets?.run_worker_first).toEqual(
+      expect.arrayContaining(["/api/*", "/assets/*", "/robots.txt"]),
+    );
+  });
+});

--- a/worker/preview-config.test.ts
+++ b/worker/preview-config.test.ts
@@ -37,32 +37,38 @@ describe("the preview channel configuration (ADR 0057)", () => {
     // Two more hostnames would be two more unlisted doors to the same build.
     expect(preview.workers_dev).toBe(false);
     expect(preview.preview_urls).toBe(false);
-    // And it must never name the production domain, inherited or written.
-    expect(JSON.stringify(preview)).not.toContain(
+    // The production domain appears once, as the origin gallery reads are
+    // fetched from; never as a route this Worker would answer for.
+    expect(preview.vars?.ICM_GALLERY_UPSTREAM).toBe(
+      "https://analog-canvas.tokenzhang.com",
+    );
+    expect(JSON.stringify(preview.routes)).not.toContain(
       "analog-canvas.tokenzhang.com",
     );
+    // No environments inside this file: nothing to inherit, nothing to forget.
     expect(preview.env).toBeUndefined();
   });
 
   it("declares its channel, and production declares none", () => {
     expect(preview.vars?.ICM_CHANNEL).toBe("preview");
     expect(production.vars?.ICM_CHANNEL).toBeUndefined();
+    expect(production.vars?.ICM_GALLERY_UPSTREAM).toBeUndefined();
   });
 
-  it("reads the production gallery and owns everything else", () => {
-    const bindings = new Map(
-      preview.durable_objects!.bindings.map((binding) => [
-        binding.name,
-        binding,
-      ]),
+  it("binds no Durable Object of the production script", () => {
+    // A binding has no read-only mode, and this Worker runs code production
+    // has not accepted yet. Gallery reads go over HTTP to the public API
+    // instead; accounts, sessions, gallery store, and analytics are the
+    // preview's own, and every bound class has its migration.
+    const bindings = preview.durable_objects!.bindings;
+    for (const binding of bindings) {
+      expect(binding.script_name, binding.name).toBeUndefined();
+    }
+    const migrated = new Set(
+      preview.migrations?.flatMap((m) => m.new_sqlite_classes ?? []),
     );
-    expect(bindings.get("GALLERY")).toEqual({
-      name: "GALLERY",
-      class_name: "GalleryDO",
-      script_name: "interactive-circuit-maker",
-    });
-    for (const own of ["ANALYTICS", "AGENT_SESSION", "AUTH"]) {
-      expect(bindings.get(own)?.script_name, own).toBeUndefined();
+    for (const binding of bindings) {
+      expect(migrated.has(binding.class_name), binding.class_name).toBe(true);
     }
   });
 
@@ -76,11 +82,6 @@ describe("the preview channel configuration (ADR 0057)", () => {
       "./containers/ngspice/Dockerfile",
     );
     expect(preview.containers?.[0]?.max_instances).toBe(1);
-    expect(
-      preview.migrations?.some((migration) =>
-        migration.new_sqlite_classes?.includes("NgspiceContainer"),
-      ),
-    ).toBe(true);
     // Production has no container yet: it arrives with a promoted release.
     expect(
       production.durable_objects?.bindings.some((b) => b.name === "NGSPICE"),

--- a/worker/test-support/cloudflare-workers-stub.ts
+++ b/worker/test-support/cloudflare-workers-stub.ts
@@ -1,0 +1,23 @@
+/**
+ * Stand-in for the `cloudflare:workers` runtime module under Vitest.
+ *
+ * `@cloudflare/containers` extends `DurableObject` from that module, which
+ * exists only inside the Workers runtime. The Worker's entry module exports
+ * the container class (a bound Durable Object class has to be exported from
+ * the entry), so any test that imports the entry pulls the runtime module in.
+ * Nothing in these tests constructs a container; the classes only need to be
+ * defined. Wired up as a Vitest alias in vitest.config.ts.
+ */
+export class DurableObject<Env = unknown> {
+  constructor(
+    readonly ctx: unknown,
+    readonly env: Env,
+  ) {}
+}
+
+export class WorkerEntrypoint<Env = unknown> {
+  constructor(
+    readonly ctx: unknown,
+    readonly env: Env,
+  ) {}
+}

--- a/wrangler.preview.jsonc
+++ b/wrangler.preview.jsonc
@@ -20,6 +20,12 @@
   "vars": {
     // Read by worker/channel.ts and, through /api/channel, by the editor.
     "ICM_CHANNEL": "preview",
+    // Where the preview reads the gallery from: the public site's own public
+    // API, over HTTP, exactly as any anonymous visitor would. No Durable
+    // Object of the production script is bound here, because a binding has
+    // no read-only mode and this Worker runs code production has not
+    // accepted yet. Writes never leave this Worker (see channel.ts).
+    "ICM_GALLERY_UPSTREAM": "https://analog-canvas.tokenzhang.com",
   },
   "assets": {
     "binding": "ASSETS",
@@ -33,14 +39,11 @@
     "bindings": [
       { "name": "ANALYTICS", "class_name": "AnalyticsDO" },
       { "name": "AGENT_SESSION", "class_name": "AgentSessionDO" },
-      // The production gallery, live. worker/channel.ts refuses every write
-      // to it while the channel is preview, so an unreleased build can read
-      // real circuits and never change one.
-      {
-        "name": "GALLERY",
-        "class_name": "GalleryDO",
-        "script_name": "interactive-circuit-maker",
-      },
+      // The preview's own, empty gallery store. Gallery reads are served from
+      // the public site through ICM_GALLERY_UPSTREAM instead; this binding
+      // exists so the route module has something to hand a write to, and the
+      // channel rules refuse every write before it gets that far.
+      { "name": "GALLERY", "class_name": "GalleryDO" },
       // The preview's own accounts: nobody signs in here, and no login
       // provider is configured, so this namespace stays empty by design.
       { "name": "AUTH", "class_name": "AuthDO" },
@@ -53,7 +56,8 @@
     { "tag": "v1", "new_sqlite_classes": ["AnalyticsDO"] },
     { "tag": "v2", "new_sqlite_classes": ["AgentSessionDO"] },
     { "tag": "v3", "new_sqlite_classes": ["AuthDO"] },
-    { "tag": "v4", "new_sqlite_classes": ["NgspiceContainer"] },
+    { "tag": "v4", "new_sqlite_classes": ["GalleryDO"] },
+    { "tag": "v5", "new_sqlite_classes": ["NgspiceContainer"] },
   ],
   "containers": [
     {

--- a/wrangler.preview.jsonc
+++ b/wrangler.preview.jsonc
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://raw.githubusercontent.com/cloudflare/workers-sdk/main/packages/wrangler/config-schema.json",
+  // The preview channel (ADR 0057). Its own file on purpose: an environment
+  // inside wrangler.jsonc inherits every key it does not override, and that is
+  // how a staging deploy took the production custom domain on 2026-09-03.
+  // Nothing here inherits from anything.
+  "name": "interactive-circuit-maker-preview",
+  "main": "./worker/index.ts",
+  "compatibility_date": "2026-08-11",
+  // One address. The workers.dev and version-preview hostnames would be two
+  // more doors to the same build, uncounted and unlisted.
+  "workers_dev": false,
+  "preview_urls": false,
+  "routes": [
+    {
+      "pattern": "analog-canvas-preview.tokenzhang.com",
+      "custom_domain": true,
+    },
+  ],
+  "vars": {
+    // Read by worker/channel.ts and, through /api/channel, by the editor.
+    "ICM_CHANNEL": "preview",
+  },
+  "assets": {
+    "binding": "ASSETS",
+    "directory": "./apps/editor/dist",
+    "not_found_handling": "single-page-application",
+    // Same as production, plus robots.txt: the preview answers it itself
+    // with a full disallow so search engines never list unreleased work.
+    "run_worker_first": ["/api/*", "/assets/*", "/robots.txt"],
+  },
+  "durable_objects": {
+    "bindings": [
+      { "name": "ANALYTICS", "class_name": "AnalyticsDO" },
+      { "name": "AGENT_SESSION", "class_name": "AgentSessionDO" },
+      // The production gallery, live. worker/channel.ts refuses every write
+      // to it while the channel is preview, so an unreleased build can read
+      // real circuits and never change one.
+      {
+        "name": "GALLERY",
+        "class_name": "GalleryDO",
+        "script_name": "interactive-circuit-maker",
+      },
+      // The preview's own accounts: nobody signs in here, and no login
+      // provider is configured, so this namespace stays empty by design.
+      { "name": "AUTH", "class_name": "AuthDO" },
+      // The simulation container (ADR 0055). Bound here first; production
+      // receives it when a release that carries the feature is promoted.
+      { "name": "NGSPICE", "class_name": "NgspiceContainer" },
+    ],
+  },
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["AnalyticsDO"] },
+    { "tag": "v2", "new_sqlite_classes": ["AgentSessionDO"] },
+    { "tag": "v3", "new_sqlite_classes": ["AuthDO"] },
+    { "tag": "v4", "new_sqlite_classes": ["NgspiceContainer"] },
+  ],
+  "containers": [
+    {
+      "class_name": "NgspiceContainer",
+      "image": "./containers/ngspice/Dockerfile",
+      // The Dockerfile copies the Sky130 model files from pdk/ at the
+      // repository root, which the preview workflow stages before deploying.
+      // .dockerignore keeps everything else out of the build context.
+      "image_build_context": ".",
+      // One running simulator, one person's run at a time. Measure before
+      // raising either; the harness has to guard its own concurrency.
+      "instance_type": "basic",
+      "max_instances": 1,
+    },
+  ],
+  "observability": {
+    "enabled": true,
+  },
+}


### PR DESCRIPTION
Implements [ADR 0057](docs/adr/0057-release-channels-preview-and-production.md), the owner's decision after the 2026-09-03 outage: a **preview** channel where large versions and the simulation feature land first, and **production** that will deploy only from a release.

## What this adds (production untouched)

- `wrangler.preview.jsonc`: its own file, so nothing inherits from `wrangler.jsonc`. Worker `interactive-circuit-maker-preview` at `analog-canvas-preview.tokenzhang.com` only (workers.dev and version previews off), `ICM_CHANNEL=preview`, **no Durable Object of the production script bound**: gallery reads are fetched from the public site's own API over HTTP with no cookie, and the preview keeps its own empty gallery store, accounts, sessions, and analytics. The ngspice container (`NgspiceContainer`, `basic`, one instance) is bound here first.
- `worker/channel.ts`: `/api/channel`, `robots.txt` disallow and `noindex` on every preview response, the gallery read-through, and a refusal of every write to `/api/gallery*` and `/api/projects*` on the preview, before any handler runs.
- `.github/workflows/deploy-preview.yml`: on every merge to `main`, stage the Sky130 model files from one pinned volare release (tag + SHA-256 of each archive), deploy, then verify: entry script answers as JavaScript, missing asset 404, channel says preview, robots/noindex, gallery reads and a write is refused, and one resistor divider simulates through the container.
- Editor: asks `/api/channel` once; the preview wears a permanent banner and its Publish action explains that publishing happens on the production site.
- Tests: `worker/channel.test.ts`, `worker/preview-config.test.ts`, `scripts/preview-workflow.test.mjs`, `apps/editor/src/document/release-channel.test.ts`; a Vitest alias stubs `cloudflare:workers` for the container library.

## Before the first preview deploy succeeds

- Cloudflare **Containers** must be enabled on the account; the deploy builds the image on the runner (Docker is present on `ubuntu-latest`).
- The custom domain is created by the deploy on the `tokenzhang.com` zone with the existing token.
- The `cloudflare-preview` GitHub environment is created on first use.

If the container part fails on the account, the job is red and production is unaffected; that result is the deployment probe ADR 0055's plan asks for.

## Next (separate PRs)

Production trigger to `v*` tags / a named commit with a green preview deploy; retire `env.staging` and `worker/staging-gate.ts`; docs and AGENTS.md updated to "merge deploys the preview".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
