### PR TITLE
refactor(build): the typecheck now fails on a parameter nothing reads

### DIFF
--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -3727,7 +3727,6 @@ export function App({
       pendingSymbolId,
       pendingComponentPlacement: Boolean(pendingComponentPlacement),
       vddRailMode,
-      copyPlacementActive: copyPlacement !== null,
       waveformPlacementActive: pendingWaveformPlacement !== null,
       snapPlacementPoint: (point) => {
         const pitch =

--- a/apps/editor/src/canvas/editor-canvas-event-handlers.ts
+++ b/apps/editor/src/canvas/editor-canvas-event-handlers.ts
@@ -69,7 +69,6 @@ interface CanvasEventHandlerDependencies {
     pendingSymbolId: string | null;
     pendingComponentPlacement: boolean;
     vddRailMode: boolean;
-    copyPlacementActive: boolean;
     waveformPlacementActive: boolean;
     snapPlacementPoint: (point: Point) => Point;
     commitCopyPlacement: (point: Point) => void;
@@ -149,7 +148,6 @@ export function createEditorCanvasEventHandlers({
     pendingSymbolId,
     pendingComponentPlacement,
     vddRailMode,
-    copyPlacementActive,
     waveformPlacementActive,
     snapPlacementPoint,
     commitCopyPlacement,

--- a/packages/derived/src/contact.ts
+++ b/packages/derived/src/contact.ts
@@ -203,7 +203,6 @@ function routeEndpointDirections(
 function contactIncidents(
   document: SchematicDocument,
   resolver: SymbolResolver,
-  netId: string,
   endpoints: readonly RouteEndpoint[],
   point: Point,
   geometry: ResolvedDocumentRoutingGeometry,
@@ -288,7 +287,6 @@ function netContacts(
       const incidents = contactIncidents(
         document,
         resolver,
-        net.id,
         endpoints,
         point,
         geometry,

--- a/packages/edit-engine/src/routing-planner.ts
+++ b/packages/edit-engine/src/routing-planner.ts
@@ -686,7 +686,6 @@ function endpointLandingAt(
  */
 function landingEdits(
   document: SchematicDocument,
-  resolver: SymbolResolver,
   movedEndpoint: RouteEndpoint,
   movedNetId: string | null,
   landing: EndpointLanding,
@@ -799,7 +798,6 @@ export function proposeLooseRouteTranslation(
       edits.push(
         ...landingEdits(
           document,
-          landing.resolver,
           movedEndpoint,
           route.netId,
           landed,
@@ -1027,7 +1025,6 @@ export function proposeRouteEndpointMove(
     edits.push(
       ...landingEdits(
         base,
-        resolver,
         { kind: "junction", junctionId },
         route.netId,
         landing,

--- a/packages/edit-engine/src/transaction-connectivity.ts
+++ b/packages/edit-engine/src/transaction-connectivity.ts
@@ -387,7 +387,6 @@ export function retargetConnectivityEvidenceOwner(
 export function retargetOwnerEvidenceAfterSplit(
   draft: SchematicDocument,
   originalNetId: string,
-  netIdByEndpoint: ReadonlyMap<string, string>,
   changedObjectIds: Set<string>,
 ): void {
   const instanceNetId = (instanceId: string): string | undefined =>

--- a/packages/edit-engine/src/transaction-route-topology.ts
+++ b/packages/edit-engine/src/transaction-route-topology.ts
@@ -646,12 +646,7 @@ export function applyRouteTopologyEdit(
             changedObjectIds.add(remainingRoute.id);
           }
         }
-        retargetOwnerEvidenceAfterSplit(
-          draft,
-          net.id,
-          netIdByEndpoint,
-          changedObjectIds,
-        );
+        retargetOwnerEvidenceAfterSplit(draft, net.id, changedObjectIds);
         propagateSpiceSourceEvidenceAfterSplit(
           draft,
           net.id,

--- a/packages/symbols/src/pdk-registry.ts
+++ b/packages/symbols/src/pdk-registry.ts
@@ -29,9 +29,8 @@ export const reviewedSky130MosModels = {
 export function reviewedSky130MosModelSuggestions(
   symbolId: string,
 ): readonly string[] {
-  return reviewedExternalModelSuggestions(symbolId).filter(
-    (name) => symbolId === "nmos" || symbolId === "pmos",
-  );
+  if (symbolId !== "nmos" && symbolId !== "pmos") return [];
+  return reviewedExternalModelSuggestions(symbolId);
 }
 
 export function resolvePdkSymbolMapping(

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -4,6 +4,7 @@
     "jsx": "react-jsx",
     "noEmit": true,
     "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "paths": {
       "@icm/agent-adapter": ["./packages/agent-adapter/src/index.ts"],
       "@icm/agent-adapter/kit": ["./packages/agent-adapter/src/agent-kit.ts"],


### PR DESCRIPTION
#589 turned on `noUnusedLocals` and left `noUnusedParameters` off, because its
findings needed decisions rather than a mechanical fix. This resolves them and
turns the flag on.

Every site turned out to be the same shape: a parameter whose job moved
somewhere else, with the declaration left behind. In no case had a caller
stopped threading a value the body still needs — which is exactly what an
underscore prefix would have buried instead of answering. No parameter here is
renamed to `_`.

| Site | Verdict |
| --- | --- |
| `contactIncidents` — `netId` | #540 hoisted `route.netId !== netId` into the caller as the pre-scoped `routesForNet`. Inert since. |
| `retargetOwnerEvidenceAfterSplit` — `netIdByEndpoint` | `9e97be0e` deleted the `free-port` owner branch holding the only read and moved the same lookup into the caller, which now reconciles every remaining Route's `netId` from the map first. |
| `landingEdits` — `resolver` | **A fifth site**, added by #582 after the four were counted. The resolver belongs to `endpointLandingAt`, which both callers run one line earlier; neither `planDirectEndpointConnection` nor `proposeEndpointRouteAttachment` accepts one. |
| `reviewedSky130MosModelSuggestions` | The `.filter` predicate ignored its own element and tested the enclosing `symbolId`, so it kept everything or nothing. Now an early guard. |
| `copyPlacementActive` | Superseded by `interactionKind() === "copy-placement"`, which guards both the commit and the preview clear. |

### On the two arity changes

`retargetOwnerEvidenceAfterSplit` is `export`ed, so I checked whether it
escapes: `transaction-connectivity.js` is absent from
`packages/edit-engine/src/index.ts`, nothing re-exports it, and the package
publishes a single `.` entry. The `export` keyword serves one sibling module,
so the arity change cannot reach a consumer. `contactIncidents` and
`landingEdits` are module-private with one and two call sites.

`copyPlacementActive` is removed from its interface and from the `App.tsx`
literal feeding it as well as from the destructuring pattern — a required
property nothing reads is the same dead weight one step earlier. The
identically named `inputPlanes` property is a different, live one and stays.

### Validation

`pnpm gate:plan -- --base main` selects `full-delivery`, so `pnpm ci:check`
ran (under the repo gate lock). Static, 2500 unit tests, `pnpm -r build`, and
the release/packaged-MCP smoke all passed.

The browser suite reported 348 passed and one failure:
`wiring-semantics.spec.ts:122`, expecting 3 route hit targets and seeing 2 —
byte-identical to the failure #589 documented and filed for separate
investigation, which fails the same way on this machine with neither that
commit nor this one present. It is green on CI's Linux runners, so the remote
checks here are the authoritative verdict.

That spec is worth naming explicitly because it exercises the path this PR
touches: it drags a loose wire onto another so the target splits. The change
to `landingEdits` cannot affect it — detection happens in `endpointLandingAt`,
which is untouched and still receives the resolver at both call sites, and the
split is emitted by `proposeEndpointRouteAttachment`, which is untouched and
never took a resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
