### PR TITLE
test(preview): require the public Agent simulation journey

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -48,6 +48,8 @@ jobs:
           # preview editor, so its Connect Agent surface is enabled here.
           # Production stays human-only (docs/agent/README.md).
           VITE_ICM_AGENT_UI: enabled
+      - run: pnpm --filter @icm/mcp-server... build
+      - run: pnpm exec playwright install --with-deps chromium
       - name: Deploy to preview
         run: pnpm dlx wrangler@4.120.1 deploy --config wrangler.preview.jsonc
         env:
@@ -146,3 +148,13 @@ jobs:
       # simulator host; a green status without numbers is not acceptance.
       - name: Run the preview's numerical and vertical simulation acceptance
         run: node scripts/preview-simulation-smoke.mjs "$PREVIEW_URL"
+      - name: Run the public Agent/MCP simulation journey
+        run: node scripts/preview-agent-simulation-journey.mjs "$PREVIEW_URL"
+      - name: Preserve the Agent/MCP simulation receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-agent-simulation-${{ github.sha }}
+          path: test-results/preview-agent-simulation/
+          if-no-files-found: error
+          retention-days: 14

--- a/scripts/preview-agent-simulation-journey.mjs
+++ b/scripts/preview-agent-simulation-journey.mjs
@@ -1,0 +1,299 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { createInterface } from "node:readline";
+
+import { chromium } from "@playwright/test";
+import { compileStructuredSimulation } from "../packages/netlist/dist/index.js";
+import { parseProject } from "../packages/project-protocol/dist/index.js";
+import { validateHostedSky130Result } from "./preview-simulation-smoke.mjs";
+
+const baseUrl = new URL(
+  process.argv[2] ?? "https://analog-canvas-preview.tokenzhang.com",
+);
+const outputDirectory = resolve(
+  process.env.ICM_ACCEPTANCE_OUTPUT_DIR ??
+    "test-results/preview-agent-simulation",
+);
+const projectText = await readFile(
+  new URL(
+    "../apps/editor/src/examples/five-transistor-ota-sky130.icproj.json",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const project = parseProject(projectText);
+assert(project.simulation, "The acceptance Project has no saved setup");
+const compiled = await compileStructuredSimulation(project, project.simulation);
+assert(compiled.ok, "The acceptance Project no longer compiles");
+
+await mkdir(outputDirectory, { recursive: true });
+const privateDirectory = await mkdtemp(join(tmpdir(), "analog-canvas-mcp-"));
+const report = {
+  schemaVersion: 1,
+  target: baseUrl.origin,
+  fixture: "sky130-ota-5t",
+  startedAt: new Date().toISOString(),
+};
+
+let browser;
+let mcp;
+let paired = false;
+let sequence = 0;
+const pending = new Map();
+
+function rpc(method, params) {
+  return new Promise((resolveReply, reject) => {
+    const id = ++sequence;
+    const timeout = setTimeout(() => {
+      pending.delete(id);
+      reject(new Error(`MCP request timed out: ${method}`));
+    }, 150_000);
+    pending.set(id, {
+      resolve(value) {
+        clearTimeout(timeout);
+        resolveReply(value);
+      },
+      reject(error) {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    });
+    mcp.stdin.write(
+      `${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`,
+    );
+  });
+}
+
+async function tool(name, args = {}, allowProblem = false) {
+  const reply = await rpc("tools/call", { name, arguments: args });
+  const text = reply.content?.find((item) => item.type === "text")?.text;
+  assert.equal(typeof text, "string", `${name} returned no text result`);
+  const value = JSON.parse(text);
+  if (reply.isError && !allowProblem) {
+    throw new Error(`${name} failed: ${text}`);
+  }
+  return value;
+}
+
+async function startMcp() {
+  mcp = spawn(process.execPath, [resolve("apps/mcp-server/dist/main.js")], {
+    cwd: resolve("."),
+    env: {
+      ...process.env,
+      ANALOG_CANVAS_API_URL: baseUrl.origin,
+      ANALOG_CANVAS_MCP_CONNECTOR: join(privateDirectory, "connector.json"),
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const stderr = [];
+  mcp.stderr.on("data", (chunk) => stderr.push(String(chunk).slice(-2_000)));
+  mcp.once("exit", (code, signal) => {
+    if (pending.size) {
+      const error = new Error(
+        `MCP exited ${code ?? signal ?? "unknown"}: ${stderr.join("").slice(-4_000)}`,
+      );
+      for (const request of pending.values()) request.reject(error);
+      pending.clear();
+    }
+  });
+  createInterface({ input: mcp.stdout }).on("line", (line) => {
+    let reply;
+    try {
+      reply = JSON.parse(line);
+    } catch {
+      return;
+    }
+    const request = pending.get(reply.id);
+    if (!request) return;
+    pending.delete(reply.id);
+    if (reply.error) request.reject(new Error(JSON.stringify(reply.error)));
+    else request.resolve(reply.result);
+  });
+  await rpc("initialize", {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "preview-simulation-acceptance", version: "1" },
+  });
+  mcp.stdin.write(
+    `${JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" })}\n`,
+  );
+}
+
+async function stopMcp() {
+  if (!mcp) return;
+  const child = mcp;
+  mcp = undefined;
+  child.stdin.end();
+  await new Promise((resolveExit) => {
+    const timeout = setTimeout(() => {
+      child.kill();
+      resolveExit();
+    }, 5_000);
+    child.once("exit", () => {
+      clearTimeout(timeout);
+      resolveExit();
+    });
+  });
+}
+
+async function exportArtifact(artifact, name) {
+  assert(artifact, `Missing ${name} artifact`);
+  const saved = await tool("simulation_files", {
+    request: { action: "artifact", artifactId: artifact.id },
+    outputPath: join(outputDirectory, name),
+  });
+  assert.notEqual(saved.ok, false, `Could not export ${name}`);
+  return {
+    name,
+    sha256: artifact.sha256,
+    byteLength: artifact.byteLength,
+  };
+}
+
+try {
+  browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: { width: 1_440, height: 1_000 },
+  });
+  const page = await context.newPage();
+  await page.goto(new URL("/editor", baseUrl).toString());
+  await page.getByTestId("project-file").setInputFiles({
+    name: "sky130-ota-5t.icproj.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(projectText),
+  });
+
+  await page
+    .locator("summary")
+    .filter({ hasText: /^Agent$/ })
+    .click();
+  await page
+    .getByRole("button", { name: "Connect Agent", exact: true })
+    .click();
+  await page.getByTestId("agent-preset-full").click();
+  const claimElement = page.getByTestId("agent-claim-code");
+  await claimElement.waitFor({ state: "attached", timeout: 30_000 });
+  const claimCode = await claimElement.textContent();
+  assert(claimCode, "The preview returned no Agent claim code");
+
+  await startMcp();
+  const connection = await tool("connect", { claimCode });
+  assert.equal(connection.ok, true);
+  assert.equal(connection.mode, "claimed");
+  paired = true;
+  // Claiming and attaching the browser are distinct relay events. The MCP
+  // receipt may arrive first, so wait on the product's own connected state
+  // instead of racing the first circuit request or hiding it behind a sleep.
+  await page
+    .getByTestId("agent-status")
+    .filter({ hasText: "Connected" })
+    .waitFor({ state: "visible", timeout: 30_000 });
+
+  const invalidSetup = structuredClone(project.simulation);
+  invalidSetup.input.probes[0].netId = "missing-acceptance-net";
+  const refused = await tool(
+    "simulation",
+    {
+      request: {
+        operation: "prepare",
+        source: { kind: "structured", setup: invalidSetup },
+      },
+    },
+    true,
+  );
+  assert.equal(refused.ok, false);
+  assert.equal(refused.error.recovery, "fix-input");
+
+  const prepared = await tool("simulation", {
+    request: { operation: "prepare", source: { kind: "structured" } },
+  });
+  assert.equal(prepared.ok, true);
+  assert.deepEqual(prepared.prepared.vectors, compiled.vectors);
+  const started = await tool("simulation", {
+    request: {
+      operation: "start",
+      preparedId: prepared.prepared.id,
+      digest: prepared.prepared.digest,
+    },
+  });
+  assert.equal(started.ok, true);
+
+  let finished;
+  for (let attempt = 0; attempt < 180; attempt++) {
+    finished = await tool("simulation", {
+      request: { operation: "read", runId: started.run.id },
+    });
+    assert.equal(finished.ok, true);
+    if (!["running", "cancelling"].includes(finished.run.state)) break;
+    await new Promise((resolveWait) => setTimeout(resolveWait, 500));
+  }
+  assert(finished, "The run returned no final state");
+  assert.equal(finished.run.state, "finished");
+  assert.equal(finished.run.result?.outcome.status, "completed");
+  const accepted = validateHostedSky130Result(
+    finished.run.result,
+    "operator-host",
+    prepared.prepared.inputRevision,
+    prepared.prepared.vectors,
+  );
+
+  const exports = [];
+  for (const name of ["out.raw", "result.json", "ac-1.csv"]) {
+    exports.push(
+      await exportArtifact(
+        finished.run.artifacts.find((artifact) => artifact.name === name),
+        name,
+      ),
+    );
+  }
+  exports.push(
+    await exportArtifact(
+      prepared.prepared.artifacts.find(
+        (artifact) => artifact.name === "prepared.cir",
+      ),
+      "prepared.cir",
+    ),
+  );
+
+  report.status = "passed";
+  report.completedAt = new Date().toISOString();
+  report.connection = { mode: connection.mode };
+  report.recoverableError = refused.error.code;
+  report.run = {
+    state: finished.run.state,
+    outcome: finished.run.result.outcome.status,
+    profileId: finished.run.result.metadata.environment.profileId,
+    environmentFingerprint: accepted.environmentFingerprint,
+    inputRevision: prepared.prepared.inputRevision,
+  };
+  report.exports = exports;
+  await tool("disconnect");
+  paired = false;
+  console.log(
+    `Preview Agent/MCP OTA journey passed (${accepted.environmentFingerprint})`,
+  );
+} catch (error) {
+  report.status = "failed";
+  report.completedAt = new Date().toISOString();
+  report.error = error instanceof Error ? error.message : String(error);
+  if (browser) {
+    const pages = browser.contexts().flatMap((context) => context.pages());
+    await pages[0]
+      ?.screenshot({ path: join(outputDirectory, "failure.png") })
+      .catch(() => {});
+  }
+  process.exitCode = 1;
+  console.error(report.error);
+} finally {
+  if (paired && mcp) await tool("disconnect").catch(() => {});
+  await stopMcp();
+  if (browser) await browser.close();
+  await writeFile(
+    join(outputDirectory, "receipt.json"),
+    `${JSON.stringify(report, null, 2)}\n`,
+  );
+  await rm(privateDirectory, { recursive: true, force: true });
+}

--- a/scripts/preview-workflow.test.mjs
+++ b/scripts/preview-workflow.test.mjs
@@ -43,6 +43,13 @@ describe("the preview deploy", () => {
     expect(preview).toContain(
       'node scripts/preview-simulation-smoke.mjs "$PREVIEW_URL"',
     );
+    expect(preview).toContain("VITE_ICM_AGENT_UI: enabled");
+    expect(preview).toContain("pnpm --filter @icm/mcp-server... build");
+    expect(preview).toContain("playwright install --with-deps chromium");
+    expect(preview).toContain(
+      'node scripts/preview-agent-simulation-journey.mjs "$PREVIEW_URL"',
+    );
+    expect(preview).toContain("preview-agent-simulation-${{ github.sha }}");
     // The reusable smoke is responsible for explicit transport selection,
     // numeric validation, and environment parity; the workflow must not
     // quietly restore an inline, default-executor-only probe.
@@ -53,5 +60,7 @@ describe("the preview deploy", () => {
 
   it("does not leak into the production workflow", () => {
     expect(production).not.toContain("wrangler.preview.jsonc");
+    expect(production).not.toContain("VITE_ICM_AGENT_UI: enabled");
+    expect(production).not.toContain("preview-agent-simulation-journey.mjs");
   });
 });


### PR DESCRIPTION
## Summary
- enable the existing Connect Agent surface only in Preview builds
- pair the deployed browser host with the packaged stdio MCP adapter
- require recoverable prepare failure, corrected OTA OP/AC, and deck/raw/result/CSV export
- preserve a sanitized receipt while keeping the connector and claim credential ephemeral

## Boundary
Production remains human-Agent-UI disabled. This changes no Agent permissions, simulation protocol, executor, Project schema, or production deployment. The existing direct API numerical acceptance remains separate and still runs first.

## Validation
- 
ode --check scripts/preview-agent-simulation-journey.mjs
- pnpm test:local scripts/preview-workflow.test.mjs apps/editor/src/agent/public-agent-ui.test.ts
- pnpm --filter @icm/mcp-server... build
- pnpm gate:preflight -- --base origin/main
- pnpm gate:full: 2621 unit tests passed, 26 skipped; build/release/performance checks passed; 354 browser tests passed

The live public journey is intentionally exercised by the post-deploy Preview workflow because the current deployed build does not expose the pairing entry.