### PR TITLE
feat(editor): draw bent arrows with quiet visual snapping

### DIFF
--- a/apps/editor/e2e/drafting.spec.ts
+++ b/apps/editor/e2e/drafting.spec.ts
@@ -101,9 +101,9 @@ test("outline arrow style is chosen before stamp/drag and shares editable geomet
   await expect(outline).toHaveCount(2);
 });
 
-// Two-phase drafting creation: click to set the start, move to preview, click to
-// commit. Arrow commits on the second click; construction line commits on the
-// second click too (a 2-point line). Uses real mouse clicks (not pointer
+// Multi-phase drafting creation: click to set the start, move to preview, click
+// a final vertex, then Enter. Line arrows and construction lines retain clicks
+// as bends until Enter or double-click finishes. Uses real mouse clicks (not pointer
 // dispatch) so the editor's onClick handler — which gates on event.detail === 1
 // — fires, and a pointermove drives the hover preview between the two clicks.
 async function clickCreate(
@@ -119,8 +119,7 @@ async function clickCreate(
   await page.mouse.click(start.x, start.y);
   await page.mouse.move(end.x, end.y);
   await page.mouse.click(end.x, end.y);
-  // Arrows commit on the second click. Construction lines retain that click as
-  // a vertex so users can add bends; Enter accepts the current preview end.
+  // The click is a vertex; Enter accepts it as the current endpoint.
   await page.keyboard.press("Enter");
 }
 
@@ -971,6 +970,99 @@ test("two-phase click-creates an arrow", async ({ page }) => {
   await expect(
     page.locator('[data-layer="drafting"] g[data-kind="draft-arrow"]'),
   ).toHaveCount(1);
+});
+
+test("line arrow clicks add bends and snap through to an arbitrary rectangle edge", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await awaitEditorReady(page);
+  await clickDrawTool(page, "rectangle");
+  await clickCreate(page, { x: 430, y: 220 }, { x: 650, y: 400 });
+  const rectangle = page.locator('[data-kind="draft-rectangle"]');
+  const target = await rectangle.evaluate((element) => {
+    const polygon = element as SVGPolygonElement;
+    const matrix = polygon.getScreenCTM();
+    if (!matrix || polygon.points.numberOfItems < 2) return null;
+    const from = polygon.points.getItem(0);
+    const to = polygon.points.getItem(1);
+    const logical = {
+      x: from.x + (to.x - from.x) * 0.37,
+      y: from.y + (to.y - from.y) * 0.37,
+    };
+    const screen = new DOMPoint(logical.x, logical.y).matrixTransform(matrix);
+    const screenFrom = new DOMPoint(from.x, from.y).matrixTransform(matrix);
+    const screenTo = new DOMPoint(to.x, to.y).matrixTransform(matrix);
+    const dx = screenTo.x - screenFrom.x;
+    const dy = screenTo.y - screenFrom.y;
+    const length = Math.hypot(dx, dy) || 1;
+    return {
+      exact: { x: screen.x, y: screen.y },
+      near: {
+        x: screen.x + (-dy / length) * 2,
+        y: screen.y + (dx / length) * 2,
+      },
+    };
+  });
+  if (!target) throw new Error("Rectangle edge is not measurable");
+
+  await clickDrawTool(page, "arrow");
+  await page.mouse.click(target.exact.x - 110, target.exact.y - 80);
+  await page.mouse.click(target.exact.x - 55, target.exact.y - 25);
+  await page.mouse.move(target.near.x, target.near.y);
+  await expect(page.locator(".drafting-create-snap")).toHaveCount(1);
+  await page.mouse.dblclick(target.near.x, target.near.y);
+
+  const line = page.locator(
+    '[data-layer="drafting"] g[data-kind="draft-arrow"] > polyline',
+  );
+  const head = page.locator(
+    '[data-layer="drafting"] g[data-kind="draft-arrow"] > polygon',
+  );
+  await expect(line).toHaveCount(1);
+  const geometry = await Promise.all([
+    line.evaluate((element) => {
+      const polyline = element as SVGPolylineElement;
+      return Array.from(
+        { length: polyline.points.numberOfItems },
+        (_, index) => {
+          const point = polyline.points.getItem(index);
+          return { x: point.x, y: point.y };
+        },
+      );
+    }),
+    rectangle.evaluate((element) => {
+      const polygon = element as SVGPolygonElement;
+      return [polygon.points.getItem(0), polygon.points.getItem(1)].map(
+        (point) => ({ x: point.x, y: point.y }),
+      );
+    }),
+    head.evaluate((element) => {
+      const polygon = element as SVGPolygonElement;
+      return Array.from(
+        { length: polygon.points.numberOfItems },
+        (_, index) => {
+          const point = polygon.points.getItem(index);
+          return { x: point.x, y: point.y };
+        },
+      );
+    }),
+  ]);
+  expect(geometry[0]).toHaveLength(3);
+  const edge = geometry[1];
+  const edgeLength = Math.hypot(
+    edge[1]!.x - edge[0]!.x,
+    edge[1]!.y - edge[0]!.y,
+  );
+  const distanceToEdge = (point: { x: number; y: number }): number =>
+    Math.abs(
+      (point.x - edge[0]!.x) * (edge[1]!.y - edge[0]!.y) -
+        (point.y - edge[0]!.y) * (edge[1]!.x - edge[0]!.x),
+    ) / edgeLength;
+  // The shaft is shortened under the head; its triangle tip owns the exact
+  // persisted endpoint and therefore the edge capture.
+  expect(Math.min(...geometry[2].map(distanceToEdge))).toBeLessThanOrEqual(0.5);
+  await expect(page.locator(".drafting-create-snap")).toHaveCount(0);
 });
 
 // Shape-based hit — a construction line selects via its stroke and does not

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -344,7 +344,7 @@ const LIBRARY_PANEL_STORAGE_KEY = "icm.library-panel-open.v1";
 const LIBRARY_WIDTH_STORAGE_KEY = "icm.library-panel-width.v1";
 const COMPACT_LAYOUT_MEDIA_QUERY = "(max-width: 860px)";
 const DRAG_START_DISTANCE_PX = 4;
