### PR TITLE
feat(simulation): box in the deck the container runs

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,182 @@
+name: Simulation container
+
+# Nothing else in CI builds this image. The preview deploy builds it, on push
+# to main — which is after a merge, so a Dockerfile that does not build takes
+# the preview channel down rather than failing a review. This job is the check
+# that happens first: the image builds, it runs as the account it claims to,
+# nothing a deck can reach is writable, and it still answers a circuit.
+
+on:
+  pull_request:
+    paths:
+      - "containers/ngspice/**"
+      - ".github/workflows/container.yml"
+      - ".dockerignore"
+      - "wrangler.preview.jsonc"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: container-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  image:
+    name: Build and exercise the image
+    runs-on: ubuntu-latest
+    # The base image carries a source-built ngspice and the Sky130 models in
+    # both forms; pulling it is the slow part, not the build.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build the image
+        run: docker build -t icm-ngspice:pr -f containers/ngspice/Dockerfile .
+
+      # What the image promises about itself, asked of the image rather than
+      # read off the Dockerfile. Each check runs as the image's own user,
+      # which is the account a deck's `.control` block would run as.
+      - name: Check the execution boundary
+        run: |
+          set -euo pipefail
+          uid="$(docker run --rm icm-ngspice:pr id -u)"
+          if [ "$uid" != "10001" ]; then
+            echo "The image must run as the unprivileged account, got uid $uid"
+            exit 1
+          fi
+          # The model tree and the simulator are the base image's, not ours,
+          # so their permissions are asserted rather than assumed.
+          for path in /opt/sky130 /opt/ngspice /opt/harness; do
+            if docker run --rm icm-ngspice:pr \
+                sh -c "touch $path/written-by-a-deck" 2>/dev/null; then
+              echo "$path is writable by the account a deck runs as."
+              exit 1
+            fi
+          done
+          if docker run --rm icm-ngspice:pr \
+              sh -c 'touch /opt/harness/entrypoint.mjs' 2>/dev/null; then
+            echo "The harness itself is writable by the account a deck runs as."
+            exit 1
+          fi
+          docker run --rm icm-ngspice:pr sh -c 'test -w /run/simulation' \
+            || { echo "The run root must be writable, or no run can start."; exit 1; }
+          # The continuous library is the reason for this base image (#551).
+          # The Worker points every model-backed deck at exactly this path.
+          docker run --rm icm-ngspice:pr \
+            sh -c 'test -f /opt/sky130/continuous/sky130.lib.spice' \
+            || { echo "The pinned base no longer carries the continuous library."; exit 1; }
+
+      - name: Simulate one circuit in the image
+        run: |
+          set -euo pipefail
+          docker run -d --name icm-ngspice-check -p 127.0.0.1:8080:8080 icm-ngspice:pr
+          trap 'docker logs icm-ngspice-check || true; docker rm -f icm-ngspice-check >/dev/null 2>&1 || true' EXIT
+          # Readiness waits on the model-tree fingerprint, which is a hash of
+          # every file the image ships; that is the slow part of a cold start.
+          for _ in $(seq 1 180); do
+            if curl --silent --fail --max-time 5 http://127.0.0.1:8080/health > /tmp/health.json; then
+              break
+            fi
+            sleep 1
+          done
+          cat /tmp/health.json; echo
+          node -e '
+            const health = require("/tmp/health.json");
+            if (health.status !== "ready") throw new Error("container not ready");
+            if (health.busy !== false) throw new Error("a fresh container is not busy");
+            if (health.limits.concurrentRuns !== 1) throw new Error("the slot is not single");
+            if (health.environment.simulator.name !== "ngspice") throw new Error("no simulator identified");
+            if (!/^[0-9a-f]{64}$/.test(health.environment.fingerprint)) throw new Error("no fingerprint");
+            console.log("simulator:", health.environment.simulator.version);
+          '
+          # A resistor divider, the smallest circuit ngspice can answer for,
+          # and one that needs no device model — the models are covered by the
+          # preview deploy, which simulates through the real container on
+          # every merge. What is asked here is whether a deck runs at all
+          # under the account, the limits, and the directory this image gives
+          # it, and whether the rawfile it asked for comes back.
+          node -e '
+            const deck = [
+              "* container check",
+              "V1 in 0 DC 1",
+              "R1 in out 1k",
+              "R2 out 0 1k",
+              ".control",
+              "op",
+              "print v(out)",
+              "write out.raw",
+              ".endc",
+              ".end",
+              "",
+            ].join("\n");
+            process.stdout.write(JSON.stringify({ deck, timeoutMs: 30000 }));
+          ' > /tmp/run-request.json
+          curl --silent --show-error --fail --max-time 60 \
+            -H 'content-type: application/json' \
+            --data @/tmp/run-request.json \
+            http://127.0.0.1:8080/run > /tmp/run-result.json
+          node -e '
+            const result = require("/tmp/run-result.json");
+            console.log(result.log);
+            if (result.timedOut) throw new Error("the divider timed out");
+            if (result.exitCode !== 0) throw new Error(`exit ${result.exitCode} signal ${result.signal}`);
+            if (result.truncated) throw new Error("a divider must not reach the output cap");
+            if (!/0\.5|5\.0+e-01/.test(result.log)) {
+              throw new Error("the divider did not report half a volt");
+            }
+            // The rawfile the deck asked for comes back as text, uninterpreted.
+            if (result.rawfileFormat !== "ascii") {
+              throw new Error(`rawfile format ${result.rawfileFormat}`);
+            }
+            if (!/Plotname/i.test(result.rawfile ?? "")) {
+              throw new Error("the rawfile does not look like one");
+            }
+            console.log("rawfile:", result.rawfileName, result.rawfile.length, "bytes");
+          '
+          # The single slot, asked of the running container rather than only
+          # of the harness in unit tests: a second request during a run is
+          # refused with Retry-After, not queued behind it.
+          node -e '
+            const deck = [
+              "* a run long enough to still be running",
+              "V1 in 0 DC 1",
+              "R1 in out 1k",
+              "C1 out 0 1u",
+              ".tran 1n 200m",
+              ".end",
+              "",
+            ].join("\n");
+            process.stdout.write(JSON.stringify({ deck, timeoutMs: 30000 }));
+          ' > /tmp/slow-request.json
+          curl --silent --show-error --max-time 90 -o /tmp/slow-result.json \
+            -H 'content-type: application/json' --data @/tmp/slow-request.json \
+            http://127.0.0.1:8080/run &
+          slow=$!
+          busy=""
+          for _ in $(seq 1 100); do
+            if curl --silent --fail --max-time 5 http://127.0.0.1:8080/health \
+                | grep -q '"busy":true'; then
+              busy=yes
+              break
+            fi
+            sleep 0.2
+          done
+          if [ -z "$busy" ]; then
+            echo "The container never reported itself busy; the guard cannot be observed."
+            wait "$slow" || true
+            exit 1
+          fi
+          second="$(curl --silent --max-time 20 -o /tmp/second.json -D /tmp/second.head \
+            --write-out '%{http_code}' \
+            -H 'content-type: application/json' --data @/tmp/run-request.json \
+            http://127.0.0.1:8080/run)"
+          wait "$slow" || true
+          cat /tmp/second.json; echo
+          if [ "$second" != "503" ]; then
+            echo "A second concurrent run must be refused with 503, got $second"
+            exit 1
+          fi
+          grep -iq '^retry-after:' /tmp/second.head \
+            || { echo "A refusal must say when to come back."; cat /tmp/second.head; exit 1; }

