### PR TITLE
feat(simulation): close input-run-result consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ edit model.
   and child Cells.
 - **Projects and interchange:** save a private Cloud Project, import/export
   canonical `.icproj.json`, import structural `.cir`, `.sp`, and `.spi` files, and export
-  deterministic structural SPICE or Spectre. Analog Canvas does not supply
-  simulation, PDKs, device models, corners, stimuli, or analyses.
+  deterministic structural SPICE or Spectre. The Preview editor also provides
+  a saved Testbench setup and a fixed ngspice/SKY130 environment for qualified
+  OP, AC, and TRAN runs; Production availability remains release-controlled.
 - **Publication-ready output:** the web editor's SVG and PDF exports remain
   vector graphics; PNG is rendered at 3× raster scale.
 - **Community publishing:** signed-in users can publish selected circuits with

--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -257,7 +257,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
               timeSeconds: [0, 1e-9, 10e-9],
               probes: [
                 {
-                  name: "v(out)",
+                  name: requestedVector,
                   quantity: "voltage",
                   unit: "V",
                   value: [0, 0.5, 1],
@@ -319,6 +319,7 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await panel.getByLabel("TRAN step (s)").fill("1e-9");
   await panel.getByLabel("TRAN stop (s)").fill("1e-6");
   await panel.getByLabel("TRAN maximum step (s)").fill("5e-10");
+  await panel.getByLabel(/Output name for/).fill("first-output");
   await panel.getByRole("button", { name: "Apply setup" }).click();
   await panel.getByRole("button", { name: "Run", exact: true }).click();
   await expect.poll(() => executions).toBe(1);
@@ -332,9 +333,10 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     "0.500000",
   );
   await panel.getByRole("tab", { name: "Plot" }).click();
-  await expect(panel.locator(".spice-ac-plot svg")).toHaveCount(2);
+  await expect(panel.locator(".spice-ac-plot svg")).toHaveCount(3);
   await expect(panel.locator('svg[aria-label="AC magnitude"]')).toBeVisible();
   await expect(panel.locator('svg[aria-label="AC phase"]')).toBeVisible();
+  await expect(panel.getByText("first-output", { exact: true })).toHaveCount(2);
   const magnitudePlot = panel
     .locator(".ac-plot-row")
     .filter({ hasText: "Magnitude" })
@@ -361,6 +363,9 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     panel.locator('svg[aria-label="Transient voltage"]'),
   ).toBeVisible();
   await panel.getByRole("tab", { name: "Files" }).click();
+  await expect(
+    panel.getByRole("button", { name: "evidence-manifest.json" }),
+  ).toBeVisible();
   const download = page.waitForEvent("download");
   await panel
     .getByRole("button", { name: /\.csv$/ })
@@ -380,11 +385,16 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   );
   expect(executions).toBe(1);
   await panel.getByRole("button", { name: "Settings" }).click();
+  await panel.getByLabel(/Output name for/).fill("new-output");
   await panel.getByLabel("Temperature (°C)").fill("30");
   await panel.getByRole("button", { name: "Apply setup" }).click();
   await expect(panel.getByRole("alert")).toContainText(
     "earlier Project revision",
   );
+  await panel.getByRole("button", { name: "Results" }).click();
+  await panel.getByRole("tab", { name: "Plot" }).click();
+  await expect(panel.getByText("first-output", { exact: true })).toHaveCount(2);
+  await expect(panel.getByText("new-output", { exact: true })).toHaveCount(0);
   pending = new Promise<void>((r) => {
     release = r;
   });

