### PR TITLE
feat(simulation): supervise each harness run lifecycle

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -97,7 +97,7 @@ jobs:
           node -e '
             const health = require("/tmp/health.json");
             if (health.status !== "ready") throw new Error("container not ready");
-            if (health.busy !== false) throw new Error("a fresh container is not busy");
+            if (health.activity?.state !== "idle") throw new Error("a fresh container is not idle");
             if (health.limits.concurrentRuns !== 1) throw new Error("the slot is not single");
             if (health.environment.simulator.name !== "ngspice") throw new Error("no simulator identified");
             if (!/^[0-9a-f]{64}$/.test(health.environment.fingerprint)) throw new Error("no fingerprint");
@@ -171,17 +171,17 @@ jobs:
             -H 'content-type: application/json' --data @/tmp/slow-request.json \
             http://127.0.0.1:8080/run &
           slow=$!
-          busy=""
+          active=""
           for _ in $(seq 1 100); do
             if curl --silent --fail --max-time 5 http://127.0.0.1:8080/health \
-                | grep -q '"busy":true'; then
-              busy=yes
+                | grep -q '"state":"active"'; then
+              active=yes
               break
             fi
             sleep 0.2
           done
-          if [ -z "$busy" ]; then
-            echo "The container never reported itself busy; the guard cannot be observed."
+          if [ -z "$active" ]; then
+            echo "The container never reported an active run; the guard cannot be observed."
             wait "$slow" || true
             exit 1
           fi
@@ -197,3 +197,56 @@ jobs:
           fi
           grep -iq '^retry-after:' /tmp/second.head \
             || { echo "A refusal must say when to come back."; cat /tmp/second.head; exit 1; }
+
+      - name: Replace a harness whose run lease expires
+        run: |
+          set -euo pipefail
+          docker run -d --name icm-ngspice-recovery --restart unless-stopped \
+            -e SIMULATION_RUN_LIFECYCLE_GRACE_MS=1 \
+            -p 127.0.0.1:8081:8080 icm-ngspice:pr
+          trap 'docker update --restart=no icm-ngspice-recovery >/dev/null 2>&1 || true; docker logs icm-ngspice-recovery || true; docker rm -f icm-ngspice-recovery >/dev/null 2>&1 || true' EXIT
+
+          ready() {
+            curl --silent --fail --max-time 5 http://127.0.0.1:8081/health \
+              | grep -q '"status":"ready"'
+          }
+          for _ in $(seq 1 180); do
+            if ready; then break; fi
+            sleep 1
+          done
+          ready || { echo "The recovery container never became ready."; exit 1; }
+
+          # One millisecond is intentionally impossible for this transient
+          # analysis. The process timeout starts termination; the one
+          # millisecond lifecycle grace then proves that a lease which cannot
+          # settle makes PID 1 exit instead of remaining busy forever.
+          node -e '
+            const deck = [
+              "V1 in 0 DC 1",
+              "R1 in out 1k",
+              "C1 out 0 1u",
+              ".tran 1n 200m",
+              ".end",
+              "",
+            ].join("\n");
+            process.stdout.write(JSON.stringify({ deck, timeoutMs: 1 }));
+          ' > /tmp/watchdog-request.json
+          curl --silent --show-error --max-time 10 \
+            -H 'content-type: application/json' --data @/tmp/watchdog-request.json \
+            http://127.0.0.1:8081/run > /tmp/watchdog-result.json || true
+
+          restarted=""
+          for _ in $(seq 1 180); do
+            count="$(docker inspect --format '{{.RestartCount}}' icm-ngspice-recovery)"
+            if [ "$count" -ge 1 ] && ready; then
+              restarted=yes
+              break
+            fi
+            sleep 1
+          done
+          if [ -z "$restarted" ]; then
+            echo "The fatal harness was not replaced by a ready instance."
+            docker inspect --format 'restart count: {{.RestartCount}}, status: {{.State.Status}}' icm-ngspice-recovery
+            exit 1
+          fi
+          echo "The expired run retired its harness; restart count: $(docker inspect --format '{{.RestartCount}}' icm-ngspice-recovery)"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -122,15 +122,14 @@ jobs:
             exit 1
           fi
       # A resistor divider, the smallest circuit ngspice can answer for. It
-      # proves the whole chain: container built, models present, harness up,
-      # Worker talking to it. The circuit's own answer is checked by tests
-      # elsewhere; here the question is only "did a simulation happen".
+      # proves the whole chain: runner available, harness up, Worker talking
+      # to it, rawfile parsed, and the expected number returned.
       - name: Simulate one circuit on the preview
         run: |
           set -euo pipefail
           body="$(node -e '
             const netlist = [".subckt divider in out", "R1 in out 1k", "R2 out 0 1k", ".ends divider"].join("\n");
-            const testbench = ["V1 in 0 DC 1", "X1 in out divider", ".op", ".end"].join("\n");
+            const testbench = ["V1 in 0 DC 1", "X1 in out divider", ".control", "op", "write out.raw", ".endc", ".end"].join("\n");
             process.stdout.write(JSON.stringify({ netlist, testbench, inputRevision: "preview-smoke", timeoutMs: 110000 }));
           ')"
           result="$(curl --silent --show-error --max-time 120 \
@@ -140,14 +139,25 @@ jobs:
             "${PREVIEW_URL}/api/simulate")"
           cat /tmp/preview-simulation.json; echo
           if [ "$result" != "200" ]; then
-            echo "The preview simulator answered HTTP $result; see the body above."
+            node -e '
+              const body = require("/tmp/preview-simulation.json");
+              console.error(`Preview execution infrastructure failed: ${body.error ?? "unknown"}${body.reason ? ` (${body.reason})` : ""}: ${body.message ?? "no message"}`);
+            '
             exit 1
           fi
