### PR TITLE
fix(deploy): the preview check waits for the edge to serve one build

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -81,14 +81,29 @@ jobs:
             *'"preview"'*) ;;
             *) echo "The preview does not know it is the preview: $channel"; exit 1 ;;
           esac
-          shell="$(curl --fail --silent --show-error --max-time 20 "${PREVIEW_URL}/editor")"
-          entry="$(printf '%s' "$shell" | grep -o '/assets/[A-Za-z0-9._-]*\.js' | head -n 1)"
-          if [ -z "$entry" ]; then
-            echo "The editor shell references no script; it cannot boot."
-            exit 1
-          fi
-          entry_result="$(curl --silent --output /dev/null --max-time 20 \
-            --write-out '%{http_code} %{content_type}' "${PREVIEW_URL}${entry}")"
+          # The shell and its hashed entry script come from one build, but the
+          # edge does not switch them in the same instant: right after a
+          # deploy it served the previous shell (a cache HIT) whose script the
+          # new deployment had already replaced, and the check read 404 for a
+          # preview that was healthy a minute later (2026-09-04, #618). So the
+          # pair is read together and re-read until they agree, for up to two
+          # minutes; a real mismatch still fails, just not on the first look.
+          entry_result=""
+          for _ in $(seq 1 12); do
+            shell="$(curl --fail --silent --show-error --max-time 20 \
+              -H 'Cache-Control: no-cache' "${PREVIEW_URL}/editor")"
+            entry="$(printf '%s' "$shell" | grep -o '/assets/[A-Za-z0-9._-]*\.js' | head -n 1)"
+            if [ -z "$entry" ]; then
+              echo "The editor shell references no script; it cannot boot."
+              exit 1
+            fi
+            entry_result="$(curl --silent --output /dev/null --max-time 20 \
+              --write-out '%{http_code} %{content_type}' "${PREVIEW_URL}${entry}")"
+            case "$entry_result" in
+              200*javascript*) break ;;
+              *) echo "Entry script ${entry} answered ${entry_result}; waiting for the edge to catch up"; sleep 10 ;;
+            esac
+          done
           case "$entry_result" in
             200*javascript*) ;;
             *) echo "The editor's entry script answered: $entry_result"; exit 1 ;;


### PR DESCRIPTION
Right after #618 deployed, `Verify preview` read the previous shell from the edge cache (`cf-cache-status: HIT`) and asked for the entry script the new deployment had just replaced: `404 text/plain`, a red run, and a preview that was healthy a minute later (`/assets/index-DqtLHIGG.js` → 200). The shell and its script are now read together and re-read until they agree, for up to two minutes, with a `Cache-Control: no-cache` request for the shell; a genuine mismatch still fails.

Workflow only; `scripts/preview-workflow.test.mjs` and `pnpm ci:static` green. The failed run for #618 was re-run by hand and is the real check for that commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)