### PR TITLE
feat(simulation): build the simulator container on the benchmark image, by digest

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -21,12 +21,6 @@ concurrency:
 
 env:
   PREVIEW_URL: https://analog-canvas-preview.tokenzhang.com
-  # The Sky130 model files the container image copies, pinned to one volare
-  # release by tag and by the SHA-256 of each archive. Changing the models is
-  # a deliberate edit here, never a drift.
-  SKY130_TAG: sky130-c6d73a35f524070e85faff4a6a9eef49553ebc2b
-  SKY130_COMMON_SHA256: 8a7f06212c6d9fa5a1da6145f559f48a903434a5c5b6cd5352363700b6cadb94
-  SKY130_FD_PR_SHA256: dcb49c7450dfb55c91ce315d258563895df1ed75d4a9090064aade8290030a87
 
 jobs:
   preview:
@@ -49,26 +43,6 @@ jobs:
       - run: pnpm --filter @icm/editor... build
         env:
           VITE_ICM_TIMING_UI: disabled
-      # The Dockerfile copies pdk/sky130A/libs.tech/ngspice and
-      # pdk/sky130A/libs.ref/sky130_fd_pr from the build context. Only those
-      # two trees are extracted: the archives also carry sky130B and every
-      # other tool's files, none of which ngspice reads.
-      - name: Stage the Sky130 model files for the container image
-        run: |
-          set -euo pipefail
-          mkdir -p pdk/download
-          for asset in common sky130_fd_pr; do
-            curl --fail --silent --show-error --location --max-time 300 \
-              --output "pdk/download/${asset}.tar.zst" \
-              "https://github.com/efabless/volare/releases/download/${SKY130_TAG}/${asset}.tar.zst"
-          done
-          echo "${SKY130_COMMON_SHA256}  pdk/download/common.tar.zst" | sha256sum --check -
-          echo "${SKY130_FD_PR_SHA256}  pdk/download/sky130_fd_pr.tar.zst" | sha256sum --check -
-          tar --zstd -xf pdk/download/common.tar.zst -C pdk --wildcards 'sky130A/libs.tech/ngspice/*'
-          tar --zstd -xf pdk/download/sky130_fd_pr.tar.zst -C pdk --wildcards 'sky130A/libs.ref/sky130_fd_pr/spice/*'
-          rm -rf pdk/download
-          test -f pdk/sky130A/libs.tech/ngspice/sky130.lib.spice
-          du -sh pdk/sky130A/libs.tech/ngspice pdk/sky130A/libs.ref/sky130_fd_pr/spice
       - name: Deploy to preview
         run: pnpm dlx wrangler@4.120.1 deploy --config wrangler.preview.jsonc
         env:

--- a/containers/ngspice/Dockerfile
+++ b/containers/ngspice/Dockerfile
@@ -1,60 +1,44 @@
-# ngspice with the Sky130 device models, and nothing else.
+# The simulator the benchmark suite runs, plus our harness, and nothing else.
 #
-# Size is the design constraint, not thrift: Cloudflare Containers cold-start
-# in proportion to image size, and a simulation the author is waiting on pays
-# that start every time a sleeping container wakes. The full Sky130
-# distribution is 2.1 GB; the files ngspice actually reads are 52 MB — 4 MB of
-# corner and parameter decks under libs.tech/ngspice, plus 48 MB of device
-# model cards under libs.ref/sky130_fd_pr/spice. The remainder is GDS, LEF,
-# and Magic layout that no circuit simulator opens, so it never enters the
-# image.
+# The base is analog-arena's own simulator image, pinned by digest: ngspice 46
+# built from source at /opt/ngspice, and the Sky130 models at /opt/sky130 in
+# both forms, the binned PDK checkout and the CONTINUOUS (unbinned) library at
+# /opt/sky130/continuous/sky130.lib.spice. Two reasons this replaced the slim
+# Debian image built here on 2026-09-01:
 #
-# The build takes the PDK from a volare-style checkout supplied as a build
-# context path, rather than downloading 2.1 GB during every build.
+# - The binned models cap device width at 100 µm and refused the benchmark's
+#   own reference OTA (#551). The continuous library has no such ceiling and
+#   is not something a volare checkout can produce.
+# - Simulator and models are now byte-identical to what the benchmark runs,
+#   so a numerical disagreement in the acceptance comparison can only mean
+#   our export is wrong. The slim image left a second explanation (two
+#   different ngspice builds) that no test could ever rule out.
+#
+# The digest is the environment lock. Changing it is a deliberate edit here;
+# the image reports the resulting binary and model-tree hashes at runtime.
+ARG BASE_IMAGE=ghcr.io/arcadia-1/circuit-bench-sky130-ngspice@sha256:2da03dc7f1ead7ddc33f2f930a0487ae8618e51518009344584a98fca41a621d
+FROM ${BASE_IMAGE}
 