-          grep -q '"executor":"hosted-container"' /tmp/preview-simulation.json
-          # HTTP 200 is the route answering, not the circuit being solved: a
-          # timed-out or failed run also arrives as 200. The first live run
-          # timed out at 60 s and would have passed a status-only check.
-          if ! grep -q '"status":"completed"' /tmp/preview-simulation.json; then
-            echo "The simulation did not complete; see the outcome above."
-            exit 1
-          fi
+          node -e '
+            const result = require("/tmp/preview-simulation.json");
+            if (result.metadata?.environment?.executor !== "hosted-container") {
+              throw new Error("the runner did not identify the hosted execution environment");
+            }
+            if (result.outcome?.status !== "completed") {
+              const detail = (result.diagnostics ?? []).map(one => one.text).join("; ");
+              throw new Error(`the circuit reached ${result.outcome?.status ?? "no terminal state"}: ${detail}`);
+            }
+            const op = result.data?.analyses?.find(one => one.analysis === "op");
+            const out = op?.probes?.find(one => one.name.toLowerCase() === "v(out)");
+            if (!out || Math.abs(out.value - 0.5) > 1e-9) {
+              throw new Error(`the divider OP result is ${out?.value ?? "missing"}, expected 0.5`);
+            }
+            console.log(`divider v(out): ${out.value}`);
+          '

--- a/.github/workflows/simulator-host.yml
+++ b/.github/workflows/simulator-host.yml
@@ -165,10 +165,13 @@ jobs:
         if: github.event_name == 'push' || inputs.action == 'deploy'
         run: |
           set -euo pipefail
-          ssh sim 'mkdir -p ~/analog-canvas-sim/build/containers/ngspice'
-          scp -q containers/ngspice/Dockerfile containers/ngspice/entrypoint.mjs sim:~/analog-canvas-sim/build/containers/ngspice/
+          ssh sim 'mkdir -p ~/analog-canvas-sim/build/containers/ngspice ~/analog-canvas-sim/bin'
+          scp -q containers/ngspice/Dockerfile containers/ngspice/entrypoint.mjs containers/ngspice/run-supervisor.mjs sim:~/analog-canvas-sim/build/containers/ngspice/
+          scp -q containers/ngspice/verify-host-runtime.sh sim:~/analog-canvas-sim/bin/verify-runtime.sh
+          ssh sim 'chmod 755 ~/analog-canvas-sim/bin/verify-runtime.sh'
           echo "${GITHUB_SHA::8}" | ssh sim 'cat > ~/analog-canvas-sim/build/SOURCE_COMMIT'
           ssh sim '~/analog-canvas-sim/bin/rebuild.sh'
+          ssh sim '~/analog-canvas-sim/bin/verify-runtime.sh'
 
       - name: Verify the host answers through its tunnel
         if: github.event_name == 'push' || inputs.action != 'probe'

--- a/containers/ngspice/Dockerfile
+++ b/containers/ngspice/Dockerfile
@@ -67,7 +67,7 @@ WORKDIR ${RUN_ROOT}
 # The build context is the repository root (wrangler.preview.jsonc sets
 # image_build_context to "."), so every COPY is repo-root relative.
 ARG HARNESS_DIR=containers/ngspice
-COPY ${HARNESS_DIR}/entrypoint.mjs /opt/harness/entrypoint.mjs
+COPY ${HARNESS_DIR}/entrypoint.mjs ${HARNESS_DIR}/run-supervisor.mjs /opt/harness/
 
 # Nothing a deck can reach is writable except its own run directory.
 #

--- a/containers/ngspice/entrypoint.mjs
+++ b/containers/ngspice/entrypoint.mjs
@@ -33,6 +33,8 @@ import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 
+import { SimulationRunSupervisor } from "./run-supervisor.mjs";
+
 const MODEL_ROOT = process.env.SKY130_MODEL_ROOT ?? "/opt/sky130/sky130A";
 const PORT = Number(process.env.PORT ?? 8080);
 
@@ -93,6 +95,10 @@ const DEFAULT_TIMEOUT_MS = 30_000;
  * here because this is the side that pays for it.
  */
 const MAX_TIMEOUT_MS = positiveEnv("SIMULATION_MAX_TIMEOUT_MS", 120_000);
+const LIFECYCLE_GRACE_MS = positiveEnv(
+  "SIMULATION_RUN_LIFECYCLE_GRACE_MS",
+  10_000,
+);
 
 /**
  * Kernel limits handed to the simulator. `RLIMIT_NPROC` is the fork bomb's
@@ -110,9 +116,6 @@ const MAX_TIMEOUT_MS = positiveEnv("SIMULATION_MAX_TIMEOUT_MS", 120_000);
 const MAX_PROCESSES = optionalPositiveEnv("SIMULATION_MAX_PROCESSES");
 /** `ulimit -f` counts 512-byte blocks in dash and 1 KiB blocks in bash. */
 const MAX_FILE_BLOCKS = optionalPositiveEnv("SIMULATION_MAX_FILE_BLOCKS");
-
-/** Seconds a caller is asked to wait when the single slot is taken. */
-const BUSY_RETRY_AFTER_SECONDS = 2;
 
 /** How long the startup identity probe may take before it is given up on. */
 const PROBE_TIMEOUT_MS = positiveEnv("SIMULATION_PROBE_TIMEOUT_MS", 5_000);
@@ -132,6 +135,12 @@ function optionalPositiveEnv(name) {
   const raw = Number(process.env[name]);
   return Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : null;
 }
