### PR TITLE
feat(simulation): qualify structured transient analysis

### DIFF
--- a/apps/editor/src/agent/use-agent-session.ts
+++ b/apps/editor/src/agent/use-agent-session.ts
@@ -382,7 +382,7 @@ export function useAgentSession(
                           "cancel",
                           "export",
                         ] as const,
-                        analyses: ["op", "ac"] as const,
+                        analyses: ["op", "ac", "tran"] as const,
                         maxTimeoutMs: AGENT_SIMULATION_MAX_TIMEOUT_MS,
                         synchronous: false as const,
                       },

--- a/apps/editor/src/examples/common-source-amplifier.icproj.json
+++ b/apps/editor/src/examples/common-source-amplifier.icproj.json
@@ -1344,7 +1344,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/current-mirror-loaded-differential-pair.icproj.json
+++ b/apps/editor/src/examples/current-mirror-loaded-differential-pair.icproj.json
@@ -1271,7 +1271,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/five-transistor-ota-sky130.icproj.json
+++ b/apps/editor/src/examples/five-transistor-ota-sky130.icproj.json
@@ -3014,7 +3014,7 @@
   ],
   "id": "project-five-transistor-ota-sky130",
   "name": "Five-Transistor OTA (Sky130)",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "simulation": {
     "version": 1,
     "input": {

--- a/apps/editor/src/examples/fully-differential-two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/fully-differential-two-stage-op-amp.icproj.json
@@ -2487,7 +2487,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/apps/editor/src/examples/two-stage-op-amp.icproj.json
+++ b/apps/editor/src/examples/two-stage-op-amp.icproj.json
@@ -778,7 +778,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "New Circuit",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/containers/ngspice/hosted-sky130-profile.json
+++ b/containers/ngspice/hosted-sky130-profile.json
@@ -24,6 +24,6 @@
   "qualifiedScope": {
     "devices": ["sky130_fd_pr__nfet_01v8", "sky130_fd_pr__pfet_01v8"],
     "sections": ["tt"],
-    "analyses": ["op", "ac"]
+    "analyses": ["op", "ac", "tran"]
   }
 }

--- a/containers/ngspice/profile-contract.test.mjs
+++ b/containers/ngspice/profile-contract.test.mjs
@@ -36,7 +36,7 @@ describe("the hosted SKY130 Profile", () => {
     expect(profile.qualifiedScope).toEqual({
       devices: ["sky130_fd_pr__nfet_01v8", "sky130_fd_pr__pfet_01v8"],
       sections: ["tt"],
-      analyses: ["op", "ac"],
+      analyses: ["op", "ac", "tran"],
     });
   });
 });

--- a/docs/overall-product-plan.md
+++ b/docs/overall-product-plan.md
@@ -68,7 +68,7 @@ revision, lock, or transaction invariants.
   ordered hierarchy interface rather than another Net-label mechanism.
 - Routes describe visible geometry; they may stretch locally during movement
   without changing logical connectivity.
-- A Project's canonical content is schema-37 JSON. Explicit Save updates one
+- A Project's canonical content is schema-38 JSON. Explicit Save updates one
   stable private Cloud Project; `.icproj.json` is portable interchange, and
   browser recovery is an origin-local, non-authoritative copy.
 - Visual variants may change presentation but never remove electrical terminal

--- a/docs/specs/editor-interaction.md
+++ b/docs/specs/editor-interaction.md
@@ -444,8 +444,8 @@ Open, demo load, restore, and human-approved staged import replace the entire
 Project through one replacement boundary; they are not Edit Engine
 transactions. Replacement cancels pending recovery for the outgoing Project
 and terminates its Agent session. A complete Project covered by the schema
-24→37 upgrade chain may be upgraded at the read boundary and then enters the
-editor only as schema-37; migrated files are marked as needing save.
+24→38 upgrade chain may be upgraded at the read boundary and then enters the
+editor only as schema-38; migrated files are marked as needing save.
 
 Selection, viewport, active tool, previews, Agent tokens, and approval UI are
 transient and never enter Project JSON. Recovery is scheduled only after a

--- a/docs/specs/persistence-and-recovery.md
+++ b/docs/specs/persistence-and-recovery.md
@@ -5,13 +5,13 @@ Status: `accepted`
 Primary owner: Worker Cloud Project storage, `packages/project-protocol`, and
 the editor document lifecycle
 
-Project content uses canonical schema-37 JSON. A private Cloud Project is the
+Project content uses canonical schema-38 JSON. A private Cloud Project is the
 formal saved resource; `.icproj.json` is portable import/export and backup.
 The current-only model in `packages/model` validates the normalized shape;
 `packages/project-protocol` owns parsing, compatibility diagnostics,
 and canonical serialization. Persistence validates the complete current schema
-before import or Cloud Save. The explicit schema 24→37 chain upgrades supported
-historical files; serialization always writes schema 37. The 32→33 adapter
+before import or Cloud Save. The explicit schema 24→38 chain upgrades supported
+historical files; serialization always writes schema 38. The 32→33 adapter
 rejects ownerless Net equivalence instead of guessing replacement electrical
 semantics, and the 33→34 adapter removes hidden electrical name authority while
 preserving source spelling as provenance. The 34→35 adapter unifies parallel
@@ -19,11 +19,12 @@ Instance naming fields into one authored Reference. The 35→36 adapter repairs
 styled Instance designators that schema 35 materialized as literal labels,
 while retaining descriptive attached text. The 36→37 adapter only advances
 the version stamp for the new optional Project `simulation` setup; no
-existing Project has authored one, and none is inferred. Versions outside the
-implemented chain are rejected.
+existing Project has authored one, and none is inferred. The 37→38 adapter
+adds no data: it only admits explicitly authored structured TRAN analyses.
+Versions outside the implemented chain are rejected.
 
 Recovery state is a non-authoritative browser safety copy. It may restore a
-complete schema-37 Project or a supported historical record that validates
+complete schema-38 Project or a supported historical record that validates
 after the chained upgrade, associated with a recorded working-copy session.
 Corrupt, incompatible, or partial recovery data is discarded or retained as raw
 data without changing the live Project. User-saved Library examples are the

--- a/docs/specs/project-file-format.md
+++ b/docs/specs/project-file-format.md
@@ -2,14 +2,14 @@
 
 Status: `accepted`
 
-Current Project schema: `37`
+Current Project schema: `38`
 
 Primary owners: `packages/model` (current shape) and
 `packages/project-protocol` (file boundary)
 
 An `.icproj.json` file is canonical JSON for one complete `CircuitProject`.
 `@icm/project-protocol` exposes `parseProject`. The file boundary accepts every
-schema covered by its explicit 24→37 upgrade chain. Schema 32 added optional
+schema covered by its explicit 24→38 upgrade chain. Schema 32 added optional
 presentation-only `Annotation.textColor`; schema 33 removes ownerless
 `explicit-equivalence` connectivity. The 32→33 adapter advances the version
 stamp only when that retired record is absent. If one exists, it rejects at the
@@ -29,9 +29,12 @@ Schema 37 adds the optional Project `simulation` field: one persisted
 `SimulationSetup` (ADR 0055) naming the Testbench root Cell, the analyses, the
 probes, and the environment Profile selection. Results and run data never
 enter the file. An absent field means no authored setup, which is every
