### PR TITLE
Improve waveform navigation, axis controls and A/B measurements

### DIFF
--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -431,8 +431,39 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     panel.locator(".transient-results-explorer .ac-cursor-readout"),
   ).toHaveCount(0);
   await expect(rightTimeLabel).not.toHaveText(fullTimeLabel ?? "");
+  const zoomTimeLabel = await rightTimeLabel.textContent();
+  await transientShell.getByRole("button", { name: "Previous view" }).click();
+  await expect(rightTimeLabel).toHaveText(fullTimeLabel ?? "");
+  await transientShell.getByRole("button", { name: "Next view" }).click();
+  await expect(rightTimeLabel).toHaveText(zoomTimeLabel ?? "");
   await transientShell.getByRole("button", { name: "Fit plot" }).click();
   await expect(rightTimeLabel).toHaveText(fullTimeLabel ?? "");
+  const yLabels = await transientPlot
+    .locator('svg text[text-anchor="end"]')
+    .allTextContents();
+  await transientShell.getByRole("button", { name: "Control X axes" }).click();
+  const xDrag = (await transientPlot.boundingBox())!;
+  await page.mouse.move(
+    xDrag.x + xDrag.width * 0.3,
+    xDrag.y + xDrag.height * 0.5,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    xDrag.x + xDrag.width * 0.7,
+    xDrag.y + xDrag.height * 0.5,
+  );
+  await page.mouse.up();
+  await expect(rightTimeLabel).not.toHaveText(fullTimeLabel ?? "");
+  expect(
+    await transientPlot
+      .locator('svg text[text-anchor="end"]')
+      .allTextContents(),
+  ).toEqual(yLabels);
+  await transientShell
+    .getByRole("button", { name: "Fit X", exact: true })
+    .click();
+  await expect(rightTimeLabel).toHaveText(fullTimeLabel ?? "");
+  await transientShell.getByRole("button", { name: "Control XY axes" }).click();
   await transientPlot.click({
     position: {
       x: transientBounds!.width * 0.5,
@@ -451,11 +482,79 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     },
   });
   await expect(fixedReadout).toHaveText(measurement ?? "");
+  await transientShell.getByRole("button", { name: "Place marker B" }).click();
+  await transientPlot.click({
+    position: {
+      x: transientBounds!.width * 0.9,
+      y: transientBounds!.height * 0.4,
+    },
+  });
+  await expect(fixedReadout).toContainText("ΔX:");
+  await expect(fixedReadout).toContainText("ΔY");
+  await expect(fixedReadout).toContainText("1/|Δt|");
+  const markersBeforeRemount = await fixedReadout.textContent();
+  await transientShell
+    .getByRole("button", { name: "Ranges", exact: true })
+    .click();
+  const ranges = transientShell.getByRole("form", { name: "Axis ranges" });
+  await ranges.getByLabel("Auto X", { exact: true }).uncheck();
+  await ranges.getByLabel("X minimum").fill("8e-9");
+  await ranges.getByLabel("X maximum").fill("2e-9");
+  await ranges.getByRole("button", { name: "Apply ranges" }).click();
+  await expect(ranges.getByRole("alert")).toContainText("Minimum must be less");
+  await ranges.getByLabel("X minimum").fill("2e-9");
+  await ranges.getByLabel("X maximum").fill("8e-9");
+  await ranges.getByLabel("Auto Y", { exact: true }).uncheck();
+  await ranges.getByLabel("Y minimum").fill("-1");
+  await ranges.getByLabel("Y maximum").fill("2");
+  await ranges.getByRole("button", { name: "Apply ranges" }).click();
+  await expect(ranges).toHaveCount(0);
+  const savedTicks = await rightTimeLabel.textContent();
+  await panel.getByRole("tab", { name: "Files" }).click();
+  await panel.getByRole("tab", { name: "Plot" }).click();
+  await expect(rightTimeLabel).toHaveText(savedTicks ?? "");
+  await expect(fixedReadout).toHaveText(markersBeforeRemount ?? "");
+  const transientOutputs = panel.locator(".transient-results-explorer");
+  await transientOutputs
+    .getByRole("button", { name: "Hide first-output" })
+    .click();
+  await panel.getByRole("tab", { name: "Files" }).click();
+  await panel.getByRole("tab", { name: "Plot" }).click();
+  await expect(
+    transientOutputs.getByRole("button", { name: "Show first-output" }),
+  ).toBeVisible();
+  await expect(transientPlot).toHaveCount(0);
+  await transientOutputs
+    .getByRole("button", { name: "Show first-output" })
+    .click();
+  await expect(rightTimeLabel).toHaveText(savedTicks ?? "");
+  await expect(fixedReadout).toHaveText(markersBeforeRemount ?? "");
+  await transientShell.getByRole("button", { name: "Previous view" }).click();
+  await expect(rightTimeLabel).toHaveText(fullTimeLabel ?? "");
+  await transientShell.getByRole("button", { name: "Next view" }).click();
+  await expect(rightTimeLabel).toHaveText(savedTicks ?? "");
   await transientShell.getByRole("button", { name: "Open plot" }).click();
   const waveformDialog = page.getByRole("dialog", {
     name: "Transient voltage plot",
   });
   await expect(waveformDialog.locator(".ac-cursor-readout")).toBeVisible();
+  const expandedViewport = await waveformDialog
+    .locator(".spice-ac-plot")
+    .boundingBox();
+  const expandedTick = await waveformDialog
+    .locator('svg text[text-anchor="middle"]')
+    .last()
+    .boundingBox();
+  expect(expandedTick!.y + expandedTick!.height).toBeLessThanOrEqual(
+    expandedViewport!.y + expandedViewport!.height,
+  );
+  await expect(waveformDialog.locator("line.ac-grid").first()).not.toHaveCSS(
+    "stroke",
+    "none",
+  );
+  await waveformDialog.screenshot({
+    path: test.info().outputPath("waveform-tools.png"),
+  });
   await waveformDialog.getByRole("button", { name: "Close plot" }).click();
   await panel.getByRole("tab", { name: "Files" }).click();
   await expect(
@@ -490,11 +589,20 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   await panel.getByRole("tab", { name: "Plot" }).click();
   await expect(panel.getByText("first-output", { exact: true })).toHaveCount(2);
   await expect(panel.getByText("new-output", { exact: true })).toHaveCount(0);
+  await panel.getByRole("button", { name: "Run", exact: true }).click();
+  await expect.poll(() => executions).toBe(2);
+  await expect(panel.getByRole("status")).toHaveText("finished · completed");
+  await panel.getByRole("tab", { name: "Plot" }).click();
+  await expect(panel.locator(".ac-cursor-readout")).toHaveCount(0);
+  await expect(
+    transientShell.getByRole("button", { name: "Previous view" }),
+  ).toBeDisabled();
+  await expect(panel.getByText("new-output", { exact: true })).toHaveCount(2);
   pending = new Promise<void>((r) => {
     release = r;
   });
   await panel.getByRole("button", { name: "Run", exact: true }).click();
-  await expect.poll(() => executions).toBe(2);
+  await expect.poll(() => executions).toBe(3);
   await panel.getByRole("button", { name: "Cancel run" }).click();
   await expect(panel.getByRole("status")).toContainText("cancelled");
   expect(cancellations).toBe(1);

--- a/apps/editor/e2e/agent-simulation.spec.ts
+++ b/apps/editor/e2e/agent-simulation.spec.ts
@@ -345,6 +345,26 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
   const plotBeforeWheel = await magnitudePlot.innerHTML();
   await magnitudePlot.dispatchEvent("wheel", { deltaY: -120 });
   await expect(magnitudePlot).toHaveJSProperty("innerHTML", plotBeforeWheel);
+  const acBounds = (await magnitudePlot.boundingBox())!;
+  await page.mouse.move(
+    acBounds.x + acBounds.width * 0.3,
+    acBounds.y + acBounds.height * 0.3,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    acBounds.x + acBounds.width * 0.7,
+    acBounds.y + acBounds.height * 0.7,
+  );
+  await page.mouse.up();
+  await expect(magnitudePlot).not.toHaveJSProperty(
+    "innerHTML",
+    plotBeforeWheel,
+  );
+  await magnitudePlot
+    .locator("..")
+    .getByRole("button", { name: "Fit plot" })
+    .click();
+  await expect(magnitudePlot).toHaveJSProperty("innerHTML", plotBeforeWheel);
   await magnitudePlot.hover();
   await expect(
     panel.getByRole("button", { name: "Zoom in" }).first(),
@@ -354,7 +374,19 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     page.getByRole("dialog", { name: "voltage magnitude plot" }),
   ).toBeVisible();
   await page.getByRole("button", { name: "Close plot" }).click();
-  await magnitudePlot.locator("polyline[data-trace-id]").dispatchEvent("click");
+  const tracePoint = await magnitudePlot
+    .locator("polyline[data-trace-id]")
+    .evaluate((element) => {
+      const line = element as SVGPolylineElement;
+      const point = line.points.getItem(
+        Math.floor(line.points.numberOfItems / 2),
+      );
+      const screen = new DOMPoint(point.x, point.y).matrixTransform(
+        line.getScreenCTM()!,
+      );
+      return { x: screen.x, y: screen.y };
+    });
+  await page.mouse.click(tracePoint.x, tracePoint.y);
   await expect(
     panel.locator(".simulation-output-browser > .selected"),
   ).toHaveCount(1);
@@ -373,14 +405,13 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     "none",
   );
   await transientPlot.hover();
-  const boxZoom = transientShell.getByRole("button", { name: "Box zoom" });
-  const inspectPlot = transientShell.getByRole("button", {
-    name: "Inspect plot",
-  });
-  const rightTimeLabel = transientPlot.locator('svg text[text-anchor="end"]');
+  const rightTimeLabel = transientPlot
+    .locator('svg text[text-anchor="middle"]')
+    .last();
   const fullTimeLabel = await rightTimeLabel.textContent();
