### PR TITLE
feat(simulation): close the human probe authoring gap

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -73,8 +73,17 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
     4,
   );
   await expect(
-    panel.getByText("net-dut-tail (XDUT)", { exact: false }),
+    panel.locator("li").filter({ hasText: "XDUT · ota_5t · tail" }),
   ).toBeVisible();
+  await panel
+    .getByLabel("Add voltage probe")
+    .selectOption({ label: "XDUT · ota_5t · vinp" });
+  await panel
+    .getByLabel("Add source-current probe")
+    .selectOption({ label: "Testbench · VINP current" });
+  await expect(panel.getByRole("button", { name: "Remove probe" })).toHaveCount(
+    6,
+  );
   await panel.getByRole("button", { name: "Apply setup" }).click();
   await panel.getByRole("button", { name: "Prepare deck" }).click();
   const deckDownload = page.waitForEvent("download");
@@ -84,7 +93,14 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
   const stream = await (await deckDownload).createReadStream();
   let deck = "";
   for await (const chunk of stream!) deck += chunk.toString();
-  for (const vector of ["v(vout)", "v(ibias)", "v(xdut.tail)", "v(xdut.nleft)"])
+  for (const vector of [
+    "v(vout)",
+    "v(ibias)",
+    "v(xdut.tail)",
+    "v(xdut.nleft)",
+    "v(xdut.vinp)",
+    "i(vinp)",
+  ])
     expect(deck).toContain(vector);
   expect(deck).toMatch(/ac dec 10 1 (?:1000000000|1e\+?9)/i);
   expect(executions).toBe(0);
@@ -92,7 +108,25 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
   const saved = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(),
   );
-  expect(saved.simulation).toEqual(project.simulation);
+  const { probes: savedProbes, ...savedInput } = saved.simulation.input;
+  const { probes: originalProbes, ...originalInput } =
+    project.simulation!.input;
+  expect(savedInput).toEqual(originalInput);
+  expect(savedProbes.slice(0, 4)).toEqual(originalProbes);
+  expect(savedProbes.slice(4)).toMatchObject([
+    {
+      kind: "net-voltage",
+      documentId: "document-ota-5t",
+      netId: "net-cell-pin-pvinp",
+      occurrence: ["XDUT"],
+    },
+    {
+      kind: "source-current",
+      documentId: "document-ota-5t-testbench",
+      instanceId: "VINP",
+      occurrence: [],
+    },
+  ]);
   await page.reload();
   await page.getByTestId("project-file").setInputFiles({
     name: "reopened.icproj.json",
@@ -104,7 +138,7 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
     .click();
   await panel.getByText("Setup", { exact: true }).click();
   await expect(panel.getByRole("button", { name: "Remove probe" })).toHaveCount(
-    4,
+    6,
   );
   await expect(panel.getByLabel("Stop (Hz)")).toHaveValue("1000000000");
 });
