### PR TITLE
feat(simulation): expose structured transient workspace

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -48,7 +48,7 @@ test("the qualified OTA setup opens unchanged and preserves all root and hierarc
       json: {
         configured: true,
         inputs: ["structured", "raw"],
-        analyses: ["op", "ac"],
+        analyses: ["op", "ac", "tran"],
         parsedAnalyses: ["op", "ac", "tran"],
         profiles: [{ id: profile.id, corners: ["tt"] }],
         maxTimeoutMs: 120000,
@@ -201,7 +201,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
         json: {
           configured: true,
           inputs: ["structured", "raw"],
-          analyses: ["op", "ac"],
+          analyses: ["op", "ac", "tran"],
           parsedAnalyses: ["op", "ac", "tran"],
           profiles: [{ id: profile.id, corners: ["tt"] }],
           maxTimeoutMs: 120000,
@@ -248,6 +248,19 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
                   unit: "V",
                   real: [10, 7, 1],
                   imag: [0, -3, -1],
+                },
+              ],
+            },
+            {
+              analysis: "tran",
+              plotName: "Transient response",
+              timeSeconds: [0, 1e-9, 10e-9],
+              probes: [
+                {
+                  name: "v(out)",
+                  quantity: "voltage",
+                  unit: "V",
+                  value: [0, 0.5, 1],
                 },
               ],
             },
@@ -302,6 +315,10 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await panel
     .getByLabel("Add voltage probe")
     .selectOption({ label: "Testbench · vout" });
+  await panel.getByLabel("TRAN", { exact: true }).check();
+  await panel.getByLabel("TRAN step (s)").fill("1e-9");
+  await panel.getByLabel("TRAN stop (s)").fill("1e-6");
+  await panel.getByLabel("TRAN maximum step (s)").fill("5e-10");
   await panel.getByRole("button", { name: "Apply setup" }).click();
   await panel.getByRole("button", { name: "Run", exact: true }).click();
   await expect.poll(() => executions).toBe(1);
@@ -340,6 +357,9 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     panel.locator(".simulation-output-browser > .selected"),
   ).toHaveCount(1);
   await expect(page.getByTestId("net-highlight-overlay")).toBeVisible();
+  await expect(
+    panel.locator('svg[aria-label="Transient voltage"]'),
+  ).toBeVisible();
   await panel.getByRole("tab", { name: "Files" }).click();
   const download = page.waitForEvent("download");
   await panel
@@ -378,6 +398,16 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   expect(
     JSON.parse(saved.toString()).simulation.input.environment.temperatureC,
   ).toBe(30);
+  expect(
+    JSON.parse(saved.toString()).simulation.input.analyses.find(
+      (analysis: { kind: string }) => analysis.kind === "tran",
+    ),
+  ).toEqual({
+    kind: "tran",
+    stepSeconds: 1e-9,
+    stopSeconds: 1e-6,
+    maxStepSeconds: 5e-10,
+  });
   await page.reload();
   // Explicit import is the persistence contract, not browser recovery heuristics.
   await page.getByTestId("project-file").setInputFiles({
@@ -388,6 +418,8 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await page.getByTestId("open-analog-simulation").click();
   await panel.getByRole("button", { name: "Settings" }).click();
   await expect(panel.getByLabel("Temperature (°C)")).toHaveValue("30");
+  await expect(panel.getByLabel("TRAN", { exact: true })).toBeChecked();
+  await expect(panel.getByLabel("TRAN step (s)")).toHaveValue("1e-9");
   await expect(panel.getByRole("status")).toHaveText("No run yet");
 });
 

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -15,6 +15,7 @@ import type {
 import { downloadTextArtifact } from "../../document/project-file-service";
 import type { BrowserSimulationSession } from "./browser-simulation-session";
 import { AcResultsExplorer } from "./ac-results-explorer";
+import { TransientResultsExplorer } from "./transient-results-explorer";
 import {
   deriveSimulationProbeOptions,
   simulationProbeTargetKey,
@@ -530,11 +531,30 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                         : {})}
                     />
                   ))}
