### PR TITLE
test(editor): the wire-splice drag aims at the wire, not where it used to be

### DIFF
--- a/apps/editor/e2e/wiring-semantics.spec.ts
+++ b/apps/editor/e2e/wiring-semantics.spec.ts
@@ -1,5 +1,5 @@
 import { createEmptyProject } from "@icm/model";
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 
 import { chooseComponent, clickDrawTool } from "./editor-fixtures";
 
@@ -19,6 +19,65 @@ async function instanceIds(page: Page): Promise<string[]> {
     .evaluateAll((elements) =>
       elements.map((element) => element.getAttribute("data-canvas-hit-id")!),
     );
+}
+
+/**
+ * Where document points are on screen, through the canvas's own screen CTM.
+ *
+ * That matrix is the transform the editor inverts to read every pointer, so
+ * aiming a gesture through it is aiming at exactly the document coordinate
+ * named. A rendered bounding box is not a substitute: Chromium's box model
+ * counts an SVG stroke as part of the shape, and the hit polylines carry a
+ * 14px non-scaling one.
+ */
+async function onScreen(
+  canvas: Locator,
+  points: readonly { x: number; y: number }[],
+): Promise<{ x: number; y: number }[]> {
+  const screen = await canvas.evaluate((element, logical) => {
+    const matrix = (element as SVGSVGElement).getScreenCTM();
+    if (!matrix) return null;
+    return logical.map((point) => {
+      const mapped = new DOMPoint(point.x, point.y).matrixTransform(matrix);
+      return { x: mapped.x, y: mapped.y };
+    });
+  }, points);
+  if (!screen) throw new Error("Canvas geometry is not measurable");
+  return screen;
+}
+
+/**
+ * Hold until the canvas has stopped moving under the pointer.
+ *
+ * Panel toggles animate the workspace grid, and the canvas keeps growing into
+ * the freed column for the whole transition: the drawing slides sideways and
+ * the document-to-pixel scale climbs as it goes. The aria attribute a toggle
+ * flips is set on the click, not at the end of that animation, so a pixel-
+ * exact gesture measured straight afterwards aims at where the drawing WAS.
+ */
+async function awaitCanvasSettled(canvas: Locator): Promise<void> {
+  await canvas.evaluate(
+    (element) =>
+      new Promise<void>((resolve) => {
+        const svg = element as SVGSVGElement;
+        const read = () => {
+          const matrix = svg.getScreenCTM();
+          return matrix
+            ? `${matrix.a} ${matrix.d} ${matrix.e} ${matrix.f}`
+            : "";
+        };
+        let previous = read();
+        let stillFrames = 0;
+        const step = () => {
+          const current = read();
+          stillFrames = current === previous ? stillFrames + 1 : 0;
+          previous = current;
+          if (stillFrames >= 3) resolve();
+          else requestAnimationFrame(step);
+        };
+        requestAnimationFrame(step);
+      }),
+  );
 }
 
 test("wire can start from any interior point of an existing net", async ({
@@ -151,11 +210,14 @@ test("dragging a wire's end onto another wire joins them into one net", async ({
     "false",
   );
 
+  await awaitCanvasSettled(canvas);
+
   // Drag the vertical wire down so its lower end comes to rest on the
   // horizontal one. This is the gesture that used to leave two nets touching
   // at a point, with an ambiguous-junction error the author could not clear.
-  // The travel is measured from what is actually rendered rather than assumed
-  // from the click coordinates, so page scale cannot leave the end just shy.
+  // The travel is read from what is actually rendered rather than assumed from
+  // the click coordinates, and aimed through the canvas transform, so the end
+  // is released ON the wire instead of a rounding step past it.
   const routes = page.locator('[data-canvas-hit-kind="route"]');
   const drawn = await routes.evaluateAll((elements) =>
     elements.map((element) => {
@@ -175,22 +237,17 @@ test("dragging a wire's end onto another wire joins them into one net", async ({
   );
   const horizontal = drawn.find((route) => route.maxX - route.minX > 0)!;
   const vertical = drawn.find((route) => route.maxY - route.minY > 0)!;
-  // Drawn coordinates are document units; the drag is in screen pixels, so
-  // derive the scale from a span that is known in both.
-  const horizontalBox = (await routes
-    .nth(drawn.indexOf(horizontal))
-    .boundingBox())!;
-  const verticalBox = (await routes
-    .nth(drawn.indexOf(vertical))
-    .boundingBox())!;
-  const scale = horizontalBox.width / (horizontal.maxX - horizontal.minX);
-  const travel = (horizontal.minY - vertical.maxY) * scale;
-  const grabX = verticalBox.x + verticalBox.width / 2;
-  const grabY = verticalBox.y + verticalBox.height / 2;
-  await page.mouse.move(grabX, grabY);
+  const grabbedAt = (vertical.minY + vertical.maxY) / 2;
+  const travel = horizontal.minY - vertical.maxY;
+  const [grab, halfway, release] = await onScreen(canvas, [
+    { x: vertical.minX, y: grabbedAt },
+    { x: vertical.minX, y: grabbedAt + travel / 2 },
+    { x: vertical.minX, y: grabbedAt + travel },
+  ]);
+  await page.mouse.move(grab!.x, grab!.y);
   await page.mouse.down();
-  await page.mouse.move(grabX, grabY + travel / 2, { steps: 6 });
-  await page.mouse.move(grabX, grabY + travel, { steps: 6 });
+  await page.mouse.move(halfway!.x, halfway!.y, { steps: 6 });
+  await page.mouse.move(release!.x, release!.y, { steps: 6 });
   await page.mouse.up();
 
   // The landing tapped the horizontal wire: it splits, and a junction dot
@@ -320,19 +377,7 @@ test("the preview draws the wire the release commits, contacts and all", async (
     buffer: Buffer.from(JSON.stringify(project)),
   });
   const canvas = page.getByTestId("schematic-canvas");
-  const onScreen = async (points: readonly { x: number; y: number }[]) => {
-    const screen = await canvas.evaluate((element, logical) => {
-      const matrix = (element as SVGSVGElement).getScreenCTM();
-      if (!matrix) return null;
-      return logical.map((point) => {
-        const mapped = new DOMPoint(point.x, point.y).matrixTransform(matrix);
-        return { x: mapped.x, y: mapped.y };
-      });
-    }, points);
-    if (!screen) throw new Error("Canvas geometry is not measurable");
-    return screen;
-  };
-  const [start, end] = await onScreen([
+  const [start, end] = await onScreen(canvas, [
     { x: 40, y: 100 },
     { x: 200, y: 100 },
   ]);


### PR DESCRIPTION
## What was wrong

`apps/editor/e2e/wiring-semantics.spec.ts` — "dragging a wire's end onto another
wire joins them into one net" — failed on macOS and passed on every CI shard,
deterministically, solo on an idle machine. It blocked `pnpm ci:check` on that
machine outright: 348 of 349 browser specs passed and this one did not.

It was never the editor. The press missed the wire.

### 1. The gesture was aimed at a layout still in motion

The test collapses the selection shelf to clear the drawing surface and waits
for `aria-expanded` to read `"false"`. That attribute flips on the click. The
canvas then keeps growing into the freed column for hundreds of milliseconds —
`.selection-dock` transitions its `width` and `.app-workspace` its
`grid-template-columns`, 160ms each — and the drawing slides sideways the whole
way. Sampled through the canvas's screen CTM in one run:

| moment | canvas width | px per document unit | vertical wire's client x |
| --- | --- | --- | --- |
| shelf reported closed | 776.5 | 0.809 | 514.9 |
| pointer moved to the grab point | 881.2 | 0.918 | 550.9 |
| pointer pressed | 921.4 | 0.938 | 568.1 |
| settled | 992.0 | 0.938 | 603.4 |

The test pressed at x≈515 against a 14px hit band. The press landed on empty
page and opened a marquee — the status bar still read "Selection cleared" at the
end, which is a marquee finishing on nothing. Nothing was ever dragged, so
nothing spliced, so there were 2 routes rather than 3.

`page.mouse` is the only pointer API in this suite with no actionability check,
which is why this test and no other is exposed to it. `awaitCanvasSettled` holds
until the canvas's screen CTM stops changing.

### 2. The travel was scaled by a stroke

Only reachable once the first defect was fixed. The travel came from
`horizontalBox.width / spanDoc`, and Playwright's `boundingBox()` counts an SVG
stroke as part of the shape. The hit polyline carries a 14px non-scaling one, so
the scale read 0.9935 where the canvas transform said 0.9375. Over a 250-unit
span that stretched an 80-unit drop to 84.78 — and the drag delta is rounded to
the 10-unit grid, so the gesture stood **0.22 document units, a fifth of a
pixel**, from landing a step past the wire and splicing nothing.

The travel now maps through the canvas's own screen CTM: the transform the
editor inverts to read every pointer, so the end is released ON the wire.
`onScreen` was already written for exactly this a few tests down in the same
file; it moves to module scope and both tests use it.

## What is not changed

No editor code, and no assertion. `toHaveCount(3)`, the junction dot, and the
clean re-check all stand as they were. The product behaves correctly: a delta is
rounded to the grid, and an end released on a conductor bonds, exactly as
`docs/specs/connectivity-and-routing.md` says.

## Validation

- The whole `wiring-semantics` spec three consecutive times: 7 passed each
  (13.1s, 14.2s, 13.6s).
- Two controls, both measured **before** the fix, both against the shipped
  arithmetic:
  - settle wait alone → **passes**, overshoot 4.779 against a limit of 5,
    leaving 3 routes, 1 junction, and "Moved route-ui-6 onto the wire it now
    shares a net with";
  - CTM aiming alone, no settle wait → **still fails** at 2 routes.

  So the stale layout is the cause and the inflated scale was all the margin
  there was.
- `pnpm ci:check` on the merge commit — reported in a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
