### PR TITLE
fix(deploy): the preview stamps every path and gives the simulator a core

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -79,6 +79,14 @@ jobs:
       - name: Verify preview
         run: |
           set -euo pipefail
+          # The custom domain is created by the deploy; the first one took a
+          # few minutes to resolve, and every check below needs the name.
+          for _ in $(seq 1 60); do
+            if curl --silent --output /dev/null --max-time 10 "${PREVIEW_URL}/api/channel"; then
+              break
+            fi
+            sleep 5
+          done
           channel="$(curl --fail --silent --show-error --max-time 20 \
             --retry 5 --retry-delay 2 --retry-all-errors \
             "${PREVIEW_URL}/api/channel")"
@@ -136,7 +144,7 @@ jobs:
           body="$(node -e '
             const netlist = [".subckt divider in out", "R1 in out 1k", "R2 out 0 1k", ".ends divider"].join("\n");
             const testbench = ["V1 in 0 DC 1", "X1 in out divider", ".op", ".end"].join("\n");
-            process.stdout.write(JSON.stringify({ netlist, testbench, inputRevision: "preview-smoke", timeoutMs: 60000 }));
+            process.stdout.write(JSON.stringify({ netlist, testbench, inputRevision: "preview-smoke", timeoutMs: 110000 }));
           ')"
           result="$(curl --silent --show-error --max-time 120 \
             --output /tmp/preview-simulation.json \
@@ -149,3 +157,10 @@ jobs:
             exit 1
           fi
           grep -q '"executor":"hosted-container"' /tmp/preview-simulation.json
+          # HTTP 200 is the route answering, not the circuit being solved: a
+          # timed-out or failed run also arrives as 200. The first live run
+          # timed out at 60 s and would have passed a status-only check.
+          if ! grep -q '"status":"completed"' /tmp/preview-simulation.json; then
+            echo "The simulation did not complete; see the outcome above."
+            exit 1
+          fi

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -61,6 +61,14 @@ The following values are rejected before a simulator runs:
 A hosted configuration rejected at this boundary returns
 `simulation-environment-invalid`; it is not reported as a circuit failure.
 
+The library is added only when the deck needs a device model: when it
+contains a semiconductor device card (MOSFET, diode, BJT, JFET) or names a
+Sky130 model anywhere outside comments and continuation lines. A deck of
+passives, sources, and dependent sources runs without it, because loading the
+`tt` corner costs about 16 s of CPU before any analysis (measured 2026-09-04
+with ngspice 46 on a resistor divider) and buys such a deck nothing. The
+configuration metadata then reports `modelLibrary: null`.
+
 ## Run metadata V1
 
 Every completed, failed, dropped-input, or timed-out simulator run carries one

--- a/packages/spice-run/src/index.test.ts
+++ b/packages/spice-run/src/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildSimulationDeck,
+  deckNeedsModelLibrary,
   classifySimulationOutcome,
   createSimulationEnvironmentMetadata,
   createSimulationInputMetadata,
@@ -261,6 +262,33 @@ describe("timeout ceiling", () => {
     // unbounded bill as much as a user waiting on nothing.
     expect(resolveTimeoutMs(10 * MAX_SIMULATION_TIMEOUT_MS)).toBe(
       MAX_SIMULATION_TIMEOUT_MS,
+    );
+  });
+});
+
+describe("model library on demand", () => {
+  it("asks for the library only when a device needs a model", () => {
+    // Passives, sources, and a subcircuit of them: no model card to look up,
+    // so no 16 s corner load.
+    expect(
+      deckNeedsModelLibrary(
+        ".subckt divider in out\nR1 in out 1k\nR2 out 0 1k\n.ends\nV1 in 0 DC 1\nX1 in out divider\n.op",
+      ),
+    ).toBe(false);
+    expect(deckNeedsModelLibrary("C1 a 0 1p\nL1 a b 1n\nE1 c 0 a 0 2")).toBe(
+      false,
+    );
+    // A MOSFET, a diode, a BJT, or a JFET card, or any Sky130 name.
+    expect(deckNeedsModelLibrary("M1 out in 0 0 nfet")).toBe(true);
+    expect(deckNeedsModelLibrary("D1 a 0 dmod")).toBe(true);
+    expect(deckNeedsModelLibrary("Q1 c b e npn")).toBe(true);
+    expect(deckNeedsModelLibrary("J1 d g s jmod")).toBe(true);
+    expect(
+      deckNeedsModelLibrary("XM1 d g s b sky130_fd_pr__nfet_01v8 w=1 l=0.15"),
+    ).toBe(true);
+    // A comment or a continuation line is not a device.
+    expect(deckNeedsModelLibrary("* M1 would need a model\n+ M2 too")).toBe(
+      false,
     );
   });
 });

--- a/packages/spice-run/src/index.ts
+++ b/packages/spice-run/src/index.ts
@@ -137,8 +137,13 @@ export interface SimulationResult {
   metadata: SimulationRunMetadata;
 }
 