+
+const runSupervisor = new SimulationRunSupervisor({
+  defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+  maxTimeoutMs: MAX_TIMEOUT_MS,
+  lifecycleGraceMs: LIFECYCLE_GRACE_MS,
+});
 
 /**
  * Ask a binary something, with a deadline.
@@ -272,11 +281,9 @@ async function observeEnvironment(ngspiceBin) {
 const LIMITS = {
   deckBytes: MAX_DECK_BYTES,
   outputBytes: MAX_OUTPUT_BYTES,
-  defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
-  maxTimeoutMs: MAX_TIMEOUT_MS,
+  ...runSupervisor.limits,
   maxProcesses: MAX_PROCESSES,
   maxFileBlocks: MAX_FILE_BLOCKS,
-  concurrentRuns: 1,
 };
 
 /**
@@ -318,28 +325,12 @@ const environmentPromise = ngspiceBinaryPromise.then(observeEnvironment);
 // Keep a missing binary or model tree observable through /health and /run
 // instead of letting Node treat the startup probe as an unhandled rejection.
 environmentPromise.catch(() => undefined);
-
-/**
- * One job at a time, held by a flag rather than a queue.
- *
- * This is not `max_instances` wearing another hat. That setting bounds how
- * many containers Cloudflare will run; this bounds how many runs one of them
- * accepts, and it is the only one of the two that a second request inside an
- * already-busy container can see. Refusing is the honest answer: two ngspice
- * processes on one core do not both finish sooner, they both miss their
- * deadline, and the second caller would rather be told to come back.
- */
-let busy = false;
-
-function acquireSlot() {
-  if (busy) return false;
-  busy = true;
-  return true;
-}
-
-function releaseSlot() {
-  busy = false;
-}
+const runtimeReadyPromise = Promise.all([
+  ngspiceBinaryPromise,
+  environmentPromise,
+  runRootPromise,
+]);
+runtimeReadyPromise.catch(() => undefined);
 
 /**
  * A capped sink for one of the simulator's two streams.
@@ -434,28 +425,6 @@ function simulatorCommand(binary) {
 }
 
 /**
- * Kill the run's whole process group.
- *
- * `detached: true` gives the simulator its own session, so its pid is also
- * its process-group id and the negative pid reaches everything it started.
- * Signalling the pid alone was the bug: a deck whose `.control` block shells
- * out leaves the child running with the pipes still open, so the deadline
- * expired and the work did not stop.
- */
-function killProcessGroup(child, signal) {
-  if (typeof child.pid !== "number") return;
-  try {
-    process.kill(-child.pid, signal);
-  } catch {
-    try {
-      child.kill(signal);
-    } catch {
-      // Already gone; nothing to stop.
-    }
-  }
-}
-
-/**
  * Run ngspice in batch mode over one deck, inside one directory.
  *
  * `-b` is batch, so the author's own `.control` block drives the run and we
@@ -464,13 +433,12 @@ function killProcessGroup(child, signal) {
  * streams are captured because ngspice splits its diagnostics across them,
  * and the caller needs both to tell a dropped device from a clean run.
  */
