### PR TITLE
feat(simulation): keep both preview executors live

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -121,43 +121,8 @@ jobs:
             echo "A gallery write on the preview must be refused, got: $write"
             exit 1
           fi
-      # A resistor divider, the smallest circuit ngspice can answer for. It
-      # proves the whole chain: runner available, harness up, Worker talking
-      # to it, rawfile parsed, and the expected number returned.
-      - name: Simulate one circuit on the preview
-        run: |
-          set -euo pipefail
-          body="$(node -e '
-            const netlist = [".subckt divider in out", "R1 in out 1k", "R2 out 0 1k", ".ends divider"].join("\n");
-            const testbench = ["V1 in 0 DC 1", "X1 in out divider", ".control", "op", "write out.raw", ".endc", ".end"].join("\n");
-            process.stdout.write(JSON.stringify({ netlist, testbench, inputRevision: "preview-smoke", timeoutMs: 110000 }));
-          ')"
-          result="$(curl --silent --show-error --max-time 120 \
-            --output /tmp/preview-simulation.json \
-            --write-out '%{http_code}' \
-            -H 'content-type: application/json' --data "$body" \
-            "${PREVIEW_URL}/api/simulate")"
-          cat /tmp/preview-simulation.json; echo
-          if [ "$result" != "200" ]; then
-            node -e '
-              const body = require("/tmp/preview-simulation.json");
-              console.error(`Preview execution infrastructure failed: ${body.error ?? "unknown"}${body.reason ? ` (${body.reason})` : ""}: ${body.message ?? "no message"}`);
-            '
-            exit 1
-          fi
-          node -e '
-            const result = require("/tmp/preview-simulation.json");
-            if (result.metadata?.environment?.executor !== "hosted-container") {
-              throw new Error("the runner did not identify the hosted execution environment");
-            }
-            if (result.outcome?.status !== "completed") {
-              const detail = (result.diagnostics ?? []).map(one => one.text).join("; ");
-              throw new Error(`the circuit reached ${result.outcome?.status ?? "no terminal state"}: ${detail}`);
-            }
-            const op = result.data?.analyses?.find(one => one.analysis === "op");
-            const out = op?.probes?.find(one => one.name.toLowerCase() === "v(out)");
-            if (!out || Math.abs(out.value - 0.5) > 1e-9) {
-              throw new Error(`the divider OP result is ${out?.value ?? "missing"}, expected 0.5`);
-            }
-            console.log(`divider v(out): ${out.value}`);
-          '
+      # The same divider must cross both Preview execution substrates and
+      # produce the same measured environment identity and numerical result.
+      # This is an explicit parity check, never an automatic fallback.
+      - name: Simulate one circuit on both preview executors
+        run: node scripts/preview-simulation-smoke.mjs "$PREVIEW_URL"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -132,7 +132,17 @@ benchmark base image by digest — so the numbers do not depend on the choice:
   `/run` only to the bearer token in its `SIMULATION_ACCESS_TOKEN`; the
   Worker presents the same value from its secret `SIMULATION_UPSTREAM_TOKEN`,
   which `deploy-preview.yml` sets from the repository secret of the same name
-  on every deploy. When the var is set the container binding is never woken.
+  on every deploy.
+
+Preview registers both executors at once. `SIMULATION_DEFAULT_EXECUTOR` chooses
+the normal route (`operator-host` today), while a diagnostic request may name
+`cloudflare-container` or `operator-host` explicitly. The Worker never retries
+one executor on the other: an unavailable target is reported as infrastructure
+failure instead of hiding it behind fallback. Every response reports the
+selected transport in `execution.target`; `metadata.environment` continues to
+identify the image, simulator, and model bytes that actually performed the
+run. The Preview deploy sends the same divider through both explicit targets
+and requires the numerical result and environment fingerprint to agree.
 
 The current operator host is the Frankfurt machine, under its `analogcanvas`
 account, in `~/analog-canvas-sim/`. `bin/up.sh` runs the image with a
