### PR TITLE
feat(editor): make simulation results explorable

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -79,11 +79,18 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
   await expect(
     panel.locator("li").filter({ hasText: "XDUT · ota_5t · tail" }),
   ).toBeVisible();
+  await panel.getByRole("button", { name: "Pick voltage on canvas" }).click();
+  await page.getByTestId("route-hit-tb-vinp-route").click({ force: true });
+  await expect(panel.getByRole("button", { name: "Remove probe" })).toHaveCount(
+    5,
+  );
+  await panel.getByRole("button", { name: "Remove probe" }).last().click();
+  await panel.getByRole("button", { name: "Picking voltage Nets…" }).click();
   await panel
     .getByLabel("Add voltage probe")
     .selectOption({ label: "XDUT · ota_5t · vinp" });
   await panel
-    .getByLabel("Add source-current probe")
+    .getByLabel("Add current output")
     .selectOption({ label: "Testbench · VINP current" });
   await expect(panel.getByRole("button", { name: "Remove probe" })).toHaveCount(
     6,
@@ -298,7 +305,9 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     "0.500000",
   );
   await panel.getByRole("tab", { name: "Plot" }).click();
-  await expect(panel.locator(".spice-ac-plot svg")).toHaveCount(1);
+  await expect(panel.locator(".spice-ac-plot svg")).toHaveCount(2);
+  await expect(panel.locator('svg[aria-label="AC magnitude"]')).toBeVisible();
+  await expect(panel.locator('svg[aria-label="AC phase"]')).toBeVisible();
   await panel.getByRole("tab", { name: "Files" }).click();
   const download = page.waitForEvent("download");
   await panel
