### PR TITLE
fix(simulation): a run whose measurements came back is not a failure

### DIFF
--- a/apps/local-host/src/simulate.ts
+++ b/apps/local-host/src/simulate.ts
@@ -18,10 +18,9 @@ import { isAbsolute, join, resolve } from "node:path";
 
 import {
   buildSimulationDeck,
-  classifySimulationOutcome,
   createSimulationEnvironmentMetadata,
   createSimulationInputMetadata,
-  readNgspiceDiagnostics,
+  readNgspiceRun,
   resolveTimeoutMs,
   simulationConfigurationMetadata,
   type ModelLibrarySelection,
@@ -56,6 +55,7 @@ function runProcess(
 ): Promise<{
   log: string;
   exitCode: number | null;
+  signal: string | null;
   timedOut: boolean;
   durationMs: number;
   spawnError: Error | null;
@@ -91,6 +91,10 @@ function runProcess(
               : error
                 ? 1
                 : 0,
+          // A run the kernel killed is a fragment, not an answer, and the
+          // hosted surface already says so; ADR 0055 keeps the two surfaces
+          // behind one result shape, so this one reports it too.
+          signal: timedOut ? null : (error?.signal ?? null),
           timedOut,
           durationMs: Date.now() - startedAt,
           spawnError,
@@ -185,15 +189,17 @@ export async function simulateLocally(
         message: `No simulator at "${binary}". Install ngspice, or set NGSPICE_BIN to its path.`,
       };
     }
-    const diagnostics = readNgspiceDiagnostics(run.log);
+    const { outcome, diagnostics } = readNgspiceRun({
+      log: run.log,
+      exitCode: run.exitCode,
+      signal: run.signal,
+      timedOut: run.timedOut,
+      timeoutMs,
+    });
     return {
       kind: "ran",
       result: {
-        outcome: classifySimulationOutcome(diagnostics, {
-          timedOut: run.timedOut,
-          timeoutMs,
-          exitCode: run.exitCode,
-        }),
+        outcome,
         diagnostics,
         log: run.log,
         durationMs: run.durationMs,

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -154,8 +154,14 @@ into the Project, undo history, Gallery, or recovery copy.
   emission, quoted paths, verbatim testbench preservation, and rejected deck
   injection.
 - `worker/simulation.test.ts` verifies the hosted Sky130 `tt` default,
-  deployment overrides, configuration-error classification, and the verified
-  run metadata envelope.
+  deployment overrides, configuration-error classification, the verified
+  run metadata envelope, that a `.control` testbench whose measurements came
+  back is not reported as failed whatever the exit status, and that no failed
+  response is returned without a diagnostic.
+- `packages/spice-run/src/index.test.ts` verifies the outcome table above
+  against captured ngspice output, including the ngspice-39 `.control` shape
+  of issue #568, a deck no analysis ran on, and a sweep over logs, exit
+  statuses, and signals asserting that no failure is ever returned bare.
 - The pinned local authority pack under ignored `.reference-src/` demonstrates
   that ngspice 47 completes a Sky130 NFET operating-point deck with
   `.lib ... tt`, while top-level `.include` produces repeated subcircuit
@@ -239,6 +245,55 @@ result and may wait briefly; `cancel` terminates the process and frees the
 slot. A run id is bound to the session or Project owner that started it.
 There is no run history store: a receipt that outlives the runner's memory
 reads as lost, and a lost run is never silently rerun.
+
+## Run outcome
+
+A finished simulator process is classified from what ngspice said and what it
+produced. The process exit status is never on its own a verdict:
+
+- **Exit status zero is not evidence that results exist.** A deck whose
+  resistor line is malformed exits zero while discarding the device and
+  solving what remains.
+- **A non-zero exit status is not evidence that they do not.** ngspice 39
+  ends a batch pass over an author's `.control` block by printing
+  `Note: No ".plot", ".print", or ".fourier" lines; no simulations run` and
+  exiting non-zero — after that block has already run every analysis and
+  printed every value asked for. Failing on that status reported correct
+  simulations as failed for every `.control` testbench (issue #568), and a
+  `.control` block is both what the ngspice documentation tells an author to
+  write and what ADR 0055 leaves in the author's hands.
+
+Success is therefore decided by whether the requested measurements came back,
+not by the absence of any particular note. A run produced results when ngspice
+reported an analysis producing data rows, or printed a value for a name. That
+evidence is read from console text for classification only; the numbers
+themselves still come from the ASCII rawfile and never from the log.
+
+The classification is:
+
+| condition                          | outcome                        |
+| ---------------------------------- | ------------------------------ |
+| the ceiling terminated it          | `timed-out`                    |
+| a diagnostic of severity `error`   | `failed`                       |
+| no analysis produced results       | `failed`                       |
+| ngspice discarded part of the deck | `completed-with-dropped-input` |
+| otherwise                          | `completed`                    |
+
+A signal killed the process is a failure even when values were already
+printed, because what came back is a fragment of the answer rather than the
+answer. So is an empty log: a batch run always prints at least its banner.
+
+**A failed outcome always carries at least one diagnostic.** `status: "failed"`
+beside an empty `diagnostics` array leaves the author with nothing to act on
+and the next debugger with no thread to pull, whatever the cause. Where
+ngspice explains itself, its own words are kept unedited; where it does not,
+the harness states the fact it does have — the signal that killed the run,
+that no analysis produced results and the status it exited with, or, if it
+can say nothing else, that the run was classified as failed without a
+reason, which is itself the finding to report.
+
+Both execution surfaces classify through the same reader in `@icm/spice-run`,
+so a container run and a local run cannot drift apart on this.
 
 ## Result data
 

--- a/packages/spice-run/src/index.test.ts
+++ b/packages/spice-run/src/index.test.ts
@@ -3,16 +3,19 @@ import { describe, expect, it } from "vitest";
 import {
   buildSimulationDeck,
   deckNeedsModelLibrary,
-  classifySimulationOutcome,
   createSimulationEnvironmentMetadata,
   createSimulationInputMetadata,
   DEFAULT_SIMULATION_TIMEOUT_MS,
   isSimulationEnvironmentMetadata,
   MAX_SIMULATION_TIMEOUT_MS,
   readNgspiceDiagnostics,
+  readNgspiceRun,
+  readNgspiceRunEvidence,
   resolveTimeoutMs,
   simulationConfigurationMetadata,
   verifySimulationEnvironmentMetadata,
+  type NgspiceProcessResult,
+  type NgspiceRunReading,
 } from "./index.js";
 
 /**
@@ -61,6 +64,104 @@ v(out) = 5.000000e-01
 Note: Simulation executed from .control section
 `;
 
+/**
+ * Captured from ngspice 46 on 2026-09-04 by running the deck this repository
+ * builds. `op` and `print` are inside the author's `.control` block, which is
+ * what ADR 0055 means by "the testbench is the author's" and what the ngspice
+ * documentation tells an author to write. Exit status 0, and no note.
+ */
+const CONTROL_BLOCK_OUTPUT = `
+Note: No compatibility mode selected!
+
+
+Circuit: * analog canvas simulation deck
+
+Doing analysis at TEMP = 27.000000 and TNOM = 27.000000
+
+Using SPARSE 1.3 as Direct Linear Solver
+
+No. of Data Rows : 1
+v(mid) = 5.000000e-01
+Note: Simulation executed from .control section
+`;
+
+/**
+ * The same run through the preview container, whose ngspice is 39 (issue
+ * #568). The control block ran every analysis and printed every value asked
+ * for; ngspice's batch pass then noted, for its own reasons, that the deck
+ * carried no `.plot`/`.print`/`.fourier` card and exited non-zero.
+ *
+ * The banner lines are the measured ngspice-46 run above; the closing note
+ * and the values are quoted from the issue's recorded ngspice-39 responses.
+ */
+const NGSPICE_39_CONTROL_BLOCK_OUTPUT = `
+Note: No compatibility mode selected!
+
+
+Circuit: * analog canvas simulation deck
+
+Doing analysis at TEMP = 27.000000 and TNOM = 27.000000
+
+No. of Data Rows : 1
+v(vout)       = 7.661889e-01
+v(ibias)      = 6.018893e-01
+v(xdut.tail)  = 2.907461e-01
+v(xdut.nleft) = 7.661889e-01
+gain_db       = 4.183501e+01
+ugb           = 3.302606e+07
+Note: Simulation executed from .control section
+
+Note: No ".plot", ".print", or ".fourier" lines; no simulations run
+`;
+
+/**
+ * Captured from ngspice 46 on 2026-09-04: a deck with a circuit and no
+ * analysis at all. Nothing was solved and no vector exists, and ngspice says
+ * so in as many words before exiting 1.
+ */
+const NO_ANALYSIS_OUTPUT = `
+Error: incomplete or empty netlist
+       or no ".plot", ".print", or ".fourier" lines in batch mode;
+no simulations run!
+
+Note: No compatibility mode selected!
+
+
+Circuit: * analog canvas simulation deck
+
+`;
+
+/**
+ * Captured from ngspice 46 on 2026-09-04: an `op` inside a `.control` block
+ * with no `print`. The author asked for no value, but the analysis ran and
+ * ngspice counted its rows, so the run produced a result.
+ */
+const CONTROL_BLOCK_NO_PRINT_OUTPUT = `
+Note: No compatibility mode selected!
+
+
+Circuit: * analog canvas simulation deck
+
+Doing analysis at TEMP = 27.000000 and TNOM = 27.000000
+
+No. of Data Rows : 1
+Note: Simulation executed from .control section
+`;
+
+function read(
+  log: string,
+  overrides: Partial<NgspiceProcessResult> = {},
+): NgspiceRunReading {
+  return readNgspiceRun({
+    log,
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    timeoutMs: 30_000,
+    ...overrides,
+  });
+}
+
 describe("ngspice output reading", () => {
   it("never calls a run clean when ngspice discarded part of the deck", () => {
     const diagnostics = readNgspiceDiagnostics(DROPPED_RESISTOR_OUTPUT);
@@ -72,54 +173,200 @@ describe("ngspice output reading", () => {
 
     // The measured trap: ngspice exits 0 here. Reading the status alone would
     // report success for a circuit missing a resistor.
-    expect(
-      classifySimulationOutcome(diagnostics, {
-        timedOut: false,
-        timeoutMs: 30_000,
-        exitCode: 0,
-      }),
-    ).toEqual({ status: "completed-with-dropped-input" });
+    expect(read(DROPPED_RESISTOR_OUTPUT).outcome).toEqual({
+      status: "completed-with-dropped-input",
+    });
   });
 
   it("keeps ngspice's own words for a missing model", () => {
-    const diagnostics = readNgspiceDiagnostics(MISSING_MODEL_OUTPUT);
+    const { outcome, diagnostics } = read(MISSING_MODEL_OUTPUT, {
+      exitCode: 1,
+    });
     expect(diagnostics.map((diagnostic) => diagnostic.text)).toContain(
       "could not find a valid modelname",
     );
     expect(
       diagnostics.some((diagnostic) => diagnostic.severity === "error"),
     ).toBe(true);
-    expect(
-      classifySimulationOutcome(diagnostics, {
-        timedOut: false,
-        timeoutMs: 30_000,
-        exitCode: 1,
-      }),
-    ).toEqual({ status: "failed" });
+    expect(outcome).toEqual({ status: "failed" });
   });
 
   it("reports a clean run as clean", () => {
-    const diagnostics = readNgspiceDiagnostics(CLEAN_OUTPUT);
-    expect(diagnostics).toEqual([]);
-    expect(
-      classifySimulationOutcome(diagnostics, {
-        timedOut: false,
-        timeoutMs: 30_000,
-        exitCode: 0,
-      }),
-    ).toEqual({ status: "completed" });
+    expect(read(CLEAN_OUTPUT)).toEqual({
+      outcome: { status: "completed" },
+      diagnostics: [],
+    });
   });
 
   it("says a timeout is a timeout, not a broken circuit", () => {
     // A long analysis and a wrong circuit look identical from the outside;
     // the author is told which one happened.
     expect(
-      classifySimulationOutcome(readNgspiceDiagnostics(CLEAN_OUTPUT), {
-        timedOut: true,
-        timeoutMs: 30_000,
-        exitCode: null,
-      }),
+      read(CLEAN_OUTPUT, { timedOut: true, exitCode: null }).outcome,
     ).toEqual({ status: "timed-out", timeoutMs: 30_000 });
+  });
+});
+
+describe("what a run produced", () => {
+  it("counts a printed value and an analysis, and ignores ngspice's prose", () => {
+    const evidence = readNgspiceRunEvidence(CONTROL_BLOCK_OUTPUT);
+    expect(evidence.printedValueNames).toEqual(["v(mid)"]);
+    expect(evidence.analysisDataRows).toEqual([1]);
+    expect(evidence.producedResults).toBe(true);
+
+    // ngspice's own chatter contains `=` and a number on several lines. None
+    // of it is a value the author asked for, and none of it may stand in for
+    // one, or a run that measured nothing would look like a run that did.
+    const chatter = readNgspiceRunEvidence(
+      [
+        "Doing analysis at TEMP = 27.000000 and TNOM = 27.000000",
+        "Total analysis time (seconds) = 0.000642",
+        "Total DRAM available = 16384.000 MB.",
+        "DRAM currently available =  155.172 MB.",
+        "Maximum ngspice program size =    9.844 MB.",
+        "No. of Data Rows : 0",
+      ].join("\n"),
+    );
+    expect(chatter.printedValueNames).toEqual([]);
+    expect(chatter.analysisDataRows).toEqual([]);
+    expect(chatter.producedResults).toBe(false);
+  });
+
+  it("counts an analysis that ran without the author printing anything", () => {
+    // `op` with no `print`: no value was requested, but a vector exists.
+    const evidence = readNgspiceRunEvidence(CONTROL_BLOCK_NO_PRINT_OUTPUT);
+    expect(evidence.printedValueNames).toEqual([]);
+    expect(evidence.producedResults).toBe(true);
+    expect(read(CONTROL_BLOCK_NO_PRINT_OUTPUT).outcome).toEqual({
+      status: "completed",
+    });
+  });
+});
+
+describe("a run whose measurements came back is not a failure", () => {
+  it("completes a `.control` testbench that ngspice 39 exited non-zero on", () => {
+    // Issue #568. The container simulated a five-transistor sky130 OTA and
+    // got exactly the right answer; the service reported `failed` with an
+    // empty `diagnostics` array, because the only thing consulted was the
+    // exit status. ngspice 39 ends a batch pass over a `.control` deck with
+    // a note about the `.print` cards it did not find, and exits non-zero,
+    // after the control block has already run and printed.
+    const { outcome, diagnostics } = read(NGSPICE_39_CONTROL_BLOCK_OUTPUT, {
+      exitCode: 1,
+    });
+    expect(outcome).toEqual({ status: "completed" });
+    expect(diagnostics).toEqual([]);
+
+    // The measurements the author asked for are the reason it completed.
+    const evidence = readNgspiceRunEvidence(NGSPICE_39_CONTROL_BLOCK_OUTPUT);
+    expect(evidence.printedValueNames).toEqual([
+      "v(vout)",
+      "v(ibias)",
+      "v(xdut.tail)",
+      "v(xdut.nleft)",
+      "gain_db",
+      "ugb",
+    ]);
+  });
+
+  it("does not decide success from that note's absence either", () => {
+    // The note is ngspice 39's wording. A simulator that prints a different
+    // one, or none, must not change the verdict: results decide it. Same
+    // deck, same values, note removed, still non-zero.
+    const withoutNote = NGSPICE_39_CONTROL_BLOCK_OUTPUT.replace(
+      /^Note: No "\.plot".*$/mu,
+      "",
+    );
+    expect(withoutNote).not.toContain('No ".plot"');
+    expect(read(withoutNote, { exitCode: 1 }).outcome).toEqual({
+      status: "completed",
+    });
+  });
+});
+
+describe("a run that produced nothing is a failure that says so", () => {
+  it("fails a deck no analysis ran on", () => {
+    // Measured ngspice 46: a circuit with no analysis. No vector exists, so
+    // there is nothing to report however the process exited.
+    const { outcome, diagnostics } = read(NO_ANALYSIS_OUTPUT, { exitCode: 1 });
+    expect(readNgspiceRunEvidence(NO_ANALYSIS_OUTPUT).producedResults).toBe(
+      false,
+    );
+    expect(outcome).toEqual({ status: "failed" });
+    expect(diagnostics.map((diagnostic) => diagnostic.text)).toContain(
+      "Error: incomplete or empty netlist",
+    );
+    expect(
+      diagnostics.some((diagnostic) =>
+        /no analysis results/iu.test(diagnostic.text),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps a silent or signal-killed run a failure (#566)", () => {
+    const silent = read("", { exitCode: 0 });
+    expect(silent.outcome).toEqual({ status: "failed" });
+    expect(silent.diagnostics[0]!.text).toContain("no output");
+
+    const killed = read("", { exitCode: 128, signal: "SIGKILL" });
+    expect(killed.outcome).toEqual({ status: "failed" });
+    expect(killed.diagnostics[0]!.text).toContain("SIGKILL");
+
+    // A kill that lands after some values were printed is still a kill: what
+    // came back is a fragment of the answer, not the answer.
+    const cutOff = read(CONTROL_BLOCK_OUTPUT, {
+      exitCode: 128,
+      signal: "SIGKILL",
+    });
+    expect(cutOff.outcome).toEqual({ status: "failed" });
+    expect(cutOff.diagnostics[0]!.text).toContain("SIGKILL");
+  });
+
+  it("never reports a failure without a diagnostic", () => {
+    // The half of #568 that has nothing to do with which ngspice is running:
+    // `status: "failed"` beside `diagnostics: []` gives the author nothing to
+    // act on and the next debugger no thread to pull. Whatever a process does,
+    // a failed verdict comes with at least one line explaining it.
+    const logs = [
+      "",
+      "   \n  \n",
+      CLEAN_OUTPUT,
+      CONTROL_BLOCK_OUTPUT,
+      CONTROL_BLOCK_NO_PRINT_OUTPUT,
+      NGSPICE_39_CONTROL_BLOCK_OUTPUT,
+      NO_ANALYSIS_OUTPUT,
+      MISSING_MODEL_OUTPUT,
+      DROPPED_RESISTOR_OUTPUT,
+      "ngspice said something nobody has a pattern for yet",
+    ];
+    const exitCodes = [0, 1, 2, 128, null];
+    const signals = [null, "SIGKILL", "SIGSEGV"];
+
+    let failures = 0;
+    for (const log of logs) {
+      for (const exitCode of exitCodes) {
+        for (const signal of signals) {
+          for (const timedOut of [false, true]) {
+            const { outcome, diagnostics } = read(log, {
+              exitCode,
+              signal,
+              timedOut,
+            });
+            if (outcome.status !== "failed") continue;
+            failures += 1;
+            expect(
+              diagnostics.length,
+              `failed with no diagnostic: exit ${String(exitCode)}, signal ${String(signal)}, log ${JSON.stringify(log.slice(0, 40))}`,
+            ).toBeGreaterThanOrEqual(1);
+            expect(
+              diagnostics.some((diagnostic) => diagnostic.severity === "error"),
+            ).toBe(true);
+          }
+        }
+      }
+    }
+    // The sweep has to actually reach the failed branch to prove anything.
+    expect(failures).toBeGreaterThan(0);
   });
 });
 

--- a/packages/spice-run/src/index.ts
+++ b/packages/spice-run/src/index.ts
@@ -96,9 +96,12 @@ export function isSimulationInputRevision(
 }
 
 /**
- * One line ngspice said about the run. `severity` is our reading of it; `text`
- * is always ngspice's own, unedited, because a designer reads the original and
- * a paraphrase would lose the node names and line numbers that make it useful.
+ * One line about the run. `severity` is our reading of it; `text` is ngspice's
+ * own and unedited whenever ngspice said it, because a designer reads the
+ * original and a paraphrase would lose the node names and line numbers that
+ * make it useful. The harness writes a line itself only to state something
+ * ngspice did not: that the process was killed, or that it returned no
+ * results at all.
  */
 export interface SimulationDiagnostic {
   severity: "error" | "warning" | "info";
@@ -121,7 +124,10 @@ export type SimulationOutcome =
    * plain success.
    */
   | { status: "completed-with-dropped-input" }
-  /** ngspice refused the deck or stopped partway. */
+  /**
+   * ngspice refused the deck, stopped partway, or returned no results. Always
+   * accompanied by at least one diagnostic saying which; see readNgspiceRun.
+   */
   | { status: "failed" }
   /** We stopped ngspice at the ceiling. Says so in as many words. */
   | { status: "timed-out"; timeoutMs: number };
@@ -385,24 +391,162 @@ export function readNgspiceDiagnostics(output: string): SimulationDiagnostic[] {
 }
 
 /**
- * The outcome, from the diagnostics rather than the exit status — except for
- * a timeout, which only the caller can know about.
+ * `name = number`, which is how ngspice reports a scalar the author asked
+ * for — `print v(out)` and `meas ac gain_db ...` both land here. The name
+ * must be a single token ending at the `=`, which is what separates a
+ * requested value from ngspice's own prose: "Doing analysis at TEMP =
+ * 27.000000" and "Total DRAM available = 16384.000 MB." have a word boundary
+ * before the `=` and never match.
  */
-export function classifySimulationOutcome(
+const PRINTED_VALUE_PATTERN = /^\s*([A-Za-z_][^\s=]*)\s*=\s*[+-]?(?:\d|\.\d)/u;
+
+/** ngspice's own count of what an analysis produced, one line per plot. */
+const DATA_ROWS_PATTERN = /^\s*no\.\s*of\s*data\s*rows\s*:\s*(\d+)/iu;
+
+/**
+ * What a run produced, in ngspice's own report of it.
+ *
+ * This is evidence that vectors exist, never the numbers themselves: the
+ * simulation spec reads results from the ASCII rawfile and never from console
+ * text, so only names and counts are collected here.
+ */
+export interface SimulationRunEvidence {
+  /** Names ngspice printed a value for. The value itself is not read. */
+  readonly printedValueNames: readonly string[];
+  /** Row counts ngspice reported, one entry per analysis that produced data. */
+  readonly analysisDataRows: readonly number[];
+  /** True when ngspice said at least one analysis produced something. */
+  readonly producedResults: boolean;
+}
+
+export function readNgspiceRunEvidence(output: string): SimulationRunEvidence {
+  const printedValueNames: string[] = [];
+  const analysisDataRows: number[] = [];
+  for (const line of output.split(/\r?\n/u)) {
+    const rows = DATA_ROWS_PATTERN.exec(line);
+    if (rows) {
+      const count = Number(rows[1]);
+      if (count > 0) analysisDataRows.push(count);
+      continue;
+    }
+    const printed = PRINTED_VALUE_PATTERN.exec(line);
+    if (printed) printedValueNames.push(printed[1]!);
+  }
+  return {
+    printedValueNames,
+    analysisDataRows,
+    producedResults:
+      printedValueNames.length > 0 || analysisDataRows.length > 0,
+  };
+}
+
+/**
+ * The outcome, from what ngspice said and what it produced.
+ *
+ * The exit status is not an argument here, and that is the point. ngspice 39
+ * ends a batch run over an author's `.control` block by printing
+ * `Note: No ".plot", ".print", or ".fourier" lines; no simulations run` and
+ * exiting non-zero — after the control block has already run every analysis
+ * and printed every value asked for. Failing on that status reported a
+ * correct simulation as failed (issue #568), and reading the absence of that
+ * note as success would only move the guess to the next simulator's wording.
+ * A run succeeded when the measurements came back; the status merely helps
+ * explain a run where they did not.
+ */
+function classifySimulationOutcome(
   diagnostics: readonly SimulationDiagnostic[],
-  options: { timedOut: boolean; timeoutMs: number; exitCode: number | null },
+  options: {
+    timedOut: boolean;
+    timeoutMs: number;
+    producedResults: boolean;
+  },
 ): SimulationOutcome {
   if (options.timedOut) {
     return { status: "timed-out", timeoutMs: options.timeoutMs };
   }
-  if (
-    diagnostics.some((diagnostic) => diagnostic.severity === "error") ||
-    (options.exitCode !== null && options.exitCode !== 0)
-  ) {
+  if (diagnostics.some((diagnostic) => diagnostic.severity === "error")) {
+    return { status: "failed" };
+  }
+  if (!options.producedResults) {
     return { status: "failed" };
   }
   if (diagnostics.some((diagnostic) => diagnostic.droppedInput)) {
     return { status: "completed-with-dropped-input" };
   }
   return { status: "completed" };
+}
+
+/** How the simulator process ended, as the surface running it observed it. */
+export interface NgspiceProcessResult {
+  /** Everything ngspice wrote, both streams, in the order captured. */
+  log: string;
+  /** The process exit status, or null when we stopped it ourselves. */
+  exitCode: number | null;
+  /** The signal that killed it, when one did. */
+  signal?: string | null;
+  timedOut: boolean;
+  timeoutMs: number;
+}
+
+/** An outcome and the diagnostics that account for it, read together. */
+export interface NgspiceRunReading {
+  outcome: SimulationOutcome;
+  diagnostics: SimulationDiagnostic[];
+}
+
+/**
+ * Read one finished ngspice process into an outcome and its diagnostics.
+ *
+ * Both surfaces go through here so a container run and a local run classify
+ * identically, and so one rule holds in one place: **a failed run always
+ * carries at least one diagnostic.** `status: "failed"` beside an empty
+ * `diagnostics` array leaves the author nothing to act on and the next
+ * debugger nothing to pull, which is how issue #568 stayed invisible; when
+ * the harness cannot say why a run failed, saying that is the finding.
+ */
+export function readNgspiceRun(run: NgspiceProcessResult): NgspiceRunReading {
+  const diagnostics = readNgspiceDiagnostics(run.log);
+  const signal = run.signal ?? null;
+  const evidence = readNgspiceRunEvidence(run.log);
+
+  // A signal death is a failure even when values were already printed: the
+  // run was cut off, so whatever came back is a fragment of the answer.
+  // Measured 2026-09-04, the kernel killing ngspice mid-corner-load on a
+  // 1 GiB instance (ADR 0055 amendment, item 10).
+  if (!run.timedOut && signal) {
+    diagnostics.push({
+      severity: "error",
+      text: `The simulator was terminated by ${signal} before it finished.`,
+    });
+  } else if (!run.timedOut && !evidence.producedResults) {
+    diagnostics.push({
+      severity: "error",
+      text:
+        run.log.trim().length === 0
+          ? "The simulator produced no output, so this run has no result."
+          : `The simulator reported no analysis results${
+              run.exitCode ? ` and exited with status ${run.exitCode}` : ""
+            }, so this run produced no numbers to return.`,
+    });
+  }
+
+  const outcome = classifySimulationOutcome(diagnostics, {
+    timedOut: run.timedOut,
+    timeoutMs: run.timeoutMs,
+    producedResults: evidence.producedResults,
+  });
+
+  // The invariant, enforced rather than assumed. Nothing above should reach
+  // this, and if a later change does, the gap reports itself instead of
+  // reaching an author as a bare "failed".
+  if (outcome.status === "failed" && diagnostics.length === 0) {
+    diagnostics.push({
+      severity: "error",
+      text: `The simulator run was classified as failed, but nothing in its output says why (exit status ${
+        run.exitCode === null ? "unreported" : run.exitCode
+      }). Please report this run.`,
+    });
+  }
+
+  return { outcome, diagnostics };
 }

--- a/worker/simulation.test.ts
+++ b/worker/simulation.test.ts
@@ -54,6 +54,35 @@ function stubRunner(
 const NETLIST = ".subckt amp in out\nM1 out in 0 0 nfet\n.ends\nXA in out amp";
 const TESTBENCH = "V1 in 0 DC 1\n.control\nop\nprint v(out)\n.endc";
 
+/**
+ * The container's ngspice 39 over a `.control` testbench (issue #568): every
+ * requested value printed, then a batch-pass note about the `.print` cards
+ * the deck does not carry, then a non-zero exit. Values quoted from the
+ * issue's recorded responses.
+ */
+const NGSPICE_39_CONTROL_BLOCK_LOG = `
+Circuit: * analog canvas simulation deck
+
+Doing analysis at TEMP = 27.000000 and TNOM = 27.000000
+
+No. of Data Rows : 1
+v(vout)       = 7.661889e-01
+v(ibias)      = 6.018893e-01
+gain_db       = 4.183501e+01
+ugb           = 3.302606e+07
+Note: Simulation executed from .control section
+
+Note: No ".plot", ".print", or ".fourier" lines; no simulations run
+`;
+
+/** ngspice 46 over a deck naming a model it cannot resolve. */
+const MISSING_MODEL_LOG = `
+Circuit: * analog canvas simulation deck
+
+could not find a valid modelname
+    Simulation interrupted due to error!
+`;
+
 describe("simulation route", () => {
   it("ignores paths that are not its own", async () => {
     expect(
@@ -166,6 +195,84 @@ describe("simulation route", () => {
     expect(
       ((await late!.json()) as { outcome: { status: string } }).outcome.status,
     ).toBe("timed-out");
+  });
+
+  it("returns the numbers when a `.control` testbench produced them", async () => {
+    // Issue #568. The preview container's ngspice is 39: it ends a batch pass
+    // over an author's `.control` deck by noting the `.print` cards it did
+    // not find and exiting non-zero, AFTER the control block has run every
+    // analysis and printed every value. The route reported `failed` with an
+    // empty `diagnostics` array, so the correct answer in the same response
+    // never reached the author and nothing said why.
+    //
+    // A `.control` block is how the ngspice documentation says to write a
+    // testbench and what ADR 0055 leaves to the author, so this shape is the
+    // normal case. A `.print`-directive testbench would pass either way.
+    const response = await routeSimulationRequest(
+      post({ netlist: NETLIST, testbench: TESTBENCH }),
+      stubRunner({
+        log: NGSPICE_39_CONTROL_BLOCK_LOG,
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        durationMs: 30_853,
+      }),
+    );
+    const payload = (await response!.json()) as {
+      outcome: { status: string };
+      diagnostics: unknown[];
+      log: string;
+    };
+    expect(payload.outcome).toEqual({ status: "completed" });
+    expect(payload.diagnostics).toEqual([]);
+    expect(payload.log).toContain("v(vout)       = 7.661889e-01");
+  });
+
+  it("never returns a failed outcome without a diagnostic", async () => {
+    // The half of #568 independent of which ngspice runs: an author reading
+    // `failed` with nothing beside it has no action, and the next debugger
+    // has no thread. Every route response that says failed carries a reason.
+    const runs = [
+      { log: "", exitCode: 0, timedOut: false, durationMs: 45_295 },
+      { log: "", exitCode: 1, timedOut: false, durationMs: 12 },
+      {
+        log: "",
+        exitCode: 128,
+        signal: "SIGKILL",
+        timedOut: false,
+        durationMs: 45_295,
+      },
+      {
+        log: "Circuit: * deck\nsomething nobody has a pattern for\n",
+        exitCode: 3,
+        timedOut: false,
+        durationMs: 40,
+      },
+      { log: MISSING_MODEL_LOG, exitCode: 1, timedOut: false, durationMs: 22 },
+    ];
+    let failures = 0;
+    for (const run of runs) {
+      const response = await routeSimulationRequest(
+        post({ netlist: NETLIST, testbench: TESTBENCH }),
+        stubRunner(run),
+      );
+      const payload = (await response!.json()) as {
+        outcome: { status: string };
+        diagnostics: { severity: string; text: string }[];
+      };
+      if (payload.outcome.status !== "failed") continue;
+      failures += 1;
+      expect(payload.diagnostics.length, JSON.stringify(run)).toBeGreaterThan(
+        0,
+      );
+      expect(
+        payload.diagnostics.some(
+          (diagnostic) =>
+            diagnostic.severity === "error" && diagnostic.text.length > 0,
+        ),
+      ).toBe(true);
+    }
+    expect(failures).toBe(runs.length);
   });
 
   it("uses the deployment's explicit Sky130 path and section", async () => {

--- a/worker/simulation.ts
+++ b/worker/simulation.ts
@@ -16,11 +16,10 @@
  */
 import {
   buildSimulationDeck,
-  classifySimulationOutcome,
   deckNeedsModelLibrary,
   createSimulationInputMetadata,
   isSimulationInputRevision,
-  readNgspiceDiagnostics,
+  readNgspiceRun,
   resolveTimeoutMs,
   simulationConfigurationMetadata,
   verifySimulationEnvironmentMetadata,
@@ -187,30 +186,18 @@ export async function routeSimulationRequest(
     );
   }
   const log = typeof raw.log === "string" ? raw.log : "";
-  const diagnostics = readNgspiceDiagnostics(log);
-  const timedOut = raw.timedOut === true;
-  // A simulator that died by a signal, or that printed nothing at all,
-  // did not complete: a batch run always prints at least its banner and
-  // the analysis it did. Exit 0 with no output was measured on 2026-09-04
-  // when the kernel killed ngspice mid-corner-load; it must never read as
-  // success (ADR 0055 amendment, item 10).
-  if (!timedOut && typeof raw.signal === "string" && raw.signal) {
-    diagnostics.push({
-      severity: "error",
-      text: `The simulator was terminated by ${raw.signal} before it finished.`,
-    });
-  } else if (!timedOut && log.trim().length === 0) {
-    diagnostics.push({
-      severity: "error",
-      text: "The simulator produced no output, so this run has no result.",
-    });
-  }
+  // What ngspice said and what it produced decide the outcome together, in
+  // the one place both surfaces share, so a failure always arrives with a
+  // reason and a run that returned its measurements is never called failed.
+  const { outcome, diagnostics } = readNgspiceRun({
+    log,
+    exitCode: typeof raw.exitCode === "number" ? raw.exitCode : null,
+    signal: typeof raw.signal === "string" && raw.signal ? raw.signal : null,
+    timedOut: raw.timedOut === true,
+    timeoutMs,
+  });
   const result: SimulationResult = {
-    outcome: classifySimulationOutcome(diagnostics, {
-      timedOut,
-      timeoutMs,
-      exitCode: typeof raw.exitCode === "number" ? raw.exitCode : null,
-    }),
+    outcome,
     diagnostics,
     log,
     durationMs: typeof raw.durationMs === "number" ? raw.durationMs : 0,


### PR DESCRIPTION
Closes #568.

## The defect

Every simulation through the preview environment returned `{"status":"failed"}`
with `diagnostics: []` while the same response's `log` held the correct
numbers — the five-transistor sky130 OTA matching ngspice 46 digit for digit
in 30.9 s, and a two-resistor divider in 12 ms.

## Root cause

`classifySimulationOutcome` failed a run on `exitCode !== 0` alone, and nothing
turned that status into a diagnostic. That is the **only** path in the old code
to `failed` with an empty diagnostics array, which is what the issue reports.

The container runs ngspice 39. It ends a batch pass over an author's `.control`
block by printing `Note: No ".plot", ".print", or ".fourier" lines; no
simulations run` and exiting non-zero — *after* that block has already run every
analysis and printed every value asked for.

HEAD's classifier, lifted verbatim out of `git show HEAD:packages/spice-run/src/index.ts`
and run over the log recorded in the issue with exit status 1:

```
HEAD (before fix) on the #568 log, exit 1:
  outcome     : {"status":"failed"}
  diagnostics : []
```

A `.control` block is what the ngspice documentation tells an author to write
and what ADR 0055 leaves in their hands, so this is the normal shape, not an
edge case: every simulation written the documented way came back failed.

## What changed

- **Success is decided by whether the requested measurements came back** — an
  analysis reporting data rows, or a printed value for a name — not by the exit
  status, and not by the absence of a note a simulator prints for its own
  reasons. Reading that note's *absence* as success would only move the guess to
  the next ngspice's wording, so it is not consulted at all. The evidence is read
  from console text for classification only; the numbers themselves still come
  from the rawfile, per the spec's result protocol.
- **A failed outcome always carries at least one diagnostic.** Where ngspice
  explains itself its words are kept unedited; where it does not, the harness
  states what it has — the signal, or that no analysis produced results and the
  status it exited with — and, if it can say nothing else, that the run was
  classified as failed without a reason, which is itself the finding to report.
- **One reader.** `readNgspiceRun` returns the outcome and its diagnostics
  together so the invariant holds in one place, and both surfaces go through it.
  The container route's signal and empty-log checks moved into it, and the local
  host gained them — it had the same defect and reported neither.
  `classifySimulationOutcome` is no longer exported, so an outcome cannot be
  formed without the diagnostics that account for it.
- `docs/specs/simulation.md` gains a **Run outcome** section. The spec already
  said an exit code of zero is not evidence that results exist; it now also says
  a non-zero one is not evidence that they do not, and records the outcome table
  and the diagnostic invariant.

**#566 is preserved and tested.** A signal-killed run fails even when values were
already printed — what came back is a fragment of the answer — and an empty log
still fails.

## Tests

Each exit condition from the issue, in `packages/spice-run/src/index.test.ts` and
`worker/simulation.test.ts`:

| test | asserts |
| --- | --- |
| `completes a \`.control\` testbench that ngspice 39 exited non-zero on` | the regression shape: `.control` block, exit 1, the batch note → `completed`. Fails against the old logic (proof above). |
| `returns the numbers when a \`.control\` testbench produced them` | the same through the whole `/api/simulate` route |
| `never reports a failure without a diagnostic` | a sweep over 10 logs × 5 exit statuses × 3 signals × timed-out: every `failed` carries an error diagnostic |
| `never returns a failed outcome without a diagnostic` | the same invariant at the route |
| `fails a deck no analysis ran on` | a run producing no vectors is still a failure, and says why |
| `keeps a silent or signal-killed run a failure (#566)` | including a kill that lands *after* values were printed |
| `does not decide success from that note's absence either` | same deck with the note removed, still non-zero, still `completed` |
| `counts a printed value and an analysis, and ignores ngspice's prose` | `Doing analysis at TEMP = 27.000000`, `Total DRAM available = ...` are not measurements |

The fixtures are captured output, not written by hand: ngspice 46 on 2026-09-04
for the `.control`, no-print, and no-analysis decks (exit 0 with no note for the
first two; exit 1 with `Error: incomplete or empty netlist` for the third), and
the issue's recorded ngspice-39 response for the regression shape. The
`apps/local-host` tests run the real ngspice 46 on the machine.

`pnpm gate:affected -- --base origin/main` green: static contracts, test-impact,
364 unit files / 2406 tests, release verification.

## Live preview verification

Pending — the preview Worker deploys from `main` (ADR 0057), so the reproduction
from #568 will be POSTed at the deployed preview after merge and the response
pasted here.

## Noted, not fixed

The container took 30.9 s for a circuit that takes 17.1 s locally. I did not
find the cause cheaply and did not chase it, so this is a pointer rather than a
finding. The container already gets a full core (`instance_type: standard-2`,
#562) and ngspice's solve here is single-threaded, so the plainest explanation
is per-core speed — a cloud vCPU against local Apple Silicon — not
under-provisioning. That is a hypothesis; nothing here measured it. Worth its
own issue if the wait matters.

Note that #570's rebase onto ngspice 46 would make this symptom disappear on its
own without fixing the criterion — which is why the regression test asserts the
ngspice-39 shape rather than the new image's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