-function runNgspice(binary, directory, timeoutMs) {
+function runNgspice(binary, directory, run) {
   return new Promise((resolve) => {
     const startedAt = Date.now();
     const stdout = createCappedSink(Math.ceil(MAX_OUTPUT_BYTES / 2));
     const stderr = createCappedSink(Math.floor(MAX_OUTPUT_BYTES / 2));
     const { command, args } = simulatorCommand(binary);
-    let timedOut = false;
     let settled = false;
     let exited = null;
     let spawnError = null;
@@ -486,17 +454,14 @@ function runNgspice(binary, directory, timeoutMs) {
       // way for a deck to hang forever waiting on it.
       stdio: ["ignore", "pipe", "pipe"],
     });
-
-    const timer = setTimeout(() => {
-      timedOut = true;
-      killProcessGroup(child, "SIGKILL");
-    }, timeoutMs);
+    run.attachProcess(child);
 
     const settle = () => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
       if (graceTimer) clearTimeout(graceTimer);
+      const timedOut = run.timedOut;
+      run.detachProcess(child);
       const signal = exited?.signal ?? null;
       const numericCode = typeof exited?.code === "number" ? exited.code : null;
       // A child that died by a signal we did not send (the kernel's OOM
@@ -531,7 +496,7 @@ function runNgspice(binary, directory, timeoutMs) {
       // Reap anything the deck left behind, then stop waiting for the pipes.
       // A grandchild holding the inherited stdout open is exactly why `close`
       // alone is not the end of a run.
-      killProcessGroup(child, "SIGKILL");
+      run.terminateAttachedProcess();
       graceTimer = setTimeout(settle, 200);
       graceTimer.unref?.();
     });
@@ -613,111 +578,107 @@ async function readRawfile(directory) {
   }
 }
 
-function resolveTimeoutMs(requested) {
-  if (!Number.isFinite(requested)) return DEFAULT_TIMEOUT_MS;
-  return Math.min(Math.max(Math.trunc(requested), 1), MAX_TIMEOUT_MS);
-}
-
 async function handleRun(body) {
   const deck = typeof body?.deck === "string" ? body.deck : null;
   if (!deck) return { status: 400, payload: { error: "missing-deck" } };
   if (Buffer.byteLength(deck, "utf8") > MAX_DECK_BYTES) {
     return { status: 413, payload: { error: "deck-too-large" } };
   }
-  const timeoutMs = resolveTimeoutMs(body?.timeoutMs);
 
-  if (!acquireSlot()) {
+  let runtime;
+  try {
+    runtime = await runtimeReadyPromise;
+  } catch (error) {
     return {
       status: 503,
-      headers: { "retry-after": String(BUSY_RETRY_AFTER_SECONDS) },
+      payload: {
+        error: "simulator-not-ready",
+        message: `The simulator runtime is not ready: ${String(error)}`,
+      },
+    };
+  }
+
+  const [binary, environment, runRoot] = runtime;
+  const admission = await runSupervisor.tryExecute(
+    { timeoutMs: body?.timeoutMs },
+    async (run) => {
+      let directory = null;
+      try {
+        // Every run gets a private cwd, HOME and TMPDIR. The model tree is
+        // outside it and read-only.
+        try {
+          directory = await mkdtemp(join(runRoot, "run-"));
+        } catch (error) {
+          return {
+            status: 500,
+            payload: {
+              error: "run-directory-unavailable",
+              message: `The simulator could not make a directory for this run: ${String(error)}`,
+            },
+          };
+        }
+        await writeFile(join(directory, DECK_NAME), deck, "utf8");
+        await writeFile(
+          join(directory, SPICEINIT_NAME),
+          "set filetype=ascii\n",
+          "utf8",
+        );
+
+        const result = await runNgspice(binary, directory, run);
+        run.phase("collecting");
+        const raw = deckRequestsRawfile(deck)
+          ? await readRawfile(directory)
+          : { rawfile: null, rawfileName: null, rawfileFormat: null };
+
+        const truncatedOutputs = [
+          ...(result.truncated ? ["log"] : []),
+          ...(raw.truncated ? ["rawfile"] : []),
+        ];
+        const log = `${result.stdout}${result.stderr}${
+          result.truncated
+            ? `\n*** output truncated by the simulation harness at ${MAX_OUTPUT_BYTES} bytes ***\n`
+            : ""
+        }`;
+
+        return {
+          status: 200,
+          payload: {
+            log,
+            exitCode: result.exitCode,
+            signal: result.signal,
+            timedOut: result.timedOut,
+            durationMs: result.durationMs,
+            truncated: truncatedOutputs.length > 0,
+            truncatedOutputs,
+            rawfile: raw.rawfile,
+            rawfileName: raw.rawfileName,
+            rawfileFormat: raw.rawfileFormat,
+            limits: { ...LIMITS, timeoutMs: run.timeoutMs },
+            environment,
+          },
+        };
+      } finally {
+        run.phase("cleaning");
+        if (directory) {
+          await rm(directory, { recursive: true, force: true }).catch(() => {});
+        }
+      }
+    },
+  );
+
+  if (admission.kind === "busy") {
+    return {
+      status: 503,
+      headers: { "retry-after": String(admission.retryAfterSeconds) },
       payload: {
         error: "simulator-busy",
         message:
           "This simulator runs one circuit at a time and is running another one.",
-        retryAfterSeconds: BUSY_RETRY_AFTER_SECONDS,
+        retryAfterSeconds: admission.retryAfterSeconds,
       },
     };
   }
-
-  /** Assigned inside the try, read by the finally; null if it never got made. */
-  let directory = null;
-  // Everything from here to the end of the run is inside the slot, so it is
-  // all inside the try that gives the slot back. Making the run's directory
-  // used to sit between the two: a container whose run root was not writable
-  // answered one 500 and then refused every later request as busy, forever,
-  // because the only path that released the slot was never reached. Measured
-  // on the preview channel, 2026-09-04.
-  try {
-    // Every run gets its own directory, made fresh and removed whole. It is
-    // the cwd, so a deck's relative file access lands here and nowhere else;
-    // it is HOME, so the `.spiceinit` ngspice reads is the one written below
-    // and never a shared file another run could have left; and it is TMPDIR.
-    // The model tree the deck includes is outside it and read-only.
-    try {
-      directory = await mkdtemp(join(await runRootPromise, "run-"));
-    } catch (error) {
-      // A run that could not start is not a run that failed. Only this
-      // failure is named here; anything later is the run's own and reaches
-      // the generic handler with its own words.
-      return {
-        status: 500,
-        payload: {
-          error: "run-directory-unavailable",
-          message: `The simulator could not make a directory for this run: ${String(error)}`,
-        },
-      };
-    }
-    await writeFile(join(directory, DECK_NAME), deck, "utf8");
-    // ASCII rawfiles, so `write` produces something a reader can read.
-    // ngspice's default is binary; this is the environment's setting, not an
-    // edit to the deck, and the author's own `.control` block overrides it.
-    await writeFile(
-      join(directory, SPICEINIT_NAME),
-      "set filetype=ascii\n",
-      "utf8",
-    );
-
-    const binary = await ngspiceBinaryPromise;
-    const result = await runNgspice(binary, directory, timeoutMs);
-    const raw = deckRequestsRawfile(deck)
-      ? await readRawfile(directory)
-      : { rawfile: null, rawfileName: null, rawfileFormat: null };
-
-    const truncatedOutputs = [
-      ...(result.truncated ? ["log"] : []),
-      ...(raw.truncated ? ["rawfile"] : []),
-    ];
-    const log = `${result.stdout}${result.stderr}${
-      result.truncated
-        ? `\n*** output truncated by the simulation harness at ${MAX_OUTPUT_BYTES} bytes ***\n`
-        : ""
-    }`;
-
-    return {
-      status: 200,
-      payload: {
-        log,
-        exitCode: result.exitCode,
-        signal: result.signal,
-        timedOut: result.timedOut,
-        durationMs: result.durationMs,
-        truncated: truncatedOutputs.length > 0,
-        truncatedOutputs,
-        rawfile: raw.rawfile,
-        rawfileName: raw.rawfileName,
-        rawfileFormat: raw.rawfileFormat,
-        limits: { ...LIMITS, timeoutMs },
-        environment: await environmentPromise,
-      },
-    };
-  } finally {
-    // The disk does not survive a sleep, but a woken container serves many
-    // runs before sleeping and one author's deck is not another's business.
-    if (directory) {
-      await rm(directory, { recursive: true, force: true }).catch(() => {});
-    }
-    releaseSlot();
-  }
+  return admission.value;
 }
 
 const server = createServer((request, response) => {
@@ -737,20 +698,22 @@ const server = createServer((request, response) => {
     // broken one. The run root is reported because a container that cannot
     // write one answers every run with the same failure, and a deploy check
     // should be able to see that before a circuit does.
-    Promise.all([environmentPromise, runRootPromise]).then(
-      ([environment, runRoot]) =>
-        send(200, {
-          status: "ready",
-          busy,
+    runtimeReadyPromise.then(
+      ([, environment, runRoot]) => {
+        const activity = runSupervisor.snapshot();
+        send(activity.state === "fatal" ? 503 : 200, {
+          status: activity.state === "fatal" ? "not-ready" : "ready",
+          activity,
           limits: LIMITS,
           runRoot,
           ...(runRootFailures.length > 0 ? { runRootFailures } : {}),
           environment,
-        }),
+        });
+      },
       (error) =>
         send(503, {
           status: "not-ready",
-          busy,
+          activity: runSupervisor.snapshot(),
           limits: LIMITS,
           error: String(error),
         }),

--- a/containers/ngspice/entrypoint.test.mjs
+++ b/containers/ngspice/entrypoint.test.mjs
@@ -195,13 +195,23 @@ describe("the single slot", () => {
       });
       // Wait for the slot to actually be taken rather than for a duration:
       // /health answers during a run precisely so this is observable.
+      let activeHealth = null;
       for (let attempt = 0; attempt < 100; attempt += 1) {
         const health = await (
           await fetch(`http://127.0.0.1:${port}/health`)
         ).json();
-        if (health.busy === true) break;
+        if (health.activity?.state === "active") {
+          activeHealth = health;
+          break;
+        }
         await wait(50);
       }
+      expect(activeHealth?.activity).toMatchObject({
+        state: "active",
+        phase: "running",
+      });
+      expect(activeHealth?.activity.heldMs).toBeGreaterThanOrEqual(0);
+      expect(activeHealth?.activity.deadlineInMs).toBeGreaterThan(0);
 
       const second = await run(port, { deck: "* second\n.end\n" });
       expect(second.status).toBe(503);
@@ -417,11 +427,11 @@ describe("health", () => {
 
     const response = await fetch(`http://127.0.0.1:${port}/health`);
     const payload = await response.json();
-
     expect(response.status).toBe(200);
     expect(payload.status).toBe("ready");
-    expect(payload.busy).toBe(false);
+    expect(payload.activity).toEqual({ state: "idle" });
     expect(payload.limits.concurrentRuns).toBe(1);
+    expect(payload.limits.lifecycleGraceMs).toBeGreaterThan(0);
     expect(payload.limits.outputBytes).toBeGreaterThan(0);
     expect(payload.environment.executor).toBe("hosted-container");
     expect(payload.environment.simulator.name).toBe("ngspice");
@@ -473,8 +483,9 @@ describe("a run root that cannot be written", () => {
       expect(second.status).toBe(500);
       expect(second.payload.error).toBe("run-directory-unavailable");
       expect(
-        (await (await fetch(`http://127.0.0.1:${port}/health`)).json()).busy,
-      ).toBe(false);
+        (await (await fetch(`http://127.0.0.1:${port}/health`)).json())
+          .activity,
+      ).toEqual({ state: "idle" });
     },
   );
 

--- a/containers/ngspice/run-supervisor.mjs
+++ b/containers/ngspice/run-supervisor.mjs
@@ -1,0 +1,258 @@
+/**
+ * Own one simulator process from admission through cleanup.
+ *
+ * This is deliberately not a queue and not a product Run resource. It is the
+ * process-local safety boundary inside one harness: one active lease, one
+ * process tree, and one finite lifetime. If that lifetime cannot be brought to
+ * a clean end, the safe recovery is to retire the whole harness rather than
+ * admit a second process beside an uncertain first one.
+ */
+
+const DEFAULT_RETRY_AFTER_SECONDS = 2;
+const DEFAULT_LIFECYCLE_GRACE_MS = 10_000;
+
+const TRANSITIONS = new Map([
+  ["preparing", new Set(["running", "collecting", "cleaning"])],
+  ["running", new Set(["terminating", "collecting", "cleaning"])],
+  ["terminating", new Set(["collecting", "cleaning"])],
+  ["collecting", new Set(["cleaning"])],
+  ["cleaning", new Set()],
+  ["fatal", new Set()],
+]);
+
+function positiveInteger(value, fallback) {
+  return Number.isFinite(value) && value > 0 ? Math.trunc(value) : fallback;
+}
+
+export function resolveRunTimeout(
+  requested,
+  { defaultTimeoutMs, maxTimeoutMs },
+) {
+  const fallback = positiveInteger(defaultTimeoutMs, 30_000);
+  const maximum = positiveInteger(maxTimeoutMs, 120_000);
+  if (!Number.isFinite(requested)) return Math.min(fallback, maximum);
+  return Math.min(Math.max(Math.trunc(requested), 1), maximum);
+}
+
+/** Kill the detached simulator session, falling back to its direct PID. */
+export function terminateProcessGroup(child, signal = "SIGKILL") {
+  if (!child || typeof child.pid !== "number") return;
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // The process has already gone. Termination is idempotent.
+    }
+  }
+}
+
+function defaultFailStop(event) {
+  // One bounded record, with no deck or user data, before PID 1 retires.
+  console.error(JSON.stringify(event));
+  process.exit(70);
+}
+
+export class SimulationRunSupervisor {
+  #active = null;
+  #sequence = 0;
+  #defaultTimeoutMs;
+  #maxTimeoutMs;
+  #lifecycleGraceMs;
+  #retryAfterSeconds;
+  #now;
+  #setTimer;
+  #clearTimer;
+  #terminate;
+  #failStop;
+
+  constructor({
+    defaultTimeoutMs = 30_000,
+    maxTimeoutMs = 120_000,
+    lifecycleGraceMs = DEFAULT_LIFECYCLE_GRACE_MS,
+    retryAfterSeconds = DEFAULT_RETRY_AFTER_SECONDS,
+    now = Date.now,
+    setTimer = setTimeout,
+    clearTimer = clearTimeout,
+    terminate = terminateProcessGroup,
+    failStop = defaultFailStop,
+  } = {}) {
+    this.#defaultTimeoutMs = positiveInteger(defaultTimeoutMs, 30_000);
+    this.#maxTimeoutMs = positiveInteger(maxTimeoutMs, 120_000);
+    this.#lifecycleGraceMs = positiveInteger(
+      lifecycleGraceMs,
+      DEFAULT_LIFECYCLE_GRACE_MS,
+    );
+    this.#retryAfterSeconds = positiveInteger(
+      retryAfterSeconds,
+      DEFAULT_RETRY_AFTER_SECONDS,
+    );
+    this.#now = now;
+    this.#setTimer = setTimer;
+    this.#clearTimer = clearTimer;
+    this.#terminate = terminate;
+    this.#failStop = failStop;
+  }
+
+  get limits() {
+    return {
+      concurrentRuns: 1,
+      defaultTimeoutMs: this.#defaultTimeoutMs,
+      maxTimeoutMs: this.#maxTimeoutMs,
+      lifecycleGraceMs: this.#lifecycleGraceMs,
+    };
+  }
+
+  snapshot() {
+    const active = this.#active;
+    if (!active) return { state: "idle" };
+    const now = this.#now();
+    return {
+      state: active.phase === "fatal" ? "fatal" : "active",
+      phase: active.phase,
+      heldMs: Math.max(0, now - active.acquiredAt),
+      deadlineInMs: Math.max(0, active.hardDeadlineAt - now),
+      ...(active.terminationReason
+        ? { terminationReason: active.terminationReason }
+        : {}),
+    };
+  }
+
+  async tryExecute({ timeoutMs } = {}, operation) {
+    if (typeof operation !== "function") {
+      throw new TypeError("A supervised run needs an operation.");
+    }
+    if (this.#active) {
+      return {
+        kind: "busy",
+        retryAfterSeconds: this.#retryAfterSeconds,
+      };
+    }
+
+    const effectiveTimeoutMs = resolveRunTimeout(timeoutMs, {
+      defaultTimeoutMs: this.#defaultTimeoutMs,
+      maxTimeoutMs: this.#maxTimeoutMs,
+    });
+    const acquiredAt = this.#now();
+    const active = {
+      leaseId: ++this.#sequence,
+      phase: "preparing",
+      acquiredAt,
+      timeoutMs: effectiveTimeoutMs,
+      hardDeadlineAt: acquiredAt + effectiveTimeoutMs + this.#lifecycleGraceMs,
+      child: null,
+      processTimer: null,
+      hardTimer: null,
+      terminationReason: null,
+    };
+    this.#active = active;
+
+    active.hardTimer = this.#setTimer(
+      () => this.#expireLease(active),
+      effectiveTimeoutMs + this.#lifecycleGraceMs,
+    );
+    active.hardTimer?.unref?.();
+
+    const context = this.#context(active, effectiveTimeoutMs);
+    try {
+      return {
+        kind: "completed",
+        value: await operation(context),
+      };
+    } finally {
+      // A fail-stop dependency is injectable in tests and may return. Never
+      // turn a fatal lease back into an idle supervisor in that case.
+      if (this.#active === active && active.phase !== "fatal") {
+        this.#clearActive(active);
+      }
+    }
+  }
+
+  #context(active, effectiveTimeoutMs) {
+    const ensureOwner = () => {
+      if (this.#active !== active) {
+        throw new Error("This run lease no longer owns the simulator slot.");
+      }
+      if (active.phase === "fatal") {
+        throw new Error("This run lease has entered the fatal state.");
+      }
+    };
+
+    return Object.freeze({
+      timeoutMs: effectiveTimeoutMs,
+      phase: (next) => {
+        ensureOwner();
+        if (next === active.phase) return;
+        if (!TRANSITIONS.get(active.phase)?.has(next)) {
+          throw new Error(
+            `Invalid simulator run transition: ${active.phase} -> ${next}.`,
+          );
+        }
+        active.phase = next;
+      },
+      attachProcess: (child) => {
+        ensureOwner();
+        if (active.child) {
+          throw new Error("This run lease already owns a simulator process.");
+        }
+        if (active.phase !== "preparing") {
+          throw new Error(
+            `A simulator process cannot start during ${active.phase}.`,
+          );
+        }
+        active.child = child;
+        active.phase = "running";
+        active.processTimer = this.#setTimer(() => {
+          if (this.#active !== active || active.phase === "fatal") return;
+          active.phase = "terminating";
+          active.terminationReason = "timeout";
+          this.#terminate(active.child, "SIGKILL");
+        }, effectiveTimeoutMs);
+        active.processTimer?.unref?.();
+      },
+      terminateAttachedProcess: () => {
+        ensureOwner();
+        this.#terminate(active.child, "SIGKILL");
+      },
+      detachProcess: (child) => {
+        ensureOwner();
+        if (active.child !== child) return;
+        if (active.processTimer) this.#clearTimer(active.processTimer);
+        active.processTimer = null;
+        active.child = null;
+      },
+      get timedOut() {
+        return active.terminationReason === "timeout";
+      },
+    });
+  }
+
+  #expireLease(active) {
+    if (this.#active !== active || active.phase === "fatal") return;
+    const previousPhase = active.phase;
+    active.phase = "fatal";
+    active.terminationReason = "watchdog";
+    if (active.processTimer) this.#clearTimer(active.processTimer);
+    active.processTimer = null;
+    this.#terminate(active.child, "SIGKILL");
+    this.#failStop({
+      event: "simulation-run-watchdog",
+      reason: "run-lease-expired",
+      phase: previousPhase,
+      heldMs: Math.max(0, this.#now() - active.acquiredAt),
+      timeoutMs: active.timeoutMs,
+      hardDeadlineAt: active.hardDeadlineAt,
+      childAttached: active.child !== null,
+    });
+  }
+
+  #clearActive(active) {
+    if (active.processTimer) this.#clearTimer(active.processTimer);
+    if (active.hardTimer) this.#clearTimer(active.hardTimer);
+    active.processTimer = null;
+    active.hardTimer = null;
+    active.child = null;
+    this.#active = null;
+  }
+}