+                {run?.result?.data?.analyses
+                  .filter((analysis) => analysis.analysis === "tran")
+                  .map((analysis, index) => (
+                    <TransientResultsExplorer
+                      key={`tran-${index}`}
+                      analysis={analysis}
+                      vectors={prepared?.vectors ?? []}
+                      probes={
+                        project.simulation?.input.kind === "structured"
+                          ? project.simulation.input.probes
+                          : []
+                      }
+                      labels={outputLabels}
+                      {...(props.onFocusProbe
+                        ? { onFocusProbe: props.onFocusProbe }
+                        : {})}
+                    />
+                  ))}
                 {!run?.result?.data?.analyses.some(
-                  (analysis) => analysis.analysis === "ac",
+                  (analysis) =>
+                    analysis.analysis === "ac" || analysis.analysis === "tran",
                 ) ? (
                   <p className="simulation-empty-result">
-                    Run an AC analysis to see a plot.
+                    Run an AC or transient analysis to see a plot.
                   </p>
                 ) : null}
               </div>
@@ -762,6 +782,16 @@ function SetupEditor({
                         kind: "tran",
                         stepSeconds: Number(data.get("tranStepSeconds")),
                         stopSeconds: Number(data.get("tranStopSeconds")),
+                        ...optionalFormNumber(
+                          data,
+                          "tranStartSeconds",
+                          "startSeconds",
+                        ),
+                        ...optionalFormNumber(
+                          data,
+                          "tranMaxStepSeconds",
+                          "maxStepSeconds",
+                        ),
                       },
                     ]
                   : []),
@@ -938,6 +968,28 @@ function SetupEditor({
                 defaultValue={tran?.stopSeconds ?? 1e-6}
               />
             </label>
+            <label>
+              TRAN start saving (s)
+              <input
+                name="tranStartSeconds"
+                type="number"
+                step="any"
+                min="0"
+                defaultValue={tran?.startSeconds ?? ""}
+                placeholder="0"
+              />
+            </label>
+            <label>
+              TRAN maximum step (s)
+              <input
+                name="tranMaxStepSeconds"
+                type="number"
+                step="any"
+                min="0"
+                defaultValue={tran?.maxStepSeconds ?? ""}
+                placeholder="Simulator default"
+              />
+            </label>
           </div>
         ) : null}
         <ProbeSelect
@@ -1018,6 +1070,15 @@ function SetupEditor({
       </form>
     </aside>
   );
+}
+
+function optionalFormNumber(
+  data: FormData,
+  formName: "tranStartSeconds" | "tranMaxStepSeconds",
+  outputName: "startSeconds" | "maxStepSeconds",
+): Partial<Record<typeof outputName, number>> {
+  const value = String(data.get(formName) ?? "").trim();
+  return value ? { [outputName]: Number(value) } : {};
 }
 
 function probeFromOption(

--- a/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
@@ -1,0 +1,68 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  TransientResultsExplorer,
+  transientPolylinePoints,
+} from "./transient-results-explorer";
+
+describe("Transient Results Explorer", () => {
+  it("maps the simulator's actual time coordinates rather than point indices", () => {
+    const points = transientPolylinePoints([0, 1e-9, 10e-9], [0, 0.5, 1]);
+    const x = points.split(" ").map((point) => Number(point.split(",")[0]));
+    expect(x[1]! - x[0]!).toBeLessThan((x[2]! - x[0]!) / 5);
+  });
+
+  it("presents linked voltage and current time-domain outputs", () => {
+    const markup = renderToStaticMarkup(
+      <TransientResultsExplorer
+        analysis={{
+          analysis: "tran",
+          plotName: "Transient Analysis",
+          timeSeconds: [0, 1e-9, 10e-9],
+          probes: [
+            {
+              name: "v(out)",
+              quantity: "voltage",
+              unit: "V",
+              value: [0, 0.5, 1],
+            },
+            {
+              name: "i(v1)",
+              quantity: "current",
+              unit: "A",
+              value: [0, 1e-3, 0],
+            },
+          ],
+        }}
+        vectors={[
+          { probeId: "probe-out", vector: "v(out)", quantity: "voltage" },
+          { probeId: "probe-v1", vector: "i(v1)", quantity: "current" },
+        ]}
+        probes={[
+          {
+            id: "probe-out",
+            kind: "net-voltage",
+            documentId: "tb",
+            anchor: { kind: "base-net", netId: "out" },
+            occurrence: [],
+          },
+          {
+            id: "probe-v1",
+            kind: "source-current",
+            documentId: "tb",
+            instanceId: "V1",
+            occurrence: [],
+          },
+        ]}
+        labels={{ "probe-out": "VOUT", "probe-v1": "IIN" }}
+      />,
+    );
+
+    expect(markup).toContain("VOUT");
+    expect(markup).toContain("IIN");
+    expect(markup).toContain('aria-label="Transient voltage"');
+    expect(markup).toContain('aria-label="Transient current"');
+    expect(markup.match(/data-trace-index=/gu)).toHaveLength(2);
+  });
+});

