### PR TITLE
fix(simulation): one Sky130 library, and no way to quietly use another

### DIFF
--- a/packages/spice-run/src/index.test.ts
+++ b/packages/spice-run/src/index.test.ts
@@ -12,6 +12,8 @@ import {
   MAX_SIMULATION_TIMEOUT_MS,
   readNgspiceDiagnostics,
   resolveTimeoutMs,
+  SKY130_LIBRARY_PATH,
+  SKY130_LIBRARY_SECTION,
   simulationConfigurationMetadata,
   verifySimulationEnvironmentMetadata,
 } from "./index.js";
@@ -176,6 +178,15 @@ Note: No ".plot", ".print", or ".fourier" lines; no simulations run
         timeoutMs: 30_000,
       }),
     ).toEqual({ status: "timed-out", timeoutMs: 30_000 });
+  });
+});
+
+describe("the model library", () => {
+  it("names the pinned image's library, and only that one", () => {
+    // Every surface reads this constant, so a change here is a change
+    // everywhere rather than a fourth spelling that drifts from the others.
+    expect(SKY130_LIBRARY_PATH).toBe("/opt/sky130/continuous/sky130.lib.spice");
+    expect(SKY130_LIBRARY_SECTION).toBe("tt");
   });
 });
 

--- a/packages/spice-run/src/index.ts
+++ b/packages/spice-run/src/index.ts
@@ -191,6 +191,27 @@ export function deckNeedsModelLibrary(text: string): boolean {
  * The model library line is the one thing we contribute, because the author
  * cannot know the container's paths. Everything after it is theirs verbatim.
  */
+/**
+ * The one Sky130 library this product simulates against, at the path the
+ * pinned container image puts it.
+ *
+ * There is deliberately no search. A machine with a volare or ciel checkout
+ * has the BINNED model set, which is a different library: its widest
+ * `nfet_01v8` bin stops at 100 um, so the benchmark suite's own reference
+ * devices do not resolve at all, and the circuits that do resolve answer
+ * differently -- on the five-transistor OTA the unity-gain bandwidth moves
+ * 11% (#551). Falling back to whatever a machine happens to have would mean
+ * two runs of the same circuit disagreeing with no way to tell which library
+ * answered, which is worse than not running.
+ *
+ * `SKY130_LIB_PATH` overrides it for a host that mounts the same library
+ * somewhere else. It is not a way to select a different one.
+ */
+export const SKY130_LIBRARY_PATH = "/opt/sky130/continuous/sky130.lib.spice";
+
+/** The corner every surface defaults to. */
+export const SKY130_LIBRARY_SECTION = "tt";
+
 export function buildSimulationDeck(
   request: Pick<SimulationRequest, "netlist" | "testbench">,
   modelLibrary: ModelLibrarySelection | null,

--- a/scripts/simulation-acceptance.mjs
+++ b/scripts/simulation-acceptance.mjs
@@ -18,7 +18,7 @@
 import { execFile } from "node:child_process";
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 
@@ -30,6 +30,7 @@ import {
   printSpiceNetlist,
 } from "../packages/netlist/dist/index.js";
 import { importSpiceSources } from "../packages/spice/dist/index.js";
+import { SKY130_LIBRARY_PATH } from "../packages/spice-run/dist/index.js";
 
 const run = promisify(execFile);
 const workspace = process.cwd();
@@ -51,25 +52,20 @@ function skip(reason) {
   process.exit(0);
 }
 
-// The binned Sky130 library, wherever this machine keeps it. A volare or ciel
-// checkout is the usual answer; the container image lays it out under /opt.
+// The one library, at the path the pinned container image puts it. There is
+// deliberately no search of the machine: a volare or ciel checkout holds the
+// BINNED model set, which is a different library that answers differently and
+// refuses the benchmark's own reference devices outright. Silently using it
+// would make this script's numbers incomparable with the product's, which is
+// the one thing it exists to rule out.
 function findModelLibrary() {
-  // An explicitly given path that is not there is an error, never a reason to
-  // quietly use a different one. Which library answers decides the numbers
-  // this script compares, so substituting one silently would report a
-  // comparison the caller did not ask for.
   const fromEnv = process.env.SKY130_LIB_PATH;
   if (fromEnv && !existsSync(fromEnv)) {
     console.error(`SKY130_LIB_PATH points at nothing: ${fromEnv}`);
     process.exit(1);
   }
-  const candidates = [
-    ...(fromEnv ? [fromEnv] : []),
-    join(homedir(), ".volare/sky130A/libs.tech/ngspice/sky130.lib.spice"),
-    join(homedir(), ".ciel/sky130A/libs.tech/ngspice/sky130.lib.spice"),
-    "/opt/sky130/sky130A/libs.tech/ngspice/sky130.lib.spice",
-  ];
-  return candidates.find((path) => existsSync(path));
+  const path = fromEnv ?? SKY130_LIBRARY_PATH;
+  return existsSync(path) ? path : undefined;
 }
 
 async function findNgspice() {
@@ -149,7 +145,11 @@ const ngspice = await findNgspice();
 if (!ngspice) skip("ngspice is not on PATH");
 const libraryPath = findModelLibrary();
 if (!libraryPath) {
-  skip("no Sky130 ngspice library found (set SKY130_LIB_PATH to point at one)");
+  skip(
+    `no Sky130 library at ${SKY130_LIBRARY_PATH}. It comes from the pinned ` +
+      `container image, not from a PDK checkout; set SKY130_LIB_PATH if this ` +
+      `host mounts that same library elsewhere.`,
+  );
 }
 
 const referencePath = resolve(

--- a/scripts/simulation-acceptance.test.mjs
+++ b/scripts/simulation-acceptance.test.mjs
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * One library, and no way to quietly use another.
+ *
+ * A machine with a volare or ciel checkout has the BINNED Sky130 model set.
+ * It is not a lesser copy of the same thing: its widest `nfet_01v8` bin stops
+ * at 100 um, so the benchmark suite's own reference devices do not resolve at
+ * all, and the circuits that do resolve answer differently — on the
+ * five-transistor OTA the unity-gain bandwidth moves 11% (#551).
+ *
+ * A search that falls back to it produces two runs of one circuit that
+ * disagree, with nothing in either result saying why. Skipping is the better
+ * outcome, so these assertions exist to keep a helpful-looking fallback from
+ * being added back.
+ */
+const script = readFileSync("scripts/simulation-acceptance.mjs", "utf8");
+
+describe("simulation acceptance uses one library", () => {
+  it("does not look for a PDK checkout on the machine", () => {
+    // The path forms, not the words: the file explains in prose why a volare
+    // or ciel checkout is the wrong library, and that explanation is the
+    // reason these assertions exist rather than something to forbid.
+    expect(script).not.toMatch(/["'`~][.\/]*volare\//u);
+    expect(script).not.toMatch(/["'`~][.\/]*ciel\//u);
+    expect(script).not.toMatch(/homedir\s*\(/u);
+  });
+
+  it("takes the path from the shared constant, not a literal of its own", () => {
+    expect(script).toContain("SKY130_LIBRARY_PATH");
+    // A second spelling of the path is a second place for it to drift.
+    expect(script).not.toContain("/opt/sky130/continuous");
+  });
+
+  it("skips rather than substituting when that library is absent", () => {
+    expect(script).toMatch(/skip\(/u);
+    expect(script).toContain("comes from the pinned");
+  });
+});

--- a/worker/simulation.ts
+++ b/worker/simulation.ts
@@ -23,6 +23,8 @@ import {
   isSimulationInputRevision,
   readNgspiceDiagnostics,
   resolveTimeoutMs,
+  SKY130_LIBRARY_PATH,
+  SKY130_LIBRARY_SECTION,
   simulationConfigurationMetadata,
   verifySimulationEnvironmentMetadata,
   type ModelLibrarySelection,
@@ -45,8 +47,6 @@ export interface SimulationEnv {
 
 // The continuous (unbinned) Sky130 library the benchmark image ships; the
 // binned checkout it also carries caps device width at 100 µm (#551).
-const DEFAULT_LIB_PATH = "/opt/sky130/continuous/sky130.lib.spice";
-const DEFAULT_LIB_SECTION = "tt";
 
 /** A deck this large is a mistake upstream, not a simulation worth waking for. */
 const MAX_INPUT_BYTES = 2 * 1024 * 1024;
@@ -127,8 +127,8 @@ export async function routeSimulationRequest(
     modelLibrary = deckNeedsModelLibrary(`${netlist}\n${testbench}`)
       ? {
           directive: "lib",
-          path: env.SKY130_LIB_PATH ?? DEFAULT_LIB_PATH,
-          section: env.SKY130_LIB_SECTION ?? DEFAULT_LIB_SECTION,
+          path: env.SKY130_LIB_PATH ?? SKY130_LIBRARY_PATH,
+          section: env.SKY130_LIB_SECTION ?? SKY130_LIBRARY_SECTION,
         }
       : null;
     deck = buildSimulationDeck({ netlist, testbench }, modelLibrary);


### PR DESCRIPTION
## The problem

`scripts/simulation-acceptance.mjs` searched the machine for a Sky130 library and used whichever it found first — a volare checkout, then a ciel checkout, then the container's path. On any development machine that meant the **binned** model set.

That is not a lesser copy of the same library. It is a different one:

- Its widest `nfet_01v8` bin stops at 100 µm, so the benchmark suite's own reference devices **do not resolve at all**. Measured, same circuit, same deck:

  ```
  preview (continuous)  completed, i(vdd) = -2.68882e-03
  local   (binned)      Error: could not find a valid modelname
                        Simulation interrupted due to error!
  ```

- The circuits that *do* resolve answer differently. The five-transistor OTA, measured through the preview before and after the container moved to the continuous library:

  | | binned | continuous | shift |
  | --- | --- | --- | --- |
  | `v(vout)` | 7.661889e-01 | 7.589797e-01 | −0.94 % |
  | `gain_db` | 4.183501e+01 | 4.159247e+01 | −0.24 dB |
  | `ugb` | 3.302606e+07 | 3.658549e+07 | **+10.8 %** |

So the acceptance script and the product could each report a confident number for one circuit, disagree by 11 %, and **neither result would say which library answered**. Skipping is better than that.

## Change

One path, `SKY130_LIBRARY_PATH`, exported from `@icm/spice-run` and read by the Worker and the script alike: the pinned container image's continuous library.

`SKY130_LIB_PATH` still overrides it for a host that mounts *that same library* somewhere else. It is not a way to select a different one.

When it is absent the script skips, and says where the library comes from — a PDK checkout cannot produce it:

```
Skipping simulation acceptance: no Sky130 library at
/opt/sky130/continuous/sky130.lib.spice. It comes from the pinned container
image, not from a PDK checkout; set SKY130_LIB_PATH if this host mounts that
same library elsewhere.
```

**The Worker's behaviour does not change** — it already defaulted to this path. What changes is that the path is no longer written down in two places.

## Guard

A test reads the script and rejects a machine-search being added back. It forbids the path *forms* rather than the words, because the file explains in prose why those checkouts are the wrong library, and that explanation is the reason the test exists.

Verified by reintroducing a volare fallback:

```
× does not look for a PDK checkout on the machine
  Tests  1 failed | 2 passed (3)
```

175 tests pass across `packages/spice-run`, `worker`, `apps/local-host`, and the new guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)