--- a/containers/ngspice/run-supervisor.test.mjs
+++ b/containers/ngspice/run-supervisor.test.mjs
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  resolveRunTimeout,
+  SimulationRunSupervisor,
+} from "./run-supervisor.mjs";
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("SimulationRunSupervisor", () => {
+  it("admits one lease, reports its phase, and refuses a second", async () => {
+    const held = deferred();
+    const supervisor = new SimulationRunSupervisor();
+    const first = supervisor.tryExecute({ timeoutMs: 10_000 }, async (run) => {
+      run.phase("collecting");
+      await held.promise;
+      run.phase("cleaning");
+      return "done";
+    });
+
+    expect(supervisor.snapshot()).toMatchObject({
+      state: "active",
+      phase: "collecting",
+    });
+    await expect(
+      supervisor.tryExecute({ timeoutMs: 10_000 }, () => "second"),
+    ).resolves.toEqual({ kind: "busy", retryAfterSeconds: 2 });
+
+    held.resolve();
+    await expect(first).resolves.toEqual({ kind: "completed", value: "done" });
+    expect(supervisor.snapshot()).toEqual({ state: "idle" });
+  });
+
+  it("owns process timeout and records why it terminated the tree", async () => {
+    vi.useFakeTimers();
+    try {
+      const processEnded = deferred();
+      const terminate = vi.fn(() => processEnded.resolve());
+      const child = { pid: 42 };
+      const supervisor = new SimulationRunSupervisor({
+        now: () => Date.now(),
+        terminate,
+      });
+
+      const execution = supervisor.tryExecute(
+        { timeoutMs: 100 },
+        async (run) => {
+          run.attachProcess(child);
+          await processEnded.promise;
+          const timedOut = run.timedOut;
+          run.detachProcess(child);
+          run.phase("collecting");
+          run.phase("cleaning");
+          return timedOut;
+        },
+      );
+
+      await vi.advanceTimersByTimeAsync(100);
+      await expect(execution).resolves.toEqual({
+        kind: "completed",
+        value: true,
+      });
+      expect(terminate).toHaveBeenCalledWith(child, "SIGKILL");
+      expect(supervisor.snapshot()).toEqual({ state: "idle" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fail-stops when an admitted operation never settles", async () => {
+    vi.useFakeTimers();
+    try {
+      const never = deferred();
+      const terminate = vi.fn();
+      const failStop = vi.fn();
+      const child = { pid: 77 };
+      const supervisor = new SimulationRunSupervisor({
+        lifecycleGraceMs: 25,
+        now: () => Date.now(),
+        terminate,
+        failStop,
+      });
+
+      void supervisor.tryExecute({ timeoutMs: 100 }, async (run) => {
+        run.attachProcess(child);
+        await never.promise;
+      });
+
+      await vi.advanceTimersByTimeAsync(125);
+
+      expect(terminate).toHaveBeenLastCalledWith(child, "SIGKILL");
+      expect(failStop).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "simulation-run-watchdog",
+          reason: "run-lease-expired",
+        }),
+      );
+      expect(supervisor.snapshot()).toMatchObject({
+        state: "fatal",
+        phase: "fatal",
+        terminationReason: "watchdog",
+      });
+      await expect(
+        supervisor.tryExecute({}, () => "never admitted"),
+      ).resolves.toMatchObject({ kind: "busy" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not let health snapshots extend the hard deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const failStop = vi.fn();
+      const supervisor = new SimulationRunSupervisor({
+        lifecycleGraceMs: 50,
+        now: () => Date.now(),
+        failStop,
+      });
+      const never = deferred();
+      void supervisor.tryExecute({ timeoutMs: 100 }, () => never.promise);
+
+      for (let elapsed = 0; elapsed < 150; elapsed += 10) {
+        supervisor.snapshot();
+        await vi.advanceTimersByTimeAsync(10);
+      }
+
+      expect(failStop).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects invalid phase movement instead of hiding lifecycle drift", async () => {
+    const supervisor = new SimulationRunSupervisor();
+    await expect(
+      supervisor.tryExecute({}, async (run) => {
+        run.phase("cleaning");
+        run.phase("running");
+      }),
+    ).rejects.toThrow("cleaning -> running");
+    expect(supervisor.snapshot()).toEqual({ state: "idle" });
+  });
+});
+
+describe("resolveRunTimeout", () => {
+  const limits = { defaultTimeoutMs: 30_000, maxTimeoutMs: 120_000 };
+
+  it("uses the default and clamps both ends", () => {
+    expect(resolveRunTimeout(undefined, limits)).toBe(30_000);
+    expect(resolveRunTimeout(-10, limits)).toBe(1);
+    expect(resolveRunTimeout(900_000, limits)).toBe(120_000);
+  });
+});

--- a/containers/ngspice/verify-host-runtime.sh
+++ b/containers/ngspice/verify-host-runtime.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -eu
+
+container="${SIMULATION_CONTAINER_NAME:-analog-canvas-ngspice}"
+
+fail() {
+  printf 'simulator host runtime invalid: %s\n' "$1" >&2
+  exit 1
+}
+
+value() {
+  docker inspect --format "$1" "$container"
+}
+
+restart="$(value '{{.HostConfig.RestartPolicy.Name}}')"
+case "$restart" in
+  always|unless-stopped) ;;
+  *) fail "restart policy is '$restart', expected always or unless-stopped" ;;
+esac
+
+[ "$(value '{{.HostConfig.ReadonlyRootfs}}')" = "true" ] \
+  || fail "root filesystem is writable"
+
+cap_drop="$(value '{{json .HostConfig.CapDrop}}')"
+case "$cap_drop" in
+  *ALL*) ;;
+  *) fail "the container does not drop all Linux capabilities" ;;
+esac
+
+pids="$(value '{{.HostConfig.PidsLimit}}')"
+[ "$pids" -gt 0 ] 2>/dev/null || fail "there is no positive PID limit"
+
+nanocpus="$(value '{{.HostConfig.NanoCpus}}')"
+[ "$nanocpus" -eq 8000000000 ] 2>/dev/null \
+  || fail "CPU limit is $nanocpus nanocpus, expected 8000000000"
+
+memory="$(value '{{.HostConfig.Memory}}')"
+[ "$memory" -eq 17179869184 ] 2>/dev/null \
+  || fail "memory limit is $memory bytes, expected 17179869184"
+
+published="$(value '{{json .HostConfig.PortBindings}}')"
+case "$published" in
+  null|'{}') ;;
+  *) fail "the simulator publishes host ports: $published" ;;
+esac
+
+run_root_rw="$(value '{{range .Mounts}}{{if eq .Destination "/var/lib/simulation"}}{{.RW}}{{end}}{{end}}')"
+[ "$run_root_rw" = "true" ] \
+  || fail "the private run-root volume is absent or read-only"
+
+printf 'simulator host runtime verified: restart=%s pids=%s cpus=8 memory=16GiB\n' \
+  "$restart" "$pids"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -153,7 +153,15 @@ Cloudflare with `CLOUDFLARE_TUNNEL_API_TOKEN` (Account → Cloudflare Tunnel:
 Edit, Zone → DNS: Edit on the site's zone), a token separate from the deploy
 token on purpose; before the tunnel exists, an automatic rebuild verifies the
 harness from inside the host's network instead; on the host
-`bin/health.sh` asks the harness for its health from inside that network. The host has 32 cores; the
+`bin/health.sh` asks the harness for its health from inside that network.
+The host's operator-owned `up.sh` and `rebuild.sh` remain outside the
+repository, but their result is no longer trusted by description alone: the
+workflow installs the tracked `containers/ngspice/verify-host-runtime.sh` and
+requires the running container to have an automatic restart policy, a
+read-only root, all capabilities dropped, bounded PIDs, 8 CPUs, 16 GiB, no
+published host port, and a writable private run-root volume. Automatic restart
+is part of the Run Supervisor's fail-stop contract; without it a safe harness
+exit would become a permanent outage. The host has 32 cores; the
 harness still runs one job at a time, by its own slot, until the executor
 contract gains a concurrency count.
 

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -247,6 +247,10 @@ minimums before either is offered to the public:
 - A timeout terminates the whole process tree and the result says
   `timedOut`. Deck size, log size, result-file size, and duration are
   capped; anything cut is reported as truncated rather than presented whole.
+- One process-local Run Supervisor owns admission, phase, timeout, process
+  termination, result collection, cleanup, and the slot's absolute lifetime.
+  If an admitted operation cannot settle inside that lifetime, the harness
+  exits rather than clear the slot beside a process it cannot prove ended.
 - Raw `.control` is permitted. Isolation, not prohibition, keeps a control
   script inside its own job.
 - `GET /health` reports the observed environment facts of the metadata
@@ -306,6 +310,14 @@ signals the whole process group. A deck whose `.control` block shells out
 otherwise leaves a child running past the deadline it was started under,
 still writing, with the container's slot already given to the next caller.
 
+The process timeout is a normal terminal outcome when the group stops and
+cleanup completes. A separate lease watchdog covers the entire interval from
+admission through directory removal. It is not a second circuit timeout: if
+it expires, the harness has lost the ability to prove the slot safe, marks
+itself fatal, kills the group best-effort, and exits so the container runtime
+can replace the instance. Health traffic neither extends nor resets this
+deadline.
+
 **Limits.**
 
 | Limit | Value | Enforced by |
@@ -315,6 +327,7 @@ still writing, with the container's slot already given to the next caller.
 | Returned output | 1 MiB per run | truncation, reported |
 | Default deadline | 30 s | applied when the caller names none |
 | Maximum deadline | 120 s | a longer request is clamped to it |
+| Lifecycle grace | 10 s | hard lease watchdog after the run deadline |
 | Identity probe | 5 s | given up on, not waited for |
 | Processes | 128 (`RLIMIT_NPROC`) | image-set `ulimit` before `exec` |
 | Written file size | 256 MiB (`RLIMIT_FSIZE`) | image-set `ulimit` before `exec` |
@@ -351,10 +364,12 @@ under the same cap; turning its vectors into numbers is
 [Result data](#result-data) and is not done here.
 
 **Readiness.** `GET /health` answers during a run as well as between runs,
-reporting the environment facts, the limits, and whether the slot is taken. A
-check that can only ask when the container is idle cannot tell a busy
-simulator from a broken one. A missing simulator binary or model tree answers
-`503 not-ready` rather than a success with absent facts.
+reporting the environment facts, limits, and the Run Supervisor's one
+`activity` projection. It is `idle`, or it names the active phase, elapsed
+time, and remaining hard-deadline time; it contains no lease id, deck, user,
+or circuit data. A missing simulator binary or model tree answers `503
+not-ready` rather than a success with absent facts. Health is a read-only
+snapshot and never changes the run or its timers.
 
 ## Run lifecycle
 

--- a/scripts/preview-workflow.test.mjs
+++ b/scripts/preview-workflow.test.mjs
@@ -42,8 +42,11 @@ describe("the preview deploy", () => {
     expect(preview).toContain("must be refused");
     expect(preview).toContain("/api/simulate");
     expect(preview).toContain("hosted-container");
-    // A 200 with a timed-out outcome is not a simulation.
-    expect(preview).toContain('"status":"completed"');
+    // A 200 with a timed-out outcome is not a simulation, and a completed
+    // outcome without the expected number is not an end-to-end proof.
+    expect(preview).toContain('outcome?.status !== "completed"');
+    expect(preview).toContain('one.name.toLowerCase() === "v(out)"');
+    expect(preview).toContain("Math.abs(out.value - 0.5)");
     // The domain is created by the deploy and takes time to resolve.
     expect(preview).toMatch(/for _ in \$\(seq 1 \d+\); do\s*\n\s*if curl/u);
   });


### PR DESCRIPTION
## Summary

- replace the harness's independent busy flag, timeout and kill paths with one process-local Run Supervisor
- fail-stop an irrecoverable run lease so Docker/Cloudflare can replace the harness
- expose read-only lifecycle health, verify operator-host restart/isolation, and prove Docker restart in CI
- strengthen preview smoke from status-only to parsed resistor-divider OP output

Closes #586.

## Validation

- pnpm ci:static
- focused unit/workflow/render tests: 66 passed
- pnpm build
- pnpm release:verify:built
- full unit: 2493 passed; Windows-only POSIX harness fixture failures remain locally, and one unrelated render timeout passed on focused rerun
- full Playwright: 348/349; the unrelated formula-alert timing failure passed on focused rerun
- pnpm gate:preflight -- --base origin/main

Local Docker Desktop was unavailable, so the new Linux image/restart proof is intentionally enforced by the remote container workflow.