### PR TITLE
docs(specs): freeze the simulation contract of the first release (F0)

### DIFF
--- a/docs/adr/0055-simulation-is-part-of-the-product.md
+++ b/docs/adr/0055-simulation-is-part-of-the-product.md
@@ -157,3 +157,95 @@ The version moves `0.1.0` to `0.2.0` to mark the scope change, and a
 - ADR 0054 for the single Instance Reference authority the netlist prints.
 - `analog-arena` `benchmarks/v2` for the circuit and testbench shapes this
   targets.
+
+## Amendment — 2026-09-04: the contract of the first release, frozen
+
+The owner asked for the simulation feature to be finished on the preview
+channel (ADR 0057) and promoted to production afterwards. The vertical
+integration plan written for that work (v3, in the roadmap branch) reviewed
+the implementation as it stood and found the pieces present but not joined:
+the panel not mounted, no producer of operating-point results, the
+requested analyses not driving the deck, runs returning only a log, and no
+container bound anywhere. This amendment freezes what the first release is,
+so the joining work has one contract to build against. The rules below
+supersede the sentences of the original decision they contradict; the
+[simulation spec](../specs/simulation.md) carries the normative detail.
+
+1. **Analyses.** The first structured release covers DC operating point,
+   AC, and transient. Transient uses `.tran tstep tstop [tstart [tmax]]`
+   with no `UIC` unless the author asks; the solver's real time axis is the
+   result, never a resampled one.
+2. **What is simulatable.** A circuit is simulatable when every placed
+   instance resolves either to a native SPICE primitive the deck printer
+   knows (resistors, capacitors, inductors, independent voltage and current
+   sources, ground) or to a device model present in the selected
+   environment. The original rule required a PDK model behind every
+   instance; that would have refused an ideal resistor. Abstract blocks are
+   still refused, by name, before anything runs.
+3. **Two inputs, one run.** The author's intent is the authority. It is
+   expressed either as a **structured** setup the product compiles into a
+   deck, or as **raw SPICE** the author submits as an entry file with its
+   dependencies. Exactly one of the two drives a run; the product never
+   appends stimulus, analyses, or a root call to raw text and never guesses
+   a testbench. "The testbench is the author's" keeps its meaning and drops
+   the implied requirement that it be hand-written: helpers may generate
+   text, and the author submits it.
+4. **Roots.** The simulation root is a Cell chosen for one setup
+   (`rootDocumentId`); it is not the Project's top and choosing it never
+   changes the top. The compiled deck instantiates that root exactly once;
+   a document that only defines `.subckt`s is not a run.
+5. **Sources.** DC bias, AC magnitude and phase, and a transient waveform
+   are components of the same source instance, printed by the descriptor.
+   `PULSE` and `SIN` are formal parameters in the first release; `PWL`
+   arrives through raw input. The existing pulse source keeps its symbol
+   and its clock-style parameters, which are normalised into the same
+   waveform parameters rather than becoming a second authority.
+6. **Persistence.** A Project may carry one optional `SimulationSetup`
+   holding either the structured input or the raw files. Results, run ids,
+   simulator paths, and caches are never persisted. The schema version
+   moves when the setup lands, not before.
+7. **Environment.** The hosted simulator is a container image pinned by
+   digest, and the model set is part of that pin. Direction chosen: the
+   image is built on the benchmark toolchain image
+   `ghcr.io/arcadia-1/circuit-bench-sky130-ngspice` by digest, so the
+   simulator and the model library are the same bytes the benchmark suite
+   runs, and a numerical disagreement can only mean the export is wrong,
+   never that two ngspice builds differ. The binned Sky130 models a volare
+   checkout provides cap device width at 100 µm and refuse the benchmark's
+   own reference circuit (#551). **Open until the owner confirms** that the
+   image is pullable by the deploy runner, or provides a read token; until
+   then the volare subset stays and #551 stays open.
+8. **Execution boundary.** Before the hosted route is public: the process
+   runs as a non-root user, in a fresh working directory per run, with a
+   minimal environment carrying no platform secret; a timeout terminates
+   the whole process tree; one container runs one job at a time and answers
+   `busy` otherwise; deck size, output size, and duration are capped, and
+   truncation is reported rather than hidden. Raw `.control` is a real
+   capability, so isolation is the answer to it, not a ban.
+9. **Run lifecycle.** A run is started from an immutable prepared input and
+   answered with a receipt; status and results are read, and a cancel
+   really terminates the process. The input identity covers the whole
+   hierarchy the root reaches plus the setup, so editing a sub-Cell makes a
+   result stale; a stale result is kept, marked, and never re-bound to the
+   changed circuit.
+10. **Results.** Numbers come from ngspice's rawfile, not from console text.
+    The result carries per-probe operating-point scalars with units, AC as
+    a frequency axis with complex values per probe, and transient as the
+    real time axis with real values per probe. CSV is derived from that
+    same data. A magnitude is never labelled a gain until the author has
+    named an input and an output.
+11. **Rollout.** The feature lands on the preview channel first, with the
+    container bound there; production receives the binding with a promoted
+    release.
+12. **Not in the first release.** DC sweeps, corners and Monte Carlo with
+    dedicated UI, Verilog-A, a second simulator, cross-Project live library
+    references, automatic two-way sync between arbitrary SPICE and the
+    drawing, and any run history store. Raw input may still express what
+    the environment's ngspice can execute; absence of a dedicated control is
+    not a refusal to run.
+
+Validation grows accordingly: closed-form fixtures (a resistor divider, an
+RC low-pass, an RC step) whose rawfiles are asserted against arithmetic;
+the five-transistor OTA acceptance comparison against ngspice on the
+reference netlist; and the preview deploy simulating one circuit through
+the real container on every merge.

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -14,8 +14,11 @@ simulator-readable model libraries. These are separate responsibilities and
 are assembled only in the transient simulation deck; none changes the Project
 schema or the structural netlist export.
 
-This contract covers deck assembly and model-library selection. It does not
-define result parsing, persisted simulation profiles, or the editor workflow.
+This contract covers deck assembly, model-library selection, and, since the
+2026-09-04 amendment of ADR 0055, the shape of a run: its inputs, root,
+sources and analyses, execution boundary, lifecycle, and result data. It does
+not define the editor workflow, which follows the editor interaction spec
+once the pieces exist.
 
 ## Model-library selection
 
@@ -149,3 +152,128 @@ into the Project, undo history, Gallery, or recovery copy.
   that ngspice 47 completes a Sky130 NFET operating-point deck with
   `.lib ... tt`, while top-level `.include` produces repeated subcircuit
   definitions across sections.
+
+## Inputs and root
+
+A run has exactly one input form:
+
+- **Structured**: a `SimulationSetup` naming a `rootDocumentId` in the
+  Project, the analyses to run with their parameters, and the probes to
+  record. The product compiles it: the design netlist of everything the root
+  reaches, one instantiation of the root, the environment's model library,
+  the analyses, the saves, and `.end`.
+- **Raw**: an entry SPICE file and its dependency files as submitted by the
+  author or an Agent. The product resolves declared dependencies and the
+  environment's library mapping, and adds nothing else: no stimulus, no
+  analysis, no root call, no `.control`.
+
+Both feed the same immutable prepared input, whose identity covers the exact
+file bytes, the environment selection, and, for the structured form, every
+Document the root reaches plus the setup. A change to any of them is a new
+input; a result computed from an older input is stale and says so.
+
+The simulation root is a Cell chosen for the setup. It is not
+`project.topDocumentId`, and selecting it never changes the top. Extraction,
+diagnostics, dependency collection, occurrence mapping, and input identity
+all use the same root. A deck that only defines `.subckt`s and instantiates
+nothing is not a run.
+
+## Sources and analyses
+
+`SimulationAnalysis` is `"op" | "ac" | "tran"`.
+
+- `.op` has no parameters.
+- `.ac` takes the sweep kind (`dec`, `oct`, or `lin`), the points per
+  interval or in total, and the start and stop frequencies in hertz.
+- `.tran` takes `tstep` and `tstop`, optionally `tstart` and `tmax`, all in
+  seconds, finite and positive with `tstart < tstop`. No `UIC` is emitted
+  unless the author asks. `tstart` does not move the start of integration,
+  and `tstep` does not make the output equally spaced; the solver's time
+  axis is returned as computed.
+
+A voltage or current source instance carries its DC value, its AC magnitude
+and phase, and its transient waveform as formal parameters printed by the
+device descriptor. The first release's waveforms are `PULSE` (low, high,
+delay, rise, fall, width, period) and `SIN` (offset, amplitude, frequency,
+optional delay, damping, phase). `PWL` is reachable through raw input. The
+existing pulse voltage source keeps its symbol; its clock-style parameters
+are normalised into the same waveform parameters so that only one set is
+authoritative.
+
+`VDD`, `GND`, and Net labels are markers, never energy: a marker does not
+become a source in the deck.
+
+## Execution boundary
+
+The hosted runner (`containers/ngspice`) and the local host share these
+minimums before either is offered to the public:
+
+- ngspice runs as a non-root user, in a working directory created for the
+  run and removed afterwards, with a minimal environment that carries no
+  platform or user secret. The model tree is read-only.
+- One container runs one job at a time. A second request while a job is
+  running is answered `503` with `Retry-After`; `max_instances` limits
+  containers, not processes, so the harness guards its own slot.
+- A timeout terminates the whole process tree and the result says
+  `timedOut`. Deck size, log size, result-file size, and duration are
+  capped; anything cut is reported as truncated rather than presented whole.
+- Raw `.control` is permitted. Isolation, not prohibition, keeps a control
+  script inside its own job.
+- `GET /health` reports the observed environment facts of the metadata
+  envelope so a deployment can be verified without running a circuit.
+
+## Run lifecycle
+
+The service exposes `prepare`, `start`, `read`, `cancel`, and `export`.
+`start` executes exactly the prepared input whose digest it was given and
+returns a short receipt with a run id; `read` returns status or the final
+result and may wait briefly; `cancel` terminates the process and frees the
+slot. A run id is bound to the session or Project owner that started it.
+There is no run history store: a receipt that outlives the runner's memory
+reads as lost, and a lost run is never silently rerun.
+
+## Result data
+
+Numbers are read from ngspice's ASCII rawfile, never from console text. The
+result extends `SimulationResult` with:
+
+- `op`: one entry per probe with `value` and `unit`;
+- `ac`: `frequencyHz` and, per probe, `real` and `imag` arrays of the same
+  length; magnitude and phase are derived from these, and a magnitude is
+  labelled a gain only when the author has named an input and an output;
+- `tran`: `timeSeconds` as computed by the solver and, per probe, a `value`
+  array of the same length; different plots keep their own axes and are not
+  resampled to share a table.
+
+Array lengths, analysis and probe identities, non-finite values, an empty or
+truncated rawfile, and a requested vector that is missing are all checked; an
+exit code of zero is not evidence that the requested results exist. CSV is
+derived from this data (AC keeps real and imaginary parts; transient keeps
+the real time points) and never from a second parse.
+
+Probes name existing objects (a terminal, a Route, a Junction, or a Base Net)
+plus the hierarchy occurrence; the mapping from probe to simulator vector
+name is produced at compile time and never inferred from result text. Raw
+input carries no Canvas mapping unless one is proven valid.
+
+## Rollout
+
+The hosted route ships on the preview channel first (ADR 0057), where the
+container is bound; production receives the binding with a promoted
+release. A deployment without the binding answers
+`simulation-not-configured`, a fact about the deployment.
+
+## Deterministic validation (first release)
+
+- Closed-form fixtures under `fixtures/ngspice-rawfile/`: a resistor divider
+  operating point, an RC low-pass AC sweep, and an RC step transient, each
+  with the deck that produced it. The parser is asserted against the
+  arithmetic, not against itself: AC to a relative tolerance of `1e-12`,
+  transient to `1e-3`, on a time axis whose step spans six orders of
+  magnitude.
+- `scripts/simulation-acceptance.mjs`: the five-transistor OTA from
+  `analog-arena`, exported by this product and simulated against the
+  reference netlist under one testbench, agreeing on node voltages, gain,
+  and unity-gain bandwidth.
+- The preview deploy simulates one circuit through the real container on
+  every merge.