--- a/containers/ngspice/Dockerfile
+++ b/containers/ngspice/Dockerfile
@@ -25,6 +25,29 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
+# The deck that runs here was written by someone who is not the operator of
+# this container, and raw `.control` is permitted by the contract — isolation,
+# not prohibition, is what keeps a control script inside its own job. Root is
+# the wrong account to hand that to. An unprivileged one cannot write the
+# simulator, the models, or the harness, and the only directory it can write
+# is the scratch root that every run's private directory is made under.
+#
+# The guards matter because the base image is not ours: it may already carry
+# this uid, and answering that with a build failure would make a base image
+# swap a Dockerfile edit.
+ARG RUN_UID=10001
+ARG RUN_GID=10001
+ARG RUN_USER=simulate
+ARG RUN_ROOT=/run/simulation
+RUN set -eu; \
+    if ! getent group "${RUN_GID}" >/dev/null 2>&1; then \
+        groupadd --system --gid "${RUN_GID}" "${RUN_USER}"; \
+    fi; \
+    if ! getent passwd "${RUN_UID}" >/dev/null 2>&1; then \
+        useradd --system --uid "${RUN_UID}" --gid "${RUN_GID}" \
+            --home-dir "${RUN_ROOT}" --shell /usr/sbin/nologin "${RUN_USER}"; \
+    fi
+
 # Where the harness finds the simulator and the model tree it fingerprints.
 # The base image already sets SKY130_MODEL_LIB to the continuous library; the
 # Worker selects that same path (worker/simulation.ts).
@@ -33,12 +56,49 @@ ENV NGSPICE_BIN=/opt/ngspice/bin/ngspice \
 
 # A container wakes with a fresh disk, so the run directory is scratch by
 # nature. Declaring it here documents that nothing survives a sleep.
-WORKDIR /run/simulation
+WORKDIR ${RUN_ROOT}
 
 # The build context is the repository root (wrangler.preview.jsonc sets
 # image_build_context to "."), so every COPY is repo-root relative.
 ARG HARNESS_DIR=containers/ngspice
 COPY ${HARNESS_DIR}/entrypoint.mjs /opt/harness/entrypoint.mjs
+
+# Nothing a deck can reach is writable except its own run directory.
+#
+# The harness is ours and small, so it is simply stripped of every write bit.
+# The simulator and the model tree came with the base image and are measured
+# in gigabytes: `chmod -R` over them would copy every file into a new layer
+# and double the image, for a tree whose files are already root-owned. So
+# only the files that are actually group- or other-writable are corrected,
+# which on a well-built base is none of them and costs an empty layer. That
+# the property really holds is not assumed — the container workflow asserts
+# it by trying to write, as the run account, and requiring failure.
+RUN set -eu; \
+    chmod -R a-w /opt/harness; \
+    find /opt/sky130 /opt/ngspice -perm /022 -exec chmod go-w {} + || true; \
+    mkdir -p "${RUN_ROOT}"; \
+    chown "${RUN_UID}:${RUN_GID}" "${RUN_ROOT}"; \
+    chmod 700 "${RUN_ROOT}"
+
+# Where the harness makes each run's private directory, and the two kernel
+# limits it starts the simulator under. The limits are set here rather than
+# defaulted in the harness because they only mean anything against a known
+# account: RLIMIT_NPROC counts every process this uid owns, and in this image
+# that is the harness and one simulator. 128 processes is far above anything
+# ngspice reaches — it does not fork — and far below a fork bomb. 524288
+# blocks is 256 MiB in dash's 512-byte units, a ceiling on what one `write`
+# can pour onto the scratch disk; no rawfile of a schematic-sized circuit
+# comes near it.
+#
+# RUN_ROOT is spelled once, above, and referred to from here on: an image that
+# prepared one directory while the harness looked in another would fail every
+# run at the first mkdtemp.
+ENV SIMULATION_RUN_ROOT=${RUN_ROOT} \
+    SIMULATION_MAX_PROCESSES=128 \
+    SIMULATION_MAX_FILE_BLOCKS=524288 \
+    HOME=${RUN_ROOT}
+
+USER ${RUN_UID}:${RUN_GID}
 
 EXPOSE 8080
 CMD ["node", "/opt/harness/entrypoint.mjs"]

--- a/containers/ngspice/entrypoint.mjs
+++ b/containers/ngspice/entrypoint.mjs
@@ -1,33 +1,183 @@
 // The container's whole job: accept a deck, run ngspice on it, return what
 // ngspice said. It decides nothing about the circuit.
 //
+// It does decide how that deck is allowed to run, and that is the harder
+// half. What executes here is somebody else's SPICE: a `.control` block is a
+// small language with file access, and the author of a deck is not the
+// operator of this container. So the run is boxed in on every side that can
+// be boxed in from inside the process — a fresh directory per run that is
+// also the only writable place the simulator can see, an environment built
+// from nothing rather than inherited, one job at a time, a deadline that
+// kills the whole process group rather than one pid, and a cap on every byte
+// that comes back. The container's own answer for what it cannot enforce
+// from in here — who it runs as, and what the model tree permits — is in the
+// Dockerfile beside this file.
+//
 // A container wakes with a fresh disk and sleeps after ten idle minutes, so