-const SNAP_CAPTURE_RADIUS_PX = 7;
+const SNAP_CAPTURE_RADIUS_PX = 4;
 
 /** Persisted Junctions are grid points, including on ±45° Route segments. */
 

--- a/apps/editor/src/canvas/canvas-gesture-controller.ts
+++ b/apps/editor/src/canvas/canvas-gesture-controller.ts
@@ -43,7 +43,7 @@ import {
 // ordinary drag so a click can still cycle the active wire corner.
 const PAN_START_DISTANCE_PX = 10;
 export const KEYBOARD_PAN_STEP_PX = 48;
-const DRAFTING_SNAP_CAPTURE_RADIUS_PX = 7;
+const DRAFTING_SNAP_CAPTURE_RADIUS_PX = 4;
 
 type SetViewBox = (
   next: GridRect | CameraRectInput | ((current: GridRect) => CameraRectInput),

--- a/apps/editor/src/canvas/editor-canvas-event-handlers.ts
+++ b/apps/editor/src/canvas/editor-canvas-event-handlers.ts
@@ -321,15 +321,16 @@ export function createEditorCanvasEventHandlers({
     onPointerCancel: finishCanvasGesture,
     onClick(event: CanvasMouseEvent) {
       const target = event.target as Element;
-      const onBackground =
-        target === event.currentTarget || target.tagName === "rect";
+      const acceptsDraftingPoint = !target.closest(
+        '[data-testid="canvas-text-editor"]',
+      );
       if (
         (tool === "arrow" ||
           tool === "construction-line" ||
           tool === "rectangle" ||
           tool === "circle") &&
         event.detail === 1 &&
-        onBackground
+        acceptsDraftingPoint
       ) {
         handleDraftingCanvasClick(
           // Raw pointer: the drafting controller rounds by the annotation
@@ -423,7 +424,7 @@ export function createEditorCanvasEventHandlers({
         tool === "rectangle" ||
         tool === "circle"
       ) {
-        if (target !== event.currentTarget && target.tagName !== "rect") return;
+        if (target.closest('[data-testid="canvas-text-editor"]')) return;
         finishDraftingCreate();
         return;
       }

--- a/apps/editor/src/canvas/editor-drafting-hit-targets.test.tsx
+++ b/apps/editor/src/canvas/editor-drafting-hit-targets.test.tsx
@@ -3,7 +3,53 @@ import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
-import { EditorDraftingHandles } from "./editor-drafting-hit-targets";
+import {
+  EditorDraftingHandles,
+  EditorDraftingHitTargets,
+} from "./editor-drafting-hit-targets";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+describe("EditorDraftingHitTargets", () => {
+  it("lets an active arrow draw and snap through existing drafting strokes", () => {
+    const document = createEmptyDocument("main", "Drawing");
+    document.drafting = {
+      objects: [
+        {
+          id: "box",
+          kind: "rectangle",
+          locked: false,
+          zIndex: 0,
+          anchor: { kind: "free", position: { x: 50, y: 50 } },
+          center: { x: 50, y: 50 },
+          width: 40,
+          height: 20,
+          rotation: 0,
+          lineStyle: "solid",
+        },
+      ],
+    };
+    const markup = renderToStaticMarkup(
+      <svg>
+        <EditorDraftingHitTargets
+          document={document}
+          resolver={resolver}
+          tool="arrow"
+          selectedDraftingId={null}
+          supplementalDraftingIds={[]}
+          onPointerDown={vi.fn()}
+          onConstructionLineEdit={vi.fn()}
+          onArrowEdit={vi.fn()}
+          onTextEdit={vi.fn()}
+          onTextContextMenu={vi.fn()}
+        />
+      </svg>,
+    );
+
+    expect(markup).toContain('data-testid="drafting-hit-box"');
+    expect(markup).toContain('pointer-events="none"');
+  });
+});
 
 describe("EditorDraftingHandles", () => {
   it("shows one uniform scale handle for a selected waveform group", () => {
@@ -47,7 +93,7 @@ describe("EditorDraftingHandles", () => {
       <svg>
         <EditorDraftingHandles
           document={document}
-          resolver={new InMemorySymbolResolver(builtInSymbols)}
+          resolver={resolver}
           selectedDraftingId="wave-b"
           selectedDraftingIds={["wave-a", "wave-b"]}
           onHandlePointerDown={vi.fn()}

--- a/apps/editor/src/canvas/editor-drafting-hit-targets.tsx
+++ b/apps/editor/src/canvas/editor-drafting-hit-targets.tsx
@@ -66,6 +66,12 @@ export function EditorDraftingHitTargets({
   ) => void;
 }) {
   return (document.drafting?.objects ?? []).map((object) => {
+    const drawingThroughScene =
+      tool === "wire" ||
+      tool === "arrow" ||
+      tool === "construction-line" ||
+      tool === "rectangle" ||
+      tool === "circle";
     const geometry = resolveDraftingObjectGeometry(document, resolver, object);
     const draggable = !object.locked && Boolean(draftingDragOrigin(object));
     const selected =
@@ -93,7 +99,9 @@ export function EditorDraftingHitTargets({
             },
           }
         : {}),
-      pointerEvents: tool === "wire" ? ("none" as const) : undefined,
+      // Active drawing tools see the underlying scene as snap geometry, not
+      // as interactive hit targets. Nothing new is painted for this behavior.
+      pointerEvents: drawingThroughScene ? ("none" as const) : undefined,
     };
     if (
       object.kind === "construction-line" &&
@@ -173,7 +181,7 @@ export function EditorDraftingHitTargets({
               className={selectedClass}
               points={serializePolylinePoints(head)}
               fill="transparent"
-              pointerEvents={tool === "wire" ? "none" : "all"}
+              pointerEvents={drawingThroughScene ? "none" : "all"}
               onDoubleClick={doubleClick}
             />
           ))}

--- a/apps/editor/src/features/drafting/drafting-create-controller.test.ts
+++ b/apps/editor/src/features/drafting/drafting-create-controller.test.ts
@@ -74,7 +74,7 @@ describe("drafting create controller", () => {
       tool: "arrow",
       source: { x: 10, y: 20 },
       hover: { x: 90, y: 20 },
-      waypoints: [],
+      waypoints: [{ x: 50, y: 60 }],
       setSource: vi.fn(),
       setHover: vi.fn(),
       setWaypoints: vi.fn(),
@@ -91,11 +91,49 @@ describe("drafting create controller", () => {
     expect(transact).toHaveBeenCalledWith([
       expect.objectContaining({
         kind: "upsert_drafting_object",
-        object: expect.objectContaining({ id: "arrow-1", kind: "arrow" }),
+        object: expect.objectContaining({
+          id: "arrow-1",
+          kind: "arrow",
+          waypoints: [{ x: 50, y: 60 }],
+        }),
       }),
     ]);
     expect(setTool).toHaveBeenCalledWith("pointer");
     expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a line arrow active while clicks add visible bends", () => {
+    const setWaypoints = vi.fn();
+    const transact = vi.fn(() => ({ ok: true }));
+    const controller = createDraftingCreateController({
+      document: createEmptyDocument("cell", "Cell"),
+      angleMode: "free",
+      annotationGrid: 5,
+      resolver: new InMemorySymbolResolver(builtInSymbols),
+      visibleEndpoints: [],
+      routeGeometryRecords: [],
+      tool: "arrow",
+      source: { x: 10, y: 20 },
+      hover: { x: 10, y: 20 },
+      waypoints: [],
+      setSource: vi.fn(),
+      setHover: vi.fn(),
+      setWaypoints,
+      setSnapPoint: vi.fn(),
+      clear: vi.fn(),
+      setTool: vi.fn(),
+      transact,
+      setStatus: vi.fn(),
+      nextId: () => "arrow-1",
+    });
+
+    controller.handleCanvasClick({ x: 43, y: 37 }, false, false, 4);
+
+    expect(setWaypoints).toHaveBeenCalledOnce();
+    expect(transact).not.toHaveBeenCalled();
+    expect(
+      (setWaypoints.mock.calls[0]![0] as (points: never[]) => unknown)([]),
+    ).toEqual([{ x: 45, y: 35 }]);
   });
 
   it("creates a circle from its center and radius point", () => {

--- a/apps/editor/src/features/drafting/drafting-create-controller.ts
+++ b/apps/editor/src/features/drafting/drafting-create-controller.ts
@@ -9,7 +9,10 @@ import type { SymbolResolver } from "@icm/symbols";
 
 import { closestPointOnSegment } from "../../canvas/canvas-geometry";
 import type { EditorTool } from "../../interaction/interaction-state";
-import { buildSceneSnapTargets } from "../../snap/candidates";
+import {
+  buildDraftingProjectionSnapTargets,
+  buildSceneSnapTargets,
+} from "../../snap/candidates";
 import {
   resolvePointSnap,
   SNAP_PROFILES,
@@ -149,10 +152,15 @@ export function createDraftingCreateController({
         kind: "route" as const,
       })),
     );
+    const constrained =
+      angleStep && origin
+        ? constrainDraftingAngle(origin, point, angleStep)
+        : point;
     const resolved = resolvePointSnap(
-      point,
+      constrained,
       [
         ...buildSceneSnapTargets(document, resolver, visibleEndpoints),
+        ...buildDraftingProjectionSnapTargets(document, resolver, constrained),
         ...routeTargets,
       ],
       {
@@ -161,19 +169,19 @@ export function createDraftingCreateController({
         profile: SNAP_PROFILES.draftingHandle,
       },
     );
-    let snapped: DerivedPoint = {
-      x: point.x + resolved.delta.x,
-      y: point.y + resolved.delta.y,
+    let snapped: DerivedPoint = resolved.pointMatch?.point ?? {
+      x: constrained.x + resolved.delta.x,
+      y: constrained.y + resolved.delta.y,
     };
     const hasObjectSnap =
       (resolved.xMatch && resolved.xMatch.targetKind !== "grid") ||
       (resolved.yMatch && resolved.yMatch.targetKind !== "grid");
-    if (angleStep && origin)
-      snapped = constrainDraftingAngle(origin, snapped, angleStep);
-    const gridPoint = snapGridPoint(snapped, annotationGrid);
+    const finalPoint = resolved.pointMatch
+      ? snapGridPoint(snapped, 1)
+      : snapGridPoint(snapped, annotationGrid);
     return {
-      point: gridPoint,
-      snap: hasObjectSnap ? gridPoint : null,
+      point: finalPoint,
+      snap: hasObjectSnap ? finalPoint : null,
       guides: resolved.guides,
     };
   };
@@ -181,9 +189,9 @@ export function createDraftingCreateController({
   const commitVertices = (points: Point[]): void => {
     if (points.length < 2) return;
     const id = nextId("construction");
-    const snappedPoints = points.map((point) =>
-      snapGridPoint(point, annotationGrid),
-    );
+    // snapPoint already applies either an exact visual capture (one logical
+    // unit precision) or the Annotation Grid. Do not erase edge captures here.
+    const snappedPoints = points.map((point) => ({ ...point }));
     if (
       transact([
         {
@@ -205,7 +213,38 @@ export function createDraftingCreateController({
     }
   };
 
-  const commit = (active: DraftingTool, start: Point, end: Point): void => {
+  const commitArrow = (points: Point[]): void => {
+    if (points.length < 2) return;
+    const id = nextId("arrow");
+    const snappedPoints = points.map((point) => ({ ...point }));
+    const from = snappedPoints[0]!;
+    const to = snappedPoints.at(-1)!;
+    const object = applyArrowPreset(
+      {
+        id,
+        kind: "arrow",
+        locked: false,
+        zIndex: 0,
+        anchor: { kind: "free", position: from },
+        from: { kind: "free", position: from },
+        to: { kind: "free", position: to },
+        ...(snappedPoints.length > 2
+          ? { waypoints: snappedPoints.slice(1, -1) }
+          : {}),
+      },
+      arrowPreset,
+    );
+    if (object && transact([{ kind: "upsert_drafting_object", object }]).ok) {
+      setStatus(`Added free arrow ${id}`);
+      setTool("pointer");
+    }
+  };
+
+  const commit = (
+    active: Exclude<DraftingTool, "arrow">,
+    start: Point,
+    end: Point,
+  ): void => {
     const id = nextId(active === "construction-line" ? "construction" : active);
     const snappedStart = snapGridPoint(start, annotationGrid);
     const snappedEnd = snapGridPoint(end, annotationGrid);
@@ -274,28 +313,6 @@ export function createDraftingCreateController({
       ) {
         setStatus(`Added rectangle ${id}`);
       }
-    } else if (active === "arrow") {
-      if (
-        transact([
-          {
-            kind: "upsert_drafting_object",
-            object: applyArrowPreset(
-              {
-                id,
-                kind: "arrow",
-                locked: false,
-                zIndex: 0,
-                anchor: { kind: "free", position: snappedStart },
-                from: { kind: "free", position: snappedStart },
-                to: { kind: "free", position: snappedEnd },
-              },
-              arrowPreset,
-            )!,
-          },
-        ]).ok
-      ) {
-        setStatus(`Added free arrow ${id}`);
-      }
     } else if (
       transact([
         {
@@ -340,25 +357,25 @@ export function createDraftingCreateController({
       setWaypoints([]);
       setStatus(
         active === "arrow"
-          ? "Arrow: click the end point (Enter to finish, Esc to cancel)"
+          ? "Arrow: click bends; double-click or Enter to finish (Esc cancels)"
           : active === "rectangle"
             ? "Rectangle: click the opposite corner (Esc to cancel)"
             : active === "circle"
               ? "Circle: click the radius point (Esc to cancel)"
               : "Construction line: click next vertex (Enter to finish, Esc to cancel)",
       );
-    } else if (
-      active === "arrow" ||
-      active === "rectangle" ||
-      active === "circle"
-    ) {
+    } else if (active === "rectangle" || active === "circle") {
       commit(active, source, resolved.point);
       clear();
     } else {
       setWaypoints((current) => [...current, resolved.point]);
       setHover(resolved.point);
       setSnapPoint(resolved.snap);
-      setStatus(`Construction line: ${waypoints.length + 1} bend(s)`);
+      setStatus(
+        active === "arrow"
+          ? `Arrow: ${waypoints.length + 1} bend(s) · double-click or Enter to finish`
+          : `Construction line: ${waypoints.length + 1} bend(s)`,
+      );
     }
   };
 
@@ -367,7 +384,15 @@ export function createDraftingCreateController({
     if (!active || source === null) return;
     if (active === "arrow" && arrowPreset.family === "outline") return;
     const end = hover ?? source;
-    if (active === "arrow" || active === "rectangle" || active === "circle") {
+    if (active === "arrow") {
+      const points = [source, ...waypoints];
+      if (
+        end.x !== points[points.length - 1]!.x ||
+        end.y !== points[points.length - 1]!.y
+      )
+        points.push(end);
+      commitArrow(points);
+    } else if (active === "rectangle" || active === "circle") {
       if (source.x !== end.x || source.y !== end.y) commit(active, source, end);
     } else {
       const points = [source, ...waypoints];

--- a/apps/editor/src/snap/candidates.test.ts
+++ b/apps/editor/src/snap/candidates.test.ts
@@ -3,6 +3,7 @@ import { builtInSymbols, InMemorySymbolResolver } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
 
 import {
+  buildDraftingProjectionSnapTargets,
   buildRectangleEdgeSnapAnchors,
   buildSceneSnapTargetIndex,
   buildSceneSnapTargets,
@@ -21,6 +22,72 @@ function expectPointsCloseTo(
 }
 
 describe("snap candidate builder", () => {
+  it("projects to arbitrary rectangle edges without adding visible anchors", () => {
+    const document = createEmptyDocument("doc", "Snap");
+    document.drafting = {
+      objects: [
+        {
+          id: "rectangle-1",
+          kind: "rectangle",
+          locked: false,
+          zIndex: 0,
+          anchor: { kind: "free", position: { x: 100, y: 100 } },
+          center: { x: 100, y: 100 },
+          width: 40,
+          height: 20,
+          rotation: 0,
+          lineStyle: "solid",
+        },
+      ],
+    };
+
+    const targets = buildDraftingProjectionSnapTargets(
+      document,
+      new InMemorySymbolResolver(builtInSymbols),
+      { x: 93, y: 92 },
+    );
+
+    expect(targets).toHaveLength(4);
+    expect(targets.map((target) => target.point)).toContainEqual({
+      x: 93,
+      y: 90,
+    });
+    expect(targets.every((target) => target.kind === "drafting")).toBe(true);
+  });
+
+  it("projects to a circle perimeter and excludes the object being edited", () => {
+    const document = createEmptyDocument("doc", "Snap");
+    document.drafting = {
+      objects: [
+        {
+          id: "circle-1",
+          kind: "circle",
+          locked: false,
+          zIndex: 0,
+          anchor: { kind: "free", position: { x: 50, y: 50 } },
+          center: { x: 50, y: 50 },
+          radius: 20,
+          lineStyle: "solid",
+        },
+      ],
+    };
+    const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+    expect(
+      buildDraftingProjectionSnapTargets(document, resolver, {
+        x: 66,
+        y: 62,
+      }).at(0)?.point,
+    ).toEqual({ x: 66, y: 62 });
+    expect(
+      buildDraftingProjectionSnapTargets(
+        document,
+        resolver,
+        { x: 66, y: 62 },
+        new Set(["circle-1"]),
+      ),
+    ).toEqual([]);
+  });
   it("excludes every moving instance from static snap targets", () => {
     const document = createEmptyDocument("doc", "Snap");
     document.instances.push({

--- a/apps/editor/src/snap/candidates.ts
+++ b/apps/editor/src/snap/candidates.ts
@@ -3,6 +3,7 @@ import type { WireSource } from "@icm/edit-engine";
 import type { Point, Rect, SchematicDocument } from "@icm/model";
 import type { SymbolResolver } from "@icm/symbols";
 
+import { closestPointOnSegment } from "../canvas/canvas-geometry";
 import { instanceVisibleHitBox } from "../canvas/instance-geometry";
 import type { SnapAnchor, SnapTargetKind } from "./engine";
 
@@ -141,6 +142,118 @@ export function buildRectangleEdgeSnapAnchors(
       }));
     });
   });
+}
+
+function quadraticPoint(
+  from: Point,
+  control: Point,
+  to: Point,
+  t: number,
+): Point {
+  const inverse = 1 - t;
+  return {
+    x: inverse * inverse * from.x + 2 * inverse * t * control.x + t * t * to.x,
+    y: inverse * inverse * from.y + 2 * inverse * t * control.y + t * t * to.y,
+  };
+}
+
+/** Exact point on a quadratic selected through a bounded one-dimensional search. */
+function closestPointOnQuadratic(
+  point: Point,
+  from: Point,
+  control: Point,
+  to: Point,
+): Point {
+  const distanceSquared = (t: number): number => {
+    const candidate = quadraticPoint(from, control, to, t);
+    return (candidate.x - point.x) ** 2 + (candidate.y - point.y) ** 2;
+  };
+  const samples = 24;
+  let best = 0;
+  for (let index = 1; index <= samples; index += 1) {
+    if (distanceSquared(index / samples) < distanceSquared(best / samples))
+      best = index;
+  }
+  let left = Math.max(0, (best - 1) / samples);
+  let right = Math.min(1, (best + 1) / samples);
+  for (let iteration = 0; iteration < 18; iteration += 1) {
+    const first = left + (right - left) / 3;
+    const second = right - (right - left) / 3;
+    if (distanceSquared(first) <= distanceSquared(second)) right = second;
+    else left = first;
+  }
+  return quadraticPoint(from, control, to, (left + right) / 2);
+}
+
+/**
+ * Pointer-local visual projections. They are transient coordinate candidates,
+ * never persisted attachments or electrical contacts.
+ */
+export function buildDraftingProjectionSnapTargets(
+  document: SchematicDocument,
+  resolver: SymbolResolver,
+  point: Point,
+  excludedDraftingIds: ReadonlySet<string> = new Set(),
+): SnapAnchor[] {
+  const targets: SnapAnchor[] = [];
+  const segment = (
+    objectId: string,
+    index: number,
+    from: Point,
+    to: Point,
+    control?: Point | null,
+  ): void => {
+    targets.push({
+      id: `drafting:${objectId}:projection-${index}`,
+      point: control
+        ? closestPointOnQuadratic(point, from, control, to)
+        : closestPointOnSegment(point, from, to),
+      kind: "drafting",
+    });
+  };
+  for (const object of document.drafting?.objects ?? []) {
+    if (excludedDraftingIds.has(object.id)) continue;
+    const geometry = resolveDraftingObjectGeometry(document, resolver, object);
+    if (geometry.kind === "arrow" || geometry.kind === "construction-line") {
+      for (let index = 0; index < geometry.vertices.length - 1; index += 1) {
+        segment(
+          object.id,
+          index,
+          geometry.vertices[index]!,
+          geometry.vertices[index + 1]!,
+          geometry.curveControls[index],
+        );
+      }
+    } else if (geometry.kind === "rectangle") {
+      for (let index = 0; index < geometry.corners.length; index += 1) {
+        segment(
+          object.id,
+          index,
+          geometry.corners[index]!,
+          geometry.corners[(index + 1) % geometry.corners.length]!,
+        );
+      }
+    } else if (geometry.kind === "circle") {
+      const dx = point.x - geometry.center.x;
+      const dy = point.y - geometry.center.y;
+      const length = Math.hypot(dx, dy);
+      if (length > 0) {
+        targets.push({
+          id: `drafting:${object.id}:projection-circle`,
+          point: {
+            x: geometry.center.x + (dx / length) * geometry.radius,
+            y: geometry.center.y + (dy / length) * geometry.radius,
+          },
+          kind: "drafting",
+        });
+      }
+    } else if (geometry.kind === "leader") {
+      segment(object.id, 0, geometry.anchor, geometry.target);
+    } else if (geometry.kind === "callout") {
+      segment(object.id, 0, geometry.textPosition, geometry.target);
+    }
+  }
+  return targets;
 }
 
 export function buildInstanceAnchors(

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -56,9 +56,16 @@ palette-first manual authoring; no Project file needs to be opened first.
 ## Arrow styles
 
 Choose a style from the arrow tool's dropdown **before** drawing. Its main
-button and `A` reuse the last creation style. Line arrows use start/end clicks
-and support curves; outline arrows are complete hollow shapes: move to preview,
+button and `A` reuse the last creation style. For a line arrow, click each bend
+in sequence and double-click or press `Enter` at the endpoint; it can later be
+curved. Outline arrows are complete straight hollow shapes: move to preview,
 click to stamp a compact default, or drag a bounding box to set width and length.
+
+Arrow and construction-line points snap quietly to nearby pins, wires and
+drawing geometry, including any point along a rectangle, circle, line or curve.
+Only the transient capture marker is shown; no snap points are added to the
+drawing. Hold `Alt` to suppress snapping. A visual snap aligns coordinates but
+does not create electrical connectivity or make one drawing follow another.
 
 Select an arrow and press `Q` for Properties. **Style** is the same icon gallery,
 including filled/open single- and double-headed line arrows and hollow outline


### PR DESCRIPTION
## Summary

- keep line-arrow creation active across bend clicks and finish with double-click or Enter
- snap arrow and construction-line points to arbitrary rectangle/circle edges, line segments and curves with a drafting-only 4 px capture radius
- preserve the existing transient marker without adding persistent highlights, attachment semantics or electrical connectivity

## Validation

- gate preflight passed: static contracts and test-impact
- 2,404 unit tests passed; 5 existing skips
- 132 manual-editor and 2 viewport browser tests passed
- focused arrow/snap unit contracts and 3 focused browser scenarios passed
- typecheck, build and diff check passed

Test-Impact: tests-updated