-  await boxZoom.click();
-  await expect(boxZoom).toHaveAttribute("aria-pressed", "true");
+  const toolbarBounds = await transientShell
+    .getByLabel("Plot tools")
+    .boundingBox();
   const transientBounds = await transientPlot.boundingBox();
   expect(transientBounds).not.toBeNull();
   await page.mouse.move(
@@ -393,10 +424,39 @@ test("human simulation uses saved setup, survives minimizing, recovers a bad inp
     transientBounds!.y + transientBounds!.height * 0.7,
   );
   await page.mouse.up();
-  await expect(inspectPlot).toHaveAttribute("aria-pressed", "true");
+  expect(toolbarBounds!.y + toolbarBounds!.height).toBeLessThanOrEqual(
+    transientBounds!.y,
+  );
+  await expect(
+    panel.locator(".transient-results-explorer .ac-cursor-readout"),
+  ).toHaveCount(0);
   await expect(rightTimeLabel).not.toHaveText(fullTimeLabel ?? "");
   await transientShell.getByRole("button", { name: "Fit plot" }).click();
   await expect(rightTimeLabel).toHaveText(fullTimeLabel ?? "");
+  await transientPlot.click({
+    position: {
+      x: transientBounds!.width * 0.5,
+      y: transientBounds!.height * 0.5,
+    },
+  });
+  const fixedReadout = panel.locator(
+    ".transient-results-explorer .ac-cursor-readout",
+  );
+  await expect(fixedReadout).toBeVisible();
+  const measurement = await fixedReadout.textContent();
+  await transientPlot.hover({
+    position: {
+      x: transientBounds!.width * 0.8,
+      y: transientBounds!.height * 0.4,
+    },
+  });
+  await expect(fixedReadout).toHaveText(measurement ?? "");
+  await transientShell.getByRole("button", { name: "Open plot" }).click();
+  const waveformDialog = page.getByRole("dialog", {
+    name: "Transient voltage plot",
+  });
+  await expect(waveformDialog.locator(".ac-cursor-readout")).toBeVisible();
+  await waveformDialog.getByRole("button", { name: "Close plot" }).click();
   await panel.getByRole("tab", { name: "Files" }).click();
   await expect(
     panel.getByRole("button", { name: "evidence-manifest.json" }),

--- a/apps/editor/src/features/simulation/ac-response-plot.test.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.test.ts
@@ -30,15 +30,17 @@ describe("AC response plot", () => {
     const layout = layoutAcPlot([singlePole()], { width: 600, height: 300 });
     expect(layout).not.toBeNull();
     // A sweep from 1 Hz to 1 MHz reads as decades, not as raw sample points.
-    expect(layout!.frequency.ticks).toEqual([1, 10, 100, 1e3, 1e4, 1e5, 1e6]);
+    expect(layout!.frequency.ticks).toEqual([1, 100, 1e4, 1e6]);
   });
 
-  it("rounds the magnitude axis outward to readable steps", () => {
+  it("contains the data with readable adaptive grid steps", () => {
     const layout = layoutAcPlot([singlePole()], { width: 600, height: 300 })!;
     // The trace spans about -20 dB to 40 dB; the axis must contain it and
     // land on round gridlines rather than on the data's own extremes.
     expect(layout.magnitude.min).toBeLessThanOrEqual(-20);
-    expect(layout.magnitude.max).toBeGreaterThanOrEqual(40);
+    expect(layout.magnitude.max).toBeGreaterThanOrEqual(
+      singlePole().points[0]!.magnitudeDb,
+    );
     expect(layout.magnitude.ticks).toContain(0);
   });
 

--- a/apps/editor/src/features/simulation/ac-response-plot.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.ts
@@ -69,6 +69,7 @@ export interface AcResponseSvgOptions {
   kind: AcPlotKind;
   /** Shared cursor frequency for paired magnitude/phase plots. */
   cursorFrequency?: number;
+  cursorFrequencyB?: number;
   /** The interactive Results Browser owns the legend when false. */
   showLegend?: boolean;
   /** Selected Results Browser trace, emphasized on the plot. */
@@ -293,12 +294,18 @@ export function acResponseSvg(
           })
           .join("")
       : "";
-  const cursor =
-    options.cursorFrequency !== undefined &&
-    options.cursorFrequency >= layout.frequency.min &&
-    options.cursorFrequency <= layout.frequency.max
-      ? `<line class="ac-cursor" x1="${project.x(options.cursorFrequency).toFixed(2)}" y1="${frame.y}" x2="${project.x(options.cursorFrequency).toFixed(2)}" y2="${frame.y + frame.height}"/>`
-      : "";
+  const cursor = ([options.cursorFrequency, options.cursorFrequencyB] as const)
+    .map((frequency, index) => {
+      if (
+        frequency === undefined ||
+        frequency < layout.frequency.min ||
+        frequency > layout.frequency.max
+      )
+        return "";
+      const x = project.x(frequency).toFixed(2);
+      return `<g pointer-events="none"><line class="ac-cursor" style="stroke:${index === 0 ? "#175cd3" : "#c4320a"}" x1="${x}" y1="${frame.y}" x2="${x}" y2="${frame.y + frame.height}"/><text x="${Number(x) + 3}" y="${frame.y + 12}">${index === 0 ? "A" : "B"}</text></g>`;
+    })
+    .join("");
 
   return (
     `<svg xmlns="http://www.w3.org/2000/svg" class="ac-response" viewBox="0 0 ${size.width} ${size.height}" width="${size.width}" height="${size.height}" role="img" aria-label="AC ${options.kind}">` +

--- a/apps/editor/src/features/simulation/ac-response-plot.ts
+++ b/apps/editor/src/features/simulation/ac-response-plot.ts
@@ -1,3 +1,4 @@
+import { waveformTicks } from "./waveform-interaction";
 /**
  * A Bode plot for AC analysis results.
  *
@@ -74,6 +75,7 @@ export interface AcResponseSvgOptions {
   selectedTraceId?: string;
   /** Explicit axes-toolbar range; traces are clipped to this interval. */
   frequencyRange?: readonly [number, number];
+  valueRange?: readonly [number, number];
 }
 
 const MARGIN = { left: 56, right: 56, top: 16, bottom: 32 };
@@ -88,29 +90,36 @@ function niceDecades(min: number, max: number): number[] {
   return ticks;
 }
 
-/** Round a linear range outward to readable round numbers. */
-function niceLinear(min: number, max: number, step: number): AcPlotAxis {
-  const low = Math.floor(min / step) * step;
-  const high = Math.ceil(max / step) * step;
-  const ticks: number[] = [];
-  for (let value = low; value <= high + step / 2; value += step) {
-    ticks.push(Math.round(value * 1e6) / 1e6);
-  }
-  return { ticks, min: low, max: high === low ? low + step : high };
+function adaptiveAxis(
+  range: readonly [number, number],
+  height: number,
+): AcPlotAxis {
+  const margin = Math.max(Math.abs(range[0]) * 0.05, 1);
+  const min = range[0] === range[1] ? range[0] - margin : range[0];
+  const max = range[0] === range[1] ? range[1] + margin : range[1];
+  return { min, max, ticks: waveformTicks(min, max, height > 400 ? 10 : 5) };
 }
 
 export function layoutAcPlot(
   traces: readonly AcTrace[],
   size: AcPlotSize,
   frequencyRange?: readonly [number, number],
+  valueOverride?: { kind: AcPlotKind; range: readonly [number, number] },
 ): AcPlotLayout | null {
   const points = traces.flatMap((trace) => trace.points);
   const usable = points.filter((point) => point.frequency > 0);
   if (usable.length === 0) return null;
 
   const frequencies = usable.map((point) => point.frequency);
-  const magnitudes = usable.map((point) => point.magnitudeDb);
-  const phases = usable.map((point) => point.phaseDeg);
+  const inView = usable.filter(
+    (point) =>
+      !frequencyRange ||
+      (point.frequency >= frequencyRange[0] &&
+        point.frequency <= frequencyRange[1]),
+  );
+  const visible = inView.length ? inView : usable;
+  const magnitudes = visible.map((point) => point.magnitudeDb);
+  const phases = visible.map((point) => point.phaseDeg);
   const frame = {
     x: MARGIN.left,
     y: MARGIN.top,
@@ -125,7 +134,18 @@ export function layoutAcPlot(
     (frequency) => frequency >= fMin && frequency <= fMax,
   );
   const frequency: AcPlotAxis = {
-    ticks: decades,
+    ticks:
+      decades.length >= 2
+        ? decades.filter(
+            (_, i) =>
+              i %
+                Math.max(
+                  1,
+                  Math.ceil(decades.length / (size.width > 1000 ? 10 : 5)),
+                ) ===
+              0,
+          )
+        : waveformTicks(fMin, fMax, 5),
     min: frequencyRange ? fMin : niceDecades(dataMin, dataMax)[0]!,
     max: frequencyRange ? fMax : niceDecades(dataMin, dataMax).at(-1)!,
   };
@@ -136,8 +156,18 @@ export function layoutAcPlot(
     size,
     frame,
     frequency,
-    magnitude: niceLinear(Math.min(...magnitudes), Math.max(...magnitudes), 20),
-    phase: niceLinear(Math.min(...phases), Math.max(...phases), 45),
+    magnitude: adaptiveAxis(
+      valueOverride?.kind === "magnitude"
+        ? valueOverride.range
+        : [Math.min(...magnitudes), Math.max(...magnitudes)],
+      size.height,
+    ),
+    phase: adaptiveAxis(
+      valueOverride?.kind === "phase"
+        ? valueOverride.range
+        : [Math.min(...phases), Math.max(...phases)],
+      size.height,
+    ),
     frequencyAt: (x: number) =>
       10 ** (logMin + ((x - frame.x) / frame.width) * logSpan),
   };
@@ -203,7 +233,14 @@ export function acResponseSvg(
   size: AcPlotSize,
   options: AcResponseSvgOptions = { kind: "magnitude" },
 ): string | null {
-  const layout = layoutAcPlot(traces, size, options.frequencyRange);
+  const layout = layoutAcPlot(
+    traces,
+    size,
+    options.frequencyRange,
+    options.valueRange
+      ? { kind: options.kind, range: options.valueRange }
+      : undefined,
+  );
   if (!layout) return null;
   const project = projection(layout);
   const { frame } = layout;
@@ -219,7 +256,7 @@ export function acResponseSvg(
     }),
     ...axis.ticks.map((value) => {
       const y = axisY(value).toFixed(2);
-      return `<line class="ac-grid" x1="${frame.x}" y1="${y}" x2="${frame.x + frame.width}" y2="${y}"/><text class="ac-axis-label" x="${frame.x - 8}" y="${y}" text-anchor="end" dominant-baseline="middle">${value}${unit}</text>`;
+      return `<line class="ac-grid" x1="${frame.x}" y1="${y}" x2="${frame.x + frame.width}" y2="${y}"/><text class="ac-axis-label" x="${frame.x - 8}" y="${y}" text-anchor="end" dominant-baseline="middle">${Number(value.toPrecision(6))}${unit}</text>`;
     }),
   ].join("");
 
@@ -232,7 +269,7 @@ export function acResponseSvg(
         options.selectedTraceId === id ? " ac-trace-selected" : "";
       const identity = `data-trace-index="${index}" data-trace-id="${escapeXml(id)}"`;
       return (
-        `<polyline class="ac-trace-hit" ${identity} points="${points}"/>` +
+        `<polyline class="ac-trace-hit" fill="none" stroke="transparent" stroke-width="12" pointer-events="stroke" ${identity} points="${points}"/>` +
         `<polyline class="ac-trace ac-trace-${colorIndex % 6}${selected}" points="${points}"/>`
       );
     })

--- a/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.test.tsx
@@ -1,12 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import {
-  AcResultsExplorer,
-  panFrequencyRange,
-  unwrapPhaseDegrees,
-  zoomFrequencyRange,
-} from "./ac-results-explorer";
+import { AcResultsExplorer, unwrapPhaseDegrees } from "./ac-results-explorer";
 
 describe("AC Results Explorer", () => {
   it("unwraps phase without inventing 360-degree discontinuities", () => {
@@ -58,17 +53,5 @@ describe("AC Results Explorer", () => {
     expect(markup).toContain('aria-label="Plot tools"');
     expect(markup).toContain('aria-label="Open plot"');
     expect(markup).not.toContain("Wheel to zoom");
-  });
-
-  it("keeps explicit zoom and pan inside the simulated frequency sweep", () => {
-    const full = [1, 1e6] as const;
-    const zoomed = zoomFrequencyRange(full, full, "in");
-    expect(zoomed[0]).toBeGreaterThan(full[0]);
-    expect(zoomed[1]).toBeLessThan(full[1]);
-
-    const panned = panFrequencyRange(zoomed, full, "right");
-    expect(panned[0]).toBeGreaterThan(zoomed[0]);
-    expect(panned[1]).toBeLessThanOrEqual(full[1]);
-    expect(panFrequencyRange(full, full, "left")).toEqual(full);
   });
 });

--- a/apps/editor/src/features/simulation/ac-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type SetStateAction } from "react";
 import { WaveformInteraction, useWaveformWidth } from "./waveform-interaction";
+import { useWaveformView } from "./waveform-view";
+import { WaveformTools, WaveformMeasurements } from "./waveform-tools";
 import type { SimulationProbeSpec } from "@icm/model";
 import type { AcResult } from "@icm/spice-run";
 import type { Prepared } from "@icm/simulation-service/contract";
 
 import {
   acResponseSvg,
-  formatFrequency,
   layoutAcPlot,
   type AcPlotKind,
   type AcPoint,
@@ -25,6 +26,7 @@ interface ExpandedPlot {
 }
 
 export interface AcResultsExplorerProps {
+  resultKey?: string;
   analysis: AcResult;
   vectors: Prepared["vectors"];
   probes: readonly SimulationProbeSpec[];
@@ -107,110 +109,32 @@ function outputTraces(
   });
 }
 
-function normalizedLogRange(
-  low: number,
-  high: number,
-  fullRange: readonly [number, number],
-): readonly [number, number] {
-  const fullLow = Math.log(fullRange[0]);
-  const fullHigh = Math.log(fullRange[1]);
-  if (high - low >= fullHigh - fullLow - 1e-12) return fullRange;
-  const requestedSpan = Math.min(high - low, fullHigh - fullLow);
-  let nextLow = low;
-  let nextHigh = high;
-  if (nextLow < fullLow) {
-    nextLow = fullLow;
-    nextHigh = fullLow + requestedSpan;
-  }
-  if (nextHigh > fullHigh) {
-    nextHigh = fullHigh;
-    nextLow = fullHigh - requestedSpan;
-  }
-  return [Math.exp(nextLow), Math.exp(nextHigh)];
-}
-
-/** Explicit axes-toolbar zoom; the document or panel wheel is never captured. */
-export function zoomFrequencyRange(
-  currentRange: readonly [number, number],
-  fullRange: readonly [number, number],
-  direction: "in" | "out",
-  centerFrequency = Math.sqrt(currentRange[0] * currentRange[1]),
-): readonly [number, number] {
-  const low = Math.log(currentRange[0]);
-  const high = Math.log(currentRange[1]);
-  const center = Math.log(
-    Math.min(currentRange[1], Math.max(currentRange[0], centerFrequency)),
-  );
-  const scale = direction === "in" ? 0.6 : 1.7;
-  return normalizedLogRange(
-    center - (center - low) * scale,
-    center + (high - center) * scale,
-    fullRange,
-  );
-}
-
-/** Pan one fifth of the visible logarithmic span without leaving the sweep. */
-export function panFrequencyRange(
-  currentRange: readonly [number, number],
-  fullRange: readonly [number, number],
-  direction: "left" | "right",
-): readonly [number, number] {
-  const low = Math.log(currentRange[0]);
-  const high = Math.log(currentRange[1]);
-  const shift = (high - low) * 0.2 * (direction === "left" ? -1 : 1);
-  return normalizedLogRange(low + shift, high + shift, fullRange);
-}
-
-function rangesEqual(
-  left: readonly [number, number],
-  right: readonly [number, number],
-): boolean {
-  return (
-    Math.abs(Math.log(left[0] / right[0])) < 1e-9 &&
-    Math.abs(Math.log(left[1] / right[1])) < 1e-9
-  );
-}
-
 export function AcResultsExplorer({
   analysis,
   vectors,
   probes,
   labels = {},
   onFocusProbe,
+  resultKey,
 }: AcResultsExplorerProps) {
   const measured = useWaveformWidth();
   const traces = useMemo(
     () => outputTraces(analysis, vectors, probes, labels),
     [analysis, labels, probes, vectors],
   );
-  const [hidden, setHidden] = useState<ReadonlySet<string>>(() => new Set());
-  const [solo, setSolo] = useState<string | null>(null);
-  const [selected, setSelected] = useState<string | null>(null);
-  const [valueRanges, setValueRanges] = useState<
-    Record<string, readonly [number, number] | undefined>
-  >({});
-  const [markerFrequency, setMarkerFrequency] = useState<number>();
-  const [frequencyRange, setFrequencyRange] =
-    useState<readonly [number, number]>();
+  const controller = useWaveformView(resultKey);
+  const { hidden, solo, selected, markers } = controller.state;
+  const setHidden = (value: SetStateAction<ReadonlySet<string>>) =>
+    controller.set("hidden", value);
+  const setSolo = (value: SetStateAction<string | null>) =>
+    controller.set("solo", value);
+  const setSelected = (value: string) => controller.set("selected", value);
+  const frequencyRange = controller.view.x;
+  const valueRanges = controller.view.y;
   const [expandedPlot, setExpandedPlot] = useState<ExpandedPlot | null>(null);
-  const fullRange = useMemo<readonly [number, number]>(() => {
-    const frequencies = analysis.frequencyHz.filter(
-      (frequency) => frequency > 0,
-    );
-    return [Math.min(...frequencies), Math.max(...frequencies)];
-  }, [analysis.frequencyHz]);
   const visible = traces.filter(
     (trace) => !hidden.has(trace.id) && (solo === null || solo === trace.id),
   );
-  const cursorFrequency = markerFrequency;
-  const cursorRows =
-    cursorFrequency === undefined
-      ? []
-      : visible.map((trace) => ({
-          trace,
-          point: closestPoint(trace.points, cursorFrequency),
-        }));
-
   useEffect(() => {
     if (!expandedPlot) return;
     const close = (event: KeyboardEvent) => {
@@ -226,94 +150,6 @@ export function AcResultsExplorer({
     setSelected(trace.id);
     if (trace.probe) onFocusProbe?.(trace.probe);
   };
-
-  const updateRange = (
-    action: "zoom-in" | "zoom-out" | "pan-left" | "pan-right" | "fit",
-  ): void => {
-    if (action === "fit" || fullRange[0] === fullRange[1]) {
-      setFrequencyRange(undefined);
-      setValueRanges({});
-      return;
-    }
-    const current = frequencyRange ?? fullRange;
-    const next = action.startsWith("zoom")
-      ? zoomFrequencyRange(
-          current,
-          fullRange,
-          action === "zoom-in" ? "in" : "out",
-          cursorFrequency,
-        )
-      : panFrequencyRange(
-          current,
-          fullRange,
-          action === "pan-left" ? "left" : "right",
-        );
-    setFrequencyRange(rangesEqual(next, fullRange) ? undefined : next);
-  };
-
-  const plotToolbar = (plot: ExpandedPlot, expanded: boolean) => (
-    <div
-      className={`ac-plot-toolbar${expanded ? " expanded" : ""}`}
-      aria-label="Plot tools"
-      onClick={(event) => event.stopPropagation()}
-      onDoubleClick={(event) => event.stopPropagation()}
-      onPointerMove={(event) => event.stopPropagation()}
-    >
-      <button
-        type="button"
-        aria-label="Zoom in"
-        onClick={() => updateRange("zoom-in")}
-      >
-        +
-      </button>
-      <button
-        type="button"
-        aria-label="Zoom out"
-        onClick={() => updateRange("zoom-out")}
-      >
-        −
-      </button>
-      <button
-        type="button"
-        aria-label="Pan left"
-        onClick={() => updateRange("pan-left")}
-      >
-        ←
-      </button>
-      <button
-        type="button"
-        aria-label="Pan right"
-        onClick={() => updateRange("pan-right")}
-      >
-        →
-      </button>
-      <button
-        type="button"
-        aria-label="Fit plot"
-        onClick={() => updateRange("fit")}
-      >
-        Fit
-      </button>
-      {markerFrequency !== undefined ? (
-        <button
-          type="button"
-          aria-label="Clear marker"
-          onClick={() => setMarkerFrequency(undefined)}
-        >
-          ×│
-        </button>
-      ) : null}
-      {!expanded ? (
-        <button
-          type="button"
-          aria-label="Open plot"
-          onClick={() => setExpandedPlot(plot)}
-        >
-          ⛶
-        </button>
-      ) : null}
-    </div>
-  );
 
   const renderPlot = (
     plot: ExpandedPlot,
@@ -339,7 +175,8 @@ export function AcResultsExplorer({
       ...(valueRange ? { valueRange } : {}),
       showLegend: false,
       ...(frequencyRange === undefined ? {} : { frequencyRange }),
-      ...(cursorFrequency === undefined ? {} : { cursorFrequency }),
+      ...(markers.A === undefined ? {} : { cursorFrequency: markers.A }),
+      ...(markers.B === undefined ? {} : { cursorFrequencyB: markers.B }),
       ...(selected === null ? {} : { selectedTraceId: selected }),
     });
     return (
@@ -348,38 +185,52 @@ export function AcResultsExplorer({
         title={expanded ? undefined : "Double-click to open this plot"}
       >
         <WaveformInteraction
+          axes={controller.state.axes}
           frame={layout.frame}
-          onZoom={(start, end) => {
-            setFrequencyRange([
-              frequencyAt(Math.min(start.x, end.x)),
-              frequencyAt(Math.max(start.x, end.x)),
-            ]);
-            setValueRanges((current) => ({
-              ...current,
-              [plot.quantity + plot.kind]: [
-                axis.max - Math.max(start.y, end.y) * (axis.max - axis.min),
-                axis.max - Math.min(start.y, end.y) * (axis.max - axis.min),
-              ],
-            }));
-          }}
+          onZoom={(start, end) =>
+            controller.commit({
+              x:
+                controller.state.axes === "y"
+                  ? [layout.frequency.min, layout.frequency.max]
+                  : [
+                      frequencyAt(Math.min(start.x, end.x)),
+                      frequencyAt(Math.max(start.x, end.x)),
+                    ],
+              y: {
+                ...valueRanges,
+                [plot.quantity + plot.kind]:
+                  controller.state.axes === "x"
+                    ? [axis.min, axis.max]
+                    : [
+                        axis.max -
+                          Math.max(start.y, end.y) * (axis.max - axis.min),
+                        axis.max -
+                          Math.min(start.y, end.y) * (axis.max - axis.min),
+                      ],
+              },
+            })
+          }
           onPan={(delta) => {
-            const range = frequencyRange ?? [
-              layout.frequency.min,
-              layout.frequency.max,
-            ];
-            const shift = -delta.x * Math.log(range[1]! / range[0]!);
-            setFrequencyRange(
-              normalizedLogRange(
-                Math.log(range[0]!) + shift,
-                Math.log(range[1]!) + shift,
-                fullRange,
-              ),
-            );
-            const dy = delta.y * (axis.max - axis.min);
-            setValueRanges((current) => ({
-              ...current,
-              [plot.quantity + plot.kind]: [axis.min + dy, axis.max + dy],
-            }));
+            const shift =
+                -delta.x *
+                Math.log(layout.frequency.max / layout.frequency.min),
+              dy = delta.y * (axis.max - axis.min);
+            controller.commit({
+              x:
+                controller.state.axes === "y"
+                  ? [layout.frequency.min, layout.frequency.max]
+                  : [
+                      layout.frequency.min * Math.exp(shift),
+                      layout.frequency.max * Math.exp(shift),
+                    ],
+              y: {
+                ...valueRanges,
+                [plot.quantity + plot.kind]:
+                  controller.state.axes === "x"
+                    ? [axis.min, axis.max]
+                    : [axis.min + dy, axis.max + dy],
+              },
+            });
           }}
           onPick={(point, id) => {
             if (id) focusTrace(id);
@@ -387,9 +238,7 @@ export function AcResultsExplorer({
             const trace =
               plotTraces.find((trace) => trace.id === id) ?? plotTraces[0];
             if (trace?.points.length)
-              setMarkerFrequency(
-                closestPoint(trace.points, frequency).frequency,
-              );
+              controller.mark(closestPoint(trace.points, frequency).frequency);
           }}
           onOpen={() => !expanded && setExpandedPlot(plot)}
         >
@@ -398,10 +247,52 @@ export function AcResultsExplorer({
             dangerouslySetInnerHTML={{ __html: svg ?? "" }}
           />
         </WaveformInteraction>
-        {plotToolbar(plot, expanded)}
+        <WaveformTools
+          controller={controller}
+          plotKey={plot.quantity + plot.kind}
+          x={[layout.frequency.min, layout.frequency.max]}
+          y={[axis.min, axis.max]}
+          xUnit="Hz"
+          yUnit={plot.kind === "phase" ? "°" : "dB"}
+          logarithmicX
+          {...(!expanded ? { onOpen: () => setExpandedPlot(plot) } : {})}
+        />
+        {!expanded && measurement(plot)}
       </div>
     );
   };
+
+  const measurement = (plot?: ExpandedPlot) => (
+    <WaveformMeasurements
+      a={markers.A}
+      b={markers.B}
+      unit="Hz"
+      rows={visible
+        .filter((trace) => !plot || trace.quantity === plot.quantity)
+        .flatMap((trace) => {
+          const a =
+            markers.A === undefined || !trace.points.length
+              ? undefined
+              : closestPoint(trace.points, markers.A);
+          const b =
+            markers.B === undefined || !trace.points.length
+              ? undefined
+              : closestPoint(trace.points, markers.B);
+          return (plot ? [plot.kind] : (["magnitude", "phase"] as const)).map(
+            (kind) => {
+              const property =
+                kind === "magnitude" ? "magnitudeDb" : "phaseDeg";
+              return {
+                label: trace.label + " " + kind,
+                unit: kind === "magnitude" ? "dB" : "°",
+                ...(a ? { a: a[property] } : {}),
+                ...(b ? { b: b[property] } : {}),
+              };
+            },
+          );
+        })}
+    />
+  );
 
   return (
     <div ref={measured.ref} className="ac-results-explorer">
@@ -476,17 +367,6 @@ export function AcResultsExplorer({
       {visible.length === 0 ? (
         <p className="simulation-empty-result">All Outputs are hidden.</p>
       ) : null}
-      {cursorFrequency !== undefined ? (
-        <div className="ac-cursor-readout" role="status">
-          <strong>{formatFrequency(cursorFrequency)}</strong>
-          {cursorRows.map(({ trace, point }) => (
-            <span key={trace.id}>
-              {trace.label}: {point.magnitudeDb.toFixed(3)} dB ·{" "}
-              {point.phaseDeg.toFixed(2)}°
-            </span>
-          ))}
-        </div>
-      ) : null}
       {expandedPlot ? (
         <div
           className="ac-plot-dialog-backdrop"
@@ -523,17 +403,7 @@ export function AcResultsExplorer({
               ),
               true,
             )}
-            {cursorFrequency !== undefined ? (
-              <div className="ac-cursor-readout" role="status">
-                <strong>{formatFrequency(cursorFrequency)}</strong>
-                {cursorRows.map(({ trace, point }) => (
-                  <span key={trace.id}>
-                    {trace.label}: {point.magnitudeDb.toFixed(3)} dB ·{" "}
-                    {point.phaseDeg.toFixed(2)}°
-                  </span>
-                ))}
-              </div>
-            ) : null}
+            {measurement(expandedPlot)}
           </section>
         </div>
       ) : null}

--- a/apps/editor/src/features/simulation/ac-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/ac-results-explorer.tsx
@@ -1,10 +1,5 @@
-import {
-  useEffect,
-  useMemo,
-  useState,
-  type MouseEvent as ReactMouseEvent,
-  type PointerEvent,
-} from "react";
+import { useEffect, useMemo, useState } from "react";
+import { WaveformInteraction, useWaveformWidth } from "./waveform-interaction";
 import type { SimulationProbeSpec } from "@icm/model";
 import type { AcResult } from "@icm/spice-run";
 import type { Prepared } from "@icm/simulation-service/contract";
@@ -14,7 +9,6 @@ import {
   formatFrequency,
   layoutAcPlot,
   type AcPlotKind,
-  type AcPlotSize,
   type AcPoint,
   type AcTrace,
 } from "./ac-response-plot";
@@ -184,6 +178,7 @@ export function AcResultsExplorer({
   labels = {},
   onFocusProbe,
 }: AcResultsExplorerProps) {
+  const measured = useWaveformWidth();
   const traces = useMemo(
     () => outputTraces(analysis, vectors, probes, labels),
     [analysis, labels, probes, vectors],
@@ -191,7 +186,9 @@ export function AcResultsExplorer({
   const [hidden, setHidden] = useState<ReadonlySet<string>>(() => new Set());
   const [solo, setSolo] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
-  const [hoverFrequency, setHoverFrequency] = useState<number>();
+  const [valueRanges, setValueRanges] = useState<
+    Record<string, readonly [number, number] | undefined>
+  >({});
   const [markerFrequency, setMarkerFrequency] = useState<number>();
   const [frequencyRange, setFrequencyRange] =
     useState<readonly [number, number]>();
@@ -205,7 +202,7 @@ export function AcResultsExplorer({
   const visible = traces.filter(
     (trace) => !hidden.has(trace.id) && (solo === null || solo === trace.id),
   );
-  const cursorFrequency = hoverFrequency ?? markerFrequency;
+  const cursorFrequency = markerFrequency;
   const cursorRows =
     cursorFrequency === undefined
       ? []
@@ -223,22 +220,6 @@ export function AcResultsExplorer({
     return () => window.removeEventListener("keydown", close);
   }, [expandedPlot]);
 
-  const frequencyAtPointer = (
-    event: PointerEvent<HTMLDivElement> | ReactMouseEvent<HTMLDivElement>,
-    size: AcPlotSize,
-    plotTraces: readonly OutputTrace[],
-  ): number | undefined => {
-    const bounds = event.currentTarget.getBoundingClientRect();
-    const layout = layoutAcPlot(plotTraces, size, frequencyRange);
-    if (!layout) return undefined;
-    const svgX = ((event.clientX - bounds.left) / bounds.width) * size.width;
-    const frequency = layout.frequencyAt(svgX);
-    return Math.min(
-      layout.frequency.max,
-      Math.max(layout.frequency.min, frequency),
-    );
-  };
-
   const focusTrace = (traceId: string): void => {
     const trace = traces.find((candidate) => candidate.id === traceId);
     if (!trace) return;
@@ -251,6 +232,7 @@ export function AcResultsExplorer({
   ): void => {
     if (action === "fit" || fullRange[0] === fullRange[1]) {
       setFrequencyRange(undefined);
+      setValueRanges({});
       return;
     }
     const current = frequencyRange ?? fullRange;
@@ -338,9 +320,23 @@ export function AcResultsExplorer({
     plotTraces: readonly OutputTrace[],
     expanded = false,
   ) => {
-    const size = expanded ? EXPANDED_PLOT_SIZE : PLOT_SIZE;
+    const size = expanded
+      ? EXPANDED_PLOT_SIZE
+      : { ...PLOT_SIZE, width: measured.width };
+    const valueRange = valueRanges[plot.quantity + plot.kind];
+    const layout = layoutAcPlot(
+      plotTraces,
+      size,
+      frequencyRange,
+      valueRange ? { kind: plot.kind, range: valueRange } : undefined,
+    );
+    if (!layout) return null;
+    const axis = layout[plot.kind];
+    const frequencyAt = (x: number) =>
+      layout.frequencyAt(layout.frame.x + x * layout.frame.width);
     const svg = acResponseSvg(plotTraces, size, {
       kind: plot.kind,
+      ...(valueRange ? { valueRange } : {}),
       showLegend: false,
       ...(frequencyRange === undefined ? {} : { frequencyRange }),
       ...(cursorFrequency === undefined ? {} : { cursorFrequency }),
@@ -351,34 +347,64 @@ export function AcResultsExplorer({
         className={`ac-plot-shell${expanded ? " expanded" : ""}`}
         title={expanded ? undefined : "Double-click to open this plot"}
       >
-        <div
-          className="spice-ac-plot interactive"
-          onPointerMove={(event) => {
-            const frequency = frequencyAtPointer(event, size, plotTraces);
-            if (frequency !== undefined) setHoverFrequency(frequency);
+        <WaveformInteraction
+          frame={layout.frame}
+          onZoom={(start, end) => {
+            setFrequencyRange([
+              frequencyAt(Math.min(start.x, end.x)),
+              frequencyAt(Math.max(start.x, end.x)),
+            ]);
+            setValueRanges((current) => ({
+              ...current,
+              [plot.quantity + plot.kind]: [
+                axis.max - Math.max(start.y, end.y) * (axis.max - axis.min),
+                axis.max - Math.min(start.y, end.y) * (axis.max - axis.min),
+              ],
+            }));
           }}
-          onPointerLeave={() => setHoverFrequency(undefined)}
-          onClick={(event) => {
-            const traceElement = (event.target as Element).closest(
-              "[data-trace-id]",
+          onPan={(delta) => {
+            const range = frequencyRange ?? [
+              layout.frequency.min,
+              layout.frequency.max,
+            ];
+            const shift = -delta.x * Math.log(range[1]! / range[0]!);
+            setFrequencyRange(
+              normalizedLogRange(
+                Math.log(range[0]!) + shift,
+                Math.log(range[1]!) + shift,
+                fullRange,
+              ),
             );
-            const traceId = traceElement?.getAttribute("data-trace-id");
-            if (traceId) focusTrace(traceId);
-            const frequency = frequencyAtPointer(event, size, plotTraces);
-            if (frequency !== undefined) setMarkerFrequency(frequency);
+            const dy = delta.y * (axis.max - axis.min);
+            setValueRanges((current) => ({
+              ...current,
+              [plot.quantity + plot.kind]: [axis.min + dy, axis.max + dy],
+            }));
           }}
-          onDoubleClick={() => {
-            if (!expanded) setExpandedPlot(plot);
+          onPick={(point, id) => {
+            if (id) focusTrace(id);
+            const frequency = frequencyAt(point.x);
+            const trace =
+              plotTraces.find((trace) => trace.id === id) ?? plotTraces[0];
+            if (trace?.points.length)
+              setMarkerFrequency(
+                closestPoint(trace.points, frequency).frequency,
+              );
           }}
-          dangerouslySetInnerHTML={{ __html: svg ?? "" }}
-        />
+          onOpen={() => !expanded && setExpandedPlot(plot)}
+        >
+          <div
+            className="waveform-svg"
+            dangerouslySetInnerHTML={{ __html: svg ?? "" }}
+          />
+        </WaveformInteraction>
         {plotToolbar(plot, expanded)}
       </div>
     );
   };
 
   return (
-    <div className="ac-results-explorer">
+    <div ref={measured.ref} className="ac-results-explorer">
       <header>
         <strong>{analysis.plotName}</strong>
       </header>
@@ -497,6 +523,17 @@ export function AcResultsExplorer({
               ),
               true,
             )}
+            {cursorFrequency !== undefined ? (
+              <div className="ac-cursor-readout" role="status">
+                <strong>{formatFrequency(cursorFrequency)}</strong>
+                {cursorRows.map(({ trace, point }) => (
+                  <span key={trace.id}>
+                    {trace.label}: {point.magnitudeDb.toFixed(3)} dB ·{" "}
+                    {point.phaseDeg.toFixed(2)}°
+                  </span>
+                ))}
+              </div>
+            ) : null}
           </section>
         </div>
       ) : null}

--- a/apps/editor/src/features/simulation/spice-simulation-surface.tsx
+++ b/apps/editor/src/features/simulation/spice-simulation-surface.tsx
@@ -561,7 +561,8 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                   .filter((analysis) => analysis.analysis === "ac")
                   .map((analysis, index) => (
                     <AcResultsExplorer
-                      key={index}
+                      key={`${run.id}:ac:${index}`}
+                      resultKey={`${run.id}:ac:${index}`}
                       analysis={analysis}
                       vectors={runPresentation?.prepared.vectors ?? []}
                       probes={runPresentation?.probes ?? []}
@@ -583,7 +584,8 @@ export function SpiceSimulationSurface(props: SpiceSimulationSurfaceProps) {
                   .filter((analysis) => analysis.analysis === "tran")
                   .map((analysis, index) => (
                     <TransientResultsExplorer
-                      key={`tran-${index}`}
+                      key={`${run.id}:tran:${index}`}
+                      resultKey={`${run.id}:tran:${index}`}
                       analysis={analysis}
                       vectors={runPresentation?.prepared.vectors ?? []}
                       probes={runPresentation?.probes ?? []}

--- a/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
@@ -2,10 +2,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import {
-  changeTransientTimeRange,
   TransientResultsExplorer,
   transientPolylinePoints,
   transientValueExtent,
+  transientVisibleValues,
 } from "./transient-results-explorer";
 
 describe("Transient Results Explorer", () => {
@@ -22,6 +22,7 @@ describe("Transient Results Explorer", () => {
   });
 
   it("retains the segment crossing a zoom window between solver samples", () => {
+    expect(transientVisibleValues([0, 10], [0, 1], [4, 6])).toEqual([0.4, 0.6]);
     const points = transientPolylinePoints([0, 10], [0, 1], [0, 1], [4, 6]);
     expect(points.split(" ")).toHaveLength(2);
     const xs = points.split(" ").map((point) => Number(point.split(",")[0]));
@@ -87,17 +88,5 @@ describe("Transient Results Explorer", () => {
     expect(markup).toContain(
       'class="ac-trace-hit" fill="none" stroke="transparent" stroke-width="12" pointer-events="stroke"',
     );
-  });
-
-  it("keeps explicit linear zoom and pan inside the transient interval", () => {
-    expect(changeTransientTimeRange([0, 10], [0, 10], "zoom-in")).toEqual([
-      2, 8,
-    ]);
-    expect(changeTransientTimeRange([2, 8], [0, 10], "pan-right")).toEqual([
-      3.2, 9.2,
-    ]);
-    expect(changeTransientTimeRange([0, 10], [0, 10], "pan-left")).toEqual([
-      0, 10,
-    ]);
   });
 });

--- a/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.test.tsx
@@ -4,7 +4,6 @@ import { describe, expect, it } from "vitest";
 import {
   changeTransientTimeRange,
   TransientResultsExplorer,
-  transientBoxZoomRanges,
   transientPolylinePoints,
   transientValueExtent,
 } from "./transient-results-explorer";
@@ -22,17 +21,12 @@ describe("Transient Results Explorer", () => {
     expect(extent[1]).toBeCloseTo(1.89, 10);
   });
 
-  it("maps a dragged plot rectangle onto ordered time and value ranges", () => {
-    const ranges = transientBoxZoomRanges(
-      { x: 572.5, y: 188.5 },
-      { x: 233.5, y: 73.5 },
-      [0, 10],
-      [0, 4],
-    );
-    expect(ranges.time[0]).toBeCloseTo(2.5);
-    expect(ranges.time[1]).toBeCloseTo(7.5);
-    expect(ranges.value[0]).toBeCloseTo(1);
-    expect(ranges.value[1]).toBeCloseTo(3);
+  it("retains the segment crossing a zoom window between solver samples", () => {
+    const points = transientPolylinePoints([0, 10], [0, 1], [0, 1], [4, 6]);
+    expect(points.split(" ")).toHaveLength(2);
+    const xs = points.split(" ").map((point) => Number(point.split(",")[0]));
+    expect(xs[0]).toBeLessThan(64);
+    expect(xs[1]).toBeGreaterThan(742);
   });
 
   it("presents linked voltage and current time-domain outputs", () => {
@@ -87,7 +81,8 @@ describe("Transient Results Explorer", () => {
     expect(markup).toContain('aria-label="Transient current"');
     expect(markup.match(/data-trace-index=/gu)).toHaveLength(2);
     expect(markup).toContain('aria-label="Plot tools"');
-    expect(markup.match(/aria-label="Box zoom"/gu)).toHaveLength(2);
+    expect(markup.match(/drag to zoom, click to measure/gu)).toHaveLength(2);
+    expect(markup).not.toContain('aria-label="Inspect plot"');
     expect(markup.match(/aria-label="Open plot"/gu)).toHaveLength(2);
     expect(markup).toContain(
       'class="ac-trace-hit" fill="none" stroke="transparent" stroke-width="12" pointer-events="stroke"',

--- a/apps/editor/src/features/simulation/transient-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.tsx
@@ -1,10 +1,10 @@
+import { useEffect, useId, useMemo, useState } from "react";
 import {
-  useEffect,
-  useMemo,
-  useState,
-  type MouseEvent as ReactMouseEvent,
-  type PointerEvent,
-} from "react";
+  WaveformInteraction,
+  waveformTicks,
+  waveformTickLabel,
+  useWaveformWidth,
+} from "./waveform-interaction";
 import type { SimulationProbeSpec } from "@icm/model";
 import type { TransientResult } from "@icm/spice-run";
 import type { Prepared } from "@icm/simulation-service/contract";
@@ -37,19 +37,15 @@ const PLOT = {
 } as const;
 const EXPANDED_PLOT = { ...PLOT, width: 1400, height: 700 } as const;
 
-type PlotGeometry = typeof PLOT | typeof EXPANDED_PLOT;
+type PlotGeometry = {
+  width: number;
+  height: number;
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+};
 type PlotQuantity = "voltage" | "current";
-
-interface PlotPoint {
-  readonly x: number;
-  readonly y: number;
-}
-
-interface ZoomBox {
-  readonly quantity: PlotQuantity;
-  readonly start: PlotPoint;
-  readonly current: PlotPoint;
-}
 
 function finiteExtent(values: readonly number[]): readonly [number, number] {
   let min = Number.POSITIVE_INFINITY;
@@ -82,41 +78,6 @@ export function transientValueExtent(
   return [center - margin, center + margin];
 }
 
-function clampPlotPoint(point: PlotPoint, plot: PlotGeometry): PlotPoint {
-  return {
-    x: Math.min(plot.width - plot.right, Math.max(plot.left, point.x)),
-    y: Math.min(plot.height - plot.bottom, Math.max(plot.top, point.y)),
-  };
-}
-
-export function transientBoxZoomRanges(
-  start: PlotPoint,
-  end: PlotPoint,
-  timeRange: readonly [number, number],
-  valueRange: readonly [number, number],
-  plot: PlotGeometry = PLOT,
-): {
-  readonly time: readonly [number, number];
-  readonly value: readonly [number, number];
-} {
-  const first = clampPlotPoint(start, plot);
-  const last = clampPlotPoint(end, plot);
-  const plotWidth = plot.width - plot.left - plot.right;
-  const plotHeight = plot.height - plot.top - plot.bottom;
-  const timeAt = (x: number) =>
-    timeRange[0] +
-    ((x - plot.left) / plotWidth) * (timeRange[1] - timeRange[0]);
-  const valueAt = (y: number) =>
-    valueRange[1] -
-    ((y - plot.top) / plotHeight) * (valueRange[1] - valueRange[0]);
-  const times = [timeAt(first.x), timeAt(last.x)].sort((a, b) => a - b);
-  const values = [valueAt(first.y), valueAt(last.y)].sort((a, b) => a - b);
-  return {
-    time: [times[0]!, times[1]!],
-    value: [values[0]!, values[1]!],
-  };
-}
-
 function compact(value: number): string {
   if (value === 0) return "0";
   const magnitude = Math.abs(value);
@@ -139,7 +100,7 @@ export function transientPolylinePoints(
   values: readonly number[],
   yExtent: readonly [number, number] = finiteExtent(values),
   timeExtent: readonly [number, number] = finiteExtent(timeSeconds),
-  plot: typeof PLOT | typeof EXPANDED_PLOT = PLOT,
+  plot: PlotGeometry = PLOT,
 ): string {
   const count = Math.min(timeSeconds.length, values.length);
   if (count === 0) return "";
@@ -154,8 +115,9 @@ export function transientPolylinePoints(
     if (
       !Number.isFinite(time) ||
       !Number.isFinite(value) ||
-      time < timeExtent[0] ||
-      time > timeExtent[1]
+      (time < timeExtent[0] &&
+        (timeSeconds[index + 1] ?? time) < timeExtent[0]) ||
+      (time > timeExtent[1] && (timeSeconds[index - 1] ?? time) > timeExtent[1])
     )
       continue;
     const x = plot.left + ((time - timeExtent[0]) / timeSpan) * plotWidth;
@@ -233,6 +195,8 @@ export function TransientResultsExplorer({
   labels = {},
   onFocusProbe,
 }: TransientResultsExplorerProps) {
+  const measured = useWaveformWidth();
+  const clipPrefix = useId();
   const traces = useMemo(
     () => outputTraces(analysis, vectors, probes, labels),
     [analysis, labels, probes, vectors],
@@ -240,16 +204,11 @@ export function TransientResultsExplorer({
   const [hidden, setHidden] = useState<ReadonlySet<string>>(() => new Set());
   const [solo, setSolo] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
-  const [hoverTime, setHoverTime] = useState<number>();
   const [markerTime, setMarkerTime] = useState<number>();
   const [timeRange, setTimeRange] = useState<readonly [number, number]>();
   const [valueRanges, setValueRanges] = useState<
     Partial<Record<PlotQuantity, readonly [number, number]>>
   >({});
-  const [interactionMode, setInteractionMode] = useState<
-    "inspect" | "box-zoom"
-  >("inspect");
-  const [zoomBox, setZoomBox] = useState<ZoomBox>();
   const [expandedQuantity, setExpandedQuantity] = useState<
     "voltage" | "current" | null
   >(null);
@@ -257,14 +216,12 @@ export function TransientResultsExplorer({
     (trace) => !hidden.has(trace.id) && (solo === null || solo === trace.id),
   );
   const fullRange = finiteExtent(analysis.timeSeconds);
-  const cursorTime = hoverTime ?? markerTime;
+  const cursorTime = markerTime;
 
   useEffect(() => {
     const cancelTransientPlotAction = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
       setExpandedQuantity(null);
-      setZoomBox(undefined);
-      setInteractionMode("inspect");
     };
     window.addEventListener("keydown", cancelTransientPlotAction);
     return () =>
@@ -285,7 +242,6 @@ export function TransientResultsExplorer({
     if (action === "fit") {
       setTimeRange(undefined);
       setValueRanges((current) => ({ ...current, [quantity]: undefined }));
-      setZoomBox(undefined);
       return;
     }
     const next = changeTransientTimeRange(
@@ -299,71 +255,11 @@ export function TransientResultsExplorer({
     );
   };
 
-  const timeAtPointer = (
-    event: PointerEvent<HTMLDivElement> | ReactMouseEvent<HTMLDivElement>,
-    plot: PlotGeometry,
-  ) => {
-    const point = plotPointAtPointer(event, plot);
-    const bounds = event.currentTarget.getBoundingClientRect();
-    const range = timeRange ?? fullRange;
-    if (bounds.width === 0) return range[0];
-    return Math.min(
-      range[1],
-      Math.max(
-        range[0],
-        range[0] +
-          ((point.x - plot.left) / (plot.width - plot.left - plot.right)) *
-            (range[1] - range[0]),
-      ),
-    );
-  };
-
-  const plotPointAtPointer = (
-    event: PointerEvent<HTMLDivElement> | ReactMouseEvent<HTMLDivElement>,
-    plot: PlotGeometry,
-  ): PlotPoint => {
-    const bounds = event.currentTarget.getBoundingClientRect();
-    if (bounds.width === 0 || bounds.height === 0) {
-      return { x: plot.left, y: plot.top };
-    }
-    return clampPlotPoint(
-      {
-        x: ((event.clientX - bounds.left) / bounds.width) * plot.width,
-        y: ((event.clientY - bounds.top) / bounds.height) * plot.height,
-      },
-      plot,
-    );
-  };
-
   const toolbar = (quantity: PlotQuantity, expanded: boolean) => (
     <div
       className={`ac-plot-toolbar${expanded ? " expanded" : ""}`}
       aria-label="Plot tools"
     >
-      <button
-        type="button"
-        aria-label="Inspect plot"
-        aria-pressed={interactionMode === "inspect"}
-        title="Inspect and place a marker"
-        onClick={() => {
-          setInteractionMode("inspect");
-          setZoomBox(undefined);
-        }}
-      >
-        ⌖
-      </button>
-      <button
-        type="button"
-        aria-label="Box zoom"
-        aria-pressed={interactionMode === "box-zoom"}
-        title="Drag a rectangle to zoom"
-        onClick={() => {
-          setInteractionMode("box-zoom");
-          setZoomBox(undefined);
-        }}
-      >
-        ▧
-      </button>
       <button
         type="button"
         aria-label="Zoom in"
@@ -425,8 +321,11 @@ export function TransientResultsExplorer({
     quantityTraces: readonly TransientTrace[],
     expanded = false,
   ) => {
-    const geometry = expanded ? EXPANDED_PLOT : PLOT;
+    const geometry = expanded
+      ? EXPANDED_PLOT
+      : { ...PLOT, width: measured.width };
     const range = timeRange ?? fullRange;
+    const clipId = `${clipPrefix}-${quantity}-${expanded}`;
     const visibleValues = quantityTraces.flatMap((trace) =>
       trace.values.filter(
         (_value, index) =>
@@ -445,77 +344,50 @@ export function TransientResultsExplorer({
             (geometry.width - geometry.left - geometry.right);
     return (
       <div className={`ac-plot-shell${expanded ? " expanded" : ""}`}>
-        <div
-          className={`spice-ac-plot interactive ${interactionMode}`}
-          onPointerDown={(event) => {
-            if (interactionMode !== "box-zoom" || event.button !== 0) return;
-            const point = plotPointAtPointer(event, geometry);
-            event.currentTarget.setPointerCapture(event.pointerId);
-            setZoomBox({ quantity, start: point, current: point });
-            event.preventDefault();
+        <WaveformInteraction
+          frame={{
+            x: geometry.left,
+            y: geometry.top,
+            width: geometry.width - geometry.left - geometry.right,
+            height: geometry.height - geometry.top - geometry.bottom,
           }}
-          onPointerMove={(event) => {
-            if (
-              interactionMode === "box-zoom" &&
-              zoomBox?.quantity === quantity
-            ) {
-              const point = plotPointAtPointer(event, geometry);
-              setZoomBox((current) =>
-                current?.quantity === quantity
-                  ? { ...current, current: point }
-                  : current,
-              );
-              return;
-            }
-            if (interactionMode === "inspect") {
-              setHoverTime(timeAtPointer(event, geometry));
-            }
+          onZoom={(start, end) => {
+            const x = [start.x, end.x].sort((a, b) => a - b);
+            const y = [start.y, end.y].sort((a, b) => a - b);
+            setTimeRange([
+              range[0] + x[0]! * (range[1] - range[0]),
+              range[0] + x[1]! * (range[1] - range[0]),
+            ]);
+            setValueRanges((current) => ({
+              ...current,
+              [quantity]: [
+                extent[1] - y[1]! * (extent[1] - extent[0]),
+                extent[1] - y[0]! * (extent[1] - extent[0]),
+              ],
+            }));
           }}
-          onPointerUp={(event) => {
-            if (
-              interactionMode !== "box-zoom" ||
-              zoomBox?.quantity !== quantity
-            )
-              return;
-            const end = plotPointAtPointer(event, geometry);
-            const width = Math.abs(end.x - zoomBox.start.x);
-            const height = Math.abs(end.y - zoomBox.start.y);
-            if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-              event.currentTarget.releasePointerCapture(event.pointerId);
-            }
-            if (width >= 5 && height >= 5) {
-              const next = transientBoxZoomRanges(
-                zoomBox.start,
-                end,
-                range,
-                extent,
-                geometry,
-              );
-              setTimeRange(next.time);
-              setValueRanges((current) => ({
-                ...current,
-                [quantity]: next.value,
-              }));
-              setInteractionMode("inspect");
-            }
-            setZoomBox(undefined);
-            setHoverTime(undefined);
+          onPan={(delta) => {
+            const shift = -delta.x * (range[1] - range[0]);
+            setTimeRange(
+              clampRange(range[0] + shift, range[1] + shift, fullRange),
+            );
+            const dy = delta.y * (extent[1] - extent[0]);
+            setValueRanges((current) => ({
+              ...current,
+              [quantity]: [extent[0] + dy, extent[1] + dy],
+            }));
           }}
-          onPointerCancel={() => setZoomBox(undefined)}
-          onPointerLeave={() => setHoverTime(undefined)}
-          onClick={(event) => {
-            if (interactionMode !== "inspect") return;
-            const id = (event.target as Element)
-              .closest("[data-trace-id]")
-              ?.getAttribute("data-trace-id");
+          onPick={(point, id) => {
             if (id) focusTrace(id);
-            setMarkerTime(timeAtPointer(event, geometry));
+            const time = range[0] + point.x * (range[1] - range[0]);
+            const nearest = analysis.timeSeconds.reduce(
+              (best, value) =>
+                Math.abs(value - time) < Math.abs(best - time) ? value : best,
+              analysis.timeSeconds[0] ?? time,
+            );
+            setMarkerTime(nearest);
           }}
-          onDoubleClick={() =>
-            interactionMode === "inspect" &&
-            !expanded &&
-            setExpandedQuantity(quantity)
-          }
+          onOpen={() => !expanded && setExpandedQuantity(quantity)}
         >
           <svg
             role="img"
@@ -536,24 +408,85 @@ export function TransientResultsExplorer({
               x2={geometry.width - geometry.right}
               y2={geometry.height - geometry.bottom}
             />
-            <text x={geometry.left} y={geometry.height - 8}>
-              {compact(range[0])}s
-            </text>
-            <text
-              textAnchor="end"
-              x={geometry.width - geometry.right}
-              y={geometry.height - 8}
-            >
-              {compact(range[1])}s
-            </text>
-            <text x={4} y={geometry.top + 5}>
-              {compact(extent[1])}
-              {unit}
-            </text>
-            <text x={4} y={geometry.height - geometry.bottom}>
-              {compact(extent[0])}
-              {unit}
-            </text>
+            {waveformTicks(
+              range[0],
+              range[1],
+              Math.max(2, Math.floor(geometry.width / 110)),
+            ).map((value) => {
+              const x =
+                geometry.left +
+                ((value - range[0]) / (range[1] - range[0])) *
+                  (geometry.width - geometry.left - geometry.right);
+              return (
+                <g key={value}>
+                  <line
+                    className="ac-grid"
+                    x1={x}
+                    x2={x}
+                    y1={geometry.top}
+                    y2={geometry.height - geometry.bottom}
+                  />
+                  <text
+                    className="ac-axis-label"
+                    textAnchor="middle"
+                    x={x}
+                    y={geometry.height - 8}
+                  >
+                    {waveformTickLabel(
+                      value,
+                      (range[1] - range[0]) /
+                        Math.max(2, Math.floor(geometry.width / 110)),
+                      "s",
+                    )}
+                  </text>
+                </g>
+              );
+            })}
+            {waveformTicks(
+              extent[0],
+              extent[1],
+              Math.max(2, Math.floor(geometry.height / 55)),
+            ).map((value) => {
+              const y =
+                geometry.top +
+                ((extent[1] - value) / (extent[1] - extent[0])) *
+                  (geometry.height - geometry.top - geometry.bottom);
+              return (
+                <g key={value}>
+                  <line
+                    className="ac-grid"
+                    x1={geometry.left}
+                    x2={geometry.width - geometry.right}
+                    y1={y}
+                    y2={y}
+                  />
+                  <text
+                    className="ac-axis-label"
+                    textAnchor="end"
+                    x={geometry.left - 6}
+                    y={y}
+                    dominantBaseline="middle"
+                  >
+                    {waveformTickLabel(
+                      value,
+                      (extent[1] - extent[0]) /
+                        Math.max(2, Math.floor(geometry.height / 55)),
+                      unit,
+                    )}
+                  </text>
+                </g>
+              );
+            })}
+            <defs>
+              <clipPath id={clipId}>
+                <rect
+                  x={geometry.left}
+                  y={geometry.top}
+                  width={geometry.width - geometry.left - geometry.right}
+                  height={geometry.height - geometry.top - geometry.bottom}
+                />
+              </clipPath>
+            </defs>
             {quantityTraces.map((trace) => {
               const points = transientPolylinePoints(
                 analysis.timeSeconds,
@@ -565,6 +498,7 @@ export function TransientResultsExplorer({
               return (
                 <g
                   key={trace.id}
+                  clipPath={`url(#${clipId})`}
                   data-trace-id={trace.id}
                   data-trace-index={trace.colorIndex}
                 >
@@ -596,17 +530,8 @@ export function TransientResultsExplorer({
                 y2={geometry.height - geometry.bottom}
               />
             )}
-            {zoomBox?.quantity === quantity ? (
-              <rect
-                className="ac-zoom-box"
-                x={Math.min(zoomBox.start.x, zoomBox.current.x)}
-                y={Math.min(zoomBox.start.y, zoomBox.current.y)}
-                width={Math.abs(zoomBox.current.x - zoomBox.start.x)}
-                height={Math.abs(zoomBox.current.y - zoomBox.start.y)}
-              />
-            ) : null}
           </svg>
-        </div>
+        </WaveformInteraction>
         {toolbar(quantity, expanded)}
       </div>
     );
@@ -628,7 +553,10 @@ export function TransientResultsExplorer({
         });
 
   return (
-    <div className="transient-results-explorer ac-results-explorer">
+    <div
+      ref={measured.ref}
+      className="transient-results-explorer ac-results-explorer"
+    >
       <header>
         <div>
           <strong>{analysis.plotName}</strong>
@@ -740,6 +668,17 @@ export function TransientResultsExplorer({
               expandedQuantity,
               visible.filter((trace) => trace.quantity === expandedQuantity),
               true,
+            )}
+            {cursorTime === undefined ? null : (
+              <div className="ac-cursor-readout" role="status">
+                <strong>{compact(cursorTime)}s</strong>
+                {cursorRows.map(({ trace, value }) => (
+                  <span key={trace.id}>
+                    {trace.label}: {Number(value.toPrecision(6))}{" "}
+                    {trace.unit ?? ""}
+                  </span>
+                ))}
+              </div>
             )}
           </section>
         </div>

--- a/apps/editor/src/features/simulation/transient-results-explorer.tsx
+++ b/apps/editor/src/features/simulation/transient-results-explorer.tsx
@@ -1,10 +1,18 @@
-import { useEffect, useId, useMemo, useState } from "react";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+  type SetStateAction,
+} from "react";
 import {
   WaveformInteraction,
   waveformTicks,
   waveformTickLabel,
   useWaveformWidth,
 } from "./waveform-interaction";
+import { useWaveformView } from "./waveform-view";
+import { WaveformTools, WaveformMeasurements } from "./waveform-tools";
 import type { SimulationProbeSpec } from "@icm/model";
 import type { TransientResult } from "@icm/spice-run";
 import type { Prepared } from "@icm/simulation-service/contract";
@@ -20,6 +28,7 @@ interface TransientTrace {
 }
 
 export interface TransientResultsExplorerProps {
+  resultKey?: string;
   analysis: TransientResult;
   vectors: Prepared["vectors"];
   probes: readonly SimulationProbeSpec[];
@@ -76,6 +85,29 @@ export function transientValueExtent(
   if (extent[1] - extent[0] > tolerance) return extent;
   const margin = Math.max(Math.abs(center) * 0.05, 1e-12);
   return [center - margin, center + margin];
+}
+
+/** Include line intersections at the viewport boundaries when it contains no solver sample. */
+export function transientVisibleValues(
+  times: readonly number[],
+  values: readonly number[],
+  range: readonly [number, number],
+): number[] {
+  const result: number[] = [];
+  for (let i = 0; i < Math.min(times.length, values.length); i++) {
+    const x = times[i]!,
+      y = values[i]!;
+    if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+    if (x >= range[0] && x <= range[1]) result.push(y);
+    if (i === 0) continue;
+    const prevX = times[i - 1]!,
+      prevY = values[i - 1]!;
+    if (!Number.isFinite(prevY) || x <= prevX) continue;
+    for (const edge of range)
+      if (prevX < edge && x > edge)
+        result.push(prevY + ((y - prevY) * (edge - prevX)) / (x - prevX));
+  }
+  return result;
 }
 
 function compact(value: number): string {
@@ -154,46 +186,13 @@ function outputTraces(
   });
 }
 
-function clampRange(
-  low: number,
-  high: number,
-  full: readonly [number, number],
-): readonly [number, number] {
-  const span = Math.min(high - low, full[1] - full[0]);
-  if (low < full[0]) return [full[0], full[0] + span];
-  if (high > full[1]) return [full[1] - span, full[1]];
-  return [low, high];
-}
-
-export function changeTransientTimeRange(
-  current: readonly [number, number],
-  full: readonly [number, number],
-  action: "zoom-in" | "zoom-out" | "pan-left" | "pan-right",
-  center = (current[0] + current[1]) / 2,
-): readonly [number, number] {
-  const span = current[1] - current[0];
-  if (action.startsWith("zoom")) {
-    const nextSpan = Math.min(
-      full[1] - full[0],
-      span * (action === "zoom-in" ? 0.6 : 1.7),
-    );
-    const fraction = span ? (center - current[0]) / span : 0.5;
-    return clampRange(
-      center - nextSpan * fraction,
-      center + nextSpan * (1 - fraction),
-      full,
-    );
-  }
-  const shift = span * 0.2 * (action === "pan-left" ? -1 : 1);
-  return clampRange(current[0] + shift, current[1] + shift, full);
-}
-
 export function TransientResultsExplorer({
   analysis,
   vectors,
   probes,
   labels = {},
   onFocusProbe,
+  resultKey,
 }: TransientResultsExplorerProps) {
   const measured = useWaveformWidth();
   const clipPrefix = useId();
@@ -201,14 +200,15 @@ export function TransientResultsExplorer({
     () => outputTraces(analysis, vectors, probes, labels),
     [analysis, labels, probes, vectors],
   );
-  const [hidden, setHidden] = useState<ReadonlySet<string>>(() => new Set());
-  const [solo, setSolo] = useState<string | null>(null);
-  const [selected, setSelected] = useState<string | null>(null);
-  const [markerTime, setMarkerTime] = useState<number>();
-  const [timeRange, setTimeRange] = useState<readonly [number, number]>();
-  const [valueRanges, setValueRanges] = useState<
-    Partial<Record<PlotQuantity, readonly [number, number]>>
-  >({});
+  const controller = useWaveformView(resultKey);
+  const { hidden, solo, selected, markers } = controller.state;
+  const setHidden = (value: SetStateAction<ReadonlySet<string>>) =>
+    controller.set("hidden", value);
+  const setSolo = (value: React.SetStateAction<string | null>) =>
+    controller.set("solo", value);
+  const setSelected = (value: string) => controller.set("selected", value);
+  const timeRange = controller.view.x;
+  const valueRanges = controller.view.y;
   const [expandedQuantity, setExpandedQuantity] = useState<
     "voltage" | "current" | null
   >(null);
@@ -216,7 +216,6 @@ export function TransientResultsExplorer({
     (trace) => !hidden.has(trace.id) && (solo === null || solo === trace.id),
   );
   const fullRange = finiteExtent(analysis.timeSeconds);
-  const cursorTime = markerTime;
 
   useEffect(() => {
     const cancelTransientPlotAction = (event: KeyboardEvent) => {
@@ -235,87 +234,6 @@ export function TransientResultsExplorer({
     if (trace.probe) onFocusProbe?.(trace.probe);
   };
 
-  const updateRange = (
-    action: "zoom-in" | "zoom-out" | "pan-left" | "pan-right" | "fit",
-    quantity: PlotQuantity,
-  ) => {
-    if (action === "fit") {
-      setTimeRange(undefined);
-      setValueRanges((current) => ({ ...current, [quantity]: undefined }));
-      return;
-    }
-    const next = changeTransientTimeRange(
-      timeRange ?? fullRange,
-      fullRange,
-      action,
-      cursorTime,
-    );
-    setTimeRange(
-      next[0] === fullRange[0] && next[1] === fullRange[1] ? undefined : next,
-    );
-  };
-
-  const toolbar = (quantity: PlotQuantity, expanded: boolean) => (
-    <div
-      className={`ac-plot-toolbar${expanded ? " expanded" : ""}`}
-      aria-label="Plot tools"
-    >
-      <button
-        type="button"
-        aria-label="Zoom in"
-        onClick={() => updateRange("zoom-in", quantity)}
-      >
-        +
-      </button>
-      <button
-        type="button"
-        aria-label="Zoom out"
-        onClick={() => updateRange("zoom-out", quantity)}
-      >
-        −
-      </button>
-      <button
-        type="button"
-        aria-label="Pan left"
-        onClick={() => updateRange("pan-left", quantity)}
-      >
-        ←
-      </button>
-      <button
-        type="button"
-        aria-label="Pan right"
-        onClick={() => updateRange("pan-right", quantity)}
-      >
-        →
-      </button>
-      <button
-        type="button"
-        aria-label="Fit plot"
-        onClick={() => updateRange("fit", quantity)}
-      >
-        Fit
-      </button>
-      {markerTime !== undefined ? (
-        <button
-          type="button"
-          aria-label="Clear marker"
-          onClick={() => setMarkerTime(undefined)}
-        >
-          ×│
-        </button>
-      ) : null}
-      {!expanded ? (
-        <button
-          type="button"
-          aria-label="Open plot"
-          onClick={() => setExpandedQuantity(quantity)}
-        >
-          ⛶
-        </button>
-      ) : null}
-    </div>
-  );
-
   const plot = (
     quantity: PlotQuantity,
     quantityTraces: readonly TransientTrace[],
@@ -327,24 +245,15 @@ export function TransientResultsExplorer({
     const range = timeRange ?? fullRange;
     const clipId = `${clipPrefix}-${quantity}-${expanded}`;
     const visibleValues = quantityTraces.flatMap((trace) =>
-      trace.values.filter(
-        (_value, index) =>
-          analysis.timeSeconds[index]! >= range[0] &&
-          analysis.timeSeconds[index]! <= range[1],
-      ),
+      transientVisibleValues(analysis.timeSeconds, trace.values, range),
     );
     const automaticExtent = transientValueExtent(visibleValues);
     const extent = valueRanges[quantity] ?? automaticExtent;
     const unit = quantityTraces.find((trace) => trace.unit)?.unit ?? "";
-    const cursorX =
-      cursorTime === undefined
-        ? undefined
-        : geometry.left +
-          ((cursorTime - range[0]) / (range[1] - range[0])) *
-            (geometry.width - geometry.left - geometry.right);
     return (
       <div className={`ac-plot-shell${expanded ? " expanded" : ""}`}>
         <WaveformInteraction
+          axes={controller.state.axes}
           frame={{
             x: geometry.left,
             y: geometry.top,
@@ -354,28 +263,42 @@ export function TransientResultsExplorer({
           onZoom={(start, end) => {
             const x = [start.x, end.x].sort((a, b) => a - b);
             const y = [start.y, end.y].sort((a, b) => a - b);
-            setTimeRange([
-              range[0] + x[0]! * (range[1] - range[0]),
-              range[0] + x[1]! * (range[1] - range[0]),
-            ]);
-            setValueRanges((current) => ({
-              ...current,
-              [quantity]: [
-                extent[1] - y[1]! * (extent[1] - extent[0]),
-                extent[1] - y[0]! * (extent[1] - extent[0]),
-              ],
-            }));
+            controller.commit({
+              x:
+                controller.state.axes === "y"
+                  ? range
+                  : [
+                      range[0] + x[0]! * (range[1] - range[0]),
+                      range[0] + x[1]! * (range[1] - range[0]),
+                    ],
+              y: {
+                ...valueRanges,
+                [quantity]:
+                  controller.state.axes === "x"
+                    ? extent
+                    : [
+                        extent[1] - y[1]! * (extent[1] - extent[0]),
+                        extent[1] - y[0]! * (extent[1] - extent[0]),
+                      ],
+              },
+            });
           }}
           onPan={(delta) => {
-            const shift = -delta.x * (range[1] - range[0]);
-            setTimeRange(
-              clampRange(range[0] + shift, range[1] + shift, fullRange),
-            );
-            const dy = delta.y * (extent[1] - extent[0]);
-            setValueRanges((current) => ({
-              ...current,
-              [quantity]: [extent[0] + dy, extent[1] + dy],
-            }));
+            const shift = -delta.x * (range[1] - range[0]),
+              dy = delta.y * (extent[1] - extent[0]);
+            controller.commit({
+              x:
+                controller.state.axes === "y"
+                  ? range
+                  : [range[0] + shift, range[1] + shift],
+              y: {
+                ...valueRanges,
+                [quantity]:
+                  controller.state.axes === "x"
+                    ? extent
+                    : [extent[0] + dy, extent[1] + dy],
+              },
+            });
           }}
           onPick={(point, id) => {
             if (id) focusTrace(id);
@@ -385,7 +308,7 @@ export function TransientResultsExplorer({
                 Math.abs(value - time) < Math.abs(best - time) ? value : best,
               analysis.timeSeconds[0] ?? time,
             );
-            setMarkerTime(nearest);
+            controller.mark(nearest);
           }}
           onOpen={() => !expanded && setExpandedQuantity(quantity)}
         >
@@ -517,40 +440,81 @@ export function TransientResultsExplorer({
                 </g>
               );
             })}
-            {cursorX === undefined ? null : (
-              <line
-                className="ac-cursor"
-                stroke="#101828"
-                strokeWidth={1}
-                strokeDasharray="2 2"
-                pointerEvents="none"
-                x1={cursorX}
-                y1={geometry.top}
-                x2={cursorX}
-                y2={geometry.height - geometry.bottom}
-              />
-            )}
+            {(["A", "B"] as const).map((name) => {
+              const time = markers[name];
+              if (time === undefined || time < range[0] || time > range[1])
+                return null;
+              const x =
+                geometry.left +
+                ((time - range[0]) / (range[1] - range[0])) *
+                  (geometry.width - geometry.left - geometry.right);
+              return (
+                <g key={name} pointerEvents="none">
+                  <line
+                    className="ac-cursor"
+                    stroke={name === "A" ? "#175cd3" : "#c4320a"}
+                    strokeWidth={1}
+                    strokeDasharray="3 3"
+                    x1={x}
+                    x2={x}
+                    y1={geometry.top}
+                    y2={geometry.height - geometry.bottom}
+                  />
+                  <text x={x + 3} y={geometry.top + 12}>
+                    {name}
+                  </text>
+                </g>
+              );
+            })}
           </svg>
         </WaveformInteraction>
-        {toolbar(quantity, expanded)}
+        <WaveformTools
+          controller={controller}
+          plotKey={quantity}
+          x={range}
+          y={extent}
+          xUnit="s"
+          yUnit={unit}
+          {...(!expanded
+            ? { onOpen: () => setExpandedQuantity(quantity) }
+            : {})}
+        />
+        {!expanded && measurement(quantity)}
       </div>
     );
   };
 
-  const cursorRows =
-    cursorTime === undefined
-      ? []
-      : visible.map((trace) => {
-          const index = analysis.timeSeconds.reduce(
-            (best, time, candidate) =>
-              Math.abs(time - cursorTime) <
-              Math.abs(analysis.timeSeconds[best]! - cursorTime)
-                ? candidate
-                : best,
-            0,
-          );
-          return { trace, value: trace.values[index] ?? 0 };
-        });
+  const measurement = (quantity?: PlotQuantity) => (
+    <WaveformMeasurements
+      a={markers.A}
+      b={markers.B}
+      unit="s"
+      time
+      rows={visible
+        .filter((trace) => !quantity || trace.quantity === quantity)
+        .map((trace) => {
+          const valueAt = (x: number | undefined) => {
+            if (x === undefined) return undefined;
+            const index = analysis.timeSeconds.reduce(
+              (best, time, candidate) =>
+                Math.abs(time - x) < Math.abs(analysis.timeSeconds[best]! - x)
+                  ? candidate
+                  : best,
+              0,
+            );
+            return trace.values[index];
+          };
+          const a = valueAt(markers.A),
+            b = valueAt(markers.B);
+          return {
+            label: trace.label,
+            unit: trace.unit ?? "",
+            ...(a === undefined ? {} : { a }),
+            ...(b === undefined ? {} : { b }),
+          };
+        })}
+    />
+  );
 
   return (
     <div
@@ -628,16 +592,6 @@ export function TransientResultsExplorer({
       {visible.length === 0 ? (
         <p className="simulation-empty-result">All Outputs are hidden.</p>
       ) : null}
-      {cursorTime === undefined ? null : (
-        <div className="ac-cursor-readout" role="status">
-          <strong>{compact(cursorTime)}s</strong>
-          {cursorRows.map(({ trace, value }) => (
-            <span key={trace.id}>
-              {trace.label}: {Number(value.toPrecision(6))} {trace.unit ?? ""}
-            </span>
-          ))}
-        </div>
-      )}
       {expandedQuantity ? (
         <div
           className="ac-plot-dialog-backdrop"
@@ -669,17 +623,7 @@ export function TransientResultsExplorer({
               visible.filter((trace) => trace.quantity === expandedQuantity),
               true,
             )}
-            {cursorTime === undefined ? null : (
-              <div className="ac-cursor-readout" role="status">
-                <strong>{compact(cursorTime)}s</strong>
-                {cursorRows.map(({ trace, value }) => (
-                  <span key={trace.id}>
-                    {trace.label}: {Number(value.toPrecision(6))}{" "}
-                    {trace.unit ?? ""}
-                  </span>
-                ))}
-              </div>
-            )}
+            {measurement(expandedQuantity)}
           </section>
         </div>
       ) : null}

--- a/apps/editor/src/features/simulation/waveform-interaction.test.ts
+++ b/apps/editor/src/features/simulation/waveform-interaction.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { waveformTicks, waveformTickLabel } from "./waveform-interaction";
+import { layoutAcPlot } from "./ac-response-plot";
+
+describe("waveform axes", () => {
+  it("adapts tick spacing to nanoseconds and a zoomed small signal", () => {
+    expect(waveformTickLabel(1.8000005, 5e-7, "V")).not.toBe(
+      waveformTickLabel(1.800001, 5e-7, "V"),
+    );
+    expect(waveformTicks(0, 1e-9, 5)).toEqual([
+      0, 2e-10, 4e-10, 6e-10, 8e-10, 1e-9,
+    ]);
+    const ticks = waveformTicks(1.799999, 1.800001, 5);
+    expect(ticks.length).toBeGreaterThan(2);
+    expect(new Set(ticks).size).toBe(ticks.length);
+    expect(waveformTicks(2, 2)).toEqual([]);
+  });
+  it("keeps frequency ticks inside a sub-decade zoom and respects explicit Y zoom", () => {
+    const result = layoutAcPlot(
+      [
+        {
+          label: "out",
+          points: [
+            { frequency: 100, magnitudeDb: 1, phaseDeg: 0 },
+            { frequency: 1000, magnitudeDb: 5, phaseDeg: 10 },
+          ],
+        },
+      ],
+      { width: 500, height: 280 },
+      [240, 280],
+      { kind: "magnitude", range: [2, 3] },
+    )!;
+    expect(result.frequency.ticks.length).toBeGreaterThan(2);
+    expect(
+      result.frequency.ticks.every((tick) => tick >= 240 && tick <= 280),
+    ).toBe(true);
+    expect(result.magnitude.min).toBe(2);
+    expect(result.magnitude.max).toBe(3);
+  });
+});

--- a/apps/editor/src/features/simulation/waveform-interaction.tsx
+++ b/apps/editor/src/features/simulation/waveform-interaction.tsx
@@ -1,0 +1,204 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+  type PointerEvent,
+} from "react";
+
+export function useWaveformWidth() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(760);
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry && entry.contentRect.width > 0)
+        setWidth(Math.max(280, Math.round(entry.contentRect.width)));
+    });
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+  return { ref, width };
+}
+
+export interface WaveformPoint {
+  x: number;
+  y: number;
+}
+
+/** Pointer gestures share the SVG's transform, including letterboxing. */
+export function WaveformInteraction({
+  children,
+  frame,
+  onZoom,
+  onPick,
+  onPan,
+  onOpen,
+}: {
+  children: ReactNode;
+  frame: { x: number; y: number; width: number; height: number };
+  onZoom(start: WaveformPoint, end: WaveformPoint): void;
+  onPick(point: WaveformPoint, traceId?: string): void;
+  onPan(delta: WaveformPoint): void;
+  onOpen(): void;
+}) {
+  const drag = useRef<
+    | {
+        start: WaveformPoint;
+        clientX: number;
+        clientY: number;
+        pan: boolean;
+        traceId?: string;
+      }
+    | undefined
+  >(undefined);
+  const [box, setBox] = useState<{
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  }>();
+  const pointAt = (
+    event: PointerEvent<HTMLDivElement>,
+  ): WaveformPoint | undefined => {
+    const svg = event.currentTarget.querySelector("svg");
+    const transform = svg?.getScreenCTM();
+    if (!svg || !transform) return;
+    const point = new DOMPoint(event.clientX, event.clientY).matrixTransform(
+      transform.inverse(),
+    );
+    return {
+      x: Math.max(0, Math.min(1, (point.x - frame.x) / frame.width)),
+      y: Math.max(0, Math.min(1, (point.y - frame.y) / frame.height)),
+    };
+  };
+  return (
+    <div
+      className="spice-ac-plot interactive"
+      tabIndex={0}
+      aria-label="Waveform: drag to zoom, click to measure, Shift-drag to pan"
+      title="Drag to zoom · Click to measure · Shift-drag to pan · Double-click to expand"
+      onKeyDown={(event) => {
+        if (event.key === "Escape" && drag.current) {
+          drag.current = undefined;
+          setBox(undefined);
+          event.stopPropagation();
+        }
+      }}
+      onPointerDown={(event) => {
+        if (event.button !== 0) return;
+        const start = pointAt(event);
+        if (!start) return;
+        const traceId = (event.target as Element)
+          .closest("[data-trace-id]")
+          ?.getAttribute("data-trace-id");
+        drag.current = {
+          start,
+          clientX: event.clientX,
+          clientY: event.clientY,
+          pan: event.shiftKey,
+          ...(traceId ? { traceId } : {}),
+        };
+        event.currentTarget.focus();
+        event.currentTarget.setPointerCapture(event.pointerId);
+        event.preventDefault();
+      }}
+      onPointerMove={(event) => {
+        const start = drag.current;
+        if (
+          !start ||
+          start.pan ||
+          Math.hypot(
+            event.clientX - start.clientX,
+            event.clientY - start.clientY,
+          ) < 5
+        )
+          return;
+        const bounds = event.currentTarget.getBoundingClientRect();
+        setBox({
+          left: Math.min(start.clientX, event.clientX) - bounds.left,
+          top: Math.min(start.clientY, event.clientY) - bounds.top,
+          width: Math.abs(event.clientX - start.clientX),
+          height: Math.abs(event.clientY - start.clientY),
+        });
+      }}
+      onPointerUp={(event) => {
+        const start = drag.current;
+        const end = pointAt(event);
+        drag.current = undefined;
+        setBox(undefined);
+        if (event.currentTarget.hasPointerCapture(event.pointerId))
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        if (!start || !end) return;
+        if (
+          Math.hypot(
+            event.clientX - start.clientX,
+            event.clientY - start.clientY,
+          ) < 5
+        )
+          onPick(end, start.traceId);
+        else if (start.pan)
+          onPan({ x: end.x - start.start.x, y: end.y - start.start.y });
+        else if (
+          Math.abs(end.x - start.start.x) > 0.005 &&
+          Math.abs(end.y - start.start.y) > 0.005
+        )
+          onZoom(start.start, end);
+      }}
+      onPointerCancel={() => {
+        drag.current = undefined;
+        setBox(undefined);
+      }}
+      onDoubleClick={onOpen}
+    >
+      {children}
+      {box && <div className="waveform-selection" style={box} />}
+    </div>
+  );
+}
+
+/** Bounded, readable 1/2/5 ticks; recomputed from the visible range. */
+export function waveformTicks(min: number, max: number, count = 6): number[] {
+  if (!Number.isFinite(min) || !Number.isFinite(max) || max <= min) return [];
+  const rough = (max - min) / Math.max(2, count);
+  const power = 10 ** Math.floor(Math.log10(rough));
+  const step = ([1, 2, 5, 10].find((n) => n * power >= rough) ?? 10) * power;
+  const first = Math.ceil(min / step - 1e-10);
+  const last = Math.floor(max / step + 1e-10);
+  return Array.from(
+    { length: Math.max(0, Math.min(100, last - first + 1)) },
+    (_, i) => Number(((first + i) * step).toPrecision(12)),
+  );
+}
+
+export function waveformTickLabel(
+  value: number,
+  step: number,
+  unit: string,
+): string {
+  const exponent = Math.max(
+    -15,
+    Math.min(
+      9,
+      Math.floor(Math.log10(Math.abs(value) || Math.abs(step) || 1) / 3) * 3,
+    ),
+  );
+  const scale = 10 ** exponent;
+  const prefix =
+    new Map([
+      [-15, "f"],
+      [-12, "p"],
+      [-9, "n"],
+      [-6, "µ"],
+      [-3, "m"],
+      [0, ""],
+      [3, "k"],
+      [6, "M"],
+      [9, "G"],
+    ]).get(exponent) ?? "";
+  const decimals = Math.min(
+    15,
+    Math.max(0, -Math.floor(Math.log10(Math.abs(step) / scale || 1))),
+  );
+  return `${(value / scale).toFixed(decimals)} ${prefix}${unit}`;
+}

--- a/apps/editor/src/features/simulation/waveform-interaction.tsx
+++ b/apps/editor/src/features/simulation/waveform-interaction.tsx
@@ -34,6 +34,7 @@ export function WaveformInteraction({
   onPick,
   onPan,
   onOpen,
+  axes = "xy",
 }: {
   children: ReactNode;
   frame: { x: number; y: number; width: number; height: number };
@@ -41,6 +42,7 @@ export function WaveformInteraction({
   onPick(point: WaveformPoint, traceId?: string): void;
   onPan(delta: WaveformPoint): void;
   onOpen(): void;
+  axes?: "xy" | "x" | "y";
 }) {
   const drag = useRef<
     | {
@@ -58,6 +60,9 @@ export function WaveformInteraction({
     width: number;
     height: number;
   }>();
+  const lastPick = useRef<{ time: number; x: number; y: number } | undefined>(
+    undefined,
+  );
   const pointAt = (
     event: PointerEvent<HTMLDivElement>,
   ): WaveformPoint | undefined => {
@@ -78,6 +83,9 @@ export function WaveformInteraction({
       tabIndex={0}
       aria-label="Waveform: drag to zoom, click to measure, Shift-drag to pan"
       title="Drag to zoom · Click to measure · Shift-drag to pan · Double-click to expand"
+      onBlur={() => {
+        lastPick.current = undefined;
+      }}
       onKeyDown={(event) => {
         if (event.key === "Escape" && drag.current) {
           drag.current = undefined;
@@ -115,11 +123,35 @@ export function WaveformInteraction({
         )
           return;
         const bounds = event.currentTarget.getBoundingClientRect();
+        const transform = event.currentTarget
+          .querySelector("svg")
+          ?.getScreenCTM();
+        const topLeft = transform
+          ? new DOMPoint(frame.x, frame.y).matrixTransform(transform)
+          : undefined;
+        const bottomRight = transform
+          ? new DOMPoint(
+              frame.x + frame.width,
+              frame.y + frame.height,
+            ).matrixTransform(transform)
+          : undefined;
         setBox({
-          left: Math.min(start.clientX, event.clientX) - bounds.left,
-          top: Math.min(start.clientY, event.clientY) - bounds.top,
-          width: Math.abs(event.clientX - start.clientX),
-          height: Math.abs(event.clientY - start.clientY),
+          left:
+            (axes === "y" && topLeft
+              ? topLeft.x
+              : Math.min(start.clientX, event.clientX)) - bounds.left,
+          top:
+            (axes === "x" && topLeft
+              ? topLeft.y
+              : Math.min(start.clientY, event.clientY)) - bounds.top,
+          width:
+            axes === "y" && topLeft && bottomRight
+              ? bottomRight.x - topLeft.x
+              : Math.abs(event.clientX - start.clientX),
+          height:
+            axes === "x" && topLeft && bottomRight
+              ? bottomRight.y - topLeft.y
+              : Math.abs(event.clientY - start.clientY),
         });
       }}
       onPointerUp={(event) => {
@@ -135,13 +167,31 @@ export function WaveformInteraction({
             event.clientX - start.clientX,
             event.clientY - start.clientY,
           ) < 5
-        )
-          onPick(end, start.traceId);
-        else if (start.pan)
+        ) {
+          const previous = lastPick.current;
+          // AC SVG nodes are regenerated when a marker is placed. Recognize
+          // the second click on the stable viewport, not a replaced SVG node.
+          if (
+            previous &&
+            event.timeStamp - previous.time < 450 &&
+            Math.hypot(event.clientX - previous.x, event.clientY - previous.y) <
+              5
+          ) {
+            lastPick.current = undefined;
+            onOpen();
+          } else {
+            lastPick.current = {
+              time: event.timeStamp,
+              x: event.clientX,
+              y: event.clientY,
+            };
+            onPick(end, start.traceId);
+          }
+        } else if (start.pan)
           onPan({ x: end.x - start.start.x, y: end.y - start.start.y });
         else if (
-          Math.abs(end.x - start.start.x) > 0.005 &&
-          Math.abs(end.y - start.start.y) > 0.005
+          (axes === "y" || Math.abs(end.x - start.start.x) > 0.005) &&
+          (axes === "x" || Math.abs(end.y - start.start.y) > 0.005)
         )
           onZoom(start.start, end);
       }}
@@ -149,7 +199,6 @@ export function WaveformInteraction({
         drag.current = undefined;
         setBox(undefined);
       }}
-      onDoubleClick={onOpen}
     >
       {children}
       {box && <div className="waveform-selection" style={box} />}

--- a/apps/editor/src/features/simulation/waveform-tools.tsx
+++ b/apps/editor/src/features/simulation/waveform-tools.tsx
@@ -1,0 +1,282 @@
+import { useState } from "react";
+import {
+  parseWaveformRange,
+  zoomWaveformRange,
+  type WaveformController,
+  type WaveformRange,
+} from "./waveform-view";
+
+export function WaveformTools({
+  controller: c,
+  plotKey,
+  x,
+  y,
+  xUnit,
+  yUnit,
+  logarithmicX = false,
+  onOpen,
+}: {
+  controller: WaveformController;
+  plotKey: string;
+  x: WaveformRange;
+  y: WaveformRange;
+  xUnit: string;
+  yUnit: string;
+  logarithmicX?: boolean;
+  onOpen?: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const fit = (axis: "xy" | "x" | "y") =>
+    c.commit({
+      x: axis === "y" ? x : undefined,
+      y: { ...c.view.y, [plotKey]: axis === "x" ? y : undefined },
+    });
+  const zoom = (factor: number) =>
+    c.commit({
+      x: c.state.axes === "y" ? x : zoomWaveformRange(x, factor, logarithmicX),
+      y:
+        c.state.axes === "x"
+          ? { ...c.view.y, [plotKey]: y }
+          : { ...c.view.y, [plotKey]: zoomWaveformRange(y, factor) },
+    });
+  return (
+    <div className="ac-plot-toolbar waveform-tools" aria-label="Plot tools">
+      <button
+        type="button"
+        aria-label="Previous view"
+        disabled={c.state.index === 0}
+        onClick={() => c.travel(-1)}
+      >
+        ↶
+      </button>
+      <button
+        type="button"
+        aria-label="Next view"
+        disabled={c.state.index === c.state.history.length - 1}
+        onClick={() => c.travel(1)}
+      >
+        ↷
+      </button>
+      <div role="group" aria-label="Controlled axes">
+        {(["xy", "x", "y"] as const).map((axis) => (
+          <button
+            type="button"
+            key={axis}
+            aria-label={`Control ${axis.toUpperCase()} axes`}
+            aria-pressed={c.state.axes === axis}
+            onClick={() => c.set("axes", axis)}
+          >
+            {axis.toUpperCase()}
+          </button>
+        ))}
+      </div>
+      <button type="button" aria-label="Zoom in" onClick={() => zoom(0.6)}>
+        +
+      </button>
+      <button type="button" aria-label="Zoom out" onClick={() => zoom(1.7)}>
+        −
+      </button>
+      <button type="button" aria-label="Fit plot" onClick={() => fit("xy")}>
+        Fit
+      </button>
+      <button type="button" aria-label="Fit X" onClick={() => fit("x")}>
+        Fit X
+      </button>
+      <button type="button" aria-label="Fit Y" onClick={() => fit("y")}>
+        Fit Y
+      </button>
+      <button
+        type="button"
+        aria-expanded={editing}
+        onClick={() => setEditing(!editing)}
+      >
+        Ranges
+      </button>
+      <div role="group" aria-label="Active marker">
+        {(["A", "B"] as const).map((marker) => (
+          <button
+            key={marker}
+            type="button"
+            aria-label={`Place marker ${marker}`}
+            aria-pressed={c.state.activeMarker === marker}
+            onClick={() => c.set("activeMarker", marker)}
+          >
+            {marker}
+          </button>
+        ))}
+      </div>
+      {
+        <button
+          type="button"
+          aria-label="Clear markers"
+          disabled={
+            c.state.markers.A === undefined && c.state.markers.B === undefined
+          }
+          onClick={() => c.set("markers", {})}
+        >
+          ×│
+        </button>
+      }
+      {onOpen && (
+        <button type="button" aria-label="Open plot" onClick={onOpen}>
+          ⛶
+        </button>
+      )}
+      {editing && (
+        <WaveformRangeEditor
+          x={x}
+          y={y}
+          xUnit={xUnit}
+          yUnit={yUnit}
+          xAuto={c.view.x === undefined}
+          yAuto={c.view.y[plotKey] === undefined}
+          logarithmicX={logarithmicX}
+          onCancel={() => setEditing(false)}
+          onApply={(nextX, nextY) => {
+            c.commit({ x: nextX, y: { ...c.view.y, [plotKey]: nextY } });
+            setEditing(false);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function WaveformRangeEditor({
+  x,
+  y,
+  xAuto,
+  yAuto,
+  xUnit,
+  yUnit,
+  logarithmicX,
+  onApply,
+  onCancel,
+}: {
+  x: WaveformRange;
+  y: WaveformRange;
+  xAuto: boolean;
+  yAuto: boolean;
+  xUnit: string;
+  yUnit: string;
+  logarithmicX: boolean;
+  onApply(x: WaveformRange | undefined, y: WaveformRange | undefined): void;
+  onCancel(): void;
+}) {
+  const [autoX, setAutoX] = useState(xAuto),
+    [autoY, setAutoY] = useState(yAuto);
+  const [bounds, setBounds] = useState({
+    x0: String(x[0]),
+    x1: String(x[1]),
+    y0: String(y[0]),
+    y1: String(y[1]),
+  });
+  const [error, setError] = useState("");
+  return (
+    <form
+      className="waveform-range-editor"
+      aria-label="Axis ranges"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const nextX = autoX
+          ? undefined
+          : parseWaveformRange(bounds.x0, bounds.x1, logarithmicX);
+        const nextY = autoY
+          ? undefined
+          : parseWaveformRange(bounds.y0, bounds.y1);
+        if (typeof nextX === "string" || typeof nextY === "string") {
+          setError(typeof nextX === "string" ? `X: ${nextX}` : `Y: ${nextY}`);
+          return;
+        }
+        onApply(nextX, nextY);
+      }}
+    >
+      {(["x", "y"] as const).map((axis) => (
+        <fieldset key={axis}>
+          <legend>
+            {axis.toUpperCase()} ({axis === "x" ? xUnit : yUnit})
+          </legend>
+          <label>
+            <input
+              type="checkbox"
+              aria-label={`Auto ${axis.toUpperCase()}`}
+              checked={axis === "x" ? autoX : autoY}
+              onChange={(event) =>
+                (axis === "x" ? setAutoX : setAutoY)(event.target.checked)
+              }
+            />
+            Auto
+          </label>
+          {([0, 1] as const).map((index) => (
+            <label key={index}>
+              {index === 0 ? "Min" : "Max"}
+              <input
+                aria-label={`${axis.toUpperCase()} ${index === 0 ? "minimum" : "maximum"}`}
+                value={bounds[`${axis}${index}`]}
+                disabled={axis === "x" ? autoX : autoY}
+                onChange={(event) =>
+                  setBounds({
+                    ...bounds,
+                    [`${axis}${index}`]: event.target.value,
+                  })
+                }
+              />
+            </label>
+          ))}
+        </fieldset>
+      ))}
+      {error && <p role="alert">{error}</p>}
+      <button type="submit">Apply ranges</button>
+      <button type="button" onClick={onCancel}>
+        Cancel
+      </button>
+    </form>
+  );
+}
+
+export function WaveformMeasurements({
+  a,
+  b,
+  unit,
+  rows,
+  time = false,
+}: {
+  a: number | undefined;
+  b: number | undefined;
+  unit: string;
+  rows: readonly { label: string; unit: string; a?: number; b?: number }[];
+  time?: boolean;
+}) {
+  if (a === undefined && b === undefined) return null;
+  const format = (value: number | undefined) =>
+    value === undefined ? "—" : Number(value.toPrecision(8)).toString();
+  return (
+    <div
+      className="ac-cursor-readout"
+      role="status"
+      aria-label="Marker measurements"
+    >
+      <strong>
+        A: {format(a)} {unit} · B: {format(b)} {unit}
+        {a !== undefined && b !== undefined && (
+          <>
+            {" "}
+            · ΔX: {format(b - a)} {unit}
+            {time && b !== a && (
+              <> · 1/|Δt|: {format(1 / Math.abs(b - a))} Hz</>
+            )}
+          </>
+        )}
+      </strong>
+      {rows.map((row) => (
+        <span key={row.label}>
+          {row.label}: A {format(row.a)} · B {format(row.b)}
+          {row.a !== undefined && row.b !== undefined && (
+            <> · ΔY {format(row.b - row.a)}</>
+          )}{" "}
+          {row.unit}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/editor/src/features/simulation/waveform-view.test.ts
+++ b/apps/editor/src/features/simulation/waveform-view.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  commitWaveformView,
+  initialWaveformState,
+  travelWaveformView,
+  parseWaveformRange,
+  zoomWaveformRange,
+} from "./waveform-view";
+
+describe("waveform views", () => {
+  it("restores both axes and Auto, then discards the forward branch on a new edit", () => {
+    const initial = initialWaveformState();
+    const first = commitWaveformView(initial, {
+      x: [1, 2],
+      y: { voltage: [0, 1] },
+    });
+    const second = commitWaveformView(first, {
+      x: [1.2, 1.4],
+      y: { voltage: [0.2, 0.3] },
+    });
+    const back = travelWaveformView(second, -1);
+    expect(back.history[back.index]).toEqual(first.history[first.index]);
+    expect(travelWaveformView(back, 1)).toEqual(second);
+    const branch = commitWaveformView(back, { x: undefined, y: {} });
+    expect(branch.history).toHaveLength(3);
+    expect(branch.history[branch.index]).toEqual(initial.history[0]);
+    expect(travelWaveformView(branch, 1).index).toBe(branch.index);
+    expect(commitWaveformView(branch, { x: undefined, y: {} })).toBe(branch);
+  });
+  it("bounds navigation history without dropping unrelated markers or hidden traces", () => {
+    let state = {
+      ...initialWaveformState(),
+      markers: { A: 1, B: 2 },
+      hidden: new Set(["out"]),
+    };
+    for (let i = 0; i < 70; i++)
+      state = {
+        ...commitWaveformView(state, { x: [i, i + 1], y: {} }),
+        markers: state.markers,
+        hidden: state.hidden,
+      };
+    expect(state.history).toHaveLength(50);
+    expect(state.markers).toEqual({ A: 1, B: 2 });
+    expect(state.hidden.has("out")).toBe(true);
+  });
+  it("accepts scientific notation and returns recoverable errors for invalid axis limits", () => {
+    expect(parseWaveformRange("1e-9", "2e-9")).toEqual([1e-9, 2e-9]);
+    for (const range of [
+      ["", "1"],
+      ["2", "1"],
+      ["0", "Infinity"],
+      ["1", "1"],
+    ])
+      expect(typeof parseWaveformRange(range[0]!, range[1]!)).toBe("string");
+    expect(typeof parseWaveformRange("0", "100", true)).toBe("string");
+  });
+  it("zooms linear and logarithmic axes about their correct centers", () => {
+    expect(zoomWaveformRange([0, 10], 0.6)).toEqual([2, 8]);
+    const log = zoomWaveformRange([1, 1e6], 0.5, true);
+    expect(log[0] * log[1]).toBeCloseTo(1e6, 4);
+    expect(log[0]).toBeCloseTo(10 ** 1.5);
+    expect(log[1]).toBeCloseTo(10 ** 4.5);
+  });
+});

--- a/apps/editor/src/features/simulation/waveform-view.ts
+++ b/apps/editor/src/features/simulation/waveform-view.ts
@@ -1,0 +1,142 @@
+import { useEffect, useState, type SetStateAction } from "react";
+
+export type WaveformRange = readonly [number, number];
+export type WaveformAxes = "xy" | "x" | "y";
+export type MarkerName = "A" | "B";
+export interface WaveformView {
+  x: WaveformRange | undefined;
+  y: Readonly<Record<string, WaveformRange | undefined>>;
+}
+export interface WaveformState {
+  history: readonly WaveformView[];
+  index: number;
+  axes: WaveformAxes;
+  markers: Partial<Record<MarkerName, number>>;
+  activeMarker: MarkerName;
+  hidden: ReadonlySet<string>;
+  solo: string | null;
+  selected: string | null;
+}
+export function initialWaveformState(): WaveformState {
+  return {
+    history: [{ x: undefined, y: {} }],
+    index: 0,
+    axes: "xy",
+    markers: {},
+    activeMarker: "A",
+    hidden: new Set(),
+    solo: null,
+    selected: null,
+  };
+}
+
+export function commitWaveformView(
+  state: WaveformState,
+  view: WaveformView,
+): WaveformState {
+  if (
+    [view.x, ...Object.values(view.y)].some(
+      (range) =>
+        range &&
+        (!Number.isFinite(range[0]) ||
+          !Number.isFinite(range[1]) ||
+          range[0] >= range[1]),
+    )
+  )
+    return state;
+  if (JSON.stringify(state.history[state.index]) === JSON.stringify(view))
+    return state;
+  const history = [...state.history.slice(0, state.index + 1), view].slice(-50);
+  return { ...state, history, index: history.length - 1 };
+}
+export function travelWaveformView(
+  state: WaveformState,
+  delta: number,
+): WaveformState {
+  return {
+    ...state,
+    index: Math.max(0, Math.min(state.history.length - 1, state.index + delta)),
+  };
+}
+
+/** Session-only result views. Unique run/analysis keys prevent reuse on a new run.
+ * Bounded storage survives tab/panel unmounts without retaining numeric results.
+ */
+const resultViews = new Map<string, WaveformState>();
+export function useWaveformView(resultKey?: string) {
+  const [state, setState] = useState(
+    () =>
+      (resultKey ? resultViews.get(resultKey) : undefined) ??
+      initialWaveformState(),
+  );
+  useEffect(() => {
+    if (resultKey) {
+      resultViews.delete(resultKey);
+      resultViews.set(resultKey, state);
+      if (resultViews.size > 24)
+        resultViews.delete(resultViews.keys().next().value!);
+    }
+  }, [resultKey, state]);
+  const update = (apply: (current: WaveformState) => WaveformState) =>
+    setState(apply);
+  const set = <K extends keyof WaveformState>(
+    key: K,
+    value: SetStateAction<WaveformState[K]>,
+  ) =>
+    update((current) => ({
+      ...current,
+      [key]:
+        typeof value === "function"
+          ? (value as (v: WaveformState[K]) => WaveformState[K])(current[key])
+          : value,
+    }));
+  return {
+    state,
+    view: state.history[state.index]!,
+    set,
+    commit: (view: WaveformView) =>
+      update((current) => commitWaveformView(current, view)),
+    travel: (delta: number) =>
+      update((current) => travelWaveformView(current, delta)),
+    mark: (x: number) =>
+      update((current) => ({
+        ...current,
+        markers: { ...current.markers, [current.activeMarker]: x },
+      })),
+  };
+}
+export type WaveformController = ReturnType<typeof useWaveformView>;
+
+export function parseWaveformRange(
+  low: string,
+  high: string,
+  logarithmic = false,
+): WaveformRange | string {
+  const min = Number(low),
+    max = Number(high);
+  if (
+    !low.trim() ||
+    !high.trim() ||
+    !Number.isFinite(min) ||
+    !Number.isFinite(max)
+  )
+    return "Enter finite minimum and maximum values.";
+  if (min >= max) return "Minimum must be less than maximum.";
+  if (logarithmic && min <= 0)
+    return "Logarithmic frequency limits must be positive.";
+  return [min, max];
+}
+
+export function zoomWaveformRange(
+  range: WaveformRange,
+  factor: number,
+  logarithmic = false,
+): WaveformRange {
+  const low = logarithmic ? Math.log(range[0]) : range[0];
+  const high = logarithmic ? Math.log(range[1]) : range[1];
+  const center = (low + high) / 2,
+    half = ((high - low) * factor) / 2;
+  return logarithmic
+    ? [Math.exp(center - half), Math.exp(center + half)]
+    : [center - half, center + half];
+}

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -802,12 +802,14 @@
   place-items: center;
 }
 .ac-plot-shell.expanded svg {
+  position: absolute;
+  inset: 0;
   width: 100%;
-  max-height: calc(92vh - 90px);
+  height: 100%;
+  max-height: none;
 }
 .ac-cursor-readout {
-  position: sticky;
-  bottom: 0;
+  position: relative;
   display: grid;
   gap: 2px;
   padding: 7px 9px;
@@ -1220,15 +1222,21 @@
   stroke-width: 1;
 }
 
-.ac-response .ac-grid {
+.ac-response .ac-grid,
+.transient-results-explorer .ac-grid {
   stroke: var(--icm-border-subtle, #eceff3);
   stroke-width: 1;
 }
 
-.ac-response .ac-axis-label {
-  font-size: 9px;
+.ac-response .ac-axis-label,
+.transient-results-explorer .ac-axis-label {
+  font-size: 12px;
   fill: var(--icm-text-muted, #667085);
   font-variant-numeric: tabular-nums;
+}
+
+.ac-plot-shell.expanded .ac-axis-label {
+  font-size: 16px;
 }
 
 /* Traces are distinguished by hue, and one plot may carry several. The
@@ -1285,6 +1293,44 @@
 }
 .waveform-svg {
   display: contents;
+}
+.waveform-tools {
+  align-self: stretch;
+  justify-content: flex-end;
+}
+.waveform-tools > [role="group"] {
+  display: flex;
+  border-left: 1px solid var(--icm-border);
+  padding-left: 4px;
+}
+.waveform-range-editor {
+  flex-basis: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 6px;
+}
+.waveform-range-editor fieldset {
+  display: flex;
+  flex: 1 1 220px;
+  min-width: 0;
+  gap: 6px;
+  border: 1px solid var(--icm-border);
+  border-radius: var(--icm-radius-sm);
+}
+.waveform-range-editor label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+.waveform-range-editor input:not([type="checkbox"]) {
+  width: 100%;
+  min-width: 0;
+}
+.waveform-range-editor [role="alert"] {
+  flex-basis: 100%;
+  color: var(--icm-danger, #b42318);
 }
 .spice-ac-plot.interactive {
   overflow: hidden;

--- a/apps/editor/src/styles/editor-simulation.css
+++ b/apps/editor/src/styles/editor-simulation.css
@@ -708,12 +708,15 @@
 .ac-plot-shell {
   position: relative;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 .ac-plot-toolbar {
-  position: absolute;
-  z-index: 2;
-  top: 7px;
-  right: 7px;
+  position: relative;
+  order: -1;
+  align-self: flex-end;
+  flex-wrap: wrap;
   display: flex;
   gap: 2px;
   padding: 3px;
@@ -721,9 +724,8 @@
   border-radius: var(--icm-radius-sm);
   background: color-mix(in srgb, var(--icm-surface) 94%, transparent);
   box-shadow: var(--icm-shadow-sm);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 100ms ease;
+  opacity: 1;
+  pointer-events: auto;
 }
 .ac-plot-shell:hover .ac-plot-toolbar,
 .ac-plot-shell:focus-within .ac-plot-toolbar,
@@ -788,11 +790,13 @@
   font-size: 18px;
 }
 .ac-plot-shell.expanded {
-  display: grid;
+  display: flex;
   min-height: 0;
   padding: 12px;
 }
 .ac-plot-shell.expanded .spice-ac-plot {
+  flex: 1;
+  overflow: hidden;
   display: grid;
   min-height: 0;
   place-items: center;
@@ -1272,4 +1276,20 @@
   font-size: 10px;
   fill: var(--icm-text, #101828);
   font-family: var(--icm-mono, ui-monospace, monospace);
+}
+.waveform-selection {
+  position: absolute;
+  pointer-events: none;
+  border: 1px solid #175cd3;
+  background: rgb(23 92 211 / 12%);
+}
+.waveform-svg {
+  display: contents;
+}
+.spice-ac-plot.interactive {
+  overflow: hidden;
+  user-select: none;
+}
+.ac-plot-dialog {
+  grid-template-rows: auto minmax(0, 1fr) auto;
 }


### PR DESCRIPTION
AC and TRAN plots now share direct drag-to-zoom, click-to-measure and Shift-drag pan, plus view Back/Forward, independent X/Y control, Fit X/Y, exact Auto/manual range editing, and A/B markers with delta measurements. Invalid ranges produce an inline correction instead of interrupting the session. Hovering does not scan samples or update readings. Tools and readouts occupy space outside the plot.

The shared gesture component uses the SVG screen transform so letterboxing does not shift selection coordinates. Tick density follows the available width and visible range; transient labels adapt precision and engineering units. Transient segments crossing zoom boundaries are preserved and clipped. Bounded session-only view state is keyed by unique run/analysis identity: tabs and panel remounts retain ranges, navigation history, markers and output visibility, while new runs start fresh. Repeated per-explorer controls and navigation helpers are removed. Output selection, Solo and Canvas highlighting remain available.

Validation includes preflight, workspace unit/integration tests and the five affected browser flows on an isolated port. Browser coverage exercises direct AC/TRAN zoom, navigation history, single-axis gestures, exact range recovery, A/B readouts, tab-remount preservation, visibility, new-run reset, expanded plots and Net highlighting. No Project or simulator protocol changes.

Interaction references: [MATLAB chart interactions](https://www.mathworks.com/help/matlab/creating_plots/control-axes-interactions.html), [Cadence ViVA](https://www.cadence.com/content/dam/cadence-www/global/en_US/documents/tools/custom-ic-analog-rf-design/virtuoso-visualization-analysis-ds.pdf).
