### PR TITLE
feat(netlist): analyze a design from an explicit root

### DIFF
--- a/packages/netlist/src/current-contract.test.ts
+++ b/packages/netlist/src/current-contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  createEmptyDocument,
   createEmptyProject,
   deriveStableId,
   type CircuitProject,
@@ -460,6 +461,88 @@ describe("current formal cell interface", () => {
 
     expect(repeated).toEqual(first);
     expect(reopened).toEqual(first);
+  });
+
+  it("preserves the Project top when analyzing an explicit Testbench root", () => {
+    const project = createEmptyProject("project", "Project", "dut");
+    const dut = project.documents[0]!;
+    dut.netlist!.name = "dut";
+    const testbench = createEmptyDocument("tb", "Testbench");
+    testbench.netlist!.name = "testbench";
+    testbench.instances.push({
+      id: "X_DUT",
+      symbolId: "dut-symbol",
+      placement: null,
+      reference: "X_DUT",
+      netlist: {
+        binding: { kind: "subcircuit", childDocumentId: dut.id },
+        parameters: {},
+      },
+    });
+    const unrelated = createEmptyDocument("unrelated", "Unrelated");
+    for (const [document, netId, spelling] of [
+      [dut, "net-dut-vdd", "VDD"],
+      [testbench, "net-tb-vdd", "vdd"],
+      [unrelated, "net-unrelated-vdd", "VDd"],
+    ] as const) {
+      document.nets.push({ id: netId, terminals: [] });
+      claimNet(document, netId, spelling, "global");
+    }
+    project.documents.push(testbench, unrelated);
+    const before = JSON.stringify(project);
+
+    const result = analyzeDesignNetlist(project, { rootDocumentId: "tb" });
+
+    expect(
+      result.diagnostics.filter((item) => item.severity === "error"),
+    ).toEqual([]);
+    expect(result.ir?.topCellId).toBe("tb");
+    expect(result.ir?.cells.map((cell) => cell.id)).toEqual(["dut", "tb"]);
+    expect(result.ir?.globals).toEqual(["vdd"]);
+    expect(
+      result.ir?.cells.map(
+        (cell) => cell.nets.find((net) => net.scope === "global")?.name,
+      ),
+    ).toEqual(["vdd", "vdd"]);
+    expect(result.ir?.cells.some((cell) => cell.id === "unrelated")).toBe(
+      false,
+    );
+    expect(project.topDocumentId).toBe("dut");
+    expect(JSON.stringify(project)).toBe(before);
+  });
+
+  it("keeps omitted and explicit Project-top analysis identical", () => {
+    const project = resistorProject({ value: "10k" });
+
+    expect(
+      analyzeDesignNetlist(project, {
+        rootDocumentId: project.topDocumentId,
+      }),
+    ).toEqual(analyzeDesignNetlist(project));
+  });
+
+  it("diagnoses an unknown explicit root without throwing", () => {
+    const project = createEmptyProject("project", "Project");
+
+    const result = analyzeDesignNetlist(project, {
+      rootDocumentId: "missing-testbench",
+    });
+
+    expect(result.ir).toBeNull();
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "MISSING_ROOT_CELL",
+        documentId: project.topDocumentId,
+        objectIds: [],
+        message:
+          "Simulation root references unknown Document missing-testbench",
+        primary: expect.objectContaining({
+          documentId: project.topDocumentId,
+          kind: "document",
+          objectId: project.topDocumentId,
+        }),
+      }),
+    ]);
   });
 
   it("rejects parameters that would become ambiguous under case folding", () => {

--- a/packages/netlist/src/extract.ts
+++ b/packages/netlist/src/extract.ts
@@ -96,11 +96,21 @@ function attachDiagnosticLocators(
 
 function reachableDocuments(
   project: CircuitProject,
+  rootDocumentId: StableId,
   diagnostics: NetlistDiagnostic[],
 ): SchematicDocument[] {
   const byId = new Map(
     project.documents.map((document) => [document.id, document]),
   );
+  if (!byId.has(rootDocumentId)) {
+    diagnostic(
+      diagnostics,
+      project.topDocumentId,
+      "MISSING_ROOT_CELL",
+      `Simulation root references unknown Document ${rootDocumentId}`,
+    );
+    return [];
+  }
   const ordered: SchematicDocument[] = [];
   const visiting = new Set<string>();
   const visited = new Set<string>();
@@ -125,7 +135,7 @@ function reachableDocuments(
     if (!document) {
       diagnostic(
         diagnostics,
-        parentId ?? project.topDocumentId,
+        parentId ?? rootDocumentId,
         "MISSING_CHILD_CELL",
         `Hierarchy binding references unknown Document ${documentId}`,
         instanceId ? [instanceId] : [],
@@ -147,11 +157,11 @@ function reachableDocuments(
     ordered.push(document);
   }
 
-  visit(project.topDocumentId);
+  visit(rootDocumentId);
   if (ordered.length > MAX_CELLS) {
     diagnostic(
       diagnostics,
-      project.topDocumentId,
+      rootDocumentId,
       "CELL_LIMIT_EXCEEDED",
       `Reachable hierarchy has ${ordered.length} cells; maximum is ${MAX_CELLS}`,
     );
@@ -169,6 +179,8 @@ interface CellNetContext {
 export interface DesignNetlistAnalysisOptions {
   format?: NetlistFormat;
   namingProfile?: NetlistNamingProfile;
+  /** Read-only analysis root. Omission preserves structural-export behavior. */
+  rootDocumentId?: StableId;
 }
 
 type ResolvedDesignNetlistAnalysisOptions =
@@ -1258,10 +1270,19 @@ export function analyzeDesignNetlist(
   const resolvedOptions: ResolvedDesignNetlistAnalysisOptions = {
     format: options.format ?? "spice",
     namingProfile: options.namingProfile ?? "native",
+    rootDocumentId: options.rootDocumentId ?? project.topDocumentId,
   };
   const diagnostics: NetlistDiagnostic[] = [];
-  const documents = reachableDocuments(project, diagnostics);
-  const nameProjection = deriveProjectNetNameProjection(project);
+  const documents = reachableDocuments(
+    project,
+    resolvedOptions.rootDocumentId,
+    diagnostics,
+  );
+  const nameProjection = deriveProjectNetNameProjection(
+    resolvedOptions.rootDocumentId === project.topDocumentId
+      ? project
+      : { ...project, topDocumentId: resolvedOptions.rootDocumentId },
+  );
   const documentsById = new Map(
     project.documents.map((document) => [document.id, document]),
   );
@@ -1317,7 +1338,7 @@ export function analyzeDesignNetlist(
   ].sort(compareText);
   return {
     ir: {
-      topCellId: project.topDocumentId,
+      topCellId: resolvedOptions.rootDocumentId,
       cells,
       globals,
       externalMasters: [


### PR DESCRIPTION
## Summary
- add a read-only rootDocumentId option to design-netlist analysis while preserving the existing Project-top default
- use the selected root for hierarchy reachability, global-name projection, diagnostics, and IR identity without mutating the Project
- return a structured MISSING_ROOT_CELL diagnostic for an unknown root

This is the first bounded F2 slice from #569. It does not implement SimulationSetup or the deck compiler, so #569 remains open.

## Validation
- pnpm test:local packages/netlist/src/current-contract.test.ts (31 passed)
- pnpm --filter @icm/netlist... build
- pnpm gate:preflight -- --base origin/main
- pnpm ci:check before rebase: 2,527 unit tests passed, 349 browser tests passed, build/release/golden/performance checks passed
- post-rebase focused tests and build passed
- git diff --check

Test-Impact: tests-updated

Refs #569