### PR TITLE
feat(netlist): compile a structured simulation setup into a deck

### DIFF
--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -267,6 +267,13 @@ into the Project, undo history, Gallery, or recovery copy.
 - `packages/spice-run/src/index.test.ts` verifies exact `.lib` and `.include`
   emission, quoted paths, verbatim testbench preservation, and rejected deck
   injection.
+- `packages/netlist/src/simulation-compile.test.ts` asserts the compiled deck
+  and vector bindings byte for byte and every refusal, then runs the compiled
+  decks through local ngspice when the machine has one: an equal divider
+  solved at exactly 0.5 V with both plots in one rawfile, a Net probed through
+  an occurrence, and a source probed through one. The last is the check that
+  cannot be faked, because the wrong hierarchical spelling leaves no rawfile
+  to read rather than a wrong number.
 - `packages/spice-run/src/rawfile.test.ts` and `result-data.test.ts` run
   against three rawfiles ngspice 46 wrote, under
   `fixtures/ngspice-rawfile/`, each beside the deck that produced it. Every
@@ -326,6 +333,49 @@ Instance placed in that Testbench; its referenced Cell is reached through the
 normal hierarchy. Extraction, diagnostics, dependency collection, occurrence
 mapping, and input identity all use the same Testbench root. A deck that only
 defines `.subckt`s and instantiates nothing is not a run.
+
+### Compiling a structured setup
+
+`compileStructuredSimulation` in `@icm/netlist` is that compilation. It is
+pure: same Project and setup, byte-identical output, ordered by the printer.
+It returns the runner's `netlist` and `testbench` plus the probe-to-vector
+bindings, or diagnostics naming the objects to go look at; it never throws and
+never selects a model library.
+
+The `netlist` half is every reached Cell except the root, printed by the same
+`.subckt` printer the structural export uses. The `testbench` half is the root
+Cell's own instance cards -- the same printing, without the `.subckt` wrapper
+-- then one `.control` block: `set filetype=ascii`, `set appendwrite`, and for
+each analysis its ngspice command (`op`, `ac dec 10 1 1000000`) followed by
+`write out.raw` with every probe vector. There are deliberately **no** `.op` or
+`.ac` cards beside the block: ngspice 46 then runs the deck's own analyses
+again after the block and reports
+`Error: no data saved for A.C. Small signal analysis`, which classifies as a
+failed run. `set appendwrite` is equally load-bearing, because `write`
+truncates by default and a second analysis would silently replace the first
+one's plot instead of adding to it.
+
+Vector names are ngspice's, measured on ngspice 46 and lower-cased because the
+rawfile lower-cases them whatever the deck spelled:
+
+| probe                                  | vector         |
+| -------------------------------------- | -------------- |
+| Net in the root                        | `v(mid)`       |
+| Net through occurrence `X1`, then `X2` | `v(x1.x2.mid)` |
+| Voltage source in the root             | `i(v1)`        |
+| Voltage source through occurrence `X1` | `i(v.x1.v2)`   |
+
+The nested source is the one that cannot be guessed: `i(x1.v2)` is refused
+outright ("no such function as i"), because ngspice expands a device inside a
+call to `<type letter>.<call path>.<device>`. One refused vector aborts the
+whole `write`, so a wrong name leaves no rawfile at all rather than one missing
+column. For the same reason a `source-current` probe on an independent current
+source is refused at compile time: ngspice solves no branch current for one.
+
+`inputRevision` is `structured-1-<sha256>` over both halves and the canonical
+setup. The setup is in the hash because the environment selection -- Profile,
+corner, temperature -- changes the run without changing one character of the
+deck.
 
 ## Sources and analyses
 
@@ -455,17 +505,17 @@ deadline.
 
 **Limits.**
 
-| Limit | Value | Enforced by |
-| --- | --- | --- |
-| Deck size | 2 MiB | rejected `413 deck-too-large` |
-| Request body | 4 MiB | connection closed, `413 request-too-large` |
-| Returned output | 1 MiB per run | truncation, reported |
-| Default deadline | 30 s | applied when the caller names none |
-| Maximum deadline | 120 s | a longer request is clamped to it |
-| Lifecycle grace | 10 s | hard lease watchdog after the run deadline |
-| Identity probe | 5 s | given up on, not waited for |
-| Processes | 128 (`RLIMIT_NPROC`) | image-set `ulimit` before `exec` |
-| Written file size | 256 MiB (`RLIMIT_FSIZE`) | image-set `ulimit` before `exec` |
+| Limit             | Value                    | Enforced by                                |
+| ----------------- | ------------------------ | ------------------------------------------ |
+| Deck size         | 2 MiB                    | rejected `413 deck-too-large`              |
+| Request body      | 4 MiB                    | connection closed, `413 request-too-large` |
+| Returned output   | 1 MiB per run            | truncation, reported                       |
+| Default deadline  | 30 s                     | applied when the caller names none         |
+| Maximum deadline  | 120 s                    | a longer request is clamped to it          |
+| Lifecycle grace   | 10 s                     | hard lease watchdog after the run deadline |
+| Identity probe    | 5 s                      | given up on, not waited for                |
+| Processes         | 128 (`RLIMIT_NPROC`)     | image-set `ulimit` before `exec`           |
+| Written file size | 256 MiB (`RLIMIT_FSIZE`) | image-set `ulimit` before `exec`           |
 
 The returned-output cap is divided between the simulator's two streams, so a
 flood of printed values on one cannot push the single line that explains the
@@ -576,19 +626,19 @@ rawfile line. Nothing is padded, interpolated, or carried forward from a
 neighbouring point, because a fabricated number is indistinguishable from a
 measured one once it reaches a chart. The refusals are:
 
-| code | what the file did |
-| --- | --- |
-| `empty-file` | no rawfile content at all |
-| `unsupported-format` | a binary rawfile, or not a rawfile |
-| `header-incomplete` | ends before a plot is fully described |
-| `header-invalid` | a header line is unreadable or missing |
+| code                    | what the file did                                     |
+| ----------------------- | ----------------------------------------------------- |
+| `empty-file`            | no rawfile content at all                             |
+| `unsupported-format`    | a binary rawfile, or not a rawfile                    |
+| `header-incomplete`     | ends before a plot is fully described                 |
+| `header-invalid`        | a header line is unreadable or missing                |
 | `variable-line-invalid` | a `Variables:` line declares no index, name, quantity |
-| `point-block-invalid` | a point has the wrong number of values, or no index |
-| `point-count-mismatch` | recovered points disagree with `No. Points` |
-| `value-malformed` | a value is not a number |
-| `value-not-finite` | a value is `nan`, `inf`, or an overflow |
+| `point-block-invalid`   | a point has the wrong number of values, or no index   |
+| `point-count-mismatch`  | recovered points disagree with `No. Points`           |
+| `value-malformed`       | a value is not a number                               |
+| `value-not-finite`      | a value is `nan`, `inf`, or an overflow               |
 
-Checking that a *requested* vector is present belongs to the caller, because
+Checking that a _requested_ vector is present belongs to the caller, because
 only the compiled setup knows what was asked for. This layer reports what the
 file holds.
 

--- a/packages/netlist/package.json
+++ b/packages/netlist/package.json
@@ -17,6 +17,7 @@
     "@icm/derived": "workspace:*",
     "@icm/devices": "workspace:*",
     "@icm/model": "workspace:*",
