### PR TITLE
fix(simulation): rotate Cloudflare containers with profiles

### DIFF
--- a/worker/simulation.test.ts
+++ b/worker/simulation.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import { createSimulationEnvironmentMetadata } from "@icm/spice-run";
+import hostedSky130Profile from "../containers/ngspice/hosted-sky130-profile.json";
 
 import { routeSimulationRequest, type SimulationEnv } from "./simulation";
 
@@ -59,6 +60,37 @@ const NETLIST = ".subckt amp in out\nM1 out in 0 0 nfet\n.ends\nXA in out amp";
 const TESTBENCH = "V1 in 0 DC 1\n.control\nop\nprint v(out)\n.endc";
 
 describe("simulation route", () => {
+  it("starts a new Cloudflare container generation when the Profile changes", async () => {
+    let selectedKey: string | undefined;
+    const environment: SimulationEnv = {
+      NGSPICE: {
+        getByName: (key) => {
+          selectedKey = key;
+          return {
+            fetch: async () =>
+              Response.json({
+                environment: HOSTED_ENVIRONMENT,
+                log: "ngspice completed",
+                exitCode: 0,
+                timedOut: false,
+                durationMs: 5,
+              }),
+          };
+        },
+      },
+    };
+
+    await routeSimulationRequest(
+      post({
+        netlist: ".subckt divider in out\nR1 in out 1k\n.ends",
+        testbench: "V1 in 0 DC 1\nX1 in out divider\n.op",
+      }),
+      environment,
+    );
+
+    expect(selectedKey).toBe(`profile:${hostedSky130Profile.id}`);
+  });
+
   it("ignores paths that are not its own", async () => {
     expect(
       await routeSimulationRequest(post({}, "/api/gallery"), {}),

--- a/worker/simulation.ts
+++ b/worker/simulation.ts
@@ -32,6 +32,7 @@ import {
   type SimulationResult,
   type SimulationResultData,
 } from "@icm/spice-run";
+import hostedSky130Profile from "../containers/ngspice/hosted-sky130-profile.json";
 
 /** What a container-backed runner has to offer this module. */
 export interface NgspiceRunner {
@@ -65,6 +66,15 @@ export interface SimulationEnv {
 
 /** A deck this large is a mistake upstream, not a simulation worth waking for. */
 const MAX_INPUT_BYTES = 2 * 1024 * 1024;
+
+/**
+ * Cloudflare Containers are owned by a named Durable Object. An image deploy
+ * does not evict an already-warm object immediately, so a fixed key can route
+ * a new Worker to the previous Profile for the rest of its idle lifetime.
+ * Keying the object by the versioned Profile identity makes a Profile change
+ * start a fresh container while unchanged deploys keep their warm instance.
+ */
+const CLOUDFLARE_CONTAINER_INSTANCE_KEY = `profile:${hostedSky130Profile.id}`;
 
 interface SimulationRequestBody {
   netlist?: unknown;
@@ -217,7 +227,7 @@ async function describeRefusal(
 export async function routeSimulationRequest(
   request: Request,
   env: SimulationEnv,
-  runnerKey = "shared",
+  runnerKey = CLOUDFLARE_CONTAINER_INSTANCE_KEY,
 ): Promise<Response | null> {
   const url = new URL(request.url);
   if (url.pathname !== "/api/simulate") return null;


### PR DESCRIPTION
## Summary
- key the Cloudflare simulator Durable Object by the hosted Profile ID
- start a fresh container generation whenever the Profile changes
- preserve warm-container reuse for deploys that keep the same Profile

## Root cause
PR #608 deployed the new pinned Profile image successfully, but Cloudflare continued serving the already-warm shared container from the previous image. The new Worker correctly rejected its old environment metadata, so Preview's dual-executor gate failed. The fixed key would repeat this on every Profile/image protocol change.

## Validation
- pnpm test:local worker/simulation.test.ts (30 passed)
- pnpm ci:static
- pnpm test:local (2524 passed, 22 skipped)
- pnpm gate:preflight -- --base origin/main

Test-Impact: tests-updated