### PR TITLE
test(simulation): close the structured preview journey

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -136,8 +136,8 @@ jobs:
             echo "A gallery write on the preview must be refused, got: $write"
             exit 1
           fi
-      # The divider runs on the preview's simulator host, and the answer has
-      # to be a number with a measured environment identity behind it, not a
-      # green status.
-      - name: Simulate one circuit on the preview's simulator host
+      # A divider checks the transport and the persisted OTA Project checks the
+      # product compiler plus OP/AC model evidence. Both run on the preview's
+      # simulator host; a green status without numbers is not acceptance.
+      - name: Run the preview's numerical and vertical simulation acceptance
         run: node scripts/preview-simulation-smoke.mjs "$PREVIEW_URL"

--- a/apps/editor/src/examples/five-transistor-ota-sky130.icproj.json
+++ b/apps/editor/src/examples/five-transistor-ota-sky130.icproj.json
@@ -554,6 +554,7 @@
               "kind": "primitive"
             },
             "parameters": {
+              "acMagnitude": "1",
               "dc": "0.9"
             }
           },
@@ -3014,6 +3015,60 @@
   "id": "project-five-transistor-ota-sky130",
   "name": "Five-Transistor OTA (Sky130)",
   "schemaVersion": 37,
+  "simulation": {
+    "version": 1,
+    "input": {
+      "kind": "structured",
+      "rootDocumentId": "document-ota-5t-testbench",
+      "analyses": [
+        {
+          "kind": "op"
+        },
+        {
+          "kind": "ac",
+          "sweep": "dec",
+          "points": 10,
+          "startHz": 1,
+          "stopHz": 1000000000
+        }
+      ],
+      "probes": [
+        {
+          "id": "probe-vout",
+          "kind": "net-voltage",
+          "documentId": "document-ota-5t-testbench",
+          "netId": "tb-vout-net",
+          "occurrence": []
+        },
+        {
+          "id": "probe-ibias",
+          "kind": "net-voltage",
+          "documentId": "document-ota-5t-testbench",
+          "netId": "tb-ibias-net",
+          "occurrence": []
+        },
+        {
+          "id": "probe-tail",
+          "kind": "net-voltage",
+          "documentId": "document-ota-5t",
+          "netId": "net-dut-tail",
+          "occurrence": ["XDUT"]
+        },
+        {
+          "id": "probe-nleft",
+          "kind": "net-voltage",
+          "documentId": "document-ota-5t",
+          "netId": "net-dut-nleft",
+          "occurrence": ["XDUT"]
+        }
+      ],
+      "environment": {
+        "profileId": "sky130-core-continuous-ngspice46-v1",
+        "corner": "tt",
+        "temperatureC": 27
+      }
+    }
+  },
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/library-examples.test.ts
+++ b/apps/editor/src/examples/library-examples.test.ts
@@ -8,7 +8,11 @@ import {
 } from "@icm/derived";
 import { CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
 import type { CircuitProject } from "@icm/model";
-import { analyzeDesignNetlist, printSpiceNetlist } from "@icm/netlist";
+import {
+  analyzeDesignNetlist,
+  compileStructuredSimulation,
+  printSpiceNetlist,
+} from "@icm/netlist";
 import { serializeProject } from "@icm/project-protocol";
 import { builtInSymbols, createProjectSymbolResolver } from "@icm/symbols";
 import { describe, expect, it } from "vitest";
@@ -268,6 +272,37 @@ describe("the bundled five-transistor Sky130 OTA", () => {
       testbench.instances.filter((instance) => instance.symbolId === "ground")
         .length,
     ).toBeGreaterThan(0);
+  });
+
+  it("persists and compiles its OP and AC acceptance setup", async () => {
+    expect(project.simulation).toBeDefined();
+    const compiled = await compileStructuredSimulation(
+      project,
+      project.simulation!,
+    );
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+
+    expect(compiled.request.analyses).toEqual(["op", "ac"]);
+    expect(compiled.request.testbench).toContain("VINP");
+    expect(compiled.request.testbench).toContain("AC 1 0");
+    expect(compiled.request.testbench).toContain("op");
+    expect(compiled.request.testbench).toContain("ac dec 10 1 1000000000");
+    expect(compiled.request.testbench).toContain("set appendwrite");
+    expect(compiled.vectors).toEqual([
+      { probeId: "probe-vout", vector: "v(vout)", quantity: "voltage" },
+      { probeId: "probe-ibias", vector: "v(ibias)", quantity: "voltage" },
+      {
+        probeId: "probe-tail",
+        vector: "v(xdut.tail)",
+        quantity: "voltage",
+      },
+      {
+        probeId: "probe-nleft",
+        vector: "v(xdut.nleft)",
+        quantity: "voltage",
+      },
+    ]);
   });
 
   it("passes the Check-and-Save gates with no electrical rule issue", () => {

--- a/containers/ngspice/hosted-sky130-profile.json
+++ b/containers/ngspice/hosted-sky130-profile.json
@@ -24,6 +24,6 @@
   "qualifiedScope": {
     "devices": ["sky130_fd_pr__nfet_01v8", "sky130_fd_pr__pfet_01v8"],
     "sections": ["tt"],
-    "analyses": ["op"]
+    "analyses": ["op", "ac"]
   }
 }

--- a/containers/ngspice/profile-contract.test.mjs
+++ b/containers/ngspice/profile-contract.test.mjs
@@ -36,7 +36,7 @@ describe("the hosted SKY130 Profile", () => {
     expect(profile.qualifiedScope).toEqual({
       devices: ["sky130_fd_pr__nfet_01v8", "sky130_fd_pr__pfet_01v8"],
       sections: ["tt"],
-      analyses: ["op"],
+      analyses: ["op", "ac"],
     });
   });
 });

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -288,10 +288,12 @@ into the Project, undo history, Gallery, or recovery copy.
   deployment overrides, configuration-error classification, and the verified
   run metadata envelope.
 - `containers/ngspice/profile-contract.test.mjs` binds the Profile to the
