### PR TITLE
feat(editor): streamline independent source properties

### DIFF
--- a/apps/editor/e2e/component-insert.spec.ts
+++ b/apps/editor/e2e/component-insert.spec.ts
@@ -1172,13 +1172,30 @@ test("ordinary source Properties switch waveforms without erasing inactive value
   await page.getByTestId("hit-V1").click();
   await page.keyboard.press("q");
 
-  const waveform = page.getByLabel("Component waveform");
+  const waveform = page.getByLabel("Component transient");
   await expect(waveform).toHaveValue("dc");
+  await expect(waveform.locator('option[value="dc"]')).toHaveText("None");
+  const parameters = page.getByLabel("Component parameters and display");
+  await expect(parameters).toContainText("AC phase / deg");
+  await expect(parameters).not.toContainText("Small-signal phase");
   await expect(page.getByLabel("Component low")).toHaveCount(0);
   await expect(page.getByLabel("Component amplitude")).toHaveCount(0);
 
   await waveform.selectOption("pulse");
+  const low = page.getByLabel("Component low");
   const high = page.getByLabel("Component high");
+  const rise = page.getByLabel("Component rise time");
+  const fall = page.getByLabel("Component fall time");
+  const [lowBox, highBox, riseBox, fallBox] = await Promise.all([
+    low.boundingBox(),
+    high.boundingBox(),
+    rise.boundingBox(),
+    fall.boundingBox(),
+  ]);
+  expect(lowBox?.y).toBe(highBox?.y);
+  expect(riseBox?.y).toBe(fallBox?.y);
+  expect(lowBox!.x).toBeLessThan(highBox!.x);
+  expect(riseBox!.x).toBeLessThan(fallBox!.x);
   await expect(high).toHaveValue("1");
   await high.fill("2.5");
 

--- a/apps/editor/src/features/component-insert/component-parameters.test.ts
+++ b/apps/editor/src/features/component-insert/component-parameters.test.ts
@@ -97,7 +97,12 @@ describe("component parameter catalogue", () => {
         unit,
       });
       expect(parameters.find(({ key }) => key === "waveform")).toMatchObject({
-        options: [{ value: "dc" }, { value: "pulse" }, { value: "sin" }],
+        label: "Transient",
+        options: [
+          { value: "dc", label: "None" },
+          { value: "pulse", label: "PULSE" },
+          { value: "sin", label: "SIN" },
+        ],
       });
       expect(parameters.find(({ key }) => key === "acMagnitude")).toMatchObject(
         {

--- a/apps/editor/src/features/properties/component-electrical-properties.test.tsx
+++ b/apps/editor/src/features/properties/component-electrical-properties.test.tsx
@@ -62,7 +62,7 @@ describe("component electrical properties", () => {
     expect(markup).not.toContain("Component compatibility field");
   });
 
-  it("keeps W, L, and NF labels compact while retaining their tooltips", () => {
+  it("keeps W, L, and NF labels compact while retaining other device guidance", () => {
     const document = createEmptyDocument("cell", "Cell");
     const instance: (typeof document.instances)[number] = {
       id: "M1",
@@ -216,18 +216,31 @@ describe("component electrical properties", () => {
       );
 
     const dc = render("dc");
-    expect(dc).toContain('aria-label="Component waveform"');
+    expect(dc).toContain('aria-label="Component transient"');
+    expect(dc).toContain('<option value="dc" selected="">None</option>');
+    expect(dc).toContain('data-parameter-row="dc-waveform"');
+    expect(dc).toContain('data-parameter-row="acMagnitude-acPhase"');
     expect(dc).not.toContain('aria-label="Component low"');
     expect(dc).not.toContain('aria-label="Component amplitude"');
 
     const pulse = render("pulse");
+    expect(pulse).not.toContain("Small-signal");
+    expect(pulse).not.toContain("PULSE value");
+    expect(pulse).toContain('aria-label="Component ac magnitude"');
+    expect(pulse).toContain('aria-label="Component ac phase"');
     expect(pulse).toContain('aria-label="Component low"');
     expect(pulse).toContain('aria-label="Component period"');
+    expect(pulse).toContain('data-parameter-row="low-high"');
+    expect(pulse).toContain('data-parameter-row="rise-fall"');
+    expect(pulse).toContain('data-parameter-row="width-period"');
     expect(pulse).not.toContain('aria-label="Component amplitude"');
 
     const sin = render("sin");
     expect(sin).toContain('aria-label="Component amplitude"');
     expect(sin).toContain('aria-label="Component frequency"');
+    expect(sin).toContain('data-parameter-row="offset-amplitude"');
+    expect(sin).toContain('data-parameter-row="frequency-phase"');
+    expect(sin).toContain('data-parameter-row="delay-damping"');
     expect(sin).not.toContain('aria-label="Component low"');
   });
 });

--- a/apps/editor/src/features/properties/component-electrical-properties.tsx
+++ b/apps/editor/src/features/properties/component-electrical-properties.tsx
@@ -11,6 +11,50 @@ import { derivedFingerWidth } from "./finger-width";
 type Instance = SchematicDocument["instances"][number];
 const COMPACT_PARAMETER_LABELS = new Set(["W", "L", "NF"]);
 
+const SOURCE_BASE_PARAMETER_ROWS = [
+  ["dc", "waveform"],
+  ["acMagnitude", "acPhase"],
+] as const;
+
+const SOURCE_TRANSIENT_PARAMETER_ROWS = {
+  dc: [],
+  pulse: [["low", "high"], ["delay"], ["rise", "fall"], ["width", "period"]],
+  sin: [
+    ["offset", "amplitude"],
+    ["frequency", "phase"],
+    ["delay", "damping"],
+  ],
+} as const;
+
+function parameterRows(
+  parameters: readonly ComponentParameter[],
+  waveform: string | undefined,
+): readonly (readonly ComponentParameter[])[] {
+  if (!parameters.some(({ key }) => key === "waveform")) {
+    return parameters.map((parameter) => [parameter]);
+  }
+
+  const byKey = new Map(
+    parameters.map((parameter) => [parameter.key, parameter]),
+  );
+  const transientRows =
+    waveform === "pulse" || waveform === "sin"
+      ? SOURCE_TRANSIENT_PARAMETER_ROWS[waveform]
+      : SOURCE_TRANSIENT_PARAMETER_ROWS.dc;
+  const orderedKeys = [...SOURCE_BASE_PARAMETER_ROWS, ...transientRows];
+  const used = new Set<string>(orderedKeys.flat());
+  return [
+    ...orderedKeys
+      .map((keys) =>
+        keys.flatMap((key) => (byKey.has(key) ? [byKey.get(key)!] : [])),
+      )
+      .filter((row) => row.length > 0),
+    ...parameters
+      .filter(({ key }) => !used.has(key))
+      .map((parameter) => [parameter]),
+  ];
+}
+
 export function ComponentElectricalProperties({
   instance,
   parameters,
@@ -76,15 +120,19 @@ export function ComponentElectricalProperties({
   onAdditionalParametersCancel: () => void;
 }) {
   const fingerWidth = derivedFingerWidth(parameterValues.w, parameterValues.nf);
+  const descriptor = deviceDescriptor(instance.symbolId);
   const waveform =
-    parameterValues.waveform ||
-    deviceDescriptor(instance.symbolId)?.sourceWaveformDefault;
+    parameterValues.waveform || descriptor?.sourceWaveformDefault;
   const primaryParameters = parameters.filter(
     (parameter) =>
       !parameter.compatibilityOnly &&
       (!parameter.visibleForSourceWaveforms ||
         ((waveform === "pulse" || waveform === "sin") &&
           parameter.visibleForSourceWaveforms.includes(waveform))),
+  );
+  const primaryParameterRows = parameterRows(primaryParameters, waveform);
+  const isIndependentSource = primaryParameters.some(
+    ({ key }) => key === "waveform",
   );
   // A toggle that cannot change the drawing is not an option, it is a dead
   // control: schematic-only glyphs neither draw a reference nor carry a
@@ -94,7 +142,7 @@ export function ComponentElectricalProperties({
   // instance has and this Symbol draws, and a value this device supports.
   const referenceToggleable = referenceLabelRenderable && referenceAvailable;
   const displayable = referenceToggleable || valueSupported;
-  const isMos = deviceDescriptor(instance.symbolId)?.deviceClass === "mos";
+  const isMos = descriptor?.deviceClass === "mos";
   if (primaryParameters.length === 0 && !displayable && !instance.netlist) {
     return null;
   }
@@ -105,42 +153,65 @@ export function ComponentElectricalProperties({
     >
       <div className="property-section-heading">Parameters</div>
       <div className="component-parameter-grid">
-        {primaryParameters.map((parameter, index) => (
-          <label key={parameter.key} title={parameter.help}>
-            <span className="property-parameter-name">
-              {parameter.label}
-              {parameter.unit ? ` / ${parameter.unit}` : ""}
-              {isMos && COMPACT_PARAMETER_LABELS.has(parameter.label) ? null : (
-                <em>({parameter.help})</em>
-              )}
-            </span>
-            {parameter.options ? (
-              <select
-                aria-label={`Component ${parameter.label.toLowerCase()}`}
-                value={parameterValues[parameter.key] ?? ""}
-                onChange={(event) =>
-                  onParameterChange(parameter.key, event.currentTarget.value)
-                }
+        {primaryParameterRows.map((row) => (
+          <div
+            className="component-parameter-row"
+            data-parameter-row={row.map(({ key }) => key).join("-")}
+            key={row.map(({ key }) => key).join("-")}
+          >
+            {row.map((parameter) => (
+              <label
+                key={parameter.key}
+                title={isIndependentSource ? undefined : parameter.help}
               >
-                {parameter.options.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            ) : (
-              <input
-                ref={index === 0 ? firstInputRef : undefined}
-                aria-label={`Component ${parameter.label.toLowerCase()}`}
-                inputMode={parameter.inputMode}
-                value={parameterValues[parameter.key] ?? ""}
-                placeholder={parameter.placeholder}
-                onChange={(event) =>
-                  onParameterChange(parameter.key, event.currentTarget.value)
-                }
-              />
-            )}
-          </label>
+                <span className="property-parameter-name">
+                  {parameter.label}
+                  {parameter.unit ? ` / ${parameter.unit}` : ""}
+                  {isIndependentSource ||
+                  (isMos &&
+                    COMPACT_PARAMETER_LABELS.has(parameter.label)) ? null : (
+                    <em>({parameter.help})</em>
+                  )}
+                </span>
+                {parameter.options ? (
+                  <select
+                    aria-label={`Component ${parameter.label.toLowerCase()}`}
+                    value={parameterValues[parameter.key] ?? ""}
+                    onChange={(event) =>
+                      onParameterChange(
+                        parameter.key,
+                        event.currentTarget.value,
+                      )
+                    }
+                  >
+                    {parameter.options.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    ref={
+                      parameter.key === primaryParameters[0]?.key
+                        ? firstInputRef
+                        : undefined
+                    }
+                    aria-label={`Component ${parameter.label.toLowerCase()}`}
+                    inputMode={parameter.inputMode}
+                    value={parameterValues[parameter.key] ?? ""}
+                    placeholder={parameter.placeholder}
+                    onChange={(event) =>
+                      onParameterChange(
+                        parameter.key,
+                        event.currentTarget.value,
+                      )
+                    }
+                  />
+                )}
+              </label>
+            ))}
+          </div>
         ))}
       </div>
       {fingerWidth ? (

--- a/apps/editor/src/styles/editor-properties.css
+++ b/apps/editor/src/styles/editor-properties.css
@@ -61,6 +61,16 @@
   gap: 0.45rem;
 }
 
+.component-parameter-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.35rem;
+}
+
+.component-parameter-row > label:only-child {
+  grid-column: 1 / -1;
+}
+
 .component-readonly-fields .property-identity-target {
   grid-column: 1 / -1;
 }

--- a/packages/devices/src/descriptors/independent-source-parameters.ts
+++ b/packages/devices/src/descriptors/independent-source-parameters.ts
@@ -19,11 +19,11 @@ export function independentSourceParameters(
     },
     {
       name: "waveform",
-      label: "Waveform",
+      label: "Transient",
       required: false,
       editor: "select",
       options: [
-        { value: "dc", label: "DC" },
+        { value: "dc", label: "None" },
         { value: "pulse", label: "PULSE" },
         { value: "sin", label: "SIN" },
       ],

--- a/packages/devices/src/registry.test.ts
+++ b/packages/devices/src/registry.test.ts
@@ -197,9 +197,14 @@ describe("built-in device registry", () => {
       expect(
         descriptor.parameters.find(({ name }) => name === "waveform"),
       ).toMatchObject({
+        label: "Transient",
         editor: "select",
         defaultValue: "dc",
-        options: [{ value: "dc" }, { value: "pulse" }, { value: "sin" }],
+        options: [
+          { value: "dc", label: "None" },
+          { value: "pulse", label: "PULSE" },
+          { value: "sin", label: "SIN" },
+        ],
       });
       // The AC fields are optional and default to nothing: a placed source is
       // DC-only until an author writes a magnitude, and the printed card never


### PR DESCRIPTION
## Summary
- remove inline explanatory prose from ordinary voltage/current source Properties
- arrange related controls into compact semantic rows
- rename the transient selector to Transient: None/PULSE/SIN so AC and transient intent are not presented as competing modes
- preserve independent DC, AC, PULSE, and SIN netlist semantics

## Validation
- pnpm gate:preflight -- --base origin/main
- pnpm gate:full
  - 2674 unit/integration tests passed
  - 356 browser tests passed
  - production build, release smoke, golden checks, and performance baseline passed

Test-Impact: tests-updated