@@ -167,7 +177,8 @@ contract gains a concurrency count.
 
 Either way `metadata.environment.executor` reads `hosted-container`: the
 harness is the same container image, and the fingerprint identifies it, not
-the machine underneath.
+the machine underneath. `execution.target` is the separate transport identity
+that distinguishes Cloudflare from the operator host.
 
 ### The retired staging environment
 

--- a/scripts/preview-simulation-smoke.mjs
+++ b/scripts/preview-simulation-smoke.mjs
@@ -1,0 +1,209 @@
+/**
+ * Preview's dual-executor numerical smoke.
+ *
+ * The same deck is sent through both hosted transports. A green HTTP response
+ * is not enough: the selected executor, terminal outcome, rawfile-derived
+ * operating-point value, and measured simulator/model identity all have to be
+ * present. The two environment fingerprints must agree because both Preview
+ * substrates run the same pinned image.
+ */
+import { pathToFileURL } from "node:url";
+
+const EXECUTORS = ["cloudflare-container", "operator-host"];
+const SHA256 = /^[0-9a-f]{64}$/u;
+
+export const DIVIDER_REQUEST = {
+  netlist: [
+    ".subckt divider in out",
+    "R1 in out 1k",
+    "R2 out 0 1k",
+    ".ends divider",
+  ].join("\n"),
+  testbench: [
+    "V1 in 0 DC 1",
+    "X1 in mid divider",
+    ".control",
+    "set filetype=ascii",
+    "op",
+    "write out.raw v(mid)",
+    ".endc",
+    ".end",
+  ].join("\n"),
+  timeoutMs: 110_000,
+};
+
+function object(value, label) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} is absent or is not an object.`);
+  }
+  return value;
+}
+
+function diagnosticSummary(payload) {
+  if (!Array.isArray(payload.diagnostics)) return "no diagnostics";
+  const messages = payload.diagnostics
+    .map((item) =>
+      typeof item === "object" && item !== null && "text" in item
+        ? String(item.text)
+        : "",
+    )
+    .filter(Boolean);
+  return messages.length > 0
+    ? messages.slice(0, 3).join(" | ")
+    : "no diagnostics";
+}
+
+export function validatePreviewSimulationResult(payload, expectedTarget) {
+  const result = object(payload, "simulation response");
+  const execution = object(result.execution, "execution metadata");
+  if (execution.target !== expectedTarget) {
+    throw new Error(
+      `requested ${expectedTarget}, but the Worker reported ${String(execution.target)}.`,
+    );
+  }
+
+  const outcome = object(result.outcome, "simulation outcome");
+  if (outcome.status !== "completed") {
+    throw new Error(
+      `${expectedTarget} ended as ${String(outcome.status)}: ${diagnosticSummary(result)}`,
+    );
+  }
+
+  const metadata = object(result.metadata, "run metadata");
+  const environment = object(metadata.environment, "environment metadata");
+  const simulator = object(environment.simulator, "simulator identity");
+  const models = object(environment.models, "model identity");
+  if (simulator.name !== "ngspice" || typeof simulator.version !== "string") {
+    throw new Error(
+      `${expectedTarget} did not identify ngspice and its version.`,
+    );
+  }
+  if (!SHA256.test(String(simulator.binarySha256))) {
+    throw new Error(
+      `${expectedTarget} returned no valid simulator binary digest.`,
+    );
+  }
+  if (!SHA256.test(String(models.contentSha256))) {
+    throw new Error(`${expectedTarget} returned no valid model-tree digest.`);
+  }
+  if (!SHA256.test(String(environment.fingerprint))) {
+    throw new Error(
+      `${expectedTarget} returned no valid environment fingerprint.`,
+    );
+  }
+
+  const data = object(result.data, "parsed result data");
+  if (!Array.isArray(data.analyses)) {
+    throw new Error(`${expectedTarget} returned no parsed analyses.`);
+  }
+  const operatingPoint = data.analyses.find(
+    (analysis) =>
+      typeof analysis === "object" &&
+      analysis !== null &&
+      analysis.analysis === "op",
+  );
+  if (!operatingPoint || !Array.isArray(operatingPoint.probes)) {
+    throw new Error(`${expectedTarget} returned no operating-point analysis.`);
+  }
+  const midpoint = operatingPoint.probes.find(
+    (probe) =>
+      typeof probe === "object" && probe !== null && probe.name === "v(mid)",
+  );
+  if (!midpoint || typeof midpoint.value !== "number") {
+    throw new Error(`${expectedTarget} returned no scalar v(mid).`);
+  }
+  if (Math.abs(midpoint.value - 0.5) > 1e-12) {
+    throw new Error(
+      `${expectedTarget} solved the equal divider as ${midpoint.value}, expected 0.5.`,
+    );
+  }
+
+  return {
+    target: expectedTarget,
+    value: midpoint.value,
+    environmentFingerprint: environment.fingerprint,
+    simulatorVersion: simulator.version,
+  };
+}
+
+export async function runPreviewSimulationSmoke({
+  baseUrl,
+  target,
+  fetchImpl = fetch,
+}) {
+  const response = await fetchImpl(new URL("/api/simulate", baseUrl), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      ...DIVIDER_REQUEST,
+      inputRevision: `preview-smoke-${target}`,
+      executorTarget: target,
+    }),
+    signal: AbortSignal.timeout(120_000),
+  });
+  const text = await response.text();
+  let payload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    throw new Error(
+      `${target} answered HTTP ${response.status} with non-JSON: ${text.slice(0, 400)}`,
+    );
+  }
+  if (!response.ok) {
+    const error = object(payload, "simulation refusal");
+    throw new Error(
+      `${target} answered HTTP ${response.status}: ${String(error.error ?? "unknown-error")}` +
+        `${error.reason ? ` (${String(error.reason)})` : ""}` +
+        `${error.message ? `: ${String(error.message)}` : ""}`,
+    );
+  }
+  return validatePreviewSimulationResult(payload, target);
+}
+
+export function validateExecutorParity(results) {
+  if (results.length !== EXECUTORS.length) {
+    throw new Error(
+      `expected ${EXECUTORS.length} executor results, received ${results.length}.`,
+    );
+  }
+  const fingerprints = new Set(
+    results.map((result) => result.environmentFingerprint),
+  );
+  if (fingerprints.size !== 1) {
+    throw new Error(
+      `Preview executors do not share one environment: ${results
+        .map((result) => `${result.target}=${result.environmentFingerprint}`)
+        .join(", ")}`,
+    );
+  }
+}
+
+async function main() {
+  const baseUrl = process.argv[2];
+  if (!baseUrl) {
+    throw new Error(
+      "usage: node scripts/preview-simulation-smoke.mjs https://preview.example",
+    );
+  }
+  const results = [];
+  for (const target of EXECUTORS) {
+    const result = await runPreviewSimulationSmoke({ baseUrl, target });
+    results.push(result);
+    console.log(
+      `${result.target}: v(mid)=${result.value}, ${result.simulatorVersion}, environment=${result.environmentFingerprint}`,
+    );
+  }
+  validateExecutorParity(results);
+  console.log("Preview executor parity: passed");
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/preview-simulation-smoke.test.mjs
+++ b/scripts/preview-simulation-smoke.test.mjs
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  runPreviewSimulationSmoke,
+  validateExecutorParity,
+  validatePreviewSimulationResult,
+} from "./preview-simulation-smoke.mjs";
+
+const SHA = "a".repeat(64);
+
+function result(target, overrides = {}) {
+  return {
+    execution: { target },
+    outcome: { status: "completed" },
+    diagnostics: [],
+    metadata: {
+      environment: {
+        fingerprint: SHA,
+        simulator: {
+          name: "ngspice",
+          version: "ngspice-46",
+          binarySha256: SHA,
+        },
+        models: { id: "sky130A", contentSha256: SHA },
+      },
+    },
+    data: {
+      analyses: [
+        {
+          analysis: "op",
+          probes: [{ name: "v(mid)", value: 0.5 }],
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+describe("the Preview dual-executor smoke", () => {
+  it("accepts a numerical operating point with measured environment identity", () => {
+    expect(
+      validatePreviewSimulationResult(
+        result("cloudflare-container"),
+        "cloudflare-container",
+      ),
+    ).toEqual({
+      target: "cloudflare-container",
+      value: 0.5,
+      environmentFingerprint: SHA,
+      simulatorVersion: "ngspice-46",
+    });
+  });
+
+  it("refuses a success-shaped response from the wrong executor", () => {
+    expect(() =>
+      validatePreviewSimulationResult(
+        result("operator-host"),
+        "cloudflare-container",
+      ),
+    ).toThrow(/reported operator-host/u);
+  });
+
+  it("refuses completed without the requested number", () => {
+    expect(() =>
+      validatePreviewSimulationResult(
+        result("operator-host", { data: { analyses: [] } }),
+        "operator-host",
+      ),
+    ).toThrow(/operating-point/u);
+  });
+
+  it("refuses two executors that measured different environments", () => {
+    expect(() =>
+      validateExecutorParity([
+        {
+          target: "cloudflare-container",
+          environmentFingerprint: "a".repeat(64),
+        },
+        {
+          target: "operator-host",
+          environmentFingerprint: "b".repeat(64),
+        },
+      ]),
+    ).toThrow(/do not share one environment/u);
+  });
+
+  it("names infrastructure refusals instead of calling them circuit failures", async () => {
+    await expect(
+      runPreviewSimulationSmoke({
+        baseUrl: "https://preview.example",
+        target: "operator-host",
+        fetchImpl: async () =>
+          Response.json(
+            {
+              error: "simulator-refused",
+              reason: "simulator-busy",
+              message: "one circuit at a time",
+            },
+            { status: 502 },
+          ),
+      }),
+    ).rejects.toThrow(
+      "operator-host answered HTTP 502: simulator-refused (simulator-busy): one circuit at a time",
+    );
+  });
+});

--- a/scripts/preview-workflow.test.mjs
+++ b/scripts/preview-workflow.test.mjs
@@ -40,13 +40,13 @@ describe("the preview deploy", () => {
     expect(preview).toContain("noindex");
     expect(preview).toContain("must read the production gallery");
     expect(preview).toContain("must be refused");
-    expect(preview).toContain("/api/simulate");
-    expect(preview).toContain("hosted-container");
-    // A 200 with a timed-out outcome is not a simulation, and a completed
-    // outcome without the expected number is not an end-to-end proof.
-    expect(preview).toContain('outcome?.status !== "completed"');
-    expect(preview).toContain('one.name.toLowerCase() === "v(out)"');
-    expect(preview).toContain("Math.abs(out.value - 0.5)");
+    expect(preview).toContain(
+      'node scripts/preview-simulation-smoke.mjs "$PREVIEW_URL"',
+    );
+    // The reusable smoke is responsible for explicit transport selection,
+    // numeric validation, and environment parity; the workflow must not
+    // quietly restore an inline, default-executor-only probe.
+    expect(preview).not.toContain('"${PREVIEW_URL}/api/simulate"');
     // The domain is created by the deploy and takes time to resolve.
     expect(preview).toMatch(/for _ in \$\(seq 1 \d+\); do\s*\n\s*if curl/u);
   });

--- a/worker/preview-config.test.ts
+++ b/worker/preview-config.test.ts
@@ -88,6 +88,13 @@ describe("the preview channel configuration (ADR 0057)", () => {
       "./containers/ngspice/Dockerfile",
     );
     expect(preview.containers?.[0]?.max_instances).toBe(1);
+    // Preview builds both substrates behind one Worker contract. The host is
+    // the current default, but the binding remains available for explicit
+    // parity checks; configuring one must not erase the other.
+    expect(preview.vars?.SIMULATION_UPSTREAM_URL).toBe(
+      "https://sim-fra.analog-canvas.tokenzhang.com",
+    );
+    expect(preview.vars?.SIMULATION_DEFAULT_EXECUTOR).toBe("operator-host");
     // Production has no container yet: it arrives with a promoted release.
     expect(
       production.durable_objects?.bindings.some((b) => b.name === "NGSPICE"),

--- a/worker/simulation.test.ts
+++ b/worker/simulation.test.ts
@@ -78,6 +78,51 @@ describe("simulation route", () => {
     expect(payload.message).toContain("deployment");
   });
 
+  it("rejects an executor target that is not part of the Preview contract", async () => {
+    const response = await routeSimulationRequest(
+      post({
+        netlist: NETLIST,
+        testbench: TESTBENCH,
+        executorTarget: "automatic-fallback",
+      }),
+      stubRunner({}),
+    );
+    expect(response?.status).toBe(400);
+    expect((await response!.json()) as unknown).toMatchObject({
+      error: "invalid-executor-target",
+    });
+  });
+
+  it("reports an invalid deployment default before attempting a run", async () => {
+    const response = await routeSimulationRequest(
+      post({ netlist: NETLIST, testbench: TESTBENCH }),
+      {
+        ...stubRunner({}),
+        SIMULATION_DEFAULT_EXECUTOR: "somewhere-cheaper",
+      },
+    );
+    expect(response?.status).toBe(503);
+    expect((await response!.json()) as unknown).toMatchObject({
+      error: "simulation-executor-configuration-invalid",
+    });
+  });
+
+  it("names an explicitly selected executor that this deployment lacks", async () => {
+    const response = await routeSimulationRequest(
+      post({
+        netlist: NETLIST,
+        testbench: TESTBENCH,
+        executorTarget: "operator-host",
+      }),
+      stubRunner({}),
+    );
+    expect(response?.status).toBe(503);
+    expect((await response!.json()) as unknown).toMatchObject({
+      error: "simulation-executor-unavailable",
+      execution: { target: "operator-host" },
+    });
+  });
+
   it("requires the author's testbench and never invents one", async () => {
     const response = await routeSimulationRequest(
       post({ netlist: NETLIST }),
@@ -281,6 +326,7 @@ describe("simulation route", () => {
     );
     const payload = (await response!.json()) as {
       outcome: { status: string };
+      execution?: { target: string };
       data?: {
         analyses: {
           analysis: string;
@@ -289,6 +335,7 @@ describe("simulation route", () => {
       };
     };
     expect(payload.outcome.status).toBe("completed");
+    expect(payload.execution?.target).toBe("cloudflare-container");
     const analysis = payload.data?.analyses[0];
     expect(analysis?.analysis).toBe("op");
     const mid = analysis?.probes.find((probe) => probe.name === "v(mid)");
@@ -453,7 +500,11 @@ describe("simulation route", () => {
 
   it("carries a status alone when the refusal said nothing", async () => {
     const payload = await refusal(500, "");
-    expect(payload).toEqual({ error: "simulator-refused", status: 500 });
+    expect(payload).toEqual({
+      error: "simulator-refused",
+      execution: { target: "cloudflare-container" },
+      status: 500,
+    });
   });
 
   it("clips a refusal that answers with a payload instead of a sentence", async () => {
@@ -501,9 +552,94 @@ describe("simulation route", () => {
         env,
       );
       expect(response?.status).toBe(200);
+      expect((await response!.clone().json()) as unknown).toMatchObject({
+        execution: { target: "operator-host" },
+      });
       expect(seen.url).toBe("https://sim-fra.example.test/run");
       expect(seen.authorization).toBe("Bearer host-token");
       expect(JSON.parse(seen.body!)).toMatchObject({ timeoutMs: 60_000 });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("can select the bound Cloudflare container while the operator host is configured", async () => {
+    let containerRuns = 0;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new Error("the operator host must not be called");
+    }) as typeof fetch;
+    try {
+      const response = await routeSimulationRequest(
+        post({
+          netlist: NETLIST,
+          testbench: TESTBENCH,
+          executorTarget: "cloudflare-container",
+        }),
+        {
+          NGSPICE: {
+            getByName: () => ({
+              fetch: async () => {
+                containerRuns += 1;
+                return Response.json({
+                  environment: HOSTED_ENVIRONMENT,
+                  log: "ok",
+                  exitCode: 0,
+                });
+              },
+            }),
+          },
+          SIMULATION_UPSTREAM_URL: "https://sim-fra.example.test/",
+          SIMULATION_UPSTREAM_TOKEN: "host-token",
+          SIMULATION_DEFAULT_EXECUTOR: "operator-host",
+        },
+      );
+      expect(response?.status).toBe(200);
+      expect(containerRuns).toBe(1);
+      expect((await response!.json()) as unknown).toMatchObject({
+        execution: { target: "cloudflare-container" },
+      });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it("can select the operator host while the Cloudflare container is the default", async () => {
+    let hostRuns = 0;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      hostRuns += 1;
+      return Response.json({
+        environment: HOSTED_ENVIRONMENT,
+        log: "ok",
+        exitCode: 0,
+      });
+    }) as typeof fetch;
+    try {
+      const response = await routeSimulationRequest(
+        post({
+          netlist: NETLIST,
+          testbench: TESTBENCH,
+          executorTarget: "operator-host",
+        }),
+        {
+          NGSPICE: {
+            getByName: () => ({
+              fetch: async () => {
+                throw new Error("the container must not be woken");
+              },
+            }),
+          },
+          SIMULATION_UPSTREAM_URL: "https://sim-fra.example.test/",
+          SIMULATION_UPSTREAM_TOKEN: "host-token",
+          SIMULATION_DEFAULT_EXECUTOR: "cloudflare-container",
+        },
+      );
+      expect(response?.status).toBe(200);
+      expect(hostRuns).toBe(1);
+      expect((await response!.json()) as unknown).toMatchObject({
+        execution: { target: "operator-host" },
+      });
     } finally {
       globalThis.fetch = realFetch;
     }

--- a/worker/simulation.ts
+++ b/worker/simulation.ts
@@ -49,6 +49,11 @@ export interface SimulationEnv {
    */
   SIMULATION_UPSTREAM_URL?: string;
   SIMULATION_UPSTREAM_TOKEN?: string;
+  /**
+   * Preview policy, not circuit state. Both executors may be configured at
+   * once; this chooses the one used when a caller names no target.
+   */
+  SIMULATION_DEFAULT_EXECUTOR?: string;
   /** Where the models live inside the image. */
   SKY130_LIB_PATH?: string;
   /** Section in the sectioned Sky130 library; `tt` when omitted. */
@@ -66,6 +71,18 @@ interface SimulationRequestBody {
   testbench?: unknown;
   timeoutMs?: unknown;
   inputRevision?: unknown;
+  executorTarget?: unknown;
+}
+
+export type SimulationExecutorTarget = "cloudflare-container" | "operator-host";
+
+interface SelectedRunner {
+  target: SimulationExecutorTarget;
+  runner: NgspiceRunner;
+}
+
+interface HostedExecutionMetadata {
+  target: SimulationExecutorTarget;
 }
 
 /**
@@ -86,18 +103,42 @@ function remoteRunner(base: string, token: string | undefined): NgspiceRunner {
 }
 
 /**
- * A container instance per author, so one person's long analysis never queues
- * behind another's. The name is opaque; nothing about a run is kept between
- * runs, because a woken container starts with a fresh disk.
- *
- * An operator-run host takes precedence over the container binding: a
- * deployment that names one has decided where its simulations run, and the
- * container's only cost is being woken, which this never does.
+ * Resolve one explicitly named executor. A Preview deployment may register
+ * both at once; selecting one never wakes, probes, or retries through the
+ * other. An uncertain run must not be duplicated on a fallback executor.
  */
-function runnerFor(env: SimulationEnv, key: string): NgspiceRunner | null {
-  const upstream = env.SIMULATION_UPSTREAM_URL?.trim();
-  if (upstream) return remoteRunner(upstream, env.SIMULATION_UPSTREAM_TOKEN);
-  return env.NGSPICE ? env.NGSPICE.getByName(key) : null;
+function runnerFor(
+  env: SimulationEnv,
+  key: string,
+  target: SimulationExecutorTarget,
+): SelectedRunner | null {
+  if (target === "operator-host") {
+    const upstream = env.SIMULATION_UPSTREAM_URL?.trim();
+    return upstream
+      ? {
+          target,
+          runner: remoteRunner(upstream, env.SIMULATION_UPSTREAM_TOKEN),
+        }
+      : null;
+  }
+  return env.NGSPICE ? { target, runner: env.NGSPICE.getByName(key) } : null;
+}
+
+function isExecutorTarget(value: unknown): value is SimulationExecutorTarget {
+  return value === "cloudflare-container" || value === "operator-host";
+}
+
+function defaultExecutorTarget(
+  env: SimulationEnv,
+): SimulationExecutorTarget | "invalid" {
+  const configured = env.SIMULATION_DEFAULT_EXECUTOR?.trim();
+  if (configured) return isExecutorTarget(configured) ? configured : "invalid";
+
+  // Backwards-compatible default: a deployment that configured only the
+  // upstream host keeps using it; otherwise the bound container is canonical.
+  return env.SIMULATION_UPSTREAM_URL?.trim()
+    ? "operator-host"
+    : "cloudflare-container";
 }
 
 /**
@@ -184,26 +225,58 @@ export async function routeSimulationRequest(
     return Response.json({ error: "method-not-allowed" }, { status: 405 });
   }
 
-  const runner = runnerFor(env, runnerKey);
-  if (!runner) {
-    // Deployment state, not circuit state. Said plainly so an author is not
-    // left wondering what is wrong with their design.
-    return Response.json(
-      {
-        error: "simulation-not-configured",
-        message:
-          "This deployment has neither a simulation container bound nor a simulator host configured, so no circuit can be run here.",
-      },
-      { status: 503 },
-    );
-  }
-
   let body: SimulationRequestBody;
   try {
     body = (await request.json()) as SimulationRequestBody;
   } catch {
     return Response.json({ error: "invalid-json" }, { status: 400 });
   }
+  if (
+    body.executorTarget !== undefined &&
+    !isExecutorTarget(body.executorTarget)
+  ) {
+    return Response.json(
+      {
+        error: "invalid-executor-target",
+        message:
+          'executorTarget must be "cloudflare-container" or "operator-host".',
+      },
+      { status: 400 },
+    );
+  }
+
+  const configuredDefault = defaultExecutorTarget(env);
+  if (configuredDefault === "invalid") {
+    return Response.json(
+      {
+        error: "simulation-executor-configuration-invalid",
+        message:
+          "SIMULATION_DEFAULT_EXECUTOR does not name a supported Preview executor.",
+      },
+      { status: 503 },
+    );
+  }
+  const target = body.executorTarget ?? configuredDefault;
+  const selected = runnerFor(env, runnerKey, target);
+  if (!selected) {
+    const noExecutorConfigured =
+      !env.NGSPICE && !env.SIMULATION_UPSTREAM_URL?.trim();
+    return Response.json(
+      noExecutorConfigured
+        ? {
+            error: "simulation-not-configured",
+            message:
+              "This deployment has neither a simulation container bound nor a simulator host configured, so no circuit can be run here.",
+          }
+        : {
+            error: "simulation-executor-unavailable",
+            execution: { target },
+            message: `The Preview executor "${target}" is not configured in this deployment.`,
+          },
+      { status: 503 },
+    );
+  }
+  const execution: HostedExecutionMetadata = { target: selected.target };
   const netlist = typeof body.netlist === "string" ? body.netlist : null;
   const testbench = typeof body.testbench === "string" ? body.testbench : null;
   if (
@@ -253,7 +326,7 @@ export async function routeSimulationRequest(
 
   let containerResponse: Response;
   try {
-    containerResponse = await runner.fetch("http://container/run", {
+    containerResponse = await selected.runner.fetch("http://container/run", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ deck, timeoutMs }),
@@ -262,6 +335,7 @@ export async function routeSimulationRequest(
     return Response.json(
       {
         error: "simulator-unreachable",
+        execution,
         message: error instanceof Error ? error.message : String(error),
       },
       { status: 502 },
@@ -273,6 +347,7 @@ export async function routeSimulationRequest(
     return Response.json(
       {
         error: "simulator-unauthorized",
+        execution,
         message:
           "The simulator host refused this deployment's credentials; check SIMULATION_UPSTREAM_TOKEN.",
       },
@@ -283,6 +358,7 @@ export async function routeSimulationRequest(
     return Response.json(
       {
         error: "simulator-refused",
+        execution,
         status: containerResponse.status,
         ...(await describeRefusal(containerResponse)),
       },
@@ -309,6 +385,7 @@ export async function routeSimulationRequest(
     return Response.json(
       {
         error: "simulator-protocol-invalid",
+        execution,
         message: "The simulator did not identify its execution environment.",
       },
       { status: 502 },
@@ -366,7 +443,8 @@ export async function routeSimulationRequest(
     typeof raw.exitCode === "number" ? raw.exitCode : null,
   );
   if (exitStatus) diagnostics.push(exitStatus);
-  const result: SimulationResult = {
+  const result: SimulationResult & { execution: HostedExecutionMetadata } = {
+    execution,
     outcome: classifySimulationOutcome(diagnostics, {
       timedOut,
       timeoutMs,

--- a/wrangler.preview.jsonc
+++ b/wrangler.preview.jsonc
@@ -26,13 +26,13 @@
     // no read-only mode and this Worker runs code production has not
     // accepted yet. Writes never leave this Worker (see channel.ts).
     "ICM_GALLERY_UPSTREAM": "https://analog-canvas.tokenzhang.com",
-    // Where simulations run. Unset, the NGSPICE container binding below is
-    // the simulator. Set to the public hostname of an operator-run harness
-    // (the same image, behind a Cloudflare Tunnel), it takes over and the
-    // container is never woken; the host's token arrives as the Worker
-    // secret SIMULATION_UPSTREAM_TOKEN (deploy-preview.yml). See
-    // docs/deployment.md, "Where the simulator runs".
-    // "SIMULATION_UPSTREAM_URL": "https://sim-fra.analog-canvas.tokenzhang.com",
+    // Preview carries both execution substrates while the simulation
+    // foundation is built. The Worker chooses the default below, and a
+    // diagnostic/acceptance request may name either one explicitly; there is
+    // no automatic fallback after a run starts. Production has neither of
+    // these Preview decisions until a release deliberately promotes them.
+    "SIMULATION_UPSTREAM_URL": "https://sim-fra.analog-canvas.tokenzhang.com",
+    "SIMULATION_DEFAULT_EXECUTOR": "operator-host",
   },
   "assets": {
     "binding": "ASSETS",


### PR DESCRIPTION
## Outcome

Preview keeps both supported simulation substrates addressable through one Worker contract:

- operator-host is the explicit default;
- cloudflare-container remains available by explicit request;
- responses identify the selected transport as xecution.target;
- failures never trigger automatic cross-executor fallback;
- the deploy gate sends the same numerical divider run through both targets and requires the result and measured environment fingerprint to agree.

This supersedes #593's exclusive host cutover. Production configuration is unchanged.

## Validation

- pnpm test:local worker/simulation.test.ts worker/preview-config.test.ts scripts/preview-simulation-smoke.test.mjs scripts/preview-workflow.test.mjs (46 passed)
- pnpm typecheck
- pnpm gate:preflight -- --base origin/main
- git diff --check

pnpm gate:full reached the full unit suite, where the pre-existing POSIX shell harness fixtures in containers/ngspice/entrypoint.test.mjs fail on Windows with spawn EFTYPE; PR #598's Linux merge-queue run proved those tests green. This PR therefore requires the normal remote full-delivery checks before merge.

Closes #565