-// every run writes its deck, reads its output, and leaves nothing behind that
-// a later run could depend on.
-import { execFile } from "node:child_process";
+// every run writes its deck, reads its output, and leaves nothing behind
+// that a later run could depend on.
+import { execFile, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  open,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 
-const NGSPICE_BIN = process.env.NGSPICE_BIN ?? "/usr/bin/ngspice";
 const MODEL_ROOT = process.env.SKY130_MODEL_ROOT ?? "/opt/sky130/sky130A";
 const PORT = Number(process.env.PORT ?? 8080);
+
+/**
+ * Where a run's private directory is made. A directory the image gives to the
+ * unprivileged run user, not the shared world-writable `/tmp`: two things
+ * live under `/tmp` on a general-purpose image and neither of them should be
+ * reachable by a deck.
+ */
+const RUN_ROOT = process.env.SIMULATION_RUN_ROOT ?? tmpdir();
+
 /** Refuse a deck larger than this rather than spend a container waking for it. */
 const MAX_DECK_BYTES = 2 * 1024 * 1024;
 
+/**
+ * The ceiling on everything this container hands back for one run: the log
+ * and, when the deck asked for one, the rawfile. A deck can print without
+ * bound — a `.control` loop around `print` is three lines — and the answer to
+ * that is a cap and a truthful `truncated`, never a quietly shortened result
+ * that reads like the whole one.
+ */
+const MAX_OUTPUT_BYTES = positiveEnv(
+  "SIMULATION_MAX_OUTPUT_BYTES",
+  1024 * 1024,
+);
+
+/** Requested when the caller names no deadline of its own. */
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * The deadline ceiling. The Worker in front of this already clamps to
+ * `MAX_SIMULATION_TIMEOUT_MS`, but a container that trusts its caller for how
+ * long to occupy its only slot has no limit at all — the clamp is repeated
+ * here because this is the side that pays for it.
+ */
+const MAX_TIMEOUT_MS = positiveEnv("SIMULATION_MAX_TIMEOUT_MS", 120_000);
+
+/**
+ * Kernel limits handed to the simulator. `RLIMIT_NPROC` is the fork bomb's
+ * ceiling; `RLIMIT_FSIZE` bounds what one `write` can pour onto the scratch
+ * disk, which the output cap does not — that cap governs what is returned,
+ * not what is written.
+ *
+ * Neither is set unless the image sets it, and the image does. They are not
+ * defaulted here on purpose: `RLIMIT_NPROC` counts every process the account
+ * owns, so a number chosen for a container that runs one simulator would
+ * refuse to fork on a developer's machine, where the same account already
+ * owns hundreds. The numbers belong where the account is known, which is the
+ * Dockerfile.
+ */
+const MAX_PROCESSES = optionalPositiveEnv("SIMULATION_MAX_PROCESSES");
+/** `ulimit -f` counts 512-byte blocks in dash and 1 KiB blocks in bash. */
+const MAX_FILE_BLOCKS = optionalPositiveEnv("SIMULATION_MAX_FILE_BLOCKS");
+
+/** Seconds a caller is asked to wait when the single slot is taken. */
+const BUSY_RETRY_AFTER_SECONDS = 2;
+
+/** How long the startup identity probe may take before it is given up on. */
+const PROBE_TIMEOUT_MS = positiveEnv("SIMULATION_PROBE_TIMEOUT_MS", 5_000);
+
+/** The deck, and the only file this harness itself puts in the run directory. */
+const DECK_NAME = "deck.cir";
+const SPICEINIT_NAME = ".spiceinit";
+
+function positiveEnv(name, fallback) {
+  const raw = Number(process.env[name]);
+  return Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : fallback;
+}
+
+/** A limit the image may set and this harness does not invent. */
+function optionalPositiveEnv(name) {
+  if (process.env[name] === undefined) return null;
+  const raw = Number(process.env[name]);
+  return Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : null;
+}
+
+/**
+ * Ask a binary something, with a deadline.
+ *
+ * The deadline is the point. This runs at startup to identify the simulator,
+ * and `/health` and the first run both wait on the answer — so a binary that
+ * does not return from `--version` would leave the container permanently not
+ * ready and permanently unable to say why. An unanswered probe reports
+ * `unreported` and the container gets on with its job.
+ */
 function commandOutput(binary, args) {
   return new Promise((resolve) => {
-    execFile(binary, args, (error, stdout, stderr) => {
-      resolve(error ? "unreported" : `${stdout ?? ""}${stderr ?? ""}`.trim());
-    });
+    execFile(
+      binary,
+      args,
+      {
+        timeout: PROBE_TIMEOUT_MS,
+        killSignal: "SIGKILL",
+        // The identity probe is the simulator too, so it gets the same
+        // constructed environment a run does, and a working directory that is
+        // neither the harness's own nor the scratch root a run is made under.
+        // Measured, not theorised: while these tests were being written, a
+        // stand-in that ignored `--version` wrote its output file into the
+        // repository the harness had been started from.
+        cwd: "/",
+        env: runEnvironment("/nonexistent"),
+      },
+      (error, stdout, stderr) => {
+        resolve(error ? "unreported" : `${stdout ?? ""}${stderr ?? ""}`.trim());
+      },
+    );
   });
 }
 
 function ngspiceVersion(output) {
   const match = output.match(/\bngspice[-\s]+([0-9][A-Za-z0-9.+-]*)/iu);
   return match ? `ngspice-${match[1]}` : "unreported";
+}
+
+async function isExecutable(path) {
+  try {
+    await access(path, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Find the simulator without assuming where the base image put it.
+ *
+ * `NGSPICE_BIN` names it when the image knows; when that path is not there —
+ * which is what a swapped base image looks like from in here (issue #551) —
+ * `ngspice` is looked up on PATH instead. A miss returns the path that was
+ * looked for, so `/health` reports a missing binary rather than this
+ * resolving into something else.
+ */
+async function resolveNgspiceBinary() {
+  const configured = process.env.NGSPICE_BIN ?? "/usr/bin/ngspice";
+  if (await isExecutable(configured)) return configured;
+  const name = configured.includes("/") ? "ngspice" : configured || "ngspice";
+  const search = (process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin").split(
+    ":",
+  );
+  for (const directory of search) {
+    if (directory.length === 0) continue;
+    const candidate = join(directory, name);
+    if (await isExecutable(candidate)) return candidate;
+  }
+  return configured;
 }
 
 async function sha256File(path) {
@@ -63,10 +213,10 @@ async function sha256Tree(root) {
   return hash.digest("hex");
 }
 
-async function observeEnvironment() {
+async function observeEnvironment(ngspiceBin) {
   const [versionOutput, binarySha256, modelTreeSha256] = await Promise.all([
-    commandOutput(NGSPICE_BIN, ["--version"]),
-    sha256File(NGSPICE_BIN),
+    commandOutput(ngspiceBin, ["--version"]),
+    sha256File(ngspiceBin),
     sha256Tree(MODEL_ROOT),
   ]);
   const facts = {
@@ -90,65 +240,324 @@ async function observeEnvironment() {
   };
 }
 
-const environmentPromise = observeEnvironment();
+/**
+ * What this container will and will not do, in the numbers it enforces.
+ * Reported by `/health` and with every run so a deploy check, and a reader of
+ * one result, can see the boundary rather than infer it.
+ */
+const LIMITS = {
+  deckBytes: MAX_DECK_BYTES,
+  outputBytes: MAX_OUTPUT_BYTES,
+  defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+  maxTimeoutMs: MAX_TIMEOUT_MS,
+  maxProcesses: MAX_PROCESSES,
+  maxFileBlocks: MAX_FILE_BLOCKS,
+  concurrentRuns: 1,
+};
+
+const ngspiceBinaryPromise = resolveNgspiceBinary();
+const environmentPromise = ngspiceBinaryPromise.then(observeEnvironment);
 // Keep a missing binary or model tree observable through /health and /run
 // instead of letting Node treat the startup probe as an unhandled rejection.
 environmentPromise.catch(() => undefined);
 
 /**
- * Run ngspice in batch mode over one deck.
+ * One job at a time, held by a flag rather than a queue.
+ *
+ * This is not `max_instances` wearing another hat. That setting bounds how
+ * many containers Cloudflare will run; this bounds how many runs one of them
+ * accepts, and it is the only one of the two that a second request inside an
+ * already-busy container can see. Refusing is the honest answer: two ngspice
+ * processes on one core do not both finish sooner, they both miss their
+ * deadline, and the second caller would rather be told to come back.
+ */
+let busy = false;
+
+function acquireSlot() {
+  if (busy) return false;
+  busy = true;
+  return true;
+}
+
+function releaseSlot() {
+  busy = false;
+}
+
+/**
+ * A capped sink for one of the simulator's two streams.
+ *
+ * Each stream gets its own half of the budget on purpose. ngspice splits its
+ * diagnostics across stdout and stderr — the parse warning that silently
+ * drops a device on one, the fatal error on the other — so a single shared
+ * budget would let a flood of printed values on stdout push the one line that
+ * explains the run out of the answer.
+ */
+function createCappedSink(limit) {
+  const chunks = [];
+  let bytes = 0;
+  let truncated = false;
+  return {
+    write(chunk) {
+      if (bytes >= limit) {
+        truncated = true;
+        return;
+      }
+      const room = limit - bytes;
+      if (chunk.length > room) {
+        chunks.push(chunk.subarray(0, room));
+        bytes = limit;
+        truncated = true;
+        return;
+      }
+      chunks.push(chunk);
+      bytes += chunk.length;
+    },
+    get truncated() {
+      return truncated;
+    },
+    text() {
+      return Buffer.concat(chunks).toString("utf8");
+    },
+  };
+}
+
+/**
+ * The environment the simulator runs in, built rather than inherited.
+ *
+ * `process.env` in a hosted container holds whatever the platform put there,
+ * and a `.control` block can print all of it. Nothing in that set is a
+ * simulator input, so none of it is passed: the child gets a PATH, a HOME and
+ * a TMPDIR that are the run's own directory, and a C locale so numbers parse
+ * the same way whatever the host is set to.
+ */
+function runEnvironment(directory) {
+  return {
+    PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    HOME: directory,
+    TMPDIR: directory,
+    LANG: "C",
+    LC_ALL: "C",
+    TERM: "dumb",
+  };
+}
+
+/**
+ * Start the simulator, under the image's kernel limits when it set any.
+ *
+ * `exec` means the shell is replaced by ngspice rather than sitting above it,
+ * so the pid we hold is the simulator's own and the process group has no
+ * extra member in it. A shell without `ulimit`, or one refusing a limit,
+ * still runs the deck: the limits are a ceiling on a hostile deck, not a
+ * precondition for an honest one.
+ */
+function simulatorCommand(binary) {
+  const preamble = [
+    MAX_FILE_BLOCKS === null
+      ? null
+      : `ulimit -f ${MAX_FILE_BLOCKS} 2>/dev/null || true`,
+    MAX_PROCESSES === null
+      ? null
+      : `ulimit -u ${MAX_PROCESSES} 2>/dev/null || true`,
+  ].filter((clause) => clause !== null);
+  if (preamble.length === 0) {
+    return { command: binary, args: ["-b", DECK_NAME] };
+  }
+  return {
+    command: "/bin/sh",
+    args: [
+      "-c",
+      `${preamble.join("; ")}; exec "$@"`,
+      "sh",
+      binary,
+      "-b",
+      DECK_NAME,
+    ],
+  };
+}
+
+/**
+ * Kill the run's whole process group.
+ *
+ * `detached: true` gives the simulator its own session, so its pid is also
+ * its process-group id and the negative pid reaches everything it started.
+ * Signalling the pid alone was the bug: a deck whose `.control` block shells
+ * out leaves the child running with the pipes still open, so the deadline
+ * expired and the work did not stop.
+ */
+function killProcessGroup(child, signal) {
+  if (typeof child.pid !== "number") return;
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // Already gone; nothing to stop.
+    }
+  }
+}
+
+/**
+ * Run ngspice in batch mode over one deck, inside one directory.
  *
  * `-b` is batch, so the author's own `.control` block drives the run and we
- * add no analysis of our own. Both streams are captured because ngspice
- * splits its diagnostics across them: the parse warning that silently drops a
- * device arrives on one, the fatal error on the other, and the caller needs
- * both to tell a dropped device from a clean run.
+ * add no analysis of our own. The deck is named relatively against the run's
+ * cwd so the temporary path never appears in the log the author reads. Both
+ * streams are captured because ngspice splits its diagnostics across them,
+ * and the caller needs both to tell a dropped device from a clean run.
  */
-function runNgspice(deckPath, timeoutMs) {
+function runNgspice(binary, directory, timeoutMs) {
   return new Promise((resolve) => {
     const startedAt = Date.now();
+    const stdout = createCappedSink(Math.ceil(MAX_OUTPUT_BYTES / 2));
+    const stderr = createCappedSink(Math.floor(MAX_OUTPUT_BYTES / 2));
+    const { command, args } = simulatorCommand(binary);
     let timedOut = false;
-    const child = execFile(
-      NGSPICE_BIN,
-      ["-b", deckPath],
-      {
-        timeout: timeoutMs,
-        maxBuffer: 16 * 1024 * 1024,
-        killSignal: "SIGKILL",
-      },
-      (error, stdout, stderr) => {
-        // execFile reports a timeout as a killed process, which is also what
-        // a crash looks like; the flag set by the timer is what separates
-        // them, because a timeout is an answer and a crash is not.
-        //
-        // A child that died by a signal we did not send (the kernel's OOM
-        // killer, measured on 2026-09-04 while a 1 GiB instance parsed the
-        // Sky130 corner) reports error.code as null, which the first version
-        // of this harness read as exit 0 — a "completed" run with an empty
-        // log. A signal death is a failure, and it says which signal.
-        const signal = error?.signal ?? null;
-        const numericCode = typeof error?.code === "number" ? error.code : null;
-        const exitCode = timedOut
-          ? null
-          : error
-            ? (numericCode ?? (signal ? 128 : 1))
-            : 0;
-        resolve({
-          log: `${stdout ?? ""}${stderr ?? ""}`,
-          exitCode,
-          signal: timedOut ? null : signal,
-          timedOut,
-          durationMs: Date.now() - startedAt,
-        });
-      },
-    );
+    let settled = false;
+    let exited = null;
+    let spawnError = null;
+    let graceTimer = null;
+
+    const child = spawn(command, args, {
+      cwd: directory,
+      env: runEnvironment(directory),
+      // Its own session, so the deadline can reach everything the deck
+      // started and not just the process we launched.
+      detached: true,
+      // No stdin: a batch run has nothing to read, and an inherited one is a
+      // way for a deck to hang forever waiting on it.
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
     const timer = setTimeout(() => {
       timedOut = true;
-      child.kill("SIGKILL");
+      killProcessGroup(child, "SIGKILL");
     }, timeoutMs);
-    child.on("exit", () => clearTimeout(timer));
-    child.on("error", () => clearTimeout(timer));
+
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (graceTimer) clearTimeout(graceTimer);
+      const signal = exited?.signal ?? null;
+      const numericCode = typeof exited?.code === "number" ? exited.code : null;
+      // A child that died by a signal we did not send (the kernel's OOM
+      // killer, measured on 2026-09-04 while a 1 GiB instance parsed the
+      // Sky130 corner) reports no exit code, which the first version of this
+      // harness read as exit 0 — a "completed" run with an empty log. A
+      // signal death is a failure, and it says which signal.
+      const exitCode = timedOut
+        ? null
+        : spawnError
+          ? null
+          : (numericCode ?? (signal ? 128 : 1));
+      resolve({
+        stdout: stdout.text(),
+        stderr: stderr.text(),
+        truncated: stdout.truncated || stderr.truncated,
+        exitCode,
+        signal: timedOut ? null : signal,
+        timedOut,
+        spawnError,
+        durationMs: Date.now() - startedAt,
+      });
+    };
+
+    child.stdout?.on("data", (chunk) => stdout.write(chunk));
+    child.stderr?.on("data", (chunk) => stderr.write(chunk));
+    child.stdout?.on("error", () => {});
+    child.stderr?.on("error", () => {});
+
+    child.on("exit", (code, signal) => {
+      exited = { code, signal };
+      // Reap anything the deck left behind, then stop waiting for the pipes.
+      // A grandchild holding the inherited stdout open is exactly why `close`
+      // alone is not the end of a run.
+      killProcessGroup(child, "SIGKILL");
+      graceTimer = setTimeout(settle, 200);
+      graceTimer.unref?.();
+    });
+    child.on("close", settle);
+    child.on("error", (error) => {
+      spawnError = error;
+      settle();
+    });
   });
+}
+
+/** Whether the deck asked the simulator to write vectors out at all. */
+function deckRequestsRawfile(deck) {
+  for (const raw of deck.split(/\r?\n/u)) {
+    const line = raw.trim();
+    if (line.length === 0 || line.startsWith("*")) continue;
+    if (/^\.save\b/iu.test(line)) return true;
+    if (/(^|\s|;)write(\s|$)/iu.test(line)) return true;
+  }
+  return false;
+}
+
+/**
+ * Read back the rawfile the deck wrote, capped like everything else.
+ *
+ * Not parsed here, deliberately: reading a rawfile into vectors is a contract
+ * with its own tests and its own owner, and a container that half-parses is a
+ * second place for that contract to live. This returns the text and the name
+ * of the file it came from. A binary rawfile is reported by name with no
+ * text rather than as mojibake — ngspice writes ASCII when the run's
+ * `.spiceinit` asks for it, and a deck that overrides that gets a name back
+ * saying so.
+ */
+async function readRawfile(directory) {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch {
+    return { rawfile: null, rawfileName: null, rawfileFormat: null };
+  }
+  const candidates = entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .filter((name) => name !== DECK_NAME && name !== SPICEINIT_NAME)
+    .sort();
+  const preferred =
+    candidates.find((name) => name.toLowerCase().endsWith(".raw")) ??
+    candidates[0];
+  if (!preferred) {
+    return { rawfile: null, rawfileName: null, rawfileFormat: null };
+  }
+
+  let handle;
+  try {
+    handle = await open(join(directory, preferred), "r");
+    // One byte past the cap, so "exactly at the cap" and "cut short" are
+    // distinguishable rather than both looking complete.
+    const buffer = Buffer.alloc(MAX_OUTPUT_BYTES + 1);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    const read = buffer.subarray(0, bytesRead);
+    if (read.includes(0)) {
+      return {
+        rawfile: null,
+        rawfileName: preferred,
+        rawfileFormat: "binary",
+      };
+    }
+    const truncated = bytesRead > MAX_OUTPUT_BYTES;
+    return {
+      rawfile: read.subarray(0, MAX_OUTPUT_BYTES).toString("utf8"),
+      rawfileName: preferred,
+      rawfileFormat: "ascii",
+      truncated,
+    };
+  } catch {
+    return { rawfile: null, rawfileName: null, rawfileFormat: null };
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+}
+
+function resolveTimeoutMs(requested) {
+  if (!Number.isFinite(requested)) return DEFAULT_TIMEOUT_MS;
+  return Math.min(Math.max(Math.trunc(requested), 1), MAX_TIMEOUT_MS);
 }
 
 async function handleRun(body) {
@@ -157,30 +566,84 @@ async function handleRun(body) {
   if (Buffer.byteLength(deck, "utf8") > MAX_DECK_BYTES) {
     return { status: 413, payload: { error: "deck-too-large" } };
   }
-  const timeoutMs = Number.isFinite(body?.timeoutMs)
-    ? Math.max(1, Math.trunc(body.timeoutMs))
-    : 30_000;
+  const timeoutMs = resolveTimeoutMs(body?.timeoutMs);
 
-  const directory = await mkdtemp(join(tmpdir(), "icm-sim-"));
-  const deckPath = join(directory, "deck.cir");
+  if (!acquireSlot()) {
+    return {
+      status: 503,
+      headers: { "retry-after": String(BUSY_RETRY_AFTER_SECONDS) },
+      payload: {
+        error: "simulator-busy",
+        message:
+          "This simulator runs one circuit at a time and is running another one.",
+        retryAfterSeconds: BUSY_RETRY_AFTER_SECONDS,
+      },
+    };
+  }
+
+  // Every run gets its own directory, made fresh and removed whole. It is the
+  // cwd, so a deck's relative file access lands here and nowhere else; it is
+  // HOME, so the `.spiceinit` ngspice reads is the one written below and
+  // never a shared file another run could have left; and it is TMPDIR. The
+  // model tree the deck includes is outside it and read-only.
+  const directory = await mkdtemp(join(RUN_ROOT, "run-"));
   try {
-    await writeFile(deckPath, deck, "utf8");
-    const result = await runNgspice(deckPath, timeoutMs);
+    await writeFile(join(directory, DECK_NAME), deck, "utf8");
+    // ASCII rawfiles, so `write` produces something a reader can read.
+    // ngspice's default is binary; this is the environment's setting, not an
+    // edit to the deck, and the author's own `.control` block overrides it.
+    await writeFile(
+      join(directory, SPICEINIT_NAME),
+      "set filetype=ascii\n",
+      "utf8",
+    );
+
+    const binary = await ngspiceBinaryPromise;
+    const result = await runNgspice(binary, directory, timeoutMs);
+    const raw = deckRequestsRawfile(deck)
+      ? await readRawfile(directory)
+      : { rawfile: null, rawfileName: null, rawfileFormat: null };
+
+    const truncatedOutputs = [
+      ...(result.truncated ? ["log"] : []),
+      ...(raw.truncated ? ["rawfile"] : []),
+    ];
+    const log = `${result.stdout}${result.stderr}${
+      result.truncated
+        ? `\n*** output truncated by the simulation harness at ${MAX_OUTPUT_BYTES} bytes ***\n`
+        : ""
+    }`;
+
     return {
       status: 200,
-      payload: { ...result, environment: await environmentPromise },
+      payload: {
+        log,
+        exitCode: result.exitCode,
+        signal: result.signal,
+        timedOut: result.timedOut,
+        durationMs: result.durationMs,
+        truncated: truncatedOutputs.length > 0,
+        truncatedOutputs,
+        rawfile: raw.rawfile,
+        rawfileName: raw.rawfileName,
+        rawfileFormat: raw.rawfileFormat,
+        limits: { ...LIMITS, timeoutMs },
+        environment: await environmentPromise,
+      },
     };
   } finally {
     // The disk does not survive a sleep, but a woken container serves many
     // runs before sleeping and one author's deck is not another's business.
     await rm(directory, { recursive: true, force: true }).catch(() => {});
+    releaseSlot();
   }
 }
 
 const server = createServer((request, response) => {
-  const send = (status, payload) => {
+  const send = (status, payload, headers = {}) => {
     const body = JSON.stringify(payload);
     response.writeHead(status, {
+      ...headers,
       "content-type": "application/json",
       "content-length": Buffer.byteLength(body),
     });
@@ -188,9 +651,19 @@ const server = createServer((request, response) => {
   };
 
   if (request.method === "GET" && request.url === "/health") {
+    // Answered while a run is in flight, on purpose: a deploy check that can
+    // only ask when the container is idle cannot tell a busy simulator from a
+    // broken one.
     environmentPromise.then(
-      (environment) => send(200, { status: "ready", environment }),
-      (error) => send(503, { status: "not-ready", error: String(error) }),
+      (environment) =>
+        send(200, { status: "ready", busy, limits: LIMITS, environment }),
+      (error) =>
+        send(503, {
+          status: "not-ready",
+          busy,
+          limits: LIMITS,
+          error: String(error),
+        }),
     );
     return;
   }
@@ -219,12 +692,17 @@ const server = createServer((request, response) => {
       return;
     }
     handleRun(body).then(
-      ({ status, payload }) => send(status, payload),
+      ({ status, payload, headers }) => send(status, payload, headers),
       (error) => send(500, { error: String(error) }),
     );
   });
 });
 
+await mkdir(RUN_ROOT, { recursive: true }).catch(() => {});
 server.listen(PORT, () => {
-  console.log(`ngspice harness listening on ${PORT}`);
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : PORT;
+  // The port, not the requested one: the tests ask for an ephemeral port and
+  // read it back from here.
+  console.log(`ngspice harness listening on ${port}`);
 });

--- a/containers/ngspice/entrypoint.test.mjs
+++ b/containers/ngspice/entrypoint.test.mjs
@@ -1,0 +1,415 @@
+// What the container promises about running somebody else's SPICE, asserted
+// against the harness as it actually starts: a real process, a real socket,
+// and a stand-in simulator that misbehaves in the specific ways a hostile or
+// merely runaway deck would. None of these need ngspice, on purpose — the
+// question here is the box around the simulator, not the simulator.
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  realpath,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+const ENTRYPOINT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "entrypoint.mjs",
+);
+
+/** Long enough for a process start plus a deliberate deadline; not a guess. */
+const SLOW_TEST_MS = 30_000;
+
+let workspace;
+let modelRoot;
+const running = [];
+
+beforeAll(async () => {
+  // realpath because macOS hands out /var/folders paths that a child's
+  // getcwd() reports as /private/var, and one of these tests compares the
+  // run directory the simulator saw against the root it was made under.
+  workspace = await realpath(await mkdtemp(join(tmpdir(), "icm-harness-")));
+  // A stand-in for the model tree: the harness hashes whatever is there to
+  // fingerprint the environment, and one file is enough to hash.
+  modelRoot = join(workspace, "models");
+  await mkdir(modelRoot, { recursive: true });
+  await writeFile(join(modelRoot, "sky130.lib.spice"), "* stand-in\n", "utf8");
+});
+
+afterAll(async () => {
+  if (workspace) await rm(workspace, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  while (running.length > 0) running.pop()();
+});
+
+/**
+ * A stand-in simulator. The harness runs it exactly as it runs ngspice —
+ * `-b deck.cir`, in the run's own directory, under the run's own environment —
+ * so a shell script is enough to act out a flood, a fork, or a hang.
+ */
+async function simulator(name, body) {
+  const path = join(workspace, name);
+  // Every stand-in answers the startup identity probe first, as ngspice does.
+  // A simulator that does not return from `--version` is a separate failure
+  // with its own bound in the harness, not the subject of these tests.
+  const probe = `case "$1" in --version) echo 'ngspice-46 stand-in'; exit 0;; esac\n`;
+  await writeFile(path, `#!/bin/sh\n${probe}${body}`, "utf8");
+  await chmod(path, 0o755);
+  return path;
+}
+
+/** Start the harness on an ephemeral port and read the port back from it. */
+async function startHarness(binary, env = {}) {
+  const runRoot = await realpath(await mkdtemp(join(tmpdir(), "icm-runs-")));
+  const child = spawn(process.execPath, [ENTRYPOINT], {
+    env: {
+      PATH: process.env.PATH,
+      PORT: "0",
+      NGSPICE_BIN: binary,
+      SKY130_MODEL_ROOT: modelRoot,
+      SIMULATION_RUN_ROOT: runRoot,
+      // The file-size ceiling is set for every harness under test so the
+      // shell wrapper that applies it is the path being exercised. The
+      // process ceiling is not: RLIMIT_NPROC counts every process this
+      // developer's account owns, and a container-sized number would refuse
+      // to fork here. One test sets it deliberately.
+      SIMULATION_MAX_FILE_BLOCKS: "524288",
+      ...env,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  const stop = () => child.kill("SIGKILL");
+  running.push(stop);
+  const port = await new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`harness did not start: ${output}`)),
+      15_000,
+    );
+    timer.unref();
+    const read = (chunk) => {
+      output += chunk.toString("utf8");
+      const match = output.match(/listening on (\d+)/u);
+      if (!match) return;
+      clearTimeout(timer);
+      resolve(Number(match[1]));
+    };
+    child.stdout.on("data", read);
+    child.stderr.on("data", read);
+    child.once("exit", (code) =>
+      reject(new Error(`harness exited with ${code}: ${output}`)),
+    );
+  });
+  return { port, runRoot, stop };
+}
+
+function run(port, body) {
+  return fetch(`http://127.0.0.1:${port}/run`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function json(response) {
+  return { status: response.status, payload: await response.json() };
+}
+
+const wait = (ms) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms).unref?.();
+  });
+
+describe("the run directory", () => {
+  it("gives every run its own, and takes it away again", async () => {
+    // The simulator reports where it was started. Two runs must not answer
+    // with the same place: a shared working directory is how one author's
+    // deck reads the file another author's deck wrote.
+    const { port, runRoot } = await startHarness(
+      await simulator("pwd.sh", "pwd\n"),
+    );
+
+    const first = await json(await run(port, { deck: "* one\n.end\n" }));
+    const second = await json(await run(port, { deck: "* two\n.end\n" }));
+
+    const firstDirectory = first.payload.log.trim();
+    const secondDirectory = second.payload.log.trim();
+    expect(firstDirectory).not.toBe(secondDirectory);
+    expect(firstDirectory.startsWith(runRoot)).toBe(true);
+    expect(secondDirectory.startsWith(runRoot)).toBe(true);
+    // And nothing of either run is left behind for the next one to find.
+    expect(existsSync(firstDirectory)).toBe(false);
+    expect(existsSync(secondDirectory)).toBe(false);
+  });
+
+  it("hands the simulator an environment it built, not the one it inherited", async () => {
+    const { port } = await startHarness(await simulator("env.sh", "env\n"), {
+      ICM_HARNESS_SENTINEL: "must-not-reach-a-deck",
+    });
+
+    const { payload } = await json(await run(port, { deck: "* env\n.end\n" }));
+
+    // A `.control` block can print its environment. Nothing the platform put
+    // in this process is a simulator input, so none of it is passed on.
+    expect(payload.log).not.toContain("must-not-reach-a-deck");
+    expect(payload.log).toContain("LC_ALL=C");
+    // HOME is the run's own directory, so the `.spiceinit` ngspice reads is
+    // this run's and never a file some earlier run left in a shared home.
+    expect(payload.log).toMatch(/^HOME=.*run-/mu);
+  });
+});
+
+describe("the single slot", () => {
+  it(
+    "refuses a second run while one is in flight, and says when to come back",
+    { timeout: SLOW_TEST_MS },
+    async () => {
+      const release = join(workspace, "release-the-blocker");
+      await rm(release, { force: true });
+      const { port } = await startHarness(
+        await simulator(
+          "blocker.sh",
+          // Bounded, so a failing assertion can never leave a process
+          // spinning after the harness that started it has been stopped.
+          `i=0\n` +
+            `while [ ! -f "${release}" ] && [ $i -lt 200 ]; do\n` +
+            `  sleep 0.1\n` +
+            `  i=$((i+1))\n` +
+            `done\n` +
+            `echo released\n`,
+        ),
+      );
+
+      const first = run(port, {
+        deck: "* blocking\n.end\n",
+        timeoutMs: 20_000,
+      });
+      // Wait for the slot to actually be taken rather than for a duration:
+      // /health answers during a run precisely so this is observable.
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        const health = await (
+          await fetch(`http://127.0.0.1:${port}/health`)
+        ).json();
+        if (health.busy === true) break;
+        await wait(50);
+      }
+
+      const second = await run(port, { deck: "* second\n.end\n" });
+      expect(second.status).toBe(503);
+      expect(second.headers.get("retry-after")).toBe("2");
+      const refusal = await second.json();
+      expect(refusal.error).toBe("simulator-busy");
+
+      await writeFile(release, "", "utf8");
+      const { status, payload } = await json(await first);
+      expect(status).toBe(200);
+      expect(payload.log).toContain("released");
+      expect(payload.timedOut).toBe(false);
+
+      // And the slot comes back: the guard is a slot, not a one-shot fuse.
+      const third = await json(await run(port, { deck: "* third\n.end\n" }));
+      expect(third.status).toBe(200);
+    },
+  );
+});
+
+describe("the deadline", () => {
+  it(
+    "kills the whole process group, not just the process it started",
+    { timeout: SLOW_TEST_MS },
+    async () => {
+      const heartbeat = join(workspace, "grandchild-heartbeat");
+      await rm(heartbeat, { force: true });
+      // A deck whose `.control` block shells out leaves a grandchild behind.
+      // Signalling the simulator's pid alone lets it outlive the deadline it
+      // was started under, still writing, with the container's slot released.
+      const { port } = await startHarness(
+        await simulator(
+          "forker.sh",
+          `{ i=0\n` +
+            `  while [ $i -lt 100 ]; do\n` +
+            `    echo tick >> "${heartbeat}"\n` +
+            `    sleep 0.2\n` +
+            `    i=$((i+1))\n` +
+            `  done; } &\n` +
+            `sleep 30\n`,
+        ),
+      );
+
+      const { payload } = await json(
+        await run(port, { deck: "* forks\n.end\n", timeoutMs: 900 }),
+      );
+      expect(payload.timedOut).toBe(true);
+      expect(payload.exitCode).toBe(null);
+
+      const atDeadline = (await stat(heartbeat)).size;
+      // The grandchild really was running, or this test proves nothing.
+      expect(atDeadline).toBeGreaterThan(0);
+      await wait(1_000);
+      expect((await stat(heartbeat)).size).toBe(atDeadline);
+    },
+  );
+
+  it(
+    "clamps a deadline the caller asked for beyond the ceiling",
+    { timeout: SLOW_TEST_MS },
+    async () => {
+      const { port } = await startHarness(
+        await simulator("sleeper.sh", "sleep 30\n"),
+        { SIMULATION_MAX_TIMEOUT_MS: "1200" },
+      );
+
+      const startedAt = Date.now();
+      const { payload } = await json(
+        await run(port, { deck: "* forever\n.end\n", timeoutMs: 86_400_000 }),
+      );
+
+      expect(payload.timedOut).toBe(true);
+      expect(payload.limits.timeoutMs).toBe(1200);
+      expect(Date.now() - startedAt).toBeLessThan(10_000);
+    },
+  );
+});
+
+describe("the output cap", () => {
+  it("truncates past the cap and says so, rather than shortening quietly", async () => {
+    const { port } = await startHarness(
+      await simulator(
+        "flood.sh",
+        "i=0\n" +
+          "while [ $i -lt 400 ]; do\n" +
+          "  echo 0123456789012345678901234567890123456789\n" +
+          "  i=$((i+1))\n" +
+          "done\n" +
+          "echo 'a diagnosis that must survive the flood' >&2\n",
+      ),
+      { SIMULATION_MAX_OUTPUT_BYTES: "512" },
+    );
+
+    const { payload } = await json(await run(port, { deck: "* loud\n.end\n" }));
+
+    expect(payload.truncated).toBe(true);
+    expect(payload.truncatedOutputs).toContain("log");
+    expect(payload.log).toContain("output truncated by the simulation harness");
+    // The cap, plus the one line that says the cap was reached.
+    expect(payload.log.length).toBeLessThan(700);
+    // Each stream gets its own half of the budget, so a flood on stdout
+    // cannot push the line that explains the run off the end of stderr.
+    expect(payload.log).toContain("a diagnosis that must survive the flood");
+  });
+
+  it("truncates an oversized rawfile and names it in the same breath", async () => {
+    const { port } = await startHarness(
+      await simulator(
+        "bigraw.sh",
+        "i=0\n" +
+          "while [ $i -lt 200 ]; do\n" +
+          "  echo 0123456789012345678901234567890123456789 >> out.raw\n" +
+          "  i=$((i+1))\n" +
+          "done\n" +
+          "echo wrote\n",
+      ),
+      { SIMULATION_MAX_OUTPUT_BYTES: "512" },
+    );
+
+    const { payload } = await json(
+      await run(port, { deck: "* big\n.save v(out)\n.end\n" }),
+    );
+
+    expect(payload.truncated).toBe(true);
+    expect(payload.truncatedOutputs).toContain("rawfile");
+    expect(payload.rawfileName).toBe("out.raw");
+    expect(payload.rawfile.length).toBeLessThanOrEqual(512);
+  });
+});
+
+describe("the rawfile", () => {
+  it("comes back as text when the deck asked for one", async () => {
+    const { port } = await startHarness(
+      await simulator(
+        "writer.sh",
+        "printf 'Title: divider\\nPlotname: op\\nValues:\\n0\\t0.5\\n' > out.raw\n" +
+          "echo analysis done\n",
+      ),
+    );
+
+    const { payload } = await json(
+      await run(port, { deck: "* op\n.save v(out)\n.end\n" }),
+    );
+
+    expect(payload.rawfileName).toBe("out.raw");
+    expect(payload.rawfileFormat).toBe("ascii");
+    expect(payload.rawfile).toContain("Plotname: op");
+    // Read, not parsed: turning vectors into results is a separate contract.
+    expect(payload.truncated).toBe(false);
+  });
+
+  it("stays out of the answer when the deck never asked for one", async () => {
+    const { port } = await startHarness(
+      await simulator("stray.sh", "echo scratch > leftover.txt\necho done\n"),
+    );
+
+    const { payload } = await json(await run(port, { deck: "* op\n.end\n" }));
+
+    expect(payload.rawfile).toBe(null);
+    expect(payload.rawfileName).toBe(null);
+  });
+});
+
+describe("health", () => {
+  it("reports the environment and the limits it enforces", async () => {
+    const { port } = await startHarness(
+      await simulator("v.sh", "echo ngspice-46\n"),
+    );
+
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.status).toBe("ready");
+    expect(payload.busy).toBe(false);
+    expect(payload.limits.concurrentRuns).toBe(1);
+    expect(payload.limits.outputBytes).toBeGreaterThan(0);
+    expect(payload.environment.executor).toBe("hosted-container");
+    expect(payload.environment.simulator.name).toBe("ngspice");
+    expect(payload.environment.fingerprint).toMatch(/^[0-9a-f]{64}$/u);
+  });
+
+  it("refuses to call itself ready when the models are not there", async () => {
+    const { port } = await startHarness(await simulator("v2.sh", "echo hi\n"), {
+      SKY130_MODEL_ROOT: join(workspace, "no-such-model-tree"),
+    });
+
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+
+    expect(response.status).toBe(503);
+    expect((await response.json()).status).toBe("not-ready");
+  });
+});
+
+describe("the kernel limits", () => {
+  it("runs the deck under the limits the image sets", async () => {
+    const { port } = await startHarness(
+      await simulator("limits.sh", "ulimit -f\necho ran\n"),
+      { SIMULATION_MAX_PROCESSES: "4096", SIMULATION_MAX_FILE_BLOCKS: "1024" },
+    );
+
+    const { payload } = await json(
+      await run(port, { deck: "* limited\n.end\n" }),
+    );
+
+    expect(payload.log).toContain("ran");
+    expect(payload.log).toContain("1024");
+    expect(payload.limits.maxFileBlocks).toBe(1024);
+    expect(payload.limits.maxProcesses).toBe(4096);
+  });
+});

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -2,7 +2,8 @@
 
 Status: accepted
 
-Owners: `packages/spice-run`, `apps/local-host`, `worker`
+Owners: `packages/spice-run`, `apps/local-host`, `worker`,
+`containers/ngspice`
 
 Related decision: [ADR 0055](../adr/0055-simulation-is-part-of-the-product.md)
 
@@ -251,6 +252,101 @@ minimums before either is offered to the public:
 - `GET /health` reports the observed environment facts of the metadata
   envelope so a deployment can be verified without running a circuit.
 
+### How the hosted container meets it
+
+The numbers below belong to `containers/ngspice` and are enforced there,
+independently of anything the Worker in front of it checked. The Worker's
+request shape is unchanged by any of it; the response fields are additive.
+None of it depends on which base image is pinned: the base is a build
+argument and its digest is the environment lock.
+
+**Account and filesystem.** The harness and the simulator run as uid 10001.
+The simulator, the model tree, and the harness are not writable by that
+account — the harness is stripped of every write bit at build time, while the
+base image's own trees are corrected only where a file is group- or
+other-writable, because a recursive `chmod` over gigabytes of models would
+double the image for a tree that is already root-owned. That the property
+holds is asserted, not assumed: the container workflow tries to write each
+path as the run account and requires failure.
+
+Each run gets a private directory, made immediately before it and removed
+whole immediately after it however it ended. That directory is the
+simulator's working directory, its `HOME`, and its `TMPDIR`, and it is the
+only writable location the simulator is given, so one author's deck can
+neither read nor overwrite what another's wrote. The deck is written there as
+`deck.cir` and named relatively, so no host path appears in the log the
+author reads.
+
+**Environment.** The simulator's environment is constructed, not inherited:
+`PATH`, `HOME`, `TMPDIR`, `TERM`, and a `C` locale, and nothing else. A
+`.control` block can print its environment, and nothing the hosting platform
+placed in the harness's own is a simulator input. The identity probe that
+names the simulator at startup runs under the same environment, and under a
+five-second deadline — `/health` and the first run both wait on its answer,
+so a binary that never returns from `--version` would otherwise leave the
+container permanently not-ready and unable to say why.
+
+The run's directory holds a `.spiceinit` containing `set filetype=ascii`, so
+`write` produces the ASCII rawfile that [Result data](#result-data) is read
+from.
+That is an environment setting, not an edit to the deck: the author's own
+`.control` block overrides it, and the deck's text is never modified.
+
+**Deadline.** The simulator is started in its own session and the deadline
+signals the whole process group. A deck whose `.control` block shells out
+otherwise leaves a child running past the deadline it was started under,
+still writing, with the container's slot already given to the next caller.
+
+**Limits.**
+
+| Limit | Value | Enforced by |
+| --- | --- | --- |
+| Deck size | 2 MiB | rejected `413 deck-too-large` |
+| Request body | 4 MiB | connection closed, `413 request-too-large` |
+| Returned output | 1 MiB per run | truncation, reported |
+| Default deadline | 30 s | applied when the caller names none |
+| Maximum deadline | 120 s | a longer request is clamped to it |
+| Identity probe | 5 s | given up on, not waited for |
+| Processes | 128 (`RLIMIT_NPROC`) | image-set `ulimit` before `exec` |
+| Written file size | 256 MiB (`RLIMIT_FSIZE`) | image-set `ulimit` before `exec` |
+
+The returned-output cap is divided between the simulator's two streams, so a
+flood of printed values on one cannot push the single line that explains the
+run off the end of the other. The two kernel limits are set by the image
+rather than defaulted by the harness, because `RLIMIT_NPROC` counts every
+process the account owns and a number chosen for a container that runs one
+simulator is wrong anywhere else.
+
+**Added response fields.** A consumer that does not read these is unaffected.
+
+```ts
+interface ContainerRunResponse {
+  /** Capped; carries a one-line notice in the text when it was cut. */
+  log: string;
+  /** True when the log or the rawfile reached the cap. */
+  truncated: boolean;
+  truncatedOutputs: ("log" | "rawfile")[];
+  /** The rawfile's text when the deck asked for one and it is ASCII. */
+  rawfile: string | null;
+  rawfileName: string | null;
+  rawfileFormat: "ascii" | "binary" | null;
+  /** The limits above, with the deadline this run actually got. */
+  limits: Record<string, number | null>;
+}
+```
+
+A truncated result says so rather than arriving quietly shortened, because a
+shortened log read as a whole one is a wrong answer about a circuit. The
+rawfile is returned when the deck contains `.save` or `write`, verbatim and
+under the same cap; turning its vectors into numbers is
+[Result data](#result-data) and is not done here.
+
+**Readiness.** `GET /health` answers during a run as well as between runs,
+reporting the environment facts, the limits, and whether the slot is taken. A
+check that can only ask when the container is idle cannot tell a busy
+simulator from a broken one. A missing simulator binary or model tree answers
+`503 not-ready` rather than a success with absent facts.
+
 ## Run lifecycle
 
 The service exposes `prepare`, `start`, `read`, `cancel`, and `export`.
@@ -452,5 +548,17 @@ release. A deployment without the binding answers
   `analog-arena`, exported by this product and simulated against the
   reference netlist under one testbench, agreeing on node voltages, gain,
   and unity-gain bandwidth.
+- `containers/ngspice/entrypoint.test.mjs` starts the harness as a real
+  process and asserts the execution boundary against stand-in simulators
+  that misbehave deliberately: a private directory per run that is removed
+  afterwards, a constructed environment, the single slot's `503` and
+  `Retry-After`, a deadline that kills a forked grandchild, the clamped
+  deadline ceiling, output and rawfile truncation, and readiness.
+- `.github/workflows/container.yml` builds the image on every pull request
+  that touches it and asks the built image itself: that it runs as the
+  unprivileged account, that the simulator, models, and harness refuse that
+  account's writes, that the pinned base still carries the continuous
+  library, that a resistor divider comes back with its operating point and
+  its rawfile, and that a second concurrent run is refused.
 - The preview deploy simulates one circuit through the real container on
   every merge.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,9 @@ export default defineConfig({
     },
     include: [
       "apps/**/*.test.{ts,tsx}",
+      // The simulation container's harness: plain Node, no bundler, and its
+      // own tests beside it for the same reason scripts/ has them.
+      "containers/**/*.test.mjs",
       "worker/**/*.test.ts",
       "packages/**/*.test.{ts,tsx}",
       "scripts/**/*.test.mjs",


### PR DESCRIPTION
## What

Hardens the ngspice simulation container's execution environment — the minimums `docs/specs/simulation.md` froze for the first release, implemented and asserted.

The container is where somebody else's SPICE executes, and the contract permits raw `.control` on the grounds that *isolation, not prohibition* keeps a control script inside its own job. There was no isolation: it ran as root, with no per-run working directory, an inherited environment, no concurrency guard, and a deadline that signalled one pid — so an ngspice that forked outlived the deadline it was started under, still writing, with the container's slot already given to the next caller.

**The image:** an unprivileged account (uid 10001); the harness stripped of every write bit; `RLIMIT_NPROC` and `RLIMIT_FSIZE` set by the image rather than defaulted by the harness, because `RLIMIT_NPROC` counts every process the account owns and a container-sized number would refuse to fork anywhere else.

The base image's own trees are handled differently on purpose: `/opt/sky130` and `/opt/ngspice` are gigabytes and already root-owned, so `chmod -R` would copy every file into a new layer and double the image to change nothing. Only files that are actually group- or other-writable are corrected. The property is then **asserted rather than assumed** — the new workflow tries to write each path as the run account and requires failure.

**The harness:** a private directory per run — cwd, `HOME` and `TMPDIR`, removed whole afterwards; a constructed environment, not an inherited one; a deadline that signals the whole process group; one run at a time, answering a second with `503` and `Retry-After`; and a cap on every returned byte, reported as `truncated`/`truncatedOutputs` with a notice in the log, never a quietly shortened result.

The single slot is **not** `max_instances` wearing another hat — that bounds how many containers exist, this bounds how many runs one container accepts, and only this one is visible to a second request inside an already-running container.

## Two defects found while writing the tests

- The startup identity probe had no timeout. A binary that does not return from `--version` left the container permanently not-ready and unable to say why — `/health` and the first run both wait on that answer.
- The probe inherited the harness's working directory, so a misbehaving simulator wrote its output file into the directory the harness was started from. It now runs under the same constructed environment as a deck, from a directory that is neither the harness's nor the scratch root.

## For the rawfile results the spec reads numbers from

A deck containing `.save` or `write` gets the ASCII rawfile text back as `rawfile`, under the same cap and **unparsed** — reading vectors out of it is the result-data contract, not this one. The run's `.spiceinit` sets `filetype=ascii` so `write` produces something readable at all; that is an environment setting, not an edit to the deck, and the author's `.control` block overrides it.

`worker/simulation.ts` is untouched. Every new response field is additive and optional.

## Rebased mid-flight

This was written against the slim Debian image and rebased onto #570's benchmark base, which landed while it was in progress and answered #551. Nothing here depends on that answer: the base is a build argument pinned by digest, and every statement in the execution-boundary section holds whichever image it names. The models-staging build arguments the earlier version carried are gone along with the staging stage they parameterised.

## Two deliberate steps outside the owned files

- `vitest.config.ts` includes `containers/**/*.test.mjs`, or the new tests never run in `pnpm test` and the coverage claim is empty.
- `.github/workflows/container.yml` is new. **Nothing in CI built this image**: the preview deploy builds it on push to `main`, which is after a merge, so a broken Dockerfile took the preview channel down rather than failing a review.

## Validation

`containers/ngspice/entrypoint.test.mjs` — 12 tests, starting the harness as a real process against stand-in simulators that misbehave deliberately. The two named exit-condition behaviours were **mutation-checked**, not assumed: replacing the group kill with a single-pid kill leaves the forked grandchild writing and fails the deadline test; disabling the busy flag fails the single-slot test.

The new CI job is the judge of the image, and it has run green on this branch:

```
{"status":"ready","busy":false,"limits":{"deckBytes":2097152,"outputBytes":1048576,
 "defaultTimeoutMs":30000,"maxTimeoutMs":120000,"maxProcesses":128,
 "maxFileBlocks":524288,"concurrentRuns":1}, ... "version":"ngspice-46" ...}
simulator: ngspice-46
v(out) = 5.000000e-01
rawfile: out.raw 326 bytes
{"error":"simulator-busy","message":"This simulator runs one circuit at a time
 and is running another one.","retryAfterSeconds":2}
```

## Review note, not fixed here

`docs/specs/simulation.md` still opens with "This contract covers deck assembly and model-library selection… It does not define result parsing", which the **Result data** section added by #559 contradicts. That is that target's Scope paragraph to correct, not this one's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