-  digest-pinned image and exact startup bytes. The Preview gate then sends the
-  tracked five-transistor OTA through both hosted executors, requires the
-  Profile identity and `tt` model selection, reads structured OP data, and
-  compares four internal/output voltages against the recorded qualification
+  digest-pinned image and exact startup bytes. The Preview gate opens the
+  tracked five-transistor OTA Project, compiles its persisted structured setup,
+  and sends that exact prepared OP+AC request through the operator-host
+  executor. It requires the Profile identity and `tt` model selection, checks
+  all four compile-time probe bindings, compares four OP voltages, and compares
+  representative complex AC samples against the recorded qualification
   fixture. Missing local ngspice never skips this hosted gate.
 - The pinned local authority pack under ignored `.reference-src/` demonstrates
   that ngspice 47 completes a Sky130 NFET operating-point deck with
@@ -857,6 +859,13 @@ release. A deployment without the binding answers
   `analog-arena`, exported by this product and simulated against the
   reference netlist under one testbench, agreeing on node voltages, gain,
   and unity-gain bandwidth.
+- `scripts/preview-simulation-smoke.mjs`: the bundled five-transistor OTA
+  Project is the vertical acceptance asset. Its saved `SimulationSetup` is
+  parsed and compiled by the production Project/netlist packages before the
+  generated OP+AC request reaches Preview. The returned input revision,
+  environment Profile, model corner, frequency axis, probe series, OP values,
+  and selected AC complex samples must all agree with the tracked
+  qualification evidence; a handwritten deck cannot satisfy this path.
 - `containers/ngspice/entrypoint.test.mjs` starts the harness as a real
   process and asserts the execution boundary against stand-in simulators
   that misbehave deliberately: a private directory per run that is removed

