### PR TITLE
fix(spice-run): an operating point lists each probe once

### DIFF
--- a/fixtures/ngspice-rawfile/README.md
+++ b/fixtures/ngspice-rawfile/README.md
@@ -1,16 +1,17 @@
 # ngspice ASCII rawfile fixtures
 
-Three rawfiles written by ngspice 46, each beside the deck that produced it.
+Four rawfiles written by ngspice 46, each beside the deck that produced it.
 They exist so a parser is tested against output a simulator actually wrote,
 not against output someone believed it writes.
 
 Regenerate any of them with `ngspice -b <name>.deck.spi` from this directory.
 
-| file | plot | flags | vars | points |
-| --- | --- | --- | --- | --- |
-| `divider-op.raw` | Operating Point | real | 3 | 1 |
-| `rc-ac.raw` | AC Analysis | **complex** | 4 | 17 |
-| `rc-tran.raw` | Transient Analysis | real | 4 | 79 |
+| file                    | plot               | flags       | vars           | points |
+| ----------------------- | ------------------ | ----------- | -------------- | ------ |
+| `divider-op.raw`        | Operating Point    | real        | 3              | 1      |
+| `divider-op-listed.raw` | Operating Point    | real        | 4 (one echoed) | 1      |
+| `rc-ac.raw`             | AC Analysis        | **complex** | 4              | 17     |
+| `rc-tran.raw`           | Transient Analysis | real        | 4              | 79     |
 
 ## What each one is for
 
@@ -21,6 +22,14 @@ the parser once produced it.
 **`divider-op`** — 1 V across two 1 kΩ resistors. `v(mid)` is 0.5 V exactly,
 and the fixture holds `5.000000000000000e-01`. One plot, one point: the
 smallest shape the format takes.
+
+**`divider-op-listed`** — the same divider, but its deck names the vectors
+to write (`write … v(in) v(mid) i(v1)`), which is how a compiled simulation
+setup asks for exactly its probes. ngspice writes the plot's scale before the
+listed vectors, and an operating-point plot's scale is its first vector, so
+`v(in)` appears twice in `Variables:` with one value. The reader must report
+the probe once; the fixture exists so that echo is tested against a file the
+simulator wrote.
 
 **`rc-ac`** — R = 1 kΩ, C = 1 µF, so H(f) = 1/(1 + jf/f_c) with
 f_c = 1/(2π·RC) = 159.1549 Hz. Every one of the 17 points can be asserted

--- a/fixtures/ngspice-rawfile/divider-op-listed.deck.spi
+++ b/fixtures/ngspice-rawfile/divider-op-listed.deck.spi
@@ -1,0 +1,11 @@
+* Resistive divider, operating point, written with an explicit vector list:
+* the same 1 V across 1k + 1k, but `write` names v(in) v(mid) i(v1).
+V1 in 0 1
+R1 in mid 1k
+R2 mid 0 1k
+.control
+set filetype=ascii
+op
+write divider-op-listed.raw v(in) v(mid) i(v1)
+.endc
+.end

--- a/fixtures/ngspice-rawfile/divider-op-listed.raw
+++ b/fixtures/ngspice-rawfile/divider-op-listed.raw
@@ -1,0 +1,18 @@
+Title: * resistive divider, operating point, written with an explicit vector list:
+Date: Sat Sep  5 08:54:42  2026
+Command: ngspice-46, Build 
+Plotname: Operating Point
+Flags: real
+No. Variables: 4
+No. Points: 1
+Variables:
+	0	v(in)	voltage
+	1	v(in)	voltage
+	2	v(mid)	voltage
+	3	i(v1)	current
+Values:
+ 0	1.000000000000000e+00
+	1.000000000000000e+00
+	5.000000000000000e-01
+	-5.000000000000000e-04
+

--- a/packages/spice-run/src/result-data.test.ts
+++ b/packages/spice-run/src/result-data.test.ts
@@ -111,6 +111,38 @@ describe("an operating point", () => {
   });
 });
 
