### PR TITLE
feat(deploy): make the operator host recoverable from source

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -32,6 +32,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Validate the operator-host topology
+        env:
+          SIMULATION_ACCESS_TOKEN: ci-contract-token
+          TUNNEL_TOKEN: ci-contract-token
+          SIMULATION_IMAGE_TAG: pr
+        run: |
+          docker compose --project-name analog-canvas-sim \
+            --profile tunnel \
+            -f containers/ngspice/host/compose.yaml \
+            config --quiet
+
       - name: Build the image
         run: docker build -t icm-ngspice:pr -f containers/ngspice/Dockerfile .
 

--- a/.github/workflows/simulator-host.yml
+++ b/.github/workflows/simulator-host.yml
@@ -103,6 +103,23 @@ jobs:
             echo "list dns:      (zone not visible to this token)"
           fi
 
+      - name: Install the tracked host lifecycle bundle
+        if: github.event_name == 'push' || inputs.action != 'probe'
+        env:
+          SIMULATION_ACCESS_TOKEN: ${{ secrets.SIMULATION_UPSTREAM_TOKEN }}
+        run: |
+          set -euo pipefail
+          [ -n "$SIMULATION_ACCESS_TOKEN" ] || { echo "::error::SIMULATION_UPSTREAM_TOKEN is empty"; exit 1; }
+          release="analog-canvas-sim/releases/$GITHUB_SHA"
+          ssh sim "rm -rf ~/$release && mkdir -p ~/$release"
+          tar -cf - containers/ngspice | ssh sim "tar -xf - -C ~/$release"
+          printf '%s\n' "$GITHUB_SHA" | ssh sim "cat > ~/$release/SOURCE_COMMIT"
+          ssh sim "chmod 755 ~/$release/containers/ngspice/host/*.sh ~/$release/containers/ngspice/verify-host-runtime.sh"
+          ssh sim "~/$release/containers/ngspice/host/bootstrap.sh"
+          # The access token travels over SSH on stdin and is never an
+          # argument, a log line, or a file in the checkout.
+          printf '%s' "$SIMULATION_ACCESS_TOKEN" | ssh sim 'umask 077; { printf "SIMULATION_ACCESS_TOKEN="; cat; printf "\n"; } > ~/analog-canvas-sim/secrets/runtime.env'
+
       - name: Create the tunnel, its ingress, and its DNS name; hand the token to the host
         if: github.event_name == 'workflow_dispatch' && inputs.action == 'bootstrap-tunnel'
         env:
@@ -158,20 +175,15 @@ jobs:
           # The connector token goes to the host and nowhere else.
           token_json="$(curl --silent "${auth[@]}" "$base/accounts/$account_id/cfd_tunnel/$tunnel_id/token")"
           echo "$token_json" | jq -e '.success' >/dev/null || fail "reading the tunnel token failed" "$token_json"
-          echo "$token_json" | jq -r '.result' | ssh sim 'umask 077; { printf "TUNNEL_TOKEN="; cat; } > ~/analog-canvas-sim/tunnel.env && echo "tunnel.env written ($(wc -c < ~/analog-canvas-sim/tunnel.env) bytes)"'
-          ssh sim '~/analog-canvas-sim/bin/up.sh'
+          echo "$token_json" | jq -r '.result' | ssh sim 'umask 077; { printf "TUNNEL_TOKEN="; cat; } > ~/analog-canvas-sim/secrets/tunnel.env && echo "tunnel.env written ($(wc -c < ~/analog-canvas-sim/secrets/tunnel.env) bytes)"'
+          ssh sim "~/analog-canvas-sim/releases/$GITHUB_SHA/containers/ngspice/host/deploy.sh"
 
-      - name: Copy the harness to the host, rebuild, restart
+      - name: Build and deploy the tracked host topology
         if: github.event_name == 'push' || inputs.action == 'deploy'
         run: |
           set -euo pipefail
