### PR TITLE
fix(simulation): one failure stopped the simulator answering at all

### DIFF
--- a/containers/ngspice/Dockerfile
+++ b/containers/ngspice/Dockerfile
@@ -38,7 +38,12 @@ RUN apt-get update \
 ARG RUN_UID=10001
 ARG RUN_GID=10001
 ARG RUN_USER=simulate
-ARG RUN_ROOT=/run/simulation
+# Not /run. A container runtime commonly mounts a tmpfs there, which replaces
+# whatever the image built underneath it -- so the directory created and
+# chowned during the build is gone at runtime, and a non-root process finds a
+# root-owned mount where its home is supposed to be. Every run then fails
+# inside mkdtemp. /var/lib is where a service's own working files belong.
+ARG RUN_ROOT=/var/lib/simulation
 RUN set -eu; \
     if ! getent group "${RUN_GID}" >/dev/null 2>&1; then \
         groupadd --system --gid "${RUN_GID}" "${RUN_USER}"; \

--- a/containers/ngspice/entrypoint.mjs
+++ b/containers/ngspice/entrypoint.mjs
@@ -44,6 +44,9 @@ const PORT = Number(process.env.PORT ?? 8080);
  */
 const RUN_ROOT = process.env.SIMULATION_RUN_ROOT ?? tmpdir();
 
+/** Set at startup when RUN_ROOT cannot hold a run; see the check below. */
+let runRootError = null;
+
 /** Refuse a deck larger than this rather than spend a container waking for it. */
 const MAX_DECK_BYTES = 2 * 1024 * 1024;
 
@@ -568,6 +571,13 @@ async function handleRun(body) {
   }
   const timeoutMs = resolveTimeoutMs(body?.timeoutMs);
 
