### PR TITLE
fix(deploy): install Compose without host elevation

### DIFF
--- a/containers/ngspice/host/README.md
+++ b/containers/ngspice/host/README.md
@@ -25,8 +25,8 @@ writes its connector token without printing it.
 The host account needs:
 
 - an x86-64 or ARM64 Linux host with Docker Engine; the tracked bootstrap
-  installs the digest-pinned Docker Compose 2.33.1 plugin when it is absent;
-- passwordless `sudo` for that one-time plugin installation;
+  installs the digest-pinned Docker Compose 2.33.1 plugin into the operator's
+  user-level Docker CLI directory when it is absent;
 - permission to use the Docker daemon without an interactive elevation;
 - enough capacity for the declared 8 CPU and 16 GiB harness limit;
 - the SSH key and host identity represented by the repository's
@@ -38,8 +38,8 @@ in this directory.
 ## Recover onto a clean host
 
 1. Install Docker Engine plus `curl` and `sha256sum`, create the non-root
-   operator account, grant it access to Docker, and allow passwordless `sudo`
-   for repository-owned bootstrap.
+   operator account, and grant it access to Docker. Bootstrap does not require
+   root or `sudo`.
 2. Point `SIM_HOST_ADDR`, `SIM_HOST_USER`, `SIM_HOST_SSH_KEY`, and
    `SIM_HOST_KNOWN_HOSTS` at the replacement machine.
 3. Run **Simulator host / bootstrap-tunnel**. This installs the tracked bundle,

--- a/containers/ngspice/host/bootstrap.sh
+++ b/containers/ngspice/host/bootstrap.sh
@@ -11,19 +11,6 @@ fail() {
 command -v docker >/dev/null 2>&1 || fail "docker is not installed"
 compose_version="2.33.1"
 
-as_root() {
-  if [ "$(id -u)" -eq 0 ]; then
-    "$@"
-    return
-  fi
-
-  command -v sudo >/dev/null 2>&1 \
-    || fail "installing the Docker Compose plugin requires root or sudo"
-  sudo -n true >/dev/null 2>&1 \
-    || fail "installing the Docker Compose plugin requires passwordless sudo"
-  sudo -n "$@"
-}
-
 install_compose_plugin() {
   command -v curl >/dev/null 2>&1 \
     || fail "installing the Docker Compose plugin requires curl"
@@ -51,9 +38,9 @@ install_compose_plugin() {
     --output "$compose_tmp"
   printf '%s  %s\n' "$compose_sha256" "$compose_tmp" | sha256sum --check --status \
     || fail "the Docker Compose download did not match its pinned digest"
-  as_root install -d -m 755 /usr/local/lib/docker/cli-plugins
-  as_root install -m 755 "$compose_tmp" \
-    /usr/local/lib/docker/cli-plugins/docker-compose
+  compose_plugin_dir="$HOME/.docker/cli-plugins"
+  install -d -m 755 "$compose_plugin_dir"
+  install -m 755 "$compose_tmp" "$compose_plugin_dir/docker-compose"
   rm -f "$compose_tmp"
   trap - 0 1 2 15
 }

--- a/scripts/simulator-host-workflow.test.mjs
+++ b/scripts/simulator-host-workflow.test.mjs
@@ -26,7 +26,8 @@ describe("the operator simulator host", () => {
       "docker/compose/releases/download/v$compose_version",
     );
     expect(bootstrap).toContain("sha256sum --check --status");
-    expect(bootstrap).toContain("sudo -n");
+    expect(bootstrap).toContain("$HOME/.docker/cli-plugins");
+    expect(bootstrap).not.toContain("sudo");
   });
 
   it("keeps the harness private and resource bounded in one desired-state file", () => {


### PR DESCRIPTION
## Summary

- install the pinned Compose plugin in the operator account's supported user-level Docker CLI directory
- remove the unnecessary passwordless-sudo host requirement
- keep digest verification and exact 2.33.1 runtime identity unchanged

## Why

The follow-up deployment after #604 confirmed that the operator account can use Docker but has no passwordless sudo. Docker supports ~/.docker/cli-plugins, so widening host privileges is unnecessary.

Follow-up to #603 and #604; fixes deployment run 33886652924.

## Validation

- POSIX shell syntax
- focused simulator-host workflow tests
- static contracts and typecheck
- diff check

Test-Impact: tests-updated