### PR TITLE
feat(simulation): derive qualified capabilities from profile

### DIFF
--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -588,6 +588,15 @@ snapshot and never changes the run or its timers.
 
 ## Run lifecycle
 
+The capability response does not maintain a second analysis allow-list. Its
+structured `analyses` are read from the selected hosted Profile's qualified
+scope; `parsedAnalyses` is reported separately because the rawfile reader may
+understand results which structured preparation is not yet qualified to
+author. The response also advertises the execution harness' `maxOutputBytes`.
+Preparation estimates ASCII rawfile size from analysis points and compiled
+probe vectors. Exceeding that estimate adds a truncation warning but never
+blocks an Agent or human from starting the run.
+
 The service exposes `prepare`, `start`, `read`, `cancel`, and `export`.
 `start` executes exactly the prepared input whose digest it was given and
 returns a short receipt with a run id; `read` returns status or the final

--- a/packages/simulation-service/src/contract.ts
+++ b/packages/simulation-service/src/contract.ts
@@ -113,6 +113,8 @@ export const CapabilitiesSchema = z.strictObject({
     .optional(),
   maxTimeoutMs: z.number(),
   maxInputBytes: z.number(),
+  /** Maximum raw simulator output returned by the selected execution harness. */
+  maxOutputBytes: z.number().int().positive().optional(),
   cancel: z.boolean(),
 });
 export type Capabilities = z.infer<typeof CapabilitiesSchema>;

--- a/packages/simulation-service/src/index.ts
+++ b/packages/simulation-service/src/index.ts
@@ -2,3 +2,4 @@ export * from "./contract.js";
 export * from "./files.js";
 export * from "./service.js";
 export * from "./hosted-executor.js";
+export * from "./result-volume.js";

--- a/packages/simulation-service/src/result-volume.test.ts
+++ b/packages/simulation-service/src/result-volume.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  estimateSimulationOutputBytes,
+  outputVolumeWarning,
+} from "./result-volume.js";
+
+describe("simulation result volume estimate", () => {
+  it("counts AC points by sweep semantics and every requested vector", () => {
+    const linear = estimateSimulationOutputBytes(
+      [
+        {
+          kind: "ac",
+          sweep: "lin",
+          points: 10,
+          startHz: 1,
+          stopHz: 1e6,
+        },
+      ],
+      2,
+    );
+    const decade = estimateSimulationOutputBytes(
+      [
+        {
+          kind: "ac",
+          sweep: "dec",
+          points: 10,
+          startHz: 1,
+          stopHz: 1e6,
+        },
+      ],
+      2,
+    );
+    expect(decade).toBeGreaterThan(linear);
+  });
+
+  it("warns without refusing when a transient estimate exceeds the limit", () => {
+    const warning = outputVolumeWarning(
+      [
+        {
+          kind: "tran",
+          stepSeconds: 1e-9,
+          stopSeconds: 1e-3,
+        },
+      ],
+      8,
+      1024 * 1024,
+    );
+    expect(warning).toContain("run remains allowed");
+    expect(warning).toContain("may be truncated");
+  });
+});