-/** The ceiling a request gets when it names none. */
-export const DEFAULT_SIMULATION_TIMEOUT_MS = 30_000;
+/**
+ * The ceiling a request gets when it names none. Loading the Sky130 `tt`
+ * corner alone costs about 16 s of CPU on a fast core (measured 2026-09-04
+ * with ngspice 46 on a resistor divider), so a circuit that needs models
+ * cannot fit a 30 s ceiling on a shared container core.
+ */
+export const DEFAULT_SIMULATION_TIMEOUT_MS = 60_000;
 /**
  * The ceiling a request cannot exceed. A container bills for the time it is
  * awake, not the time it computes, so an unbounded analysis is an unbounded
@@ -154,6 +159,29 @@ export function resolveTimeoutMs(requested: number | undefined): number {
     Math.max(Math.trunc(requested), 1),
     MAX_SIMULATION_TIMEOUT_MS,
   );
+}
+
+/**
+ * Whether a deck needs the environment's device-model library at all.
+ *
+ * Loading the Sky130 corner is the single most expensive thing a run does:
+ * about 16 s of CPU for the `tt` section alone, before any analysis. A
+ * resistor divider or an RC network has no model card to look up, so it
+ * pays that cost for nothing. The library is added when the deck contains a
+ * semiconductor device card (MOSFET, diode, BJT, JFET) or names a Sky130
+ * model anywhere; passives, sources, and dependent sources run without it.
+ * Comments and continuation lines are skipped so a remark cannot trigger it.
+ */
+export function deckNeedsModelLibrary(text: string): boolean {
+  for (const raw of text.split(/\r?\n/u)) {
+    const line = raw.trim();
+    if (line.length === 0 || line.startsWith("*") || line.startsWith("+")) {
+      continue;
+    }
+    if (/sky130_/iu.test(line)) return true;
+    if (/^[mdqj][a-z0-9_$.:-]*\s/iu.test(line)) return true;
+  }
+  return false;
 }
 
 /**

--- a/scripts/preview-workflow.test.mjs
+++ b/scripts/preview-workflow.test.mjs
@@ -41,6 +41,10 @@ describe("the preview deploy", () => {
     expect(preview).toContain("must be refused");
     expect(preview).toContain("/api/simulate");
     expect(preview).toContain("hosted-container");
+    // A 200 with a timed-out outcome is not a simulation.
+    expect(preview).toContain('"status":"completed"');
+    // The domain is created by the deploy and takes time to resolve.
+    expect(preview).toMatch(/for _ in \$\(seq 1 \d+\); do\s*\n\s*if curl/u);
   });
 
   it("does not leak into the production workflow", () => {

--- a/worker/preview-config.test.ts
+++ b/worker/preview-config.test.ts
@@ -20,6 +20,7 @@ function readConfig(file: string): {
     image: string;
     max_instances?: number;
     image_build_context?: string;
+    instance_type?: string;
   }[];
   env?: Record<string, unknown>;
 } {
@@ -116,10 +117,19 @@ describe("the preview channel configuration (ADR 0057)", () => {
     }
   });
 
-  it("answers robots.txt itself so the preview is never listed", () => {
+  it("runs the Worker on every path so noindex and robots reach the shell", () => {
+    // The stamp and the robots answer live in the Worker; a path the asset
+    // layer answers alone never carries them. The first live verification
+    // found /editor without noindex for exactly that reason.
     expect(preview.assets?.binding).toBe("ASSETS");
-    expect(preview.assets?.run_worker_first).toEqual(
-      expect.arrayContaining(["/api/*", "/assets/*", "/robots.txt"]),
-    );
+    expect(preview.assets?.run_worker_first).toBe(true);
+    // Production keeps its narrow list: it has nothing to stamp.
+    expect(Array.isArray(production.assets?.run_worker_first)).toBe(true);
+  });
+
+  it("gives the simulator a core that can parse the model corner", () => {
+    // Measured: about 16 s of CPU to load the Sky130 tt corner. A quarter
+    // core timed out a resistor divider at 60 s on the first live run.
+    expect(preview.containers?.[0]?.instance_type).toBe("standard-2");
   });
 });

--- a/worker/simulation.test.ts
+++ b/worker/simulation.test.ts
@@ -106,6 +106,26 @@ describe("simulation route", () => {
     expect(ours).not.toMatch(/\.ac\b|\.dc\b|\.tran\b|\.control/iu);
   });
 
+  it("leaves the model library out of a deck that needs no model", async () => {
+    // A resistor divider has nothing to look up; the Sky130 corner costs
+    // about 16 s of CPU to parse, so it is added only for device cards.
+    const seen: { deck?: string; timeoutMs?: number } = {};
+    const response = await routeSimulationRequest(
+      post({
+        netlist: ".subckt divider in out\nR1 in out 1k\nR2 out 0 1k\n.ends",
+        testbench: "V1 in 0 DC 1\nX1 in out divider\n.op",
+      }),
+      stubRunner(
+        { log: "", exitCode: 0, timedOut: false, durationMs: 5 },
+        seen,
+      ),
+    );
+    expect(seen.deck).not.toMatch(/^\s*\.lib\b/mu);
+    expect((await response!.json()) as unknown).toMatchObject({
+      metadata: { configuration: { modelLibrary: null } },
+    });
+  });
+
   it("uses the deployment's explicit Sky130 path and section", async () => {
     const seen: { deck?: string; timeoutMs?: number } = {};
     const env = stubRunner(

--- a/worker/simulation.ts
+++ b/worker/simulation.ts
@@ -17,6 +17,7 @@
 import {
   buildSimulationDeck,
   classifySimulationOutcome,
+  deckNeedsModelLibrary,
   createSimulationInputMetadata,
   isSimulationInputRevision,
   readNgspiceDiagnostics,
@@ -117,13 +118,17 @@ export async function routeSimulationRequest(
     typeof body.timeoutMs === "number" ? body.timeoutMs : undefined,
   );
   let deck: string;
-  let modelLibrary: ModelLibrarySelection;
+  let modelLibrary: ModelLibrarySelection | null;
   try {
-    modelLibrary = {
-      directive: "lib",
-      path: env.SKY130_LIB_PATH ?? DEFAULT_LIB_PATH,
-      section: env.SKY130_LIB_SECTION ?? DEFAULT_LIB_SECTION,
-    };
+    // The corner load is the expensive part of every run; a deck with no
+    // device to model is spared it (see deckNeedsModelLibrary).
+    modelLibrary = deckNeedsModelLibrary(`${netlist}\n${testbench}`)
+      ? {
+          directive: "lib",
+          path: env.SKY130_LIB_PATH ?? DEFAULT_LIB_PATH,
+          section: env.SKY130_LIB_SECTION ?? DEFAULT_LIB_SECTION,
+        }
+      : null;
     deck = buildSimulationDeck({ netlist, testbench }, modelLibrary);
   } catch (error) {
     return Response.json(

--- a/wrangler.preview.jsonc
+++ b/wrangler.preview.jsonc
@@ -31,9 +31,12 @@
     "binding": "ASSETS",
     "directory": "./apps/editor/dist",
     "not_found_handling": "single-page-application",
-    // Same as production, plus robots.txt: the preview answers it itself
-    // with a full disallow so search engines never list unreleased work.
-    "run_worker_first": ["/api/*", "/assets/*", "/robots.txt"],
+    // Every path runs the Worker first here, unlike production. The noindex
+    // stamp and the robots answer live in the Worker, and a path the asset
+    // layer answers on its own is a path they never reach: the first live
+    // verification found the shell served without noindex for exactly that
+    // reason. What is served does not change; only that the Worker sees it.
+    "run_worker_first": true,
   },
   "durable_objects": {
     "bindings": [
@@ -67,9 +70,13 @@
       // repository root, which the preview workflow stages before deploying.
       // .dockerignore keeps everything else out of the build context.
       "image_build_context": ".",
-      // One running simulator, one person's run at a time. Measure before
-      // raising either; the harness has to guard its own concurrency.
-      "instance_type": "basic",
+      // One running simulator, one person's run at a time; the harness has
+      // to guard its own concurrency. The size was measured, not guessed:
+      // loading the Sky130 tt corner takes about 16 s of CPU on a fast core
+      // (ngspice 46, 2026-09-04), and on "basic" (a quarter core) the first
+      // live run of a resistor divider timed out at 60 s before printing a
+      // line. A full core keeps a model-backed run inside the ceiling.
+      "instance_type": "standard-2",
       "max_instances": 1,
     },
   ],


### PR DESCRIPTION
The second preview deploy went live (run 33819247884) and its verification found two things only a live run could show:

- **No `noindex` on the shell.** The stamp lives in the Worker and `/editor` is answered by the asset layer before the Worker runs. The preview now runs the Worker on every path (`run_worker_first: true`), as staging already does after #552; what is served is unchanged.
- **The resistor divider timed out at 60 s** with an empty log. Measured locally: loading the Sky130 `tt` corner costs ~16 s of CPU on a fast core (ngspice 46); on `basic` (a quarter core) it cannot fit. Fixes: the model library is added only when the deck has a device to model (MOSFET, diode, BJT, JFET, or a Sky130 name — `deckNeedsModelLibrary`), so passives-only decks skip it entirely; the container moves to `standard-2` (one core); the default ceiling moves 30 s → 60 s (max stays 120 s).

Also: the probe now demands `"status":"completed"` (an HTTP 200 arrives for a timed-out run too), and verification waits for the deploy-created domain to resolve before asking anything of it.

Spec updated with the on-demand rule; tests cover the rule, the Worker's `modelLibrary: null` metadata, the configuration, and the workflow contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