+describe("an operating point written with an explicit vector list", () => {
+  // `write file v(in) v(mid) i(v1)` is how a compiled setup asks for exactly
+  // its probes. ngspice 46 answers by writing the plot's scale first, and an
+  // operating point's scale is its first vector, so the file carries v(in)
+  // twice (see the fixture's Variables block). A table with the same probe
+  // on two rows is what a reader sees if it takes the file at its word.
+  it("reads each probe once and the same numbers as the unlisted write", () => {
+    const listed = only("divider-op-listed.raw", "op");
+    const whole = only("divider-op.raw", "op");
+    expect(listed.probes.map((probe) => probe.name)).toEqual([
+      "v(in)",
+      "v(mid)",
+      "i(v1)",
+    ]);
+    expect(listed.probes).toEqual(whole.probes);
+  });
+
+  it("still refuses a file that gives one probe two different values", () => {
+    const contradiction = fixture("divider-op-listed.raw").replace(
+      /(Values:\n 0\t)(\S+)/u,
+      (_, head: string, value: string) => `${head}${Number(value) + 1}`,
+    );
+    const reading = readSimulationData(contradiction);
+    expect(reading.status).toBe("unusable");
+    if (reading.status === "unusable") {
+      expect(reading.diagnostics.map((d) => d.text).join(" ")).toMatch(
+        /two different values for "v\(in\)"/u,
+      );
+    }
+  });
+});
+
 describe("an AC sweep", () => {
   const ac = (): AcResult => only("rc-ac.raw", "ac");
   const probe = (analysis: AcResult, name: string) =>

--- a/packages/spice-run/src/result-data.ts
+++ b/packages/spice-run/src/result-data.ts
@@ -229,6 +229,7 @@ function readOperatingPoint(plot: RawfilePlot): PlotReading {
     };
   }
   const probes: OperatingPointProbe[] = [];
+  const seen = new Map<string, number>();
   for (const vector of plot.vectors) {
     const value = vector.real[0];
     if (value === undefined) {
@@ -238,6 +239,22 @@ function readOperatingPoint(plot: RawfilePlot): PlotReading {
         ),
       };
     }
+    // ngspice's `write` with an explicit vector list emits the plot's scale
+    // before the listed vectors, and an operating-point plot's scale is its
+    // first vector, so the first requested probe arrives twice with one
+    // value. That echo is the format, not a second probe; two different
+    // values under one name would be a real contradiction and is refused.
+    const key = `${vector.variable.name}\u0000${vector.variable.quantity}`;
+    const earlier = seen.get(key);
+    if (earlier !== undefined) {
+      if (earlier === value) continue;
+      return {
+        diagnostic: error(
+          `The operating point holds two different values for "${vector.variable.name}": ${earlier} and ${value}.`,
+        ),
+      };
+    }
+    seen.set(key, value);
     probes.push({ ...probeOf(vector), value });
   }
   return { analysis: { analysis: "op", plotName: plot.plotName, probes } };


### PR DESCRIPTION
## Symptom

Run the bundled five-transistor OTA on the preview: the OP table shows `v(vout)` on two rows.

## Cause

A compiled setup asks for exactly its probes: `write out.raw v(vout) v(ibias) v(xdut.tail) v(xdut.nleft)`. ngspice 46 answers a *listed* `write` by emitting the plot's scale before the listed vectors, and an operating-point plot's scale is its first vector, so the first probe arrives twice with one value. Reproduced locally with ngspice 46 (`Variables:` block of the new fixture). AC and transient plots are unaffected because their scale is the sweep axis, which is never one of the listed vectors.

## Fix

`readOperatingPoint` reports a repeated (name, quantity) pair once when the value is identical, and refuses a file that gives one probe two different values (a real contradiction). New fixture `fixtures/ngspice-rawfile/divider-op-listed.raw`, written by ngspice 46 from the deck beside it, carries the echo; two tests cover both branches.

## Verification

- `pnpm test:local packages/spice-run packages/simulation-service worker/simulation.test.ts`: 8 files, 120 tests pass.
- `pnpm typecheck`, Prettier on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
