### PR TITLE
feat(deploy): the preview editor can pair an Agent

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -43,6 +43,11 @@ jobs:
       - run: pnpm --filter @icm/editor... build
         env:
           VITE_ICM_TIMING_UI: disabled
+          # The preview is the channel that simulates (ADR 0057) and simulation
+          # is Agent-first (ADR 0055): an Agent must be able to pair with the
+          # preview editor, so its Connect Agent surface is enabled here.
+          # Production stays human-only (docs/agent/README.md).
+          VITE_ICM_AGENT_UI: enabled
       - name: Deploy to preview
         run: pnpm dlx wrangler@4.120.1 deploy --config wrangler.preview.jsonc
         env:

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -38,6 +38,12 @@ claim UI or reconnect a prior browser session. Trusted development or staging
 builds can enable that browser surface with `VITE_ICM_AGENT_UI=enabled`; the
 API and MCP contracts themselves are unchanged.
 
+The preview channel enables it (`VITE_ICM_AGENT_UI: enabled` in
+`.github/workflows/deploy-preview.yml`), because the preview is where
+simulation runs and simulation is Agent-first (ADR 0055): open **Agent →
+Connect Agent** in the preview editor for a Claim Code and start the MCP
+adapter with `ANALOG_CANVAS_API_URL=https://analog-canvas-preview.tokenzhang.com`.
+
 ## External Agent bootstrap (no MCP)
 
 An Agent without this repository receives a connection setup from the editor.


### PR DESCRIPTION
## Why

The preview is the only channel that simulates (ADR 0057) and simulation is designed Agent-first (ADR 0055). But the preview build inherited the production default of hiding the **Connect Agent** surface (`PUBLIC_AGENT_UI_ENABLED = !PROD`), so no Agent could obtain a Claim Code on the preview and the merged MCP `simulation` tool had no reachable host. Verified on the live preview: the editor shows no Agent menu.

## What

- `.github/workflows/deploy-preview.yml`: the editor build sets `VITE_ICM_AGENT_UI: enabled`. Production is unchanged.
- `docs/agent/README.md`: where the switch lives and which `ANALOG_CANVAS_API_URL` to give the MCP adapter for the preview.

## Verification

- `resolvePublicAgentUiEnabled` already covers the `enabled` branch (unit-tested); this only sets the build-time input.
- After the deploy: Agent → Connect Agent on the preview, then MCP `connect` + `simulation` prepare/start/read on the bundled five-transistor OTA. Results will be posted on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