--- a/apps/editor/src/app/App.tsx
+++ b/apps/editor/src/app/App.tsx
@@ -1029,6 +1029,7 @@ export function App({
     sequence: number;
     documentId: string;
     netId: string;
+    occurrence?: readonly string[];
   } | null>(null);
   const [pendingWaveformPlacement, setPendingWaveformPlacement] =
     useState<PendingWaveformPlacement | null>(null);
@@ -1529,10 +1530,21 @@ export function App({
     }
     const group = logicalNets.byBaseNetId.get(baseNetId);
     if (analogSimulationOpen) {
+      const setupRootId =
+        project.simulation?.input.kind === "structured"
+          ? project.simulation.input.rootDocumentId
+          : undefined;
+      const occurrence =
+        documentStack.length > 0
+          ? documentStack.map((frame) => frame.instanceId)
+          : setupRootId === document.id
+            ? []
+            : undefined;
       setAnalogPickedNet((current) => ({
         sequence: (current?.sequence ?? 0) + 1,
         documentId: document.id,
         netId: baseNetId,
+        ...(occurrence === undefined ? {} : { occurrence }),
       }));
       setStatus(`Added voltage Output ${group?.name ?? baseNetId}`);
       return;
@@ -4631,7 +4643,10 @@ export function App({
               pickNetsActive={simulationPickNetsActive}
               pickedNet={analogPickedNet}
               onPickNetsChange={setSimulationPickMode}
-              onFocusProbe={(probe) => {
+              onFocusDiagnostic={(locator) =>
+                navigateToLocator(locator, `Located ${locator.kind}`)
+              }
+              onFocusProbe={(probe, preparedRootDocumentId) => {
                 const targetDocument = project.documents.find(
                   (candidate) => candidate.id === probe.documentId,
                 );
@@ -4653,9 +4668,10 @@ export function App({
                 }
                 const input = project.simulation?.input;
                 const rootDocumentId =
-                  input?.kind === "structured"
+                  preparedRootDocumentId ??
+                  (input?.kind === "structured"
                     ? input.rootDocumentId
-                    : probe.documentId;
+                    : probe.documentId);
                 const hierarchyPath = simulationProbeHierarchyPath(
                   project,
                   rootDocumentId,

--- a/apps/editor/src/features/simulation/simulation-probe-options.test.ts
+++ b/apps/editor/src/features/simulation/simulation-probe-options.test.ts
@@ -4,6 +4,7 @@ import { CircuitProjectSchema } from "@icm/model";
 import fiveTransistorOtaSky130 from "../../examples/five-transistor-ota-sky130.icproj.json";
 import {
   deriveSimulationProbeOptions,
+  matchSimulationVoltageProbeOptions,
   resolveSimulationVoltageProbeNetId,
   simulationProbeHierarchyPath,
   simulationProbeTargetKey,
@@ -72,6 +73,20 @@ describe("simulation probe choices", () => {
     expect(
       targets.map((option) => simulationProbeTargetKey(option.target)),
     ).toEqual(targets.map((option) => option.key));
+
+    expect(
+      matchSimulationVoltageProbeOptions(project, targets, {
+        documentId: "document-ota-5t",
+        netId: "net-dut-tail",
+      }),
+    ).toHaveLength(2);
+    expect(
+      matchSimulationVoltageProbeOptions(project, targets, {
+        documentId: "document-ota-5t",
+        netId: "net-dut-tail",
+        occurrence: ["XDUT2"],
+      }).map((option) => option.target.occurrence),
+    ).toEqual([["XDUT2"]]);
   });
 
   it("resolves an object anchor for canvas focus and matches its whole Logical Net", () => {

--- a/apps/editor/src/features/simulation/simulation-probe-options.ts
+++ b/apps/editor/src/features/simulation/simulation-probe-options.ts
@@ -29,6 +29,12 @@ export interface SimulationProbeOptions {
   readonly sourceCurrent: readonly SimulationProbeOption<SourceCurrentProbeTarget>[];
 }
 
+export interface PickedSimulationNet {
+  readonly documentId: string;
+  readonly netId: string;
+  readonly occurrence?: readonly string[];
+}
+
 export function simulationProbeTargetKey(target: ProbeTarget): string {
   const occurrence = target.occurrence.join("/");
   if (target.kind === "source-current")
@@ -88,6 +94,28 @@ export function simulationVoltageProbeTargetsNet(
     resolveDocumentLogicalNets(document)
       .byBaseNetId.get(anchoredNetId)
       ?.baseNetIds.includes(netId) ?? false
+  );
+}
+
+/**
+ * Resolve a canvas pick without collapsing repeated Cell occurrences. A
+ * definition-only pick intentionally returns every matching occurrence so the
+ * caller can ask instead of silently choosing X1 over X2.
+ */
+export function matchSimulationVoltageProbeOptions(
+  project: CircuitProject,
+  options: readonly SimulationProbeOption<VoltageProbeTarget>[],
+  picked: PickedSimulationNet,
+): readonly SimulationProbeOption<VoltageProbeTarget>[] {
+  return options.filter(
+    (candidate) =>
+      candidate.target.documentId === picked.documentId &&
+      (picked.occurrence === undefined ||
+        (candidate.target.occurrence.length === picked.occurrence.length &&
+          candidate.target.occurrence.every(
+            (id, index) => id === picked.occurrence?.[index],
+          ))) &&
+      simulationVoltageProbeTargetsNet(project, candidate.target, picked.netId),
   );
 }
 

--- a/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.test.tsx
@@ -48,4 +48,35 @@ describe("SpiceSimulationSurface workspace", () => {
     expect(markup).not.toContain("<span>Preview</span>");
     expect(markup).not.toContain('class="simulation-results-dock"');
   });
+
+  it("keeps a saved raw setup distinct from the structured editor", () => {
+    const project = createEmptyProject("raw-simulation", "Raw");
+    project.simulation = {
+      version: 1,
+      input: {
+        kind: "raw",
+        entry: "tb.cir",
+        files: [{ path: "tb.cir", text: ".end\n" }],
+        dependencies: [],
+        environment: { profileId: "raw-profile" },
+      },
+    };
+    const markup = renderToStaticMarkup(
+      <SpiceSimulationSurface
+        open
+        project={project}
+        activeDocumentId={project.topDocumentId}
+        session={{} as BrowserSimulationSession}
+        onMinimize={() => undefined}
+        onExit={() => undefined}
+        onSaveSetup={() => true}
+        onOpenCell={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Raw setup");
+    expect(markup).toContain("tb.cir");
+    expect(markup).toContain("Switch to structured setup");
+    expect(markup).not.toContain("Add voltage probe");
+  });
 });

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import {
+  type ObjectLocator,
   SimulationSetupSchema,
   type CircuitProject,
   type SimulationSetup,
@@ -9,6 +10,7 @@ import type {
   ArtifactRef,
   Capabilities,
   Prepared,
+  Problem,
   Run,
   SimulationReply,
 } from "@icm/simulation-service/contract";
@@ -18,8 +20,8 @@ import { AcResultsExplorer } from "./ac-results-explorer";
 import { TransientResultsExplorer } from "./transient-results-explorer";
 import {
   deriveSimulationProbeOptions,
+  matchSimulationVoltageProbeOptions,
   simulationProbeTargetKey,
-  simulationVoltageProbeTargetsNet,
   type SimulationProbeOption,
 } from "./simulation-probe-options";
 
@@ -57,9 +59,27 @@ export interface SpiceSimulationSurfaceProps {
     readonly sequence: number;
     readonly documentId: string;
     readonly netId: string;
+    /** Instance ids from the selected Testbench root to this Cell. */
+    readonly occurrence?: readonly string[];
   } | null;
   onPickNetsChange?(active: boolean): void;
-  onFocusProbe?(probe: SimulationStructuredInput["probes"][number]): void;
+  onFocusProbe?(
+    probe: SimulationStructuredInput["probes"][number],
+    rootDocumentId?: string,
+  ): void;
+  onFocusDiagnostic?(locator: ObjectLocator): void;
+}
+
+interface PreparedPresentation {
+  readonly prepared: Prepared;
+  readonly probes: SimulationStructuredInput["probes"];
+  readonly labels: Readonly<Record<string, string>>;
+  readonly analysisLabel: string;
+  readonly rootDocumentId?: string;
+}
+
+function uiProblem(code: string, message: string): Problem {
+  return { code, message, stage: "input", recovery: "fix-input" };
 }
 
 /** A projection of the same prepare/start/read/cancel service used by MCP.
@@ -69,11 +89,12 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const [capabilities, setCapabilities] = useState<Capabilities>();
   const [prepared, setPrepared] = useState<Prepared>();
   const [run, setRun] = useState<Run>();
-  const [error, setError] = useState("");
+  const [problem, setProblem] = useState<Problem>();
   const [busy, setBusy] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [outputLabels, setOutputLabels] = useState<Record<string, string>>({});
-  const [setupOpen, setSetupOpen] = useState(!project.simulation);
+  const preparedPresentations = useRef(new Map<string, PreparedPresentation>());
+  const [setupOpen, setSetupOpen] = useState(true);
   const [resultsOpen, setResultsOpen] = useState(false);
   const [resultTab, setResultTab] = useState<ResultTab>("summary");
   const [exitConfirmationOpen, setExitConfirmationOpen] = useState(false);
@@ -93,9 +114,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   const receive = (reply: SimulationReply) => {
     if (!alive.current) return;
     if (!reply.ok) {
-      setError(
-        `${reply.error.code}: ${reply.error.message}${reply.error.diagnostics?.map((d) => `\n${d.code}: ${d.message}`).join("") ?? ""}`,
-      );
+      setProblem(reply.error);
       if (project.simulation) {
         setSetupOpen(false);
         setResultsOpen(true);
@@ -106,7 +125,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
       }
     } else if ("run" in reply) {
       setRun(reply.run);
-      setError("");
+      setProblem(undefined);
       if (
         reply.run.result ||
         reply.run.error ||
@@ -118,13 +137,13 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
       }
     } else if ("prepared" in reply) {
       setPrepared(reply.prepared);
-      setError("");
+      setProblem(undefined);
       setSetupOpen(false);
       setResultsOpen(true);
       setResultTab("files");
     } else if ("capabilities" in reply) {
       setCapabilities(reply.capabilities);
-      setError("");
+      setProblem(undefined);
     }
   };
   useEffect(() => {
@@ -158,7 +177,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     if (lock.current) return;
     lock.current = true;
     setBusy(true);
-    setError("");
+    setProblem(undefined);
     try {
       const reply = await session.handle({
         operation: "prepare",
@@ -167,6 +186,26 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
           expectedStructureRevision: project.structureRevision,
         },
       });
+      if (reply.ok && "prepared" in reply) {
+        const input = project.simulation?.input;
+        preparedPresentations.current.set(reply.prepared.id, {
+          prepared: structuredClone(reply.prepared),
+          probes:
+            input?.kind === "structured" ? structuredClone(input.probes) : [],
+          labels: { ...outputLabels },
+          analysisLabel:
+            input?.kind === "structured"
+              ? input.analyses
+                  .map((analysis) => analysis.kind.toUpperCase())
+                  .join(" + ")
+              : input?.kind === "raw"
+                ? "RAW"
+                : "",
+          ...(input?.kind === "structured"
+            ? { rootDocumentId: input.rootDocumentId }
+            : {}),
+        });
+      }
       receive(reply);
       if (start && reply.ok && "prepared" in reply && alive.current)
         receive(
@@ -191,7 +230,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
         offset,
       });
       if (!chunk.ok) {
-        setError(chunk.error.message);
+        setProblem(chunk.error);
         return;
       }
       if (!("text" in chunk)) return;
@@ -199,7 +238,8 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
       offset = chunk.nextOffset;
     }
     const result = downloadTextArtifact(text, artifact.name);
-    if (result.status === "failed") setError(result.message);
+    if (result.status === "failed")
+      setProblem(uiProblem("ARTIFACT_DOWNLOAD_FAILED", result.message));
   };
   const running = run && ["running", "cancelling"].includes(run.state);
   const activeCell = project.documents.find(
@@ -251,25 +291,29 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
     run?.inputStatus === "changed"
       ? "Result belongs to an earlier Project revision. Run again to use the current circuit."
       : "";
-  const attention =
-    error ||
-    staleMessage ||
-    (run?.error ? `${run.error.code}: ${run.error.message}` : "");
-  const attentionSummary = error
-    ? error.startsWith("SIMULATION_CAPABILITIES_UNAVAILABLE")
+  const activeProblem = problem ?? run?.error;
+  const attention = activeProblem || staleMessage;
+  const problemSearchText = activeProblem
+    ? [
+        activeProblem.code,
+        activeProblem.message,
+        ...(activeProblem.diagnostics ?? []).flatMap((diagnostic) => [
+          diagnostic.code,
+          diagnostic.message,
+        ]),
+      ].join(" ")
+    : "";
+  const attentionSummary = activeProblem
+    ? activeProblem.code === "SIMULATION_CAPABILITIES_UNAVAILABLE"
       ? "Simulation service is unavailable in this environment."
-      : /probe/i.test(error)
+      : /probe/i.test(problemSearchText)
         ? "The probe selection needs attention. Open Console for details."
         : "Simulation needs attention. Open Console for details."
-    : attention;
-  const analysisLabel =
-    project.simulation?.input.kind === "structured"
-      ? project.simulation.input.analyses
-          .map((analysis) => analysis.kind.toUpperCase())
-          .join(" + ")
-      : project.simulation?.input.kind === "raw"
-        ? "RAW"
-        : undefined;
+    : staleMessage;
+  const runPresentation = run
+    ? preparedPresentations.current.get(run.preparedId)
+    : undefined;
+  const analysisLabel = runPresentation?.analysisLabel;
   return (
     <section
       hidden={!open}
@@ -413,7 +457,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
         <div className="simulation-workspace-notice" role="alert">
           <strong>Needs attention</strong>
           <span>{attentionSummary}</span>
-          {error && run ? (
+          {activeProblem?.recovery === "retry-same-request" && run ? (
             <button
               onClick={() =>
                 void session
@@ -444,7 +488,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
           {...props}
           capabilities={capabilities}
           onDirty={setDirty}
-          onError={setError}
+          onProblem={setProblem}
           outputLabels={outputLabels}
           onOutputLabelChange={(probeId, label) =>
             setOutputLabels((current) => {
@@ -499,7 +543,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                     choosing a new run.
                   </p>
                 ) : null}
-                {prepared?.warnings.map((warning, index) => (
+                {runPresentation?.prepared.warnings.map((warning, index) => (
                   <p key={index}>{warning}</p>
                 ))}
                 {run?.resultPreview ? (
@@ -519,15 +563,19 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                     <AcResultsExplorer
                       key={index}
                       analysis={analysis}
-                      vectors={prepared?.vectors ?? []}
-                      probes={
-                        project.simulation?.input.kind === "structured"
-                          ? project.simulation.input.probes
-                          : []
-                      }
-                      labels={outputLabels}
+                      vectors={runPresentation?.prepared.vectors ?? []}
+                      probes={runPresentation?.probes ?? []}
+                      labels={runPresentation?.labels ?? {}}
                       {...(props.onFocusProbe
-                        ? { onFocusProbe: props.onFocusProbe }
+                        ? {
+                            onFocusProbe: (
+                              probe: SimulationStructuredInput["probes"][number],
+                            ) =>
+                              props.onFocusProbe?.(
+                                probe,
+                                runPresentation?.rootDocumentId,
+                              ),
+                          }
                         : {})}
                     />
                   ))}
@@ -537,15 +585,19 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                     <TransientResultsExplorer
                       key={`tran-${index}`}
                       analysis={analysis}
-                      vectors={prepared?.vectors ?? []}
-                      probes={
-                        project.simulation?.input.kind === "structured"
-                          ? project.simulation.input.probes
-                          : []
-                      }
-                      labels={outputLabels}
+                      vectors={runPresentation?.prepared.vectors ?? []}
+                      probes={runPresentation?.probes ?? []}
+                      labels={runPresentation?.labels ?? {}}
                       {...(props.onFocusProbe
-                        ? { onFocusProbe: props.onFocusProbe }
+                        ? {
+                            onFocusProbe: (
+                              probe: SimulationStructuredInput["probes"][number],
+                            ) =>
+                              props.onFocusProbe?.(
+                                probe,
+                                runPresentation?.rootDocumentId,
+                              ),
+                          }
                         : {})}
                     />
                   ))}
@@ -599,11 +651,13 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
 
             {resultTab === "console" ? (
               <div className="simulation-console-view">
-                {error ? <pre>{error}</pre> : null}
-                {run?.error ? (
-                  <pre>
-                    {run.error.code}: {run.error.message}
-                  </pre>
+                {activeProblem ? (
+                  <SimulationProblemView
+                    problem={activeProblem}
+                    {...(props.onFocusDiagnostic
+                      ? { onFocus: props.onFocusDiagnostic }
+                      : {})}
+                  />
                 ) : null}
                 {run?.result ? (
                   <pre>
@@ -614,7 +668,7 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                     {run.result.log}
                   </pre>
                 ) : null}
-                {!error && !run?.error && !run?.result ? (
+                {!activeProblem && !run?.result ? (
                   <p className="simulation-empty-result">
                     Simulator diagnostics will appear here.
                   </p>
@@ -667,6 +721,75 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
   );
 }
 
+const RECOVERY_LABELS: Record<Problem["recovery"], string> = {
+  "fix-input": "Review the highlighted input and apply the correction.",
+  reprepare: "The input changed. Prepare it again before running.",
+  "retry-same-request":
+    "The response is uncertain. Refresh this run; do not start a duplicate.",
+  "retry-after":
+    "Keep the current work and try again after the service recovers.",
+  reauthorize:
+    "Reconnect the simulation session, then continue with the same Project.",
+  "not-retryable":
+    "This run will not be retried automatically. Preserve its files before starting another.",
+};
+
+function SimulationProblemView({
+  problem,
+  onFocus,
+}: {
+  problem: Problem;
+  onFocus?: (locator: ObjectLocator) => void;
+}) {
+  const locator = (
+    value: NonNullable<NonNullable<Problem["diagnostics"]>[number]["primary"]>,
+  ): ObjectLocator => ({
+    documentId: value.documentId,
+    hierarchyPath: value.hierarchyPath.map((frame) => ({ ...frame })),
+    kind: value.kind,
+    objectId: value.objectId,
+    ...(value.endpoint === undefined ? {} : { endpoint: value.endpoint }),
+    ...(value.sourceRef === undefined ? {} : { sourceRef: value.sourceRef }),
+  });
+  return (
+    <section className="simulation-problem" aria-label="Simulation problem">
+      <header>
+        <strong>{problem.code}</strong>
+        <small>
+          {problem.stage} · {problem.recovery}
+        </small>
+      </header>
+      <p>{problem.message}</p>
+      <p>{RECOVERY_LABELS[problem.recovery]}</p>
+      {problem.retryAfterMs !== undefined ? (
+        <small>
+          Try again after {Math.ceil(problem.retryAfterMs / 1000)} s.
+        </small>
+      ) : null}
+      {problem.diagnostics?.length ? (
+        <ul>
+          {problem.diagnostics.map((diagnostic, index) => (
+            <li key={`${diagnostic.code}:${index}`}>
+              <span>
+                <strong>{diagnostic.code}</strong> {diagnostic.message}
+                {diagnostic.field ? <small>{diagnostic.field}</small> : null}
+              </span>
+              {diagnostic.primary && onFocus ? (
+                <button
+                  type="button"
+                  onClick={() => onFocus(locator(diagnostic.primary!))}
+                >
+                  Show
+                </button>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}
+
 function SetupEditor({
   project,
   activeDocumentId,
@@ -674,7 +797,7 @@ function SetupEditor({
   capabilities,
   onSaveSetup,
   onDirty,
-  onError,
+  onProblem,
   pickNetsActive,
   pickedNet,
   onPickNetsChange,
@@ -683,7 +806,7 @@ function SetupEditor({
 }: SpiceSimulationSurfaceProps & {
   capabilities: Capabilities | undefined;
   onDirty(value: boolean): void;
-  onError(value: string): void;
+  onProblem(value: Problem | undefined): void;
   outputLabels: Readonly<Record<string, string>>;
   onOutputLabelChange(probeId: string, label: string): void;
 }) {
@@ -710,6 +833,14 @@ function SetupEditor({
   const [profileId, setProfileId] = useState(
     saved?.environment.profileId ?? DEVELOPMENT_PROFILE_ID,
   );
+  const rawSaved =
+    project.simulation?.input.kind === "raw"
+      ? project.simulation.input
+      : undefined;
+  const [switchFromRaw, setSwitchFromRaw] = useState(false);
+  const [pickCandidates, setPickCandidates] = useState<
+    readonly SimulationProbeOption[]
+  >([]);
   useEffect(() => {
     const defaultProfileId = capabilities?.profiles[0]?.id;
     if (
@@ -721,18 +852,23 @@ function SetupEditor({
   }, [capabilities?.profiles[0]?.id, profileId, saved?.environment.profileId]);
   useEffect(() => {
     if (!pickedNet) return;
-    const option = probeOptions.voltage.find(
-      (candidate) =>
-        candidate.target.documentId === pickedNet.documentId &&
-        simulationVoltageProbeTargetsNet(
-          project,
-          candidate.target,
-          pickedNet.netId,
-        ),
+    const candidates = matchSimulationVoltageProbeOptions(
+      project,
+      probeOptions.voltage,
+      pickedNet,
     );
+    if (candidates.length > 1) {
+      setPickCandidates(candidates);
+      onProblem(undefined);
+      return;
+    }
+    const option = candidates[0];
     if (!option) {
-      onError(
-        "That Net is outside the selected Testbench occurrence. Choose it from the Output list or change the Testbench Cell.",
+      onProblem(
+        uiProblem(
+          "PROBE_TARGET_UNAVAILABLE",
+          "That Net is outside the selected Testbench occurrence. Choose it from the Output list or change the Testbench Cell.",
+        ),
       );
       return;
     }
@@ -740,11 +876,40 @@ function SetupEditor({
     if (probes.some((probe) => simulationProbeTargetKey(probe) === key)) return;
     setProbes((current) => [...current, probeFromOption(option)]);
     onDirty(true);
-    onError("");
+    setPickCandidates([]);
+    onProblem(undefined);
   }, [pickedNet?.sequence]);
   useEffect(() => {
     onDirty(false);
   }, []);
+  if (rawSaved && !switchFromRaw) {
+    return (
+      <aside className="simulation-setup-panel" aria-label="Simulation setup">
+        <header>
+          <div>
+            <small>Simulation</small>
+            <strong>Raw setup</strong>
+          </div>
+        </header>
+        <div className="simulation-raw-summary">
+          <p>
+            <strong>{rawSaved.entry}</strong>
+          </p>
+          <p>
+            {rawSaved.files.length} authored file(s) ·{" "}
+            {rawSaved.dependencies.length} dependency declaration(s)
+          </p>
+          <p>Profile: {rawSaved.environment.profileId}</p>
+          <button type="button" onClick={() => setSwitchFromRaw(true)}>
+            Switch to structured setup…
+          </button>
+          <button type="button" onClick={() => onSaveSetup(null)}>
+            Delete setup
+          </button>
+        </div>
+      </aside>
+    );
+  }
   return (
     <aside className="simulation-setup-panel" aria-label="Simulation setup">
       <header>
@@ -807,15 +972,23 @@ function SetupEditor({
             },
           });
           if (!parsed.success) {
-            onError(parsed.error.issues.map((i) => i.message).join("\n"));
+            onProblem(
+              uiProblem(
+                "SIMULATION_SETUP_INVALID",
+                parsed.error.issues.map((i) => i.message).join("\n"),
+              ),
+            );
             return;
           }
           if (onSaveSetup(parsed.data)) {
             onDirty(false);
-            onError("");
+            onProblem(undefined);
           } else
-            onError(
-              "Setup was not applied. See the editor status; your draft is retained.",
+            onProblem(
+              uiProblem(
+                "SIMULATION_SETUP_NOT_APPLIED",
+                "Setup was not applied. See the editor status; your draft is retained.",
+              ),
             );
         }}
       >
@@ -1012,6 +1185,27 @@ function SetupEditor({
             </button>
           }
         />
+        {pickCandidates.length > 1 ? (
+          <fieldset
+            className="simulation-setup-group"
+            aria-label="Choose Net occurrence"
+          >
+            <legend>Choose occurrence</legend>
+            {pickCandidates.map((option) => (
+              <button
+                type="button"
+                key={option.key}
+                onClick={() => {
+                  setProbes((current) => [...current, probeFromOption(option)]);
+                  setPickCandidates([]);
+                  onDirty(true);
+                }}
+              >
+                {option.label}
+              </button>
+            ))}
+          </fieldset>
+        ) : null}
         <ProbeSelect
           label="Add current output"
           placeholder="Choose a voltage-source branch"

--- a/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import {
+  changeTransientTimeRange,
   TransientResultsExplorer,
   transientPolylinePoints,
 } from "./transient-results-explorer";
@@ -64,5 +65,19 @@ describe("Transient Results Explorer", () => {
     expect(markup).toContain('aria-label="Transient voltage"');
     expect(markup).toContain('aria-label="Transient current"');
     expect(markup.match(/data-trace-index=/gu)).toHaveLength(2);
+    expect(markup).toContain('aria-label="Plot tools"');
+    expect(markup.match(/aria-label="Open plot"/gu)).toHaveLength(2);
+  });
+
+  it("keeps explicit linear zoom and pan inside the transient interval", () => {
+    expect(changeTransientTimeRange([0, 10], [0, 10], "zoom-in")).toEqual([
+      2, 8,
+    ]);
+    expect(changeTransientTimeRange([2, 8], [0, 10], "pan-right")).toEqual([
+      3.2, 9.2,
+    ]);
+    expect(changeTransientTimeRange([0, 10], [0, 10], "pan-left")).toEqual([
+      0, 10,
+    ]);
   });
 });

--- a/apps/editor/src/features/simulation/transient-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.tsx
@@ -1,4 +1,10 @@
-import { useMemo, useState } from "react";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent,
+} from "react";
 import type { SimulationProbeSpec } from "@icm/model";
 import type { TransientResult } from "@icm/spice-run";
 import type { Prepared } from "@icm/simulation-service/contract";
@@ -23,12 +29,13 @@ export interface TransientResultsExplorerProps {
 
 const PLOT = {
   width: 760,
-  height: 230,
+  height: 280,
   left: 64,
-  right: 14,
-  top: 14,
-  bottom: 32,
+  right: 18,
+  top: 16,
+  bottom: 34,
 } as const;
+const EXPANDED_PLOT = { ...PLOT, width: 1400, height: 700 } as const;
 
 function finiteExtent(values: readonly number[]): readonly [number, number] {
   let min = Number.POSITIVE_INFINITY;
@@ -65,21 +72,28 @@ export function transientPolylinePoints(
   timeSeconds: readonly number[],
   values: readonly number[],
   yExtent: readonly [number, number] = finiteExtent(values),
+  timeExtent: readonly [number, number] = finiteExtent(timeSeconds),
+  plot: typeof PLOT | typeof EXPANDED_PLOT = PLOT,
 ): string {
   const count = Math.min(timeSeconds.length, values.length);
   if (count === 0) return "";
-  const [timeMin, timeMax] = finiteExtent(timeSeconds.slice(0, count));
-  const timeSpan = timeMax - timeMin;
+  const timeSpan = timeExtent[1] - timeExtent[0];
   const valueSpan = yExtent[1] - yExtent[0];
-  const plotWidth = PLOT.width - PLOT.left - PLOT.right;
-  const plotHeight = PLOT.height - PLOT.top - PLOT.bottom;
+  const plotWidth = plot.width - plot.left - plot.right;
+  const plotHeight = plot.height - plot.top - plot.bottom;
   const points: string[] = [];
   for (let index = 0; index < count; index += 1) {
     const time = timeSeconds[index]!;
     const value = values[index]!;
-    if (!Number.isFinite(time) || !Number.isFinite(value)) continue;
-    const x = PLOT.left + ((time - timeMin) / timeSpan) * plotWidth;
-    const y = PLOT.top + ((yExtent[1] - value) / valueSpan) * plotHeight;
+    if (
+      !Number.isFinite(time) ||
+      !Number.isFinite(value) ||
+      time < timeExtent[0] ||
+      time > timeExtent[1]
+    )
+      continue;
+    const x = plot.left + ((time - timeExtent[0]) / timeSpan) * plotWidth;
+    const y = plot.top + ((yExtent[1] - value) / valueSpan) * plotHeight;
     points.push(`${x.toFixed(2)},${y.toFixed(2)}`);
   }
   return points.join(" ");
@@ -112,6 +126,40 @@ function outputTraces(
   });
 }
 
+function clampRange(
+  low: number,
+  high: number,
+  full: readonly [number, number],
+): readonly [number, number] {
+  const span = Math.min(high - low, full[1] - full[0]);
+  if (low < full[0]) return [full[0], full[0] + span];
+  if (high > full[1]) return [full[1] - span, full[1]];
+  return [low, high];
+}
+
+export function changeTransientTimeRange(
+  current: readonly [number, number],
+  full: readonly [number, number],
+  action: "zoom-in" | "zoom-out" | "pan-left" | "pan-right",
+  center = (current[0] + current[1]) / 2,
+): readonly [number, number] {
+  const span = current[1] - current[0];
+  if (action.startsWith("zoom")) {
+    const nextSpan = Math.min(
+      full[1] - full[0],
+      span * (action === "zoom-in" ? 0.6 : 1.7),
+    );
+    const fraction = span ? (center - current[0]) / span : 0.5;
+    return clampRange(
+      center - nextSpan * fraction,
+      center + nextSpan * (1 - fraction),
+      full,
+    );
+  }
+  const shift = span * 0.2 * (action === "pan-left" ? -1 : 1);
+  return clampRange(current[0] + shift, current[1] + shift, full);
+}
+
 export function TransientResultsExplorer({
   analysis,
   vectors,
@@ -124,18 +172,267 @@ export function TransientResultsExplorer({
     [analysis, labels, probes, vectors],
   );
   const [hidden, setHidden] = useState<ReadonlySet<string>>(() => new Set());
+  const [solo, setSolo] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
-  const visible = traces.filter((trace) => !hidden.has(trace.id));
-  const [timeMin, timeMax] = finiteExtent(analysis.timeSeconds);
+  const [hoverTime, setHoverTime] = useState<number>();
+  const [markerTime, setMarkerTime] = useState<number>();
+  const [timeRange, setTimeRange] = useState<readonly [number, number]>();
+  const [expandedQuantity, setExpandedQuantity] = useState<
+    "voltage" | "current" | null
+  >(null);
+  const visible = traces.filter(
+    (trace) => !hidden.has(trace.id) && (solo === null || solo === trace.id),
+  );
+  const fullRange = finiteExtent(analysis.timeSeconds);
+  const cursorTime = hoverTime ?? markerTime;
+
+  useEffect(() => {
+    if (!expandedQuantity) return;
+    const close = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setExpandedQuantity(null);
+    };
+    window.addEventListener("keydown", close);
+    return () => window.removeEventListener("keydown", close);
+  }, [expandedQuantity]);
+
+  const focusTrace = (traceId: string) => {
+    const trace = traces.find((candidate) => candidate.id === traceId);
+    if (!trace) return;
+    setSelected(trace.id);
+    if (trace.probe) onFocusProbe?.(trace.probe);
+  };
+
+  const updateRange = (
+    action: "zoom-in" | "zoom-out" | "pan-left" | "pan-right" | "fit",
+  ) => {
+    if (action === "fit") return setTimeRange(undefined);
+    const next = changeTransientTimeRange(
+      timeRange ?? fullRange,
+      fullRange,
+      action,
+      cursorTime,
+    );
+    setTimeRange(
+      next[0] === fullRange[0] && next[1] === fullRange[1] ? undefined : next,
+    );
+  };
+
+  const timeAtPointer = (
+    event: PointerEvent<HTMLDivElement> | ReactMouseEvent<HTMLDivElement>,
+    plot: typeof PLOT | typeof EXPANDED_PLOT,
+  ) => {
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const range = timeRange ?? fullRange;
+    const svgX = ((event.clientX - bounds.left) / bounds.width) * plot.width;
+    return Math.min(
+      range[1],
+      Math.max(
+        range[0],
+        range[0] +
+          ((svgX - plot.left) / (plot.width - plot.left - plot.right)) *
+            (range[1] - range[0]),
+      ),
+    );
+  };
+
+  const toolbar = (quantity: "voltage" | "current", expanded: boolean) => (
+    <div
+      className={`ac-plot-toolbar${expanded ? " expanded" : ""}`}
+      aria-label="Plot tools"
+    >
+      <button
+        type="button"
+        aria-label="Zoom in"
+        onClick={() => updateRange("zoom-in")}
+      >
+        +
+      </button>
+      <button
+        type="button"
+        aria-label="Zoom out"
+        onClick={() => updateRange("zoom-out")}
+      >
+        −
+      </button>
+      <button
+        type="button"
+        aria-label="Pan left"
+        onClick={() => updateRange("pan-left")}
+      >
+        ←
+      </button>
+      <button
+        type="button"
+        aria-label="Pan right"
+        onClick={() => updateRange("pan-right")}
+      >
+        →
+      </button>
+      <button
+        type="button"
+        aria-label="Fit plot"
+        onClick={() => updateRange("fit")}
+      >
+        Fit
+      </button>
+      {markerTime !== undefined ? (
+        <button
+          type="button"
+          aria-label="Clear marker"
+          onClick={() => setMarkerTime(undefined)}
+        >
+          ×│
+        </button>
+      ) : null}
+      {!expanded ? (
+        <button
+          type="button"
+          aria-label="Open plot"
+          onClick={() => setExpandedQuantity(quantity)}
+        >
+          ⛶
+        </button>
+      ) : null}
+    </div>
+  );
+
+  const plot = (
+    quantity: "voltage" | "current",
+    quantityTraces: readonly TransientTrace[],
+    expanded = false,
+  ) => {
+    const geometry = expanded ? EXPANDED_PLOT : PLOT;
+    const range = timeRange ?? fullRange;
+    const visibleValues = quantityTraces.flatMap((trace) =>
+      trace.values.filter(
+        (_value, index) =>
+          analysis.timeSeconds[index]! >= range[0] &&
+          analysis.timeSeconds[index]! <= range[1],
+      ),
+    );
+    const extent = finiteExtent(visibleValues);
+    const unit = quantityTraces.find((trace) => trace.unit)?.unit ?? "";
+    const cursorX =
+      cursorTime === undefined
+        ? undefined
+        : geometry.left +
+          ((cursorTime - range[0]) / (range[1] - range[0])) *
+            (geometry.width - geometry.left - geometry.right);
+    return (
+      <div className={`ac-plot-shell${expanded ? " expanded" : ""}`}>
+        <div
+          className="spice-ac-plot interactive"
+          onPointerMove={(event) =>
+            setHoverTime(timeAtPointer(event, geometry))
+          }
+          onPointerLeave={() => setHoverTime(undefined)}
+          onClick={(event) => {
+            const id = (event.target as Element)
+              .closest("[data-trace-id]")
+              ?.getAttribute("data-trace-id");
+            if (id) focusTrace(id);
+            setMarkerTime(timeAtPointer(event, geometry));
+          }}
+          onDoubleClick={() => !expanded && setExpandedQuantity(quantity)}
+        >
+          <svg
+            role="img"
+            aria-label={`Transient ${quantity}`}
+            viewBox={`0 0 ${geometry.width} ${geometry.height}`}
+          >
+            <line
+              className="transient-axis"
+              x1={geometry.left}
+              y1={geometry.top}
+              x2={geometry.left}
+              y2={geometry.height - geometry.bottom}
+            />
+            <line
+              className="transient-axis"
+              x1={geometry.left}
+              y1={geometry.height - geometry.bottom}
+              x2={geometry.width - geometry.right}
+              y2={geometry.height - geometry.bottom}
+            />
+            <text x={geometry.left} y={geometry.height - 8}>
+              {compact(range[0])}s
+            </text>
+            <text
+              textAnchor="end"
+              x={geometry.width - geometry.right}
+              y={geometry.height - 8}
+            >
+              {compact(range[1])}s
+            </text>
+            <text x={4} y={geometry.top + 5}>
+              {compact(extent[1])}
+              {unit}
+            </text>
+            <text x={4} y={geometry.height - geometry.bottom}>
+              {compact(extent[0])}
+              {unit}
+            </text>
+            {quantityTraces.map((trace) => {
+              const points = transientPolylinePoints(
+                analysis.timeSeconds,
+                trace.values,
+                extent,
+                range,
+                geometry,
+              );
+              return (
+                <g
+                  key={trace.id}
+                  data-trace-id={trace.id}
+                  data-trace-index={trace.colorIndex}
+                >
+                  <polyline className="ac-trace-hit" points={points} />
+                  <polyline
+                    className={`transient-trace ac-trace-${trace.colorIndex % 6}${selected === trace.id ? " ac-trace-selected" : ""}`}
+                    points={points}
+                  />
+                </g>
+              );
+            })}
+            {cursorX === undefined ? null : (
+              <line
+                className="ac-cursor"
+                x1={cursorX}
+                y1={geometry.top}
+                x2={cursorX}
+                y2={geometry.height - geometry.bottom}
+              />
+            )}
+          </svg>
+        </div>
+        {toolbar(quantity, expanded)}
+      </div>
+    );
+  };
+
+  const cursorRows =
+    cursorTime === undefined
+      ? []
+      : visible.map((trace) => {
+          const index = analysis.timeSeconds.reduce(
+            (best, time, candidate) =>
+              Math.abs(time - cursorTime) <
+              Math.abs(analysis.timeSeconds[best]! - cursorTime)
+                ? candidate
+                : best,
+            0,
+          );
+          return { trace, value: trace.values[index] ?? 0 };
+        });
 
   return (
-    <div className="transient-results-explorer">
+    <div className="transient-results-explorer ac-results-explorer">
       <header>
         <div>
           <strong>{analysis.plotName}</strong>
           <small>
-            {analysis.timeSeconds.length} solver points · {compact(timeMin)}s to{" "}
-            {compact(timeMax)}s
+            {analysis.timeSeconds.length} solver points ·{" "}
+            {compact(fullRange[0])}s to {compact(fullRange[1])}s
           </small>
         </div>
       </header>
@@ -164,15 +461,21 @@ export function TransientResultsExplorer({
               <button
                 type="button"
                 className="simulation-output-name"
-                onClick={() => {
-                  setSelected(trace.id);
-                  if (trace.probe) onFocusProbe?.(trace.probe);
-                }}
+                onClick={() => focusTrace(trace.id)}
               >
                 <strong>{trace.label}</strong>
                 <small>
                   {trace.quantity} · {trace.probe ? "linked" : trace.id}
                 </small>
+              </button>
+              <button
+                type="button"
+                aria-pressed={solo === trace.id}
+                onClick={() =>
+                  setSolo((current) => (current === trace.id ? null : trace.id))
+                }
+              >
+                Solo
               </button>
             </div>
           );
@@ -182,67 +485,63 @@ export function TransientResultsExplorer({
         const quantityTraces = visible.filter(
           (trace) => trace.quantity === quantity,
         );
-        if (quantityTraces.length === 0) return null;
-        const extent = finiteExtent(
-          quantityTraces.flatMap((trace) => trace.values),
-        );
-        const unit = quantityTraces.find((trace) => trace.unit)?.unit ?? "";
-        return (
-          <section key={quantity} className="transient-quantity-group">
+        return quantityTraces.length ? (
+          <section
+            key={quantity}
+            className="transient-quantity-group ac-quantity-group"
+          >
             <h4>{quantity === "voltage" ? "Voltage" : "Current"}</h4>
-            <svg
-              role="img"
-              aria-label={`Transient ${quantity}`}
-              viewBox={`0 0 ${PLOT.width} ${PLOT.height}`}
-            >
-              <line
-                className="transient-axis"
-                x1={PLOT.left}
-                y1={PLOT.top}
-                x2={PLOT.left}
-                y2={PLOT.height - PLOT.bottom}
-              />
-              <line
-                className="transient-axis"
-                x1={PLOT.left}
-                y1={PLOT.height - PLOT.bottom}
-                x2={PLOT.width - PLOT.right}
-                y2={PLOT.height - PLOT.bottom}
-              />
-              <text x={PLOT.left} y={PLOT.height - 8}>
-                {compact(timeMin)}s
-              </text>
-              <text
-                textAnchor="end"
-                x={PLOT.width - PLOT.right}
-                y={PLOT.height - 8}
-              >
-                {compact(timeMax)}s
-              </text>
-              <text x={4} y={PLOT.top + 5}>
-                {compact(extent[1])}
-                {unit}
-              </text>
-              <text x={4} y={PLOT.height - PLOT.bottom}>
-                {compact(extent[0])}
-                {unit}
-              </text>
-              {quantityTraces.map((trace) => (
-                <polyline
-                  key={trace.id}
-                  className={`transient-trace ac-trace-${trace.colorIndex % 6}`}
-                  data-trace-index={trace.colorIndex}
-                  points={transientPolylinePoints(
-                    analysis.timeSeconds,
-                    trace.values,
-                    extent,
-                  )}
-                />
-              ))}
-            </svg>
+            {plot(quantity, quantityTraces)}
           </section>
-        );
+        ) : null;
       })}
+      {visible.length === 0 ? (
+        <p className="simulation-empty-result">All Outputs are hidden.</p>
+      ) : null}
+      {cursorTime === undefined ? null : (
+        <div className="ac-cursor-readout" role="status">
+          <strong>{compact(cursorTime)}s</strong>
+          {cursorRows.map(({ trace, value }) => (
+            <span key={trace.id}>
+              {trace.label}: {Number(value.toPrecision(6))} {trace.unit ?? ""}
+            </span>
+          ))}
+        </div>
+      )}
+      {expandedQuantity ? (
+        <div
+          className="ac-plot-dialog-backdrop"
+          onMouseDown={(event) =>
+            event.currentTarget === event.target && setExpandedQuantity(null)
+          }
+        >
+          <section
+            className="ac-plot-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-label={`Transient ${expandedQuantity} plot`}
+          >
+            <header>
+              <div>
+                <strong>{analysis.plotName}</strong>
+                <span>{expandedQuantity} · transient waveform</span>
+              </div>
+              <button
+                type="button"
+                aria-label="Close plot"
+                onClick={() => setExpandedQuantity(null)}
+              >
+                ×
+              </button>
+            </header>
+            {plot(
+              expandedQuantity,
+              visible.filter((trace) => trace.quantity === expandedQuantity),
+              true,
+            )}
+          </section>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -324,6 +324,19 @@
 .simulation-setup-panel form > button {
   margin: 8px 8px 0 0;
 }
+.simulation-raw-summary {
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  font-size: var(--icm-font-sm);
+}
+.simulation-raw-summary p {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+.simulation-raw-summary button {
+  justify-self: start;
+}
 .simulation-probe-select {
   grid-template-columns: minmax(110px, 0.8fr) minmax(130px, 1.2fr);
 }
@@ -466,6 +479,44 @@
   overflow-wrap: anywhere;
   max-height: 260px;
   overflow: auto;
+}
+.simulation-problem {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid #fdb022;
+  border-radius: var(--icm-radius-sm);
+  background: #fffaeb;
+}
+.simulation-problem > header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.simulation-problem > header small,
+.simulation-problem li small {
+  color: var(--icm-text-muted);
+}
+.simulation-problem p {
+  margin: 0;
+}
+.simulation-problem ul {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.simulation-problem li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 6px;
+  border-top: 1px solid color-mix(in srgb, #fdb022 45%, transparent);
+}
+.simulation-problem li span {
+  display: grid;
+  flex: 1;
 }
 .spice-simulation-surface table {
   width: 100%;

--- a/containers/ngspice/entrypoint.mjs
+++ b/containers/ngspice/entrypoint.mjs
@@ -27,6 +27,7 @@ import {
   readFile,
   readdir,
   rm,
+  symlink,
   writeFile,
 } from "node:fs/promises";
 import { createServer } from "node:http";
@@ -238,6 +239,8 @@ async function loadEnvironmentProfile() {
     !isSha256(profile.simulator.binarySha256) ||
     typeof profile.models?.id !== "string" ||
     !isSha256(profile.models.contentSha256) ||
+    typeof profile.models.library?.runtimePath !== "string" ||
+    !profile.models.library.runtimePath.startsWith("/") ||
     !isSha256(profile.startup?.contentSha256)
   ) {
     throw new Error(`Simulation Profile ${PROFILE_PATH} is malformed.`);
@@ -339,6 +342,14 @@ async function observeEnvironment(ngspiceBin) {
         .digest("hex"),
     },
     startupText,
+    dependency:
+      profile === null
+        ? null
+        : {
+            id: profile.models.id,
+            sha256: profile.models.contentSha256,
+            runtimePath: profile.models.library.runtimePath,
+          },
   };
 }
 
@@ -663,6 +674,7 @@ async function handleRun(body) {
   if (token && cancelledTokens.has(token))
     return { status: 409, payload: { error: "run-cancelled" } };
   const files = body.files ?? [];
+  const dependencies = body.dependencies ?? [];
   const entryPath = body.entryPath ?? DECK_NAME;
   const safePath = (p) =>
     typeof p === "string" &&
@@ -675,8 +687,29 @@ async function handleRun(body) {
   if (
     !Array.isArray(files) ||
     files.length > 24 ||
+    !Array.isArray(dependencies) ||
+    dependencies.length > 24 ||
     !safePath(entryPath) ||
     files.some((f) => !f || !safePath(f.path) || typeof f.text !== "string") ||
+    dependencies.some(
+      (dependency) =>
+        !dependency ||
+        typeof dependency.id !== "string" ||
+        typeof dependency.sha256 !== "string" ||
+        !safePath(dependency.mountPath),
+    ) ||
+    dependencies.some((dependency, index) =>
+      dependencies.some(
+        (candidate, candidateIndex) =>
+          candidateIndex !== index &&
+          candidate.mountPath === dependency.mountPath,
+      ),
+    ) ||
+    dependencies.some(
+      (dependency) =>
+        dependency.mountPath === entryPath ||
+        files.some((file) => file.path === dependency.mountPath),
+    ) ||
     files.reduce((n, f) => n + Buffer.byteLength(f.text, "utf8"), 0) >
       MAX_DECK_BYTES
   )
@@ -699,6 +732,18 @@ async function handleRun(body) {
   }
 
   const [binary, observed, runRoot] = runtime;
+  if (
+    dependencies.some(
+      (dependency) =>
+        observed.dependency === null ||
+        dependency.id !== observed.dependency.id ||
+        dependency.sha256 !== observed.dependency.sha256,
+    )
+  )
+    return {
+      status: 400,
+      payload: { error: "simulation-dependency-unavailable" },
+    };
   const admission = await runSupervisor.tryExecute(
     { timeoutMs: body?.timeoutMs, token },
     async (run) => {
@@ -720,6 +765,15 @@ async function handleRun(body) {
         for (const file of files) {
           await mkdir(dirname(join(directory, file.path)), { recursive: true });
           await writeFile(join(directory, file.path), file.text, "utf8");
+        }
+        for (const dependency of dependencies) {
+          await mkdir(dirname(join(directory, dependency.mountPath)), {
+            recursive: true,
+          });
+          await symlink(
+            observed.dependency.runtimePath,
+            join(directory, dependency.mountPath),
+          );
         }
         await mkdir(dirname(join(directory, entryPath)), { recursive: true });
         await writeFile(join(directory, entryPath), deck, "utf8");

--- a/containers/ngspice/entrypoint.test.mjs
+++ b/containers/ngspice/entrypoint.test.mjs
@@ -540,7 +540,11 @@ describeHarness("health", () => {
           version: "ngspice-46",
           binarySha256: "0".repeat(64),
         },
-        models: { id: "test-models", contentSha256: "1".repeat(64) },
+        models: {
+          id: "test-models",
+          contentSha256: "1".repeat(64),
+          library: { runtimePath: "/opt/models/test-models.spice" },
+        },
         startup: { contentSha256: "2".repeat(64) },
       }),
       "utf8",

--- a/containers/ngspice/entrypoint.test.mjs
+++ b/containers/ngspice/entrypoint.test.mjs
@@ -152,6 +152,20 @@ describeHarness("the run directory", () => {
       expect(
         (await run(port, { ...request, files: [{ path, text: "x" }] })).status,
       ).toBe(400);
+    expect(
+      (
+        await run(port, {
+          ...request,
+          dependencies: [
+            {
+              id: "unadvertised-model",
+              sha256: "a".repeat(64),
+              mountPath: "models/device.lib",
+            },
+          ],
+        })
+      ).status,
+    ).toBe(400);
   });
   it(
     "cancels an owning run, releases its slot, and remembers a pre-admission cancellation",

--- a/docs/specs/simulation.md
+++ b/docs/specs/simulation.md
@@ -293,6 +293,13 @@ electrical syntax. Project raw dependencies that no available environment
 owner can resolve produce located, recoverable preparation diagnostics; the
 service never falls back to arbitrary host paths.
 
+A raw dependency resolves only when its logical id and SHA-256 match a
+dependency advertised by the selected Profile. The author chooses a safe
+relative mount path; the Worker and harness validate the declaration again,
+then the harness links that path to the Profile-owned, read-only model file in
+the private run directory. Client-supplied absolute paths, URLs, and unverified
+model substitutions are never resolution mechanisms.
+
 A structured setup stores only a stable environment Profile ID and the
 author's allowed selections such as corner and temperature. It never copies a
 Profile manifest, model path, simulator digest, or measured environment
@@ -883,6 +890,19 @@ in File Resource artifacts, read in bounded UTF-16 `offset`/`maxChars` slices
 with `nextOffset`. MCP local export assembles and verifies the complete file.
 Storage-capacity failures keep available evidence and return an explicit error;
 they are not permission failures or proof of simulation success.
+
+Each completed run also publishes `evidence-manifest.json`. It binds the run,
+prepared digest, input revision, environment identity, probe-vector mapping,
+and the names, sizes, and hashes of every preceding artifact. The manifest is
+the portable inventory for the existing File Resource artifacts; it is not a
+second result store and does not claim an external model tree is embedded.
+
+The human Results view binds mappings and authored probe labels by the Run's
+own `preparedId`, never by the latest Setup or most recent Prepare. Historical
+numeric data remains viewable after the Project changes, while stale object
+locations are refused by normal locator resolution. AC and TRAN share the same
+output browser, explicit plot tools, marker, expanded view, and back-annotation
+boundary; TRAN uses a linear time axis and does not revive Digital Simulation.
 
 Recoverable problems use `{code,message,stage,recovery,diagnostics?}`. Ordinary
 compile errors, unavailable Profiles, simulator failures and busy responses do

--- a/packages/simulation-service/src/contract.ts
+++ b/packages/simulation-service/src/contract.ts
@@ -107,7 +107,16 @@ export const CapabilitiesSchema = z.strictObject({
   inputs: z.array(z.enum(["structured", "raw"])),
   analyses: z.array(z.enum(["op", "ac", "tran"])),
   parsedAnalyses: z.array(z.enum(["op", "ac", "tran"])),
-  profiles: z.array(z.strictObject({ id: Id, corners: z.array(z.string()) })),
+  profiles: z.array(
+    z.strictObject({
+      id: Id,
+      corners: z.array(z.string()),
+      /** Environment-owned files addressable by raw Project dependencies. */
+      dependencies: z
+        .array(z.strictObject({ id: Id, sha256: Digest }))
+        .optional(),
+    }),
+  ),
   modelLibrary: z
     .strictObject({ path: z.string(), section: z.string() })
     .optional(),

--- a/packages/simulation-service/src/hosted-executor.test.ts
+++ b/packages/simulation-service/src/hosted-executor.test.ts
@@ -6,6 +6,7 @@ const input: ExecutionInput = {
   netlist: "",
   testbench: "* test",
   files: [],
+  dependencies: [],
   inputRevision: "rev",
   environment: { profileId: "p" },
 };

--- a/packages/simulation-service/src/service.test.ts
+++ b/packages/simulation-service/src/service.test.ts
@@ -220,6 +220,81 @@ describe("shared simulation lifecycle", () => {
     expect(f.executor.execute).not.toHaveBeenCalled();
   });
 
+  it("resolves a declared raw dependency only through the selected Profile", async () => {
+    const f = fixture();
+    const modelDigest = "a".repeat(64);
+    f.executor.capabilities = async () => ({
+      ...caps,
+      profiles: [
+        {
+          id: "test",
+          corners: ["tt"],
+          dependencies: [{ id: "device-models", sha256: modelDigest }],
+        },
+      ],
+    });
+    f.project.simulation = {
+      version: 1,
+      input: {
+        kind: "raw",
+        entry: "tb.cir",
+        files: [
+          {
+            path: "tb.cir",
+            text: '.lib "models/device.lib" tt\n.end\n',
+          },
+        ],
+        dependencies: [
+          {
+            id: "device-models",
+            mountPath: "models/device.lib",
+            sha256: modelDigest,
+          },
+        ],
+        environment: { profileId: "test" },
+      },
+    };
+
+    const prepared = unwrap(
+      await f.service.handle(
+        {
+          operation: "prepare",
+          source: {
+            kind: "project-setup",
+            expectedStructureRevision: f.project.structureRevision,
+          },
+        },
+        "project-dependency-resolved",
+      ),
+      "prepared",
+    );
+    unwrap(
+      await f.service.handle(
+        {
+          operation: "start",
+          preparedId: prepared.id,
+          digest: prepared.digest,
+        },
+        "run-dependency-resolved",
+      ),
+      "run",
+    );
+    expect(f.executor.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dependencies: [
+          {
+            id: "device-models",
+            mountPath: "models/device.lib",
+            sha256: modelDigest,
+          },
+        ],
+      }),
+      expect.any(String),
+      undefined,
+    );
+    f.release();
+  });
+
   it("rejects stale Project setup preparation by structure revision", async () => {
     const f = fixture();
     expect(
@@ -304,8 +379,27 @@ describe("shared simulation lifecycle", () => {
         "op-0.csv",
         "result.json",
         "executed.cir",
+        "evidence-manifest.json",
       ]),
     );
+    const evidence = finished.artifacts.find(
+      (artifact) => artifact.name === "evidence-manifest.json",
+    )!;
+    const evidenceRead = await f.files.handle({
+      action: "artifact",
+      artifactId: evidence.id,
+    });
+    expect(evidenceRead).toMatchObject({ ok: true });
+    if (!evidenceRead.ok || !("text" in evidenceRead)) throw Error("evidence");
+    expect(JSON.parse(evidenceRead.text)).toMatchObject({
+      schemaVersion: 1,
+      run: { id: finished.id, preparedId: prepared.id },
+      prepared: { digest: prepared.digest },
+      artifacts: expect.arrayContaining([
+        expect.objectContaining({ name: "out.raw" }),
+        expect.objectContaining({ name: "result.json" }),
+      ]),
+    });
     expect(unwrap(await f.service.handle(op, "next"), "run").id).not.toBe(
       run.id,
     );

--- a/packages/simulation-service/src/service.ts
+++ b/packages/simulation-service/src/service.ts
@@ -29,6 +29,7 @@ export interface ExecutionInput {
   inputRevision: string;
   environment: Prepared["environment"];
   files: { path: string; text: string }[];
+  dependencies: { id: string; mountPath: string; sha256: string }[];
   entryPath?: string;
   preparedDeck?: string;
 }
@@ -61,6 +62,7 @@ type PrepareSource = Extract<
 >["source"];
 type InternalRun = {
   view: Run;
+  prepared: Prepared;
   token: string;
   expiresAt: number;
   done: Promise<void>;
@@ -325,6 +327,7 @@ export class SimulationService {
           inputRevision: compiled.request.inputRevision!,
           environment: setup.input.environment,
           files: [],
+          dependencies: [],
         };
         vectors = [...compiled.vectors];
         warnings = compiled.warnings.map((w) => w.message);
@@ -342,8 +345,6 @@ export class SimulationService {
         );
       } else {
         const rawInput = setup.input;
-        if (rawInput.dependencies.length > 0)
-          return unresolvedDependencyProblem(rawInput);
         const entry = rawInput.files.find(
           (file) => file.path === rawInput.entry,
         );
@@ -360,6 +361,9 @@ export class SimulationService {
           inputRevision: await rawInputRevision(rawInput),
           environment: rawInput.environment,
           files: rawInput.files.map((file) => ({ ...file })),
+          dependencies: rawInput.dependencies.map((dependency) => ({
+            ...dependency,
+          })),
           entryPath: rawInput.entry,
         };
       }
@@ -384,6 +388,7 @@ export class SimulationService {
         ),
         environment: op.source.environment,
         files: workspace.files.map((f) => ({ ...f })),
+        dependencies: [],
       };
       // Preserve entry-relative includes by running the actual entry path.
       input.entryPath = workspace.entry!;
@@ -397,6 +402,26 @@ export class SimulationService {
         "Select a Profile advertised by capabilities",
         "prepare",
       );
+    if (input.mode === "raw" && input.dependencies.length > 0) {
+      const available = new Map(
+        (profile.dependencies ?? []).map((dependency) => [
+          dependency.id,
+          dependency.sha256,
+        ]),
+      );
+      if (
+        input.dependencies.some(
+          (dependency) => available.get(dependency.id) !== dependency.sha256,
+        )
+      )
+        return unresolvedDependencyProblem({
+          kind: "raw",
+          entry: input.entryPath!,
+          files: input.files,
+          dependencies: input.dependencies,
+          environment: input.environment,
+        });
+    }
     if (
       input.environment.corner &&
       !profile.corners.includes(input.environment.corner)
@@ -571,6 +596,7 @@ export class SimulationService {
     };
     const entry: InternalRun = {
       view,
+      prepared: structuredClone(prepared.view),
       token: crypto.randomUUID(),
       expiresAt: this.now() + TTL,
       done: Promise.resolve(),
@@ -619,6 +645,31 @@ export class SimulationService {
           "text/csv",
           simulationAnalysisToCsv(analysis),
         );
+      const evidenceArtifacts = run.view.artifacts.map((item) => ({ ...item }));
+      await artifact(
+        "evidence-manifest.json",
+        "application/json",
+        JSON.stringify(
+          {
+            schemaVersion: 1,
+            run: {
+              id: run.view.id,
+              preparedId: run.view.preparedId,
+              inputRevision: run.view.inputRevision,
+            },
+            prepared: {
+              digest: run.prepared.digest,
+              mode: run.prepared.mode,
+              environment: run.prepared.environment,
+              vectors: run.prepared.vectors,
+            },
+            environment: output.result.metadata.environment,
+            artifacts: evidenceArtifacts,
+          },
+          null,
+          2,
+        ),
+      );
       if (epoch === this.epoch)
         run.view.state = output.cancelled ? "cancelled" : "finished";
     } catch (error) {

--- a/worker/simulation.test.ts
+++ b/worker/simulation.test.ts
@@ -37,7 +37,11 @@ const HOSTED_ENVIRONMENT = await createSimulationEnvironmentMetadata({
 /** Stands in for the container, recording the deck it was handed. */
 function stubRunner(
   reply: Record<string, unknown>,
-  seen: { deck?: string; timeoutMs?: number } = {},
+  seen: {
+    deck?: string;
+    timeoutMs?: number;
+    dependencies?: unknown;
+  } = {},
 ): SimulationEnv {
   return {
     NGSPICE: {
@@ -46,9 +50,11 @@ function stubRunner(
           const sent = JSON.parse(String(init?.body)) as {
             deck: string;
             timeoutMs: number;
+            dependencies?: unknown;
           };
           seen.deck = sent.deck;
           seen.timeoutMs = sent.timeoutMs;
+          seen.dependencies = sent.dependencies;
           return Response.json({ environment: HOSTED_ENVIRONMENT, ...reply });
         },
       }),
@@ -70,13 +76,28 @@ describe("simulation route", () => {
       inputs: ["structured", "raw"],
       analyses: hostedSky130Profile.qualifiedScope.analyses,
       parsedAnalyses: ["op", "ac", "tran"],
+      profiles: [
+        {
+          id: hostedSky130Profile.id,
+          dependencies: [
+            {
+              id: hostedSky130Profile.models.id,
+              sha256: hostedSky130Profile.models.contentSha256,
+            },
+          ],
+        },
+      ],
       maxInputBytes: 2 * 1024 * 1024,
       maxOutputBytes: 1024 * 1024,
       cancel: true,
     });
   });
   it("raw mode preserves a complete deck and relative files; exact prepared input is checked", async () => {
-    const seen: { deck?: string; timeoutMs?: number } = {};
+    const seen: {
+      deck?: string;
+      timeoutMs?: number;
+      dependencies?: unknown;
+    } = {};
     const deck = "raw title\n.include parts.inc\nV1 in 0 1\n.op\n.end";
     const body = {
       mode: "raw",
@@ -86,6 +107,13 @@ describe("simulation route", () => {
       files: [{ path: "parts.inc", text: "R1 in 0 1k" }],
       entryPath: "main.cir",
       inputRevision: "revision-raw",
+      dependencies: [
+        {
+          id: hostedSky130Profile.models.id,
+          sha256: hostedSky130Profile.models.contentSha256,
+          mountPath: "models/sky130.lib.spice",
+        },
+      ],
     };
     const response = await routeSimulationRequest(
       post(body),
@@ -93,6 +121,7 @@ describe("simulation route", () => {
     );
     expect(response!.status).toBe(200);
     expect(seen.deck).toBe(deck);
+    expect(seen.dependencies).toEqual(body.dependencies);
     expect(
       (await routeSimulationRequest(
         post({ ...body, preparedDeck: "other" }),

--- a/worker/simulation.ts
+++ b/worker/simulation.ts
@@ -92,6 +92,7 @@ interface SimulationRequestBody {
     temperatureC?: unknown;
   };
   files?: unknown;
+  dependencies?: unknown;
   entryPath?: unknown;
   runToken?: unknown;
   preparedDeck?: unknown;
@@ -298,6 +299,12 @@ export async function routeSimulationRequest(
         {
           id: hostedSky130Profile.id,
           corners: [env.SKY130_LIB_SECTION ?? SKY130_LIBRARY_SECTION],
+          dependencies: [
+            {
+              id: hostedSky130Profile.models.id,
+              sha256: hostedSky130Profile.models.contentSha256,
+            },
+          ],
         },
       ],
       modelLibrary: {
@@ -371,6 +378,7 @@ export async function routeSimulationRequest(
       { status: 400 },
     );
   const files = body.files ?? [];
+  const dependencies = body.dependencies ?? [];
   const safePath = (p: unknown): p is string =>
     typeof p === "string" &&
     p.length > 0 &&
@@ -385,6 +393,26 @@ export async function routeSimulationRequest(
     files.some((f) => !f || !safePath(f.path) || typeof f.text !== "string") ||
     files.reduce((n, f) => n + new TextEncoder().encode(f.text).length, 0) >
       MAX_INPUT_BYTES ||
+    !Array.isArray(dependencies) ||
+    dependencies.length > 24 ||
+    dependencies.some(
+      (dependency) =>
+        !dependency ||
+        dependency.id !== hostedSky130Profile.models.id ||
+        dependency.sha256 !== hostedSky130Profile.models.contentSha256 ||
+        !safePath(dependency.mountPath),
+    ) ||
+    dependencies.some((dependency, index) =>
+      dependencies.some(
+        (candidate, candidateIndex) =>
+          candidateIndex !== index &&
+          candidate.mountPath === dependency.mountPath,
+      ),
+    ) ||
+    dependencies.some((dependency) =>
+      files.some((file) => file.path === dependency.mountPath),
+    ) ||
+    (dependencies.length > 0 && body.mode !== "raw") ||
     (body.entryPath !== undefined && !safePath(body.entryPath))
   )
     return Response.json({ error: "invalid-input-files" }, { status: 400 });
@@ -459,6 +487,7 @@ export async function routeSimulationRequest(
         deck,
         timeoutMs,
         files,
+        dependencies,
         ...(body.entryPath ? { entryPath: body.entryPath } : {}),
         ...(body.runToken ? { runToken: body.runToken } : {}),
       }),


### PR DESCRIPTION
## Summary
- bind displayed probes, labels, locators, and diagnostics to the exact prepared input used by each run
- unify AC and TRAN result exploration with selection, visibility, markers, zoom, pan, expansion, and safe canvas backannotation
- resolve raw-deck dependencies only through the selected environment profile and publish a digest-bound evidence manifest
- keep raw and structured setup modes explicit without introducing Project Manager or a second lifecycle protocol

## Validation
- pnpm install --frozen-lockfile
- pnpm gate:preflight -- --base origin/main
- pnpm gate:full (static, 395 unit files / 2674 tests, builds, performance, goldens, release smokes passed; browser stage had one unrelated formula-input timing failure)
- isolated failed browser test passed on rerun
- pnpm test:e2e:local (356/356 passed)

Test-Impact: tests-updated