--- a/packages/simulation-service/src/result-volume.ts
+++ b/packages/simulation-service/src/result-volume.ts
@@ -1,0 +1,82 @@
+/**
+ * Conservative, advisory size estimation for ngspice's ASCII rawfile.
+ *
+ * This deliberately stays independent of the persisted SimulationSetup
+ * schema so parser support may remain broader than structured authoring. The
+ * estimate is a warning input, never an execution admission check.
+ */
+export type ResultVolumeAnalysis =
+  | { readonly kind: "op" }
+  | {
+      readonly kind: "ac";
+      readonly sweep: "dec" | "oct" | "lin";
+      readonly points: number;
+      readonly startHz: number;
+      readonly stopHz: number;
+    }
+  | {
+      readonly kind: "tran";
+      readonly stepSeconds: number;
+      readonly stopSeconds: number;
+      readonly startSeconds?: number;
+    };
+
+const RAWFILE_HEADER_BYTES = 4096;
+const ASCII_REAL_VALUE_BYTES = 24;
+const ASCII_COMPLEX_VALUE_BYTES = 48;
+
+function acPointCount(analysis: Extract<ResultVolumeAnalysis, { kind: "ac" }>) {
+  if (analysis.sweep === "lin") return Math.max(1, analysis.points);
+  const intervals =
+    analysis.sweep === "dec"
+      ? Math.log10(analysis.stopHz / analysis.startHz)
+      : Math.log2(analysis.stopHz / analysis.startHz);
+  return Math.max(1, Math.ceil(intervals * analysis.points) + 1);
+}
+
+function tranPointCount(
+  analysis: Extract<ResultVolumeAnalysis, { kind: "tran" }>,
+) {
+  const start = analysis.startSeconds ?? 0;
+  // ngspice uses adaptive internal timesteps. Four times the requested output
+  // grid is an intentionally conservative warning estimate, not a promise.
+  return Math.max(
+    1,
+    (Math.ceil((analysis.stopSeconds - start) / analysis.stepSeconds) + 1) * 4,
+  );
+}
+
+export function estimateSimulationOutputBytes(
+  analyses: readonly ResultVolumeAnalysis[],
+  probeCount: number,
+): number {
+  let bytes = RAWFILE_HEADER_BYTES;
+  for (const analysis of analyses) {
+    if (analysis.kind === "op") {
+      bytes += RAWFILE_HEADER_BYTES + probeCount * ASCII_REAL_VALUE_BYTES;
+      continue;
+    }
+    const points =
+      analysis.kind === "ac"
+        ? acPointCount(analysis)
+        : tranPointCount(analysis);
+    const bytesPerValue =
+      analysis.kind === "ac"
+        ? ASCII_COMPLEX_VALUE_BYTES
+        : ASCII_REAL_VALUE_BYTES;
+    // One scale vector (frequency or time) plus every requested probe.
+    bytes += RAWFILE_HEADER_BYTES + points * (probeCount + 1) * bytesPerValue;
+  }
+  return Math.ceil(bytes);
+}
+
+export function outputVolumeWarning(
+  analyses: readonly ResultVolumeAnalysis[],
+  probeCount: number,
+  maxOutputBytes: number | undefined,
+): string | null {
+  if (maxOutputBytes === undefined) return null;
+  const estimated = estimateSimulationOutputBytes(analyses, probeCount);
+  if (estimated <= maxOutputBytes) return null;
+  return `Estimated ASCII raw output is about ${estimated} bytes for ${probeCount} probes, above this executor's ${maxOutputBytes}-byte output limit; the run remains allowed but its result may be truncated.`;
+}

--- a/packages/simulation-service/src/service.test.ts
+++ b/packages/simulation-service/src/service.test.ts
@@ -22,6 +22,7 @@ const caps: Capabilities = {
   profiles: [{ id: "test", corners: ["tt"] }],
   maxTimeoutMs: 120000,
   maxInputBytes: 1048576,
+  maxOutputBytes: 1048576,
   cancel: true,
 };
 const deck =
@@ -318,6 +319,7 @@ describe("shared simulation lifecycle", () => {
     f.executor.capabilities = async () => ({
       ...caps,
       profiles: [{ id: profileId, corners: ["tt"] }],
+      maxOutputBytes: 100,
     });
     const service = new SimulationService(f.files, f.executor, () => project);
     const prepared = unwrap(
@@ -329,6 +331,24 @@ describe("shared simulation lifecycle", () => {
     );
     expect(prepared.vectors.length).toBeGreaterThan(0);
     expect(prepared.mode).toBe("structured");
+    expect(prepared.warnings).toEqual([
+      expect.stringContaining("run remains allowed"),
+    ]);
     expect(f.executor.execute).not.toHaveBeenCalled();
+
+    f.executor.capabilities = async () => ({
+      ...caps,
+      analyses: ["op"],
+      profiles: [{ id: profileId, corners: ["tt"] }],
+    });
+    expect(
+      await service.handle(
+        { operation: "prepare", source: { kind: "structured" } },
+        "ota-unqualified",
+      ),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "SIMULATION_ANALYSIS_UNQUALIFIED" },
+    });
   });
 });

--- a/packages/simulation-service/src/service.ts
+++ b/packages/simulation-service/src/service.ts
@@ -16,7 +16,16 @@ import {
   type Problem,
   type SimulationOperation,
 } from "./contract.js";
+import {
+  outputVolumeWarning,
+  type ResultVolumeAnalysis,
+} from "./result-volume.js";
 import { SimulationFiles, sha256 } from "./files.js";
