### PR TITLE
fix(deploy): name preview simulation smoke failures

### DIFF
--- a/scripts/preview-simulation-smoke.mjs
+++ b/scripts/preview-simulation-smoke.mjs
@@ -11,6 +11,12 @@ import { pathToFileURL } from "node:url";
 
 const EXECUTORS = ["cloudflare-container", "operator-host"];
 const SHA256 = /^[0-9a-f]{64}$/u;
+const REQUEST_ERRORS = new Set([
+  "deck-too-large",
+  "invalid-json",
+  "invalid-request",
+  "method-not-allowed",
+]);
 
 export const DIVIDER_REQUEST = {
   netlist: [
@@ -58,18 +64,26 @@ export function validatePreviewSimulationResult(payload, expectedTarget) {
   const execution = object(result.execution, "execution metadata");
   if (execution.target !== expectedTarget) {
     throw new Error(
-      `requested ${expectedTarget}, but the Worker reported ${String(execution.target)}.`,
+      `[result:wrong-executor] requested ${expectedTarget}, but the Worker reported ${String(execution.target)}.`,
     );
   }
 
   const outcome = object(result.outcome, "simulation outcome");
   if (outcome.status !== "completed") {
+    const layer = outcome.status === "timed-out" ? "run" : "simulation";
     throw new Error(
-      `${expectedTarget} ended as ${String(outcome.status)}: ${diagnosticSummary(result)}`,
+      `[${layer}:${String(outcome.status)}] ${expectedTarget} did not complete: ${diagnosticSummary(result)}`,
     );
   }
 
   const metadata = object(result.metadata, "run metadata");
+  const input = object(metadata.input, "input metadata");
+  const expectedRevision = `preview-smoke-${expectedTarget}`;
+  if (input.inputRevision !== expectedRevision) {
+    throw new Error(
+      `[result:stale-input] requested ${expectedRevision}, but the Worker returned ${String(input.inputRevision)}.`,
+    );
+  }
   const environment = object(metadata.environment, "environment metadata");
   const simulator = object(environment.simulator, "simulator identity");
   const models = object(environment.models, "model identity");
@@ -147,13 +161,15 @@ export async function runPreviewSimulationSmoke({
     payload = JSON.parse(text);
   } catch {
     throw new Error(
-      `${target} answered HTTP ${response.status} with non-JSON: ${text.slice(0, 400)}`,
+      `[protocol:non-json] ${target} answered HTTP ${response.status}: ${text.slice(0, 400)}`,
     );
   }
   if (!response.ok) {
     const error = object(payload, "simulation refusal");
+    const code = String(error.error ?? `http-${response.status}`);
+    const layer = REQUEST_ERRORS.has(code) ? "request" : "infrastructure";
     throw new Error(
-      `${target} answered HTTP ${response.status}: ${String(error.error ?? "unknown-error")}` +
+      `[${layer}:${code}] ${target} answered HTTP ${response.status}` +
         `${error.reason ? ` (${String(error.reason)})` : ""}` +
         `${error.message ? `: ${String(error.message)}` : ""}`,
     );
@@ -172,7 +188,7 @@ export function validateExecutorParity(results) {
   );
   if (fingerprints.size !== 1) {
     throw new Error(
-      `Preview executors do not share one environment: ${results
+      `[result:environment-mismatch] Preview executors do not share one environment: ${results
         .map((result) => `${result.target}=${result.environmentFingerprint}`)
         .join(", ")}`,
     );

--- a/scripts/preview-simulation-smoke.test.mjs
+++ b/scripts/preview-simulation-smoke.test.mjs
@@ -14,6 +14,7 @@ function result(target, overrides = {}) {
     outcome: { status: "completed" },
     diagnostics: [],
     metadata: {
+      input: { inputRevision: `preview-smoke-${target}` },
       environment: {
         fingerprint: SHA,
         simulator: {
@@ -69,6 +70,20 @@ describe("the Preview dual-executor smoke", () => {
     ).toThrow(/operating-point/u);
   });
 
+  it("refuses a result for a different input revision", () => {
+    expect(() =>
+      validatePreviewSimulationResult(
+        result("operator-host", {
+          metadata: {
+            input: { inputRevision: "preview-smoke-cloudflare-container" },
+            environment: result("operator-host").metadata.environment,
+          },
+        }),
+        "operator-host",
+      ),
+    ).toThrow(/\[result:stale-input\].*preview-smoke-cloudflare-container/u);
+  });
+
   it("refuses two executors that measured different environments", () => {
     expect(() =>
       validateExecutorParity([
@@ -100,7 +115,54 @@ describe("the Preview dual-executor smoke", () => {
           ),
       }),
     ).rejects.toThrow(
-      "operator-host answered HTTP 502: simulator-refused (simulator-busy): one circuit at a time",
+      "[infrastructure:simulator-refused] operator-host answered HTTP 502 (simulator-busy): one circuit at a time",
+    );
+  });
+
+  it("names a malformed smoke request separately from executor failure", async () => {
+    await expect(
+      runPreviewSimulationSmoke({
+        baseUrl: "https://preview.example",
+        target: "cloudflare-container",
+        fetchImpl: async () =>
+          Response.json(
+            {
+              error: "invalid-request",
+              message: "a circuit and testbench are required",
+            },
+            { status: 400 },
+          ),
+      }),
+    ).rejects.toThrow(
+      "[request:invalid-request] cloudflare-container answered HTTP 400: a circuit and testbench are required",
+    );
+  });
+
+  it("keeps a timed-out run separate from an infrastructure refusal", () => {
+    expect(() =>
+      validatePreviewSimulationResult(
+        result("operator-host", {
+          outcome: { status: "timed-out" },
+          diagnostics: [{ text: "the deadline expired" }],
+        }),
+        "operator-host",
+      ),
+    ).toThrow(/\[run:timed-out\].*the deadline expired/u);
+  });
+
+  it("names a non-JSON response as a protocol failure", async () => {
+    await expect(
+      runPreviewSimulationSmoke({
+        baseUrl: "https://preview.example",
+        target: "operator-host",
+        fetchImpl: async () =>
+          new Response("bad gateway", {
+            status: 502,
+            headers: { "content-type": "text/plain" },
+          }),
+      }),
+    ).rejects.toThrow(
+      "[protocol:non-json] operator-host answered HTTP 502: bad gateway",
     );
   });
 });


### PR DESCRIPTION
## Summary
- build on #600's dual-executor known-answer smoke instead of adding a second verifier
- preserve request, infrastructure, run, protocol, and numerical-result failure layers in Preview deploy logs
- reject a result whose echoed input revision belongs to a different executor request
- keep numerical value, executor identity, environment digest, and parity checks unchanged

## Validation
- pnpm ci:static
- pnpm test:impact -- --base origin/main
- pnpm test:local scripts/preview-simulation-smoke.test.mjs scripts/preview-workflow.test.mjs (13 passed)
- git diff --check

The earlier local full run, before #600 landed, exposed main/#598 harness tests returning simulator-not-ready on this Windows host; GitHub's Linux unit suite passed. After rebasing onto #600 this branch only changes the existing smoke script and its tests, so the focused gate plan does not require the local full fallback.

The unrelated untracked .vscode/ directory was excluded.