### PR TITLE
fix(preview): preserve Agent WebSocket upgrade responses

### DIFF
--- a/worker/channel.test.ts
+++ b/worker/channel.test.ts
@@ -134,4 +134,25 @@ describe("release channel", () => {
     const untouched = markPreviewResponse(new Response("shell"), {});
     expect(untouched.headers.get("x-robots-tag")).toBeNull();
   });
+
+  it("preserves the WebSocket upgrade response without rebuilding or mutating it", () => {
+    // Node's Response rejects 101; model the workerd-only extension on a
+    // real Response. The original implementation throws on reconstruction.
+    const upgrade = new Response(null, {
+      headers: { "sec-websocket-protocol": "icm-editor" },
+    });
+    const socket = {};
+    Object.defineProperties(upgrade, {
+      status: { value: 101 },
+      webSocket: { value: socket },
+    });
+    const marked = markPreviewResponse(upgrade, { ICM_CHANNEL: "preview" });
+    expect(marked).toBe(upgrade);
+    expect(marked.status).toBe(101);
+    expect((marked as Response & { webSocket: unknown }).webSocket).toBe(
+      socket,
+    );
+    expect(marked.headers.get("sec-websocket-protocol")).toBe("icm-editor");
+    expect(marked.headers.get("x-robots-tag")).toBeNull();
+  });
 });

--- a/worker/channel.ts
+++ b/worker/channel.ts
@@ -130,6 +130,10 @@ export function markPreviewResponse(
   env: ChannelEnv,
 ): Response {
   if (releaseChannel(env) !== "preview") return response;
+  // A 101 response transfers a live WebSocket, not an indexable document.
+  // Rebuilding it as an ordinary HTTP response drops workerd's webSocket
+  // attachment and turns a successful Agent handshake into HTTP 500.
+  if (response.status === 101) return response;
   const headers = new Headers(response.headers);
   headers.set("x-robots-tag", "noindex, nofollow, noarchive");
   return new Response(response.body, {


### PR DESCRIPTION
Independent fix discovered during live acceptance of #627 / #628 against Preview a1e91ff5. Session creation returns 200; editor WebSocket handshakes repeatedly return 500. The Preview noindex wrapper reconstructs the 101 response without its workerd WebSocket attachment. Pass protocol upgrades through untouched; ordinary HTTP noindex stamping and production behavior remain unchanged.

Validation: focused channel regression 9/9, static contracts, formatting and diff checks passed. Selected preflight / affected workspace-unit validation is running; required CI must pass. Regression models the workerd-only Response extension because Node Response cannot construct status 101.

Not deployed, not auto-merge. Real cloud MCP qualification remains blocked until this fix is deployed and rerun. No simulation protocol or permission changes.