+  if (runRootError) {
+    return {
+      status: 503,
+      payload: { error: "simulator-unusable", message: runRootError },
+    };
+  }
+
   if (!acquireSlot()) {
     return {
       status: 503,
@@ -586,8 +596,9 @@ async function handleRun(body) {
   // HOME, so the `.spiceinit` ngspice reads is the one written below and
   // never a shared file another run could have left; and it is TMPDIR. The
   // model tree the deck includes is outside it and read-only.
-  const directory = await mkdtemp(join(RUN_ROOT, "run-"));
+  let directory;
   try {
+    directory = await mkdtemp(join(RUN_ROOT, "run-"));
     await writeFile(join(directory, DECK_NAME), deck, "utf8");
     // ASCII rawfiles, so `write` produces something a reader can read.
     // ngspice's default is binary; this is the environment's setting, not an
@@ -634,7 +645,9 @@ async function handleRun(body) {
   } finally {
     // The disk does not survive a sleep, but a woken container serves many
     // runs before sleeping and one author's deck is not another's business.
-    await rm(directory, { recursive: true, force: true }).catch(() => {});
+    if (directory) {
+      await rm(directory, { recursive: true, force: true }).catch(() => {});
+    }
     releaseSlot();
   }
 }
@@ -656,7 +669,15 @@ const server = createServer((request, response) => {
     // broken one.
     environmentPromise.then(
       (environment) =>
-        send(200, { status: "ready", busy, limits: LIMITS, environment }),
+        runRootError
+          ? send(503, {
+              status: "not-ready",
+              busy,
+              limits: LIMITS,
+              environment,
+              error: runRootError,
+            })
+          : send(200, { status: "ready", busy, limits: LIMITS, environment }),
       (error) =>
         send(503, {
           status: "not-ready",
@@ -698,7 +719,25 @@ const server = createServer((request, response) => {
   });
 });
 
-await mkdir(RUN_ROOT, { recursive: true }).catch(() => {});
+// Whether the run root exists and is writable, decided once at startup.
+//
+// This used to be `mkdir(...).catch(() => {})`, and swallowing it was how a
+// container came up reporting itself ready while every run failed: the first
+// request threw inside `mkdtemp`, and the answer to that is a 500 with a
+// stringified errno that names a path and explains nothing.
+//
+// `/run` is the reason it can fail at all. A runtime commonly mounts a tmpfs
+// there, which replaces whatever the image built underneath -- including the
+// directory this harness was given and the ownership it was granted -- so a
+// non-root process finds a root-owned mount where its home used to be.
+try {
+  await mkdir(RUN_ROOT, { recursive: true });
+  const probe = await mkdtemp(join(RUN_ROOT, "startup-"));
+  await rm(probe, { recursive: true, force: true });
+} catch (error) {
+  runRootError = `The run root ${RUN_ROOT} is not usable: ${String(error)}`;
+  console.error(runRootError);
+}
 server.listen(PORT, () => {
   const address = server.address();
   const port = typeof address === "object" && address ? address.port : PORT;

--- a/containers/ngspice/entrypoint.test.mjs
+++ b/containers/ngspice/entrypoint.test.mjs
@@ -396,6 +396,53 @@ describe("health", () => {
   });
 });
 
+describe("a failure does not wedge the simulator", () => {
+  it("hands the slot back when the run directory cannot be made", async () => {
+    // The measured outage, 2026-09-04: `mkdtemp` sat between taking the single
+    // run slot and the `try` that returns it, so the first failure kept the
+    // slot forever. One 500 went out and every request after it was answered
+    // "busy" — by a container running nothing at all. The deploy check saw a
+    // 500 once and 503 from then on, which reads like load and was not.
+    const { port, runRoot } = await startHarness(
+      await simulator("wedge.sh", "echo ngspice-46\n"),
+    );
+    // Take the run root away underneath a started harness, which is what a
+    // tmpfs mounted over it amounts to.
+    await rm(runRoot, { recursive: true, force: true });
+    await writeFile(runRoot, "not a directory\n", "utf8");
+
+    const first = await run(port, { deck: "* one\n.end\n" });
+    expect(first.status).not.toBe(503);
+
+    const second = await run(port, { deck: "* two\n.end\n" });
+    const body = await second.json();
+    // Whatever the answer is, it must not be "another circuit is running".
+    expect(body.error).not.toBe("simulator-busy");
+
+    const health = await fetch(`http://127.0.0.1:${port}/health`);
+    expect((await health.json()).busy).toBe(false);
+  });
+
+  it("says its run root is unusable instead of calling itself ready", async () => {
+    // Swallowing the startup mkdir is how a container came up reporting
+    // "ready" while every run failed. A deploy that trusts /health has to be
+    // told the truth by it.
+    const notADirectory = join(workspace, "run-root-is-a-file");
+    await writeFile(notADirectory, "occupied\n", "utf8");
+    const { port } = await startHarness(
+      await simulator("wedge2.sh", "echo ngspice-46\n"),
+      { SIMULATION_RUN_ROOT: notADirectory },
+    );
+
+    const health = await fetch(`http://127.0.0.1:${port}/health`);
+    expect(health.status).toBe(503);
+    expect((await health.json()).status).toBe("not-ready");
+
+    const response = await run(port, { deck: "* x\n.end\n" });
+    expect((await response.json()).error).toBe("simulator-unusable");
+  });
+});
+
 describe("the kernel limits", () => {
   it("runs the deck under the limits the image sets", async () => {
     const { port } = await startHarness(


### PR DESCRIPTION
## What was happening

The preview's simulator answered **503 to every request**. Not under load — it was running nothing at all.

```
$ POST /api/simulate   (four times, 20 s apart)
{"error":"simulator-refused","status":503}
{"error":"simulator-refused","status":503}
{"error":"simulator-refused","status":503}
{"error":"simulator-refused","status":503}
```

The Deploy Preview check that runs one circuit after each merge failed, and so did every simulation anyone tried.

## Cause

`mkdtemp` sat between taking the single run slot and the `try` whose `finally` gives it back:

```js
if (!acquireSlot()) return busy503;
const directory = await mkdtemp(join(RUN_ROOT, "run-"));   // ← throws here
try { … } finally { rm(directory); releaseSlot(); }        // ← never reached
```

One failure kept the slot forever. A 500 went out, and everything after it was answered *"this simulator is running another circuit"* by a container with nothing in flight.

What the pipeline saw — a 500 once, then steady 503 — reads exactly like a busy service. That is why it did not look like a bug.

## Three changes

**The slot always comes back.** The run directory is made inside the `try`. This is the one that turns a wedged container into a failing request.

**The startup check stops swallowing its error.** It was `mkdir(RUN_ROOT).catch(() => {})`, which is how a container comes up reporting itself *ready* while every run fails. It now proves the directory by making and removing one inside it, refuses runs with `simulator-unusable`, and makes `/health` answer not-ready. A deploy check that trusts `/health` has to be told the truth by it.

**`RUN_ROOT` moves from `/run/simulation` to `/var/lib/simulation`.** This is the likely cause rather than a certainty: a container runtime commonly mounts a tmpfs over `/run`, replacing the directory the image created and the ownership it granted — so the non-root user this image runs as finds a root-owned mount where its home should be. `/var/lib` is where a service's own working files belong, and nothing mounts over it.

## Tests

Both fail against the previous entrypoint — verified by stashing it:

```
× hands the slot back when the run directory cannot be made
× says its run root is unusable instead of calling itself ready
  Tests  2 failed | 12 passed (14)
```

The first takes the run root away underneath a started harness — which is what a tmpfs mounted over it amounts to — and requires the next request to be answered by something other than "busy". The second gives it a run root that is a file and requires `/health` to say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)