@@ -381,6 +390,15 @@ test("Simulation creates an ordinary testbench and offers the current Cell at th
   expect(saved.simulation).toBeUndefined();
   await page.getByTestId("open-analog-simulation").click();
   await expect(page.getByLabel("Testbench Cell")).toHaveValue(tb.id);
+  const simulationResize = page.getByTestId("simulation-resize-handle");
+  const initialWidth = Number(
+    await simulationResize.getAttribute("aria-valuenow"),
+  );
+  await simulationResize.press("ArrowRight");
+  await expect(simulationResize).toHaveAttribute(
+    "aria-valuenow",
+    String(initialWidth + 8),
+  );
   await expect(page.getByTestId("library-toggle")).toBeDisabled();
   await expect(page.getByTestId("examples-toggle")).toBeDisabled();
   await page.getByRole("button", { name: "Minimize simulation" }).click();

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -296,6 +296,10 @@ const DEFAULT_VIEWBOX: GridRect = { x: 0, y: 0, width: 960, height: 640 };
 const RECENT_COMPONENTS_STORAGE_KEY = "icm.recent-components.v1";
 const LIBRARY_PANEL_STORAGE_KEY = "icm.library-panel-open.v1";
 const LIBRARY_WIDTH_STORAGE_KEY = "icm.library-panel-width.v1";
+const SIMULATION_WIDTH_STORAGE_KEY = "icm.simulation-panel-width.v1";
+const SIMULATION_WIDTH_MIN = 320;
+const SIMULATION_WIDTH_MAX = 760;
+const SIMULATION_WIDTH_DEFAULT = 440;
 const COMPACT_LAYOUT_MEDIA_QUERY = "(max-width: 860px)";
 const DRAG_START_DISTANCE_PX = 4;
 const SNAP_CAPTURE_RADIUS_PX = 4;
@@ -336,6 +340,34 @@ export function App({
     pointerX: number;
     width: number;
   } | null>(null);
+  const simulationResizeOriginRef = useRef<{
+    pointerX: number;
+    width: number;
+  } | null>(null);
+  const [simulationWidth, setSimulationWidthState] = useState(() => {
+    if (typeof window === "undefined") return SIMULATION_WIDTH_DEFAULT;
+    try {
+      const stored = Number(
+        window.localStorage.getItem(SIMULATION_WIDTH_STORAGE_KEY),
+      );
+      return Number.isFinite(stored) && stored > 0
+        ? Math.min(SIMULATION_WIDTH_MAX, Math.max(SIMULATION_WIDTH_MIN, stored))
+        : SIMULATION_WIDTH_DEFAULT;
+    } catch {
+      return SIMULATION_WIDTH_DEFAULT;
+    }
+  });
+  const setSimulationWidth = (width: number): void => {
+    const next = Math.round(
+      Math.min(SIMULATION_WIDTH_MAX, Math.max(SIMULATION_WIDTH_MIN, width)),
+    );
+    setSimulationWidthState(next);
+    try {
+      window.localStorage.setItem(SIMULATION_WIDTH_STORAGE_KEY, String(next));
+    } catch {
+      // Resizing remains available when browser storage is unavailable.
+    }
+  };
   const {
     libraryPanelOpen,
     libraryWidth,
@@ -701,10 +733,12 @@ export function App({
     setAnalogSimulationState("open");
   };
   const minimizeAnalogSimulation = (): void => {
+    setSimulationPickNetsActive(false);
     setAnalogSimulationState("minimized");
     setSelectionOpen(simulationPropertiesOpenBeforeRef.current);
   };
   const exitAnalogSimulation = (): void => {
+    setSimulationPickNetsActive(false);
     void humanSimulationSession.clear();
     setAnalogSimulationState("closed");
     setSimulationDraftContext(null);
@@ -987,6 +1021,11 @@ export function App({
   const [simulationSavedNetIds, setSimulationSavedNetIds] = useState<
     Set<string>
   >(() => new Set());
+  const [analogPickedNet, setAnalogPickedNet] = useState<{
+    sequence: number;
+    documentId: string;
+    netId: string;
+  } | null>(null);
   const [pendingWaveformPlacement, setPendingWaveformPlacement] =
     useState<PendingWaveformPlacement | null>(null);
   const [waveformPlacementPoint, setWaveformPlacementPoint] =
@@ -1485,6 +1524,15 @@ export function App({
       return;
     }
     const group = logicalNets.byBaseNetId.get(baseNetId);
+    if (analogSimulationOpen) {
+      setAnalogPickedNet((current) => ({
+        sequence: (current?.sequence ?? 0) + 1,
+        documentId: document.id,
+        netId: baseNetId,
+      }));
+      setStatus(`Added voltage Output ${group?.name ?? baseNetId}`);
+      return;
+    }
     setSimulationSavedNetIds((current) => {
       const next = new Set(current);
       if (next.has(baseNetId)) next.delete(baseNetId);
@@ -4548,7 +4596,12 @@ export function App({
               ? "app-workspace"
               : "app-workspace library-collapsed"
         }
-        style={{ "--icm-shapes-width": `${libraryWidth}px` } as CSSProperties}
+        style={
+          {
+            "--icm-shapes-width": `${libraryWidth}px`,
+            "--icm-simulation-width": `${simulationWidth}px`,
+          } as CSSProperties
+        }
       >
         {analogSimulationOpened ? (
           <Suspense fallback={null}>
@@ -4571,8 +4624,59 @@ export function App({
                 return committed;
               }}
               onOpenCell={(id) => switchDocument(id)}
+              pickNetsActive={simulationPickNetsActive}
+              pickedNet={analogPickedNet}
+              onPickNetsChange={setSimulationPickMode}
+              onFocusProbe={(probe) => {
+                if (probe.kind === "net-voltage") {
+                  switchDocument(probe.documentId);
+                  highlightNet(probe.netId, probe.documentId);
+                }
+              }}
             />
           </Suspense>
+        ) : null}
+        {analogSimulationOpen ? (
+          <div
+            className="simulation-resize-handle"
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize the Simulation panel"
+            aria-valuenow={simulationWidth}
+            aria-valuemin={SIMULATION_WIDTH_MIN}
+            aria-valuemax={SIMULATION_WIDTH_MAX}
+            tabIndex={0}
+            data-testid="simulation-resize-handle"
+            onPointerDown={(event) => {
+              event.preventDefault();
+              event.currentTarget.setPointerCapture(event.pointerId);
+              simulationResizeOriginRef.current = {
+                pointerX: event.clientX,
+                width: simulationWidth,
+              };
+            }}
+            onPointerMove={(event) => {
+              const origin = simulationResizeOriginRef.current;
+              if (!origin) return;
+              setSimulationWidth(
+                origin.width + (event.clientX - origin.pointerX),
+              );
+            }}
+            onPointerUp={(event) => {
+              simulationResizeOriginRef.current = null;
+              event.currentTarget.releasePointerCapture(event.pointerId);
+            }}
+            onKeyDown={(event) => {
+              const step = event.shiftKey ? 32 : 8;
+              if (event.key === "ArrowLeft") {
+                event.preventDefault();
+                setSimulationWidth(simulationWidth - step);
+              } else if (event.key === "ArrowRight") {
+                event.preventDefault();
+                setSimulationWidth(simulationWidth + step);
+              }
+            }}
+          />
         ) : null}
         {!analogSimulationOpen && leftPanelMode === "library" ? (
           <ShapesPanel

--- a/apps/editor/src/features/simulation/ac-response-plot.test.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.test.ts
@@ -55,14 +55,24 @@ describe("AC response plot", () => {
     ).toBeCloseTo(1e3, 6);
   });
 
-  it("draws magnitude and phase as separate traces on one frame", () => {
-    const svg = acResponseSvg([singlePole()], { width: 600, height: 300 })!;
+  it("draws magnitude and phase as separate Bode plots", () => {
+    const magnitude = acResponseSvg(
+      [singlePole()],
+      { width: 600, height: 300 },
+      { kind: "magnitude" },
+    )!;
+    const phase = acResponseSvg(
+      [singlePole()],
+      { width: 600, height: 300 },
+      { kind: "phase" },
+    )!;
 
-    expect(svg.startsWith("<svg")).toBe(true);
-    // One polyline for magnitude and one for phase, per trace.
-    expect(svg.match(/<polyline/gu)).toHaveLength(2);
-    expect(svg).toContain('class="ac-trace ac-trace-0 ac-phase"');
-    expect(svg).toContain('aria-label="AC response"');
+    expect(magnitude.match(/<polyline/gu)).toHaveLength(1);
+    expect(phase.match(/<polyline/gu)).toHaveLength(1);
+    expect(magnitude).toContain('aria-label="AC magnitude"');
+    expect(phase).toContain('aria-label="AC phase"');
+    expect(magnitude).toContain("dB");
+    expect(phase).toContain("°");
   });
 
   it("declines to invent a plot when there is nothing to draw", () => {
@@ -102,6 +112,7 @@ describe("AC response plot", () => {
         { label: "vdb(vout_loaded)", points: singlePole().points },
       ],
       { width: 600, height: 300 },
+      { kind: "magnitude" },
     )!;
 
     expect(svg).toContain("vdb(vout)");

--- a/apps/editor/src/features/simulation/ac-response-plot.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.ts
@@ -31,6 +31,8 @@ export interface AcPoint {
 export interface AcTrace {
   /** The expression the author asked for, printed verbatim as the legend. */
   label: string;
+  /** Stable Results Browser colour slot, independent of hide/show filtering. */
+  colorIndex?: number;
   points: readonly AcPoint[];
 }
 
@@ -55,6 +57,17 @@ export interface AcPlotLayout {
   phase: AcPlotAxis;
   /** Frequency in Hz for an x in SVG units, for crosshair readout. */
   frequencyAt: (x: number) => number;
+}
+
+export type AcPlotKind = "magnitude" | "phase";
+
+export interface AcResponseSvgOptions {
+  /** One physical quantity per plot. Bode magnitude and phase never share an axis. */
+  kind: AcPlotKind;
+  /** Shared cursor frequency for paired magnitude/phase plots. */
+  cursorFrequency?: number;
+  /** The interactive Results Browser owns the legend when false. */
+  showLegend?: boolean;
 }
 
 const MARGIN = { left: 56, right: 56, top: 16, bottom: 32 };
@@ -174,67 +187,69 @@ function polyline(
     .join(" ");
 }
 
-/**
- * Magnitude and phase on one frame: magnitude solid against the left axis,
- * phase dashed against the right. Two stacked frames read better on paper but
- * halve the vertical resolution of each in a side panel, and the pairing that
- * matters — gain and phase at the same frequency — is read along one vertical
- * line.
- */
 export function acResponseSvg(
   traces: readonly AcTrace[],
   size: AcPlotSize,
+  options: AcResponseSvgOptions = { kind: "magnitude" },
 ): string | null {
   const layout = layoutAcPlot(traces, size);
   if (!layout) return null;
   const project = projection(layout);
   const { frame } = layout;
+  const axis = options.kind === "magnitude" ? layout.magnitude : layout.phase;
+  const axisY =
+    options.kind === "magnitude" ? project.magnitudeY : project.phaseY;
+  const unit = options.kind === "magnitude" ? "dB" : "°";
 
   const gridLines = [
     ...layout.frequency.ticks.map((hz) => {
       const x = project.x(hz).toFixed(2);
       return `<line class="ac-grid" x1="${x}" y1="${frame.y}" x2="${x}" y2="${frame.y + frame.height}"/><text class="ac-axis-label" x="${x}" y="${frame.y + frame.height + 18}" text-anchor="middle">${escapeXml(formatFrequency(hz))}</text>`;
     }),
-    ...layout.magnitude.ticks.map((db) => {
-      const y = project.magnitudeY(db).toFixed(2);
-      return `<line class="ac-grid" x1="${frame.x}" y1="${y}" x2="${frame.x + frame.width}" y2="${y}"/><text class="ac-axis-label" x="${frame.x - 8}" y="${y}" text-anchor="end" dominant-baseline="middle">${db} dB</text>`;
-    }),
-    ...layout.phase.ticks.map((deg) => {
-      const y = project.phaseY(deg).toFixed(2);
-      return `<text class="ac-axis-label ac-phase" x="${frame.x + frame.width + 8}" y="${y}" dominant-baseline="middle">${deg}°</text>`;
+    ...axis.ticks.map((value) => {
+      const y = axisY(value).toFixed(2);
+      return `<line class="ac-grid" x1="${frame.x}" y1="${y}" x2="${frame.x + frame.width}" y2="${y}"/><text class="ac-axis-label" x="${frame.x - 8}" y="${y}" text-anchor="end" dominant-baseline="middle">${value}${unit}</text>`;
     }),
   ].join("");
 
   const curves = traces
     .map((trace, index) => {
-      const magnitude = polyline(trace, project, "magnitude");
-      const phase = polyline(trace, project, "phase");
-      return (
-        `<polyline class="ac-trace ac-trace-${index % 6}" points="${magnitude}"/>` +
-        `<polyline class="ac-trace ac-trace-${index % 6} ac-phase" points="${phase}"/>`
-      );
+      const colorIndex = trace.colorIndex ?? index;
+      const points = polyline(trace, project, options.kind);
+      return `<polyline class="ac-trace ac-trace-${colorIndex % 6}" data-trace-index="${index}" points="${points}"/>`;
     })
     .join("");
 
   // The author asked for these expressions by name; printing them back is the
   // only way to tell two curves apart, and colour alone would leave anyone
   // who cannot separate the hues with an unreadable plot.
-  const legend = traces
-    .map((trace, index) => {
-      const y = frame.y + 12 + index * 14;
-      const swatchX = frame.x + 10;
-      return (
-        `<line class="ac-trace ac-trace-${index % 6}" x1="${swatchX}" y1="${y}" x2="${swatchX + 16}" y2="${y}"/>` +
-        `<text class="ac-legend-text" x="${swatchX + 22}" y="${y + 3}">${escapeXml(trace.label)}</text>`
-      );
-    })
-    .join("");
+  const legend =
+    (options.showLegend ?? true)
+      ? traces
+          .map((trace, index) => {
+            const colorIndex = trace.colorIndex ?? index;
+            const y = frame.y + 12 + index * 14;
+            const swatchX = frame.x + 10;
+            return (
+              `<line class="ac-trace ac-trace-${colorIndex % 6}" x1="${swatchX}" y1="${y}" x2="${swatchX + 16}" y2="${y}"/>` +
+              `<text class="ac-legend-text" x="${swatchX + 22}" y="${y + 3}">${escapeXml(trace.label)}</text>`
+            );
+          })
+          .join("")
+      : "";
+  const cursor =
+    options.cursorFrequency !== undefined &&
+    options.cursorFrequency >= layout.frequency.min &&
+    options.cursorFrequency <= layout.frequency.max
+      ? `<line class="ac-cursor" x1="${project.x(options.cursorFrequency).toFixed(2)}" y1="${frame.y}" x2="${project.x(options.cursorFrequency).toFixed(2)}" y2="${frame.y + frame.height}"/>`
+      : "";
 
   return (
-    `<svg xmlns="http://www.w3.org/2000/svg" class="ac-response" viewBox="0 0 ${size.width} ${size.height}" width="${size.width}" height="${size.height}" role="img" aria-label="AC response">` +
+    `<svg xmlns="http://www.w3.org/2000/svg" class="ac-response" viewBox="0 0 ${size.width} ${size.height}" width="${size.width}" height="${size.height}" role="img" aria-label="AC ${options.kind}">` +
     `<rect class="ac-frame" x="${frame.x}" y="${frame.y}" width="${frame.width}" height="${frame.height}"/>` +
     gridLines +
     curves +
+    cursor +
     legend +
     `</svg>`
   );

--- a/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { AcResultsExplorer, unwrapPhaseDegrees } from "./ac-results-explorer";
+
+describe("AC Results Explorer", () => {
+  it("unwraps phase without inventing 360-degree discontinuities", () => {
+    expect(unwrapPhaseDegrees([170, 179, -178, -165])).toEqual([
+      170, 179, 182, 195,
+    ]);
+    expect(unwrapPhaseDegrees([-170, -179, 178, 165])).toEqual([
+      -170, -179, -182, -195,
+    ]);
+  });
+
+  it("presents one Output with separate magnitude and phase plots", () => {
+    const markup = renderToStaticMarkup(
+      <AcResultsExplorer
+        analysis={{
+          analysis: "ac",
+          plotName: "AC Analysis",
+          frequencyHz: [10, 100],
+          probes: [
+            {
+              name: "v(out)",
+              quantity: "voltage",
+              unit: "V",
+              real: [1, 0.5],
+              imag: [0, -0.5],
+            },
+          ],
+        }}
+        vectors={[
+          { probeId: "probe-out", vector: "v(out)", quantity: "voltage" },
+        ]}
+        probes={[
+          {
+            id: "probe-out",
+            kind: "net-voltage",
+            documentId: "tb",
+            netId: "out",
+            occurrence: [],
+          },
+        ]}
+        labels={{ "probe-out": "VOUT" }}
+      />,
+    );
+
+    expect(markup).toContain("VOUT");
+    expect(markup).toContain('aria-label="AC magnitude"');
+    expect(markup).toContain('aria-label="AC phase"');
+    expect(markup.match(/data-trace-index="0"/gu)).toHaveLength(2);
+  });
+});

--- a/apps/editor/src/features/simulation/ac-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.tsx
@@ -1,0 +1,285 @@
+import { useMemo, useState, type PointerEvent, type WheelEvent } from "react";
+import type { SimulationProbeSpec } from "@icm/model";
+import type { AcResult } from "@icm/spice-run";
+import type { Prepared } from "@icm/simulation-service/contract";
+
+import {
+  acResponseSvg,
+  formatFrequency,
+  layoutAcPlot,
+  type AcPoint,
+  type AcTrace,
+} from "./ac-response-plot";
+
+interface OutputTrace extends AcTrace {
+  id: string;
+  quantity: "voltage" | "current";
+  probe?: SimulationProbeSpec;
+}
+
+export interface AcResultsExplorerProps {
+  analysis: AcResult;
+  vectors: Prepared["vectors"];
+  probes: readonly SimulationProbeSpec[];
+  labels?: Readonly<Record<string, string>>;
+  onFocusProbe?(probe: SimulationProbeSpec): void;
+}
+
+const PLOT_SIZE = { width: 760, height: 220 } as const;
+
+/** Keep phase continuous instead of drawing artificial 360-degree jumps. */
+export function unwrapPhaseDegrees(values: readonly number[]): number[] {
+  const unwrapped: number[] = [];
+  for (const value of values) {
+    const previous = unwrapped.at(-1);
+    if (previous === undefined) {
+      unwrapped.push(value);
+      continue;
+    }
+    let next = value;
+    while (next - previous > 180) next -= 360;
+    while (next - previous < -180) next += 360;
+    unwrapped.push(next);
+  }
+  return unwrapped;
+}
+
+function closestPoint(points: readonly AcPoint[], frequency: number): AcPoint {
+  return points.reduce((best, point) =>
+    Math.abs(Math.log(point.frequency / frequency)) <
+    Math.abs(Math.log(best.frequency / frequency))
+      ? point
+      : best,
+  );
+}
+
+function cropTrace(
+  trace: OutputTrace,
+  range?: readonly [number, number],
+): OutputTrace {
+  if (!range) return trace;
+  const inside = trace.points.filter(
+    (point) => point.frequency >= range[0] && point.frequency <= range[1],
+  );
+  if (inside.length >= 2) return { ...trace, points: inside };
+  return trace;
+}
+
+function outputTraces(
+  analysis: AcResult,
+  vectors: Prepared["vectors"],
+  probes: readonly SimulationProbeSpec[],
+  labels: Readonly<Record<string, string>>,
+): OutputTrace[] {
+  const vectorsByName = new Map(
+    vectors.map((vector) => [vector.vector.toLowerCase(), vector]),
+  );
+  const probesById = new Map(probes.map((probe) => [probe.id, probe]));
+  return analysis.probes.map((resultProbe, index) => {
+    const binding = vectorsByName.get(resultProbe.name.toLowerCase());
+    const authored = binding ? probesById.get(binding.probeId) : undefined;
+    const phases = unwrapPhaseDegrees(
+      resultProbe.real.map(
+        (real, pointIndex) =>
+          (Math.atan2(resultProbe.imag[pointIndex] ?? 0, real) * 180) / Math.PI,
+      ),
+    );
+    return {
+      id: binding?.probeId ?? resultProbe.name,
+      label: (binding && labels[binding.probeId]) || resultProbe.name,
+      colorIndex: index,
+      quantity:
+        binding?.quantity ??
+        (resultProbe.quantity === "current" ? "current" : "voltage"),
+      ...(authored ? { probe: authored } : {}),
+      points: analysis.frequencyHz.map((frequency, pointIndex) => ({
+        frequency,
+        magnitudeDb:
+          20 *
+          Math.log10(
+            Math.max(
+              Math.hypot(
+                resultProbe.real[pointIndex] ?? 0,
+                resultProbe.imag[pointIndex] ?? 0,
+              ),
+              1e-30,
+            ),
+          ),
+        phaseDeg: phases[pointIndex] ?? 0,
+      })),
+    };
+  });
+}
+
+export function AcResultsExplorer({
+  analysis,
+  vectors,
+  probes,
+  labels = {},
+  onFocusProbe,
+}: AcResultsExplorerProps) {
+  const traces = useMemo(
+    () => outputTraces(analysis, vectors, probes, labels),
+    [analysis, labels, probes, vectors],
+  );
+  const [hidden, setHidden] = useState<ReadonlySet<string>>(() => new Set());
+  const [solo, setSolo] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [cursorFrequency, setCursorFrequency] = useState<number>();
+  const [frequencyRange, setFrequencyRange] =
+    useState<readonly [number, number]>();
+  const fullRange = useMemo<readonly [number, number]>(() => {
+    const frequencies = analysis.frequencyHz.filter(
+      (frequency) => frequency > 0,
+    );
+    return [Math.min(...frequencies), Math.max(...frequencies)];
+  }, [analysis.frequencyHz]);
+  const visible = traces.filter(
+    (trace) => !hidden.has(trace.id) && (solo === null || solo === trace.id),
+  );
+  const cursorRows =
+    cursorFrequency === undefined
+      ? []
+      : visible.map((trace) => ({
+          trace,
+          point: closestPoint(trace.points, cursorFrequency),
+        }));
+
+  const pointAtPointer = (event: PointerEvent<HTMLDivElement>) => {
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const trace = cropTrace(visible[0] ?? traces[0]!, frequencyRange);
+    const layout = layoutAcPlot([trace], PLOT_SIZE);
+    if (!layout) return;
+    const svgX =
+      ((event.clientX - bounds.left) / bounds.width) * PLOT_SIZE.width;
+    const frequency = layout.frequencyAt(svgX);
+    setCursorFrequency(
+      Math.min(layout.frequency.max, Math.max(layout.frequency.min, frequency)),
+    );
+  };
+  const zoom = (event: WheelEvent<HTMLDivElement>) => {
+    if (fullRange[0] === fullRange[1]) return;
+    event.preventDefault();
+    const current = frequencyRange ?? fullRange;
+    const center = cursorFrequency ?? Math.sqrt(current[0] * current[1]);
+    const scale = event.deltaY < 0 ? 0.72 : 1.38;
+    const left = Math.log(center / current[0]) * scale;
+    const right = Math.log(current[1] / center) * scale;
+    const next: readonly [number, number] = [
+      Math.max(fullRange[0], center / Math.exp(left)),
+      Math.min(fullRange[1], center * Math.exp(right)),
+    ];
+    setFrequencyRange(next[1] > next[0] ? next : undefined);
+  };
+
+  return (
+    <div className="ac-results-explorer">
+      <header>
+        <div>
+          <strong>{analysis.plotName}</strong>
+          <small>Wheel to zoom · move over either plot to inspect</small>
+        </div>
+        <button type="button" onClick={() => setFrequencyRange(undefined)}>
+          Fit
+        </button>
+      </header>
+      <div
+        className="simulation-output-browser"
+        aria-label="Simulation outputs"
+      >
+        {traces.map((trace) => {
+          const isVisible = !hidden.has(trace.id);
+          return (
+            <div
+              key={trace.id}
+              className={selected === trace.id ? "selected" : undefined}
+            >
+              <button
+                type="button"
+                className={`simulation-output-swatch ac-trace-${(trace.colorIndex ?? 0) % 6}`}
+                aria-label={`${isVisible ? "Hide" : "Show"} ${trace.label}`}
+                aria-pressed={isVisible}
+                onClick={() => {
+                  setHidden((current) => {
+                    const next = new Set(current);
+                    if (next.has(trace.id)) next.delete(trace.id);
+                    else next.add(trace.id);
+                    return next;
+                  });
+                }}
+              />
+              <button
+                type="button"
+                className="simulation-output-name"
+                onClick={() => {
+                  setSelected(trace.id);
+                  if (trace.probe) onFocusProbe?.(trace.probe);
+                }}
+              >
+                <strong>{trace.label}</strong>
+                <small>
+                  {trace.quantity} · {trace.probe ? "linked" : trace.id}
+                </small>
+              </button>
+              <button
+                type="button"
+                aria-pressed={solo === trace.id}
+                onClick={() =>
+                  setSolo((current) => (current === trace.id ? null : trace.id))
+                }
+              >
+                Solo
+              </button>
+            </div>
+          );
+        })}
+      </div>
+      {(["voltage", "current"] as const).map((quantity) => {
+        const quantityTraces = visible
+          .filter((trace) => trace.quantity === quantity)
+          .map((trace) => cropTrace(trace, frequencyRange));
+        if (quantityTraces.length === 0) return null;
+        return (
+          <section key={quantity} className="ac-quantity-group">
+            <h4>{quantity === "voltage" ? "Voltage" : "Current"}</h4>
+            {(["magnitude", "phase"] as const).map((kind) => {
+              const svg = acResponseSvg(quantityTraces, PLOT_SIZE, {
+                kind,
+                showLegend: false,
+                ...(cursorFrequency === undefined ? {} : { cursorFrequency }),
+              });
+              return (
+                <div key={kind} className="ac-plot-row">
+                  <strong>
+                    {kind === "magnitude" ? "Magnitude" : "Phase"}
+                  </strong>
+                  <div
+                    className="spice-ac-plot interactive"
+                    onPointerMove={pointAtPointer}
+                    onPointerLeave={() => setCursorFrequency(undefined)}
+                    onWheel={zoom}
+                    dangerouslySetInnerHTML={{ __html: svg ?? "" }}
+                  />
+                </div>
+              );
+            })}
+          </section>
+        );
+      })}
+      {visible.length === 0 ? (
+        <p className="simulation-empty-result">All Outputs are hidden.</p>
+      ) : null}
+      {cursorFrequency !== undefined ? (
+        <div className="ac-cursor-readout" role="status">
+          <strong>{formatFrequency(cursorFrequency)}</strong>
+          {cursorRows.map(({ trace, point }) => (
+            <span key={trace.id}>
+              {trace.label}: {point.magnitudeDb.toFixed(3)} dB ·{" "}
+              {point.phaseDeg.toFixed(2)}°
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/editor/src/features/simulation/spice-simulation-panel.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-panel.tsx
@@ -100,8 +100,19 @@ function ResultView({ run }: { run: SimulationRunState }) {
       </section>
     );
   }
-  const acSvg = run.acTraces?.length
-    ? acResponseSvg(run.acTraces, { width: 640, height: 320 })
+  const acMagnitudeSvg = run.acTraces?.length
+    ? acResponseSvg(
+        run.acTraces,
+        { width: 640, height: 220 },
+        { kind: "magnitude" },
+      )
+    : null;
+  const acPhaseSvg = run.acTraces?.length
+    ? acResponseSvg(
+        run.acTraces,
+        { width: 640, height: 220 },
+        { kind: "phase" },
+      )
     : null;
   return (
     <section aria-label="Simulation result">
@@ -112,15 +123,13 @@ function ResultView({ run }: { run: SimulationRunState }) {
           voltage on the canvas; select or hover any other net to read it.
         </p>
       ) : null}
-      {acSvg ? (
-        <div
-          className="simulation-ac-plot"
-          data-testid="simulation-ac-plot"
-          // The plot is produced as an SVG string by a pure module so it can
-          // be tested and later exported through the same path as any other
-          // drawing.
-          dangerouslySetInnerHTML={{ __html: acSvg }}
-        />
+      {acMagnitudeSvg && acPhaseSvg ? (
+        <div className="simulation-ac-plot" data-testid="simulation-ac-plot">
+          <strong>Magnitude</strong>
+          <div dangerouslySetInnerHTML={{ __html: acMagnitudeSvg }} />
+          <strong>Phase</strong>
+          <div dangerouslySetInnerHTML={{ __html: acPhaseSvg }} />
+        </div>
       ) : null}
       <pre className="simulation-log" data-testid="simulation-log">
         {run.log}

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -28,6 +28,8 @@ describe("SpiceSimulationSurface workspace", () => {
     expect(markup).toContain('aria-label="Simulation setup"');
     expect(markup).toContain('aria-pressed="true">Setup');
     expect(markup).toContain('aria-pressed="false">Results');
+    expect(markup).toContain("Pick voltage on canvas");
+    expect(markup).toContain("Add current output");
     expect(markup).not.toContain('class="simulation-results-dock"');
   });
 });

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -14,7 +14,7 @@ import type {
 } from "@icm/simulation-service/contract";
 import { downloadTextArtifact } from "../../document/project-file-service";
 import type { BrowserSimulationSession } from "./browser-simulation-session";
-import { acResponseSvg } from "./ac-response-plot";
+import { AcResultsExplorer } from "./ac-results-explorer";
 import {
   deriveSimulationProbeOptions,
   simulationProbeTargetKey,
@@ -43,6 +43,14 @@ export interface SpiceSimulationSurfaceProps {
   onExit(): void;
   onSaveSetup(setup: SimulationSetup | null): boolean;
   onOpenCell(documentId: string): void;
+  pickNetsActive?: boolean;
+  pickedNet?: {
+    readonly sequence: number;
+    readonly documentId: string;
+    readonly netId: string;
+  } | null;
+  onPickNetsChange?(active: boolean): void;
+  onFocusProbe?(probe: SimulationStructuredInput["probes"][number]): void;
 }
 
 /** A projection of the same prepare/start/read/cancel service used by MCP.
@@ -55,6 +63,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const [error, setError] = useState("");
   const [busy, setBusy] = useState(false);
   const [dirty, setDirty] = useState(false);
+  const [outputLabels, setOutputLabels] = useState<Record<string, string>>({});
   const [setupOpen, setSetupOpen] = useState(!project.simulation);
   const [resultsOpen, setResultsOpen] = useState(false);
   const [resultTab, setResultTab] = useState<ResultTab>("summary");
@@ -430,6 +439,15 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
           capabilities={capabilities}
           onDirty={setDirty}
           onError={setError}
+          outputLabels={outputLabels}
+          onOutputLabelChange={(probeId, label) =>
+            setOutputLabels((current) => {
+              if (label.trim()) return { ...current, [probeId]: label };
+              const next = { ...current };
+              delete next[probeId];
+              return next;
+            })
+          }
         />
       ) : null}
 
@@ -492,44 +510,20 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                 {run?.result?.data?.analyses
                   .filter((analysis) => analysis.analysis === "ac")
                   .map((analysis, index) => (
-                    <section key={index} aria-label="AC results">
-                      <h3>{analysis.plotName}</h3>
-                      <div
-                        className="spice-ac-plot"
-                        dangerouslySetInnerHTML={{
-                          __html:
-                            acResponseSvg(
-                              analysis.probes.map((probe) => ({
-                                label: probe.name,
-                                points: analysis.frequencyHz.map(
-                                  (frequency, pointIndex) => ({
-                                    frequency,
-                                    magnitudeDb:
-                                      20 *
-                                      Math.log10(
-                                        Math.max(
-                                          Math.hypot(
-                                            probe.real[pointIndex] ?? 0,
-                                            probe.imag[pointIndex] ?? 0,
-                                          ),
-                                          1e-30,
-                                        ),
-                                      ),
-                                    phaseDeg:
-                                      (Math.atan2(
-                                        probe.imag[pointIndex] ?? 0,
-                                        probe.real[pointIndex] ?? 0,
-                                      ) *
-                                        180) /
-                                      Math.PI,
-                                  }),
-                                ),
-                              })),
-                              { width: 760, height: 300 },
-                            ) ?? "",
-                        }}
-                      />
-                    </section>
+                    <AcResultsExplorer
+                      key={index}
+                      analysis={analysis}
+                      vectors={prepared?.vectors ?? []}
+                      probes={
+                        project.simulation?.input.kind === "structured"
+                          ? project.simulation.input.probes
+                          : []
+                      }
+                      labels={outputLabels}
+                      {...(props.onFocusProbe
+                        ? { onFocusProbe: props.onFocusProbe }
+                        : {})}
+                    />
                   ))}
                 {!run?.result?.data?.analyses.some(
                   (analysis) => analysis.analysis === "ac",
@@ -656,10 +650,17 @@ function SetupEditor({
   onSaveSetup,
   onDirty,
   onError,
+  pickNetsActive,
+  pickedNet,
+  onPickNetsChange,
+  outputLabels,
+  onOutputLabelChange,
 }: SpiceSimulationSurfaceProps & {
   capabilities: Capabilities | undefined;
   onDirty(value: boolean): void;
   onError(value: string): void;
+  outputLabels: Readonly<Record<string, string>>;
+  onOutputLabelChange(probeId: string, label: string): void;
 }) {
   const saved =
     project.simulation?.input.kind === "structured"
@@ -678,6 +679,25 @@ function SetupEditor({
     ]),
   );
   const ac = saved?.analyses.find((a) => a.kind === "ac");
+  useEffect(() => {
+    if (!pickedNet) return;
+    const option = probeOptions.voltage.find(
+      (candidate) =>
+        candidate.target.documentId === pickedNet.documentId &&
+        candidate.target.netId === pickedNet.netId,
+    );
+    if (!option) {
+      onError(
+        "That Net is outside the selected Testbench occurrence. Choose it from the Output list or change the Testbench Cell.",
+      );
+      return;
+    }
+    const key = simulationProbeTargetKey(option.target);
+    if (probes.some((probe) => simulationProbeTargetKey(probe) === key)) return;
+    setProbes((current) => [...current, probeFromOption(option)]);
+    onDirty(true);
+    onError("");
+  }, [pickedNet?.sequence]);
   useEffect(() => {
     onDirty(false);
   }, []);
@@ -842,9 +862,17 @@ function SetupEditor({
             onDirty(true);
           }}
         />
+        <button
+          type="button"
+          className={pickNetsActive ? "simulation-pick-active" : undefined}
+          aria-pressed={pickNetsActive}
+          onClick={() => onPickNetsChange?.(!pickNetsActive)}
+        >
+          {pickNetsActive ? "Picking voltage Nets…" : "Pick voltage on canvas"}
+        </button>
         <ProbeSelect
-          label="Add source-current probe"
-          placeholder="Choose a voltage source"
+          label="Add current output"
+          placeholder="Choose a voltage-source branch"
           options={probeOptions.sourceCurrent}
           probes={probes}
           onAdd={(option) => {
@@ -852,15 +880,35 @@ function SetupEditor({
             onDirty(true);
           }}
         />
-        <ul>
+        <ul className="simulation-probe-list" aria-label="Configured Outputs">
           {probes.map((p) => (
             <li key={p.id}>
-              {probeLabels.get(simulationProbeTargetKey(p)) ??
-                `Unavailable: ${p.kind === "net-voltage" ? p.netId : p.instanceId}${p.occurrence.length ? ` (${p.occurrence.join("/")})` : ""}`}
+              <span>
+                <input
+                  aria-label={`Output name for ${probeLabels.get(simulationProbeTargetKey(p)) ?? p.id}`}
+                  value={outputLabels[p.id] ?? ""}
+                  placeholder={
+                    probeLabels.get(simulationProbeTargetKey(p)) ??
+                    (p.kind === "net-voltage" ? p.netId : p.instanceId)
+                  }
+                  onChange={(event) => {
+                    event.stopPropagation();
+                    const label = event.currentTarget.value;
+                    onOutputLabelChange(p.id, label);
+                  }}
+                />
+                <small>
+                  {p.kind === "net-voltage" ? "Voltage" : "Current"} ·{" "}
+                  {probeLabels.get(simulationProbeTargetKey(p)) ??
+                    "Target unavailable"}
+                </small>
+              </span>
               <button
                 type="button"
+                aria-label="Remove probe"
                 onClick={() => {
                   setProbes(probes.filter((v) => v.id !== p.id));
+                  onOutputLabelChange(p.id, "");
                   onDirty(true);
                 }}
               >
@@ -869,7 +917,10 @@ function SetupEditor({
             </li>
           ))}
         </ul>
-        <p>Sources are edited on the testbench canvas.</p>
+        <p>
+          Voltage Outputs target Nets. Current Outputs target a measurable
+          device branch; sources are edited on the testbench canvas.
+        </p>
         <button type="submit">Apply setup</button>
         {saved && (
           <button type="button" onClick={() => onSaveSetup(null)}>

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -255,6 +255,41 @@
 .simulation-setup-panel form > button {
   margin: 8px 8px 0 0;
 }
+.simulation-pick-active {
+  border-color: var(--icm-accent) !important;
+  color: #fff !important;
+  background: var(--icm-accent) !important;
+}
+
+.simulation-probe-list {
+  display: grid;
+  gap: 6px;
+  margin: 12px 0;
+  padding: 0;
+  list-style: none;
+}
+.simulation-probe-list li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 6px;
+  align-items: center;
+  padding: 7px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface-muted);
+}
+.simulation-probe-list li > span {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+.simulation-probe-list small {
+  overflow: hidden;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 .simulation-results-dock {
   flex: 1 1 auto;
@@ -362,6 +397,120 @@
 .spice-ac-plot svg {
   width: 100%;
   height: auto;
+}
+
+.ac-results-explorer {
+  position: relative;
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+.ac-results-explorer > header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.ac-results-explorer > header > div {
+  display: grid;
+  min-width: 0;
+}
+.ac-results-explorer > header small {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.ac-results-explorer > header button {
+  margin-left: auto;
+}
+.simulation-output-browser {
+  display: grid;
+  gap: 4px;
+}
+.simulation-output-browser > div {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr) auto;
+  gap: 5px;
+  align-items: center;
+  padding: 3px;
+  border: 1px solid transparent;
+  border-radius: var(--icm-radius-sm);
+}
+.simulation-output-browser > div.selected {
+  border-color: var(--icm-accent);
+  background: var(--icm-surface-muted);
+}
+.simulation-output-browser button {
+  min-height: 26px;
+  padding: 3px 7px;
+}
+.simulation-output-browser .simulation-output-swatch {
+  width: 18px;
+  min-height: 18px;
+  padding: 0;
+  border: 4px solid currentColor;
+  border-radius: 50%;
+  background: currentColor;
+}
+.simulation-output-swatch[aria-pressed="false"] {
+  background: transparent;
+  opacity: 0.45;
+}
+.simulation-output-name {
+  display: grid;
+  min-width: 0;
+  border-color: transparent !important;
+  background: transparent !important;
+  text-align: left;
+}
+.simulation-output-name strong,
+.simulation-output-name small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.simulation-output-name small {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.ac-quantity-group {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+.ac-quantity-group > h4 {
+  margin: 4px 0 0;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.ac-plot-row {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+.ac-plot-row > strong {
+  font-size: var(--icm-font-xs);
+}
+.spice-ac-plot.interactive {
+  position: relative;
+  min-width: 0;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: #fff;
+  cursor: crosshair;
+  touch-action: none;
+}
+.ac-cursor-readout {
+  position: sticky;
+  bottom: 0;
+  display: grid;
+  gap: 2px;
+  padding: 7px 9px;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-sm);
+  background: color-mix(in srgb, var(--icm-surface) 94%, transparent);
+  box-shadow: var(--icm-shadow-sm);
+  font-size: var(--icm-font-xs);
 }
 
 @media (max-width: 700px) {
@@ -734,6 +883,13 @@
   stroke-width: 1.2;
 }
 
+.ac-response .ac-cursor {
+  stroke: #101828;
+  stroke-width: 1;
+  stroke-dasharray: 2 2;
+  pointer-events: none;
+}
+
 .ac-response .ac-frame {
   fill: none;
   stroke: var(--icm-border, #d5d9e0);
@@ -771,6 +927,25 @@
 }
 .ac-response .ac-trace-5 {
   stroke: #026aa2;
+}
+
+.simulation-output-swatch.ac-trace-0 {
+  color: #175cd3;
+}
+.simulation-output-swatch.ac-trace-1 {
+  color: #b54708;
+}
+.simulation-output-swatch.ac-trace-2 {
+  color: #067647;
+}
+.simulation-output-swatch.ac-trace-3 {
+  color: #6941c6;
+}
+.simulation-output-swatch.ac-trace-4 {
+  color: #b42318;
+}
+.simulation-output-swatch.ac-trace-5 {
+  color: #026aa2;
 }
 
 .ac-response .ac-legend-text {

--- a/apps/editor/src/styles/editor-workspace.css
+++ b/apps/editor/src/styles/editor-workspace.css
@@ -15,9 +15,9 @@
 }
 
 .app-workspace.simulation-mode {
-  grid-template-columns: minmax(320px, 34vw) minmax(0, 1fr) auto;
+  grid-template-columns: var(--icm-simulation-width) minmax(0, 1fr) auto;
   grid-template-areas: "simulation canvas props";
-  transition: grid-template-columns 160ms ease;
+  transition: none;
 }
 
 /* Sits on the Library's right edge, overlapping the canvas by a few pixels so
@@ -34,6 +34,28 @@
 
 .library-resize-handle:hover,
 .library-resize-handle:focus-visible {
+  background: linear-gradient(
+    to right,
+    transparent 3px,
+    var(--icm-accent) 3px,
+    var(--icm-accent) 5px,
+    transparent 5px
+  );
+  outline: none;
+}
+
+.simulation-resize-handle {
+  grid-area: canvas;
+  z-index: 3;
+  width: 9px;
+  margin-left: -5px;
+  cursor: col-resize;
+  touch-action: none;
+  background: transparent;
+}
+
+.simulation-resize-handle:hover,
+.simulation-resize-handle:focus-visible {
   background: linear-gradient(
     to right,
     transparent 3px,
@@ -600,7 +622,9 @@
   }
 
   .app-workspace.simulation-mode {
-    grid-template-columns: minmax(300px, 40vw) minmax(0, 1fr) auto;
+    grid-template-columns:
+      min(var(--icm-simulation-width), 52vw) minmax(0, 1fr)
+      auto;
     grid-template-areas: "simulation canvas props";
   }
 }
@@ -622,7 +646,7 @@
   }
 
   .app-workspace.simulation-mode {
-    grid-template-columns: minmax(290px, 44vw) minmax(0, 1fr);
+    grid-template-columns: min(var(--icm-simulation-width), 62vw) minmax(0, 1fr);
     grid-template-areas: "simulation canvas";
   }
 


### PR DESCRIPTION
## Summary
- add a resizable Simulation workspace and direct canvas Net picking
- separate AC magnitude and phase with probe-aware visibility, aliases, cursors, and zoom
- distinguish voltage and source-current outputs while preserving raw-setup compatibility

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main
  - 2654 unit tests passed, 26 skipped
  - 5 Agent/browser tests passed
  - 134 Editor/browser tests passed

Test-Impact: tests-updated