+    "@icm/spice-run": "workspace:*",
     "@icm/symbols": "workspace:*"
   },
   "devDependencies": {

--- a/packages/netlist/src/index.ts
+++ b/packages/netlist/src/index.ts
@@ -3,3 +3,4 @@ export * from "./formal-interface.js";
 export * from "./ir.js";
 export * from "./net-name-codec.js";
 export * from "./printers.js";
+export * from "./simulation-compile.js";

--- a/packages/netlist/src/printers.ts
+++ b/packages/netlist/src/printers.ts
@@ -170,6 +170,20 @@ function spiceInstance(instance: DesignNetlistInstance): string[] {
   return wrapSpice(tokens);
 }
 
+/**
+ * The device cards of one Cell, without the `.subckt` wrapper that would make
+ * them a definition.
+ *
+ * A simulation testbench is the same Cell printed as top-level cards
+ * (`docs/specs/simulation.md`, "Inputs and root"), so it must be the same
+ * printing: a second implementation of a card is a second chance to disagree
+ * with the `.subckt` body about pin order, a parameter spelling, or a source's
+ * AC stimulus.
+ */
+export function printSpiceInstanceCards(cell: DesignNetlistCell): string[] {
+  return cell.instances.flatMap((instance) => spiceInstance(instance));
+}
+
 function spiceCell(cell: DesignNetlistCell): string[] {
   const lines = wrapSpice([
     ".subckt",
@@ -184,7 +198,7 @@ function spiceCell(cell: DesignNetlistCell): string[] {
         ]
       : []),
   ]);
-  for (const instance of cell.instances) lines.push(...spiceInstance(instance));
+  lines.push(...printSpiceInstanceCards(cell));
   lines.push(`.ends ${cell.name}`);
   return lines;
 }

