### PR TITLE
fix(deploy): the simulator-host workflow takes a tunnel token of its own

### DIFF
--- a/.github/workflows/simulator-host.yml
+++ b/.github/workflows/simulator-host.yml
@@ -74,7 +74,11 @@ jobs:
       - name: Probe what the Cloudflare token may do
         if: github.event_name == 'workflow_dispatch' && inputs.action == 'probe'
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # A token of its own for the tunnel and the DNS name — the deploy
+          # token can see the zone but may not touch tunnels or records, and
+          # widening it would widen every deploy. Falls back to the deploy
+          # token so the probe can still say what that one may do.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TUNNEL_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
@@ -93,7 +97,11 @@ jobs:
       - name: Create the tunnel, its ingress, and its DNS name; hand the token to the host
         if: github.event_name == 'workflow_dispatch' && inputs.action == 'bootstrap-tunnel'
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # A token of its own for the tunnel and the DNS name — the deploy
+          # token can see the zone but may not touch tunnels or records, and
+          # widening it would widen every deploy. Falls back to the deploy
+          # token so the probe can still say what that one may do.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TUNNEL_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
@@ -154,6 +162,16 @@ jobs:
         if: github.event_name == 'push' || inputs.action != 'probe'
         run: |
           set -euo pipefail
+          # Until the tunnel has been bootstrapped there is no public name to
+          # ask; a rebuild is then verified from inside the host's own network,
+          # and says so, rather than failing for the tunnel's absence.
+          if [ -z "$(ssh sim 'docker ps --quiet --filter name=^analog-canvas-tunnel$')" ]; then
+            echo "::notice::no tunnel is running on the host yet; verifying inside its network"
+            ssh sim '~/analog-canvas-sim/bin/health.sh' > /tmp/health.json
+            jq -e '.status == "ready"' /tmp/health.json >/dev/null || { echo "::error::the harness is not ready on the host"; cat /tmp/health.json || true; exit 1; }
+            echo "ready on the host: ngspice $(jq -r '.environment.simulator.version' /tmp/health.json)"
+            exit 0
+          fi
           for _ in $(seq 1 30); do
             if curl --silent --fail --max-time 10 "https://$SIM_HOSTNAME/health" > /tmp/health.json; then break; fi
             sleep 10

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -148,7 +148,11 @@ tunnel; run by hand it can `probe` what the Cloudflare token may do or
 `bootstrap-tunnel` — create the named tunnel, its ingress, and the DNS name,
 and hand the connector token to the host over SSH without ever printing it.
 It reaches the host with the repository secrets `SIM_HOST_ADDR`,
-`SIM_HOST_USER`, `SIM_HOST_SSH_KEY`, and `SIM_HOST_KNOWN_HOSTS`; on the host
+`SIM_HOST_USER`, `SIM_HOST_SSH_KEY`, and `SIM_HOST_KNOWN_HOSTS`, and speaks to
+Cloudflare with `CLOUDFLARE_TUNNEL_API_TOKEN` (Account → Cloudflare Tunnel:
+Edit, Zone → DNS: Edit on the site's zone), a token separate from the deploy
+token on purpose; before the tunnel exists, an automatic rebuild verifies the
+harness from inside the host's network instead; on the host
 `bin/health.sh` asks the harness for its health from inside that network. The host has 32 cores; the
 harness still runs one job at a time, by its own slot, until the executor
 contract gains a concurrency count.


### PR DESCRIPTION
The first `probe` run of the `Simulator host` workflow answered: the deploy token can list the zone (200) but not tunnels (404) or DNS records (403). Widening the token that every deploy uses is the wrong fix, so the workflow now prefers a dedicated `CLOUDFLARE_TUNNEL_API_TOKEN` (Account → Cloudflare Tunnel: Edit; Zone → DNS: Edit on `tokenzhang.com`) and falls back to the deploy token only so `probe` can still report what that one may do.

The automatic rebuild after a merge also stops failing for the tunnel's absence: with no tunnel container on the host yet it verifies `/health` from inside the host's network and says so (the merge of #587 rebuilt the host correctly and only this step went red); once the tunnel exists it asks through the public name and requires `/run` to answer 401.

Workflow and documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)