### PR TITLE
fix(simulation): an exit code is not a verdict on the circuit

### DIFF
--- a/apps/local-host/src/simulate.ts
+++ b/apps/local-host/src/simulate.ts
@@ -21,6 +21,7 @@ import {
   classifySimulationOutcome,
   createSimulationEnvironmentMetadata,
   createSimulationInputMetadata,
+  describeExitStatus,
   readNgspiceDiagnostics,
   resolveTimeoutMs,
   simulationConfigurationMetadata,
@@ -186,13 +187,26 @@ export async function simulateLocally(
       };
     }
     const diagnostics = readNgspiceDiagnostics(run.log);
+    // The rule the hosted route has carried since #566, which this path had
+    // been getting only by accident of the exit code: a batch run always
+    // prints at least its banner, so silence is not a result. It has to be
+    // stated here now that the exit code no longer decides anything.
+    if (!run.timedOut && run.log.trim().length === 0) {
+      diagnostics.push({
+        severity: "error",
+        text: "The simulator produced no output, so this run has no result.",
+      });
+    }
+    // Reported, never decisive: see describeExitStatus. Pushed after the
+    // check above so a silent run still reads as the error it is.
+    const exitStatus = describeExitStatus(run.exitCode);
+    if (exitStatus) diagnostics.push(exitStatus);
     return {
       kind: "ran",
       result: {
         outcome: classifySimulationOutcome(diagnostics, {
           timedOut: run.timedOut,
           timeoutMs,
-          exitCode: run.exitCode,
         }),
         diagnostics,
         log: run.log,

--- a/packages/spice-run/src/index.test.ts
+++ b/packages/spice-run/src/index.test.ts
@@ -4,6 +4,7 @@ import {
   buildSimulationDeck,
   deckNeedsModelLibrary,
   classifySimulationOutcome,
+  describeExitStatus,
   createSimulationEnvironmentMetadata,
   createSimulationInputMetadata,
   DEFAULT_SIMULATION_TIMEOUT_MS,
@@ -76,7 +77,6 @@ describe("ngspice output reading", () => {
       classifySimulationOutcome(diagnostics, {
         timedOut: false,
         timeoutMs: 30_000,
-        exitCode: 0,
       }),
     ).toEqual({ status: "completed-with-dropped-input" });
   });
@@ -93,7 +93,6 @@ describe("ngspice output reading", () => {
       classifySimulationOutcome(diagnostics, {
         timedOut: false,
         timeoutMs: 30_000,
-        exitCode: 1,
       }),
     ).toEqual({ status: "failed" });
   });
@@ -105,9 +104,67 @@ describe("ngspice output reading", () => {
       classifySimulationOutcome(diagnostics, {
         timedOut: false,
         timeoutMs: 30_000,
-        exitCode: 0,
       }),
     ).toEqual({ status: "completed" });
+  });
+
+  /**
+   * Captured from the hosted container (ngspice 39) on 2026-09-04. The author's
+   * testbench was a `.control` block, which ran and printed every value asked
+   * for -- and then the batch pass found no `.plot`/`.print` card and said so,
+   * and the process exited non-zero. ngspice 46 exits 0 for the same deck.
+   */
+  const CONTROL_BLOCK_OUTPUT = `
+Circuit: * Analog Canvas simulation deck
+
+Doing analysis at TEMP = 27.000000 and TNOM = 27.000000
+
+v(vout) = 7.661889e-01
+v(ibias) = 6.018893e-01
+
+Note: No ".plot", ".print", or ".fourier" lines; no simulations run
+`;
+
+  it("does not fail a run that printed its results, whatever ngspice exited", () => {
+    // #568: every hosted simulation came back failed while the response
+    // carried the right values, because the exit status alone was enough to
+    // condemn it. That status varies with the ngspice build, not with the run.
+    const diagnostics = readNgspiceDiagnostics(CONTROL_BLOCK_OUTPUT);
+    expect(
+      diagnostics.some((diagnostic) => diagnostic.severity === "error"),
+    ).toBe(false);
+    expect(
+      classifySimulationOutcome(diagnostics, {
+        timedOut: false,
+        timeoutMs: 30_000,
+      }),
+    ).toEqual({ status: "completed" });
+  });
+
+  it("reports the odd exit rather than hiding it", () => {
+    // Not failing on it is not the same as pretending it did not happen.
+    const noted = describeExitStatus(1);
+    expect(noted?.severity).toBe("warning");
+    expect(noted?.text).toContain("exited with code 1");
+    expect(describeExitStatus(0)).toBeNull();
+    expect(describeExitStatus(null)).toBeNull();
+  });
+
+  it("never fails without saying why", () => {
+    // A refusal with an empty diagnostics array leaves the author nothing to
+    // act on and the next debugger nothing to follow. Failure is reachable
+    // only through an error diagnostic now, so the pairing cannot recur.
+    const outcome = classifySimulationOutcome([], {
+      timedOut: false,
+      timeoutMs: 30_000,
+    });
+    expect(outcome.status).not.toBe("failed");
+
+    const silent = classifySimulationOutcome(
+      [{ severity: "error", text: "The simulator produced no output." }],
+      { timedOut: false, timeoutMs: 30_000 },
+    );
+    expect(silent).toEqual({ status: "failed" });
   });
 
   it("says a timeout is a timeout, not a broken circuit", () => {
@@ -117,7 +174,6 @@ describe("ngspice output reading", () => {
       classifySimulationOutcome(readNgspiceDiagnostics(CLEAN_OUTPUT), {
         timedOut: true,
         timeoutMs: 30_000,
-        exitCode: null,
       }),
     ).toEqual({ status: "timed-out", timeoutMs: 30_000 });
   });

--- a/packages/spice-run/src/index.ts
+++ b/packages/spice-run/src/index.ts
@@ -385,20 +385,60 @@ export function readNgspiceDiagnostics(output: string): SimulationDiagnostic[] {
 }
 
 /**
+ * The diagnostic a non-zero exit deserves, or null when the exit says nothing.
+ *
+ * ngspice's exit status is not a verdict on the circuit. Version 39 exits
+ * non-zero after a batch pass that has already run the author's `.control`
+ * block and printed every value asked for, because that pass then finds no
+ * `.plot`/`.print`/`.fourier` card and says so; version 46 exits 0 for the
+ * identical deck. So the status varies with the build, not with the run.
+ *
+ * It is still worth reporting. A caller that ignored it entirely would hide
+ * the one clue available when a run goes wrong in a way nothing printed.
+ */
+export function describeExitStatus(
+  exitCode: number | null,
+): SimulationDiagnostic | null {
+  if (exitCode === null || exitCode === 0) return null;
+  return {
+    severity: "warning",
+    text:
+      `The simulator exited with code ${exitCode}. Some builds of ngspice do ` +
+      `this after a run that produced everything asked of it, so check the ` +
+      `results below before treating it as a problem.`,
+  };
+}
+
+/**
  * The outcome, from the diagnostics rather than the exit status — except for
  * a timeout, which only the caller can know about.
+ *
+ * The exit status was once enough on its own to fail a run, which discarded
+ * correct answers: on 2026-09-04 every simulation the hosted container ran
+ * came back `failed` with an empty `diagnostics` array while the response
+ * carried the right values, including a five-transistor OTA whose operating
+ * point matched ngspice 46 with a full PDK to every digit (#568). Nothing had
+ * gone wrong; ngspice 39 exits non-zero for its own reasons.
+ *
+ * A run therefore fails only when something said so. That is a deliberate
+ * trade: an exit code that is the sole evidence of a real failure now reports
+ * `completed` beside the warning from `describeExitStatus`, which is the
+ * lesser harm — the author sees the fact and their results, instead of a
+ * refusal with no reason attached. It also makes `failed` with no diagnostic
+ * unreachable rather than merely unlikely.
+ *
+ * The stronger criterion is whether the requested measurements came back, and
+ * that needs the result parsing this cannot see yet (F3-1). It should replace
+ * this reading rather than sit beside it.
  */
 export function classifySimulationOutcome(
   diagnostics: readonly SimulationDiagnostic[],
-  options: { timedOut: boolean; timeoutMs: number; exitCode: number | null },
+  options: { timedOut: boolean; timeoutMs: number },
 ): SimulationOutcome {
   if (options.timedOut) {
     return { status: "timed-out", timeoutMs: options.timeoutMs };
   }
-  if (
-    diagnostics.some((diagnostic) => diagnostic.severity === "error") ||
-    (options.exitCode !== null && options.exitCode !== 0)
-  ) {
+  if (diagnostics.some((diagnostic) => diagnostic.severity === "error")) {
     return { status: "failed" };
   }
   if (diagnostics.some((diagnostic) => diagnostic.droppedInput)) {

--- a/worker/simulation.ts
+++ b/worker/simulation.ts
@@ -18,6 +18,7 @@ import {
   buildSimulationDeck,
   classifySimulationOutcome,
   deckNeedsModelLibrary,
+  describeExitStatus,
   createSimulationInputMetadata,
   isSimulationInputRevision,
   readNgspiceDiagnostics,
@@ -206,11 +207,16 @@ export async function routeSimulationRequest(
       text: "The simulator produced no output, so this run has no result.",
     });
   }
+  // Reported, never decisive: see describeExitStatus. Pushed after the checks
+  // above so a signal or a silent run still reads as the error it is.
+  const exitStatus = describeExitStatus(
+    typeof raw.exitCode === "number" ? raw.exitCode : null,
+  );
+  if (exitStatus) diagnostics.push(exitStatus);
   const result: SimulationResult = {
     outcome: classifySimulationOutcome(diagnostics, {
       timedOut,
       timeoutMs,
-      exitCode: typeof raw.exitCode === "number" ? raw.exitCode : null,
     }),
     diagnostics,
     log,


### PR DESCRIPTION
Fixes #568.

## What was happening

Every simulation the hosted container ran came back as a failure, while the same response carried the correct answer.

```
outcome     : {"status": "failed"}
diagnostics : []
log         : v(vout) = 7.661889e-01 …
```

That OTA's operating point, gain and unity-gain bandwidth match ngspice 46 with a full local PDK **to every digit** — the comparison `pnpm sim:accept` (#557) performs. A two-resistor divider through the same route failed too, in twelve milliseconds, with `v(mid) = 5.000000e-01` in its log.

## Cause

`classifySimulationOutcome` failed a run whenever the exit status was non-zero:

```ts
if (
  diagnostics.some((d) => d.severity === "error") ||
  (options.exitCode !== null && options.exitCode !== 0)   // ← this
) {
  return { status: "failed" };
}
```

That status is a property of the ngspice build, not of the run. Version 39 exits non-zero after a batch pass that has **already executed the author's `.control` block and printed everything asked of it** — the pass then finds no `.plot`/`.print`/`.fourier` card and says so. Version 46 exits 0 for the identical deck, verified locally on the deck `buildSimulationDeck` produces. The container runs 39.

It also explains the empty `diagnostics`: that note matches none of the error patterns and was never diagnostic-worthy. The only thing condemning the run was a bare number.

ADR 0055 makes the testbench the author's, and a `.control` block is how the ngspice documentation says to write one. So this was every author's first simulation, not an edge case.

## Change

A run fails only when something said so. The exit code is **reported instead of obeyed** — `describeExitStatus` turns a non-zero exit into a warning the author sees beside their results.

## Two consequences, stated rather than left to be discovered

**An exit code that is the sole evidence of a real failure now reads as `completed`,** with that warning attached. This is a deliberate trade. A refusal with no reason attached teaches the author nothing and throws away a correct answer; a completed result carrying "the simulator exited with code 1" tells them what happened and lets them judge. It also makes `failed` beside an empty `diagnostics` unreachable rather than merely unlikely.

The stronger criterion — whether the *requested measurements* came back — needs the result parsing of F3-1, which the classifier cannot see yet. **It should replace this reading rather than sit beside it.**

**#566 is untouched.** A run killed by a signal, or one that printed nothing, still fails. The `local-host` path had been getting the silent-run case only by accident of the exit code, so it now states the rule the hosted route has carried since #566.

## Tests

Three added, and the first fails against the previous logic — verified by restoring the `exitCode` clause and re-running:

```
× does not fail a run that printed its results, whatever ngspice exited
  Tests  1 failed | 15 passed (16)
```

Its fixture is captured container output with a `.control`-block testbench. A test written with `.print` directives would pass against the broken code, which is the trap this one exists to avoid.

The other two pin that a non-zero exit is reported as a warning, and that failure is reachable only through an error diagnostic.

`packages/spice-run`, `worker`, `apps/local-host`: 171 tests pass.

## Verifying on the live preview

This cannot be confirmed from unit tests alone — the symptom was in the deployed service. After this deploys, POST the reproduction from #568 to `analog-canvas-preview.tokenzhang.com/api/simulate` and confirm `outcome.status` is no longer `failed`. I will do that and post the response here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)