### PR TITLE
feat(editor): add minimal shared-service analog simulation UI

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -14,7 +14,216 @@ const profile = JSON.parse(
     "utf8",
   ),
 ) as { id: string };
-import { openMenu } from "./editor-fixtures.js";
+import { openMenu, downloadBytes } from "./editor-fixtures.js";
+import { CircuitProjectSchema } from "@icm/model";
+import ota from "../src/examples/five-transistor-ota-sky130.icproj.json";
+
+test("human simulation uses saved setup, survives closing, recovers a bad input and exports results", async ({
+  page,
+}) => {
+  const project = CircuitProjectSchema.parse(ota);
+  project.simulation = {
+    version: 1,
+    input: {
+      kind: "structured",
+      rootDocumentId: project.topDocumentId,
+      analyses: [
+        { kind: "op" },
+        { kind: "ac", sweep: "dec", points: 10, startHz: 1, stopHz: 1e6 },
+      ],
+      probes: [
+        {
+          id: "out",
+          kind: "net-voltage",
+          documentId: project.topDocumentId,
+          netId: "missing-net",
+          occurrence: [],
+        },
+      ],
+      environment: { profileId: profile.id },
+    },
+  };
+  let calls = 0,
+    executions = 0,
+    cancellations = 0;
+  let release = () => {};
+  let pending = new Promise<void>((r) => {
+    release = r;
+  });
+  await page.route("**/api/simulate", async (route) => {
+    calls++;
+    const body = route.request().postDataJSON();
+    if (body.operation === "capabilities")
+      return route.fulfill({
+        json: {
+          configured: true,
+          inputs: ["structured", "raw"],
+          analyses: ["op", "ac"],
+          parsedAnalyses: ["op", "ac", "tran"],
+          profiles: [{ id: profile.id, corners: ["tt"] }],
+          maxTimeoutMs: 120000,
+          maxInputBytes: 1048576,
+          cancel: true,
+        },
+      });
+    if (body.operation === "cancel") {
+      cancellations++;
+      release();
+      return route.fulfill({ json: { ok: true } });
+    }
+    executions++;
+    await pending;
+    const rawfile = readFileSync(
+      new URL(
+        "../../../fixtures/ngspice-rawfile/divider-op.raw",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    const reading = readSimulationData(rawfile);
+    if (reading.status !== "read") throw Error("raw fixture");
+    await route.fulfill({
+      json: {
+        outcome: { status: "completed" },
+        diagnostics: [],
+        log: "ngspice OP",
+        durationMs: 1,
+        data: {
+          ...reading.data,
+          analyses: [
+            ...reading.data.analyses,
+            {
+              analysis: "ac",
+              plotName: "AC response",
+              frequencyHz: [1, 10, 100],
+              probes: [
+                {
+                  name: "v(out)",
+                  quantity: "voltage",
+                  unit: "V",
+                  real: [10, 7, 1],
+                  imag: [0, -3, -1],
+                },
+              ],
+            },
+          ],
+        },
+        rawfile,
+        executedDeck: body.preparedDeck,
+        cancelled: cancellations > 0,
+        metadata: {
+          schemaVersion: 1,
+          input: await createSimulationInputMetadata({
+            inputRevision: body.inputRevision,
+            netlist: body.netlist,
+            testbench: body.testbench,
+            deck: body.preparedDeck,
+          }),
+          configuration: { modelLibrary: null },
+          environment: await createSimulationEnvironmentMetadata({
+            executor: "local-host",
+            reproducibility: "observed",
+            profileId: profile.id,
+            platform: "linux/x64",
+            simulator: { name: "ngspice", version: "47", binarySha256: null },
+            models: null,
+            startupSha256: null,
+          }),
+        },
+      },
+    });
+  });
+  await page.goto("/editor");
+  await page.getByTestId("project-file").setInputFiles({
+    name: "simulation.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(project)),
+  });
+  await expect(page.getByTestId("schematic-canvas")).toBeVisible();
+  expect(calls).toBe(0);
+  await page.getByTestId("open-analog-simulation").click();
+  const panel = page.getByRole("region", { name: "Analog simulation" });
+  await panel.getByRole("button", { name: "Run", exact: true }).click();
+  await expect(panel.getByRole("alert")).toContainText(/PROBE|probe/);
+  expect(executions).toBe(0);
+  await panel.getByText("Setup", { exact: true }).click();
+  await panel.getByRole("button", { name: "Remove probe" }).click();
+  await panel.getByLabel("Add voltage probe").selectOption("tb-vout-net");
+  await panel.getByRole("button", { name: "Apply setup" }).click();
+  await panel.getByRole("button", { name: "Run", exact: true }).click();
+  await expect.poll(() => executions).toBe(1);
+  await panel.getByRole("button", { name: "Close simulation" }).click();
+  expect(cancellations).toBe(0);
+  release();
+  await page.getByTestId("open-analog-simulation").click();
+  await expect(panel.getByRole("status")).toHaveText("finished · completed");
+  await expect(panel.getByRole("region", { name: "OP results" })).toContainText(
+    "0.500000",
+  );
+  await expect(panel.locator(".spice-ac-plot svg")).toHaveCount(1);
+  const download = page.waitForEvent("download");
+  await panel
+    .getByRole("button", { name: /\.csv$/ })
+    .first()
+    .click();
+  expect((await download).suggestedFilename()).toMatch(/\.csv$/);
+  await panel.getByText("Setup", { exact: true }).click();
+  await panel.getByLabel("Temperature (°C)").fill("30");
+  await panel.getByRole("button", { name: "Apply setup" }).click();
+  await expect(panel.getByRole("alert")).toContainText(
+    "earlier Project revision",
+  );
+  pending = new Promise<void>((r) => {
+    release = r;
+  });
+  await panel.getByRole("button", { name: "Run", exact: true }).click();
+  await expect.poll(() => executions).toBe(2);
+  await panel.getByRole("button", { name: "Cancel run" }).click();
+  await expect(panel.getByRole("status")).toContainText("cancelled");
+  expect(cancellations).toBe(1);
+  await panel.getByRole("button", { name: "Close simulation" }).click();
+  const saved = await downloadBytes(page, "File", "Export Project File…");
+  expect(
+    JSON.parse(saved.toString()).simulation.input.environment.temperatureC,
+  ).toBe(30);
+  await page.reload();
+  // Explicit import is the persistence contract, not browser recovery heuristics.
+  await page.getByTestId("project-file").setInputFiles({
+    name: "saved.icproj.json",
+    mimeType: "application/json",
+    buffer: saved,
+  });
+  await page.getByTestId("open-analog-simulation").click();
+  await panel.getByText("Setup", { exact: true }).click();
+  await expect(panel.getByLabel("Temperature (°C)")).toHaveValue("30");
+  await expect(panel.getByRole("status")).toHaveText("No run yet");
+});
+
+test("Simulation creates an ordinary testbench and offers the current Cell at the cursor", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  await page.getByTestId("open-analog-simulation").click();
+  await page
+    .getByRole("button", { name: "New testbench from current Cell" })
+    .click();
+  await page
+    .getByTestId("schematic-canvas")
+    .click({ position: { x: 320, y: 180 } });
+  await page.keyboard.press("Escape");
+  const saved = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(),
+  );
+  const tb = saved.documents.find(
+    (d: { name: string }) => d.name === "Main_tb",
+  );
+  expect(tb.instances[0].netlist.binding).toEqual({
+    kind: "subcircuit",
+    childDocumentId: "document-main",
+  });
+  expect(saved.topDocumentId).toBe("document-main");
+  expect(saved.simulation).toBeUndefined();
+});
 
 test("Agent raw simulation recovers input errors, returns a run receipt and exports through Files", async ({
   page,

--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -13,7 +13,7 @@ const profile = JSON.parse(
     ),
     "utf8",
   ),
-) as { id: string };
+) as { id: string; simulator: { version: string } };
 import { openMenu, downloadBytes } from "./editor-fixtures.js";
 import { CircuitProjectSchema } from "@icm/model";
 const ota = JSON.parse(
@@ -25,6 +25,89 @@ const ota = JSON.parse(
     "utf8",
   ),
 );
