### PR TITLE
feat(simulation): qualify the hosted SKY130 profile

### DIFF
--- a/apps/local-host/src/simulate.ts
+++ b/apps/local-host/src/simulate.ts
@@ -141,12 +141,14 @@ async function observeLocalEnvironment(
   return createSimulationEnvironmentMetadata({
     executor: "local-host",
     reproducibility: "observed",
+    profileId: null,
     platform: `${process.platform}/${process.arch}`,
     simulator: { name: "ngspice", version, binarySha256 },
     models:
       modelLibrary && modelSha256
         ? { id: "configured-model-library", contentSha256: modelSha256 }
         : null,
+    startupSha256: null,
   });
 }
 

--- a/containers/ngspice/Dockerfile
+++ b/containers/ngspice/Dockerfile
@@ -58,7 +58,9 @@ RUN set -eu; \
 # The base image already sets SKY130_MODEL_LIB to the continuous library; the
 # Worker selects that same path (worker/simulation.ts).
 ENV NGSPICE_BIN=/opt/ngspice/bin/ngspice \
-    SKY130_MODEL_ROOT=/opt/sky130
+    SKY130_MODEL_ROOT=/opt/sky130 \
+    SIMULATION_PROFILE_PATH=/opt/harness/hosted-sky130-profile.json \
+    SIMULATION_STARTUP_PATH=/opt/harness/hosted.spiceinit
 
 # A container wakes with a fresh disk, so the run directory is scratch by
 # nature. Declaring it here documents that nothing survives a sleep.
@@ -68,6 +70,8 @@ WORKDIR ${RUN_ROOT}
 # image_build_context to "."), so every COPY is repo-root relative.
 ARG HARNESS_DIR=containers/ngspice
 COPY ${HARNESS_DIR}/entrypoint.mjs ${HARNESS_DIR}/run-supervisor.mjs /opt/harness/
+COPY ${HARNESS_DIR}/hosted-sky130-profile.json /opt/harness/hosted-sky130-profile.json
+COPY ${HARNESS_DIR}/hosted.spiceinit /opt/harness/hosted.spiceinit
 
 # Nothing a deck can reach is writable except its own run directory.
 #

--- a/containers/ngspice/entrypoint.mjs
+++ b/containers/ngspice/entrypoint.mjs
@@ -36,6 +36,8 @@ import { join, relative } from "node:path";
 import { SimulationRunSupervisor } from "./run-supervisor.mjs";
 
 const MODEL_ROOT = process.env.SKY130_MODEL_ROOT ?? "/opt/sky130/sky130A";
+const PROFILE_PATH = process.env.SIMULATION_PROFILE_PATH?.trim() || null;
+const STARTUP_PATH = process.env.SIMULATION_STARTUP_PATH?.trim() || null;
 const PORT = Number(process.env.PORT ?? 8080);
 
 /**
@@ -123,6 +125,7 @@ const PROBE_TIMEOUT_MS = positiveEnv("SIMULATION_PROBE_TIMEOUT_MS", 5_000);
 /** The deck, and the only file this harness itself puts in the run directory. */
 const DECK_NAME = "deck.cir";
 const SPICEINIT_NAME = ".spiceinit";
