### PR TITLE
Fix DC sweep parsing against real ngspice 46 output

### DIFF
--- a/fixtures/ngspice-rawfile/README.md
+++ b/fixtures/ngspice-rawfile/README.md
@@ -35,9 +35,10 @@ the probe once; the fixture exists so that echo is tested against a file the
 simulator wrote.
 
 **`divider-dc`** — the same divider swept from 0 V to 1.5 V. Its values are
-closed-form protocol data (`v(mid) = v(in)/2`) and are deliberately identified
-as reconstructed rather than simulator-qualified. The Profile gate must
-regenerate it in the pinned image before DC promotion.
+recorded from the pinned Preview operator host (ngspice 46) on 2026-09-06,
+using the adjacent deck. They satisfy `v(mid) = v(in)/2`. The ASCII scale is
+`v(v-sweep)`, not the bare `v-sweep` formerly assumed by reconstructed data.
+Environment fingerprint: `33c245e5df6dc12077b6a2e4ebf308777b0e9014fe9bfdafc3285c614688561d`.
 
 **`rc-ac`** — R = 1 kΩ, C = 1 µF, so H(f) = 1/(1 + jf/f_c) with
 f_c = 1/(2π·RC) = 159.1549 Hz. Every one of the 17 points can be asserted

--- a/fixtures/ngspice-rawfile/divider-dc.raw
+++ b/fixtures/ngspice-rawfile/divider-dc.raw
@@ -1,12 +1,12 @@
 Title: * resistive divider dc transfer curve
-Date: Reconstructed protocol fixture
-Command: reconstructed, not ngspice output
+Date: Sun Sep  6 04:47:17  2026
+Command: ngspice-46, Build Thu Jul 23 12:10:16 UTC 2026
 Plotname: DC transfer characteristic
 Flags: real
 No. Variables: 4
 No. Points: 4
 Variables:
-	0	v-sweep	voltage
+	0	v(v-sweep)	voltage
 	1	v(in)	voltage
 	2	v(mid)	voltage
 	3	i(v1)	current

