### PR TITLE
fix(deploy): provide private simulator scratch

### DIFF
--- a/containers/ngspice/host/README.md
+++ b/containers/ngspice/host/README.md
@@ -13,6 +13,12 @@ harness. Neither service publishes a host port. `deploy.sh` and `health.sh` are
 thin operators over that definition; `../verify-host-runtime.sh` independently
 checks the security and resource boundary after deployment.
 
+The image root remains read-only. Ngspice still calls the operating system's
+`tmpfile()` even though each authored run has its own private work directory,
+so Compose mounts a 64 MiB, non-executable tmpfs at `/tmp`, owned only by the
+unprivileged simulation account. It is memory-backed scratch, not a persistent
+volume, and disappears with the container.
+
 ## Repository-owned deployment
 
 The **Simulator host** GitHub workflow copies the exact
@@ -56,6 +62,8 @@ in this directory.
    ```
 
    An unauthenticated `POST /run` must return HTTP 401; the workflow checks it.
+   `health.sh` also runs an equal-resistor divider and requires `v(mid) = 0.5`,
+   so a ready HTTP process without writable simulator scratch cannot pass.
 
 For a destructive drill, use a disposable host, run Compose `down --volumes`
 against its current tracked file, remove `~/analog-canvas-sim`, and repeat the

--- a/containers/ngspice/host/compose.yaml
+++ b/containers/ngspice/host/compose.yaml
@@ -11,6 +11,8 @@ services:
       SIMULATION_ACCESS_TOKEN: ${SIMULATION_ACCESS_TOKEN:?set SIMULATION_ACCESS_TOKEN in the host runtime env}
     restart: unless-stopped
     read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=64m,uid=10001,gid=10001,mode=0700
     cap_drop:
       - ALL
     security_opt:

--- a/containers/ngspice/host/health.sh
+++ b/containers/ngspice/host/health.sh
@@ -4,6 +4,7 @@ set -eu
 container="${SIMULATION_CONTAINER_NAME:-analog-canvas-ngspice}"
 attempts="${SIMULATION_HEALTH_ATTEMPTS:-180}"
 interval="${SIMULATION_HEALTH_INTERVAL_SECONDS:-1}"
+script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 
 case "$attempts" in
   ''|*[!0-9]*)
@@ -19,15 +20,27 @@ esac
 probe='const response = await fetch("http://127.0.0.1:8080/health"); const text = await response.text(); if (!response.ok) throw new Error(`health ${response.status}: ${text}`); const value = JSON.parse(text); if (value.status !== "ready") throw new Error(`health status ${value.status}`); process.stdout.write(text);'
 
 i=1
+ready=false
 while [ "$i" -le "$attempts" ]; do
   if health="$(docker exec "$container" node --input-type=module -e "$probe" 2>/dev/null)"; then
-    printf '%s\n' "$health"
-    exit 0
+    ready=true
+    break
   fi
   sleep "$interval"
   i=$((i + 1))
 done
 
-printf 'simulator host health failed after %s attempts\n' "$attempts" >&2
-docker logs --tail 100 "$container" >&2 || true
-exit 1
+if [ "$ready" != true ]; then
+  printf 'simulator host health failed after %s attempts\n' "$attempts" >&2
+  docker logs --tail 100 "$container" >&2 || true
+  exit 1
+fi
+
+if ! smoke_result="$(docker exec -i "$container" node --input-type=module < "$script_dir/numerical-smoke.mjs")"; then
+  printf 'simulator host numerical smoke failed\n' >&2
+  docker logs --tail 100 "$container" >&2 || true
+  exit 1
+fi
+
+printf '%s\n' "$smoke_result" >&2
+printf '%s\n' "$health"

--- a/containers/ngspice/host/numerical-smoke.mjs
+++ b/containers/ngspice/host/numerical-smoke.mjs
@@ -1,0 +1,74 @@
+import { pathToFileURL } from "node:url";
+
+export const deck = [
+  "V1 in 0 DC 1",
+  "R1 in mid 1k",
+  "R2 mid 0 1k",
+  ".control",
+  "set filetype=ascii",
+  "op",
+  "write out.raw v(mid)",
+  ".endc",
+  ".end",
+].join("\n");
+
+export function readMidpoint(rawfile) {
+  const variable = /^\s*(\d+)\s+v\(mid\)\s+\S+/mu.exec(rawfile);
+  const valuesAt = rawfile.search(/^\s*Values:\s*$/mu);
+  if (!variable || valuesAt < 0) {
+    throw new Error(
+      "the numerical smoke rawfile has no v(mid) operating-point value",
+    );
+  }
+  const values = rawfile
+    .slice(valuesAt)
+    .split(/\r?\n/u)
+    .slice(1)
+    .filter((line) => line.trim())
+    .map((line) => Number(line.trim().split(/\s+/u).at(-1)));
+  const midpoint = values[Number(variable[1])];
+  if (!Number.isFinite(midpoint) || Math.abs(midpoint - 0.5) > 1e-12) {
+    throw new Error(
+      `the numerical smoke solved v(mid) as ${midpoint}, expected 0.5`,
+    );
+  }
+  return midpoint;
+}
+
+export async function runNumericalSmoke({
+  fetchImpl = fetch,
+  token = process.env.SIMULATION_ACCESS_TOKEN,
+} = {}) {
+  if (!token) throw new Error("the container has no simulation access token");
+
+  const response = await fetchImpl("http://127.0.0.1:8080/run", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ deck, timeoutMs: 30_000 }),
+  });
+  const text = await response.text();
+  if (!response.ok) throw new Error(`run ${response.status}: ${text}`);
+
+  const result = JSON.parse(text);
+  if (result.timedOut === true) {
+    throw new Error("the numerical smoke timed out");
+  }
+  if (result.rawfileFormat !== "ascii" || typeof result.rawfile !== "string") {
+    throw new Error(
+      `the numerical smoke returned no ASCII rawfile: ${result.log ?? "no log"}`,
+    );
+  }
+
+  return readMidpoint(result.rawfile);
+}
+
+if (
+  process.argv[1] === undefined ||
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  const midpoint = await runNumericalSmoke();
+  process.stdout.write(`numerical smoke: v(mid)=${midpoint}`);
+}

--- a/containers/ngspice/host/numerical-smoke.test.mjs
+++ b/containers/ngspice/host/numerical-smoke.test.mjs
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { readMidpoint, runNumericalSmoke } from "./numerical-smoke.mjs";
+
+const rawfile = [
+  "Title: operator host smoke",
+  "Plotname: Operating Point",
+  "No. Variables: 2",
+  "No. Points: 1",
+  "Variables:",
+  " 0 v(in) voltage",
+  " 1 v(mid) voltage",
+  "Values:",
+  " 0 1.000000000000000e+00",
+  "   5.000000000000000e-01",
+  "",
+].join("\n");
+
+describe("the operator-host numerical smoke", () => {
+  it("requires the equal divider's rawfile value", () => {
+    expect(readMidpoint(rawfile)).toBe(0.5);
+    expect(() =>
+      readMidpoint(rawfile.replace("5.000000000000000e-01", "0.4")),
+    ).toThrow("expected 0.5");
+  });
+
+  it("runs through the authenticated harness contract", async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json({ timedOut: false, rawfileFormat: "ascii", rawfile }),
+    );
+
+    await expect(
+      runNumericalSmoke({ fetchImpl, token: "test-token" }),
+    ).resolves.toBe(0.5);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "http://127.0.0.1:8080/run",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          authorization: "Bearer test-token",
+        }),
+      }),
+    );
+  });
+
+  it("reports the filesystem symptom instead of accepting an empty result", async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json({
+        timedOut: false,
+        rawfileFormat: null,
+        rawfile: null,
+        log: "tmpfile(): Read-only file system",
+      }),
+    );
+
+    await expect(
+      runNumericalSmoke({ fetchImpl, token: "test-token" }),
+    ).rejects.toThrow("tmpfile(): Read-only file system");
+  });
+});

--- a/containers/ngspice/verify-host-runtime.sh
+++ b/containers/ngspice/verify-host-runtime.sh
@@ -48,5 +48,14 @@ run_root_rw="$(value '{{range .Mounts}}{{if eq .Destination "/var/lib/simulation
 [ "$run_root_rw" = "true" ] \
   || fail "the private run-root volume is absent or read-only"
 
-printf 'simulator host runtime verified: restart=%s pids=%s cpus=8 memory=16GiB\n' \
+tmpfs_options="$(value '{{index .HostConfig.Tmpfs "/tmp"}}')"
+[ -n "$tmpfs_options" ] || fail "the private /tmp tmpfs is absent"
+for option in noexec nosuid nodev uid=10001 gid=10001 mode=0700; do
+  case ",$tmpfs_options," in
+    *",$option,"*) ;;
+    *) fail "the /tmp tmpfs is missing option $option: $tmpfs_options" ;;
+  esac
+done
+
+printf 'simulator host runtime verified: restart=%s pids=%s cpus=8 memory=16GiB tmpfs=/tmp\n' \
   "$restart" "$pids"

--- a/scripts/simulator-host-workflow.test.mjs
+++ b/scripts/simulator-host-workflow.test.mjs
@@ -6,6 +6,15 @@ const workflow = readFileSync(".github/workflows/simulator-host.yml", "utf8");
 const compose = readFileSync("containers/ngspice/host/compose.yaml", "utf8");
 const bootstrap = readFileSync("containers/ngspice/host/bootstrap.sh", "utf8");
 const deploy = readFileSync("containers/ngspice/host/deploy.sh", "utf8");
+const health = readFileSync("containers/ngspice/host/health.sh", "utf8");
+const numericalSmoke = readFileSync(
+  "containers/ngspice/host/numerical-smoke.mjs",
+  "utf8",
+);
+const runtimeVerification = readFileSync(
+  "containers/ngspice/verify-host-runtime.sh",
+  "utf8",
+);
 
 describe("the operator simulator host", () => {
   it("installs and invokes only repository-owned lifecycle scripts", () => {
@@ -33,6 +42,9 @@ describe("the operator simulator host", () => {
   it("keeps the harness private and resource bounded in one desired-state file", () => {
     expect(compose).toContain("container_name: analog-canvas-ngspice");
     expect(compose).toContain("read_only: true");
+    expect(compose).toContain(
+      "/tmp:rw,noexec,nosuid,nodev,size=64m,uid=10001,gid=10001,mode=0700",
+    );
     expect(compose).toMatch(/cap_drop:\s*\n\s*- ALL/u);
     expect(compose).toContain("pids_limit: 256");
     expect(compose).toContain("cpus: 8.0");
@@ -42,6 +54,14 @@ describe("the operator simulator host", () => {
     expect(compose).toContain(
       "cloudflare/cloudflared:2025.8.1@sha256:b77d84e8704db38db22c22661cf7e56468c526e3a6a5fe9c8b7c151452fa1472",
     );
+  });
+
+  it("proves a real numerical run can use private temporary storage", () => {
+    expect(health).toContain("numerical-smoke.mjs");
+    expect(numericalSmoke).toContain('fetchImpl("http://127.0.0.1:8080/run"');
+    expect(numericalSmoke).toContain("write out.raw v(mid)");
+    expect(numericalSmoke).toContain("Math.abs(midpoint - 0.5) > 1e-12");
+    expect(runtimeVerification).toContain("the private /tmp tmpfs is absent");
   });
 
   it("uses the tracked topology instead of repeating docker run flags", () => {


### PR DESCRIPTION
## Summary

- mount a bounded, non-executable /tmp tmpfs for the unprivileged ngspice process while keeping the image root read-only
- verify the tmpfs ownership/security contract from the live Docker runtime
- extend host health with an authenticated equal-divider OP run that must return (mid)=0.5`n
## Root cause

The Compose topology introduced by #603 had ead_only: true but no writable /tmp. The operator-host ngspice process logged 	mpfile(): Read-only file system, returned no rawfile, and caused the post-deploy Preview parity smoke to fail even though /health was ready. This is the red Deploy Preview run attached to #606; the #606 Simulator host workflow itself succeeded.

## Validation

- Compose config expansion
- POSIX shell syntax
- numerical smoke and host workflow tests: 9 passed
- static contracts/typecheck
- release verification
- gate preflight and diff check

Local Docker runtime proof was unavailable because Docker Desktop is not running. The PR Linux image check and post-merge operator-host deployment own the remaining runtime boundary.

Test-Impact: tests-updated