### PR TITLE
fix(simulation): a silent or signal-killed simulator run is a failure, not a result

### DIFF
--- a/containers/ngspice/entrypoint.mjs
+++ b/containers/ngspice/entrypoint.mjs
@@ -31,7 +31,9 @@ function ngspiceVersion(output) {
 }
 
 async function sha256File(path) {
-  return createHash("sha256").update(await readFile(path)).digest("hex");
+  return createHash("sha256")
+    .update(await readFile(path))
+    .digest("hex");
 }
 
 async function sha256Tree(root) {
@@ -109,14 +111,32 @@ function runNgspice(deckPath, timeoutMs) {
     const child = execFile(
       NGSPICE_BIN,
       ["-b", deckPath],
-      { timeout: timeoutMs, maxBuffer: 16 * 1024 * 1024, killSignal: "SIGKILL" },
+      {
+        timeout: timeoutMs,
+        maxBuffer: 16 * 1024 * 1024,
+        killSignal: "SIGKILL",
+      },
       (error, stdout, stderr) => {
         // execFile reports a timeout as a killed process, which is also what
         // a crash looks like; the flag set by the timer is what separates
         // them, because a timeout is an answer and a crash is not.
+        //
+        // A child that died by a signal we did not send (the kernel's OOM
+        // killer, measured on 2026-09-04 while a 1 GiB instance parsed the
+        // Sky130 corner) reports error.code as null, which the first version
+        // of this harness read as exit 0 — a "completed" run with an empty
+        // log. A signal death is a failure, and it says which signal.
+        const signal = error?.signal ?? null;
+        const numericCode = typeof error?.code === "number" ? error.code : null;
+        const exitCode = timedOut
+          ? null
+          : error
+            ? (numericCode ?? (signal ? 128 : 1))
+            : 0;
         resolve({
           log: `${stdout ?? ""}${stderr ?? ""}`,
-          exitCode: timedOut ? null : (error?.code ?? 0),
+          exitCode,
+          signal: timedOut ? null : signal,
           timedOut,
           durationMs: Date.now() - startedAt,
         });

--- a/worker/simulation.test.ts
+++ b/worker/simulation.test.ts
@@ -126,6 +126,48 @@ describe("simulation route", () => {
     });
   });
 
+  it("never reports a silent or signal-killed run as completed", async () => {
+    // Measured 2026-09-04: the kernel killed ngspice mid-corner-load on a
+    // 1 GiB instance; the harness reported exit 0 and an empty log, and the
+    // route said "completed". A run with no output has no result.
+    const silent = await routeSimulationRequest(
+      post({ netlist: NETLIST, testbench: TESTBENCH }),
+      stubRunner({ log: "", exitCode: 0, timedOut: false, durationMs: 45295 }),
+    );
+    const silentBody = (await silent!.json()) as {
+      outcome: { status: string };
+      diagnostics: { severity: string; text: string }[];
+    };
+    expect(silentBody.outcome.status).toBe("failed");
+    expect(silentBody.diagnostics[0]?.text).toContain("no output");
+
+    const killed = await routeSimulationRequest(
+      post({ netlist: NETLIST, testbench: TESTBENCH }),
+      stubRunner({
+        log: "",
+        exitCode: 128,
+        signal: "SIGKILL",
+        timedOut: false,
+        durationMs: 45295,
+      }),
+    );
+    const killedBody = (await killed!.json()) as {
+      outcome: { status: string };
+      diagnostics: { severity: string; text: string }[];
+    };
+    expect(killedBody.outcome.status).toBe("failed");
+    expect(killedBody.diagnostics[0]?.text).toContain("SIGKILL");
+
+    // A timeout stays a timeout, whatever the log holds.
+    const late = await routeSimulationRequest(
+      post({ netlist: NETLIST, testbench: TESTBENCH, timeoutMs: 5000 }),
+      stubRunner({ log: "", exitCode: null, timedOut: true, durationMs: 5010 }),
+    );
+    expect(
+      ((await late!.json()) as { outcome: { status: string } }).outcome.status,
+    ).toBe("timed-out");
+  });
+
   it("uses the deployment's explicit Sky130 path and section", async () => {
     const seen: { deck?: string; timeoutMs?: number } = {};
     const env = stubRunner(

--- a/worker/simulation.ts
+++ b/worker/simulation.ts
@@ -169,6 +169,7 @@ export async function routeSimulationRequest(
   const raw = (await containerResponse.json()) as {
     log?: unknown;
     exitCode?: unknown;
+    signal?: unknown;
     timedOut?: unknown;
     durationMs?: unknown;
     environment?: unknown;
@@ -187,9 +188,26 @@ export async function routeSimulationRequest(
   }
   const log = typeof raw.log === "string" ? raw.log : "";
   const diagnostics = readNgspiceDiagnostics(log);
+  const timedOut = raw.timedOut === true;
+  // A simulator that died by a signal, or that printed nothing at all,
+  // did not complete: a batch run always prints at least its banner and
+  // the analysis it did. Exit 0 with no output was measured on 2026-09-04
+  // when the kernel killed ngspice mid-corner-load; it must never read as
+  // success (ADR 0055 amendment, item 10).
+  if (!timedOut && typeof raw.signal === "string" && raw.signal) {
+    diagnostics.push({
+      severity: "error",
+      text: `The simulator was terminated by ${raw.signal} before it finished.`,
+    });
+  } else if (!timedOut && log.trim().length === 0) {
+    diagnostics.push({
+      severity: "error",
+      text: "The simulator produced no output, so this run has no result.",
+    });
+  }
   const result: SimulationResult = {
     outcome: classifySimulationOutcome(diagnostics, {
-      timedOut: raw.timedOut === true,
+      timedOut,
       timeoutMs,
       exitCode: typeof raw.exitCode === "number" ? raw.exitCode : null,
     }),


### PR DESCRIPTION
Measured on the live preview (#565): a one-transistor operating point against the Sky130 corner ran 45 s on the still-1 GiB container, was OOM-killed, and came back as `completed` with an empty log. The harness read `execFile`'s null error code as exit 0; the route read exit 0 with no diagnostics as success.

- `containers/ngspice/entrypoint.mjs`: a signal death reports a non-zero exit and names the signal.
- `worker/simulation.ts`: a run terminated by a signal, or one that produced no output at all, is classified `failed` with an error diagnostic; a timeout stays a timeout.
- `worker/simulation.test.ts` covers all three.

The corner-load cost and recycling the awake container are tracked in #565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)