### PR TITLE
fix(deploy): copy the harness from the repository root the image is built from

### DIFF
--- a/containers/ngspice/Dockerfile
+++ b/containers/ngspice/Dockerfile
@@ -46,7 +46,12 @@ ENV SKY130_MODEL_ROOT=/opt/sky130/sky130A \
 # nature. Declaring it here documents that nothing survives a sleep.
 WORKDIR /run/simulation
 
-COPY entrypoint.mjs /opt/harness/entrypoint.mjs
+# The build context is the repository root (wrangler.preview.jsonc sets
+# image_build_context to "."), because the model files above are staged
+# there. Every COPY is therefore repo-root relative, this one included; the
+# first preview deploy failed on exactly this line when it was not.
+ARG HARNESS_DIR=containers/ngspice
+COPY ${HARNESS_DIR}/entrypoint.mjs /opt/harness/entrypoint.mjs
 RUN apt-get update \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*

--- a/worker/preview-config.test.ts
+++ b/worker/preview-config.test.ts
@@ -15,7 +15,12 @@ function readConfig(file: string): {
     bindings: { name: string; class_name: string; script_name?: string }[];
   };
   migrations?: { tag: string; new_sqlite_classes?: string[] }[];
-  containers?: { class_name: string; image: string; max_instances?: number }[];
+  containers?: {
+    class_name: string;
+    image: string;
+    max_instances?: number;
+    image_build_context?: string;
+  }[];
   env?: Record<string, unknown>;
 } {
   const source = readFileSync(resolve(process.cwd(), file), "utf8");
@@ -86,6 +91,29 @@ describe("the preview channel configuration (ADR 0057)", () => {
     expect(
       production.durable_objects?.bindings.some((b) => b.name === "NGSPICE"),
     ).toBe(false);
+  });
+
+  it("builds the container from the repository root, and the Dockerfile agrees", () => {
+    // The model files are staged at pdk/ in the repository root, so the build
+    // context is the root and every COPY in the Dockerfile must be written
+    // relative to it. The first preview deploy failed on a COPY that was
+    // relative to the Dockerfile's own directory instead.
+    expect(preview.containers?.[0]?.image_build_context).toBe(".");
+    const dockerfile = readFileSync(
+      resolve(process.cwd(), "containers/ngspice/Dockerfile"),
+      "utf8",
+    );
+    for (const line of dockerfile.split("\n")) {
+      if (!line.startsWith("COPY ") || line.includes("--from=")) continue;
+      const source = line.split(/\s+/u)[1] ?? "";
+      expect(
+        source.startsWith("pdk/") ||
+          source.startsWith("containers/") ||
+          source.startsWith("${SKY130_ROOT}") ||
+          source.startsWith("${HARNESS_DIR}"),
+        line,
+      ).toBe(true);
+    }
   });
 
   it("answers robots.txt itself so the preview is never listed", () => {


### PR DESCRIPTION
The first preview deploy (run 33818222676) built the image on the runner and failed on `COPY entrypoint.mjs`, which was relative to the Dockerfile's directory while the build context is the repository root (`image_build_context: "."`, where the Sky130 model files are staged). Every `COPY` is now root-relative through an `ARG`, and `worker/preview-config.test.ts` reads the Dockerfile and refuses any `COPY` that is not.

Nothing about Cloudflare was exercised yet; the failure came before the push. Merging re-runs the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)