### PR TITLE
fix(deploy): the simulator-host workflow runs in the preview environment

### DIFF
--- a/.github/workflows/simulator-host.yml
+++ b/.github/workflows/simulator-host.yml
@@ -46,6 +46,10 @@ jobs:
   host:
     name: ${{ github.event_name == 'push' && 'deploy' || inputs.action }}
     runs-on: ubuntu-latest
+    # The account id and the deploy token live in this environment's secrets,
+    # as the preview deploy reads them; without it CLOUDFLARE_ACCOUNT_ID is
+    # empty and every account-scoped request routes to /accounts//… (7003).
+    environment: cloudflare-preview
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The first `bootstrap-tunnel` run asked Cloudflare for `/accounts//cfd_tunnel` (error 7003): `CLOUDFLARE_ACCOUNT_ID` was empty in the job. The preview and production deploys read it from their GitHub environments (`cloudflare-preview`, `cloudflare-production`); a job with no environment sees none of those secrets. The job now runs in `cloudflare-preview`, exactly as the preview deploy does.

Workflow only. Local check: `pnpm ci:static`; the full browser suite cannot exercise a workflow file, and remote CI runs it regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)