@@ -245,7 +279,9 @@ test("human simulation uses saved setup, survives closing, recovers a bad input 
   expect(executions).toBe(0);
   await panel.getByText("Setup", { exact: true }).click();
   await panel.getByRole("button", { name: "Remove probe" }).click();
-  await panel.getByLabel("Add voltage probe").selectOption("tb-vout-net");
+  await panel
+    .getByLabel("Add voltage probe")
+    .selectOption({ label: "Testbench · vout" });
   await panel.getByRole("button", { name: "Apply setup" }).click();
   await panel.getByRole("button", { name: "Run", exact: true }).click();
   await expect.poll(() => executions).toBe(1);

--- a/apps/editor/src/features/simulation/simulation-probe-options.test.ts
+++ b/apps/editor/src/features/simulation/simulation-probe-options.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { CircuitProjectSchema } from "@icm/model";
+
+import fiveTransistorOtaSky130 from "../../examples/five-transistor-ota-sky130.icproj.json";
+import {
+  deriveSimulationProbeOptions,
+  simulationProbeTargetKey,
+} from "./simulation-probe-options";
+
+describe("simulation probe choices", () => {
+  it("keeps hierarchy occurrences and voltage-source currents addressable", () => {
+    const project = CircuitProjectSchema.parse(fiveTransistorOtaSky130);
+    const options = deriveSimulationProbeOptions(
+      project,
+      "document-ota-5t-testbench",
+    );
+
+    expect(
+      options.voltage.find((option) => option.target.netId === "net-dut-tail"),
+    ).toMatchObject({
+      label: "XDUT · ota_5t · tail",
+      target: {
+        kind: "net-voltage",
+        documentId: "document-ota-5t",
+        netId: "net-dut-tail",
+        occurrence: ["XDUT"],
+      },
+    });
+    expect(options.sourceCurrent.map((option) => option.label)).toEqual([
+      "Testbench · VDD current",
+      "Testbench · VINP current",
+      "Testbench · VINN current",
+    ]);
+  });
+
+  it("gives repeated calls of the same Cell different target identities", () => {
+    const project = CircuitProjectSchema.parse(fiveTransistorOtaSky130);
+    const testbench = project.documents.find(
+      (document) => document.id === "document-ota-5t-testbench",
+    )!;
+    const first = testbench.instances.find(
+      (instance) => instance.id === "XDUT",
+    )!;
+    testbench.instances.push({
+      ...structuredClone(first),
+      id: "XDUT2",
+      reference: "XDUT2",
+    });
+
+    const targets = deriveSimulationProbeOptions(
+      project,
+      testbench.id,
+    ).voltage.filter((option) => option.target.netId === "net-dut-tail");
+    expect(targets.map((option) => option.target.occurrence)).toEqual([
+      ["XDUT"],
+      ["XDUT2"],
+    ]);
+    expect(new Set(targets.map((option) => option.key)).size).toBe(2);
+    expect(
+      targets.map((option) => simulationProbeTargetKey(option.target)),
+    ).toEqual(targets.map((option) => option.key));
+  });
+});

--- a/apps/editor/src/features/simulation/simulation-probe-options.ts
+++ b/apps/editor/src/features/simulation/simulation-probe-options.ts
@@ -1,0 +1,113 @@
+import type {
+  CircuitProject,
+  SchematicDocument,
+  SimulationProbeSpec,
+} from "@icm/model";
+import { resolveDocumentLogicalNets } from "@icm/derived";
+
+type VoltageProbeTarget = Omit<
+  Extract<SimulationProbeSpec, { kind: "net-voltage" }>,
+  "id"
+>;
+type SourceCurrentProbeTarget = Omit<
+  Extract<SimulationProbeSpec, { kind: "source-current" }>,
+  "id"
+>;
+type ProbeTarget = VoltageProbeTarget | SourceCurrentProbeTarget;
+
+export interface SimulationProbeOption<
+  Target extends ProbeTarget = ProbeTarget,
+> {
+  readonly key: string;
+  readonly label: string;
+  readonly target: Target;
+}
+
+export interface SimulationProbeOptions {
+  readonly voltage: readonly SimulationProbeOption<VoltageProbeTarget>[];
+  readonly sourceCurrent: readonly SimulationProbeOption<SourceCurrentProbeTarget>[];
+}
+
+export function simulationProbeTargetKey(target: ProbeTarget): string {
+  const occurrence = target.occurrence.join("/");
+  return target.kind === "net-voltage"
+    ? `voltage:${occurrence}:${target.documentId}:${target.netId}`
+    : `current:${occurrence}:${target.documentId}:${target.instanceId}`;
+}
+
+/**
+ * Enumerate concrete probe targets below one simulation root. An occurrence
+ * is kept for every hierarchy call, so two instances of one Cell remain two
+ * different choices. This is an editor projection of the persisted probe
+ * contract; it does not invent a second measurement object.
+ */
+export function deriveSimulationProbeOptions(
+  project: CircuitProject,
+  rootDocumentId: string,
+): SimulationProbeOptions {
+  const documents = new Map(
+    project.documents.map((document) => [document.id, document]),
+  );
+  const root = documents.get(rootDocumentId);
+  const voltage: SimulationProbeOption<VoltageProbeTarget>[] = [];
+  const sourceCurrent: SimulationProbeOption<SourceCurrentProbeTarget>[] = [];
+  if (!root) return { voltage, sourceCurrent };
+
+  const visit = (
+    document: SchematicDocument,
+    occurrence: readonly string[],
+    displayPath: readonly string[],
+    ancestry: ReadonlySet<string>,
+  ) => {
+    const logicalNets = resolveDocumentLogicalNets(document);
+    const prefix = displayPath.length
+      ? `${displayPath.join("/")} · ${document.name}`
+      : document.name;
+    // One visible choice per electrical Logical Net. Several Base Nets may be
+    // joined by the same scoped label (notably repeated Ground markers); the
+    // user should not have to choose among indistinguishable aliases.
+    for (const net of logicalNets.groups) {
+      const target: VoltageProbeTarget = {
+        kind: "net-voltage",
+        documentId: document.id,
+        netId: net.id,
+        occurrence: [...occurrence],
+      };
+      voltage.push({
+        key: simulationProbeTargetKey(target),
+        label: `${prefix} · ${net.name ?? net.id}`,
+        target,
+      });
+    }
+    for (const instance of document.instances) {
+      const binding = instance.netlist?.binding;
+      if (
+        (binding?.kind === "primitive" || binding?.kind === "model") &&
+        binding.deviceClass === "voltage-source"
+      ) {
+        const target: SourceCurrentProbeTarget = {
+          kind: "source-current",
+          documentId: document.id,
+          instanceId: instance.id,
+          occurrence: [...occurrence],
+        };
+        sourceCurrent.push({
+          key: simulationProbeTargetKey(target),
+          label: `${prefix} · ${instance.reference ?? instance.id} current`,
+          target,
+        });
+      }
+      if (binding?.kind !== "subcircuit") continue;
+      const child = documents.get(binding.childDocumentId);
+      if (!child || ancestry.has(child.id) || occurrence.length >= 64) continue;
+      visit(
+        child,
+        [...occurrence, instance.id],
+        [...displayPath, instance.reference ?? instance.id],
+        new Set([...ancestry, child.id]),
+      );
+    }
+  };
+  visit(root, [], [], new Set([root.id]));
+  return { voltage, sourceCurrent };
+}

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -4,7 +4,6 @@ import {
   type CircuitProject,
   type SimulationSetup,
 } from "@icm/model";
-import { resolveDocumentLogicalNets } from "@icm/derived";
 import type {
   ArtifactRef,
   Capabilities,
@@ -15,6 +14,11 @@ import type {
 import { downloadTextArtifact } from "../../document/project-file-service";
 import type { BrowserSimulationSession } from "./browser-simulation-session";
 import { acResponseSvg } from "./ac-response-plot";
+import {
+  deriveSimulationProbeOptions,
+  simulationProbeTargetKey,
+  type SimulationProbeOption,
+} from "./simulation-probe-options";
 
 export interface SpiceSimulationSurfaceProps {
   open: boolean;
@@ -399,7 +403,13 @@ function SetupEditor({
   );
   const [probes, setProbes] = useState(saved?.probes ?? []);
   const root = project.documents.find((d) => d.id === rootId);
-  const nets = root ? resolveDocumentLogicalNets(root) : undefined;
+  const probeOptions = deriveSimulationProbeOptions(project, rootId);
+  const probeLabels = new Map(
+    [...probeOptions.voltage, ...probeOptions.sourceCurrent].map((option) => [
+      option.key,
+      option.label,
+    ]),
+  );
   const ac = saved?.analyses.find((a) => a.kind === "ac");
   useEffect(() => {
     onDirty(false);
@@ -550,37 +560,31 @@ function SetupEditor({
             defaultValue={ac?.stopHz ?? 1e6}
           />
         </label>
-        <label>
-          Add voltage probe
-          <select
-            value=""
-            onChange={(e) => {
-              if (!e.target.value) return;
-              setProbes([
-                ...probes,
-                {
-                  id: crypto.randomUUID(),
-                  kind: "net-voltage",
-                  documentId: rootId,
-                  netId: e.target.value,
-                  occurrence: [],
-                },
-              ]);
-            }}
-          >
-            <option value="">Choose a Net in the testbench</option>
-            {root?.nets.map((n) => (
-              <option key={n.id} value={n.id}>
-                {nets?.byBaseNetId.get(n.id)?.name ?? n.id}
-              </option>
-            ))}
-          </select>
-        </label>
+        <ProbeSelect
+          label="Add voltage probe"
+          placeholder="Choose a Net in the testbench hierarchy"
+          options={probeOptions.voltage}
+          probes={probes}
+          onAdd={(option) => {
+            setProbes([...probes, probeFromOption(option)]);
+            onDirty(true);
+          }}
+        />
+        <ProbeSelect
+          label="Add source-current probe"
+          placeholder="Choose a voltage source"
+          options={probeOptions.sourceCurrent}
+          probes={probes}
+          onAdd={(option) => {
+            setProbes([...probes, probeFromOption(option)]);
+            onDirty(true);
+          }}
+        />
         <ul>
           {probes.map((p) => (
             <li key={p.id}>
-              {p.kind === "net-voltage" ? p.netId : p.instanceId}
-              {p.occurrence.length ? ` (${p.occurrence.join("/")})` : ""}
+              {probeLabels.get(simulationProbeTargetKey(p)) ??
+                `Unavailable: ${p.kind === "net-voltage" ? p.netId : p.instanceId}${p.occurrence.length ? ` (${p.occurrence.join("/")})` : ""}`}
               <button
                 type="button"
                 onClick={() => {
@@ -593,10 +597,7 @@ function SetupEditor({
             </li>
           ))}
         </ul>
-        <p>
-          Existing hierarchical/current probes are preserved. Sources are edited
-          on the testbench canvas.
-        </p>
+        <p>Sources are edited on the testbench canvas.</p>
         <button type="submit">Apply setup</button>
         {saved && (
           <button type="button" onClick={() => onSaveSetup(null)}>
@@ -605,5 +606,68 @@ function SetupEditor({
         )}
       </form>
     </details>
+  );
+}
+
+function probeFromOption(
+  option: SimulationProbeOption,
+): SimulationSetup["input"]["probes"][number] {
+  const target = option.target;
+  if (target.kind === "net-voltage") {
+    return {
+      id: crypto.randomUUID(),
+      kind: target.kind,
+      documentId: target.documentId,
+      netId: target.netId,
+      occurrence: [...target.occurrence],
+    };
+  }
+  return {
+    id: crypto.randomUUID(),
+    kind: target.kind,
+    documentId: target.documentId,
+    instanceId: target.instanceId,
+    occurrence: [...target.occurrence],
+  };
+}
+
+function ProbeSelect({
+  label,
+  placeholder,
+  options,
+  probes,
+  onAdd,
+}: {
+  label: string;
+  placeholder: string;
+  options: readonly SimulationProbeOption[];
+  probes: SimulationSetup["input"]["probes"];
+  onAdd(option: SimulationProbeOption): void;
+}) {
+  const selected = new Set(probes.map(simulationProbeTargetKey));
+  return (
+    <label>
+      {label}
+      <select
+        value=""
+        onChange={(event) => {
+          const option = options.find(
+            (candidate) => candidate.key === event.target.value,
+          );
+          if (option) onAdd(option);
+        }}
+      >
+        <option value="">{placeholder}</option>
+        {options.map((option) => (
+          <option
+            key={option.key}
+            value={option.key}
+            disabled={selected.has(option.key)}
+          >
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
   );
 }

--- a/docs/user/analog-simulation.md
+++ b/docs/user/analog-simulation.md
@@ -23,10 +23,12 @@ same hierarchy, followed by the existing simulation configure operation.
 ## Setup, run and results
 
 Open **Setup**, choose the testbench Cell and advertised environment Profile,
-then set OP/AC, optional corner/temperature, and voltage probes. Existing
-hierarchical and source-current probes authored by the Agent are preserved
-and can be removed individually. Apply commits `set_simulation_setup` into
-the Project; saving/exporting and reopening the Project retains this setup.
+then set OP/AC, optional corner/temperature, and probes. Voltage probes may
+target a Net at the Testbench root or in a concrete DUT occurrence; current
+probes may target voltage sources. Each choice is written to the same
+occurrence-aware probe contract that Agent authoring uses. Apply commits
+`set_simulation_setup` into the Project; saving/exporting and reopening the
+Project retains this setup.
 
 **Prepare deck** compiles without running. **Run** prepares the current saved
 setup and starts that immutable input through the same service as MCP. It
@@ -50,8 +52,8 @@ are transient, not saved inside the Project.
 
 This is the B/C local-DUT and minimal human interface slice, not completion
 of all F1R/F5 requirements in the [v13 plan](../roadmap/simulation-vertical-integration-plan-v13.md).
-Cross-Project publication, a GUI hierarchy probe picker, structured TRAN and
-multi-run comparison remain outside this slice. Raw/Agent workflows retain
-their existing capabilities. Browser regressions use a controlled executor
+Cross-Project publication, structured TRAN and multi-run comparison remain
+outside this slice. Raw/Agent workflows retain their existing capabilities.
+Browser regressions use a controlled executor
 to verify interaction/protocol behavior; they do **not** certify OTA numbers,
 model qualification or the separate real Preview acceptance journey.


### PR DESCRIPTION
## Summary
- project the existing occurrence-aware probe contract into the human Simulation setup
- let users select root or hierarchical voltage Nets and voltage-source branch currents
- keep repeated Cell occurrences distinct, collapse same Logical-Net aliases, and retain unavailable saved probes for repair

## Scope
This is the bounded Probe-authoring closeout for the Preview MVP. It does not add a measurement schema, cross-Project import, TRAN authoring, or executor changes.

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
  - 2623 unit tests passed, 26 skipped
  - 5 selected Agent/Simulation browser tests passed

Contributes to the current #560 / #564 MVP exit without claiming their deferred raw/TRAN or full F5 scope.