### PR TITLE
fix(deploy): the simulator host gives ngspice a writable /tmp

### DIFF
--- a/containers/ngspice/host/compose.yaml
+++ b/containers/ngspice/host/compose.yaml
@@ -20,6 +20,17 @@ services:
     mem_limit: 16g
     volumes:
       - run-root:/var/lib/simulation
+      # ngspice opens its scratch files with tmpfile(), which glibc always
+      # places under /tmp — TMPDIR is not consulted. With a read-only root and
+      # no mount here every run died at once ("tmpfile(): Read-only file
+      # system") and the preview's simulation was down from 15:11Z to the fix
+      # on 2026-09-04. A private tmpfs, world-writable with the sticky bit
+      # (Docker's default mode for a tmpfs mount), is what the simulator needs
+      # and nothing a deck writes there survives the container.
+      - type: tmpfs
+        target: /tmp
+        tmpfs:
+          size: 1073741824
     networks:
       - simulation
 

--- a/containers/ngspice/verify-host-runtime.sh
+++ b/containers/ngspice/verify-host-runtime.sh
@@ -48,5 +48,11 @@ run_root_rw="$(value '{{range .Mounts}}{{if eq .Destination "/var/lib/simulation
 [ "$run_root_rw" = "true" ] \
   || fail "the private run-root volume is absent or read-only"
 
+# ngspice's tmpfile() always goes to /tmp; on a read-only root that must be a
+# private tmpfs or every run dies with "tmpfile(): Read-only file system".
+tmp_type="$(value '{{range .Mounts}}{{if eq .Destination "/tmp"}}{{.Type}}{{end}}{{end}}')"
+[ "$tmp_type" = "tmpfs" ] \
+  || fail "/tmp is not a private tmpfs, so the simulator cannot open its scratch files"
+
 printf 'simulator host runtime verified: restart=%s pids=%s cpus=8 memory=16GiB\n' \
   "$restart" "$pids"


### PR DESCRIPTION
## Outage

Since the Compose definition (#603) took over the operator host at 15:11Z, every simulation died at once with `tmpfile(): Read-only file system`, and every Deploy Preview since failed at its smoke (`parsed result data is absent`). The harness runs with a read-only root and one writable volume (the run root); ngspice opens scratch files with `tmpfile()`, which glibc always places under `/tmp` — `TMPDIR` is not consulted.

## Fix

- `containers/ngspice/host/compose.yaml`: the simulator service mounts a private 1 GiB tmpfs at `/tmp` (Docker's default tmpfs mode is world-writable with the sticky bit).
- `containers/ngspice/verify-host-runtime.sh`: fails when `/tmp` is not a tmpfs mount, so the boundary cannot quietly lose it again.

Already applied on the host through `host/deploy.sh` (container recreated, verifier green, a Sky130 `.op` through the preview returns `v(out) = 1.753893 V` in 0.46 s), so the preview simulates again now; this PR makes the deployed tree match. Merging triggers the `Simulator host` deploy and a fresh Deploy Preview, whose smoke is the check.

Also filed #613: the Worker reported these dead runs as `completed` with a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)