-existing Project, so the 36→37 adapter rewrites nothing.
-The public file boundary supplies only schema 37 in memory and writes only
-schema 37; versions older than 24 or newer than 37 are rejected.
+existing Project, so the 36→37 adapter rewrites nothing. Schema 38 adds
+structured TRAN with explicit seconds-valued step, stop, optional start, and
+optional maximum-step fields. Existing setups remain valid, so the 37→38
+adapter also rewrites nothing. The public file boundary supplies only schema
+38 in memory and writes only schema 38; versions older than 24 or newer than
+38 are rejected.
 
 ## Current authorities
 
@@ -108,8 +111,8 @@ schema 37; versions older than 24 or newer than 37 are rejected.
 ## Read and write
 
 ```text
-import text -> parse JSON -> require Project schema 24 through 37
--> converge to schema 37 -> strict schema-37 validation -> install unbound
+import text -> parse JSON -> require Project schema 24 through 38
+-> converge to schema 38 -> strict schema-38 validation -> install unbound
 export -> strict validation -> canonical key ordering -> Blob download
 ```
 
@@ -120,7 +123,7 @@ after explicit human approval in the editor.
 A migrated imported file is marked dirty. The editor never overwrites a source
 selected through the browser file input; the user may Save it as a Cloud
 Project or explicitly export upgraded bytes. Browser recovery records may be
-canonicalized to v37 only after a successful validated write.
+canonicalized to v38 only after a successful validated write.
 
 Project entry does not physically merge Base Nets. Matching authoritative names
 resolve as one Logical Net; conflicting claims remain a blocking diagnostic.
@@ -133,7 +136,7 @@ open, and recovery remain exact.
 Canonical serialization ends with one newline and is byte-stable across
 serialize/parse/serialize. The current corpus is listed in
 `fixtures/projects/compatibility-corpus.json`; its accepted entries must all be
-already canonical Project schema 37. The rejected corpus names expected
+already canonical Project schema 38. The rejected corpus names expected
 validation failures.
 
 Viewport, selection, undo history, canvas overlays, Agent credentials,

--- a/docs/specs/schematic-model.md
+++ b/docs/specs/schematic-model.md
@@ -5,7 +5,7 @@ Status: `accepted`
 Primary owner: `packages/model`
 
 The Project contains Documents; each Document owns revisioned electrical,
-geometric, and presentation facts. The current model is strict schema 37 and has
+geometric, and presentation facts. The current model is strict schema 38 and has
 no compatibility shape.
 
 ## Coordinate domains
@@ -193,8 +193,8 @@ ordinary Schematic edits inside one Project structural transaction. The
 Project's `structureRevision` protects this cross-Document boundary and the
 editor records it as one undoable structural commit.
 
-Persistence writes only schema 37. The reader carries every schema in its
-explicit 24→37 upgrade chain forward, then supplies the current model only; no
+Persistence writes only schema 38. The reader carries every schema in its
+explicit 24→38 upgrade chain forward, then supplies the current model only; no
 compatibility shape enters runtime electrical derivation. The 32→33 step
 rejects ownerless equivalence rather than guessing replacement connectivity.
 The 33→34 step converts hidden imported names into non-electrical hints or
@@ -208,3 +208,5 @@ The 36→37 step adds the optional Project `simulation` field, the persisted
 rewrites nothing: an absent field already means no authored setup. The setup
 is Project-level authored intent, not a Document fact; it names a Testbench
 root Cell and never creates, removes, or renames connectivity.
+The 37→38 step admits explicit-SI structured TRAN parameters and invents no
+transient intent for existing setups.

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -71,9 +71,10 @@ downgraded to an observed hosted run. An ordinary local host remains
 Profile.
 
 The first qualified scope is deliberately narrow and factual: the continuous
-`sky130_fd_pr__nfet_01v8` and `sky130_fd_pr__pfet_01v8` wrappers, `tt`, and an
-operating-point analysis plus the OTA AC sweep covered by the hosted acceptance
-fixture. Adding transient, another corner, or another device family extends
+`sky130_fd_pr__nfet_01v8` and `sky130_fd_pr__pfet_01v8` wrappers, `tt`, and
+OP/AC/TRAN covered by the hosted acceptance fixture. TRAN qualification
+includes an ideal RC step and a structured SKY130 OTA pulse response on the
+pinned ngspice 46 environment. Adding another corner or device family extends
 this same Profile contract only after a model-backed fixture passes the hosted
 gate; a locally available PDK is not evidence by itself.
 
@@ -185,10 +186,9 @@ hierarchy, and structural-export behavior. The setup follows the ordinary
 Project save, recovery, Gallery, revision, and undo/redo boundaries; it is not
 stored in a simulation-only sidecar or a second persistence service.
 
