### PR TITLE
feat(editor): a component can wear a label its Reference cannot be

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,17 @@ it now accepts anything the upgrade chain can carry forward.
 **A missing code chunk answers with a refresh rather than a stack trace**, and
 a stuck page can get itself unstuck.
 
+### Labels
+
+**A component can wear any label.** A Reference still follows its device
+prefix — a resistor is `R…` — because the netlist prints it as the element
+token. Typing something else over the Reference label, such as `gm`, no longer
+ends in a refusal: the editor offers to keep the Reference for the netlist and
+show the typed text as a label in its place. Properties gains a `Label` field
+for the same free text on any placed component, including blocks that have no
+Reference at all. The label is presentation only; it never reaches the
+netlist.
+
 ### Unchanged
 
 The electrical model is untouched. Connectivity is still explicit, a crossing

--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -1128,8 +1128,10 @@ test("carries a manual Value through placement and Q property editing", async ({
   await expect(
     page.getByRole("button", { name: "Discard changes" }),
   ).toHaveCount(0);
+  // Reference, then the free Label, then Symbol: the Label row is the
+  // attached text a Reference cannot be, and it sits next to the Reference.
   await expect(page.getByLabel("Component identity")).toContainText(
-    "ReferenceSymbolresistorCell",
+    "ReferenceLabelSymbolresistorCell",
   );
   await expect(page.getByLabel("Component identity")).not.toContainText(
     "Device class",

--- a/apps/editor/e2e/reference-label.spec.ts
+++ b/apps/editor/e2e/reference-label.spec.ts
@@ -1,0 +1,149 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  awaitEditorReady,
+  chooseComponent,
+  downloadBytes,
+} from "./editor-fixtures.js";
+
+// A resistor's Reference starts with R because the netlist prints it as the
+// element token: `gm1 a b 10k` would be a controlled source. Until now typing
+// `gm` over the label ended in exactly that refusal, and the only way to show
+// the text was a separate Text object placed by hand. The label is
+// presentation; the Reference is the electrical fact. So the refusal becomes
+// an offer to keep one and show the other.
+test("typing a non-Reference text over R1 offers to show it as a label", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await awaitEditorReady(page);
+  await chooseComponent(page, "resistor");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 360, y: 240 } });
+  await page.keyboard.press("Escape");
+
+  await page.getByTestId("annotation-hit-instance-label-R1").dblclick();
+  const editor = page.getByRole("textbox", { name: "Canvas text editor" });
+  await editor.fill("gm");
+  await page.getByRole("button", { name: "Apply text changes" }).click();
+
+  const offer = page.getByTestId("reference-label-offer");
+  await expect(offer).toContainText(
+    "“gm” cannot be this component’s Reference",
+  );
+  await expect(offer).toContainText("Keep Reference “R1”");
+  // Nothing was renamed or refused behind the person's back.
+  await expect(page.getByTestId("canvas-text-editor")).toBeVisible();
+
+  // Declining keeps the editor open with the text still in it.
+  await offer.getByRole("button", { name: "Keep editing" }).click();
+  await expect(offer).toHaveCount(0);
+  await expect(editor).toHaveText("gm");
+
+  await page.getByRole("button", { name: "Apply text changes" }).click();
+  await offer.getByRole("button", { name: "Show as label" }).click();
+  await expect(page.getByTestId("canvas-text-editor")).toHaveCount(0);
+  await expect(page.getByTestId("status")).toHaveText(
+    "Showing “gm” as a label; Reference R1 is unchanged",
+  );
+
+  // The canvas reads gm where R1 stood; R1 is hidden, not renamed.
+  const annotations = page.locator('[data-layer="annotations"]');
+  await expect(
+    annotations.locator('[data-object-id="instance-label-R1"]'),
+  ).toHaveCount(0);
+  const label = annotations.locator('[data-object-id^="instance-text-"]');
+  await expect(label).toHaveCount(1);
+  await expect(label).toContainText("gm");
+
+  await page.getByTestId("hit-R1").click();
+  await page.getByTestId("selection-shelf").click();
+  const properties = page.getByRole("complementary", { name: "Properties" });
+  await expect(properties.getByLabel("Component reference")).toHaveValue("R1");
+  await expect(properties.getByLabel("Component label")).toHaveValue("gm");
+  await expect(
+    properties.getByLabel("Component display toggles").getByLabel("Reference"),
+  ).not.toBeChecked();
+
+  // The Project keeps the Reference as the netlist token and the text as
+  // literal attached content with no binding at all.
+  const project = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(
+      "utf8",
+    ),
+  );
+  expect(project.documents[0].instances[0].reference).toBe("R1");
+  const saved: Array<{ id: string }> = project.documents[0].annotations;
+  expect(
+    saved.find((annotation) => annotation.id === "instance-label-R1"),
+  ).toMatchObject({
+    visible: false,
+    binding: { kind: "instance-reference", instanceId: "R1" },
+  });
+  const literal = saved.find((annotation) =>
+    annotation.id.startsWith("instance-text-"),
+  ) as { content?: { runs: RichTextRunLike[] } } | undefined;
+  expect(literal).toMatchObject({
+    kind: "instance-label",
+    anchor: { kind: "object", objectId: "R1" },
+  });
+  // The text keeps the styled runs the Reference label was edited in — that
+  // is what "in its place" looks like — so compare the characters, not the
+  // run structure.
+  expect(plainText(literal?.content?.runs ?? [])).toBe("gm");
+  expect(literal).not.toHaveProperty("binding");
+});
+
+interface RichTextRunLike {
+  kind: string;
+  value?: string;
+  children?: RichTextRunLike[];
+}
+
+function plainText(runs: RichTextRunLike[]): string {
+  return runs.map((run) => run.value ?? plainText(run.children ?? [])).join("");
+}
+
+// The same text box from the other side: Properties. A label typed there
+// joins the Reference rather than replacing it, and clearing it takes only
+// the label away.
+test("Properties gives a placed component a free label without touching its Reference", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await awaitEditorReady(page);
+  await chooseComponent(page, "resistor");
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 360, y: 240 } });
+  await page.keyboard.press("Escape");
+
+  await page.getByTestId("hit-R1").click();
+  await page.getByTestId("selection-shelf").click();
+  const properties = page.getByRole("complementary", { name: "Properties" });
+  const labelField = properties.getByLabel("Component label");
+  await expect(labelField).toHaveValue("");
+  await labelField.fill("1/gm");
+  await labelField.press("Enter");
+  await expect(page.getByTestId("status")).toHaveText("Set label to 1/gm");
+
+  const annotations = page.locator('[data-layer="annotations"]');
+  const label = annotations.locator('[data-object-id^="instance-text-"]');
+  await expect(label).toContainText("1/gm");
+  await expect(
+    annotations.locator('[data-object-id="instance-label-R1"]'),
+  ).toContainText("R1");
+  await expect(properties.getByLabel("Component reference")).toHaveValue("R1");
+  await expect(properties.getByLabel("Component label")).toHaveValue("1/gm");
+
+  await properties.getByLabel("Component label").fill("");
+  await properties.getByLabel("Component label").press("Enter");
+  await expect(page.getByTestId("status")).toHaveText(
+    "Removed the component label",
+  );
+  await expect(label).toHaveCount(0);
+  await expect(
+    annotations.locator('[data-object-id="instance-label-R1"]'),
+  ).toContainText("R1");
+});

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -151,6 +151,7 @@ import { useVisualClipboard } from "../features/clipboard/visual-clipboard";
 import { deriveWireUnderSymbolWarnings } from "../canvas/wire-under-symbol";
 import { createPlacementTrayCommands } from "../features/component-insert/placement-tray-commands";
 import { componentTargetDescription } from "../features/properties/component-identity-properties";