-          ssh sim 'mkdir -p ~/analog-canvas-sim/build/containers/ngspice ~/analog-canvas-sim/bin'
-          scp -q containers/ngspice/Dockerfile containers/ngspice/entrypoint.mjs containers/ngspice/run-supervisor.mjs sim:~/analog-canvas-sim/build/containers/ngspice/
-          scp -q containers/ngspice/verify-host-runtime.sh sim:~/analog-canvas-sim/bin/verify-runtime.sh
-          ssh sim 'chmod 755 ~/analog-canvas-sim/bin/verify-runtime.sh'
-          echo "${GITHUB_SHA::8}" | ssh sim 'cat > ~/analog-canvas-sim/build/SOURCE_COMMIT'
-          ssh sim '~/analog-canvas-sim/bin/rebuild.sh'
-          ssh sim '~/analog-canvas-sim/bin/verify-runtime.sh'
+          ssh sim "~/analog-canvas-sim/releases/$GITHUB_SHA/containers/ngspice/host/deploy.sh"
+          ssh sim '~/analog-canvas-sim/current/containers/ngspice/verify-host-runtime.sh'
 
       - name: Verify the host answers through its tunnel
         if: github.event_name == 'push' || inputs.action != 'probe'
@@ -182,7 +194,7 @@ jobs:
           # and says so, rather than failing for the tunnel's absence.
           if [ -z "$(ssh sim 'docker ps --quiet --filter name=^analog-canvas-tunnel$')" ]; then
             echo "::notice::no tunnel is running on the host yet; verifying inside its network"
-            ssh sim '~/analog-canvas-sim/bin/health.sh' > /tmp/health.json
+            ssh sim '~/analog-canvas-sim/current/containers/ngspice/host/health.sh' > /tmp/health.json
             jq -e '.status == "ready"' /tmp/health.json >/dev/null || { echo "::error::the harness is not ready on the host"; cat /tmp/health.json || true; exit 1; }
             echo "ready on the host: ngspice $(jq -r '.environment.simulator.version' /tmp/health.json)"
             exit 0

--- a/containers/ngspice/host/README.md
+++ b/containers/ngspice/host/README.md
@@ -1,0 +1,78 @@
+# Operator simulator host
+
+This directory is the executable recovery record for the operator-run ngspice
+host. The host is disposable: simulation runs are temporary, and no Project or
+result data is stored here. A replacement host needs only Docker, the Compose
+plugin, this repository, and the deployment secrets.
+
+`compose.yaml` is the sole desired-state definition. It gives the harness a
+private run-root volume and an internal network with no egress. `cloudflared`
+joins that network and a separate egress network, so it is the only path to the
+harness. Neither service publishes a host port. `deploy.sh` and `health.sh` are
+thin operators over that definition; `../verify-host-runtime.sh` independently
+checks the security and resource boundary after deployment.
+
+## Repository-owned deployment
+
+The **Simulator host** GitHub workflow copies the exact
+`containers/ngspice/` tree into a commit-addressed directory on the host,
+writes the access token from the protected `cloudflare-preview` environment,
+builds the pinned image, starts the services, and verifies the result. Its
+`bootstrap-tunnel` action creates or reuses the named Cloudflare Tunnel and
+writes its connector token without printing it.
+
+The host account needs:
+
+- a Linux host with Docker Engine and Docker Compose 2.33.1 or newer;
+- permission to use the Docker daemon without an interactive elevation;
+- enough capacity for the declared 8 CPU and 16 GiB harness limit;
+- the SSH key and host identity represented by the repository's
+  `SIM_HOST_*` environment secrets.
+
+No lifecycle script is installed by hand. The workflow invokes only the files
+in this directory.
+
+## Recover onto a clean host
+
+1. Install Docker Engine and the Compose plugin, create the non-root operator
+   account, and grant that account access to Docker.
+2. Point `SIM_HOST_ADDR`, `SIM_HOST_USER`, `SIM_HOST_SSH_KEY`, and
+   `SIM_HOST_KNOWN_HOSTS` at the replacement machine.
+3. Run **Simulator host / bootstrap-tunnel**. This installs the tracked bundle,
+   restores the named tunnel/DNS configuration, writes both runtime secrets,
+   and deploys the services.
+4. Run **Simulator host / deploy** once more as a recovery drill. It must be
+   idempotent.
+5. Require all three checks to pass:
+
+   ```sh
+   ~/analog-canvas-sim/current/containers/ngspice/host/health.sh
+   ~/analog-canvas-sim/current/containers/ngspice/verify-host-runtime.sh
+   curl --fail https://sim-fra.analog-canvas.tokenzhang.com/health
+   ```
+
+   An unauthenticated `POST /run` must return HTTP 401; the workflow checks it.
+
+For a destructive drill, use a disposable host, run Compose `down --volumes`
+against its current tracked file, remove `~/analog-canvas-sim`, and repeat the
+five steps. Nothing from the old host should be copied. GitHub environment
+secrets and the Cloudflare account are control-plane inputs, not backup files
+inside this repository.
+
+## Manual local proof
+
+For development on a Docker-capable Linux machine, create the runtime secret
+without committing it and deploy from a checkout:
+
+```sh
+export SIMULATOR_HOST_HOME="$HOME/analog-canvas-sim-test"
+containers/ngspice/host/bootstrap.sh
+umask 077
+printf 'SIMULATION_ACCESS_TOKEN=%s\n' "$SIMULATION_ACCESS_TOKEN" \
+  > "$SIMULATOR_HOST_HOME/secrets/runtime.env"
+containers/ngspice/host/deploy.sh
+containers/ngspice/verify-host-runtime.sh
+```
+
+Without `secrets/tunnel.env`, only the harness starts. This is intentional for
+local proof and for the first deployment before the named tunnel exists.