--- a/fixtures/simulation-acceptance/hosted-sky130-core-continuous-v1.json
+++ b/fixtures/simulation-acceptance/hosted-sky130-core-continuous-v1.json
@@ -1,9 +1,10 @@
 {
-  "schemaVersion": 1,
-  "fixtureId": "ota-5t-balanced-op-v1",
+  "schemaVersion": 2,
+  "fixtureId": "ota-5t-structured-op-ac-v1",
   "profileId": "sky130-core-continuous-ngspice46-v1",
-  "analysis": "op",
+  "analyses": ["op", "ac"],
   "inputs": {
+    "project": "apps/editor/src/examples/five-transistor-ota-sky130.icproj.json",
     "netlist": "fixtures/simulation-acceptance/ota-5t.spi",
     "testbench": "fixtures/simulation-acceptance/ota-5t-hosted.testbench.spice"
   },
@@ -16,5 +17,51 @@
     "v(ibias)": { "value": 0.6044031364286973, "absoluteTolerance": 1e-8 },
     "v(xdut.tail)": { "value": 0.2848671983031419, "absoluteTolerance": 1e-8 },
     "v(xdut.nleft)": { "value": 0.7589797395214736, "absoluteTolerance": 1e-8 }
+  },
+  "expectedAc": {
+    "pointCount": 91,
+    "startHz": 1,
+    "stopHz": 1000000000,
+    "frequencyRelativeTolerance": 1e-12,
+    "probes": {
+      "v(vout)": {
+        "samples": [
+          {
+            "index": 0,
+            "real": 120.1227317562375,
+            "imag": -0.0003511468844918635,
+            "absoluteTolerance": 1e-8
+          },
+          {
+            "index": 30,
+            "real": 120.1217100790957,
+            "imag": -0.3511439119206514,
+            "absoluteTolerance": 1e-8
+          },
+          {
+            "index": 60,
+            "real": 12.1813224169096,
+            "imag": -37.09123686627677,
+            "absoluteTolerance": 1e-8
+          },
+          {
+            "index": 90,
+            "real": -0.04031087451053017,
+            "imag": -0.006331573453656596,
+            "absoluteTolerance": 1e-8
+          }
+        ]
+      },
+      "v(xdut.tail)": {
+        "samples": [
+          {
+            "index": 60,
+            "real": 0.4417357549275905,
+            "imag": -0.1070857397604748,
+            "absoluteTolerance": 1e-8
+          }
+        ]
+      }
+    }
   }
 }

--- a/packages/spice-run/src/environment-profile.test.ts
+++ b/packages/spice-run/src/environment-profile.test.ts
@@ -31,7 +31,7 @@ describe("hosted simulation Profile", () => {
       runtimePath: "/opt/sky130/continuous/sky130.lib.spice",
       sections: ["tt"],
     });
