### PR TITLE
feat(simulation): refine setup and result exploration

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -67,7 +67,7 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
     .getByRole("button", { name: "Analog simulation", exact: true })
     .click();
   const panel = page.getByRole("region", { name: "Analog simulation" });
-  await panel.getByText("Setup", { exact: true }).click();
+  await panel.getByRole("button", { name: "Settings" }).click();
   await expect(panel.getByLabel("Testbench Cell")).toHaveValue(
     originalSetupInput.rootDocumentId,
   );
@@ -79,13 +79,13 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
   await expect(
     panel.locator("li").filter({ hasText: "XDUT · ota_5t · tail" }),
   ).toBeVisible();
-  await panel.getByRole("button", { name: "Pick voltage on canvas" }).click();
+  await panel.getByRole("button", { name: "Pick on canvas" }).click();
   await page.getByTestId("route-hit-tb-vinp-route").click({ force: true });
   await expect(panel.getByRole("button", { name: "Remove probe" })).toHaveCount(
     5,
   );
   await panel.getByRole("button", { name: "Remove probe" }).last().click();
-  await panel.getByRole("button", { name: "Picking voltage Nets…" }).click();
+  await panel.getByRole("button", { name: "Picking Nets…" }).click();
   await panel
     .getByLabel("Add voltage probe")
     .selectOption({ label: "XDUT · ota_5t · vinp" });
@@ -150,7 +150,7 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
   await page
     .getByRole("button", { name: "Analog simulation", exact: true })
     .click();
-  await panel.getByText("Setup", { exact: true }).click();
+  await panel.getByRole("button", { name: "Settings" }).click();
   await expect(panel.getByRole("button", { name: "Remove probe" })).toHaveCount(
     6,
   );
@@ -216,6 +216,8 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     }
     executions++;
     await pending;