-Schema 37 lands the field as the optional `CircuitProject.simulation`, with
-this shape. The structured form is the first one persisted; the raw form joins
-`input` as a second `kind` when it lands, and `tran` joins
-`SimulationAnalysisSpec` when its parameters are persisted.
+Schema 37 landed the optional `CircuitProject.simulation`; schema 38 extends
+its structured analysis union with explicit-SI transient parameters. The raw
+form joins `input` as a second `kind` when it lands.
 
 ```ts
 interface SimulationSetup {
@@ -209,6 +209,13 @@ type SimulationAnalysisSpec =
       points: number; // positive integer
       startHz: number; // > 0
       stopHz: number; // > startHz
+    }
+  | {
+      kind: "tran";
+      stepSeconds: number; // > 0, requested output interval
+      stopSeconds: number; // > 0
+      startSeconds?: number; // >= 0 and < stopSeconds
+      maxStepSeconds?: number; // > 0, optional solver ceiling
     };
 type SimulationProbeSpec =
   | {
@@ -871,10 +878,12 @@ release. A deployment without the binding answers
 - `scripts/preview-simulation-smoke.mjs`: the bundled five-transistor OTA
   Project is the vertical acceptance asset. Its saved `SimulationSetup` is
   parsed and compiled by the production Project/netlist packages before the
-  generated OP+AC request reaches Preview. The returned input revision,
-  environment Profile, model corner, frequency axis, probe series, OP values,
-  and selected AC complex samples must all agree with the tracked
-  qualification evidence; a handwritten deck cannot satisfy this path.
+  generated OP+AC and structured TRAN requests reach Preview. The same gate
+  also runs an ideal RC pulse deck. Returned input revisions, environment
+  Profile, model corner, frequency/time axes, probe series, OP values,
+  selected AC complex samples, and OTA transient extrema must agree with the
+  tracked ngspice 46 qualification evidence; a handwritten deck alone cannot
+  satisfy this path.
 - `containers/ngspice/entrypoint.test.mjs` starts the harness as a real
   process and asserts the execution boundary against stand-in simulators
   that misbehave deliberately: a private directory per run that is removed

--- a/docs/user/project-compatibility.md
+++ b/docs/user/project-compatibility.md
@@ -1,6 +1,6 @@
 # Project File Compatibility
 
-The released Project schema version is `37`. It retains schematic-only
+The released Project schema version is `38`. It retains schematic-only
 hierarchy integrity, a Project structural revision, stable formal Cell ports,
 and definition-level Cell symbol presentation. It also has one typed Instance
 netlist authority, formal Cell parameters, and Project-local external
@@ -33,7 +33,7 @@ text, a fraction, or a coefficient needs more room, and never clips or shrinks
 the formula to satisfy an undersized request. A canonical v34 file can be
 opened, saved, reopened, and saved again without byte drift.
 
-Schemas v24 through v37 are accepted through the explicit chained upgrades.
+Schemas v24 through v38 are accepted through the explicit chained upgrades.
 Schema v32 adds optional `Annotation.textColor`; schema v33 removes the
 ownerless `explicit-equivalence` record. A v32 file without that record changes
 only its version stamp. A file containing it is rejected at the exact evidence
@@ -47,9 +47,10 @@ reference-shaped RichText labels as mapped Reference presentations while
 retaining descriptive attached text. Schema v37 adds the optional Project
 `simulation` setup, which records which Cell is the testbench, which analyses
 and probes to run, and which simulator profile to use; simulation results are
-never saved, and a v36 file changes only its version stamp.
+never saved, and a v36 file changes only its version stamp. Schema v38 adds
+structured TRAN parameters in seconds; a v37 file also changes only its stamp.
 The original file is never overwritten silently. Schemas older than v24 and
-versions newer than v37 are rejected by the project-file boundary.
+versions newer than v38 are rejected by the project-file boundary.
 
 The canonical-current corpus at
 [`fixtures/projects/compatibility-corpus.json`](../../fixtures/projects/compatibility-corpus.json)

--- a/fixtures/gallery-redline/2rmm2vb45f.icproj.json
+++ b/fixtures/gallery-redline/2rmm2vb45f.icproj.json
@@ -5347,7 +5347,7 @@
   ],
   "id": "project-898510e0e3b15ad5",
   "name": "Switched_Capacitor_DAC_6bit (SPICE Import Demo)",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "source": {
     "dialect": "spice3f5-core",
     "entry": "circuit.spi",

--- a/fixtures/gallery-redline/3tfmrzevfe.icproj.json
+++ b/fixtures/gallery-redline/3tfmrzevfe.icproj.json
@@ -3588,7 +3588,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "deadtime",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/gallery-redline/7sxpwb4am7.icproj.json
+++ b/fixtures/gallery-redline/7sxpwb4am7.icproj.json
@@ -1362,7 +1362,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-6c056e6c-b17b-4a66-aab9-06d0b380b437",
   "name": "Figure 17.19(b)",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/gallery-redline/b5cn37k3a9.icproj.json
+++ b/fixtures/gallery-redline/b5cn37k3a9.icproj.json
@@ -1141,7 +1141,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "widlar",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/gallery-redline/f22q5vhdb5.icproj.json
+++ b/fixtures/gallery-redline/f22q5vhdb5.icproj.json
@@ -2055,7 +2055,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-888e7106-b15b-4186-a980-d5a88c004d4c",
   "name": "suppression of skew",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/gallery-redline/ycg43babwa.icproj.json
+++ b/fixtures/gallery-redline/ycg43babwa.icproj.json
@@ -2778,7 +2778,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-main",
   "name": "LTC3452",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/compatibility-corpus.json
+++ b/fixtures/projects/compatibility-corpus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "description": "Canonical schema-v37 Project corpus. Historical schema upgrades are covered by synthesized tests rather than retained duplicate assets.",
+  "description": "Canonical schema-v38 Project corpus. Historical schema upgrades are covered by synthesized tests rather than retained duplicate assets.",
   "current": [
     "fixtures/projects/minimal/project.icproj.json",
     "fixtures/projects/phase-1-manual/project.icproj.json",

--- a/fixtures/projects/instance-value-display/project.icproj.json
+++ b/fixtures/projects/instance-value-display/project.icproj.json
@@ -1075,7 +1075,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "instance-value-display",
   "name": "Instance Value Display",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/minimal/project.icproj.json
+++ b/fixtures/projects/minimal/project.icproj.json
@@ -32,7 +32,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-minimal",
   "name": "Minimal Project",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-1-manual/project.icproj.json
+++ b/fixtures/projects/phase-1-manual/project.icproj.json
@@ -58,7 +58,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-1-manual",
   "name": "Phase 1 Manual Editor",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-3-routing/project.icproj.json
+++ b/fixtures/projects/phase-3-routing/project.icproj.json
@@ -170,7 +170,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-routing",
   "name": "Phase 3 Routing Demo",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/phase-5-dense-analog/project.icproj.json
+++ b/fixtures/projects/phase-5-dense-analog/project.icproj.json
@@ -421,7 +421,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-phase-5-dense-analog",
   "name": "Current Differential Stage",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/projects/rejected-missing-top/project.icproj.json
+++ b/fixtures/projects/rejected-missing-top/project.icproj.json
@@ -32,7 +32,7 @@
   "externalSubcircuitDefinitions": [],
   "id": "project-rejected",
   "name": "Rejected",
-  "schemaVersion": 37,
+  "schemaVersion": 38,
   "source": {
     "dialect": "none",
     "entry": null,

--- a/fixtures/simulation-acceptance/hosted-sky130-core-continuous-v1.json
+++ b/fixtures/simulation-acceptance/hosted-sky130-core-continuous-v1.json
@@ -1,8 +1,8 @@
 {
-  "schemaVersion": 2,
-  "fixtureId": "ota-5t-structured-op-ac-v1",
+  "schemaVersion": 3,
+  "fixtureId": "ota-5t-structured-op-ac-tran-v1",
   "profileId": "sky130-core-continuous-ngspice46-v1",
-  "analyses": ["op", "ac"],
+  "analyses": ["op", "ac", "tran"],
   "inputs": {
     "project": "apps/editor/src/examples/five-transistor-ota-sky130.icproj.json",
     "netlist": "fixtures/simulation-acceptance/ota-5t.spi",
@@ -61,6 +61,37 @@
             "absoluteTolerance": 1e-8
           }
         ]
+      }
+    }
+  },
+  "expectedTran": {
+    "analysis": {
+      "kind": "tran",
+      "stepSeconds": 2e-8,
+      "stopSeconds": 0.000004
+    },
+    "source": {
+      "instanceId": "VINP",
+      "parameters": {
+        "low": "0.89",
+        "high": "0.91",
+        "delay": "1u",
+        "rise": "1n",
+        "fall": "1n",
+        "width": "1u",
+        "period": "3u"
+      }
+    },
+    "pointCount": 232,
+    "stopSeconds": 0.000004,
+    "timeAbsoluteTolerance": 1e-15,
+    "probes": {
+      "v(vout)": {
+        "first": 0.3342235191104477,
+        "minimum": 0.3342107447553537,
+        "maximum": 1.698172273444083,
+        "last": 0.3342235434776202,
+        "absoluteTolerance": 1e-8
       }
     }
   }

--- a/packages/agent-adapter/src/schema.ts
+++ b/packages/agent-adapter/src/schema.ts
@@ -90,7 +90,7 @@ export const AgentSimulationResourceCapabilitySchema = z.strictObject({
   operations: z.array(
     z.enum(["prepare", "start", "read", "cancel", "export", "capabilities"]),
   ),
-  analyses: z.array(z.enum(["op", "ac"])),
+  analyses: z.array(z.enum(["op", "ac", "tran"])),
   maxTimeoutMs: z.number().int().positive(),
   synchronous: z.literal(false),
 });

--- a/packages/model/src/schema.test.ts
+++ b/packages/model/src/schema.test.ts
@@ -918,12 +918,29 @@ describe("SimulationSetup schema", () => {
     expect(ac({ stopHz: 5 })).toBe(false);
     expect(ac({ stopHz: Number.POSITIVE_INFINITY })).toBe(false);
     expect(ac({ tstop: 1 })).toBe(false);
-    expect(
+    const tran = (overrides: Record<string, unknown>) =>
       SimulationSetupSchema.safeParse({
         ...setup(),
-        input: { ...setup().input, analyses: [{ kind: "tran" }] },
-      }).success,
-    ).toBe(false);
+        input: {
+          ...setup().input,
+          analyses: [
+            {
+              kind: "tran",
+              stepSeconds: 1e-9,
+              stopSeconds: 1e-6,
+              ...overrides,
+            },
+          ],
+        },
+      }).success;
+    expect(tran({})).toBe(true);
+    expect(tran({ startSeconds: 0, maxStepSeconds: 1e-10 })).toBe(true);
+    expect(tran({ stepSeconds: 0 })).toBe(false);
+    expect(tran({ stopSeconds: Number.POSITIVE_INFINITY })).toBe(false);
+    expect(tran({ startSeconds: -1 })).toBe(false);
+    expect(tran({ startSeconds: 2e-6 })).toBe(false);
+    expect(tran({ maxStepSeconds: 0 })).toBe(false);
+    expect(tran({ tstop: 1 })).toBe(false);
 
     const environment = (overrides: Record<string, unknown>) => {
       const candidate = setup();

--- a/packages/model/src/schema/common.ts
+++ b/packages/model/src/schema/common.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-export const CURRENT_PROJECT_SCHEMA_VERSION = 37;
+export const CURRENT_PROJECT_SCHEMA_VERSION = 38;
 
 export const StableIdSchema = z.string().min(1).max(256);
 /** Strict persisted/presentation hex color token. Format: `#RRGGBB`. */