--- a/packages/netlist/src/simulation-compile.test.ts
+++ b/packages/netlist/src/simulation-compile.test.ts
@@ -1,0 +1,855 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import {
+  createEmptyDocument,
+  createEmptyProject,
+  deriveStableId,
+  type CircuitProject,
+  type SchematicDocument,
+  type SimulationAnalysisSpec,
+  type SimulationProbeSpec,
+  type SimulationSetup,
+} from "@icm/model";
+import { buildSimulationDeck, readSimulationData } from "@icm/spice-run";
+import { describe, expect, it } from "vitest";
+
+import { compileStructuredSimulation } from "./simulation-compile.js";
+
+const run = promisify(execFile);
+
+/**
+ * The integration test below runs the SIMULATOR ON THIS MACHINE when there is
+ * one and skips itself when there is not, the same bargain
+ * `scripts/simulation-acceptance.mjs` makes: a deck asserted against a mock
+ * agrees with whatever we believe today, which is exactly what the vector
+ * names in this module must not be verified against.
+ */
+const ngspicePath = await run("which", ["ngspice"])
+  .then(({ stdout }) => stdout.trim() || null)
+  .catch(() => null);
+const withSimulator = ngspicePath ? it : it.skip;
+
+function claimNet(
+  document: SchematicDocument,
+  netId: string,
+  name: string,
+  scope: "local" | "global" = "local",
+  powerDomain?: "vdd" | "ground",
+): void {
+  const labelId = deriveStableId(
+    "fixture-net-label",
+    document.id,
+    netId,
+    name,
+    scope,
+  );
+  document.annotations.push({
+    id: labelId,
+    kind: powerDomain ? "power-label" : "net-label",
+    binding: { kind: "net-name", netId },
+    netId,
+    anchor: { kind: "free", position: { x: 0, y: 0 } },
+    alignment: "start",
+    rotation: 0,
+    locked: false,
+  });
+  document.connectivityEvidence.push({
+    id: deriveStableId("fixture-net-name", document.id, netId),
+    kind: "name-claim",
+    netId,
+    name,
+    owner: { kind: "net-label", annotationId: labelId },
+    scope,
+    ...(powerDomain ? { powerDomain } : {}),
+  });
+}
+
+function resistor(id: string, reference: string, value: string) {
+  return {
+    id,
+    symbolId: "resistor",
+    placement: null,
+    reference,
+    netlist: {
+      binding: { kind: "primitive", deviceClass: "resistor" },
+      parameters: { value },
+    },
+  } as const;
+}
+
+/**
+ * A Testbench in the Project top: a 1 V source with a unit AC stimulus driving
+ * an equal resistor divider to ground. Its operating point is arithmetic, not
+ * a recorded number: `mid` is exactly 0.5 V and the source sinks exactly
+ * 0.5 mA.
+ */
+function dividerProject(): CircuitProject {
+  const project = createEmptyProject("project", "Project", "tb");
+  const testbench = project.documents[0]!;
+  testbench.netlist!.name = "tb";
+  testbench.instances.push(
+    {
+      id: "inst-v1",
+      symbolId: "voltage-source",
+      placement: null,
+      reference: "V1",
+      netlist: {
+        binding: { kind: "primitive", deviceClass: "voltage-source" },
+        parameters: { dc: "1", acMagnitude: "1" },
+      },
+    },
+    resistor("inst-r1", "R1", "1k"),
+    resistor("inst-r2", "R2", "1k"),
+  );
+  testbench.nets.push(
+    {
+      id: "net-in",
+      terminals: [
+        { instanceId: "inst-v1", pinName: "+" },
+        { instanceId: "inst-r1", pinName: "1" },
+      ],
+    },
+    {
+      id: "net-mid",
+      terminals: [
+        { instanceId: "inst-r1", pinName: "2" },
+        { instanceId: "inst-r2", pinName: "1" },
+      ],
+    },
+    {
+      id: "net-gnd",
+      terminals: [
+        { instanceId: "inst-v1", pinName: "-" },
+        { instanceId: "inst-r2", pinName: "2" },
+      ],
+    },
+  );
+  claimNet(testbench, "net-in", "in");
+  claimNet(testbench, "net-mid", "mid");
+  claimNet(testbench, "net-gnd", "0", "global", "ground");
+  return project;
+}
+
+/**
+ * The same divider, split across a hierarchy: the Testbench holds the source
+ * and one subcircuit call, and the two resistors and their shared node live
+ * inside the DUT Cell. `mid` is reachable only through the occurrence.
+ */
+function hierarchyProject(): CircuitProject {
+  const project = createEmptyProject("project", "Project", "tb");
+  const testbench = project.documents[0]!;
+  testbench.netlist!.name = "tb";
+  const dut = createEmptyDocument("dut", "DUT");
+  dut.netlist = {
+    name: "dut",
+    formalParameters: [],
+    terminals: [
+      {
+        id: "dut-terminal-in",
+        name: "in",
+        netId: "dut-net-in",
+        direction: "input",
+        interfaceInstanceIds: ["dut-port-in"],
+      },
+      {
+        id: "dut-terminal-out",
+        name: "out",
+        netId: "dut-net-out",
+        direction: "output",
+        interfaceInstanceIds: ["dut-port-out"],
+      },
+    ],
+  };
+  dut.instances.push(
+    { id: "dut-port-in", symbolId: "port", placement: null },
+    { id: "dut-port-out", symbolId: "port", placement: null },
+    resistor("dut-r1", "R1", "1k"),
+    resistor("dut-r2", "R2", "1k"),
+  );
+  dut.nets.push(
+    {
+      id: "dut-net-in",
+      terminals: [
+        { instanceId: "dut-port-in", pinName: "P" },
+        { instanceId: "dut-r1", pinName: "1" },
+      ],
+    },
+    {
+      id: "dut-net-mid",
+      terminals: [
+        { instanceId: "dut-r1", pinName: "2" },
+        { instanceId: "dut-r2", pinName: "1" },
+      ],
+    },
+    {
+      id: "dut-net-out",
+      terminals: [
+        { instanceId: "dut-r2", pinName: "2" },
+        { instanceId: "dut-port-out", pinName: "P" },
+      ],
+    },
+  );
+  claimNet(dut, "dut-net-mid", "mid");
+  project.documents.push(dut);
+
+  testbench.instances.push(
+    {
+      id: "inst-v1",
+      symbolId: "voltage-source",
+      placement: null,
+      reference: "V1",
+      netlist: {
+        binding: { kind: "primitive", deviceClass: "voltage-source" },
+        parameters: { dc: "1" },
+      },
+    },
+    {
+      id: "inst-x1",
+      symbolId: "dut-symbol",
+      placement: null,
+      reference: "X1",
+      netlist: {
+        binding: { kind: "subcircuit", childDocumentId: "dut" },
+        parameters: {},
+      },
+    },
+  );
+  testbench.nets.push(
+    {
+      id: "net-in",
+      terminals: [
+        { instanceId: "inst-v1", pinName: "+" },
+        { instanceId: "inst-x1", pinName: "in" },
+      ],
+    },
+    {
+      id: "net-gnd",
+      terminals: [
+        { instanceId: "inst-v1", pinName: "-" },
+        { instanceId: "inst-x1", pinName: "out" },
+      ],
+    },
+  );
+  claimNet(testbench, "net-in", "in");
+  claimNet(testbench, "net-gnd", "0", "global", "ground");
+  return project;
+}
+
+/**
+ * The hierarchy project with a 0 V source in series inside the DUT: the
+ * classic SPICE ammeter, placed where only an occurrence can address it.
+ */
+function nestedSourceProject(): CircuitProject {
+  const project = hierarchyProject();
+  const dut = project.documents.find((document) => document.id === "dut")!;
+  dut.instances.push({
+    id: "dut-v2",
+    symbolId: "voltage-source",
+    placement: null,
+    reference: "V2",
+    netlist: {
+      binding: { kind: "primitive", deviceClass: "voltage-source" },
+      parameters: { dc: "0" },
+    },
+  });
+  dut.nets.find((net) => net.id === "dut-net-mid")!.terminals = [
+    { instanceId: "dut-r1", pinName: "2" },
+    { instanceId: "dut-v2", pinName: "+" },
+  ];
+  dut.nets.push({
+    id: "dut-net-sense",
+    terminals: [
+      { instanceId: "dut-v2", pinName: "-" },
+      { instanceId: "dut-r2", pinName: "1" },
+    ],
+  });
+  claimNet(dut, "dut-net-sense", "sense");
+  return project;
+}
+
+const OP: SimulationAnalysisSpec = { kind: "op" };
+const AC: SimulationAnalysisSpec = {
+  kind: "ac",
+  sweep: "dec",
+  points: 10,
+  startHz: 1,
+  stopHz: 1e6,
+};
+
+function setup(
+  rootDocumentId: string,
+  analyses: SimulationAnalysisSpec[],
+  probes: SimulationProbeSpec[],
+): SimulationSetup {
+  return {
+    version: 1,
+    input: {
+      kind: "structured",
+      rootDocumentId,
+      analyses,
+      probes,
+      environment: { profileId: "hosted-sky130-core-continuous-v1" },
+    },
+  };
+}
+
+function netProbe(
+  id: string,
+  documentId: string,
+  netId: string,
+  occurrence: string[] = [],
+): SimulationProbeSpec {
+  return { id, kind: "net-voltage", documentId, netId, occurrence };
+}
+
+function currentProbe(
+  id: string,
+  documentId: string,
+  instanceId: string,
+  occurrence: string[] = [],
+): SimulationProbeSpec {
+  return { id, kind: "source-current", documentId, instanceId, occurrence };
+}
+
+const dividerSetup = setup(
+  "tb",
+  [OP, AC],
+  [
+    netProbe("probe-in", "tb", "net-in"),
+    netProbe("probe-mid", "tb", "net-mid"),
+    currentProbe("probe-source", "tb", "inst-v1"),
+  ],
+);
+
+function codes(diagnostics: readonly { code: string }[]): string[] {
+  return diagnostics.map((item) => item.code);
+}
+
+describe("compiling a structured simulation setup", () => {
+  it("prints a flat Testbench as top-level cards and a saving control block", async () => {
+    const compiled = await compileStructuredSimulation(
+      dividerProject(),
+      dividerSetup,
+      { timeoutMs: 30_000 },
+    );
+
+    expect(compiled.diagnostics).toEqual([]);
+    if (!compiled.ok) return;
+    // Nothing the root reaches is a subcircuit, so the netlist half defines
+    // nothing and says so rather than repeating the testbench.
+    expect(compiled.request.netlist).toBe(
+      "* Generated by Interactive Circuit Maker netlist-export/1.0\n",
+    );
+    expect(compiled.request.testbench).toBe(
+      [
+        "* Analog Canvas testbench tb",
+        "R1 in mid 1k",
+        "R2 mid 0 1k",
+        "V1 in 0 DC 1 AC 1 0",
+        ".control",
+        "set filetype=ascii",
+        "set appendwrite",
+        "op",
+        "write out.raw v(in) v(mid) i(v1)",
+        "ac dec 10 1 1000000",
+        "write out.raw v(in) v(mid) i(v1)",
+        ".endc",
+        ".end",
+        "",
+      ].join("\n"),
+    );
+    expect(compiled.request.analyses).toEqual(["op", "ac"]);
+    expect(compiled.request.timeoutMs).toBe(30_000);
+    expect(compiled.request.inputRevision).toMatch(
+      /^structured-1-[0-9a-f]{64}$/u,
+    );
+    expect(compiled.vectors).toEqual([
+      { probeId: "probe-in", vector: "v(in)", quantity: "voltage" },
+      { probeId: "probe-mid", vector: "v(mid)", quantity: "voltage" },
+      { probeId: "probe-source", vector: "i(v1)", quantity: "current" },
+    ]);
+  });
+
+  it("omits a timeout the caller did not ask for", async () => {
+    const compiled = await compileStructuredSimulation(
+      dividerProject(),
+      dividerSetup,
+    );
+
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    expect("timeoutMs" in compiled.request).toBe(false);
+  });
+
+  it("declares a global Net in the half the deck reads first", async () => {
+    // `.global` has to precede every card that uses the name, and the runner
+    // concatenates the netlist half ahead of the testbench. A global reached
+    // only from the root must therefore still be declared over there.
+    const project = dividerProject();
+    const testbench = project.documents[0]!;
+    testbench.instances.push(resistor("inst-r3", "R3", "10k"));
+    testbench.nets.push({
+      id: "net-vdd",
+      terminals: [{ instanceId: "inst-r3", pinName: "1" }],
+    });
+    testbench.nets
+      .find((net) => net.id === "net-mid")!
+      .terminals.push({ instanceId: "inst-r3", pinName: "2" });
+    claimNet(testbench, "net-vdd", "VDD", "global", "vdd");
+
+    const compiled = await compileStructuredSimulation(
+      project,
+      setup("tb", [OP], [netProbe("probe-mid", "tb", "net-mid")]),
+    );
+
+    expect(compiled.diagnostics).toEqual([]);
+    if (!compiled.ok) return;
+    expect(compiled.request.netlist).toBe(
+      [
+        "* Generated by Interactive Circuit Maker netlist-export/1.0",
+        ".global VDD",
+        "",
+      ].join("\n"),
+    );
+    expect(compiled.request.testbench).toContain("R3 VDD mid 10k\n");
+  });
+
+  it("defines every reached Cell once and instantiates only the root", async () => {
+    const compiled = await compileStructuredSimulation(
+      hierarchyProject(),
+      setup(
+        "tb",
+        [OP],
+        [
+          netProbe("probe-mid", "dut", "dut-net-mid", ["inst-x1"]),
+          currentProbe("probe-source", "tb", "inst-v1"),
+        ],
+      ),
+    );
+
+    expect(compiled.diagnostics).toEqual([]);
+    if (!compiled.ok) return;
+    expect(compiled.request.netlist).toBe(
+      [
+        "* Generated by Interactive Circuit Maker netlist-export/1.0",
+        "",
+        ".subckt dut in out",
+        "R1 in mid 1k",
+        "R2 mid out 1k",
+        ".ends dut",
+        "",
+      ].join("\n"),
+    );
+    expect(compiled.request.testbench).toBe(
+      [
+        "* Analog Canvas testbench tb",
+        "V1 in 0 DC 1",
+        "X1 in 0 dut",
+        ".control",
+        "set filetype=ascii",
+        "set appendwrite",
+        "op",
+        "write out.raw v(x1.mid) i(v1)",
+        ".endc",
+        ".end",
+        "",
+      ].join("\n"),
+    );
+    // ngspice writes the node inside a call as `x1.mid`, in lower case
+    // whatever the deck spelled, so this is the name that comes back.
+    expect(compiled.vectors).toEqual([
+      { probeId: "probe-mid", vector: "v(x1.mid)", quantity: "voltage" },
+      { probeId: "probe-source", vector: "i(v1)", quantity: "current" },
+    ]);
+  });
+
+  it("saves one vector for two probes that name the same node", async () => {
+    const project = dividerProject();
+    const compiled = await compileStructuredSimulation(
+      project,
+      setup(
+        "tb",
+        [OP],
+        [
+          netProbe("probe-a", "tb", "net-mid"),
+          netProbe("probe-b", "tb", "net-mid"),
+        ],
+      ),
+    );
+
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    expect(compiled.request.testbench).toContain("write out.raw v(mid)\n");
+    expect(compiled.vectors.map((vector) => vector.probeId)).toEqual([
+      "probe-a",
+      "probe-b",
+    ]);
+  });
+
+  it("names a source inside a call the way ngspice expands it", async () => {
+    // A source in the DUT, not the Testbench: ngspice expands a device inside
+    // a call to `<type>.<call path>.<device>`, so its branch is `i(v.x1.v2)`
+    // and never `i(x1.v2)`.
+    const compiled = await compileStructuredSimulation(
+      nestedSourceProject(),
+      setup(
+        "tb",
+        [OP],
+        [currentProbe("probe-inner", "dut", "dut-v2", ["inst-x1"])],
+      ),
+    );
+
+    expect(compiled.diagnostics).toEqual([]);
+    if (!compiled.ok) return;
+    expect(compiled.vectors).toEqual([
+      { probeId: "probe-inner", vector: "i(v.x1.v2)", quantity: "current" },
+    ]);
+  });
+
+  it("compiles the same Project and setup to identical bytes", async () => {
+    const first = await compileStructuredSimulation(
+      dividerProject(),
+      dividerSetup,
+    );
+    const repeated = await compileStructuredSimulation(
+      dividerProject(),
+      dividerSetup,
+    );
+    const reopened = await compileStructuredSimulation(
+      JSON.parse(JSON.stringify(dividerProject())) as CircuitProject,
+      JSON.parse(JSON.stringify(dividerSetup)) as SimulationSetup,
+    );
+
+    expect(repeated).toEqual(first);
+    expect(reopened).toEqual(first);
+  });
+
+  it("changes the input revision when the environment selection changes", async () => {
+    // The corner never reaches the deck, and it decides the numbers. An
+    // identity covering only the deck bytes would call two different runs one.
+    const withTt = await compileStructuredSimulation(
+      dividerProject(),
+      dividerSetup,
+    );
+    const cornered = structuredClone(dividerSetup);
+    cornered.input.environment.corner = "ss";
+    const withSs = await compileStructuredSimulation(
+      dividerProject(),
+      cornered,
+    );
+
+    expect(withTt.ok && withSs.ok).toBe(true);
+    if (!withTt.ok || !withSs.ok) return;
+    expect(withTt.request.testbench).toBe(withSs.request.testbench);
+    expect(withTt.request.inputRevision).not.toBe(withSs.request.inputRevision);
+  });
+});
+
+describe("refusing a structured simulation setup", () => {
+  it("reports the extractor's own findings when the root is unknown", async () => {
+    const compiled = await compileStructuredSimulation(
+      dividerProject(),
+      setup("missing", [OP], [netProbe("probe-mid", "tb", "net-mid")]),
+    );
+
+    expect(compiled.ok).toBe(false);
+    expect(codes(compiled.diagnostics)).toContain("MISSING_ROOT_CELL");
+  });
+
+  it("refuses a root that defines subcircuits and instantiates none", async () => {
+    const project = hierarchyProject();
+    const testbench = project.documents[0]!;
+    testbench.instances = [];
+    testbench.nets = [{ id: "net-probe", terminals: [] }];
+    testbench.annotations = [];
+    testbench.connectivityEvidence = [];
+    claimNet(testbench, "net-probe", "probe");
+
+    const compiled = await compileStructuredSimulation(
+      project,
+      setup("tb", [OP], [netProbe("probe-node", "tb", "net-probe")]),
+    );
+
+    expect(compiled.ok).toBe(false);
+    expect(codes(compiled.diagnostics)).toEqual([
+      "SIMULATION_ROOT_HAS_NO_INSTANCES",
+    ]);
+  });
+
+  it("refuses a setup with no analysis and a setup with no probe", async () => {
+    const compiled = await compileStructuredSimulation(
+      dividerProject(),
+      setup("tb", [], []),
+    );
+
+    expect(compiled.ok).toBe(false);
+    expect(codes(compiled.diagnostics)).toEqual([
+      "SIMULATION_NO_ANALYSIS",
+      "SIMULATION_NO_PROBE",
+    ]);
+  });
+
+  it("refuses the same analysis twice", async () => {
+    const compiled = await compileStructuredSimulation(
+      dividerProject(),
+      setup("tb", [OP, OP], [netProbe("probe-mid", "tb", "net-mid")]),
+    );
+
+    expect(compiled.ok).toBe(false);
+    expect(codes(compiled.diagnostics)).toEqual([
+      "SIMULATION_DUPLICATE_ANALYSIS",
+    ]);
+  });
+
+  it("refuses a probe on an object that is not in the Project", async () => {
+    const compiled = await compileStructuredSimulation(
+      dividerProject(),
+      setup(
+        "tb",
+        [OP],
+        [
+          netProbe("probe-document", "nowhere", "net-mid"),
+          netProbe("probe-net", "tb", "net-nowhere"),
+          currentProbe("probe-instance", "tb", "inst-nowhere"),
+        ],
+      ),
+    );
+
+    expect(compiled.ok).toBe(false);
+    expect(codes(compiled.diagnostics)).toEqual([
+      "SIMULATION_PROBE_UNKNOWN_DOCUMENT",
+      "SIMULATION_PROBE_UNKNOWN_NET",
+      "SIMULATION_PROBE_UNKNOWN_INSTANCE",
+    ]);
+  });
+
+  it("refuses an occurrence that is not a path of hierarchy Instances", async () => {
+    const compiled = await compileStructuredSimulation(
+      hierarchyProject(),
+      setup(
+        "tb",
+        [OP],
+        [netProbe("probe-mid", "dut", "dut-net-mid", ["inst-v1"])],
+      ),
+    );
+
+    expect(compiled.ok).toBe(false);
+    expect(codes(compiled.diagnostics)).toEqual([
+      "SIMULATION_PROBE_OCCURRENCE_INVALID",
+    ]);
+    expect(compiled.diagnostics[0]?.message).toContain("inst-v1");
+  });
+
+  it("refuses an occurrence that lands somewhere other than the probe's Document", async () => {
+    const compiled = await compileStructuredSimulation(
+      hierarchyProject(),
+      setup("tb", [OP], [netProbe("probe-mid", "dut", "dut-net-mid")]),
+    );
+
+    expect(compiled.ok).toBe(false);
+    expect(codes(compiled.diagnostics)).toEqual([
+      "SIMULATION_PROBE_OCCURRENCE_INVALID",
+    ]);
+    expect(compiled.diagnostics[0]?.message).toContain("reaches Document tb");
+  });
+
+  it("refuses a source-current probe on something that is not a source", async () => {
+    const compiled = await compileStructuredSimulation(
+      dividerProject(),
+      setup("tb", [OP], [currentProbe("probe-resistor", "tb", "inst-r1")]),
+    );
+
+    expect(compiled.ok).toBe(false);
+    expect(codes(compiled.diagnostics)).toEqual([
+      "SIMULATION_PROBE_NOT_A_SOURCE",
+    ]);
+  });
+
+  it("refuses a source-current probe on a current source", async () => {
+    // Measured, not assumed: ngspice 46 keeps no branch vector for an
+    // independent current source, and one refused vector aborts the whole
+    // `write` -- so a deck carrying `i(i1)` produces no rawfile at all.
+    const project = dividerProject();
+    const testbench = project.documents[0]!;
+    testbench.instances.push({
+      id: "inst-i1",
+      symbolId: "current-source",
+      placement: null,
+      reference: "I1",
+      netlist: {
+        binding: { kind: "primitive", deviceClass: "current-source" },
+        parameters: { dc: "1m" },
+      },
+    });
+    testbench.nets
+      .find((net) => net.id === "net-in")!
+      .terminals.push({ instanceId: "inst-i1", pinName: "+" });
+    testbench.nets
+      .find((net) => net.id === "net-gnd")!
+      .terminals.push({ instanceId: "inst-i1", pinName: "-" });
+
+    const compiled = await compileStructuredSimulation(
+      project,
+      setup("tb", [OP], [currentProbe("probe-current", "tb", "inst-i1")]),
+    );
+
+    expect(compiled.ok).toBe(false);
+    expect(codes(compiled.diagnostics)).toEqual([
+      "SIMULATION_PROBE_SOURCE_HAS_NO_BRANCH_CURRENT",
+    ]);
+  });
+});
+
+/**
+ * Run a compiled request the way the hosted runner does: the environment's
+ * model library, then the two halves, then `.end`. A passive divider needs no
+ * library, so `null` here is the whole deck.
+ *
+ * The rawfile is read from the run directory rather than from the log, and a
+ * missing one throws — which is the proof this test ran a simulator at all.
+ */
+async function simulate(
+  request: Parameters<typeof buildSimulationDeck>[0],
+): Promise<{ log: string; rawfile: string }> {
+  const deck = buildSimulationDeck(request, null);
+  const directory = await mkdtemp(join(tmpdir(), "icm-compile-sim-"));
+  try {
+    await writeFile(join(directory, "deck.cir"), deck, "utf8");
+    const finished = await run(ngspicePath!, ["-b", "deck.cir"], {
+      cwd: directory,
+    }).catch((error: { stdout?: string; stderr?: string }) => ({
+      stdout: error.stdout ?? "",
+      stderr: error.stderr ?? "",
+    }));
+    return {
+      log: `${finished.stdout}\n${finished.stderr}`,
+      rawfile: await readFile(join(directory, "out.raw"), "utf8"),
+    };
+  } finally {
+    await rm(directory, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+describe("the compiled deck against ngspice", () => {
+  withSimulator(
+    "solves the divider and returns every vector the compiler named",
+    async () => {
+      const compiled = await compileStructuredSimulation(
+        dividerProject(),
+        dividerSetup,
+      );
+      expect(compiled.ok).toBe(true);
+      if (!compiled.ok) return;
+
+      const { log, rawfile } = await simulate(compiled.request);
+
+      // The deck must not carry an analysis card beside its control block:
+      // ngspice 46 then re-runs the deck's own analyses afterwards and reports
+      // an error the runner classifies as a failed run.
+      expect(log).not.toMatch(/^\s*error[: ]/imu);
+
+      const reading = readSimulationData(rawfile);
+      expect(reading.status).toBe("read");
+      if (reading.status !== "read") return;
+      // Both analyses reached one rawfile: `write` truncates by default, so
+      // without `set appendwrite` the AC plot would have replaced the OP one.
+      expect(
+        reading.data.analyses.map((analysis) => analysis.analysis),
+      ).toEqual(["op", "ac"]);
+
+      for (const analysis of reading.data.analyses) {
+        const present = new Set(analysis.probes.map((probe) => probe.name));
+        for (const vector of compiled.vectors) {
+          expect(present).toContain(vector.vector);
+        }
+      }
+
+      const operatingPoint = reading.data.analyses[0]!;
+      if (operatingPoint.analysis !== "op") return;
+      const mid = operatingPoint.probes.find(
+        (probe) => probe.name === "v(mid)",
+      );
+      // Two equal resistors across 1 V: arithmetic, not a recorded number.
+      expect(mid?.value).toBe(0.5);
+      expect(mid?.unit).toBe("V");
+      const source = operatingPoint.probes.find(
+        (probe) => probe.name === "i(v1)",
+      );
+      // A source's branch current is positive into its `+` terminal, so a
+      // 1 V source driving 2 kOhm sinks half a milliamp.
+      expect(source?.value).toBeCloseTo(-0.5e-3, 12);
+      expect(source?.unit).toBe("A");
+    },
+    60_000,
+  );
+
+  withSimulator(
+    "resolves a Net probed through a subcircuit occurrence",
+    async () => {
+      const compiled = await compileStructuredSimulation(
+        hierarchyProject(),
+        setup(
+          "tb",
+          [OP],
+          [netProbe("probe-mid", "dut", "dut-net-mid", ["inst-x1"])],
+        ),
+      );
+      expect(compiled.ok).toBe(true);
+      if (!compiled.ok) return;
+      expect(compiled.vectors[0]?.vector).toBe("v(x1.mid)");
+
+      const { rawfile } = await simulate(compiled.request);
+      const reading = readSimulationData(rawfile);
+      expect(reading.status).toBe("read");
+      if (reading.status !== "read") return;
+      const operatingPoint = reading.data.analyses[0]!;
+      expect(operatingPoint.analysis).toBe("op");
+      if (operatingPoint.analysis !== "op") return;
+      expect(
+        operatingPoint.probes.find((probe) => probe.name === "v(x1.mid)")
+          ?.value,
+      ).toBe(0.5);
+    },
+    60_000,
+  );
+
+  withSimulator(
+    "resolves a source probed through a subcircuit occurrence",
+    async () => {
+      const compiled = await compileStructuredSimulation(
+        nestedSourceProject(),
+        setup(
+          "tb",
+          [OP],
+          [currentProbe("probe-inner", "dut", "dut-v2", ["inst-x1"])],
+        ),
+      );
+      expect(compiled.ok).toBe(true);
+      if (!compiled.ok) return;
+      expect(compiled.vectors[0]?.vector).toBe("i(v.x1.v2)");
+
+      const { log, rawfile } = await simulate(compiled.request);
+      // The spelling this asserts is the one ngspice refuses to substitute:
+      // `i(x1.v2)` is "no such function as i", and one refused vector aborts
+      // the whole `write`, so a wrong name here leaves no rawfile to read.
+      expect(log).not.toMatch(/^\s*error[: ]/imu);
+
+      const reading = readSimulationData(rawfile);
+      expect(reading.status).toBe("read");
+      if (reading.status !== "read") return;
+      const operatingPoint = reading.data.analyses[0]!;
+      expect(operatingPoint.analysis).toBe("op");
+      if (operatingPoint.analysis !== "op") return;
+      // 1 V across the two 1 kOhm resistors the sense source sits between.
+      expect(
+        operatingPoint.probes.find((probe) => probe.name === "i(v.x1.v2)")
+          ?.value,
+      ).toBeCloseTo(0.5e-3, 12);
+    },
+    60_000,
+  );
+});

--- a/packages/netlist/src/simulation-compile.ts
+++ b/packages/netlist/src/simulation-compile.ts
@@ -1,0 +1,637 @@
+/**
+ * Compiling a structured `SimulationSetup` into the request a runner executes.
+ *
+ * `docs/specs/simulation.md` ("Inputs and root") settles what a structured run
+ * is: the design netlist of everything the Testbench root reaches, one
+ * instantiation of that root, the analyses, the saves, and `.end`. This module
+ * is that compilation, and nothing else — it selects no model library, starts
+ * no process, and reads no result. The environment owns its library paths and
+ * the runner owns the deck's final bytes.
+ *
+ * Two things make it worth its own module rather than a caller's string
+ * concatenation.
+ *
+ * **The probe-to-vector mapping is produced here or nowhere.** A rawfile comes
+ * back naming `v(x1.mid)`, not a Net id. Recovering the Net from that text
+ * afterwards means re-deriving hierarchy and net naming from a string the
+ * simulator wrote, which is exactly the guess this product refuses elsewhere.
+ * So every probe is bound to its ngspice vector name at compile time, and the
+ * caller checks the names it asked for against the names it got.
+ *
+ * **The deck's shape is measured, not assumed.** Every naming rule below was
+ * taken from decks ngspice 46 actually ran; the notes on each say which
+ * behavior forced the choice.
+ */
+
+import { directObjectLocator, resolveDocumentLogicalNets } from "@icm/derived";
+import type { HierarchyFrame, ObjectLocator } from "@icm/derived";
+import type {
+  CircuitProject,
+  SchematicDocument,
+  SimulationAnalysisSpec,
+  SimulationProbeSpec,
+  SimulationSetup,
+  StableId,
+} from "@icm/model";
+import type { SimulationAnalysis, SimulationRequest } from "@icm/spice-run";
+
+import { analyzeDesignNetlist } from "./extract.js";
+import type {
+  DesignNetlistCell,
+  DesignNetlistInstance,
+  NetlistDiagnostic,
+} from "./ir.js";
+import { printSpiceInstanceCards, printSpiceNetlist } from "./printers.js";
+
+/** One probe bound to the vector name ngspice will write for it. */
+export interface CompiledSimulationVector {
+  readonly probeId: string;
+  /** ngspice's own spelling, lowercase: `v(mid)`, `v(x1.mid)`, `i(v.x1.v2)`. */
+  readonly vector: string;
+  readonly quantity: "voltage" | "current";
+}
+
+export type CompiledSimulation =
+  | {
+      readonly ok: true;
+      readonly request: SimulationRequest;
+      readonly vectors: readonly CompiledSimulationVector[];
+      /** A compiled setup carries no findings; a refused one carries them all. */
+      readonly diagnostics: readonly [];
+    }
+  | {
+      readonly ok: false;
+      /** Never empty: a refusal always says what to go look at. */
+      readonly diagnostics: readonly NetlistDiagnostic[];
+    };
+
+export interface CompileStructuredSimulationOptions {
+  /** Wall-clock ceiling passed through to the runner, in milliseconds. */
+  readonly timeoutMs?: number;
+}
+
+/**
+ * The rawfile the deck writes.
+ *
+ * A relative name on purpose: the run directory is the simulator's working
+ * directory, and an absolute path would put a host directory in the log an
+ * author reads.
+ */
+const RAWFILE_NAME = "out.raw";
+
+/** Compiler identity carried by `inputRevision`, so a change invalidates results. */
+const COMPILER_REVISION_PREFIX = "structured-1";
+
+function locator(
+  documentId: StableId,
+  kind: "document" | "instance" | "net",
+  objectId: StableId,
+  hierarchyPath: readonly HierarchyFrame[] = [],
+): ObjectLocator {
+  return hierarchyPath.length === 0
+    ? directObjectLocator(documentId, kind, objectId)
+    : { documentId, hierarchyPath: [...hierarchyPath], kind, objectId };
+}
+
+function diagnostic(
+  code: string,
+  documentId: StableId,
+  message: string,
+  objectIds: StableId[] = [],
+  primary: ObjectLocator = directObjectLocator(
+    documentId,
+    "document",
+    documentId,
+  ),
+): NetlistDiagnostic {
+  return { code, severity: "error", documentId, objectIds, primary, message };
+}
+
+/**
+ * A number as one SPICE token.
+ *
+ * `String(1e21)` is `"1e+21"`, and the `+` buys nothing while giving a dialect
+ * one more thing to disagree about. Everything else is JavaScript's own
+ * shortest round-tripping spelling, so the deck carries the author's value and
+ * not a rounded copy of it.
+ */
+function spiceNumber(value: number): string {
+  return String(value).replace("e+", "e");
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+/**
+ * The setup, in one spelling that does not depend on key insertion order.
+ *
+ * The deck bytes already cover the circuit and the analyses. The environment
+ * selection is the part that changes the run without changing a single
+ * character of the deck, which is exactly why it belongs in the identity.
+ */
+function canonicalSetup(setup: SimulationSetup): string {
+  const input = setup.input;
+  return JSON.stringify({
+    version: setup.version,
+    input: {
+      kind: input.kind,
+      rootDocumentId: input.rootDocumentId,
+      analyses: input.analyses.map((analysis) =>
+        analysis.kind === "op"
+          ? { kind: analysis.kind }
+          : {
+              kind: analysis.kind,
+              sweep: analysis.sweep,
+              points: analysis.points,
+              startHz: analysis.startHz,
+              stopHz: analysis.stopHz,
+            },
+      ),
+      probes: input.probes.map((probe) =>
+        probe.kind === "net-voltage"
+          ? {
+              id: probe.id,
+              kind: probe.kind,
+              documentId: probe.documentId,
+              netId: probe.netId,
+              occurrence: [...probe.occurrence],
+            }
+          : {
+              id: probe.id,
+              kind: probe.kind,
+              documentId: probe.documentId,
+              instanceId: probe.instanceId,
+              occurrence: [...probe.occurrence],
+            },
+      ),
+      environment: {
+        profileId: input.environment.profileId,
+        corner: input.environment.corner ?? null,
+        temperatureC: input.environment.temperatureC ?? null,
+      },
+    },
+  });
+}
+
+/** The `.control` command that runs one analysis, in ngspice's own words. */
+function analysisCommand(analysis: SimulationAnalysisSpec): string {
+  return analysis.kind === "op"
+    ? "op"
+    : `ac ${analysis.sweep} ${String(analysis.points)} ${spiceNumber(
+        analysis.startHz,
+      )} ${spiceNumber(analysis.stopHz)}`;
+}
+
+function analysisTag(analysis: SimulationAnalysisSpec): SimulationAnalysis {
+  return analysis.kind;
+}
+
+interface ResolvedOccurrence {
+  /** Instance references from the root down, lowercase, as ngspice spells them. */
+  readonly path: readonly string[];
+  readonly documentId: StableId;
+  readonly hierarchyPath: readonly HierarchyFrame[];
+}
+
+/**
+ * Walk a probe's occurrence from the root and report where it lands.
+ *
+ * The occurrence is the list of hierarchy Instance ids from the root down.
+ * Every step has to be an Instance in the Document the previous step reached,
+ * and it has to be bound as a subcircuit: a path that merely names existing
+ * ids is not a path through the hierarchy, and the node prefix it would build
+ * would name a subcircuit call that is not in the deck.
+ */
+function resolveOccurrence(
+  probe: SimulationProbeSpec,
+  rootDocumentId: StableId,
+  documentsById: ReadonlyMap<string, SchematicDocument>,
+  diagnostics: NetlistDiagnostic[],
+): ResolvedOccurrence | null {
+  const path: string[] = [];
+  const hierarchyPath: HierarchyFrame[] = [];
+  let documentId = rootDocumentId;
+  for (const instanceId of probe.occurrence) {
+    const document = documentsById.get(documentId);
+    const instance = document?.instances.find(
+      (candidate) => candidate.id === instanceId,
+    );
+    const binding = instance?.netlist?.binding;
+    if (!document || !instance || binding?.kind !== "subcircuit") {
+      diagnostics.push(
+        diagnostic(
+          "SIMULATION_PROBE_OCCURRENCE_INVALID",
+          documentId,
+          `Probe ${probe.id} names ${instanceId} in its occurrence, which is not a hierarchy Instance of Document ${documentId}`,
+          [instanceId],
+        ),
+      );
+      return null;
+    }
+    if (!instance.reference) {
+      diagnostics.push(
+        diagnostic(
+          "SIMULATION_PROBE_OCCURRENCE_INVALID",
+          documentId,
+          `Hierarchy Instance ${instanceId} has no Reference designator, so it names no subcircuit call in the deck`,
+          [instanceId],
+        ),
+      );
+      return null;
+    }
+    path.push(instance.reference.toLowerCase());
+    hierarchyPath.push({
+      parentDocumentId: documentId,
+      instanceId,
+      childDocumentId: binding.childDocumentId,
+    });
+    documentId = binding.childDocumentId;
+  }
+  if (documentId !== probe.documentId) {
+    diagnostics.push(
+      diagnostic(
+        "SIMULATION_PROBE_OCCURRENCE_INVALID",
+        documentId,
+        `Probe ${probe.id} names Document ${probe.documentId}, but its occurrence reaches Document ${documentId}`,
+        [],
+        locator(documentId, "document", documentId, hierarchyPath),
+      ),
+    );
+    return null;
+  }
+  return { path, documentId, hierarchyPath };
+}
+
+/**
+ * The node name ngspice gives a Net inside an occurrence.
+ *
+ * Measured on ngspice 46: a Net inside subcircuit call `X1` is written
+ * `v(x1.mid)`, and two levels down `v(x1.x2.mid)`. The rawfile spells every
+ * variable in lower case whatever the deck said, so the name emitted here is
+ * lowercased to be the name that comes back.
+ */
+function netVoltageVector(
+  occurrencePath: readonly string[],
+  netName: string,
+): string {
+  return `v(${[...occurrencePath, netName].join(".").toLowerCase()})`;
+}
+
+/**
+ * The branch-current name ngspice gives a source inside an occurrence.
+ *
+ * Measured on ngspice 46: a top-level source is `i(v1)`, but a source inside a
+ * subcircuit call is NOT `i(x1.v2)` — that spelling is refused outright, and
+ * one refused vector aborts the whole `write`. ngspice expands a device inside
+ * a call to `<type letter>.<call path>.<device>`, so the branch is
+ * `v.x1.v2#branch` and its function form is `i(v.x1.v2)`. Writing either
+ * spelling puts `i(v.x1.v2)` in the rawfile.
+ */
+function sourceCurrentVector(
+  occurrencePath: readonly string[],
+  reference: string,
+): string {
+  const typeLetter = reference.slice(0, 1);
+  const device =
+    occurrencePath.length === 0
+      ? reference
+      : [typeLetter, ...occurrencePath, reference].join(".");
+  return `i(${device.toLowerCase()})`;
+}
+
+function cellNetName(
+  cell: DesignNetlistCell,
+  document: SchematicDocument,
+  netId: StableId,
+): string | undefined {
+  const logicalNet =
+    resolveDocumentLogicalNets(document).byBaseNetId.get(netId);
+  if (!logicalNet) return undefined;
+  return cell.nets.find((net) => net.id === logicalNet.id)?.name;
+}
+
+function compileProbe(
+  probe: SimulationProbeSpec,
+  rootDocumentId: StableId,
+  documentsById: ReadonlyMap<string, SchematicDocument>,
+  cellsById: ReadonlyMap<string, DesignNetlistCell>,
+  diagnostics: NetlistDiagnostic[],
+): CompiledSimulationVector | null {
+  if (!documentsById.has(probe.documentId)) {
+    diagnostics.push(
+      diagnostic(
+        "SIMULATION_PROBE_UNKNOWN_DOCUMENT",
+        rootDocumentId,
+        `Probe ${probe.id} references unknown Document ${probe.documentId}`,
+      ),
+    );
+    return null;
+  }
+  const occurrence = resolveOccurrence(
+    probe,
+    rootDocumentId,
+    documentsById,
+    diagnostics,
+  );
+  if (!occurrence) return null;
+  const document = documentsById.get(occurrence.documentId)!;
+  const cell = cellsById.get(occurrence.documentId);
+  if (!cell) {
+    diagnostics.push(
+      diagnostic(
+        "SIMULATION_PROBE_UNREACHED_DOCUMENT",
+        occurrence.documentId,
+        `Probe ${probe.id} reads Document ${occurrence.documentId}, which the simulation root does not reach`,
+      ),
+    );
+    return null;
+  }
+
+  if (probe.kind === "net-voltage") {
+    const netExists = document.nets.some((net) => net.id === probe.netId);
+    if (!netExists) {
+      diagnostics.push(
+        diagnostic(
+          "SIMULATION_PROBE_UNKNOWN_NET",
+          occurrence.documentId,
+          `Probe ${probe.id} references unknown Net ${probe.netId} in Document ${occurrence.documentId}`,
+          [probe.netId],
+        ),
+      );
+      return null;
+    }
+    const netName = cellNetName(cell, document, probe.netId);
+    if (!netName) {
+      diagnostics.push(
+        diagnostic(
+          "SIMULATION_PROBE_NET_NOT_EXPORTED",
+          occurrence.documentId,
+          `Probe ${probe.id} reads Net ${probe.netId}, which the netlist does not print as a node`,
+          [probe.netId],
+          locator(
+            occurrence.documentId,
+            "net",
+            probe.netId,
+            occurrence.hierarchyPath,
+          ),
+        ),
+      );
+      return null;
+    }
+    return {
+      probeId: probe.id,
+      vector: netVoltageVector(occurrence.path, netName),
+      quantity: "voltage",
+    };
+  }
+
+  const instance = document.instances.find(
+    (candidate) => candidate.id === probe.instanceId,
+  );
+  if (!instance) {
+    diagnostics.push(
+      diagnostic(
+        "SIMULATION_PROBE_UNKNOWN_INSTANCE",
+        occurrence.documentId,
+        `Probe ${probe.id} references unknown Instance ${probe.instanceId} in Document ${occurrence.documentId}`,
+        [probe.instanceId],
+      ),
+    );
+    return null;
+  }
+  const probeLocator = locator(
+    occurrence.documentId,
+    "instance",
+    probe.instanceId,
+    occurrence.hierarchyPath,
+  );
+  const printed: DesignNetlistInstance | undefined = cell.instances.find(
+    (candidate) => candidate.id === probe.instanceId,
+  );
+  if (printed?.deviceClass === "current-source") {
+    // ngspice 46 keeps no branch vector for an independent current source: its
+    // current is an input, not a solved unknown, and `i(i1)` is refused. One
+    // refused vector aborts the whole `write`, so this has to be caught here
+    // rather than discovered as an empty rawfile.
+    diagnostics.push(
+      diagnostic(
+        "SIMULATION_PROBE_SOURCE_HAS_NO_BRANCH_CURRENT",
+        occurrence.documentId,
+        `Probe ${probe.id} reads the current of current source ${instance.reference ?? probe.instanceId}, which ngspice solves for no branch current; probe a series voltage source instead`,
+        [probe.instanceId],
+        probeLocator,
+      ),
+    );
+    return null;
+  }
+  if (printed?.deviceClass !== "voltage-source" || !printed.reference) {
+    diagnostics.push(
+      diagnostic(
+        "SIMULATION_PROBE_NOT_A_SOURCE",
+        occurrence.documentId,
+        `Probe ${probe.id} reads the current of Instance ${instance.reference ?? probe.instanceId}, which is not a voltage source`,
+        [probe.instanceId],
+        probeLocator,
+      ),
+    );
+    return null;
+  }
+  return {
+    probeId: probe.id,
+    vector: sourceCurrentVector(occurrence.path, printed.reference),
+    quantity: "current",
+  };
+}
+
+/**
+ * The testbench: the root Cell as top-level cards, then one `.control` block.
+ *
+ * Three measured facts shape the block, all from ngspice 46.
+ *
+ * A deck carrying `.op`/`.ac` cards *and* a `.control` block runs the deck's
+ * own analyses again after the block and reports
+ * `Error: no data saved for A.C. Small signal analysis`, which the runner
+ * classifies as a failed run. So the analyses are `.control` commands and
+ * there are no analysis cards, which is also the convention the hosted smoke
+ * has been running.
+ *
+ * `write` truncates by default, so a second analysis would silently replace
+ * the first one's plot. `set appendwrite` makes the file hold every plot back
+ * to back, which is the shape the rawfile reader already reads.
+ *
+ * `set filetype=ascii` is set by the hosted container's `.spiceinit` too, but
+ * a deck that only works inside that container is not a deck this module can
+ * test against a local simulator.
+ */
+function testbenchText(
+  rootCell: DesignNetlistCell,
+  cards: readonly string[],
+  analyses: readonly SimulationAnalysisSpec[],
+  vectors: readonly string[],
+): string {
+  const save = [`write ${RAWFILE_NAME}`, ...vectors].join(" ");
+  const lines = [
+    `* Analog Canvas testbench ${rootCell.name}`,
+    ...cards,
+    ".control",
+    "set filetype=ascii",
+    "set appendwrite",
+  ];
+  for (const analysis of analyses) {
+    lines.push(analysisCommand(analysis), save);
+  }
+  lines.push(".endc", ".end");
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Compile a structured setup into one runner request and its probe bindings.
+ *
+ * Pure and deterministic: the same Project and setup produce byte-identical
+ * text, in the printer's own ordering. Nothing is thrown — a setup that cannot
+ * be compiled comes back as diagnostics naming the objects to go look at.
+ */
+export async function compileStructuredSimulation(
+  project: CircuitProject,
+  setup: SimulationSetup,
+  options: CompileStructuredSimulationOptions = {},
+): Promise<CompiledSimulation> {
+  const input = setup.input;
+  const rootDocumentId = input.rootDocumentId;
+  const diagnostics: NetlistDiagnostic[] = [];
+
+  const seenKinds = new Set<string>();
+  for (const analysis of input.analyses) {
+    if (seenKinds.has(analysis.kind)) {
+      diagnostics.push(
+        diagnostic(
+          "SIMULATION_DUPLICATE_ANALYSIS",
+          rootDocumentId,
+          `Simulation setup requests the ${analysis.kind} analysis more than once`,
+        ),
+      );
+    }
+    seenKinds.add(analysis.kind);
+  }
+  if (input.analyses.length === 0) {
+    diagnostics.push(
+      diagnostic(
+        "SIMULATION_NO_ANALYSIS",
+        rootDocumentId,
+        "Simulation setup requests no analysis, so there is nothing to run",
+      ),
+    );
+  }
+  if (input.probes.length === 0) {
+    // A run records what it was asked to record. `write` with no vectors saves
+    // the whole plot under names nothing here can bind back to a Net, which
+    // reaches the author as numbers with no circuit attached.
+    diagnostics.push(
+      diagnostic(
+        "SIMULATION_NO_PROBE",
+        rootDocumentId,
+        "Simulation setup names no probe, so the run would record no vector to read back",
+      ),
+    );
+  }
+
+  const analysis = analyzeDesignNetlist(project, { rootDocumentId });
+  const ir = analysis.ir;
+  if (!ir) {
+    return {
+      ok: false,
+      diagnostics: [
+        ...analysis.diagnostics.filter((item) => item.severity === "error"),
+        ...diagnostics,
+      ],
+    };
+  }
+
+  const documentsById = new Map(
+    project.documents.map((document) => [document.id, document]),
+  );
+  const cellsById = new Map(ir.cells.map((cell) => [cell.id, cell]));
+  const rootCell = cellsById.get(rootDocumentId);
+  if (!rootCell) {
+    return {
+      ok: false,
+      diagnostics: [
+        ...diagnostics,
+        diagnostic(
+          "SIMULATION_ROOT_NOT_EXPORTED",
+          rootDocumentId,
+          `Simulation root Document ${rootDocumentId} produced no Cell to instantiate`,
+        ),
+      ],
+    };
+  }
+
+  const cards = printSpiceInstanceCards(rootCell);
+  if (cards.length === 0) {
+    // ADR 0055 and the spec both say it: a deck that only defines `.subckt`s
+    // and instantiates nothing is not a run.
+    diagnostics.push(
+      diagnostic(
+        "SIMULATION_ROOT_HAS_NO_INSTANCES",
+        rootDocumentId,
+        `Simulation root Cell ${rootCell.name} instantiates nothing, so the deck defines subcircuits and simulates none of them`,
+      ),
+    );
+  }
+
+  const vectors: CompiledSimulationVector[] = [];
+  for (const probe of input.probes) {
+    const compiled = compileProbe(
+      probe,
+      rootDocumentId,
+      documentsById,
+      cellsById,
+      diagnostics,
+    );
+    if (compiled) vectors.push(compiled);
+  }
+
+  if (diagnostics.length > 0) return { ok: false, diagnostics };
+
+  const netlist = printSpiceNetlist({
+    ...ir,
+    cells: ir.cells.filter((cell) => cell.id !== rootDocumentId),
+  });
+  // Two probes may share one node — a Net probed twice, or two Base Nets of one
+  // Logical Net. The deck saves each vector once; the bindings keep both.
+  const savedVectors = [...new Set(vectors.map((vector) => vector.vector))];
+  const testbench = testbenchText(
+    rootCell,
+    cards,
+    input.analyses,
+    savedVectors,
+  );
+  // NUL between the three parts, not a newline or a space: a separator that
+  // can occur inside a part lets one part's tail read as the next part's
+  // head, and two different inputs then hash to the same revision.
+  const inputRevision = `${COMPILER_REVISION_PREFIX}-${await sha256Hex(
+    `${netlist}\u0000${testbench}\u0000${canonicalSetup(setup)}`,
+  )}`;
+
+  return {
+    ok: true,
+    request: {
+      netlist,
+      testbench,
+      analyses: input.analyses.map(analysisTag),
+      inputRevision,
+      ...(options.timeoutMs === undefined
+        ? {}
+        : { timeoutMs: options.timeoutMs }),
+    },
+    vectors,
+    diagnostics: [],
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       "@icm/model":
         specifier: workspace:*
         version: link:../model
+      "@icm/spice-run":
+        specifier: workspace:*
+        version: link:../spice-run
       "@icm/symbols":
         specifier: workspace:*
         version: link:../symbols


### PR DESCRIPTION
Work package F2 of the simulation MVP. Closes #569.

Based on `main`: F1 (#618) merged while this was in flight, so this branch sits
directly on `main` and needs no temporary base.

## What it does

`compileStructuredSimulation(project, setup, { timeoutMs? })` in
`@icm/netlist` turns a persisted `SimulationSetup` plus the Project into
exactly what the hosted `/api/simulate` route already consumes — a
`SimulationRequest`'s `netlist` and `testbench` — plus the binding from every
probe to the ngspice vector name that comes back in the rawfile. It is pure
and deterministic, never throws, and selects no model library: the environment
still owns its paths and the runner still owns the deck's final bytes.

```ts
type CompiledSimulation =
  | {
      ok: true;
      request: SimulationRequest;
      vectors: ReadonlyArray<{
        probeId: string;
        vector: string;
        quantity: "voltage" | "current";
      }>;
      diagnostics: readonly [];
    }
  | { ok: false; diagnostics: readonly NetlistDiagnostic[] };
```

Nothing forks the printer. Extraction is `analyzeDesignNetlist` from the
setup's Testbench root, the `.subckt` half is `printSpiceNetlist` over the same
IR with the root Cell removed, and the testbench half is the root Cell's own
cards through one new export, `printSpiceInstanceCards`, which `spiceCell` now
calls too — so a top-level card and a `.subckt` body card cannot disagree about
pin order, a parameter spelling, or a source's AC stimulus.

## Measured against ngspice 46, not assumed

Every deck-shape and naming rule below came from decks the local simulator
actually ran.

- **No analysis cards.** An `.op`/`.ac` card beside a `.control` block makes
  ngspice run the deck's own analyses again after the block and print
  `Error: no data saved for A.C. Small signal analysis`, which `@icm/spice-run`
  classifies as a failed run. The analyses are `.control` commands instead —
  the convention the hosted smoke's `DIVIDER_REQUEST` already runs.
- **`set appendwrite`.** `write` truncates by default, so a second analysis
  silently replaces the first one's plot. With it the rawfile holds both plots
  back to back, which is the shape the reader already reads.
- **Node names.** A Net inside call `X1` is `v(x1.mid)`, two deep
  `v(x1.x2.mid)`. The rawfile lower-cases every name whatever the deck spelled.
- **Nested branch currents.** `i(x1.v2)` is refused outright, and one refused
  vector aborts the whole `write`, leaving no rawfile at all. ngspice expands a
  device inside a call to `<type letter>.<call path>.<device>`, so the branch is
  `v.x1.v2#branch` and the written name is `i(v.x1.v2)`.
- **Current sources have no branch vector**, so a `source-current` probe on one
  is refused at compile time rather than discovered as an empty rawfile.

## Contract decisions taken here

Written into `docs/specs/simulation.md` under "Inputs and root":

1. The analyses live in the `.control` block rather than as dot-cards, for the
   measured reason above. The brief asked for both; ngspice says only one.
2. A setup naming no probe is refused (`SIMULATION_NO_PROBE`): `write` with no
   vectors saves a plot nothing can bind back to a Net, which reaches an author
   as numbers with no circuit attached.
3. `inputRevision` is `structured-1-<sha256>` over both halves and the
   canonical setup. The setup is in the hash because the environment selection
   — Profile, corner, temperature — changes the run without changing one
   character of the deck.

`@icm/netlist` gains a dependency on `@icm/spice-run` so the compiled request
IS the runner's type rather than a copy that can drift. spice-run has no
dependencies of its own, so the layering stays acyclic and browser-safe; the
hash uses Web Crypto rather than a new package.

## Validation

`pnpm typecheck`, `pnpm test:local packages/netlist packages/spice-run`
(127 passing, 20 new), `pnpm ci:static`, `pnpm build`,
`pnpm test:impact -- --base origin/main`.

Three of the new tests run the compiled decks through local ngspice 46 and skip
cleanly on a machine without it, reading the rawfile with `@icm/spice-run`: the
divider's exact 0.5 V with both plots in one file, a Net probed through an
occurrence, and a source probed through one. The last was A/B'd against the
wrong spelling and fails at the simulator — no rawfile written — not merely at
a unit assertion.

`pnpm ci:check` and Playwright are deliberately not run here; the coordinating
session owns the mainline gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
