### PR TITLE
fix(simulation): a refused run says why, in the container's own words

### DIFF
--- a/worker/simulation.test.ts
+++ b/worker/simulation.test.ts
@@ -379,6 +379,93 @@ describe("simulation route", () => {
     });
   });
 
+  /** Stands in for a container that answered, but refused the run. */
+  function refusingRunner(status: number, body: string): SimulationEnv {
+    return {
+      NGSPICE: {
+        getByName: () => ({
+          fetch: async () =>
+            new Response(body, {
+              status,
+              headers: { "content-type": "application/json" },
+            }),
+        }),
+      },
+    };
+  }
+
+  async function refusal(status: number, body: string) {
+    const response = await routeSimulationRequest(
+      post({ netlist: NETLIST, testbench: TESTBENCH }),
+      refusingRunner(status, body),
+    );
+    expect(response?.status).toBe(502);
+    return (await response!.json()) as Record<string, unknown>;
+  }
+
+  it("says why the simulator refused, in the container's own words", async () => {
+    // The outage of 2026-09-04. A container that could not make a run
+    // directory held its only slot, so every later request was refused as
+    // busy; from outside, the bare status was indistinguishable from a
+    // simulator honestly running someone else's circuit.
+    const payload = await refusal(
+      503,
+      JSON.stringify({
+        error: "simulator-busy",
+        message:
+          "This simulator runs one circuit at a time and is running another one.",
+        retryAfterSeconds: 2,
+      }),
+    );
+    expect(payload).toMatchObject({
+      error: "simulator-refused",
+      status: 503,
+      reason: "simulator-busy",
+    });
+    expect(String(payload.message)).toContain("one circuit at a time");
+  });
+
+  it("separates a container that cannot start a run from one that is busy", async () => {
+    const payload = await refusal(
+      500,
+      JSON.stringify({
+        error: "run-directory-unavailable",
+        message:
+          "The simulator could not make a directory for this run: Error: EACCES",
+      }),
+    );
+    expect(payload).toMatchObject({
+      error: "simulator-refused",
+      status: 500,
+      reason: "run-directory-unavailable",
+    });
+  });
+
+  it("relays a refusal that is not JSON, which is when it is the only clue", async () => {
+    const payload = await refusal(502, "upstream connect error");
+    expect(payload).toMatchObject({
+      error: "simulator-refused",
+      status: 502,
+      message: "upstream connect error",
+    });
+    expect(payload.reason).toBeUndefined();
+  });
+
+  it("carries a status alone when the refusal said nothing", async () => {
+    const payload = await refusal(500, "");
+    expect(payload).toEqual({ error: "simulator-refused", status: 500 });
+  });
+
+  it("clips a refusal that answers with a payload instead of a sentence", async () => {
+    const payload = await refusal(
+      500,
+      JSON.stringify({ error: "x".repeat(5_000) }),
+    );
+    // Bounded: another service's output does not get to set the size of this
+    // one's response.
+    expect(String(payload.reason).length).toBeLessThanOrEqual(401);
+  });
+
   it("distinguishes an unreachable simulator from a failing circuit", async () => {
     const env: SimulationEnv = {
       NGSPICE: {

--- a/worker/simulation.ts
+++ b/worker/simulation.ts
@@ -69,6 +69,79 @@ function runnerFor(env: SimulationEnv, key: string): NgspiceRunner | null {
   return env.NGSPICE ? env.NGSPICE.getByName(key) : null;
 }
 
+/**
+ * How much of a refusal's body is worth carrying back. A refusal is a
+ * sentence, not a payload; more than this is a container misbehaving, and it
+ * is clipped rather than relayed.
+ */
+const MAX_REFUSAL_MESSAGE_CHARS = 400;
+
+function clipRefusalText(text: string): string {
+  return text.length > MAX_REFUSAL_MESSAGE_CHARS
+    ? `${text.slice(0, MAX_REFUSAL_MESSAGE_CHARS)}\u2026`
+    : text;
+}
+
+/**
+ * Why the container refused, in its own words.
+ *
+ * The status code alone is not a diagnosis, and this route used to answer
+ * every refusal with nothing else. The harness already distinguishes a
+ * container that is running someone else's circuit (`simulator-busy`, with a
+ * retry hint) from one that could not make a directory for the run at all
+ * (`run-directory-unavailable`, naming the failure it hit) — and both arrived
+ * here as a bare number.
+ *
+ * On 2026-09-04 that cost the preview channel an outage: a container whose
+ * run root was unwritable answered one 500 and then held its single slot
+ * forever, so every later request came back `503`. From outside, `503` is
+ * also what an honestly busy simulator says. The fault was one line in the
+ * harness, and finding it meant inferring container state from the sequence
+ * of status codes across repeated probes, because the sentence that named it
+ * was discarded here. Carrying that sentence costs nothing.
+ *
+ * Carried, never trusted: this is another service's output, so it is read as
+ * text, bounded, and reported under its own keys rather than spread into the
+ * response where it could shadow a field of this route's own.
+ */
+async function describeRefusal(
+  response: Response,
+): Promise<{ reason?: string; message?: string }> {
+  let body: string;
+  try {
+    body = await response.text();
+  } catch {
+    // A refusal whose body cannot even be read still has its status, which
+    // is what the caller had before this existed.
+    return {};
+  }
+  const trimmed = body.trim();
+  if (trimmed.length === 0) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    // Not JSON. A proxy in front of the container, or a harness that died
+    // before it could answer in its own format, replies in plain text — and
+    // that text is then the only clue there is.
+    return { message: clipRefusalText(trimmed) };
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return { message: clipRefusalText(trimmed) };
+  }
+  const fields = parsed as { error?: unknown; message?: unknown };
+  const reason = typeof fields.error === "string" ? fields.error : null;
+  const message = typeof fields.message === "string" ? fields.message : null;
+  if (reason === null && message === null) {
+    return { message: clipRefusalText(trimmed) };
+  }
+  return {
+    ...(reason === null ? {} : { reason: clipRefusalText(reason) }),
+    ...(message === null ? {} : { message: clipRefusalText(message) }),
+  };
+}
+
 export async function routeSimulationRequest(
   request: Request,
   env: SimulationEnv,
@@ -165,7 +238,11 @@ export async function routeSimulationRequest(
   }
   if (!containerResponse.ok) {
     return Response.json(
-      { error: "simulator-refused", status: containerResponse.status },
+      {
+        error: "simulator-refused",
+        status: containerResponse.status,
+        ...(await describeRefusal(containerResponse)),
+      },
       { status: 502 },
     );
   }


### PR DESCRIPTION
## What this changes

The simulation route answered every container refusal with a bare upstream status:

```json
{"error":"simulator-refused","status":503}
```

The container's own explanation was read off the wire and thrown away. It now travels with the refusal as `reason` (the container's error code) and `message` (its sentence).

## Why

This is what the preview outage of 2026-09-04 cost to diagnose.

A container whose run root was unwritable answered one `500` and then held its single run slot forever (fixed in #584), so every later request came back `503`. From outside, `503` is also exactly what an honestly busy simulator says — the harness's own `simulator-busy` — and `500` says nothing at all.

The harness already had precise words for both cases:

| container says | means |
| --- | --- |
| `simulator-busy` | running someone else's circuit; retry hint attached |
| `run-directory-unavailable` | could not make a directory for this run, naming the OS failure |

None of them reached the caller. Finding a one-line harness fault meant inferring container state from the *sequence* of status codes across repeated probes. Carrying the sentence the container already wrote costs nothing.

## Shape

- `reason` / `message` are additive. A refusal with an empty body answers exactly what it answered before, so nothing reading this response today has to change.
- A refusal that is not JSON is relayed as `message` — a proxy in front of the container, or a harness that died mid-answer, replies in plain text, and that text is then the only clue there is.
- Carried, never trusted: another service's output is read as text, clipped to 400 characters, and reported under its own keys rather than spread into the response where it could shadow a field of this route's own.

## Tests

The refusal branch had **no test at all**. It has five. Three fail against the unchanged route (verified by re-running them against `origin/main`'s `worker/simulation.ts`); the other two are guards — that an empty refusal keeps its current shape, and that a container answering with a payload instead of a sentence cannot set the size of this route's response.

## Reported, not fixed here

The deploy's simulation smoke runs about **8 seconds** after `wrangler` swaps the container image, so it tests whichever instance happens to be serving — usually still the previous one.

That is a false green as well as a false red. #573 shipped a broken image at 08:26Z behind a check that passed against the instance it replaced; the failure only surfaced one merge later, which is why it looked like #580 caused it.

Closing it needs the container to report an identity the workflow can compare against what it just pushed — the container target's contract to move, not this one's. Noting explicitly that a naive retry would make it **worse**: polling keeps the wedged instance awake and stops it being recycled. That was measured here — the preview only recovered after ~11 minutes of no requests at all.

## Validation

- `pnpm test:local worker/simulation.test.ts` — 22 passed
- new assertions re-run against `origin/main`'s route — 3 fail without the change
- `pnpm typecheck`, `pnpm gate:preflight -- --base origin/main`, `pnpm gate:affected -- --base origin/main` — all green
- Live preview after #584: two consecutive runs `"status":"completed"`, divider solving `out = 5.000000e-01` on a 1 V source, `v1#branch = -5.0e-04`

Test-Impact: tests-updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