-    expect(HOSTED_SKY130_PROFILE.qualifiedScope.analyses).toEqual(["op"]);
+    expect(HOSTED_SKY130_PROFILE.qualifiedScope.analyses).toEqual(["op", "ac"]);
   });
 
   it("accepts exact observed identity and names every drift", () => {

--- a/scripts/preview-simulation-smoke.mjs
+++ b/scripts/preview-simulation-smoke.mjs
@@ -35,10 +35,12 @@ if (qualification.profileId !== profile.id) {
     `Qualification ${qualification.fixtureId} targets ${String(qualification.profileId)}, not Profile ${profile.id}.`,
   );
 }
-if (!profile.qualifiedScope.analyses.includes(qualification.analysis)) {
-  throw new Error(
-    `Qualification ${qualification.fixtureId} uses undeclared analysis ${String(qualification.analysis)}.`,
-  );
+for (const analysis of qualification.analyses) {
+  if (!profile.qualifiedScope.analyses.includes(analysis)) {
+    throw new Error(
+      `Qualification ${qualification.fixtureId} uses undeclared analysis ${String(analysis)}.`,
+    );
+  }
 }
 if (
   qualification.modelLibrary.directive !== profile.models.library.directive ||
@@ -78,18 +80,44 @@ export const DIVIDER_REQUEST = {
   timeoutMs: 110_000,
 };
 
-export const HOSTED_SKY130_REQUEST = {
-  netlist: readFileSync(
-    new URL(`../${qualification.inputs.netlist}`, import.meta.url),
-    "utf8",
-  ),
-  testbench: readFileSync(
-    new URL(`../${qualification.inputs.testbench}`, import.meta.url),
-    "utf8",
-  ),
-  analyses: ["op"],
-  timeoutMs: 110_000,
-};
+export async function compileHostedSky130Project() {
+  const [{ compileStructuredSimulation }, { parseProject }] = await Promise.all(
+    [import("@icm/netlist"), import("@icm/project-protocol")],
+  );
+  const project = parseProject(
+    readFileSync(
+      new URL(`../${qualification.inputs.project}`, import.meta.url),
+      "utf8",
+    ),
+  );
+  if (!project.simulation) {
+    throw new Error(
+      `Qualification ${qualification.fixtureId} Project has no persisted SimulationSetup.`,
+    );
+  }
+  const selection = project.simulation.input.environment;
+  if (
+    selection.profileId !== qualification.profileId ||
+    selection.corner !== qualification.modelLibrary.section
+  ) {
+    throw new Error(
+      `Qualification ${qualification.fixtureId} Project does not select its declared Profile and corner.`,
+    );
+  }
+  const compiled = await compileStructuredSimulation(
+    project,
+    project.simulation,
+    { timeoutMs: 110_000 },
+  );
+  if (!compiled.ok) {
+    throw new Error(
+      `Qualification ${qualification.fixtureId} did not compile: ${compiled.diagnostics
+        .map((diagnostic) => `${diagnostic.code}: ${diagnostic.message}`)
+        .join(" | ")}`,
+    );
+  }
+  return compiled;
+}
 
 function object(value, label) {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -207,7 +235,16 @@ export function validatePreviewSimulationResult(payload, expectedTarget) {
   };
 }
 
-export function validateHostedSky130Result(payload, expectedTarget) {
+function relativeError(actual, expected) {
+  return Math.abs(actual - expected) / Math.max(Math.abs(expected), 1);
+}
+
+export function validateHostedSky130Result(
+  payload,
+  expectedTarget,
+  expectedInputRevision,
+  expectedVectors,
+) {
   const result = object(payload, "simulation response");
   const execution = object(result.execution, "execution metadata");
   if (execution.target !== expectedTarget) {
@@ -222,10 +259,9 @@ export function validateHostedSky130Result(payload, expectedTarget) {
   }
   const metadata = object(result.metadata, "run metadata");
   const input = object(metadata.input, "input metadata");
-  const expectedRevision = `preview-sky130-${expectedTarget}`;
-  if (input.inputRevision !== expectedRevision) {
+  if (input.inputRevision !== expectedInputRevision) {
     throw new Error(
-      `[result:stale-input] requested ${expectedRevision}, but the Worker returned ${String(input.inputRevision)}.`,
+      `[result:stale-input] requested ${expectedInputRevision}, but the Worker returned ${String(input.inputRevision)}.`,
     );
   }
   const configuration = object(
@@ -250,7 +286,7 @@ export function validateHostedSky130Result(payload, expectedTarget) {
         (analysis) =>
           typeof analysis === "object" &&
           analysis !== null &&
-          analysis.analysis === qualification.analysis,
+          analysis.analysis === "op",
       )
     : null;
   if (!operatingPoint || !Array.isArray(operatingPoint.probes)) {
@@ -275,6 +311,86 @@ export function validateHostedSky130Result(payload, expectedTarget) {
     }
     values[name] = probe.value;
   }
+
+  const ac = Array.isArray(data.analyses)
+    ? data.analyses.find(
+        (analysis) =>
+          typeof analysis === "object" &&
+          analysis !== null &&
+          analysis.analysis === "ac",
+      )
+    : null;
+  if (!ac || !Array.isArray(ac.frequencyHz) || !Array.isArray(ac.probes)) {
+    throw new Error(`${expectedTarget} returned no qualified AC result.`);
+  }
+  const expectedAc = qualification.expectedAc;
+  if (ac.frequencyHz.length !== expectedAc.pointCount) {
+    throw new Error(
+      `${expectedTarget} returned ${ac.frequencyHz.length} AC points, expected ${expectedAc.pointCount}.`,
+    );
+  }
+  const firstFrequency = ac.frequencyHz[0];
+  const lastFrequency = ac.frequencyHz.at(-1);
+  if (
+    typeof firstFrequency !== "number" ||
+    relativeError(firstFrequency, expectedAc.startHz) >
+      expectedAc.frequencyRelativeTolerance ||
+    typeof lastFrequency !== "number" ||
+    relativeError(lastFrequency, expectedAc.stopHz) >
+      expectedAc.frequencyRelativeTolerance
+  ) {
+    throw new Error(
+      `${expectedTarget} returned an unexpected AC frequency axis (${String(firstFrequency)} .. ${String(lastFrequency)}).`,
+    );
+  }
+  for (const binding of expectedVectors) {
+    const probe = ac.probes.find(
+      (candidate) =>
+        typeof candidate === "object" &&
+        candidate !== null &&
+        candidate.name === binding.vector,
+    );
+    if (!probe || !Array.isArray(probe.real) || !Array.isArray(probe.imag)) {
+      throw new Error(
+        `${expectedTarget} returned no AC series for ${binding.probeId} (${binding.vector}).`,
+      );
+    }
+    if (
+      probe.real.length !== expectedAc.pointCount ||
+      probe.imag.length !== expectedAc.pointCount
+    ) {
+      throw new Error(
+        `${expectedTarget} returned an incomplete AC series for ${binding.vector}.`,
+      );
+    }
+  }
+  for (const [name, expected] of Object.entries(expectedAc.probes)) {
+    const probe = ac.probes.find(
+      (candidate) =>
+        typeof candidate === "object" &&
+        candidate !== null &&
+        candidate.name === name,
+    );
+    if (!probe || !Array.isArray(probe.real) || !Array.isArray(probe.imag)) {
+      throw new Error(
+        `${expectedTarget} returned no qualified AC series ${name}.`,
+      );
+    }
+    for (const sample of expected.samples) {
+      const real = probe.real[sample.index];
+      const imag = probe.imag[sample.index];
+      if (
+        typeof real !== "number" ||
+        typeof imag !== "number" ||
+        Math.abs(real - sample.real) > sample.absoluteTolerance ||
+        Math.abs(imag - sample.imag) > sample.absoluteTolerance
+      ) {
+        throw new Error(
+          `${expectedTarget} solved ${name}[${sample.index}] as ${String(real)} + j${String(imag)}, expected ${sample.real} + j${sample.imag} ± ${sample.absoluteTolerance}.`,
+        );
+      }
+    }
+  }
   return {
     target: expectedTarget,
     fixtureId: qualification.fixtureId,
@@ -288,12 +404,12 @@ export async function runHostedSky130Acceptance({
   target,
   fetchImpl = fetch,
 }) {
+  const compiled = await compileHostedSky130Project();
   const response = await fetchImpl(new URL("/api/simulate", baseUrl), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({
-      ...HOSTED_SKY130_REQUEST,
-      inputRevision: `preview-sky130-${target}`,
+      ...compiled.request,
       executorTarget: target,
     }),
     signal: AbortSignal.timeout(120_000),
@@ -313,7 +429,12 @@ export async function runHostedSky130Acceptance({
       `[infrastructure:${String(refusal.error ?? `http-${response.status}`)}] ${target} model qualification answered HTTP ${response.status}`,
     );
   }
-  return validateHostedSky130Result(payload, target);
+  return validateHostedSky130Result(
+    payload,
+    target,
+    compiled.request.inputRevision,
+    compiled.vectors,
+  );
 }
 
 export async function runPreviewSimulationSmoke({

--- a/scripts/preview-simulation-smoke.test.mjs
+++ b/scripts/preview-simulation-smoke.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  compileHostedSky130Project,
   runHostedSky130Acceptance,
   runPreviewSimulationSmoke,
   validateExecutorParity,
@@ -16,6 +17,16 @@ const MODEL_SHA =
   "0bf299f0e3e1616478203d370107865635fd08935bb1a9cf9db18efd31703100";
 const STARTUP_SHA =
   "5ad94681e17bba379ac84d01fe7773458b34f9bbd77c127a3738f1af47ad5634";
+const EXPECTED_VECTORS = [
+  { probeId: "probe-vout", vector: "v(vout)", quantity: "voltage" },
+  { probeId: "probe-ibias", vector: "v(ibias)", quantity: "voltage" },
+  { probeId: "probe-tail", vector: "v(xdut.tail)", quantity: "voltage" },
+  {
+    probeId: "probe-nleft",
+    vector: "v(xdut.nleft)",
+    quantity: "voltage",
+  },
+];
 
 function result(target, overrides = {}) {
   return {
@@ -53,13 +64,40 @@ function result(target, overrides = {}) {
   };
 }
 
-function modelResult(target, overrides = {}) {
+function modelResult(
+  target,
+  overrides = {},
+  inputRevision = `preview-sky130-${target}`,
+) {
   const base = result(target);
+  const frequencyHz = Array.from(
+    { length: 91 },
+    (_, index) => 10 ** (index / 10),
+  );
+  const acProbes = EXPECTED_VECTORS.map(({ vector }) => ({
+    name: vector,
+    real: Array(91).fill(0),
+    imag: Array(91).fill(0),
+  }));
+  const vout = acProbes.find((probe) => probe.name === "v(vout)");
+  const tail = acProbes.find((probe) => probe.name === "v(xdut.tail)");
+  if (!vout || !tail) throw new Error("test AC probes are incomplete");
+  for (const [index, real, imag] of [
+    [0, 120.1227317562375, -0.0003511468844918635],
+    [30, 120.1217100790957, -0.3511439119206514],
+    [60, 12.1813224169096, -37.09123686627677],
+    [90, -0.04031087451053017, -0.006331573453656596],
+  ]) {
+    vout.real[index] = real;
+    vout.imag[index] = imag;
+  }
+  tail.real[60] = 0.4417357549275905;
+  tail.imag[60] = -0.1070857397604748;
   return {
     ...base,
     metadata: {
       ...base.metadata,
-      input: { inputRevision: `preview-sky130-${target}` },
+      input: { inputRevision },
       configuration: {
         modelLibrary: { directive: "lib", section: "tt" },
       },
@@ -74,6 +112,11 @@ function modelResult(target, overrides = {}) {
             { name: "v(xdut.tail)", value: 0.2848671983031419 },
             { name: "v(xdut.nleft)", value: 0.7589797395214736 },
           ],
+        },
+        {
+          analysis: "ac",
+          frequencyHz,
+          probes: acProbes,
         },
       ],
     },
@@ -225,10 +268,12 @@ describe("the hosted SKY130 qualification", () => {
       validateHostedSky130Result(
         modelResult("cloudflare-container"),
         "cloudflare-container",
+        "preview-sky130-cloudflare-container",
+        EXPECTED_VECTORS,
       ),
     ).toMatchObject({
       target: "cloudflare-container",
-      fixtureId: "ota-5t-balanced-op-v1",
+      fixtureId: "ota-5t-structured-op-ac-v1",
       environmentFingerprint: SHA,
       values: { "v(vout)": 0.7589797395133877 },
     });
@@ -238,15 +283,38 @@ describe("the hosted SKY130 qualification", () => {
     const candidate = modelResult("operator-host");
     candidate.data.analyses[0].probes[0].value = 0.8;
     expect(() =>
-      validateHostedSky130Result(candidate, "operator-host"),
+      validateHostedSky130Result(
+        candidate,
+        "operator-host",
+        "preview-sky130-operator-host",
+        EXPECTED_VECTORS,
+      ),
     ).toThrow(/solved v\(vout\) as 0\.8/u);
+  });
+
+  it("refuses AC drift outside the recorded tolerance", () => {
+    const candidate = modelResult("operator-host");
+    candidate.data.analyses[1].probes[0].real[60] = 13;
+    expect(() =>
+      validateHostedSky130Result(
+        candidate,
+        "operator-host",
+        "preview-sky130-operator-host",
+        EXPECTED_VECTORS,
+      ),
+    ).toThrow(/solved v\(vout\)\[60\] as 13/u);
   });
 
   it("refuses a run that did not load the qualified corner", () => {
     const candidate = modelResult("operator-host");
     candidate.metadata.configuration.modelLibrary.section = "ff";
     expect(() =>
-      validateHostedSky130Result(candidate, "operator-host"),
+      validateHostedSky130Result(
+        candidate,
+        "operator-host",
+        "preview-sky130-operator-host",
+        EXPECTED_VECTORS,
+      ),
     ).toThrow(/qualified model-library section/u);
   });
 
@@ -257,12 +325,23 @@ describe("the hosted SKY130 qualification", () => {
       target: "operator-host",
       fetchImpl: async (_url, init) => {
         submitted = JSON.parse(init.body);
-        return Response.json(modelResult("operator-host"));
+        return Response.json(
+          modelResult("operator-host", {}, submitted.inputRevision),
+        );
       },
     });
     expect(submitted.executorTarget).toBe("operator-host");
     expect(submitted.netlist).toContain(".subckt ota_5t");
+    expect(submitted.testbench).toContain("set appendwrite");
     expect(submitted.testbench).toContain("write out.raw v(vout)");
-    expect(accepted.fixtureId).toBe("ota-5t-balanced-op-v1");
+    expect(submitted.testbench).toContain("ac dec 10 1 1000000000");
+    expect(accepted.fixtureId).toBe("ota-5t-structured-op-ac-v1");
+  });
+
+  it("compiles the persisted Project setup into the qualified request", async () => {
+    const compiled = await compileHostedSky130Project();
+    expect(compiled.request.analyses).toEqual(["op", "ac"]);
+    expect(compiled.vectors).toEqual(EXPECTED_VECTORS);
+    expect(compiled.request.inputRevision).toMatch(/^[0-9a-f]{64}$/u);
   });
 });


### PR DESCRIPTION
## Outcome

The tracked five-transistor Sky130 OTA is now the vertical Preview acceptance asset instead of a raw handwritten-deck bypass.

- persist one OP+AC SimulationSetup on the bundled Project
- compile that Project with the production Project/netlist packages in Preview smoke
- verify the echoed input revision, Profile/corner, four probe bindings, OP values, 91-point frequency axis, and representative complex AC samples
- qualify AC alongside OP for the pinned hosted Profile
- keep the handwritten netlist/testbench only as reference provenance

## Validation

- focused simulation/example/Profile tests: 66 passed
- live current Preview operator-host: divider and structured OTA OP+AC passed under pinned ngspice-46 fingerprint
- pnpm gate:preflight -- --base origin/main: passed
- pnpm gate:full: static, 2609 unit tests, build, release/performance/golden checks passed; browser suite had 349 pass and one unrelated existing drafting text timing failure
- isolated retry of that exact drafting E2E: passed
- git diff --check: passed

Test-Impact: tests-updated