-FROM debian:bookworm-slim AS models
-
-ARG SKY130_ROOT=pdk/sky130A
-COPY ${SKY130_ROOT}/libs.tech/ngspice /stage/sky130A/libs.tech/ngspice
-COPY ${SKY130_ROOT}/libs.ref/sky130_fd_pr /stage/sky130A/libs.ref/sky130_fd_pr
-
-# Layout data is the 2 GB the simulator never reads. Dropping it here keeps
-# the copied tree out of the final image's layers entirely.
-RUN find /stage/sky130A/libs.ref/sky130_fd_pr \
-        -mindepth 1 -maxdepth 1 -type d ! -name spice -exec rm -rf {} + \
-    && find /stage -type f \
-        ! -name '*.spice' ! -name '*.lib' ! -name '*.lib.spice' \
-        ! -name '*.mod' ! -name '*.model' ! -name '*.pm3' -delete \
-    && du -sh /stage
-
-FROM debian:bookworm-slim
-
-# ngspice from Debian: a packaged build tracks upstream fixes and is far
-# smaller than a source build with its toolchain.
+# The harness is a Node program; the base image has none. Debian bookworm's
+# packaged Node is enough for it (fs, http, child_process, crypto).
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ngspice \
+    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=models /stage/sky130A /opt/sky130/sky130A
-
-# Where the run harness resolves `.lib` paths from. The models are read-only
-# and identical for every run; nothing about a run is written here.
-ENV SKY130_MODEL_ROOT=/opt/sky130/sky130A \
-    NGSPICE_BIN=/usr/bin/ngspice
+# Where the harness finds the simulator and the model tree it fingerprints.
+# The base image already sets SKY130_MODEL_LIB to the continuous library; the
+# Worker selects that same path (worker/simulation.ts).
+ENV NGSPICE_BIN=/opt/ngspice/bin/ngspice \
+    SKY130_MODEL_ROOT=/opt/sky130
 
 # A container wakes with a fresh disk, so the run directory is scratch by
 # nature. Declaring it here documents that nothing survives a sleep.
 WORKDIR /run/simulation
 
 # The build context is the repository root (wrangler.preview.jsonc sets
-# image_build_context to "."), because the model files above are staged
-# there. Every COPY is therefore repo-root relative, this one included; the
-# first preview deploy failed on exactly this line when it was not.
+# image_build_context to "."), so every COPY is repo-root relative.
 ARG HARNESS_DIR=containers/ngspice
 COPY ${HARNESS_DIR}/entrypoint.mjs /opt/harness/entrypoint.mjs
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends nodejs \
-    && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 8080
 CMD ["node", "/opt/harness/entrypoint.mjs"]

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -34,13 +34,17 @@ type ModelLibrarySelection =
 - Paths are quoted when emitted and must contain no quote or line break.
 - A library section is one non-empty SPICE token.
 
-The hosted Sky130 environment selects the `tt` section of
-`sky130.lib.spice` by default and may override the path and section through
-deployment configuration. Its valid default output is:
+The hosted Sky130 environment runs the benchmark suite's own simulator image
+(pinned by digest in `containers/ngspice/Dockerfile`) and selects the `tt`
+section of its **continuous** (unbinned) library by default; deployment
+configuration may override the path and section. Its valid default output is:
 
 ```spice
-.lib "/opt/sky130/sky130A/libs.tech/ngspice/sky130.lib.spice" tt
+.lib "/opt/sky130/continuous/sky130.lib.spice" tt
 ```
