### PR TITLE
fix(simulation): make transient plots inspectable

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -362,6 +362,41 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await expect(
     panel.locator('svg[aria-label="Transient voltage"]'),
   ).toBeVisible();
+  const transientPlot = panel
+    .locator(".transient-quantity-group")
+    .filter({ hasText: "Voltage" })
+    .locator(".spice-ac-plot")
+    .first();
+  const transientShell = transientPlot.locator("..");
+  await expect(transientPlot.locator(".ac-trace-hit")).toHaveAttribute(
+    "fill",
+    "none",
+  );
+  await transientPlot.hover();
+  const boxZoom = transientShell.getByRole("button", { name: "Box zoom" });
+  const inspectPlot = transientShell.getByRole("button", {
+    name: "Inspect plot",
+  });
+  const rightTimeLabel = transientPlot.locator('svg text[text-anchor="end"]');
+  const fullTimeLabel = await rightTimeLabel.textContent();
+  await boxZoom.click();
+  await expect(boxZoom).toHaveAttribute("aria-pressed", "true");
+  const transientBounds = await transientPlot.boundingBox();
+  expect(transientBounds).not.toBeNull();
+  await page.mouse.move(
+    transientBounds!.x + transientBounds!.width * 0.3,
+    transientBounds!.y + transientBounds!.height * 0.3,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    transientBounds!.x + transientBounds!.width * 0.7,
+    transientBounds!.y + transientBounds!.height * 0.7,
+  );
+  await page.mouse.up();
+  await expect(inspectPlot).toHaveAttribute("aria-pressed", "true");
+  await expect(rightTimeLabel).not.toHaveText(fullTimeLabel ?? "");
+  await transientShell.getByRole("button", { name: "Fit plot" }).click();
+  await expect(rightTimeLabel).toHaveText(fullTimeLabel ?? "");
   await panel.getByRole("tab", { name: "Files" }).click();
   await expect(
     panel.getByRole("button", { name: "evidence-manifest.json" }),

--- a/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
@@ -4,7 +4,9 @@ import { describe, expect, it } from "vitest";
 import {
   changeTransientTimeRange,
   TransientResultsExplorer,
+  transientBoxZoomRanges,
   transientPolylinePoints,
+  transientValueExtent,
 } from "./transient-results-explorer";
 
 describe("Transient Results Explorer", () => {
@@ -12,6 +14,25 @@ describe("Transient Results Explorer", () => {
     const points = transientPolylinePoints([0, 1e-9, 10e-9], [0, 0.5, 1]);
     const x = points.split(" ").map((point) => Number(point.split(",")[0]));
     expect(x[1]! - x[0]!).toBeLessThan((x[2]! - x[0]!) / 5);
+  });
+
+  it("does not magnify simulator round-off around a constant signal", () => {
+    const extent = transientValueExtent([1.8, 1.8 + 1e-13, 1.8 - 1e-13]);
+    expect(extent[0]).toBeCloseTo(1.71, 10);
+    expect(extent[1]).toBeCloseTo(1.89, 10);
+  });
+
+  it("maps a dragged plot rectangle onto ordered time and value ranges", () => {
+    const ranges = transientBoxZoomRanges(
+      { x: 572.5, y: 188.5 },
+      { x: 233.5, y: 73.5 },
+      [0, 10],
+      [0, 4],
+    );
+    expect(ranges.time[0]).toBeCloseTo(2.5);
+    expect(ranges.time[1]).toBeCloseTo(7.5);
+    expect(ranges.value[0]).toBeCloseTo(1);
+    expect(ranges.value[1]).toBeCloseTo(3);
   });
 
   it("presents linked voltage and current time-domain outputs", () => {
@@ -66,7 +87,11 @@ describe("Transient Results Explorer", () => {
     expect(markup).toContain('aria-label="Transient current"');
     expect(markup.match(/data-trace-index=/gu)).toHaveLength(2);
     expect(markup).toContain('aria-label="Plot tools"');
+    expect(markup.match(/aria-label="Box zoom"/gu)).toHaveLength(2);
     expect(markup.match(/aria-label="Open plot"/gu)).toHaveLength(2);
+    expect(markup).toContain(
+      'class="ac-trace-hit" fill="none" stroke="transparent" stroke-width="12" pointer-events="stroke"',
+    );
   });
 
   it("keeps explicit linear zoom and pan inside the transient interval", () => {

--- a/apps/editor/src/features/simulation/transient-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.tsx
@@ -37,6 +37,20 @@ const PLOT = {
 } as const;
 const EXPANDED_PLOT = { ...PLOT, width: 1400, height: 700 } as const;
 
+type PlotGeometry = typeof PLOT | typeof EXPANDED_PLOT;
+type PlotQuantity = "voltage" | "current";
+
+interface PlotPoint {
+  readonly x: number;
+  readonly y: number;
+}
+
+interface ZoomBox {
+  readonly quantity: PlotQuantity;
+  readonly start: PlotPoint;
+  readonly current: PlotPoint;
+}
+
 function finiteExtent(values: readonly number[]): readonly [number, number] {
   let min = Number.POSITIVE_INFINITY;
   let max = Number.NEGATIVE_INFINITY;
@@ -49,6 +63,58 @@ function finiteExtent(values: readonly number[]): readonly [number, number] {
   if (min !== max) return [min, max];
   const margin = Math.max(Math.abs(min) * 0.05, 1e-12);
   return [min - margin, max + margin];
+}
+
+/**
+ * Treat simulator round-off around a constant signal as a constant. Without
+ * this tolerance, a few femtovolts of numerical noise consume the whole plot
+ * height even though both axis labels round to the same value.
+ */
+export function transientValueExtent(
+  values: readonly number[],
+): readonly [number, number] {
+  const extent = finiteExtent(values);
+  const center = (extent[0] + extent[1]) / 2;
+  const magnitude = Math.max(Math.abs(extent[0]), Math.abs(extent[1]));
+  const tolerance = Math.max(magnitude * 1e-9, 1e-12);
+  if (extent[1] - extent[0] > tolerance) return extent;
+  const margin = Math.max(Math.abs(center) * 0.05, 1e-12);
+  return [center - margin, center + margin];
+}
+
+function clampPlotPoint(point: PlotPoint, plot: PlotGeometry): PlotPoint {
+  return {
+    x: Math.min(plot.width - plot.right, Math.max(plot.left, point.x)),
+    y: Math.min(plot.height - plot.bottom, Math.max(plot.top, point.y)),
+  };
+}
+
+export function transientBoxZoomRanges(
+  start: PlotPoint,
+  end: PlotPoint,
+  timeRange: readonly [number, number],
+  valueRange: readonly [number, number],
+  plot: PlotGeometry = PLOT,
+): {
+  readonly time: readonly [number, number];
+  readonly value: readonly [number, number];
+} {
+  const first = clampPlotPoint(start, plot);
+  const last = clampPlotPoint(end, plot);
+  const plotWidth = plot.width - plot.left - plot.right;
+  const plotHeight = plot.height - plot.top - plot.bottom;
+  const timeAt = (x: number) =>
+    timeRange[0] +
+    ((x - plot.left) / plotWidth) * (timeRange[1] - timeRange[0]);
+  const valueAt = (y: number) =>
+    valueRange[1] -
+    ((y - plot.top) / plotHeight) * (valueRange[1] - valueRange[0]);
+  const times = [timeAt(first.x), timeAt(last.x)].sort((a, b) => a - b);
+  const values = [valueAt(first.y), valueAt(last.y)].sort((a, b) => a - b);
+  return {
+    time: [times[0]!, times[1]!],
+    value: [values[0]!, values[1]!],
+  };
 }
 
 function compact(value: number): string {
@@ -177,6 +243,13 @@ export function TransientResultsExplorer({
   const [hoverTime, setHoverTime] = useState<number>();
   const [markerTime, setMarkerTime] = useState<number>();
   const [timeRange, setTimeRange] = useState<readonly [number, number]>();
+  const [valueRanges, setValueRanges] = useState<
+    Partial<Record<PlotQuantity, readonly [number, number]>>
+  >({});
+  const [interactionMode, setInteractionMode] = useState<
+    "inspect" | "box-zoom"
+  >("inspect");
+  const [zoomBox, setZoomBox] = useState<ZoomBox>();
   const [expandedQuantity, setExpandedQuantity] = useState<
     "voltage" | "current" | null
   >(null);
@@ -187,13 +260,16 @@ export function TransientResultsExplorer({
   const cursorTime = hoverTime ?? markerTime;
 
   useEffect(() => {
-    if (!expandedQuantity) return;
-    const close = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setExpandedQuantity(null);
+    const cancelTransientPlotAction = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setExpandedQuantity(null);
+      setZoomBox(undefined);
+      setInteractionMode("inspect");
     };
-    window.addEventListener("keydown", close);
-    return () => window.removeEventListener("keydown", close);
-  }, [expandedQuantity]);
+    window.addEventListener("keydown", cancelTransientPlotAction);
+    return () =>
+      window.removeEventListener("keydown", cancelTransientPlotAction);
+  }, []);
 
   const focusTrace = (traceId: string) => {
     const trace = traces.find((candidate) => candidate.id === traceId);
@@ -204,8 +280,14 @@ export function TransientResultsExplorer({
 
   const updateRange = (
     action: "zoom-in" | "zoom-out" | "pan-left" | "pan-right" | "fit",
+    quantity: PlotQuantity,
   ) => {
-    if (action === "fit") return setTimeRange(undefined);
+    if (action === "fit") {
+      setTimeRange(undefined);
+      setValueRanges((current) => ({ ...current, [quantity]: undefined }));
+      setZoomBox(undefined);
+      return;
+    }
     const next = changeTransientTimeRange(
       timeRange ?? fullRange,
       fullRange,
@@ -219,59 +301,101 @@ export function TransientResultsExplorer({
 
   const timeAtPointer = (
     event: PointerEvent<HTMLDivElement> | ReactMouseEvent<HTMLDivElement>,
-    plot: typeof PLOT | typeof EXPANDED_PLOT,
+    plot: PlotGeometry,
   ) => {
+    const point = plotPointAtPointer(event, plot);
     const bounds = event.currentTarget.getBoundingClientRect();
     const range = timeRange ?? fullRange;
-    const svgX = ((event.clientX - bounds.left) / bounds.width) * plot.width;
+    if (bounds.width === 0) return range[0];
     return Math.min(
       range[1],
       Math.max(
         range[0],
         range[0] +
-          ((svgX - plot.left) / (plot.width - plot.left - plot.right)) *
+          ((point.x - plot.left) / (plot.width - plot.left - plot.right)) *
             (range[1] - range[0]),
       ),
     );
   };
 
-  const toolbar = (quantity: "voltage" | "current", expanded: boolean) => (
+  const plotPointAtPointer = (
+    event: PointerEvent<HTMLDivElement> | ReactMouseEvent<HTMLDivElement>,
+    plot: PlotGeometry,
+  ): PlotPoint => {
+    const bounds = event.currentTarget.getBoundingClientRect();
+    if (bounds.width === 0 || bounds.height === 0) {
+      return { x: plot.left, y: plot.top };
+    }
+    return clampPlotPoint(
+      {
+        x: ((event.clientX - bounds.left) / bounds.width) * plot.width,
+        y: ((event.clientY - bounds.top) / bounds.height) * plot.height,
+      },
+      plot,
+    );
+  };
+
+  const toolbar = (quantity: PlotQuantity, expanded: boolean) => (
     <div
       className={`ac-plot-toolbar${expanded ? " expanded" : ""}`}
       aria-label="Plot tools"
     >
       <button
         type="button"
+        aria-label="Inspect plot"
+        aria-pressed={interactionMode === "inspect"}
+        title="Inspect and place a marker"
+        onClick={() => {
+          setInteractionMode("inspect");
+          setZoomBox(undefined);
+        }}
+      >
+        ⌖
+      </button>
+      <button
+        type="button"
+        aria-label="Box zoom"
+        aria-pressed={interactionMode === "box-zoom"}
+        title="Drag a rectangle to zoom"
+        onClick={() => {
+          setInteractionMode("box-zoom");
+          setZoomBox(undefined);
+        }}
+      >
+        ▧
+      </button>
+      <button
+        type="button"
         aria-label="Zoom in"
-        onClick={() => updateRange("zoom-in")}
+        onClick={() => updateRange("zoom-in", quantity)}
       >
         +
       </button>
       <button
         type="button"
         aria-label="Zoom out"
-        onClick={() => updateRange("zoom-out")}
+        onClick={() => updateRange("zoom-out", quantity)}
       >
         −
       </button>
       <button
         type="button"
         aria-label="Pan left"
-        onClick={() => updateRange("pan-left")}
+        onClick={() => updateRange("pan-left", quantity)}
       >
         ←
       </button>
       <button
         type="button"
         aria-label="Pan right"
-        onClick={() => updateRange("pan-right")}
+        onClick={() => updateRange("pan-right", quantity)}
       >
         →
       </button>
       <button
         type="button"
         aria-label="Fit plot"
-        onClick={() => updateRange("fit")}
+        onClick={() => updateRange("fit", quantity)}
       >
         Fit
       </button>
@@ -297,7 +421,7 @@ export function TransientResultsExplorer({
   );
 
   const plot = (
-    quantity: "voltage" | "current",
+    quantity: PlotQuantity,
     quantityTraces: readonly TransientTrace[],
     expanded = false,
   ) => {
@@ -310,7 +434,8 @@ export function TransientResultsExplorer({
           analysis.timeSeconds[index]! <= range[1],
       ),
     );
-    const extent = finiteExtent(visibleValues);
+    const automaticExtent = transientValueExtent(visibleValues);
+    const extent = valueRanges[quantity] ?? automaticExtent;
     const unit = quantityTraces.find((trace) => trace.unit)?.unit ?? "";
     const cursorX =
       cursorTime === undefined
@@ -321,19 +446,76 @@ export function TransientResultsExplorer({
     return (
       <div className={`ac-plot-shell${expanded ? " expanded" : ""}`}>
         <div
-          className="spice-ac-plot interactive"
-          onPointerMove={(event) =>
-            setHoverTime(timeAtPointer(event, geometry))
-          }
+          className={`spice-ac-plot interactive ${interactionMode}`}
+          onPointerDown={(event) => {
+            if (interactionMode !== "box-zoom" || event.button !== 0) return;
+            const point = plotPointAtPointer(event, geometry);
+            event.currentTarget.setPointerCapture(event.pointerId);
+            setZoomBox({ quantity, start: point, current: point });
+            event.preventDefault();
+          }}
+          onPointerMove={(event) => {
+            if (
+              interactionMode === "box-zoom" &&
+              zoomBox?.quantity === quantity
+            ) {
+              const point = plotPointAtPointer(event, geometry);
+              setZoomBox((current) =>
+                current?.quantity === quantity
+                  ? { ...current, current: point }
+                  : current,
+              );
+              return;
+            }
+            if (interactionMode === "inspect") {
+              setHoverTime(timeAtPointer(event, geometry));
+            }
+          }}
+          onPointerUp={(event) => {
+            if (
+              interactionMode !== "box-zoom" ||
+              zoomBox?.quantity !== quantity
+            )
+              return;
+            const end = plotPointAtPointer(event, geometry);
+            const width = Math.abs(end.x - zoomBox.start.x);
+            const height = Math.abs(end.y - zoomBox.start.y);
+            if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+              event.currentTarget.releasePointerCapture(event.pointerId);
+            }
+            if (width >= 5 && height >= 5) {
+              const next = transientBoxZoomRanges(
+                zoomBox.start,
+                end,
+                range,
+                extent,
+                geometry,
+              );
+              setTimeRange(next.time);
+              setValueRanges((current) => ({
+                ...current,
+                [quantity]: next.value,
+              }));
+              setInteractionMode("inspect");
+            }
+            setZoomBox(undefined);
+            setHoverTime(undefined);
+          }}
+          onPointerCancel={() => setZoomBox(undefined)}
           onPointerLeave={() => setHoverTime(undefined)}
           onClick={(event) => {
+            if (interactionMode !== "inspect") return;
             const id = (event.target as Element)
               .closest("[data-trace-id]")
               ?.getAttribute("data-trace-id");
             if (id) focusTrace(id);
             setMarkerTime(timeAtPointer(event, geometry));
           }}
-          onDoubleClick={() => !expanded && setExpandedQuantity(quantity)}
+          onDoubleClick={() =>
+            interactionMode === "inspect" &&
+            !expanded &&
+            setExpandedQuantity(quantity)
+          }
         >
           <svg
             role="img"
@@ -386,7 +568,14 @@ export function TransientResultsExplorer({
                   data-trace-id={trace.id}
                   data-trace-index={trace.colorIndex}
                 >
-                  <polyline className="ac-trace-hit" points={points} />
+                  <polyline
+                    className="ac-trace-hit"
+                    fill="none"
+                    stroke="transparent"
+                    strokeWidth={12}
+                    pointerEvents="stroke"
+                    points={points}
+                  />
                   <polyline
                     className={`transient-trace ac-trace-${trace.colorIndex % 6}${selected === trace.id ? " ac-trace-selected" : ""}`}
                     points={points}
@@ -397,12 +586,25 @@ export function TransientResultsExplorer({
             {cursorX === undefined ? null : (
               <line
                 className="ac-cursor"
+                stroke="#101828"
+                strokeWidth={1}
+                strokeDasharray="2 2"
+                pointerEvents="none"
                 x1={cursorX}
                 y1={geometry.top}
                 x2={cursorX}
                 y2={geometry.height - geometry.bottom}
               />
             )}
+            {zoomBox?.quantity === quantity ? (
+              <rect
+                className="ac-zoom-box"
+                x={Math.min(zoomBox.start.x, zoomBox.current.x)}
+                y={Math.min(zoomBox.start.y, zoomBox.current.y)}
+                width={Math.abs(zoomBox.current.x - zoomBox.start.x)}
+                height={Math.abs(zoomBox.current.y - zoomBox.start.y)}
+              />
+            ) : null}
           </svg>
         </div>
         {toolbar(quantity, expanded)}

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -562,6 +562,29 @@
   stroke-linejoin: round;
   vector-effect: non-scaling-stroke;
 }
+.transient-trace.ac-trace-selected {
+  stroke-width: 3;
+}
+.transient-quantity-group .ac-trace-hit {
+  fill: none;
+  stroke: transparent;
+  stroke-width: 12;
+  pointer-events: stroke;
+  cursor: pointer;
+}
+.spice-ac-plot.box-zoom {
+  cursor: crosshair;
+  touch-action: none;
+  user-select: none;
+}
+.ac-zoom-box {
+  fill: color-mix(in srgb, var(--icm-accent, #175cd3) 12%, transparent);
+  stroke: var(--icm-accent, #175cd3);
+  stroke-width: 1;
+  stroke-dasharray: 4 3;
+  pointer-events: none;
+  vector-effect: non-scaling-stroke;
+}
 .transient-trace.ac-trace-0 {
   color: #175cd3;
 }
@@ -714,6 +737,11 @@
   padding: 2px 6px;
   background: var(--icm-surface);
   font-size: var(--icm-font-xs);
+}
+.ac-plot-toolbar button[aria-pressed="true"] {
+  border-color: var(--icm-accent, #175cd3);
+  background: color-mix(in srgb, var(--icm-accent, #175cd3) 12%, white);
+  color: var(--icm-accent, #175cd3);
 }
 .ac-plot-dialog-backdrop {
   position: fixed;


### PR DESCRIPTION
## Summary
- make transient hit targets stroke-only so SVG never closes them into black filled polygons
- treat tiny solver round-off as a constant signal instead of expanding it across the full Y axis
- add explicit Inspect and one-shot Box Zoom modes with two-dimensional range selection, Escape cancellation, and Fit recovery
- restore visible cursor and selected-trace feedback in the transient renderer

## Strategy
SVG remains the renderer. Interaction state is kept separate from simulation data, so a later high-density trace layer can move to Canvas without changing probes, axes, markers, or viewport semantics.

## Validation
- pnpm typecheck
- focused transient unit tests: 5/5
- focused human simulation browser journey: passed
- pnpm gate:affected -- --base origin/main: 2676 unit tests and 5 selected browser tests passed
- pnpm gate:preflight -- --base origin/main

Test-Impact: tests-updated