### PR TITLE
feat(simulation): the route returns numbers, not just console text

### DIFF
--- a/worker/simulation.test.ts
+++ b/worker/simulation.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it } from "vitest";
 
 import { createSimulationEnvironmentMetadata } from "@icm/spice-run";
@@ -255,6 +257,111 @@ describe("simulation route", () => {
     expect(payload.outcome.status).toBe("completed-with-dropped-input");
     expect(payload.diagnostics[0]!.droppedInput).toBe(true);
     expect(payload.diagnostics[0]!.text).toContain("ignored!");
+  });
+
+  /** Written by ngspice 46, not by hand. See fixtures/ngspice-rawfile/README.md. */
+  const DIVIDER_RAWFILE = readFileSync(
+    "fixtures/ngspice-rawfile/divider-op.raw",
+    "utf8",
+  );
+
+  it("returns the numbers when the harness sends a rawfile back", async () => {
+    // The whole point of the route: an author gets values, not a wall of
+    // console text they have to read with their eyes.
+    const response = await routeSimulationRequest(
+      post({ netlist: NETLIST, testbench: TESTBENCH }),
+      stubRunner({
+        log: "Circuit: * divider\nNo. of Data Rows : 1\n",
+        exitCode: 0,
+        timedOut: false,
+        durationMs: 11,
+        rawfile: DIVIDER_RAWFILE,
+        rawfileFormat: "ascii",
+      }),
+    );
+    const payload = (await response!.json()) as {
+      outcome: { status: string };
+      data?: {
+        analyses: {
+          analysis: string;
+          probes: { name: string; value?: number }[];
+        }[];
+      };
+    };
+    expect(payload.outcome.status).toBe("completed");
+    const analysis = payload.data?.analyses[0];
+    expect(analysis?.analysis).toBe("op");
+    const mid = analysis?.probes.find((probe) => probe.name === "v(mid)");
+    // A resistive divider of two equal resistors. Arithmetic, not a snapshot.
+    expect(mid?.value).toBeCloseTo(0.5, 12);
+  });
+
+  it("carries no data when the testbench wrote no rawfile", async () => {
+    // Not every deck asks for one, and not asking is not a failure.
+    const response = await routeSimulationRequest(
+      post({ netlist: NETLIST, testbench: TESTBENCH }),
+      stubRunner({
+        log: "Circuit: * divider\nv(mid) = 5.000000e-01\n",
+        exitCode: 0,
+        timedOut: false,
+        durationMs: 8,
+      }),
+    );
+    const payload = (await response!.json()) as {
+      outcome: { status: string };
+      data?: unknown;
+    };
+    expect(payload.outcome.status).toBe("completed");
+    expect(payload.data).toBeUndefined();
+  });
+
+  it("fails a run that printed a log and wrote no vectors", async () => {
+    // The other half of #568. An exit code of zero called this a success, and
+    // it reached the author as an empty chart with nothing to explain it.
+    const response = await routeSimulationRequest(
+      post({ netlist: NETLIST, testbench: TESTBENCH }),
+      stubRunner({
+        log: "Circuit: * divider\nNo. of Data Rows : 0\n",
+        exitCode: 0,
+        timedOut: false,
+        durationMs: 9,
+        rawfile: "Title: nothing\n",
+        rawfileFormat: "ascii",
+      }),
+    );
+    const payload = (await response!.json()) as {
+      outcome: { status: string };
+      diagnostics: { severity: string; text: string }[];
+      data?: unknown;
+    };
+    expect(payload.outcome.status).toBe("failed");
+    expect(payload.data).toBeUndefined();
+    // A failure always says why.
+    expect(payload.diagnostics.some((one) => one.severity === "error")).toBe(
+      true,
+    );
+  });
+
+  it("says what to change when the rawfile is binary", async () => {
+    const response = await routeSimulationRequest(
+      post({ netlist: NETLIST, testbench: TESTBENCH }),
+      stubRunner({
+        log: "Circuit: * divider\n",
+        exitCode: 0,
+        timedOut: false,
+        durationMs: 7,
+        rawfile: null,
+        rawfileFormat: "binary",
+      }),
+    );
+    const payload = (await response!.json()) as {
+      outcome: { status: string };
+      diagnostics: { text: string }[];
+    };
+    expect(payload.outcome.status).toBe("failed");
+    expect(payload.diagnostics.map((one) => one.text).join(" ")).toContain(
+      "set filetype=ascii",
+    );
   });
 
   it("passes a timeout through as a timeout, carrying the ceiling", async () => {

--- a/worker/simulation.ts
+++ b/worker/simulation.ts
@@ -22,11 +22,13 @@ import {
   createSimulationInputMetadata,
   isSimulationInputRevision,
   readNgspiceDiagnostics,
+  readSimulationData,
   resolveTimeoutMs,
   simulationConfigurationMetadata,
   verifySimulationEnvironmentMetadata,
   type ModelLibrarySelection,
   type SimulationResult,
+  type SimulationResultData,
 } from "@icm/spice-run";
 
 /** What a container-backed runner has to offer this module. */
@@ -175,6 +177,10 @@ export async function routeSimulationRequest(
     timedOut?: unknown;
     durationMs?: unknown;
     environment?: unknown;
+    // Present once the harness reads back the file a deck wrote. Optional
+    // because a deck that never calls `write` leaves nothing to send.
+    rawfile?: unknown;
+    rawfileFormat?: unknown;
   };
   const environment = await verifySimulationEnvironmentMetadata(
     raw.environment,
@@ -207,6 +213,33 @@ export async function routeSimulationRequest(
       text: "The simulator produced no output, so this run has no result.",
     });
   }
+  // The numbers, when the harness sent a rawfile back.
+  //
+  // This is where a simulation stops being a wall of console text. Until it
+  // was wired up, `@icm/spice-run` could read a rawfile and nothing asked it
+  // to: the route returned `log` and the editor had no numbers to draw. A
+  // deck that never calls `write` still returns no data, and that is a fact
+  // about the testbench rather than a failure.
+  //
+  // The reading's own diagnostics join the run's, which is what finally makes
+  // the outcome depend on whether the measurements came back. `#568` could
+  // only stop an exit code from condemning a correct run; this is the other
+  // half — a run that printed a batch log and wrote no vectors is now the
+  // failure it always was, where an exit code of zero called it a success.
+  let data: SimulationResultData | undefined;
+  const rawfile = typeof raw.rawfile === "string" ? raw.rawfile : null;
+  if (raw.rawfileFormat === "binary") {
+    diagnostics.push({
+      severity: "error",
+      text:
+        "The simulator wrote a binary rawfile, which carries no numbers this " +
+        "reader can use. Put `set filetype=ascii` before `write`.",
+    });
+  } else if (rawfile !== null && rawfile.trim().length > 0) {
+    const reading = readSimulationData(rawfile);
+    diagnostics.push(...reading.diagnostics);
+    if (reading.status === "read") data = reading.data;
+  }
   // Reported, never decisive: see describeExitStatus. Pushed after the checks
   // above so a signal or a silent run still reads as the error it is.
   const exitStatus = describeExitStatus(
@@ -220,6 +253,9 @@ export async function routeSimulationRequest(
     }),
     diagnostics,
     log,
+    // Omitted rather than null when there is nothing to carry: the field's
+    // contract is that its presence means numbers were read.
+    ...(data ? { data } : {}),
     durationMs: typeof raw.durationMs === "number" ? raw.durationMs : 0,
     metadata: {
       schemaVersion: 1,


### PR DESCRIPTION
## The gap

`@icm/spice-run` could read an ngspice rawfile into vectors (#571), and **nothing asked it to**:

```
packages/spice-run   readSimulationData  ✓  exists
worker/simulation.ts                     ✗  never calls it
```

So a simulation ended at a wall of console text. The editor had no numbers to draw, and the API returned `log` and nothing else.

## Change

The route reads the rawfile the harness sends back and returns `SimulationResult.data` — the field #571 already reserved.

- A deck that never calls `write` returns no data. That is a fact about the testbench, not a failure.
- A binary rawfile is named as such, with the one line that fixes it (`set filetype=ascii`).
- `data` is omitted rather than null when absent, because the field's contract is that its presence means numbers were read.

## It closes the half of #568 that #568 could not

#568 stopped an exit code from condemning a run whose measurements came back. Deciding the **opposite** case — a run that printed a batch log and wrote no vectors — needed a reader that could see whether they had, and that reader had not landed yet.

It has now. The reading's diagnostics join the run's, so that case is the failure it always was. An exit status of zero used to call it a success, and the author got an empty chart with nothing to explain it.

## Tests

Four route tests. **Three fail against the unwired route** — verified by stashing the change and re-running:

```
× returns the numbers when the harness sends a rawfile back
× fails a run that printed a log and wrote no vectors
× says what to change when the rawfile is binary
  Tests  3 failed | 14 passed (17)
```

The first uses `fixtures/ngspice-rawfile/divider-op.raw` — written by ngspice 46, not by hand — and asserts `v(mid)` against the arithmetic of two equal resistors rather than against a recorded number.

216 tests pass across `worker`, `packages/spice-run`, `apps/local-host`.

## Sequencing

The harness only sends `rawfile` once #573 lands. Until then this reads a field that never arrives and `data` is simply absent, so it is safe to merge in either order — but simulation does not return numbers end to end until both are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)