### PR TITLE
fix(deploy): bootstrap the pinned Compose plugin

### DIFF
--- a/containers/ngspice/host/README.md
+++ b/containers/ngspice/host/README.md
@@ -2,8 +2,9 @@
 
 This directory is the executable recovery record for the operator-run ngspice
 host. The host is disposable: simulation runs are temporary, and no Project or
-result data is stored here. A replacement host needs only Docker, the Compose
-plugin, this repository, and the deployment secrets.
+result data is stored here. A replacement host needs Docker, `curl`,
+`sha256sum`, this repository, and the deployment secrets; the tracked
+bootstrap installs the pinned Compose plugin.
 
 `compose.yaml` is the sole desired-state definition. It gives the harness a
 private run-root volume and an internal network with no egress. `cloudflared`
@@ -23,7 +24,9 @@ writes its connector token without printing it.
 
 The host account needs:
 
-- a Linux host with Docker Engine and Docker Compose 2.33.1 or newer;
+- an x86-64 or ARM64 Linux host with Docker Engine; the tracked bootstrap
+  installs the digest-pinned Docker Compose 2.33.1 plugin when it is absent;
+- passwordless `sudo` for that one-time plugin installation;
 - permission to use the Docker daemon without an interactive elevation;
 - enough capacity for the declared 8 CPU and 16 GiB harness limit;
 - the SSH key and host identity represented by the repository's
@@ -34,8 +37,9 @@ in this directory.
 
 ## Recover onto a clean host
 
-1. Install Docker Engine and the Compose plugin, create the non-root operator
-   account, and grant that account access to Docker.
+1. Install Docker Engine plus `curl` and `sha256sum`, create the non-root
+   operator account, grant it access to Docker, and allow passwordless `sudo`
+   for repository-owned bootstrap.
 2. Point `SIM_HOST_ADDR`, `SIM_HOST_USER`, `SIM_HOST_SSH_KEY`, and
    `SIM_HOST_KNOWN_HOSTS` at the replacement machine.
 3. Run **Simulator host / bootstrap-tunnel**. This installs the tracked bundle,

--- a/containers/ngspice/host/bootstrap.sh
+++ b/containers/ngspice/host/bootstrap.sh
@@ -9,8 +9,62 @@ fail() {
 }
 
 command -v docker >/dev/null 2>&1 || fail "docker is not installed"
-docker compose version >/dev/null 2>&1 \
-  || fail "the Docker Compose plugin is not installed"
+compose_version="2.33.1"
+
+as_root() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+    return
+  fi
+
+  command -v sudo >/dev/null 2>&1 \
+    || fail "installing the Docker Compose plugin requires root or sudo"
+  sudo -n true >/dev/null 2>&1 \
+    || fail "installing the Docker Compose plugin requires passwordless sudo"
+  sudo -n "$@"
+}
+
+install_compose_plugin() {
+  command -v curl >/dev/null 2>&1 \
+    || fail "installing the Docker Compose plugin requires curl"
+  command -v sha256sum >/dev/null 2>&1 \
+    || fail "installing the Docker Compose plugin requires sha256sum"
+
+  case "$(uname -m)" in
+    x86_64|amd64)
+      compose_arch="x86_64"
+      compose_sha256="3efda1ad6caed49dedd5644cadbf7e0c9cc3d74d8844ca5237b6a43ac1ef1a46"
+      ;;
+    aarch64|arm64)
+      compose_arch="aarch64"
+      compose_sha256="fa0e077510c852237b0da426d0daf6853446e7760145ce7665ec401892a4d0de"
+      ;;
+    *) fail "Docker Compose $compose_version is not pinned for $(uname -m)" ;;
+  esac
+
+  compose_tmp="$(mktemp)"
+  trap 'rm -f "$compose_tmp"' 0 1 2 15
+  printf 'installing pinned Docker Compose %s for %s\n' \
+    "$compose_version" "$compose_arch"
+  curl --fail --location --silent --show-error \
+    "https://github.com/docker/compose/releases/download/v$compose_version/docker-compose-linux-$compose_arch" \
+    --output "$compose_tmp"
+  printf '%s  %s\n' "$compose_sha256" "$compose_tmp" | sha256sum --check --status \
+    || fail "the Docker Compose download did not match its pinned digest"
+  as_root install -d -m 755 /usr/local/lib/docker/cli-plugins
+  as_root install -m 755 "$compose_tmp" \
+    /usr/local/lib/docker/cli-plugins/docker-compose
+  rm -f "$compose_tmp"
+  trap - 0 1 2 15
+}
+
+compose_current="$(docker compose version --short 2>/dev/null || true)"
+if [ "${compose_current#v}" != "$compose_version" ]; then
+  install_compose_plugin
+fi
+compose_current="$(docker compose version --short 2>/dev/null || true)"
+[ "${compose_current#v}" = "$compose_version" ] \
+  || fail "Docker Compose $compose_version is unavailable after installation"
 docker info >/dev/null 2>&1 \
   || fail "the current account cannot reach the Docker daemon"
 

--- a/scripts/simulator-host-workflow.test.mjs
+++ b/scripts/simulator-host-workflow.test.mjs
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 const workflow = readFileSync(".github/workflows/simulator-host.yml", "utf8");
 const compose = readFileSync("containers/ngspice/host/compose.yaml", "utf8");
+const bootstrap = readFileSync("containers/ngspice/host/bootstrap.sh", "utf8");
 const deploy = readFileSync("containers/ngspice/host/deploy.sh", "utf8");
 
 describe("the operator simulator host", () => {
@@ -16,6 +17,16 @@ describe("the operator simulator host", () => {
     expect(workflow).not.toMatch(
       /analog-canvas-sim\/(?:bin\/)?(?:up|rebuild|health)\.sh/u,
     );
+  });
+
+  it("can provision the pinned Compose v2 dependency", () => {
+    expect(bootstrap).toContain("docker compose version");
+    expect(bootstrap).toContain('compose_version="2.33.1"');
+    expect(bootstrap).toContain(
+      "docker/compose/releases/download/v$compose_version",
+    );
+    expect(bootstrap).toContain("sha256sum --check --status");
+    expect(bootstrap).toContain("sudo -n");
   });
 
   it("keeps the harness private and resource bounded in one desired-state file", () => {


### PR DESCRIPTION
## Summary

- install digest-pinned Docker Compose 2.33.1 when the operator host lacks the plugin
- support the host's x86-64 architecture and ARM64 replacement hosts
- document bootstrap prerequisites and protect the dependency contract

## Why

The first deployment after #603 failed because the existing operator host has Docker Engine but no Compose v2 plugin. The recovery flow must provision its declared runtime dependency rather than only diagnose that it is absent.

Follow-up to #603 and the deployment failure in run 33884853957.

## Validation

- POSIX shell syntax
- pnpm test:local scripts/simulator-host-workflow.test.mjs`n- pnpm ci:static`n- pnpm release:verify`n- git diff --check`n
Test-Impact: tests-updated