### PR TITLE
refactor(editor): dock simulation beside the testbench

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -349,9 +349,11 @@ test("Simulation creates an ordinary testbench and offers the current Cell at th
 }) => {
   await page.goto("/editor");
   await page.getByTestId("open-analog-simulation").click();
-  await page
-    .getByRole("button", { name: "New testbench from current Cell" })
-    .click();
+  await page.getByRole("button", { name: "New Testbench Cell…" }).click();
+  const dialog = page.getByRole("dialog", { name: "New Testbench Cell" });
+  await expect(dialog.getByLabel("DUT Cell")).toHaveValue("document-main");
+  await expect(dialog.getByText("Auto-derived")).toBeVisible();
+  await dialog.getByRole("button", { name: "Create Testbench" }).click();
   await page
     .getByTestId("schematic-canvas")
     .click({ position: { x: 320, y: 180 } });

--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -15,7 +15,7 @@ const profile = JSON.parse(
   ),
 ) as { id: string; simulator: { version: string } };
 import { openMenu, downloadBytes } from "./editor-fixtures.js";
-import { CircuitProjectSchema } from "@icm/model";
+import { parseProject } from "@icm/project-protocol";
 const ota = JSON.parse(
   readFileSync(
     new URL(
@@ -29,7 +29,7 @@ const ota = JSON.parse(
 test("the qualified OTA setup opens unchanged and preserves all root and hierarchical probes", async ({
   page,
 }) => {
-  const project = CircuitProjectSchema.parse(ota);
+  const project = parseProject(JSON.stringify(ota));
   expect(project.simulation!.input.probes).toHaveLength(4);
   expect(
     project.simulation!.input.probes.filter((p) => p.occurrence.length > 0),
@@ -146,7 +146,7 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
 test("human simulation uses saved setup, survives minimizing, recovers a bad input and exports results", async ({
   page,
 }) => {
-  const project = CircuitProjectSchema.parse(ota);
+  const project = parseProject(JSON.stringify(ota));
   project.simulation = {
     version: 1,
     input: {

--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -290,10 +290,13 @@ test("human simulation uses saved setup, survives closing, recovers a bad input 
   release();
   await page.getByTestId("open-analog-simulation").click();
   await expect(panel.getByRole("status")).toHaveText("finished · completed");
+  await panel.getByRole("tab", { name: "Operating Point" }).click();
   await expect(panel.getByRole("region", { name: "OP results" })).toContainText(
     "0.500000",
   );
+  await panel.getByRole("tab", { name: "Plot" }).click();
   await expect(panel.locator(".spice-ac-plot svg")).toHaveCount(1);
+  await panel.getByRole("tab", { name: "Files" }).click();
   const download = page.waitForEvent("download");
   await panel
     .getByRole("button", { name: /\.csv$/ })

--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -104,7 +104,7 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
     expect(deck).toContain(vector);
   expect(deck).toMatch(/ac dec 10 1 (?:1000000000|1e\+?9)/i);
   expect(executions).toBe(0);
-  await panel.getByRole("button", { name: "Close simulation" }).click();
+  await panel.getByRole("button", { name: "Minimize simulation" }).click();
   const saved = JSON.parse(
     (await downloadBytes(page, "File", "Export Project File…")).toString(),
   );
@@ -143,7 +143,7 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
   await expect(panel.getByLabel("Stop (Hz)")).toHaveValue("1000000000");
 });
 
-test("human simulation uses saved setup, survives closing, recovers a bad input and exports results", async ({
+test("human simulation uses saved setup, survives minimizing, recovers a bad input and exports results", async ({
   page,
 }) => {
   const project = CircuitProjectSchema.parse(ota);
@@ -285,7 +285,7 @@ test("human simulation uses saved setup, survives closing, recovers a bad input 
   await panel.getByRole("button", { name: "Apply setup" }).click();
   await panel.getByRole("button", { name: "Run", exact: true }).click();
   await expect.poll(() => executions).toBe(1);
-  await panel.getByRole("button", { name: "Close simulation" }).click();
+  await panel.getByRole("button", { name: "Minimize simulation" }).click();
   expect(cancellations).toBe(0);
   release();
   await page.getByTestId("open-analog-simulation").click();
@@ -329,7 +329,7 @@ test("human simulation uses saved setup, survives closing, recovers a bad input 
   await panel.getByRole("button", { name: "Cancel run" }).click();
   await expect(panel.getByRole("status")).toContainText("cancelled");
   expect(cancellations).toBe(1);
-  await panel.getByRole("button", { name: "Close simulation" }).click();
+  await panel.getByRole("button", { name: "Minimize simulation" }).click();
   const saved = await downloadBytes(page, "File", "Export Project File…");
   expect(
     JSON.parse(saved.toString()).simulation.input.environment.temperatureC,
@@ -351,7 +351,10 @@ test("Simulation creates an ordinary testbench and offers the current Cell at th
   page,
 }) => {
   await page.goto("/editor");
-  await page.getByTestId("open-analog-simulation").click();
+  await page
+    .locator(".command-menu > summary")
+    .filter({ hasText: "Edit" })
+    .click();
   await page.getByRole("button", { name: "New Testbench Cell…" }).click();
   const dialog = page.getByRole("dialog", { name: "New Testbench Cell" });
   await expect(dialog.getByLabel("DUT Cell")).toHaveValue("document-main");
@@ -375,6 +378,30 @@ test("Simulation creates an ordinary testbench and offers the current Cell at th
   expect(saved.simulation).toBeUndefined();
   await page.getByTestId("open-analog-simulation").click();
   await expect(page.getByLabel("Testbench Cell")).toHaveValue(tb.id);
+  await expect(page.getByTestId("library-toggle")).toBeDisabled();
+  await expect(page.getByTestId("examples-toggle")).toBeDisabled();
+  await page.getByRole("button", { name: "Minimize simulation" }).click();
+  await expect(page.getByTestId("library-toggle")).toBeEnabled();
+  await expect(page.getByTestId("open-analog-simulation")).toContainText(
+    "Minimized",
+  );
+  await page.getByTestId("open-analog-simulation").click();
+  await page.getByRole("button", { name: "Exit simulation" }).click();
+  const exitConfirmation = page.getByRole("alertdialog");
+  await expect(exitConfirmation).toContainText("temporary run files");
+  await exitConfirmation.getByRole("button", { name: "Keep working" }).click();
+  await expect(
+    page.getByRole("region", { name: "Analog simulation" }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Exit simulation" }).click();
+  await page
+    .getByRole("alertdialog")
+    .getByRole("button", { name: "Exit Simulation" })
+    .click();
+  await expect(
+    page.getByRole("region", { name: "Analog simulation" }),
+  ).toHaveCount(0);
+  await expect(page.getByTestId("library-toggle")).toBeEnabled();
 });
 
 test("Agent raw simulation recovers input errors, returns a run receipt and exports through Files", async ({

--- a/apps/editor/e2e/hierarchy.spec.ts
+++ b/apps/editor/e2e/hierarchy.spec.ts
@@ -106,6 +106,53 @@ test("reviews an unreferenced top Symbol and places that DUT in an ordinary new 
   await expect(page.getByTestId("active-instance-count")).toHaveText("1");
 });
 
+test("creates a Testbench and places a same-Project Cell from the canvas menu", async ({
+  page,
+}) => {
+  await page.goto("/editor");
+  const canvas = page.getByTestId("schematic-canvas");
+  await canvas.click({ button: "right", position: { x: 360, y: 220 } });
+  await page
+    .getByTestId("canvas-context-menu")
+    .getByRole("menuitem", { name: "New Testbench Cell…" })
+    .click();
+
+  const dialog = page.getByRole("dialog", { name: "New Testbench Cell" });
+  await dialog
+    .getByLabel("Place the DUT Symbol View after creating the testbench")
+    .uncheck();
+  await dialog.getByRole("button", { name: "Create Testbench" }).click();
+  await expect(page.getByTestId("active-document-name")).toHaveText("Main_tb");
+  await expect(page.getByTestId("active-instance-count")).toHaveText("0");
+
+  await canvas.click({ button: "right", position: { x: 360, y: 220 } });
+  await page
+    .getByTestId("canvas-context-menu")
+    .getByRole("menuitem", { name: "Place Cell from this Project…" })
+    .click();
+  await page
+    .getByRole("dialog", { name: "Place Hierarchical Cell" })
+    .getByRole("option", { name: /Main/u })
+    .click();
+  await canvas.click({ position: { x: 360, y: 220 } });
+  await page.keyboard.press("Escape");
+
+  const project = JSON.parse(
+    (await downloadBytes(page, "File", "Export Project File…")).toString(
+      "utf8",
+    ),
+  );
+  expect(project.topDocumentId).toBe("document-main");
+  const testbench = project.documents.find(
+    (candidate: { name: string }) => candidate.name === "Main_tb",
+  );
+  expect(testbench.instances).toHaveLength(1);
+  expect(testbench.instances[0].netlist.binding).toEqual({
+    kind: "subcircuit",
+    childDocumentId: "document-main",
+  });
+});
+
 test("shows the hierarchy row only once there is a hierarchy", async ({
   page,
 }) => {

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -2,7 +2,14 @@ import {
   DEFAULT_ARROW_PRESET,
   type ArrowPreset,
 } from "../features/drafting/arrow-presets";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { CSSProperties, PointerEvent as ReactPointerEvent } from "react";
 import "../styles/editor-entry.css";
 import type {
@@ -144,6 +151,7 @@ import {
 import { EditorDialogLayer } from "./editor-dialog-layer";
 import { EditorAppChrome } from "./editor-app-chrome";
 import { EditorPropertiesDock } from "./editor-properties-dock";
+import { LazySpiceSimulationSurface } from "./lazy-editor-dialogs";
 import type { NewTestbenchRequest } from "../features/simulation/new-testbench-dialog";
 import { useProjectCheck } from "./use-project-check";
 import { summarizeVisualDiagnostics } from "../features/selection/selection-inspector-details";
@@ -667,8 +675,12 @@ export function App({
       }),
     [editorDocumentController, projectSessionId],
   );
-  const [analogSimulationOpened, setAnalogSimulationOpened] = useState(false);
-  const [analogSimulationOpen, setAnalogSimulationOpen] = useState(false);
+  const [analogSimulationState, setAnalogSimulationState] = useState<
+    "closed" | "open" | "minimized"
+  >("closed");
+  const simulationPropertiesOpenBeforeRef = useRef(false);
+  const analogSimulationOpened = analogSimulationState !== "closed";
+  const analogSimulationOpen = analogSimulationState === "open";
   const humanSimulationSession = useMemo(
     () =>
       new BrowserSimulationSession({
@@ -683,6 +695,21 @@ export function App({
     },
     [humanSimulationSession],
   );
+  const openAnalogSimulation = (): void => {
+    simulationPropertiesOpenBeforeRef.current = selectionOpen;
+    setSelectionOpen(false);
+    setAnalogSimulationState("open");
+  };
+  const minimizeAnalogSimulation = (): void => {
+    setAnalogSimulationState("minimized");
+    setSelectionOpen(simulationPropertiesOpenBeforeRef.current);
+  };
+  const exitAnalogSimulation = (): void => {
+    void humanSimulationSession.clear();
+    setAnalogSimulationState("closed");
+    setSimulationDraftContext(null);
+    setSelectionOpen(simulationPropertiesOpenBeforeRef.current);
+  };
   const {
     cloudBinding,
     savedProjectBaseline,
@@ -2997,7 +3024,7 @@ export function App({
       dutDocumentId: dut.id,
       rootDocumentId: testbench.id,
     });
-    setAnalogSimulationOpen(false);
+    if (analogSimulationOpen) minimizeAnalogSimulation();
     if (request.placeDut) {
       beginProjectCellPlacement(dut.id);
       setStatus(
@@ -3915,10 +3942,8 @@ export function App({
     <main className="app-shell">
       {renderCrashRequested() ? <RenderCrashProbe /> : null}
       <EditorAppChrome
-        simulationAction={() => {
-          setAnalogSimulationOpened(true);
-          setAnalogSimulationOpen(true);
-        }}
+        simulationAction={openAnalogSimulation}
+        simulationState={analogSimulationState}
         releaseChannel={releaseChannel}
         projectName={project.name}
         projectSchemaVersion={project.schemaVersion}
@@ -4112,7 +4137,8 @@ export function App({
             );
           },
           leftPanelMode,
-          libraryPanelOpen: visibleLibraryPanelOpen,
+          libraryPanelOpen: !analogSimulationOpen && visibleLibraryPanelOpen,
+          leftPanelsDisabled: analogSimulationOpen,
           tool,
           documentSettingsOpen,
           undo: {
@@ -4191,30 +4217,6 @@ export function App({
         }}
       />
       <EditorDialogLayer
-        simulation={
-          analogSimulationOpened
-            ? {
-                sessionKey: projectSessionId,
-                session: humanSimulationSession,
-                project,
-                activeDocumentId: document.id,
-                ...(simulationDraftContext
-                  ? { draftContext: simulationDraftContext }
-                  : {}),
-                open: analogSimulationOpen,
-                onClose: () => setAnalogSimulationOpen(false),
-                onSaveSetup: (setup) => {
-                  const committed = commitStructure("set-simulation-setup", [
-                    { kind: "set_simulation_setup", setup },
-                  ]);
-                  if (committed) setSimulationDraftContext(null);
-                  return committed;
-                },
-                onOpenCell: (id) => switchDocument(id),
-                onNewTestbench: () => openNewTestbenchDialog(),
-              }
-            : undefined
-        }
         help={
           helpOpen ? { closeButtonRef: helpCloseRef, onClose: closeHelp } : null
         }
@@ -4540,13 +4542,39 @@ export function App({
       />
       <div
         className={
-          visibleLibraryPanelOpen
-            ? "app-workspace"
-            : "app-workspace library-collapsed"
+          analogSimulationOpen
+            ? "app-workspace simulation-mode"
+            : visibleLibraryPanelOpen
+              ? "app-workspace"
+              : "app-workspace library-collapsed"
         }
         style={{ "--icm-shapes-width": `${libraryWidth}px` } as CSSProperties}
       >
-        {leftPanelMode === "library" ? (
+        {analogSimulationOpened ? (
+          <Suspense fallback={null}>
+            <LazySpiceSimulationSurface
+              key={projectSessionId}
+              session={humanSimulationSession}
+              project={project}
+              activeDocumentId={document.id}
+              {...(simulationDraftContext
+                ? { draftContext: simulationDraftContext }
+                : {})}
+              open={analogSimulationOpen}
+              onMinimize={minimizeAnalogSimulation}
+              onExit={exitAnalogSimulation}
+              onSaveSetup={(setup) => {
+                const committed = commitStructure("set-simulation-setup", [
+                  { kind: "set_simulation_setup", setup },
+                ]);
+                if (committed) setSimulationDraftContext(null);
+                return committed;
+              }}
+              onOpenCell={(id) => switchDocument(id)}
+            />
+          </Suspense>
+        ) : null}
+        {!analogSimulationOpen && leftPanelMode === "library" ? (
           <ShapesPanel
             styleProfileId={document.presentation.styleProfileId}
             open={visibleLibraryPanelOpen}
@@ -4554,14 +4582,14 @@ export function App({
               editorCommands.execute({ id: "insert.start", launch })
             }
           />
-        ) : (
+        ) : !analogSimulationOpen ? (
           <ExamplesPanel
             open={visibleLibraryPanelOpen}
             onOpenGalleryExample={(id) => void insertGalleryEntryById(id)}
             onOpenExample={openLibraryExample}
           />
-        )}
-        {visibleLibraryPanelOpen ? (
+        ) : null}
+        {!analogSimulationOpen && visibleLibraryPanelOpen ? (
           <div
             className="library-resize-handle"
             role="separator"
@@ -5181,6 +5209,7 @@ export function App({
         />
         <EditorCanvasSurface
           empty={canvasIsEmpty}
+          showQuickStart={!analogSimulationOpen}
           cameraRuntime={cameraRuntime}
           onWheel={handleWheel}
           onPinch={zoomAtClientPoint}

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -144,6 +144,7 @@ import {
 import { EditorDialogLayer } from "./editor-dialog-layer";
 import { EditorAppChrome } from "./editor-app-chrome";
 import { EditorPropertiesDock } from "./editor-properties-dock";
+import type { NewTestbenchRequest } from "../features/simulation/new-testbench-dialog";
 import { useProjectCheck } from "./use-project-check";
 import { summarizeVisualDiagnostics } from "../features/selection/selection-inspector-details";
 import {
@@ -530,6 +531,17 @@ export function App({
   );
   const [importReviewOpen, setImportReviewOpen] = useState(false);
   const [cellManagerOpen, setCellManagerOpen] = useState(false);
+  const [newTestbenchDutId, setNewTestbenchDutId] = useState<string | null>(
+    null,
+  );
+  const [simulationDraftContext, setSimulationDraftContext] = useState<{
+    dutDocumentId: string;
+    rootDocumentId: string;
+  } | null>(null);
+  useEffect(() => {
+    setNewTestbenchDutId(null);
+    setSimulationDraftContext(null);
+  }, [project.id]);
   const [canvasContextMenu, setCanvasContextMenu] = useState<{
     x: number;
     y: number;
@@ -2919,6 +2931,83 @@ export function App({
     setStatus("Choose a Cell, then place it on the canvas");
   }
 
+  function openNewTestbenchDialog(dutDocumentId = document.id): void {
+    cancelAllTransientInteraction();
+    setCanvasContextMenu(null);
+    setNewTestbenchDutId(dutDocumentId);
+  }
+
+  function beginProjectCellPlacement(childDocumentId: string): void {
+    const child = project.documents.find(
+      (candidate) => candidate.id === childDocumentId,
+    );
+    if (!child?.netlist) {
+      setStatus("The selected DUT Cell no longer exists");
+      return;
+    }
+    const cellName =
+      child.sourceBinding?.cellName ?? child.netlist.name ?? child.name;
+    beginComponentPlacement({
+      kind: "cell",
+      symbolId: hierarchicalSymbolId(cellName),
+      childDocumentId: child.id,
+      cellName,
+      parameters: {},
+      initialRotation: 0,
+      showReference: true,
+      referenceText: null,
+      showValue: true,
+    });
+  }
+
+  function createTestbenchCell(request: NewTestbenchRequest): void {
+    const dut = project.documents.find(
+      (candidate) => candidate.id === request.dutDocumentId,
+    );
+    if (!dut?.netlist) {
+      setStatus("Could not create Testbench: the selected DUT Cell is missing");
+      return;
+    }
+    if (
+      project.documents.some(
+        (candidate) =>
+          candidate.name.toLowerCase() === request.name.toLowerCase(),
+      )
+    ) {
+      setStatus(
+        `Could not create Testbench: Cell ${request.name} already exists`,
+      );
+      return;
+    }
+    const testbench = createEmptyDocument(createId("document"), request.name);
+    testbench.netlist!.name = request.name;
+    testbench.presentation = structuredClone(dut.presentation);
+    if (
+      !commitStructure(
+        "create-testbench-cell",
+        planCreateCell(testbench),
+        testbench.id,
+      )
+    ) {
+      return;
+    }
+    setDocumentStack([]);
+    setNewTestbenchDutId(null);
+    setSimulationDraftContext({
+      dutDocumentId: dut.id,
+      rootDocumentId: testbench.id,
+    });
+    setAnalogSimulationOpen(false);
+    if (request.placeDut) {
+      beginProjectCellPlacement(dut.id);
+      setStatus(
+        `Created Testbench ${testbench.name}. Click to place the ${dut.name} Symbol View; Esc exits.`,
+      );
+    } else {
+      setStatus(`Created Testbench Cell ${testbench.name}`);
+    }
+  }
+
   const selectedFormalTerminal = selectedInstance
     ? document.netlist?.terminals.find((terminal) =>
         terminal.interfaceInstanceIds.includes(selectedInstance.id),
@@ -3890,6 +3979,11 @@ export function App({
         }}
         searchOpen={searchOpen}
         onManageCells={() => setCellManagerOpen(true)}
+        onNewTestbench={() => openNewTestbenchDialog()}
+        placeProjectCell={{
+          enabled: cellInsertCandidates.length > 0,
+          execute: placeCellInstance,
+        }}
         onOpenSearch={() => setSearchOpen(true)}
         undo={{
           enabled: editorCommands.state({ id: "history.undo" }).enabled,
@@ -4104,53 +4198,20 @@ export function App({
                 session: humanSimulationSession,
                 project,
                 activeDocumentId: document.id,
+                ...(simulationDraftContext
+                  ? { draftContext: simulationDraftContext }
+                  : {}),
                 open: analogSimulationOpen,
                 onClose: () => setAnalogSimulationOpen(false),
-                onSaveSetup: (setup) =>
-                  commitStructure("set-simulation-setup", [
+                onSaveSetup: (setup) => {
+                  const committed = commitStructure("set-simulation-setup", [
                     { kind: "set_simulation_setup", setup },
-                  ]),
-                onOpenCell: (id) => switchDocument(id),
-                onCreateTestbench: () => {
-                  let name = `${document.name}_tb`;
-                  for (
-                    let i = 2;
-                    project.documents.some((d) => d.name === name);
-                    i++
-                  )
-                    name = `${document.name}_tb_${i}`;
-                  const tb = createEmptyDocument(createId("document"), name);
-                  tb.netlist!.name = name;
-                  tb.presentation = structuredClone(document.presentation);
-                  if (
-                    commitStructure(
-                      "create-testbench-cell",
-                      planCreateCell(tb),
-                      tb.id,
-                    )
-                  ) {
-                    setDocumentStack([]);
-                    setAnalogSimulationOpen(false);
-                    const cellName =
-                      document.sourceBinding?.cellName ??
-                      document.netlist?.name ??
-                      document.name;
-                    beginComponentPlacement({
-                      kind: "cell",
-                      symbolId: hierarchicalSymbolId(cellName),
-                      childDocumentId: document.id,
-                      cellName,
-                      parameters: {},
-                      initialRotation: 0,
-                      showReference: true,
-                      referenceText: null,
-                      showValue: true,
-                    });
-                    setStatus(
-                      `Created ${name}. Click to place ${cellName}; configure Simulation setup when ready.`,
-                    );
-                  }
+                  ]);
+                  if (committed) setSimulationDraftContext(null);
+                  return committed;
                 },
+                onOpenCell: (id) => switchDocument(id),
+                onNewTestbench: () => openNewTestbenchDialog(),
               }
             : undefined
         }
@@ -4327,6 +4388,16 @@ export function App({
                     ),
                   );
                 },
+              }
+            : null
+        }
+        newTestbench={
+          newTestbenchDutId
+            ? {
+                documents: project.documents,
+                initialDutDocumentId: newTestbenchDutId,
+                onCancel: () => setNewTestbenchDutId(null),
+                onCreate: createTestbenchCell,
               }
             : null
         }
@@ -5550,6 +5621,16 @@ export function App({
               editorCommands.execute({ id: "selection.align", mode })
             }
             actions={[
+              {
+                label: "New Testbench Cell…",
+                enabled: true,
+                execute: () => openNewTestbenchDialog(),
+              },
+              {
+                label: "Place Cell from this Project…",
+                enabled: cellInsertCandidates.length > 0,
+                execute: placeCellInstance,
+              },
               ...(["png", "svg"] as const).map((format) => ({
                 label: `Copy as ${format.toUpperCase()}`,
                 enabled: editorCommands.state({

--- a/apps/editor/src/app/editor-app-chrome.tsx
+++ b/apps/editor/src/app/editor-app-chrome.tsx
@@ -39,6 +39,8 @@ export interface EditorAppChromeProps {
   fileCommands: ComponentProps<typeof FileCommandMenu>;
   searchOpen: boolean;
   onManageCells: () => void;
+  onNewTestbench: () => void;
+  placeProjectCell: CommandAction;
   onOpenSearch: () => void;
   undo: CommandAction;
   redo: CommandAction;
@@ -81,6 +83,8 @@ export function EditorAppChrome({
   fileCommands,
   searchOpen,
   onManageCells,
+  onNewTestbench,
+  placeProjectCell,
   onOpenSearch,
   undo,
   redo,
@@ -199,6 +203,16 @@ export function EditorAppChrome({
                   onClick={onManageCells}
                 >
                   Manage Cells…
+                </button>
+                <button type="button" onClick={onNewTestbench}>
+                  New Testbench Cell…
+                </button>
+                <button
+                  type="button"
+                  onClick={placeProjectCell.execute}
+                  disabled={!placeProjectCell.enabled}
+                >
+                  Place Cell from this Project…
                 </button>
                 <button
                   type="button"

--- a/apps/editor/src/app/editor-app-chrome.tsx
+++ b/apps/editor/src/app/editor-app-chrome.tsx
@@ -57,6 +57,7 @@ export interface EditorAppChromeProps {
   onOpenNetlistPreflight: () => void;
   agentAction: { label: string; execute: () => void } | null;
   simulationAction?: () => void;
+  simulationState?: "closed" | "open" | "minimized";
   publishGalleryOpen: boolean;
   onPublishGallery: () => void;
   helpButtonRef: RefObject<HTMLButtonElement | null>;
@@ -101,6 +102,7 @@ export function EditorAppChrome({
   onOpenNetlistPreflight,
   agentAction,
   simulationAction,
+  simulationState = "closed",
   publishGalleryOpen,
   onPublishGallery,
   helpButtonRef,
@@ -321,9 +323,12 @@ export function EditorAppChrome({
                 type="button"
                 data-testid="open-analog-simulation"
                 aria-label="Analog simulation"
+                aria-pressed={simulationState === "open"}
                 onClick={simulationAction}
               >
-                Simulation
+                {simulationState === "minimized"
+                  ? "Simulation · Minimized"
+                  : "Simulation"}
               </button>
             ) : null}
             {agentAction ? (

--- a/apps/editor/src/app/editor-dialog-layer.tsx
+++ b/apps/editor/src/app/editor-dialog-layer.tsx
@@ -10,6 +10,7 @@ import {
 } from "../components/recovery-banners";
 import {
   LazyCellManagerDialog,
+  LazyNewTestbenchDialog,
   LazySpiceSimulationSurface,
   LazyConnectAgentPanel,
   LazyEditorHelpDialog,
@@ -45,6 +46,7 @@ export interface EditorDialogLayerProps {
     onConfirm: () => void;
   } | null;
   cellManager: ComponentProps<typeof LazyCellManagerDialog> | null;
+  newTestbench: ComponentProps<typeof LazyNewTestbenchDialog> | null;
   netlistPreflight: ComponentProps<typeof LazyNetlistPreflightDialog> | null;
   publishGallery: ComponentProps<typeof LazyPublishGalleryDialog> | null;
   versionHistory: ComponentProps<typeof LazyVersionHistoryDialog> | null;
@@ -70,6 +72,7 @@ export function EditorDialogLayer({
   insertComponent,
   cellReset,
   cellManager,
+  newTestbench,
   netlistPreflight,
   publishGallery,
   versionHistory,
@@ -147,6 +150,7 @@ export function EditorDialogLayer({
           </div>
         ) : null}
         {cellManager ? <LazyCellManagerDialog {...cellManager} /> : null}
+        {newTestbench ? <LazyNewTestbenchDialog {...newTestbench} /> : null}
         {netlistPreflight ? (
           <LazyNetlistPreflightDialog {...netlistPreflight} />
         ) : null}

--- a/apps/editor/src/app/editor-dialog-layer.tsx
+++ b/apps/editor/src/app/editor-dialog-layer.tsx
@@ -11,7 +11,6 @@ import {
 import {
   LazyCellManagerDialog,
   LazyNewTestbenchDialog,
-  LazySpiceSimulationSurface,
   LazyConnectAgentPanel,
   LazyEditorHelpDialog,
   LazyInsertComponentDialog,
@@ -25,11 +24,6 @@ import {
 } from "./lazy-editor-dialogs";
 
 export interface EditorDialogLayerProps {
-  simulation?:
-    | (ComponentProps<typeof LazySpiceSimulationSurface> & {
-        sessionKey: string;
-      })
-    | undefined;
   help: ComponentProps<typeof LazyEditorHelpDialog> | null;
   chunkLoadFailure: ComponentProps<typeof ChunkLoadBanner> | null;
   recoveryFailure: ComponentProps<typeof RecoveryFailureBanner> | null;
@@ -60,7 +54,6 @@ export interface EditorDialogLayerProps {
 
 /** All modal/overlay UI kept outside the persistent editor workspace. */
 export function EditorDialogLayer({
-  simulation,
   help,
   chunkLoadFailure,
   recoveryFailure,
@@ -82,12 +75,6 @@ export function EditorDialogLayer({
   return (
     <>
       <Suspense fallback={null}>
-        {simulation ? (
-          <LazySpiceSimulationSurface
-            key={simulation.sessionKey}
-            {...simulation}
-          />
-        ) : null}
         {help ? <LazyEditorHelpDialog {...help} /> : null}
         {chunkLoadFailure ? <ChunkLoadBanner {...chunkLoadFailure} /> : null}
         {recoveryFailure ? (

--- a/apps/editor/src/app/lazy-editor-dialogs.ts
+++ b/apps/editor/src/app/lazy-editor-dialogs.ts
@@ -37,6 +37,12 @@ export const LazySpiceSimulationSurface = lazyChunk("inline", () =>
   })),
 );
 
+export const LazyNewTestbenchDialog = lazyChunk("dialog", () =>
+  import("../features/simulation/new-testbench-dialog").then((module) => ({
+    default: module.NewTestbenchDialog,
+  })),
+);
+
 export const LazyNetlistPreflightDialog = lazyChunk("dialog", () =>
   import("../features/netlist-export/netlist-preflight-dialog").then(
     (module) => ({ default: module.NetlistPreflightDialog }),

--- a/apps/editor/src/canvas/editor-canvas-surface.tsx
+++ b/apps/editor/src/canvas/editor-canvas-surface.tsx
@@ -29,6 +29,7 @@ import type { CameraRuntime } from "./camera-runtime";
 
 export interface EditorCanvasSurfaceProps {
   empty: boolean;
+  showQuickStart?: boolean;
   className: string;
   viewBox: string;
   cameraRuntime: CameraRuntime;
@@ -102,6 +103,7 @@ function CanvasShortcutChord({ keys }: { keys: readonly string[] }) {
 /** SVG scene composition; interaction semantics arrive through typed models. */
 export function EditorCanvasSurface({
   empty,
+  showQuickStart = true,
   className,
   viewBox,
   cameraRuntime,
@@ -220,7 +222,7 @@ export function EditorCanvasSurface({
   }, [cameraRuntime]);
   return (
     <section className="canvas-panel">
-      {empty ? (
+      {empty && showQuickStart ? (
         <aside
           className="canvas-shortcut-menu"
           data-testid="canvas-empty-state"

--- a/apps/editor/src/features/editor-shell/drawing-toolbar.tsx
+++ b/apps/editor/src/features/editor-shell/drawing-toolbar.tsx
@@ -17,6 +17,7 @@ interface ToolbarCommand {
 export interface DrawingToolbarProps {
   leftPanelMode: "examples" | "library";
   libraryPanelOpen: boolean;
+  leftPanelsDisabled?: boolean;
   tool: EditorTool;
   arrowPreset?: ArrowPreset;
   onArrowPresetChange?: (preset: ArrowPreset) => void;
@@ -35,6 +36,7 @@ export interface DrawingToolbarProps {
 export function DrawingToolbar({
   leftPanelMode,
   libraryPanelOpen,
+  leftPanelsDisabled = false,
   tool,
   arrowPreset = DEFAULT_ARROW_PRESET,
   onArrowPresetChange,
@@ -68,6 +70,7 @@ export function DrawingToolbar({
         aria-controls="examples-panel"
         aria-expanded={examplesOpen}
         data-testid="examples-toggle"
+        disabled={leftPanelsDisabled}
         onClick={onToggleExamples}
       >
         <ToolIcon name="examples" />
@@ -83,6 +86,7 @@ export function DrawingToolbar({
         aria-controls="shapes-library-panel"
         aria-expanded={libraryOpen}
         data-testid="library-toggle"
+        disabled={leftPanelsDisabled}
         onClick={onToggleLibrary}
       >
         <ToolIcon name="library" />

--- a/apps/editor/src/features/simulation/new-testbench-dialog.test.tsx
+++ b/apps/editor/src/features/simulation/new-testbench-dialog.test.tsx
@@ -1,0 +1,56 @@
+import { createEmptyDocument } from "@icm/model";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  NewTestbenchDialog,
+  nextTestbenchCellName,
+} from "./new-testbench-dialog";
+
+describe("NewTestbenchDialog", () => {
+  const dut = createEmptyDocument("document-main", "Main");
+  const existing = createEmptyDocument("document-main-tb", "Main_tb");
+
+  it("allocates a readable unused name for the selected DUT", () => {
+    expect(nextTestbenchCellName([dut], dut.id)).toBe("Main_tb");
+    expect(nextTestbenchCellName([dut, existing], dut.id)).toBe("Main_tb_2");
+  });
+
+  it("makes the Symbol View and hierarchy reference explicit", () => {
+    const onCreate = vi.fn();
+    const markup = renderToStaticMarkup(
+      <NewTestbenchDialog
+        documents={[dut]}
+        initialDutDocumentId={dut.id}
+        onCancel={() => undefined}
+        onCreate={onCreate}
+      />,
+    );
+
+    expect(markup).toContain('role="dialog"');
+    expect(markup).toContain("New Testbench Cell");
+    expect(markup).toContain("Auto-derived");
+    expect(markup).toContain("not a copied symbol");
+    expect(markup).toContain('value="Main_tb"');
+    expect(markup).toContain("Place the DUT Symbol View");
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+
+  it("shows a reviewed Symbol View without changing Cell ownership", () => {
+    const reviewed = structuredClone(dut);
+    reviewed.presentation.cellSymbol = {
+      minimumBodySize: { width: 100, height: 80 },
+    };
+    const markup = renderToStaticMarkup(
+      <NewTestbenchDialog
+        documents={[reviewed]}
+        initialDutDocumentId={reviewed.id}
+        onCancel={() => undefined}
+        onCreate={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Reviewed");
+    expect(markup).toContain("reference to this Cell");
+  });
+});

--- a/apps/editor/src/features/simulation/new-testbench-dialog.tsx
+++ b/apps/editor/src/features/simulation/new-testbench-dialog.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react";
+
+import type { SchematicDocument } from "@icm/model";
+
+export interface NewTestbenchRequest {
+  readonly dutDocumentId: string;
+  readonly name: string;
+  readonly placeDut: boolean;
+}
+
+export function nextTestbenchCellName(
+  documents: readonly SchematicDocument[],
+  dutDocumentId: string,
+): string {
+  const dut = documents.find((document) => document.id === dutDocumentId);
+  const base = `${dut?.name ?? "DUT"}_tb`;
+  if (!documents.some((document) => document.name === base)) return base;
+  for (let suffix = 2; ; suffix += 1) {
+    const candidate = `${base}_${suffix}`;
+    if (!documents.some((document) => document.name === candidate)) {
+      return candidate;
+    }
+  }
+}
+
+/**
+ * One explicit boundary between a reusable DUT Cell and an ordinary
+ * testbench Cell. The dialog only collects intent; Project edits and cursor
+ * placement remain owned by App and the existing hierarchy placement path.
+ */
+export function NewTestbenchDialog({
+  documents,
+  initialDutDocumentId,
+  onCancel,
+  onCreate,
+}: {
+  documents: readonly SchematicDocument[];
+  initialDutDocumentId: string;
+  onCancel(): void;
+  onCreate(request: NewTestbenchRequest): void;
+}) {
+  const initialDut =
+    documents.find((document) => document.id === initialDutDocumentId) ??
+    documents[0];
+  const [dutDocumentId, setDutDocumentId] = useState(initialDut?.id ?? "");
+  const [name, setName] = useState(() =>
+    nextTestbenchCellName(documents, initialDut?.id ?? ""),
+  );
+  const [placeDut, setPlaceDut] = useState(true);
+  const dut = documents.find((document) => document.id === dutDocumentId);
+  const duplicate = documents.some(
+    (document) => document.name.toLowerCase() === name.trim().toLowerCase(),
+  );
+  const portCount = dut?.netlist?.terminals.length ?? 0;
+
+  return (
+    <div
+      className="insert-dialog-backdrop"
+      onPointerDown={(event) =>
+        event.target === event.currentTarget && onCancel()
+      }
+    >
+      <form
+        className="editor-action-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="new-testbench-title"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!dut || !name.trim() || duplicate) return;
+          onCreate({ dutDocumentId, name: name.trim(), placeDut });
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") onCancel();
+        }}
+      >
+        <header className="editor-action-dialog-header">
+          <p>Project hierarchy</p>
+          <h2 id="new-testbench-title">New Testbench Cell</h2>
+        </header>
+        <div className="editor-action-dialog-body">
+          <p>
+            Keep the design Cell reusable, then place its Symbol View in a
+            separate testbench Cell.
+          </p>
+          <label className="editor-action-dialog-field">
+            <span>DUT Cell</span>
+            <select
+              autoFocus
+              aria-label="DUT Cell"
+              value={dutDocumentId}
+              onChange={(event) => {
+                const nextDutId = event.currentTarget.value;
+                setDutDocumentId(nextDutId);
+                setName(nextTestbenchCellName(documents, nextDutId));
+              }}
+            >
+              {documents.map((document) => (
+                <option key={document.id} value={document.id}>
+                  {document.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="editor-action-dialog-field">
+            <span>Symbol View</span>
+            <strong>
+              {dut?.presentation.cellSymbol ? "Reviewed" : "Auto-derived"}
+            </strong>
+            <small>
+              {portCount} formal {portCount === 1 ? "port" : "ports"}; the
+              testbench stores a reference to this Cell, not a copied symbol.
+            </small>
+          </div>
+          <label className="editor-action-dialog-field">
+            <span>Testbench Cell name</span>
+            <input
+              aria-label="Testbench Cell name"
+              value={name}
+              onChange={(event) => setName(event.currentTarget.value)}
+            />
+          </label>
+          {duplicate ? (
+            <p role="alert">A Cell with this name already exists.</p>
+          ) : null}
+          <label>
+            <input
+              type="checkbox"
+              checked={placeDut}
+              onChange={(event) => setPlaceDut(event.currentTarget.checked)}
+            />
+            Place the DUT Symbol View after creating the testbench
+          </label>
+        </div>
+        <footer className="editor-action-dialog-actions">
+          <button type="button" onClick={onCancel}>
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="primary"
+            disabled={!dut || !name.trim() || duplicate}
+          >
+            Create Testbench
+          </button>
+        </footer>
+      </form>
+    </div>
+  );
+}

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -6,7 +6,7 @@ import type { BrowserSimulationSession } from "./browser-simulation-session";
 import { SpiceSimulationSurface } from "./spice-simulation-surface";
 
 describe("SpiceSimulationSurface workspace", () => {
-  it("opens as a task bar plus an on-demand setup surface over the canvas", () => {
+  it("opens as a docked setup workspace without blocking a plain Cell", () => {
     const project = createEmptyProject("simulation-workspace", "Amplifier");
     const markup = renderToStaticMarkup(
       <SpiceSimulationSurface
@@ -14,17 +14,17 @@ describe("SpiceSimulationSurface workspace", () => {
         project={project}
         activeDocumentId={project.topDocumentId}
         session={{} as BrowserSimulationSession}
-        onClose={() => undefined}
+        onMinimize={() => undefined}
+        onExit={() => undefined}
         onSaveSetup={() => true}
         onOpenCell={() => undefined}
-        onNewTestbench={() => undefined}
       />,
     );
 
     expect(markup).toContain('class="simulation-taskbar"');
     expect(markup).toContain('data-testid="simulation-cell-flow"');
-    expect(markup).toContain("Derived Symbol");
-    expect(markup).toContain("Create Testbench");
+    expect(markup).toContain("This Cell has no DUT instance");
+    expect(markup).toContain("Edit → New Testbench Cell");
     expect(markup).toContain('aria-label="Simulation setup"');
     expect(markup).toContain('aria-pressed="true">Setup');
     expect(markup).toContain('aria-pressed="false">Results');

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -1,0 +1,33 @@
+import { createEmptyProject } from "@icm/model";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { BrowserSimulationSession } from "./browser-simulation-session";
+import { SpiceSimulationSurface } from "./spice-simulation-surface";
+
+describe("SpiceSimulationSurface workspace", () => {
+  it("opens as a task bar plus an on-demand setup surface over the canvas", () => {
+    const project = createEmptyProject("simulation-workspace", "Amplifier");
+    const markup = renderToStaticMarkup(
+      <SpiceSimulationSurface
+        open
+        project={project}
+        activeDocumentId={project.topDocumentId}
+        session={{} as BrowserSimulationSession}
+        onClose={() => undefined}
+        onSaveSetup={() => true}
+        onOpenCell={() => undefined}
+        onNewTestbench={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain('class="simulation-taskbar"');
+    expect(markup).toContain('data-testid="simulation-cell-flow"');
+    expect(markup).toContain("Derived Symbol");
+    expect(markup).toContain("Create Testbench");
+    expect(markup).toContain('aria-label="Simulation setup"');
+    expect(markup).toContain('aria-pressed="true">Setup');
+    expect(markup).toContain('aria-pressed="false">Results');
+    expect(markup).not.toContain('class="simulation-results-dock"');
+  });
+});

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -38,10 +38,10 @@ export interface SpiceSimulationSurfaceProps {
     readonly rootDocumentId: string;
   };
   session: BrowserSimulationSession;
-  onClose(): void;
+  onMinimize(): void;
+  onExit(): void;
   onSaveSetup(setup: SimulationSetup | null): boolean;
   onOpenCell(documentId: string): void;
-  onNewTestbench(): void;
 }
 
 /** A projection of the same prepare/start/read/cancel service used by MCP.
@@ -57,6 +57,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const [setupOpen, setSetupOpen] = useState(!project.simulation);
   const [resultsOpen, setResultsOpen] = useState(false);
   const [resultTab, setResultTab] = useState<ResultTab>("summary");
+  const [exitConfirmationOpen, setExitConfirmationOpen] = useState(false);
   useEffect(() => {
     if (!open || project.simulation) return;
     setResultsOpen(false);
@@ -185,11 +186,13 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const draftDut = project.documents.find(
     (candidate) => candidate.id === props.draftContext?.dutDocumentId,
   );
-  const draftRoot = project.documents.find(
-    (candidate) => candidate.id === props.draftContext?.rootDocumentId,
-  );
   const savedRoot = project.documents.find(
     (candidate) => candidate.id === project.simulation?.input.rootDocumentId,
+  );
+  const hasDutInstance = Boolean(
+    activeCell?.instances.some(
+      (instance) => instance.netlist?.binding?.kind === "subcircuit",
+    ),
   );
   const artifactGroups = [
     ...(prepared
@@ -243,76 +246,38 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
       aria-label="Analog simulation"
       onKeyDown={(e) => {
         e.stopPropagation();
-        if (e.key === "Escape") props.onClose();
+        if (e.key === "Escape") props.onMinimize();
       }}
     >
       <header className="simulation-taskbar">
         <div className="simulation-brand">
           <strong>Simulation</strong>
-          <span>Preview</span>
+          <span>{analysisLabel || "Preview"}</span>
         </div>
         <div
           className="simulation-cell-context"
           data-testid="simulation-cell-flow"
         >
-          {props.draftContext ? (
-            <>
-              <button
-                disabled={!draftDut}
-                onClick={() => draftDut && props.onOpenCell(draftDut.id)}
-              >
-                <small>DUT</small>
-                {draftDut?.name ?? "Missing Cell"}
-              </button>
-              <span aria-hidden="true">→</span>
-              <span className="simulation-symbol-stage">Symbol View</span>
-              <span aria-hidden="true">→</span>
-              <button
-                disabled={!draftRoot}
-                onClick={() => draftRoot && props.onOpenCell(draftRoot.id)}
-              >
-                <small>Testbench</small>
-                {draftRoot?.name ?? "Missing Cell"}
-              </button>
-            </>
-          ) : project.simulation ? (
-            <>
-              <button
-                disabled={!savedRoot}
-                onClick={() => savedRoot && props.onOpenCell(savedRoot.id)}
-              >
-                <small>Testbench</small>
-                {savedRoot?.name ?? "Missing Cell"}
-              </button>
-              {activeCell && activeCell.id !== savedRoot?.id ? (
-                <span className="simulation-editing-cell">
-                  Editing {activeCell.name}
-                </span>
-              ) : null}
-            </>
-          ) : (
-            <>
-              <button
-                disabled={!activeCell}
-                onClick={() => activeCell && props.onOpenCell(activeCell.id)}
-              >
-                <small>DUT</small>
-                {activeCell?.name ?? "Missing Cell"}
-              </button>
-              <span aria-hidden="true">→</span>
-              <span className="simulation-symbol-stage">
-                {activeCell?.presentation.cellSymbol
-                  ? "Reviewed Symbol"
-                  : "Derived Symbol"}
-              </span>
-              <span aria-hidden="true">→</span>
-              <button onClick={props.onNewTestbench}>Create Testbench</button>
-            </>
-          )}
+          <button
+            disabled={!activeCell}
+            onClick={() => activeCell && props.onOpenCell(activeCell.id)}
+          >
+            <small>Cell</small>
+            {activeCell?.name ?? "Missing Cell"}
+          </button>
+          {draftDut ? (
+            <button onClick={() => props.onOpenCell(draftDut.id)}>
+              <small>DUT</small>
+              {draftDut.name}
+            </button>
+          ) : null}
+          {savedRoot && savedRoot.id !== activeCell?.id ? (
+            <button onClick={() => props.onOpenCell(savedRoot.id)}>
+              <small>Setup root</small>
+              {savedRoot.name}
+            </button>
+          ) : null}
         </div>
-        {analysisLabel ? (
-          <span className="simulation-analysis-chip">{analysisLabel}</span>
-        ) : null}
         <span
           className={`simulation-status-chip simulation-status-${run?.state ?? (prepared ? "prepared" : "idle")}`}
           role="status"
@@ -324,8 +289,8 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
             type="button"
             aria-pressed={setupOpen}
             onClick={() => {
-              if (!setupOpen) setResultsOpen(false);
-              setSetupOpen(!setupOpen);
+              setResultsOpen(false);
+              setSetupOpen(true);
             }}
           >
             Setup
@@ -334,8 +299,8 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
             type="button"
             aria-pressed={resultsOpen}
             onClick={() => {
-              if (!resultsOpen) setSetupOpen(false);
-              setResultsOpen(!resultsOpen);
+              setSetupOpen(false);
+              setResultsOpen(true);
             }}
           >
             Results
@@ -369,20 +334,55 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
           ) : (
             <button
               className="simulation-primary-button"
-              onClick={props.onNewTestbench}
+              onClick={() => {
+                setResultsOpen(false);
+                setSetupOpen(true);
+              }}
             >
-              New Testbench Cell…
+              Set up
             </button>
           )}
           <button
+            className="simulation-minimize-button"
+            onClick={props.onMinimize}
+            aria-label="Minimize simulation"
+          >
+            —
+          </button>
+          <button
             className="simulation-close-button"
-            onClick={props.onClose}
-            aria-label="Close simulation"
+            onClick={() => setExitConfirmationOpen(true)}
+            aria-label="Exit simulation"
           >
             ×
           </button>
         </div>
       </header>
+
+      {!project.simulation && !hasDutInstance ? (
+        <p className="simulation-context-hint">
+          This Cell has no DUT instance. You can continue here, or use Edit →
+          New Testbench Cell before simulation.
+        </p>
+      ) : null}
+
+      {exitConfirmationOpen ? (
+        <div className="simulation-exit-confirmation" role="alertdialog">
+          <strong>Exit Simulation?</strong>
+          <p>
+            Unapplied setup changes and temporary run files will be discarded.
+            An active run will be cancelled.
+          </p>
+          <div>
+            <button onClick={() => setExitConfirmationOpen(false)}>
+              Keep working
+            </button>
+            <button className="simulation-stop-button" onClick={props.onExit}>
+              Exit Simulation
+            </button>
+          </div>
+        </div>
+      ) : null}
 
       {attention ? (
         <div className="simulation-workspace-notice" role="alert">
@@ -420,7 +420,6 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
           capabilities={capabilities}
           onDirty={setDirty}
           onError={setError}
-          onDismiss={() => setSetupOpen(false)}
         />
       ) : null}
 
@@ -443,13 +442,6 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                 </button>
               ))}
             </div>
-            <button
-              type="button"
-              aria-label="Close results"
-              onClick={() => setResultsOpen(false)}
-            >
-              ×
-            </button>
           </header>
           <div className="simulation-results-body">
             {resultTab === "summary" ? (
@@ -654,12 +646,10 @@ function SetupEditor({
   onSaveSetup,
   onDirty,
   onError,
-  onDismiss,
 }: SpiceSimulationSurfaceProps & {
   capabilities: Capabilities | undefined;
   onDirty(value: boolean): void;
   onError(value: string): void;
-  onDismiss(): void;
 }) {
   const saved = project.simulation?.input;
   const [rootId, setRootId] = useState(
@@ -685,9 +675,6 @@ function SetupEditor({
           <small>Simulation</small>
           <strong>Setup</strong>
         </div>
-        <button type="button" aria-label="Close setup" onClick={onDismiss}>
-          ×
-        </button>
       </header>
       <form
         onChange={() => onDirty(true)}

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -24,11 +24,15 @@ export interface SpiceSimulationSurfaceProps {
   open: boolean;
   project: CircuitProject;
   activeDocumentId: string;
+  draftContext?: {
+    readonly dutDocumentId: string;
+    readonly rootDocumentId: string;
+  };
   session: BrowserSimulationSession;
   onClose(): void;
   onSaveSetup(setup: SimulationSetup | null): boolean;
   onOpenCell(documentId: string): void;
-  onCreateTestbench(): void;
+  onNewTestbench(): void;
 }
 
 /** A projection of the same prepare/start/read/cancel service used by MCP.
@@ -138,6 +142,18 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     if (result.status === "failed") setError(result.message);
   };
   const running = run && ["running", "cancelling"].includes(run.state);
+  const activeCell = project.documents.find(
+    (candidate) => candidate.id === props.activeDocumentId,
+  );
+  const draftDut = project.documents.find(
+    (candidate) => candidate.id === props.draftContext?.dutDocumentId,
+  );
+  const draftRoot = project.documents.find(
+    (candidate) => candidate.id === props.draftContext?.rootDocumentId,
+  );
+  const savedRoot = project.documents.find(
+    (candidate) => candidate.id === project.simulation?.input.rootDocumentId,
+  );
   const artifactGroups = [
     ...(prepared
       ? [
@@ -181,9 +197,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
           simulator.
         </p>
         <div className="spice-simulation-actions">
-          <button onClick={props.onCreateTestbench}>
-            New testbench from current Cell
-          </button>
+          <button onClick={props.onNewTestbench}>New Testbench Cell…</button>
           {project.simulation && (
             <button
               onClick={() => {
@@ -195,6 +209,31 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
             </button>
           )}
         </div>
+        <p data-testid="simulation-cell-flow">
+          {props.draftContext ? (
+            <>
+              DUT: <strong>{draftDut?.name ?? "Missing Cell"}</strong>
+              {" → "}Symbol View{" → "}Testbench:{" "}
+              <strong>{draftRoot?.name ?? "Missing Cell"}</strong>
+            </>
+          ) : project.simulation ? (
+            <>
+              Testbench: <strong>{savedRoot?.name ?? "Missing Cell"}</strong>
+              {activeCell && activeCell.id !== savedRoot?.id
+                ? ` · editing ${activeCell.name}`
+                : ""}
+            </>
+          ) : (
+            <>
+              DUT: <strong>{activeCell?.name ?? "Missing Cell"}</strong>
+              {" → "}Symbol View:{" "}
+              {activeCell?.presentation.cellSymbol
+                ? "reviewed"
+                : "auto-derived"}
+              {" → "}create a Testbench
+            </>
+          )}
+        </p>
         <SetupEditor
           key={
             JSON.stringify(project.simulation) ??
@@ -388,6 +427,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
 function SetupEditor({
   project,
   activeDocumentId,
+  draftContext,
   capabilities,
   onSaveSetup,
   onDirty,
@@ -399,7 +439,7 @@ function SetupEditor({
 }) {
   const saved = project.simulation?.input;
   const [rootId, setRootId] = useState(
-    saved?.rootDocumentId ?? activeDocumentId,
+    saved?.rootDocumentId ?? draftContext?.rootDocumentId ?? activeDocumentId,
   );
   const [probes, setProbes] = useState(saved?.probes ?? []);
   const root = project.documents.find((d) => d.id === rootId);

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -20,6 +20,15 @@ import {
   type SimulationProbeOption,
 } from "./simulation-probe-options";
 
+const RESULT_TABS = [
+  ["summary", "Summary"],
+  ["plot", "Plot"],
+  ["operating-point", "Operating Point"],
+  ["console", "Console"],
+  ["files", "Files"],
+] as const;
+type ResultTab = (typeof RESULT_TABS)[number][0];
+
 export interface SpiceSimulationSurfaceProps {
   open: boolean;
   project: CircuitProject;
@@ -45,6 +54,14 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const [error, setError] = useState("");
   const [busy, setBusy] = useState(false);
   const [dirty, setDirty] = useState(false);
+  const [setupOpen, setSetupOpen] = useState(!project.simulation);
+  const [resultsOpen, setResultsOpen] = useState(false);
+  const [resultTab, setResultTab] = useState<ResultTab>("summary");
+  useEffect(() => {
+    if (!open || project.simulation) return;
+    setResultsOpen(false);
+    setSetupOpen(true);
+  }, [open, project.simulation, props.activeDocumentId]);
   const lock = useRef(false);
   const alive = useRef(true);
   useEffect(() => {
@@ -59,12 +76,32 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
       setError(
         `${reply.error.code}: ${reply.error.message}${reply.error.diagnostics?.map((d) => `\n${d.code}: ${d.message}`).join("") ?? ""}`,
       );
+      if (project.simulation) {
+        setSetupOpen(false);
+        setResultsOpen(true);
+        setResultTab("console");
+      } else {
+        setSetupOpen(true);
+        setResultsOpen(false);
+      }
     } else if ("run" in reply) {
       setRun(reply.run);
       setError("");
+      if (
+        reply.run.result ||
+        reply.run.error ||
+        ["finished", "cancelled", "lost"].includes(reply.run.state)
+      ) {
+        setSetupOpen(false);
+        setResultsOpen(true);
+        setResultTab("summary");
+      }
     } else if ("prepared" in reply) {
       setPrepared(reply.prepared);
       setError("");
+      setSetupOpen(false);
+      setResultsOpen(true);
+      setResultTab("files");
     } else if ("capabilities" in reply) {
       setCapabilities(reply.capabilities);
       setError("");
@@ -174,6 +211,31 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
         ]
       : []),
   ];
+  const statusLabel = busy
+    ? "Preparing…"
+    : run
+      ? `${run.state}${run.result ? ` · ${run.result.outcome.status}` : ""}`
+      : prepared
+        ? "Deck prepared"
+        : "No run yet";
+  const staleMessage =
+    run?.inputStatus === "changed"
+      ? "Result belongs to an earlier Project revision. Run again to use the current circuit."
+      : "";
+  const attention =
+    error ||
+    staleMessage ||
+    (run?.error ? `${run.error.code}: ${run.error.message}` : "");
+  const attentionSummary = error
+    ? error.startsWith("SIMULATION_CAPABILITIES_UNAVAILABLE")
+      ? "Simulation service is unavailable in this environment."
+      : /probe/i.test(error)
+        ? "The probe selection needs attention. Open Console for details."
+        : "Simulation needs attention. Open Console for details."
+    : attention;
+  const analysisLabel = project.simulation?.input.analyses
+    .map((analysis) => analysis.kind.toUpperCase())
+    .join(" + ");
   return (
     <section
       hidden={!open}
@@ -184,56 +246,171 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
         if (e.key === "Escape") props.onClose();
       }}
     >
-      <header>
-        <strong>Simulation · Preview</strong>
-        <button onClick={props.onClose} aria-label="Close simulation">
-          ×
-        </button>
-      </header>
-      <div className="spice-simulation-body">
-        <p>
-          Build the testbench on the canvas. Source DC/AC values live in
-          instance Properties. Run sends the prepared circuit to the configured
-          simulator.
-        </p>
-        <div className="spice-simulation-actions">
-          <button onClick={props.onNewTestbench}>New Testbench Cell…</button>
-          {project.simulation && (
-            <button
-              onClick={() => {
-                props.onOpenCell(project.simulation!.input.rootDocumentId);
-                props.onClose();
-              }}
-            >
-              Edit testbench
-            </button>
-          )}
+      <header className="simulation-taskbar">
+        <div className="simulation-brand">
+          <strong>Simulation</strong>
+          <span>Preview</span>
         </div>
-        <p data-testid="simulation-cell-flow">
+        <div
+          className="simulation-cell-context"
+          data-testid="simulation-cell-flow"
+        >
           {props.draftContext ? (
             <>
-              DUT: <strong>{draftDut?.name ?? "Missing Cell"}</strong>
-              {" → "}Symbol View{" → "}Testbench:{" "}
-              <strong>{draftRoot?.name ?? "Missing Cell"}</strong>
+              <button
+                disabled={!draftDut}
+                onClick={() => draftDut && props.onOpenCell(draftDut.id)}
+              >
+                <small>DUT</small>
+                {draftDut?.name ?? "Missing Cell"}
+              </button>
+              <span aria-hidden="true">→</span>
+              <span className="simulation-symbol-stage">Symbol View</span>
+              <span aria-hidden="true">→</span>
+              <button
+                disabled={!draftRoot}
+                onClick={() => draftRoot && props.onOpenCell(draftRoot.id)}
+              >
+                <small>Testbench</small>
+                {draftRoot?.name ?? "Missing Cell"}
+              </button>
             </>
           ) : project.simulation ? (
             <>
-              Testbench: <strong>{savedRoot?.name ?? "Missing Cell"}</strong>
-              {activeCell && activeCell.id !== savedRoot?.id
-                ? ` · editing ${activeCell.name}`
-                : ""}
+              <button
+                disabled={!savedRoot}
+                onClick={() => savedRoot && props.onOpenCell(savedRoot.id)}
+              >
+                <small>Testbench</small>
+                {savedRoot?.name ?? "Missing Cell"}
+              </button>
+              {activeCell && activeCell.id !== savedRoot?.id ? (
+                <span className="simulation-editing-cell">
+                  Editing {activeCell.name}
+                </span>
+              ) : null}
             </>
           ) : (
             <>
-              DUT: <strong>{activeCell?.name ?? "Missing Cell"}</strong>
-              {" → "}Symbol View:{" "}
-              {activeCell?.presentation.cellSymbol
-                ? "reviewed"
-                : "auto-derived"}
-              {" → "}create a Testbench
+              <button
+                disabled={!activeCell}
+                onClick={() => activeCell && props.onOpenCell(activeCell.id)}
+              >
+                <small>DUT</small>
+                {activeCell?.name ?? "Missing Cell"}
+              </button>
+              <span aria-hidden="true">→</span>
+              <span className="simulation-symbol-stage">
+                {activeCell?.presentation.cellSymbol
+                  ? "Reviewed Symbol"
+                  : "Derived Symbol"}
+              </span>
+              <span aria-hidden="true">→</span>
+              <button onClick={props.onNewTestbench}>Create Testbench</button>
             </>
           )}
-        </p>
+        </div>
+        {analysisLabel ? (
+          <span className="simulation-analysis-chip">{analysisLabel}</span>
+        ) : null}
+        <span
+          className={`simulation-status-chip simulation-status-${run?.state ?? (prepared ? "prepared" : "idle")}`}
+          role="status"
+        >
+          {dirty ? "Setup changed" : statusLabel}
+        </span>
+        <div className="simulation-task-actions">
+          <button
+            type="button"
+            aria-pressed={setupOpen}
+            onClick={() => {
+              if (!setupOpen) setResultsOpen(false);
+              setSetupOpen(!setupOpen);
+            }}
+          >
+            Setup
+          </button>
+          <button
+            type="button"
+            aria-pressed={resultsOpen}
+            onClick={() => {
+              if (!resultsOpen) setSetupOpen(false);
+              setResultsOpen(!resultsOpen);
+            }}
+          >
+            Results
+          </button>
+          <button
+            disabled={busy || !!running || dirty || !project.simulation}
+            onClick={() => void execute(false)}
+          >
+            Prepare deck
+          </button>
+          {running ? (
+            <button
+              className="simulation-stop-button"
+              disabled={run.state === "cancelling"}
+              onClick={() =>
+                void session
+                  .handle({ operation: "cancel", runId: run.id })
+                  .then(receive)
+              }
+            >
+              Cancel run
+            </button>
+          ) : project.simulation ? (
+            <button
+              className="simulation-primary-button"
+              disabled={busy || dirty}
+              onClick={() => void execute(true)}
+            >
+              Run
+            </button>
+          ) : (
+            <button
+              className="simulation-primary-button"
+              onClick={props.onNewTestbench}
+            >
+              New Testbench Cell…
+            </button>
+          )}
+          <button
+            className="simulation-close-button"
+            onClick={props.onClose}
+            aria-label="Close simulation"
+          >
+            ×
+          </button>
+        </div>
+      </header>
+
+      {attention ? (
+        <div className="simulation-workspace-notice" role="alert">
+          <strong>Needs attention</strong>
+          <span>{attentionSummary}</span>
+          {error && run ? (
+            <button
+              onClick={() =>
+                void session
+                  .handle({ operation: "read", runId: run.id })
+                  .then(receive)
+              }
+            >
+              Refresh run status
+            </button>
+          ) : null}
+        </div>
+      ) : capabilities?.configured === false ? (
+        <div className="simulation-workspace-notice">
+          Simulator not configured. You can still edit the Project and setup.
+        </div>
+      ) : dirty ? (
+        <div className="simulation-workspace-notice">
+          Apply setup changes before running.
+        </div>
+      ) : null}
+
+      {setupOpen ? (
         <SetupEditor
           key={
             JSON.stringify(project.simulation) ??
@@ -243,183 +420,228 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
           capabilities={capabilities}
           onDirty={setDirty}
           onError={setError}
+          onDismiss={() => setSetupOpen(false)}
         />
-        <div className="spice-simulation-actions">
-          <button
-            disabled={busy || !!running || dirty || !project.simulation}
-            onClick={() => void execute(false)}
-          >
-            Prepare deck
-          </button>
-          <button
-            disabled={busy || !!running || dirty || !project.simulation}
-            onClick={() => void execute(true)}
-          >
-            Run
-          </button>
-          <button
-            disabled={!running || run.state === "cancelling"}
-            onClick={() =>
-              void session
-                .handle({ operation: "cancel", runId: run!.id })
-                .then(receive)
-            }
-          >
-            Cancel run
-          </button>
-        </div>
-        {dirty && <p>Apply setup changes before running.</p>}
-        {capabilities?.configured === false && (
-          <p>
-            Simulator not configured. You can still edit the Project and setup.
-          </p>
-        )}
-        <p role="status">
-          {busy
-            ? "Preparing…"
-            : run
-              ? `${run.state}${run.result ? ` · ${run.result.outcome.status}` : ""}`
-              : prepared
-                ? "Deck prepared"
-                : "No run yet"}
-        </p>
-        {error && <pre role="alert">{error}</pre>}
-        {error && run && (
-          <button
-            onClick={() =>
-              void session
-                .handle({ operation: "read", runId: run.id })
-                .then(receive)
-            }
-          >
-            Refresh run status
-          </button>
-        )}
-        {run?.state === "lost" && (
-          <p>
-            The executor response is unknown. This run was not automatically
-            resubmitted; inspect its evidence before choosing a new run.
-          </p>
-        )}
-        {(run || prepared) && (
-          <details>
-            <summary>Input identity</summary>
-            <pre>
-              {prepared &&
-                `Prepared ${prepared.id}\nInput ${prepared.inputRevision}\n`}
-              {run &&
-                `Run ${run.id}\nPrepared ${run.preparedId}\nInput ${run.inputRevision}`}
-            </pre>
-          </details>
-        )}
-        {prepared?.warnings.map((warning, i) => (
-          <p key={i}>{warning}</p>
-        ))}
-        {run?.inputStatus === "changed" && (
-          <p role="alert">
-            Result belongs to an earlier Project revision. Run again to use the
-            current circuit.
-          </p>
-        )}
-        {run?.error && (
-          <pre role="alert">
-            {run.error.code}: {run.error.message}
-          </pre>
-        )}
-        {run?.result && (
-          <>
-            {run.resultPreview && (
-              <p>
-                Result preview is bounded. Export artifacts for complete data.
-              </p>
-            )}
-            {run.result.data?.analyses.map((analysis, i) => (
-              <section
-                key={i}
-                aria-label={`${analysis.analysis.toUpperCase()} results`}
-              >
-                <h3>{analysis.plotName}</h3>
-                {analysis.analysis === "op" && (
-                  <table>
-                    <thead>
-                      <tr>
-                        <th>Vector</th>
-                        <th>Value</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {analysis.probes.map((p) => (
-                        <tr key={p.name}>
-                          <td>{p.name}</td>
-                          <td>
-                            {p.value.toPrecision(6)} {p.unit}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                )}
-                {analysis.analysis === "ac" && (
-                  <div
-                    className="spice-ac-plot"
-                    dangerouslySetInnerHTML={{
-                      __html:
-                        acResponseSvg(
-                          analysis.probes.map((p) => ({
-                            label: p.name,
-                            points: analysis.frequencyHz.map(
-                              (frequency, index) => ({
-                                frequency,
-                                magnitudeDb:
-                                  20 *
-                                  Math.log10(
-                                    Math.max(
-                                      Math.hypot(
-                                        p.real[index] ?? 0,
-                                        p.imag[index] ?? 0,
+      ) : null}
+
+      {resultsOpen ? (
+        <section
+          className="simulation-results-dock"
+          aria-label="Simulation results"
+        >
+          <header className="simulation-results-header">
+            <div role="tablist" aria-label="Result views">
+              {RESULT_TABS.map(([id, label]) => (
+                <button
+                  key={id}
+                  type="button"
+                  role="tab"
+                  aria-selected={resultTab === id}
+                  onClick={() => setResultTab(id)}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              aria-label="Close results"
+              onClick={() => setResultsOpen(false)}
+            >
+              ×
+            </button>
+          </header>
+          <div className="simulation-results-body">
+            {resultTab === "summary" ? (
+              <div className="simulation-result-summary">
+                <div>
+                  <small>Run state</small>
+                  <strong>{statusLabel}</strong>
+                </div>
+                <div>
+                  <small>Input</small>
+                  <strong>{run?.inputStatus ?? "current"}</strong>
+                </div>
+                <div>
+                  <small>Analyses</small>
+                  <strong>{analysisLabel || "Not configured"}</strong>
+                </div>
+                {run?.state === "lost" ? (
+                  <p>
+                    The executor response is unknown. This run was not
+                    automatically resubmitted; inspect its evidence before
+                    choosing a new run.
+                  </p>
+                ) : null}
+                {prepared?.warnings.map((warning, index) => (
+                  <p key={index}>{warning}</p>
+                ))}
+                {run?.resultPreview ? (
+                  <p>
+                    Result preview is bounded. Export artifacts for complete
+                    data.
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+
+            {resultTab === "plot" ? (
+              <div className="simulation-analysis-view">
+                {run?.result?.data?.analyses
+                  .filter((analysis) => analysis.analysis === "ac")
+                  .map((analysis, index) => (
+                    <section key={index} aria-label="AC results">
+                      <h3>{analysis.plotName}</h3>
+                      <div
+                        className="spice-ac-plot"
+                        dangerouslySetInnerHTML={{
+                          __html:
+                            acResponseSvg(
+                              analysis.probes.map((probe) => ({
+                                label: probe.name,
+                                points: analysis.frequencyHz.map(
+                                  (frequency, pointIndex) => ({
+                                    frequency,
+                                    magnitudeDb:
+                                      20 *
+                                      Math.log10(
+                                        Math.max(
+                                          Math.hypot(
+                                            probe.real[pointIndex] ?? 0,
+                                            probe.imag[pointIndex] ?? 0,
+                                          ),
+                                          1e-30,
+                                        ),
                                       ),
-                                      1e-30,
-                                    ),
-                                  ),
-                                phaseDeg:
-                                  (Math.atan2(
-                                    p.imag[index] ?? 0,
-                                    p.real[index] ?? 0,
-                                  ) *
-                                    180) /
-                                  Math.PI,
-                              }),
-                            ),
-                          })),
-                          { width: 640, height: 320 },
-                        ) ?? "",
-                    }}
-                  />
+                                    phaseDeg:
+                                      (Math.atan2(
+                                        probe.imag[pointIndex] ?? 0,
+                                        probe.real[pointIndex] ?? 0,
+                                      ) *
+                                        180) /
+                                      Math.PI,
+                                  }),
+                                ),
+                              })),
+                              { width: 760, height: 300 },
+                            ) ?? "",
+                        }}
+                      />
+                    </section>
+                  ))}
+                {!run?.result?.data?.analyses.some(
+                  (analysis) => analysis.analysis === "ac",
+                ) ? (
+                  <p className="simulation-empty-result">
+                    Run an AC analysis to see a plot.
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+
+            {resultTab === "operating-point" ? (
+              <div className="simulation-analysis-view">
+                {run?.result?.data?.analyses
+                  .filter((analysis) => analysis.analysis === "op")
+                  .map((analysis, index) => (
+                    <section key={index} aria-label="OP results">
+                      <h3>{analysis.plotName}</h3>
+                      <table>
+                        <thead>
+                          <tr>
+                            <th>Vector</th>
+                            <th>Value</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {analysis.probes.map((probe) => (
+                            <tr key={probe.name}>
+                              <td>{probe.name}</td>
+                              <td>
+                                {probe.value.toPrecision(6)} {probe.unit}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </section>
+                  ))}
+                {!run?.result?.data?.analyses.some(
+                  (analysis) => analysis.analysis === "op",
+                ) ? (
+                  <p className="simulation-empty-result">
+                    Run an operating-point analysis to see values.
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+
+            {resultTab === "console" ? (
+              <div className="simulation-console-view">
+                {error ? <pre>{error}</pre> : null}
+                {run?.error ? (
+                  <pre>
+                    {run.error.code}: {run.error.message}
+                  </pre>
+                ) : null}
+                {run?.result ? (
+                  <pre>
+                    {run.result.diagnostics
+                      .map((diagnostic) => diagnostic.text)
+                      .join("\n")}
+                    {"\n"}
+                    {run.result.log}
+                  </pre>
+                ) : null}
+                {!error && !run?.error && !run?.result ? (
+                  <p className="simulation-empty-result">
+                    Simulator diagnostics will appear here.
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+
+            {resultTab === "files" ? (
+              <div className="simulation-files-view">
+                {(run || prepared) && (
+                  <details>
+                    <summary>Input identity</summary>
+                    <pre>
+                      {prepared &&
+                        `Prepared ${prepared.id}\nInput ${prepared.inputRevision}\n`}
+                      {run &&
+                        `Run ${run.id}\nPrepared ${run.preparedId}\nInput ${run.inputRevision}`}
+                    </pre>
+                  </details>
                 )}
-              </section>
-            ))}
-            <details>
-              <summary>Diagnostics and console</summary>
-              <pre>
-                {run.result.diagnostics.map((d) => d.text).join("\n")}
-                {"\n"}
-                {run.result.log}
-              </pre>
-            </details>
-          </>
-        )}
-        {artifactGroups.map((group) => (
-          <details open key={group.label} aria-label={group.label}>
-            <summary>{group.label}</summary>
-            <small>{group.identity}</small>
-            {group.artifacts.map((a) => (
-              <button key={a.id} onClick={() => void download(a)}>
-                {a.name}
-              </button>
-            ))}
-          </details>
-        ))}
-      </div>
+                {artifactGroups.map((group) => (
+                  <section key={group.label} aria-label={group.label}>
+                    <div>
+                      <strong>{group.label}</strong>
+                      <small>{group.identity}</small>
+                    </div>
+                    <div className="simulation-artifact-list">
+                      {group.artifacts.map((artifact) => (
+                        <button
+                          key={artifact.id}
+                          onClick={() => void download(artifact)}
+                        >
+                          {artifact.name}
+                        </button>
+                      ))}
+                    </div>
+                  </section>
+                ))}
+                {artifactGroups.length === 0 ? (
+                  <p className="simulation-empty-result">
+                    Prepare a deck or run the simulation to create files.
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        </section>
+      ) : null}
     </section>
   );
 }
@@ -432,10 +654,12 @@ function SetupEditor({
   onSaveSetup,
   onDirty,
   onError,
+  onDismiss,
 }: SpiceSimulationSurfaceProps & {
   capabilities: Capabilities | undefined;
   onDirty(value: boolean): void;
   onError(value: string): void;
+  onDismiss(): void;
 }) {
   const saved = project.simulation?.input;
   const [rootId, setRootId] = useState(
@@ -455,8 +679,16 @@ function SetupEditor({
     onDirty(false);
   }, []);
   return (
-    <details open={!saved}>
-      <summary>Setup</summary>
+    <aside className="simulation-setup-panel" aria-label="Simulation setup">
+      <header>
+        <div>
+          <small>Simulation</small>
+          <strong>Setup</strong>
+        </div>
+        <button type="button" aria-label="Close setup" onClick={onDismiss}>
+          ×
+        </button>
+      </header>
       <form
         onChange={() => onDirty(true)}
         onSubmit={(event) => {
@@ -645,7 +877,7 @@ function SetupEditor({
           </button>
         )}
       </form>
-    </details>
+    </aside>
   );
 }
 

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -1,54 +1,353 @@
 /* Local-development Digital Simulation tool window and waveform viewer. */
 
-/* Analog is a lazy, non-modal drawer; the original canvas remains editable. */
+/* Analog simulation is a lazy workspace layer. Only its task bar and open
+   docks accept pointer input, so the testbench canvas stays fully editable. */
 .spice-simulation-surface {
   position: fixed;
-  top: 90px;
-  right: 16px;
+  top: 92px;
+  right: clamp(300px, 23vw, 390px);
+  bottom: 44px;
+  left: clamp(230px, 19vw, 320px);
   z-index: 29;
-  width: min(510px, calc(100vw - 32px));
-  max-height: calc(100dvh - 120px);
-  overflow: auto;
+  color: var(--icm-text);
+  pointer-events: none;
+}
+.spice-simulation-surface > * {
+  pointer-events: auto;
+}
+.spice-simulation-surface button,
+.spice-simulation-surface input,
+.spice-simulation-surface select {
+  font: inherit;
+}
+.spice-simulation-surface button {
+  min-height: 30px;
+  padding: 5px 10px;
   border: 1px solid var(--icm-border-strong);
-  border-radius: var(--icm-radius-md);
+  border-radius: var(--icm-radius-sm);
   background: var(--icm-surface);
   color: var(--icm-text);
-  box-shadow: var(--icm-shadow-md);
+  cursor: pointer;
+}
+.spice-simulation-surface button:hover:not(:disabled) {
+  border-color: var(--icm-accent);
+  background: var(--icm-surface-muted);
+}
+.spice-simulation-surface button:disabled {
+  cursor: default;
+  opacity: 0.46;
 }
 .spice-simulation-surface[hidden] {
   display: none;
 }
-.spice-simulation-surface header,
-.spice-simulation-actions {
+
+.simulation-taskbar {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-areas:
+    "brand context context"
+    "analysis status actions";
+  align-items: center;
+  gap: 5px var(--icm-space-2);
+  min-height: 70px;
+  padding: 7px 8px;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-md);
+  background: color-mix(in srgb, var(--icm-surface) 96%, transparent);
+  box-shadow: var(--icm-shadow-md);
+  backdrop-filter: blur(10px);
+}
+.simulation-brand {
+  grid-area: brand;
+  display: grid;
+  line-height: 1.05;
+}
+.simulation-brand strong {
+  font-size: var(--icm-font-sm);
+}
+.simulation-brand span,
+.simulation-taskbar small,
+.simulation-editing-cell {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.simulation-cell-context,
+.simulation-task-actions {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 8px;
+  gap: 5px;
+  min-width: 0;
 }
-.spice-simulation-surface header {
-  padding: 12px;
+.simulation-cell-context {
+  grid-area: context;
+  flex: 1;
+  overflow: hidden;
+}
+.simulation-task-actions {
+  grid-area: actions;
+  justify-self: end;
+}
+.simulation-cell-context button {
+  display: grid;
+  flex: 0 1 auto;
+  min-width: 0;
+  padding: 3px 8px;
+  border-color: var(--icm-border);
+  line-height: 1.05;
+  text-align: left;
+}
+.simulation-cell-context button:not(:last-child) {
+  max-width: 150px;
+}
+.simulation-cell-context button,
+.simulation-symbol-stage,
+.simulation-editing-cell {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.simulation-symbol-stage,
+.simulation-analysis-chip,
+.simulation-status-chip {
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: var(--icm-surface-muted);
+  font-size: var(--icm-font-xs);
+  white-space: nowrap;
+}
+.simulation-analysis-chip {
+  grid-area: analysis;
+  color: var(--icm-text-muted);
+}
+.simulation-status-chip {
+  grid-area: status;
+  justify-self: start;
+  color: var(--icm-text-muted);
+  border: 1px solid var(--icm-border);
+}
+.simulation-status-running,
+.simulation-status-cancelling {
+  color: var(--icm-accent);
+  border-color: var(--icm-accent);
+}
+.simulation-status-finished {
+  color: #067647;
+  border-color: #75e0a7;
+  background: #ecfdf3;
+}
+.simulation-primary-button {
+  border-color: var(--icm-accent) !important;
+  color: #fff !important;
+  background: var(--icm-accent) !important;
+  font-weight: 650;
+}
+.simulation-stop-button {
+  color: #b42318 !important;
+  border-color: #fda29b !important;
+}
+.simulation-close-button {
+  width: 30px;
+  padding: 0 !important;
+  font-size: 18px !important;
+}
+
+.simulation-workspace-notice {
+  position: absolute;
+  top: 80px;
+  right: 0;
+  left: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--icm-space-2);
+  padding: 8px 10px;
+  border: 1px solid #fdb022;
+  border-radius: var(--icm-radius-sm);
+  color: #7a2e0e;
+  background: #fffaeb;
+  box-shadow: var(--icm-shadow-sm);
+  font-size: var(--icm-font-xs);
+}
+.simulation-workspace-notice span {
+  flex: 1;
+  white-space: pre-wrap;
+}
+
+.simulation-setup-panel {
+  position: absolute;
+  top: 80px;
+  right: 0;
+  bottom: 0;
+  width: min(380px, 46vw);
+  overflow: auto;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-md);
+  background: var(--icm-surface);
+  box-shadow: var(--icm-shadow-md);
+}
+.simulation-workspace-notice + .simulation-setup-panel {
+  top: 126px;
+}
+.simulation-setup-panel > header,
+.simulation-results-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--icm-space-2);
+  padding: 8px 10px;
   border-bottom: 1px solid var(--icm-border);
+  background: var(--icm-surface-muted);
 }
-.spice-simulation-surface header button {
+.simulation-setup-panel > header > div {
+  display: grid;
+  line-height: 1.1;
+}
+.simulation-setup-panel > header small {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.simulation-setup-panel > header button,
+.simulation-results-header > button {
+  width: 30px;
   margin-left: auto;
+  padding: 0;
+  font-size: 18px;
 }
-.spice-simulation-body {
-  padding: 12px;
+.simulation-setup-panel form {
+  padding: 10px 12px 16px;
 }
-.spice-simulation-surface label {
-  display: flex;
+.simulation-setup-panel label {
+  display: grid;
+  grid-template-columns: minmax(110px, 0.8fr) minmax(130px, 1.2fr);
   align-items: center;
-  justify-content: space-between;
   gap: 8px;
-  margin: 8px 0;
+  margin: 9px 0;
+  font-size: var(--icm-font-sm);
 }
 .spice-simulation-surface input:not([type="checkbox"]),
 .spice-simulation-surface select {
+  width: 100%;
   min-width: 0;
-  max-width: 65%;
+  min-height: 32px;
+  padding: 5px 8px;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-sm);
+  color: var(--icm-text);
+  background: var(--icm-surface);
 }
-.spice-simulation-surface details {
-  margin: 12px 0;
+.spice-simulation-surface select {
+  appearance: none;
+  padding-right: 26px;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--icm-text-muted) 50%),
+    linear-gradient(135deg, var(--icm-text-muted) 50%, transparent 50%);
+  background-position:
+    calc(100% - 13px) 13px,
+    calc(100% - 8px) 13px;
+  background-repeat: no-repeat;
+  background-size: 5px 5px;
+}
+.simulation-setup-panel form > button {
+  margin: 8px 8px 0 0;
+}
+
+.simulation-results-dock {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  height: min(38vh, 370px);
+  min-height: 190px;
+  overflow: hidden;
+  resize: vertical;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-md) var(--icm-radius-md) 0 0;
+  background: var(--icm-surface);
+  box-shadow: var(--icm-shadow-md);
+}
+.simulation-results-header [role="tablist"] {
+  display: flex;
+  gap: 2px;
+  overflow-x: auto;
+}
+.simulation-results-header [role="tab"] {
+  border-color: transparent;
+  background: transparent;
+  white-space: nowrap;
+}
+.simulation-results-header [role="tab"][aria-selected="true"] {
+  color: var(--icm-accent);
+  border-color: var(--icm-border);
+  background: var(--icm-surface);
+  font-weight: 650;
+}
+.simulation-results-body {
+  min-height: 0;
+  padding: 12px;
+  overflow: auto;
+}
+.simulation-result-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(120px, 1fr));
+  gap: var(--icm-space-2);
+}
+.simulation-result-summary > div {
+  display: grid;
+  gap: 3px;
+  padding: 10px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface-muted);
+}
+.simulation-result-summary small,
+.simulation-files-view small {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.simulation-result-summary > p {
+  grid-column: 1 / -1;
+}
+.simulation-analysis-view section {
+  min-width: 0;
+}
+.simulation-analysis-view h3 {
+  margin: 0 0 8px;
+  font-size: var(--icm-font-sm);
+}
+.simulation-empty-result {
+  display: grid;
+  min-height: 110px;
+  place-items: center;
+  color: var(--icm-text-muted);
+}
+.simulation-files-view {
+  display: grid;
+  gap: 10px;
+}
+.simulation-files-view > section {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) minmax(220px, 2fr);
+  gap: 12px;
+  align-items: center;
+  padding: 10px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+}
+.simulation-files-view > section > div:first-child {
+  display: grid;
+  gap: 3px;
+}
+.simulation-artifact-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 .spice-simulation-surface pre {
   white-space: pre-wrap;
@@ -59,10 +358,56 @@
 .spice-simulation-surface table {
   width: 100%;
   text-align: left;
+  border-collapse: collapse;
+}
+.spice-simulation-surface th,
+.spice-simulation-surface td {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--icm-border);
 }
 .spice-ac-plot svg {
   width: 100%;
   height: auto;
+}
+
+@media (max-width: 1050px) {
+  .spice-simulation-surface {
+    right: 12px;
+    left: 12px;
+  }
+  .simulation-symbol-stage {
+    display: none;
+  }
+}
+
+@media (max-width: 700px) {
+  .spice-simulation-surface {
+    top: 82px;
+  }
+  .simulation-taskbar {
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas:
+      "context context"
+      "status actions";
+  }
+  .simulation-brand,
+  .simulation-analysis-chip,
+  .simulation-task-actions > button:nth-child(3) {
+    display: none;
+  }
+  .simulation-setup-panel {
+    left: 0;
+    width: auto;
+  }
+  .simulation-results-dock {
+    height: 44vh;
+  }
+  .simulation-result-summary {
+    grid-template-columns: 1fr;
+  }
+  .simulation-files-view > section {
+    grid-template-columns: 1fr;
+  }
 }
 
 .digital-simulation-window {

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -3,17 +3,15 @@
 /* Analog simulation is a lazy workspace layer. Only its task bar and open
    docks accept pointer input, so the testbench canvas stays fully editable. */
 .spice-simulation-surface {
-  position: fixed;
-  top: 92px;
-  right: clamp(300px, 23vw, 390px);
-  bottom: 44px;
-  left: clamp(230px, 19vw, 320px);
-  z-index: 29;
+  grid-area: simulation;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border-right: 1px solid var(--icm-border-strong);
   color: var(--icm-text);
-  pointer-events: none;
-}
-.spice-simulation-surface > * {
-  pointer-events: auto;
+  background: var(--icm-surface);
 }
 .spice-simulation-surface button,
 .spice-simulation-surface input,
@@ -42,24 +40,17 @@
 }
 
 .simulation-taskbar {
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   grid-template-areas:
-    "brand context context"
-    "analysis status actions";
+    "brand status"
+    "context context"
+    "actions actions";
   align-items: center;
-  gap: 5px var(--icm-space-2);
-  min-height: 70px;
-  padding: 7px 8px;
-  border: 1px solid var(--icm-border-strong);
-  border-radius: var(--icm-radius-md);
-  background: color-mix(in srgb, var(--icm-surface) 96%, transparent);
-  box-shadow: var(--icm-shadow-md);
-  backdrop-filter: blur(10px);
+  gap: 8px var(--icm-space-2);
+  padding: 12px;
+  border-bottom: 1px solid var(--icm-border);
+  background: var(--icm-surface);
 }
 .simulation-brand {
   grid-area: brand;
@@ -67,11 +58,10 @@
   line-height: 1.05;
 }
 .simulation-brand strong {
-  font-size: var(--icm-font-sm);
+  font-size: var(--icm-font-lg);
 }
 .simulation-brand span,
-.simulation-taskbar small,
-.simulation-editing-cell {
+.simulation-taskbar small {
   color: var(--icm-text-muted);
   font-size: var(--icm-font-xs);
 }
@@ -84,12 +74,12 @@
 }
 .simulation-cell-context {
   grid-area: context;
-  flex: 1;
-  overflow: hidden;
+  flex-wrap: wrap;
 }
 .simulation-task-actions {
   grid-area: actions;
-  justify-self: end;
+  flex-wrap: wrap;
+  justify-self: stretch;
 }
 .simulation-cell-context button {
   display: grid;
@@ -103,25 +93,17 @@
 .simulation-cell-context button:not(:last-child) {
   max-width: 150px;
 }
-.simulation-cell-context button,
-.simulation-symbol-stage,
-.simulation-editing-cell {
+.simulation-cell-context button {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.simulation-symbol-stage,
-.simulation-analysis-chip,
 .simulation-status-chip {
   padding: 4px 8px;
   border-radius: 999px;
   background: var(--icm-surface-muted);
   font-size: var(--icm-font-xs);
   white-space: nowrap;
-}
-.simulation-analysis-chip {
-  grid-area: analysis;
-  color: var(--icm-text-muted);
 }
 .simulation-status-chip {
   grid-area: status;
@@ -149,6 +131,10 @@
   color: #b42318 !important;
   border-color: #fda29b !important;
 }
+.simulation-minimize-button {
+  margin-left: auto;
+}
+.simulation-minimize-button,
 .simulation-close-button {
   width: 30px;
   padding: 0 !important;
@@ -156,19 +142,15 @@
 }
 
 .simulation-workspace-notice {
-  position: absolute;
-  top: 80px;
-  right: 0;
-  left: 0;
   display: flex;
   align-items: flex-start;
   gap: var(--icm-space-2);
+  margin: 8px 10px 0;
   padding: 8px 10px;
   border: 1px solid #fdb022;
   border-radius: var(--icm-radius-sm);
   color: #7a2e0e;
   background: #fffaeb;
-  box-shadow: var(--icm-shadow-sm);
   font-size: var(--icm-font-xs);
 }
 .simulation-workspace-notice span {
@@ -176,20 +158,38 @@
   white-space: pre-wrap;
 }
 
-.simulation-setup-panel {
-  position: absolute;
-  top: 80px;
-  right: 0;
-  bottom: 0;
-  width: min(380px, 46vw);
-  overflow: auto;
-  border: 1px solid var(--icm-border-strong);
-  border-radius: var(--icm-radius-md);
-  background: var(--icm-surface);
-  box-shadow: var(--icm-shadow-md);
+.simulation-context-hint {
+  margin: 10px 12px 0;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  line-height: 1.45;
 }
-.simulation-workspace-notice + .simulation-setup-panel {
-  top: 126px;
+
+.simulation-exit-confirmation {
+  margin: 10px 12px 0;
+  padding: 10px;
+  border: 1px solid #fda29b;
+  border-radius: var(--icm-radius-sm);
+  background: #fff4f2;
+  font-size: var(--icm-font-sm);
+}
+.simulation-exit-confirmation p {
+  margin: 5px 0 10px;
+  color: var(--icm-text-muted);
+  line-height: 1.4;
+}
+.simulation-exit-confirmation > div {
+  display: flex;
+  gap: 6px;
+}
+
+.simulation-setup-panel {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  border: 0;
+  border-top: 1px solid var(--icm-border);
+  background: var(--icm-surface);
 }
 .simulation-setup-panel > header,
 .simulation-results-header {
@@ -257,20 +257,14 @@
 }
 
 .simulation-results-dock {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  flex: 1 1 auto;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
-  height: min(38vh, 370px);
-  min-height: 190px;
+  min-height: 0;
   overflow: hidden;
-  resize: vertical;
-  border: 1px solid var(--icm-border-strong);
-  border-radius: var(--icm-radius-md) var(--icm-radius-md) 0 0;
+  border: 0;
+  border-top: 1px solid var(--icm-border);
   background: var(--icm-surface);
-  box-shadow: var(--icm-shadow-md);
 }
 .simulation-results-header [role="tablist"] {
   display: flex;
@@ -370,20 +364,7 @@
   height: auto;
 }
 
-@media (max-width: 1050px) {
-  .spice-simulation-surface {
-    right: 12px;
-    left: 12px;
-  }
-  .simulation-symbol-stage {
-    display: none;
-  }
-}
-
 @media (max-width: 700px) {
-  .spice-simulation-surface {
-    top: 82px;
-  }
   .simulation-taskbar {
     grid-template-columns: minmax(0, 1fr) auto;
     grid-template-areas:
@@ -391,16 +372,8 @@
       "status actions";
   }
   .simulation-brand,
-  .simulation-analysis-chip,
   .simulation-task-actions > button:nth-child(3) {
     display: none;
-  }
-  .simulation-setup-panel {
-    left: 0;
-    width: auto;
-  }
-  .simulation-results-dock {
-    height: 44vh;
   }
   .simulation-result-summary {
     grid-template-columns: 1fr;

--- a/apps/editor/src/styles/editor-workspace.css
+++ b/apps/editor/src/styles/editor-workspace.css
@@ -14,6 +14,12 @@
   grid-template-columns: 0 minmax(0, 1fr) auto;
 }
 
+.app-workspace.simulation-mode {
+  grid-template-columns: minmax(320px, 34vw) minmax(0, 1fr) auto;
+  grid-template-areas: "simulation canvas props";
+  transition: grid-template-columns 160ms ease;
+}
+
 /* Sits on the Library's right edge, overlapping the canvas by a few pixels so
    the grab target is comfortable without stealing layout width. */
 .library-resize-handle {
@@ -592,6 +598,11 @@
       min(220px, var(--icm-shapes-width)) minmax(0, 1fr)
       auto;
   }
+
+  .app-workspace.simulation-mode {
+    grid-template-columns: minmax(300px, 40vw) minmax(0, 1fr) auto;
+    grid-template-areas: "simulation canvas props";
+  }
 }
 
 @media (max-width: 860px) {
@@ -608,6 +619,11 @@
 
   .app-workspace.library-collapsed {
     grid-template-columns: 0 minmax(0, 1fr);
+  }
+
+  .app-workspace.simulation-mode {
+    grid-template-columns: minmax(290px, 44vw) minmax(0, 1fr);
+    grid-template-areas: "simulation canvas";
   }
 
   .app-workspace.library-collapsed .shapes-panel {


### PR DESCRIPTION
## Summary

- keep testbench construction in the ordinary same-Project Editor workflow
- dock Simulation as a top-aligned left workspace beside the testbench canvas
- hide Library, Gallery, and Quick Start while Simulation is active
- preserve the Simulation session across minimize, restore normal Editor chrome, and confirm before discarding temporary state
- keep entry advisory rather than blocking when the current Cell has no DUT
- load the qualified OTA fixture through the canonical Project migration path after schema 38

No persistent schema or new simulation protocol is introduced.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm gate:preflight -- --base origin/main`
- `ICM_E2E_PORT=4174 ICM_E2E_ISOLATED=1 pnpm gate:affected -- --base origin/main`
  - 2644 unit tests passed, 26 skipped
  - 16 hierarchy browser tests passed
  - 5 Agent/Simulation browser tests passed
  - 134 Editor browser tests passed
  - 8 runtime-safety browser tests passed
  - 2 viewport browser tests passed
