### PR TITLE
fix(simulation): derive terminal outcomes from run evidence

### DIFF
--- a/apps/local-host/src/simulate.test.ts
+++ b/apps/local-host/src/simulate.test.ts
@@ -54,6 +54,28 @@ describe("local simulation", () => {
   });
 
   withSimulator(
+    "returns requested vectors through the shared result policy",
+    async () => {
+      const outcome = await simulateLocally({
+        netlist: "V1 in 0 DC 1\nR1 in out 1k\nR2 out 0 1k",
+        testbench:
+          ".control\nset filetype=ascii\nop\nwrite out.raw v(out)\n.endc",
+      });
+      expect(outcome.kind).toBe("ran");
+      if (outcome.kind !== "ran") return;
+      expect(outcome.result.outcome.status).toBe("completed");
+      const operatingPoint = outcome.result.data?.analyses.find(
+        (analysis) => analysis.analysis === "op",
+      );
+      expect(operatingPoint?.analysis).toBe("op");
+      if (operatingPoint?.analysis !== "op") return;
+      expect(
+        operatingPoint.probes.find((probe) => probe.name === "v(out)")?.value,
+      ).toBeCloseTo(0.5, 12);
+    },
+  );
+
+  withSimulator(
     "never calls a run clean when the simulator dropped a device",
     async () => {
       // The measured trap: ngspice exits 0 having discarded the resistor.

--- a/apps/local-host/src/simulate.ts
+++ b/apps/local-host/src/simulate.ts
@@ -12,17 +12,23 @@
  */
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 
 import {
   buildSimulationDeck,
-  classifySimulationOutcome,
   createSimulationEnvironmentMetadata,
   createSimulationInputMetadata,
-  describeExitStatus,
-  readNgspiceDiagnostics,
+  deckRequestsRawfile,
+  evaluateSimulationRun,
   resolveTimeoutMs,
   simulationConfigurationMetadata,
   type ModelLibrarySelection,
@@ -50,13 +56,19 @@ export interface LocalSimulatorUnavailable {
 export type LocalSimulationOutcome =
   { kind: "ran"; result: SimulationResult } | LocalSimulatorUnavailable;
 
+const LOCAL_RAWFILE_MAX_BYTES = 16 * 1024 * 1024;
+
 function runProcess(
   binary: string,
   deckPath: string,
+  workingDirectory: string,
   timeoutMs: number,
 ): Promise<{
   log: string;
+  stdout: string;
+  stderr: string;
   exitCode: number | null;
+  signal: string | null;
   timedOut: boolean;
   durationMs: number;
   spawnError: Error | null;
@@ -69,6 +81,7 @@ function runProcess(
       binary,
       ["-b", deckPath],
       {
+        cwd: workingDirectory,
         timeout: timeoutMs,
         maxBuffer: 16 * 1024 * 1024,
         killSignal: "SIGKILL",
@@ -84,6 +97,8 @@ function runProcess(
           spawnError = error;
         }
         resolve({
+          stdout: stdout ?? "",
+          stderr: stderr ?? "",
           log: `${stdout ?? ""}${stderr ?? ""}`,
           exitCode: timedOut
             ? null
@@ -92,6 +107,8 @@ function runProcess(
               : error
                 ? 1
                 : 0,
+          signal:
+            timedOut || typeof error?.signal !== "string" ? null : error.signal,
           timedOut,
           durationMs: Date.now() - startedAt,
           spawnError,
@@ -105,6 +122,35 @@ function runProcess(
     child.on("exit", () => clearTimeout(timer));
     child.on("error", () => clearTimeout(timer));
   });
+}
+
+async function readRunRawfile(directory: string): Promise<{
+  rawfile: string | null;
+  rawfileFormat: "ascii" | "binary" | null;
+  rawfileTruncated: boolean;
+}> {
+  const candidates = (await readdir(directory, { withFileTypes: true }))
+    .filter((entry) => entry.isFile() && entry.name !== "deck.cir")
+    .map((entry) => entry.name)
+    .sort();
+  const name =
+    candidates.find((candidate) => candidate.toLowerCase().endsWith(".raw")) ??
+    candidates[0];
+  if (!name) {
+    return { rawfile: null, rawfileFormat: null, rawfileTruncated: false };
+  }
+  const path = join(directory, name);
+  if ((await stat(path)).size > LOCAL_RAWFILE_MAX_BYTES) {
+    return { rawfile: null, rawfileFormat: null, rawfileTruncated: true };
+  }
+  const content = await readFile(path);
+  return content.includes(0)
+    ? { rawfile: null, rawfileFormat: "binary", rawfileTruncated: false }
+    : {
+        rawfile: content.toString("utf8"),
+        rawfileFormat: "ascii",
+        rawfileTruncated: false,
+      };
 }
 
 function probeVersion(binary: string): Promise<string> {
@@ -163,7 +209,12 @@ export async function simulateLocally(
 ): Promise<LocalSimulationOutcome> {
   const binary = options.ngspicePath ?? process.env.NGSPICE_BIN ?? "ngspice";
   const timeoutMs = resolveTimeoutMs(request.timeoutMs);
-  const modelLibrary = options.modelLibrary ?? null;
+  // ngspice runs inside the private per-run directory so authored output
+  // cannot leak into the host's process cwd. Preserve the existing meaning of
+  // a relative configured model path by resolving it before changing cwd.
+  const modelLibrary = options.modelLibrary
+    ? { ...options.modelLibrary, path: resolve(options.modelLibrary.path) }
+    : null;
   const deck = buildSimulationDeck(request, modelLibrary);
   const [inputMetadata, environment] = await Promise.all([
     createSimulationInputMetadata({
@@ -181,37 +232,44 @@ export async function simulateLocally(
   const deckPath = join(directory, "deck.cir");
   try {
     await writeFile(deckPath, deck, "utf8");
-    const run = await runProcess(binary, deckPath, timeoutMs);
+    const run = await runProcess(binary, deckPath, directory, timeoutMs);
     if (run.spawnError) {
       return {
         kind: "simulator-unavailable",
         message: `No simulator at "${binary}". Install ngspice, or set NGSPICE_BIN to its path.`,
       };
     }
-    const diagnostics = readNgspiceDiagnostics(run.log);
-    // The rule the hosted route has carried since #566, which this path had
-    // been getting only by accident of the exit code: a batch run always
-    // prints at least its banner, so silence is not a result. It has to be
-    // stated here now that the exit code no longer decides anything.
-    if (!run.timedOut && run.log.trim().length === 0) {
-      diagnostics.push({
-        severity: "error",
-        text: "The simulator produced no output, so this run has no result.",
-      });
-    }
-    // Reported, never decisive: see describeExitStatus. Pushed after the
-    // check above so a silent run still reads as the error it is.
-    const exitStatus = describeExitStatus(run.exitCode);
-    if (exitStatus) diagnostics.push(exitStatus);
+    const rawfileExpected = deckRequestsRawfile(deck);
+    const artifact = rawfileExpected
+      ? await readRunRawfile(directory)
+      : {
+          rawfile: null,
+          rawfileFormat: null,
+          rawfileTruncated: false,
+        };
+    const evaluated = evaluateSimulationRun(
+      { rawfile: rawfileExpected ? "required" : "not-required" },
+      {
+        log: run.log,
+        stdout: run.stdout,
+        stderr: run.stderr,
+        exitCode: run.exitCode,
+        signal: run.signal,
+        timedOut: run.timedOut,
+        durationMs: run.durationMs,
+        rawfile: artifact.rawfile,
+        rawfileFormat: artifact.rawfileFormat,
+        rawfileTruncated: artifact.rawfileTruncated,
+      },
+      { timeoutMs },
+    );
     return {
       kind: "ran",
       result: {
-        outcome: classifySimulationOutcome(diagnostics, {
-          timedOut: run.timedOut,
-          timeoutMs,
-        }),
-        diagnostics,
+        outcome: evaluated.outcome,
+        diagnostics: evaluated.diagnostics,
         log: run.log,
+        ...(evaluated.data ? { data: evaluated.data } : {}),
         durationMs: run.durationMs,
         metadata: {
           schemaVersion: 1,

--- a/containers/ngspice/entrypoint.mjs
+++ b/containers/ngspice/entrypoint.mjs
@@ -690,7 +690,8 @@ async function handleRun(body) {
 
         const result = await runNgspice(binary, directory, run);
         run.phase("collecting");
-        const raw = deckRequestsRawfile(deck)
+        const rawfileRequested = deckRequestsRawfile(deck);
+        const raw = rawfileRequested
           ? await readRawfile(directory)
           : { rawfile: null, rawfileName: null, rawfileFormat: null };
 
@@ -708,10 +709,15 @@ async function handleRun(body) {
           status: 200,
           payload: {
             log,
+            // Keep the streams separate as execution facts. `log` remains
+            // during the rolling protocol transition and for human display.
+            stdout: result.stdout,
+            stderr: result.stderr,
             exitCode: result.exitCode,
             signal: result.signal,
             timedOut: result.timedOut,
             durationMs: result.durationMs,
+            rawfileRequested,
             truncated: truncatedOutputs.length > 0,
             truncatedOutputs,
             rawfile: raw.rawfile,

--- a/containers/ngspice/entrypoint.test.mjs
+++ b/containers/ngspice/entrypoint.test.mjs
@@ -316,6 +316,8 @@ describeHarness("the output cap", () => {
     expect(payload.truncated).toBe(true);
     expect(payload.truncatedOutputs).toContain("log");
     expect(payload.log).toContain("output truncated by the simulation harness");
+    expect(payload.stdout).toContain("0123456789");
+    expect(payload.stderr).toContain("a diagnosis that must survive the flood");
     // The cap, plus the one line that says the cap was reached.
     expect(payload.log.length).toBeLessThan(700);
     // Each stream gets its own half of the budget, so a flood on stdout
@@ -345,6 +347,7 @@ describeHarness("the output cap", () => {
     expect(payload.truncatedOutputs).toContain("rawfile");
     expect(payload.rawfileName).toBe("out.raw");
     expect(payload.rawfile.length).toBeLessThanOrEqual(512);
+    expect(payload.rawfileRequested).toBe(true);
   });
 });
 
@@ -365,6 +368,9 @@ describeHarness("the rawfile", () => {
     expect(payload.rawfileName).toBe("out.raw");
     expect(payload.rawfileFormat).toBe("ascii");
     expect(payload.rawfile).toContain("Plotname: op");
+    expect(payload.rawfileRequested).toBe(true);
+    expect(payload.stdout).toContain("analysis done");
+    expect(payload.stderr).toBe("");
     // Read, not parsed: turning vectors into results is a separate contract.
     expect(payload.truncated).toBe(false);
   });
@@ -378,6 +384,7 @@ describeHarness("the rawfile", () => {
 
     expect(payload.rawfile).toBe(null);
     expect(payload.rawfileName).toBe(null);
+    expect(payload.rawfileRequested).toBe(false);
   });
 });
 

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -545,9 +545,14 @@ simulator is wrong anywhere else.
 interface ContainerRunResponse {
   /** Capped; carries a one-line notice in the text when it was cut. */
   log: string;
+  /** The same capped output before human-readable concatenation. */
+  stdout: string;
+  stderr: string;
   /** True when the log or the rawfile reached the cap. */
   truncated: boolean;
   truncatedOutputs: ("log" | "rawfile")[];
+  /** What the harness observed in the submitted deck before collection. */
+  rawfileRequested: boolean;
   /** The rawfile's text when the deck asked for one and it is ASCII. */
   rawfile: string | null;
   rawfileName: string | null;
@@ -562,6 +567,14 @@ shortened log read as a whole one is a wrong answer about a circuit. The
 rawfile is returned when the deck contains `.save` or `write`, verbatim and
 under the same cap; turning its vectors into numbers is
 [Result data](#result-data) and is not done here.
+
+`stdout` and `stderr` remain separate execution facts even though `log`
+retains their human-readable concatenation. A runtime or libc failure on
+stderr is not evidence that ngspice accepted a deck merely because it made
+the combined log non-empty. `rawfileRequested` records the collection
+decision made by the harness; the Worker independently derives the same
+expectation from the prepared deck and rejects an explicit disagreement as a
+protocol failure.
 
 **Readiness.** `GET /health` answers during a run as well as between runs,
 reporting the environment facts, limits, and the Run Supervisor's one
@@ -723,6 +736,22 @@ empty, and an `unusable` reading always carries at least one `error`
 diagnostic saying what to go look at. Those diagnostics join the run's own, so
 a rawfile with no vectors classifies as `failed` -- reached, like every other
 failure, through an error diagnostic rather than through an exit code.
+
+The same evidence policy covers the absence of a file. One pure evaluator in
+`@icm/spice-run` owns the terminal verdict consumed by the Worker, Agent, GUI,
+and Preview checks:
+
+- when the deck requested a rawfile, `completed` requires a readable file with
+  at least one supported analysis and its vectors;
+- when the deck requested no rawfile, `completed` requires positive evidence
+  that ngspice accepted the deck, such as its `Circuit:` banner or analysis
+  output; arbitrary non-empty stderr is not evidence;
+- a non-zero exit code remains diagnostic rather than decisive when all
+  requested results arrived, because supported ngspice builds disagree about
+  the exit status of otherwise identical completed control-block runs.
+
+Preview qualification may additionally require a named environment, probes,
+and numeric tolerances. It does not reclassify the underlying run.
 
 ### CSV
 

--- a/packages/spice-run/src/index.test.ts
+++ b/packages/spice-run/src/index.test.ts
@@ -1,13 +1,18 @@
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it } from "vitest";
 
 import {
   buildSimulationDeck,
   deckNeedsModelLibrary,
+  deckRequestsRawfile,
   classifySimulationOutcome,
   describeExitStatus,
   createSimulationEnvironmentMetadata,
   createSimulationInputMetadata,
   DEFAULT_SIMULATION_TIMEOUT_MS,
+  evaluateSimulationRun,
+  hasNgspiceExecutionEvidence,
   isSimulationEnvironmentMetadata,
   MAX_SIMULATION_TIMEOUT_MS,
   readNgspiceDiagnostics,
@@ -178,6 +183,157 @@ Note: No ".plot", ".print", or ".fourier" lines; no simulations run
         timeoutMs: 30_000,
       }),
     ).toEqual({ status: "timed-out", timeoutMs: 30_000 });
+  });
+});
+
+describe("simulation run evidence", () => {
+  const dividerRawfile = readFileSync(
+    new URL(
+      "../../../fixtures/ngspice-rawfile/divider-op.raw",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const observation = (
+    overrides: Partial<Parameters<typeof evaluateSimulationRun>[1]> = {},
+  ): Parameters<typeof evaluateSimulationRun>[1] => ({
+    log: CLEAN_OUTPUT,
+    stdout: CLEAN_OUTPUT,
+    stderr: "",
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    durationMs: 10,
+    rawfile: null,
+    rawfileFormat: null,
+    rawfileTruncated: false,
+    ...overrides,
+  });
+
+  it("requires positive ngspice evidence rather than any non-empty log", () => {
+    const evaluated = evaluateSimulationRun(
+      { rawfile: "not-required" },
+      observation({
+        log: "tmpfile(): Read-only file system\n",
+        stdout: "",
+        stderr: "tmpfile(): Read-only file system\n",
+        exitCode: 1,
+      }),
+      { timeoutMs: 30_000 },
+    );
+
+    expect(evaluated.outcome).toEqual({ status: "failed" });
+    expect(
+      evaluated.diagnostics.some(
+        (diagnostic) =>
+          diagnostic.severity === "error" &&
+          diagnostic.text.includes("no evidence"),
+      ),
+    ).toBe(true);
+    expect(
+      evaluated.diagnostics.some((diagnostic) =>
+        diagnostic.text.includes("exited with code 1"),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts a no-rawfile run only when ngspice execution is visible", () => {
+    expect(
+      evaluateSimulationRun({ rawfile: "not-required" }, observation(), {
+        timeoutMs: 30_000,
+      }).outcome,
+    ).toEqual({ status: "completed" });
+
+    const dropped = evaluateSimulationRun(
+      { rawfile: "not-required" },
+      observation({
+        log: DROPPED_RESISTOR_OUTPUT,
+        stdout: DROPPED_RESISTOR_OUTPUT,
+      }),
+      { timeoutMs: 30_000 },
+    );
+    expect(dropped.outcome).toEqual({
+      status: "completed-with-dropped-input",
+    });
+  });
+
+  it("fails when the deck promised a rawfile but returned no vectors", () => {
+    const evaluated = evaluateSimulationRun(
+      { rawfile: "required" },
+      observation(),
+      { timeoutMs: 30_000 },
+    );
+
+    expect(evaluated.outcome).toEqual({ status: "failed" });
+    expect(evaluated.diagnostics.map((item) => item.text).join(" ")).toContain(
+      "requested a rawfile",
+    );
+  });
+
+  it("accepts readable requested vectors despite a non-zero exit", () => {
+    const evaluated = evaluateSimulationRun(
+      { rawfile: "required" },
+      observation({
+        log: "",
+        stdout: "",
+        exitCode: 1,
+        rawfile: dividerRawfile,
+        rawfileFormat: "ascii",
+      }),
+      { timeoutMs: 30_000 },
+    );
+
+    expect(evaluated.outcome).toEqual({ status: "completed" });
+    expect(evaluated.data?.analyses).toHaveLength(1);
+    expect(evaluated.diagnostics).toEqual([
+      expect.objectContaining({ severity: "warning" }),
+    ]);
+  });
+
+  it("refuses a truncated requested rawfile even when its prefix parses", () => {
+    const evaluated = evaluateSimulationRun(
+      { rawfile: "required" },
+      observation({
+        rawfile: dividerRawfile,
+        rawfileFormat: "ascii",
+        rawfileTruncated: true,
+      }),
+      { timeoutMs: 30_000 },
+    );
+    expect(evaluated.outcome).toEqual({ status: "failed" });
+    expect(evaluated.data).toBeUndefined();
+    expect(evaluated.diagnostics.map((item) => item.text).join(" ")).toContain(
+      "truncated",
+    );
+  });
+
+  it("keeps timeout and signal termination distinct from exit status", () => {
+    expect(
+      evaluateSimulationRun(
+        { rawfile: "not-required" },
+        observation({ timedOut: true, log: "", stdout: "" }),
+        { timeoutMs: 5_000 },
+      ).outcome,
+    ).toEqual({ status: "timed-out", timeoutMs: 5_000 });
+
+    const killed = evaluateSimulationRun(
+      { rawfile: "not-required" },
+      observation({ signal: "SIGKILL", log: "", stdout: "" }),
+      { timeoutMs: 30_000 },
+    );
+    expect(killed.outcome).toEqual({ status: "failed" });
+    expect(killed.diagnostics.map((item) => item.text).join(" ")).toContain(
+      "SIGKILL",
+    );
+  });
+
+  it("detects the artifact promise and only recognised execution evidence", () => {
+    expect(
+      deckRequestsRawfile(".control\nop\nwrite out.raw v(out)\n.endc"),
+    ).toBe(true);
+    expect(deckRequestsRawfile("* write ignored.raw\n.op\n.end")).toBe(false);
+    expect(hasNgspiceExecutionEvidence(CLEAN_OUTPUT)).toBe(true);
+    expect(hasNgspiceExecutionEvidence("tmpfile(): failed\n")).toBe(false);
   });
 });
 

--- a/packages/spice-run/src/index.ts
+++ b/packages/spice-run/src/index.ts
@@ -12,7 +12,10 @@ export * from "./rawfile.js";
 export * from "./result-data.js";
 export * from "./environment-profile.js";
 
-import type { SimulationResultData } from "./result-data.js";
+import {
+  readSimulationData,
+  type SimulationResultData,
+} from "./result-data.js";
 
 export type SimulationAnalysis = "op" | "ac";
 
@@ -200,6 +203,25 @@ export function deckNeedsModelLibrary(text: string): boolean {
     }
     if (/sky130_/iu.test(line)) return true;
     if (/^[mdqj][a-z0-9_$.:-]*\s/iu.test(line)) return true;
+  }
+  return false;
+}
+
+/**
+ * Whether a prepared deck promises a numeric rawfile.
+ *
+ * This is an execution expectation, not an attempt to understand SPICE. The
+ * harness makes the same observation before collecting output; the Worker
+ * uses this copy to decide what result the submitted deck promised. Keeping
+ * the expectation beside the result evaluator prevents each consumer from
+ * inventing its own meaning for an absent file.
+ */
+export function deckRequestsRawfile(deck: string): boolean {
+  for (const raw of deck.split(/\r?\n/u)) {
+    const line = raw.trim();
+    if (line.length === 0 || line.startsWith("*")) continue;
+    if (/^\.save\b/iu.test(line)) return true;
+    if (/(^|\s|;)write(\s|$)/iu.test(line)) return true;
   }
   return false;
 }
@@ -471,16 +493,11 @@ export function describeExitStatus(
  * point matched ngspice 46 with a full PDK to every digit (#568). Nothing had
  * gone wrong; ngspice 39 exits non-zero for its own reasons.
  *
- * A run therefore fails only when something said so. That is a deliberate
- * trade: an exit code that is the sole evidence of a real failure now reports
- * `completed` beside the warning from `describeExitStatus`, which is the
- * lesser harm — the author sees the fact and their results, instead of a
- * refusal with no reason attached. It also makes `failed` with no diagnostic
- * unreachable rather than merely unlikely.
- *
- * The stronger criterion is whether the requested measurements came back, and
- * that needs the result parsing this cannot see yet (F3-1). It should replace
- * this reading rather than sit beside it.
+ * This remains the small final reduction from diagnostics to a terminal
+ * outcome. `evaluateSimulationRun` below owns the stronger evidence policy:
+ * it first proves that the run produced what its deck requested, then calls
+ * this function. Consumers must use that evaluator rather than treating this
+ * reduction as a complete run policy.
  */
 export function classifySimulationOutcome(
   diagnostics: readonly SimulationDiagnostic[],
@@ -496,4 +513,140 @@ export function classifySimulationOutcome(
     return { status: "completed-with-dropped-input" };
   }
   return { status: "completed" };
+}
+
+/** Facts observed after the simulator process stopped. No field is a verdict. */
+export interface SimulationExecutionObservation {
+  /** Human-readable combined output retained by the public result contract. */
+  readonly log: string;
+  /** Separate streams when the harness supplies them; optional during rollout. */
+  readonly stdout?: string;
+  readonly stderr?: string;
+  readonly exitCode: number | null;
+  readonly signal: string | null;
+  readonly timedOut: boolean;
+  readonly durationMs: number;
+  readonly rawfile: string | null;
+  readonly rawfileFormat: "ascii" | "binary" | null;
+  readonly rawfileTruncated: boolean;
+}
+
+/** What the submitted deck promised to produce for this run. */
+export interface SimulationRunExpectations {
+  readonly rawfile: "required" | "not-required";
+}
+
+/** The policy-owned part of a SimulationResult, before metadata is attached. */
+export interface EvaluatedSimulationRun {
+  readonly outcome: SimulationOutcome;
+  readonly diagnostics: readonly SimulationDiagnostic[];
+  readonly data?: SimulationResultData;
+}
+
+/**
+ * Evidence that ngspice at least accepted and entered a batch run.
+ *
+ * This is deliberately a fallback for decks that requested no rawfile. A
+ * readable rawfile is stronger evidence and does not need a console banner.
+ * Keep the test narrow: arbitrary non-empty stderr is not proof that a deck
+ * ran, which is the exact hole recorded by #613.
+ */
+export function hasNgspiceExecutionEvidence(output: string): boolean {
+  return (
+    /^\s*circuit\s*:/imu.test(output) ||
+    /^\s*doing analysis at\b/imu.test(output) ||
+    /^\s*no\. of data rows\s*:/imu.test(output) ||
+    /^\s*note:\s*simulation executed from \.control section\b/imu.test(output)
+  );
+}
+
+/**
+ * Turn one execution observation into the only product terminal verdict.
+ *
+ * Success is positive evidence, not the absence of a recognised error line:
+ * a deck that requested vectors must return readable vectors; a deck that did
+ * not must at least show that ngspice accepted the deck. The exit code remains
+ * diagnostic because supported ngspice builds can exit non-zero after
+ * producing every requested result.
+ */
+export function evaluateSimulationRun(
+  expectations: SimulationRunExpectations,
+  observation: SimulationExecutionObservation,
+  options: { timeoutMs: number },
+): EvaluatedSimulationRun {
+  const diagnostics = readNgspiceDiagnostics(observation.log);
+
+  if (
+    !observation.timedOut &&
+    observation.signal !== null &&
+    observation.signal.length > 0
+  ) {
+    diagnostics.push({
+      severity: "error",
+      text: `The simulator was terminated by ${observation.signal} before it finished.`,
+    });
+  }
+
+  let data: SimulationResultData | undefined;
+  if (observation.rawfileTruncated) {
+    diagnostics.push({
+      severity: "error",
+      text: "The simulator rawfile was truncated, so its numeric result is incomplete.",
+    });
+  } else if (observation.rawfileFormat === "binary") {
+    diagnostics.push({
+      severity: "error",
+      text:
+        "The simulator wrote a binary rawfile, which carries no numbers this " +
+        "reader can use. Put `set filetype=ascii` before `write`.",
+    });
+  } else if (
+    observation.rawfile !== null &&
+    observation.rawfile.trim().length > 0
+  ) {
+    const reading = readSimulationData(observation.rawfile);
+    diagnostics.push(...reading.diagnostics);
+    if (reading.status === "read") data = reading.data;
+  }
+
+  if (!observation.timedOut && data === undefined) {
+    if (expectations.rawfile === "required") {
+      const alreadyExplained = diagnostics.some(
+        (diagnostic) => diagnostic.severity === "error",
+      );
+      if (!alreadyExplained) {
+        diagnostics.push({
+          severity: "error",
+          text: "The deck requested a rawfile, but the simulator returned no readable vectors.",
+        });
+      }
+    } else if (
+      !hasNgspiceExecutionEvidence(
+        observation.stdout === undefined && observation.stderr === undefined
+          ? observation.log
+          : `${observation.stdout ?? ""}${observation.stderr ?? ""}`,
+      )
+    ) {
+      diagnostics.push({
+        severity: "error",
+        text:
+          observation.log.trim().length === 0
+            ? "The simulator produced no output, so this run has no result."
+            : "The simulator output contains no evidence that ngspice accepted or ran the deck.",
+      });
+    }
+  }
+
+  const exitStatus = describeExitStatus(observation.exitCode);
+  if (exitStatus) diagnostics.push(exitStatus);
+
+  const outcome = classifySimulationOutcome(diagnostics, {
+    timedOut: observation.timedOut,
+    timeoutMs: options.timeoutMs,
+  });
+  return {
+    outcome,
+    diagnostics,
+    ...(data === undefined ? {} : { data }),
+  };
 }

--- a/worker/simulation.test.ts
+++ b/worker/simulation.test.ts
@@ -396,6 +396,85 @@ describe("simulation route", () => {
     expect(payload.data).toBeUndefined();
   });
 
+  it("fails a non-empty runtime error that contains no execution evidence", async () => {
+    // #613: this exact host failure was reported as completed for four hours
+    // because a non-empty log plus a non-decisive exit code fell through the
+    // old diagnostic-only classifier.
+    const response = await routeSimulationRequest(
+      post({ netlist: NETLIST, testbench: TESTBENCH }),
+      stubRunner({
+        log: "tmpfile(): Read-only file system\n",
+        stdout: "",
+        stderr: "tmpfile(): Read-only file system\n",
+        exitCode: 1,
+        timedOut: false,
+        durationMs: 6,
+        rawfileRequested: false,
+      }),
+    );
+    const payload = (await response!.json()) as {
+      outcome: { status: string };
+      diagnostics: { severity: string; text: string }[];
+    };
+    expect(payload.outcome.status).toBe("failed");
+    expect(payload.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: "error",
+          text: expect.stringContaining("no evidence"),
+        }),
+      ]),
+    );
+  });
+
+  it("requires vectors when the submitted deck requested a rawfile", async () => {
+    const response = await routeSimulationRequest(
+      post({
+        netlist: NETLIST,
+        testbench: "V1 in 0 DC 1\n.control\nop\nwrite out.raw v(out)\n.endc",
+      }),
+      stubRunner({
+        log: "Circuit: * amp\nNo. of Data Rows : 1\n",
+        stdout: "Circuit: * amp\nNo. of Data Rows : 1\n",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+        durationMs: 8,
+        rawfileRequested: true,
+        rawfile: null,
+        rawfileFormat: null,
+      }),
+    );
+    const payload = (await response!.json()) as {
+      outcome: { status: string };
+      diagnostics: { text: string }[];
+    };
+    expect(payload.outcome.status).toBe("failed");
+    expect(payload.diagnostics.map((item) => item.text).join(" ")).toContain(
+      "requested a rawfile",
+    );
+  });
+
+  it("refuses a harness that disagrees about the deck's artifact promise", async () => {
+    const response = await routeSimulationRequest(
+      post({
+        netlist: NETLIST,
+        testbench: "V1 in 0 DC 1\n.control\nop\nwrite out.raw v(out)\n.endc",
+      }),
+      stubRunner({
+        log: "Circuit: * amp\n",
+        exitCode: 0,
+        timedOut: false,
+        durationMs: 5,
+        rawfileRequested: false,
+      }),
+    );
+    expect(response?.status).toBe(502);
+    expect((await response!.json()) as unknown).toMatchObject({
+      error: "simulator-protocol-invalid",
+    });
+  });
+
   it("fails a run that printed a log and wrote no vectors", async () => {
     // The other half of #568. An exit code of zero called this a success, and
     // it reached the author as an empty chart with nothing to explain it.

--- a/worker/simulation.ts
+++ b/worker/simulation.ts
@@ -16,13 +16,11 @@
  */
 import {
   buildSimulationDeck,
-  classifySimulationOutcome,
   deckNeedsModelLibrary,
-  describeExitStatus,
+  deckRequestsRawfile,
+  evaluateSimulationRun,
   createSimulationInputMetadata,
   isSimulationInputRevision,
-  readNgspiceDiagnostics,
-  readSimulationData,
   resolveTimeoutMs,
   SKY130_LIBRARY_PATH,
   SKY130_LIBRARY_SECTION,
@@ -30,7 +28,6 @@ import {
   verifySimulationEnvironmentMetadata,
   type ModelLibrarySelection,
   type SimulationResult,
-  type SimulationResultData,
 } from "@icm/spice-run";
 import hostedSky130Profile from "../containers/ngspice/hosted-sky130-profile.json";
 
@@ -378,6 +375,8 @@ export async function routeSimulationRequest(
 
   const raw = (await containerResponse.json()) as {
     log?: unknown;
+    stdout?: unknown;
+    stderr?: unknown;
     exitCode?: unknown;
     signal?: unknown;
     timedOut?: unknown;
@@ -387,6 +386,8 @@ export async function routeSimulationRequest(
     // because a deck that never calls `write` leaves nothing to send.
     rawfile?: unknown;
     rawfileFormat?: unknown;
+    rawfileRequested?: unknown;
+    truncatedOutputs?: unknown;
   };
   const environment = await verifySimulationEnvironmentMetadata(
     raw.environment,
@@ -402,68 +403,56 @@ export async function routeSimulationRequest(
     );
   }
   const log = typeof raw.log === "string" ? raw.log : "";
-  const diagnostics = readNgspiceDiagnostics(log);
-  const timedOut = raw.timedOut === true;
-  // A simulator that died by a signal, or that printed nothing at all,
-  // did not complete: a batch run always prints at least its banner and
-  // the analysis it did. Exit 0 with no output was measured on 2026-09-04
-  // when the kernel killed ngspice mid-corner-load; it must never read as
-  // success (ADR 0055 amendment, item 10).
-  if (!timedOut && typeof raw.signal === "string" && raw.signal) {
-    diagnostics.push({
-      severity: "error",
-      text: `The simulator was terminated by ${raw.signal} before it finished.`,
-    });
-  } else if (!timedOut && log.trim().length === 0) {
-    diagnostics.push({
-      severity: "error",
-      text: "The simulator produced no output, so this run has no result.",
-    });
+  const rawfileExpected = deckRequestsRawfile(deck);
+  // New harnesses report the same fact they used when collecting artifacts.
+  // Accept an absent field during a rolling deployment, but never accept an
+  // explicit disagreement: one side would otherwise judge a different run
+  // contract from the other.
+  if (
+    typeof raw.rawfileRequested === "boolean" &&
+    raw.rawfileRequested !== rawfileExpected
+  ) {
+    return Response.json(
+      {
+        error: "simulator-protocol-invalid",
+        execution,
+        message:
+          "The simulator disagreed with the Worker about whether the deck requested a rawfile.",
+      },
+      { status: 502 },
+    );
   }
-  // The numbers, when the harness sent a rawfile back.
-  //
-  // This is where a simulation stops being a wall of console text. Until it
-  // was wired up, `@icm/spice-run` could read a rawfile and nothing asked it
-  // to: the route returned `log` and the editor had no numbers to draw. A
-  // deck that never calls `write` still returns no data, and that is a fact
-  // about the testbench rather than a failure.
-  //
-  // The reading's own diagnostics join the run's, which is what finally makes
-  // the outcome depend on whether the measurements came back. `#568` could
-  // only stop an exit code from condemning a correct run; this is the other
-  // half — a run that printed a batch log and wrote no vectors is now the
-  // failure it always was, where an exit code of zero called it a success.
-  let data: SimulationResultData | undefined;
   const rawfile = typeof raw.rawfile === "string" ? raw.rawfile : null;
-  if (raw.rawfileFormat === "binary") {
-    diagnostics.push({
-      severity: "error",
-      text:
-        "The simulator wrote a binary rawfile, which carries no numbers this " +
-        "reader can use. Put `set filetype=ascii` before `write`.",
-    });
-  } else if (rawfile !== null && rawfile.trim().length > 0) {
-    const reading = readSimulationData(rawfile);
-    diagnostics.push(...reading.diagnostics);
-    if (reading.status === "read") data = reading.data;
-  }
-  // Reported, never decisive: see describeExitStatus. Pushed after the checks
-  // above so a signal or a silent run still reads as the error it is.
-  const exitStatus = describeExitStatus(
-    typeof raw.exitCode === "number" ? raw.exitCode : null,
+  const truncatedOutputs = Array.isArray(raw.truncatedOutputs)
+    ? raw.truncatedOutputs
+    : [];
+  const evaluated = evaluateSimulationRun(
+    { rawfile: rawfileExpected ? "required" : "not-required" },
+    {
+      log,
+      ...(typeof raw.stdout === "string" ? { stdout: raw.stdout } : {}),
+      ...(typeof raw.stderr === "string" ? { stderr: raw.stderr } : {}),
+      exitCode: typeof raw.exitCode === "number" ? raw.exitCode : null,
+      signal: typeof raw.signal === "string" ? raw.signal : null,
+      timedOut: raw.timedOut === true,
+      durationMs: typeof raw.durationMs === "number" ? raw.durationMs : 0,
+      rawfile,
+      rawfileFormat:
+        raw.rawfileFormat === "ascii" || raw.rawfileFormat === "binary"
+          ? raw.rawfileFormat
+          : null,
+      rawfileTruncated: truncatedOutputs.includes("rawfile"),
+    },
+    { timeoutMs },
   );
-  if (exitStatus) diagnostics.push(exitStatus);
   const result: SimulationResult & { execution: HostedExecutionMetadata } = {
     execution,
-    outcome: classifySimulationOutcome(diagnostics, {
-      timedOut,
-      timeoutMs,
-    }),
-    diagnostics,
+    outcome: evaluated.outcome,
+    diagnostics: evaluated.diagnostics,
     log,
     // Omitted rather than null when there is nothing to carry: the field's
     // contract is that its presence means numbers were read.
-    ...(data ? { data } : {}),
+    ...(evaluated.data ? { data: evaluated.data } : {}),
     durationMs: typeof raw.durationMs === "number" ? raw.durationMs : 0,
     metadata: {
       schemaVersion: 1,


### PR DESCRIPTION
## Summary
- preserve separate simulator stdout/stderr and the harness rawfile expectation
- centralize terminal result evaluation in @icm/spice-run for Worker and local-host runs
- fail missing, unreadable, truncated, or vectorless required artifacts while retaining valid nonzero-exit results
- run local ngspice in a private directory and cap rawfile collection

Closes #613.

## Validation
- pnpm test:local packages/spice-run worker/simulation.test.ts apps/local-host/src/simulate.test.ts apps/local-host/src/simulate-endpoint.test.ts scripts/preview-simulation-smoke.test.mjs
- pnpm typecheck
- pnpm gate:preflight -- --base origin/main
- pnpm gate:full (2,582 unit tests passed; 349 browser tests passed)

Agent/MCP lifecycle files are intentionally outside this change so parallel F4 work can continue against the unchanged public SimulationResult shape.