--- a/packages/spice-run/src/result-data.test.ts
+++ b/packages/spice-run/src/result-data.test.ts
@@ -239,11 +239,45 @@ describe("an AC sweep", () => {
 describe("a DC sweep", () => {
   const dc = (): DcSweepResult => only("divider-dc.raw", "dc");
 
+  it.each(["v-sweep", "v(v-sweep)", "i(i-sweep)", "temp-sweep", "res-sweep"])(
+    "recognizes %s without rewriting its recorded name",
+    (name) => {
+      const [analysis] = expectAnalyses(
+        readSimulationData(
+          fixture("divider-dc.raw").replace("v(v-sweep)", name),
+        ),
+      );
+      expect(analysis?.analysis).toBe("dc");
+      if (analysis?.analysis !== "dc") throw new Error("Expected DC");
+      expect(analysis.sweep.name).toBe(name);
+      expect(analysis.sweep.values).toEqual([0, 0.5, 1, 1.5]);
+    },
+  );
+
+  it.each(["v(out)", "v(not-a-sweep)"])(
+    "does not guess a missing scale from the first vector %s",
+    (name) => {
+      const reading = readSimulationData(
+        fixture("divider-dc.raw").replace("v(v-sweep)", name),
+      );
+      expect(reading.status).toBe("unusable");
+      expect(reading.diagnostics[0]?.text).toContain("0 DC sweep axes");
+    },
+  );
+
+  it("rejects ambiguous scales instead of choosing one", () => {
+    const reading = readSimulationData(
+      fixture("divider-dc.raw").replace("v(in)", "i(i-sweep)"),
+    );
+    expect(reading.status).toBe("unusable");
+    expect(reading.diagnostics[0]?.text).toContain("2 DC sweep axes");
+  });
+
   it("keeps ngspice's recorded sweep axis and divider arithmetic", () => {
     const analysis = dc();
     expect(analysis.plotName).toBe("DC transfer characteristic");
     expect(analysis.sweep).toEqual({
-      name: "v-sweep",
+      name: "v(v-sweep)",
       quantity: "voltage",
       unit: "V",
       values: [0, 0.5, 1, 1.5],
@@ -260,7 +294,7 @@ describe("a DC sweep", () => {
   it("exports the simulator axis and every probe without rebuilding values", () => {
     const analysis = dc();
     const lines = simulationAnalysisToCsv(analysis).trimEnd().split("\n");
-    expect(lines[0]).toBe("v-sweep [V],v(in) [V],v(mid) [V],i(v1) [A]");
+    expect(lines[0]).toBe("v(v-sweep) [V],v(in) [V],v(mid) [V],i(v1) [A]");
     expect(lines.slice(1).map((line) => line.split(",").map(Number))).toEqual(
       analysis.sweep.values.map((sweep, point) => [
         sweep,

--- a/packages/spice-run/src/result-data.ts
+++ b/packages/spice-run/src/result-data.ts
@@ -241,16 +241,18 @@ function readDcSweep(plot: RawfilePlot): PlotReading {
       ),
     };
   }
-  // ngspice names the independent DC scale `v-sweep`, `i-sweep`,
-  // `res-sweep`, or `temp-sweep`. Use that declared identity instead of the
-  // first vector: explicit `write` lists may echo or reorder vectors.
+  // ASCII `write` wraps voltage/current scales, e.g. ngspice 46 emits
+  // `v(v-sweep)`. Recognize the scale identity without renaming the raw vector.
+  // Do not guess from position: explicit write lists may reorder vectors.
   const candidates = plot.vectors.filter((vector) =>
-    /-sweep$/iu.test(vector.variable.name),
+    /^(?:[vi]\((?:v|i|res|temp)-sweep\)|(?:v|i|res|temp)-sweep)$/iu.test(
+      vector.variable.name,
+    ),
   );
   if (candidates.length !== 1) {
     return {
       diagnostic: error(
-        `The "${plot.plotName}" plot declares ${candidates.length} DC sweep axes; exactly one named *-sweep is required for a one-dimensional DC result.`,
+        `The "${plot.plotName}" plot declares ${candidates.length} DC sweep axes; exactly one recognized sweep vector (bare or voltage/current-wrapped) is required for a one-dimensional DC result.`,
       ),
     };
   }

--- a/scripts/preview-simulation-smoke.mjs
+++ b/scripts/preview-simulation-smoke.mjs
@@ -393,7 +393,7 @@ export function validateDcDividerResult(payload, expectedTarget) {
   if (!dc || !Array.isArray(dc.sweep?.values) || !Array.isArray(dc.probes)) {
     throw new Error(`${expectedTarget} returned no structured DC result.`);
   }
-  if (dc.sweep.name !== "v-sweep") {
+  if (dc.sweep.name !== "v(v-sweep)") {
     throw new Error(`${expectedTarget} returned an unexpected DC sweep axis.`);
   }
   const expectedAxis = [0, 0.5, 1, 1.5];

--- a/scripts/preview-simulation-smoke.test.mjs
+++ b/scripts/preview-simulation-smoke.test.mjs
@@ -135,7 +135,7 @@ describe("the Preview dual-executor smoke", () => {
         analyses: [
           {
             analysis: "dc",
-            sweep: { name: "v-sweep", values: [0, 0.5, 1, 1.5] },
+            sweep: { name: "v(v-sweep)", values: [0, 0.5, 1, 1.5] },
             probes: [{ name: "v(out)", value: [0, 0.25, 0.5, 0.75] }],
           },
         ],


### PR DESCRIPTION
## Cause and fix
The pinned Preview ngspice 46 writes the DC scale as `v(v-sweep)`. The parser and smoke check assumed bare `v-sweep`, based on a reconstructed fixture. Recognize wrapped scale identity while preserving raw names. Missing or ambiguous axes still fail; no arithmetic tolerance is relaxed.

## Evidence
Reproduced against the Preview operator host. Simulator returned four correct divider samples (0, 0.25, 0.5, 0.75 V), but parsing rejected the scale. Replaced the reconstructed fixture with actual pinned-host output and recorded environment fingerprint.

## Validation
- Frozen install and preflight passed.
- Focused parser/smoke tests: 50 passed.
- Full local delivery gate running; required CI and deployed Preview numerical acceptance must pass before completion.