--- a/containers/ngspice/host/bootstrap.sh
+++ b/containers/ngspice/host/bootstrap.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -eu
+
+host_home="${SIMULATOR_HOST_HOME:-$HOME/analog-canvas-sim}"
+
+fail() {
+  printf 'simulator host bootstrap failed: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v docker >/dev/null 2>&1 || fail "docker is not installed"
+docker compose version >/dev/null 2>&1 \
+  || fail "the Docker Compose plugin is not installed"
+docker info >/dev/null 2>&1 \
+  || fail "the current account cannot reach the Docker daemon"
+
+mkdir -p "$host_home/releases" "$host_home/secrets"
+chmod 700 "$host_home/secrets"
+
+# The first repository-owned deployment may land on the host created by #587.
+# Preserve its connector credential while moving it to the only location the
+# tracked topology reads. A clean replacement host has no legacy file and
+# takes the ordinary bootstrap-tunnel path instead.
+if [ -f "$host_home/tunnel.env" ] \
+    && [ ! -f "$host_home/secrets/tunnel.env" ]; then
+  mv "$host_home/tunnel.env" "$host_home/secrets/tunnel.env"
+  chmod 600 "$host_home/secrets/tunnel.env"
+  printf 'migrated legacy tunnel credential into the tracked host layout\n'
+fi
+
+printf 'simulator host ready for repository-owned deployment: %s\n' "$host_home"

--- a/containers/ngspice/host/compose.yaml
+++ b/containers/ngspice/host/compose.yaml
@@ -1,0 +1,58 @@
+name: analog-canvas-sim
+
+services:
+  simulator:
+    image: analog-canvas-ngspice:${SIMULATION_IMAGE_TAG:-local}
+    build:
+      context: ../../..
+      dockerfile: containers/ngspice/Dockerfile
+    container_name: analog-canvas-ngspice
+    environment:
+      SIMULATION_ACCESS_TOKEN: ${SIMULATION_ACCESS_TOKEN:?set SIMULATION_ACCESS_TOKEN in the host runtime env}
+    restart: unless-stopped
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 256
+    cpus: 8.0
+    mem_limit: 16g
+    volumes:
+      - run-root:/var/lib/simulation
+    networks:
+      - simulation
+
+  tunnel:
+    image: cloudflare/cloudflared:2025.8.1@sha256:b77d84e8704db38db22c22661cf7e56468c526e3a6a5fe9c8b7c151452fa1472
+    container_name: analog-canvas-tunnel
+    profiles:
+      - tunnel
+    command:
+      - tunnel
+      - --no-autoupdate
+      - run
+    environment:
+      TUNNEL_TOKEN: ${TUNNEL_TOKEN:-}
+    restart: unless-stopped
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 128
+    networks:
+      tunnel-egress:
+        gw_priority: 1
+      simulation: {}
+
+volumes:
+  run-root:
+    name: analog-canvas-simulation-run-root
+
+networks:
+  simulation:
+    name: analog-canvas-sim-internal
+    internal: true
+  tunnel-egress:
+    name: analog-canvas-tunnel-egress

--- a/containers/ngspice/host/deploy.sh
+++ b/containers/ngspice/host/deploy.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+set -eu
+
+script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+source_root="$(CDPATH= cd -- "$script_dir/../../.." && pwd)"
+host_home="${SIMULATOR_HOST_HOME:-$HOME/analog-canvas-sim}"
+runtime_env="$host_home/secrets/runtime.env"
+tunnel_env="$host_home/secrets/tunnel.env"
+compose_file="$script_dir/compose.yaml"
+
+fail() {
+  printf 'simulator host deploy failed: %s\n' "$1" >&2
+  exit 1
+}
+
+"$script_dir/bootstrap.sh" >/dev/null
+
+[ -f "$runtime_env" ] || fail "missing $runtime_env"
+grep -Eq '^SIMULATION_ACCESS_TOKEN=.+$' "$runtime_env" \
+  || fail "$runtime_env does not contain SIMULATION_ACCESS_TOKEN"
+
+if [ -f "$source_root/SOURCE_COMMIT" ]; then
+  source_commit="$(sed -n '1p' "$source_root/SOURCE_COMMIT" | tr -d '\r\n')"
+elif command -v git >/dev/null 2>&1 \
+    && git -C "$source_root" rev-parse --verify HEAD >/dev/null 2>&1; then
+  source_commit="$(git -C "$source_root" rev-parse HEAD)"
+else
+  fail "SOURCE_COMMIT is absent and the source is not a Git checkout"
+fi
+
+printf '%s\n' "$source_commit" | grep -Eq '^[0-9a-f]{7,40}$' \
+  || fail "SOURCE_COMMIT is not a Git object id"
+SIMULATION_IMAGE_TAG="$(printf '%s' "$source_commit" | cut -c1-12)"
+export SIMULATION_IMAGE_TAG
+
+tunnel_enabled=false
+if [ -f "$tunnel_env" ]; then
+  grep -Eq '^TUNNEL_TOKEN=.+$' "$tunnel_env" \
+    || fail "$tunnel_env exists but does not contain TUNNEL_TOKEN"
+  tunnel_enabled=true
+fi
+
+if [ "$tunnel_enabled" = true ]; then
+  compose() {
+    docker compose --project-name analog-canvas-sim \
+      --env-file "$runtime_env" --env-file "$tunnel_env" \
+      --profile tunnel -f "$compose_file" "$@"
+  }
+else
+  compose() {
+    docker compose --project-name analog-canvas-sim \
+      --env-file "$runtime_env" -f "$compose_file" "$@"
+  }
+fi
+
+# The #587 host used the same deliberate container names but created them with
+# operator-owned docker commands. Compose cannot adopt such a container. The
+# one-time transition removes only those exact legacy resources; a container
+# already owned by this Compose project is updated normally.
+replace_legacy_container() {
+  legacy_container="$1"
+  if ! docker inspect "$legacy_container" >/dev/null 2>&1; then
+    return
+  fi
+  owner="$(docker inspect --format '{{index .Config.Labels "com.docker.compose.project"}}' "$legacy_container" 2>/dev/null || true)"
+  if [ "$owner" != "analog-canvas-sim" ]; then
+    printf 'replacing legacy container outside tracked Compose ownership: %s\n' \
+      "$legacy_container"
+    docker rm -f "$legacy_container" >/dev/null
+  fi
+}
+
+compose build --pull simulator
+replace_legacy_container analog-canvas-ngspice
+if [ "$tunnel_enabled" = true ]; then
+  replace_legacy_container analog-canvas-tunnel
+  compose up -d --remove-orphans
+else
+  compose up -d simulator
+fi
+
+"$script_dir/health.sh" >/dev/null
+ln -sfn "$source_root" "$host_home/current"
+
+printf 'simulator host deployed: commit=%s image=analog-canvas-ngspice:%s tunnel=%s\n' \
+  "$source_commit" "$SIMULATION_IMAGE_TAG" "$tunnel_enabled"

--- a/containers/ngspice/host/health.sh
+++ b/containers/ngspice/host/health.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -eu
+
+container="${SIMULATION_CONTAINER_NAME:-analog-canvas-ngspice}"
+attempts="${SIMULATION_HEALTH_ATTEMPTS:-180}"
+interval="${SIMULATION_HEALTH_INTERVAL_SECONDS:-1}"
+
+case "$attempts" in
+  ''|*[!0-9]*)
+    printf 'SIMULATION_HEALTH_ATTEMPTS must be a positive integer\n' >&2
+    exit 1
+    ;;
+esac
+[ "$attempts" -gt 0 ] || {
+  printf 'SIMULATION_HEALTH_ATTEMPTS must be positive\n' >&2
+  exit 1
+}
+
+probe='const response = await fetch("http://127.0.0.1:8080/health"); const text = await response.text(); if (!response.ok) throw new Error(`health ${response.status}: ${text}`); const value = JSON.parse(text); if (value.status !== "ready") throw new Error(`health status ${value.status}`); process.stdout.write(text);'
+
+i=1
+while [ "$i" -le "$attempts" ]; do
+  if health="$(docker exec "$container" node --input-type=module -e "$probe" 2>/dev/null)"; then
+    printf '%s\n' "$health"
+    exit 0
+  fi
+  sleep "$interval"
+  i=$((i + 1))
+done
+
+printf 'simulator host health failed after %s attempts\n' "$attempts" >&2
+docker logs --tail 100 "$container" >&2 || true
+exit 1

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -145,35 +145,34 @@ run. The Preview deploy sends the same divider through both explicit targets
 and requires the numerical result and environment fingerprint to agree.
 
 The current operator host is the Frankfurt machine, under its `analogcanvas`