+    const requestedVector =
+      /write\s+out\.raw\s+([^\s]+)/iu.exec(body.preparedDeck)?.[1] ?? "v(out)";
     const rawfile = readFileSync(
       new URL(
         "../../../fixtures/ngspice-rawfile/divider-op.raw",
@@ -241,7 +243,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
               frequencyHz: [1, 10, 100],
               probes: [
                 {
-                  name: "v(out)",
+                  name: requestedVector,
                   quantity: "voltage",
                   unit: "V",
                   real: [10, 7, 1],
@@ -295,7 +297,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await panel.getByRole("button", { name: "Run", exact: true }).click();
   await expect(panel.getByRole("alert")).toContainText(/PROBE|probe/);
   expect(executions).toBe(0);
-  await panel.getByText("Setup", { exact: true }).click();
+  await panel.getByRole("button", { name: "Settings" }).click();
   await panel.getByRole("button", { name: "Remove probe" }).click();
   await panel
     .getByLabel("Add voltage probe")
@@ -316,6 +318,28 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await expect(panel.locator(".spice-ac-plot svg")).toHaveCount(2);
   await expect(panel.locator('svg[aria-label="AC magnitude"]')).toBeVisible();
   await expect(panel.locator('svg[aria-label="AC phase"]')).toBeVisible();
+  const magnitudePlot = panel
+    .locator(".ac-plot-row")
+    .filter({ hasText: "Magnitude" })
+    .locator(".spice-ac-plot")
+    .first();
+  const plotBeforeWheel = await magnitudePlot.innerHTML();
+  await magnitudePlot.dispatchEvent("wheel", { deltaY: -120 });
+  await expect(magnitudePlot).toHaveJSProperty("innerHTML", plotBeforeWheel);
+  await magnitudePlot.hover();
+  await expect(
+    panel.getByRole("button", { name: "Zoom in" }).first(),
+  ).toBeVisible();
+  await magnitudePlot.dblclick();
+  await expect(
+    page.getByRole("dialog", { name: "voltage magnitude plot" }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Close plot" }).click();
+  await magnitudePlot.locator("polyline[data-trace-id]").dispatchEvent("click");
+  await expect(
+    panel.locator(".simulation-output-browser > .selected"),
+  ).toHaveCount(1);
+  await expect(page.getByTestId("net-highlight-overlay")).toBeVisible();
   await panel.getByRole("tab", { name: "Files" }).click();
   const download = page.waitForEvent("download");
   await panel
@@ -335,7 +359,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     oldRunIdentity,
   );
   expect(executions).toBe(1);
-  await panel.getByText("Setup", { exact: true }).click();
+  await panel.getByRole("button", { name: "Settings" }).click();
   await panel.getByLabel("Temperature (°C)").fill("30");
   await panel.getByRole("button", { name: "Apply setup" }).click();
   await expect(panel.getByRole("alert")).toContainText(
@@ -362,7 +386,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     buffer: saved,
   });
   await page.getByTestId("open-analog-simulation").click();
-  await panel.getByText("Setup", { exact: true }).click();
+  await panel.getByRole("button", { name: "Settings" }).click();
   await expect(panel.getByLabel("Temperature (°C)")).toHaveValue("30");
   await expect(panel.getByRole("status")).toHaveText("No run yet");
 });

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -111,7 +111,10 @@ import {
   operatingPointLabels,
   type OperatingPointDisplay,
 } from "../features/simulation/operating-point-labels";
-import { resolveSimulationVoltageProbeNetId } from "../features/simulation/simulation-probe-options";
+import {
+  resolveSimulationVoltageProbeNetId,
+  simulationProbeHierarchyPath,
+} from "../features/simulation/simulation-probe-options";
 import { TimingSimulationPanel } from "../features/simulation/timing-simulation-panel";
 import { TIMING_UI_ENABLED } from "../features/simulation/timing-ui";
 import { updateComponentParameterValues } from "../features/component-insert/component-parameters";
@@ -4629,14 +4632,60 @@ export function App({
               pickedNet={analogPickedNet}
               onPickNetsChange={setSimulationPickMode}
               onFocusProbe={(probe) => {
-                if (probe.kind === "net-voltage") {
-                  switchDocument(probe.documentId);
-                  const netId = resolveSimulationVoltageProbeNetId(
-                    project,
-                    probe,
+                const targetDocument = project.documents.find(
+                  (candidate) => candidate.id === probe.documentId,
+                );
+                const voltageNetId =
+                  probe.kind === "net-voltage"
+                    ? resolveSimulationVoltageProbeNetId(project, probe)
+                    : undefined;
+                const targetExists =
+                  probe.kind === "net-voltage"
+                    ? voltageNetId !== undefined
+                    : targetDocument?.instances.some(
+                        (instance) => instance.id === probe.instanceId,
+                      ) === true;
+                if (!targetExists) {
+                  setStatus(
+                    "This Output no longer matches the current Project; update the Setup and run again",
                   );
-                  if (netId) highlightNet(netId, probe.documentId);
+                  return;
                 }
+                const input = project.simulation?.input;
+                const rootDocumentId =
+                  input?.kind === "structured"
+                    ? input.rootDocumentId
+                    : probe.documentId;
+                const hierarchyPath = simulationProbeHierarchyPath(
+                  project,
+                  rootDocumentId,
+                  probe.occurrence,
+                );
+                if (hierarchyPath === null) {
+                  setStatus("The Output occurrence no longer exists");
+                  return;
+                }
+                navigateToLocator(
+                  probe.kind === "net-voltage"
+                    ? {
+                        documentId: probe.documentId,
+                        hierarchyPath,
+                        kind: "net",
+                        objectId: voltageNetId!,
+                      }
+                    : {
+                        documentId: probe.documentId,
+                        hierarchyPath,
+                        kind: "instance",
+                        objectId: probe.instanceId,
+                      },
+                  probe.kind === "net-voltage"
+                    ? `Located simulation Net ${voltageNetId}`
+                    : `Located simulation source ${probe.instanceId}`,
+                );
+                // Back-annotation should not unexpectedly open the ordinary
+                // Properties dock over the simulation workspace.
+                setSelectionOpen(false);
               }}
             />
           </Suspense>

--- a/apps/editor/src/features/simulation/ac-response-plot.test.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.test.ts
@@ -55,6 +55,24 @@ describe("AC response plot", () => {
     ).toBeCloseTo(1e3, 6);
   });
 
+  it("uses an explicit toolbar range without changing the trace data", () => {
+    const range = [10, 1e4] as const;
+    const layout = layoutAcPlot(
+      [singlePole()],
+      { width: 600, height: 300 },
+      range,
+    )!;
+    const svg = acResponseSvg(
+      [singlePole()],
+      { width: 600, height: 300 },
+      { kind: "magnitude", frequencyRange: range },
+    )!;
+
+    expect(layout.frequency.min).toBe(range[0]);
+    expect(layout.frequency.max).toBe(range[1]);
+    expect(svg).toContain("clip-path");
+  });
+
   it("draws magnitude and phase as separate Bode plots", () => {
     const magnitude = acResponseSvg(
       [singlePole()],
@@ -67,12 +85,31 @@ describe("AC response plot", () => {
       { kind: "phase" },
     )!;
 
-    expect(magnitude.match(/<polyline/gu)).toHaveLength(1);
-    expect(phase.match(/<polyline/gu)).toHaveLength(1);
+    expect(
+      magnitude.match(/<polyline class="ac-trace ac-trace-/gu),
+    ).toHaveLength(1);
+    expect(phase.match(/<polyline class="ac-trace ac-trace-/gu)).toHaveLength(
+      1,
+    );
     expect(magnitude).toContain('aria-label="AC magnitude"');
     expect(phase).toContain('aria-label="AC phase"');
     expect(magnitude).toContain("dB");
     expect(phase).toContain("°");
+  });
+
+  it("keeps a trace addressable and emphasizes the selected line", () => {
+    const trace = { ...singlePole(), id: "probe-output" };
+    const svg = acResponseSvg(
+      [trace],
+      { width: 600, height: 300 },
+      {
+        kind: "magnitude",
+        selectedTraceId: trace.id,
+      },
+    )!;
+
+    expect(svg).toContain('data-trace-id="probe-output"');
+    expect(svg).toContain("ac-trace-selected");
   });
 
   it("declines to invent a plot when there is nothing to draw", () => {

--- a/apps/editor/src/features/simulation/ac-response-plot.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.ts
@@ -29,6 +29,8 @@ export interface AcPoint {
 }
 
 export interface AcTrace {
+  /** Stable result-browser identity used for line selection. */
+  id?: string;
   /** The expression the author asked for, printed verbatim as the legend. */
   label: string;
   /** Stable Results Browser colour slot, independent of hide/show filtering. */
@@ -68,6 +70,10 @@ export interface AcResponseSvgOptions {
   cursorFrequency?: number;
   /** The interactive Results Browser owns the legend when false. */
   showLegend?: boolean;
+  /** Selected Results Browser trace, emphasized on the plot. */
+  selectedTraceId?: string;
+  /** Explicit axes-toolbar range; traces are clipped to this interval. */
+  frequencyRange?: readonly [number, number];
 }
 
 const MARGIN = { left: 56, right: 56, top: 16, bottom: 32 };
@@ -96,6 +102,7 @@ function niceLinear(min: number, max: number, step: number): AcPlotAxis {
 export function layoutAcPlot(
   traces: readonly AcTrace[],
   size: AcPlotSize,
+  frequencyRange?: readonly [number, number],
 ): AcPlotLayout | null {
   const points = traces.flatMap((trace) => trace.points);
   const usable = points.filter((point) => point.frequency > 0);
@@ -110,13 +117,17 @@ export function layoutAcPlot(
     width: Math.max(1, size.width - MARGIN.left - MARGIN.right),
     height: Math.max(1, size.height - MARGIN.top - MARGIN.bottom),
   };
-  const fMin = Math.min(...frequencies);
-  const fMax = Math.max(...frequencies);
-  const decades = niceDecades(fMin, fMax);
+  const dataMin = Math.min(...frequencies);
+  const dataMax = Math.max(...frequencies);
+  const fMin = frequencyRange?.[0] ?? dataMin;
+  const fMax = frequencyRange?.[1] ?? dataMax;
+  const decades = niceDecades(fMin, fMax).filter(
+    (frequency) => frequency >= fMin && frequency <= fMax,
+  );
   const frequency: AcPlotAxis = {
     ticks: decades,
-    min: decades[0]!,
-    max: decades.at(-1)!,
+    min: frequencyRange ? fMin : niceDecades(dataMin, dataMax)[0]!,
+    max: frequencyRange ? fMax : niceDecades(dataMin, dataMax).at(-1)!,
   };
   const logMin = Math.log10(frequency.min);
   const logSpan = Math.log10(frequency.max) - logMin || 1;
@@ -192,7 +203,7 @@ export function acResponseSvg(
   size: AcPlotSize,
   options: AcResponseSvgOptions = { kind: "magnitude" },
 ): string | null {
-  const layout = layoutAcPlot(traces, size);
+  const layout = layoutAcPlot(traces, size, options.frequencyRange);
   if (!layout) return null;
   const project = projection(layout);
   const { frame } = layout;
@@ -216,9 +227,17 @@ export function acResponseSvg(
     .map((trace, index) => {
       const colorIndex = trace.colorIndex ?? index;
       const points = polyline(trace, project, options.kind);
-      return `<polyline class="ac-trace ac-trace-${colorIndex % 6}" data-trace-index="${index}" points="${points}"/>`;
+      const id = trace.id ?? trace.label;
+      const selected =
+        options.selectedTraceId === id ? " ac-trace-selected" : "";
+      const identity = `data-trace-index="${index}" data-trace-id="${escapeXml(id)}"`;
+      return (
+        `<polyline class="ac-trace-hit" ${identity} points="${points}"/>` +
+        `<polyline class="ac-trace ac-trace-${colorIndex % 6}${selected}" points="${points}"/>`
+      );
     })
     .join("");
+  const clipId = `ac-clip-${options.kind}-${size.width}-${size.height}`;
 
   // The author asked for these expressions by name; printing them back is the
   // only way to tell two curves apart, and colour alone would leave anyone
@@ -246,9 +265,10 @@ export function acResponseSvg(
 
   return (
     `<svg xmlns="http://www.w3.org/2000/svg" class="ac-response" viewBox="0 0 ${size.width} ${size.height}" width="${size.width}" height="${size.height}" role="img" aria-label="AC ${options.kind}">` +
+    `<defs><clipPath id="${clipId}"><rect x="${frame.x}" y="${frame.y}" width="${frame.width}" height="${frame.height}"/></clipPath></defs>` +
     `<rect class="ac-frame" x="${frame.x}" y="${frame.y}" width="${frame.width}" height="${frame.height}"/>` +
     gridLines +
-    curves +
+    `<g clip-path="url(#${clipId})">${curves}</g>` +
     cursor +
     legend +
     `</svg>`

--- a/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { AcResultsExplorer, unwrapPhaseDegrees } from "./ac-results-explorer";
+import {
+  AcResultsExplorer,
+  panFrequencyRange,
+  unwrapPhaseDegrees,
+  zoomFrequencyRange,
+} from "./ac-results-explorer";
 
 describe("AC Results Explorer", () => {
   it("unwraps phase without inventing 360-degree discontinuities", () => {
@@ -50,5 +55,20 @@ describe("AC Results Explorer", () => {
     expect(markup).toContain('aria-label="AC magnitude"');
     expect(markup).toContain('aria-label="AC phase"');
     expect(markup.match(/data-trace-index="0"/gu)).toHaveLength(2);
+    expect(markup).toContain('aria-label="Plot tools"');
+    expect(markup).toContain('aria-label="Open plot"');
+    expect(markup).not.toContain("Wheel to zoom");
+  });
+
+  it("keeps explicit zoom and pan inside the simulated frequency sweep", () => {
+    const full = [1, 1e6] as const;
+    const zoomed = zoomFrequencyRange(full, full, "in");
+    expect(zoomed[0]).toBeGreaterThan(full[0]);
+    expect(zoomed[1]).toBeLessThan(full[1]);
+
+    const panned = panFrequencyRange(zoomed, full, "right");
+    expect(panned[0]).toBeGreaterThan(zoomed[0]);
+    expect(panned[1]).toBeLessThanOrEqual(full[1]);
+    expect(panFrequencyRange(full, full, "left")).toEqual(full);
   });
 });

--- a/apps/editor/src/features/simulation/ac-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.tsx
@@ -1,4 +1,10 @@
-import { useMemo, useState, type PointerEvent, type WheelEvent } from "react";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent,
+} from "react";
 import type { SimulationProbeSpec } from "@icm/model";
 import type { AcResult } from "@icm/spice-run";
 import type { Prepared } from "@icm/simulation-service/contract";
@@ -7,6 +13,8 @@ import {
   acResponseSvg,
   formatFrequency,
   layoutAcPlot,
+  type AcPlotKind,
+  type AcPlotSize,
   type AcPoint,
   type AcTrace,
 } from "./ac-response-plot";
@@ -17,6 +25,11 @@ interface OutputTrace extends AcTrace {
   probe?: SimulationProbeSpec;
 }
 
+interface ExpandedPlot {
+  quantity: OutputTrace["quantity"];
+  kind: AcPlotKind;
+}
+
 export interface AcResultsExplorerProps {
   analysis: AcResult;
   vectors: Prepared["vectors"];
@@ -25,7 +38,8 @@ export interface AcResultsExplorerProps {
   onFocusProbe?(probe: SimulationProbeSpec): void;
 }
 
-const PLOT_SIZE = { width: 760, height: 220 } as const;
+const PLOT_SIZE = { width: 760, height: 280 } as const;
+const EXPANDED_PLOT_SIZE = { width: 1400, height: 700 } as const;
 
 /** Keep phase continuous instead of drawing artificial 360-degree jumps. */
 export function unwrapPhaseDegrees(values: readonly number[]): number[] {
@@ -51,18 +65,6 @@ function closestPoint(points: readonly AcPoint[], frequency: number): AcPoint {
       ? point
       : best,
   );
-}
-
-function cropTrace(
-  trace: OutputTrace,
-  range?: readonly [number, number],
-): OutputTrace {
-  if (!range) return trace;
-  const inside = trace.points.filter(
-    (point) => point.frequency >= range[0] && point.frequency <= range[1],
-  );
-  if (inside.length >= 2) return { ...trace, points: inside };
-  return trace;
 }
 
 function outputTraces(
@@ -111,6 +113,70 @@ function outputTraces(
   });
 }
 
+function normalizedLogRange(
+  low: number,
+  high: number,
+  fullRange: readonly [number, number],
+): readonly [number, number] {
+  const fullLow = Math.log(fullRange[0]);
+  const fullHigh = Math.log(fullRange[1]);
+  if (high - low >= fullHigh - fullLow - 1e-12) return fullRange;
+  const requestedSpan = Math.min(high - low, fullHigh - fullLow);
+  let nextLow = low;
+  let nextHigh = high;
+  if (nextLow < fullLow) {
+    nextLow = fullLow;
+    nextHigh = fullLow + requestedSpan;
+  }
+  if (nextHigh > fullHigh) {
+    nextHigh = fullHigh;
+    nextLow = fullHigh - requestedSpan;
+  }
+  return [Math.exp(nextLow), Math.exp(nextHigh)];
+}
+
+/** Explicit axes-toolbar zoom; the document or panel wheel is never captured. */
+export function zoomFrequencyRange(
+  currentRange: readonly [number, number],
+  fullRange: readonly [number, number],
+  direction: "in" | "out",
+  centerFrequency = Math.sqrt(currentRange[0] * currentRange[1]),
+): readonly [number, number] {
+  const low = Math.log(currentRange[0]);
+  const high = Math.log(currentRange[1]);
+  const center = Math.log(
+    Math.min(currentRange[1], Math.max(currentRange[0], centerFrequency)),
+  );
+  const scale = direction === "in" ? 0.6 : 1.7;
+  return normalizedLogRange(
+    center - (center - low) * scale,
+    center + (high - center) * scale,
+    fullRange,
+  );
+}
+
+/** Pan one fifth of the visible logarithmic span without leaving the sweep. */
+export function panFrequencyRange(
+  currentRange: readonly [number, number],
+  fullRange: readonly [number, number],
+  direction: "left" | "right",
+): readonly [number, number] {
+  const low = Math.log(currentRange[0]);
+  const high = Math.log(currentRange[1]);
+  const shift = (high - low) * 0.2 * (direction === "left" ? -1 : 1);
+  return normalizedLogRange(low + shift, high + shift, fullRange);
+}
+
+function rangesEqual(
+  left: readonly [number, number],
+  right: readonly [number, number],
+): boolean {
+  return (
+    Math.abs(Math.log(left[0] / right[0])) < 1e-9 &&
+    Math.abs(Math.log(left[1] / right[1])) < 1e-9
+  );
+}
+
 export function AcResultsExplorer({
   analysis,
   vectors,
@@ -125,9 +191,11 @@ export function AcResultsExplorer({
   const [hidden, setHidden] = useState<ReadonlySet<string>>(() => new Set());
   const [solo, setSolo] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
-  const [cursorFrequency, setCursorFrequency] = useState<number>();
+  const [hoverFrequency, setHoverFrequency] = useState<number>();
+  const [markerFrequency, setMarkerFrequency] = useState<number>();
   const [frequencyRange, setFrequencyRange] =
     useState<readonly [number, number]>();
+  const [expandedPlot, setExpandedPlot] = useState<ExpandedPlot | null>(null);
   const fullRange = useMemo<readonly [number, number]>(() => {
     const frequencies = analysis.frequencyHz.filter(
       (frequency) => frequency > 0,
@@ -137,6 +205,7 @@ export function AcResultsExplorer({
   const visible = traces.filter(
     (trace) => !hidden.has(trace.id) && (solo === null || solo === trace.id),
   );
+  const cursorFrequency = hoverFrequency ?? markerFrequency;
   const cursorRows =
     cursorFrequency === undefined
       ? []
@@ -145,43 +214,173 @@ export function AcResultsExplorer({
           point: closestPoint(trace.points, cursorFrequency),
         }));
 
-  const pointAtPointer = (event: PointerEvent<HTMLDivElement>) => {
+  useEffect(() => {
+    if (!expandedPlot) return;
+    const close = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setExpandedPlot(null);
+    };
+    window.addEventListener("keydown", close);
+    return () => window.removeEventListener("keydown", close);
+  }, [expandedPlot]);
+
+  const frequencyAtPointer = (
+    event: PointerEvent<HTMLDivElement> | ReactMouseEvent<HTMLDivElement>,
+    size: AcPlotSize,
+    plotTraces: readonly OutputTrace[],
+  ): number | undefined => {
     const bounds = event.currentTarget.getBoundingClientRect();
-    const trace = cropTrace(visible[0] ?? traces[0]!, frequencyRange);
-    const layout = layoutAcPlot([trace], PLOT_SIZE);
-    if (!layout) return;
-    const svgX =
-      ((event.clientX - bounds.left) / bounds.width) * PLOT_SIZE.width;
+    const layout = layoutAcPlot(plotTraces, size, frequencyRange);
+    if (!layout) return undefined;
+    const svgX = ((event.clientX - bounds.left) / bounds.width) * size.width;
     const frequency = layout.frequencyAt(svgX);
-    setCursorFrequency(
-      Math.min(layout.frequency.max, Math.max(layout.frequency.min, frequency)),
+    return Math.min(
+      layout.frequency.max,
+      Math.max(layout.frequency.min, frequency),
     );
   };
-  const zoom = (event: WheelEvent<HTMLDivElement>) => {
-    if (fullRange[0] === fullRange[1]) return;
-    event.preventDefault();
+
+  const focusTrace = (traceId: string): void => {
+    const trace = traces.find((candidate) => candidate.id === traceId);
+    if (!trace) return;
+    setSelected(trace.id);
+    if (trace.probe) onFocusProbe?.(trace.probe);
+  };
+
+  const updateRange = (
+    action: "zoom-in" | "zoom-out" | "pan-left" | "pan-right" | "fit",
+  ): void => {
+    if (action === "fit" || fullRange[0] === fullRange[1]) {
+      setFrequencyRange(undefined);
+      return;
+    }
     const current = frequencyRange ?? fullRange;
-    const center = cursorFrequency ?? Math.sqrt(current[0] * current[1]);
-    const scale = event.deltaY < 0 ? 0.72 : 1.38;
-    const left = Math.log(center / current[0]) * scale;
-    const right = Math.log(current[1] / center) * scale;
-    const next: readonly [number, number] = [
-      Math.max(fullRange[0], center / Math.exp(left)),
-      Math.min(fullRange[1], center * Math.exp(right)),
-    ];
-    setFrequencyRange(next[1] > next[0] ? next : undefined);
+    const next = action.startsWith("zoom")
+      ? zoomFrequencyRange(
+          current,
+          fullRange,
+          action === "zoom-in" ? "in" : "out",
+          cursorFrequency,
+        )
+      : panFrequencyRange(
+          current,
+          fullRange,
+          action === "pan-left" ? "left" : "right",
+        );
+    setFrequencyRange(rangesEqual(next, fullRange) ? undefined : next);
+  };
+
+  const plotToolbar = (plot: ExpandedPlot, expanded: boolean) => (
+    <div
+      className={`ac-plot-toolbar${expanded ? " expanded" : ""}`}
+      aria-label="Plot tools"
+      onClick={(event) => event.stopPropagation()}
+      onDoubleClick={(event) => event.stopPropagation()}
+      onPointerMove={(event) => event.stopPropagation()}
+    >
+      <button
+        type="button"
+        aria-label="Zoom in"
+        onClick={() => updateRange("zoom-in")}
+      >
+        +
+      </button>
+      <button
+        type="button"
+        aria-label="Zoom out"
+        onClick={() => updateRange("zoom-out")}
+      >
+        −
+      </button>
+      <button
+        type="button"
+        aria-label="Pan left"
+        onClick={() => updateRange("pan-left")}
+      >
+        ←
+      </button>
+      <button
+        type="button"
+        aria-label="Pan right"
+        onClick={() => updateRange("pan-right")}
+      >
+        →
+      </button>
+      <button
+        type="button"
+        aria-label="Fit plot"
+        onClick={() => updateRange("fit")}
+      >
+        Fit
+      </button>
+      {markerFrequency !== undefined ? (
+        <button
+          type="button"
+          aria-label="Clear marker"
+          onClick={() => setMarkerFrequency(undefined)}
+        >
+          ×│
+        </button>
+      ) : null}
+      {!expanded ? (
+        <button
+          type="button"
+          aria-label="Open plot"
+          onClick={() => setExpandedPlot(plot)}
+        >
+          ⛶
+        </button>
+      ) : null}
+    </div>
+  );
+
+  const renderPlot = (
+    plot: ExpandedPlot,
+    plotTraces: readonly OutputTrace[],
+    expanded = false,
+  ) => {
+    const size = expanded ? EXPANDED_PLOT_SIZE : PLOT_SIZE;
+    const svg = acResponseSvg(plotTraces, size, {
+      kind: plot.kind,
+      showLegend: false,
+      ...(frequencyRange === undefined ? {} : { frequencyRange }),
+      ...(cursorFrequency === undefined ? {} : { cursorFrequency }),
+      ...(selected === null ? {} : { selectedTraceId: selected }),
+    });
+    return (
+      <div
+        className={`ac-plot-shell${expanded ? " expanded" : ""}`}
+        title={expanded ? undefined : "Double-click to open this plot"}
+      >
+        <div
+          className="spice-ac-plot interactive"
+          onPointerMove={(event) => {
+            const frequency = frequencyAtPointer(event, size, plotTraces);
+            if (frequency !== undefined) setHoverFrequency(frequency);
+          }}
+          onPointerLeave={() => setHoverFrequency(undefined)}
+          onClick={(event) => {
+            const traceElement = (event.target as Element).closest(
+              "[data-trace-id]",
+            );
+            const traceId = traceElement?.getAttribute("data-trace-id");
+            if (traceId) focusTrace(traceId);
+            const frequency = frequencyAtPointer(event, size, plotTraces);
+            if (frequency !== undefined) setMarkerFrequency(frequency);
+          }}
+          onDoubleClick={() => {
+            if (!expanded) setExpandedPlot(plot);
+          }}
+          dangerouslySetInnerHTML={{ __html: svg ?? "" }}
+        />
+        {plotToolbar(plot, expanded)}
+      </div>
+    );
   };
 
   return (
     <div className="ac-results-explorer">
       <header>
-        <div>
-          <strong>{analysis.plotName}</strong>
-          <small>Wheel to zoom · move over either plot to inspect</small>
-        </div>
-        <button type="button" onClick={() => setFrequencyRange(undefined)}>
-          Fit
-        </button>
+        <strong>{analysis.plotName}</strong>
       </header>
       <div
         className="simulation-output-browser"
@@ -211,10 +410,7 @@ export function AcResultsExplorer({
               <button
                 type="button"
                 className="simulation-output-name"
-                onClick={() => {
-                  setSelected(trace.id);
-                  if (trace.probe) onFocusProbe?.(trace.probe);
-                }}
+                onClick={() => focusTrace(trace.id)}
               >
                 <strong>{trace.label}</strong>
                 <small>
@@ -235,34 +431,19 @@ export function AcResultsExplorer({
         })}
       </div>
       {(["voltage", "current"] as const).map((quantity) => {
-        const quantityTraces = visible
-          .filter((trace) => trace.quantity === quantity)
-          .map((trace) => cropTrace(trace, frequencyRange));
+        const quantityTraces = visible.filter(
+          (trace) => trace.quantity === quantity,
+        );
         if (quantityTraces.length === 0) return null;
         return (
           <section key={quantity} className="ac-quantity-group">
             <h4>{quantity === "voltage" ? "Voltage" : "Current"}</h4>
-            {(["magnitude", "phase"] as const).map((kind) => {
-              const svg = acResponseSvg(quantityTraces, PLOT_SIZE, {
-                kind,
-                showLegend: false,
-                ...(cursorFrequency === undefined ? {} : { cursorFrequency }),
-              });
-              return (
-                <div key={kind} className="ac-plot-row">
-                  <strong>
-                    {kind === "magnitude" ? "Magnitude" : "Phase"}
-                  </strong>
-                  <div
-                    className="spice-ac-plot interactive"
-                    onPointerMove={pointAtPointer}
-                    onPointerLeave={() => setCursorFrequency(undefined)}
-                    onWheel={zoom}
-                    dangerouslySetInnerHTML={{ __html: svg ?? "" }}
-                  />
-                </div>
-              );
-            })}
+            {(["magnitude", "phase"] as const).map((kind) => (
+              <div key={kind} className="ac-plot-row">
+                <strong>{kind === "magnitude" ? "Magnitude" : "Phase"}</strong>
+                {renderPlot({ quantity, kind }, quantityTraces)}
+              </div>
+            ))}
           </section>
         );
       })}
@@ -278,6 +459,45 @@ export function AcResultsExplorer({
               {point.phaseDeg.toFixed(2)}°
             </span>
           ))}
+        </div>
+      ) : null}
+      {expandedPlot ? (
+        <div
+          className="ac-plot-dialog-backdrop"
+          onMouseDown={(event) => {
+            if (event.currentTarget === event.target) setExpandedPlot(null);
+          }}
+        >
+          <section
+            className="ac-plot-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-label={`${expandedPlot.quantity} ${expandedPlot.kind} plot`}
+          >
+            <header>
+              <div>
+                <strong>{analysis.plotName}</strong>
+                <span>
+                  {expandedPlot.quantity === "voltage" ? "Voltage" : "Current"}{" "}
+                  · {expandedPlot.kind === "magnitude" ? "Magnitude" : "Phase"}
+                </span>
+              </div>
+              <button
+                type="button"
+                aria-label="Close plot"
+                onClick={() => setExpandedPlot(null)}
+              >
+                ×
+              </button>
+            </header>
+            {renderPlot(
+              expandedPlot,
+              visible.filter(
+                (trace) => trace.quantity === expandedPlot.quantity,
+              ),
+              true,
+            )}
+          </section>
         </div>
       ) : null}
     </div>

--- a/apps/editor/src/features/simulation/simulation-probe-options.test.ts
+++ b/apps/editor/src/features/simulation/simulation-probe-options.test.ts
@@ -5,6 +5,7 @@ import fiveTransistorOtaSky130 from "../../examples/five-transistor-ota-sky130.i
 import {
   deriveSimulationProbeOptions,
   resolveSimulationVoltageProbeNetId,
+  simulationProbeHierarchyPath,
   simulationProbeTargetKey,
   simulationVoltageProbeTargetsNet,
 } from "./simulation-probe-options";
@@ -94,5 +95,26 @@ describe("simulation probe choices", () => {
     expect(
       simulationVoltageProbeTargetsNet(project, target, "net-dut-vout"),
     ).toBe(false);
+  });
+
+  it("resolves a probe occurrence to the canvas hierarchy path", () => {
+    const project = CircuitProjectSchema.parse(fiveTransistorOtaSky130);
+
+    expect(
+      simulationProbeHierarchyPath(project, "document-ota-5t-testbench", [
+        "XDUT",
+      ]),
+    ).toEqual([
+      {
+        parentDocumentId: "document-ota-5t-testbench",
+        instanceId: "XDUT",
+        childDocumentId: "document-ota-5t",
+      },
+    ]);
+    expect(
+      simulationProbeHierarchyPath(project, "document-ota-5t-testbench", [
+        "missing-instance",
+      ]),
+    ).toBeNull();
   });
 });

--- a/apps/editor/src/features/simulation/simulation-probe-options.ts
+++ b/apps/editor/src/features/simulation/simulation-probe-options.ts
@@ -4,7 +4,7 @@ import type {
   SimulationProbeSpec,
   SimulationVoltageProbeAnchor,
 } from "@icm/model";
-import { resolveDocumentLogicalNets } from "@icm/derived";
+import { resolveDocumentLogicalNets, type HierarchyFrame } from "@icm/derived";
 
 type VoltageProbeTarget = Omit<
   Extract<SimulationProbeSpec, { kind: "net-voltage" }>,
@@ -105,6 +105,40 @@ function voltageAnchor(
   if (junction) return { kind: "junction", junctionId: junction.id };
   const route = document.routes.find((item) => ids.has(item.netId));
   return route ? { kind: "route", routeId: route.id } : undefined;
+}
+
+/**
+ * Resolve the persisted occurrence ids into the same hierarchy frames used by
+ * canvas navigation. This is presentation-only: probe identity remains the
+ * authored document/object/occurrence tuple.
+ */
+export function simulationProbeHierarchyPath(
+  project: CircuitProject,
+  rootDocumentId: string,
+  occurrence: readonly string[],
+): readonly HierarchyFrame[] | null {
+  const documents = new Map(
+    project.documents.map((document) => [document.id, document]),
+  );
+  let parent = documents.get(rootDocumentId);
+  if (!parent) return null;
+  const frames: HierarchyFrame[] = [];
+  for (const instanceId of occurrence) {
+    const instance = parent.instances.find(
+      (candidate) => candidate.id === instanceId,
+    );
+    const binding = instance?.netlist?.binding;
+    if (binding?.kind !== "subcircuit") return null;
+    const child = documents.get(binding.childDocumentId);
+    if (!child) return null;
+    frames.push({
+      parentDocumentId: parent.id,
+      instanceId,
+      childDocumentId: child.id,
+    });
+    parent = child;
+  }
+  return frames;
 }
 
 /**

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -22,14 +22,30 @@ describe("SpiceSimulationSurface workspace", () => {
     );
 
     expect(markup).toContain('class="simulation-taskbar"');
-    expect(markup).toContain('data-testid="simulation-cell-flow"');
+    expect(markup).not.toContain('data-testid="simulation-cell-flow"');
     expect(markup).toContain("This Cell has no DUT instance");
     expect(markup).toContain("Edit → New Testbench Cell");
     expect(markup).toContain('aria-label="Simulation setup"');
-    expect(markup).toContain('aria-pressed="true">Setup');
+    expect(markup).toContain('aria-pressed="true">Settings');
     expect(markup).toContain('aria-pressed="false">Results');
-    expect(markup).toContain("Pick voltage on canvas");
+    expect(markup).toContain('<select name="profileId"');
+    expect(markup).not.toContain("<datalist");
+    expect(markup).toContain("sky130-core-continuous-ngspice46-v1");
+    expect(markup).toContain('class="simulation-probe-control"');
+    expect(markup).toContain("Choose a Net");
+    expect(markup).toContain("Pick on canvas");
+    expect(markup).not.toContain("Pick voltage on canvas");
     expect(markup).toContain("Add current output");
+    expect(markup).toContain(
+      'class="simulation-setup-group simulation-analysis-row"',
+    );
+    expect(markup).toContain(
+      'class="simulation-setup-group simulation-inline-fields columns-2"',
+    );
+    expect(markup).toContain("TRAN");
+    expect(markup).not.toContain("Voltage Outputs target Nets");
+    expect(markup).not.toContain("Current Outputs target a measurable");
+    expect(markup).not.toContain("<span>Preview</span>");
     expect(markup).not.toContain('class="simulation-results-dock"');
   });
 });

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import {
   SimulationSetupSchema,
   type CircuitProject,
@@ -29,6 +29,13 @@ const RESULT_TABS = [
   ["console", "Console"],
   ["files", "Files"],
 ] as const;
+
+// Vite's UI-only development server has no execution capabilities endpoint.
+// Keep its single Preview profile visible for setup authoring; a deployed
+// executor's advertised profiles remain authoritative whenever available.
+const DEVELOPMENT_PROFILE_ID = import.meta.env.DEV
+  ? "sky130-core-continuous-ngspice46-v1"
+  : "";
 type ResultTab = (typeof RESULT_TABS)[number][0];
 
 export interface SpiceSimulationSurfaceProps {
@@ -275,32 +282,26 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
       <header className="simulation-taskbar">
         <div className="simulation-brand">
           <strong>Simulation</strong>
-          <span>{analysisLabel || "Preview"}</span>
         </div>
-        <div
-          className="simulation-cell-context"
-          data-testid="simulation-cell-flow"
-        >
-          <button
-            disabled={!activeCell}
-            onClick={() => activeCell && props.onOpenCell(activeCell.id)}
+        {draftDut || (savedRoot && savedRoot.id !== activeCell?.id) ? (
+          <div
+            className="simulation-cell-context"
+            data-testid="simulation-cell-flow"
           >
-            <small>Cell</small>
-            {activeCell?.name ?? "Missing Cell"}
-          </button>
-          {draftDut ? (
-            <button onClick={() => props.onOpenCell(draftDut.id)}>
-              <small>DUT</small>
-              {draftDut.name}
-            </button>
-          ) : null}
-          {savedRoot && savedRoot.id !== activeCell?.id ? (
-            <button onClick={() => props.onOpenCell(savedRoot.id)}>
-              <small>Setup root</small>
-              {savedRoot.name}
-            </button>
-          ) : null}
-        </div>
+            {draftDut ? (
+              <button onClick={() => props.onOpenCell(draftDut.id)}>
+                <small>DUT</small>
+                {draftDut.name}
+              </button>
+            ) : null}
+            {savedRoot && savedRoot.id !== activeCell?.id ? (
+              <button onClick={() => props.onOpenCell(savedRoot.id)}>
+                <small>Setup root</small>
+                {savedRoot.name}
+              </button>
+            ) : null}
+          </div>
+        ) : null}
         <span
           className={`simulation-status-chip simulation-status-${run?.state ?? (prepared ? "prepared" : "idle")}`}
           role="status"
@@ -316,7 +317,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
               setSetupOpen(true);
             }}
           >
-            Setup
+            Settings
           </button>
           <button
             type="button"
@@ -683,6 +684,21 @@ function SetupEditor({
     ]),
   );
   const ac = saved?.analyses.find((a) => a.kind === "ac");
+  const tran = saved?.analyses.find((a) => a.kind === "tran");
+  const [acEnabled, setAcEnabled] = useState(!!ac);
+  const [tranEnabled, setTranEnabled] = useState(!!tran);
+  const [profileId, setProfileId] = useState(
+    saved?.environment.profileId ?? DEVELOPMENT_PROFILE_ID,
+  );
+  useEffect(() => {
+    const defaultProfileId = capabilities?.profiles[0]?.id;
+    if (
+      !saved?.environment.profileId &&
+      defaultProfileId &&
+      (!profileId || profileId === DEVELOPMENT_PROFILE_ID)
+    )
+      setProfileId(defaultProfileId);
+  }, [capabilities?.profiles[0]?.id, profileId, saved?.environment.profileId]);
   useEffect(() => {
     if (!pickedNet) return;
     const option = probeOptions.voltage.find(
@@ -740,6 +756,15 @@ function SetupEditor({
                       },
                     ]
                   : []),
+                ...(data.has("tran")
+                  ? [
+                      {
+                        kind: "tran",
+                        stepSeconds: Number(data.get("tranStepSeconds")),
+                        stopSeconds: Number(data.get("tranStopSeconds")),
+                      },
+                    ]
+                  : []),
               ],
               probes,
               environment: {
@@ -777,107 +802,164 @@ function SetupEditor({
         </label>
         <label>
           Environment profile
-          <input
+          <select
             name="profileId"
             required
-            list="simulation-profiles"
-            defaultValue={
-              saved?.environment.profileId ??
-              capabilities?.profiles[0]?.id ??
-              ""
-            }
-          />
-        </label>
-        <datalist id="simulation-profiles">
-          {capabilities?.profiles.map((p) => (
-            <option key={p.id} value={p.id} />
-          ))}
-        </datalist>
-        <label>
-          Corner
-          <input
-            name="corner"
-            defaultValue={saved?.environment.corner ?? ""}
-            placeholder="Profile default"
-          />
-        </label>
-        <label>
-          Temperature (°C)
-          <input
-            name="temperatureC"
-            type="number"
-            step="any"
-            defaultValue={saved?.environment.temperatureC ?? ""}
-            placeholder="Profile default"
-          />
-        </label>
-        <label>
-          <input
-            name="op"
-            type="checkbox"
-            defaultChecked={
-              !saved || saved.analyses.some((a) => a.kind === "op")
-            }
-          />
-          Operating point (OP)
-        </label>
-        <label>
-          <input name="ac" type="checkbox" defaultChecked={!!ac} />
-          AC sweep
-        </label>
-        <label>
-          Sweep
-          <select name="sweep" defaultValue={ac?.sweep ?? "dec"}>
-            <option value="dec">Decade</option>
-            <option value="oct">Octave</option>
-            <option value="lin">Linear</option>
+            value={profileId}
+            onChange={(event) => setProfileId(event.currentTarget.value)}
+          >
+            {!profileId ? (
+              <option value="" disabled>
+                {capabilities ? "No profiles available" : "Loading profiles…"}
+              </option>
+            ) : null}
+            {profileId &&
+            !capabilities?.profiles.some(
+              (profile) => profile.id === profileId,
+            ) ? (
+              <option value={profileId}>{profileId}</option>
+            ) : null}
+            {capabilities?.profiles.map((profile) => (
+              <option key={profile.id} value={profile.id}>
+                {profile.id}
+              </option>
+            ))}
           </select>
         </label>
-        <label>
-          Points
-          <input
-            name="points"
-            type="number"
-            min="1"
-            defaultValue={ac?.points ?? 20}
-          />
-        </label>
-        <label>
-          Start (Hz)
-          <input
-            name="startHz"
-            type="number"
-            step="any"
-            defaultValue={ac?.startHz ?? 1}
-          />
-        </label>
-        <label>
-          Stop (Hz)
-          <input
-            name="stopHz"
-            type="number"
-            step="any"
-            defaultValue={ac?.stopHz ?? 1e6}
-          />
-        </label>
+        <div className="simulation-setup-group simulation-inline-fields columns-2">
+          <label>
+            Corner
+            <input
+              name="corner"
+              defaultValue={saved?.environment.corner ?? ""}
+              placeholder="Profile default"
+            />
+          </label>
+          <label>
+            Temperature (°C)
+            <input
+              name="temperatureC"
+              type="number"
+              step="any"
+              defaultValue={saved?.environment.temperatureC ?? ""}
+              placeholder="Profile default"
+            />
+          </label>
+        </div>
+        <fieldset className="simulation-setup-group simulation-analysis-row">
+          <legend>Analyses</legend>
+          <label>
+            <input
+              name="op"
+              type="checkbox"
+              defaultChecked={
+                !saved || saved.analyses.some((a) => a.kind === "op")
+              }
+            />
+            OP
+          </label>
+          <label>
+            <input
+              name="ac"
+              type="checkbox"
+              checked={acEnabled}
+              onChange={(event) => setAcEnabled(event.currentTarget.checked)}
+            />
+            AC
+          </label>
+          <label>
+            <input
+              name="tran"
+              type="checkbox"
+              checked={tranEnabled}
+              onChange={(event) => setTranEnabled(event.currentTarget.checked)}
+            />
+            TRAN
+          </label>
+        </fieldset>
+        {acEnabled ? (
+          <div className="simulation-setup-group simulation-analysis-settings">
+            <label>
+              AC sweep
+              <select name="sweep" defaultValue={ac?.sweep ?? "dec"}>
+                <option value="dec">Decade</option>
+                <option value="oct">Octave</option>
+                <option value="lin">Linear</option>
+              </select>
+            </label>
+            <div className="simulation-inline-fields columns-3">
+              <label>
+                Points
+                <input
+                  name="points"
+                  type="number"
+                  min="1"
+                  defaultValue={ac?.points ?? 20}
+                />
+              </label>
+              <label>
+                Start (Hz)
+                <input
+                  name="startHz"
+                  type="number"
+                  step="any"
+                  defaultValue={ac?.startHz ?? 1}
+                />
+              </label>
+              <label>
+                Stop (Hz)
+                <input
+                  name="stopHz"
+                  type="number"
+                  step="any"
+                  defaultValue={ac?.stopHz ?? 1e6}
+                />
+              </label>
+            </div>
+          </div>
+        ) : null}
+        {tranEnabled ? (
+          <div className="simulation-setup-group simulation-inline-fields columns-2">
+            <label>
+              TRAN step (s)
+              <input
+                name="tranStepSeconds"
+                type="number"
+                step="any"
+                defaultValue={tran?.stepSeconds ?? 1e-9}
+              />
+            </label>
+            <label>
+              TRAN stop (s)
+              <input
+                name="tranStopSeconds"
+                type="number"
+                step="any"
+                defaultValue={tran?.stopSeconds ?? 1e-6}
+              />
+            </label>
+          </div>
+        ) : null}
         <ProbeSelect
           label="Add voltage probe"
-          placeholder="Choose a Net in the testbench hierarchy"
+          placeholder="Choose a Net"
           options={probeOptions.voltage}
           probes={probes}
           onAdd={(option) => {
             setProbes([...probes, probeFromOption(option)]);
             onDirty(true);
           }}
+          trailingAction={
+            <button
+              type="button"
+              className={pickNetsActive ? "simulation-pick-active" : undefined}
+              aria-pressed={pickNetsActive}
+              onClick={() => onPickNetsChange?.(!pickNetsActive)}
+            >
+              {pickNetsActive ? "Picking Nets…" : "Pick on canvas"}
+            </button>
+          }
         />
-        <button
-          type="button"
-          className={pickNetsActive ? "simulation-pick-active" : undefined}
-          aria-pressed={pickNetsActive}
-          onClick={() => onPickNetsChange?.(!pickNetsActive)}
-        >
-          {pickNetsActive ? "Picking voltage Nets…" : "Pick voltage on canvas"}
-        </button>
         <ProbeSelect
           label="Add current output"
           placeholder="Choose a voltage-source branch"
@@ -927,10 +1009,6 @@ function SetupEditor({
             </li>
           ))}
         </ul>
-        <p>
-          Voltage Outputs target Nets. Current Outputs target a measurable
-          device branch; sources are edited on the testbench canvas.
-        </p>
         <button type="submit">Apply setup</button>
         {saved && (
           <button type="button" onClick={() => onSaveSetup(null)}>
@@ -970,37 +1048,42 @@ function ProbeSelect({
   options,
   probes,
   onAdd,
+  trailingAction,
 }: {
   label: string;
   placeholder: string;
   options: readonly SimulationProbeOption[];
   probes: SimulationStructuredInput["probes"];
   onAdd(option: SimulationProbeOption): void;
+  trailingAction?: ReactNode;
 }) {
   const selected = new Set(probes.map(simulationProbeTargetKey));
   return (
-    <label>
-      {label}
-      <select
-        value=""
-        onChange={(event) => {
-          const option = options.find(
-            (candidate) => candidate.key === event.target.value,
-          );
-          if (option) onAdd(option);
-        }}
-      >
-        <option value="">{placeholder}</option>
-        {options.map((option) => (
-          <option
-            key={option.key}
-            value={option.key}
-            disabled={selected.has(option.key)}
-          >
-            {option.label}
-          </option>
-        ))}
-      </select>
+    <label className="simulation-probe-select">
+      <span>{label}</span>
+      <span className="simulation-probe-control">
+        <select
+          value=""
+          onChange={(event) => {
+            const option = options.find(
+              (candidate) => candidate.key === event.target.value,
+            );
+            if (option) onAdd(option);
+          }}
+        >
+          <option value="">{placeholder}</option>
+          {options.map((option) => (
+            <option
+              key={option.key}
+              value={option.key}
+              disabled={selected.has(option.key)}
+            >
+              {option.label}
+            </option>
+          ))}
+        </select>
+        {trailingAction}
+      </span>
     </label>
   );
 }

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -44,13 +44,18 @@
   grid-template-columns: minmax(0, 1fr) auto;
   grid-template-areas:
     "brand status"
-    "context context"
     "actions actions";
   align-items: center;
   gap: 8px var(--icm-space-2);
   padding: 12px;
   border-bottom: 1px solid var(--icm-border);
   background: var(--icm-surface);
+}
+.simulation-taskbar:has(.simulation-cell-context) {
+  grid-template-areas:
+    "brand status"
+    "context context"
+    "actions actions";
 }
 .simulation-brand {
   grid-area: brand;
@@ -219,15 +224,79 @@
   font-size: 18px;
 }
 .simulation-setup-panel form {
-  padding: 10px 12px 16px;
+  padding: 8px 10px 12px;
 }
 .simulation-setup-panel label {
   display: grid;
   grid-template-columns: minmax(110px, 0.8fr) minmax(130px, 1.2fr);
   align-items: center;
   gap: 8px;
-  margin: 9px 0;
+  margin: 6px 0;
   font-size: var(--icm-font-sm);
+}
+.simulation-inline-fields {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  margin: 6px 0;
+}
+.simulation-inline-fields.columns-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.simulation-inline-fields.columns-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.simulation-inline-fields > label {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 4px;
+  min-width: 0;
+  margin: 0;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.simulation-setup-group {
+  margin: 8px 0;
+  padding: 8px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: color-mix(
+    in srgb,
+    var(--icm-surface-muted) 34%,
+    var(--icm-surface)
+  );
+}
+.simulation-analysis-row {
+  display: grid;
+  grid-template-columns: auto repeat(3, minmax(54px, 1fr));
+  gap: 6px;
+  align-items: center;
+  min-width: 0;
+  margin: 8px 0;
+  padding: 7px 8px;
+}
+.simulation-analysis-row legend {
+  float: left;
+  margin-right: 4px;
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.simulation-analysis-row > label {
+  display: flex;
+  grid-template-columns: none;
+  gap: 5px;
+  justify-content: center;
+  min-width: 0;
+  min-height: 30px;
+  margin: 0;
+  padding: 4px 6px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: var(--icm-surface-muted);
+  white-space: nowrap;
+}
+.simulation-analysis-settings {
+  padding: 7px 8px 8px;
 }
 .spice-simulation-surface input:not([type="checkbox"]),
 .spice-simulation-surface select {
@@ -254,6 +323,20 @@
 }
 .simulation-setup-panel form > button {
   margin: 8px 8px 0 0;
+}
+.simulation-probe-select {
+  grid-template-columns: minmax(110px, 0.8fr) minmax(130px, 1.2fr);
+}
+.simulation-probe-control {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 6px;
+  align-items: center;
+  min-width: 0;
+}
+.simulation-probe-control > button {
+  min-height: 32px;
+  white-space: nowrap;
 }
 .simulation-pick-active {
   border-color: var(--icm-accent) !important;
@@ -500,6 +583,97 @@
   cursor: crosshair;
   touch-action: none;
 }
+.ac-plot-shell {
+  position: relative;
+  min-width: 0;
+}
+.ac-plot-toolbar {
+  position: absolute;
+  z-index: 2;
+  top: 7px;
+  right: 7px;
+  display: flex;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+  background: color-mix(in srgb, var(--icm-surface) 94%, transparent);
+  box-shadow: var(--icm-shadow-sm);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 100ms ease;
+}
+.ac-plot-shell:hover .ac-plot-toolbar,
+.ac-plot-shell:focus-within .ac-plot-toolbar,
+.ac-plot-toolbar.expanded {
+  opacity: 1;
+  pointer-events: auto;
+}
+.ac-plot-toolbar button {
+  min-width: 27px;
+  min-height: 25px;
+  padding: 2px 6px;
+  background: var(--icm-surface);
+  font-size: var(--icm-font-xs);
+}
+.ac-plot-dialog-backdrop {
+  position: fixed;
+  z-index: 80;
+  inset: 0;
+  display: grid;
+  padding: 4vh 4vw;
+  place-items: center;
+  background: rgb(15 23 42 / 42%);
+}
+.ac-plot-dialog {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  width: min(1400px, 92vw);
+  height: min(820px, 92vh);
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border: 1px solid var(--icm-border-strong);
+  border-radius: var(--icm-radius-md);
+  background: var(--icm-surface);
+  box-shadow: var(--icm-shadow-md);
+}
+.ac-plot-dialog > header {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--icm-border);
+  background: var(--icm-surface-muted);
+}
+.ac-plot-dialog > header > div {
+  display: grid;
+}
+.ac-plot-dialog > header span {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+  text-transform: capitalize;
+}
+.ac-plot-dialog > header button {
+  min-width: 30px;
+  margin-left: auto;
+  padding: 2px;
+  font-size: 18px;
+}
+.ac-plot-shell.expanded {
+  display: grid;
+  min-height: 0;
+  padding: 12px;
+}
+.ac-plot-shell.expanded .spice-ac-plot {
+  display: grid;
+  min-height: 0;
+  place-items: center;
+}
+.ac-plot-shell.expanded svg {
+  width: 100%;
+  max-height: calc(92vh - 90px);
+}
 .ac-cursor-readout {
   position: sticky;
   bottom: 0;
@@ -517,8 +691,14 @@
   .simulation-taskbar {
     grid-template-columns: minmax(0, 1fr) auto;
     grid-template-areas:
+      "status status"
+      "actions actions";
+  }
+  .simulation-taskbar:has(.simulation-cell-context) {
+    grid-template-areas:
       "context context"
-      "status actions";
+      "status status"
+      "actions actions";
   }
   .simulation-brand,
   .simulation-task-actions > button:nth-child(3) {
@@ -876,6 +1056,19 @@
   fill: none;
   stroke-width: 1.5;
   stroke-linejoin: round;
+  pointer-events: none;
+}
+
+.ac-response .ac-trace.ac-trace-selected {
+  stroke-width: 3;
+}
+
+.ac-response .ac-trace-hit {
+  fill: none;
+  stroke: transparent;
+  stroke-width: 12;
+  pointer-events: stroke;
+  cursor: pointer;
 }
 
 .ac-response .ac-trace.ac-phase {


### PR DESCRIPTION
## Summary
- compact and align Simulation settings, profile and probe controls
- replace wheel zoom with explicit plot tools, markers, trace selection and expanded magnitude/phase plots
- backannotate voltage and current outputs through the canonical hierarchy/object locator while preserving stable probe anchors

## Validation
- focused simulation unit tests
- isolated human simulation Playwright flow
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main (running locally; required checks remain authoritative)

Test-Impact: tests-updated