### PR TITLE
refactor(model): own the canonical object locator contract

### DIFF
--- a/packages/derived/src/object-locator.test.ts
+++ b/packages/derived/src/object-locator.test.ts
@@ -1,0 +1,30 @@
+import {
+  HierarchyFrameSchema as ModelHierarchyFrameSchema,
+  ObjectLocatorKindSchema as ModelObjectLocatorKindSchema,
+  ObjectLocatorSchema as ModelObjectLocatorSchema,
+} from "@icm/model";
+import { describe, expect, it } from "vitest";
+
+import {
+  directObjectLocator,
+  HierarchyFrameSchema,
+  ObjectLocatorKindSchema,
+  ObjectLocatorSchema,
+} from "./object-locator.js";
+
+describe("derived object locator facade", () => {
+  it("reexports the canonical model schemas rather than defining copies", () => {
+    expect(ObjectLocatorSchema).toBe(ModelObjectLocatorSchema);
+    expect(ObjectLocatorKindSchema).toBe(ModelObjectLocatorKindSchema);
+    expect(HierarchyFrameSchema).toBe(ModelHierarchyFrameSchema);
+  });
+
+  it("constructs direct locators with the canonical empty hierarchy path", () => {
+    expect(directObjectLocator("main", "net", "net-1")).toEqual({
+      documentId: "main",
+      hierarchyPath: [],
+      kind: "net",
+      objectId: "net-1",
+    });
+  });
+});