+
+type StructuredResultVolumeAnalysis = Extract<
+  ResultVolumeAnalysis,
+  { kind: "op" | "ac" }
+>;
 
 export interface ExecutionInput {
   mode: "structured" | "raw";
@@ -224,6 +233,7 @@ export class SimulationService {
     let input: ExecutionInput;
     let vectors: Prepared["vectors"] = [];
     let warnings: string[] = [];
+    let structuredAnalyses: StructuredResultVolumeAnalysis[] | null = null;
     if (op.source.kind === "structured") {
       const project = structuredClone(this.getProject());
       const setup = op.source.setup ?? project.simulation;
@@ -266,6 +276,9 @@ export class SimulationService {
       };
       vectors = [...compiled.vectors];
       warnings = compiled.warnings.map((w) => w.message);
+      structuredAnalyses = setup.input.analyses.map((analysis) => ({
+        ...analysis,
+      }));
     } else {
       const read = this.files.snapshot(
         op.source.workspaceId,
@@ -303,6 +316,23 @@ export class SimulationService {
         "The selected Profile does not support this corner",
         "prepare",
       );
+    if (structuredAnalyses) {
+      const unsupported = structuredAnalyses.find(
+        (analysis) => !caps.analyses.includes(analysis.kind),
+      );
+      if (unsupported)
+        return problem(
+          "SIMULATION_ANALYSIS_UNQUALIFIED",
+          `Analysis ${unsupported.kind} is not qualified by the selected Profile`,
+          "prepare",
+        );
+      const volumeWarning = outputVolumeWarning(
+        structuredAnalyses,
+        vectors.length,
+        caps.maxOutputBytes,
+      );
+      if (volumeWarning) warnings.push(volumeWarning);
+    }
     input.preparedDeck =
       input.mode === "raw"
         ? input.testbench

--- a/worker/simulation.test.ts
+++ b/worker/simulation.test.ts
@@ -68,6 +68,10 @@ describe("simulation route", () => {
     expect(await response!.json()).toMatchObject({
       configured: false,
       inputs: ["structured", "raw"],
+      analyses: hostedSky130Profile.qualifiedScope.analyses,
+      parsedAnalyses: ["op", "ac", "tran"],
+      maxInputBytes: 2 * 1024 * 1024,
+      maxOutputBytes: 1024 * 1024,
       cancel: true,
     });
   });

--- a/worker/simulation.ts
+++ b/worker/simulation.ts
@@ -56,6 +56,8 @@ export interface SimulationEnv {
   SKY130_LIB_PATH?: string;
   /** Section in the sectioned Sky130 library; `tt` when omitted. */
   SKY130_LIB_SECTION?: string;
+  /** Must match the selected harness' SIMULATION_MAX_OUTPUT_BYTES. */
+  SIMULATION_MAX_OUTPUT_BYTES?: string;
 }
 
 // The continuous (unbinned) Sky130 library the benchmark image ships; the
@@ -63,6 +65,14 @@ export interface SimulationEnv {
 
 /** A deck this large is a mistake upstream, not a simulation worth waking for. */
 const MAX_INPUT_BYTES = 2 * 1024 * 1024;
+const DEFAULT_MAX_OUTPUT_BYTES = 1024 * 1024;
+
+function advertisedMaxOutputBytes(env: SimulationEnv): number {
+  const configured = Number(env.SIMULATION_MAX_OUTPUT_BYTES);
+  return Number.isInteger(configured) && configured > 0
+    ? configured
+    : DEFAULT_MAX_OUTPUT_BYTES;
+}
 
 /**
  * Cloudflare Containers are owned by a named Durable Object. An image deploy
@@ -282,7 +292,7 @@ export async function routeSimulationRequest(
     return Response.json({
       configured: !!selected,
       inputs: ["structured", "raw"],
-      analyses: ["op", "ac"],
+      analyses: hostedSky130Profile.qualifiedScope.analyses,
       parsedAnalyses: ["op", "ac", "tran"],
       profiles: [
         {
@@ -295,7 +305,8 @@ export async function routeSimulationRequest(
         section: env.SKY130_LIB_SECTION ?? SKY130_LIBRARY_SECTION,
       },
       maxTimeoutMs: 120000,
-      maxInputBytes: 1024 * 1024,
+      maxInputBytes: MAX_INPUT_BYTES,
+      maxOutputBytes: advertisedMaxOutputBytes(env),
       cancel: true,
     });
   }


### PR DESCRIPTION
## Summary
- derive structured analysis capabilities from the hosted Profile qualified scope
- expose the execution output budget and warn on oversized AC/TRAN result estimates without blocking runs
- reject structured preparation only when an analysis is not qualified

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main (2627 passed, 26 skipped)

Test-Impact: tests-updated