+
+The binned models a PDK checkout provides cap device width at 100 µm and
+refuse wide devices (#551); they are not the hosted default.
 
 It must not include that top-level sectioned library with `.include`, because
 doing so expands multiple corner sections into the same deck and redefines

--- a/scripts/preview-workflow.test.mjs
+++ b/scripts/preview-workflow.test.mjs
@@ -20,12 +20,13 @@ describe("the preview deploy", () => {
     expect(preview).toContain("analog-canvas-preview.tokenzhang.com");
   });
 
-  it("pins the model files it bakes into the container image", () => {
-    expect(preview).toMatch(/SKY130_TAG: sky130-[0-9a-f]{40}/u);
-    expect(preview).toMatch(/SKY130_COMMON_SHA256: [0-9a-f]{64}/u);
-    expect(preview).toMatch(/SKY130_FD_PR_SHA256: [0-9a-f]{64}/u);
-    expect(preview).toContain("sha256sum --check");
-    expect(preview).toContain("sky130.lib.spice");
+  it("stages nothing for the image: the benchmark base image carries the models", () => {
+    // The Dockerfile's FROM is the environment lock (see
+    // worker/preview-config.test.ts); the workflow has no model download
+    // to pin or verify any more.
+    expect(preview).not.toContain("SKY130_TAG");
+    expect(preview).not.toContain("sha256sum");
+    expect(preview).not.toContain("volare");
   });
 
   it("verifies what a preview is for", () => {

--- a/worker/preview-config.test.ts
+++ b/worker/preview-config.test.ts
@@ -117,6 +117,22 @@ describe("the preview channel configuration (ADR 0057)", () => {
     }
   });
 
+  it("builds the simulator on the benchmark image, pinned by digest", () => {
+    // Simulator and models byte-identical to what analog-arena runs, so an
+    // acceptance disagreement can only mean our export is wrong (#551); and
+    // the continuous library has no device-width ceiling.
+    const dockerfile = readFileSync(
+      resolve(process.cwd(), "containers/ngspice/Dockerfile"),
+      "utf8",
+    );
+    expect(dockerfile).toMatch(
+      /^ARG BASE_IMAGE=ghcr\.io\/arcadia-1\/circuit-bench-sky130-ngspice@sha256:[0-9a-f]{64}$/mu,
+    );
+    expect(dockerfile).toMatch(/^FROM \$\{BASE_IMAGE\}$/mu);
+    // No second simulator installed over the pinned one.
+    expect(dockerfile).not.toMatch(/apt-get install[^\n]*\bngspice\b/u);
+  });
+
   it("runs the Worker on every path so noindex and robots reach the shell", () => {
     // The stamp and the robots answer live in the Worker; a path the asset
     // layer answers alone never carries them. The first live verification

--- a/worker/simulation.test.ts
+++ b/worker/simulation.test.ts
@@ -99,9 +99,7 @@ describe("simulation route", () => {
     expect(seen.deck).toContain(NETLIST);
     // Our own contribution is the model selection and nothing analysis-shaped.
     const ours = seen.deck!.replace(TESTBENCH, "").replace(NETLIST, "");
-    expect(ours).toContain(
-      '.lib "/opt/sky130/sky130A/libs.tech/ngspice/sky130.lib.spice" tt',
-    );
+    expect(ours).toContain('.lib "/opt/sky130/continuous/sky130.lib.spice" tt');
     expect(ours).not.toMatch(/^\s*\.include\b/mu);
     expect(ours).not.toMatch(/\.ac\b|\.dc\b|\.tran\b|\.control/iu);
   });

--- a/worker/simulation.ts
+++ b/worker/simulation.ts
@@ -42,8 +42,9 @@ export interface SimulationEnv {
   SKY130_LIB_SECTION?: string;
 }
 
-const DEFAULT_LIB_PATH =
-  "/opt/sky130/sky130A/libs.tech/ngspice/sky130.lib.spice";
+// The continuous (unbinned) Sky130 library the benchmark image ships; the
+// binned checkout it also carries caps device width at 100 µm (#551).
+const DEFAULT_LIB_PATH = "/opt/sky130/continuous/sky130.lib.spice";
 const DEFAULT_LIB_SECTION = "tt";
 
 /** A deck this large is a mistake upstream, not a simulation worth waking for. */


### PR DESCRIPTION
Owner's decision (2026-09-04): the hosted simulator is the benchmark suite's own image, `ghcr.io/arcadia-1/circuit-bench-sky130-ngspice`, publicly pullable (verified anonymously against ghcr: linux/amd64, Debian bookworm, ngspice 46 at `/opt/ngspice`, `SKY130_MODEL_LIB=/opt/sky130/continuous/sky130.lib.spice`, ~98 MB compressed).

- `containers/ngspice/Dockerfile`: `FROM` the image by digest; only Node is added for the harness. The volare model stage is gone.
- `worker/simulation.ts`: default library is the continuous one (no 100 µm width ceiling).
- `deploy-preview.yml`: no model download or SHA pins; the image carries the models.
- Tests: the Dockerfile must `FROM` the digest-pinned image and install no second ngspice; the workflow stages nothing.
- Docs: spec example path and ADR 0055 amendment item 7 marked decided.

The digest is the environment lock; changing it is a deliberate edit. Merging deploys the preview, whose smoke simulates a resistor divider through the new image; a Sky130 transistor probe follows by hand.

Closes #551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)