--- a/packages/derived/src/object-locator.ts
+++ b/packages/derived/src/object-locator.ts
@@ -1,56 +1,15 @@
-import {
-  RouteEndpointSchema,
-  SourceSpanSchema,
-  StableIdSchema,
+import type { ObjectLocator, ObjectLocatorKind } from "@icm/model";
+
+export {
+  HierarchyFrameSchema,
+  ObjectLocatorKindSchema,
+  ObjectLocatorSchema,
 } from "@icm/model";
-import type { RouteEndpoint, SourceSpan } from "@icm/model";
-import { z } from "zod";
-
-/**
- * Canonical Project-scoped object address (ADR 0015).
- *
- * A direct object in a Document always has `hierarchyPath: []`; a future
- * hierarchy-aware result carries the explicit parent-instance chain rather
- * than relying on a Document id alone.
- */
-export const ObjectLocatorKindSchema = z.enum([
-  "document",
-  "instance",
-  "net",
-  "route",
-  "junction",
-  "terminal",
-  "annotation",
-  "no-connect",
-]);
-export const HierarchyFrameSchema = z.strictObject({
-  parentDocumentId: StableIdSchema,
-  instanceId: StableIdSchema,
-  childDocumentId: StableIdSchema,
-});
-export const ObjectLocatorSchema = z.strictObject({
-  documentId: StableIdSchema,
-  hierarchyPath: z.array(HierarchyFrameSchema).max(32),
-  kind: ObjectLocatorKindSchema,
-  objectId: StableIdSchema,
-  endpoint: RouteEndpointSchema.optional(),
-  sourceRef: SourceSpanSchema.optional(),
-});
-
-export type ObjectLocatorKind = z.infer<typeof ObjectLocatorKindSchema>;
-export interface HierarchyFrame {
-  parentDocumentId: string;
-  instanceId: string;
-  childDocumentId: string;
-}
-export interface ObjectLocator {
-  documentId: string;
-  hierarchyPath: readonly HierarchyFrame[];
-  kind: ObjectLocatorKind;
-  objectId: string;
-  endpoint?: RouteEndpoint;
-  sourceRef?: SourceSpan;
-}
+export type {
+  HierarchyFrame,
+  ObjectLocator,
+  ObjectLocatorKind,
+} from "@icm/model";
 
 /** Construct an unambiguous locator for an object directly in a Document. */
 export function directObjectLocator<K extends ObjectLocatorKind>(

--- a/packages/model/src/schema/index.ts
+++ b/packages/model/src/schema/index.ts
@@ -1,5 +1,6 @@
 export * from "./common.js";
 export * from "./source.js";
+export * from "./object-locator.js";
 export * from "./instance.js";
 export * from "./connectivity.js";
 export * from "./routing.js";

--- a/packages/model/src/schema/object-locator.test.ts
+++ b/packages/model/src/schema/object-locator.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { ObjectLocatorSchema } from "./object-locator.js";
+
+describe("object locator contract", () => {
+  it("round-trips a hierarchy-aware terminal locator without changing JSON", () => {
+    const locator = {
+      documentId: "child",
+      hierarchyPath: [
+        {
+          parentDocumentId: "top",
+          instanceId: "X1",
+          childDocumentId: "child",
+        },
+      ],
+      kind: "terminal" as const,
+      objectId: "M1:G",
+      endpoint: { kind: "terminal" as const, instanceId: "M1", pinName: "G" },
+      sourceRef: {
+        fileId: "design.sp",
+        start: { offset: 12, line: 2, column: 1 },
+        end: { offset: 24, line: 2, column: 13 },
+      },
+    };
+
+    expect(ObjectLocatorSchema.parse(locator)).toEqual(locator);
+  });
+
+  it("keeps the contract strict", () => {
+    expect(() =>
+      ObjectLocatorSchema.parse({
+        documentId: "top",
+        hierarchyPath: [],
+        kind: "instance",
+        objectId: "M1",
+        legacyPath: [],
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/model/src/schema/object-locator.ts
+++ b/packages/model/src/schema/object-locator.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+import { StableIdSchema } from "./common.js";
+import { RouteEndpointSchema } from "./routing.js";
+import { SourceSpanSchema } from "./source.js";
+
+/** Canonical Project-scoped object kinds used by diagnostics and navigation. */
+export const ObjectLocatorKindSchema = z.enum([
+  "document",
+  "instance",
+  "net",
+  "route",
+  "junction",
+  "terminal",
+  "annotation",
+  "no-connect",
+]);
+
+/** One parent-instance step in an occurrence-aware hierarchy address. */
+export const HierarchyFrameSchema = z.strictObject({
+  parentDocumentId: StableIdSchema,
+  instanceId: StableIdSchema,
+  childDocumentId: StableIdSchema,
+});
+
+/**
+ * Canonical Project-scoped object address (ADR 0015).
+ *
+ * A direct object in a Document has `hierarchyPath: []`; an object reached
+ * through hierarchy carries the explicit parent-instance chain rather than
+ * relying on a Document id alone.
+ */
+export const ObjectLocatorSchema = z.strictObject({
+  documentId: StableIdSchema,
+  hierarchyPath: z.array(HierarchyFrameSchema).max(32),
+  kind: ObjectLocatorKindSchema,
+  objectId: StableIdSchema,
+  endpoint: RouteEndpointSchema.optional(),
+  sourceRef: SourceSpanSchema.optional(),
+});

--- a/packages/model/src/schema/types.ts
+++ b/packages/model/src/schema/types.ts
@@ -17,6 +17,20 @@ export type Mirror = z.infer<typeof Schema.MirrorSchema>;
 export type Orientation = z.infer<typeof Schema.OrientationSchema>;
 export type SourcePosition = z.infer<typeof Schema.SourcePositionSchema>;
 export type SourceSpan = z.infer<typeof Schema.SourceSpanSchema>;
+export type ObjectLocatorKind = z.infer<typeof Schema.ObjectLocatorKindSchema>;
+export interface HierarchyFrame {
+  parentDocumentId: string;
+  instanceId: string;
+  childDocumentId: string;
+}
+export interface ObjectLocator {
+  documentId: string;
+  hierarchyPath: readonly HierarchyFrame[];
+  kind: ObjectLocatorKind;
+  objectId: string;
+  endpoint?: RouteEndpoint;
+  sourceRef?: SourceSpan;
+}
 export type SourceManifest = z.infer<typeof Schema.SourceManifestSchema>;
 export type SymbolLibraryLock = z.infer<typeof Schema.SymbolLibraryLockSchema>;
 export type InstanceImportProvenance = z.infer<


### PR DESCRIPTION
## Summary
- move the canonical ObjectLocator, HierarchyFrame, and kind schemas/types into @icm/model
- keep @icm/derived as a zero-copy compatibility facade plus the direct-object constructor
- lock serialized parity and schema identity with focused tests

## Boundaries
This is the second bounded prerequisite slice for #560. It does not add SimulationSetup, change the Project schema version, modify source parameters, introduce a deck compiler, or add GUI/MCP/cloud behavior. #560 remains open.

## Validation
- pnpm test:local packages/model/src/schema/object-locator.test.ts packages/derived/src/object-locator.test.ts
- pnpm --filter @icm/agent-adapter... build
- pnpm gate:preflight -- --base origin/main
- pnpm ci:check (2530 unit tests; all builds/release checks; 349 browser tests)
- git diff --check origin/main...HEAD

Test-Impact: tests-updated