### PR TITLE
feat(deploy): the preview simulates on the operator host

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -134,8 +134,11 @@ benchmark base image by digest — so the numbers do not depend on the choice:
   which `deploy-preview.yml` sets from the repository secret of the same name
   on every deploy. When the var is set the container binding is never woken.
 
-The current operator host is the Frankfurt machine, under its `analogcanvas`
-account, in `~/analog-canvas-sim/`. `bin/up.sh` runs the image with a
+The preview runs its simulations on the operator host: `wrangler.preview.jsonc`
+sets `SIMULATION_UPSTREAM_URL` to `https://sim-fra.analog-canvas.tokenzhang.com`,
+so its container binding stays asleep and costs nothing. The current operator
+host is the Frankfurt machine, under its `analogcanvas` account, in
+`~/analog-canvas-sim/`. `bin/up.sh` runs the image with a
 read-only root filesystem, the run root on a volume the image initialised
 for the run account, no capabilities, a pid limit, 8 CPUs and 16 GiB, on an
 internal Docker network that has no route to the internet; `cloudflared` is

--- a/wrangler.preview.jsonc
+++ b/wrangler.preview.jsonc
@@ -32,7 +32,7 @@
     // container is never woken; the host's token arrives as the Worker
     // secret SIMULATION_UPSTREAM_TOKEN (deploy-preview.yml). See
     // docs/deployment.md, "Where the simulator runs".
-    // "SIMULATION_UPSTREAM_URL": "https://sim-fra.analog-canvas.tokenzhang.com",
+    "SIMULATION_UPSTREAM_URL": "https://sim-fra.analog-canvas.tokenzhang.com",
   },
   "assets": {
     "binding": "ASSETS",


### PR DESCRIPTION
One line: `wrangler.preview.jsonc` names the Frankfurt host (`https://sim-fra.analog-canvas.tokenzhang.com`) as the simulator, so `/api/simulate` on the preview runs there — 32 cores instead of one, no per-second bill, no 120 s ceiling — and the Cloudflare container binding stays asleep. The Worker presents the host's token from the secret `deploy-preview.yml` already sets (#587); the host answers 401 to anyone else.

**Do not merge before the tunnel is verified**: the preview deploy runs a simulation as its last check and would go red for the tunnel's absence. The `Simulator host` workflow's `bootstrap-tunnel` run is the gate for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)