+const DEFAULT_STARTUP = "set filetype=ascii\n";
 
 function positiveEnv(name, fallback) {
   const raw = Number(process.env[name]);
@@ -219,6 +222,34 @@ async function sha256File(path) {
     .digest("hex");
 }
 
+function isSha256(value) {
+  return typeof value === "string" && /^[0-9a-f]{64}$/u.test(value);
+}
+
+async function loadEnvironmentProfile() {
+  if (PROFILE_PATH === null) return null;
+  const profile = JSON.parse(await readFile(PROFILE_PATH, "utf8"));
+  if (
+    profile?.schemaVersion !== 1 ||
+    typeof profile.id !== "string" ||
+    typeof profile.platform !== "string" ||
+    profile.simulator?.name !== "ngspice" ||
+    typeof profile.simulator.version !== "string" ||
+    !isSha256(profile.simulator.binarySha256) ||
+    typeof profile.models?.id !== "string" ||
+    !isSha256(profile.models.contentSha256) ||
+    !isSha256(profile.startup?.contentSha256)
+  ) {
+    throw new Error(`Simulation Profile ${PROFILE_PATH} is malformed.`);
+  }
+  if (STARTUP_PATH === null) {
+    throw new Error(
+      "A pinned Simulation Profile requires SIMULATION_STARTUP_PATH.",
+    );
+  }
+  return profile;
+}
+
 async function sha256Tree(root) {
   const hash = createHash("sha256");
   async function visit(directory) {
@@ -247,29 +278,62 @@ async function sha256Tree(root) {
 }
 
 async function observeEnvironment(ngspiceBin) {
-  const [versionOutput, binarySha256, modelTreeSha256] = await Promise.all([
-    commandOutput(ngspiceBin, ["--version"]),
-    sha256File(ngspiceBin),
-    sha256Tree(MODEL_ROOT),
-  ]);
+  const profile = await loadEnvironmentProfile();
+  const startupText =
+    STARTUP_PATH === null
+      ? DEFAULT_STARTUP
+      : await readFile(STARTUP_PATH, "utf8");
+  const [versionOutput, binarySha256, modelTreeSha256, startupSha256] =
+    await Promise.all([
+      commandOutput(ngspiceBin, ["--version"]),
+      sha256File(ngspiceBin),
+      sha256Tree(MODEL_ROOT),
+      Promise.resolve(createHash("sha256").update(startupText).digest("hex")),
+    ]);
+  const platform = `${process.platform}/${process.arch}`;
+  const version = ngspiceVersion(versionOutput);
+  if (profile !== null) {
+    const mismatches = [
+      ["platform", profile.platform, platform],
+      ["simulator version", profile.simulator.version, version],
+      ["simulator binary SHA-256", profile.simulator.binarySha256, binarySha256],
+      ["model tree SHA-256", profile.models.contentSha256, modelTreeSha256],
+      ["startup SHA-256", profile.startup.contentSha256, startupSha256],
+    ].filter(([, expected, actual]) => expected !== actual);
+    if (mismatches.length > 0) {
+      throw new Error(
+        `Simulation environment does not match Profile ${profile.id}: ${mismatches
+          .map(([label, expected, actual]) =>
+            `${label} expected ${expected}, observed ${actual}`,
+          )
+          .join("; ")}`,
+      );
+    }
+  }
   const facts = {
     executor: "hosted-container",
-    // The current Docker inputs are not locked yet. This must not say pinned
-    // until the image is verified against the accepted environment lock.
-    reproducibility: "observed",
-    platform: `${process.platform}/${process.arch}`,
+    reproducibility: profile === null ? "observed" : "pinned",
+    profileId: profile?.id ?? null,
+    platform,
     simulator: {
       name: "ngspice",
-      version: ngspiceVersion(versionOutput),
+      version,
       binarySha256,
     },
-    models: { id: "sky130A", contentSha256: modelTreeSha256 },
+    models: {
+      id: profile?.models.id ?? "sky130A",
+      contentSha256: modelTreeSha256,
+    },
+    startupSha256: profile === null ? null : startupSha256,
   };
   return {
-    ...facts,
-    fingerprint: createHash("sha256")
-      .update(JSON.stringify(facts))
-      .digest("hex"),
+    environment: {
+      ...facts,
+      fingerprint: createHash("sha256")
+        .update(JSON.stringify(facts))
+        .digest("hex"),
+    },
+    startupText,
   };
 }
 
@@ -598,7 +662,7 @@ async function handleRun(body) {
     };
   }
 
-  const [binary, environment, runRoot] = runtime;
+  const [binary, observed, runRoot] = runtime;
   const admission = await runSupervisor.tryExecute(
     { timeoutMs: body?.timeoutMs },
     async (run) => {
@@ -620,7 +684,7 @@ async function handleRun(body) {
         await writeFile(join(directory, DECK_NAME), deck, "utf8");
         await writeFile(
           join(directory, SPICEINIT_NAME),
-          "set filetype=ascii\n",
+          observed.startupText,
           "utf8",
         );
 
@@ -654,7 +718,7 @@ async function handleRun(body) {
             rawfileName: raw.rawfileName,
             rawfileFormat: raw.rawfileFormat,
             limits: { ...LIMITS, timeoutMs: run.timeoutMs },
-            environment,
+            environment: observed.environment,
           },
         };
       } finally {
@@ -699,7 +763,7 @@ const server = createServer((request, response) => {
     // write one answers every run with the same failure, and a deploy check
     // should be able to see that before a circuit does.
     runtimeReadyPromise.then(
-      ([, environment, runRoot]) => {
+      ([, observed, runRoot]) => {
         const activity = runSupervisor.snapshot();
         send(activity.state === "fatal" ? 503 : 200, {
           status: activity.state === "fatal" ? "not-ready" : "ready",
@@ -707,7 +771,7 @@ const server = createServer((request, response) => {
           limits: LIMITS,
           runRoot,
           ...(runRootFailures.length > 0 ? { runRootFailures } : {}),
-          environment,
+          environment: observed.environment,
         });
       },
       (error) =>

--- a/containers/ngspice/entrypoint.test.mjs
+++ b/containers/ngspice/entrypoint.test.mjs
@@ -19,6 +19,12 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
+// The stand-in simulator below is deliberately a POSIX shell program because
+// the production harness is a Linux container and its process-group/ulimit
+// behavior is part of the contract. Windows cannot execute that fixture
+// (`spawn EFTYPE`); pure Profile and metadata contracts remain cross-platform.
+const describeHarness = process.platform === "win32" ? describe.skip : describe;
+
 const ENTRYPOINT = join(
   dirname(fileURLToPath(import.meta.url)),
   "entrypoint.mjs",
@@ -129,7 +135,7 @@ const wait = (ms) =>
     setTimeout(resolve, ms).unref?.();
   });
 
-describe("the run directory", () => {
+describeHarness("the run directory", () => {
   it("gives every run its own, and takes it away again", async () => {
     // The simulator reports where it was started. Two runs must not answer
     // with the same place: a shared working directory is how one author's
@@ -168,7 +174,7 @@ describe("the run directory", () => {
   });
 });
 
-describe("the single slot", () => {
+describeHarness("the single slot", () => {
   it(
     "refuses a second run while one is in flight, and says when to come back",
     { timeout: SLOW_TEST_MS },
@@ -232,7 +238,7 @@ describe("the single slot", () => {
   );
 });
 
-describe("the deadline", () => {
+describeHarness("the deadline", () => {
   it(
     "kills the whole process group, not just the process it started",
     { timeout: SLOW_TEST_MS },
@@ -290,7 +296,7 @@ describe("the deadline", () => {
   );
 });
 
-describe("the output cap", () => {
+describeHarness("the output cap", () => {
   it("truncates past the cap and says so, rather than shortening quietly", async () => {
     const { port } = await startHarness(
       await simulator(
@@ -342,7 +348,7 @@ describe("the output cap", () => {
   });
 });
 
-describe("the rawfile", () => {
+describeHarness("the rawfile", () => {
   it("comes back as text when the deck asked for one", async () => {
     const { port } = await startHarness(
       await simulator(
@@ -375,7 +381,7 @@ describe("the rawfile", () => {
   });
 });
 
-describe("the access token", () => {
+describeHarness("the access token", () => {
   it("is not asked for when none is configured", async () => {
     const binary = await simulator("quiet.sh", "echo ok\n");
     const { port } = await startHarness(binary);
@@ -419,7 +425,7 @@ describe("the access token", () => {
   });
 });
 
-describe("health", () => {
+describeHarness("health", () => {
   it("reports the environment and the limits it enforces", async () => {
     const { port } = await startHarness(
       await simulator("v.sh", "echo ngspice-46\n"),
@@ -448,9 +454,45 @@ describe("health", () => {
     expect(response.status).toBe(503);
     expect((await response.json()).status).toBe("not-ready");
   });
+
+  it("fails closed when measured runtime identity differs from the Profile", async () => {
+    const startupPath = join(workspace, "profile.spiceinit");
+    const profilePath = join(workspace, "mismatched-profile.json");
+    await writeFile(startupPath, "set filetype=ascii\n", "utf8");
+    await writeFile(
+      profilePath,
+      JSON.stringify({
+        schemaVersion: 1,
+        id: "test-profile-v1",
+        platform: `${process.platform}/${process.arch}`,
+        simulator: {
+          name: "ngspice",
+          version: "ngspice-46",
+          binarySha256: "0".repeat(64),
+        },
+        models: { id: "test-models", contentSha256: "1".repeat(64) },
+        startup: { contentSha256: "2".repeat(64) },
+      }),
+      "utf8",
+    );
+    const { port } = await startHarness(
+      await simulator("profile-mismatch.sh", "echo should-not-run\n"),
+      {
+        SIMULATION_PROFILE_PATH: profilePath,
+        SIMULATION_STARTUP_PATH: startupPath,
+      },
+    );
+
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    const payload = await response.json();
+    expect(response.status).toBe(503);
+    expect(payload.status).toBe("not-ready");
+    expect(payload.error).toContain("test-profile-v1");
+    expect(payload.error).toContain("expected");
+  });
 });
 
-describe("a run root that cannot be written", () => {
+describeHarness("a run root that cannot be written", () => {
   it(
     "says so, and does not keep the slot it took",
     { timeout: SLOW_TEST_MS },
@@ -507,7 +549,7 @@ describe("a run root that cannot be written", () => {
   });
 });
 
-describe("the kernel limits", () => {
+describeHarness("the kernel limits", () => {
   it("runs the deck under the limits the image sets", async () => {
     const { port } = await startHarness(
       await simulator("limits.sh", "ulimit -f\necho ran\n"),

--- a/containers/ngspice/hosted-sky130-profile.json
+++ b/containers/ngspice/hosted-sky130-profile.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": 1,
+  "id": "sky130-core-continuous-ngspice46-v1",
+  "sourceImage": "ghcr.io/arcadia-1/circuit-bench-sky130-ngspice@sha256:2da03dc7f1ead7ddc33f2f930a0487ae8618e51518009344584a98fca41a621d",
+  "platform": "linux/x64",
+  "simulator": {
+    "name": "ngspice",
+    "version": "ngspice-46",
+    "binarySha256": "e9b0e776ac656de5e470f6b339c4a7254c961d77714b4b94f4b71be2422e7b46"
+  },
+  "models": {
+    "id": "sky130A-continuous",
+    "contentSha256": "0bf299f0e3e1616478203d370107865635fd08935bb1a9cf9db18efd31703100",
+    "library": {
+      "directive": "lib",
+      "runtimePath": "/opt/sky130/continuous/sky130.lib.spice",
+      "sections": ["tt"]
+    }
+  },
+  "startup": {
+    "filetype": "ascii",
+    "contentSha256": "5ad94681e17bba379ac84d01fe7773458b34f9bbd77c127a3738f1af47ad5634"
+  },
+  "qualifiedScope": {
+    "devices": ["sky130_fd_pr__nfet_01v8", "sky130_fd_pr__pfet_01v8"],
+    "sections": ["tt"],
+    "analyses": ["op"]
+  }
+}

--- a/containers/ngspice/hosted.spiceinit
+++ b/containers/ngspice/hosted.spiceinit
@@ -1,0 +1,1 @@
+set filetype=ascii

--- a/containers/ngspice/profile-contract.test.mjs
+++ b/containers/ngspice/profile-contract.test.mjs
@@ -1,0 +1,42 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const directory = dirname(fileURLToPath(import.meta.url));
+const profile = JSON.parse(
+  await readFile(join(directory, "hosted-sky130-profile.json"), "utf8"),
+);
+const startup = await readFile(join(directory, "hosted.spiceinit"));
+const dockerfile = await readFile(join(directory, "Dockerfile"), "utf8");
+
+describe("the hosted SKY130 Profile", () => {
+  it("pins the exact base image, startup policy and runtime paths", () => {
+    expect(profile.id).toBe("sky130-core-continuous-ngspice46-v1");
+    expect(dockerfile).toContain(`ARG BASE_IMAGE=${profile.sourceImage}`);
+    expect(createHash("sha256").update(startup).digest("hex")).toBe(
+      profile.startup.contentSha256,
+    );
+    expect(dockerfile).toContain(
+      "SIMULATION_PROFILE_PATH=/opt/harness/hosted-sky130-profile.json",
+    );
+    expect(dockerfile).toContain(
+      "SIMULATION_STARTUP_PATH=/opt/harness/hosted.spiceinit",
+    );
+    expect(profile.models.library).toEqual({
+      directive: "lib",
+      runtimePath: "/opt/sky130/continuous/sky130.lib.spice",
+      sections: ["tt"],
+    });
+  });
+
+  it("qualifies only the scope backed by the tracked hosted fixture", () => {
+    expect(profile.qualifiedScope).toEqual({
+      devices: ["sky130_fd_pr__nfet_01v8", "sky130_fd_pr__pfet_01v8"],
+      sections: ["tt"],
+      analyses: ["op"],
+    });
+  });
+});

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -52,6 +52,31 @@ configuration may override the path and section. Its valid default output is:
 The binned models a PDK checkout provides cap device width at 100 µm and
 refuse wide devices (#551); they are not the hosted default.
 
+### Hosted SKY130 Profile
+
+`containers/ngspice/hosted-sky130-profile.json` is the single machine-readable
+contract for the first hosted environment. It names the digest-pinned source
+image, platform, ngspice version and binary digest, complete model-tree digest,
+continuous-library mapping, accepted corner, startup-policy digest, and the
+device/analysis scope that has actually passed qualification. A Profile is a
+runtime contract, not a sample circuit and not a promise about every device in
+the SKY130 PDK.
+
+At container startup the harness measures the real binary, model tree,
+platform, and `.spiceinit` bytes. It reports `reproducibility: "pinned"` and the
+Profile ID only when every measured identity matches. A missing, malformed, or
+mismatched Profile leaves `/health` and `/run` not ready; it is never silently
+downgraded to an observed hosted run. An ordinary local host remains
+`observed` and may use its explicitly configured library without claiming this
+Profile.
+
+The first qualified scope is deliberately narrow and factual: the continuous
+`sky130_fd_pr__nfet_01v8` and `sky130_fd_pr__pfet_01v8` wrappers, `tt`, and an
+operating-point analysis. Adding AC, transient, another corner, or another
+device family extends this same Profile contract only after a model-backed
+fixture passes the hosted gate; a locally available PDK is not evidence by
+itself.
+
 It must not include that top-level sectioned library with `.include`, because
 doing so expands multiple corner sections into the same deck and redefines
 device wrappers. A local host with a plain standalone model file may instead
@@ -103,6 +128,7 @@ interface SimulationRunMetadata {
     fingerprint: string;
     executor: "hosted-container" | "local-host";
     reproducibility: "observed" | "pinned";
+    profileId: string | null;
     platform: string;
     simulator: {
       name: "ngspice";
@@ -110,6 +136,7 @@ interface SimulationRunMetadata {
       binarySha256: string | null;
     };
     models: { id: string; contentSha256: string } | null;
+    startupSha256: string | null;
   };
 }
 ```
@@ -122,11 +149,10 @@ still covers its exact emitted spelling.
 
 An environment fingerprint is the SHA-256 of canonical environment facts. A
 consumer verifies that fingerprint before accepting a runner response. The
-current container and local host report `observed`: the container measures its
-ngspice binary and complete runtime model tree, while the local host reports
-the facts it can observe from the user's installation. `pinned` is reserved
-for a later image that verifies every input against an accepted environment
-lock; metadata plumbing alone must never claim reproducibility.
+hosted container reports `pinned` only after matching the Profile at startup;
+the local host reports `observed` facts from the user's installation with null
+Profile and startup identities. Metadata plumbing alone never claims
+reproducibility.
 
 This envelope establishes provenance only. The numbers themselves are
 [Result data](#result-data). Bindings from a probe back to circuit objects
@@ -195,6 +221,12 @@ into the Project, undo history, Gallery, or recovery copy.
 - `worker/simulation.test.ts` verifies the hosted Sky130 `tt` default,
   deployment overrides, configuration-error classification, and the verified
   run metadata envelope.
+- `containers/ngspice/profile-contract.test.mjs` binds the Profile to the
+  digest-pinned image and exact startup bytes. The Preview gate then sends the
+  tracked five-transistor OTA through both hosted executors, requires the
+  Profile identity and `tt` model selection, reads structured OP data, and
+  compares four internal/output voltages against the recorded qualification
+  fixture. Missing local ngspice never skips this hosted gate.
 - The pinned local authority pack under ignored `.reference-src/` demonstrates
   that ngspice 47 completes a Sky130 NFET operating-point deck with
   `.lib ... tt`, while top-level `.include` produces repeated subcircuit

--- a/fixtures/simulation-acceptance/hosted-sky130-core-continuous-v1.json
+++ b/fixtures/simulation-acceptance/hosted-sky130-core-continuous-v1.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "fixtureId": "ota-5t-balanced-op-v1",
+  "profileId": "sky130-core-continuous-ngspice46-v1",
+  "analysis": "op",
+  "inputs": {
+    "netlist": "fixtures/simulation-acceptance/ota-5t.spi",
+    "testbench": "fixtures/simulation-acceptance/ota-5t-hosted.testbench.spice"
+  },
+  "modelLibrary": {
+    "directive": "lib",
+    "section": "tt"
+  },
+  "expectedProbes": {
+    "v(vout)": { "value": 0.7589797395133877, "absoluteTolerance": 1e-8 },
+    "v(ibias)": { "value": 0.6044031364286973, "absoluteTolerance": 1e-8 },
+    "v(xdut.tail)": { "value": 0.2848671983031419, "absoluteTolerance": 1e-8 },
+    "v(xdut.nleft)": { "value": 0.7589797395214736, "absoluteTolerance": 1e-8 }
+  }
+}

--- a/fixtures/simulation-acceptance/ota-5t-hosted.testbench.spice
+++ b/fixtures/simulation-acceptance/ota-5t-hosted.testbench.spice
@@ -1,0 +1,12 @@
+VDD vdd 0 DC 1.8
+VINP vinp 0 DC 0.9
+VINN vinn 0 DC 0.9
+IBIAS vdd ibias DC 15u
+XDUT 0 ibias vdd vinn vinp vout ota_5t
+CL vout 0 1p
+.control
+set filetype=ascii
+op
+write out.raw v(vout) v(ibias) v(xdut.tail) v(xdut.nleft)
+.endc
+.end

--- a/packages/spice-run/src/environment-profile.test.ts
+++ b/packages/spice-run/src/environment-profile.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+import {
+  hostedProfileMismatches,
+  validateHostedSimulationProfile,
+} from "./environment-profile.js";
+
+const HOSTED_SKY130_PROFILE = validateHostedSimulationProfile(
+  JSON.parse(
+    readFileSync(
+      new URL(
+        "../../../containers/ngspice/hosted-sky130-profile.json",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+  ),
+);
+
+describe("hosted simulation Profile", () => {
+  it("is a complete named contract for the deployed SKY130 environment", () => {
+    expect(validateHostedSimulationProfile(HOSTED_SKY130_PROFILE)).toBe(
+      HOSTED_SKY130_PROFILE,
+    );
+    expect(HOSTED_SKY130_PROFILE.id).toBe(
+      "sky130-core-continuous-ngspice46-v1",
+    );
+    expect(HOSTED_SKY130_PROFILE.models.library).toMatchObject({
+      directive: "lib",
+      runtimePath: "/opt/sky130/continuous/sky130.lib.spice",
+      sections: ["tt"],
+    });
+    expect(HOSTED_SKY130_PROFILE.qualifiedScope.analyses).toEqual(["op"]);
+  });
+
+  it("accepts exact observed identity and names every drift", () => {
+    const observed = {
+      platform: HOSTED_SKY130_PROFILE.platform,
+      simulatorVersion: HOSTED_SKY130_PROFILE.simulator.version,
+      simulatorBinarySha256: HOSTED_SKY130_PROFILE.simulator.binarySha256,
+      modelTreeSha256: HOSTED_SKY130_PROFILE.models.contentSha256,
+      startupSha256: HOSTED_SKY130_PROFILE.startup.contentSha256,
+    };
+    expect(hostedProfileMismatches(HOSTED_SKY130_PROFILE, observed)).toEqual(
+      [],
+    );
+    expect(
+      hostedProfileMismatches(HOSTED_SKY130_PROFILE, {
+        ...observed,
+        simulatorVersion: "ngspice-47",
+        startupSha256: "0".repeat(64),
+      }),
+    ).toEqual([
+      "simulator version: expected ngspice-46, observed ngspice-47",
+      `startup SHA-256: expected ${HOSTED_SKY130_PROFILE.startup.contentSha256}, observed ${"0".repeat(64)}`,
+    ]);
+  });
+
+  it("rejects an incomplete contract", () => {
+    expect(() =>
+      validateHostedSimulationProfile({
+        ...HOSTED_SKY130_PROFILE,
+        simulator: { name: "ngspice", version: "ngspice-46" },
+      }),
+    ).toThrow(/incomplete or malformed/u);
+  });
+});

--- a/packages/spice-run/src/environment-profile.ts
+++ b/packages/spice-run/src/environment-profile.ts
@@ -1,0 +1,109 @@
+export interface HostedSimulationProfile {
+  readonly schemaVersion: 1;
+  readonly id: string;
+  readonly sourceImage: string;
+  readonly platform: string;
+  readonly simulator: {
+    readonly name: "ngspice";
+    readonly version: string;
+    readonly binarySha256: string;
+  };
+  readonly models: {
+    readonly id: string;
+    readonly contentSha256: string;
+    readonly library: {
+      readonly directive: "lib";
+      readonly runtimePath: string;
+      readonly sections: readonly string[];
+    };
+  };
+  readonly startup: {
+    readonly filetype: "ascii";
+    readonly contentSha256: string;
+  };
+  readonly qualifiedScope: {
+    readonly devices: readonly string[];
+    readonly sections: readonly string[];
+    readonly analyses: readonly ("op" | "ac" | "tran")[];
+  };
+}
+
+const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
+
+export function validateHostedSimulationProfile(
+  value: unknown,
+): HostedSimulationProfile {
+  if (!value || typeof value !== "object") {
+    throw new Error("The hosted simulation Profile is not an object.");
+  }
+  const profile = value as Partial<HostedSimulationProfile>;
+  if (
+    profile.schemaVersion !== 1 ||
+    typeof profile.id !== "string" ||
+    profile.id.length === 0 ||
+    typeof profile.sourceImage !== "string" ||
+    !profile.sourceImage.includes("@sha256:") ||
+    typeof profile.platform !== "string" ||
+    profile.simulator?.name !== "ngspice" ||
+    typeof profile.simulator.version !== "string" ||
+    !SHA256_PATTERN.test(profile.simulator.binarySha256 ?? "") ||
+    typeof profile.models?.id !== "string" ||
+    !SHA256_PATTERN.test(profile.models.contentSha256 ?? "") ||
+    profile.models.library?.directive !== "lib" ||
+    typeof profile.models.library.runtimePath !== "string" ||
+    !Array.isArray(profile.models.library.sections) ||
+    profile.models.library.sections.length === 0 ||
+    profile.startup?.filetype !== "ascii" ||
+    !SHA256_PATTERN.test(profile.startup.contentSha256 ?? "") ||
+    !Array.isArray(profile.qualifiedScope?.devices) ||
+    !Array.isArray(profile.qualifiedScope?.sections) ||
+    !Array.isArray(profile.qualifiedScope?.analyses)
+  ) {
+    throw new Error(
+      "The hosted simulation Profile is incomplete or malformed.",
+    );
+  }
+  return profile as HostedSimulationProfile;
+}
+
+export interface ObservedHostedEnvironmentIdentity {
+  readonly platform: string;
+  readonly simulatorVersion: string;
+  readonly simulatorBinarySha256: string;
+  readonly modelTreeSha256: string;
+  readonly startupSha256: string;
+}
+
+export function hostedProfileMismatches(
+  profile: HostedSimulationProfile,
+  observed: ObservedHostedEnvironmentIdentity,
+): readonly string[] {
+  const mismatches: string[] = [];
+  const compare = (label: string, expected: string, actual: string): void => {
+    if (actual !== expected) {
+      mismatches.push(`${label}: expected ${expected}, observed ${actual}`);
+    }
+  };
+  compare("platform", profile.platform, observed.platform);
+  compare(
+    "simulator version",
+    profile.simulator.version,
+    observed.simulatorVersion,
+  );
+  compare(
+    "simulator binary SHA-256",
+    profile.simulator.binarySha256,
+    observed.simulatorBinarySha256,
+  );
+  compare(
+    "model tree SHA-256",
+    profile.models.contentSha256,
+    observed.modelTreeSha256,
+  );
+  compare(
+    "startup SHA-256",
+    profile.startup.contentSha256,
+    observed.startupSha256,
+  );
+  return mismatches;
+}

--- a/packages/spice-run/src/index.test.ts
+++ b/packages/spice-run/src/index.test.ts
@@ -275,6 +275,7 @@ describe("simulation run metadata", () => {
     const environment = await createSimulationEnvironmentMetadata({
       executor: "hosted-container",
       reproducibility: "observed",
+      profileId: null,
       platform: "linux/x64",
       simulator: {
         name: "ngspice",
@@ -287,6 +288,7 @@ describe("simulation run metadata", () => {
         contentSha256:
           "17c208a699228f5acb87bf59c09c22a4c4d3937b6766b4957737d34e8e075f64",
       },
+      startupSha256: null,
     });
     expect(environment.reproducibility).toBe("observed");
     expect(environment.fingerprint).toMatch(/^[0-9a-f]{64}$/u);

--- a/packages/spice-run/src/index.ts
+++ b/packages/spice-run/src/index.ts
@@ -10,6 +10,7 @@
 
 export * from "./rawfile.js";
 export * from "./result-data.js";
+export * from "./environment-profile.js";
 
 import type { SimulationResultData } from "./result-data.js";
 
@@ -67,6 +68,8 @@ export interface SimulationEnvironmentFacts {
   executor: "hosted-container" | "local-host";
   /** `pinned` is reserved for a build verified against an environment lock. */
   reproducibility: "observed" | "pinned";
+  /** Named runtime contract, or null for an unqualified local environment. */
+  profileId: string | null;
   platform: string;
   simulator: {
     name: "ngspice";
@@ -77,6 +80,8 @@ export interface SimulationEnvironmentFacts {
     id: string;
     contentSha256: string;
   } | null;
+  /** Exact startup-policy bytes used for this run, when managed by a Profile. */
+  startupSha256: string | null;
 }
 
 export interface SimulationEnvironmentMetadata extends SimulationEnvironmentFacts {
@@ -277,6 +282,7 @@ function canonicalEnvironmentFacts(facts: SimulationEnvironmentFacts): string {
   return JSON.stringify({
     executor: facts.executor,
     reproducibility: facts.reproducibility,
+    profileId: facts.profileId,
     platform: facts.platform,
     simulator: {
       name: facts.simulator.name,
@@ -286,6 +292,7 @@ function canonicalEnvironmentFacts(facts: SimulationEnvironmentFacts): string {
     models: facts.models
       ? { id: facts.models.id, contentSha256: facts.models.contentSha256 }
       : null,
+    startupSha256: facts.startupSha256,
   });
 }
 
@@ -323,6 +330,9 @@ export function isSimulationEnvironmentMetadata(
       candidate.executor === "local-host") &&
     (candidate.reproducibility === "observed" ||
       candidate.reproducibility === "pinned") &&
+    (candidate.profileId === null ||
+      (typeof candidate.profileId === "string" &&
+        candidate.profileId.length > 0)) &&
     typeof candidate.platform === "string" &&
     candidate.platform.length > 0 &&
     typeof candidate.fingerprint === "string" &&
@@ -339,7 +349,12 @@ export function isSimulationEnvironmentMetadata(
         typeof models.id === "string" &&
         models.id.length > 0 &&
         typeof models.contentSha256 === "string" &&
-        SHA256_PATTERN.test(models.contentSha256)))
+        SHA256_PATTERN.test(models.contentSha256))) &&
+    (candidate.startupSha256 === null ||
+      (typeof candidate.startupSha256 === "string" &&
+        SHA256_PATTERN.test(candidate.startupSha256))) &&
+    (candidate.reproducibility !== "pinned" ||
+      (candidate.profileId !== null && candidate.startupSha256 !== null))
   );
 }
 

--- a/scripts/preview-simulation-smoke.mjs
+++ b/scripts/preview-simulation-smoke.mjs
@@ -8,6 +8,44 @@
  * substrates run the same pinned image.
  */
 import { pathToFileURL } from "node:url";
+import { readFileSync } from "node:fs";
+
+const profile = JSON.parse(
+  readFileSync(
+    new URL(
+      "../containers/ngspice/hosted-sky130-profile.json",
+      import.meta.url,
+    ),
+    "utf8",
+  ),
+);
+const qualification = JSON.parse(
+  readFileSync(
+    new URL(
+      "../fixtures/simulation-acceptance/hosted-sky130-core-continuous-v1.json",
+      import.meta.url,
+    ),
+    "utf8",
+  ),
+);
+if (qualification.profileId !== profile.id) {
+  throw new Error(
+    `Qualification ${qualification.fixtureId} targets ${String(qualification.profileId)}, not Profile ${profile.id}.`,
+  );
+}
+if (!profile.qualifiedScope.analyses.includes(qualification.analysis)) {
+  throw new Error(
+    `Qualification ${qualification.fixtureId} uses undeclared analysis ${String(qualification.analysis)}.`,
+  );
+}
+if (
+  qualification.modelLibrary.directive !== profile.models.library.directive ||
+  !profile.models.library.sections.includes(qualification.modelLibrary.section)
+) {
+  throw new Error(
+    `Qualification ${qualification.fixtureId} uses a model selection outside Profile ${profile.id}.`,
+  );
+}
 
 const EXECUTORS = ["cloudflare-container", "operator-host"];
 const SHA256 = /^[0-9a-f]{64}$/u;
@@ -38,6 +76,19 @@ export const DIVIDER_REQUEST = {
   timeoutMs: 110_000,
 };
 
+export const HOSTED_SKY130_REQUEST = {
+  netlist: readFileSync(
+    new URL(`../${qualification.inputs.netlist}`, import.meta.url),
+    "utf8",
+  ),
+  testbench: readFileSync(
+    new URL(`../${qualification.inputs.testbench}`, import.meta.url),
+    "utf8",
+  ),
+  analyses: ["op"],
+  timeoutMs: 110_000,
+};
+
 function object(value, label) {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error(`${label} is absent or is not an object.`);
@@ -57,6 +108,39 @@ function diagnosticSummary(payload) {
   return messages.length > 0
     ? messages.slice(0, 3).join(" | ")
     : "no diagnostics";
+}
+
+function validatePinnedEnvironment(environment, target) {
+  const simulator = object(environment.simulator, "simulator identity");
+  const models = object(environment.models, "model identity");
+  if (environment.reproducibility !== "pinned") {
+    throw new Error(`${target} did not verify its runtime as pinned.`);
+  }
+  if (environment.profileId !== profile.id) {
+    throw new Error(
+      `${target} reported Profile ${String(environment.profileId)}, expected ${profile.id}.`,
+    );
+  }
+  if (
+    simulator.name !== profile.simulator.name ||
+    simulator.version !== profile.simulator.version ||
+    simulator.binarySha256 !== profile.simulator.binarySha256
+  ) {
+    throw new Error(`${target} does not match the Profile simulator identity.`);
+  }
+  if (
+    models.id !== profile.models.id ||
+    models.contentSha256 !== profile.models.contentSha256
+  ) {
+    throw new Error(`${target} does not match the Profile model identity.`);
+  }
+  if (environment.startupSha256 !== profile.startup.contentSha256) {
+    throw new Error(`${target} does not match the Profile startup identity.`);
+  }
+  if (!SHA256.test(String(environment.fingerprint))) {
+    throw new Error(`${target} returned no valid environment fingerprint.`);
+  }
+  return { simulator, models };
 }
 
 export function validatePreviewSimulationResult(payload, expectedTarget) {
@@ -85,26 +169,7 @@ export function validatePreviewSimulationResult(payload, expectedTarget) {
     );
   }
   const environment = object(metadata.environment, "environment metadata");
-  const simulator = object(environment.simulator, "simulator identity");
-  const models = object(environment.models, "model identity");
-  if (simulator.name !== "ngspice" || typeof simulator.version !== "string") {
-    throw new Error(
-      `${expectedTarget} did not identify ngspice and its version.`,
-    );
-  }
-  if (!SHA256.test(String(simulator.binarySha256))) {
-    throw new Error(
-      `${expectedTarget} returned no valid simulator binary digest.`,
-    );
-  }
-  if (!SHA256.test(String(models.contentSha256))) {
-    throw new Error(`${expectedTarget} returned no valid model-tree digest.`);
-  }
-  if (!SHA256.test(String(environment.fingerprint))) {
-    throw new Error(
-      `${expectedTarget} returned no valid environment fingerprint.`,
-    );
-  }
+  const { simulator } = validatePinnedEnvironment(environment, expectedTarget);
 
   const data = object(result.data, "parsed result data");
   if (!Array.isArray(data.analyses)) {
@@ -138,6 +203,115 @@ export function validatePreviewSimulationResult(payload, expectedTarget) {
     environmentFingerprint: environment.fingerprint,
     simulatorVersion: simulator.version,
   };
+}
+
+export function validateHostedSky130Result(payload, expectedTarget) {
+  const result = object(payload, "simulation response");
+  const execution = object(result.execution, "execution metadata");
+  if (execution.target !== expectedTarget) {
+    throw new Error(
+      `[result:wrong-executor] requested ${expectedTarget}, but the Worker reported ${String(execution.target)}.`,
+    );
+  }
+  if (object(result.outcome, "simulation outcome").status !== "completed") {
+    throw new Error(
+      `[simulation:model-qualification] ${expectedTarget} did not complete: ${diagnosticSummary(result)}`,
+    );
+  }
+  const metadata = object(result.metadata, "run metadata");
+  const input = object(metadata.input, "input metadata");
+  const expectedRevision = `preview-sky130-${expectedTarget}`;
+  if (input.inputRevision !== expectedRevision) {
+    throw new Error(
+      `[result:stale-input] requested ${expectedRevision}, but the Worker returned ${String(input.inputRevision)}.`,
+    );
+  }
+  const configuration = object(
+    metadata.configuration,
+    "configuration metadata",
+  );
+  const modelLibrary = object(configuration.modelLibrary, "model selection");
+  if (
+    modelLibrary.directive !== qualification.modelLibrary.directive ||
+    modelLibrary.section !== qualification.modelLibrary.section
+  ) {
+    throw new Error(
+      `${expectedTarget} did not run the qualified model-library section.`,
+    );
+  }
+  const environment = object(metadata.environment, "environment metadata");
+  validatePinnedEnvironment(environment, expectedTarget);
+
+  const data = object(result.data, "parsed result data");
+  const operatingPoint = Array.isArray(data.analyses)
+    ? data.analyses.find(
+        (analysis) =>
+          typeof analysis === "object" &&
+          analysis !== null &&
+          analysis.analysis === qualification.analysis,
+      )
+    : null;
+  if (!operatingPoint || !Array.isArray(operatingPoint.probes)) {
+    throw new Error(`${expectedTarget} returned no qualified OP result.`);
+  }
+
+  const values = {};
+  for (const [name, expected] of Object.entries(qualification.expectedProbes)) {
+    const probe = operatingPoint.probes.find(
+      (candidate) =>
+        typeof candidate === "object" &&
+        candidate !== null &&
+        candidate.name === name,
+    );
+    if (!probe || typeof probe.value !== "number") {
+      throw new Error(`${expectedTarget} returned no scalar ${name}.`);
+    }
+    if (Math.abs(probe.value - expected.value) > expected.absoluteTolerance) {
+      throw new Error(
+        `${expectedTarget} solved ${name} as ${probe.value}, expected ${expected.value} ± ${expected.absoluteTolerance}.`,
+      );
+    }
+    values[name] = probe.value;
+  }
+  return {
+    target: expectedTarget,
+    fixtureId: qualification.fixtureId,
+    values,
+    environmentFingerprint: environment.fingerprint,
+  };
+}
+
+export async function runHostedSky130Acceptance({
+  baseUrl,
+  target,
+  fetchImpl = fetch,
+}) {
+  const response = await fetchImpl(new URL("/api/simulate", baseUrl), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      ...HOSTED_SKY130_REQUEST,
+      inputRevision: `preview-sky130-${target}`,
+      executorTarget: target,
+    }),
+    signal: AbortSignal.timeout(120_000),
+  });
+  const text = await response.text();
+  let payload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    throw new Error(
+      `[protocol:non-json] ${target} model qualification answered HTTP ${response.status}: ${text.slice(0, 400)}`,
+    );
+  }
+  if (!response.ok) {
+    const refusal = object(payload, "simulation refusal");
+    throw new Error(
+      `[infrastructure:${String(refusal.error ?? `http-${response.status}`)}] ${target} model qualification answered HTTP ${response.status}`,
+    );
+  }
+  return validateHostedSky130Result(payload, target);
 }
 
 export async function runPreviewSimulationSmoke({
@@ -212,6 +386,17 @@ async function main() {
   }
   validateExecutorParity(results);
   console.log("Preview executor parity: passed");
+
+  const qualifications = [];
+  for (const target of EXECUTORS) {
+    const result = await runHostedSky130Acceptance({ baseUrl, target });
+    qualifications.push(result);
+    console.log(
+      `${result.target}: ${result.fixtureId} passed, environment=${result.environmentFingerprint}`,
+    );
+  }
+  validateExecutorParity(qualifications);
+  console.log(`Hosted SKY130 Profile ${profile.id}: qualified`);
 }
 
 if (

--- a/scripts/preview-simulation-smoke.test.mjs
+++ b/scripts/preview-simulation-smoke.test.mjs
@@ -1,12 +1,21 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  runHostedSky130Acceptance,
   runPreviewSimulationSmoke,
   validateExecutorParity,
+  validateHostedSky130Result,
   validatePreviewSimulationResult,
 } from "./preview-simulation-smoke.mjs";
 
 const SHA = "a".repeat(64);
+const PROFILE_ID = "sky130-core-continuous-ngspice46-v1";
+const BINARY_SHA =
+  "e9b0e776ac656de5e470f6b339c4a7254c961d77714b4b94f4b71be2422e7b46";
+const MODEL_SHA =
+  "0bf299f0e3e1616478203d370107865635fd08935bb1a9cf9db18efd31703100";
+const STARTUP_SHA =
+  "5ad94681e17bba379ac84d01fe7773458b34f9bbd77c127a3738f1af47ad5634";
 
 function result(target, overrides = {}) {
   return {
@@ -15,14 +24,21 @@ function result(target, overrides = {}) {
     diagnostics: [],
     metadata: {
       input: { inputRevision: `preview-smoke-${target}` },
+      configuration: { modelLibrary: null },
       environment: {
+        reproducibility: "pinned",
+        profileId: PROFILE_ID,
+        startupSha256: STARTUP_SHA,
         fingerprint: SHA,
         simulator: {
           name: "ngspice",
           version: "ngspice-46",
-          binarySha256: SHA,
+          binarySha256: BINARY_SHA,
         },
-        models: { id: "sky130A", contentSha256: SHA },
+        models: {
+          id: "sky130A-continuous",
+          contentSha256: MODEL_SHA,
+        },
       },
     },
     data: {
@@ -30,6 +46,34 @@ function result(target, overrides = {}) {
         {
           analysis: "op",
           probes: [{ name: "v(mid)", value: 0.5 }],
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+function modelResult(target, overrides = {}) {
+  const base = result(target);
+  return {
+    ...base,
+    metadata: {
+      ...base.metadata,
+      input: { inputRevision: `preview-sky130-${target}` },
+      configuration: {
+        modelLibrary: { directive: "lib", section: "tt" },
+      },
+    },
+    data: {
+      analyses: [
+        {
+          analysis: "op",
+          probes: [
+            { name: "v(vout)", value: 0.7589797395133877 },
+            { name: "v(ibias)", value: 0.6044031364286973 },
+            { name: "v(xdut.tail)", value: 0.2848671983031419 },
+            { name: "v(xdut.nleft)", value: 0.7589797395214736 },
+          ],
         },
       ],
     },
@@ -68,6 +112,14 @@ describe("the Preview dual-executor smoke", () => {
         "operator-host",
       ),
     ).toThrow(/operating-point/u);
+  });
+
+  it("refuses an observed environment that has not earned the Profile", () => {
+    const candidate = result("cloudflare-container");
+    candidate.metadata.environment.reproducibility = "observed";
+    expect(() =>
+      validatePreviewSimulationResult(candidate, "cloudflare-container"),
+    ).toThrow(/did not verify its runtime as pinned/u);
   });
 
   it("refuses a result for a different input revision", () => {
@@ -164,5 +216,53 @@ describe("the Preview dual-executor smoke", () => {
     ).rejects.toThrow(
       "[protocol:non-json] operator-host answered HTTP 502: bad gateway",
     );
+  });
+});
+
+describe("the hosted SKY130 qualification", () => {
+  it("accepts the model-backed OTA operating point", () => {
+    expect(
+      validateHostedSky130Result(
+        modelResult("cloudflare-container"),
+        "cloudflare-container",
+      ),
+    ).toMatchObject({
+      target: "cloudflare-container",
+      fixtureId: "ota-5t-balanced-op-v1",
+      environmentFingerprint: SHA,
+      values: { "v(vout)": 0.7589797395133877 },
+    });
+  });
+
+  it("refuses numerical drift outside the recorded tolerance", () => {
+    const candidate = modelResult("operator-host");
+    candidate.data.analyses[0].probes[0].value = 0.8;
+    expect(() =>
+      validateHostedSky130Result(candidate, "operator-host"),
+    ).toThrow(/solved v\(vout\) as 0\.8/u);
+  });
+
+  it("refuses a run that did not load the qualified corner", () => {
+    const candidate = modelResult("operator-host");
+    candidate.metadata.configuration.modelLibrary.section = "ff";
+    expect(() =>
+      validateHostedSky130Result(candidate, "operator-host"),
+    ).toThrow(/qualified model-library section/u);
+  });
+
+  it("sends the model fixture through the selected executor", async () => {
+    let submitted;
+    const accepted = await runHostedSky130Acceptance({
+      baseUrl: "https://preview.example",
+      target: "operator-host",
+      fetchImpl: async (_url, init) => {
+        submitted = JSON.parse(init.body);
+        return Response.json(modelResult("operator-host"));
+      },
+    });
+    expect(submitted.executorTarget).toBe("operator-host");
+    expect(submitted.netlist).toContain(".subckt ota_5t");
+    expect(submitted.testbench).toContain("write out.raw v(vout)");
+    expect(accepted.fixtureId).toBe("ota-5t-balanced-op-v1");
   });
 });

--- a/worker/simulation.test.ts
+++ b/worker/simulation.test.ts
@@ -17,6 +17,7 @@ function post(body: unknown, path = "/api/simulate"): Request {
 const HOSTED_ENVIRONMENT = await createSimulationEnvironmentMetadata({
   executor: "hosted-container",
   reproducibility: "observed",
+  profileId: null,
   platform: "linux/x64",
   simulator: {
     name: "ngspice",
@@ -29,6 +30,7 @@ const HOSTED_ENVIRONMENT = await createSimulationEnvironmentMetadata({
     contentSha256:
       "17c208a699228f5acb87bf59c09c22a4c4d3937b6766b4957737d34e8e075f64",
   },
+  startupSha256: null,
 });
 
 /** Stands in for the container, recording the deck it was handed. */


### PR DESCRIPTION
## Summary
- add one named, versioned hosted SKY130/ngspice Profile and fail closed when measured runtime identity drifts
- extend run metadata with Profile and startup identity while keeping local hosts explicitly observed
- qualify a tracked five-transistor OTA operating point through both Preview executors with structured numerical assertions

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:full -- --base origin/main (2523 unit tests passed, 349 browser tests passed)
- current Preview calibration run produced the tracked OTA OP values from the same digest-pinned ngspice 46/model image

## Boundary
- no Project schema change
- no local ngspice requirement for the hosted gate
- first Profile qualifies only continuous core NFET/PFET, TT, and OP; AC/TRAN/corners/device expansion remains evidence-gated

Test-Impact: tests-updated