--- a/packages/model/src/schema/instance-style.test.ts
+++ b/packages/model/src/schema/instance-style.test.ts
@@ -150,12 +150,12 @@ describe("SignalFlowParametersSchema", () => {
 });
 
 describe("CircuitProject schema version", () => {
-  it("current schema version is 37", () => {
-    expect(CURRENT_PROJECT_SCHEMA_VERSION).toBe(37);
+  it("current schema version is 38", () => {
+    expect(CURRENT_PROJECT_SCHEMA_VERSION).toBe(38);
   });
 
-  it("createEmptyProject produces schema version 37", () => {
-    expect(createEmptyProject("test", "Test").schemaVersion).toBe(37);
+  it("createEmptyProject produces schema version 38", () => {
+    expect(createEmptyProject("test", "Test").schemaVersion).toBe(38);
   });
 
   it("validates style and Signal Flow metadata together", () => {

--- a/packages/model/src/schema/simulation.ts
+++ b/packages/model/src/schema/simulation.ts
@@ -27,9 +27,31 @@ export const SimulationAcAnalysisSchema = z
     message: "AC stop frequency must be greater than the start frequency",
     path: ["stopHz"],
   });
+export const SimulationTransientAnalysisSchema = z
+  .strictObject({
+    kind: z.literal("tran"),
+    /** Requested output interval, in seconds (`tstep` in ngspice). */
+    stepSeconds: z.number().finite().positive(),
+    /** End of the transient interval, in seconds (`tstop`). */
+    stopSeconds: z.number().finite().positive(),
+    /** Optional first saved time, in seconds (`tstart`); defaults to zero. */
+    startSeconds: z.number().finite().nonnegative().optional(),
+    /** Optional maximum internal timestep, in seconds (`tmax`). */
+    maxStepSeconds: z.number().finite().positive().optional(),
+  })
+  .refine(
+    (analysis) =>
+      analysis.startSeconds === undefined ||
+      analysis.stopSeconds > analysis.startSeconds,
+    {
+      message: "TRAN stop time must be greater than the start time",
+      path: ["stopSeconds"],
+    },
+  );
 export const SimulationAnalysisSpecSchema = z.discriminatedUnion("kind", [
   SimulationOperatingPointAnalysisSchema,
   SimulationAcAnalysisSchema,
+  SimulationTransientAnalysisSchema,
 ]);
 
 /**

--- a/packages/netlist/src/simulation-compile.test.ts
+++ b/packages/netlist/src/simulation-compile.test.ts
@@ -705,18 +705,28 @@ describe("refusing a setup that cannot be simulated", () => {
     });
   });
 
-  it("reports an analysis kind this release does not compile", async () => {
+  it("writes explicit-SI transient parameters in ngspice argument order", async () => {
     const result = await compile(
       dividerProject(),
       setupWith({
         analyses: [
-          { kind: "tran" },
-        ] as unknown as SimulationSetup["input"]["analyses"],
+          {
+            kind: "tran",
+            stepSeconds: 1e-6,
+            stopSeconds: 1e-3,
+            startSeconds: 1e-4,
+            maxStepSeconds: 1e-7,
+          },
+        ],
       }),
     );
 
-    expect(result.ok).toBe(false);
-    expect(codes(result)).toEqual(["SIMULATION_UNSUPPORTED_ANALYSIS"]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.request.analyses).toEqual(["tran"]);
+    expect(result.request.testbench).toContain(
+      "\ntran 0.000001 0.001 0.0001 1e-7\nwrite out.raw",
+    );
   });
 
   it("reports a source-current probe on an Instance that is not a source", async () => {

--- a/packages/netlist/src/simulation-compile.ts
+++ b/packages/netlist/src/simulation-compile.ts
@@ -151,6 +151,23 @@ function analysisCommand(analysis: SimulationAnalysisSpec): string {
         spiceNumber(analysis.startHz),
         spiceNumber(analysis.stopHz),
       ].join(" ");
+    case "tran": {
+      const values = [
+        "tran",
+        spiceNumber(analysis.stepSeconds),
+        spiceNumber(analysis.stopSeconds),
+      ];
+      if (
+        analysis.startSeconds !== undefined ||
+        analysis.maxStepSeconds !== undefined
+      ) {
+        values.push(spiceNumber(analysis.startSeconds ?? 0));
+      }
+      if (analysis.maxStepSeconds !== undefined) {
+        values.push(spiceNumber(analysis.maxStepSeconds));
+      }
+      return values.join(" ");
+    }
   }
 }
 
@@ -169,13 +186,21 @@ function canonicalSetup(setup: SimulationSetup): string {
     analyses: input.analyses.map((analysis) =>
       analysis.kind === "op"
         ? { kind: analysis.kind }
-        : {
-            kind: analysis.kind,
-            sweep: analysis.sweep,
-            points: analysis.points,
-            startHz: analysis.startHz,
-            stopHz: analysis.stopHz,
-          },
+        : analysis.kind === "ac"
+          ? {
+              kind: analysis.kind,
+              sweep: analysis.sweep,
+              points: analysis.points,
+              startHz: analysis.startHz,
+              stopHz: analysis.stopHz,
+            }
+          : {
+              kind: analysis.kind,
+              stepSeconds: analysis.stepSeconds,
+              stopSeconds: analysis.stopSeconds,
+              startSeconds: analysis.startSeconds ?? null,
+              maxStepSeconds: analysis.maxStepSeconds ?? null,
+            },
     ),
     probes: input.probes.map((probe) =>
       probe.kind === "net-voltage"
@@ -472,7 +497,7 @@ export async function compileStructuredSimulation(
 
   const analyses: SimulationAnalysis[] = [];
   for (const item of input.analyses) {
-    if (item.kind === "op" || item.kind === "ac") {
+    if (item.kind === "op" || item.kind === "ac" || item.kind === "tran") {
       analyses.push(item.kind);
       continue;
     }

--- a/packages/project-protocol/src/instance-style-migration.test.ts
+++ b/packages/project-protocol/src/instance-style-migration.test.ts
@@ -31,6 +31,7 @@ import {
 import { upgradeSchema34To35 } from "./transforms/instance-reference.js";
 import { upgradeSchema35To36 } from "./transforms/instance-reference-annotation.js";
 import { upgradeSchema36To37 } from "./transforms/simulation-setup.js";
+import { upgradeSchema37To38 } from "./transforms/structured-tran.js";
 
 describe("schema migrations through hidden Net-name retirement", () => {
   it("keeps each retained historical transform independently usable", () => {
@@ -46,6 +47,7 @@ describe("schema migrations through hidden Net-name retirement", () => {
     const v35 = upgradeSchema34To35(v34);
     const v36 = upgradeSchema35To36(v35);
     const v37 = upgradeSchema36To37(v36);
+    const v38 = upgradeSchema37To38(v37);
 
     expect(v29.schemaVersion).toBe(29);
     expect(v30.schemaVersion).toBe(30);
@@ -55,7 +57,8 @@ describe("schema migrations through hidden Net-name retirement", () => {
     expect(v34.schemaVersion).toBe(34);
     expect(v35.schemaVersion).toBe(35);
     expect(v36.schemaVersion).toBe(36);
-    expect(v37.schemaVersion).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
+    expect(v37.schemaVersion).toBe(37);
+    expect(v38.schemaVersion).toBe(CURRENT_PROJECT_SCHEMA_VERSION);
   });
 
   it("reports non-rewriting 28→29 through 32→33 upgrades as unchanged", () => {

--- a/packages/project-protocol/src/load.ts
+++ b/packages/project-protocol/src/load.ts
@@ -25,6 +25,7 @@ import {
   upgradeSchema34To35,
   upgradeSchema35To36,
   upgradeSchema36To37,
+  upgradeSchema37To38,
 } from "./previous-to-current.js";
 import { repairBoundFormatOverrides } from "./transforms/bound-format-override.js";
 import { repairLegacyReviewedExternalReferences } from "./transforms/reviewed-external-reference.js";
@@ -52,6 +53,7 @@ const UPGRADE_CHAIN: ReadonlyArray<
   upgradeSchema34To35,
   upgradeSchema35To36,
   upgradeSchema36To37,
+  upgradeSchema37To38,
 ];
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/project-protocol/src/persistence.test.ts
+++ b/packages/project-protocol/src/persistence.test.ts
@@ -400,7 +400,7 @@ describe("Project persistence", () => {
 
   it("rejects schemas outside the supported chain window", () => {
     const project = createEmptyProject("project-test", "Test Project");
-    for (const schemaVersion of [1, 22, 23, 38, 99]) {
+    for (const schemaVersion of [1, 22, 23, 39, 99]) {
       expect(() =>
         parseProject(JSON.stringify({ ...project, schemaVersion })),
       ).toThrow(

--- a/packages/project-protocol/src/previous-to-current.ts
+++ b/packages/project-protocol/src/previous-to-current.ts
@@ -107,3 +107,11 @@ export type {
   Schema36To37MigrationReport,
   Schema36To37MigrationResult,
 } from "./transforms/simulation-setup.js";
+export {
+  upgradeSchema37To38,
+  upgradeSchema37To38WithReport,
+} from "./transforms/structured-tran.js";
+export type {
+  Schema37To38MigrationReport,
+  Schema37To38MigrationResult,
+} from "./transforms/structured-tran.js";

--- a/packages/project-protocol/src/structured-tran-migration.test.ts
+++ b/packages/project-protocol/src/structured-tran-migration.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { createEmptyProject, CURRENT_PROJECT_SCHEMA_VERSION } from "@icm/model";
+
+import { tryParseProjectWithMetadata } from "./load.js";
+import {
+  upgradeSchema37To38,
+  upgradeSchema37To38WithReport,
+} from "./transforms/structured-tran.js";
+
+describe("schema 37 to 38 migration (structured TRAN)", () => {
+  it("advances the version without inventing an analysis", () => {
+    const previous = {
+      ...createEmptyProject("project", "Project"),
+      schemaVersion: 37,
+    } as unknown as Record<string, unknown>;
+
+    expect(upgradeSchema37To38(previous)).toMatchObject({
+      schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION,
+    });
+    expect(upgradeSchema37To38WithReport(previous).report).toEqual({
+      changed: false,
+    });
+  });
+
+  it("loads an existing schema-37 setup unchanged", () => {
+    const project = createEmptyProject("project", "Project", "tb");
+    const previous = {
+      ...project,
+      schemaVersion: 37,
+      simulation: {
+        version: 1,
+        input: {
+          kind: "structured",
+          rootDocumentId: "tb",
+          analyses: [{ kind: "op" }],
+          probes: [],
+          environment: { profileId: "profile" },
+        },
+      },
+    };
+    const loaded = tryParseProjectWithMetadata(JSON.stringify(previous));
+    expect(loaded).toMatchObject({
+      ok: true,
+      sourceSchemaVersion: 37,
+      migrated: true,
+      project: { schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION },
+    });
+  });
+});

--- a/packages/project-protocol/src/transforms/structured-tran.ts
+++ b/packages/project-protocol/src/transforms/structured-tran.ts
@@ -1,0 +1,24 @@
+export interface Schema37To38MigrationReport {
+  /** Schema 38 extends SimulationSetup with TRAN; existing setups need no rewrite. */
+  readonly changed: false;
+}
+
+export interface Schema37To38MigrationResult {
+  readonly project: Record<string, unknown>;
+  readonly report: Schema37To38MigrationReport;
+}
+
+/** Upgrade schema 37 to 38 without inventing a transient analysis. */
+export function upgradeSchema37To38WithReport(
+  raw: Record<string, unknown>,
+): Schema37To38MigrationResult {
+  const project = structuredClone(raw);
+  project.schemaVersion = 38;
+  return { project, report: { changed: false } };
+}
+
+export function upgradeSchema37To38(
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  return upgradeSchema37To38WithReport(raw).project;
+}

--- a/packages/simulation-service/src/contract.ts
+++ b/packages/simulation-service/src/contract.ts
@@ -105,7 +105,7 @@ export type SimulationOperation = z.infer<typeof SimulationOperationSchema>;
 export const CapabilitiesSchema = z.strictObject({
   configured: z.boolean(),
   inputs: z.array(z.enum(["structured", "raw"])),
-  analyses: z.array(z.enum(["op", "ac"])),
+  analyses: z.array(z.enum(["op", "ac", "tran"])),
   parsedAnalyses: z.array(z.enum(["op", "ac", "tran"])),
   profiles: z.array(z.strictObject({ id: Id, corners: z.array(z.string()) })),
   modelLibrary: z

--- a/packages/simulation-service/src/service.test.ts
+++ b/packages/simulation-service/src/service.test.ts
@@ -351,4 +351,32 @@ describe("shared simulation lifecycle", () => {
       error: { code: "SIMULATION_ANALYSIS_UNQUALIFIED" },
     });
   });
+
+  it("prepares qualified TRAN and keeps an oversized estimate advisory", async () => {
+    const project = CircuitProjectSchema.parse(ota);
+    if (!project.simulation) throw new Error("fixture has no setup");
+    project.simulation.input.analyses = [
+      { kind: "tran", stepSeconds: 1e-9, stopSeconds: 1e-3 },
+    ];
+    project.simulation.input.environment.profileId = "test";
+    const f = fixture();
+    f.executor.capabilities = async () => ({
+      ...caps,
+      analyses: ["op", "ac", "tran"],
+      maxOutputBytes: 1024,
+    });
+    const service = new SimulationService(f.files, f.executor, () => project);
+    const prepared = unwrap(
+      await service.handle(
+        { operation: "prepare", source: { kind: "structured" } },
+        "tran",
+      ),
+      "prepared",
+    );
+    expect(prepared.mode).toBe("structured");
+    expect(prepared.warnings).toEqual([
+      expect.stringContaining("run remains allowed"),
+    ]);
+    expect(f.executor.execute).not.toHaveBeenCalled();
+  });
 });

--- a/packages/simulation-service/src/service.ts
+++ b/packages/simulation-service/src/service.ts
@@ -22,11 +22,6 @@ import {
 } from "./result-volume.js";
 import { SimulationFiles, sha256 } from "./files.js";
 
-type StructuredResultVolumeAnalysis = Extract<
-  ResultVolumeAnalysis,
-  { kind: "op" | "ac" }
->;
-
 export interface ExecutionInput {
   mode: "structured" | "raw";
   netlist: string;
@@ -233,7 +228,7 @@ export class SimulationService {
     let input: ExecutionInput;
     let vectors: Prepared["vectors"] = [];
     let warnings: string[] = [];
-    let structuredAnalyses: StructuredResultVolumeAnalysis[] | null = null;
+    let structuredAnalyses: ResultVolumeAnalysis[] | null = null;
     if (op.source.kind === "structured") {
       const project = structuredClone(this.getProject());
       const setup = op.source.setup ?? project.simulation;
@@ -276,9 +271,18 @@ export class SimulationService {
       };
       vectors = [...compiled.vectors];
       warnings = compiled.warnings.map((w) => w.message);
-      structuredAnalyses = setup.input.analyses.map((analysis) => ({
-        ...analysis,
-      }));
+      structuredAnalyses = setup.input.analyses.map((analysis) =>
+        analysis.kind === "tran"
+          ? {
+              kind: analysis.kind,
+              stepSeconds: analysis.stepSeconds,
+              stopSeconds: analysis.stopSeconds,
+              ...(analysis.startSeconds === undefined
+                ? {}
+                : { startSeconds: analysis.startSeconds }),
+            }
+          : { ...analysis },
+      );
     } else {
       const read = this.files.snapshot(
         op.source.workspaceId,

--- a/packages/spice-run/src/environment-profile.test.ts
+++ b/packages/spice-run/src/environment-profile.test.ts
@@ -31,7 +31,11 @@ describe("hosted simulation Profile", () => {
       runtimePath: "/opt/sky130/continuous/sky130.lib.spice",
       sections: ["tt"],
     });
-    expect(HOSTED_SKY130_PROFILE.qualifiedScope.analyses).toEqual(["op", "ac"]);
+    expect(HOSTED_SKY130_PROFILE.qualifiedScope.analyses).toEqual([
+      "op",
+      "ac",
+      "tran",
+    ]);
   });
 
   it("accepts exact observed identity and names every drift", () => {

--- a/packages/spice-run/src/index.ts
+++ b/packages/spice-run/src/index.ts
@@ -18,14 +18,14 @@ import {
   type SimulationResultData,
 } from "./result-data.js";
 
-export type SimulationAnalysis = "op" | "ac";
+export type SimulationAnalysis = "op" | "ac" | "tran";
 
 export interface SimulationRequest {
   /** Circuit netlist from @icm/netlist. Subcircuits and device cards only. */
   netlist: string;
   /** The author's testbench: stimulus, loads, analysis, prints. Theirs. */
   testbench: string;
-  /** Which analyses the caller expects; the first release covers two. */
+  /** Which analyses the caller expects from the prepared deck. */
   analyses: readonly SimulationAnalysis[];
   /** Wall-clock ceiling for the ngspice process, in milliseconds. */
   timeoutMs?: number;

--- a/scripts/preview-simulation-smoke.mjs
+++ b/scripts/preview-simulation-smoke.mjs
@@ -80,6 +80,24 @@ export const DIVIDER_REQUEST = {
   timeoutMs: 110_000,
 };
 
+export const RC_TRAN_REQUEST = {
+  mode: "raw",
+  netlist: "",
+  testbench: [
+    "RC transient qualification",
+    "V1 in 0 PULSE(0 1 0 1n 1n 5u 10u)",
+    "R1 in out 1k",
+    "C1 out 0 1n",
+    ".control",
+    "set filetype=ascii",
+    "tran 10n 10u",
+    "write out.raw v(in) v(out)",
+    ".endc",
+    ".end",
+  ].join("\n"),
+  timeoutMs: 30_000,
+};
+
 export async function compileHostedSky130Project() {
   const [{ compileStructuredSimulation }, { parseProject }] = await Promise.all(
     [import("@icm/netlist"), import("@icm/project-protocol")],
@@ -112,6 +130,43 @@ export async function compileHostedSky130Project() {
   if (!compiled.ok) {
     throw new Error(
       `Qualification ${qualification.fixtureId} did not compile: ${compiled.diagnostics
+        .map((diagnostic) => `${diagnostic.code}: ${diagnostic.message}`)
+        .join(" | ")}`,
+    );
+  }
+  return compiled;
+}
+
+export async function compileHostedSky130TransientProject() {
+  const [{ compileStructuredSimulation }, { parseProject }] = await Promise.all(
+    [import("@icm/netlist"), import("@icm/project-protocol")],
+  );
+  const project = parseProject(
+    readFileSync(
+      new URL(`../${qualification.inputs.project}`, import.meta.url),
+      "utf8",
+    ),
+  );
+  const expected = qualification.expectedTran;
+  const source = project.documents
+    .flatMap((document) => document.instances)
+    .find((instance) => instance.id === expected.source.instanceId);
+  if (!source?.netlist || !project.simulation) {
+    throw new Error(
+      `Qualification ${qualification.fixtureId} has no transient source or setup.`,
+    );
+  }
+  source.symbolId = "pulse-voltage-source";
+  source.netlist.parameters = { ...expected.source.parameters };
+  project.simulation.input.analyses = [{ ...expected.analysis }];
+  const compiled = await compileStructuredSimulation(
+    project,
+    project.simulation,
+    { timeoutMs: 60_000 },
+  );
+  if (!compiled.ok) {
+    throw new Error(
+      `Qualification ${qualification.fixtureId} TRAN did not compile: ${compiled.diagnostics
         .map((diagnostic) => `${diagnostic.code}: ${diagnostic.message}`)
         .join(" | ")}`,
     );
@@ -233,6 +288,141 @@ export function validatePreviewSimulationResult(payload, expectedTarget) {
     environmentFingerprint: environment.fingerprint,
     simulatorVersion: simulator.version,
   };
+}
+
+function transientAnalysis(payload, expectedTarget) {
+  const result = object(payload, "simulation response");
+  const execution = object(result.execution, "execution metadata");
+  if (execution.target !== expectedTarget) {
+    throw new Error(
+      `[result:wrong-executor] requested ${expectedTarget}, but the Worker reported ${String(execution.target)}.`,
+    );
+  }
+  if (object(result.outcome, "simulation outcome").status !== "completed") {
+    throw new Error(
+      `[simulation:tran] ${expectedTarget} did not complete: ${diagnosticSummary(result)}`,
+    );
+  }
+  validatePinnedEnvironment(
+    object(object(result.metadata, "run metadata").environment, "environment"),
+    expectedTarget,
+  );
+  const data = object(result.data, "parsed result data");
+  const tran = Array.isArray(data.analyses)
+    ? data.analyses.find(
+        (analysis) =>
+          typeof analysis === "object" &&
+          analysis !== null &&
+          analysis.analysis === "tran",
+      )
+    : null;
+  if (
+    !tran ||
+    !Array.isArray(tran.timeSeconds) ||
+    !Array.isArray(tran.probes)
+  ) {
+    throw new Error(`${expectedTarget} returned no structured TRAN result.`);
+  }
+  return { result, tran };
+}
+
+export function validateRcTransientResult(payload, expectedTarget) {
+  const { tran } = transientAnalysis(payload, expectedTarget);
+  if (
+    tran.timeSeconds.length !== 1027 ||
+    Math.abs(tran.timeSeconds.at(-1) - 1e-5) > 1e-15
+  ) {
+    throw new Error(`${expectedTarget} returned an unexpected RC time axis.`);
+  }
+  const output = tran.probes.find((probe) => probe?.name === "v(out)");
+  if (!output || !Array.isArray(output.value)) {
+    throw new Error(`${expectedTarget} returned no RC v(out) series.`);
+  }
+  const maximum = Math.max(...output.value);
+  const last = output.value.at(-1);
+  if (
+    typeof last !== "number" ||
+    Math.abs(maximum - 0.9932657010978244) > 1e-10 ||
+    Math.abs(last - 0.006702329182061853) > 1e-10
+  ) {
+    throw new Error(
+      `${expectedTarget} returned unexpected RC step values (max=${maximum}, last=${String(last)}).`,
+    );
+  }
+  return { target: expectedTarget, pointCount: tran.timeSeconds.length };
+}
+
+export function validateHostedSky130TransientResult(
+  payload,
+  expectedTarget,
+  expectedInputRevision,
+  expectedVectors,
+) {
+  const { result, tran } = transientAnalysis(payload, expectedTarget);
+  const metadata = object(result.metadata, "run metadata");
+  const input = object(metadata.input, "input metadata");
+  if (input.inputRevision !== expectedInputRevision) {
+    throw new Error(`${expectedTarget} returned stale structured TRAN data.`);
+  }
+  const modelLibrary = object(
+    object(metadata.configuration, "configuration metadata").modelLibrary,
+    "model selection",
+  );
+  if (
+    modelLibrary.directive !== qualification.modelLibrary.directive ||
+    modelLibrary.section !== qualification.modelLibrary.section
+  ) {
+    throw new Error(
+      `${expectedTarget} did not run TRAN with the qualified model-library section.`,
+    );
+  }
+  const expected = qualification.expectedTran;
+  if (
+    tran.timeSeconds.length !== expected.pointCount ||
+    Math.abs(tran.timeSeconds.at(-1) - expected.stopSeconds) >
+      expected.timeAbsoluteTolerance
+  ) {
+    throw new Error(`${expectedTarget} returned an unexpected OTA time axis.`);
+  }
+  for (const binding of expectedVectors) {
+    const probe = tran.probes.find(
+      (candidate) => candidate?.name === binding.vector,
+    );
+    if (
+      !probe ||
+      !Array.isArray(probe.value) ||
+      probe.value.length !== expected.pointCount
+    ) {
+      throw new Error(
+        `${expectedTarget} returned no complete TRAN series for ${binding.vector}.`,
+      );
+    }
+  }
+  for (const [name, expectation] of Object.entries(expected.probes)) {
+    const probe = tran.probes.find((candidate) => candidate?.name === name);
+    if (!probe || !Array.isArray(probe.value)) {
+      throw new Error(
+        `${expectedTarget} returned no qualified TRAN series ${name}.`,
+      );
+    }
+    const actual = {
+      first: probe.value[0],
+      minimum: Math.min(...probe.value),
+      maximum: Math.max(...probe.value),
+      last: probe.value.at(-1),
+    };
+    for (const key of ["first", "minimum", "maximum", "last"]) {
+      if (
+        typeof actual[key] !== "number" ||
+        Math.abs(actual[key] - expectation[key]) > expectation.absoluteTolerance
+      ) {
+        throw new Error(
+          `${expectedTarget} solved TRAN ${name}.${key} as ${String(actual[key])}, expected ${expectation[key]}.`,
+        );
+      }
+    }
+  }
+  return { target: expectedTarget, pointCount: tran.timeSeconds.length };
 }
 
 function relativeError(actual, expected) {
@@ -437,6 +627,56 @@ export async function runHostedSky130Acceptance({
   );
 }
 
+export async function runHostedSky130TransientAcceptance({
+  baseUrl,
+  target,
+  fetchImpl = fetch,
+}) {
+  const compiled = await compileHostedSky130TransientProject();
+  const response = await fetchImpl(new URL("/api/simulate", baseUrl), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ...compiled.request, executorTarget: target }),
+    signal: AbortSignal.timeout(120_000),
+  });
+  const payload = await response.json();
+  if (!response.ok) {
+    throw new Error(
+      `[infrastructure:http-${response.status}] ${target} TRAN qualification failed.`,
+    );
+  }
+  return validateHostedSky130TransientResult(
+    payload,
+    target,
+    compiled.request.inputRevision,
+    compiled.vectors,
+  );
+}
+
+export async function runPreviewTransientSmoke({
+  baseUrl,
+  target,
+  fetchImpl = fetch,
+}) {
+  const response = await fetchImpl(new URL("/api/simulate", baseUrl), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      ...RC_TRAN_REQUEST,
+      inputRevision: `preview-rc-tran-${target}`,
+      executorTarget: target,
+    }),
+    signal: AbortSignal.timeout(60_000),
+  });
+  const payload = await response.json();
+  if (!response.ok) {
+    throw new Error(
+      `[infrastructure:http-${response.status}] ${target} RC TRAN smoke failed.`,
+    );
+  }
+  return validateRcTransientResult(payload, target);
+}
+
 export async function runPreviewSimulationSmoke({
   baseUrl,
   target,
@@ -508,6 +748,11 @@ async function main() {
   validateExecutorParity(results);
   console.log("Preview executor parity: passed");
 
+  for (const target of EXECUTORS) {
+    const result = await runPreviewTransientSmoke({ baseUrl, target });
+    console.log(`${result.target}: RC TRAN ${result.pointCount} points passed`);
+  }
+
   const qualifications = [];
   for (const target of EXECUTORS) {
     const result = await runHostedSky130Acceptance({ baseUrl, target });
@@ -517,6 +762,15 @@ async function main() {
     );
   }
   validateExecutorParity(qualifications);
+  for (const target of EXECUTORS) {
+    const result = await runHostedSky130TransientAcceptance({
+      baseUrl,
+      target,
+    });
+    console.log(
+      `${result.target}: SKY130 OTA TRAN ${result.pointCount} points passed`,
+    );
+  }
   console.log(`Hosted SKY130 Profile ${profile.id}: qualified`);
 }
 

--- a/scripts/preview-simulation-smoke.test.mjs
+++ b/scripts/preview-simulation-smoke.test.mjs
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 
 import {
   compileHostedSky130Project,
+  compileHostedSky130TransientProject,
   runHostedSky130Acceptance,
+  runHostedSky130TransientAcceptance,
   runPreviewSimulationSmoke,
+  validateHostedSky130TransientResult,
   validateExecutorParity,
   validateHostedSky130Result,
   validatePreviewSimulationResult,
@@ -273,7 +276,7 @@ describe("the hosted SKY130 qualification", () => {
       ),
     ).toMatchObject({
       target: "cloudflare-container",
-      fixtureId: "ota-5t-structured-op-ac-v1",
+      fixtureId: "ota-5t-structured-op-ac-tran-v1",
       environmentFingerprint: SHA,
       values: { "v(vout)": 0.7589797395133877 },
     });
@@ -335,7 +338,7 @@ describe("the hosted SKY130 qualification", () => {
     expect(submitted.testbench).toContain("set appendwrite");
     expect(submitted.testbench).toContain("write out.raw v(vout)");
     expect(submitted.testbench).toContain("ac dec 10 1 1000000000");
-    expect(accepted.fixtureId).toBe("ota-5t-structured-op-ac-v1");
+    expect(accepted.fixtureId).toBe("ota-5t-structured-op-ac-tran-v1");
   });
 
   it("compiles the persisted Project setup into the qualified request", async () => {
@@ -343,5 +346,85 @@ describe("the hosted SKY130 qualification", () => {
     expect(compiled.request.analyses).toEqual(["op", "ac"]);
     expect(compiled.vectors).toEqual(EXPECTED_VECTORS);
     expect(compiled.request.inputRevision).toMatch(/^[0-9a-f]{64}$/u);
+  });
+
+  it("compiles and validates the model-backed structured transient slice", async () => {
+    const compiled = await compileHostedSky130TransientProject();
+    expect(compiled.request.analyses).toEqual(["tran"]);
+    expect(compiled.request.testbench).toContain("tran 2e-8 0.000004");
+    expect(compiled.request.testbench).toContain(
+      "VINP vinp 0 PULSE(0.89 0.91 1u 1n 1n 1u 3u)",
+    );
+
+    const values = Array(232).fill(0.3342235191104477);
+    values[1] = 0.3342107447553537;
+    values[2] = 1.698172273444083;
+    values[231] = 0.3342235434776202;
+    const payload = modelResult(
+      "operator-host",
+      {
+        data: {
+          analyses: [
+            {
+              analysis: "tran",
+              timeSeconds: [...Array(231).fill(0), 4e-6],
+              probes: EXPECTED_VECTORS.map(({ vector }) => ({
+                name: vector,
+                value: vector === "v(vout)" ? values : Array(232).fill(0.5),
+              })),
+            },
+          ],
+        },
+      },
+      compiled.request.inputRevision,
+    );
+    expect(
+      validateHostedSky130TransientResult(
+        payload,
+        "operator-host",
+        compiled.request.inputRevision,
+        compiled.vectors,
+      ),
+    ).toEqual({ target: "operator-host", pointCount: 232 });
+  });
+
+  it("sends the structured transient slice through the selected executor", async () => {
+    let submitted;
+    const compiled = await compileHostedSky130TransientProject();
+    const values = Array(232).fill(0.3342235191104477);
+    values[1] = 0.3342107447553537;
+    values[2] = 1.698172273444083;
+    values[231] = 0.3342235434776202;
+    const accepted = await runHostedSky130TransientAcceptance({
+      baseUrl: "https://preview.example",
+      target: "operator-host",
+      fetchImpl: async (_url, init) => {
+        submitted = JSON.parse(init.body);
+        return Response.json(
+          modelResult(
+            "operator-host",
+            {
+              data: {
+                analyses: [
+                  {
+                    analysis: "tran",
+                    timeSeconds: [...Array(231).fill(0), 4e-6],
+                    probes: EXPECTED_VECTORS.map(({ vector }) => ({
+                      name: vector,
+                      value:
+                        vector === "v(vout)" ? values : Array(232).fill(0.5),
+                    })),
+                  },
+                ],
+              },
+            },
+            submitted.inputRevision,
+          ),
+        );
+      },
+    });
+    expect(submitted.inputRevision).toBe(compiled.request.inputRevision);
+    expect(submitted.executorTarget).toBe("operator-host");
+    expect(accepted.pointCount).toBe(232);
   });
 });

--- a/worker/gallery-do.ts
+++ b/worker/gallery-do.ts
@@ -32,6 +32,7 @@ import {
   upgradeSchema34To35WithReport,
   upgradeSchema35To36WithReport,
   upgradeSchema36To37WithReport,
+  upgradeSchema37To38WithReport,
 } from "@icm/project-protocol";
 import {
   CURRENT_PROJECT_SCHEMA_VERSION,
@@ -1547,7 +1548,8 @@ export class GalleryDO {
         | ReturnType<typeof upgradeSchema33To34WithReport>["report"]
         | ReturnType<typeof upgradeSchema34To35WithReport>["report"]
         | ReturnType<typeof upgradeSchema35To36WithReport>["report"]
-        | ReturnType<typeof upgradeSchema36To37WithReport>["report"];
+        | ReturnType<typeof upgradeSchema36To37WithReport>["report"]
+        | ReturnType<typeof upgradeSchema37To38WithReport>["report"];
     }> = [];
     for (const source of sources) {
       const versions: Record<string, number> = {};
@@ -1647,6 +1649,15 @@ export class GalleryDO {
           }
           if (lifted.schemaVersion === 36) {
             const migration = upgradeSchema36To37WithReport(lifted);
+            lifted = migration.project;
+            migrationReports.push({
+              table: source.table,
+              id: row.id,
+              report: migration.report,
+            });
+          }
+          if (lifted.schemaVersion === 37) {
+            const migration = upgradeSchema37To38WithReport(lifted);
             lifted = migration.project;
             migrationReports.push({
               table: source.table,


### PR DESCRIPTION
## Summary
- add persisted structured TRAN analysis with explicit SI-second parameters
- compile TRAN controls through the shared simulation service and Agent capability contract
- qualify Preview ngspice 46 TRAN with RC step and SKY130 OTA numeric acceptance
- advance Project schema to 38 and keep Gallery convergence in the migration chain

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:full (2633 unit tests, build/release/performance checks, 354 browser tests)
- Preview RC transient smoke: 1027 points
- Preview SKY130 OTA transient acceptance: 232 points

Test-Impact: tests-updated