+import { literalInstanceLabelText } from "../features/instance-display/literal-instance-label";
 import {
   constrainedPowerRailEndpoint,
   constructVddRailEdits,
@@ -1536,6 +1537,7 @@ export function App({
     valueVisibilityEdits,
     updateSelectedModelTarget,
     updateSelectedReference,
+    updateSelectedLabel,
     deleteSelectedAnnotation,
     reverseSelectedCurrentArrow,
   } = createSelectionPropertyCommands({
@@ -1551,8 +1553,13 @@ export function App({
     replaceAnnotationSelection: (ids) =>
       replaceSelectionKind("annotation", ids),
     setStatus,
+    nextId: (prefix) => {
+      uniqueSuffixCounter.current += 1;
+      return `${prefix}-${uniqueSuffixCounter.current}`;
+    },
   });
   const {
+    acceptReferenceLabelOffer,
     addAdditionalParameter,
     additionalParameterDraft,
     additionalParameterDraftChanges,
@@ -1569,6 +1576,8 @@ export function App({
     commitPendingNetLabelDraft,
     commitTextEditing,
     convertFormulaToAttachedLiteral,
+    declineReferenceLabelOffer,
+    referenceLabelOffer,
     clearTextEditing,
     cancelAdditionalParameters,
     deleteSelectedRouteNetLabel,
@@ -4704,6 +4713,10 @@ export function App({
                     onMarkerNameChange: (value) =>
                       commitElectricalMarkerName(selectedInstance.id, value),
                     onReferenceChange: updateSelectedReference,
+                    label: selectedInstance.placement
+                      ? literalInstanceLabelText(document, selectedInstance.id)
+                      : null,
+                    onLabelChange: updateSelectedLabel,
                     onModelTargetChange: updateSelectedModelTarget,
                   },
                   signalFlow: selectedSignalFlowPresentation
@@ -5493,6 +5506,9 @@ export function App({
             },
             onTextDelete: deleteTextEditing,
             onConvertFormulaToLiteral: convertFormulaToAttachedLiteral,
+            referenceLabelOffer,
+            onAcceptReferenceLabelOffer: acceptReferenceLabelOffer,
+            onDeclineReferenceLabelOffer: declineReferenceLabelOffer,
             ...(editingAnnotation &&
             isRoutedMarker(editingAnnotation) &&
             effectiveRouteAttachment(editingAnnotation)

--- a/apps/editor/src/canvas/editor-transient-preview-overlays.tsx
+++ b/apps/editor/src/canvas/editor-transient-preview-overlays.tsx
@@ -95,6 +95,9 @@ export function EditorInteractionPreviews({
   onTextCancel,
   onTextDelete,
   onConvertFormulaToLiteral,
+  referenceLabelOffer,
+  onAcceptReferenceLabelOffer,
+  onDeclineReferenceLabelOffer,
   onReverseCurrentArrow,
 }: {
   boxPreview: BoxPreview | null;
@@ -115,6 +118,9 @@ export function EditorInteractionPreviews({
   onTextCancel: () => void;
   onTextDelete: () => void;
   onConvertFormulaToLiteral?: CanvasTextEditorOverlayProps["onConvertFormulaToLiteral"];
+  referenceLabelOffer?: CanvasTextEditorOverlayProps["referenceLabelOffer"];
+  onAcceptReferenceLabelOffer?: () => void;
+  onDeclineReferenceLabelOffer?: () => void;
   onReverseCurrentArrow?: () => void;
 }) {
   return (
@@ -167,6 +173,13 @@ export function EditorInteractionPreviews({
           onCancel={onTextCancel}
           onDelete={onTextDelete}
           {...(onConvertFormulaToLiteral ? { onConvertFormulaToLiteral } : {})}
+          {...(referenceLabelOffer ? { referenceLabelOffer } : {})}
+          {...(onAcceptReferenceLabelOffer
+            ? { onAcceptReferenceLabelOffer }
+            : {})}
+          {...(onDeclineReferenceLabelOffer
+            ? { onDeclineReferenceLabelOffer }
+            : {})}
           {...(onReverseCurrentArrow ? { onReverseCurrentArrow } : {})}
         />
       ) : null}

--- a/apps/editor/src/features/component-insert/placement-reference-allocation.test.ts
+++ b/apps/editor/src/features/component-insert/placement-reference-allocation.test.ts
@@ -93,6 +93,7 @@ describe("placement Reference allocation", () => {
         return { ok: true };
       },
       replaceAnnotationSelection: () => {},
+      nextId: (prefix) => `${prefix}-1`,
       setStatus: () => {},
     });
 

--- a/apps/editor/src/features/instance-display/literal-instance-label.test.ts
+++ b/apps/editor/src/features/instance-display/literal-instance-label.test.ts
@@ -1,0 +1,476 @@
+import {
+  defaultInstanceLabelPlacement,
+  resolveDocumentStyleProfile,
+} from "@icm/derived";
+import {
+  createEmptyDocument,
+  defaultDraftTextDocument,
+  flattenRichText,
+} from "@icm/model";
+import type { Annotation, SchematicDocument } from "@icm/model";
+import { InMemorySymbolResolver, builtInSymbols } from "@icm/symbols";
+import { describe, expect, it } from "vitest";
+
+import { defaultInstanceLabel } from "../wiring/route-interaction-geometry";
+import {
+  literalInstanceLabelFor,
+  literalInstanceLabelText,
+  literalLabelFromReferenceEdit,
+  planLiteralInstanceLabel,
+  referencePrefixConflict,
+} from "./literal-instance-label";
+
+const resolver = new InMemorySymbolResolver(builtInSymbols);
+
+type Instance = SchematicDocument["instances"][number];
+
+function resistor(placed = true): Instance {
+  return {
+    id: "R1",
+    symbolId: "resistor",
+    placement: placed
+      ? { position: { x: 100, y: 100 }, rotation: 0, mirror: "none" }
+      : null,
+    reference: "R1",
+    netlist: {
+      parameters: { value: "10k" },
+      binding: { kind: "primitive", deviceClass: "resistor" },
+    },
+  };
+}
+
+function documentWith(instance: Instance): SchematicDocument {
+  const document = createEmptyDocument("main", "Main");
+  document.instances.push(instance);
+  return document;
+}
+
+function referenceLabel(
+  document: SchematicDocument,
+  instance: Instance,
+): Annotation {
+  const label = defaultInstanceLabel(
+    document,
+    instance,
+    resolver,
+    resolveDocumentStyleProfile(document.presentation),
+  );
+  if (!label) throw new Error("the resistor has a default Reference label");
+  return label;
+}
+
+function slot(
+  document: SchematicDocument,
+  instance: Instance,
+  which: "reference" | "value",
+) {
+  const resolved = resolver.resolve(
+    instance.symbolId,
+    instance.symbolVariantId,
+  );
+  if (!resolved) throw new Error("resistor symbol");
+  const placement = defaultInstanceLabelPlacement(
+    instance,
+    resolved,
+    resolveDocumentStyleProfile(document.presentation),
+    document.presentation.grid,
+    which,
+  );
+  if (!placement) throw new Error(`${which} slot`);
+  return placement;
+}
+
+describe("referencePrefixConflict", () => {
+  it("names the prefix a resistor Reference has to keep", () => {
+    expect(referencePrefixConflict(resistor(), "gm")).toEqual({ prefix: "R" });
+    expect(referencePrefixConflict(resistor(), " g_m ")).toEqual({
+      prefix: "R",
+    });
+  });
+
+  it("accepts any spelling that keeps the prefix, and says nothing about empty text", () => {
+    expect(referencePrefixConflict(resistor(), "r7")).toBeNull();
+    expect(referencePrefixConflict(resistor(), "Rload")).toBeNull();
+    expect(referencePrefixConflict(resistor(), "   ")).toBeNull();
+  });
+
+  it("follows the hierarchy prefix for a subcircuit call and has no opinion without a policy", () => {
+    const call: Instance = {
+      ...resistor(),
+      id: "X1",
+      reference: "X1",
+      netlist: {
+        parameters: {},
+        binding: { kind: "external-subcircuit", definitionId: "opamp-1" },
+      },
+    };
+    expect(referencePrefixConflict(call, "U1")).toEqual({ prefix: "X" });
+    const block: Instance = {
+      id: "adder-1",
+      symbolId: "adder",
+      placement: null,
+    };
+    expect(referencePrefixConflict(block, "anything")).toBeNull();
+  });
+});
+
+describe("literalLabelFromReferenceEdit", () => {
+  it("hides the Reference projection where it stands and puts the typed text in its place", () => {
+    const instance = resistor();
+    const document = documentWith(instance);
+    const source: Annotation = {
+      ...referenceLabel(document, instance),
+      sizeScale: 1.4,
+      textColor: "#aa0000",
+    };
+    const content = {
+      runs: [
+        { kind: "text" as const, value: "g" },
+        {
+          kind: "span" as const,
+          style: "subscript" as const,
+          children: [{ kind: "text" as const, value: "m" }],
+        },
+      ],
+    };
+    const conversion = literalLabelFromReferenceEdit({
+      source,
+      content,
+      sizeScale: 1.2,
+      alignment: "end",
+      id: "instance-text-7",
+    });
+    expect(conversion).not.toBeNull();
+    expect(conversion!.edits).toEqual([
+      {
+        kind: "upsert_schematic_annotation",
+        annotation: { ...source, visible: false },
+      },
+      {
+        kind: "upsert_schematic_annotation",
+        annotation: conversion!.label,
+      },
+    ]);
+    expect(conversion!.label).toEqual({
+      id: "instance-text-7",
+      kind: "instance-label",
+      content,
+      anchor: source.anchor,
+      alignment: "end",
+      rotation: source.rotation,
+      locked: false,
+      sizeScale: 1.2,
+      textColor: "#aa0000",
+    });
+    // Free text, not a projection: the model keeps the two apart.
+    expect(conversion!.label.binding).toBeUndefined();
+  });
+
+  it("converts only a Reference projection with something to say", () => {
+    const instance = resistor();
+    const document = documentWith(instance);
+    const source = referenceLabel(document, instance);
+    expect(
+      literalLabelFromReferenceEdit({
+        source,
+        content: { runs: [{ kind: "text", value: "   " }] },
+        sizeScale: 1,
+        alignment: "start",
+        id: "instance-text-1",
+      }),
+    ).toBeNull();
+    expect(
+      literalLabelFromReferenceEdit({
+        source: {
+          ...source,
+          binding: { kind: "instance-value", instanceId: instance.id },
+        },
+        content: defaultDraftTextDocument("gm"),
+        sizeScale: 1,
+        alignment: "start",
+        id: "instance-text-1",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("planLiteralInstanceLabel", () => {
+  const nextId = () => "instance-text-1";
+
+  it("stands a new label on the value line below a shown Reference", () => {
+    const instance = resistor();
+    const document = documentWith(instance);
+    document.annotations.push(referenceLabel(document, instance));
+    const plan = planLiteralInstanceLabel({
+      document,
+      instance,
+      text: " gm ",
+      resolver,
+      nextId,
+    });
+    const value = slot(document, instance, "value");
+    expect(plan).toEqual({
+      kind: "created",
+      edits: [
+        {
+          kind: "upsert_schematic_annotation",
+          annotation: {
+            id: "instance-text-1",
+            kind: "instance-label",
+            content: defaultDraftTextDocument("gm"),
+            anchor: {
+              kind: "object",
+              objectId: "R1",
+              localOffset: {
+                x: value.position.x - 100,
+                y: value.position.y - 100,
+              },
+              fallbackPosition: value.position,
+            },
+            alignment: value.alignment,
+            rotation: 0,
+            locked: false,
+          },
+        },
+      ],
+    });
+  });
+
+  it("continues the stack past a shown value instead of covering it", () => {
+    const instance = resistor();
+    const document = documentWith(instance);
+    document.annotations.push(referenceLabel(document, instance));
+    const value = slot(document, instance, "value");
+    document.annotations.push({
+      id: "instance-value-R1",
+      kind: "instance-value",
+      binding: { kind: "instance-value", instanceId: "R1" },
+      anchor: {
+        kind: "object",
+        objectId: "R1",
+        localOffset: { x: value.position.x - 100, y: value.position.y - 100 },
+        fallbackPosition: value.position,
+      },
+      alignment: value.alignment,
+      rotation: 0,
+      locked: false,
+    });
+    const plan = planLiteralInstanceLabel({
+      document,
+      instance,
+      text: "gm",
+      resolver,
+      nextId,
+    });
+    const reference = slot(document, instance, "reference");
+    expect(plan.kind).toBe("created");
+    if (plan.kind !== "created") return;
+    const created = plan.edits[0]!;
+    if (created.kind !== "upsert_schematic_annotation") throw new Error();
+    expect(created.annotation.anchor).toEqual({
+      kind: "object",
+      objectId: "R1",
+      localOffset: {
+        x: value.position.x * 2 - reference.position.x - 100,
+        y: value.position.y * 2 - reference.position.y - 100,
+      },
+      fallbackPosition: {
+        x: value.position.x * 2 - reference.position.x,
+        y: value.position.y * 2 - reference.position.y,
+      },
+    });
+  });
+
+  it("takes the place of a hidden Reference projection, wherever it was dragged", () => {
+    const instance = resistor();
+    const document = documentWith(instance);
+    const hidden: Annotation = {
+      ...referenceLabel(document, instance),
+      anchor: {
+        kind: "object",
+        objectId: "R1",
+        localOffset: { x: -30, y: 12 },
+        fallbackPosition: { x: 70, y: 112 },
+      },
+      alignment: "end",
+      rotation: 90,
+      visible: false,
+    };
+    document.annotations.push(hidden);
+    const plan = planLiteralInstanceLabel({
+      document,
+      instance,
+      text: "gm",
+      resolver,
+      nextId,
+    });
+    expect(plan).toMatchObject({
+      kind: "created",
+      edits: [
+        {
+          annotation: {
+            anchor: hidden.anchor,
+            alignment: "end",
+            rotation: 90,
+          },
+        },
+      ],
+    });
+  });
+
+  it("uses the Reference line when the component shows no Reference at all", () => {
+    const instance: Instance = {
+      id: "adder-1",
+      symbolId: "adder",
+      placement: { position: { x: 200, y: 160 }, rotation: 0, mirror: "none" },
+    };
+    const document = documentWith(instance);
+    const plan = planLiteralInstanceLabel({
+      document,
+      instance,
+      text: "Σ",
+      resolver,
+      nextId,
+    });
+    const reference = slot(document, instance, "reference");
+    expect(plan).toMatchObject({
+      kind: "created",
+      edits: [
+        {
+          annotation: {
+            anchor: { fallbackPosition: reference.position },
+            alignment: reference.alignment,
+          },
+        },
+      ],
+    });
+  });
+
+  it("rewrites, keeps, and removes the one label it owns", () => {
+    const instance = resistor();
+    const document = documentWith(instance);
+    const existing: Annotation = {
+      id: "instance-text-3",
+      kind: "instance-label",
+      content: defaultDraftTextDocument("gm"),
+      anchor: {
+        kind: "object",
+        objectId: "R1",
+        localOffset: { x: 0, y: 20 },
+        fallbackPosition: { x: 100, y: 120 },
+      },
+      alignment: "middle",
+      rotation: 0,
+      locked: false,
+    };
+    document.annotations.push(existing);
+    expect(literalInstanceLabelFor(document, "R1")).toBe(existing);
+    expect(literalInstanceLabelText(document, "R1")).toBe("gm");
+    expect(
+      planLiteralInstanceLabel({
+        document,
+        instance,
+        text: " gm",
+        resolver,
+        nextId,
+      }),
+    ).toEqual({ kind: "unchanged" });
+    const rewritten = planLiteralInstanceLabel({
+      document,
+      instance,
+      text: "1/gm",
+      resolver,
+      nextId,
+    });
+    expect(rewritten).toEqual({
+      kind: "updated",
+      edits: [
+        {
+          kind: "upsert_schematic_annotation",
+          annotation: {
+            ...existing,
+            content: defaultDraftTextDocument("1/gm"),
+          },
+        },
+      ],
+    });
+    expect(
+      planLiteralInstanceLabel({
+        document,
+        instance,
+        text: "",
+        resolver,
+        nextId,
+      }),
+    ).toEqual({
+      kind: "removed",
+      edits: [
+        {
+          kind: "remove_schematic_annotation",
+          annotationId: "instance-text-3",
+        },
+      ],
+    });
+  });
+
+  it("has nothing to remove and nowhere to stand without a placement", () => {
+    const retained = resistor(false);
+    const document = documentWith(retained);
+    expect(
+      planLiteralInstanceLabel({
+        document,
+        instance: retained,
+        text: "",
+        resolver,
+        nextId,
+      }),
+    ).toEqual({ kind: "unchanged" });
+    expect(
+      planLiteralInstanceLabel({
+        document,
+        instance: retained,
+        text: "gm",
+        resolver,
+        nextId,
+      }),
+    ).toEqual({
+      kind: "rejected",
+      message: "Place the component before giving it a label",
+    });
+  });
+});
+
+describe("default Reference label beside a literal label", () => {
+  it("still re-creates the Reference projection when only free text is attached", () => {
+    const instance = resistor();
+    const document = documentWith(instance);
+    document.annotations.push({
+      id: "instance-text-1",
+      kind: "instance-label",
+      content: defaultDraftTextDocument("gm"),
+      anchor: {
+        kind: "object",
+        objectId: "R1",
+        localOffset: { x: 0, y: 0 },
+        fallbackPosition: { x: 100, y: 100 },
+      },
+      alignment: "start",
+      rotation: 0,
+      locked: false,
+    });
+    const label = defaultInstanceLabel(
+      document,
+      instance,
+      resolver,
+      resolveDocumentStyleProfile(document.presentation),
+    );
+    expect(label?.binding).toEqual({
+      kind: "instance-reference",
+      instanceId: "R1",
+    });
+    // The value the label resolves to is the Reference, untouched by the text.
+    expect(flattenRichText(defaultDraftTextDocument(instance.reference!))).toBe(
+      "R1",
+    );
+  });
+});

--- a/apps/editor/src/features/instance-display/literal-instance-label.ts
+++ b/apps/editor/src/features/instance-display/literal-instance-label.ts
@@ -1,0 +1,262 @@
+import { referencePolicyForInstance } from "@icm/devices";
+import {
+  defaultInstanceLabelPlacement,
+  resolveDocumentStyleProfile,
+} from "@icm/derived";
+import type { SchematicEdit } from "@icm/edit-engine";
+import { defaultDraftTextDocument, flattenRichText } from "@icm/model";
+import type {
+  Annotation,
+  RichTextDocument,
+  SchematicDocument,
+} from "@icm/model";
+import type { SymbolResolver } from "@icm/symbols";
+
+import { instanceLabelAnnotationFor } from "./default-instance-display";
+
+type Instance = SchematicDocument["instances"][number];
+
+/**
+ * The one free-text label attached to an Instance. It is ordinary literal
+ * text at a label position of the Instance: no naming, netlist, or export
+ * authority (ADR 0054). That is exactly why it may read anything — a resistor
+ * whose Reference has to stay `R…` for the netlist can still be labelled `gm`.
+ */
+export function literalInstanceLabelFor(
+  document: SchematicDocument,
+  instanceId: string,
+): Annotation | undefined {
+  return document.annotations.find(
+    (annotation) =>
+      annotation.kind === "instance-label" &&
+      annotation.content !== undefined &&
+      annotation.anchor.kind === "object" &&
+      annotation.anchor.objectId === instanceId,
+  );
+}
+
+/** The literal label's plain text, or "" when the Instance has none. */
+export function literalInstanceLabelText(
+  document: SchematicDocument,
+  instanceId: string,
+): string {
+  const label = literalInstanceLabelFor(document, instanceId);
+  return label?.content ? flattenRichText(label.content).trim() : "";
+}
+
+/**
+ * A proposed Reference the device or hierarchy prefix policy refuses, with
+ * the prefix it insists on. The netlist prints the Reference as the element
+ * token, so the leading letter is an electrical fact rather than a style.
+ */
+export function referencePrefixConflict(
+  instance: Instance,
+  reference: string,
+): { readonly prefix: string } | null {
+  const policy = referencePolicyForInstance(instance);
+  if (policy.kind !== "required") return null;
+  const proposed = reference.trim();
+  if (!proposed) return null;
+  return proposed.toUpperCase().startsWith(policy.prefix.toUpperCase())
+    ? null
+    : { prefix: policy.prefix };
+}
+
+/**
+ * The edits behind "show it as a label instead": the Reference projection is
+ * hidden where it stands and the typed text takes its place as literal
+ * attached text, keeping the size, alignment, and colour the person was
+ * looking at. `Instance.reference` is not touched.
+ */
+export function literalLabelFromReferenceEdit(options: {
+  readonly source: Annotation;
+  readonly content: RichTextDocument;
+  readonly sizeScale: number;
+  readonly alignment: Annotation["alignment"];
+  readonly id: string;
+}): {
+  readonly label: Annotation;
+  readonly edits: readonly SchematicEdit[];
+} | null {
+  const { source, content, sizeScale, alignment, id } = options;
+  if (source.binding?.kind !== "instance-reference") return null;
+  if (!flattenRichText(content).trim()) return null;
+  const { visible: _shown, ...projection } = source;
+  const label: Annotation = {
+    id,
+    kind: "instance-label",
+    content,
+    anchor: source.anchor,
+    alignment,
+    rotation: source.rotation,
+    locked: false,
+    sizeScale,
+    ...(source.textColor ? { textColor: source.textColor } : {}),
+  };
+  return {
+    label,
+    edits: [
+      {
+        kind: "upsert_schematic_annotation",
+        annotation: { ...projection, visible: false },
+      },
+      { kind: "upsert_schematic_annotation", annotation: label },
+    ],
+  };
+}
+
+export type LiteralInstanceLabelPlan =
+  | { readonly kind: "unchanged" }
+  | { readonly kind: "rejected"; readonly message: string }
+  | {
+      readonly kind: "created" | "updated" | "removed";
+      readonly edits: readonly SchematicEdit[];
+    };
+
+/**
+ * The Properties `Label` field: one literal label per Instance, created,
+ * rewritten, or removed. A new label takes the place of a hidden Reference
+ * projection; otherwise it goes on the next free label line below the
+ * Reference so it never covers the Reference or a shown value.
+ */
+export function planLiteralInstanceLabel(options: {
+  readonly document: SchematicDocument;
+  readonly instance: Instance;
+  readonly text: string;
+  readonly resolver: SymbolResolver;
+  readonly nextId: () => string;
+}): LiteralInstanceLabelPlan {
+  const { document, instance, resolver } = options;
+  const text = options.text.trim();
+  const existing = literalInstanceLabelFor(document, instance.id);
+  if (!text) {
+    return existing
+      ? {
+          kind: "removed",
+          edits: [
+            { kind: "remove_schematic_annotation", annotationId: existing.id },
+          ],
+        }
+      : { kind: "unchanged" };
+  }
+  if (existing) {
+    if (existing.content && flattenRichText(existing.content).trim() === text) {
+      return { kind: "unchanged" };
+    }
+    return {
+      kind: "updated",
+      edits: [
+        {
+          kind: "upsert_schematic_annotation",
+          annotation: { ...existing, content: defaultDraftTextDocument(text) },
+        },
+      ],
+    };
+  }
+  if (!instance.placement) {
+    return {
+      kind: "rejected",
+      message: "Place the component before giving it a label",
+    };
+  }
+  const reference = instanceLabelAnnotationFor(document, instance.id);
+  const line =
+    reference && reference.visible === false
+      ? {
+          anchor: reference.anchor,
+          alignment: reference.alignment,
+          rotation: reference.rotation,
+        }
+      : nextFreeLabelLine(
+          document,
+          instance,
+          resolver,
+          reference !== undefined,
+        );
+  if (!line) {
+    return {
+      kind: "rejected",
+      message: "This component has no label position",
+    };
+  }
+  return {
+    kind: "created",
+    edits: [
+      {
+        kind: "upsert_schematic_annotation",
+        annotation: {
+          id: options.nextId(),
+          kind: "instance-label",
+          content: defaultDraftTextDocument(text),
+          ...line,
+          locked: false,
+        },
+      },
+    ],
+  };
+}
+
+function nextFreeLabelLine(
+  document: SchematicDocument,
+  instance: Instance,
+  resolver: SymbolResolver,
+  hasReferenceLabel: boolean,
+): Pick<Annotation, "anchor" | "alignment" | "rotation"> | null {
+  if (!instance.placement) return null;
+  const resolved = resolver.resolve(
+    instance.symbolId,
+    instance.symbolVariantId,
+  );
+  if (!resolved) return null;
+  const profile = resolveDocumentStyleProfile(document.presentation);
+  const grid = document.presentation.grid;
+  const referenceLine = defaultInstanceLabelPlacement(
+    instance,
+    resolved,
+    profile,
+    grid,
+    "reference",
+  );
+  const valueLine = defaultInstanceLabelPlacement(
+    instance,
+    resolved,
+    profile,
+    grid,
+    "value",
+  );
+  if (!referenceLine || !valueLine) return null;
+  const valueLineTaken = document.annotations.some(
+    (annotation) =>
+      annotation.kind === "instance-value" &&
+      annotation.anchor.kind === "object" &&
+      annotation.anchor.objectId === instance.id &&
+      annotation.visible !== false,
+  );
+  // Continue the label stack: the value line sits one line below the
+  // Reference line, so the line after it is the same step again.
+  const line = !hasReferenceLabel
+    ? referenceLine
+    : valueLineTaken
+      ? {
+          ...valueLine,
+          position: {
+            x: valueLine.position.x * 2 - referenceLine.position.x,
+            y: valueLine.position.y * 2 - referenceLine.position.y,
+          },
+        }
+      : valueLine;
+  const origin = instance.placement.position;
+  return {
+    anchor: {
+      kind: "object",
+      objectId: instance.id,
+      localOffset: {
+        x: line.position.x - origin.x,
+        y: line.position.y - origin.y,
+      },
+      fallbackPosition: line.position,
+    },
+    alignment: line.alignment,
+    rotation: 0,
+  };
+}

--- a/apps/editor/src/features/properties/component-identity-properties.test.tsx
+++ b/apps/editor/src/features/properties/component-identity-properties.test.tsx
@@ -48,8 +48,10 @@ describe("component identity properties", () => {
           suggestions: ["sky130_fd_pr__nfet_01v8"],
           externalSubcircuit: false,
         }}
+        label={null}
         onMarkerNameChange={vi.fn()}
         onReferenceChange={vi.fn()}
+        onLabelChange={vi.fn()}
         onModelTargetChange={vi.fn()}
       />,
     );
@@ -77,12 +79,55 @@ describe("component identity properties", () => {
         targetDescription={null}
         capacitorPlateRows={null}
         modelTarget={null}
+        label={null}
         onMarkerNameChange={vi.fn()}
         onReferenceChange={vi.fn()}
+        onLabelChange={vi.fn()}
         onModelTargetChange={vi.fn()}
       />,
     );
     expect(markup).toContain("Symbol");
     expect(markup).not.toContain('aria-label="Component reference"');
+    // A retained Instance has nowhere to stand a label yet.
+    expect(markup).not.toContain('aria-label="Component label"');
+  });
+
+  it("offers a free Label beside the Reference, showing the attached text", () => {
+    const document = createEmptyDocument("cell", "Cell");
+    const instance: (typeof document.instances)[number] = {
+      id: "R1",
+      symbolId: "resistor",
+      placement: {
+        position: { x: 100, y: 100 },
+        rotation: 0,
+        mirror: "none",
+      },
+      reference: "R1",
+      netlist: {
+        parameters: {},
+        binding: { kind: "primitive", deviceClass: "resistor" },
+      },
+    };
+    const markup = renderToStaticMarkup(
+      <ComponentIdentityProperties
+        instance={instance}
+        revision={2}
+        cellName="Cell"
+        formalTerminalSelected={false}
+        portNet={null}
+        targetDescription={null}
+        capacitorPlateRows={null}
+        modelTarget={null}
+        label="gm"
+        onMarkerNameChange={vi.fn()}
+        onReferenceChange={vi.fn()}
+        onLabelChange={vi.fn()}
+        onModelTargetChange={vi.fn()}
+      />,
+    );
+    expect(markup).toContain('aria-label="Component reference"');
+    expect(markup).toContain('aria-label="Component label"');
+    expect(markup).toContain('value="gm"');
+    expect(markup).toContain('value="R1"');
   });
 });

--- a/apps/editor/src/features/properties/component-identity-properties.tsx
+++ b/apps/editor/src/features/properties/component-identity-properties.tsx
@@ -181,8 +181,10 @@ export function ComponentIdentityProperties({
   capacitorPlateRows,
   propertyTerminal,
   modelTarget,
+  label,
   onMarkerNameChange,
   onReferenceChange,
+  onLabelChange,
   onModelTargetChange,
 }: {
   instance: Instance;
@@ -200,8 +202,15 @@ export function ComponentIdentityProperties({
     onChange: (netId: string | null) => void;
   } | null;
   modelTarget: ComponentModelTargetView | null;
+  /**
+   * Free text attached to the component, or `null` when it has nowhere to
+   * stand yet (a retained Instance). It is not the Reference and never
+   * reaches the netlist, so it may read anything — `gm` on a resistor.
+   */
+  label: string | null;
   onMarkerNameChange: (value: string) => void;
   onReferenceChange: (value: string) => boolean | void;
+  onLabelChange: (value: string) => boolean | void;
   onModelTargetChange: (value: string) => void;
 }) {
   const reference = instance.reference ?? "";
@@ -245,6 +254,27 @@ export function ComponentIdentityProperties({
                   }
                   onKeyDown={(event) =>
                     handleIdentityInputKeyDown(event, reference)
+                  }
+                />
+              </dd>
+            </div>
+          ) : null}
+          {label !== null ? (
+            <div>
+              <dt>Label</dt>
+              <dd>
+                <input
+                  dir="auto"
+                  key={`${instance.id}-${revision}-label`}
+                  aria-label="Component label"
+                  aria-description="Free text shown with the component; the Reference stays as it is"
+                  defaultValue={label}
+                  placeholder="Optional text"
+                  onBlur={(event) =>
+                    commitIdentityInput(event, label, onLabelChange)
+                  }
+                  onKeyDown={(event) =>
+                    handleIdentityInputKeyDown(event, label)
                   }
                 />
               </dd>

--- a/apps/editor/src/features/properties/selection-property-commands.ts
+++ b/apps/editor/src/features/properties/selection-property-commands.ts
@@ -16,6 +16,7 @@ import {
 import type { SymbolResolver } from "@icm/symbols";
 
 import { instanceLabelAnnotationFor } from "../instance-display/default-instance-display";
+import { planLiteralInstanceLabel } from "../instance-display/literal-instance-label";
 import { bindingForEditedModel } from "../netlist-export/netlist-authoring";
 import {
   defaultInstanceLabel,
@@ -42,6 +43,7 @@ export interface SelectionPropertyCommandDependencies {
   transact: (edits: SchematicEdit[]) => TransactionResult;
   replaceAnnotationSelection: (ids: readonly string[]) => void;
   setStatus: (status: string) => void;
+  nextId: (prefix: string) => string;
 }
 
 /** Property-panel write commands and their annotation projection policy. */
@@ -56,6 +58,7 @@ export function createSelectionPropertyCommands({
   transact,
   replaceAnnotationSelection,
   setStatus,
+  nextId,
 }: SelectionPropertyCommandDependencies) {
   const styleProfile = resolveDocumentStyleProfile(document.presentation);
 
@@ -209,6 +212,33 @@ export function createSelectionPropertyCommands({
     return false;
   };
 
+  /** The Properties `Label` field: free attached text, never the Reference. */
+  const updateSelectedLabel = (value: string): boolean => {
+    if (!selectedInstance) return false;
+    const plan = planLiteralInstanceLabel({
+      document,
+      instance: selectedInstance,
+      text: value,
+      resolver,
+      nextId: () => nextId("instance-text"),
+    });
+    switch (plan.kind) {
+      case "unchanged":
+        return true;
+      case "rejected":
+        setStatus(plan.message);
+        return false;
+      default:
+        if (!transact([...plan.edits]).ok) return false;
+        setStatus(
+          plan.kind === "removed"
+            ? "Removed the component label"
+            : `Set label to ${value.trim()}`,
+        );
+        return true;
+    }
+  };
+
   const deleteSelectedAnnotation = (): void => {
     if (!selectedAnnotation) return;
     const result = transact([
@@ -245,6 +275,7 @@ export function createSelectionPropertyCommands({
     valueVisibilityEdits,
     updateSelectedModelTarget,
     updateSelectedReference,
+    updateSelectedLabel,
     deleteSelectedAnnotation,
     reverseSelectedCurrentArrow,
   };

--- a/apps/editor/src/features/properties/use-properties-editor.ts
+++ b/apps/editor/src/features/properties/use-properties-editor.ts
@@ -32,8 +32,15 @@ import {
   textDeletionEdit,
   updateTextEditingSession,
 } from "../text-editing/text-editing";
-import type { TextEditingSession } from "../text-editing/text-editing";
+import type {
+  ReferenceLabelOffer,
+  TextEditingSession,
+} from "../text-editing/text-editing";
 import { attachedInstanceFormulaAnnotation } from "../text-editing/bound-formula";
+import {
+  literalLabelFromReferenceEdit,
+  referencePrefixConflict,
+} from "../instance-display/literal-instance-label";
 import { planElectricalMarkerName } from "./electrical-marker-name";
 
 export interface InstancePropertyDraft {
@@ -159,6 +166,13 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
   const [textEditing, setTextEditing] = useState<TextEditingSession | null>(
     null,
   );
+  const [referenceLabelOffer, setReferenceLabelOffer] =
+    useState<ReferenceLabelOffer | null>(null);
+  // The offer answers one typed text in one session; anything else moving on
+  // withdraws it.
+  useEffect(() => {
+    setReferenceLabelOffer(null);
+  }, [textEditing?.owner, textEditing?.id]);
   const netLabelDraftRouteRef = useRef<string | null>(null);
   const lastSelectedInstanceKeyRef = useRef<string | null>(null);
   const instancePropertyDraftRef = useRef<InstancePropertyDraft>(
@@ -634,6 +648,7 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
       Pick<TextEditingSession, "content" | "sizeScale" | "alignment">
     >,
   ): void => {
+    if (change.content) setReferenceLabelOffer(null);
     setTextEditing((current) =>
       current ? updateTextEditingSession(current, change) : null,
     );
@@ -810,6 +825,27 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
             setTextEditing(null);
             return;
           }
+          if (name !== currentName) {
+            // A text the prefix policy refuses is more often a label than a
+            // typo: offer to keep the Reference and show the text as literal
+            // attached text, instead of ending in the Edit Engine's refusal.
+            const referenceBinding = boundAnnotation.binding;
+            const instance = options.document.instances.find(
+              (candidate) => candidate.id === referenceBinding.instanceId,
+            );
+            const conflict = instance
+              ? referencePrefixConflict(instance, name)
+              : null;
+            if (conflict && instance?.reference) {
+              setReferenceLabelOffer({
+                annotationId: boundAnnotation.id,
+                text: name,
+                reference: instance.reference,
+                prefix: conflict.prefix,
+              });
+              return;
+            }
+          }
           if (
             options.transact([
               ...(name !== currentName
@@ -881,6 +917,43 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     setTextEditing(null);
   };
 
+  const acceptReferenceLabelOffer = (): void => {
+    if (
+      !referenceLabelOffer ||
+      !textEditing ||
+      textEditing.owner !== "annotation" ||
+      textEditing.id !== referenceLabelOffer.annotationId
+    ) {
+      return;
+    }
+    const source = options.document.annotations.find(
+      (annotation) => annotation.id === textEditing.id,
+    );
+    if (!source) return;
+    const conversion = literalLabelFromReferenceEdit({
+      source,
+      content: textEditing.content,
+      sizeScale: textEditing.sizeScale,
+      alignment: textEditing.alignment,
+      id: options.nextId("instance-text"),
+    });
+    if (!conversion) {
+      options.setStatus("This text cannot become a component label");
+      return;
+    }
+    if (!options.transact([...conversion.edits]).ok) return;
+    setReferenceLabelOffer(null);
+    setTextEditing(null);
+    options.selectOnly("annotation", [conversion.label.id]);
+    options.setStatus(
+      `Showing “${referenceLabelOffer.text}” as a label; Reference ${referenceLabelOffer.reference} is unchanged`,
+    );
+  };
+
+  const declineReferenceLabelOffer = (): void => {
+    setReferenceLabelOffer(null);
+  };
+
   const convertFormulaToAttachedLiteral = (
     formula: RichTextDocument,
   ): boolean => {
@@ -915,6 +988,7 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
   };
 
   return {
+    acceptReferenceLabelOffer,
     additionalParameterDraft,
     additionalParameterDraftChanges: !sameAdditionalParameterDrafts(
       additionalParameterDraft,
@@ -935,6 +1009,8 @@ export function usePropertiesEditor(options: UsePropertiesEditorOptions) {
     commitTextEditing,
     convertFormulaToAttachedLiteral,
     cancelAdditionalParameters,
+    declineReferenceLabelOffer,
+    referenceLabelOffer,
     clearTextEditing: () => setTextEditing(null),
     deleteSelectedRouteNetLabel,
     deleteTextEditing,

--- a/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
+++ b/apps/editor/src/features/text-editing/canvas-text-editor-overlay.tsx
@@ -10,7 +10,7 @@ import type { DerivedRect, GridRect } from "@icm/model";
 import { flattenRichText } from "@icm/model";
 
 import { RichTextEditor } from "./rich-text-editor";
-import type { TextEditingSession } from "./text-editing";
+import type { ReferenceLabelOffer, TextEditingSession } from "./text-editing";
 
 type TextEditingUpdate = Partial<
   Pick<TextEditingSession, "content" | "sizeScale" | "alignment">
@@ -27,6 +27,9 @@ export interface CanvasTextEditorOverlayProps {
   onDelete(): void;
   onReverseCurrentArrow?(): void;
   onConvertFormulaToLiteral?(formula: TextEditingSession["content"]): boolean;
+  referenceLabelOffer?: ReferenceLabelOffer | null;
+  onAcceptReferenceLabelOffer?(): void;
+  onDeclineReferenceLabelOffer?(): void;
 }
 
 /**
@@ -126,6 +129,9 @@ export function CanvasTextEditorOverlay({
   onDelete,
   onReverseCurrentArrow,
   onConvertFormulaToLiteral,
+  referenceLabelOffer,
+  onAcceptReferenceLabelOffer,
+  onDeclineReferenceLabelOffer,
 }: CanvasTextEditorOverlayProps) {
   const anchorRef = useRef<SVGGElement | null>(null);
   const [canvasSize, setCanvasSize] = useState<{
@@ -228,6 +234,19 @@ export function CanvasTextEditorOverlay({
           {...(session.bindingKind === "instance-reference" &&
           onConvertFormulaToLiteral
             ? { onConvertFormulaToLiteral }
+            : {})}
+          {...(session.bindingKind === "instance-reference" &&
+          referenceLabelOffer &&
+          referenceLabelOffer.annotationId === session.id
+            ? {
+                referenceLabelOffer,
+                ...(onAcceptReferenceLabelOffer
+                  ? { onAcceptReferenceLabelOffer }
+                  : {}),
+                ...(onDeclineReferenceLabelOffer
+                  ? { onDeclineReferenceLabelOffer }
+                  : {}),
+              }
             : {})}
           onLayoutHeightChange={handleLayoutHeightChange}
           {...(onReverseCurrentArrow ? { onReverseCurrentArrow } : {})}

--- a/apps/editor/src/features/text-editing/rich-text-editor.tsx
+++ b/apps/editor/src/features/text-editing/rich-text-editor.tsx
@@ -19,6 +19,7 @@ import {
 import type { RichTextDocument, RichTextRun } from "@icm/model";
 
 import { boundFormulaPresentation } from "./bound-formula";
+import type { ReferenceLabelOffer } from "./text-editing";
 
 export interface RichTextEditorProps {
   targetKey: string;
@@ -46,6 +47,10 @@ export interface RichTextEditorProps {
   formulaSemanticText?: string;
   /** Convert a non-equivalent Formula into literal attached text. */
   onConvertFormulaToLiteral?(formula: RichTextDocument): boolean;
+  /** A refused Reference edit, offered as attached literal text instead. */
+  referenceLabelOffer?: ReferenceLabelOffer;
+  onAcceptReferenceLabelOffer?(): void;
+  onDeclineReferenceLabelOffer?(): void;
   onLayoutHeightChange?(height: number): void;
 }
 
@@ -444,6 +449,9 @@ export function RichTextEditor({
   onReverseCurrentArrow,
   formulaSemanticText,
   onConvertFormulaToLiteral,
+  referenceLabelOffer,
+  onAcceptReferenceLabelOffer,
+  onDeclineReferenceLabelOffer,
   onLayoutHeightChange,
 }: RichTextEditorProps) {
   const shellRef = useRef<HTMLDivElement>(null);
@@ -1113,6 +1121,37 @@ export function RichTextEditor({
           }}
         />
       )}
+      {referenceLabelOffer ? (
+        <div
+          className="rich-text-formula-conversion"
+          data-testid="reference-label-offer"
+          role="alert"
+        >
+          <div>
+            <strong>
+              “{referenceLabelOffer.text}” cannot be this component’s Reference
+            </strong>
+            <span>
+              Its Reference starts with “{referenceLabelOffer.prefix}” because
+              the netlist prints it. Keep Reference “
+              {referenceLabelOffer.reference}” and show “
+              {referenceLabelOffer.text}” as a label in its place?
+            </span>
+          </div>
+          <div className="rich-text-formula-conversion-actions">
+            <button type="button" onClick={onDeclineReferenceLabelOffer}>
+              Keep editing
+            </button>
+            <button
+              className="rich-text-formula-primary-action"
+              type="button"
+              onClick={onAcceptReferenceLabelOffer}
+            >
+              Show as label
+            </button>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/editor/src/features/text-editing/text-editing.ts
+++ b/apps/editor/src/features/text-editing/text-editing.ts
@@ -42,6 +42,20 @@ export interface TextEditingSession {
   defaultFormula?: string;
 }
 
+/**
+ * A Reference edit the prefix policy refused, held while the person decides
+ * whether the typed text should become attached literal text instead.
+ */
+export interface ReferenceLabelOffer {
+  readonly annotationId: string;
+  /** The typed text, as plain characters. */
+  readonly text: string;
+  /** The Reference that stays, and is printed by the netlist. */
+  readonly reference: string;
+  /** The prefix the component's Reference has to start with. */
+  readonly prefix: string;
+}
+
 export type TextEditingCommitProposal =
   | { kind: "update"; edit: SchematicEdit; id: string }
   | { kind: "delete"; edit: SchematicEdit; id: string }

--- a/apps/editor/src/features/wiring/route-interaction-geometry.ts
+++ b/apps/editor/src/features/wiring/route-interaction-geometry.ts
@@ -519,6 +519,9 @@ export function defaultInstanceLabel(
     document.annotations.some(
       (annotation) =>
         annotation.kind === "instance-label" &&
+        // Literal attached text is free text, not a projection of this name;
+        // only an existing projection makes a default one redundant.
+        annotation.binding !== undefined &&
         annotation.anchor.kind === "object" &&
         annotation.anchor.objectId === instance.id,
     )

--- a/config/validation-gates.json
+++ b/config/validation-gates.json
@@ -29,7 +29,8 @@
       "apps/editor/src/features/wiring/**",
       "apps/editor/e2e/drafting.spec.ts",
       "apps/editor/e2e/instance-table.spec.ts",
-      "apps/editor/e2e/manual-editor.spec.ts"
+      "apps/editor/e2e/manual-editor.spec.ts",
+      "apps/editor/e2e/reference-label.spec.ts"
     ],
     "editorCommands": [
       "apps/editor/src/app/editor-transaction-commands*",
@@ -301,7 +302,8 @@
         "e2eArgs": [
           "apps/editor/e2e/manual-editor.spec.ts",
           "apps/editor/e2e/drafting.spec.ts",
-          "apps/editor/e2e/instance-table.spec.ts"
+          "apps/editor/e2e/instance-table.spec.ts",
+          "apps/editor/e2e/reference-label.spec.ts"
         ]
       }
     },

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -369,6 +369,20 @@ and displayable.
 Properties and character editing of the bound canvas label both rename the one
 Instance Reference. Same-text RichText formatting stays in the Annotation and
 ordinary attached literal text never becomes a Reference.
+A character edit whose text the component's Reference prefix policy refuses
+(`gm` on a resistor, whose Reference the netlist prints as `R…`) is not
+committed as a rename and does not end in the Edit Engine's refusal: the
+editor offers to keep the Reference and show the typed text as attached
+literal text in the label's place. Accepting hides the `instance-reference`
+projection (`visible: false`), creates one literal `instance-label` Annotation
+at the same anchor with the edited size, alignment, and colour, and leaves
+`Instance.reference` unchanged; declining keeps the editor open. Properties
+exposes the same attached text as a `Label` field for every placed component,
+including one with no Reference at all: setting it creates or rewrites the one
+literal `instance-label` Annotation of that Instance — in the hidden Reference
+projection's place, otherwise on the next free label line below the Reference
+and a shown value — and clearing it removes that Annotation. Neither direction
+touches the Reference, the netlist, or export.
 For a Cell Pin, a character edit renames the terminal while a formatting-only
 edit persists a same-text annotation `formatOverride`. Properties exposes the
 Cell Pin name and direction. Net naming remains a Net Label operation.


### PR DESCRIPTION
## Why

A resistor's Reference must start with `R` because the netlist prints it as the element token: `gm1 a b 10k` would be a controlled source. Typing `gm` over the label therefore ended in a refusal, and the only way to show the text was a separate Text object placed by hand (owner request, 2026-09-04).

The label is presentation; the Reference is the electrical fact. ADR 0054 already reserves attached literal text for exactly this, so no contract changes — the editor just stops making the person do it by hand.

## What changes

- **Canvas.** A character edit of the Reference label whose text the prefix policy refuses now shows an offer instead of the Edit Engine's refusal: *keep Reference `R1` and show `gm` as a label in its place?* Accepting hides the `instance-reference` projection (`visible: false`), creates one literal `instance-label` annotation at the same anchor with the edited size, alignment and colour, and leaves `Instance.reference` untouched. Declining keeps the editor open with the text.
- **Properties.** The Identity card gains a `Label` field for every placed component, including blocks that have no Reference at all. Setting it creates or rewrites the one literal label (in the hidden Reference's place, otherwise on the next free label line below the Reference and a shown value); clearing it removes that label. The Reference field and the Reference toggle behave as before.
- A literal label no longer blocks re-creating the default Reference label from the toggle: only an existing projection makes a default one redundant.
- Spec: `docs/specs/editor-interaction.md` "Text and presentation"; CHANGELOG entry under 0.2.0.

Netlist, simulation and export are unaffected: they print `Instance.reference`, which nothing here writes.

## Verification

- `pnpm typecheck`, focused Vitest (`instance-display`, `properties`, `wiring`, `text-editing`, `canvas` — 75 tests) green.
- New unit tests: `literal-instance-label.test.ts` (prefix conflict, conversion edits, Properties label plan, default-label guard); `component-identity-properties.test.tsx` (Label field).
- New Playwright spec `apps/editor/e2e/reference-label.spec.ts`: the canvas offer end to end (decline, accept, hidden `R1`, Properties state, exported Project keeps `reference: "R1"` and an unbound literal annotation) and the Properties path (create, both labels shown, clear).
- Local `pnpm ci:check` running under the gate lock; auto-merge is enabled only once it is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)