### PR TITLE
feat(netlist): unify independent source waveforms

### DIFF
--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -419,9 +419,15 @@ and phase, and its transient waveform as formal parameters printed by the
 device descriptor. The first release's waveforms are `PULSE` (low, high,
 delay, rise, fall, width, period) and `SIN` (offset, amplitude, frequency,
 optional delay, damping, phase). `PWL` is reachable through raw input. The
-existing pulse voltage source keeps its symbol; its clock-style parameters
-are normalised into the same waveform parameters so that only one set is
-authoritative.
+`waveform` parameter explicitly selects `dc`, `pulse`, or `sin`; timing fields
+never select a waveform by their presence. An absent selector on a pre-contract
+Project is projected from the device descriptor (`dc` for ordinary sources,
+`pulse` for the existing Digital Clock) without rewriting the Project. The
+Digital Clock keeps its symbol while using the same formal PULSE fields and
+the same printer as ordinary voltage and current sources. Its
+`dutyCycle`/`initial` convenience controls may still author the canonical
+PULSE fields, but they are neither a second output authority nor emitted as
+simulator assignments.
 
 Those values are persisted only on the source Instance in the Testbench. A
 Setup or Simulation UI may address and edit that Instance through the ordinary

--- a/packages/devices/src/contract.ts
+++ b/packages/devices/src/contract.ts
@@ -68,6 +68,8 @@ export interface DeviceDescriptor {
   /** Optional fixed semantics for canonical pins; pin order remains electrical authority. */
   readonly pinSemantics?: readonly DevicePinSemantic[];
   readonly targetPolicy: DeviceNetlistTargetPolicy;
+  /** Default transient intent projected when an older source has no explicit waveform. */
+  readonly sourceWaveformDefault?: "dc" | "pulse" | "sin";
   /** Ordered authoring metadata; placeholders never create persisted values. */
   readonly parameters: readonly DeviceParameterDefinition[];
   readonly dialects: readonly ["spice", "spectre"];

--- a/packages/devices/src/descriptors/current-source.ts
+++ b/packages/devices/src/descriptors/current-source.ts
@@ -7,6 +7,7 @@ export const currentSourceDevice = {
   referencePrefix: "I",
   pinOrder: ["+", "-"],
   targetPolicy: "builtin",
+  sourceWaveformDefault: "dc",
   parameters: [
     {
       name: "dc",
@@ -18,8 +19,6 @@ export const currentSourceDevice = {
       help: "DC current",
       displayRole: "value",
     },
-    // Small-signal stimulus for `.ac` (ADR 0055): printed as `AC <mag> <phase>`
-    // after the DC value. A source with no magnitude stays DC-only.
     {
       name: "acMagnitude",
       label: "AC magnitude",

--- a/packages/devices/src/descriptors/pulse-voltage-source.ts
+++ b/packages/devices/src/descriptors/pulse-voltage-source.ts
@@ -7,6 +7,7 @@ export const pulseVoltageSourceDevice = {
   referencePrefix: "V",
   pinOrder: ["+", "-"],
   targetPolicy: "builtin",
+  sourceWaveformDefault: "pulse",
   parameters: [
     {
       name: "period",

--- a/packages/devices/src/descriptors/voltage-source.ts
+++ b/packages/devices/src/descriptors/voltage-source.ts
@@ -7,6 +7,7 @@ export const voltageSourceDevice = {
   referencePrefix: "V",
   pinOrder: ["+", "-"],
   targetPolicy: "builtin",
+  sourceWaveformDefault: "dc",
   parameters: [
     {
       name: "dc",
@@ -18,8 +19,6 @@ export const voltageSourceDevice = {
       help: "DC voltage",
       displayRole: "value",
     },
-    // Small-signal stimulus for `.ac` (ADR 0055): printed as `AC <mag> <phase>`
-    // after the DC value. A source with no magnitude stays DC-only.
     {
       name: "acMagnitude",
       label: "AC magnitude",

--- a/packages/devices/src/registry.test.ts
+++ b/packages/devices/src/registry.test.ts
@@ -162,12 +162,13 @@ describe("built-in device registry", () => {
     });
   });
 
-  it("gives independent sources formal AC magnitude and phase beside their DC value", () => {
+  it("gives independent sources formal AC controls and a DC waveform default", () => {
     for (const [id, unit] of [
       ["voltage-source", "V"],
       ["current-source", "A"],
     ] as const) {
       expect(deviceDescriptor(id)).toMatchObject({
+        sourceWaveformDefault: "dc",
         parameters: [
           { name: "dc", required: true, unitHint: unit, displayRole: "value" },
           {
@@ -193,19 +194,15 @@ describe("built-in device registry", () => {
           .every((parameter) => parameter.defaultValue === undefined),
       ).toBe(true);
     }
-    expect(
-      deviceDescriptor("pulse-voltage-source")!.parameters.map(
-        (parameter) => parameter.name,
-      ),
-    ).not.toContain("acMagnitude");
   });
 
-  it("defines a Digital Clock authoring profile over the two-terminal pulse protocol", () => {
+  it("keeps Digital Clock artwork and compatibility controls on formal PULSE intent", () => {
     expect(deviceDescriptor("pulse-voltage-source")).toMatchObject({
       deviceClass: "voltage-source",
       referencePrefix: "V",
       pinOrder: ["+", "-"],
       targetPolicy: "builtin",
+      sourceWaveformDefault: "pulse",
       parameters: [
         { name: "period", defaultValue: "10ns" },
         { name: "dutyCycle", defaultValue: "50" },

--- a/packages/devices/src/validation.ts
+++ b/packages/devices/src/validation.ts
@@ -164,6 +164,26 @@ export function validateDeviceDescriptors(
       });
     }
     if (
+      descriptor.sourceWaveformDefault !== undefined &&
+      descriptor.deviceClass !== "voltage-source" &&
+      descriptor.deviceClass !== "current-source"
+    ) {
+      issues.push({
+        deviceId: descriptor.id,
+        message: "Only independent sources may declare a waveform default",
+      });
+    }
+    if (
+      (descriptor.deviceClass === "voltage-source" ||
+        descriptor.deviceClass === "current-source") &&
+      descriptor.sourceWaveformDefault === undefined
+    ) {
+      issues.push({
+        deviceId: descriptor.id,
+        message: "Independent sources require a waveform default",
+      });
+    }
+    if (
       descriptor.mosBulkClass !== undefined &&
       descriptor.deviceClass !== "mos"
     ) {

--- a/packages/netlist/src/current-contract.test.ts
+++ b/packages/netlist/src/current-contract.test.ts
@@ -436,6 +436,95 @@ describe("current formal cell interface", () => {
     expect(printSpiceNetlist(result.ir!)).toContain("V1 VOUT 0 DC 1.8");
   });
 
+  it("projects legacy Digital Clock instances onto explicit PULSE intent", () => {
+    const project = createEmptyProject("project", "Project");
+    const document = project.documents[0]!;
+    document.instances.push({
+      id: "VCLK",
+      symbolId: "pulse-voltage-source",
+      placement: null,
+      reference: "VCLK",
+      netlist: {
+        parameters: {
+          low: "0",
+          high: "1",
+          delay: "1ns",
+          rise: "1ps",
+          fall: "1ps",
+          width: "5ns",
+          period: "10ns",
+          dutyCycle: "50",
+          initial: "0",
+        },
+      },
+    });
+    document.nets.push(
+      {
+        id: "net-clock",
+        terminals: [{ instanceId: "VCLK", pinName: "+" }],
+      },
+      {
+        id: "net-ground",
+        terminals: [{ instanceId: "VCLK", pinName: "-" }],
+      },
+    );
+    claimNet(document, "net-clock", "CLK");
+    claimNet(document, "net-ground", "0", "global", "ground");
+    const before = JSON.stringify(project);
+
+    const result = analyzeDesignNetlist(project);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.ir?.cells[0]?.instances[0]?.parameters).toContainEqual({
+      name: "waveform",
+      rawValue: "pulse",
+    });
+    expect(printSpiceNetlist(result.ir!)).toContain(
+      "VCLK CLK 0 PULSE(0 1 1ns 1ps 1ps 5ns 10ns)",
+    );
+    expect(JSON.stringify(project)).toBe(before);
+  });
+
+  it("uses explicit waveform intent and diagnoses incomplete sources", () => {
+    const project = createEmptyProject("project", "Project");
+    const document = project.documents[0]!;
+    document.instances.push({
+      id: "I1",
+      symbolId: "current-source",
+      placement: null,
+      reference: "I1",
+      netlist: {
+        parameters: {
+          dc: "1u",
+          waveform: "pulse",
+          period: "10ns",
+        },
+      },
+    });
+    document.nets.push(
+      {
+        id: "net-out",
+        terminals: [{ instanceId: "I1", pinName: "+" }],
+      },
+      {
+        id: "net-ground",
+        terminals: [{ instanceId: "I1", pinName: "-" }],
+      },
+    );
+    claimNet(document, "net-out", "OUT");
+    claimNet(document, "net-ground", "0", "global", "ground");
+
+    const result = analyzeDesignNetlist(project);
+
+    expect(result.ir).toBeNull();
+    expect(
+      result.diagnostics.filter(
+        (item) => item.code === "MISSING_SOURCE_WAVEFORM_PARAMETER",
+      ),
+    ).toHaveLength(6);
+    expect(result.diagnostics[0]).toMatchObject({ objectIds: ["I1"] });
+  });
+
   it("still rejects an explicitly incompatible built-in binding", () => {
     const project = resistorProject({ value: "10k" });
     project.documents[0]!.instances[0]!.netlist!.binding = {

--- a/packages/netlist/src/extract.ts
+++ b/packages/netlist/src/extract.ts
@@ -34,6 +34,7 @@ import {
   type NetlistFormat,
   type NetlistNamingProfile,
 } from "./net-name-codec.js";
+import { normalizeIndependentSource } from "./source-waveform.js";
 
 const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/u;
 const MAX_CELLS = 1024;
@@ -1073,6 +1074,26 @@ function extractDeviceInstance(
       [instance.id],
     );
   }
+  const authoredParameters = Object.entries(netlist.parameters)
+    .sort(([a], [b]) => compareText(a, b))
+    .map(([name, rawValue]) => ({ name, rawValue }));
+  const projectedParameters =
+    definition.deviceClass === "voltage-source" ||
+    definition.deviceClass === "current-source"
+      ? normalizeIndependentSource(
+          authoredParameters,
+          definition.sourceWaveformDefault ?? "dc",
+        )
+      : null;
+  for (const issue of projectedParameters?.issues ?? []) {
+    diagnostic(
+      diagnostics,
+      document.id,
+      issue.code,
+      `Instance ${instance.reference!}: ${issue.message}`,
+      [instance.id],
+    );
+  }
   return {
     id: instance.id,
     reference: instance.reference!,
@@ -1080,9 +1101,9 @@ function extractDeviceInstance(
     deviceClass: definition.deviceClass,
     target,
     nodes,
-    parameters: Object.entries(netlist.parameters)
-      .sort(([a], [b]) => compareText(a, b))
-      .map(([name, rawValue]) => ({ name, rawValue })),
+    parameters: projectedParameters
+      ? [...projectedParameters.parameters]
+      : authoredParameters,
   };
 }
 

--- a/packages/netlist/src/index.ts
+++ b/packages/netlist/src/index.ts
@@ -4,3 +4,4 @@ export * from "./ir.js";
 export * from "./net-name-codec.js";
 export * from "./printers.js";
 export * from "./simulation-compile.js";
+export * from "./source-waveform.js";

--- a/packages/netlist/src/printers.test.ts
+++ b/packages/netlist/src/printers.test.ts
@@ -149,6 +149,7 @@ describe("design netlist printers", () => {
     const ir = structuralIr();
     ir.cells[1]!.instances.push(
       device("vclock", "VCLOCK", "voltage-source", ["vin", "0"], null, [
+        ["waveform", "pulse"],
         ["low", "0"],
         ["high", "1"],
         ["delay", "1ns"],
@@ -169,6 +170,87 @@ describe("design netlist printers", () => {
     );
     expect(printSpiceNetlist(ir)).not.toContain("dutyCycle=");
     expect(printSpectreNetlist(ir)).not.toContain("initial=");
+  });
+
+  it("prints formal PULSE and SIN waveforms for voltage and current sources", () => {
+    const ir = structuralIr();
+    ir.cells[1]!.instances.push(
+      device("vp", "VP", "voltage-source", ["vin", "0"], null, [
+        ["dc", "0"],
+        ["acMagnitude", "1"],
+        ["waveform", "pulse"],
+        ["low", "0"],
+        ["high", "1.8"],
+        ["delay", "1ns"],
+        ["rise", "2ps"],
+        ["fall", "3ps"],
+        ["width", "4ns"],
+        ["period", "8ns"],
+      ]),
+      device("ip", "IP", "current-source", ["vout", "0"], null, [
+        ["dc", "1u"],
+        ["waveform", "pulse"],
+        ["low", "0"],
+        ["high", "10u"],
+        ["delay", "2ns"],
+        ["rise", "1ps"],
+        ["fall", "1ps"],
+        ["width", "3ns"],
+        ["period", "6ns"],
+      ]),
+      device("vs", "VS", "voltage-source", ["vin", "0"], null, [
+        ["dc", "0.9"],
+        ["waveform", "sin"],
+        ["offset", "0.9"],
+        ["amplitude", "10m"],
+        ["frequency", "1Meg"],
+      ]),
+      device("is", "IS", "current-source", ["vout", "0"], null, [
+        ["dc", "2u"],
+        ["waveform", "sin"],
+        ["offset", "2u"],
+        ["amplitude", "500n"],
+        ["frequency", "10k"],
+        ["delay", "1us"],
+        ["damping", "2"],
+        ["phase", "90"],
+      ]),
+    );
+
+    const spice = printSpiceNetlist(ir);
+    expect(spice).toContain(
+      "VP vin 0 DC 0 AC 1 0 PULSE(0 1.8 1ns 2ps 3ps 4ns 8ns)",
+    );
+    expect(spice).toContain("IP vout 0 DC 1u PULSE(0 10u 2ns 1ps 1ps 3ns 6ns)");
+    expect(spice).toContain("VS vin 0 DC 0.9 SIN(0.9 10m 1Meg 0 0 0)");
+    expect(spice).toContain("IS vout 0 DC 2u SIN(2u 500n 10k 1us 2 90)");
+
+    const spectre = printSpectreNetlist(ir);
+    expect(spectre).toContain(
+      "VP (vin 0) vsource type=pulse val0=0 val1=1.8 delay=1ns rise=2ps fall=3ps width=4ns period=8ns dc=0 mag=1 phase=0",
+    );
+    expect(spectre).toContain(
+      "IP (vout 0) isource type=pulse val0=0 val1=10u delay=2ns rise=1ps fall=1ps width=3ns period=6ns dc=1u",
+    );
+    expect(spectre).toContain(
+      "VS (vin 0) vsource type=sine dc=0.9 ampl=10m freq=1Meg delay=0 damp=0 sinephase=0",
+    );
+    expect(spectre).toContain(
+      "IS (vout 0) isource type=sine dc=2u ampl=500n freq=10k delay=1us damp=2 sinephase=90",
+    );
+  });
+
+  it("does not infer PULSE from a period parameter", () => {
+    const ir = structuralIr();
+    ir.cells[1]!.instances.push(
+      device("vdc", "VDC", "voltage-source", ["vin", "0"], null, [
+        ["dc", "1"],
+        ["waveform", "dc"],
+        ["period", "10ns"],
+      ]),
+    );
+    expect(printSpiceNetlist(ir)).toContain("\nVDC vin 0 DC 1\n");
+    expect(printSpiceNetlist(ir)).not.toContain("VDC vin 0 PULSE");
   });
 
   it("prints an independent source's AC magnitude and phase after its DC value", () => {

--- a/packages/netlist/src/printers.ts
+++ b/packages/netlist/src/printers.ts
@@ -5,6 +5,7 @@ import type {
   DesignNetlistParameter,
 } from "./ir.js";
 import type { NetlistFormat } from "./net-name-codec.js";
+import { normalizeIndependentSource } from "./source-waveform.js";
 
 export type { NetlistFormat } from "./net-name-codec.js";
 
@@ -33,67 +34,78 @@ function assignments(
     .map((item) => `${item.name}=${item.rawValue}`);
 }
 
-const PULSE_PARAMETER_NAMES = [
-  "low",
-  "high",
-  "delay",
-  "rise",
-  "fall",
-  "width",
-  "period",
-] as const;
-const DIGITAL_CLOCK_AUTHORING_PARAMETER_NAMES = [
-  "dutyCycle",
-  "initial",
-] as const;
-const ALL_CLOCK_PARAMETER_NAMES = [
-  ...PULSE_PARAMETER_NAMES,
-  ...DIGITAL_CLOCK_AUTHORING_PARAMETER_NAMES,
-] as const;
-
-function isPulseSource(instance: DesignNetlistInstance): boolean {
-  return parameter(instance.parameters, "period") !== undefined;
-}
-
-/**
- * The small-signal stimulus of an independent source, authored as the formal
- * `acMagnitude`/`acPhase` parameters of its device descriptor
- * (`docs/specs/simulation.md`, "Sources and analyses"). The phase defaults
- * to 0 once a magnitude exists; a phase without a magnitude has no card to
- * ride on and is not printed, so the deck never carries a stimulus the
- * schematic does not.
- */
-const AC_PARAMETER_NAMES = ["acMagnitude", "acPhase"] as const;
-
-function acStimulus(
-  instance: DesignNetlistInstance,
-): { magnitude: string; phase: string } | null {
-  const magnitude = parameter(instance.parameters, "acMagnitude");
-  if (magnitude === undefined) return null;
-  return {
-    magnitude,
-    phase: parameter(instance.parameters, "acPhase") ?? "0",
-  };
-}
-
-/** `DC <dc> [AC <magnitude> <phase>]` plus every remaining assignment. */
-function spiceDcSourceTokens(instance: DesignNetlistInstance): string[] {
-  const ac = acStimulus(instance);
+function spiceSourceTokens(instance: DesignNetlistInstance): string[] {
+  const source = normalizeIndependentSource(instance.parameters);
+  const transient = source.transient;
   return [
-    "DC",
-    parameter(instance.parameters, "dc")!,
-    ...(ac ? ["AC", ac.magnitude, ac.phase] : []),
-    ...assignments(instance.parameters, ["dc", ...AC_PARAMETER_NAMES]),
+    ...(source.dc === undefined ? [] : ["DC", source.dc]),
+    ...(source.ac ? ["AC", source.ac.magnitude, source.ac.phase] : []),
+    ...(transient.kind === "pulse"
+      ? [
+          `PULSE(${[
+            transient.low,
+            transient.high,
+            transient.delay,
+            transient.rise,
+            transient.fall,
+            transient.width,
+            transient.period,
+          ].join(" ")})`,
+        ]
+      : transient.kind === "sin"
+        ? [
+            `SIN(${[
+              transient.offset,
+              transient.amplitude,
+              transient.frequency,
+              transient.delay,
+              transient.damping,
+              transient.phase,
+            ].join(" ")})`,
+          ]
+        : []),
+    ...assignments(source.extraParameters),
   ];
 }
 
-/** `dc=<dc> [mag=<magnitude> phase=<phase>]` plus every remaining assignment. */
-function spectreDcSourceValues(instance: DesignNetlistInstance): string[] {
-  const ac = acStimulus(instance);
+function spectreSourceValues(instance: DesignNetlistInstance): string[] {
+  const source = normalizeIndependentSource(instance.parameters);
+  const transient = source.transient;
+  const ac = source.ac
+    ? [`mag=${source.ac.magnitude}`, `phase=${source.ac.phase}`]
+    : [];
+  if (transient.kind === "pulse") {
+    return [
+      "type=pulse",
+      `val0=${transient.low}`,
+      `val1=${transient.high}`,
+      `delay=${transient.delay}`,
+      `rise=${transient.rise}`,
+      `fall=${transient.fall}`,
+      `width=${transient.width}`,
+      `period=${transient.period}`,
+      ...(source.dc === undefined ? [] : [`dc=${source.dc}`]),
+      ...ac,
+      ...assignments(source.extraParameters),
+    ];
+  }
+  if (transient.kind === "sin") {
+    return [
+      "type=sine",
+      `dc=${transient.offset}`,
+      `ampl=${transient.amplitude}`,
+      `freq=${transient.frequency}`,
+      `delay=${transient.delay}`,
+      `damp=${transient.damping}`,
+      `sinephase=${transient.phase}`,
+      ...ac,
+      ...assignments(source.extraParameters),
+    ];
+  }
   return [
-    `dc=${parameter(instance.parameters, "dc")!}`,
-    ...(ac ? [`mag=${ac.magnitude}`, `phase=${ac.phase}`] : []),
-    ...assignments(instance.parameters, ["dc", ...AC_PARAMETER_NAMES]),
+    ...(source.dc === undefined ? [] : [`dc=${source.dc}`]),
+    ...ac,
+    ...assignments(source.extraParameters),
   ];
 }
 
@@ -129,19 +141,8 @@ function spiceInstance(instance: DesignNetlistInstance): string[] {
       ];
       break;
     case "voltage-source":
-      tokens = isPulseSource(instance)
-        ? [
-            reference,
-            ...nodes,
-            `PULSE(${PULSE_PARAMETER_NAMES.map((name) =>
-              parameter(instance.parameters, name)!,
-            ).join(" ")})`,
-            ...assignments(instance.parameters, ALL_CLOCK_PARAMETER_NAMES),
-          ]
-        : [reference, ...nodes, ...spiceDcSourceTokens(instance)];
-      break;
     case "current-source":
-      tokens = [reference, ...nodes, ...spiceDcSourceTokens(instance)];
+      tokens = [reference, ...nodes, ...spiceSourceTokens(instance)];
       break;
     case "mos":
     case "diode":
@@ -242,21 +243,11 @@ function spectreInstance(instance: DesignNetlistInstance): string {
       break;
     case "voltage-source":
       master = "vsource";
-      values = isPulseSource(instance)
-        ? [
-            "type=pulse",
-            `val0=${parameter(instance.parameters, "low")!}`,
-            `val1=${parameter(instance.parameters, "high")!}`,
-            ...PULSE_PARAMETER_NAMES.slice(2).map(
-              (name) => `${name}=${parameter(instance.parameters, name)!}`,
-            ),
-            ...assignments(instance.parameters, ALL_CLOCK_PARAMETER_NAMES),
-          ]
-        : spectreDcSourceValues(instance);
+      values = spectreSourceValues(instance);
       break;
     case "current-source":
       master = "isource";
-      values = spectreDcSourceValues(instance);
+      values = spectreSourceValues(instance);
       break;
     case "mos":
     case "diode":

--- a/packages/netlist/src/source-waveform.test.ts
+++ b/packages/netlist/src/source-waveform.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeIndependentSource } from "./source-waveform.js";
+
+describe("independent source waveform normalization", () => {
+  it("projects a descriptor default without guessing from timing fields", () => {
+    const normalized = normalizeIndependentSource(
+      [
+        { name: "dc", rawValue: "1" },
+        { name: "period", rawValue: "10ns" },
+      ],
+      "dc",
+    );
+    expect(normalized.transient).toEqual({ kind: "dc" });
+    expect(normalized.parameters).toContainEqual({
+      name: "waveform",
+      rawValue: "dc",
+    });
+  });
+
+  it("returns recoverable diagnostics for invalid or incomplete waveforms", () => {
+    expect(
+      normalizeIndependentSource(
+        [{ name: "waveform", rawValue: "triangle" }],
+        "dc",
+      ).issues,
+    ).toContainEqual(
+      expect.objectContaining({ code: "INVALID_SOURCE_WAVEFORM" }),
+    );
+    expect(
+      normalizeIndependentSource(
+        [
+          { name: "waveform", rawValue: "pulse" },
+          { name: "period", rawValue: "10ns" },
+        ],
+        "dc",
+      ).issues.map((issue) => issue.parameter),
+    ).toEqual(["low", "high", "delay", "rise", "fall", "width"]);
+  });
+
+  it("defaults optional SIN timing fields without inventing required values", () => {
+    const normalized = normalizeIndependentSource([
+      { name: "waveform", rawValue: "sin" },
+      { name: "offset", rawValue: "0.9" },
+      { name: "amplitude", rawValue: "10m" },
+      { name: "frequency", rawValue: "1Meg" },
+    ]);
+    expect(normalized.issues).toEqual([]);
+    expect(normalized.transient).toEqual({
+      kind: "sin",
+      offset: "0.9",
+      amplitude: "10m",
+      frequency: "1Meg",
+      delay: "0",
+      damping: "0",
+      phase: "0",
+    });
+  });
+});

--- a/packages/netlist/src/source-waveform.ts
+++ b/packages/netlist/src/source-waveform.ts
@@ -1,0 +1,182 @@
+import type { DesignNetlistParameter } from "./ir.js";
+
+export type IndependentSourceWaveform = "dc" | "pulse" | "sin";
+
+export const PULSE_PARAMETER_NAMES = [
+  "low",
+  "high",
+  "delay",
+  "rise",
+  "fall",
+  "width",
+  "period",
+] as const;
+export const SIN_REQUIRED_PARAMETER_NAMES = [
+  "offset",
+  "amplitude",
+  "frequency",
+] as const;
+export const SIN_OPTIONAL_PARAMETER_NAMES = [
+  "delay",
+  "damping",
+  "phase",
+] as const;
+export const AC_PARAMETER_NAMES = ["acMagnitude", "acPhase"] as const;
+const SOURCE_PARAMETER_NAMES = [
+  "waveform",
+  "dc",
+  ...AC_PARAMETER_NAMES,
+  ...PULSE_PARAMETER_NAMES,
+  ...SIN_REQUIRED_PARAMETER_NAMES,
+  ...SIN_OPTIONAL_PARAMETER_NAMES,
+  // Digital Clock convenience inputs remain loadable but never leak as
+  // arbitrary simulator assignments. The Editor already keeps the canonical
+  // PULSE fields beside them.
+  "dutyCycle",
+  "initial",
+] as const;
+
+export interface SourceParameterIssue {
+  readonly code:
+    "INVALID_SOURCE_WAVEFORM" | "MISSING_SOURCE_WAVEFORM_PARAMETER";
+  readonly parameter: string;
+  readonly message: string;
+}
+
+export type NormalizedTransientWaveform =
+  | { readonly kind: "dc" }
+  | {
+      readonly kind: "pulse";
+      readonly low: string | undefined;
+      readonly high: string | undefined;
+      readonly delay: string | undefined;
+      readonly rise: string | undefined;
+      readonly fall: string | undefined;
+      readonly width: string | undefined;
+      readonly period: string | undefined;
+    }
+  | {
+      readonly kind: "sin";
+      readonly offset: string | undefined;
+      readonly amplitude: string | undefined;
+      readonly frequency: string | undefined;
+      readonly delay: string;
+      readonly damping: string;
+      readonly phase: string;
+    };
+
+export interface NormalizedIndependentSource {
+  /** Parameters with an explicit canonical waveform projection. */
+  readonly parameters: readonly DesignNetlistParameter[];
+  readonly dc?: string;
+  readonly ac?: { readonly magnitude: string; readonly phase: string };
+  readonly transient: NormalizedTransientWaveform;
+  readonly extraParameters: readonly DesignNetlistParameter[];
+  readonly issues: readonly SourceParameterIssue[];
+}
+
+function parameterMap(parameters: readonly DesignNetlistParameter[]) {
+  return new Map(
+    parameters.map((item) => [item.name.toLowerCase(), item.rawValue]),
+  );
+}
+
+/**
+ * Normalize every independent source through one explicit waveform contract.
+ * The caller supplies a descriptor-owned default only for pre-contract
+ * projects. Presence of `period` or another timing field never selects a
+ * waveform.
+ */
+export function normalizeIndependentSource(
+  parameters: readonly DesignNetlistParameter[],
+  defaultWaveform: IndependentSourceWaveform = "dc",
+): NormalizedIndependentSource {
+  const values = parameterMap(parameters);
+  const authoredWaveform = values.get("waveform")?.trim().toLowerCase();
+  const issues: SourceParameterIssue[] = [];
+  let waveform: IndependentSourceWaveform = defaultWaveform;
+  if (authoredWaveform !== undefined) {
+    if (
+      authoredWaveform === "dc" ||
+      authoredWaveform === "pulse" ||
+      authoredWaveform === "sin"
+    ) {
+      waveform = authoredWaveform;
+    } else {
+      issues.push({
+        code: "INVALID_SOURCE_WAVEFORM",
+        parameter: "waveform",
+        message: `Source waveform must be dc, pulse, or sin; received ${authoredWaveform || "an empty value"}`,
+      });
+    }
+  }
+
+  const required =
+    waveform === "pulse"
+      ? PULSE_PARAMETER_NAMES
+      : waveform === "sin"
+        ? SIN_REQUIRED_PARAMETER_NAMES
+        : [];
+  for (const name of required) {
+    if (!values.get(name)?.trim()) {
+      issues.push({
+        code: "MISSING_SOURCE_WAVEFORM_PARAMETER",
+        parameter: name,
+        message: `${waveform.toUpperCase()} waveform requires parameter ${name}`,
+      });
+    }
+  }
+
+  const magnitude = values.get("acmagnitude")?.trim();
+  const dc = values.get("dc");
+  const canonicalParameters =
+    authoredWaveform === undefined
+      ? [...parameters, { name: "waveform", rawValue: waveform }]
+      : [...parameters];
+  canonicalParameters.sort((left, right) =>
+    left.name.localeCompare(right.name, "en", { sensitivity: "base" }),
+  );
+  const consumed = new Set(
+    SOURCE_PARAMETER_NAMES.map((name) => name.toLowerCase()),
+  );
+
+  return {
+    parameters: canonicalParameters,
+    ...(dc === undefined ? {} : { dc }),
+    ...(magnitude
+      ? {
+          ac: {
+            magnitude,
+            phase: values.get("acphase")?.trim() || "0",
+          },
+        }
+      : {}),
+    transient:
+      waveform === "pulse"
+        ? {
+            kind: "pulse",
+            low: values.get("low"),
+            high: values.get("high"),
+            delay: values.get("delay"),
+            rise: values.get("rise"),
+            fall: values.get("fall"),
+            width: values.get("width"),
+            period: values.get("period"),
+          }
+        : waveform === "sin"
+          ? {
+              kind: "sin",
+              offset: values.get("offset"),
+              amplitude: values.get("amplitude"),
+              frequency: values.get("frequency"),
+              delay: values.get("delay") ?? "0",
+              damping: values.get("damping") ?? "0",
+              phase: values.get("phase") ?? "0",
+            }
+          : { kind: "dc" },
+    extraParameters: parameters.filter(
+      (item) => !consumed.has(item.name.toLowerCase()),
+    ),
+    issues,
+  };
+}


### PR DESCRIPTION
## Summary\n- normalize voltage and current sources through one explicit DC/AC/PULSE/SIN contract\n- preserve the Digital Clock symbol and existing Editor controls while projecting its descriptor-owned PULSE default\n- stop inferring transient intent from the presence of period and return recoverable diagnostics for malformed waveform input\n- share normalized printing across SPICE and Spectre without changing Editor code\n\n## Validation\n- pnpm typecheck\n- focused: 96 passed, 1 skipped\n- real Preview ngspice 46 accepted voltage/current PULSE and SIN cards in a TRAN deck\n- full gate pass through 2,640 unit tests, workspace build, release/performance/golden checks and production smoke on first run; 353/354 browser tests passed, with the sole unrelated drafting input timing failure passing immediately in isolation\n- second full gate again passed static/unit/build/performance/golden checks; production smoke could not bind local port 4174 because an unrelated worktree already owns it, so clean-host GitHub checks remain the delivery authority\n\n## Boundary\nNo pps/editor files are modified. This completes the waveform sub-scope of #560; it does not close the remaining setup persistence work.\n\nTest-Impact: tests-updated