--- a/apps/editor/src/features/simulation/transient-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.tsx
@@ -1,0 +1,248 @@
+import { useMemo, useState } from "react";
+import type { SimulationProbeSpec } from "@icm/model";
+import type { TransientResult } from "@icm/spice-run";
+import type { Prepared } from "@icm/simulation-service/contract";
+
+interface TransientTrace {
+  readonly id: string;
+  readonly label: string;
+  readonly colorIndex: number;
+  readonly quantity: "voltage" | "current";
+  readonly unit: string | null;
+  readonly values: readonly number[];
+  readonly probe?: SimulationProbeSpec;
+}
+
+export interface TransientResultsExplorerProps {
+  analysis: TransientResult;
+  vectors: Prepared["vectors"];
+  probes: readonly SimulationProbeSpec[];
+  labels?: Readonly<Record<string, string>>;
+  onFocusProbe?(probe: SimulationProbeSpec): void;
+}
+
+const PLOT = {
+  width: 760,
+  height: 230,
+  left: 64,
+  right: 14,
+  top: 14,
+  bottom: 32,
+} as const;
+
+function finiteExtent(values: readonly number[]): readonly [number, number] {
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (const value of values) {
+    if (!Number.isFinite(value)) continue;
+    min = Math.min(min, value);
+    max = Math.max(max, value);
+  }
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return [-1, 1];
+  if (min !== max) return [min, max];
+  const margin = Math.max(Math.abs(min) * 0.05, 1e-12);
+  return [min - margin, max + margin];
+}
+
+function compact(value: number): string {
+  if (value === 0) return "0";
+  const magnitude = Math.abs(value);
+  const scales = [
+    [1e9, "G"],
+    [1e6, "M"],
+    [1e3, "k"],
+    [1, ""],
+    [1e-3, "m"],
+    [1e-6, "µ"],
+    [1e-9, "n"],
+    [1e-12, "p"],
+  ] as const;
+  const scale = scales.find(([factor]) => magnitude >= factor) ?? [1e-15, "f"];
+  return `${(value / scale[0]).toPrecision(4).replace(/\.0+$/u, "")}${scale[1]}`;
+}
+
+export function transientPolylinePoints(
+  timeSeconds: readonly number[],
+  values: readonly number[],
+  yExtent: readonly [number, number] = finiteExtent(values),
+): string {
+  const count = Math.min(timeSeconds.length, values.length);
+  if (count === 0) return "";
+  const [timeMin, timeMax] = finiteExtent(timeSeconds.slice(0, count));
+  const timeSpan = timeMax - timeMin;
+  const valueSpan = yExtent[1] - yExtent[0];
+  const plotWidth = PLOT.width - PLOT.left - PLOT.right;
+  const plotHeight = PLOT.height - PLOT.top - PLOT.bottom;
+  const points: string[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const time = timeSeconds[index]!;
+    const value = values[index]!;
+    if (!Number.isFinite(time) || !Number.isFinite(value)) continue;
+    const x = PLOT.left + ((time - timeMin) / timeSpan) * plotWidth;
+    const y = PLOT.top + ((yExtent[1] - value) / valueSpan) * plotHeight;
+    points.push(`${x.toFixed(2)},${y.toFixed(2)}`);
+  }
+  return points.join(" ");
+}
+
+function outputTraces(
+  analysis: TransientResult,
+  vectors: Prepared["vectors"],
+  probes: readonly SimulationProbeSpec[],
+  labels: Readonly<Record<string, string>>,
+): TransientTrace[] {
+  const vectorsByName = new Map(
+    vectors.map((vector) => [vector.vector.toLowerCase(), vector]),
+  );
+  const probesById = new Map(probes.map((probe) => [probe.id, probe]));
+  return analysis.probes.map((resultProbe, index) => {
+    const binding = vectorsByName.get(resultProbe.name.toLowerCase());
+    const authored = binding ? probesById.get(binding.probeId) : undefined;
+    return {
+      id: binding?.probeId ?? resultProbe.name,
+      label: (binding && labels[binding.probeId]) || resultProbe.name,
+      colorIndex: index,
+      quantity:
+        binding?.quantity ??
+        (resultProbe.quantity === "current" ? "current" : "voltage"),
+      unit: resultProbe.unit,
+      values: resultProbe.value,
+      ...(authored ? { probe: authored } : {}),
+    };
+  });
+}
+
+export function TransientResultsExplorer({
+  analysis,
+  vectors,
+  probes,
+  labels = {},
+  onFocusProbe,
+}: TransientResultsExplorerProps) {
+  const traces = useMemo(
+    () => outputTraces(analysis, vectors, probes, labels),
+    [analysis, labels, probes, vectors],
+  );
+  const [hidden, setHidden] = useState<ReadonlySet<string>>(() => new Set());
+  const [selected, setSelected] = useState<string | null>(null);
+  const visible = traces.filter((trace) => !hidden.has(trace.id));
+  const [timeMin, timeMax] = finiteExtent(analysis.timeSeconds);
+
+  return (
+    <div className="transient-results-explorer">
+      <header>
+        <div>
+          <strong>{analysis.plotName}</strong>
+          <small>
+            {analysis.timeSeconds.length} solver points · {compact(timeMin)}s to{" "}
+            {compact(timeMax)}s
+          </small>
+        </div>
+      </header>
+      <div className="simulation-output-browser" aria-label="Transient outputs">
+        {traces.map((trace) => {
+          const isVisible = !hidden.has(trace.id);
+          return (
+            <div
+              key={trace.id}
+              className={selected === trace.id ? "selected" : undefined}
+            >
+              <button
+                type="button"
+                className={`simulation-output-swatch ac-trace-${trace.colorIndex % 6}`}
+                aria-label={`${isVisible ? "Hide" : "Show"} ${trace.label}`}
+                aria-pressed={isVisible}
+                onClick={() =>
+                  setHidden((current) => {
+                    const next = new Set(current);
+                    if (next.has(trace.id)) next.delete(trace.id);
+                    else next.add(trace.id);
+                    return next;
+                  })
+                }
+              />
+              <button
+                type="button"
+                className="simulation-output-name"
+                onClick={() => {
+                  setSelected(trace.id);
+                  if (trace.probe) onFocusProbe?.(trace.probe);
+                }}
+              >
+                <strong>{trace.label}</strong>
+                <small>
+                  {trace.quantity} · {trace.probe ? "linked" : trace.id}
+                </small>
+              </button>
+            </div>
+          );
+        })}
+      </div>
+      {(["voltage", "current"] as const).map((quantity) => {
+        const quantityTraces = visible.filter(
+          (trace) => trace.quantity === quantity,
+        );
+        if (quantityTraces.length === 0) return null;
+        const extent = finiteExtent(
+          quantityTraces.flatMap((trace) => trace.values),
+        );
+        const unit = quantityTraces.find((trace) => trace.unit)?.unit ?? "";
+        return (
+          <section key={quantity} className="transient-quantity-group">
+            <h4>{quantity === "voltage" ? "Voltage" : "Current"}</h4>
+            <svg
+              role="img"
+              aria-label={`Transient ${quantity}`}
+              viewBox={`0 0 ${PLOT.width} ${PLOT.height}`}
+            >
+              <line
+                className="transient-axis"
+                x1={PLOT.left}
+                y1={PLOT.top}
+                x2={PLOT.left}
+                y2={PLOT.height - PLOT.bottom}
+              />
+              <line
+                className="transient-axis"
+                x1={PLOT.left}
+                y1={PLOT.height - PLOT.bottom}
+                x2={PLOT.width - PLOT.right}
+                y2={PLOT.height - PLOT.bottom}
+              />
+              <text x={PLOT.left} y={PLOT.height - 8}>
+                {compact(timeMin)}s
+              </text>
+              <text
+                textAnchor="end"
+                x={PLOT.width - PLOT.right}
+                y={PLOT.height - 8}
+              >
+                {compact(timeMax)}s
+              </text>
+              <text x={4} y={PLOT.top + 5}>
+                {compact(extent[1])}
+                {unit}
+              </text>
+              <text x={4} y={PLOT.height - PLOT.bottom}>
+                {compact(extent[0])}
+                {unit}
+              </text>
+              {quantityTraces.map((trace) => (
+                <polyline
+                  key={trace.id}
+                  className={`transient-trace ac-trace-${trace.colorIndex % 6}`}
+                  data-trace-index={trace.colorIndex}
+                  points={transientPolylinePoints(
+                    analysis.timeSeconds,
+                    trace.values,
+                    extent,
+                  )}
+                />
+              ))}
+            </svg>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -482,6 +482,54 @@
   height: auto;
 }
 
+.transient-results-explorer {
+  display: grid;
+  gap: 10px;
+}
+.transient-results-explorer > header > div {
+  display: grid;
+  gap: 2px;
+}
+.transient-results-explorer > header small {
+  color: var(--icm-text-muted);
+  font-size: var(--icm-font-xs);
+}
+.transient-quantity-group svg {
+  width: 100%;
+  height: auto;
+  color: var(--icm-text-muted);
+  font-size: 12px;
+}
+.transient-axis {
+  stroke: var(--icm-border-strong);
+  stroke-width: 1;
+}
+.transient-trace {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+.transient-trace.ac-trace-0 {
+  color: #175cd3;
+}
+.transient-trace.ac-trace-1 {
+  color: #b54708;
+}
+.transient-trace.ac-trace-2 {
+  color: #067647;
+}
+.transient-trace.ac-trace-3 {
+  color: #6941c6;
+}
+.transient-trace.ac-trace-4 {
+  color: #b42318;
+}
+.transient-trace.ac-trace-5 {
+  color: #026aa2;
+}
+
 .ac-results-explorer {
   position: relative;
   display: grid;

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -474,6 +474,12 @@ descriptor's DC, AC, PULSE, and SIN fields directly. Switching the selected
 waveform hides but retains inactive fields; only the selected waveform is
 printed into the prepared deck.
 
+The human Setup workspace authors OP, AC, and TRAN through this same structured
+analysis contract. TRAN exposes `tstep`, `tstop`, and the optional `tstart` and
+`tmax` values in explicit seconds. Its Plot view consumes the structured
+transient result and the simulator-recorded time axis; it does not reconstruct
+time from a point index or a requested output interval.
+
 On the voltage-source and current-source descriptors the DC value is `dc` and
 the small-signal stimulus is the optional pair `acMagnitude` (volts or
 amperes) and `acPhase` (degrees). The SPICE printer emits


### PR DESCRIPTION
## Summary
- complete the refined Simulation Settings UI with optional TRAN start-save and maximum-step fields
- render structured transient voltage/current results against ngspice's recorded time axis
- extend the human simulation journey through TRAN setup, plot, persistence and reload

## Validation
- pnpm typecheck
- 50 simulation feature tests
- focused human simulation Playwright flow
- pnpm gate:preflight -- --base origin/main
- pnpm gate:affected -- --base origin/main (2671 unit/integration tests; 5 Agent/simulation browser tests)
- git diff --check

Test-Impact: tests-updated