-account, in `~/analog-canvas-sim/`. `bin/up.sh` runs the image with a
-read-only root filesystem, the run root on a volume the image initialised
-for the run account, no capabilities, a pid limit, 8 CPUs and 16 GiB, on an
-internal Docker network that has no route to the internet; `cloudflared` is
-the only other member of that network and the only container with egress,
-and it starts only once `tunnel.env` holds `TUNNEL_TOKEN`. The
-`Simulator host` workflow (`.github/workflows/simulator-host.yml`) does the
-operating: on every merge that touches `containers/ngspice/` it copies the
-harness to the host, rebuilds, restarts, and verifies `/health` through the
-tunnel; run by hand it can `probe` what the Cloudflare token may do or
-`bootstrap-tunnel` — create the named tunnel, its ingress, and the DNS name,
-and hand the connector token to the host over SSH without ever printing it.
-It reaches the host with the repository secrets `SIM_HOST_ADDR`,
+account, in `~/analog-canvas-sim/`. Its desired state is not private machine
+configuration: [`containers/ngspice/host/compose.yaml`](../containers/ngspice/host/compose.yaml)
+is the sole definition of the harness container, tunnel container, internal
+network, egress boundary, private run-root volume, restart policy, and resource
+limits. The harness has a read-only root, no capabilities, bounded PIDs, 8 CPUs
+and 16 GiB, no published host port, and no egress. `cloudflared` alone joins
+both the internal network and an egress network.
+
+The `Simulator host` workflow (`.github/workflows/simulator-host.yml`) copies
+the exact tracked `containers/ngspice/` tree into a commit-addressed release on
+the host. It writes the protected access token over SSH, runs the tracked
+bootstrap/deploy scripts, and verifies `/health`; run by hand it can `probe`
+what the Cloudflare token may do or `bootstrap-tunnel` — create or reuse the
+named tunnel, its ingress, and DNS name, and hand the connector token to the
+host without printing it. It reaches the host with `SIM_HOST_ADDR`,
 `SIM_HOST_USER`, `SIM_HOST_SSH_KEY`, and `SIM_HOST_KNOWN_HOSTS`, and speaks to
 Cloudflare with `CLOUDFLARE_TUNNEL_API_TOKEN` (Account → Cloudflare Tunnel:
-Edit, Zone → DNS: Edit on the site's zone), a token separate from the deploy
-token on purpose; before the tunnel exists, an automatic rebuild verifies the
-harness from inside the host's network instead; on the host
-`bin/health.sh` asks the harness for its health from inside that network.
-The host's operator-owned `up.sh` and `rebuild.sh` remain outside the
-repository, but their result is no longer trusted by description alone: the
-workflow installs the tracked `containers/ngspice/verify-host-runtime.sh` and
-requires the running container to have an automatic restart policy, a
-read-only root, all capabilities dropped, bounded PIDs, 8 CPUs, 16 GiB, no
-published host port, and a writable private run-root volume. Automatic restart
+Edit, Zone → DNS: Edit on the site's zone), separate from the deploy token.
+
+No lifecycle script is operator-owned. A clean Docker-capable replacement can
+be reconstructed from the repository and protected environment secrets by the
+procedure in [`containers/ngspice/host/README.md`](../containers/ngspice/host/README.md).
+The independent `containers/ngspice/verify-host-runtime.sh` still checks the
+running result rather than trusting the Compose description. Automatic restart
 is part of the Run Supervisor's fail-stop contract; without it a safe harness
-exit would become a permanent outage. The host has 32 cores; the
-harness still runs one job at a time, by its own slot, until the executor
-contract gains a concurrency count.
+exit would become a permanent outage. The host has 32 cores; the harness still
+runs one job at a time, by its own slot, until the executor contract gains a
+concurrency count.
 
 Either way `metadata.environment.executor` reads `hosted-container`: the
 harness is the same container image, and the fingerprint identifies it, not

--- a/scripts/simulator-host-workflow.test.mjs
+++ b/scripts/simulator-host-workflow.test.mjs
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const workflow = readFileSync(".github/workflows/simulator-host.yml", "utf8");
+const compose = readFileSync("containers/ngspice/host/compose.yaml", "utf8");
+const deploy = readFileSync("containers/ngspice/host/deploy.sh", "utf8");
+
+describe("the operator simulator host", () => {
+  it("installs and invokes only repository-owned lifecycle scripts", () => {
+    expect(workflow).toContain("tar -cf - containers/ngspice");
+    expect(workflow).toContain("containers/ngspice/host/bootstrap.sh");
+    expect(workflow).toContain("containers/ngspice/host/deploy.sh");
+    expect(workflow).toContain("containers/ngspice/host/health.sh");
+    expect(workflow).toContain("containers/ngspice/verify-host-runtime.sh");
+    expect(workflow).not.toMatch(
+      /analog-canvas-sim\/(?:bin\/)?(?:up|rebuild|health)\.sh/u,
+    );
+  });
+
+  it("keeps the harness private and resource bounded in one desired-state file", () => {
+    expect(compose).toContain("container_name: analog-canvas-ngspice");
+    expect(compose).toContain("read_only: true");
+    expect(compose).toMatch(/cap_drop:\s*\n\s*- ALL/u);
+    expect(compose).toContain("pids_limit: 256");
+    expect(compose).toContain("cpus: 8.0");
+    expect(compose).toContain("mem_limit: 16g");
+    expect(compose).toContain("internal: true");
+    expect(compose).not.toMatch(/^\s*ports:/mu);
+    expect(compose).toContain(
+      "cloudflare/cloudflared:2025.8.1@sha256:b77d84e8704db38db22c22661cf7e56468c526e3a6a5fe9c8b7c151452fa1472",
+    );
+  });
+
+  it("uses the tracked topology instead of repeating docker run flags", () => {
+    expect(deploy).toContain('compose_file="$script_dir/compose.yaml"');
+    expect(deploy).toContain("docker compose");
+    expect(deploy).not.toContain("docker run");
+    expect(deploy).not.toContain("--cpus");
+    expect(deploy).not.toContain("--memory");
+    expect(deploy).not.toContain("--cap-drop");
+  });
+
+  it("bounds the one-time legacy takeover to the two known containers", () => {
+    expect(deploy).toContain("replace_legacy_container analog-canvas-ngspice");
+    expect(deploy).toContain("replace_legacy_container analog-canvas-tunnel");
+    expect(deploy).not.toMatch(/docker (?:system|volume|network) prune/u);
+  });
+});


### PR DESCRIPTION
## Outcome

Closes #599 by replacing the Frankfurt simulator host's untracked lifecycle files with a repository-owned recovery bundle.

- `containers/ngspice/host/compose.yaml` is the sole desired-state definition for the harness, tunnel, networks, volume, limits, and security boundary.
- tracked bootstrap/deploy/health scripts remain thin operators over Compose;
- `simulator-host.yml` copies a commit-addressed source bundle and invokes only tracked scripts;
- protected access/tunnel tokens stay outside Git and travel over SSH without appearing in arguments or logs;
- the first deploy migrates the old tunnel token and replaces only the two exact legacy containers;
- the existing `verify-host-runtime.sh` remains the independent post-deploy assertion layer;
- clean-host recovery and a destructive disposable-host drill are documented.

This does not change `/health`, `/run`, executor selection, fallback behavior, or simulation result contracts. It is based on `main` after #600 and #601.

## Validation

- `pnpm gate:preflight -- --base origin/main`
- focused workflow/smoke tests: 17 passed
- `pnpm docs:check`
- `docker compose ... config --quiet`
- POSIX `sh -n` on all three host scripts
- build and release verification passed
- Playwright: 349 passed
- `git diff --check`

`pnpm gate:full` passed static checks, then reproduced the existing 15 Windows/POSIX failures in `containers/ngspice/entrypoint.test.mjs`; the same focused file fails identically on `origin/main`. Build, release, and browser phases were run separately and passed. The required Linux **Build and exercise the image** PR check is the platform-valid container evidence.

Test-Impact: tests-updated