### PR TITLE
feat(hierarchy): enable first-use local DUT symbols and Agent placement

### DIFF
--- a/apps/editor/e2e/hierarchy.spec.ts
+++ b/apps/editor/e2e/hierarchy.spec.ts
@@ -60,6 +60,52 @@ async function placeCellPin(
   if (!wasExpanded) await shelf.click();
 }
 
+test("reviews an unreferenced top Symbol and places that DUT in an ordinary new TB", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await runCellCommand(page, "Manage Cells…");
+  const manager = page.getByRole("dialog", { name: "Cell Manager" });
+  await manager.getByText("Review Symbol", { exact: true }).click();
+  await expect(manager).toContainText("valid zero-port interface");
+  await manager.getByLabel("Symbol width", { exact: true }).fill("160");
+  await manager
+    .getByRole("button", { name: "Apply Symbol", exact: true })
+    .click();
+  await manager.getByRole("button", { name: "Close Cell Manager" }).click();
+  await createCell(page, "Testbench");
+  await runCellCommand(page, "Place Cell");
+  await page
+    .getByRole("dialog", { name: "Place Hierarchical Cell" })
+    .getByRole("option", { name: /Main/u })
+    .click();
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 320, y: 180 } });
+  await page.keyboard.press("Escape");
+  const project = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(
+      "utf8",
+    ),
+  );
+  expect(project.topDocumentId).toBe("document-main");
+  expect(
+    project.documents.find((d: { id: string }) => d.id === "document-main")
+      .presentation.cellSymbol.minimumBodySize.width,
+  ).toBe(160);
+  const tb = project.documents.find(
+    (d: { name: string }) => d.name === "Testbench",
+  );
+  expect(tb.instances[0].netlist.binding).toEqual({
+    kind: "subcircuit",
+    childDocumentId: "document-main",
+  });
+  await page.keyboard.press("Control+z");
+  await expect(page.getByTestId("active-instance-count")).toHaveText("0");
+  await page.keyboard.press("Control+Shift+z");
+  await expect(page.getByTestId("active-instance-count")).toHaveText("1");
+});
+
 test("shows the hierarchy row only once there is a hierarchy", async ({
   page,
 }) => {

--- a/apps/editor/src/agent/agent-capability-parity.test.ts
+++ b/apps/editor/src/agent/agent-capability-parity.test.ts
@@ -51,6 +51,73 @@ async function setup() {
 }
 
 describe("MCP → API → shared editor parity", () => {
+  it("places the original top in a new TB through public actions and retains normal history", async () => {
+    const { client, controller } = await setup();
+    expect(
+      (
+        await client.applyActions([
+          { kind: "create-cell", id: "tb", name: "Testbench" },
+        ])
+      ).ok,
+    ).toBe(true);
+    const placed = await client.applyActions(
+      [
+        {
+          kind: "place-cell",
+          childDocumentId: "main",
+          instanceId: "xdut",
+          reference: "XDUT",
+          placement: {
+            position: { x: 100, y: 100 },
+            rotation: 0,
+            mirror: "none",
+          },
+        },
+      ],
+      { documentId: "tb" },
+    );
+    expect(placed.ok, placed.message).toBe(true);
+    expect(controller.project.topDocumentId).toBe("main");
+    expect(controller.project.simulation).toBeUndefined();
+    const instance = controller.project.documents.find((d) => d.id === "tb")!
+      .instances[0]!;
+    expect(instance.netlist?.binding).toEqual({
+      kind: "subcircuit",
+      childDocumentId: "main",
+    });
+    expect(controller.resolver.resolve(instance.symbolId)).toBeTruthy();
+    expect(
+      (await client.applyActions([{ kind: "undo" }], { documentId: "tb" })).ok,
+    ).toBe(true);
+    expect(
+      controller.project.documents.find((d) => d.id === "tb")!.instances,
+    ).toHaveLength(0);
+    expect(
+      (await client.applyActions([{ kind: "redo" }], { documentId: "tb" })).ok,
+    ).toBe(true);
+    const bad = await client.applyActions(
+      [
+        {
+          kind: "place-cell",
+          childDocumentId: "tb",
+          instanceId: "loop",
+          placement: { position: { x: 0, y: 0 }, rotation: 0, mirror: "none" },
+        },
+      ],
+      { documentId: "main" },
+    );
+    expect(bad.ok).toBe(false);
+    expect(
+      controller.project.documents.find((d) => d.id === "main")!.instances,
+    ).toHaveLength(0);
+    expect(
+      (
+        await client.applyActions([
+          { kind: "rename-cell", id: "tb", name: "TB recovered" },
+        ])
+      ).ok,
+    ).toBe(true);
+  });
   it("places a retained Instance with the GUI's missing default labels", async () => {
     const { client, controller, add } = await setup();
     const id = await add();

--- a/apps/editor/src/agent/browser-agent-command.ts
+++ b/apps/editor/src/agent/browser-agent-command.ts
@@ -8,6 +8,8 @@ import {
   planInstanceUnplacement,
   planCellReset,
   planCreateCell,
+  createHierarchyInstance,
+  planPlaceCellInstance,
   planRenameCell,
   planDeleteCell,
   planEnsureNamedNet,
@@ -47,6 +49,33 @@ export function planBrowserAgentCommand(
   if (!document) throw new Error("Document not found");
   const sequence = document.revision + 1;
   switch (command.kind) {
+    case "place-cell": {
+      const child = project.documents.find(
+        (item) => item.id === command.childDocumentId,
+      );
+      if (!child?.netlist)
+        throw new Error("Cell needs a formal interface before placement");
+      const instance = createHierarchyInstance(
+        command.instanceId,
+        child,
+        command.placement,
+        command.reference,
+      );
+      const annotations = missingDefaultInstanceDisplayAnnotations(
+        document,
+        instance,
+        resolver,
+        resolveDocumentStyleProfile(document.presentation),
+      );
+      return {
+        structureEdits: planPlaceCellInstance(
+          project,
+          documentId,
+          instance,
+          annotations,
+        ),
+      };
+    }
     case "place-existing": {
       const instance = document.instances.find(
         (item) => item.id === command.instanceId,

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -11,6 +11,7 @@ import type {
 } from "@icm/agent-adapter";
 import {
   planCellReset,
+  planSetCellSymbolPresentation,
   type CellResetPlan,
   type WireSource,
 } from "@icm/edit-engine";
@@ -4237,6 +4238,16 @@ export function App({
                   setCellFormalParameters(formalParameters, documentId),
                 externalDefinitions: project.externalSubcircuitDefinitions,
                 onSetExternalDefinition: setExternalSubcircuitDefinition,
+                onSetSymbolPresentation: (documentId, presentation) => {
+                  commitStructure(
+                    "review-cell-symbol",
+                    planSetCellSymbolPresentation(
+                      project,
+                      documentId,
+                      presentation,
+                    ),
+                  );
+                },
               }
             : null
         }

--- a/apps/editor/src/features/hierarchy/cell-manager-dialog.tsx
+++ b/apps/editor/src/features/hierarchy/cell-manager-dialog.tsx
@@ -2,10 +2,12 @@ import { useEffect, useState } from "react";
 
 import type {
   ExternalSubcircuitDefinition,
+  CellSymbolPresentation,
   SchematicDocument,
 } from "@icm/model";
 
 import { CellInterfaceEditor } from "./cell-interface-dialog";
+import { CellSymbolReview } from "./cell-symbol-review";
 
 export interface CellManagerEntry {
   readonly id: string;
@@ -36,6 +38,7 @@ export function CellManagerDialog({
   onSetFormalParameters,
   externalDefinitions,
   onSetExternalDefinition,
+  onSetSymbolPresentation,
 }: {
   open: boolean;
   cells: readonly CellManagerEntry[];
@@ -62,6 +65,10 @@ export function CellManagerDialog({
   ): void;
   externalDefinitions: readonly ExternalSubcircuitDefinition[];
   onSetExternalDefinition(definition: ExternalSubcircuitDefinition): void;
+  onSetSymbolPresentation(
+    documentId: string,
+    presentation: CellSymbolPresentation | null,
+  ): void;
 }) {
   const [selectedId, setSelectedId] = useState(activeDocumentId);
   const [draftName, setDraftName] = useState("");
@@ -213,6 +220,13 @@ export function CellManagerDialog({
                   </div>
                 </header>
 
+                <CellSymbolReview
+                  key={`${selectedDocument.id}:${selectedDocument.revision}`}
+                  cell={selectedDocument}
+                  onApply={(presentation) =>
+                    onSetSymbolPresentation(selectedDocument.id, presentation)
+                  }
+                />
                 <CellInterfaceEditor
                   cell={selectedDocument}
                   callerCount={selectedEntry.callers.length}

--- a/apps/editor/src/features/hierarchy/cell-symbol-review.tsx
+++ b/apps/editor/src/features/hierarchy/cell-symbol-review.tsx
@@ -1,0 +1,154 @@
+import { useState } from "react";
+import {
+  CellSymbolPresentationSchema,
+  projectCellInterface,
+  type CellSymbolPresentation,
+  type SchematicDocument,
+} from "@icm/model";
+import { createHierarchicalBlockSymbol } from "@icm/symbols";
+import { SymbolArtwork } from "../component-insert/symbol-artwork";
+
+/** Definition preview: never manufacture a caller just to edit its master. */
+export function CellSymbolReview({
+  cell,
+  onApply,
+}: {
+  cell: SchematicDocument;
+  onApply(presentation: CellSymbolPresentation | null): void;
+}) {
+  const [draft, setDraft] = useState<CellSymbolPresentation>(
+    cell.presentation.cellSymbol ?? {},
+  );
+  const [error, setError] = useState("");
+  const ports = projectCellInterface(cell.netlist).ports;
+  const parsed = CellSymbolPresentationSchema.safeParse(draft);
+  const symbol = parsed.success
+    ? createHierarchicalBlockSymbol({
+        ...cell,
+        presentation: { ...cell.presentation, cellSymbol: parsed.data },
+      })
+    : null;
+  const setPin = (id: string, side: string, offset: number) => {
+    const placements =
+      draft.pinPlacements?.filter((p) => p.terminalId !== id) ?? [];
+    if (side !== "auto")
+      placements.push({
+        terminalId: id,
+        side: side as "west" | "east" | "north" | "south",
+        offset,
+      });
+    setDraft({ ...draft, pinPlacements: placements });
+  };
+  if (!cell.netlist)
+    return <p>Create a formal Cell interface before using it as a DUT.</p>;
+  return (
+    <details className="cell-symbol-review">
+      <summary>Review Symbol</summary>
+      <p>
+        Preview only until Apply. Pin order and electrical connections do not
+        change.
+      </p>
+      {ports.length === 0 && <p>This Cell has a valid zero-port interface.</p>}
+      <div style={{ width: 300, maxWidth: "100%", height: 170 }}>
+        {symbol && (
+          <SymbolArtwork
+            symbol={symbol}
+            className="cell-symbol-review-artwork"
+          />
+        )}
+      </div>
+      <div>
+        {(["width", "height"] as const).map((axis) => (
+          <label key={axis}>
+            Minimum body {axis}
+            <input
+              aria-label={`Symbol ${axis}`}
+              type="number"
+              min="10"
+              step="10"
+              value={draft.minimumBodySize?.[axis] ?? ""}
+              placeholder="Auto"
+              onChange={(e) =>
+                setDraft({
+                  ...draft,
+                  minimumBodySize:
+                    e.target.value === ""
+                      ? undefined
+                      : {
+                          width: draft.minimumBodySize?.width ?? 80,
+                          height: draft.minimumBodySize?.height ?? 40,
+                          [axis]: Number(e.target.value),
+                        },
+                })
+              }
+            />
+          </label>
+        ))}
+      </div>
+      {ports.map((port) => {
+        const pin = draft.pinPlacements?.find((p) => p.terminalId === port.id);
+        return (
+          <div key={port.id}>
+            <label>
+              {port.name} side{" "}
+              <select
+                aria-label={`${port.name} symbol side`}
+                value={pin?.side ?? "auto"}
+                onChange={(e) =>
+                  setPin(port.id, e.target.value, pin?.offset ?? 0)
+                }
+              >
+                {["auto", "west", "east", "north", "south"].map((side) => (
+                  <option key={side}>{side}</option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Offset{" "}
+              <input
+                aria-label={`${port.name} symbol offset`}
+                type="number"
+                step="10"
+                disabled={!pin}
+                value={pin?.offset ?? 0}
+                onChange={(e) =>
+                  setPin(port.id, pin?.side ?? "auto", Number(e.target.value))
+                }
+              />
+            </label>
+          </div>
+        );
+      })}
+      <p role="status">
+        {!parsed.success ? parsed.error.issues[0]?.message : error}
+      </p>
+      <button
+        type="button"
+        disabled={!parsed.success}
+        onClick={() => {
+          try {
+            if (parsed.success) onApply(parsed.data);
+            setError("");
+          } catch (cause) {
+            setError(
+              cause instanceof Error
+                ? cause.message
+                : "Could not update Symbol",
+            );
+          }
+        }}
+      >
+        Apply Symbol
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setDraft({});
+          onApply(null);
+        }}
+      >
+        Use default Symbol
+      </button>
+    </details>
+  );
+}

--- a/docs/user/schematic-hierarchy.md
+++ b/docs/user/schematic-hierarchy.md
@@ -77,6 +77,19 @@ symbol layout on canvas** reveals explicit drag grips for the body and pins;
 the Properties values remain the precise fallback. These are definition operations,
 not top-level drawing tools.
 
+Before the first Instance exists, **Manage Cells… → Review Symbol** previews
+the selected Cell definition using the same derived artwork. Size and pin
+changes stay local until **Apply Symbol**; **Use default Symbol** removes the
+explicit presentation. An unreferenced top Cell is reusable too: create another
+ordinary Cell, then use **Place Cell** to place the original top there. The
+Project top does not change. A valid zero-port interface is allowed; an absent
+formal interface must be authored first.
+
+Agents use the existing `create-cell` action and `place-cell` with
+`childDocumentId`, `instanceId`, optional `reference`, and `placement`, targeting
+the parent Document. The same Project transaction owns validation and history;
+these actions do not create or modify a SimulationSetup.
+
 Hierarchy presentation is saved as definition-level size and pin-placement
 intent in current Project schema 26. Schema-25 projects open through the
 bounded upgrade; schema-23 and older files remain unsupported. The block uses

--- a/packages/agent-adapter/src/authoring-command.ts
+++ b/packages/agent-adapter/src/authoring-command.ts
@@ -16,6 +16,13 @@ const SelectionSchema = z.strictObject({
 });
 export const AgentAuthoringCommandSchema = z.discriminatedUnion("kind", [
   z.strictObject({
+    kind: z.literal("place-cell"),
+    childDocumentId: StableIdSchema,
+    instanceId: StableIdSchema,
+    reference: z.string().min(1).max(128).optional(),
+    placement: PlacementSchema,
+  }),
+  z.strictObject({
     kind: z.literal("place-existing"),
     instanceId: StableIdSchema,
     placement: PlacementSchema,

--- a/packages/agent-client/src/authoring-helper.ts
+++ b/packages/agent-client/src/authoring-helper.ts
@@ -416,6 +416,7 @@ export function compileActions(
     switch (action.kind) {
       case "set-model":
       case "place-existing":
+      case "place-cell":
       case "set-net-label":
       case "transform":
       case "copy":

--- a/packages/symbols/src/hierarchical-block.test.ts
+++ b/packages/symbols/src/hierarchical-block.test.ts
@@ -10,6 +10,18 @@ import {
 } from "./hierarchical-block.js";
 
 describe("hierarchical block formal terminals", () => {
+  it("derives an unreferenced manual top before its first placement without persisting defaults", () => {
+    const project = createEmptyProject("p", "Top", "dut");
+    const before = JSON.stringify(project);
+    expect(createProjectHierarchicalSymbols(project)).toEqual([
+      expect.objectContaining({
+        name: project.documents[0]!.name,
+        hierarchicalBlock: true,
+        pins: [],
+      }),
+    ]);
+    expect(JSON.stringify(project)).toBe(before);
+  });
   it("derives pins only from the private formal cell interface", () => {
     const symbol = createHierarchicalBlockSymbol({
       name: "Child",

--- a/packages/symbols/src/hierarchical-block.ts
+++ b/packages/symbols/src/hierarchical-block.ts
@@ -42,22 +42,9 @@ export function createProjectHierarchicalSymbols(
     Partial<Pick<CircuitProject, "externalSubcircuitDefinitions">>,
   baseDefinitions: readonly SymbolDefinition[] = [],
 ): SymbolDefinition[] {
-  const referencedChildIds = new Set(
-    project.documents.flatMap((document) =>
-      document.instances.flatMap((instance) => {
-        const binding = instance.netlist?.binding;
-        return binding?.kind === "subcircuit" ? [binding.childDocumentId] : [];
-      }),
-    ),
-  );
   const internal = project.documents.flatMap((document) => {
-    if (
-      document.id === project.topDocumentId &&
-      !document.sourceBinding &&
-      !referencedChildIds.has(document.id)
-    ) {
-      return [];
-    }
+    // Top is an entry point, not a restriction on Cell reuse. First placement
+    // and definition preview must resolve before a caller exists.
     const definition = createHierarchicalBlockSymbol(document);
     return definition ? [definition] : [];
   });


### PR DESCRIPTION
Implements the bounded F1R-MVP from v13 and #585: review a formal Cell symbol before its first caller, including a never-instantiated top, then reuse that Cell in an ordinary testbench through existing hierarchy/history. Adds public create-cell/place-cell authoring parity; no new TB or simulation schema. Does not include benchmark/Profile acceptance or cross-Project publication. Validation: focused 53 unit contracts, hierarchy browser 15/15, frozen install, preflight and full gate passed (2608 unit passed, 26 skipped; 351 browser passed; static/build/release/performance). Stacked GUI work will follow separately. Do not auto-merge.