### PR DESCRIPTION
**For the owner to read before it merges: this is a product contract, not code.**

An amendment to [ADR 0055](docs/adr/0055-simulation-is-part-of-the-product.md) and new normative sections in [docs/specs/simulation.md](docs/specs/simulation.md): the contract the simulation work packages (F1–F7 of the vertical integration plan v3) build against.

Frozen here:

1. OP, AC, and **TRAN** in the first structured release; `.tran` without `UIC` by default, real time axis kept.
2. Simulatable = every instance resolves to a native primitive the printer knows or a device model in the selected environment; abstract blocks still refused by name.
3. Two inputs, one run: structured setup compiled by the product, or raw SPICE submitted as files; never both, never inferred.
4. Simulation root ≠ Project top (`rootDocumentId`); the deck instantiates the root once.
5. Sources: DC, AC, and transient components on one instance; `PULSE`/`SIN` formal, `PWL` via raw; the existing pulse source normalised, not duplicated.
6. One optional `SimulationSetup` per Project; results never persisted.
7. Environment pinned by image digest; **direction chosen, still open**: build on `ghcr.io/arcadia-1/circuit-bench-sky130-ngspice` so simulator and models match the benchmark suite (#551) — waiting on the owner to confirm the image is pullable by the deploy runner.
8. Execution boundary minimums (non-root, per-run cwd, no secrets, process-tree kill, single slot, caps with reported truncation, `/health`).
9. `prepare`/`start`/`read`/`cancel`/`export` over an immutable prepared input; stale results marked, never re-bound.
10. Numeric results from the rawfile: OP scalars, AC complex arrays, TRAN real time axis; CSV derived from the same data.
11. Preview channel first (ADR 0057).
12. Explicit not-in-first-release list.

Validation named: closed-form rawfile fixtures (divider OP, RC AC, RC step), the OTA acceptance script (#557), and the preview deploy's container smoke.

Not auto-merged on purpose: the owner decides product contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