+
+test("the qualified OTA setup opens unchanged and preserves all root and hierarchical probes", async ({
+  page,
+}) => {
+  const project = CircuitProjectSchema.parse(ota);
+  expect(project.simulation!.input.probes).toHaveLength(4);
+  expect(
+    project.simulation!.input.probes.filter((p) => p.occurrence.length > 0),
+  ).toHaveLength(2);
+  let executions = 0;
+  await page.route("**/api/simulate", async (route) => {
+    if (route.request().postDataJSON().operation !== "capabilities") {
+      executions++;
+      return route.abort();
+    }
+    return route.fulfill({
+      json: {
+        configured: true,
+        inputs: ["structured", "raw"],
+        analyses: ["op", "ac"],
+        parsedAnalyses: ["op", "ac", "tran"],
+        profiles: [{ id: profile.id, corners: ["tt"] }],
+        maxTimeoutMs: 120000,
+        maxInputBytes: 1048576,
+        cancel: true,
+      },
+    });
+  });
+  await page.goto("/editor");
+  await page.getByTestId("project-file").setInputFiles({
+    name: "qualified-ota.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(project)),
+  });
+  await page
+    .getByRole("button", { name: "Analog simulation", exact: true })
+    .click();
+  const panel = page.getByRole("region", { name: "Analog simulation" });
+  await panel.getByText("Setup", { exact: true }).click();
+  await expect(panel.getByLabel("Testbench Cell")).toHaveValue(
+    project.simulation!.input.rootDocumentId,
+  );
+  await expect(panel.getByLabel("Stop (Hz)")).toHaveValue("1000000000");
+  await expect(panel.getByLabel("Environment profile")).toHaveValue(profile.id);
+  await expect(panel.getByRole("button", { name: "Remove probe" })).toHaveCount(
+    4,
+  );
+  await expect(
+    panel.getByText("net-dut-tail (XDUT)", { exact: false }),
+  ).toBeVisible();
+  await panel.getByRole("button", { name: "Apply setup" }).click();
+  await panel.getByRole("button", { name: "Prepare deck" }).click();
+  const deckDownload = page.waitForEvent("download");
+  await panel
+    .getByRole("button", { name: "prepared.cir", exact: true })
+    .click();
+  const stream = await (await deckDownload).createReadStream();
+  let deck = "";
+  for await (const chunk of stream!) deck += chunk.toString();
+  for (const vector of ["v(vout)", "v(ibias)", "v(xdut.tail)", "v(xdut.nleft)"])
+    expect(deck).toContain(vector);
+  expect(deck).toMatch(/ac dec 10 1 (?:1000000000|1e\+?9)/i);
+  expect(executions).toBe(0);
+  await panel.getByRole("button", { name: "Close simulation" }).click();
+  const saved = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(),
+  );
+  expect(saved.simulation).toEqual(project.simulation);
+  await page.reload();
+  await page.getByTestId("project-file").setInputFiles({
+    name: "reopened.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(JSON.stringify(saved)),
+  });
+  await page
+    .getByRole("button", { name: "Analog simulation", exact: true })
+    .click();
+  await panel.getByText("Setup", { exact: true }).click();
+  await expect(panel.getByRole("button", { name: "Remove probe" })).toHaveCount(
+    4,
+  );
+  await expect(panel.getByLabel("Stop (Hz)")).toHaveValue("1000000000");
+});
 
 test("human simulation uses saved setup, survives closing, recovers a bad input and exports results", async ({
   page,
@@ -133,7 +216,11 @@ test("human simulation uses saved setup, survives closing, recovers a bad input 
             reproducibility: "observed",
             profileId: profile.id,
             platform: "linux/x64",
-            simulator: { name: "ngspice", version: "47", binarySha256: null },
+            simulator: {
+              name: "ngspice",
+              version: profile.simulator.version,
+              binarySha256: null,
+            },
             models: null,
             startupSha256: null,
           }),
@@ -333,7 +420,11 @@ test("Agent raw simulation recovers input errors, returns a run receipt and expo
             reproducibility: "observed",
             profileId: profile.id,
             platform: "linux/x64",
-            simulator: { name: "ngspice", version: "47", binarySha256: null },
+            simulator: {
+              name: "ngspice",
+              version: profile.simulator.version,
+              binarySha256: null,
+            },
             models: null,
             startupSha256: null,
           }),

--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -177,6 +177,18 @@ test("human simulation uses saved setup, survives closing, recovers a bad input 
     .first()
     .click();
   expect((await download).suggestedFilename()).toMatch(/\.csv$/);
+  const oldRunIdentity = await panel
+    .getByLabel("Run evidence")
+    .locator("small")
+    .innerText();
+  await panel.getByRole("button", { name: "Prepare deck" }).click();
+  await expect(
+    panel.getByLabel("Prepared input").locator("small"),
+  ).not.toHaveText(oldRunIdentity.split(" / prepared ")[1]!);
+  await expect(panel.getByLabel("Run evidence").locator("small")).toHaveText(
+    oldRunIdentity,
+  );
+  expect(executions).toBe(1);
   await panel.getByText("Setup", { exact: true }).click();
   await panel.getByLabel("Temperature (°C)").fill("30");
   await panel.getByRole("button", { name: "Apply setup" }).click();

--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -16,7 +16,15 @@ const profile = JSON.parse(
 ) as { id: string };
 import { openMenu, downloadBytes } from "./editor-fixtures.js";
 import { CircuitProjectSchema } from "@icm/model";
-import ota from "../src/examples/five-transistor-ota-sky130.icproj.json";
+const ota = JSON.parse(
+  readFileSync(
+    new URL(
+      "../src/examples/five-transistor-ota-sky130.icproj.json",
+      import.meta.url,
+    ),
+    "utf8",
+  ),
+);
 
 test("human simulation uses saved setup, survives closing, recovers a bad input and exports results", async ({
   page,
@@ -223,6 +231,8 @@ test("Simulation creates an ordinary testbench and offers the current Cell at th
   });
   expect(saved.topDocumentId).toBe("document-main");
   expect(saved.simulation).toBeUndefined();
+  await page.getByTestId("open-analog-simulation").click();
+  await expect(page.getByLabel("Testbench Cell")).toHaveValue(tb.id);
 });
 
 test("Agent raw simulation recovers input errors, returns a run receipt and exports through Files", async ({

--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -149,7 +149,9 @@ test("human simulation uses saved setup, survives closing, recovers a bad input 
   });
   await expect(page.getByTestId("schematic-canvas")).toBeVisible();
   expect(calls).toBe(0);
-  await page.getByTestId("open-analog-simulation").click();
+  await page
+    .getByRole("button", { name: "Analog simulation", exact: true })
+    .click();
   const panel = page.getByRole("region", { name: "Analog simulation" });
   await panel.getByRole("button", { name: "Run", exact: true }).click();
   await expect(panel.getByRole("alert")).toContainText(/PROBE|probe/);

--- a/apps/editor/src/agent/browser-agent-simulation-host.ts
+++ b/apps/editor/src/agent/browser-agent-simulation-host.ts
@@ -3,82 +3,30 @@ import {
   type AgentSimulationResourceRequest,
   type AgentSimulationResourceResponse,
 } from "@icm/agent-adapter";
-import type { CircuitProject } from "@icm/model";
-import type {
-  SimulationFiles,
-  SimulationService,
-} from "@icm/simulation-service";
-export interface BrowserAgentSimulationHostOptions {
-  getProjectSessionId: () => string;
-  getProject: () => CircuitProject;
-  files: SimulationFiles;
-  fetch?: typeof fetch;
-}
-/** Live Project adapter; domain behavior belongs to the shared service. */
+import {
+  BrowserSimulationSession,
+  type BrowserSimulationSessionOptions,
+} from "../features/simulation/browser-simulation-session";
+
+export type BrowserAgentSimulationHostOptions = BrowserSimulationSessionOptions;
+/** Transport/auth facade only; GUI and Agent use identical service semantics. */
 export class BrowserAgentSimulationHost {
-  private service: Promise<SimulationService> | undefined;
-  private boundProjectSessionId: string;
-  constructor(private options: BrowserAgentSimulationHostOptions) {
-    this.boundProjectSessionId = options.getProjectSessionId();
+  private session: BrowserSimulationSession;
+  constructor(options: BrowserAgentSimulationHostOptions) {
+    this.session = new BrowserSimulationSession(options);
   }
-  async clear() {
-    const service = this.service;
-    this.service = undefined;
-    await service?.then(
-      (host) => host.clear(),
-      () => {},
-    );
+  clear() {
+    return this.session.clear();
   }
   async handle(
     request: AgentSimulationResourceRequest,
   ): Promise<AgentSimulationResourceResponse> {
     const { apiVersion: _version, requestId, ...operation } = request;
-    if (this.options.getProjectSessionId() !== this.boundProjectSessionId)
-      return {
-        apiVersion: AGENT_API_VERSION,
-        requestId,
-        operation: operation.operation,
-        ok: false,
-        error: {
-          code: "PROJECT_REPLACED",
-          message: "The bound Project changed",
-          stage: "input",
-          recovery: "reauthorize",
-        },
-      };
-    try {
-      this.service ??= import("@icm/simulation-service").then(
-        ({ SimulationService, createHostedExecutor }) =>
-          new SimulationService(
-            this.options.files,
-            createHostedExecutor(
-              this.options.fetch ?? ((...args) => globalThis.fetch(...args)),
-            ),
-            this.options.getProject,
-          ),
-      );
-      const result = await (await this.service).handle(operation, requestId);
-      return {
-        ...result,
-        apiVersion: AGENT_API_VERSION,
-        requestId,
-        operation: operation.operation,
-      };
-    } catch {
-      this.service = undefined;
-      return {
-        apiVersion: AGENT_API_VERSION,
-        requestId,
-        operation: operation.operation,
-        ok: false,
-        error: {
-          code: "SIMULATION_HOST_UNAVAILABLE",
-          message:
-            "The simulation module could not load. The editor session remains available.",
-          stage: "read",
-          recovery: "retry-after",
-        },
-      };
-    }
+    return {
+      ...(await this.session.handle(operation, requestId)),
+      apiVersion: AGENT_API_VERSION,
+      requestId,
+      operation: operation.operation,
+    };
   }
 }

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -11,6 +11,7 @@ import type {
 } from "@icm/agent-adapter";
 import {
   planCellReset,
+  planCreateCell,
   planSetCellSymbolPresentation,
   type CellResetPlan,
   type WireSource,
@@ -33,7 +34,7 @@ import {
   resolveRouteAttachment,
 } from "@icm/derived";
 import type { HierarchyFrame } from "@icm/derived";
-import { createEmptyProject } from "@icm/model";
+import { createEmptyProject, createEmptyDocument, createId } from "@icm/model";
 import {
   resolveReviewedExternalBinding,
   reviewedExternalModelSuggestions,
@@ -218,6 +219,7 @@ import { recoveryStateLabel } from "../components/recovery-banners";
 import { BrowserAgentHost } from "../agent/browser-agent-host";
 import { BrowserAgentFileHost } from "../agent/browser-agent-file-host";
 import { BrowserAgentSimulationHost } from "../agent/browser-agent-simulation-host";
+import { BrowserSimulationSession } from "../features/simulation/browser-simulation-session";
 import { createAgentSemanticIntentHandler } from "../agent/agent-semantic-intent-handler";
 import { PUBLIC_AGENT_UI_ENABLED } from "../agent/public-agent-ui";
 import { useAgentSession } from "../agent/use-agent-session";
@@ -652,6 +654,22 @@ export function App({
         getProject: () => editorDocumentController.project,
       }),
     [editorDocumentController, projectSessionId],
+  );
+  const [analogSimulationOpened, setAnalogSimulationOpened] = useState(false);
+  const [analogSimulationOpen, setAnalogSimulationOpen] = useState(false);
+  const humanSimulationSession = useMemo(
+    () =>
+      new BrowserSimulationSession({
+        getProjectSessionId: () => editorDocumentController.projectSessionId,
+        getProject: () => editorDocumentController.project,
+      }),
+    [editorDocumentController, projectSessionId],
+  );
+  useEffect(
+    () => () => {
+      void humanSimulationSession.clear();
+    },
+    [humanSimulationSession],
   );
   const {
     cloudBinding,
@@ -3808,6 +3826,10 @@ export function App({
     <main className="app-shell">
       {renderCrashRequested() ? <RenderCrashProbe /> : null}
       <EditorAppChrome
+        simulationAction={() => {
+          setAnalogSimulationOpened(true);
+          setAnalogSimulationOpen(true);
+        }}
         releaseChannel={releaseChannel}
         projectName={project.name}
         projectSchemaVersion={project.schemaVersion}
@@ -4075,6 +4097,63 @@ export function App({
         }}
       />
       <EditorDialogLayer
+        simulation={
+          analogSimulationOpened
+            ? {
+                sessionKey: projectSessionId,
+                session: humanSimulationSession,
+                project,
+                activeDocumentId: document.id,
+                open: analogSimulationOpen,
+                onClose: () => setAnalogSimulationOpen(false),
+                onSaveSetup: (setup) =>
+                  commitStructure("set-simulation-setup", [
+                    { kind: "set_simulation_setup", setup },
+                  ]),
+                onOpenCell: (id) => switchDocument(id),
+                onCreateTestbench: () => {
+                  let name = `${document.name}_tb`;
+                  for (
+                    let i = 2;
+                    project.documents.some((d) => d.name === name);
+                    i++
+                  )
+                    name = `${document.name}_tb_${i}`;
+                  const tb = createEmptyDocument(createId("document"), name);
+                  tb.netlist!.name = name;
+                  tb.presentation = structuredClone(document.presentation);
+                  if (
+                    commitStructure(
+                      "create-testbench-cell",
+                      planCreateCell(tb),
+                      tb.id,
+                    )
+                  ) {
+                    setDocumentStack([]);
+                    setAnalogSimulationOpen(false);
+                    const cellName =
+                      document.sourceBinding?.cellName ??
+                      document.netlist?.name ??
+                      document.name;
+                    beginComponentPlacement({
+                      kind: "cell",
+                      symbolId: hierarchicalSymbolId(cellName),
+                      childDocumentId: document.id,
+                      cellName,
+                      parameters: {},
+                      initialRotation: 0,
+                      showReference: true,
+                      referenceText: null,
+                      showValue: true,
+                    });
+                    setStatus(
+                      `Created ${name}. Click to place ${cellName}; configure Simulation setup when ready.`,
+                    );
+                  }
+                },
+              }
+            : undefined
+        }
         help={
           helpOpen ? { closeButtonRef: helpCloseRef, onClose: closeHelp } : null
         }

--- a/apps/editor/src/app/editor-app-chrome.tsx
+++ b/apps/editor/src/app/editor-app-chrome.tsx
@@ -306,6 +306,7 @@ export function EditorAppChrome({
               <button
                 type="button"
                 data-testid="open-analog-simulation"
+                aria-label="Analog simulation"
                 onClick={simulationAction}
               >
                 Simulation

--- a/apps/editor/src/app/editor-app-chrome.tsx
+++ b/apps/editor/src/app/editor-app-chrome.tsx
@@ -54,6 +54,7 @@ export interface EditorAppChromeProps {
   onOpenInstanceTable: () => void;
   onOpenNetlistPreflight: () => void;
   agentAction: { label: string; execute: () => void } | null;
+  simulationAction?: () => void;
   publishGalleryOpen: boolean;
   onPublishGallery: () => void;
   helpButtonRef: RefObject<HTMLButtonElement | null>;
@@ -95,6 +96,7 @@ export function EditorAppChrome({
   onOpenInstanceTable,
   onOpenNetlistPreflight,
   agentAction,
+  simulationAction,
   publishGalleryOpen,
   onPublishGallery,
   helpButtonRef,
@@ -300,6 +302,15 @@ export function EditorAppChrome({
                 </button>
               </div>
             </details>
+            {simulationAction ? (
+              <button
+                type="button"
+                data-testid="open-analog-simulation"
+                onClick={simulationAction}
+              >
+                Simulation
+              </button>
+            ) : null}
             {agentAction ? (
               <details className="command-menu" name="editor-command-menu">
                 <summary>Agent</summary>

--- a/apps/editor/src/app/editor-dialog-layer.tsx
+++ b/apps/editor/src/app/editor-dialog-layer.tsx
@@ -10,6 +10,7 @@ import {
 } from "../components/recovery-banners";
 import {
   LazyCellManagerDialog,
+  LazySpiceSimulationSurface,
   LazyConnectAgentPanel,
   LazyEditorHelpDialog,
   LazyInsertComponentDialog,
@@ -23,6 +24,11 @@ import {
 } from "./lazy-editor-dialogs";
 
 export interface EditorDialogLayerProps {
+  simulation?:
+    | (ComponentProps<typeof LazySpiceSimulationSurface> & {
+        sessionKey: string;
+      })
+    | undefined;
   help: ComponentProps<typeof LazyEditorHelpDialog> | null;
   chunkLoadFailure: ComponentProps<typeof ChunkLoadBanner> | null;
   recoveryFailure: ComponentProps<typeof RecoveryFailureBanner> | null;
@@ -52,6 +58,7 @@ export interface EditorDialogLayerProps {
 
 /** All modal/overlay UI kept outside the persistent editor workspace. */
 export function EditorDialogLayer({
+  simulation,
   help,
   chunkLoadFailure,
   recoveryFailure,
@@ -72,6 +79,12 @@ export function EditorDialogLayer({
   return (
     <>
       <Suspense fallback={null}>
+        {simulation ? (
+          <LazySpiceSimulationSurface
+            key={simulation.sessionKey}
+            {...simulation}
+          />
+        ) : null}
         {help ? <LazyEditorHelpDialog {...help} /> : null}
         {chunkLoadFailure ? <ChunkLoadBanner {...chunkLoadFailure} /> : null}
         {recoveryFailure ? (

--- a/apps/editor/src/app/lazy-editor-dialogs.ts
+++ b/apps/editor/src/app/lazy-editor-dialogs.ts
@@ -31,6 +31,12 @@ export const LazyCellManagerDialog = lazyChunk("dialog", () =>
   })),
 );
 
+export const LazySpiceSimulationSurface = lazyChunk("inline", () =>
+  import("../features/simulation/spice-simulation-surface").then((module) => ({
+    default: module.SpiceSimulationSurface,
+  })),
+);
+
 export const LazyNetlistPreflightDialog = lazyChunk("dialog", () =>
   import("../features/netlist-export/netlist-preflight-dialog").then(
     (module) => ({ default: module.NetlistPreflightDialog }),

--- a/apps/editor/src/features/simulation/browser-simulation-session.test.ts
+++ b/apps/editor/src/features/simulation/browser-simulation-session.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { createEmptyProject } from "@icm/model";
+import { BrowserSimulationSession } from "./browser-simulation-session";
+
+describe("browser simulation ownership", () => {
+  it("loads only on demand, keeps failures recoverable, and isolates owners", async () => {
+    const project = createEmptyProject("project", "Project");
+    const fetch = vi.fn<typeof globalThis.fetch>().mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            configured: true,
+            inputs: ["structured", "raw"],
+            analyses: ["op", "ac"],
+            parsedAnalyses: ["op", "ac", "tran"],
+            profiles: [],
+            maxTimeoutMs: 10000,
+            maxInputBytes: 10000,
+            cancel: true,
+          }),
+        ),
+    );
+    const options = {
+      getProject: () => project,
+      getProjectSessionId: () => "project",
+      fetch,
+    };
+    const human = new BrowserSimulationSession(options);
+    const agent = new BrowserSimulationSession(options);
+    expect(fetch).not.toHaveBeenCalled();
+    const artifact = await human.files.put(
+      "deck.cir",
+      "text/plain",
+      "test\n.end",
+    );
+    await agent.clear();
+    expect(
+      await human.files.handle({ action: "artifact", artifactId: artifact.id }),
+    ).toMatchObject({ ok: true, text: "test\n.end" });
+    expect(
+      await human.handle({
+        operation: "prepare",
+        source: { kind: "structured" },
+      }),
+    ).toMatchObject({ ok: false, error: { code: "SIMULATION_SETUP_MISSING" } });
+    expect(await human.handle({ operation: "capabilities" })).toMatchObject({
+      ok: true,
+    });
+    await human.clear();
+    expect(
+      await human.files.handle({ action: "artifact", artifactId: artifact.id }),
+    ).toMatchObject({ ok: false });
+  });
+  it("rejects work bound to a replaced Project without touching the new Project", async () => {
+    let id = "first";
+    const fetch = vi.fn<typeof globalThis.fetch>();
+    const session = new BrowserSimulationSession({
+      getProject: () => createEmptyProject("project", "Project"),
+      getProjectSessionId: () => id,
+      fetch,
+    });
+    id = "second";
+    expect(await session.handle({ operation: "capabilities" })).toMatchObject({
+      ok: false,
+      error: { code: "PROJECT_REPLACED" },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+  it("does not revive an owner cleared while its lazy service was loading", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>();
+    const session = new BrowserSimulationSession({
+      getProject: () => createEmptyProject("project", "Project"),
+      getProjectSessionId: () => "same",
+      fetch,
+    });
+    const reading = session.handle({ operation: "capabilities" });
+    await session.clear();
+    expect(await reading).toMatchObject({
+      ok: false,
+      error: { code: "SESSION_CHANGED" },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/editor/src/features/simulation/browser-simulation-session.ts
+++ b/apps/editor/src/features/simulation/browser-simulation-session.ts
@@ -1,0 +1,91 @@
+import type { CircuitProject } from "@icm/model";
+import { SimulationFiles } from "@icm/simulation-service/files";
+import type {
+  SimulationOperation,
+  SimulationReply,
+} from "@icm/simulation-service/contract";
+import type { SimulationService } from "@icm/simulation-service";
+
+export interface BrowserSimulationSessionOptions {
+  getProjectSessionId(): string;
+  getProject(): CircuitProject;
+  files?: SimulationFiles;
+  fetch?: typeof fetch;
+}
+
+/** Shared browser composition, not a second run registry. Each owner has an
+ * isolated scope; revoking an Agent cannot cancel the human owner's run. */
+export class BrowserSimulationSession {
+  readonly files: SimulationFiles;
+  private service: Promise<SimulationService> | undefined;
+  private generation = 0;
+  private readonly projectSessionId: string;
+  constructor(private options: BrowserSimulationSessionOptions) {
+    this.projectSessionId = options.getProjectSessionId();
+    this.files = options.files ?? new SimulationFiles();
+  }
+  async clear() {
+    this.generation++;
+    const service = this.service;
+    this.service = undefined;
+    if (!this.options.files) this.files.clear();
+    await service?.then(
+      (value) => value.clear(),
+      () => {},
+    );
+  }
+  async handle(
+    operation: SimulationOperation,
+    requestId: string = crypto.randomUUID(),
+  ): Promise<SimulationReply> {
+    const generation = this.generation;
+    if (this.options.getProjectSessionId() !== this.projectSessionId)
+      return {
+        ok: false,
+        error: {
+          code: "PROJECT_REPLACED",
+          message: "The bound Project changed",
+          stage: "input",
+          recovery: "reauthorize",
+        },
+      };
+    try {
+      this.service ??= import("@icm/simulation-service").then(
+        ({ SimulationService, createHostedExecutor }) =>
+          new SimulationService(
+            this.files,
+            createHostedExecutor(
+              this.options.fetch ?? ((...args) => globalThis.fetch(...args)),
+            ),
+            this.options.getProject,
+          ),
+      );
+      const service = await this.service;
+      if (
+        generation !== this.generation ||
+        this.options.getProjectSessionId() !== this.projectSessionId
+      )
+        return {
+          ok: false,
+          error: {
+            code: "SESSION_CHANGED",
+            message: "Input owner changed during loading",
+            stage: "input",
+            recovery: "reauthorize",
+          },
+        };
+      return await service.handle(operation, requestId);
+    } catch {
+      this.service = undefined;
+      return {
+        ok: false,
+        error: {
+          code: "SIMULATION_HOST_UNAVAILABLE",
+          message: "Simulation could not load; the editor remains available",
+          stage: "read",
+          recovery: "retry-after",
+        },
+      };
+    }
+  }
+}

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -176,7 +176,10 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
           )}
         </div>
         <SetupEditor
-          key={JSON.stringify(project.simulation)}
+          key={
+            JSON.stringify(project.simulation) ??
+            `unsaved:${props.activeDocumentId}`
+          }
           {...props}
           capabilities={capabilities}
           onDirty={setDirty}
@@ -222,6 +225,33 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                 : "No run yet"}
         </p>
         {error && <pre role="alert">{error}</pre>}
+        {error && run && (
+          <button
+            onClick={() =>
+              void session
+                .handle({ operation: "read", runId: run.id })
+                .then(receive)
+            }
+          >
+            Refresh run status
+          </button>
+        )}
+        {run?.state === "lost" && (
+          <p>
+            The executor response is unknown. This run was not automatically
+            resubmitted; inspect its evidence before choosing a new run.
+          </p>
+        )}
+        {(run || prepared) && (
+          <details>
+            <summary>Input identity</summary>
+            <pre>
+              {run
+                ? `Run ${run.id}\nInput ${run.inputRevision}`
+                : `Prepared ${prepared!.id}\nInput ${prepared!.inputRevision}`}
+            </pre>
+          </details>
+        )}
         {prepared?.warnings.map((warning, i) => (
           <p key={i}>{warning}</p>
         ))}

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -1,0 +1,561 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  SimulationSetupSchema,
+  type CircuitProject,
+  type SimulationSetup,
+} from "@icm/model";
+import { resolveDocumentLogicalNets } from "@icm/derived";
+import type {
+  ArtifactRef,
+  Capabilities,
+  Prepared,
+  Run,
+  SimulationReply,
+} from "@icm/simulation-service/contract";
+import { downloadTextArtifact } from "../../document/project-file-service";
+import type { BrowserSimulationSession } from "./browser-simulation-session";
+import { acResponseSvg } from "./ac-response-plot";
+
+export interface SpiceSimulationSurfaceProps {
+  open: boolean;
+  project: CircuitProject;
+  activeDocumentId: string;
+  session: BrowserSimulationSession;
+  onClose(): void;
+  onSaveSetup(setup: SimulationSetup | null): boolean;
+  onOpenCell(documentId: string): void;
+  onCreateTestbench(): void;
+}
+
+/** A projection of the same prepare/start/read/cancel service used by MCP.
+ * The canvas remains the editor for sources, connections and DUT instances. */
+export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
+  const { session, project, open } = props;
+  const [capabilities, setCapabilities] = useState<Capabilities>();
+  const [prepared, setPrepared] = useState<Prepared>();
+  const [run, setRun] = useState<Run>();
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const lock = useRef(false);
+  const alive = useRef(true);
+  useEffect(() => {
+    alive.current = true;
+    return () => {
+      alive.current = false;
+    };
+  }, []);
+  const receive = (reply: SimulationReply) => {
+    if (!alive.current) return;
+    if (!reply.ok) {
+      setError(
+        `${reply.error.code}: ${reply.error.message}${reply.error.diagnostics?.map((d) => `\n${d.code}: ${d.message}`).join("") ?? ""}`,
+      );
+    } else if ("run" in reply) {
+      setRun(reply.run);
+      setError("");
+    } else if ("prepared" in reply) {
+      setPrepared(reply.prepared);
+      setError("");
+    } else if ("capabilities" in reply) {
+      setCapabilities(reply.capabilities);
+      setError("");
+    }
+  };
+  useEffect(() => {
+    if (open && !capabilities)
+      void session.handle({ operation: "capabilities" }).then(receive);
+  }, [open, session]);
+  // Keep tracking while the drawer is closed. A Project replacement unmounts
+  // this owner; closing a view is deliberately not cancellation.
+  useEffect(() => {
+    if (!run) return;
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const poll = async () => {
+      const reply = await session.handle({ operation: "read", runId: run.id });
+      if (stopped) return;
+      receive(reply);
+      if (
+        reply.ok &&
+        "run" in reply &&
+        ["running", "cancelling"].includes(reply.run.state)
+      )
+        timer = setTimeout(poll, 500);
+    };
+    void poll();
+    return () => {
+      stopped = true;
+      clearTimeout(timer);
+    };
+  }, [run?.id, session, project]);
+  const execute = async (start: boolean) => {
+    if (lock.current) return;
+    lock.current = true;
+    setBusy(true);
+    setError("");
+    try {
+      const reply = await session.handle({
+        operation: "prepare",
+        source: { kind: "structured" },
+      });
+      receive(reply);
+      if (start && reply.ok && "prepared" in reply && alive.current)
+        receive(
+          await session.handle({
+            operation: "start",
+            preparedId: reply.prepared.id,
+            digest: reply.prepared.digest,
+          }),
+        );
+    } finally {
+      lock.current = false;
+      if (alive.current) setBusy(false);
+    }
+  };
+  const download = async (artifact: ArtifactRef) => {
+    let offset: number | null = 0;
+    let text = "";
+    while (offset !== null) {
+      const chunk = await session.files.handle({
+        action: "artifact",
+        artifactId: artifact.id,
+        offset,
+      });
+      if (!chunk.ok) {
+        setError(chunk.error.message);
+        return;
+      }
+      if (!("text" in chunk)) return;
+      text += chunk.text;
+      offset = chunk.nextOffset;
+    }
+    const result = downloadTextArtifact(text, artifact.name);
+    if (result.status === "failed") setError(result.message);
+  };
+  const running = run && ["running", "cancelling"].includes(run.state);
+  const artifacts = [
+    ...(prepared?.artifacts ?? []),
+    ...(run?.artifacts ?? []),
+  ].filter((a, i, all) => all.findIndex((b) => b.id === a.id) === i);
+  return (
+    <section
+      hidden={!open}
+      className="spice-simulation-surface"
+      aria-label="Analog simulation"
+      onKeyDown={(e) => {
+        e.stopPropagation();
+        if (e.key === "Escape") props.onClose();
+      }}
+    >
+      <header>
+        <strong>Simulation · Preview</strong>
+        <button onClick={props.onClose} aria-label="Close simulation">
+          ×
+        </button>
+      </header>
+      <div className="spice-simulation-body">
+        <p>
+          Build the testbench on the canvas. Source DC/AC values live in
+          instance Properties. Run sends the prepared circuit to the configured
+          simulator.
+        </p>
+        <div className="spice-simulation-actions">
+          <button onClick={props.onCreateTestbench}>
+            New testbench from current Cell
+          </button>
+          {project.simulation && (
+            <button
+              onClick={() => {
+                props.onOpenCell(project.simulation!.input.rootDocumentId);
+                props.onClose();
+              }}
+            >
+              Edit testbench
+            </button>
+          )}
+        </div>
+        <SetupEditor
+          key={JSON.stringify(project.simulation)}
+          {...props}
+          capabilities={capabilities}
+          onDirty={setDirty}
+          onError={setError}
+        />
+        <div className="spice-simulation-actions">
+          <button
+            disabled={busy || !!running || dirty || !project.simulation}
+            onClick={() => void execute(false)}
+          >
+            Prepare deck
+          </button>
+          <button
+            disabled={busy || !!running || dirty || !project.simulation}
+            onClick={() => void execute(true)}
+          >
+            Run
+          </button>
+          <button
+            disabled={!running || run.state === "cancelling"}
+            onClick={() =>
+              void session
+                .handle({ operation: "cancel", runId: run!.id })
+                .then(receive)
+            }
+          >
+            Cancel run
+          </button>
+        </div>
+        {dirty && <p>Apply setup changes before running.</p>}
+        {capabilities?.configured === false && (
+          <p>
+            Simulator not configured. You can still edit the Project and setup.
+          </p>
+        )}
+        <p role="status">
+          {busy
+            ? "Preparing…"
+            : run
+              ? `${run.state}${run.result ? ` · ${run.result.outcome.status}` : ""}`
+              : prepared
+                ? "Deck prepared"
+                : "No run yet"}
+        </p>
+        {error && <pre role="alert">{error}</pre>}
+        {prepared?.warnings.map((warning, i) => (
+          <p key={i}>{warning}</p>
+        ))}
+        {run?.inputStatus === "changed" && (
+          <p role="alert">
+            Result belongs to an earlier Project revision. Run again to use the
+            current circuit.
+          </p>
+        )}
+        {run?.error && (
+          <pre role="alert">
+            {run.error.code}: {run.error.message}
+          </pre>
+        )}
+        {run?.result && (
+          <>
+            {run.resultPreview && (
+              <p>
+                Result preview is bounded. Export artifacts for complete data.
+              </p>
+            )}
+            {run.result.data?.analyses.map((analysis, i) => (
+              <section
+                key={i}
+                aria-label={`${analysis.analysis.toUpperCase()} results`}
+              >
+                <h3>{analysis.plotName}</h3>
+                {analysis.analysis === "op" && (
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Vector</th>
+                        <th>Value</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {analysis.probes.map((p) => (
+                        <tr key={p.name}>
+                          <td>{p.name}</td>
+                          <td>
+                            {p.value.toPrecision(6)} {p.unit}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+                {analysis.analysis === "ac" && (
+                  <div
+                    className="spice-ac-plot"
+                    dangerouslySetInnerHTML={{
+                      __html:
+                        acResponseSvg(
+                          analysis.probes.map((p) => ({
+                            label: p.name,
+                            points: analysis.frequencyHz.map(
+                              (frequency, index) => ({
+                                frequency,
+                                magnitudeDb:
+                                  20 *
+                                  Math.log10(
+                                    Math.max(
+                                      Math.hypot(
+                                        p.real[index] ?? 0,
+                                        p.imag[index] ?? 0,
+                                      ),
+                                      1e-30,
+                                    ),
+                                  ),
+                                phaseDeg:
+                                  (Math.atan2(
+                                    p.imag[index] ?? 0,
+                                    p.real[index] ?? 0,
+                                  ) *
+                                    180) /
+                                  Math.PI,
+                              }),
+                            ),
+                          })),
+                          { width: 640, height: 320 },
+                        ) ?? "",
+                    }}
+                  />
+                )}
+              </section>
+            ))}
+            <details>
+              <summary>Diagnostics and console</summary>
+              <pre>
+                {run.result.diagnostics.map((d) => d.text).join("\n")}
+                {"\n"}
+                {run.result.log}
+              </pre>
+            </details>
+          </>
+        )}
+        {artifacts.length > 0 && (
+          <details open>
+            <summary>Export artifacts</summary>
+            {artifacts.map((a) => (
+              <button key={a.id} onClick={() => void download(a)}>
+                {a.name}
+              </button>
+            ))}
+          </details>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function SetupEditor({
+  project,
+  activeDocumentId,
+  capabilities,
+  onSaveSetup,
+  onDirty,
+  onError,
+}: SpiceSimulationSurfaceProps & {
+  capabilities: Capabilities | undefined;
+  onDirty(value: boolean): void;
+  onError(value: string): void;
+}) {
+  const saved = project.simulation?.input;
+  const [rootId, setRootId] = useState(
+    saved?.rootDocumentId ?? activeDocumentId,
+  );
+  const [probes, setProbes] = useState(saved?.probes ?? []);
+  const root = project.documents.find((d) => d.id === rootId);
+  const nets = root ? resolveDocumentLogicalNets(root) : undefined;
+  const ac = saved?.analyses.find((a) => a.kind === "ac");
+  useEffect(() => {
+    onDirty(false);
+  }, []);
+  return (
+    <details open={!saved}>
+      <summary>Setup</summary>
+      <form
+        onChange={() => onDirty(true)}
+        onSubmit={(event) => {
+          event.preventDefault();
+          const data = new FormData(event.currentTarget);
+          const parsed = SimulationSetupSchema.safeParse({
+            version: 1,
+            input: {
+              kind: "structured",
+              rootDocumentId: rootId,
+              analyses: [
+                ...(data.has("op") ? [{ kind: "op" }] : []),
+                ...(data.has("ac")
+                  ? [
+                      {
+                        kind: "ac",
+                        sweep: data.get("sweep"),
+                        points: Number(data.get("points")),
+                        startHz: Number(data.get("startHz")),
+                        stopHz: Number(data.get("stopHz")),
+                      },
+                    ]
+                  : []),
+              ],
+              probes,
+              environment: {
+                profileId: data.get("profileId"),
+                ...(data.get("corner") ? { corner: data.get("corner") } : {}),
+                ...(data.get("temperatureC")
+                  ? { temperatureC: Number(data.get("temperatureC")) }
+                  : {}),
+              },
+            },
+          });
+          if (!parsed.success) {
+            onError(parsed.error.issues.map((i) => i.message).join("\n"));
+            return;
+          }
+          if (onSaveSetup(parsed.data)) {
+            onDirty(false);
+            onError("");
+          } else
+            onError(
+              "Setup was not applied. See the editor status; your draft is retained.",
+            );
+        }}
+      >
+        <label>
+          Testbench Cell
+          <select value={rootId} onChange={(e) => setRootId(e.target.value)}>
+            {!root && <option value={rootId}>Missing: {rootId}</option>}
+            {project.documents.map((d) => (
+              <option key={d.id} value={d.id}>
+                {d.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Environment profile
+          <input
+            name="profileId"
+            required
+            list="simulation-profiles"
+            defaultValue={
+              saved?.environment.profileId ??
+              capabilities?.profiles[0]?.id ??
+              ""
+            }
+          />
+        </label>
+        <datalist id="simulation-profiles">
+          {capabilities?.profiles.map((p) => (
+            <option key={p.id} value={p.id} />
+          ))}
+        </datalist>
+        <label>
+          Corner
+          <input
+            name="corner"
+            defaultValue={saved?.environment.corner ?? ""}
+            placeholder="Profile default"
+          />
+        </label>
+        <label>
+          Temperature (°C)
+          <input
+            name="temperatureC"
+            type="number"
+            step="any"
+            defaultValue={saved?.environment.temperatureC ?? ""}
+            placeholder="Profile default"
+          />
+        </label>
+        <label>
+          <input
+            name="op"
+            type="checkbox"
+            defaultChecked={
+              !saved || saved.analyses.some((a) => a.kind === "op")
+            }
+          />
+          Operating point (OP)
+        </label>
+        <label>
+          <input name="ac" type="checkbox" defaultChecked={!!ac} />
+          AC sweep
+        </label>
+        <label>
+          Sweep
+          <select name="sweep" defaultValue={ac?.sweep ?? "dec"}>
+            <option value="dec">Decade</option>
+            <option value="oct">Octave</option>
+            <option value="lin">Linear</option>
+          </select>
+        </label>
+        <label>
+          Points
+          <input
+            name="points"
+            type="number"
+            min="1"
+            defaultValue={ac?.points ?? 20}
+          />
+        </label>
+        <label>
+          Start (Hz)
+          <input
+            name="startHz"
+            type="number"
+            step="any"
+            defaultValue={ac?.startHz ?? 1}
+          />
+        </label>
+        <label>
+          Stop (Hz)
+          <input
+            name="stopHz"
+            type="number"
+            step="any"
+            defaultValue={ac?.stopHz ?? 1e6}
+          />
+        </label>
+        <label>
+          Add voltage probe
+          <select
+            value=""
+            onChange={(e) => {
+              if (!e.target.value) return;
+              setProbes([
+                ...probes,
+                {
+                  id: crypto.randomUUID(),
+                  kind: "net-voltage",
+                  documentId: rootId,
+                  netId: e.target.value,
+                  occurrence: [],
+                },
+              ]);
+            }}
+          >
+            <option value="">Choose a Net in the testbench</option>
+            {root?.nets.map((n) => (
+              <option key={n.id} value={n.id}>
+                {nets?.byBaseNetId.get(n.id)?.name ?? n.id}
+              </option>
+            ))}
+          </select>
+        </label>
+        <ul>
+          {probes.map((p) => (
+            <li key={p.id}>
+              {p.kind === "net-voltage" ? p.netId : p.instanceId}
+              {p.occurrence.length ? ` (${p.occurrence.join("/")})` : ""}
+              <button
+                type="button"
+                onClick={() => {
+                  setProbes(probes.filter((v) => v.id !== p.id));
+                  onDirty(true);
+                }}
+              >
+                Remove probe
+              </button>
+            </li>
+          ))}
+        </ul>
+        <p>
+          Existing hierarchical/current probes are preserved. Sources are edited
+          on the testbench canvas.
+        </p>
+        <button type="submit">Apply setup</button>
+        {saved && (
+          <button type="button" onClick={() => onSaveSetup(null)}>
+            Delete setup
+          </button>
+        )}
+      </form>
+    </details>
+  );
+}

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -134,10 +134,26 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     if (result.status === "failed") setError(result.message);
   };
   const running = run && ["running", "cancelling"].includes(run.state);
-  const artifacts = [
-    ...(prepared?.artifacts ?? []),
-    ...(run?.artifacts ?? []),
-  ].filter((a, i, all) => all.findIndex((b) => b.id === a.id) === i);
+  const artifactGroups = [
+    ...(prepared
+      ? [
+          {
+            label: "Prepared input",
+            identity: prepared.id,
+            artifacts: prepared.artifacts,
+          },
+        ]
+      : []),
+    ...(run
+      ? [
+          {
+            label: "Run evidence",
+            identity: `${run.id} / prepared ${run.preparedId}`,
+            artifacts: run.artifacts,
+          },
+        ]
+      : []),
+  ];
   return (
     <section
       hidden={!open}
@@ -246,9 +262,10 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
           <details>
             <summary>Input identity</summary>
             <pre>
-              {run
-                ? `Run ${run.id}\nInput ${run.inputRevision}`
-                : `Prepared ${prepared!.id}\nInput ${prepared!.inputRevision}`}
+              {prepared &&
+                `Prepared ${prepared.id}\nInput ${prepared.inputRevision}\n`}
+              {run &&
+                `Run ${run.id}\nPrepared ${run.preparedId}\nInput ${run.inputRevision}`}
             </pre>
           </details>
         )}
@@ -348,16 +365,17 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
             </details>
           </>
         )}
-        {artifacts.length > 0 && (
-          <details open>
-            <summary>Export artifacts</summary>
-            {artifacts.map((a) => (
+        {artifactGroups.map((group) => (
+          <details open key={group.label} aria-label={group.label}>
+            <summary>{group.label}</summary>
+            <small>{group.identity}</small>
+            {group.artifacts.map((a) => (
               <button key={a.id} onClick={() => void download(a)}>
                 {a.name}
               </button>
             ))}
           </details>
-        )}
+        ))}
       </div>
     </section>
   );

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -1,5 +1,70 @@
 /* Local-development Digital Simulation tool window and waveform viewer. */
 
+/* Analog is a lazy, non-modal drawer; the original canvas remains editable. */
+.spice-simulation-surface {
+  position: fixed;
+  top: 90px;
+  right: 16px;
+  z-index: 29;
+  width: min(510px, calc(100vw - 32px));
+  max-height: calc(100dvh - 120px);
+  overflow: auto;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-md);
+  background: var(--icm-surface);
+  color: var(--icm-text);
+  box-shadow: var(--icm-shadow-md);
+}
+.spice-simulation-surface[hidden] {
+  display: none;
+}
+.spice-simulation-surface header,
+.spice-simulation-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.spice-simulation-surface header {
+  padding: 12px;
+  border-bottom: 1px solid var(--icm-border);
+}
+.spice-simulation-surface header button {
+  margin-left: auto;
+}
+.spice-simulation-body {
+  padding: 12px;
+}
+.spice-simulation-surface label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 8px 0;
+}
+.spice-simulation-surface input:not([type="checkbox"]),
+.spice-simulation-surface select {
+  min-width: 0;
+  max-width: 65%;
+}
+.spice-simulation-surface details {
+  margin: 12px 0;
+}
+.spice-simulation-surface pre {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  max-height: 260px;
+  overflow: auto;
+}
+.spice-simulation-surface table {
+  width: 100%;
+  text-align: left;
+}
+.spice-ac-plot svg {
+  width: 100%;
+  height: auto;
+}
+
 .digital-simulation-window {
   position: fixed;
   top: 96px;

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -1,0 +1,57 @@
+# Analog simulation — minimal Preview surface
+
+Use the top **Simulation** button. Opening the editor alone does not contact
+the simulator. The simulation drawer loads on demand and leaves the existing
+canvas available; it is separate from the development-only Digital tool.
+
+## DUT and testbench
+
+1. Define the DUT Cell's formal ports. In **Edit → Manage Cells → Review
+   Symbol**, review its derived symbol before placing its first instance.
+2. With that DUT Cell active, choose **Simulation → New testbench from current
+   Cell**. An ordinary Cell is created and the DUT is offered at the cursor.
+   Click to place it; Escape cancels placement, not creation of the empty Cell.
+   The Project top is unchanged. Both operations use normal Undo/Redo.
+3. Place and wire sources on this testbench canvas. Edit their DC and AC
+   parameters in the existing instance Properties. No second copy of source
+   values is stored in the simulation setup.
+
+You can also use the regular Cell Manager and Place Cell commands. On the
+Agent side, public `create-cell` and `place-cell` authoring actions use that
+same hierarchy, followed by the existing simulation configure operation.
+
+## Setup, run and results
+
+Open **Setup**, choose the testbench Cell and advertised environment Profile,
+then set OP/AC, optional corner/temperature, and voltage probes. Existing
+hierarchical and source-current probes authored by the Agent are preserved
+and can be removed individually. Apply commits `set_simulation_setup` into
+the Project; saving/exporting and reopening the Project retains this setup.
+
+**Prepare deck** compiles without running. **Run** prepares the current saved
+setup and starts that immutable input through the same service as MCP. It
+does not run unapplied form edits. Input diagnostics leave the Project and
+session intact: correct the input and run again. Run failures keep available
+evidence and never automatically resubmit work.
+
+OP values and AC plots consume the shared structured result. Console,
+diagnostics, input identity and downloadable deck/raw/CSV artifacts are
+available alongside the result. Bounded result previews are labelled; export
+the complete artifacts when needed. Editing the Project marks older results
+as belonging to an earlier revision.
+
+Closing the drawer keeps a run alive. **Cancel run** asks the execution
+service to cancel; it is not simulated by hiding a spinner. Replacing the
+Project or closing its editor ends that browser-owned scope. Revoking an
+Agent affects its own scope, not a human run. Runtime receipts and results
+are transient, not saved inside the Project.
+
+## Current boundary
+
+This is the B/C local-DUT and minimal human interface slice, not completion
+of all F1R/F5 requirements in the [v13 plan](../roadmap/simulation-vertical-integration-plan-v13.md).
+Cross-Project publication, a GUI hierarchy probe picker, structured TRAN and
+multi-run comparison remain outside this slice. Raw/Agent workflows retain
+their existing capabilities. Browser regressions use a controlled executor
+to verify interaction/protocol behavior; they do **not** certify OTA numbers,
+model qualification or the separate real Preview acceptance journey.


### PR DESCRIPTION
Stacked C slice on B (#627), implementing bounded F5-min from v13 and #585.

- Lazy, non-modal Analog Simulation entry; the existing canvas remains the testbench/source editor.
- Current Cell to ordinary TB cursor placement, saved OP/AC setup and root voltage probes.
- Shared prepare/start/read/cancel and File artifact retrieval, structured OP/AC results, stale-input warning, separately identified prepared inputs and run evidence.
- Shared browser composition with separate human/Agent scopes: closing the drawer does not cancel; Agent revoke cannot terminate a human run.
- No deployment, Profile, benchmark or Digital production enablement changes.

## Alignment with A (#626)

B and C are rebased onto main a1e91ff5 without conflicts. Test commit 37d79366 preserves A's actual saved OTA setup: four root/hierarchical probes, XDUT occurrence paths, OP/AC through 1 GHz and sky130-core-continuous-ngspice46-v1. Opening, applying, preparing, saving and reopening must not rewrite those inputs. Controlled result metadata now takes its version from the Profile, rather than hardcoding ngspice 47. The independent recoverable-input-error test remains.

## Validation at 37d79366

- Frozen install, preflight/static, build and release/performance checks passed.
- Unit: 2614 passed, 26 skipped.
- Local complete browser run: 353/354 passed; the existing unsafe-formula case timed out waiting for its alert. Its focused repeat passed 3/3 without code changes. The failure trace is retained locally, not silently counted as a full green run.
- Latest required GitHub checks all green: run 33945817934. The earlier duplicate run 33945817553 was cancelled before executing jobs.

## Real Preview evidence (2026-09-05)

Review client 37d79366 used real Preview APIs, not a mocked executor. Initial verification used a1e91ff5; the completed GUI/MCP rerun used cb965326 after #629 deployed successfully (workflow 33947110764). Static client bytes were supplied locally to the Preview-origin browser. This is **not same-SHA deployed-UI qualification**.

GUI import -> Run -> OP/AC results -> downloads passed A's existing `validateHostedSky130Result` oracle (`ota-5t-structured-op-ac-v1`), including four OP vectors and 91-point AC. OP values: vout 0.7589797395133877 V, ibias 0.6044031364286973 V, XDUT.tail 0.2848671983031419 V, XDUT.nleft 0.7589797395214736 V. Downloaded result.json data matched the actual HTTP result; out.raw, ac-1.csv and prepared.cir exported successfully.

Runtime fingerprint: 33c245e5df6dc12077b6a2e4ebf308777b0e9014fe9bfdafc3285c614688561d (the same fingerprint recorded by A's deployed smoke).

**Live MCP passed after #629 deployed:** The initial HTTP 500 was caused by the Preview response wrapper dropping the workerd WebSocket upgrade attachment. After the fix, a real stdio MCP process paired once (`claimed`), exited, and a new process called `connect()` without a claim code (`resumed`), retaining the exact Project and Document scope. An invalid probe returned `SIMULATION_COMPILE_REFUSED` / `fix-input`; the same MCP process and authorized session then prepared the corrected saved setup, started and read a completed OP/AC run, and downloaded out.raw, result.json, ac-1.csv and prepared.cir through `simulation_files`. MCP result data matched the actual Preview HTTP response and passed the same A numerical oracle and runtime fingerprint as GUI. This was actual MCP -> Preview relay -> browser host -> Preview executor, not GUI clicks standing in for MCP calls. Recovery correctly consumes MCP tool-error content; an `isError` response is not a session termination.

Acceptance completed 2026-09-05T05:27:40Z. The isolated test session was revoked, its local connector removed, and existing user MCP configuration was untouched. No cloud Project or Gallery was modified. B/C remain review branches; same-SHA deployed-client qualification is still a later delivery step.

Guide: docs/user/analog-simulation.md. Depends on #627; do not auto-merge.
